### PR TITLE
Upgrade WebKit to 4d5e75ebd84a14edbc7ae264245dcd77fe597c10

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "8b7f6f706720ab7e5284906c29f2fbf77dfbd1e9";
+export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Upgrades WebKit from `8b7f6f70` → `4d5e75eb` (1 commit).

## bmalloc / libpas Changes

- **Windows: lazy-commit the 128 MB compact-heap reservation** ([4d5e75eb](https://github.com/oven-sh/WebKit/commit/4d5e75eb)). On Windows, `pas_compact_heap_reservation` previously committed the entire 128 MB region eagerly via `VirtualAlloc(MEM_COMMIT|MEM_RESERVE)` because `pas_page_malloc` lacks a reserve-only verb there. Only ~3–8 MB past the bump pointer is ever actually used, and the scavenger never reclaims this region. This change extends the existing PlayStation reserve-then-commit-on-bump path to Windows. Linux/macOS are unaffected (already lazy via `mmap MAP_NORESERVE`).

## Compatibility Notes

- `JSType.h`: no changes — `src/bun.js/bindings/JSType.zig` needs no update.
- WebCore bindings codegen (`Source/WebCore/bindings/scripts/`): no changes.
- Only file touched: `Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c` (+15/−2).