### PR TITLE
Fix null deref in Bun.inspect when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5290,10 +5290,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5365,7 +5366,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -451,6 +451,30 @@ const fixture = [
         },
       },
     ),
+  () =>
+    Object.setPrototypeOf(
+      {},
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    ),
+  () =>
+    Object.setPrototypeOf(
+      { yolo: 1 },
+      new Proxy(
+        { foo: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    ),
 ];
 
 describe("crash testing", () => {
@@ -465,6 +489,32 @@ describe("crash testing", () => {
       }
     });
   }
+
+  it("inspecting an object whose prototype is a Proxy with a throwing getPrototypeOf trap", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const obj = Object.setPrototypeOf({}, new Proxy({}, {
+            getPrototypeOf() { throw new Error("nope"); },
+          }));
+          process.stdout.write(Bun.inspect(obj) + "|");
+          const obj2 = Object.setPrototypeOf({ a: 1 }, new Proxy({ b: 2 }, {
+            getPrototypeOf() { throw new Error("nope"); },
+          }));
+          process.stdout.write(Bun.inspect(obj2) + "|");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("{}|");
+    expect(stdout).toContain("a: 1");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("possibly formatted emojis log", () => {


### PR DESCRIPTION
## What

`Bun.inspect()` (and anything that formats values, e.g. `expect().toBe()` failure messages) crashed with a null dereference when inspecting an object whose prototype chain contains a Proxy with a throwing `getPrototypeOf` trap, or more generally when `getPrototype()` throws while walking the chain.

```js
const obj = Object.setPrototypeOf({}, new Proxy({}, {
  getPrototypeOf() { throw new Error("nope"); },
}));
Bun.inspect(obj); // Segmentation fault at address 0x5
```

## Why

In the slow path of `JSC__JSValue__forEachPropertyImpl`, the prototype walk did:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

`getPrototype()` on a `ProxyObject` goes through `performGetPrototype`, which can throw and return an empty `JSValue`. Calling `.getObject()` on that dereferences `nullptr`.

The fast path a few lines up already null-checks the result and clears the exception; the slow path did not.

Additionally, `getPropertySlot()` could throw and return `false`, hitting `continue` before the `CLEAR_IF_EXCEPTION`, leaving a pending exception that makes the subsequent `getPrototype()` on a Proxy bail with an empty value.

## Fix

- Null-check the result of `getPrototype()` and clear any exception, matching the fast-path behavior.
- Clear exceptions from `getPropertySlot()` before the early `continue`.

Found by Fuzzilli (fingerprint `a418828b2f0a6461`).