### PR TITLE
yaml: fix assertion failure when flow mapping errors inside block mapping

### DIFF
--- a/src/interchange/yaml.zig
+++ b/src/interchange/yaml.zig
@@ -784,15 +784,20 @@ pub fn Parser(comptime enc: Encoding) type {
 
             {
                 try self.context.set(.flow_in);
+                defer self.context.unset(.flow_in);
 
-                try self.context.set(.flow_key);
-                try self.scan(.{});
-                self.context.unset(.flow_key);
+                {
+                    try self.context.set(.flow_key);
+                    defer self.context.unset(.flow_key);
+                    try self.scan(.{});
+                }
 
                 while (self.token.data != .mapping_end) {
-                    try self.context.set(.flow_key);
-                    const key = try self.parseNode(.{});
-                    self.context.unset(.flow_key);
+                    const key = key: {
+                        try self.context.set(.flow_key);
+                        defer self.context.unset(.flow_key);
+                        break :key try self.parseNode(.{});
+                    };
 
                     switch (self.token.data) {
                         .collect_entry => {
@@ -803,8 +808,8 @@ pub fn Parser(comptime enc: Encoding) type {
                             });
 
                             try self.context.set(.flow_key);
+                            defer self.context.unset(.flow_key);
                             try self.scan(.{});
-                            self.context.unset(.flow_key);
                             continue;
                         },
                         .mapping_end => {
@@ -838,12 +843,10 @@ pub fn Parser(comptime enc: Encoding) type {
 
                     if (self.token.data == .collect_entry) {
                         try self.context.set(.flow_key);
+                        defer self.context.unset(.flow_key);
                         try self.scan(.{});
-                        self.context.unset(.flow_key);
                     }
                 }
-
-                self.context.unset(.flow_in);
             }
 
             try self.scan(.{});

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -622,6 +622,14 @@ null_value: null
       expect(() => YAML.parse(":\n :  - invalid")).toThrow(SyntaxError);
     });
 
+    test("throws on invalid flow mapping inside block mapping (no assertion failure)", () => {
+      expect(() => YAML.parse("a: 1\nb: {c]}")).toThrow(SyntaxError);
+      expect(() => YAML.parse("a: 1\nb: {c: [}")).toThrow(SyntaxError);
+      expect(() => YAML.parse("a: 1\nb: { @bad }")).toThrow(SyntaxError);
+      expect(() => YAML.parse("a: 1\nb: {x: {y: ]}}")).toThrow(SyntaxError);
+      expect(() => YAML.parse("first: ok\nsecond: {key: [unclosed}")).toThrow(SyntaxError);
+    });
+
     test("handles dates and timestamps", () => {
       const yaml = `
 date: 2024-01-15


### PR DESCRIPTION
## What does this PR do?

Fixes an internal assertion failure (`yaml.zig:76: unset`) when a syntax error inside a flow mapping occurs while parsing a block mapping value.

### Root cause

`parseFlowMapping` pushed `.flow_in` / `.flow_key` onto the parser context stack with explicit `unset` calls instead of `defer`. When any `try` between the push and pop failed (e.g. `unexpectedToken()` on input like `{c]}`), those contexts leaked on the stack.

If this happened from inside `parseBlockMapping` — which *does* `defer self.context.unset(.block_in)` — the outer defer fired during error unwinding, popped `.flow_in`/`.flow_key` instead of `.block_in`, and tripped the assertion.

`parseFlowSequence` already used `defer` for its `.flow_in` push; this brings `parseFlowMapping` in line.

### Repro

```js
Bun.YAML.parse("a: 1\nb: {c]}");
```

Debug build before: `panic: reached unreachable code` (assertion at `Context.Stack.unset`).
After: throws `SyntaxError` as expected.

## How did you verify your code works?

- Confirmed unfixed debug build panics on the repro inputs; fixed build throws `SyntaxError`.
- `bun bd test test/js/bun/yaml/yaml.test.ts` — 196 pass, 0 fail
- `bun bd test test/js/bun/yaml/yaml-test-suite.test.ts` — 362 pass, 0 fail
- Added regression test covering 5 variants of malformed flow mappings nested in block mappings.