### PR TITLE
WTFTimer: fix "integer part of floating point value out of bounds" panic from JSC GC scheduler

### DIFF
--- a/src/bun.js/api/Timer/WTFTimer.zig
+++ b/src/bun.js/api/Timer/WTFTimer.zig
@@ -36,15 +36,19 @@ inline fn runWithoutRemoving(this: *const WTFTimer) void {
 pub fn update(this: *WTFTimer, seconds: f64, repeat: bool) void {
     // There's only one of these per VM, and each VM has its own imminent_gc_timer
     // Only set imminent if it's not already set to avoid overwriting another timer
-    if (seconds == 0) {
+    if (!(seconds > 0)) {
         _ = this.imminent.cmpxchgStrong(null, this, .seq_cst, .seq_cst);
         return;
-    } else {
-        // Clear imminent if this timer was the one that set it
-        _ = this.imminent.cmpxchgStrong(this, null, .seq_cst, .seq_cst);
     }
+    // Clear imminent if this timer was the one that set it
+    _ = this.imminent.cmpxchgStrong(this, null, .seq_cst, .seq_cst);
 
-    const modf = std.math.modf(seconds);
+    // seconds can be +inf: JSC's GC scheduler divides by gcTimeSlice, which is 0 whenever
+    // bytes*deathRate truncates to 0. Other WTF::RunLoop backends saturate Seconds→int;
+    // do the same so @intFromFloat below can't panic.
+    const clamped = @min(seconds, @as(f64, std.math.maxInt(i32)));
+
+    const modf = std.math.modf(clamped);
     var interval = bun.timespec.now(.force_real_time);
     interval.sec += @intFromFloat(modf.ipart);
     interval.nsec += @intFromFloat(modf.fpart * std.time.ns_per_s);


### PR DESCRIPTION
Fixes a panic on Windows:

```
panic: integer part of floating point value out of bounds
WTFTimer.zig:113   fn WTFTimer__update
RunLoop.h:182      WTF::RunLoop::TimerBase::startOneShot
JSRunLoopTimer.cpp:164  JSC::JSRunLoopTimer::Manager::scheduleTimer
GCActivityCallback.cpp:77  JSC::GCActivityCallback::scheduleTimer
GCActivityCallback.cpp:88  JSC::GCActivityCallback::didAllocate
Heap.cpp:2621      JSC::Heap::didAllocate
...
napi_handle_scope.cpp:34  Bun::NapiHandleScopeImpl::create
```

## Cause

`GCActivityCallback::didAllocate` computes `newDelay = lastGCLength / gcTimeSlice(size_t(bytes*deathRate))`. When `bytes*deathRate < 1` the size_t truncation gives a divisor of 0, yielding `+inf` (or `NaN` when a coarse-clock GC measured `lastGCLength == 0`).

`NaN` poisons `m_delay`, so the early-return guard `if (newDelay * timerSlop > m_delay) return;` stops filtering. Because `doCollection` calls `collectAsync` — which queues the GC and returns before `willCollect` resets `m_delay` — there is a window where `m_delay` is still `NaN` but `Manager::timerDidFire` has already removed the entry. The next `didAllocate` then computes `+inf`, passes the guard, finds `timeUntilFire() == nullopt`, and `setTimeUntilFire(+inf)` reaches `startOneShot(+inf)` → `WTFTimer__update(+inf)` → `@intFromFloat` panic.

UAF is ruled out: `seconds` is a by-value parameter, and `this.imminent.cmpxchgStrong` (which dereferences `this`) succeeds before the panicking line.

## Fix

WTF's own `Seconds`→integer conversions saturate via `clampToAccepting64`; Bun's RunLoop backend was the only one that panicked. Match that contract:

- `!(seconds > 0)` instead of `seconds == 0` so NaN takes the imminent path (same as `std::max(0_s, NaN) = 0`).
- `@min(seconds, maxInt(i32))` saturates `+inf` and out-of-range finites before `@intFromFloat`. JSC's largest intentional delay is `s_decade` (~3.15e8s), so the ~2.1e9s clamp never affects real scheduling.

No regression test: the trigger requires a Windows coarse-clock 0-duration GC followed by a heap-growing GC, which is not constructible from JS.