### PR TITLE
debugger: implement /json and /json/list for target discovery

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -366,7 +366,8 @@ class Debugger {
     const { pathname } = this.#url!;
     const host = request.headers.get("host") || `${this.#url!.hostname}:${this.#url!.port}`;
     const id = pathname.startsWith("/") ? pathname.slice(1) : pathname;
-    const webSocketDebuggerUrl = `ws://${host}${pathname}`;
+    const scheme = this.#url!.protocol === "wss:" ? "wss" : "ws";
+    const webSocketDebuggerUrl = `${scheme}://${host}${pathname}`;
     return [
       {
         description: "bun instance",

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -339,7 +339,7 @@ class Debugger {
         return Response.json(versionInfo());
       case "/json":
       case "/json/list":
-      // TODO?
+        return Response.json(this.#targetInfo(request));
     }
 
     if (!this.#url!.protocol.includes("unix") && this.#url!.pathname !== pathname) {
@@ -360,6 +360,25 @@ class Debugger {
         },
       });
     }
+  }
+
+  #targetInfo(request: Request): unknown[] {
+    const { pathname } = this.#url!;
+    const host = request.headers.get("host") || `${this.#url!.hostname}:${this.#url!.port}`;
+    const id = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+    const webSocketDebuggerUrl = `ws://${host}${pathname}`;
+    return [
+      {
+        description: "bun instance",
+        devtoolsFrontendUrl: `https://debug.bun.sh/#${host}${pathname}`,
+        faviconUrl: "https://bun.com/favicon.ico",
+        id,
+        title: `bun[${process.pid}]`,
+        type: "node",
+        url: `file://${process.cwd()}`,
+        webSocketDebuggerUrl,
+      },
+    ];
   }
 
   #open(connection: ConnectionOwner, writer: Writer): void {

--- a/test/regression/issue/29265.test.ts
+++ b/test/regression/issue/29265.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("#29265 inspector exposes /json and /json/list for target discovery", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect=127.0.0.1:0", "-e", "setTimeout(() => {}, 60_000)"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const reader = proc.stderr.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  let wsUrl: URL | undefined;
+  while (!wsUrl) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffered += decoder.decode(value, { stream: true });
+    const match = buffered.match(/(ws:\/\/[^\s]+)/);
+    if (match) wsUrl = new URL(match[1]);
+  }
+  reader.releaseLock();
+  if (!wsUrl) throw new Error("inspector did not print its URL:\n" + buffered);
+
+  try {
+    const base = `http://${wsUrl.host}`;
+
+    for (const path of ["/json", "/json/list"] as const) {
+      const res = await fetch(base + path);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<Record<string, unknown>>;
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBeGreaterThan(0);
+      const target = body[0];
+      expect(typeof target.webSocketDebuggerUrl).toBe("string");
+      expect(target.webSocketDebuggerUrl).toBe(`ws://${wsUrl.host}${wsUrl.pathname}`);
+      expect(target.id).toBe(wsUrl.pathname.slice(1));
+      expect(target.type).toBe("node");
+    }
+
+    // /json/version must still work and carry the expected shape.
+    const versionRes = await fetch(base + "/json/version");
+    expect(versionRes.status).toBe(200);
+    const version = (await versionRes.json()) as Record<string, string>;
+    expect(version["Protocol-Version"]).toBe("1.3");
+    expect(version["Browser"]).toBe("Bun");
+  } finally {
+    proc.kill();
+    await proc.exited;
+  }
+});

--- a/test/regression/issue/29265.test.ts
+++ b/test/regression/issue/29265.test.ts
@@ -17,7 +17,8 @@ test("#29265 inspector exposes /json and /json/list for target discovery", async
     const { done, value } = await reader.read();
     if (done) break;
     buffered += decoder.decode(value, { stream: true });
-    const match = buffered.match(/(ws:\/\/[^\s]+)/);
+    const cleaned = buffered.replace(/\x1b\[[0-9;]*m/g, "");
+    const match = cleaned.match(/(ws:\/\/[^\s]+)/);
     if (match) wsUrl = new URL(match[1]);
   }
   reader.releaseLock();


### PR DESCRIPTION
Fixes #29265.

### What does this PR do?

WebStorm (and Chrome DevTools) discover inspector targets via `GET /json/list` and read `webSocketDebuggerUrl` from the response. Bun previously returned 404 on that path, so WebStorm failed the handshake with "Unexpected server response: 101". This implements `/json` and `/json/list` with a Node-compatible target descriptor.

### How did you verify your code works?

- Added `test/regression/issue/29265.test.ts` — fails on `USE_SYSTEM_BUN=1`, passes on the debug build.
- End-to-end in WebStorm 2026.1 (macOS): Debug now prints `Debugger attached. / hello from bun / Debugger detached.` instead of the 101 error.
