### PR TITLE
napi: run wrap finalizers in LIFO order during env teardown

### DIFF
--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -17,6 +17,8 @@
 #include "wtf/Assertions.h"
 #include "napi_macros.h"
 
+#include <wtf/ListHashSet.h>
+
 #include <optional>
 #include <unordered_set>
 #include <variant>
@@ -201,9 +203,12 @@ public:
         JSC::DeferGCForAWhile deferGC(m_vm);
 
         m_isFinishingFinalizers = true;
-        for (const BoundFinalizer& boundFinalizer : m_finalizers) {
+        // Reverse insertion order so children are torn down before parents (Node.js LIFO).
+        // ListHashSet iteration is safe against concurrent inserts, and m_isFinishingFinalizers
+        // routes all removals to active=false, so the only unsafe op (erase-current) can't occur.
+        for (auto it = m_finalizers.rbegin(); it != m_finalizers.rend(); ++it) {
             Bun::NapiHandleScope handle_scope(m_globalObject);
-            boundFinalizer.call(this);
+            it->call(this);
         }
         m_finalizers.clear();
         m_isFinishingFinalizers = false;
@@ -214,24 +219,24 @@ public:
 
     void removeFinalizer(napi_finalize callback, void* hint, void* data)
     {
-        m_finalizers.erase({ callback, hint, data });
+        m_finalizers.remove({ callback, hint, data });
     }
 
     struct BoundFinalizer;
 
     void removeFinalizer(const BoundFinalizer& finalizer)
     {
-        m_finalizers.erase(finalizer);
+        m_finalizers.remove(finalizer);
     }
 
     const auto& addFinalizer(napi_finalize callback, void* hint, void* data)
     {
-        return *m_finalizers.emplace(callback, hint, data).first;
+        return *m_finalizers.add({ callback, hint, data }).iterator;
     }
 
     bool hasFinalizers() const
     {
-        return !m_finalizers.empty();
+        return !m_finalizers.isEmpty();
     }
 
     /// Will abort the process if a duplicate entry would be added.
@@ -458,20 +463,24 @@ public:
         }
 
         struct Hash {
-            std::size_t operator()(const NapiEnv::BoundFinalizer& bound) const
+            static unsigned hash(const BoundFinalizer& bound)
             {
-                constexpr std::hash<void*> hasher;
-                constexpr std::ptrdiff_t magic = 0x9e3779b9;
-                return (hasher(reinterpret_cast<void*>(bound.callback)) + magic) ^ (hasher(bound.hint) + magic) ^ (hasher(bound.data) + magic);
+                return WTF::computeHash(reinterpret_cast<uintptr_t>(bound.callback), reinterpret_cast<uintptr_t>(bound.hint), reinterpret_cast<uintptr_t>(bound.data));
             }
+            static bool equal(const BoundFinalizer& a, const BoundFinalizer& b)
+            {
+                return a == b;
+            }
+            static constexpr bool safeToCompareToEmptyOrDeleted = false;
         };
     };
 
 private:
     Zig::GlobalObject* m_globalObject = nullptr;
     napi_module m_napiModule;
-    // TODO(@heimskr): Use WTF::HashSet
-    std::unordered_set<BoundFinalizer, BoundFinalizer::Hash> m_finalizers;
+    // ListHashSet preserves insertion order so cleanup() can run finalizers in reverse
+    // (LIFO), matching Node.js teardown semantics for napi_wrap references.
+    WTF::ListHashSet<BoundFinalizer, BoundFinalizer::Hash> m_finalizers;
     bool m_isFinishingFinalizers = false;
     JSC::VM& m_vm;
     Napi::HookSet m_cleanupHooks;

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -232,5 +232,16 @@
                 "NAPI_VERSION_EXPERIMENTAL=1",
             ],
         },
+        {
+            "target_name": "test_wrap_cleanup_order",
+            "sources": ["test_wrap_cleanup_order.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/test_wrap_cleanup_order.c
+++ b/test/napi/napi-app/test_wrap_cleanup_order.c
@@ -1,0 +1,86 @@
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Verifies napi_wrap finalizers run in reverse insertion order (LIFO) during env teardown.
+// Native modules like sqlite3/duckdb wrap a parent (Database) before children (Statement)
+// and the child destructor dereferences the parent; arbitrary order is a use-after-free.
+
+static int finalize_log[256];
+static int finalize_log_len = 0;
+static int parent_alive = 0;
+
+static void print_order(void) {
+    printf("finalize order:");
+    for (int i = 0; i < finalize_log_len; i++) {
+        printf(" %d", finalize_log[i]);
+    }
+    printf("\n");
+    fflush(stdout);
+}
+
+static void parent_finalize(napi_env env, void* data, void* hint) {
+    (void)env;
+    (void)hint;
+    finalize_log[finalize_log_len++] = *(int*)data;
+    parent_alive = 0;
+    free(data);
+    print_order();
+}
+
+static void child_finalize(napi_env env, void* data, void* hint) {
+    (void)env;
+    (void)hint;
+    if (!parent_alive) {
+        finalize_log[finalize_log_len++] = *(int*)data;
+        print_order();
+        fprintf(stderr, "FAIL: child %d finalizer ran after parent was destroyed\n", *(int*)data);
+        fflush(stderr);
+        abort();
+    }
+    finalize_log[finalize_log_len++] = *(int*)data;
+    free(data);
+}
+
+static napi_value create_parent_and_children(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+
+    int child_count = 32;
+    if (argc >= 1) {
+        napi_get_value_int32(env, args[0], &child_count);
+    }
+
+    napi_value result;
+    napi_create_array(env, &result);
+
+    napi_value parent;
+    napi_create_object(env, &parent);
+    int* parent_id = (int*)malloc(sizeof(int));
+    *parent_id = 0;
+    parent_alive = 1;
+    napi_wrap(env, parent, parent_id, parent_finalize, NULL, NULL);
+    napi_set_element(env, result, 0, parent);
+
+    for (int i = 0; i < child_count; i++) {
+        napi_value child;
+        napi_create_object(env, &child);
+        int* child_id = (int*)malloc(sizeof(int));
+        *child_id = i + 1;
+        napi_wrap(env, child, child_id, child_finalize, NULL, NULL);
+        napi_set_element(env, result, i + 1, child);
+    }
+
+    return result;
+}
+
+static napi_value init(napi_env env, napi_value exports) {
+    napi_property_descriptor properties[] = {
+        { "createParentAndChildren", 0, create_parent_and_children, 0, 0, 0, napi_default, 0 },
+    };
+    napi_define_properties(env, exports, sizeof(properties) / sizeof(properties[0]), properties);
+    return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -617,6 +617,31 @@ describe.concurrent("napi", () => {
     expect(typeof count).toBe("number");
   });
 
+  it("napi_wrap finalizers run in LIFO order during env teardown", async () => {
+    // Mirrors sqlite3/duckdb crash: a child wrapped after its parent must be finalized
+    // first so its destructor can still touch the parent. Bun previously iterated an
+    // unordered_set here, so order was hash-dependent and the child could see a freed parent.
+    const code = `
+      const addon = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/test_wrap_cleanup_order.node"))});
+      globalThis.keep = addon.createParentAndChildren(32);
+    `;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(
+      "finalize order: " +
+        Array.from({ length: 32 }, (_, i) => 32 - i)
+          .concat(0)
+          .join(" "),
+    );
+    expect(exitCode).toBe(0);
+  });
+
   it("napi_reference_unref can be called from finalizers in regular modules", async () => {
     // This test ensures that napi_reference_unref can be called during GC
     // without triggering the NAPI_CHECK_ENV_NOT_IN_GC assertion for regular modules.


### PR DESCRIPTION
## What

`NapiEnv::m_finalizers` was a `std::unordered_set`, so `cleanup()` ran `napi_wrap` finalizers in hash order at process exit. Native modules that wrap a parent object before its children (sqlite3 `Database`→`Statement`, duckdb, kuzu, node-llama-cpp) need the child destroyed first because its destructor still dereferences the parent. Hash order lets the parent go first → child finalizer segfaults on a freed pointer.

Node.js tracks these in an intrusive list and drains head-first (LIFO). This swaps the container for `WTF::ListHashSet` — insertion-ordered, O(1) remove by value, iteration documented safe against concurrent inserts — and walks `rbegin()..rend()`.

## Crash

```
Segmentation fault at address 0x00002A50
napi.h:718  Zig::NapiRef::callFinalizer
napi.cpp:833  wrap_cleanup
napi.h:440  NapiEnv::BoundFinalizer::call
napi.h:206  NapiEnv::cleanup
```

Fixes #22833 (kuzu — exact trace match in comments)

Possibly fixes (same `wrap_cleanup` crash site, no local repro): #22259 (@napi-rs/canvas, Sentry BUN-RD2), #20663 (node-llama-cpp)

Same root cause as already-closed: #24054 (sqlite3), #24959 (duckdb), #22792 (duckdb/win)

## Test

New addon `test_wrap_cleanup_order.c` wraps one parent then 32 children; child finalizer `abort()`s if the parent was already destroyed. Under `USE_SYSTEM_BUN=1` it aborts ("child N finalizer ran after parent was destroyed"); with this change both Bun and Node print `finalize order: 32 31 … 1 0`.