### PR TITLE
Add `bun test --shard=M/N` for splitting tests across CI jobs

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -696,6 +696,7 @@ _bun_test_completion() {
         '--todo[Include tests that are marked with "test.todo()"]' \
         '--coverage[Generate a coverage profile]' \
         '--bail[Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1.]:bail' \
+        '--shard[Run a subset of test files, e.g. 1/3. Useful for splitting tests across CI jobs.]:shard' \
         '--test-name-pattern[Run only tests with a name that matches the given regex]:pattern' \
         '-t[Run only tests with a name that matches the given regex]:pattern' &&
         ret=0

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -375,6 +375,10 @@ pub const Command = struct {
         /// Otherwise the value is a git ref (commit, branch, tag) to diff
         /// against.
         changed: ?[]const u8 = null,
+        /// `bun test --shard=M/N`. When set, test files are sorted by path
+        /// and only every Nth file (starting from M-1) is run. index is
+        /// 1-based; both are validated at parse time so `1 <= index <= count`.
+        shard: ?struct { index: u32, count: u32 } = null,
 
         reporters: struct {
             dots: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -247,6 +247,7 @@ pub const test_only_params = [_]ParamType{
     clap.parseParam("--parallel <NUMBER>?             Run test files in parallel using N worker processes. Implies --isolate. Defaults to CPU core count.") catch unreachable,
     clap.parseParam("--parallel-delay <NUMBER>        Milliseconds the first --parallel worker must be busy before spawning the rest. 0 spawns all immediately. Default 5.") catch unreachable,
     clap.parseParam("--test-worker                    (internal) Run as a --parallel worker, receiving files over IPC.") catch unreachable,
+    clap.parseParam("--shard <STR>                    Run a subset of test files, e.g. '--shard=1/3' runs the first of three shards. Useful for splitting tests across multiple CI jobs.") catch unreachable,
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
@@ -612,6 +613,31 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         }
         if (args.option("--changed")) |since| {
             ctx.test_options.changed = since;
+        }
+        if (args.option("--shard")) |shard| {
+            const sep = bun.strings.indexOfChar(shard, '/') orelse {
+                Output.prettyErrorln("<r><red>error<r>: --shard expects <d>'<r>index/count<d>'<r>, e.g. --shard=1/3", .{});
+                Global.exit(1);
+            };
+            const index_str = shard[0..sep];
+            const count_str = shard[sep + 1 ..];
+            const index = std.fmt.parseInt(u32, index_str, 10) catch {
+                Output.prettyErrorln("<r><red>error<r>: --shard index must be a positive integer, got \"{s}\"", .{index_str});
+                Global.exit(1);
+            };
+            const count = std.fmt.parseInt(u32, count_str, 10) catch {
+                Output.prettyErrorln("<r><red>error<r>: --shard count must be a positive integer, got \"{s}\"", .{count_str});
+                Global.exit(1);
+            };
+            if (count == 0) {
+                Output.prettyErrorln("<r><red>error<r>: --shard count must be greater than 0", .{});
+                Global.exit(1);
+            }
+            if (index == 0 or index > count) {
+                Output.prettyErrorln("<r><red>error<r>: --shard index must be between 1 and {d}, got {d}", .{ count, index });
+                Global.exit(1);
+            }
+            ctx.test_options.shard = .{ .index = index, .count = count };
         }
         ctx.test_options.update_snapshots = args.flag("--update-snapshots");
         ctx.test_options.run_todo = args.flag("--todo");

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1682,7 +1682,12 @@ pub const TestCommand = struct {
         // keeps shards roughly balanced regardless of how many files there
         // are, and is stable across runs and machines as long as the set of
         // test files is the same.
-        if (ctx.test_options.shard) |shard| {
+        //
+        // Only runs when there are files to shard — if the scanner or
+        // --changed already produced an empty list, fall through to the
+        // existing "No tests found!" / --changed messaging rather than
+        // printing a confusing "running 0/0 test files".
+        if (ctx.test_options.shard) |shard| if (test_files.len > 0) {
             std.sort.pdq(PathString, test_files, {}, struct {
                 pub fn lessThan(_: void, a: PathString, b: PathString) bool {
                     return strings.order(a.slice(), b.slice()) == .lt;
@@ -1709,14 +1714,14 @@ pub const TestCommand = struct {
             );
             Output.flush();
 
-            if (write == 0 and test_files.len > 0) {
+            if (write == 0) {
                 // There were test files, but fewer than the shard count so
                 // this shard got none. That's fine — not a "no tests
                 // found" error.
                 pass_with_no_tests_from_filter = true;
             }
             test_files = test_files[0..write];
-        }
+        };
 
         // Normally the watcher is only enabled when there are test files to
         // run; `bun test --watch` with nothing matching should still exit.

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1631,13 +1631,17 @@ pub const TestCommand = struct {
         defer ctx.allocator.free(all_test_files);
         const search_count = scanner.search_count;
 
-        var pass_with_no_tests_from_changed = false;
+        // When --changed or --shard filters the discovered test files
+        // down to zero, the "No tests found!" error path is suppressed
+        // and the run exits 0 — an empty shard or an unchanged tree
+        // is not a misconfiguration.
+        var pass_with_no_tests_from_filter = false;
         var changed_module_graph_files: []const []const u8 = &.{};
         defer {
             for (changed_module_graph_files) |p| ctx.allocator.free(p);
             ctx.allocator.free(changed_module_graph_files);
         }
-        const test_files: []PathString = if (ctx.test_options.changed) |changed_since| brk: {
+        var test_files: []PathString = if (ctx.test_options.changed) |changed_since| brk: {
             // If the Scanner found nothing, fall through to the existing
             // "no tests found" error path rather than treating it as a
             // --changed success.
@@ -1650,13 +1654,13 @@ pub const TestCommand = struct {
             changed_module_graph_files = result.module_graph_files;
             if (result.test_files.len == 0 and result.changed_count == 0) {
                 Output.prettyError("<r><d>--changed:<r> no changed files, nothing to run\n", .{});
-                pass_with_no_tests_from_changed = true;
+                pass_with_no_tests_from_filter = true;
             } else if (result.test_files.len == 0) {
                 Output.prettyError(
                     "<r><d>--changed:<r> {d} changed file{s}, but no test files are affected\n",
                     .{ result.changed_count, if (result.changed_count == 1) "" else "s" },
                 );
-                pass_with_no_tests_from_changed = true;
+                pass_with_no_tests_from_filter = true;
             } else {
                 Output.prettyError(
                     "<r><d>--changed:<r> {d} changed file{s}, running {d}/{d} test file{s}\n",
@@ -1672,6 +1676,47 @@ pub const TestCommand = struct {
             Output.flush();
             break :brk result.test_files;
         } else all_test_files;
+
+        // --shard=M/N: sort the test files for determinism, then keep only
+        // every Nth file starting at M-1. This round-robin distribution
+        // keeps shards roughly balanced regardless of how many files there
+        // are, and is stable across runs and machines as long as the set of
+        // test files is the same.
+        if (ctx.test_options.shard) |shard| {
+            std.sort.pdq(PathString, test_files, {}, struct {
+                pub fn lessThan(_: void, a: PathString, b: PathString) bool {
+                    return strings.order(a.slice(), b.slice()) == .lt;
+                }
+            }.lessThan);
+
+            var write: usize = 0;
+            for (test_files, 0..) |file, i| {
+                if (i % shard.count == shard.index - 1) {
+                    test_files[write] = file;
+                    write += 1;
+                }
+            }
+
+            Output.prettyError(
+                "<r><d>--shard={d}/{d}:<r> running {d}/{d} test file{s}\n",
+                .{
+                    shard.index,
+                    shard.count,
+                    write,
+                    test_files.len,
+                    if (test_files.len == 1) "" else "s",
+                },
+            );
+            Output.flush();
+
+            if (write == 0 and test_files.len > 0) {
+                // There were test files, but fewer than the shard count so
+                // this shard got none. That's fine — not a "no tests
+                // found" error.
+                pass_with_no_tests_from_filter = true;
+            }
+            test_files = test_files[0..write];
+        }
 
         // Normally the watcher is only enabled when there are test files to
         // run; `bun test --watch` with nothing matching should still exit.
@@ -1775,7 +1820,7 @@ pub const TestCommand = struct {
 
         var failed_to_find_any_tests = false;
 
-        if (test_files.len == 0 and !pass_with_no_tests_from_changed) {
+        if (test_files.len == 0 and !pass_with_no_tests_from_filter) {
             failed_to_find_any_tests = true;
 
             // "bun test" - positionals[0] == "test"

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// `bun test --shard=M/N` splits discovered test files across N shards.
+// Files are sorted by path first for determinism, then distributed
+// round-robin: file i goes to shard (i % N) + 1.
+
+function makeFixture(name: string, fileCount: number) {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < fileCount; i++) {
+    const id = String(i).padStart(2, "0");
+    files[`f${id}.test.ts`] = `import { test } from "bun:test"; test("t", () => { console.log("RAN f${id}"); });`;
+  }
+  return tempDir(name, files);
+}
+
+async function runShard(cwd: string, shard: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", `--shard=${shard}`],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const ran = stdout
+    .split("\n")
+    .filter(l => l.startsWith("RAN "))
+    .map(l => l.slice(4))
+    .sort();
+  return { ran, stderr, exitCode };
+}
+
+describe("--shard", () => {
+  test("partitions test files across shards with no overlap or gaps", async () => {
+    using dir = makeFixture("shard-partition", 10);
+    const cwd = String(dir);
+
+    const results = await Promise.all(["1/3", "2/3", "3/3"].map(s => runShard(cwd, s)));
+    for (const r of results) {
+      expect(r.stderr).toContain("--shard=");
+      expect(r.exitCode).toBe(0);
+    }
+
+    const all = results.flatMap(r => r.ran).sort();
+    // Every file ran exactly once across all shards.
+    expect(all).toEqual(["f00", "f01", "f02", "f03", "f04", "f05", "f06", "f07", "f08", "f09"]);
+
+    // No overlap between shards.
+    const seen = new Set<string>();
+    for (const r of results) {
+      for (const f of r.ran) {
+        expect(seen.has(f)).toBe(false);
+        seen.add(f);
+      }
+    }
+
+    // Round-robin over the sorted list: shard M gets indices M-1, M-1+N, ...
+    expect(results[0].ran).toEqual(["f00", "f03", "f06", "f09"]);
+    expect(results[1].ran).toEqual(["f01", "f04", "f07"]);
+    expect(results[2].ran).toEqual(["f02", "f05", "f08"]);
+  });
+
+  test("is deterministic across repeated runs", async () => {
+    using dir = makeFixture("shard-determinism", 12);
+    const cwd = String(dir);
+
+    const a = await runShard(cwd, "2/4");
+    const b = await runShard(cwd, "2/4");
+    expect(a.ran).toEqual(["f01", "f05", "f09"]);
+    expect(a.ran).toEqual(b.ran);
+    expect(a.exitCode).toBe(0);
+    expect(b.exitCode).toBe(0);
+  });
+
+  test("--shard=1/1 runs every test file", async () => {
+    using dir = makeFixture("shard-one", 5);
+    const cwd = String(dir);
+
+    const { ran, stderr, exitCode } = await runShard(cwd, "1/1");
+    expect(stderr).toContain("--shard=1/1:");
+    expect(ran).toEqual(["f00", "f01", "f02", "f03", "f04"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("prints the shard summary line", async () => {
+    using dir = makeFixture("shard-summary", 7);
+    const cwd = String(dir);
+
+    const { stderr, exitCode } = await runShard(cwd, "2/3");
+    expect(stderr).toMatch(/--shard=2\/3: running \d+\/7 test files/);
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty shard exits 0 without 'No tests found'", async () => {
+    // 2 files, 5 shards → shards 3, 4, 5 get nothing.
+    using dir = makeFixture("shard-empty", 2);
+    const cwd = String(dir);
+
+    const { ran, stderr, exitCode } = await runShard(cwd, "5/5");
+    expect(ran).toEqual([]);
+    expect(stderr).toContain("--shard=5/5:");
+    expect(stderr).toContain("running 0/2 test files");
+    expect(stderr).not.toContain("No tests found");
+    expect(stderr).not.toContain("did not match any test files");
+    expect(exitCode).toBe(0);
+  });
+
+  test.each([
+    ["0/3", "index must be between 1 and 3"],
+    ["4/3", "index must be between 1 and 3"],
+    ["1/0", "count must be greater than 0"],
+    ["abc", "expects"],
+    ["1/", "count must be a positive integer"],
+    ["/3", "index must be a positive integer"],
+    ["a/3", "index must be a positive integer"],
+    ["1/b", "count must be a positive integer"],
+  ])("rejects invalid --shard=%s", async (arg, needle) => {
+    using dir = makeFixture("shard-invalid", 1);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", `--shard=${arg}`],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(needle);
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -14,9 +14,9 @@ function makeFixture(name: string, fileCount: number) {
   return tempDir(name, files);
 }
 
-async function runShard(cwd: string, shard: string) {
+async function runShard(cwd: string, shard: string, extra: string[] = []) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", `--shard=${shard}`],
+    cmd: [bunExe(), "test", `--shard=${shard}`, ...extra],
     env: bunEnv,
     cwd,
     stdout: "pipe",
@@ -31,7 +31,7 @@ async function runShard(cwd: string, shard: string) {
   return { ran, stderr, exitCode };
 }
 
-describe("--shard", () => {
+describe.concurrent("--shard", () => {
   test("partitions test files across shards with no overlap or gaps", async () => {
     using dir = makeFixture("shard-partition", 10);
     const cwd = String(dir);
@@ -71,6 +71,29 @@ describe("--shard", () => {
     expect(a.ran).toEqual(b.ran);
     expect(a.exitCode).toBe(0);
     expect(b.exitCode).toBe(0);
+  });
+
+  test("composes with --randomize: shard selection happens before shuffle", async () => {
+    // Shard selection sorts, picks, then --randomize shuffles only the
+    // selected subset. So the SET of files in a shard is independent
+    // of the seed, and a fixed seed gives a reproducible order.
+    using dir = makeFixture("shard-randomize", 12);
+    const cwd = String(dir);
+
+    const plain = await runShard(cwd, "2/4");
+    const seeded1 = await runShard(cwd, "2/4", ["--seed=123"]);
+    const seeded2 = await runShard(cwd, "2/4", ["--seed=123"]);
+    const otherSeed = await runShard(cwd, "2/4", ["--seed=999999"]);
+
+    // Same set of files regardless of randomization (ran is sorted).
+    expect(plain.ran).toEqual(["f01", "f05", "f09"]);
+    expect(seeded1.ran).toEqual(plain.ran);
+    expect(seeded2.ran).toEqual(plain.ran);
+    expect(otherSeed.ran).toEqual(plain.ran);
+
+    // Same seed → same result.
+    expect(seeded1.stderr).toContain("--shard=2/4:");
+    for (const r of [plain, seeded1, seeded2, otherSeed]) expect(r.exitCode).toBe(0);
   });
 
   test("--shard=1/1 runs every test file", async () => {

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -73,10 +73,12 @@ describe.concurrent("--shard", () => {
     expect(b.exitCode).toBe(0);
   });
 
-  test("composes with --randomize: shard selection happens before shuffle", async () => {
+  test("composes with --randomize: shard selection is independent of the seed", async () => {
     // Shard selection sorts, picks, then --randomize shuffles only the
-    // selected subset. So the SET of files in a shard is independent
-    // of the seed, and a fixed seed gives a reproducible order.
+    // selected subset. This test verifies the SET of files in a shard
+    // is unaffected by randomization — every seed (and no seed) yields
+    // the same shard membership. Shuffle-order determinism under a
+    // fixed seed is covered by test-randomize.test.ts.
     using dir = makeFixture("shard-randomize", 12);
     const cwd = String(dir);
 
@@ -85,13 +87,11 @@ describe.concurrent("--shard", () => {
     const seeded2 = await runShard(cwd, "2/4", ["--seed=123"]);
     const otherSeed = await runShard(cwd, "2/4", ["--seed=999999"]);
 
-    // Same set of files regardless of randomization (ran is sorted).
     expect(plain.ran).toEqual(["f01", "f05", "f09"]);
     expect(seeded1.ran).toEqual(plain.ran);
     expect(seeded2.ran).toEqual(plain.ran);
     expect(otherSeed.ran).toEqual(plain.ran);
 
-    // Same seed → same result.
     expect(seeded1.stderr).toContain("--shard=2/4:");
     for (const r of [plain, seeded1, seeded2, otherSeed]) expect(r.exitCode).toBe(0);
   });

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -65,8 +65,7 @@ describe.concurrent("--shard", () => {
     using dir = makeFixture("shard-determinism", 12);
     const cwd = String(dir);
 
-    const a = await runShard(cwd, "2/4");
-    const b = await runShard(cwd, "2/4");
+    const [a, b] = await Promise.all([runShard(cwd, "2/4"), runShard(cwd, "2/4")]);
     expect(a.ran).toEqual(["f01", "f05", "f09"]);
     expect(a.ran).toEqual(b.ran);
     expect(a.exitCode).toBe(0);
@@ -82,10 +81,12 @@ describe.concurrent("--shard", () => {
     using dir = makeFixture("shard-randomize", 12);
     const cwd = String(dir);
 
-    const plain = await runShard(cwd, "2/4");
-    const seeded1 = await runShard(cwd, "2/4", ["--seed=123"]);
-    const seeded2 = await runShard(cwd, "2/4", ["--seed=123"]);
-    const otherSeed = await runShard(cwd, "2/4", ["--seed=999999"]);
+    const [plain, seeded1, seeded2, otherSeed] = await Promise.all([
+      runShard(cwd, "2/4"),
+      runShard(cwd, "2/4", ["--seed=123"]),
+      runShard(cwd, "2/4", ["--seed=123"]),
+      runShard(cwd, "2/4", ["--seed=999999"]),
+    ]);
 
     expect(plain.ran).toEqual(["f01", "f05", "f09"]);
     expect(seeded1.ran).toEqual(plain.ran);
@@ -94,7 +95,7 @@ describe.concurrent("--shard", () => {
 
     expect(seeded1.stderr).toContain("--shard=2/4:");
     for (const r of [plain, seeded1, seeded2, otherSeed]) expect(r.exitCode).toBe(0);
-  });
+  }, 20_000);
 
   test("--shard=1/1 runs every test file", async () => {
     using dir = makeFixture("shard-one", 5);

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -174,14 +174,15 @@ describe.concurrent("--shard", () => {
   });
 
   test("composes with --parallel: shard filters first, then workers run the subset", async () => {
-    // 4 files; --shard=1/2 keeps f00 and f02. --parallel=2 runs those across
-    // workers; each file should report a JEST_WORKER_ID in {1,2} (not the
-    // shard index), and the other shard's files must not run.
+    // 4 files; --shard=1/2 keeps f00 and f02. --parallel runs that subset.
+    // This proves the file filter happens before the coordinator distributes;
+    // worker distribution itself is covered by the JEST_WORKER_ID test in
+    // parallel.test.ts.
     const files: Record<string, string> = {};
     for (let i = 0; i < 4; i++) {
       const id = String(i).padStart(2, "0");
       files[`f${id}.test.ts`] =
-        `import {test} from "bun:test"; test("t", async () => { await Bun.sleep(200); console.log("RAN f${id} WID="+process.env.JEST_WORKER_ID); });`;
+        `import {test} from "bun:test"; test("t", () => console.log("RAN f${id} WID="+process.env.JEST_WORKER_ID));`;
     }
     using dir = tempDir("shard-parallel", files);
     await using proc = Bun.spawn({
@@ -196,10 +197,11 @@ describe.concurrent("--shard", () => {
     expect(stdout).toContain("PARALLEL");
     expect(stderr).toContain("--shard=1/2:");
     expect(stderr).toContain("running 2/4 test files");
-    // Only shard-1 files ran:
     const ran = [...out.matchAll(/RAN (f\d\d) WID=(\S+)/g)].map(m => ({ file: m[1], wid: m[2] }));
+    // Only shard-1 files ran, in any worker:
     expect(ran.map(r => r.file).sort()).toEqual(["f00", "f02"]);
-    // JEST_WORKER_ID is the local worker, not the shard:
+    // JEST_WORKER_ID is the local worker (1..K), never undefined and never the
+    // shard index. With 2 sharded files and lazy spawn, K may collapse to 1.
     for (const r of ran) {
       expect(["1", "2"]).toContain(r.wid);
     }

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -92,6 +92,26 @@ describe("--shard", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("does not print shard summary when there are no test files", async () => {
+    // With no test files at all, --shard should stay out of the way and
+    // let the normal "No tests found!" error path handle it.
+    using dir = tempDir("shard-no-files", {
+      "not-a-test.ts": "export const x = 1;",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--shard=1/3"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("--shard=");
+    expect(stderr).not.toContain("0/0");
+    expect(stderr.toLowerCase()).toContain("no tests found");
+    expect(exitCode).not.toBe(0);
+  });
+
   test("empty shard exits 0 without 'No tests found'", async () => {
     // 2 files, 5 shards → shards 3, 4, 5 get nothing.
     using dir = makeFixture("shard-empty", 2);

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -172,4 +172,37 @@ describe.concurrent("--shard", () => {
     expect(stderr).toContain(needle);
     expect(exitCode).not.toBe(0);
   });
+
+  test("composes with --parallel: shard filters first, then workers run the subset", async () => {
+    // 4 files; --shard=1/2 keeps f00 and f02. --parallel=2 runs those across
+    // workers; each file should report a JEST_WORKER_ID in {1,2} (not the
+    // shard index), and the other shard's files must not run.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 4; i++) {
+      const id = String(i).padStart(2, "0");
+      files[`f${id}.test.ts`] =
+        `import {test} from "bun:test"; test("t", async () => { await Bun.sleep(200); console.log("RAN f${id} WID="+process.env.JEST_WORKER_ID); });`;
+    }
+    using dir = tempDir("shard-parallel", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--shard=1/2", "--parallel=2"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = stdout + stderr;
+    expect(stdout).toContain("PARALLEL");
+    expect(stderr).toContain("--shard=1/2:");
+    expect(stderr).toContain("running 2/4 test files");
+    // Only shard-1 files ran:
+    const ran = [...out.matchAll(/RAN (f\d\d) WID=(\S+)/g)].map(m => ({ file: m[1], wid: m[2] }));
+    expect(ran.map(r => r.file).sort()).toEqual(["f00", "f02"]);
+    // JEST_WORKER_ID is the local worker, not the shard:
+    for (const r of ran) {
+      expect(["1", "2"]).toContain(r.wid);
+    }
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/test/test-shard.test.ts
+++ b/test/cli/test/test-shard.test.ts
@@ -95,7 +95,7 @@ describe.concurrent("--shard", () => {
 
     expect(seeded1.stderr).toContain("--shard=2/4:");
     for (const r of [plain, seeded1, seeded2, otherSeed]) expect(r.exitCode).toBe(0);
-  }, 20_000);
+  });
 
   test("--shard=1/1 runs every test file", async () => {
     using dir = makeFixture("shard-one", 5);


### PR DESCRIPTION
## What does this PR do?

Adds `bun test --shard=<index>/<count>` for splitting test files across multiple CI runners / GitHub Actions jobs.

```sh
# In a matrix of 3 jobs:
bun test --shard=1/3
bun test --shard=2/3
bun test --shard=3/3
```

```
--shard=2/3: running 3/10 test files

f01.test.ts:
(pass) t

f04.test.ts:
(pass) t

f07.test.ts:
(pass) t
```

### How it works

1. Discovered test files are **sorted by path** so every machine sees the same ordering regardless of filesystem iteration order.
2. Files are distributed **round-robin**: file at sorted index `i` belongs to shard `(i % count) + 1`. This keeps shards balanced to within one file of each other.
3. The shard index is **1-based** (`1 <= index <= count`), matching Jest, Vitest, and Playwright.
4. Composes with `--changed` (sharding is applied after the changed-files filter) and `--randomize` (shuffle happens after shard selection, within the shard).
5. If a shard ends up with zero files (e.g. 2 test files, `--shard=5/5`), it exits `0` with a status line rather than erroring with "No tests found!".

Invalid inputs (`0/3`, `4/3`, `1/0`, `abc`, `1/`, `/3`) produce a clear error and exit non-zero.

## How did you verify your code works?

- `test/cli/test/test-shard.test.ts` — 13 tests covering partitioning (union == all files, intersection == ∅), determinism across runs, `1/1` running everything, the summary line, empty-shard exit code, and all invalid-input cases.
- `bun bd test test/cli/test/test-changed.test.ts` still passes (touched the shared `pass_with_no_tests_from_filter` variable).
- Gate: `0/13` pass without the `src/` changes, `13/13` with.

Fixes #4587