### PR TITLE
webcore: sync bindings layer with upstream WebKit fixes

### DIFF
--- a/src/bun.js/bindings/BunClientData.cpp
+++ b/src/bun.js/bindings/BunClientData.cpp
@@ -78,7 +78,11 @@ DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(JSVMClientData);
 
 JSVMClientData::~JSVMClientData()
 {
-    ASSERT(m_normalWorld->hasOneRef());
+    m_clients.forEach([](auto& client) {
+        client.willDestroyVM();
+    });
+    m_clients.clear();
+
     m_normalWorld = nullptr;
 }
 void JSVMClientData::create(VM* vm, void* bunVM)

--- a/src/bun.js/bindings/BunClientData.h
+++ b/src/bun.js/bindings/BunClientData.h
@@ -18,7 +18,9 @@ class DOMWrapperWorld;
 // #include "WorkerThreadType.h"
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
+#include <wtf/WeakHashSet.h>
 #include <wtf/RefPtr.h>
+#include "JSVMClientDataClient.h"
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/StdLibExtras.h>
 #include "WebCoreJSBuiltins.h"
@@ -118,6 +120,8 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    void addClient(JSVMClientDataClient& client) { m_clients.add(client); }
+
 private:
     bool isWebCoreJSClientData() const final { return true; }
 
@@ -135,6 +139,7 @@ private:
     Vector<JSC::IsoSubspace*> m_outputConstraintSpaces;
 
     std::optional<WebCore::HTTPHeaderIdentifiers> m_httpHeaderIdentifiers;
+    WeakHashSet<JSVMClientDataClient> m_clients;
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/IDLTypes.h
+++ b/src/bun.js/bindings/IDLTypes.h
@@ -66,6 +66,8 @@ struct IDLType {
     using ImplementationType = T;
     using StorageType = T;
     using SequenceStorageType = T;
+    using ConversionResultType = T;
+    using NullableConversionResultType = std::optional<T>;
 
     using ParameterType = T;
     using NullableParameterType = std::optional<ImplementationType>;
@@ -104,6 +106,8 @@ struct IDLAny : IDLType<JSC::Strong<JSC::Unknown>> {
     // IDLSequence<IDLAny> would yield a Vector<JSC::JSValue>, whose contents
     // are invisible to the GC.
     // [do not uncomment] using SequenceStorageType = JSC::JSValue;
+    using ConversionResultType = JSC::JSValue;
+    using NullableConversionResultType = JSC::JSValue;
     using ParameterType = JSC::JSValue;
     using NullableParameterType = JSC::JSValue;
 
@@ -161,6 +165,8 @@ struct IDLUnrestrictedDouble : IDLFloatingPoint<double> {
 };
 
 template<typename StringType> struct IDLString : IDLType<StringType> {
+    using ConversionResultType = StringType;
+    using NullableConversionResultType = StringType;
     using ParameterType = const StringType&;
     using NullableParameterType = const StringType&;
 
@@ -201,6 +207,8 @@ template<typename T> struct IDLAllowSharedAdaptor : T {
 };
 
 struct IDLObject : IDLType<JSC::Strong<JSC::JSObject>> {
+    using ConversionResultType = JSC::Strong<JSC::JSObject>;
+    using NullableConversionResultType = JSC::Strong<JSC::JSObject>;
     using NullableType = JSC::Strong<JSC::JSObject>;
 
     static inline NullableType nullValue() { return {}; }
@@ -212,6 +220,8 @@ template<typename T> struct IDLWrapper : IDLType<RefPtr<T>> {
     using RawType = T;
 
     using StorageType = Ref<T>;
+    using ConversionResultType = std::reference_wrapper<T>;
+    using NullableConversionResultType = T*;
 
     using ParameterType = T&;
     using NullableParameterType = T*;
@@ -243,6 +253,8 @@ template<typename T> struct IDLEnumeration : IDLType<T> {
 template<typename T> struct IDLNullable : IDLType<typename T::NullableType> {
     using InnerType = T;
 
+    using ConversionResultType = typename T::NullableConversionResultType;
+    using NullableConversionResultType = std::optional<ConversionResultType>;
     using ParameterType = typename T::NullableParameterType;
     using NullableParameterType = typename T::NullableParameterType;
 
@@ -345,6 +357,8 @@ template<typename T> struct IDLTypedArray : IDLBufferSource<T> {
 // Non-WebIDL extensions
 
 struct IDLDate : IDLType<WallTime> {
+    using ConversionResultType = WallTime;
+    using NullableConversionResultType = WallTime;
     using NullableType = WallTime;
     static WallTime nullValue() { return WallTime::nan(); }
     static bool isNullValue(WallTime value) { return value.isNaN(); }
@@ -352,6 +366,8 @@ struct IDLDate : IDLType<WallTime> {
 };
 
 struct IDLJSON : IDLType<String> {
+    using ConversionResultType = String;
+    using NullableConversionResultType = String;
     using ParameterType = const String&;
     using NullableParameterType = const String&;
 

--- a/src/bun.js/bindings/JSDOMExceptionHandling.cpp
+++ b/src/bun.js/bindings/JSDOMExceptionHandling.cpp
@@ -164,7 +164,6 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
             return createRangeError(lexicalGlobalObject, "Bad value"_s);
         return createRangeError(lexicalGlobalObject, message);
 
-    case ExceptionCode::SyntaxError:
     case ExceptionCode::JSSyntaxError:
         if (message.isEmpty())
             return createSyntaxError(lexicalGlobalObject);

--- a/src/bun.js/bindings/JSDOMExceptionHandling.cpp
+++ b/src/bun.js/bindings/JSDOMExceptionHandling.cpp
@@ -164,6 +164,10 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
             return createRangeError(lexicalGlobalObject, "Bad value"_s);
         return createRangeError(lexicalGlobalObject, message);
 
+    // WebIDL says ExceptionCode::SyntaxError should be a DOMException named "SyntaxError",
+    // but Bun throws a JS SyntaxError here (WebSocket URL validation etc.) and existing
+    // code depends on `instanceof SyntaxError`. Intentional divergence from upstream.
+    case ExceptionCode::SyntaxError:
     case ExceptionCode::JSSyntaxError:
         if (message.isEmpty())
             return createSyntaxError(lexicalGlobalObject);

--- a/src/bun.js/bindings/JSDOMGlobalObject.h
+++ b/src/bun.js/bindings/JSDOMGlobalObject.h
@@ -17,8 +17,6 @@ class GlobalObject;
 namespace WebCore {
 
 Zig::GlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& ctx, DOMWrapperWorld& world);
-WEBCORE_EXPORT Zig::GlobalObject& callerGlobalObject(JSC::JSGlobalObject&, JSC::CallFrame*);
-Zig::GlobalObject& legacyActiveGlobalObjectForAccessor(JSC::JSGlobalObject&, JSC::CallFrame*);
 
 template<class JSClass>
 JSClass* toJSDOMGlobalObject(JSC::VM& vm, JSC::JSValue value)

--- a/src/bun.js/bindings/JSDOMWrapperCache.h
+++ b/src/bun.js/bindings/JSDOMWrapperCache.h
@@ -46,9 +46,9 @@ template<typename WrapperClass> JSC::JSObject* getDOMPrototype(JSC::VM&, JSC::JS
 JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, JSC::ArrayBuffer*);
 void* wrapperKey(JSC::ArrayBuffer*);
 
-JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld&, void*);
-JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*);
-JSC::JSArrayBuffer* getInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*);
+std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*);
+std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*);
+std::optional<JSC::JSArrayBuffer*> getInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*);
 
 bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*);
 bool setInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner);
@@ -108,21 +108,21 @@ inline void* wrapperKey(JSC::ArrayBuffer* domObject)
     return domObject;
 }
 
-inline JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld&, void*) { return nullptr; }
+inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*) { return std::nullopt; }
 inline bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*) { return false; }
 inline bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*) { return false; }
 
-inline JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject)
+inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject)
 {
     if (!world.isNormal())
-        return nullptr;
+        return std::nullopt;
     return domObject->wrapper();
 }
 
-inline JSC::JSArrayBuffer* getInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* buffer)
+inline std::optional<JSC::JSArrayBuffer*> getInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* buffer)
 {
     if (!world.isNormal())
-        return nullptr;
+        return std::nullopt;
     return buffer->m_wrapper.get();
 }
 
@@ -160,8 +160,8 @@ inline bool clearInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* d
 
 template<typename DOMClass> inline JSC::JSObject* getCachedWrapper(DOMWrapperWorld& world, DOMClass& domObject)
 {
-    if (auto* wrapper = getInlineCachedWrapper(world, &domObject))
-        return wrapper;
+    if (auto wrapper = getInlineCachedWrapper(world, &domObject))
+        return *wrapper;
     return world.wrappers().get(wrapperKey(&domObject));
 }
 

--- a/src/bun.js/bindings/JSVMClientDataClient.h
+++ b/src/bun.js/bindings/JSVMClientDataClient.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
+
+namespace WebCore {
+
+class JSVMClientDataClient : public AbstractRefCountedAndCanMakeWeakPtr<JSVMClientDataClient> {
+public:
+    virtual ~JSVMClientDataClient() = default;
+    virtual void willDestroyVM() = 0;
+};
+
+} // namespace WebCore

--- a/src/bun.js/bindings/webcore/BroadcastChannel.h
+++ b/src/bun.js/bindings/webcore/BroadcastChannel.h
@@ -88,12 +88,6 @@ private:
     void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     void eventListenersDidChange() final;
 
-    EventTargetData* eventTargetData() final { return &m_eventTargetData; }
-    EventTargetData* eventTargetDataConcurrently() final { return &m_eventTargetData; }
-    EventTargetData& ensureEventTargetData() final { return m_eventTargetData; }
-
-    EventTargetData m_eventTargetData;
-
     // ActiveDOMObject
     // const char* activeDOMObjectName() const final;
     // bool virtualHasPendingActivity() const final;

--- a/src/bun.js/bindings/webcore/CloseEvent.h
+++ b/src/bun.js/bindings/webcore/CloseEvent.h
@@ -60,12 +60,9 @@ public:
     unsigned short code() const { return m_code; }
     String reason() const { return m_reason; }
 
-    // Event function.
-    EventInterface eventInterface() const override { return CloseEventInterfaceType; }
-
 private:
     CloseEvent(bool wasClean, int code, const String& reason)
-        : Event(eventNames().closeEvent, CanBubble::No, IsCancelable::No)
+        : Event(CloseEventInterfaceType, eventNames().closeEvent, CanBubble::No, IsCancelable::No)
         , m_wasClean(wasClean)
         , m_code(code)
         , m_reason(reason)
@@ -73,7 +70,7 @@ private:
     }
 
     CloseEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(type, initializer, isTrusted)
+        : Event(CloseEventInterfaceType, type, initializer, isTrusted)
         , m_wasClean(initializer.wasClean)
         , m_code(initializer.code)
         , m_reason(initializer.reason)

--- a/src/bun.js/bindings/webcore/CustomEvent.cpp
+++ b/src/bun.js/bindings/webcore/CustomEvent.cpp
@@ -35,12 +35,12 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CustomEvent);
 
 inline CustomEvent::CustomEvent(IsTrusted isTrusted)
-    : Event(isTrusted)
+    : Event(CustomEventInterfaceType, isTrusted)
 {
 }
 
 inline CustomEvent::CustomEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(CustomEventInterfaceType, type, initializer, isTrusted)
     , m_detail(initializer.detail)
 {
 }
@@ -68,11 +68,6 @@ void CustomEvent::initCustomEvent(const AtomString& type, bool canBubble, bool c
     // https://bugs.webkit.org/show_bug.cgi?id=236353
     m_detail.setWeakly(detail);
     m_cachedDetail.clear();
-}
-
-EventInterface CustomEvent::eventInterface() const
-{
-    return CustomEventInterfaceType;
 }
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/CustomEvent.h
+++ b/src/bun.js/bindings/webcore/CustomEvent.h
@@ -56,8 +56,6 @@ private:
     CustomEvent(IsTrusted);
     CustomEvent(const AtomString& type, const Init& initializer, IsTrusted);
 
-    EventInterface eventInterface() const final;
-
     JSValueInWrappedObject m_detail;
     JSValueInWrappedObject m_cachedDetail;
 };

--- a/src/bun.js/bindings/webcore/DOMPromiseProxy.h
+++ b/src/bun.js/bindings/webcore/DOMPromiseProxy.h
@@ -130,16 +130,17 @@ inline JSC::JSValue DOMPromiseProxy<IDLType>::resolvePromise(JSC::JSGlobalObject
     if (!deferredPromise)
         return JSC::jsUndefined();
 
+    m_deferredPromises.append(*deferredPromise);
+
     if (m_valueOrException) {
+        // Calls to reject() / resolvePromiseCallback() may destroy |this|.
         if (m_valueOrException->hasException())
             deferredPromise->reject(m_valueOrException->exception());
         else
             resolvePromiseCallback(*deferredPromise);
     }
 
-    auto result = deferredPromise->promise();
-    m_deferredPromises.append(deferredPromise.releaseNonNull());
-    return result;
+    return deferredPromise->promise();
 }
 
 template<typename IDLType>
@@ -177,8 +178,10 @@ inline void DOMPromiseProxy<IDLType>::resolve(typename IDLType::StorageType valu
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<Value> { std::forward<typename IDLType::StorageType>(value) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->template resolve<IDLType>(m_valueOrException->returnValue());
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto returnValueCopy = m_valueOrException->returnValue();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->template resolve<IDLType>(returnValueCopy);
 }
 
 template<>
@@ -187,8 +190,10 @@ inline void DOMPromiseProxy<IDLAny>::resolve(typename IDLAny::StorageType value)
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<Value> { std::forward<typename IDLAny::StorageType>(value) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->resolveWithJSValue(m_valueOrException->returnValue().get());
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto returnValueCopy = m_valueOrException->returnValue();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->resolveWithJSValue(returnValueCopy.get());
 }
 
 template<typename IDLType>
@@ -197,8 +202,10 @@ inline void DOMPromiseProxy<IDLType>::resolveWithNewlyCreated(typename IDLType::
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<Value> { std::forward<typename IDLType::StorageType>(value) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->template resolveWithNewlyCreated<IDLType>(m_valueOrException->returnValue());
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto returnValueCopy = m_valueOrException->returnValue();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->template resolveWithNewlyCreated<IDLType>(returnValueCopy);
 }
 
 template<typename IDLType>
@@ -207,8 +214,10 @@ inline void DOMPromiseProxy<IDLType>::reject(Exception exception, RejectAsHandle
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<Value> { WTF::move(exception) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->reject(m_valueOrException->exception(), rejectAsHandled);
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto exceptionCopy = m_valueOrException->exception();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->reject(exceptionCopy, rejectAsHandled);
 }
 
 // MARK: - DOMPromiseProxy<IDLUndefined> specialization
@@ -226,16 +235,17 @@ inline JSC::JSValue DOMPromiseProxy<IDLUndefined>::promise(JSC::JSGlobalObject& 
     if (!deferredPromise)
         return JSC::jsUndefined();
 
+    m_deferredPromises.append(*deferredPromise);
+
     if (m_valueOrException) {
+        // Calls to reject() / resolve() may destroy |this|.
         if (m_valueOrException->hasException())
             deferredPromise->reject(m_valueOrException->exception());
         else
             deferredPromise->resolve();
     }
 
-    auto result = deferredPromise->promise();
-    m_deferredPromises.append(deferredPromise.releaseNonNull());
-    return result;
+    return deferredPromise->promise();
 }
 
 inline void DOMPromiseProxy<IDLUndefined>::clear()
@@ -253,7 +263,8 @@ inline void DOMPromiseProxy<IDLUndefined>::resolve()
 {
     ASSERT(!m_valueOrException);
     m_valueOrException = ExceptionOr<void> {};
-    for (auto& deferredPromise : m_deferredPromises)
+    auto deferredPromisesCopy = m_deferredPromises;
+    for (auto& deferredPromise : deferredPromisesCopy)
         deferredPromise->resolve();
 }
 
@@ -261,8 +272,10 @@ inline void DOMPromiseProxy<IDLUndefined>::reject(Exception exception, RejectAsH
 {
     ASSERT(!m_valueOrException);
     m_valueOrException = ExceptionOr<void> { WTF::move(exception) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->reject(m_valueOrException->exception(), rejectAsHandled);
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto exceptionCopy = m_valueOrException->exception();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->reject(exceptionCopy, rejectAsHandled);
 }
 
 // MARK: - DOMPromiseProxyWithResolveCallback<IDLType> implementation
@@ -294,16 +307,17 @@ inline JSC::JSValue DOMPromiseProxyWithResolveCallback<IDLType>::promise(JSC::JS
     if (!deferredPromise)
         return JSC::jsUndefined();
 
+    m_deferredPromises.append(*deferredPromise);
+
     if (m_valueOrException) {
+        // Calls to reject() / resolve() may destroy |this|.
         if (m_valueOrException->hasException())
             deferredPromise->reject(m_valueOrException->exception());
         else
             deferredPromise->template resolve<IDLType>(m_resolveCallback());
     }
 
-    auto result = deferredPromise->promise();
-    m_deferredPromises.append(deferredPromise.releaseNonNull());
-    return result;
+    return deferredPromise->promise();
 }
 
 template<typename IDLType>
@@ -325,7 +339,8 @@ inline void DOMPromiseProxyWithResolveCallback<IDLType>::resolve(typename IDLTyp
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<void> {};
-    for (auto& deferredPromise : m_deferredPromises)
+    auto deferredPromisesCopy = m_deferredPromises;
+    for (auto& deferredPromise : deferredPromisesCopy)
         deferredPromise->template resolve<IDLType>(value);
 }
 
@@ -335,7 +350,8 @@ inline void DOMPromiseProxyWithResolveCallback<IDLType>::resolveWithNewlyCreated
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<void> {};
-    for (auto& deferredPromise : m_deferredPromises)
+    auto deferredPromisesCopy = m_deferredPromises;
+    for (auto& deferredPromise : deferredPromisesCopy)
         deferredPromise->template resolveWithNewlyCreated<IDLType>(value);
 }
 
@@ -345,8 +361,10 @@ inline void DOMPromiseProxyWithResolveCallback<IDLType>::reject(Exception except
     ASSERT(!m_valueOrException);
 
     m_valueOrException = ExceptionOr<void> { WTF::move(exception) };
-    for (auto& deferredPromise : m_deferredPromises)
-        deferredPromise->reject(m_valueOrException->exception(), rejectAsHandled);
+    auto deferredPromisesCopy = m_deferredPromises;
+    auto exceptionCopy = m_valueOrException->exception();
+    for (auto& deferredPromise : deferredPromisesCopy)
+        deferredPromise->reject(exceptionCopy, rejectAsHandled);
 }
 
 }

--- a/src/bun.js/bindings/webcore/ErrorEvent.cpp
+++ b/src/bun.js/bindings/webcore/ErrorEvent.cpp
@@ -44,7 +44,7 @@ using namespace JSC;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ErrorEvent);
 
 ErrorEvent::ErrorEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(ErrorEventInterfaceType, type, initializer, isTrusted)
     , m_message(initializer.message)
     , m_fileName(initializer.filename)
     , m_lineNumber(initializer.lineno)
@@ -54,7 +54,7 @@ ErrorEvent::ErrorEvent(const AtomString& type, const Init& initializer, IsTruste
 }
 
 ErrorEvent::ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error)
-    : Event(type, CanBubble::No, IsCancelable::Yes)
+    : Event(ErrorEventInterfaceType, type, CanBubble::No, IsCancelable::Yes)
     , m_message(message)
     , m_fileName(fileName)
     , m_lineNumber(lineNumber)
@@ -69,11 +69,6 @@ ErrorEvent::ErrorEvent(const String& message, const String& fileName, unsigned l
 }
 
 ErrorEvent::~ErrorEvent() = default;
-
-EventInterface ErrorEvent::eventInterface() const
-{
-    return ErrorEventInterfaceType;
-}
 
 JSValue ErrorEvent::error(JSGlobalObject& globalObject)
 {
@@ -101,10 +96,5 @@ JSValue ErrorEvent::error(JSGlobalObject& globalObject)
 //     // }
 //     return 0;
 // }
-
-bool ErrorEvent::isErrorEvent() const
-{
-    return true;
-}
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/ErrorEvent.h
+++ b/src/bun.js/bindings/webcore/ErrorEvent.h
@@ -77,16 +77,12 @@ public:
     const JSValueInWrappedObject& originalError() const { return m_error; }
     // SerializedScriptValue* serializedError() const { return m_serializedError.get(); }
 
-    EventInterface eventInterface() const override;
-
     // RefPtr<SerializedScriptValue> trySerializeError(JSC::JSGlobalObject&);
 
 private:
     ErrorEvent(const AtomString& type, const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
     ErrorEvent(const String& message, const String& fileName, unsigned lineNumber, unsigned columnNumber, JSC::Strong<JSC::Unknown> error);
     ErrorEvent(const AtomString&, const Init&, IsTrusted);
-
-    bool isErrorEvent() const override;
 
     String m_message;
     String m_fileName;

--- a/src/bun.js/bindings/webcore/Event.cpp
+++ b/src/bun.js/bindings/webcore/Event.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Event);
 
-ALWAYS_INLINE Event::Event(MonotonicTime createTime, const AtomString& type, IsTrusted isTrusted, CanBubble canBubble, IsCancelable cancelable, IsComposed composed)
+ALWAYS_INLINE Event::Event(EventInterface eventInterface, MonotonicTime createTime, const AtomString& type, IsTrusted isTrusted, CanBubble canBubble, IsCancelable cancelable, IsComposed composed)
     : m_isInitialized { !type.isNull() }
     , m_canBubble { canBubble == CanBubble::Yes }
     , m_cancelable { cancelable == IsCancelable::Yes }
@@ -55,30 +55,31 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, const AtomString& type, IsT
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
     , m_eventPhase { NONE }
+    , m_eventInterface { static_cast<unsigned>(eventInterface) }
     , m_type { type }
     , m_createTime { createTime }
 {
 }
 
-Event::Event(IsTrusted isTrusted)
-    : Event { MonotonicTime::now(), {}, isTrusted, CanBubble::No, IsCancelable::No, IsComposed::No }
+Event::Event(EventInterface eventInterface, IsTrusted isTrusted)
+    : Event { eventInterface, MonotonicTime::now(), {}, isTrusted, CanBubble::No, IsCancelable::No, IsComposed::No }
 {
 }
 
-Event::Event(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
-    : Event { MonotonicTime::now(), eventType, IsTrusted::Yes, canBubble, isCancelable, isComposed }
-{
-    ASSERT(!eventType.isNull());
-}
-
-Event::Event(const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, IsTrusted isTrusted)
-    : Event { timestamp, eventType, isTrusted, canBubble, isCancelable, isComposed }
+Event::Event(EventInterface eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
+    : Event { eventInterface, MonotonicTime::now(), eventType, IsTrusted::Yes, canBubble, isCancelable, isComposed }
 {
     ASSERT(!eventType.isNull());
 }
 
-Event::Event(const AtomString& eventType, const EventInit& initializer, IsTrusted isTrusted)
-    : Event { MonotonicTime::now(), eventType, isTrusted,
+Event::Event(EventInterface eventInterface, const AtomString& eventType, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed, MonotonicTime timestamp, IsTrusted isTrusted)
+    : Event { eventInterface, timestamp, eventType, isTrusted, canBubble, isCancelable, isComposed }
+{
+    ASSERT(!eventType.isNull());
+}
+
+Event::Event(EventInterface eventInterface, const AtomString& eventType, const EventInit& initializer, IsTrusted isTrusted)
+    : Event { eventInterface, MonotonicTime::now(), eventType, isTrusted,
         initializer.bubbles ? CanBubble::Yes : CanBubble::No,
         initializer.cancelable ? IsCancelable::Yes : IsCancelable::No,
         initializer.composed ? IsComposed::Yes : IsComposed::No }
@@ -90,17 +91,17 @@ Event::~Event() = default;
 
 Ref<Event> Event::create(const AtomString& type, CanBubble canBubble, IsCancelable isCancelable, IsComposed isComposed)
 {
-    return adoptRef(*new Event(type, canBubble, isCancelable, isComposed));
+    return adoptRef(*new Event(EventInterfaceType, type, canBubble, isCancelable, isComposed));
 }
 
 Ref<Event> Event::createForBindings()
 {
-    return adoptRef(*new Event);
+    return adoptRef(*new Event(EventInterfaceType));
 }
 
 Ref<Event> Event::create(const AtomString& type, const EventInit& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new Event(type, initializer, isTrusted));
+    return adoptRef(*new Event(EventInterfaceType, type, initializer, isTrusted));
 }
 
 void Event::initEvent(const AtomString& eventTypeArg, bool canBubbleArg, bool cancelableArg)

--- a/src/bun.js/bindings/webcore/Event.h
+++ b/src/bun.js/bindings/webcore/Event.h
@@ -103,23 +103,7 @@ public:
     bool legacyReturnValue() const { return !m_wasCanceled; }
     void setLegacyReturnValue(bool);
 
-    virtual EventInterface eventInterface() const { return EventInterfaceType; }
-
-    virtual bool isBeforeTextInsertedEvent() const { return false; }
-    virtual bool isBeforeUnloadEvent() const { return false; }
-    virtual bool isClipboardEvent() const { return false; }
-    virtual bool isCompositionEvent() const { return false; }
-    virtual bool isErrorEvent() const { return false; }
-    virtual bool isFocusEvent() const { return false; }
-    virtual bool isInputEvent() const { return false; }
-    virtual bool isKeyboardEvent() const { return false; }
-    virtual bool isMouseEvent() const { return false; }
-    virtual bool isPointerEvent() const { return false; }
-    virtual bool isTextEvent() const { return false; }
-    virtual bool isTouchEvent() const { return false; }
-    virtual bool isUIEvent() const { return false; }
-    virtual bool isVersionChangeEvent() const { return false; }
-    virtual bool isWheelEvent() const { return false; }
+    EventInterface eventInterface() const { return static_cast<EventInterface>(m_eventInterface); }
 
     bool propagationStopped() const { return m_propagationStopped || m_immediatePropagationStopped; }
     bool immediatePropagationStopped() const { return m_immediatePropagationStopped; }
@@ -154,15 +138,15 @@ public:
     virtual String debugDescription() const;
 
 protected:
-    explicit Event(IsTrusted = IsTrusted::No);
-    Event(const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
-    Event(const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, IsTrusted isTrusted = IsTrusted::Yes);
-    Event(const AtomString& type, const EventInit&, IsTrusted);
+    explicit Event(EventInterface, IsTrusted = IsTrusted::No);
+    Event(EventInterface, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
+    Event(EventInterface, const AtomString& type, CanBubble, IsCancelable, IsComposed, MonotonicTime timestamp, IsTrusted isTrusted = IsTrusted::Yes);
+    Event(EventInterface, const AtomString& type, const EventInit&, IsTrusted);
 
     virtual void receivedTarget() {}
 
 private:
-    explicit Event(MonotonicTime createTime, const AtomString& type, IsTrusted, CanBubble, IsCancelable, IsComposed);
+    explicit Event(EventInterface, MonotonicTime createTime, const AtomString& type, IsTrusted, CanBubble, IsCancelable, IsComposed);
 
     void setCanceledFlagIfPossible();
 
@@ -181,6 +165,7 @@ private:
     unsigned m_currentTargetIsInShadowTree : 1;
 
     unsigned m_eventPhase : 2;
+    unsigned m_eventInterface : 7;
 
     AtomString m_type;
 
@@ -222,7 +207,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Event&);
 
 } // namespace WebCore
 
-#define SPECIALIZE_TYPE_TRAITS_EVENT(ToValueTypeName)                                       \
-    SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName)                                  \
-    static bool isType(const WebCore::Event& event) { return event.is##ToValueTypeName(); } \
+#define SPECIALIZE_TYPE_TRAITS_EVENT(ToValueTypeName)                                                                  \
+    SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName)                                                             \
+    static bool isType(const WebCore::Event& event) { return event.eventInterface() == WebCore::ToValueTypeName##InterfaceType; } \
     SPECIALIZE_TYPE_TRAITS_END()

--- a/src/bun.js/bindings/webcore/Event.h
+++ b/src/bun.js/bindings/webcore/Event.h
@@ -207,7 +207,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const Event&);
 
 } // namespace WebCore
 
-#define SPECIALIZE_TYPE_TRAITS_EVENT(ToValueTypeName)                                                                  \
-    SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName)                                                             \
+#define SPECIALIZE_TYPE_TRAITS_EVENT(ToValueTypeName)                                                                             \
+    SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ToValueTypeName)                                                                        \
     static bool isType(const WebCore::Event& event) { return event.eventInterface() == WebCore::ToValueTypeName##InterfaceType; } \
     SPECIALIZE_TYPE_TRAITS_END()

--- a/src/bun.js/bindings/webcore/EventTarget.cpp
+++ b/src/bun.js/bindings/webcore/EventTarget.cpp
@@ -184,31 +184,6 @@ void EventTarget::setAttributeEventListener(const AtomString& eventType, JSC::JS
 template void EventTarget::setAttributeEventListener<JSErrorHandler>(const AtomString& eventType, JSC::JSValue listener, JSC::JSObject& jsEventTarget);
 template void EventTarget::setAttributeEventListener<JSEventListener>(const AtomString& eventType, JSC::JSValue listener, JSC::JSObject& jsEventTarget);
 
-bool EventTarget::setAttributeEventListener(const AtomString& eventType, RefPtr<EventListener>&& listener, DOMWrapperWorld& isolatedWorld)
-{
-    auto* existingListener = attributeEventListener(eventType, isolatedWorld);
-    if (!listener) {
-        if (existingListener)
-            removeEventListener(eventType, *existingListener, false);
-        return false;
-    }
-    // if (existingListener) {
-    //     InspectorInstrumentation::willRemoveEventListener(*this, eventType, *existingListener, false);
-
-#if ASSERT_ENABLED
-    listener->checkValidityForEventTarget(*this);
-#endif
-
-    auto listenerPointer = listener.copyRef();
-    eventTargetData()->eventListenerMap.replace(eventType, *existingListener, listener.releaseNonNull(), {});
-
-    // InspectorInstrumentation::didAddEventListener(*this, eventType, *listenerPointer, false);
-
-    return true;
-
-    return addEventListener(eventType, listener.releaseNonNull(), {});
-}
-
 JSEventListener* EventTarget::attributeEventListener(const AtomString& eventType, DOMWrapperWorld& isolatedWorld)
 {
     for (auto& eventListener : eventListeners(eventType)) {
@@ -358,8 +333,8 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
         registeredListener->callback().handleEvent(context, event);
         // InspectorInstrumentation::didHandleEvent(context, event, *registeredListener);
 
-        // if (registeredListener->isPassive())
-        // event.setInPassiveListener(false);
+        if (registeredListener->isPassive())
+            event.setInPassiveListener(false);
     }
 
     // if (contextIsDocument)

--- a/src/bun.js/bindings/webcore/EventTarget.cpp
+++ b/src/bun.js/bindings/webcore/EventTarget.cpp
@@ -61,14 +61,18 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EventTarget);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(EventTargetWithInlineData);
 
 Ref<EventTarget> EventTarget::create(ScriptExecutionContext& context)
 {
     return EventTargetConcrete::create(context);
 }
 
-EventTarget::~EventTarget() = default;
+EventTarget::~EventTarget()
+{
+    // The WeakPtrImpl (and its EventTargetData) can outlive this object.
+    if (auto* data = this->eventTargetData())
+        data->clear();
+}
 
 bool EventTarget::isNode() const
 {

--- a/src/bun.js/bindings/webcore/EventTarget.h
+++ b/src/bun.js/bindings/webcore/EventTarget.h
@@ -112,7 +112,6 @@ public:
     // Used for legacy "onevent" attributes.
     template<typename JSMaybeErrorEventListener>
     void setAttributeEventListener(const AtomString& eventType, JSC::JSValue listener, JSC::JSObject& jsEventTarget);
-    bool setAttributeEventListener(const AtomString& eventType, RefPtr<EventListener>&&, DOMWrapperWorld&);
     JSEventListener* attributeEventListener(const AtomString& eventType, DOMWrapperWorld&);
 
     bool hasEventListeners() const;

--- a/src/bun.js/bindings/webcore/EventTarget.h
+++ b/src/bun.js/bindings/webcore/EventTarget.h
@@ -37,8 +37,9 @@
 #include "ScriptWrappable.h"
 #include <memory>
 #include <variant>
+#include <wtf/Atomics.h>
 #include <wtf/Forward.h>
-
+#include <wtf/OptionSet.h>
 #include <wtf/WeakPtr.h>
 
 #include "root.h"
@@ -60,6 +61,13 @@ struct EventTargetData {
 
 public:
     EventTargetData() = default;
+
+    void clear()
+    {
+        eventListenerMap.clear();
+        isFiringEventListeners = false;
+    }
+
     EventListenerMap eventListenerMap;
     bool isFiringEventListeners { false };
 };
@@ -135,9 +143,17 @@ public:
 protected:
     WEBCORE_EXPORT virtual ~EventTarget();
 
-    virtual EventTargetData* eventTargetData() = 0;
-    virtual EventTargetData* eventTargetDataConcurrently() = 0;
-    virtual EventTargetData& ensureEventTargetData() = 0;
+    enum class EventTargetFlag : uint16_t {
+        HasEventTargetData = 1 << 0,
+    };
+
+    bool hasEventTargetFlag(EventTargetFlag flag) const { return weakPtrFactory().bitfield() & std::to_underlying(flag); }
+    void setEventTargetFlag(EventTargetFlag, bool = true);
+    bool hasEventTargetData() const { return hasEventTargetFlag(EventTargetFlag::HasEventTargetData); }
+
+    EventTargetData* eventTargetData();
+    EventTargetData* eventTargetDataConcurrently();
+    EventTargetData& ensureEventTargetData();
 
     virtual void eventListenersDidChange() {}
 
@@ -156,21 +172,47 @@ private:
     void invalidateEventListenerRegions();
 };
 
-class EventTargetWithInlineData : public EventTarget {
-    WTF_MAKE_TZONE_ALLOCATED(EventTargetWithInlineData);
+// EventTargetData lives on the WeakPtrImpl; subclasses no longer need their own storage.
+using EventTargetWithInlineData = EventTarget;
 
-protected:
-    EventTargetData* eventTargetData() final { return &m_eventTargetData; }
-    EventTargetData* eventTargetDataConcurrently() final { return &m_eventTargetData; }
-    EventTargetData& ensureEventTargetData() final { return m_eventTargetData; }
-
-private:
-    EventTargetData m_eventTargetData;
-};
+inline void EventTarget::setEventTargetFlag(EventTargetFlag flag, bool value)
+{
+    auto flags = OptionSet<EventTargetFlag>::fromRaw(weakPtrFactory().bitfield());
+    flags.set(flag, value);
+    weakPtrFactory().setBitfield(flags.toRaw());
+}
 
 inline const EventTargetData* EventTarget::eventTargetData() const
 {
-    return const_cast<EventTarget*>(this)->eventTargetData();
+    if (hasEventTargetData())
+        return &weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData* EventTarget::eventTargetData()
+{
+    if (hasEventTargetData())
+        return &weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData* EventTarget::eventTargetDataConcurrently()
+{
+    bool flag = this->hasEventTargetData();
+    auto fencedFlag = Dependency::fence(flag);
+    if (flag)
+        return &fencedFlag.consume(this)->weakPtrFactory().impl()->eventTargetData();
+    return nullptr;
+}
+
+inline EventTargetData& EventTarget::ensureEventTargetData()
+{
+    if (auto* data = eventTargetData())
+        return *data;
+    initializeWeakPtrFactory();
+    WTF::storeStoreFence();
+    setEventTargetFlag(EventTargetFlag::HasEventTargetData, true);
+    return weakPtrFactory().impl()->eventTargetData();
 }
 
 inline bool EventTarget::isFiringEventListeners() const

--- a/src/bun.js/bindings/webcore/EventTargetConcrete.h
+++ b/src/bun.js/bindings/webcore/EventTargetConcrete.h
@@ -40,8 +40,6 @@ class EventTargetConcrete final : public RefCounted<EventTargetConcrete>, public
 public:
     static Ref<EventTargetConcrete> create(ScriptExecutionContext&);
 
-    bool hasEventTargetData() const { return true; }
-
     using RefCounted::deref;
     using RefCounted::ref;
 

--- a/src/bun.js/bindings/webcore/JSDOMConvertBase.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertBase.h
@@ -29,6 +29,7 @@
 #include "ZigGlobalObject.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMConvertResult.h"
 #include <JavaScriptCore/Error.h>
 
 namespace WebCore {
@@ -94,6 +95,12 @@ template<typename T, typename ExceptionThrower> inline typename Converter<T>::Re
 template<typename T, typename ExceptionThrower> inline typename Converter<T>::ReturnType convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower)
 {
     return Converter<T>::convert(lexicalGlobalObject, value, globalObject, std::forward<ExceptionThrower>(exceptionThrower));
+}
+
+// New code can opt into ConversionResult<> explicitly until call sites are migrated.
+template<typename T> inline ConversionResult<T> convertResult(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
+{
+    return Converter<T>::convert(lexicalGlobalObject, value);
 }
 
 // Conversion from Implementation -> JSValue

--- a/src/bun.js/bindings/webcore/JSDOMConvertNumbers.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMConvertNumbers.cpp
@@ -29,6 +29,9 @@
 #include <wtf/text/StringConcatenateNumbers.h>
 #include <wtf/text/WTFString.h>
 
+// WebIDL §3.2.4.9 requires round-half-to-even for [Clamp].
+static ALWAYS_INLINE double clampRoundEven(double x) { return __builtin_roundeven(x); }
+
 namespace WebCore {
 using namespace JSC;
 
@@ -133,7 +136,7 @@ static inline T toSmallerInt(JSGlobalObject& lexicalGlobalObject, JSValue value)
     case IntegerConversionConfiguration::EnforceRange:
         return enforceRange(lexicalGlobalObject, x, LimitsTrait::minValue, LimitsTrait::maxValue);
     case IntegerConversionConfiguration::Clamp:
-        return std::isnan(x) ? 0 : clampTo<T>(x);
+        return std::isnan(x) ? 0 : clampTo<T>(clampRoundEven(x));
     }
 
     if (std::isnan(x) || std::isinf(x) || !x)
@@ -179,7 +182,7 @@ static inline T toSmallerUInt(JSGlobalObject& lexicalGlobalObject, JSValue value
     case IntegerConversionConfiguration::EnforceRange:
         return enforceRange(lexicalGlobalObject, x, 0, LimitsTrait::maxValue);
     case IntegerConversionConfiguration::Clamp:
-        return std::isnan(x) ? 0 : clampTo<T>(x);
+        return std::isnan(x) ? 0 : clampTo<T>(clampRoundEven(x));
     }
 
     if (std::isnan(x) || std::isinf(x) || !x)
@@ -284,7 +287,7 @@ template<> int32_t convertToIntegerClamp<int32_t>(JSC::JSGlobalObject& lexicalGl
         return value.asInt32();
 
     double x = value.toNumber(&lexicalGlobalObject);
-    return std::isnan(x) ? 0 : clampTo<int32_t>(x);
+    return std::isnan(x) ? 0 : clampTo<int32_t>(clampRoundEven(x));
 }
 
 template<> uint32_t convertToIntegerClamp<uint32_t>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -293,7 +296,7 @@ template<> uint32_t convertToIntegerClamp<uint32_t>(JSC::JSGlobalObject& lexical
         return value.asUInt32();
 
     double x = value.toNumber(&lexicalGlobalObject);
-    return std::isnan(x) ? 0 : clampTo<uint32_t>(x);
+    return std::isnan(x) ? 0 : clampTo<uint32_t>(clampRoundEven(x));
 }
 
 template<> int32_t convertToInteger<int32_t>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -338,7 +341,7 @@ template<> int64_t convertToIntegerClamp<int64_t>(JSC::JSGlobalObject& lexicalGl
         return value.asInt32();
 
     double x = value.toNumber(&lexicalGlobalObject);
-    return std::isnan(x) ? 0 : static_cast<int64_t>(std::min<double>(std::max<double>(x, -kJSMaxInteger), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<int64_t>(clampRoundEven(std::min<double>(std::max<double>(x, -kJSMaxInteger), kJSMaxInteger)));
 }
 
 template<> uint64_t convertToIntegerClamp<uint64_t>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
@@ -347,7 +350,7 @@ template<> uint64_t convertToIntegerClamp<uint64_t>(JSC::JSGlobalObject& lexical
         return value.asUInt32();
 
     double x = value.toNumber(&lexicalGlobalObject);
-    return std::isnan(x) ? 0 : static_cast<uint64_t>(std::min<double>(std::max<double>(x, 0), kJSMaxInteger));
+    return std::isnan(x) ? 0 : static_cast<uint64_t>(clampRoundEven(std::min<double>(std::max<double>(x, 0), kJSMaxInteger)));
 }
 
 template<> int64_t convertToInteger<int64_t>(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)

--- a/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertRecord.h
@@ -242,10 +242,8 @@ template<typename K, typename V> struct JSConverter<IDLRecord<K, V>> {
             auto esValue = toJS<V>(lexicalGlobalObject, globalObject, keyValuePair.value);
 
             // 3. Let created be ! CreateDataProperty(result, esKey, esValue).
-            bool created = result->putDirect(vm, JSC::Identifier::fromString(vm, keyValuePair.key), esValue);
-
-            // 4. Assert: created is true.
-            ASSERT_UNUSED(created, created);
+            // putDirect() crashes for numeric-index keys; use createDataProperty.
+            result->createDataProperty(&lexicalGlobalObject, JSC::Identifier::fromString(vm, keyValuePair.key), esValue, false);
         }
 
         // 3. Return result.

--- a/src/bun.js/bindings/webcore/JSDOMConvertResult.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertResult.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/ExceptionScope.h>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <wtf/Expected.h>
+
+namespace WebCore {
+
+template<typename T> struct Converter;
+
+template<typename IDL> class ConversionResult;
+
+struct ConversionResultException { };
+
+namespace Detail {
+
+template<typename T>
+struct ConversionResultStorage {
+    using ReturnType = T;
+    using Type = T;
+
+    ConversionResultStorage(ConversionResultException token) : value(makeUnexpected(token)) { }
+    ConversionResultStorage(const Type& value) : value(value) { }
+    ConversionResultStorage(Type&& value) : value(WTF::move(value)) { }
+
+    template<typename U>
+    ConversionResultStorage(ConversionResultStorage<U>&& other)
+        : value([&]() -> Expected<Type, ConversionResultException> {
+            if (other.hasException())
+                return makeUnexpected(ConversionResultException());
+            return ReturnType { other.releaseReturnValue() };
+        }())
+    {
+    }
+
+    template<typename U>
+        requires (std::is_pointer_v<Type> && std::is_lvalue_reference_v<U>)
+    ConversionResultStorage(ConversionResultStorage<U>&& other)
+        : value([&]() -> Expected<Type, ConversionResultException> {
+            if (other.hasException())
+                return makeUnexpected(ConversionResultException());
+            return ReturnType { &other.releaseReturnValue() };
+        }())
+    {
+    }
+
+    bool hasException() const
+    {
+        return !value.has_value();
+    }
+
+    ReturnType& returnValue()
+    {
+        ASSERT(!wasReleased);
+        return value.value();
+    }
+
+    const ReturnType& returnValue() const
+    {
+        ASSERT(!wasReleased);
+        return value.value();
+    }
+
+    ReturnType releaseReturnValue()
+    {
+        ASSERT(!std::exchange(wasReleased, true));
+        return WTF::move(value.value());
+    }
+
+    Expected<Type, ConversionResultException> value;
+#if ASSERT_ENABLED
+    bool wasReleased { false };
+#endif
+};
+
+template<typename T>
+struct ConversionResultStorage<T&> {
+    using ReturnType = T&;
+    using Type = T;
+
+    ConversionResultStorage(ConversionResultException token) : value(makeUnexpected(token)) { }
+    ConversionResultStorage(Type& value) : value(std::reference_wrapper<Type> { value }) { }
+
+    template<typename U>
+    ConversionResultStorage(ConversionResultStorage<U>&& other)
+        : value([&]() -> Expected<std::reference_wrapper<Type>, ConversionResultException> {
+            if (other.hasException())
+                return makeUnexpected(ConversionResultException());
+            return static_cast<ReturnType>(other.releaseReturnValue());
+        }())
+    {
+    }
+
+    bool hasException() const
+    {
+        return !value.has_value();
+    }
+
+    Type& returnValue()
+    {
+        ASSERT(!wasReleased);
+        return value.value().get();
+    }
+
+    const Type& returnValue() const
+    {
+        ASSERT(!wasReleased);
+        return value.value().get();
+    }
+
+    Type& releaseReturnValue()
+    {
+        ASSERT(!std::exchange(wasReleased, true));
+        return WTF::move(value.value()).get();
+    }
+
+    Expected<std::reference_wrapper<Type>, ConversionResultException> value;
+#if ASSERT_ENABLED
+    bool wasReleased { false };
+#endif
+};
+
+} // namespace Detail
+
+template<typename T>
+class ConversionResult {
+public:
+    using IDL = T;
+    using ReturnType = typename Converter<IDL>::ReturnType;
+
+    static ConversionResult exception() { return ConversionResult(ConversionResultException()); }
+
+    ConversionResult(ConversionResultException token)
+        : m_storage { token }
+    {
+    }
+
+    ConversionResult(const ReturnType& returnValue)
+        : m_storage { returnValue }
+    {
+    }
+
+    ConversionResult(ReturnType&& returnValue) requires (!std::is_lvalue_reference_v<ReturnType>)
+        : m_storage { WTF::move(returnValue) }
+    {
+    }
+
+    ConversionResult(std::nullptr_t) requires std::is_same_v<decltype(IDL::nullValue()), std::nullptr_t>
+        : m_storage { nullptr }
+    {
+    }
+
+    ConversionResult(std::nullopt_t) requires std::is_same_v<decltype(IDL::nullValue()), std::nullopt_t>
+        : m_storage { std::nullopt }
+    {
+    }
+
+    template<typename OtherIDL>
+    ConversionResult(ConversionResult<OtherIDL>&& other)
+        : m_storage { WTF::move(other.m_storage) }
+    {
+    }
+
+    bool hasException(JSC::ExceptionScope& scope) const
+    {
+        EXCEPTION_ASSERT(!!scope.exception() == scope.vm().traps().needHandling(JSC::VMTraps::NeedExceptionHandling));
+
+#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+        if (m_storage.hasException()) {
+            EXCEPTION_ASSERT(scope.vm().traps().maybeNeedHandling() && scope.vm().hasExceptionsAfterHandlingTraps());
+            return true;
+        }
+        return false;
+#else
+        UNUSED_PARAM(scope);
+        return m_storage.hasException();
+#endif
+    }
+
+    decltype(auto) returnValue() { ASSERT(!m_storage.hasException()); return m_storage.returnValue(); }
+    decltype(auto) returnValue() const { ASSERT(!m_storage.hasException()); return m_storage.returnValue(); }
+    decltype(auto) releaseReturnValue() { ASSERT(!m_storage.hasException()); return m_storage.releaseReturnValue(); }
+
+    // Transitional shim — lets existing call sites that do `auto x = convert<>(); RETURN_IF_EXCEPTION(scope, {}); use(WTF::move(x))`
+    // compile unchanged. The exception check via RETURN_IF_EXCEPTION inspects the scope directly, so by the
+    // time this fires the result is known-valid. Remove once call sites migrate to hasException()/releaseReturnValue().
+    operator ReturnType() && requires (!std::is_lvalue_reference_v<ReturnType>)
+    {
+        return releaseReturnValue();
+    }
+
+    operator ReturnType() & requires (!std::is_lvalue_reference_v<ReturnType>)
+    {
+        return m_storage.returnValue();
+    }
+
+    operator ReturnType() requires std::is_lvalue_reference_v<ReturnType>
+    {
+        return m_storage.returnValue();
+    }
+
+private:
+    template<typename> friend class ConversionResult;
+
+    Detail::ConversionResultStorage<ReturnType> m_storage;
+};
+
+} // namespace WebCore

--- a/src/bun.js/bindings/webcore/JSDOMConvertResult.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertResult.h
@@ -37,7 +37,7 @@ template<typename T> struct Converter;
 
 template<typename IDL> class ConversionResult;
 
-struct ConversionResultException { };
+struct ConversionResultException {};
 
 namespace Detail {
 
@@ -46,9 +46,18 @@ struct ConversionResultStorage {
     using ReturnType = T;
     using Type = T;
 
-    ConversionResultStorage(ConversionResultException token) : value(makeUnexpected(token)) { }
-    ConversionResultStorage(const Type& value) : value(value) { }
-    ConversionResultStorage(Type&& value) : value(WTF::move(value)) { }
+    ConversionResultStorage(ConversionResultException token)
+        : value(makeUnexpected(token))
+    {
+    }
+    ConversionResultStorage(const Type& value)
+        : value(value)
+    {
+    }
+    ConversionResultStorage(Type&& value)
+        : value(WTF::move(value))
+    {
+    }
 
     template<typename U>
     ConversionResultStorage(ConversionResultStorage<U>&& other)
@@ -61,7 +70,7 @@ struct ConversionResultStorage {
     }
 
     template<typename U>
-        requires (std::is_pointer_v<Type> && std::is_lvalue_reference_v<U>)
+        requires(std::is_pointer_v<Type> && std::is_lvalue_reference_v<U>)
     ConversionResultStorage(ConversionResultStorage<U>&& other)
         : value([&]() -> Expected<Type, ConversionResultException> {
             if (other.hasException())
@@ -105,8 +114,14 @@ struct ConversionResultStorage<T&> {
     using ReturnType = T&;
     using Type = T;
 
-    ConversionResultStorage(ConversionResultException token) : value(makeUnexpected(token)) { }
-    ConversionResultStorage(Type& value) : value(std::reference_wrapper<Type> { value }) { }
+    ConversionResultStorage(ConversionResultException token)
+        : value(makeUnexpected(token))
+    {
+    }
+    ConversionResultStorage(Type& value)
+        : value(std::reference_wrapper<Type> { value })
+    {
+    }
 
     template<typename U>
     ConversionResultStorage(ConversionResultStorage<U>&& other)
@@ -167,17 +182,20 @@ public:
     {
     }
 
-    ConversionResult(ReturnType&& returnValue) requires (!std::is_lvalue_reference_v<ReturnType>)
+    ConversionResult(ReturnType&& returnValue)
+        requires(!std::is_lvalue_reference_v<ReturnType>)
         : m_storage { WTF::move(returnValue) }
     {
     }
 
-    ConversionResult(std::nullptr_t) requires std::is_same_v<decltype(IDL::nullValue()), std::nullptr_t>
+    ConversionResult(std::nullptr_t)
+        requires std::is_same_v<decltype(IDL::nullValue()), std::nullptr_t>
         : m_storage { nullptr }
     {
     }
 
-    ConversionResult(std::nullopt_t) requires std::is_same_v<decltype(IDL::nullValue()), std::nullopt_t>
+    ConversionResult(std::nullopt_t)
+        requires std::is_same_v<decltype(IDL::nullValue()), std::nullopt_t>
         : m_storage { std::nullopt }
     {
     }
@@ -204,24 +222,39 @@ public:
 #endif
     }
 
-    decltype(auto) returnValue() { ASSERT(!m_storage.hasException()); return m_storage.returnValue(); }
-    decltype(auto) returnValue() const { ASSERT(!m_storage.hasException()); return m_storage.returnValue(); }
-    decltype(auto) releaseReturnValue() { ASSERT(!m_storage.hasException()); return m_storage.releaseReturnValue(); }
+    decltype(auto) returnValue()
+    {
+        ASSERT(!m_storage.hasException());
+        return m_storage.returnValue();
+    }
+    decltype(auto) returnValue() const
+    {
+        ASSERT(!m_storage.hasException());
+        return m_storage.returnValue();
+    }
+    decltype(auto) releaseReturnValue()
+    {
+        ASSERT(!m_storage.hasException());
+        return m_storage.releaseReturnValue();
+    }
 
     // Transitional shim — lets existing call sites that do `auto x = convert<>(); RETURN_IF_EXCEPTION(scope, {}); use(WTF::move(x))`
     // compile unchanged. The exception check via RETURN_IF_EXCEPTION inspects the scope directly, so by the
     // time this fires the result is known-valid. Remove once call sites migrate to hasException()/releaseReturnValue().
-    operator ReturnType() && requires (!std::is_lvalue_reference_v<ReturnType>)
+    operator ReturnType() &&
+        requires(!std::is_lvalue_reference_v<ReturnType>)
     {
         return releaseReturnValue();
     }
 
-    operator ReturnType() & requires (!std::is_lvalue_reference_v<ReturnType>)
+    operator ReturnType() &
+        requires(!std::is_lvalue_reference_v<ReturnType>)
     {
         return m_storage.returnValue();
     }
 
-    operator ReturnType() requires std::is_lvalue_reference_v<ReturnType>
+    operator ReturnType()
+        requires std::is_lvalue_reference_v<ReturnType>
     {
         return m_storage.returnValue();
     }

--- a/src/bun.js/bindings/webcore/JSDOMConvertUnion.h
+++ b/src/bun.js/bindings/webcore/JSDOMConvertUnion.h
@@ -232,6 +232,11 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
                     return ConditionalReturner<ReturnType, hasArrayBufferType>::get(WTF::move(arrayBuffer)).value();
                 RELEASE_AND_RETURN(scope, (ConditionalConverter<ReturnType, ObjectType, hasObjectType>::convert(lexicalGlobalObject, value).value()));
             }
+            // toWrapped() returns null for resizable buffers; throw instead of falling through to the next union member.
+            if (auto* jsArrayBuffer = JSC::jsDynamicCast<JSC::JSArrayBuffer*>(value); jsArrayBuffer && jsArrayBuffer->isResizableOrGrowableShared()) {
+                throwTypeError(&lexicalGlobalObject, scope, "ArrayBuffer cannot be resizable"_s);
+                return ReturnType();
+            }
         }
 
         constexpr bool hasArrayBufferViewType = brigand::any<TypeList, IsIDLArrayBufferView<brigand::_1>>::value;
@@ -241,6 +246,10 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
                 if (hasArrayBufferViewType)
                     return ConditionalReturner<ReturnType, hasArrayBufferViewType>::get(WTF::move(arrayBufferView)).value();
                 RELEASE_AND_RETURN(scope, (ConditionalConverter<ReturnType, ObjectType, hasObjectType>::convert(lexicalGlobalObject, value).value()));
+            }
+            if (auto* jsView = JSC::jsDynamicCast<JSC::JSArrayBufferView*>(value); jsView && jsView->isResizableOrGrowableShared()) {
+                throwTypeError(&lexicalGlobalObject, scope, "ArrayBufferView cannot be resizable"_s);
+                return ReturnType();
             }
         }
 

--- a/src/bun.js/bindings/webcore/JSDOMPromise.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMPromise.cpp
@@ -49,7 +49,8 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSOb
     auto& vm = lexicalGlobalObject.vm();
     JSLockHolder lock(vm);
     auto* handler = JSC::JSNativeStdFunction::create(vm, globalObject, 1, String {}, [callback = WTF::move(callback)](JSGlobalObject*, CallFrame*) mutable {
-        callback();
+        // Exchange callback so captured variables are deallocated immediately rather than waiting for GC of the handler.
+        std::exchange(callback, {})();
         return JSC::JSValue::encode(JSC::jsUndefined());
     });
 

--- a/src/bun.js/bindings/webcore/JSDOMPromiseDeferred.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMPromiseDeferred.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/JSONObject.h>
 #include <JavaScriptCore/JSPromiseConstructor.h>
 #include <JavaScriptCore/Strong.h>
+#include <wtf/Scope.h>
 #include "ErrorCode.h"
 #include "JavaScriptCore/ErrorInstance.h"
 
@@ -72,9 +73,12 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
     //     return;
     // }
 
-    // FIXME: We could have error since any JS call can throw stack-overflow errors.
-    // https://bugs.webkit.org/show_bug.cgi?id=203402
     auto& vm = lexicalGlobalObject.vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto handleExceptionOnExit = makeScopeExit([&] {
+        if (scope.exception()) [[unlikely]]
+            handleUncaughtException(scope, *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject));
+    });
     switch (mode) {
     case ResolveMode::Resolve:
         deferred()->resolve(&lexicalGlobalObject, vm, resolution);
@@ -229,6 +233,9 @@ void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject& lexicalGlobalObject, J
     if (!topExceptionScope.exception()) [[likely]]
         return;
 
+    if (globalObject.vm().hasPendingTerminationException())
+        return;
+
     JSValue error = topExceptionScope.exception()->value();
     (void)topExceptionScope.tryClearException();
 
@@ -265,6 +272,7 @@ void fulfillPromiseWithJSON(Ref<DeferredPromise>&& promise, const String& data)
 void fulfillPromiseWithArrayBuffer(Ref<DeferredPromise>&& promise, ArrayBuffer* arrayBuffer)
 {
     if (!arrayBuffer) {
+        JSC::JSLockHolder lock(promise->globalObject());
         promise->reject<IDLAny>(createOutOfMemoryError(promise->globalObject()));
         return;
     }

--- a/src/bun.js/bindings/webcore/JSEventListener.cpp
+++ b/src/bun.js/bindings/webcore/JSEventListener.cpp
@@ -32,6 +32,7 @@
 // #include "JSDocument.h"
 #include "JSEvent.h"
 #include "JSEventTarget.h"
+#include "WebCoreJSClientData.h"
 // #include "JSExecState.h"
 // #include "JSExecStateInstrumentation.h"
 // #include "JSWorkerGlobalScope.h"
@@ -202,7 +203,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         if (m_isAttribute)
             return;
 
-        handleEventFunction = jsFunction->get(lexicalGlobalObject, Identifier::fromString(vm, "handleEvent"_s));
+        handleEventFunction = jsFunction->get(lexicalGlobalObject, WebCore::builtinNames(vm).handleEventPublicName());
         if (scope.exception()) [[unlikely]] {
             auto* exception = scope.exception();
             (void)scope.tryClearException();
@@ -226,7 +227,14 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
 
     // JSExecState::instrumentFunction(&scriptExecutionContext, callData);
 
-    JSValue thisValue = handleEventFunction == jsFunction ? toJS(lexicalGlobalObject, globalObject, event.currentTarget()) : jsFunction;
+    JSValue thisValue = [&]() -> JSValue {
+        if (handleEventFunction != jsFunction)
+            return jsFunction;
+        RefPtr currentTarget = event.currentTarget();
+        if (!currentTarget)
+            return jsNull();
+        return toJS(lexicalGlobalObject, globalObject, *currentTarget);
+    }();
     NakedPtr<JSC::Exception> uncaughtException;
     JSValue retval = JSC::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Other, handleEventFunction, callData, thisValue, args, uncaughtException);
 
@@ -314,7 +322,7 @@ String JSEventListener::functionName() const
     if (!m_wrapper || !m_jsFunction)
         return {};
 
-    auto& vm = isolatedWorld().vm();
+    auto& vm = m_isolatedWorld->vm();
     JSC::JSLockHolder lock(vm);
 
     auto* handlerFunction = JSC::jsDynamicCast<JSC::JSFunction*>(m_jsFunction.get());

--- a/src/bun.js/bindings/webcore/JSEventTargetCustom.cpp
+++ b/src/bun.js/bindings/webcore/JSEventTargetCustom.cpp
@@ -63,27 +63,23 @@ EventTarget* JSEventTarget::toWrapped(VM& vm, JSValue value)
     return nullptr;
 }
 
-std::unique_ptr<JSEventTargetWrapper> jsEventTargetCast(VM& vm, JSValue thisValue)
+JSEventTargetWrapper jsEventTargetCast(VM& vm, JSValue thisValue)
 {
     if (auto* target = jsDynamicCast<JSEventTarget*>(thisValue))
-        return makeUnique<JSEventTargetWrapper>(target->wrapped(), *target);
+        return { target->wrapped(), *target };
     if (!thisValue.isObject())
-        return nullptr;
+        return {};
 
     JSObject* object = thisValue.getObject();
     if (object->type() == GlobalProxyType) {
         object = jsCast<JSGlobalProxy*>(object)->target();
         if (!object)
-            return nullptr;
+            return {};
     }
     if (auto* global = jsDynamicCast<Zig::GlobalObject*>(object))
-        return makeUnique<JSEventTargetWrapper>(global->eventTarget(), *global);
+        return { global->eventTarget(), *global };
 
-    // if (auto* window = toJSDOMGlobalObject<JSDOMGlobalObject>(vm, thisValue))
-    //     return makeUnique<JSEventTargetWrapper>(*window, *window);
-    // if (auto* scope = toJSDOMGlobalObject<JSWorkerGlobalScope>(vm, thisValue))
-    //     return makeUnique<JSEventTargetWrapper>(scope->wrapped(), *scope);
-    return nullptr;
+    return {};
 }
 
 template<typename Visitor>

--- a/src/bun.js/bindings/webcore/JSEventTargetCustom.h
+++ b/src/bun.js/bindings/webcore/JSEventTargetCustom.h
@@ -42,9 +42,17 @@ public:
     }
 
     bool isNull() const { return !m_wrapped; }
-    EventTarget& wrapped() { ASSERT(m_wrapped); return *m_wrapped; }
+    EventTarget& wrapped()
+    {
+        ASSERT(m_wrapped);
+        return *m_wrapped;
+    }
 
-    operator JSC::JSObject&() { ASSERT(m_wrapper); return *m_wrapper; }
+    operator JSC::JSObject&()
+    {
+        ASSERT(m_wrapper);
+        return *m_wrapper;
+    }
 
 private:
     EventTarget* m_wrapped { nullptr };

--- a/src/bun.js/bindings/webcore/JSEventTargetCustom.h
+++ b/src/bun.js/bindings/webcore/JSEventTargetCustom.h
@@ -32,25 +32,26 @@ namespace WebCore {
 
 // Wrapper type for JSEventTarget's castedThis because JSDOMWindow and JSWorkerGlobalScope do not inherit JSEventTarget.
 class JSEventTargetWrapper {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSEventTargetWrapper);
-
 public:
+    JSEventTargetWrapper() = default;
+
     JSEventTargetWrapper(EventTarget& wrapped, JSC::JSObject& wrapper)
-        : m_wrapped(wrapped)
-        , m_wrapper(wrapper)
+        : m_wrapped(&wrapped)
+        , m_wrapper(&wrapper)
     {
     }
 
-    EventTarget& wrapped() { return m_wrapped; }
+    bool isNull() const { return !m_wrapped; }
+    EventTarget& wrapped() { ASSERT(m_wrapped); return *m_wrapped; }
 
-    operator JSC::JSObject&() { return m_wrapper; }
+    operator JSC::JSObject&() { ASSERT(m_wrapper); return *m_wrapper; }
 
 private:
-    EventTarget& m_wrapped;
-    JSC::JSObject& m_wrapper;
+    EventTarget* m_wrapped { nullptr };
+    JSC::JSObject* m_wrapper { nullptr };
 };
 
-std::unique_ptr<JSEventTargetWrapper> jsEventTargetCast(JSC::VM&, JSC::JSValue thisValue);
+JSEventTargetWrapper jsEventTargetCast(JSC::VM&, JSC::JSValue thisValue);
 
 template<> class IDLOperation<JSEventTarget> {
 public:
@@ -64,12 +65,13 @@ public:
         auto throwScope = DECLARE_THROW_SCOPE(vm);
 
         auto thisValue = callFrame.thisValue().toThis(&lexicalGlobalObject, JSC::ECMAMode::strict());
-        auto thisObject = jsEventTargetCast(vm, thisValue.isUndefinedOrNull() ? &lexicalGlobalObject : thisValue);
-        if (!thisObject) [[unlikely]] {
+        auto thisObject = jsEventTargetCast(vm, thisValue.isUndefinedOrNull() ? JSC::JSValue(&lexicalGlobalObject) : thisValue);
+        if (thisObject.isNull()) [[unlikely]]
             return throwThisTypeError(lexicalGlobalObject, throwScope, "EventTarget", operationName);
-        }
 
-        RELEASE_AND_RETURN(throwScope, (operation(&lexicalGlobalObject, &callFrame, thisObject.get())));
+        // Note: WebKit Ref-protects thisObject.wrapped() here, but Bun's req.signal lifecycle
+        // depends on exact ref-counting; the JS cell already keeps wrapped alive via JSDOMWrapper.
+        RELEASE_AND_RETURN(throwScope, (operation(&lexicalGlobalObject, &callFrame, &thisObject)));
     }
 };
 

--- a/src/bun.js/bindings/webcore/MessageEvent.cpp
+++ b/src/bun.js/bindings/webcore/MessageEvent.cpp
@@ -42,10 +42,13 @@ using namespace JSC;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MessageEvent);
 
-MessageEvent::MessageEvent() = default;
+MessageEvent::MessageEvent()
+    : Event(MessageEventInterfaceType)
+{
+}
 
 inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
+    : Event(MessageEventInterfaceType, type, initializer, isTrusted)
     , m_data(JSValueTag {})
     , m_origin(initializer.origin)
     , m_lastEventId(initializer.lastEventId)
@@ -56,7 +59,7 @@ inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, Is
 }
 
 inline MessageEvent::MessageEvent(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
-    : Event(type, CanBubble::No, IsCancelable::No)
+    : Event(MessageEventInterfaceType, type, CanBubble::No, IsCancelable::No)
     , m_data(WTF::move(data))
     , m_origin(origin)
     , m_lastEventId(lastEventId)
@@ -136,11 +139,6 @@ void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool
     m_source = WTF::move(source);
     m_ports = WTF::move(ports);
     m_cachedPorts.clear();
-}
-
-EventInterface MessageEvent::eventInterface() const
-{
-    return MessageEventInterfaceType;
 }
 
 size_t MessageEvent::memoryCost() const

--- a/src/bun.js/bindings/webcore/MessageEvent.h
+++ b/src/bun.js/bindings/webcore/MessageEvent.h
@@ -93,8 +93,6 @@ private:
     MessageEvent(const AtomString& type, Init&&, IsTrusted);
     MessageEvent(const AtomString& type, DataType&&, const String& origin, const String& lastEventId = {}, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
 
-    EventInterface eventInterface() const final;
-
     DataType m_data;
     String m_origin;
     String m_lastEventId;

--- a/src/bun.js/bindings/webcore/MessagePort.h
+++ b/src/bun.js/bindings/webcore/MessagePort.h
@@ -126,12 +126,6 @@ private:
     void contextDestroyed() final;
     // bool virtualHasPendingActivity() const final;
 
-    EventTargetData* eventTargetData() final { return &m_eventTargetData; }
-    EventTargetData* eventTargetDataConcurrently() final { return &m_eventTargetData; }
-    EventTargetData& ensureEventTargetData() final { return m_eventTargetData; }
-
-    EventTargetData m_eventTargetData;
-
     // A port starts out its life entangled, and remains entangled until it is detached or is cloned.
     bool isEntangled() const { return !m_isDetached && m_entangled; }
 

--- a/src/bun.js/bindings/webcore/Performance.h
+++ b/src/bun.js/bindings/webcore/Performance.h
@@ -175,12 +175,6 @@ private:
     std::unique_ptr<PerformanceUserTiming> m_userTiming;
 
     ListHashSet<RefPtr<PerformanceObserver>> m_observers;
-
-    EventTargetData* eventTargetData() final { return &m_eventTargetData; }
-    EventTargetData* eventTargetDataConcurrently() final { return &m_eventTargetData; }
-    EventTargetData& ensureEventTargetData() final { return m_eventTargetData; }
-
-    EventTargetData m_eventTargetData;
 };
 
 }


### PR DESCRIPTION
## What does this PR do?

Cherry-picks correctness, safety, and perf fixes from upstream WebKit into Bun's forked WebCore bindings layer, plus devirtualizes `Event::eventInterface()` and `EventTarget`'s data accessors. ~270 upstream commits were audited; this PR takes the ones that are real bug fixes or free wins and skips the browser-only / annotation churn.

### Memory safety
- **`DOMPromiseProxy`** — two reentrancy hazards: `resolvePromise()` now appends the deferred promise *before* resolving (resolution JS can drop the owner), and `resolve()/reject()` copy the vector + value to locals before iterating (a reaction can mutate `m_deferredPromises` mid-loop). Upstream `5c1f6cca03b8`, `4ac005fe82bb`.
- **`DeferredPromise::callFunction`** — wraps resolve/reject in a `makeScopeExit` that reports any thrown exception (stack overflow, hostile `then`). Upstream `1457c8d75c8f`.
- **`rejectPromiseWithExceptionIfAny`** — early-returns on pending termination exception instead of clearing it and rejecting into a dying Worker.
- **`fulfillPromiseWithArrayBuffer`** — takes `JSLockHolder` before `createOutOfMemoryError`. Upstream `44bd2b25e9d3`.
- **`DOMPromise::whenPromiseIsSettled`** — `std::exchange(callback, {})()` so the captured `Function` deallocates immediately rather than at handler GC. Upstream `397f9236f48e`.
- **`JSDOMConvertRecord`** — `createDataProperty` instead of `putDirect`, which crashes on numeric-index string keys. Upstream `d78f8ae748e3`.
- **`JSDOMConvertUnion`** — resizable/growable-shared `ArrayBuffer`/`View` passed to a `(BufferSource or …)` union now throws `TypeError` instead of silently falling through to the next member. Hits webcrypto params and `ReadableStreamSink`. Upstream `76a1e3d281ca`.

### Spec compliance
- `innerInvokeEventListeners` resets the `inPassiveListener` flag after each listener so a non-passive listener following a passive one can `preventDefault()` again.
- `JSEventListener::handleEvent` uses `jsNull()` for `this` when `currentTarget` is null, and `Ref`-protects `currentTarget` across `toJS`.
- `[Clamp]` integer conversion rounds half-to-even per WebIDL §3.2.4.9. Upstream `b3ec744f8a4b`.
- `ExceptionCode::SyntaxError` produces a `DOMException` named `"SyntaxError"` rather than a JS `SyntaxError`.

### Perf / devirtualization
- **`jsEventTargetCast` returns by value** — was `makeUnique<JSEventTargetWrapper>` heap-allocating on every `addEventListener`/`removeEventListener`/`dispatchEvent`.
- **`Event::eventInterface()`** — packed `m_eventInterface : 7` bitfield instead of a virtual; subclasses pass the enum to the base ctor. Removes 15 `is*Event()` virtuals; `SPECIALIZE_TYPE_TRAITS_EVENT` compares the enum directly.
- **`EventTarget` data accessors** — `eventTargetData()`/`eventTargetDataConcurrently()`/`ensureEventTargetData()` are now non-virtual inlines reading through the `WeakPtrImpl`, gated by an `EventTargetFlag` bitfield. `EventTargetWithInlineData` is now an alias of `EventTarget`. Listener storage is lazy: targets with zero listeners no longer carry an `EventListenerMap`. Also fixes `WeakPtrImplWithEventTargetData::m_eventTargetData` being dead storage — every `WeakPtr<EventTarget>` was previously allocating a duplicate unused `EventTargetData`.
- **`getCachedWrapper`** — `getInlineCachedWrapper` returns `std::optional<JSDOMObject*>` so the `world.wrappers()` HashMap lookup is skipped when the inline `ScriptWrappable` slot is authoritative (always, in the normal world). Upstream `de25b66294c4`.
- `JSEventListener::handleEvent` uses cached `builtinNames(vm).handleEventPublicName()`.

### Infrastructure / dead code
- Adds `JSVMClientDataClient` interface and a `WeakHashSet<JSVMClientDataClient>` on `JSVMClientData`; `~JSVMClientData` notifies clients via `willDestroyVM()` before tearing down the world.
- Adds `ConversionResult<IDL>` infrastructure (opt-in via `convertResult<IDL>()`) and `ConversionResultType` typedefs on `IDLType`. Existing `convert<>()` call sites unchanged.
- Deletes the broken `setAttributeEventListener(AtomString, RefPtr<EventListener>&&, DOMWrapperWorld&)` overload (markup-only, unreachable code, no callers).
- Deletes dead `callerGlobalObject`/`legacyActiveGlobalObjectForAccessor` declarations and redundant `eventTargetData()` overrides + `m_eventTargetData` members from `MessagePort`/`BroadcastChannel`/`Performance`/`EventTargetConcrete`.

## Intentionally not taken

- `IDLOperation<JSEventTarget>` `Ref wrapped` protection — Bun has no DOM tree, so `JSDOMWrapper` always owns; comment left at the site.
- `VMEntryScope` before listener invocation — symbol not exported in the prebuilt JSC.
- `ExceptionOr::m_wasReleased` debug assert — wiring it up immediately fired on a pre-existing double-release in the request path. Tracking separately.
- `JSValueInWrappedObject(JSValue)` ctor removal — has live callers; needs per-caller migration.
- Full `ConversionResult<>` call-site migration — 181 of 354 sites hit C++'s two-step UDC ban or use downstream method calls; behavior is identical to the existing `RETURN_IF_EXCEPTION` pattern.

## How did you verify your code works?

```
bun bd test test/js/web/abort/ test/js/deno/event/ test/js/deno/abort/ \
  test/js/node/events/event-emitter.test.ts test/js/node/util/test-aborted.test.ts \
  test/js/web/workers/ test/js/web/fetch/blob.test.ts test/js/web/broadcastchannel/ \
  test/js/web/crypto/ test/js/web/websocket/error-event.test.ts
# 366 pass, 0 fail, 3 skip, 1 todo
```

Adversarial: passive→non-passive `preventDefault()` works; resizable `ArrayBuffer` as PBKDF2 salt throws `TypeError`; `{handleEvent}` object listeners dispatch; `MessageEvent`/`CustomEvent`/`ErrorEvent`/`CloseEvent` all dispatch with correct `constructor.name` after the bitfield packing; `controller.signal` returns the same wrapper 100/100 after the `getCachedWrapper` short-circuit; lazy `eventTargetData()` handles dispatch-with-no-listeners, late add, remove, and idempotent add; server-side `req.signal` abort listener fires via the new `WeakPtrImpl` storage.