### PR TITLE
install: dedupe isolated-linker entries in peer-dep cycles

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -475,6 +475,7 @@ pub(crate) fn build_store(
                 let mut nodes_slice = nodes.slice();
                 // disjoint-column views via `split_mut`.
                 let store::node::NodeColumnsMut {
+                    pkg_id: node_pkg_ids,
                     nodes: node_nodes,
                     dep_id: node_dep_ids,
                     parent_id: node_parent_ids,
@@ -585,7 +586,10 @@ pub(crate) fn build_store(
                                     break 'walk;
                                 }
                             }
-                            node_peers[curr_id.get() as usize].insert(peer, &set_ctx)?;
+                            // A package is never its own peer.
+                            if node_pkg_ids[curr_id.get() as usize] != peer.pkg_id {
+                                node_peers[curr_id.get() as usize].insert(peer, &set_ctx)?;
+                            }
                             curr_id = node_parent_ids[curr_id.get() as usize];
                         }
                     }
@@ -618,6 +622,7 @@ pub(crate) fn build_store(
         let mut nodes_slice = nodes.slice();
         // disjoint-column views via `split_mut`.
         let store::node::NodeColumnsMut {
+            pkg_id: node_pkg_ids,
             parent_id: node_parent_ids,
             dependencies: node_dependencies,
             peers: node_peers,
@@ -829,6 +834,10 @@ pub(crate) fn build_store(
             }
 
             for &visited_parent_id in &visited_parent_node_ids {
+                // A package is never its own peer.
+                if node_pkg_ids[visited_parent_id.get() as usize] == resolved_pkg_id {
+                    continue;
+                }
                 let ctx = store::node::TransitivePeerOrderedArraySetCtx {
                     string_buf,
                     pkg_names,

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -158,6 +158,7 @@ pub fn installIsolatedPackages(
 
             const nodes_slice = nodes.slice();
             const node_parent_ids = nodes_slice.items(.parent_id);
+            const node_pkg_ids = nodes_slice.items(.pkg_id);
             const node_dependencies = nodes_slice.items(.dependencies);
             const node_peers = nodes_slice.items(.peers);
             const node_nodes = nodes_slice.items(.nodes);
@@ -354,6 +355,14 @@ pub fn installIsolatedPackages(
                 }
 
                 for (visited_parent_node_ids.items) |visited_parent_id| {
+                    // Skip nodes that are themselves the resolved peer. Otherwise, when
+                    // two packages form a peer-dependency cycle (e.g. A peers B, B peers A),
+                    // package A's peer set would include A itself via B's resolution walk —
+                    // producing a different `peer_hash` than the A instance that wasn't
+                    // reached through the cycle. Those should collapse to a single entry.
+                    if (node_pkg_ids[visited_parent_id.get()] == resolved_pkg_id) {
+                        continue;
+                    }
                     const ctx: Store.Node.TransitivePeer.OrderedArraySetCtx = .{
                         .string_buf = string_buf,
                         .pkg_names = pkg_names,

--- a/test/regression/issue/29343.test.ts
+++ b/test/regression/issue/29343.test.ts
@@ -1,0 +1,77 @@
+// Isolated linker duplicated packages caught in a peer-dependency cycle.
+//
+// When package A peers B and B peers A, the first-pass peer resolution used
+// to add each package to its own transitive-peer set (via the other side of
+// the cycle). That changed the peer hash for the instance reached through
+// the cycle vs. the instance not reached through it, so the same
+// `name@version` landed under two different `.bun/` keys. At runtime each
+// physical copy owns its own class identities, breaking `instanceof`.
+//
+// Fix: when marking visited parents with a resolved transitive peer, skip
+// any node whose own pkg_id equals the resolved peer's pkg_id — a package
+// is never its own peer.
+//
+// https://github.com/oven-sh/bun/issues/29343
+
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { readdirSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("isolated linker deduplicates packages joined by a peer-dep cycle", async () => {
+  // Two packages with mutual peer dependencies, both installed directly by
+  // the root. file: deps exercise the same store-key path as npm deps (the
+  // hoisting + peer-resolution logic is the same). Before the fix each
+  // package installed twice under `.bun/` with distinct +hex peer-hash
+  // suffixes; after the fix there is exactly one of each.
+  using dir = tempDir("isolated-peer-cycle", {
+    "app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "pa": "file:../pa",
+        "pb": "file:../pb",
+      },
+    }),
+    "app/bunfig.toml": `[install]\nlinker = "isolated"\n`,
+    "pa/package.json": JSON.stringify({
+      name: "pa",
+      version: "1.0.0",
+      peerDependencies: { "pb": "*" },
+    }),
+    "pb/package.json": JSON.stringify({
+      name: "pb",
+      version: "1.0.0",
+      peerDependencies: { "pa": "*" },
+    }),
+  });
+  const cwd = join(String(dir), "app");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  // Group `.bun/` entries by name@version, stripping the +hex peer-hash
+  // suffix. Any name@version appearing more than once means the linker
+  // failed to collapse a cyclic peer resolution onto a single entry.
+  const storeEntries = readdirSync(join(cwd, "node_modules/.bun")).filter(
+    e => !e.startsWith(".") && e !== "node_modules",
+  );
+  const byNameVersion = new Map<string, string[]>();
+  for (const entry of storeEntries) {
+    const nameVersion = entry.replace(/\+[a-f0-9]{16}$/, "");
+    const list = byNameVersion.get(nameVersion) ?? [];
+    list.push(entry);
+    byNameVersion.set(nameVersion, list);
+  }
+  const duplicates = [...byNameVersion].filter(([, copies]) => copies.length > 1);
+  expect(duplicates).toEqual([]);
+});

--- a/test/regression/issue/29343.test.ts
+++ b/test/regression/issue/29343.test.ts
@@ -1,0 +1,69 @@
+// https://github.com/oven-sh/bun/issues/29343
+
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { readdirSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("isolated linker deduplicates packages joined by a peer-dep cycle", async () => {
+  // file: deps exercise the same store-key path as npm deps; the peer
+  // resolution and hashing logic is identical.
+  using dir = tempDir("isolated-peer-cycle", {
+    "app/package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "pa": "file:../pa",
+        "pb": "file:../pb",
+      },
+    }),
+    "app/bunfig.toml": `[install]\nlinker = "isolated"\n`,
+    "pa/package.json": JSON.stringify({
+      name: "pa",
+      version: "1.0.0",
+      peerDependencies: { "pb": "*" },
+    }),
+    "pb/package.json": JSON.stringify({
+      name: "pb",
+      version: "1.0.0",
+      peerDependencies: { "pa": "*" },
+    }),
+  });
+  const cwd = join(String(dir), "app");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Drain stdout too, otherwise a large install summary could fill the pipe
+  // buffer and deadlock the child.
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  // Group `.bun/` entries by name@version, stripping the +hex peer-hash suffix.
+  const storeEntries = readdirSync(join(cwd, "node_modules/.bun")).filter(
+    e => !e.startsWith(".") && e !== "node_modules",
+  );
+  const byNameVersion = new Map<string, string[]>();
+  for (const entry of storeEntries) {
+    const nameVersion = entry.replace(/\+[a-f0-9]{16}$/, "");
+    const list = byNameVersion.get(nameVersion) ?? [];
+    list.push(entry);
+    byNameVersion.set(nameVersion, list);
+  }
+
+  // Each cycle participant must appear exactly once. Asserting the count
+  // (rather than just "no duplicates") also fails if the fix regressed into
+  // dropping a package entirely.
+  const countFor = (name: string) => storeEntries.filter(e => e.startsWith(`${name}@`)).length;
+  expect({ pa: countFor("pa"), pb: countFor("pb") }).toEqual({ pa: 1, pb: 1 });
+
+  // And no same-version package may appear under more than one store key.
+  const duplicates = [...byNameVersion].filter(([, copies]) => copies.length > 1);
+  expect(duplicates).toEqual([]);
+});


### PR DESCRIPTION
Fixes #29343.

### Repro

Two packages that mutually peer each other (e.g. `@nestjs/core` ↔ `@nestjs/microservices`) produced two copies of each in `node_modules/.bun/` under the isolated linker, with distinct `+hex` peer-hash suffixes:

```
@nestjs+core@11.1.19+5a6ac75304dbae9e/
@nestjs+core@11.1.19+f15b30b64ed412c8/
@nestjs+microservices@11.1.19+5a6ac75304dbae9e/
@nestjs+microservices@11.1.19+e57ff25a800ad42f/
```

Real runtime failure: `ListenersController` in `@nestjs/core` does `serverInstance instanceof ServerGrpc` — when the two sides are different physical copies, `instanceof` is `false` and gRPC streaming silently loses arguments.

### Cause

`src/install/isolated_install.zig` first-pass peer resolution:

```zig
var curr_id = node_id;
while (curr_id != .invalid) {
    // look for matching dep in curr_id's deps...
    try visited_parent_node_ids.append(curr_id);
    curr_id = node_parent_ids[curr_id.get()];
}
// ...then insert the resolved peer into every visited parent's peer set
```

When A peers B and B peers A, B's walk to resolve A visits `[B, A (via B's parent chain), root]`. The resolved peer A is then inserted into each visited parent's peer set — **including A itself**, via that walk. A's peer set now contains A. The other A instance (reached without going through B) doesn't. Different peer sets → different `peer_hash` → two `.bun/` entries.

### Fix

Skip visited parents whose own `pkg_id` equals the resolved peer's `pkg_id` — a package is never its own peer.

### Verification

Regression test at `test/regression/issue/29343.test.ts` uses two file: deps that mutually peer each other. Before the fix: 2 copies each of `pa` and `pb` in `.bun/`. After: 1 copy each.

Gate-check: test fails on `main`, passes on this branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/29343.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/29343.test.ts:
59 | 
60 |   // Each cycle participant must appear exactly once. Asserting the count
61 |   // (rather than just "no duplicates") also fails if the fix regressed into
62 |   // dropping a package entirely.
63 |   const countFor = (name: string) => storeEntries.filter(e => e.startsWith(`${name}@`)).length;
64 |   expect({ pa: countFor("pa"), pb: countFor("pb") }).toEqual({ pa: 1, pb: 1 });
                                                          ^
error: expect(received).toEqual(expected)

  {
-   "pa": 1,
-   "pb": 1,
+   "pa": 2,
+   "pb": 2,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/29343.test.ts:64:54)
(fail) isolated linker deduplicates packages joined by a peer-dep cycle [233.20ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [2.22s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/regression/issue/29343.test.ts:
59 | 
60 |   // Each cycle participant must appear exactly once. Asserting the count
61 |   // (rather than just "no duplicates") also fails if the fix regressed into
62 |   // dropping a package entirely.
63 |   const countFor = (name: string) => storeEntries.filter(e => e.startsWith(`${name}@`)).length;
64 |   expect({ pa: countFor("pa"), pb: countFor("pb") }).toEqual({ pa: 1, pb: 1 });
                                                          ^
error: expect(received).toEqual(expected)

  {
-   "pa": 1,
-   "pb": 1,
+   "pa": 2,
+   "pb": 2,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/regression/issue/29343.test.ts:64:54)
(fail) isolated linker deduplicates packages joined by a peer-dep cycle [7.88ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [151.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/29343.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/29343.test.ts:
(pass) isolated linker deduplicates packages joined by a peer-dep cycle [230.36ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [2.25s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 661ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/121] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/insta
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/isolated_install.rs     | 11 +++++-
 test/regression/issue/29343.test.ts | 69 +++++++++++++++++++++++++++++++++++++
 2 files changed, 79 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/install/isolated_install.rs         13     13     16
test/regression/issue/29343.test.ts      2      4     14
```

</details>

**root cause** · written by the author bot

With circular peer dependencies, the isolated linker's peer resolution could record a package as a transitive peer of itself, producing two distinct entries for the same package in the store and therefore duplicate copies in bundled output. The fix makes package IDs available during node deduplication and peer resolution so that self-referential transitive peer entries are skipped. As a result, mutually cyclic peer dependencies deduplicate to a single physical copy of each package, which a regression test now verifies.

<!-- robobun:evidence:end -->