### PR TITLE
Fix crash in forEachProperty when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5365,7 +5365,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,19 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = {};
+    const proto = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("trap");
+        },
+      },
+    );
+    Object.setPrototypeOf(obj, proto);
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Inspecting an object whose prototype chain contains a Proxy with a throwing `getPrototypeOf` trap would crash with a null pointer dereference.

```js
const obj = {};
const proto = new Proxy({}, {
  getPrototypeOf() { throw new Error("trap"); }
});
Object.setPrototypeOf(obj, proto);
console.log(obj); // segfault
```

In `JSC__JSValue__forEachPropertyImpl`, when walking the prototype chain on the slow path, `getPrototype()` can throw and return an empty `JSValue`. Calling `.getObject()` on an empty value dereferences a null `JSCell`.

The fast path in the same function already handles this case by checking the return value and clearing the exception. This applies the same handling to the slow path.

Found by Fuzzilli.