### PR TITLE
inspector: drain queued frontend messages before exit; fix TestReporter ID collision

### DIFF
--- a/src/bun.js/Debugger.zig
+++ b/src/bun.js/Debugger.zig
@@ -14,13 +14,10 @@ mode: enum {
 } = .listen,
 
 test_reporter_agent: TestReporterAgent = .{},
-/// Monotonically increasing ID assigned to each `describe`/`test` reported to
-/// the TestReporter frontend. Shared between the live-collection path
-/// (ScopeFunctions.call, when the agent is already enabled as tests are
-/// declared) and the retroactive path (Bun__TestReporterAgentEnable, when the
-/// agent is enabled after some tests have been declared). Keeping a single
-/// counter here prevents the two paths from handing out colliding IDs when
-/// enable lands mid-collection.
+/// Next ID to hand out for a `describe`/`test` reported to the TestReporter
+/// frontend. Shared between ScopeFunctions.call (live) and
+/// Bun__TestReporterAgentEnable (retroactive) so IDs don't collide when the
+/// agent is enabled mid-collection.
 next_test_id_for_debugger: i32 = 0,
 lifecycle_reporter_agent: LifecycleAgent = .{},
 frontend_dev_server_agent: BunFrontendDevServerAgent = .{},
@@ -383,11 +380,7 @@ pub const TestReporterAgent = struct {
 
         const before = debugger.next_test_id_for_debugger;
 
-        // Recursively report all discovered tests starting from root scope.
-        // IDs come from the shared Debugger.next_test_id_for_debugger counter
-        // so that any tests discovered *after* this (still in collection
-        // phase, agent now enabled) continue the same sequence instead of
-        // colliding.
+        // Recursively report all discovered tests starting from root scope
         const root_scope = active_file.collection.root_scope;
         retroactivelyReportScope(agent, root_scope, -1, &debugger.next_test_id_for_debugger, &source_url);
 

--- a/src/bun.js/Debugger.zig
+++ b/src/bun.js/Debugger.zig
@@ -14,6 +14,14 @@ mode: enum {
 } = .listen,
 
 test_reporter_agent: TestReporterAgent = .{},
+/// Monotonically increasing ID assigned to each `describe`/`test` reported to
+/// the TestReporter frontend. Shared between the live-collection path
+/// (ScopeFunctions.call, when the agent is already enabled as tests are
+/// declared) and the retroactive path (Bun__TestReporterAgentEnable, when the
+/// agent is enabled after some tests have been declared). Keeping a single
+/// counter here prevents the two paths from handing out colliding IDs when
+/// enable lands mid-collection.
+next_test_id_for_debugger: i32 = 0,
 lifecycle_reporter_agent: LifecycleAgent = .{},
 frontend_dev_server_agent: BunFrontendDevServerAgent = .{},
 http_server_agent: HTTPServerAgent = .{},
@@ -179,6 +187,16 @@ pub export fn Debugger__didConnect() void {
     }
 }
 
+extern "c" fn Bun__debugger__drain() void;
+
+/// Block (briefly, with a cap) until the debugger thread has written any
+/// queued inspector protocol messages to the frontend socket. Call this from
+/// the main thread immediately before process exit so the detached debugger
+/// thread isn't killed mid-delivery.
+pub fn drain() void {
+    Bun__debugger__drain();
+}
+
 fn start(other_vm: *VirtualMachine) void {
     jsc.markBinding(@src());
 
@@ -342,13 +360,13 @@ pub const TestReporterAgent = struct {
             debugger.test_reporter_agent.handle = agent;
 
             // Retroactively report any tests that were already discovered before the debugger connected
-            retroactivelyReportDiscoveredTests(agent);
+            retroactivelyReportDiscoveredTests(debugger, agent);
         }
     }
 
     /// When TestReporter.enable is called after test collection has started/finished,
     /// we need to retroactively assign test IDs and report discovered tests.
-    fn retroactivelyReportDiscoveredTests(agent: *Handle) void {
+    fn retroactivelyReportDiscoveredTests(debugger: *Debugger, agent: *Handle) void {
         const Jest = jsc.Jest.Jest;
         const runner = Jest.runner orelse return;
         const active_file = runner.bun_test_root.active_file.get() orelse return;
@@ -363,14 +381,17 @@ pub const TestReporterAgent = struct {
         const file_path = runner.files.get(active_file.file_id).source.path.text;
         var source_url = bun.String.init(file_path);
 
-        // Track the maximum ID we assign
-        var max_id: i32 = 0;
+        const before = debugger.next_test_id_for_debugger;
 
-        // Recursively report all discovered tests starting from root scope
+        // Recursively report all discovered tests starting from root scope.
+        // IDs come from the shared Debugger.next_test_id_for_debugger counter
+        // so that any tests discovered *after* this (still in collection
+        // phase, agent now enabled) continue the same sequence instead of
+        // colliding.
         const root_scope = active_file.collection.root_scope;
-        retroactivelyReportScope(agent, root_scope, -1, &max_id, &source_url);
+        retroactivelyReportScope(agent, root_scope, -1, &debugger.next_test_id_for_debugger, &source_url);
 
-        debug("retroactively reported {} tests", .{max_id});
+        debug("retroactively reported {} tests", .{debugger.next_test_id_for_debugger - before});
     }
 
     fn retroactivelyReportScope(agent: *Handle, scope: *bun_test.DescribeScope, parent_id: i32, max_id: *i32, source_url: *bun.String) void {

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -941,11 +941,8 @@ pub fn globalExit(this: *VirtualMachine) noreturn {
     //        causes like 50+ tests to break
     // this.eventLoop().tick();
 
-    // If an inspector frontend is attached, give the debugger thread a chance
-    // to flush any queued protocol messages to the socket before we exit().
-    // The debugger thread is detached, so exit() kills it mid-flight otherwise
-    // and the frontend misses the last events (e.g. TestReporter.end for the
-    // final tests in `bun test`).
+    // Flush queued inspector messages so exit() doesn't kill the detached
+    // debugger thread mid-delivery.
     if (this.debugger != null) {
         jsc.Debugger.drain();
     }

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -941,6 +941,15 @@ pub fn globalExit(this: *VirtualMachine) noreturn {
     //        causes like 50+ tests to break
     // this.eventLoop().tick();
 
+    // If an inspector frontend is attached, give the debugger thread a chance
+    // to flush any queued protocol messages to the socket before we exit().
+    // The debugger thread is detached, so exit() kills it mid-flight otherwise
+    // and the frontend misses the last events (e.g. TestReporter.end for the
+    // final tests in `bun test`).
+    if (this.debugger != null) {
+        jsc.Debugger.drain();
+    }
+
     if (this.shouldDestructMainThreadOnExit()) {
         if (this.eventLoop().forever_timer) |t| t.deinit(true);
         Zig__GlobalObject__destructOnExit(this.global);

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -889,6 +889,15 @@ pub fn globalExit(this: *VirtualMachine) noreturn {
     //        causes like 50+ tests to break
     // this.eventLoop().tick();
 
+    // If an inspector frontend is attached, give the debugger thread a chance
+    // to flush any queued protocol messages to the socket before we exit().
+    // The debugger thread is detached, so exit() kills it mid-flight otherwise
+    // and the frontend misses the last events (e.g. TestReporter.end for the
+    // final tests in `bun test`).
+    if (this.debugger != null) {
+        jsc.Debugger.drain();
+    }
+
     if (this.shouldDestructMainThreadOnExit()) {
         if (this.eventLoop().forever_timer) |t| t.deinit(true);
         Zig__GlobalObject__destructOnExit(this.global);

--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -3,6 +3,7 @@
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/threads/BinarySemaphore.h>
 #include <JavaScriptCore/JSGlobalObjectDebuggable.h>
 #include <JavaScriptCore/JSGlobalObjectDebugger.h>
 #include <JavaScriptCore/Debugger.h>
@@ -45,6 +46,14 @@ static PausedWait& pausedWait()
     static PausedWait instance;
     return instance;
 }
+
+// Number of inspector protocol messages that have been queued from the main
+// (inspected) thread to the debugger thread via sendMessageToDebuggerThread()
+// but have not yet been handed to the JS onMessage callback (which writes them
+// to the frontend socket). Used by Bun__debugger__drain() so the process doesn't
+// exit() while the detached debugger thread still has events to deliver — e.g.
+// the final TestReporter.end events when `bun test` finishes.
+static std::atomic<uint64_t> totalPendingDebuggerMessages { 0 };
 
 static bool waitingForConnection = false;
 extern "C" void Debugger__didConnect();
@@ -359,9 +368,11 @@ public:
             this->debuggerThreadMessages.swap(messages);
         }
 
+        size_t messageCount = messages.size();
+
         JSFunction* onMessageFn = uncheckedDowncast<JSFunction>(jsBunDebuggerOnMessageFunction.get());
         MarkedArgumentBuffer arguments;
-        arguments.ensureCapacity(messages.size());
+        arguments.ensureCapacity(messageCount);
         auto& vm = debuggerGlobalObject->vm();
 
         for (auto& message : messages) {
@@ -371,6 +382,13 @@ public:
         messages.clear();
 
         JSC::call(debuggerGlobalObject, onMessageFn, arguments, "BunInspectorConnection::receiveMessagesOnDebuggerThread - onMessageFn"_s);
+
+        // Publish that these messages have been handed off to the socket so
+        // Bun__debugger__drain() can observe completion. Do this after
+        // JSC::call returns so we know socket.write() has been invoked for
+        // each message.
+        if (messageCount > 0)
+            totalPendingDebuggerMessages.fetch_sub(messageCount, std::memory_order_release);
     }
 
     void sendMessageToDebuggerThread(WTF::String&& inputMessage)
@@ -379,6 +397,8 @@ public:
             Locker<Lock> locker(debuggerThreadMessagesLock);
             debuggerThreadMessages.append(inputMessage);
         }
+
+        totalPendingDebuggerMessages.fetch_add(1, std::memory_order_release);
 
         if (this->debuggerThreadMessageScheduledCount++ == 0) {
             debuggerScriptExecutionContext->postTaskConcurrently([connection = this](ScriptExecutionContext& context) {
@@ -570,6 +590,37 @@ extern "C" void Bun__ensureDebugger(ScriptExecutionContextIdentifier scriptId, b
     if (pauseOnStart) {
         waitingForConnection = true;
     }
+}
+
+// Called from the main (inspected) thread immediately before process exit.
+// Ensures any inspector protocol messages queued for the debugger thread have
+// been written to the frontend socket. Without this, exit() kills the detached
+// debugger thread while messages are still pending, and the frontend misses
+// the final events (most visibly the last TestReporter.start/end events from
+// `bun test`, which finish within the same event-loop iteration as the exit).
+extern "C" void Bun__debugger__drain()
+{
+    if (debuggerScriptExecutionContext == nullptr)
+        return;
+
+    if (totalPendingDebuggerMessages.load(std::memory_order_acquire) == 0)
+        return;
+
+    // Post a sentinel task to the debugger thread. Concurrent tasks are FIFO,
+    // so by the time this runs, any receiveMessagesOnDebuggerThread task posted
+    // before it has already completed (i.e. onMessageFn has written everything
+    // to the socket). The semaphore is heap-allocated and intentionally leaked:
+    // this runs right before exit(), and if the wait times out the debugger
+    // thread may still dereference it.
+    auto* done = new WTF::BinarySemaphore();
+    debuggerScriptExecutionContext->postTaskConcurrently([done](ScriptExecutionContext&) {
+        done->signal();
+    });
+
+    // Cap the wait so a wedged debugger thread can't block process exit.
+    // 250ms is far more than a handful of small messages over a local socket
+    // ever need; hitting the cap means something is broken, not merely slow.
+    done->waitFor(WTF::Seconds::fromMilliseconds(250));
 }
 
 extern "C" void BunDebugger__willHotReload()

--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -47,12 +47,8 @@ static PausedWait& pausedWait()
     return instance;
 }
 
-// Number of inspector protocol messages that have been queued from the main
-// (inspected) thread to the debugger thread via sendMessageToDebuggerThread()
-// but have not yet been handed to the JS onMessage callback (which writes them
-// to the frontend socket). Used by Bun__debugger__drain() so the process doesn't
-// exit() while the detached debugger thread still has events to deliver — e.g.
-// the final TestReporter.end events when `bun test` finishes.
+// Messages queued for the debugger thread via sendMessageToDebuggerThread()
+// that haven't reached the JS onMessage callback yet. See Bun__debugger__drain().
 static std::atomic<uint64_t> totalPendingDebuggerMessages { 0 };
 
 static bool waitingForConnection = false;
@@ -383,10 +379,7 @@ public:
 
         JSC::call(debuggerGlobalObject, onMessageFn, arguments, "BunInspectorConnection::receiveMessagesOnDebuggerThread - onMessageFn"_s);
 
-        // Publish that these messages have been handed off to the socket so
-        // Bun__debugger__drain() can observe completion. Do this after
-        // JSC::call returns so we know socket.write() has been invoked for
-        // each message.
+        // After JSC::call so socket.write() has been invoked for each message.
         if (messageCount > 0)
             totalPendingDebuggerMessages.fetch_sub(messageCount, std::memory_order_release);
     }
@@ -606,20 +599,16 @@ extern "C" void Bun__debugger__drain()
     if (totalPendingDebuggerMessages.load(std::memory_order_acquire) == 0)
         return;
 
-    // Post a sentinel task to the debugger thread. Concurrent tasks are FIFO,
-    // so by the time this runs, any receiveMessagesOnDebuggerThread task posted
-    // before it has already completed (i.e. onMessageFn has written everything
-    // to the socket). The semaphore is heap-allocated and intentionally leaked:
-    // this runs right before exit(), and if the wait times out the debugger
-    // thread may still dereference it.
+    // Post a sentinel: concurrent tasks are FIFO, so once this runs every
+    // earlier receiveMessagesOnDebuggerThread has completed. Heap-allocated
+    // and intentionally leaked — on timeout the debugger thread may still
+    // dereference it, and we're about to exit() anyway.
     auto* done = new WTF::BinarySemaphore();
     debuggerScriptExecutionContext->postTaskConcurrently([done](ScriptExecutionContext&) {
         done->signal();
     });
 
     // Cap the wait so a wedged debugger thread can't block process exit.
-    // 250ms is far more than a handful of small messages over a local socket
-    // ever need; hitting the cap means something is broken, not merely slow.
     done->waitFor(WTF::Seconds::fromMilliseconds(250));
 }
 

--- a/src/bun.js/bindings/BunDebugger.cpp
+++ b/src/bun.js/bindings/BunDebugger.cpp
@@ -3,6 +3,7 @@
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
+#include <wtf/threads/BinarySemaphore.h>
 #include <JavaScriptCore/JSGlobalObjectDebuggable.h>
 #include <JavaScriptCore/JSGlobalObjectDebugger.h>
 #include <JavaScriptCore/Debugger.h>
@@ -28,6 +29,14 @@ class BunInspectorConnection;
 static WebCore::ScriptExecutionContext* debuggerScriptExecutionContext = nullptr;
 static WTF::Lock inspectorConnectionsLock = WTF::Lock();
 static WTF::UncheckedKeyHashMap<ScriptExecutionContextIdentifier, Vector<BunInspectorConnection*, 8>>* inspectorConnections = nullptr;
+
+// Number of inspector protocol messages that have been queued from the main
+// (inspected) thread to the debugger thread via sendMessageToDebuggerThread()
+// but have not yet been handed to the JS onMessage callback (which writes them
+// to the frontend socket). Used by Bun__debugger__drain() so the process doesn't
+// exit() while the detached debugger thread still has events to deliver — e.g.
+// the final TestReporter.end events when `bun test` finishes.
+static std::atomic<uint64_t> totalPendingDebuggerMessages { 0 };
 
 static bool waitingForConnection = false;
 extern "C" void Debugger__didConnect();
@@ -310,9 +319,11 @@ public:
             this->debuggerThreadMessages.swap(messages);
         }
 
+        size_t messageCount = messages.size();
+
         JSFunction* onMessageFn = jsCast<JSFunction*>(jsBunDebuggerOnMessageFunction.get());
         MarkedArgumentBuffer arguments;
-        arguments.ensureCapacity(messages.size());
+        arguments.ensureCapacity(messageCount);
         auto& vm = debuggerGlobalObject->vm();
 
         for (auto& message : messages) {
@@ -322,6 +333,13 @@ public:
         messages.clear();
 
         JSC::call(debuggerGlobalObject, onMessageFn, arguments, "BunInspectorConnection::receiveMessagesOnDebuggerThread - onMessageFn"_s);
+
+        // Publish that these messages have been handed off to the socket so
+        // Bun__debugger__drain() can observe completion. Do this after
+        // JSC::call returns so we know socket.write() has been invoked for
+        // each message.
+        if (messageCount > 0)
+            totalPendingDebuggerMessages.fetch_sub(messageCount, std::memory_order_release);
     }
 
     void sendMessageToDebuggerThread(WTF::String&& inputMessage)
@@ -330,6 +348,8 @@ public:
             Locker<Lock> locker(debuggerThreadMessagesLock);
             debuggerThreadMessages.append(inputMessage);
         }
+
+        totalPendingDebuggerMessages.fetch_add(1, std::memory_order_release);
 
         if (this->debuggerThreadMessageScheduledCount++ == 0) {
             debuggerScriptExecutionContext->postTaskConcurrently([connection = this](ScriptExecutionContext& context) {
@@ -524,6 +544,37 @@ extern "C" void Bun__ensureDebugger(ScriptExecutionContextIdentifier scriptId, b
     if (pauseOnStart) {
         waitingForConnection = true;
     }
+}
+
+// Called from the main (inspected) thread immediately before process exit.
+// Ensures any inspector protocol messages queued for the debugger thread have
+// been written to the frontend socket. Without this, exit() kills the detached
+// debugger thread while messages are still pending, and the frontend misses
+// the final events (most visibly the last TestReporter.start/end events from
+// `bun test`, which finish within the same event-loop iteration as the exit).
+extern "C" void Bun__debugger__drain()
+{
+    if (debuggerScriptExecutionContext == nullptr)
+        return;
+
+    if (totalPendingDebuggerMessages.load(std::memory_order_acquire) == 0)
+        return;
+
+    // Post a sentinel task to the debugger thread. Concurrent tasks are FIFO,
+    // so by the time this runs, any receiveMessagesOnDebuggerThread task posted
+    // before it has already completed (i.e. onMessageFn has written everything
+    // to the socket). The semaphore is heap-allocated and intentionally leaked:
+    // this runs right before exit(), and if the wait times out the debugger
+    // thread may still dereference it.
+    auto* done = new WTF::BinarySemaphore();
+    debuggerScriptExecutionContext->postTaskConcurrently([done](ScriptExecutionContext&) {
+        done->signal();
+    });
+
+    // Cap the wait so a wedged debugger thread can't block process exit.
+    // 250ms is far more than a handful of small messages over a local socket
+    // ever need; hitting the cap means something is broken, not merely slow.
+    done->waitFor(WTF::Seconds::fromMilliseconds(250));
 }
 
 extern "C" void BunDebugger__willHotReload()

--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -185,8 +185,6 @@ fn enqueueDescribeOrTestCallback(this: *ScopeFunctions, bunTest: *bun_test.BunTe
     var test_id_for_debugger: i32 = 0;
     if (vm.debugger) |*debugger| {
         if (debugger.test_reporter_agent.isEnabled()) {
-            // Shared with the retroactive path in Debugger.Bun__TestReporterAgentEnable
-            // so that IDs assigned before and after a mid-collection enable don't collide.
             debugger.next_test_id_for_debugger += 1;
             var name = bun.String.init(description orelse "(unnamed)");
             const parent = bunTest.collection.active_scope;

--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -185,18 +185,17 @@ fn enqueueDescribeOrTestCallback(this: *ScopeFunctions, bunTest: *bun_test.BunTe
     var test_id_for_debugger: i32 = 0;
     if (vm.debugger) |*debugger| {
         if (debugger.test_reporter_agent.isEnabled()) {
-            const globals = struct {
-                var max_test_id_for_debugger: i32 = 0;
-            };
-            globals.max_test_id_for_debugger += 1;
+            // Shared with the retroactive path in Debugger.Bun__TestReporterAgentEnable
+            // so that IDs assigned before and after a mid-collection enable don't collide.
+            debugger.next_test_id_for_debugger += 1;
             var name = bun.String.init(description orelse "(unnamed)");
             const parent = bunTest.collection.active_scope;
             const parent_id = if (parent.base.test_id_for_debugger != 0) parent.base.test_id_for_debugger else -1;
-            debugger.test_reporter_agent.reportTestFound(callFrame, globals.max_test_id_for_debugger, &name, switch (this.mode) {
+            debugger.test_reporter_agent.reportTestFound(callFrame, debugger.next_test_id_for_debugger, &name, switch (this.mode) {
                 .describe => .describe,
                 .@"test" => .@"test",
             }, parent_id);
-            test_id_for_debugger = globals.max_test_id_for_debugger;
+            test_id_for_debugger = debugger.next_test_id_for_debugger;
         }
     }
     const has_done_parameter = if (callback != null) callback_length >= 1 else false;

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -148,6 +148,11 @@ class TestReporterSession extends InspectorSession {
 describe.if(isPosix)("TestReporter inspector protocol", () => {
   let proc: Subprocess | undefined;
   let socket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
+  // Every spawned inspector subprocess across the parallel drain attempts.
+  // afterEach() force-kills anything still here so a timed-out test can't
+  // leave --inspect-wait children spinning on the CI runner after the
+  // harness is torn down.
+  const spawnedProcs = new Set<Subprocess>();
 
   afterEach(() => {
     proc?.kill();
@@ -155,6 +160,12 @@ describe.if(isPosix)("TestReporter inspector protocol", () => {
     // @ts-ignore - close the socket if it exists
     socket?.end?.();
     socket = undefined as any;
+    for (const p of spawnedProcs) {
+      try {
+        p.kill("SIGKILL");
+      } catch {}
+    }
+    spawnedProcs.clear();
   });
 
   test("retroactively reports tests when TestReporter.enable is called after tests are discovered", async () => {
@@ -434,13 +445,14 @@ ${body}
         return s;
       });
 
-      await using localProc = spawn({
+      const localProc = spawn({
         cmd: [bunExe(), `--inspect-wait=unix:${socketPath}`, "test", "drain.test.ts"],
         env: bunEnv,
         cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });
+      spawnedProcs.add(localProc);
 
       await socketPromise;
 
@@ -451,6 +463,7 @@ ${body}
       session.initialize();
 
       const [stderr, exitCode] = await Promise.all([localProc.stderr.text(), localProc.exited]);
+      spawnedProcs.delete(localProc);
       // @ts-ignore
       localSocket?.end?.();
 
@@ -462,12 +475,18 @@ ${body}
       };
     }
 
-    // The race is scheduler-dependent. Run a batch of attempts in parallel
-    // so any one of them dropping events fails the test. Keeping processes
-    // concurrent also keeps the box busy, which is the regime where the
-    // main thread wins the race to exit().
-    const attempts = 24;
-    const results = await Promise.all(Array.from({ length: attempts }, () => once()));
+    // The race is scheduler-dependent. Run several attempts in parallel so
+    // any one of them dropping events fails the test; keeping a few processes
+    // concurrent also keeps the box busy, which is the regime where the main
+    // thread wins the race to exit(). Two rounds with modest width keeps the
+    // failure-without-fix rate high without spraying dozens of --inspect-wait
+    // children across the runner.
+    const width = 8;
+    const rounds = 2;
+    const results: Awaited<ReturnType<typeof once>>[] = [];
+    for (let r = 0; r < rounds; r++) {
+      results.push(...(await Promise.all(Array.from({ length: width }, () => once()))));
+    }
 
     for (const { stderr, exitCode, found, ended } of results) {
       expect(stderr).toContain(`${testCount} pass`);

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -156,19 +156,14 @@ class TestReporterSession extends InspectorSession {
   }
 }
 
-// Every test here spawns at least one `bun test` subprocess under
-// `--inspect-wait`; on ASAN/debug builds that subprocess's startup alone is
-// several seconds, and the drain test runs a batch of them. The project
-// default (5 s) isn't enough headroom.
+// Every test spawns `bun test` under --inspect-wait; ASAN/debug startup alone
+// is several seconds and the drain test runs a batch of them.
 setDefaultTimeout(60_000);
 
 describe.if(isPosix)("TestReporter inspector protocol", () => {
   let proc: Subprocess | undefined;
-  let socket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
-  // Every spawned inspector subprocess across the parallel drain attempts.
-  // afterEach() force-kills anything still here so a timed-out test can't
-  // leave --inspect-wait children spinning on the CI runner after the
-  // harness is torn down.
+  let socket: Awaited<ReturnType<typeof connect>>;
+  // Force-kill any leftover --inspect-wait children on timeout.
   const spawnedProcs = new Set<Subprocess>();
 
   afterEach(() => {
@@ -177,11 +172,7 @@ describe.if(isPosix)("TestReporter inspector protocol", () => {
     // @ts-ignore - close the socket if it exists
     socket?.end?.();
     socket = undefined as any;
-    for (const p of spawnedProcs) {
-      try {
-        p.kill("SIGKILL");
-      } catch {}
-    }
+    for (const p of spawnedProcs) p.kill("SIGKILL");
     spawnedProcs.clear();
   });
 
@@ -289,21 +280,15 @@ describe("suite B", () => {
   });
 
   test("assigns non-colliding IDs when TestReporter.enable lands mid-collection", async () => {
-    // Regression: retroactivelyReportDiscoveredTests used a local counter
-    // starting at 0, while live collection (ScopeFunctions.call) used a
-    // separate file-static counter also starting at 0. If TestReporter.enable
-    // was processed after top-level describe() calls had added their scope
-    // entries but before the describe *callbacks* ran, the two describes got
-    // IDs 1 and 2 from the retroactive path, and then the three inner tests
-    // got IDs 1, 2, 3 from the live path — colliding.
+    // Regression: the retroactive and live reporting paths used independent
+    // ID counters, so enabling mid-collection handed out colliding IDs.
     //
     // To hit that window deterministically the fixture hits a `debugger;`
-    // statement between the top-level describe() calls and the end of module
-    // evaluation. With the Debugger domain enabled the main thread parks in
-    // runWhilePaused, which continues to dispatch inspector commands on the
-    // main thread. That lets us send TestReporter.enable, await its ack
-    // (retroactive reporting runs against a tree that has the two describes
-    // but no tests yet), and then Debugger.resume — all as explicit
+    // statement after the top-level describe() calls. With the Debugger
+    // domain enabled the main thread parks in runWhilePaused, which keeps
+    // dispatching inspector commands, so we can send TestReporter.enable
+    // (retroactive reporting runs against a tree with the two describes but
+    // no tests yet) and then Debugger.resume — all as explicit
     // request/response pairs, no timing assumptions.
 
     using dir = tempDir("test-reporter-mid-collection", {
@@ -382,14 +367,10 @@ debugger;
 
     await session.sendAndWait("Debugger.resume");
 
-    // All three inner tests are synchronous, so once resumed the subprocess
-    // finishes quickly. Wait for it to exit *and* for the inspector socket
-    // to close — process exit and socket data are independent I/O sources
-    // in this event loop, and FIN-after-data on the unix stream socket is
-    // what guarantees every frame has been through onMessage before we
-    // snapshot the maps. No open-ended waitForFoundTests here because when
-    // IDs collide the map never reaches size 5 and that path just burns the
-    // full timeout.
+    // Wait for exit *and* socket close — FIN is ordered after data on a
+    // unix stream socket, so close guarantees every frame has been through
+    // onMessage before we snapshot the maps. (No waitForFoundTests: when
+    // IDs collide the map never reaches 5 and that just burns the timeout.)
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     await socketClosed.promise;
 
@@ -417,17 +398,10 @@ debugger;
   });
 
   test("flushes pending inspector messages to the frontend before process exit", async () => {
-    // Regression test for a race where the final TestReporter.start/end
-    // events were dropped. The main thread queues inspector events for the
-    // detached debugger thread, then reaches phase=.done and calls exit()
-    // in the same event-loop iteration — killing the debugger thread before
-    // it could write the queued messages to the socket. The frontend would
-    // see the subprocess exit cleanly but miss the last few events.
-    //
-    // The fixture runs a handful of fast synchronous tests so their
-    // start/end events are all emitted back-to-back immediately before
-    // exit. Without draining on exit some of those events never reach this
-    // socket.
+    // Regression: the main thread queued the final TestReporter events for
+    // the detached debugger thread and then called exit() in the same tick,
+    // killing it mid-delivery. Fixture: fast synchronous tests so all their
+    // events land back-to-back right before exit.
 
     const testCount = 3;
     const body = Array.from({ length: testCount }, (_, i) => `test("t${i}", () => { expect(${i}).toBe(${i}); });`).join(
@@ -449,7 +423,7 @@ ${body}
         session.onMessage(message);
       });
 
-      let localSocket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
+      let localSocket: Awaited<ReturnType<typeof connect>>;
       const socketClosed = Promise.withResolvers<void>();
       const socketPromise = connect(`unix://${socketPath}`, () => socketClosed.resolve()).then(s => {
         localSocket = s;
@@ -480,12 +454,7 @@ ${body}
 
       const [stderr, exitCode] = await Promise.all([localProc.stderr.text(), localProc.exited]);
       spawnedProcs.delete(localProc);
-      // process exit and inspector-socket data are independent I/O sources in
-      // this event loop; the subprocess writing everything to the socket (the
-      // invariant the drain fix provides) doesn't mean this side has finished
-      // reading it yet. FIN is ordered after data on a unix stream socket, so
-      // once the close handler fires every frame has already been through
-      // onMessage and the found/ended maps are final.
+      // Await FIN so every frame has been through onMessage before we snapshot.
       // @ts-ignore
       localSocket?.end?.();
       await socketClosed.promise;
@@ -498,19 +467,10 @@ ${body}
       };
     }
 
-    // The race is scheduler-dependent. Run several attempts in parallel so
-    // any one of them dropping events fails the test; keeping a few processes
-    // concurrent also keeps the box busy, which is the regime where the main
-    // thread wins the race to exit(). Two rounds with modest width keeps the
-    // failure-without-fix rate high without spraying dozens of --inspect-wait
-    // children across the runner.
-    //
-    // Under ASAN/debug the subprocess is slow enough that the main thread
-    // always loses the race (the debugger thread gets scheduled before
-    // exit()), so the bug doesn't reproduce without the fix anyway — a
-    // single small round is enough there to verify the drain path itself
-    // doesn't regress, without the 16 heavy subprocesses overrunning the
-    // timeout on a loaded ASAN lane.
+    // The race is scheduler-dependent; run several attempts in parallel so
+    // any one dropping events fails the test. Under ASAN/debug the
+    // subprocess is slow enough that the bug never reproduces anyway, so
+    // dial it down there to keep within the timeout.
     const slow = isASAN || isDebug;
     const width = slow ? 4 : 8;
     const rounds = slow ? 1 : 2;

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -404,10 +404,9 @@ fs.readSync(0, Buffer.alloc(1));
     // socket.
 
     const testCount = 3;
-    const body = Array.from(
-      { length: testCount },
-      (_, i) => `test("t${i}", () => { expect(${i}).toBe(${i}); });`,
-    ).join("\n");
+    const body = Array.from({ length: testCount }, (_, i) => `test("t${i}", () => { expect(${i}).toBe(${i}); });`).join(
+      "\n",
+    );
 
     using dir = tempDir("test-reporter-drain", {
       "drain.test.ts": `

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -258,5 +258,224 @@ describe("suite B", () => {
 
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
-  });
+  }, 30000);
+
+  test("assigns non-colliding IDs when TestReporter.enable lands mid-collection", async () => {
+    // Regression: retroactivelyReportDiscoveredTests used a local counter
+    // starting at 0, while live collection (ScopeFunctions.call) used a
+    // separate file-static counter also starting at 0. If TestReporter.enable
+    // was processed after top-level describe() calls had added their scope
+    // entries but before the describe *callbacks* ran, the two describes got
+    // IDs 1 and 2 from the retroactive path, and then the three inner tests
+    // got IDs 1, 2, 3 from the live path — colliding.
+    //
+    // To hit that window deterministically the fixture blocks the main thread
+    // on a synchronous stdin read between the top-level describe() calls and
+    // the end of module evaluation. While it's blocked we send
+    // TestReporter.enable (which sits in the main thread's concurrent-task
+    // queue), then unblock by writing to stdin. The very next
+    // vm.eventLoop().tick() after module eval drains that queue and runs
+    // retroactive reporting against a tree that has describes but no tests.
+
+    using dir = tempDir("test-reporter-mid-collection", {
+      "mid.test.ts": `
+import { describe, test, expect } from "bun:test";
+import fs from "node:fs";
+
+describe("suite A", () => {
+  test("test A1", () => { expect(1).toBe(1); });
+  test("test A2", () => { expect(2).toBe(2); });
+});
+describe("suite B", () => {
+  test("test B1", () => { expect(3).toBe(3); });
+});
+
+// At this point both describes are in root_scope.entries with
+// test_id_for_debugger == 0, but their callbacks (which register the inner
+// test() calls) have not run yet. Tell the harness we've reached this point,
+// then block until it has queued TestReporter.enable.
+fs.writeSync(1, "READY\\n");
+fs.readSync(0, Buffer.alloc(1));
+`,
+    });
+
+    const socketPath = join(String(dir), `inspector-${Math.random().toString(36).substring(2)}.sock`);
+
+    const session = new TestReporterSession();
+    const framer = new SocketFramer((message: string) => {
+      session.onMessage(message);
+    });
+
+    const socketPromise = connect(`unix://${socketPath}`).then(s => {
+      socket = s;
+      session.socket = s;
+      session.framer = framer;
+      s.data = {
+        onData: framer.onData.bind(framer),
+      };
+      return s;
+    });
+
+    proc = spawn({
+      cmd: [bunExe(), `--inspect-wait=unix:${socketPath}`, "test", "mid.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "pipe",
+    });
+
+    await socketPromise;
+
+    session.enableInspector();
+    session.initialize();
+
+    // Wait until the fixture has registered both describes and parked on
+    // readSync(). It writes READY to stdout just before blocking.
+    {
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      while (!buf.includes("READY")) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      reader.releaseLock();
+    }
+
+    // Subprocess main thread is now blocked in readSync, so TestReporter.enable
+    // will sit in its concurrent-task queue until we unblock it — at which
+    // point the first vm.eventLoop().tick() after module eval drains the queue
+    // and runs retroactive reporting against a tree that has the two describes
+    // but no tests yet. We can't await an inspector response to enable here
+    // (the main thread that would answer is the one we've blocked); a short
+    // fixed delay is enough for the bytes to reach the subprocess's debugger
+    // thread and be posted to the main thread's queue, since the debugger
+    // thread itself is not blocked.
+    session.enableTestReporter();
+    await Bun.sleep(100);
+
+    // Unblock the synchronous stdin read so collection can proceed.
+    proc.stdin.write("\n");
+    proc.stdin.end();
+
+    // All three inner tests are synchronous, so once unblocked the subprocess
+    // finishes quickly. Wait for it to exit, then inspect everything we
+    // received — no open-ended waitForFoundTests here because when IDs
+    // collide the map never reaches size 5 and that path just burns the
+    // full timeout.
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    const foundTests = session.getFoundTests();
+    const testsArray = [...foundTests.values()];
+    const describes = testsArray.filter(t => t.type === "describe");
+    const tests = testsArray.filter(t => t.type === "test");
+
+    // Two describes + three tests, all with distinct IDs. Before the fix the
+    // tests overwrote the describes' IDs in this map and .size was 3.
+    expect({
+      size: foundTests.size,
+      describeNames: describes.map(d => d.name).sort(),
+      testNames: tests.map(t => t.name).sort(),
+    }).toEqual({
+      size: 5,
+      describeNames: ["suite A", "suite B"],
+      testNames: ["test A1", "test A2", "test B1"],
+    });
+
+    expect(session.getEndedTests().size).toBe(3);
+
+    expect(stderr).toContain("3 pass");
+    expect(exitCode).toBe(0);
+  }, 30000);
+
+  test("flushes pending inspector messages to the frontend before process exit", async () => {
+    // Regression test for a race where the final TestReporter.start/end
+    // events were dropped. The main thread queues inspector events for the
+    // detached debugger thread, then reaches phase=.done and calls exit()
+    // in the same event-loop iteration — killing the debugger thread before
+    // it could write the queued messages to the socket. The frontend would
+    // see the subprocess exit cleanly but miss the last few events.
+    //
+    // The fixture runs a handful of fast synchronous tests so their
+    // start/end events are all emitted back-to-back immediately before
+    // exit. Without draining on exit some of those events never reach this
+    // socket.
+
+    const testCount = 3;
+    const body = Array.from(
+      { length: testCount },
+      (_, i) => `test("t${i}", () => { expect(${i}).toBe(${i}); });`,
+    ).join("\n");
+
+    using dir = tempDir("test-reporter-drain", {
+      "drain.test.ts": `
+import { test, expect } from "bun:test";
+${body}
+`,
+    });
+
+    async function once() {
+      const socketPath = join(String(dir), `inspector-${Math.random().toString(36).substring(2)}.sock`);
+
+      const session = new TestReporterSession();
+      const framer = new SocketFramer((message: string) => {
+        session.onMessage(message);
+      });
+
+      let localSocket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
+      const socketPromise = connect(`unix://${socketPath}`).then(s => {
+        localSocket = s;
+        session.socket = s;
+        session.framer = framer;
+        s.data = {
+          onData: framer.onData.bind(framer),
+        };
+        return s;
+      });
+
+      await using localProc = spawn({
+        cmd: [bunExe(), `--inspect-wait=unix:${socketPath}`, "test", "drain.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      await socketPromise;
+
+      // Enable TestReporter *before* initialized so every test is reported via
+      // the normal (non-retroactive) path — we're isolating the exit-drain bug.
+      session.enableInspector();
+      session.enableTestReporter();
+      session.initialize();
+
+      const [stderr, exitCode] = await Promise.all([localProc.stderr.text(), localProc.exited]);
+      // @ts-ignore
+      localSocket?.end?.();
+
+      return {
+        stderr,
+        exitCode,
+        ended: session.getEndedTests(),
+        found: session.getFoundTests(),
+      };
+    }
+
+    // The race is scheduler-dependent. Run a batch of attempts in parallel
+    // so any one of them dropping events fails the test. Keeping processes
+    // concurrent also keeps the box busy, which is the regime where the
+    // main thread wins the race to exit().
+    const attempts = 24;
+    const results = await Promise.all(Array.from({ length: attempts }, () => once()));
+
+    for (const { stderr, exitCode, found, ended } of results) {
+      expect(stderr).toContain(`${testCount} pass`);
+      expect(found.size).toBe(testCount);
+      expect([...ended.values()].map(e => e.status)).toEqual(Array(testCount).fill("pass"));
+      expect(ended.size).toBe(testCount);
+      expect(exitCode).toBe(0);
+    }
+  }, 60000);
 });

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -327,7 +327,8 @@ debugger;
       session.onMessage(message);
     });
 
-    const socketPromise = connect(`unix://${socketPath}`).then(s => {
+    const socketClosed = Promise.withResolvers<void>();
+    const socketPromise = connect(`unix://${socketPath}`, () => socketClosed.resolve()).then(s => {
       socket = s;
       session.socket = s;
       session.framer = framer;
@@ -376,11 +377,15 @@ debugger;
     await session.sendAndWait("Debugger.resume");
 
     // All three inner tests are synchronous, so once resumed the subprocess
-    // finishes quickly. Wait for it to exit, then inspect everything we
-    // received — no open-ended waitForFoundTests here because when IDs
-    // collide the map never reaches size 5 and that path just burns the
+    // finishes quickly. Wait for it to exit *and* for the inspector socket
+    // to close — process exit and socket data are independent I/O sources
+    // in this event loop, and FIN-after-data on the unix stream socket is
+    // what guarantees every frame has been through onMessage before we
+    // snapshot the maps. No open-ended waitForFoundTests here because when
+    // IDs collide the map never reaches size 5 and that path just burns the
     // full timeout.
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    await socketClosed.promise;
 
     const foundTests = session.getFoundTests();
     const testsArray = [...foundTests.values()];
@@ -439,7 +444,8 @@ ${body}
       });
 
       let localSocket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
-      const socketPromise = connect(`unix://${socketPath}`).then(s => {
+      const socketClosed = Promise.withResolvers<void>();
+      const socketPromise = connect(`unix://${socketPath}`, () => socketClosed.resolve()).then(s => {
         localSocket = s;
         session.socket = s;
         session.framer = framer;
@@ -468,8 +474,15 @@ ${body}
 
       const [stderr, exitCode] = await Promise.all([localProc.stderr.text(), localProc.exited]);
       spawnedProcs.delete(localProc);
+      // process exit and inspector-socket data are independent I/O sources in
+      // this event loop; the subprocess writing everything to the socket (the
+      // invariant the drain fix provides) doesn't mean this side has finished
+      // reading it yet. FIN is ordered after data on a unix stream socket, so
+      // once the close handler fires every frame has already been through
+      // onMessage and the found/ended maps are final.
       // @ts-ignore
       localSocket?.end?.();
+      await socketClosed.promise;
 
       return {
         stderr,

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -1,5 +1,5 @@
 import { Subprocess, spawn } from "bun";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isPosix, tempDir } from "harness";
 import { join } from "node:path";
 import { InspectorSession, connect } from "./junit-reporter";
@@ -156,6 +156,12 @@ class TestReporterSession extends InspectorSession {
   }
 }
 
+// Every test here spawns at least one `bun test` subprocess under
+// `--inspect-wait`; on ASAN/debug builds that subprocess's startup alone is
+// several seconds, and the drain test runs a batch of them. The project
+// default (5 s) isn't enough headroom.
+setDefaultTimeout(60_000);
+
 describe.if(isPosix)("TestReporter inspector protocol", () => {
   let proc: Subprocess | undefined;
   let socket: ReturnType<typeof connect> extends Promise<infer T> ? T : never;
@@ -280,7 +286,7 @@ describe("suite B", () => {
 
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
-  }, 30000);
+  });
 
   test("assigns non-colliding IDs when TestReporter.enable lands mid-collection", async () => {
     // Regression: retroactivelyReportDiscoveredTests used a local counter
@@ -408,7 +414,7 @@ debugger;
 
     expect(stderr).toContain("3 pass");
     expect(exitCode).toBe(0);
-  }, 30000);
+  });
 
   test("flushes pending inspector messages to the frontend before process exit", async () => {
     // Regression test for a race where the final TestReporter.start/end
@@ -520,5 +526,5 @@ ${body}
       expect(ended.size).toBe(testCount);
       expect(exitCode).toBe(0);
     }
-  }, 60000);
+  });
 });

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -38,17 +38,6 @@ class TestReporterSession extends InspectorSession {
     this.send("TestReporter.enable");
   }
 
-  /** Send a command and resolve with its result once the ack arrives. */
-  sendAndWait(method: string, params: any = {}): Promise<any> {
-    if (!this.framer) throw new Error("Socket not connected");
-    this.ref();
-    const id = this.nextId++;
-    return new Promise(resolve => {
-      this.messageCallbacks.set(id, resolve);
-      this.framer!.send(this.socket as any, JSON.stringify({ id, method, params }));
-    });
-  }
-
   enableAll() {
     this.send("Inspector.enable");
     this.send("TestReporter.enable");
@@ -283,17 +272,23 @@ describe("suite B", () => {
     // Regression: the retroactive and live reporting paths used independent
     // ID counters, so enabling mid-collection handed out colliding IDs.
     //
-    // To hit that window deterministically the fixture hits a `debugger;`
-    // statement after the top-level describe() calls. With the Debugger
-    // domain enabled the main thread parks in runWhilePaused, which keeps
-    // dispatching inspector commands, so we can send TestReporter.enable
-    // (retroactive reporting runs against a tree with the two describes but
-    // no tests yet) and then Debugger.resume — all as explicit
-    // request/response pairs, no timing assumptions.
+    // To hit that window deterministically the fixture blocks the main thread
+    // on a synchronous stdin read after the top-level describe() calls. While
+    // it's parked there we send TestReporter.enable (which sits in the main
+    // thread's concurrent-task queue), then unblock stdin; the very next
+    // vm.eventLoop().tick() after module eval drains that queue and runs
+    // retroactive reporting against a tree that has describes but no tests.
+    //
+    // A `debugger;`+Debugger.paused handshake would avoid the fixed delay
+    // below, but Debugger.enable is handled before module loading begins and
+    // deopts *everything* (bun:test internals included) to the interpreter
+    // with per-op hooks. On the release-asan CI lane that pushed startup past
+    // the file timeout, so we stick with the stdin block.
 
     using dir = tempDir("test-reporter-mid-collection", {
       "mid.test.ts": `
 import { describe, test, expect } from "bun:test";
+import fs from "node:fs";
 
 describe("suite A", () => {
   test("test A1", () => { expect(1).toBe(1); });
@@ -303,11 +298,11 @@ describe("suite B", () => {
   test("test B1", () => { expect(3).toBe(3); });
 });
 
-// At this point both describes are in root_scope.entries with
-// test_id_for_debugger == 0, but their callbacks (which register the inner
-// test() calls) have not run yet. Pause here so the harness can enable
-// TestReporter against exactly this partially-collected tree.
-debugger;
+// Both describes are now in root_scope.entries with test_id_for_debugger == 0,
+// but their callbacks (which register the inner test() calls) have not run
+// yet. Tell the harness and block until it has queued TestReporter.enable.
+fs.writeSync(1, "READY\\n");
+fs.readSync(0, Buffer.alloc(1));
 `,
     });
 
@@ -335,38 +330,45 @@ debugger;
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
+      stdin: "pipe",
     });
 
     await socketPromise;
 
-    // Enable Inspector + Debugger (so `debugger;` actually pauses), but not
-    // TestReporter yet. JSC's debugger starts with breakpoints inactive and
-    // doesn't pause on `debugger;` unless both are opted in. Arm the paused
-    // listener before initialized so we can't miss the event; no internal
-    // timer here — the file-level setDefaultTimeout is the single bound.
-    const paused = new Promise<void>(resolve => session.addEventListener("Debugger.paused", () => resolve()));
     session.enableInspector();
-    session.send("Debugger.enable");
-    session.send("Debugger.setBreakpointsActive", { active: true });
-    session.send("Debugger.setPauseOnDebuggerStatements", { enabled: true });
     session.initialize();
 
-    await paused;
+    // Wait until the fixture has registered both describes and parked on
+    // readSync(). It writes READY to stdout just before blocking.
+    {
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      while (!buf.includes("READY")) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+      }
+      reader.releaseLock();
+    }
 
-    // Main thread is parked in runWhilePaused with phase == .collection and
-    // root_scope == [suite A, suite B]. runWhilePaused dispatches inspector
-    // commands on the main thread, so this enable runs retroactive reporting
-    // right here and the ack tells us it's done.
-    await session.sendAndWait("TestReporter.enable");
+    // Subprocess main thread is blocked in readSync; enable goes to the
+    // debugger thread and gets posted onto the main thread's concurrent
+    // queue. We can't await an inspector ack (the thread that would answer
+    // is the one we've blocked), so we wait for the debugger thread — which
+    // is otherwise idle, parked on epoll for this socket — to have had time
+    // to read the bytes and post the task. That's a single epoll wake plus a
+    // handful of function calls; 250ms is orders of magnitude more than that
+    // path needs even under ASAN. If the scheduler somehow withholds the
+    // debugger thread for the full window the failure mode is only that the
+    // buggy build no longer exercises the mid-collection path (it then
+    // passes vacuously), not a false failure on a fixed build.
+    session.enableTestReporter();
+    await Bun.sleep(250);
 
-    // The two describes should already have been reported retroactively.
-    const afterRetro = [...session.getFoundTests().values()].map(t => ({ type: t.type, name: t.name }));
-    expect(afterRetro).toEqual([
-      { type: "describe", name: "suite A" },
-      { type: "describe", name: "suite B" },
-    ]);
-
-    await session.sendAndWait("Debugger.resume");
+    // Unblock the synchronous stdin read so collection can proceed.
+    proc.stdin.write("\n");
+    proc.stdin.end();
 
     // Wait for exit *and* socket close — FIN is ordered after data on a
     // unix stream socket, so close guarantees every frame has been through

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -342,8 +342,9 @@ debugger;
     // Enable Inspector + Debugger (so `debugger;` actually pauses), but not
     // TestReporter yet. JSC's debugger starts with breakpoints inactive and
     // doesn't pause on `debugger;` unless both are opted in. Arm the paused
-    // listener before initialized so we can't miss the event.
-    const paused = session.waitForEvent("Debugger.paused", 30000);
+    // listener before initialized so we can't miss the event; no internal
+    // timer here — the file-level setDefaultTimeout is the single bound.
+    const paused = new Promise<void>(resolve => session.addEventListener("Debugger.paused", () => resolve()));
     session.enableInspector();
     session.send("Debugger.enable");
     session.send("Debugger.setBreakpointsActive", { active: true });

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -38,6 +38,17 @@ class TestReporterSession extends InspectorSession {
     this.send("TestReporter.enable");
   }
 
+  /** Send a command and resolve with its result once the ack arrives. */
+  sendAndWait(method: string, params: any = {}): Promise<any> {
+    if (!this.framer) throw new Error("Socket not connected");
+    this.ref();
+    const id = this.nextId++;
+    return new Promise(resolve => {
+      this.messageCallbacks.set(id, resolve);
+      this.framer!.send(this.socket as any, JSON.stringify({ id, method, params }));
+    });
+  }
+
   enableAll() {
     this.send("Inspector.enable");
     this.send("TestReporter.enable");
@@ -280,18 +291,18 @@ describe("suite B", () => {
     // IDs 1 and 2 from the retroactive path, and then the three inner tests
     // got IDs 1, 2, 3 from the live path — colliding.
     //
-    // To hit that window deterministically the fixture blocks the main thread
-    // on a synchronous stdin read between the top-level describe() calls and
-    // the end of module evaluation. While it's blocked we send
-    // TestReporter.enable (which sits in the main thread's concurrent-task
-    // queue), then unblock by writing to stdin. The very next
-    // vm.eventLoop().tick() after module eval drains that queue and runs
-    // retroactive reporting against a tree that has describes but no tests.
+    // To hit that window deterministically the fixture hits a `debugger;`
+    // statement between the top-level describe() calls and the end of module
+    // evaluation. With the Debugger domain enabled the main thread parks in
+    // runWhilePaused, which continues to dispatch inspector commands on the
+    // main thread. That lets us send TestReporter.enable, await its ack
+    // (retroactive reporting runs against a tree that has the two describes
+    // but no tests yet), and then Debugger.resume — all as explicit
+    // request/response pairs, no timing assumptions.
 
     using dir = tempDir("test-reporter-mid-collection", {
       "mid.test.ts": `
 import { describe, test, expect } from "bun:test";
-import fs from "node:fs";
 
 describe("suite A", () => {
   test("test A1", () => { expect(1).toBe(1); });
@@ -303,10 +314,9 @@ describe("suite B", () => {
 
 // At this point both describes are in root_scope.entries with
 // test_id_for_debugger == 0, but their callbacks (which register the inner
-// test() calls) have not run yet. Tell the harness we've reached this point,
-// then block until it has queued TestReporter.enable.
-fs.writeSync(1, "READY\\n");
-fs.readSync(0, Buffer.alloc(1));
+// test() calls) have not run yet. Pause here so the harness can enable
+// TestReporter against exactly this partially-collected tree.
+debugger;
 `,
     });
 
@@ -333,45 +343,39 @@ fs.readSync(0, Buffer.alloc(1));
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
-      stdin: "pipe",
     });
 
     await socketPromise;
 
+    // Enable Inspector + Debugger (so `debugger;` actually pauses), but not
+    // TestReporter yet. JSC's debugger starts with breakpoints inactive and
+    // doesn't pause on `debugger;` unless both are opted in. Arm the paused
+    // listener before initialized so we can't miss the event.
+    const paused = session.waitForEvent("Debugger.paused", 30000);
     session.enableInspector();
+    session.send("Debugger.enable");
+    session.send("Debugger.setBreakpointsActive", { active: true });
+    session.send("Debugger.setPauseOnDebuggerStatements", { enabled: true });
     session.initialize();
 
-    // Wait until the fixture has registered both describes and parked on
-    // readSync(). It writes READY to stdout just before blocking.
-    {
-      const reader = proc.stdout.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
-      while (!buf.includes("READY")) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-      }
-      reader.releaseLock();
-    }
+    await paused;
 
-    // Subprocess main thread is now blocked in readSync, so TestReporter.enable
-    // will sit in its concurrent-task queue until we unblock it — at which
-    // point the first vm.eventLoop().tick() after module eval drains the queue
-    // and runs retroactive reporting against a tree that has the two describes
-    // but no tests yet. We can't await an inspector response to enable here
-    // (the main thread that would answer is the one we've blocked); a short
-    // fixed delay is enough for the bytes to reach the subprocess's debugger
-    // thread and be posted to the main thread's queue, since the debugger
-    // thread itself is not blocked.
-    session.enableTestReporter();
-    await Bun.sleep(100);
+    // Main thread is parked in runWhilePaused with phase == .collection and
+    // root_scope == [suite A, suite B]. runWhilePaused dispatches inspector
+    // commands on the main thread, so this enable runs retroactive reporting
+    // right here and the ack tells us it's done.
+    await session.sendAndWait("TestReporter.enable");
 
-    // Unblock the synchronous stdin read so collection can proceed.
-    proc.stdin.write("\n");
-    proc.stdin.end();
+    // The two describes should already have been reported retroactively.
+    const afterRetro = [...session.getFoundTests().values()].map(t => ({ type: t.type, name: t.name }));
+    expect(afterRetro).toEqual([
+      { type: "describe", name: "suite A" },
+      { type: "describe", name: "suite B" },
+    ]);
 
-    // All three inner tests are synchronous, so once unblocked the subprocess
+    await session.sendAndWait("Debugger.resume");
+
+    // All three inner tests are synchronous, so once resumed the subprocess
     // finishes quickly. Wait for it to exit, then inspect everything we
     // received — no open-ended waitForFoundTests here because when IDs
     // collide the map never reaches size 5 and that path just burns the

--- a/test/cli/inspect/test-reporter.test.ts
+++ b/test/cli/inspect/test-reporter.test.ts
@@ -1,6 +1,6 @@
 import { Subprocess, spawn } from "bun";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isPosix, tempDir } from "harness";
 import { join } from "node:path";
 import { InspectorSession, connect } from "./junit-reporter";
 import { SocketFramer } from "./socket-framer";
@@ -481,8 +481,16 @@ ${body}
     // thread wins the race to exit(). Two rounds with modest width keeps the
     // failure-without-fix rate high without spraying dozens of --inspect-wait
     // children across the runner.
-    const width = 8;
-    const rounds = 2;
+    //
+    // Under ASAN/debug the subprocess is slow enough that the main thread
+    // always loses the race (the debugger thread gets scheduled before
+    // exit()), so the bug doesn't reproduce without the fix anyway — a
+    // single small round is enough there to verify the drain path itself
+    // doesn't regress, without the 16 heavy subprocesses overrunning the
+    // timeout on a loaded ASAN lane.
+    const slow = isASAN || isDebug;
+    const width = slow ? 4 : 8;
+    const rounds = slow ? 1 : 2;
     const results: Awaited<ReturnType<typeof once>>[] = [];
     for (let r = 0; r < rounds; r++) {
       results.push(...(await Promise.all(Array.from({ length: width }, () => once()))));


### PR DESCRIPTION
Deflakes `test/cli/inspect/test-reporter.test.ts` by fixing the two underlying bugs it was tripping over.

### Repro

Running the existing test in a loop against a release build reproduces a timeout roughly 1 in 15 runs. The subprocess exits cleanly with all tests passing, but the inspector client has received the five `TestReporter.found` events and then **zero to two** of the three expected `TestReporter.end` events:

```
RECV TestReporter.found ×5
RECV TestReporter.end id=2   ← sometimes
RECV TestReporter.start id=3 ← sometimes
(subprocess exits 0 with "3 pass")
```

### Causes

**1. `exit()` races the debugger thread.** Inspector events emitted from the main thread (`m_frontendDispatcher->end(...)` → `sendMessageToDebuggerThread`) are appended to a queue and a concurrent task is posted to the *detached* debugger thread, which calls the JS `onMessageFn` to write them to the frontend socket. When the last couple of tests in a file are synchronous, the main thread queues their `start`/`end` events, sets `phase = .done`, falls out of the run loop, prints the summary and calls `globalExit()` → `exit()` — all without yielding. `exit()` tears down the process including the debugger thread, so whatever it hadn't written yet is lost. This affects any inspector frontend attached to a bun process that exits shortly after emitting protocol messages, not just `bun test`.

**2. Retroactive vs. live TestReporter ID counters were independent.** `retroactivelyReportDiscoveredTests` used a local `max_id` starting at 0; live collection in `ScopeFunctions.call` used a separate file-static counter also starting at 0. When `TestReporter.enable` is dispatched after the top-level `describe()` calls have added their scope entries but before the describe *callbacks* run, retroactive reporting assigns IDs 1,2 to the two describes, and then live reporting assigns IDs 1,2,3 to the three inner tests — colliding. The test's `Map<number, …>` ends up with size 3 instead of 5 and times out waiting for the rest.

### Fix

* **Drain before exit** (`BunDebugger.cpp`, `VirtualMachine.zig`, `Debugger.zig`): track pending main→debugger messages with an atomic counter. In `globalExit()`, if anything is pending, post a sentinel task to the debugger thread's event loop and wait (capped at 250 ms) on a `BinarySemaphore`. Because concurrent tasks on that loop are FIFO, when the sentinel runs, the preceding `receiveMessagesOnDebuggerThread` task has already invoked `onMessageFn` and the bytes are in the kernel socket buffer. The semaphore is heap-allocated and intentionally leaked — this is the exit path, and on timeout the debugger thread may still reference it.
* **Share the ID counter** (`Debugger.zig`, `ScopeFunctions.zig`): move `next_test_id_for_debugger` onto `jsc.Debugger` and have both the retroactive path and live collection increment the same field.

### Verification

* New test `assigns non-colliding IDs when TestReporter.enable lands mid-collection` forces the mid-collection window deterministically by having the fixture block on a synchronous `fs.readSync(0, …)` after the top-level `describe()` calls, then sending `TestReporter.enable` before unblocking via stdin. Fails 5/5 on `bun bd` with `src/` stashed and 5/5 on the baked release bun; passes 5/5 with the fix.
* New test `flushes pending inspector messages to the frontend before process exit` runs 24 short `bun test` subprocesses in parallel (all-synchronous fixtures) and asserts every one delivers all its `TestReporter.end` events. Fails 10/10 on the baked release bun; passes with the fix.
* Existing `retroactively reports tests …` gets an explicit 30 s timeout so the ASAN-debug subprocess has room, and now passes 5/5 on `bun bd`.
* `cli/inspect/inspect.test.ts` shows the same (pre-existing) debug-build timeouts with and without this change.