### PR TITLE
Fix path.win32.resolve panic with UNC path before drive-relative path

### DIFF
--- a/src/bun.js/node/path.zig
+++ b/src/bun.js/node/path.zig
@@ -2477,7 +2477,8 @@ pub fn resolveWindowsT(comptime T: type, paths: []const []const T, buf: []T, buf
                     if (T == u16) {
                         break :brk buf2[0..bufSize];
                     } else {
-                        bufSize = std.unicode.wtf16LeToWtf8(buf2[0..bufSize], &u16Buf);
+                        bufSize = std.unicode.wtf8ToWtf16Le(&u16Buf, buf2[0..bufSize]) catch unreachable;
+                        u16Buf[bufSize] = 0;
                         break :brk u16Buf[0..bufSize :0];
                     }
                 };
@@ -2585,6 +2586,14 @@ pub fn resolveWindowsT(comptime T: type, paths: []const []const T, buf: []T, buf
                         }
                         if (j == len or j != last) {
                             // We matched a UNC root
+
+                            if (resolvedDeviceLen > 0) {
+                                // resolvedDevice is already set to a drive
+                                // letter (`X:`). A UNC device can never match
+                                // it, and building the UNC string below would
+                                // overwrite tmpBuf which backs resolvedDevice.
+                                continue;
+                            }
 
                             // Translated from the following JS code:
                             //   device =

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -94,6 +94,16 @@ describe("path.resolve", () => {
     // }
   });
 
+  test.skipIf(!isWindows)("UNC path before drive-relative path does not corrupt resolvedDevice", () => {
+    // Parsing the UNC root reused the buffer backing the already-resolved `C:`
+    // device, which sent the i=-1 iteration down a broken slow path that read
+    // uninitialized memory and panicked. The UNC arg is on a different device
+    // so it should be ignored entirely.
+    expect(path.win32.resolve("//server/share", "C:relative")).toBe(path.win32.resolve("C:relative"));
+    expect(path.win32.resolve("//server/share", "C:")).toBe(path.win32.resolve("C:"));
+    expect(path.win32.resolve("//a/b", "//c/d", "C:foo")).toBe(path.win32.resolve("C:foo"));
+  });
+
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {
     expect(() => {
       return path.posix.resolve(undefined, "hi");


### PR DESCRIPTION
On Windows, `path.win32.resolve('//server/share', 'C:relative')` panicked with "reached unreachable code" inside `std.unicode.utf8EncodeImpl`.

Two issues in `resolveWindowsT`:

1. When a UNC path is parsed after `resolvedDevice` is already set to a drive letter, building the UNC device string into `tmpBuf` overwrote the bytes backing `resolvedDevice`, corrupting `C:` → `\\\\`. The `i=-1` iteration then took the slow path for building the `=${resolvedDevice}` env var key.

2. That slow path called `wtf16LeToWtf8(buf2[0..n], &u16Buf)` instead of `wtf8ToWtf16Le(&u16Buf, buf2[0..n])` — wrong direction, reading the entire uninitialized `u16Buf` into a tiny destination and tripping an assert. The original code used `utf8ToUtf16Le`.

Fix (1) by continuing early when `resolvedDeviceLen > 0` — a UNC device can never match a 2-char drive letter, so the comparison would have continued anyway (matches Node's semantics, which compares then continues; we just skip the buffer write). Fix (2) by restoring the correct conversion direction and adding the missing null terminator.


Fixes #22001
