### PR TITLE
test: run path.win32.resolve UNC/drive-relative regression on all platforms

### DIFF
--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -94,11 +94,18 @@ describe("path.resolve", () => {
     // }
   });
 
-  test.skipIf(!isWindows)("UNC path before drive-relative path does not corrupt resolvedDevice", () => {
+  test("UNC path before drive-relative path does not corrupt resolvedDevice", () => {
     // Parsing the UNC root reused the buffer backing the already-resolved `C:`
-    // device, which sent the i=-1 iteration down a broken slow path that read
-    // uninitialized memory and panicked. The UNC arg is on a different device
-    // so it should be ignored entirely.
+    // device, which corrupted it from `C:` to `\\`. The UNC arg is on a
+    // different device so it should be ignored entirely.
+    //
+    // With the corruption, the `C:/base` arg is wrongly skipped because its
+    // device no longer matches, and the i=-1 cwd fallback produces garbage (on
+    // Windows it panicked reading uninitialized memory).
+    expect(path.win32.resolve("C:/base", "//server/share", "C:relative")).toBe("C:\\base\\relative");
+    expect(path.win32.resolve("C:/base", "//a/b", "//c/d", "C:foo")).toBe("C:\\base\\foo");
+    // These depend on cwd / =C: env on the right-hand side, so just check that
+    // the UNC arg is a no-op.
     expect(path.win32.resolve("//server/share", "C:relative")).toBe(path.win32.resolve("C:relative"));
     expect(path.win32.resolve("//server/share", "C:")).toBe(path.win32.resolve("C:"));
     expect(path.win32.resolve("//a/b", "//c/d", "C:foo")).toBe(path.win32.resolve("C:foo"));


### PR DESCRIPTION
Follow-up to #29318 per [review feedback](https://github.com/oven-sh/bun/pull/29318#discussion_r3083214313).

The `resolvedDeviceLen > 0` early-continue that prevents the UNC parser from overwriting `tmpBuf` (which backs `resolvedDevice`) is not gated on `Environment.isWindows` — `path.win32.resolve` runs the same `resolveWindowsT` on every platform. But the regression test was `skipIf(!isWindows)`, so Linux/macOS CI wasn't covering it.

Simply dropping the `skipIf` isn't enough: on non-Windows the `i=-1` iteration calls `getCwdT` into `tmpBuf`, which masks the earlier corruption on both sides of the comparison. So this also adds an absolute `C:/base` segment before the UNC arg:

```js
path.win32.resolve("C:/base", "//server/share", "C:relative")
```

Without the fix, parsing `//server/share` corrupts `resolvedDevice` from `C:` to `\\\\`, so `C:/base` is wrongly rejected as a different device and resolution falls through to the cwd. On a pre-fix build this produces e.g. `/w\\workspace\\bun\\relative` instead of `C:\\base\\relative`, failing the assertion on every platform.

Verified against Node.js on Linux (returns `C:\\base\\relative`).