### PR TITLE
Fix integer overflow when reading a sliced non-regular file Blob

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -347,10 +347,7 @@ pub const ReadFile = struct {
             // read up to 4k at a time if
             // they didn't explicitly set a size and we're reading from something that's not a regular file
         } else if (stat.size == 0 and this.could_block) {
-            this.size = if (this.max_length == Blob.max_size)
-                4096
-            else
-                this.max_length;
+            this.size = @min(this.max_length, 4096);
         }
 
         if (this.offset > 0) {
@@ -384,7 +381,7 @@ pub const ReadFile = struct {
 
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
-            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size + 16) catch |err| {
+            this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
                 this.onFinish();
                 return;
@@ -669,10 +666,7 @@ pub const ReadFileUV = struct {
         } else if (stat.size == 0 and !this.is_regular_file) {
             // read up to 4k at a time if they didn't explicitly set a size and
             // we're reading from something that's not a regular file.
-            this.size = if (this.max_length == Blob.max_size)
-                4096
-            else
-                this.max_length;
+            this.size = @min(this.max_length, 4096);
         }
 
         if (this.offset > 0) {

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "bun:test";
-import { tmpdir } from "node:os";
 import { bunEnv, bunExe, isPosix } from "harness";
+import { tmpdir } from "node:os";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test";
 import { tmpdir } from "node:os";
+import { bunEnv, bunExe, isPosix } from "harness";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +9,30 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+it.skipIf(!isPosix)("reading a sliced non-regular file Blob does not overflow the initial buffer size", async () => {
+  // .slice(1) on a file Blob whose size is unknown (max_size) yields a Blob with
+  // size = max_size - 1. For a non-regular file (char device), this was used as
+  // the initial buffer capacity and `size + 16` overflowed u52.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const a = await Bun.file("/dev/null").slice(1).arrayBuffer();
+        if (a.byteLength !== 0) throw new Error("expected 0, got " + a.byteLength);
+        const b = await Bun.file("/dev/zero").slice(0, 100).arrayBuffer();
+        if (b.byteLength !== 100) throw new Error("expected 100, got " + b.byteLength);
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
 });


### PR DESCRIPTION
Fuzzilli found a crash (fingerprint `851b2e15154d15ae`) in `ReadFile.runAsyncWithFD` at `this.size + 16`.

## Root cause

`Bun.file(path).slice(1)` on a file Blob with unknown size (`Blob.max_size`) produces a sliced Blob with `size = max_size - 1`. When reading a non-regular file (char device, pipe, etc.) with `stat.size == 0`, `resolveSizeAndLastModified` set `this.size = this.max_length` whenever `max_length != Blob.max_size` — intending to use the user's explicit slice length as a buffer size hint. But after `.slice(1)`, `max_length` is `max_size - 1` (~4.5 PB), and the subsequent `this.size + 16` overflowed `u52` and panicked.

## Repro

```js
await Bun.file("/dev/null").slice(1).arrayBuffer();
// panic: integer overflow (debug builds)
```

## Fix

`this.size` here is only the *initial* buffer capacity — the read loop grows it as needed via a 64 KB stack buffer, and the actual read limit is `max_length`. Cap the initial capacity to `@min(max_length, 4096)`, which matches what already happens in the unsliced case and avoids trying to pre-allocate petabytes.

Also use saturating add (`+|`) on the `+ 16` for the regular-file path as defense in depth.

Applied the same `@min` fix to the Windows `ReadFileUV` path (which the comment says to keep in sync) — there it didn't panic but returned a spurious `ENOMEM`.