### PR TITLE
deps: bump libarchive to v3.8.7, fix all dep-update workflows

### DIFF
--- a/.github/workflows/update-cares.yml
+++ b/.github/workflows/update-cares.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildCares.cmake)
+          DEP_FILE=scripts/build/deps/cares.ts
+          CURRENT_VERSION=$(sed -nE 's/^const CARES_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildCares.cmake"
+            echo "Error: Could not find CARES_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildCares.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -73,10 +73,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildCares.cmake
+          sed -i -E 's/^(const CARES_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/cares.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -84,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildCares.cmake
+            scripts/build/deps/cares.ts
           commit-message: "deps: update c-ares to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update c-ares to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-hdrhistogram.yml
+++ b/.github/workflows/update-hdrhistogram.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildHdrHistogram.cmake)
+          DEP_FILE=scripts/build/deps/hdrhistogram.ts
+          CURRENT_VERSION=$(sed -nE 's/^const HDRHISTOGRAM_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildHdrHistogram.cmake"
+            echo "Error: Could not find HDRHISTOGRAM_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildHdrHistogram.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -76,10 +76,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildHdrHistogram.cmake
+          sed -i -E 's/^(const HDRHISTOGRAM_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/hdrhistogram.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -87,7 +88,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildHdrHistogram.cmake
+            scripts/build/deps/hdrhistogram.ts
           commit-message: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update hdrhistogram to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-highway.yml
+++ b/.github/workflows/update-highway.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildHighway.cmake)
+          DEP_FILE=scripts/build/deps/highway.ts
+          CURRENT_VERSION=$(sed -nE 's/^const HIGHWAY_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildHighway.cmake"
+            echo "Error: Could not find HIGHWAY_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildHighway.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -92,10 +92,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildHighway.cmake
+          sed -i -E 's/^(const HIGHWAY_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/highway.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -103,7 +104,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildHighway.cmake
+            scripts/build/deps/highway.ts
           commit-message: "deps: update highway to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update highway to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-libarchive.yml
+++ b/.github/workflows/update-libarchive.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildLibArchive.cmake)
+          DEP_FILE=scripts/build/deps/libarchive.ts
+          CURRENT_VERSION=$(sed -nE 's/^const LIBARCHIVE_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildLibArchive.cmake"
+            echo "Error: Could not find LIBARCHIVE_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildLibArchive.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -73,10 +73,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildLibArchive.cmake
+          sed -i -E 's/^(const LIBARCHIVE_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/libarchive.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -84,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildLibArchive.cmake
+            scripts/build/deps/libarchive.ts
           commit-message: "deps: update libarchive to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libarchive to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-libdeflate.yml
+++ b/.github/workflows/update-libdeflate.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildLibDeflate.cmake)
+          DEP_FILE=scripts/build/deps/libdeflate.ts
+          CURRENT_VERSION=$(sed -nE 's/^const LIBDEFLATE_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildLibDeflate.cmake"
+            echo "Error: Could not find LIBDEFLATE_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildLibDeflate.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -73,10 +73,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildLibDeflate.cmake
+          sed -i -E 's/^(const LIBDEFLATE_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/libdeflate.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -84,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildLibDeflate.cmake
+            scripts/build/deps/libdeflate.ts
           commit-message: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-lolhtml.yml
+++ b/.github/workflows/update-lolhtml.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildLolHtml.cmake)
+          DEP_FILE=scripts/build/deps/lolhtml.ts
+          CURRENT_VERSION=$(sed -nE 's/^const LOLHTML_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildLolHtml.cmake"
+            echo "Error: Could not find LOLHTML_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildLolHtml.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -85,10 +85,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildLolHtml.cmake
+          sed -i -E 's/^(const LOLHTML_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/lolhtml.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -96,7 +97,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildLolHtml.cmake
+            scripts/build/deps/lolhtml.ts
           commit-message: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-lshpack.yml
+++ b/.github/workflows/update-lshpack.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/BuildLshpack.cmake)
+          DEP_FILE=scripts/build/deps/lshpack.ts
+          CURRENT_VERSION=$(sed -nE 's/^const LSHPACK_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in BuildLshpack.cmake"
+            echo "Error: Could not find LSHPACK_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in BuildLshpack.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -90,10 +90,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/BuildLshpack.cmake
+          sed -i -E 's/^(const LSHPACK_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/lshpack.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -101,7 +102,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/BuildLshpack.cmake
+            scripts/build/deps/lshpack.ts
           commit-message: "deps: update lshpack to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lshpack to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-zstd.yml
+++ b/.github/workflows/update-zstd.yml
@@ -20,17 +20,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Extract the commit hash from the line after COMMIT
-          CURRENT_VERSION=$(awk '/[[:space:]]*COMMIT[[:space:]]*$/{getline; gsub(/^[[:space:]]+|[[:space:]]+$/,"",$0); print}' cmake/targets/CloneZstd.cmake)
+          DEP_FILE=scripts/build/deps/zstd.ts
+          CURRENT_VERSION=$(sed -nE 's/^const ZSTD_COMMIT = "([0-9a-f]{40})";$/\1/p' "$DEP_FILE")
 
           if [ -z "$CURRENT_VERSION" ]; then
-            echo "Error: Could not find COMMIT line in CloneZstd.cmake"
+            echo "Error: Could not find ZSTD_COMMIT in $DEP_FILE"
             exit 1
           fi
 
           # Validate that it looks like a git hash
           if ! [[ $CURRENT_VERSION =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Error: Invalid git hash format in CloneZstd.cmake"
+            echo "Error: Invalid git hash format in $DEP_FILE"
             echo "Found: $CURRENT_VERSION"
             echo "Expected: 40 character hexadecimal string"
             exit 1
@@ -73,10 +73,11 @@ jobs:
 
       - name: Update version if needed
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
+        env:
+          LATEST: ${{ steps.check-version.outputs.latest }}
         run: |
           set -euo pipefail
-          # Handle multi-line format where COMMIT and its value are on separate lines
-          sed -i -E '/[[:space:]]*COMMIT[[:space:]]*$/{n;s/[[:space:]]*([0-9a-f]+)[[:space:]]*$/    ${{ steps.check-version.outputs.latest }}/}' cmake/targets/CloneZstd.cmake
+          sed -i -E 's/^(const ZSTD_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/zstd.ts
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -84,7 +85,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
-            cmake/targets/CloneZstd.cmake
+            scripts/build/deps/zstd.ts
           commit-message: "deps: update zstd to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update zstd to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/patches/libarchive/archive_write_add_filter_gzip.c.patch
+++ b/patches/libarchive/archive_write_add_filter_gzip.c.patch
@@ -1,5 +1,5 @@
---- a/libarchive/archive_write_add_filter_gzip.c	2025-07-21 06:29:58.505101515 +0000
-+++ b/libarchive/archive_write_add_filter_gzip.c	2025-07-21 06:44:09.023676935 +0000
+--- a/libarchive/archive_write_add_filter_gzip.c
++++ b/libarchive/archive_write_add_filter_gzip.c
 @@ -59,12 +59,13 @@
  	int		 compression_level;
  	int		 timestamp;
@@ -23,10 +23,13 @@
  	f->open = &archive_compressor_gzip_open;
  	f->options = &archive_compressor_gzip_options;
  	f->close = &archive_compressor_gzip_close;
-@@ -177,6 +179,30 @@
- 		return (ARCHIVE_OK);
- 	}
- 
+@@ -180,6 +182,30 @@
+ 			if (data->original_filename == NULL)
+ 				return (ARCHIVE_WARN);
+ 		}
++		return (ARCHIVE_OK);
++	}
++
 +	if (strcmp(key, "os") == 0) {
 +		if (value == NULL) 
 +			return (ARCHIVE_WARN);
@@ -48,16 +51,13 @@
 +		else if (strcmp(value, "Unknown") == 0) data->os = 255;
 +		else return (ARCHIVE_WARN);
 +
-+		return (ARCHIVE_OK);
-+	}
-+
- 	/* Note: The "warn" return is just to inform the options
- 	 * supervisor that we didn't handle it.  It will generate
- 	 * a suitable error if no one used this option. */
-@@ -236,7 +262,7 @@
- 	    data->compressed[8] = 4;
-     else
- 	    data->compressed[8] = 0;
+ 		return (ARCHIVE_OK);
+ 	}
+ 
+@@ -245,7 +271,7 @@
+ 	} else {
+ 		data->compressed[8] = 0;
+ 	}
 -	data->compressed[9] = 3; /* OS=Unix */
 +	data->compressed[9] = data->os;
  	data->stream.next_out += 10;

--- a/scripts/build/deps/libarchive.ts
+++ b/scripts/build/deps/libarchive.ts
@@ -12,7 +12,7 @@
 import type { Dependency } from "../source.ts";
 import { depSourceDir } from "../source.ts";
 
-const LIBARCHIVE_COMMIT = "9525f90ca4bd14c7b335e2f8c84a4607b0af6bdf";
+const LIBARCHIVE_COMMIT = "ded82291ab41d5e355831b96b0e1ff49e24d8939";
 
 export const libarchive: Dependency = {
   name: "libarchive",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -274,7 +274,7 @@ it("process.versions", () => {
   // bumping a dep requires updating this test too).
   const expectedVersions = {
     boringssl: "4f4f5ef8ebc6e23cbf393428f0ab1b526773f7ac",
-    libarchive: "9525f90ca4bd14c7b335e2f8c84a4607b0af6bdf",
+    libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
     mimalloc: "9a5e1f52cdf4662f9590b69de104a4469140796f",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",


### PR DESCRIPTION
## What does this PR do?

The scheduled `update-*.yml` workflows have been failing since #28640 removed `cmake/targets/*.cmake` — they were still reading pinned commits from those files. The dependency definitions now live in `scripts/build/deps/*.ts` as `const <NAME>_COMMIT = "..."`.

**Workflows fixed** — `update-{libarchive,cares,hdrhistogram,highway,libdeflate,lolhtml,lshpack,zstd}.yml` now read/write the `_COMMIT` constant in the corresponding `scripts/build/deps/*.ts` file. The replacement step also moved to the safe `env:` pattern instead of inlining `${{ }}` into the shell.

**libarchive bumped** — 3.8.1 → 3.8.7 ([compare](https://github.com/libarchive/libarchive/compare/9525f90ca4bd14c7b335e2f8c84a4607b0af6bdf...ded82291ab41d5e355831b96b0e1ff49e24d8939)). `archive_write_add_filter_gzip.c.patch` rebased onto the new upstream, which reformatted the surrounding code; no semantic change — still adds the `gzip:os` option used by `bun pm pack` for reproducible tarballs.

The other 7 deps were not version-bumped here; their now-working workflows will open bump PRs on the next scheduled run.

Closes [oven-sh/bun#26652](https://github.com/oven-sh/bun/pull/26652)
Closes [oven-sh/bun#26432](https://github.com/oven-sh/bun/pull/26432)
Closes [oven-sh/bun#26209](https://github.com/oven-sh/bun/pull/26209)
Closes [oven-sh/bun#25955](https://github.com/oven-sh/bun/pull/25955)
Closes [oven-sh/bun#25818](https://github.com/oven-sh/bun/pull/25818)
Closes [oven-sh/bun#25726](https://github.com/oven-sh/bun/pull/25726)
Closes [oven-sh/bun#25625](https://github.com/oven-sh/bun/pull/25625)
Closes [oven-sh/bun#25507](https://github.com/oven-sh/bun/pull/25507)
Closes [oven-sh/bun#25380](https://github.com/oven-sh/bun/pull/25380)

## How did you verify your code works?

- [x] `bun scripts/build.ts --target=libarchive` — patches apply cleanly, builds `libarchive.a` with `ARCHIVE_VERSION_NUMBER 3008007`
- [x] `bun bd test test/js/bun/archive.test.ts` — 99 pass
- [x] `bun bd test test/cli/install/bun-pack.test.ts` — 70 pass
- [x] `bun pm pack` gzip header byte 9 = `0xff`, confirming the rebased patch is functional
- [x] All 8 workflows: extraction sed returns valid 40-char hash from the live `.ts` file (GNU sed)
- [x] All 8 workflows: replacement sed rewrites exactly one line, round-trips back through extraction
- [x] All 8 workflows: YAML parses, no `cmake` references remain