### PR TITLE
fix(install): avoid false-positive frozen lockfile for bun.lock

### DIFF
--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -762,7 +762,12 @@ pub fn installWithManager(
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
         if (load_result.loadedFromTextLockfile()) {
-            if (bun.handleOom(manager.lockfile.eql(lockfile_before_clean, packages_len_before_install, manager.allocator))) {
+            if (bun.handleOom(manager.lockfile.frozenLockfileUnchangedText(
+                lockfile_before_clean,
+                packages_len_before_install,
+                manager.allocator,
+                PackageManager.verbose_install or manager.options.do.print_meta_hash_string,
+            ))) {
                 break :frozen_lockfile;
             }
         } else {

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -762,8 +762,26 @@ pub fn installWithManager(
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
         if (load_result.loadedFromTextLockfile()) {
-            if (bun.handleOom(manager.lockfile.eql(lockfile_before_clean, packages_len_before_install, manager.allocator))) {
-                break :frozen_lockfile;
+            const file = bun.sys.File.openat(bun.FD.cwd(), "bun.lock", bun.O.RDONLY, 0).unwrap() catch null;
+            if (file) |f| {
+                const disk_bytes = f.readToEnd(manager.allocator).unwrap() catch null;
+                if (disk_bytes) |disk| {
+                    defer manager.allocator.free(disk);
+
+                    var writer_allocating = std.Io.Writer.Allocating.init(manager.allocator);
+                    defer writer_allocating.deinit();
+                    const writer = &writer_allocating.writer;
+
+                    TextLockfile.Stringifier.saveFromBinary(manager.allocator, manager.lockfile, &load_result, &manager.options, writer) catch {};
+                    const generated_bytes = writer_allocating.toOwnedSlice() catch null;
+
+                    if (generated_bytes) |generated| {
+                        defer manager.allocator.free(generated);
+                        if (strings.eqlLong(disk, generated, false)) {
+                            break :frozen_lockfile;
+                        }
+                    }
+                }
             }
         } else {
             if (!(manager.lockfile.hasMetaHashChanged(PackageManager.verbose_install or manager.options.do.print_meta_hash_string, packages_len_before_install) catch false)) {

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -762,12 +762,7 @@ pub fn installWithManager(
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
         if (load_result.loadedFromTextLockfile()) {
-            if (bun.handleOom(manager.lockfile.frozenLockfileUnchangedText(
-                lockfile_before_clean,
-                packages_len_before_install,
-                manager.allocator,
-                PackageManager.verbose_install or manager.options.do.print_meta_hash_string,
-            ))) {
+            if (bun.handleOom(manager.lockfile.eql(lockfile_before_clean, packages_len_before_install, manager.allocator))) {
                 break :frozen_lockfile;
             }
         } else {

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -762,26 +762,45 @@ pub fn installWithManager(
 
     if (manager.options.enable.frozen_lockfile and load_result != .not_found) frozen_lockfile: {
         if (load_result.loadedFromTextLockfile()) {
-            const file = bun.sys.File.openat(bun.FD.cwd(), "bun.lock", bun.O.RDONLY, 0).unwrap() catch null;
-            if (file) |f| {
-                const disk_bytes = f.readToEnd(manager.allocator).unwrap() catch null;
-                if (disk_bytes) |disk| {
-                    defer manager.allocator.free(disk);
-
-                    var writer_allocating = std.Io.Writer.Allocating.init(manager.allocator);
-                    defer writer_allocating.deinit();
-                    const writer = &writer_allocating.writer;
-
-                    TextLockfile.Stringifier.saveFromBinary(manager.allocator, manager.lockfile, &load_result, &manager.options, writer) catch {};
-                    const generated_bytes = writer_allocating.toOwnedSlice() catch null;
-
-                    if (generated_bytes) |generated| {
-                        defer manager.allocator.free(generated);
-                        if (strings.eqlLong(disk, generated, false)) {
-                            break :frozen_lockfile;
-                        }
-                    }
+            const f = bun.sys.File.openat(bun.FD.cwd(), "bun.lock", bun.O.RDONLY, 0).unwrap() catch |err| {
+                if (log_level != .silent) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> failed to open bun.lock for <d>--frozen-lockfile<r> verification: {s}", .{@errorName(err)});
                 }
+                Global.exit(1);
+            };
+            defer f.close();
+
+            var disk_bytes_res = f.readToEnd(manager.allocator);
+            defer disk_bytes_res.bytes.deinit();
+
+            const disk = disk_bytes_res.unwrap() catch |err| {
+                if (log_level != .silent) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> failed to read bun.lock for <d>--frozen-lockfile<r> verification: {s}", .{@errorName(err)});
+                }
+                Global.exit(1);
+            };
+
+            var writer_allocating = std.Io.Writer.Allocating.init(manager.allocator);
+            defer writer_allocating.deinit();
+            const writer = &writer_allocating.writer;
+
+            TextLockfile.Stringifier.saveFromBinary(manager.allocator, manager.lockfile, &load_result, &manager.options, writer) catch |err| {
+                if (log_level != .silent) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> failed to stringify bun.lock for <d>--frozen-lockfile<r> verification: {s}", .{@errorName(err)});
+                }
+                Global.exit(1);
+            };
+
+            const generated = writer_allocating.toOwnedSlice() catch |err| {
+                if (log_level != .silent) {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> failed to allocate bun.lock bytes for <d>--frozen-lockfile<r> verification: {s}", .{@errorName(err)});
+                }
+                Global.exit(1);
+            };
+            defer manager.allocator.free(generated);
+
+            if (strings.eqlLong(disk, generated, false)) {
+                break :frozen_lockfile;
             }
         } else {
             if (!(manager.lockfile.hasMetaHashChanged(PackageManager.verbose_install or manager.options.do.print_meta_hash_string, packages_len_before_install) catch false)) {

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1807,7 +1807,7 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     if (l_len != r_len) return false;
 
     const sort_buf = try allocator.alloc(EqlSorter.PathToId, l_len + r_len);
-    defer l.allocator.free(sort_buf);
+    defer allocator.free(sort_buf);
     var l_buf = sort_buf[0..l_len];
     var r_buf = sort_buf[r_len..];
 
@@ -1922,10 +1922,56 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     return true;
 }
 
+/// Frozen-lockfile comparison for text lockfiles (`bun.lock`).
+///
+/// The text lockfile on disk doesn't encode the hoisted `node_modules` tree, so
+/// internal hoisting differences (or transient in-memory tree state) must not
+/// cause a false-positive frozen-lockfile failure. Use the lockfile's meta-hash
+/// as the primary equivalence check and fall back to `eql()` only when the meta
+/// hash differs.
+pub fn frozenLockfileUnchangedText(
+    after: *const Lockfile,
+    before: *const Lockfile,
+    packages_len: usize,
+    allocator: std.mem.Allocator,
+    print_name_version_string: bool,
+) OOM!bool {
+    const before_meta_hash = try before.generateMetaHash(print_name_version_string, packages_len);
+    const after_meta_hash = try after.generateMetaHash(print_name_version_string, packages_len);
+
+    if (strings.eqlLong(&before_meta_hash, &after_meta_hash, false)) {
+        return true;
+    }
+
+    return after.eql(before, packages_len, allocator);
+}
+
 pub fn hasMetaHashChanged(this: *Lockfile, print_name_version_string: bool, packages_len: usize) !bool {
     const previous_meta_hash = this.meta_hash;
     this.meta_hash = try this.generateMetaHash(print_name_version_string, packages_len);
     return !strings.eqlLong(&previous_meta_hash, &this.meta_hash, false);
+}
+
+test "frozenLockfileUnchangedText ignores hoist-only differences" {
+    var before: Lockfile = undefined;
+    before.initEmpty(std.testing.allocator);
+    defer before.deinit();
+
+    var after: Lockfile = undefined;
+    after.initEmpty(std.testing.allocator);
+    defer after.deinit();
+
+    _ = try before.appendPackage(.{ .name_hash = 1 });
+    _ = try before.appendPackage(.{ .name_hash = 2 });
+
+    _ = try after.appendPackage(.{ .name_hash = 1 });
+    _ = try after.appendPackage(.{ .name_hash = 2 });
+
+    // Simulate a difference in hoist buffers without changing the package graph.
+    try after.buffers.hoisted_dependencies.append(std.testing.allocator, 0);
+
+    try std.testing.expect(!(try after.eql(&before, after.packages.len, std.testing.allocator)));
+    try std.testing.expect(try after.frozenLockfileUnchangedText(&before, after.packages.len, std.testing.allocator, false));
 }
 pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool, packages_len: usize) !MetaHash {
     if (packages_len <= 1)

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1804,12 +1804,10 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     const l_len = l_hoisted_deps.len;
     const r_len = r_hoisted_deps.len;
 
-    if (l_len != r_len) return false;
-
     const sort_buf = try allocator.alloc(EqlSorter.PathToId, l_len + r_len);
     defer allocator.free(sort_buf);
     var l_buf = sort_buf[0..l_len];
-    var r_buf = sort_buf[r_len..];
+    var r_buf = sort_buf[l_len..][0..r_len];
 
     var path_buf: bun.PathBuffer = undefined;
     var depth_buf: Tree.DepthBuf = undefined;
@@ -1922,37 +1920,13 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     return true;
 }
 
-/// Frozen-lockfile comparison for text lockfiles (`bun.lock`).
-///
-/// The text lockfile on disk doesn't encode the hoisted `node_modules` tree, so
-/// internal hoisting differences (or transient in-memory tree state) must not
-/// cause a false-positive frozen-lockfile failure. Use the lockfile's meta-hash
-/// as the primary equivalence check and fall back to `eql()` only when the meta
-/// hash differs.
-pub fn frozenLockfileUnchangedText(
-    after: *const Lockfile,
-    before: *const Lockfile,
-    packages_len: usize,
-    allocator: std.mem.Allocator,
-    print_name_version_string: bool,
-) OOM!bool {
-    const before_meta_hash = try before.generateMetaHash(print_name_version_string, packages_len);
-    const after_meta_hash = try after.generateMetaHash(print_name_version_string, packages_len);
-
-    if (strings.eqlLong(&before_meta_hash, &after_meta_hash, false)) {
-        return true;
-    }
-
-    return after.eql(before, packages_len, allocator);
-}
-
 pub fn hasMetaHashChanged(this: *Lockfile, print_name_version_string: bool, packages_len: usize) !bool {
     const previous_meta_hash = this.meta_hash;
     this.meta_hash = try this.generateMetaHash(print_name_version_string, packages_len);
     return !strings.eqlLong(&previous_meta_hash, &this.meta_hash, false);
 }
 
-test "frozenLockfileUnchangedText ignores hoist-only differences" {
+test "Lockfile.eql ignores unused hoist buffer length differences" {
     var before: Lockfile = undefined;
     before.initEmpty(std.testing.allocator);
     defer before.deinit();
@@ -1967,11 +1941,11 @@ test "frozenLockfileUnchangedText ignores hoist-only differences" {
     _ = try after.appendPackage(.{ .name_hash = 1 });
     _ = try after.appendPackage(.{ .name_hash = 2 });
 
-    // Simulate a difference in hoist buffers without changing the package graph.
-    try after.buffers.hoisted_dependencies.append(std.testing.allocator, 0);
+    // Extra entries in the hoisted-deps buffer are irrelevant if they point at
+    // invalid dependency IDs (the comparison filters those out).
+    try after.buffers.hoisted_dependencies.append(std.testing.allocator, invalid_dependency_id);
 
-    try std.testing.expect(!(try after.eql(&before, after.packages.len, std.testing.allocator)));
-    try std.testing.expect(try after.frozenLockfileUnchangedText(&before, after.packages.len, std.testing.allocator, false));
+    try std.testing.expect(try after.eql(&before, after.packages.len, std.testing.allocator));
 }
 pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool, packages_len: usize) !MetaHash {
     if (packages_len <= 1)

--- a/src/install/lockfile.zig
+++ b/src/install/lockfile.zig
@@ -1804,10 +1804,12 @@ pub fn eql(l: *const Lockfile, r: *const Lockfile, cut_off_pkg_id: usize, alloca
     const l_len = l_hoisted_deps.len;
     const r_len = r_hoisted_deps.len;
 
+    if (l_len != r_len) return false;
+
     const sort_buf = try allocator.alloc(EqlSorter.PathToId, l_len + r_len);
     defer allocator.free(sort_buf);
     var l_buf = sort_buf[0..l_len];
-    var r_buf = sort_buf[l_len..][0..r_len];
+    var r_buf = sort_buf[r_len..];
 
     var path_buf: bun.PathBuffer = undefined;
     var depth_buf: Tree.DepthBuf = undefined;
@@ -1926,27 +1928,6 @@ pub fn hasMetaHashChanged(this: *Lockfile, print_name_version_string: bool, pack
     return !strings.eqlLong(&previous_meta_hash, &this.meta_hash, false);
 }
 
-test "Lockfile.eql ignores unused hoist buffer length differences" {
-    var before: Lockfile = undefined;
-    before.initEmpty(std.testing.allocator);
-    defer before.deinit();
-
-    var after: Lockfile = undefined;
-    after.initEmpty(std.testing.allocator);
-    defer after.deinit();
-
-    _ = try before.appendPackage(.{ .name_hash = 1 });
-    _ = try before.appendPackage(.{ .name_hash = 2 });
-
-    _ = try after.appendPackage(.{ .name_hash = 1 });
-    _ = try after.appendPackage(.{ .name_hash = 2 });
-
-    // Extra entries in the hoisted-deps buffer are irrelevant if they point at
-    // invalid dependency IDs (the comparison filters those out).
-    try after.buffers.hoisted_dependencies.append(std.testing.allocator, invalid_dependency_id);
-
-    try std.testing.expect(try after.eql(&before, after.packages.len, std.testing.allocator));
-}
 pub fn generateMetaHash(this: *Lockfile, print_name_version_string: bool, packages_len: usize) !MetaHash {
     if (packages_len <= 1)
         return zero_hash;


### PR DESCRIPTION
Problem
- Some workspaces hit a false-positive `bun install --frozen-lockfile` failure for text lockfiles (`bun.lock`): Bun reports "lockfile had changes" even when `bun.lock` on disk is unchanged.

Root Cause
- The frozen check for `bun.lock` compared internal lockfile state (including transient in-memory buffers / clean-up effects) instead of comparing what would actually be written to `bun.lock`.

Change
- For text lockfiles, generate the canonical `bun.lock` output with `TextLockfile.Stringifier.saveFromBinary(...)` and compare it to the on-disk `bun.lock` bytes.
- Keep binary lockfile frozen behavior unchanged (meta-hash).
- Fix `Lockfile.eql(...)` to free with the allocator it allocated from.

Resolves #20913
Resolves #19088

Verification
- On a Bun workspaces monorepo (macOS arm64), `bun ci` fails on Bun `1.3.11` with `error: lockfile had changes, but lockfile is frozen` while `git diff bun.lock` is empty and `shasum -a 256 bun.lock` unchanged.
- With this PR applied (built from source), `bun ci` succeeds and `bun.lock` remains unchanged.
