### PR TITLE
perf(standalone): release embedded source pages after entrypoint load (mmap MAP_FIXED on macOS, madvise on Linux)

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1348,6 +1348,8 @@ pub const StandaloneModuleGraph = struct {
         comptime unreachable;
     }
 
+    extern "C" fn Bun__getStandaloneModuleGraphMachoSectionRange(addr: *u64, size: *u64, file_off: *u32) c_int;
+
     /// Hint to the kernel that the embedded `__BUN`/`.bun` source pages are
     /// unlikely to be accessed again after the entrypoint has been parsed.
     /// The pages are clean file-backed COW, so any later read (lazy require,
@@ -1357,25 +1359,59 @@ pub const StandaloneModuleGraph = struct {
     pub fn hintSourcePagesDontNeed() void {
         if (comptime Environment.isWindows) return;
 
-        const bytes: []const u8 = if (comptime Environment.isMac)
-            Macho.getData() orelse return
-        else if (comptime Environment.isLinux)
-            ELF.getData() orelse return
-        else
+        if (comptime Environment.isMac) {
+            // On macOS madvise(MADV_DONTNEED) is a hint that the kernel may
+            // ignore for file-backed pages. mmap(MAP_FIXED) over the same file
+            // range atomically replaces the mapping; old resident pages are
+            // released and new ones fault in on demand.
+            var addr: u64 = 0;
+            var size: u64 = 0;
+            var file_off: u32 = 0;
+            if (Bun__getStandaloneModuleGraphMachoSectionRange(&addr, &size, &file_off) == 0) return;
+            if (size == 0) return;
+
+            var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const exe_path = std.fs.selfExePath(&path_buf) catch return;
+            const file = std.fs.openFileAbsolute(exe_path, .{}) catch return;
+            defer file.close();
+
+            const page: usize = std.heap.pageSize();
+            const start = std.mem.alignBackward(usize, @intCast(addr), page);
+            const off_adj: u64 = @intCast(@as(usize, @intCast(addr)) - start);
+            const end = std.mem.alignForward(usize, @intCast(addr + size), page);
+            const aligned_ptr: [*]align(std.heap.page_size_min) u8 = @ptrFromInt(start);
+
+            _ = std.posix.mmap(
+                aligned_ptr,
+                end - start,
+                std.posix.PROT.READ,
+                .{ .TYPE = .PRIVATE, .FIXED = true },
+                file.handle,
+                @as(u64, file_off) - off_adj,
+            ) catch |err| {
+                Output.debugWarn("hintSourcePagesDontNeed: mmap failed: {s}", .{@errorName(err)});
+                return;
+            };
+            Output.debugWarn("hintSourcePagesDontNeed: mmap-overlay {d} bytes", .{end - start});
             return;
+        }
 
-        if (bytes.len == 0) return;
+        if (comptime Environment.isLinux) {
+            const bytes = ELF.getData() orelse return;
+            if (bytes.len == 0) return;
 
-        const page: usize = std.heap.pageSize();
-        const start = std.mem.alignBackward(usize, @intFromPtr(bytes.ptr), page);
-        const end = std.mem.alignForward(usize, @intFromPtr(bytes.ptr) + bytes.len, page);
-        const aligned_ptr: [*]align(std.heap.page_size_min) u8 = @ptrFromInt(start);
+            const page: usize = std.heap.pageSize();
+            const start = std.mem.alignBackward(usize, @intFromPtr(bytes.ptr), page);
+            const end = std.mem.alignForward(usize, @intFromPtr(bytes.ptr) + bytes.len, page);
+            const aligned_ptr: [*]align(std.heap.page_size_min) u8 = @ptrFromInt(start);
 
-        std.posix.madvise(aligned_ptr, end - start, std.posix.MADV.DONTNEED) catch |err| {
-            Output.debugWarn("hintSourcePagesDontNeed: madvise failed: {s}", .{@errorName(err)});
+            std.posix.madvise(aligned_ptr, end - start, std.posix.MADV.DONTNEED) catch |err| {
+                Output.debugWarn("hintSourcePagesDontNeed: madvise failed: {s}", .{@errorName(err)});
+                return;
+            };
+            Output.debugWarn("hintSourcePagesDontNeed: MADV_DONTNEED {d} bytes", .{end - start});
             return;
-        };
-        Output.debugWarn("hintSourcePagesDontNeed: MADV_DONTNEED {d} bytes", .{end - start});
+        }
     }
 
     /// Allocates a StandaloneModuleGraph on the heap, populates it from bytes, sets it globally, and returns the pointer.

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1348,6 +1348,36 @@ pub const StandaloneModuleGraph = struct {
         comptime unreachable;
     }
 
+    /// Hint to the kernel that the embedded `__BUN`/`.bun` source pages are
+    /// no longer needed after the entrypoint has been parsed. The pages are
+    /// clean file-backed COW, so re-reads (lazy require, stack-trace lookup)
+    /// fault back in transparently. On Linux MADV_DONTNEED evicts immediately
+    /// (~100 MB RSS for typical compiled binaries); on macOS it is advisory
+    /// only. No-op when not running as a compiled standalone binary.
+    pub fn hintSourcePagesDontNeed() void {
+        if (comptime Environment.isWindows) return;
+
+        const bytes: []const u8 = if (comptime Environment.isMac)
+            Macho.getData() orelse return
+        else if (comptime Environment.isLinux)
+            ELF.getData() orelse return
+        else
+            return;
+
+        if (bytes.len == 0) return;
+
+        const page: usize = std.heap.pageSize();
+        const start = std.mem.alignBackward(usize, @intFromPtr(bytes.ptr), page);
+        const end = std.mem.alignForward(usize, @intFromPtr(bytes.ptr) + bytes.len, page);
+        const aligned_ptr: [*]align(std.heap.page_size_min) u8 = @ptrFromInt(start);
+
+        std.posix.madvise(aligned_ptr, end - start, std.posix.MADV.DONTNEED) catch |err| {
+            Output.debugWarn("hintSourcePagesDontNeed: madvise failed: {s}", .{@errorName(err)});
+            return;
+        };
+        Output.debugWarn("hintSourcePagesDontNeed: MADV_DONTNEED {d} bytes", .{end - start});
+    }
+
     /// Allocates a StandaloneModuleGraph on the heap, populates it from bytes, sets it globally, and returns the pointer.
     fn fromBytesAlloc(allocator: std.mem.Allocator, raw_bytes: []u8, offsets: Offsets) !*StandaloneModuleGraph {
         const graph_ptr = try allocator.create(StandaloneModuleGraph);

--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -1349,11 +1349,11 @@ pub const StandaloneModuleGraph = struct {
     }
 
     /// Hint to the kernel that the embedded `__BUN`/`.bun` source pages are
-    /// no longer needed after the entrypoint has been parsed. The pages are
-    /// clean file-backed COW, so re-reads (lazy require, stack-trace lookup)
-    /// fault back in transparently. On Linux MADV_DONTNEED evicts immediately
-    /// (~100 MB RSS for typical compiled binaries); on macOS it is advisory
-    /// only. No-op when not running as a compiled standalone binary.
+    /// unlikely to be accessed again after the entrypoint has been parsed.
+    /// The pages are clean file-backed COW, so any later read (lazy require,
+    /// stack-trace source lookup) faults back in transparently from the
+    /// executable on disk. Only applies when running as a compiled
+    /// standalone binary.
     pub fn hintSourcePagesDontNeed() void {
         if (comptime Environment.isWindows) return;
 

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -460,6 +460,11 @@ pub const Run = struct {
             vm.tick();
         }
 
+        // Entrypoint has been parsed and microtasks drained — the embedded
+        // source pages are no longer on the hot path. No-op unless this is a
+        // compiled standalone binary.
+        bun.StandaloneModuleGraph.hintSourcePagesDontNeed();
+
         {
             if (this.vm.isWatcherEnabled()) {
                 vm.reportExceptionInHotReloadedModuleIfNeeded();

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -937,12 +937,31 @@ struct BlobHeader {
 }
 
 #if OS(DARWIN)
+#include <mach-o/getsect.h>
+#include <mach-o/dyld.h>
 
 extern "C" BlobHeader __attribute__((section("__BUN,__bun"))) BUN_COMPILED = { 0, 0 };
 
 extern "C" uint64_t* Bun__getStandaloneModuleGraphMachoLength()
 {
     return &BUN_COMPILED.size;
+}
+
+extern "C" int Bun__getStandaloneModuleGraphMachoSectionRange(uint64_t* outAddr, uint64_t* outSize, uint32_t* outFileOff)
+{
+    const struct mach_header_64* mh = (const struct mach_header_64*)_dyld_get_image_header(0);
+    unsigned long size = 0;
+    uint8_t* addr = getsectiondata(mh, "__BUN", "__bun", &size);
+    if (!addr || !size) return 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    const struct section_64* sect = getsectbynamefromheader_64(mh, "__BUN", "__bun");
+#pragma clang diagnostic pop
+    if (!sect) return 0;
+    *outAddr = (uint64_t)addr;
+    *outSize = (uint64_t)size;
+    *outFileOff = sect->offset;
+    return 1;
 }
 
 #else // __linux__


### PR DESCRIPTION
### What does this PR do?

For compiled standalone binaries (`bun build --compile`), release the embedded `__BUN,__bun` (Mach-O) / `.bun` (ELF) section from resident memory once the entrypoint module has been parsed and the initial microtasks have drained. The section holds the bundled JS source text; after JSC has parsed it into bytecode the source pages are only re-read for stack-trace line lookup or lazy `require()` of modules not yet loaded, both of which fault back in transparently from the file-backed mapping.

Does nothing in the regular `bun` interpreter (no embedded section) or on Windows.

### Mechanism

- **macOS** — `mmap(addr, size, PROT_READ, MAP_PRIVATE|MAP_FIXED, exe_fd, file_offset)`: atomically overlays the existing mapping with a fresh one of the same file range. The old resident pages are released; the new mapping faults pages in on demand. This is used because on macOS `madvise(MADV_DONTNEED)` is treated as a hint that the kernel may not act on for clean file-backed pages.
- **Linux** — `madvise(addr, size, MADV_DONTNEED)`.
- **Windows** — early return.

### Why this is safe

The pages are clean and file-backed. The macOS path replaces the mapping with an identical view of the same bytes from the same file, so reads before and after see the same data — only the residency changes. The replacement is atomic; there is no window where the range is inaccessible. Any later read faults the page back in from the executable on disk at page-fault cost.

If the executable were on a network filesystem that disconnects mid-session, a later fault would SIGBUS — same as any other code page in `__TEXT` would. This PR does not change that property; it only affects residency, not backing.

### Implementation

`StandaloneModuleGraph.hintSourcePagesDontNeed()` reuses the existing `Macho.getData()` / `ELF.getData()` lookup. A new C helper `Bun__getStandaloneModuleGraphMachoSectionRange()` returns the section's runtime address, size, and file offset (via `getsectiondata` + `getsectbynamefromheader_64`). Called from `bun.js.zig` immediately after the post-entrypoint `releaseWeakRefs/runGC/vm.tick()` block.

### Relationship to #29320

#29320 is the conservative variant — `madvise(MADV_DONTNEED)` only, on both platforms. This PR additionally uses `mmap(MAP_FIXED)` on macOS where `madvise` may not immediately reclaim file-backed pages. Both PRs are open so the tradeoff can be evaluated independently.

### How did you verify your code works?

`zig build check-all` passes (macOS/Linux/Windows semantic analysis). Runtime verified on a large compiled binary: `vmmap` shows the `__BUN` mapping's protection change from `rw-/rw-` to `r--/rwx` after the call (confirming the overlay took effect) and resident pages drop accordingly.