### PR TITLE
fix(s3): rename `checksumAlgorithme` -> `checksumAlgorithm` on `s3.list()` output

### DIFF
--- a/src/s3/list_objects.zig
+++ b/src/s3/list_objects.zig
@@ -36,7 +36,7 @@ const S3ListObjectsContents = struct {
     key: []const u8,
     etag: ?bun.ptr.OwnedIn([]const u8, bun.allocators.MaybeOwned(bun.DefaultAllocator)),
     checksum_type: ?[]const u8,
-    checksum_algorithme: ?[]const u8,
+    checksum_algorithm: ?[]const u8,
     last_modified: ?[]const u8,
     object_size: ?i64,
     storage_class: ?[]const u8,
@@ -125,8 +125,8 @@ pub const S3ListObjectsV2Result = struct {
                     objectInfo.put(globalObject, jsc.ZigString.static("eTag"), try bun.String.createUTF8ForJS(globalObject, etag.get()));
                 }
 
-                if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                if (item.checksum_algorithm) |checksum_algorithm| {
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithm));
                 }
 
                 if (item.checksum_type) |checksum_type| {
@@ -225,7 +225,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                     var etag: ?[]const u8 = null;
                     var etag_owned: bool = false;
                     var checksum_type: ?[]const u8 = null;
-                    var checksum_algorithme: ?[]const u8 = null;
+                    var checksum_algorithm: ?[]const u8 = null;
                     var owner_id: ?[]const u8 = null;
                     var owner_display_name: ?[]const u8 = null;
                     var is_restore_in_progress: ?bool = null;
@@ -273,7 +273,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ChecksumAlgorithm")) {
                                     if (strings.indexOf(xml[i..], "</ChecksumAlgorithm>")) |__tag_end| {
-                                        checksum_algorithme = xml[i .. i + __tag_end];
+                                        checksum_algorithm = xml[i .. i + __tag_end];
                                         i = i + __tag_end + 20;
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ETag")) {
@@ -383,7 +383,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                             .key = object_key_val,
                             .etag = if (etag) |etag_| if (etag_owned) .fromRawIn(etag_, .init()) else .fromRawIn(etag_, .initBorrowed()) else null,
                             .checksum_type = checksum_type,
-                            .checksum_algorithme = checksum_algorithme,
+                            .checksum_algorithm = checksum_algorithm,
                             .last_modified = last_modified,
                             .object_size = object_size,
                             .storage_class = storage_class,


### PR DESCRIPTION
## Summary

`s3.list()` currently emits the key `checksumAlgorithme` (French spelling) on each `contents[]` entry, but the published TypeScript type in `packages/bun-types/s3.d.ts` (L745) declares it as `checksumAlgorithm`:

```ts
contents?: {
  /** The algorithm that was used to create a checksum of the object. */
  checksumAlgorithm?: "CRC32" | "CRC32C" | "SHA1" | "SHA256" | "CRC64NVME";
  ...
}
```

So users who follow the types get `undefined`; users who `console.dir` the runtime object see the misspelled key. AWS's S3 API also uses `ChecksumAlgorithm` (no trailing e).

This PR renames the JS-facing key in `src/s3/list_objects.zig:129` so runtime matches the type.

The internal Zig field + local variables were also renamed to `checksum_algorithm` (5 occurrences in the same file) for consistency — no external impact.

Fixes #19142

## Test plan

- [x] Grep shows zero remaining `checksumAlgorithme` / `checksum_algorithme` occurrences
- [x] Published TS type unchanged (it was already correct)
- [ ] Existing S3 `list()` integration tests continue to pass (not run locally; CI will verify)

## Note on breakage

This is a runtime breaking change for anyone who destructured `contents[].checksumAlgorithme` directly (bypassing the types). Given the types have always said `checksumAlgorithm`, that group is likely very small, and leaving the misspelling in place keeps the stated type lying indefinitely. Happy to add a deprecation shim that emits both keys for one release if maintainers prefer.