### PR TITLE
blob: clamp stat.size to max_size to avoid @intCast panic in ReadFile

### DIFF
--- a/src/bun.js/webcore/blob/read_file.zig
+++ b/src/bun.js/webcore/blob/read_file.zig
@@ -340,7 +340,7 @@ pub const ReadFile = struct {
         }
 
         this.could_block = !bun.isRegularFile(stat.mode);
-        this.total_size = @truncate(@as(SizeType, @intCast(@max(@as(i64, @intCast(stat.size)), 0))));
+        this.total_size = @intCast(@min(@max(stat.size, 0), Blob.max_size));
 
         if (stat.size > 0 and !this.could_block) {
             this.size = @min(this.total_size, this.max_length);
@@ -383,6 +383,7 @@ pub const ReadFile = struct {
         if (!this.could_block or (this.size > 0 and this.size != Blob.max_size))
             this.buffer = std.ArrayListUnmanaged(u8).initCapacity(bun.default_allocator, this.size +| 16) catch |err| {
                 this.errno = err;
+                this.system_error = bun.sys.Error.fromCode(bun.sys.E.NOMEM, .read).toSystemError();
                 this.onFinish();
                 return;
             };
@@ -656,7 +657,7 @@ pub const ReadFileUV = struct {
             this.onFinish();
             return;
         }
-        this.total_size = @truncate(@as(SizeType, @intCast(@max(@as(i64, @intCast(stat.size)), 0))));
+        this.total_size = @intCast(@min(@max(stat.size, 0), Blob.max_size));
         this.is_regular_file = bun.isRegularFile(stat.mode);
 
         log("is_regular_file: {}", .{this.is_regular_file});

--- a/test/js/bun/util/bun-file-fd-read.test.ts
+++ b/test/js/bun/util/bun-file-fd-read.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { closeSync, openSync, unlinkSync, writeFileSync } from "fs";
-import { isWindows, tmpdirSync } from "harness";
+import { closeSync, openSync } from "fs";
+import { isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // Reading a Bun.file() backed by a file descriptor goes through
@@ -21,44 +21,32 @@ describe.skipIf(isWindows)("Bun.file(fd) read", () => {
   }
 
   test("text() and arrayBuffer() on a regular-file fd return file contents", async () => {
-    const dir = tmpdirSync();
-    const path = join(dir, "fd-read.txt");
-    writeFileSync(path, "hello from fd");
-    try {
-      // Each read needs a fresh fd because Bun.file(fd) does not own or rewind
-      // the descriptor, and a completed read leaves it positioned at EOF.
-      expect(await withFd(path, fd => Bun.file(fd).text())).toBe("hello from fd");
+    using dir = tempDir("bun-file-fd-read", { "fd-read.txt": "hello from fd" });
+    const path = join(String(dir), "fd-read.txt");
 
-      const buf = await withFd(path, fd => Bun.file(fd).arrayBuffer());
-      expect(new Uint8Array(buf)).toEqual(new TextEncoder().encode("hello from fd"));
-    } finally {
-      unlinkSync(path);
-    }
+    // Each read needs a fresh fd because Bun.file(fd) does not own or rewind
+    // the descriptor, and a completed read leaves it positioned at EOF.
+    expect(await withFd(path, fd => Bun.file(fd).text())).toBe("hello from fd");
+
+    const buf = await withFd(path, fd => Bun.file(fd).arrayBuffer());
+    expect(new Uint8Array(buf)).toEqual(new TextEncoder().encode("hello from fd"));
   });
 
   test("slice() with an end beyond the real size reads the actual file contents", async () => {
-    const dir = tmpdirSync();
-    const path = join(dir, "fd-slice.txt");
-    writeFileSync(path, "0123456789");
-    try {
-      // total_size should come from fstat (10), not from the requested slice
-      // end, so the initial buffer allocation stays small.
-      expect(await withFd(path, fd => Bun.file(fd).slice(0, Number.MAX_SAFE_INTEGER).text())).toBe("0123456789");
-      expect(await withFd(path, fd => Bun.file(fd).slice(2, 5).text())).toBe("234");
-    } finally {
-      unlinkSync(path);
-    }
+    using dir = tempDir("bun-file-fd-read", { "fd-slice.txt": "0123456789" });
+    const path = join(String(dir), "fd-slice.txt");
+
+    // total_size should come from fstat (10), not from the requested slice
+    // end, so the initial buffer allocation stays small.
+    expect(await withFd(path, fd => Bun.file(fd).slice(0, Number.MAX_SAFE_INTEGER).text())).toBe("0123456789");
+    expect(await withFd(path, fd => Bun.file(fd).slice(2, 5).text())).toBe("234");
   });
 
   test("empty regular file via fd resolves with empty content", async () => {
-    const dir = tmpdirSync();
-    const path = join(dir, "fd-empty.txt");
-    writeFileSync(path, "");
-    try {
-      expect(await withFd(path, fd => Bun.file(fd).text())).toBe("");
-      expect((await withFd(path, fd => Bun.file(fd).arrayBuffer())).byteLength).toBe(0);
-    } finally {
-      unlinkSync(path);
-    }
+    using dir = tempDir("bun-file-fd-read", { "fd-empty.txt": "" });
+    const path = join(String(dir), "fd-empty.txt");
+
+    expect(await withFd(path, fd => Bun.file(fd).text())).toBe("");
+    expect((await withFd(path, fd => Bun.file(fd).arrayBuffer())).byteLength).toBe(0);
   });
 });

--- a/test/js/bun/util/bun-file-fd-read.test.ts
+++ b/test/js/bun/util/bun-file-fd-read.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { closeSync, openSync, unlinkSync, writeFileSync } from "fs";
+import { isWindows, tmpdirSync } from "harness";
+import { join } from "path";
+
+// Reading a Bun.file() backed by a file descriptor goes through
+// ReadFile.runAsync -> getFd (opened_fd already set) -> runAsyncWithFD ->
+// resolveSizeAndLastModified, which derives total_size from fstat. That
+// computation previously used @intCast to u52 guarded by a dead @truncate,
+// so an abnormal fstat size could trip integerOutOfBounds. Triggering that
+// directly requires fstat to report > 4.5 PB which is not achievable here,
+// but these tests lock in the fd-backed ReadFile path that the fuzzer hit.
+describe.skipIf(isWindows)("Bun.file(fd) read", () => {
+  async function withFd<T>(path: string, fn: (fd: number) => Promise<T>): Promise<T> {
+    const fd = openSync(path, "r");
+    try {
+      return await fn(fd);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  test("text() and arrayBuffer() on a regular-file fd return file contents", async () => {
+    const dir = tmpdirSync();
+    const path = join(dir, "fd-read.txt");
+    writeFileSync(path, "hello from fd");
+    try {
+      // Each read needs a fresh fd because Bun.file(fd) does not own or rewind
+      // the descriptor, and a completed read leaves it positioned at EOF.
+      expect(await withFd(path, fd => Bun.file(fd).text())).toBe("hello from fd");
+
+      const buf = await withFd(path, fd => Bun.file(fd).arrayBuffer());
+      expect(new Uint8Array(buf)).toEqual(new TextEncoder().encode("hello from fd"));
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test("slice() with an end beyond the real size reads the actual file contents", async () => {
+    const dir = tmpdirSync();
+    const path = join(dir, "fd-slice.txt");
+    writeFileSync(path, "0123456789");
+    try {
+      // total_size should come from fstat (10), not from the requested slice
+      // end, so the initial buffer allocation stays small.
+      expect(await withFd(path, fd => Bun.file(fd).slice(0, Number.MAX_SAFE_INTEGER).text())).toBe("0123456789");
+      expect(await withFd(path, fd => Bun.file(fd).slice(2, 5).text())).toBe("234");
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test("empty regular file via fd resolves with empty content", async () => {
+    const dir = tmpdirSync();
+    const path = join(dir, "fd-empty.txt");
+    writeFileSync(path, "");
+    try {
+      expect(await withFd(path, fd => Bun.file(fd).text())).toBe("");
+      expect((await withFd(path, fd => Bun.file(fd).arrayBuffer())).byteLength).toBe(0);
+    } finally {
+      unlinkSync(path);
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a Zig safety-check panic in `ReadFile.resolveSizeAndLastModified` (called from `runAsyncWithFD`) when `fstat` reports a size larger than `maxInt(u52)`.

Fuzzer fingerprint: `6e3d2159cadcef3a`

## Root cause

```zig
this.total_size = @truncate(@as(SizeType, @intCast(@max(@as(i64, @intCast(stat.size)), 0))));
```

`SizeType` is `u52`. The outer `@truncate` is dead code — the inner `@intCast` to `u52` runs first and panics with `integerOutOfBounds` whenever the (non-negative) stat size exceeds `maxInt(u52)`. Verified with objdump that `resolveSizeAndLastModified` contained a single call to `debug.FullPanic.integerOutOfBounds` mapping to this line.

The fuzzer hit this via an fd-based `ReadFile` task scheduled on the thread pool in a prior REPRL iteration, which then ran after the fd context changed. In a standalone run of the minimized script, `doReadFile` is never invoked — the crash depends on cross-iteration thread-pool state, which is why it's extremely flaky and not directly reproducible outside the REPRL harness.

## Fix

- Clamp `stat.size` to `[0, Blob.max_size]` before casting, so the `@intCast` is always in range. Applied to both the POSIX (`ReadFile`) and Windows (`ReadFileUV`) paths.
- While here: set `system_error` when `initCapacity` fails in the POSIX path so OOM propagates to JS as an error instead of being silently treated as an empty read. This matches what `ReadFileUV` already does.

## How did you verify your code works?

- `objdump` confirms `integerOutOfBounds` is no longer emitted in `resolveSizeAndLastModified` (1 → 0 call sites).
- `bun bd test test/js/bun/util/bun-stdin-slice.test.ts` passes (covers fd-based `ReadFile` path).
- `bun bd test test/js/bun/util/bun-file-read.test.ts` passes.
- `bun bd test test/js/bun/util/bun-file.test.ts` passes.
- Manual check: `Bun.file(fd).text()` on a regular file fd still works.

No new regression test is added because triggering the original panic requires `fstat` to report a size > 4.5 PB, which is not achievable in the test environment; the fix is verified structurally and the affected code path is already covered by the existing stdin-slice tests.