### PR TITLE
server: fix AbortSignal leak on WebSocket upgrade catch-all path

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2366,6 +2366,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             ctx.request_body = body;
             var signal = jsc.WebCore.AbortSignal.new(this.globalThis);
             ctx.signal = signal;
+            signal.pendingActivityRef();
 
             var request_object = Request.new(Request.init(
                 ctx.method,

--- a/test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts
+++ b/test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// When a WebSocket upgrade request is routed through onWebSocketUpgrade's
+// catch-all path (id == 0), the RequestContext's AbortSignal must be GC-able
+// after the request completes. Previously the catch-all path skipped
+// pendingActivityRef() while finalizeWithoutDeinit unconditionally called
+// pendingActivityUnref(), underflowing the counter and making
+// hasPendingActivity() return true forever — leaking JSAbortSignal.
+test("request.signal from WebSocket upgrade catch-all is collectable after the request completes", async () => {
+  const script = /* js */ `
+    let collected = 0;
+    const registry = new FinalizationRegistry(() => {
+      collected++;
+    });
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        // Access req.signal to materialize the JSAbortSignal wrapper, and add an
+        // abort listener so isReachableFromOpaqueRoots checks hasPendingActivity().
+        req.signal.addEventListener("abort", () => {});
+        registry.register(req.signal, undefined);
+        // Do NOT upgrade — return a plain response so the request finalizes
+        // normally (flags.aborted stays false; the signal is never aborted).
+        return new Response("no upgrade");
+      },
+      websocket: {
+        message() {},
+      },
+    });
+
+    const ITERS = 10;
+    for (let i = 0; i < ITERS; i++) {
+      const { promise, resolve } = Promise.withResolvers();
+      const ws = new WebSocket(server.url.href.replace("http", "ws"));
+      // The handler returns a non-101 response, so the client sees a failed handshake.
+      ws.onerror = resolve;
+      ws.onclose = resolve;
+      await promise;
+    }
+
+    for (let i = 0; i < 10 && collected < ITERS; i++) {
+      Bun.gc(true);
+      await Bun.sleep(5);
+    }
+
+    console.log(JSON.stringify({ collected, iters: ITERS }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { collected, iters } = JSON.parse(stdout.trim());
+  if (isWindows) {
+    // FinalizationRegistry timing is flakier on Windows; require at least half.
+    expect(collected).toBeGreaterThanOrEqual(Math.floor(iters / 2));
+  } else {
+    expect(collected).toBe(iters);
+  }
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts
+++ b/test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
 // When a WebSocket upgrade request is routed through onWebSocketUpgrade's


### PR DESCRIPTION
### What does this PR do?

The catch-all WebSocket upgrade handler in `onWebSocketUpgrade` (`id == 0`, used when `Bun.serve({ fetch, websocket })` has no user routes covering `/*`) creates an `AbortSignal` and stores it in `ctx.signal` **without** calling `signal.pendingActivityRef()`:

https://github.com/oven-sh/bun/blob/9e5cb3d37c/src/bun.js/api/server.zig#L2367-L2368

The regular request path at `prepareJsRequestContext` does call it:

https://github.com/oven-sh/bun/blob/9e5cb3d37c/src/bun.js/api/server.zig#L2265-L2267

Both paths share the same release sites — `RequestContext.finalizeWithoutDeinit` and `RequestContext.onAbort` — which unconditionally call `signal.pendingActivityUnref()` when `ctx.signal` is set. For upgrade-path requests this decrements an `unsigned` counter that was never incremented, underflowing it from `0` to `UINT32_MAX`.

Once underflowed, `AbortSignal::hasPendingActivity()` returns `true` forever. `JSAbortSignalOwner::isReachableFromOpaqueRoots` ([JSAbortSignalCustom.cpp:66](https://github.com/oven-sh/bun/blob/9e5cb3d37c/src/bun.js/bindings/webcore/JSAbortSignalCustom.cpp#L51-L70)) then marks the JS wrapper as reachable whenever an abort listener is attached and the signal hasn't been aborted — which is exactly the state after a normally-completed request where the handler touched `req.signal`. The `JSAbortSignal` wrapper, its `WebCore::AbortSignal`, and the listener closure leak for every such request.

The fix mirrors the regular request path: add the matching `pendingActivityRef()` after `ctx.signal = signal`.

### How did you verify your code works?

New test `test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts` registers each `req.signal` from the upgrade catch-all in a `FinalizationRegistry` and asserts they're collected after the requests complete. On `main` this collects **0/10**; with the fix it collects **10/10**.