### PR TITLE
Fix crash in Bun.inspect with throwing Proxy prototype

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -3371,7 +3371,7 @@ pub const Formatter = struct {
                         writer.writeAll("{}");
                     }
                 } else {
-                    this.depth -= 1;
+                    this.depth -|= 1;
 
                     if (iter.always_newline) {
                         this.indent -|= 1;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5290,10 +5290,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5365,7 +5366,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "bun:test";
+
+test("Bun.inspect with throwing getter in Proxy prototype does not crash", () => {
+  const proto = {
+    get a() {
+      throw new Error("boom");
+    },
+    b: 1,
+  };
+  const obj = Object.create(new Proxy(proto, {}));
+  expect(Bun.inspect(obj)).toBeString();
+});
+
+test("Bun.inspect with throwing getPrototypeOf trap does not crash", () => {
+  const obj = {};
+  const proto = new Proxy(
+    {},
+    {
+      getPrototypeOf() {
+        throw new Error("nope");
+      },
+    },
+  );
+  Object.setPrototypeOf(obj, proto);
+  expect(Bun.inspect(obj)).toBeString();
+});
+
+test("Bun.inspect nested object with throwing Proxy prototype does not crash", () => {
+  const proto = {
+    get a() {
+      throw new Error("boom");
+    },
+  };
+  const inner = Object.create(new Proxy(proto, {}));
+  expect(Bun.inspect({ x: inner, y: inner })).toBeString();
+});

--- a/test/js/bun/util/inspect-proxy-prototype.test.ts
+++ b/test/js/bun/util/inspect-proxy-prototype.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("Bun.inspect with throwing getter in Proxy prototype does not crash", () => {
   const proto = {


### PR DESCRIPTION
Fuzzer found a crash when inspecting an object whose prototype chain contains a Proxy that throws during property access or `getPrototypeOf`.

## Root cause

In `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` / `console.log` to enumerate properties up the prototype chain):

1. `getPropertySlot()` can throw and return `false` — for example when a Proxy `[[Get]]` trap invokes a getter that throws. The pending exception was only cleared on the `true` branch, so it leaked into the subsequent `getPrototype()` call.
2. `getPrototype()` can itself throw via a Proxy `getPrototypeOf` trap (or return early due to a pending exception) and return an empty `JSValue`. Calling `.getObject()` on an empty `JSValue` passes `isCell()` and then calls `getObject()` on a null `JSCell*`.

In release builds this read `type()` from a small offset of null and segfaulted; in debug builds with safety checks it manifested as `panic: integer overflow` downstream.

## Fix

- Clear the exception from `getPropertySlot()` before the early `continue`.
- Clear the exception from `getPrototype()` and break out of the loop if it returned an empty value, matching the handling already present on the fast path.
- Make the corresponding `depth` decrement in the Zig formatter saturating, matching `indent` on the next line.

## Repro

```js
const proto = { get a() { throw new Error("boom"); } };
const obj = Object.create(new Proxy(proto, {}));
Bun.inspect(obj); // segfault before, returns "{}" after
```

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, { getPrototypeOf() { throw 0; } }));
Bun.inspect(obj); // segfault before
```