### PR TITLE
ci: kill in-flight test subprocesses on runner SIGINT/SIGTERM

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -2360,8 +2360,12 @@ function onExit(signal) {
   startGroup(label, () => {
     for (const proc of activeSubprocesses) {
       try {
+        // Windows: detached+unref so taskkill outlives our process.exit()
+        // below — CreateProcess is synchronous inside spawn(), so the child
+        // exists before this returns. Avoids serializing N×timeout under
+        // --parallel like spawnSync would.
         if (isWindows)
-          spawnSync("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore", timeout: 5000 });
+          spawn("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore", detached: true }).unref();
         else proc.kill(9);
       } catch {}
     }

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -2360,7 +2360,8 @@ function onExit(signal) {
   startGroup(label, () => {
     for (const proc of activeSubprocesses) {
       try {
-        if (isWindows) spawnSync("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore" });
+        if (isWindows)
+          spawnSync("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore", timeout: 5000 });
         else proc.kill(9);
       } catch {}
     }

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -2358,16 +2358,17 @@ function isAlwaysFailure(error) {
 function onExit(signal) {
   const label = `${getAnsi("red")}Received ${signal}, exiting...${getAnsi("reset")}`;
   startGroup(label, () => {
-    for (const proc of activeSubprocesses) {
-      try {
-        // Windows: detached+unref so taskkill outlives our process.exit()
-        // below — CreateProcess is synchronous inside spawn(), so the child
-        // exists before this returns. Avoids serializing N×timeout under
-        // --parallel like spawnSync would.
-        if (isWindows)
-          spawn("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore", detached: true }).unref();
-        else proc.kill(9);
-      } catch {}
+    // Windows: children spawned without `detached` are assigned to this
+    // process's Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, so
+    // process.exit() below already terminates the whole tree — nothing to
+    // do here. POSIX: Buildkite cancel sends SIGTERM to the runner PID only
+    // (not the group), so orphans survive unless we kill them explicitly.
+    if (!isWindows) {
+      for (const proc of activeSubprocesses) {
+        try {
+          proc.kill(9);
+        } catch {}
+      }
     }
     process.exit(getExitCode("cancel"));
   });

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -218,6 +218,12 @@ if (isBuildkite) {
 
 let coresDir;
 
+// Declared before the first top-level `await spawnSafe(...)` below — spawnSafe
+// is a hoisted function declaration that references this; with the const lower
+// in the file the Linux-only coredump sysctl call hit the TDZ.
+/** @type {Set<import("node:child_process").ChildProcess>} */
+const activeSubprocesses = new Set();
+
 if (options["coredump-upload"]) {
   // this sysctl is set in bootstrap.sh to /var/bun-cores-$distro-$release-$arch
   const sysctl = await spawnSafe({ command: "sysctl", args: ["-n", "kernel.core_pattern"] });
@@ -945,6 +951,7 @@ async function spawnSafe(options) {
         subprocess.kill(9);
       }
     }
+    activeSubprocesses.delete(subprocess);
     resolve();
   };
   await new Promise(resolve => {
@@ -975,6 +982,7 @@ async function spawnSafe(options) {
         env,
       });
       subprocess.on("spawn", () => {
+        activeSubprocesses.add(subprocess);
         timestamp = Date.now();
         timer = setTimeout(() => done(resolve), timeout);
       });
@@ -2350,6 +2358,12 @@ function isAlwaysFailure(error) {
 function onExit(signal) {
   const label = `${getAnsi("red")}Received ${signal}, exiting...${getAnsi("reset")}`;
   startGroup(label, () => {
+    for (const proc of activeSubprocesses) {
+      try {
+        if (isWindows) spawnSync("taskkill", ["/pid", String(proc.pid), "/T", "/F"], { stdio: "ignore" });
+        else proc.kill(9);
+      } catch {}
+    }
     process.exit(getExitCode("cancel"));
   });
 }


### PR DESCRIPTION
## Summary

Track `spawnSafe`'s in-flight subprocesses in a module-level `Set`, and on SIGINT/SIGTERM/SIGHUP kill them (`taskkill /T` on Windows, `proc.kill(9)` on POSIX) before exiting. Currently `onExit()` just calls `process.exit()` without killing anything, so a Buildkite job-cancel (or local Ctrl+C) orphans the running test process.

This is the conservative subset of the original process-group-kill attempt — no spawn-option changes (no `detached`, no `kill(-pid)`), so it won't reap POSIX grandchildren on the timeout path. The full process-group story can follow separately once verified on Linux CI.

The `activeSubprocesses` Set is declared above the first top-level `await spawnSafe(...)` (the Linux-only `--coredump-upload` sysctl probe at ~line 223). `spawnSafe` is a hoisted function declaration; with the const next to `spawnSafe` lower in the file, Linux CI hit `ReferenceError: Cannot access 'activeSubprocesses' before initialization` before any tests ran.

Part 3 of the macOS-CI Phase 0 stack (depends on #29315 → #29314), though this change is platform-agnostic.

## Test plan

- [x] `node --check scripts/runner.node.mjs`
- [x] Local smoke: `node scripts/runner.node.mjs --exec-path=$(which bun) --include="which.test"` runs and passes
- [x] `--coredump-upload` path reaches the sysctl call (no TDZ)
- [ ] Buildkite: Linux test-bun lanes run for real (~5min, not 10s)