### PR TITLE
Add `--frozen-lockfile` to completions for `bun install` in `fish`.

### DIFF
--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -33,7 +33,7 @@ function __fish__get_bun_bun_js_files
 end
 
 set -l bun_install_boolean_flags yarn production optional development no-save frozen-lockfile dry-run force no-cache silent verbose global
-set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
+set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Disallow changes to lockfile" "Perform a dry run without making changes" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x repl
 set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -32,7 +32,7 @@ function __fish__get_bun_bun_js_files
 	string split ' ' (bun getcompletes j)
 end
 
-set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
+set -l bun_install_boolean_flags yarn production optional development no-save frozen-lockfile dry-run force no-cache silent verbose global
 set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
 
 set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update init pm x repl


### PR DESCRIPTION
There are still a *lot* of broken shell completions, but this at least fixes: https://github.com/oven-sh/bun/issues/2503#issuecomment-3086661199

### What does this PR do?

Add `--frozen-lockfile` to completions for `bun install` in `fish`.

### How did you verify your code works?

I did not, as I don't have a practical working process for building `bun` (see https://github.com/oven-sh/bun/issues/21144).

However, this is clearly the sole source for these flags for `fish` completions.