### PR TITLE
fetch: fix FetchTasklet UAF + leak when worker terminates mid-request

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -271,6 +271,34 @@ pub fn isShuttingDown(this: *const VirtualMachine) bool {
     return this.is_shutting_down;
 }
 
+/// A weak reference to a `VirtualMachine` that can be safely queried from
+/// another thread after the VM may have been destroyed. The worker's
+/// `VirtualMachine` lives in a per-worker `MimallocArena` that is freed on
+/// `Worker.terminate()`, so a raw `*VirtualMachine` held by an off-thread
+/// task (e.g. the HTTP thread's `FetchTasklet.callback`) becomes dangling.
+/// `Handle.get()` re-validates via the global `ScriptExecutionContext` map —
+/// when the context is no longer registered, the VM is gone. There is an
+/// inherent TOCTOU between `get()` returning non-null and the caller using
+/// the pointer; that's accepted, and is strictly narrower than reading the
+/// raw pointer directly.
+pub const Handle = struct {
+    #id: bun.webcore.ScriptExecutionContext.Identifier,
+    #vm: ?*VirtualMachine,
+
+    pub fn get(self: *Handle) ?*VirtualMachine {
+        if (self.#vm == null) return null;
+        if (self.#id.globalObject() == null) self.#vm = null;
+        return self.#vm;
+    }
+};
+
+pub fn getHandle(self: *VirtualMachine) Handle {
+    return .{
+        .#id = self.global.scriptExecutionContextIdentifier(),
+        .#vm = self,
+    };
+}
+
 pub fn getTLSRejectUnauthorized(this: *const VirtualMachine) bool {
     return this.default_tls_reject_unauthorized orelse this.transpiler.env.getTLSRejectUnauthorized();
 }

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -6,7 +6,10 @@ pub const FetchTasklet = struct {
     http: ?*http.AsyncHTTP = null,
     result: http.HTTPClientResult = .{},
     metadata: ?http.HTTPResponseMetadata = null,
-    javascript_vm: *VirtualMachine = undefined,
+    /// HTTP-thread call sites must go through `vm_handle.get()`; the worker's
+    /// VirtualMachine is freed on `Worker.terminate()` while callbacks may
+    /// still be in flight, so a raw `*VirtualMachine` here would dangle.
+    vm_handle: VirtualMachine.Handle = undefined,
     global_this: *JSGlobalObject = undefined,
     request_body: HTTPRequestBody = undefined,
     request_body_streaming_buffer: ?*http.ThreadSafeStreamBuffer = null,
@@ -78,14 +81,22 @@ pub const FetchTasklet = struct {
         bun.debugAssert(count > 0);
 
         if (count == 1) {
-            if (this.javascript_vm.isShuttingDown()) {
-                this.deinit() catch |err| switch (err) {};
+            const vm = this.vm_handle.get() orelse {
+                // VM is gone (worker terminated). We can't enqueue and we
+                // can't run full deinit() here: clearAbortSignal() and the
+                // jsc.Strong/jsc.Weak deinits in clearData() touch non-atomic
+                // JSC state. Free what's owned by bun.default_allocator and
+                // intentionally leak the rest.
+                this.deinitFromThread();
+                return;
+            };
+            if (vm.isShuttingDown()) {
+                this.deinitFromThread();
                 return;
             }
             // this is really unlikely to happen, but can happen
             // lets make sure that we always call deinit from main thread
-
-            this.javascript_vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.deinit));
+            vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.deinit));
         }
     }
 
@@ -261,6 +272,53 @@ pub const FetchTasklet = struct {
         this.clearData();
 
         const allocator = bun.default_allocator;
+
+        if (this.http) |http_| {
+            this.http = null;
+            allocator.destroy(http_);
+        }
+        allocator.destroy(this);
+    }
+
+    /// Thread-safe subset of deinit(). Called from the HTTP thread when the
+    /// last ref drops after the VM is gone. Only frees state owned by
+    /// bun.default_allocator; intentionally skips AbortSignal (non-atomic
+    /// RefCounted), jsc.Strong/Weak handles, native_response (non-atomic
+    /// ref_count), and the sink (owns a JSRef) — touching any of those here
+    /// would race the JS thread tearing down the VM.
+    fn deinitFromThread(this: *FetchTasklet) void {
+        log("deinitFromThread", .{});
+        bun.assert(this.ref_count.load(.monotonic) == 0);
+
+        const allocator = bun.default_allocator;
+        if (this.url_proxy_buffer.len > 0) {
+            allocator.free(this.url_proxy_buffer);
+            this.url_proxy_buffer.len = 0;
+        }
+        if (this.hostname) |hostname| {
+            allocator.free(hostname);
+            this.hostname = null;
+        }
+        if (this.result.certificate_info) |*certificate| {
+            certificate.deinit(allocator);
+            this.result.certificate_info = null;
+        }
+        this.request_headers.entries.deinit(allocator);
+        this.request_headers.buf.deinit(allocator);
+        if (this.http) |http_| {
+            http_.clearData();
+        }
+        if (this.metadata) |*md| {
+            md.deinit(allocator);
+            this.metadata = null;
+        }
+        this.response_buffer.deinit();
+        this.scheduled_response_buffer.deinit();
+        if (this.request_body_streaming_buffer) |buffer| {
+            this.request_body_streaming_buffer = null;
+            buffer.clearDrainCallback();
+            buffer.deref();
+        }
 
         if (this.http) |http_| {
             this.http = null;
@@ -456,7 +514,9 @@ pub const FetchTasklet = struct {
         this.has_schedule_callback.store(false, .monotonic);
         const is_done = !this.result.has_more;
 
-        const vm = this.javascript_vm;
+        // onProgressUpdate runs as a ConcurrentTask on the JS thread, so the
+        // VM is alive while we're here.
+        const vm = this.vm_handle.get().?;
         // vm is shutting down we cannot touch JS
         if (vm.isShuttingDown()) {
             this.mutex.unlock();
@@ -983,7 +1043,7 @@ pub const FetchTasklet = struct {
             http_.enableResponseBodyStreaming();
         }
         // we should not keep the process alive if we are ignoring the body
-        const vm = this.javascript_vm;
+        const vm = this.vm_handle.get().?;
         this.poll_ref.unref(vm);
         // clean any remaining references
         this.clearStreamCancelHandler();
@@ -1067,7 +1127,7 @@ pub const FetchTasklet = struct {
                 },
             },
             .http = try allocator.create(http.AsyncHTTP),
-            .javascript_vm = jsc_vm,
+            .vm_handle = jsc_vm.getHandle(),
             .request_body = fetch_options.body,
             .global_this = globalThis,
             .promise = promise,
@@ -1207,10 +1267,11 @@ pub const FetchTasklet = struct {
 
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     pub fn onWriteRequestDataDrain(this: *FetchTasklet) void {
-        if (this.javascript_vm.isShuttingDown()) return;
+        const vm = this.vm_handle.get() orelse return;
+        if (vm.isShuttingDown()) return;
         // ref until the main thread callback is called
         this.ref();
-        this.javascript_vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.resumeRequestDataStream));
+        vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.resumeRequestDataStream));
     }
 
     /// This is ALWAYS called from the main thread
@@ -1440,9 +1501,28 @@ pub const FetchTasklet = struct {
                 return;
             }
         }
-        // will deinit when done with the http client (when is_done = true)
-        if (task.javascript_vm.isShuttingDown()) return;
-        task.javascript_vm.eventLoop().enqueueTaskConcurrent(task.concurrent_task.from(task, .manual_deinit));
+        const vm = task.vm_handle.get() orelse {
+            // VM is gone (worker terminated). Can't enqueue onProgressUpdate.
+            // Reset the flag we just set so a later final-chunk callback isn't
+            // gated; for the final chunk, drop the ref onProgressUpdate would
+            // have dropped so the deferred derefFromThread() above reaches
+            // zero (after mutex.unlock) and runs thread-safe cleanup.
+            task.has_schedule_callback.store(false, .monotonic);
+            if (is_done) {
+                const old = task.ref_count.fetchSub(1, .monotonic);
+                bun.debugAssert(old > 1);
+            }
+            return;
+        };
+        if (vm.isShuttingDown()) {
+            task.has_schedule_callback.store(false, .monotonic);
+            if (is_done) {
+                const old = task.ref_count.fetchSub(1, .monotonic);
+                bun.debugAssert(old > 1);
+            }
+            return;
+        }
+        vm.eventLoop().enqueueTaskConcurrent(task.concurrent_task.from(task, .manual_deinit));
     }
 };
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -319,6 +319,14 @@ pub const FetchTasklet = struct {
             buffer.clearDrainCallback();
             buffer.deref();
         }
+        switch (this.request_body) {
+            // .Sendfile closes an fd (pure syscall). .AnyBlob's variants all
+            // have atomic refcounts (Blob.Store, WTF::StringImpl) or just free
+            // a bun.default_allocator buffer (InternalBlob). .ReadableStream
+            // is a jsc.Strong — leak it.
+            .Sendfile, .AnyBlob => this.request_body.detach(),
+            .ReadableStream => {},
+        }
 
         if (this.http) |http_| {
             this.http = null;

--- a/test/js/web/fetch/fetch-worker-terminate-shutdown.test.ts
+++ b/test/js/web/fetch/fetch-worker-terminate-shutdown.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// FetchTasklet held a raw `*VirtualMachine` and read it from the HTTP thread
+// (callback / derefFromThread / onWriteRequestDataDrain). When a Worker is
+// terminated mid-fetch, the worker's VirtualMachine — allocated in a per-
+// worker MimallocArena — is freed while those callbacks are still in flight,
+// so `task.javascript_vm.isShuttingDown()` and
+// `task.javascript_vm.eventLoop().enqueueTaskConcurrent()` were UAF.
+// derefFromThread additionally ran full clearData() (including non-atomic
+// AbortSignal::deref and jsc.Strong cleanup) on the HTTP thread.
+test("Worker.terminate() while fetch with AbortSignal is in flight does not crash", async () => {
+  using dir = tempDir("fetch-worker-terminate", {
+    "worker.js": `
+      const url = process.argv[2];
+      const ctrl = new AbortController();
+      // Kick off a fetch that will be in flight when the parent terminates us.
+      fetch(url, { signal: ctrl.signal }).then(
+        async (res) => { for await (const _ of res.body) {} },
+        () => {},
+      );
+      // Tell the parent we've sent the request so it can terminate us.
+      postMessage("fetching");
+    `,
+    "main.js": `
+      const ITER = 20;
+      const server = Bun.serve({
+        port: 0,
+        async fetch() {
+          // Stream a slow body so the HTTP thread is mid-response when the
+          // worker is terminated.
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(ctrl) {
+                ctrl.write("x");
+                await Bun.sleep(60_000);
+                ctrl.close();
+              },
+            }),
+          );
+        },
+      });
+      const url = server.url.href;
+      let started = 0;
+      for (let i = 0; i < ITER; i++) {
+        const w = new Worker("./worker.js", { argv: [url] });
+        const { promise, resolve } = Promise.withResolvers();
+        w.onmessage = resolve;
+        w.onerror = (e) => { console.error("worker error", e.message); process.exit(1); };
+        await promise;
+        started++;
+        await w.terminate();
+      }
+      console.log("PASS", started);
+      server.stop(true);
+      process.exit(0);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("PASS 20\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Fixes a use-after-free + a leak when `Worker.terminate()` runs while a `fetch()` (with or without an `AbortSignal`) is still in flight.

## Root cause

`FetchTasklet.javascript_vm` is a raw `*VirtualMachine` pointing at the worker's VM, which is allocated in the worker's `MimallocArena`. `WebWorker.exitAndDeinit` destroys that arena while the HTTP thread may still be holding the tasklet, so any HTTP-thread read of `task.javascript_vm` afterwards is UAF. The existing code did exactly that in three places:

- `callback()` checked `task.javascript_vm.isShuttingDown()` and called `task.javascript_vm.eventLoop().enqueueTaskConcurrent(...)`
- `derefFromThread()` did the same, and additionally ran **full** `deinit()` on the HTTP thread when it thought the VM was shutting down — calling `clearAbortSignal()` (non-atomic `RefCounted<AbortSignal>::deref`) and `jsc.Strong`/`jsc.Weak` deinits, none of which are thread-safe
- `onWriteRequestDataDrain()` did the same check + enqueue

Separately, `callback()`'s shutdown early-return skipped enqueuing `onProgressUpdate` for the final chunk but never dropped the matching ref, so the tasklet, its `AbortSignal` ref + native callback, and several `jsc.Strong`s leaked.

## Fix

- Add `VirtualMachine.Handle` — `{ScriptExecutionContextIdentifier, ?*VirtualMachine}`. `get()` re-validates against the global `ScriptExecutionContext` map (which `getScriptExecutionContext()` already locks) and returns null once the context is unregistered (the map entry is removed in `~GlobalObject()`). Once null is observed it sticks, so subsequent calls skip the lookup.
- Replace `FetchTasklet.javascript_vm: *VirtualMachine` with `vm_handle: VirtualMachine.Handle`. HTTP-thread call sites (`callback`, `derefFromThread`, `onWriteRequestDataDrain`) use `vm_handle.get() orelse <thread-safe cleanup>`; JS-thread call sites use `vm_handle.get().?`. There is an inherent TOCTOU between `get()` returning non-null and using the pointer; that window is much narrower than reading the raw pointer directly, and avoids per-tasklet bookkeeping.
- `derefFromThread()` now calls a new `deinitFromThread()` that frees only `bun.default_allocator`-owned memory (buffers, headers, metadata, the http allocation, the tasklet itself) and intentionally leaks `AbortSignal`/`jsc.Strong`/`jsc.Weak`/`native_response`. Leaking at VM teardown is correct; racing is not.
- `callback()`'s dead-VM/shutdown branch now resets `has_schedule_callback` and drops the ref `onProgressUpdate` would have dropped, so the deferred `derefFromThread` reaches zero and runs thread-safe cleanup instead of leaking the whole tasklet.

## Test

`test/js/web/fetch/fetch-worker-terminate-shutdown.test.ts` spawns a subprocess that loops 20×: start a Worker that `fetch()`es a slow streamed body with an `AbortSignal`, wait for it to confirm the request is in flight, then `terminate()` it. Asserts the subprocess prints `PASS 20`, has empty stderr, and exits 0.

- 5/5 pass on this branch (`bun bd test`)
- 3/3 fail on system bun (segfault / ASAN use-after-poison on the HTTP thread)
- `fetch.test.ts` (341 tests) still passes
