### PR TITLE
fetch: guard ResumableSink.cancel() against re-entry after done

### DIFF
--- a/src/bun.js/webcore/ResumableSink.zig
+++ b/src/bun.js/webcore/ResumableSink.zig
@@ -226,6 +226,10 @@ pub fn ResumableSink(
         }
 
         pub fn cancel(this: *ThisSink, reason: jsc.JSValue) void {
+            // onEnd must fire at most once. After the first cancel(), #js_this is downgraded
+            // to .weak (which still resolves via tryGet), so this guard is the only thing
+            // preventing a second cancel() from re-invoking onEnd.
+            if (this.status == .done) return;
             if (this.status == .piped) {
                 reason.ensureStillAlive();
                 this.endPipe(reason);

--- a/test/js/web/fetch/fetch-abort-stream-body-fixture.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body-fixture.ts
@@ -1,0 +1,68 @@
+// Regression: aborting a fetch() whose request body is a JS ReadableStream
+// would call ResumableSink.cancel() twice (once from the abort listener, once
+// from the HTTP failure callback). The second cancel() re-invoked
+// FetchTasklet.writeEndRequest -> over-deref -> use-after-free.
+
+let onServerGotChunk: () => void = () => {};
+
+using server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    const reader = req.body!.getReader();
+    // Read the first chunk so the client knows its request-stream sink is
+    // attached and writing, then stall so the client aborts mid-upload.
+    await reader.read();
+    onServerGotChunk();
+    await reader.read().catch(() => {});
+    return new Response("unreachable");
+  },
+});
+
+const url = server.url.href;
+const ITERATIONS = 50;
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const controller = new AbortController();
+  const { promise: serverGotChunk, resolve } = Promise.withResolvers<void>();
+  onServerGotChunk = resolve;
+
+  const body = new ReadableStream({
+    pull(c) {
+      c.enqueue(new TextEncoder().encode("hello"));
+      // never close — keep the upload pending so abort lands mid-stream
+    },
+  });
+
+  const req = fetch(url, {
+    method: "POST",
+    body,
+    signal: controller.signal,
+    // @ts-ignore
+    duplex: "half",
+  });
+
+  // Wait until the server has received the first chunk, which proves the
+  // FetchTasklet's request-body ResumableSink is attached and in-flight.
+  await serverGotChunk;
+
+  controller.abort();
+
+  let err: unknown;
+  try {
+    await req;
+  } catch (e) {
+    err = e;
+  }
+  if (!(err instanceof Error) || err.name !== "AbortError") {
+    console.error("iteration", i, "did not reject with AbortError:", err);
+    process.exit(1);
+  }
+
+  // Give the HTTP-thread failure callback a chance to land and call
+  // sink.cancel() a second time.
+  await Bun.sleep(0);
+  await Bun.sleep(0);
+  Bun.gc(true);
+}
+
+console.log(`done ${ITERATIONS}`);

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fetch-abort-stream-body-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("done 50\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Adds an early-return at the top of `ResumableSink.cancel()` when `status == .done`, so `onEnd` fires at most once.

Fixes #20740
Fixes #21463


## Why

When a `fetch()` with a `ReadableStream` request body is aborted, `ResumableSink.cancel()` is called from `FetchTasklet.abortListener()` (FetchTasklet.zig:1203). The HTTP thread then completes with failure and `onProgressUpdate`'s reject path calls `sink.cancel()` a second time at FetchTasklet.zig:576 (and `onBodyReceived` at :342) — `this.sink` is only nulled in `clearSink←clearData←deinit`.

`cancel()` (ResumableSink.zig:228) guarded against re-entry only for `status == .piped`. For the JS-route sink it relied on `#js_this.tryGet()` returning null after `detachJS()`, but `JSRef.downgrade()` (JSRef.zig:153-160) preserves the wrapper value as `.weak = <wrapper>`, and `tryGet()` (JSRef.zig:111) returns non-null for any non-empty weak. So the second `cancel()` re-enters the block and re-invokes `onEnd` → `FetchTasklet.writeEndRequest` → unconditional `defer this.deref()` (FetchTasklet.zig:1286).

That second deref releases the single ref taken in `startRequestStream()` (FetchTasklet.zig:300) twice. Ref-count math: init(1) + queue(1) + startRequestStream(1) = 3 → cancel#1 deref → 2 → derefFromThread → 1 → cancel#2 deref → 0 → `deinit()`/`destroy()` runs *inside* `onProgressUpdate`, then its defer at :471-477 does `this.mutex.unlock()` + `this.deref()` on freed memory.

`jsEnd()` already has an `isDetached()` guard for the same reason; `cancel()` was missing the equivalent. Using `status == .done` (rather than `isDetached()`) keeps the `.piped` branch reachable since piped sinks never set `#js_this` to `.strong`.

## Test

`test/js/web/fetch/fetch-abort-stream-body.test.ts` reproduces the use-after-free in a debug/ASAN build:

```
[fetchtasklet] abortListener
[fetchtasklet] writeEndRequest hasError? true     <- cancel #1
[fetchtasklet] callback success=false ...
[fetchtasklet] onProgressUpdate
[fetchtasklet] onReject
[fetchtasklet] writeEndRequest hasError? true     <- cancel #2 (over-deref)
[fetchtasklet] deinit
==40720==ERROR: AddressSanitizer: use-after-poison ... in onProgressUpdate
```