### PR TITLE
bundler: inline file-loader assets imported from JS in standalone HTML

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.zig
+++ b/src/bundler/linker_context/generateChunksInParallel.zig
@@ -416,7 +416,13 @@ pub fn generateChunksInParallel(
         for (chunks, 0..) |*chunk_item, ci| {
             if (chunk_item.content == .html) continue;
             var ds: usize = 0;
-            scc[ci] = (chunk_item.intermediate_output.code(
+            // Pass `scc` so that `.asset` pieces (e.g. `import logo from "./logo.svg"` with
+            // the file loader) are resolved to data: URIs from `url_for_css` instead of
+            // being written as paths to sidecar files that don't exist in standalone mode.
+            // Sibling JS/CSS chunks may still be null at this point; `.chunk` pieces fall
+            // back to file paths when their entry in `scc` is null, matching the previous
+            // behavior for inter-chunk imports.
+            scc[ci] = (chunk_item.intermediate_output.codeStandalone(
                 null,
                 c.parse_graph,
                 &c.graph,
@@ -426,6 +432,7 @@ pub fn generateChunksInParallel(
                 &ds,
                 false,
                 false,
+                scc,
             ) catch |err| bun.handleOom(err)).buffer;
         }
     }

--- a/test/regression/issue/29298.test.ts
+++ b/test/regression/issue/29298.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/29298
+// `bun build --compile --target browser ./src/index.html` produced an HTML
+// file referencing sidecar assets (e.g. `./logo-kygw735p.svg`) that were
+// never written to disk. Assets imported from JS/TS via the `file` loader
+// must be inlined as `data:` URIs in standalone HTML mode, the same way
+// `<link rel="icon" href="./logo.svg">` already was.
+
+const SVG_BODY = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 4"><rect width="4" height="4" fill="#fbf0df"/></svg>`;
+
+test("standalone HTML inlines file-loader assets imported from JS as data URIs", async () => {
+  using dir = tempDir("issue-29298-js-import", {
+    "src/index.html": `<!doctype html>
+<html>
+  <head><title>t</title></head>
+  <body><div id="root"></div><script type="module" src="./entry.ts"></script></body>
+</html>`,
+    "src/entry.ts": `import logo from "./logo.svg";
+const img = document.createElement("img");
+img.src = logo;
+document.body.appendChild(img);
+console.log(logo);`,
+    "src/logo.svg": SVG_BODY,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--target", "browser", "--outdir", "./dist", "./src/index.html"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+
+  // Only index.html should exist in dist/ — standalone HTML is meant to be self-contained.
+  const distFiles = await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "dist") }));
+  expect(distFiles).toEqual(["index.html"]);
+
+  const html = await Bun.file(join(String(dir), "dist", "index.html")).text();
+
+  // The JS-imported SVG must NOT be referenced as a sidecar path.
+  expect(html).not.toMatch(/logo-[a-z0-9]+\.svg/);
+
+  // It must be inlined as a data: URI. Check the base64 prefix of the SVG body.
+  const expectedPrefix = Buffer.from(SVG_BODY).toString("base64").slice(0, 40);
+  expect(html).toContain(`data:image/svg+xml;base64,${expectedPrefix}`);
+});
+
+test("standalone HTML inlines assets from both <link href> and JS imports", async () => {
+  using dir = tempDir("issue-29298-link-and-import", {
+    "src/index.html": `<!doctype html>
+<html>
+  <head><link rel="icon" href="./icon.svg"><title>t</title></head>
+  <body><script type="module" src="./entry.ts"></script></body>
+</html>`,
+    "src/entry.ts": `import logo from "./logo.svg";
+document.body.dataset.logo = logo;`,
+    "src/icon.svg": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><rect width="2" height="2" fill="#ff0000"/></svg>`,
+    "src/logo.svg": `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><rect width="2" height="2" fill="#00ff00"/></svg>`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", "--target", "browser", "--outdir", "./dist", "./src/index.html"],
+    cwd: String(dir),
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+
+  const html = await Bun.file(join(String(dir), "dist", "index.html")).text();
+  expect(html).not.toMatch(/\.svg"/); // no sidecar refs anywhere
+
+  // Both SVGs end up inlined — count base64-encoded data URIs for SVG.
+  const dataUris = html.match(/data:image\/svg\+xml;base64,[A-Za-z0-9+/=]+/g) ?? [];
+  expect(dataUris.length).toBeGreaterThanOrEqual(2);
+});

--- a/test/regression/issue/29298.test.ts
+++ b/test/regression/issue/29298.test.ts
@@ -3,11 +3,6 @@ import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/29298
-// `bun build --compile --target browser ./src/index.html` produced an HTML
-// file referencing sidecar assets (e.g. `./logo-kygw735p.svg`) that were
-// never written to disk. Assets imported from JS/TS via the `file` loader
-// must be inlined as `data:` URIs in standalone HTML mode, the same way
-// `<link rel="icon" href="./logo.svg">` already was.
 
 const SVG_BODY = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 4"><rect width="4" height="4" fill="#fbf0df"/></svg>`;
 
@@ -33,9 +28,7 @@ console.log(logo);`,
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("error");
-  expect(exitCode).toBe(0);
+  const exitCode = await proc.exited;
 
   // Only index.html should exist in dist/ — standalone HTML is meant to be self-contained.
   const distFiles = await Array.fromAsync(new Bun.Glob("*").scan({ cwd: join(String(dir), "dist") }));
@@ -49,6 +42,8 @@ console.log(logo);`,
   // It must be inlined as a data: URI. Check the base64 prefix of the SVG body.
   const expectedPrefix = Buffer.from(SVG_BODY).toString("base64").slice(0, 40);
   expect(html).toContain(`data:image/svg+xml;base64,${expectedPrefix}`);
+
+  expect(exitCode).toBe(0);
 });
 
 test("standalone HTML inlines assets from both <link href> and JS imports", async () => {
@@ -71,9 +66,7 @@ document.body.dataset.logo = logo;`,
     stderr: "pipe",
     stdout: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("error");
-  expect(exitCode).toBe(0);
+  const exitCode = await proc.exited;
 
   const html = await Bun.file(join(String(dir), "dist", "index.html")).text();
   expect(html).not.toMatch(/\.svg"/); // no sidecar refs anywhere
@@ -81,4 +74,6 @@ document.body.dataset.logo = logo;`,
   // Both SVGs end up inlined — count base64-encoded data URIs for SVG.
   const dataUris = html.match(/data:image\/svg\+xml;base64,[A-Za-z0-9+/=]+/g) ?? [];
   expect(dataUris.length).toBeGreaterThanOrEqual(2);
+
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Reproduction

```bash
bun init --react -y project && cd project
bun build --compile --target browser --outdir ./dist ./src/index.html
```

Opening `dist/index.html` shows broken Bun and React logos. The HTML has `<img src="./logo-kygw735p.svg">` but no sibling file exists in `dist/`. (The `<link rel="icon" href="./logo.svg">` in `index.html` *does* get inlined as a `data:` URI — only JS-imported assets are broken.)

## Root cause

When `--compile --target browser` is used on an HTML entry point, `compile_to_standalone_html` is on and the linker deliberately drops additional output files (they'd never be loadable from an embedded HTML anyway). The HTML-chunk code path already substitutes asset references with `data:` URIs from `url_for_css` via `codeStandalone`.

But non-HTML chunks (the JS/CSS ones inlined into the HTML) are resolved in a first pass at `generateChunksInParallel.zig:419` with plain `.code()` and `standalone_chunk_contents: null`. That `null` is the gate in `codeWithSourceMapShifts` (`Chunk.zig:325, 416`) — when it's null, `.asset` pieces fall through to `additional_output_files.items[...].dest_path`, baking a path like `./logo-kygw735p.svg` into the inlined JS. No sidecar is ever written, so the reference dangles.

## Fix

Call `codeStandalone` with the in-progress `scc` array in that first pass. Sibling chunk contents may still be null while we're populating them, but that's fine: the `.chunk` branch already handles `scc[index] == null` by falling back to the file-path path (matching previous behavior for inter-chunk imports). Only `.asset` pieces need the switch, and those only read from `url_for_css`, which is populated at parse time.

## Verification

```
$ bun build --compile --target browser --outdir ./dist ./src/index.html
$ ls dist/
index.html
$ grep -c 'data:image/svg+xml;base64,' dist/index.html
4
$ grep -oE '\.\/[^"]*\.svg' dist/index.html
(nothing)
```

Before: only 2 data URIs (from `<link>` in HTML). After: 4 (JS `import` of `logo.svg` + `react.svg` both inlined too).

Added `test/regression/issue/29298.test.ts` with two cases: single JS-imported SVG and mixed HTML-`<link>` + JS-import. Both fail on main and pass with the fix.

Fixes #29298