### PR TITLE
publish: add OIDC trusted publishing for npm registries

### DIFF
--- a/src/cli/oidc.zig
+++ b/src/cli/oidc.zig
@@ -87,6 +87,12 @@ fn fetchGitHubActionsToken(allocator: std.mem.Allocator, registry: *const Npm.Re
     var response_buf = MutableString.init(allocator, 1024) catch return null;
     defer response_buf.deinit();
 
+    // AsyncHTTP.initSync has no connection-phase timeout parameter. Once the socket
+    // is open the HTTP client sets a 5-minute post-connection timeout (see
+    // onWritable in src/http.zig), but the initial TCP handshake falls through to
+    // the kernel default (~2 min on Linux). For a best-effort OIDC lookup that's
+    // acceptable — an unreachable endpoint will eventually time out and we return
+    // null, letting publish fall through to the existing NeedAuth error path.
     var req = http.AsyncHTTP.initSync(
         allocator,
         .GET,
@@ -155,6 +161,9 @@ fn exchangeToken(
     var response_buf = MutableString.init(allocator, 1024) catch return null;
     defer response_buf.deinit();
 
+    // Same timeout caveat as fetchGitHubActionsToken — no connect-phase timeout,
+    // 5-minute post-connection timeout applies. Best-effort: a hung exchange falls
+    // through to NeedAuth.
     var req = http.AsyncHTTP.initSync(
         allocator,
         .POST,

--- a/src/cli/oidc.zig
+++ b/src/cli/oidc.zig
@@ -1,0 +1,201 @@
+/// OIDC (OpenID Connect) trusted publishing for npm registries.
+///
+/// Enables tokenless authentication in CI by exchanging an OIDC identity token
+/// with the npm registry for a short-lived publish token. This eliminates the
+/// need for long-lived NPM_TOKEN secrets.
+///
+/// Supported token sources:
+///   - NPM_ID_TOKEN env var (any CI provider — GitLab CI, CircleCI, etc.)
+///   - GitHub Actions OIDC auto-fetch (via ACTIONS_ID_TOKEN_REQUEST_URL)
+///
+/// The flow:
+///   1. Read NPM_ID_TOKEN, or fetch an OIDC token from GitHub Actions
+///   2. Exchange it with the registry at /-/npm/v1/oidc/token/exchange/package/{name}
+///   3. Registry returns a short-lived npm auth token
+///
+/// References:
+///   - npm CLI: lib/utils/oidc.js
+///   - GitHub Actions OIDC: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+
+/// Attempts OIDC authentication for npm publishing.
+/// Returns a short-lived npm auth token, or null if OIDC is not available or fails.
+/// This function never returns an error — OIDC is always optional and best-effort.
+pub fn attemptOidcAuth(
+    allocator: std.mem.Allocator,
+    registry: *const Npm.Registry.Scope,
+    package_name: string,
+) ?string {
+    const identity_token = fetchIdentityToken(allocator, registry) orelse return null;
+    return exchangeToken(allocator, registry, package_name, identity_token);
+}
+
+/// Fetches an OIDC identity token from the CI environment.
+///
+/// Checks (in order):
+///   1. NPM_ID_TOKEN env var (works for all CI providers)
+///   2. GitHub Actions OIDC token request (requires id-token: write permission)
+fn fetchIdentityToken(allocator: std.mem.Allocator, registry: *const Npm.Registry.Scope) ?string {
+    // Path 1: NPM_ID_TOKEN environment variable (all CI providers)
+    if (bun.env_var.NPM_ID_TOKEN.get()) |token| {
+        if (token.len > 0) return token;
+    }
+
+    // Path 2: GitHub Actions OIDC token request
+    if (bun.env_var.GITHUB_ACTIONS.get()) {
+        return fetchGitHubActionsToken(allocator, registry);
+    }
+
+    return null;
+}
+
+/// Fetches an OIDC token from the GitHub Actions runtime.
+///
+/// GET ${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:${registry_hostname}
+/// Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}
+fn fetchGitHubActionsToken(allocator: std.mem.Allocator, registry: *const Npm.Registry.Scope) ?string {
+    const base_url = bun.env_var.ACTIONS_ID_TOKEN_REQUEST_URL.get() orelse return null;
+    const request_token = bun.env_var.ACTIONS_ID_TOKEN_REQUEST_TOKEN.get() orelse return null;
+
+    if (base_url.len == 0 or request_token.len == 0) return null;
+
+    // Build URL with audience parameter: npm:{registry_hostname}
+    // The registry URL's hostname (without port) identifies which registry we're authenticating to
+    const registry_hostname = registry.url.hostname;
+    if (registry_hostname.len == 0) return null;
+
+    // ACTIONS_ID_TOKEN_REQUEST_URL always includes a trailing '?' with query params
+    // (e.g. "https://vstoken.actions.githubusercontent.com/.identity?api-version=...&").
+    // Appending "&audience=" matches the npm CLI behavior (lib/utils/oidc.js).
+    var url_buf = std.array_list.Managed(u8).init(allocator);
+    defer url_buf.deinit();
+    url_buf.writer().print("{s}&audience=npm:{s}", .{ base_url, registry_hostname }) catch return null;
+
+    const token_url = URL.parse(url_buf.items);
+
+    // Build request headers
+    var auth_buf = std.array_list.Managed(u8).init(allocator);
+    defer auth_buf.deinit();
+    auth_buf.writer().print("Bearer {s}", .{request_token}) catch return null;
+
+    var headers: http.HeaderBuilder = .{};
+    headers.count("authorization", auth_buf.items);
+    headers.count("accept", "application/json");
+    headers.allocate(allocator) catch return null;
+    headers.append("authorization", auth_buf.items);
+    headers.append("accept", "application/json");
+
+    var response_buf = MutableString.init(allocator, 1024) catch return null;
+    defer response_buf.deinit();
+
+    var req = http.AsyncHTTP.initSync(
+        allocator,
+        .GET,
+        token_url,
+        headers.entries,
+        headers.content.ptr.?[0..headers.content.len],
+        &response_buf,
+        "",
+        null,
+        null,
+        .follow,
+    );
+
+    const res = req.sendSync() catch return null;
+    if (res.status_code != 200) return null;
+
+    // Parse response: { "value": "<JWT>" }
+    const source = logger.Source.initPathString("oidc-token", response_buf.list.items);
+    // Log is not deinitialized — matches the pattern in checkPackageVersionExists.
+    var log = logger.Log.init(allocator);
+    const json = JSON.parseUTF8(&source, &log, allocator) catch return null;
+
+    const maybe_token = json.getStringCloned(allocator, "value") catch return null;
+    const token = maybe_token orelse return null;
+    if (token.len == 0) return null;
+
+    return token;
+}
+
+/// Exchanges an OIDC identity token with the npm registry for a short-lived publish token.
+///
+/// POST ${registry}/-/npm/v1/oidc/token/exchange/package/${escapedPackageName}
+/// Authorization: Bearer ${identity_token}
+fn exchangeToken(
+    allocator: std.mem.Allocator,
+    registry: *const Npm.Registry.Scope,
+    package_name: string,
+    identity_token: string,
+) ?string {
+    const registry_url = strings.withoutTrailingSlash(registry.url.href);
+    const encoded_name = bun.fmt.dependencyUrl(package_name);
+
+    var url_buf = std.array_list.Managed(u8).init(allocator);
+    defer url_buf.deinit();
+    url_buf.writer().print("{s}/-/npm/v1/oidc/token/exchange/package/{f}", .{
+        registry_url,
+        encoded_name,
+    }) catch return null;
+
+    const exchange_url = URL.parse(url_buf.items);
+
+    // Build request headers with OIDC token as Bearer auth
+    var auth_buf = std.array_list.Managed(u8).init(allocator);
+    defer auth_buf.deinit();
+    auth_buf.writer().print("Bearer {s}", .{identity_token}) catch return null;
+
+    var headers: http.HeaderBuilder = .{};
+    headers.count("authorization", auth_buf.items);
+    headers.count("accept", "application/json");
+    headers.count("content-length", "0");
+    headers.allocate(allocator) catch return null;
+    headers.append("authorization", auth_buf.items);
+    headers.append("accept", "application/json");
+    headers.append("content-length", "0");
+
+    var response_buf = MutableString.init(allocator, 1024) catch return null;
+    defer response_buf.deinit();
+
+    var req = http.AsyncHTTP.initSync(
+        allocator,
+        .POST,
+        exchange_url,
+        headers.entries,
+        headers.content.ptr.?[0..headers.content.len],
+        &response_buf,
+        "",
+        null,
+        null,
+        .follow,
+    );
+
+    const res = req.sendSync() catch return null;
+    if (res.status_code != 200) return null;
+
+    // Parse response: { "token": "<short-lived-npm-token>" }
+    const source = logger.Source.initPathString("oidc-exchange", response_buf.list.items);
+    // Log is not deinitialized — matches the pattern in checkPackageVersionExists.
+    var log = logger.Log.init(allocator);
+    const json = JSON.parseUTF8(&source, &log, allocator) catch return null;
+
+    const maybe_token = json.getStringCloned(allocator, "token") catch return null;
+    const token = maybe_token orelse return null;
+    if (token.len == 0) return null;
+
+    return token;
+}
+
+const string = []const u8;
+
+const std = @import("std");
+
+const bun = @import("bun");
+const JSON = bun.json;
+const MutableString = bun.MutableString;
+const URL = bun.URL;
+const logger = bun.logger;
+const strings = bun.strings;
+
+const http = bun.http;
+
+const install = bun.install;
+const Npm = install.Npm;

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -532,7 +532,26 @@ pub const PublishCommand = struct {
         comptime directory_publish: bool,
         ctx: *const Context(directory_publish),
     ) PublishError!void {
-        const registry = ctx.manager.scopeForPackageName(ctx.package_name);
+        const orig_registry = ctx.manager.scopeForPackageName(ctx.package_name);
+
+        // If no auth is configured and we're in CI, attempt OIDC trusted publishing.
+        // This exchanges a CI-provided OIDC token with the npm registry for a short-lived
+        // publish token, eliminating the need for long-lived NPM_TOKEN secrets.
+        var oidc_scope: Npm.Registry.Scope = undefined;
+        const registry: *const Npm.Registry.Scope = blk: {
+            if (orig_registry.token.len == 0 and orig_registry.auth.len == 0 and
+                (orig_registry.url.password.len == 0 or orig_registry.url.username.len == 0))
+            {
+                if (bun.ci.isCI()) {
+                    if (oidc.attemptOidcAuth(ctx.allocator, orig_registry, ctx.package_name)) |token| {
+                        oidc_scope = orig_registry.*;
+                        oidc_scope.token = token;
+                        break :blk &oidc_scope;
+                    }
+                }
+            }
+            break :blk orig_registry;
+        };
 
         if (registry.token.len == 0 and (registry.url.password.len == 0 or registry.url.username.len == 0)) {
             return error.NeedAuth;
@@ -1453,6 +1472,7 @@ const E = bun.ast.E;
 const G = bun.ast.G;
 
 const Command = bun.cli.Command;
+const oidc = @import("oidc.zig");
 const Pack = bun.cli.PackCommand;
 const Run = bun.cli.RunCommand;
 const prompt = bun.cli.InitCommand.prompt;

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -26,6 +26,8 @@
 //!                      everything. This means that we potentially scan through envp a lot of
 //!                      times, even though we could only do it once.
 
+pub const ACTIONS_ID_TOKEN_REQUEST_TOKEN = New(kind.string, "ACTIONS_ID_TOKEN_REQUEST_TOKEN", .{});
+pub const ACTIONS_ID_TOKEN_REQUEST_URL = New(kind.string, "ACTIONS_ID_TOKEN_REQUEST_URL", .{});
 pub const AGENT = New(kind.string, "AGENT", .{});
 pub const BUN_AGENT_RULE_DISABLED = New(kind.boolean, "BUN_AGENT_RULE_DISABLED", .{ .default = false });
 pub const BUN_COMPILE_TARGET_TARBALL_URL = New(kind.string, "BUN_COMPILE_TARGET_TARBALL_URL", .{});
@@ -114,6 +116,7 @@ pub const NODE_CHANNEL_FD = New(kind.string, "NODE_CHANNEL_FD", .{});
 pub const BUN_INTERNAL_WEBVIEW_HOST = New(kind.string, "BUN_INTERNAL_WEBVIEW_HOST", .{});
 pub const NODE_PRESERVE_SYMLINKS_MAIN = New(kind.boolean, "NODE_PRESERVE_SYMLINKS_MAIN", .{ .default = false });
 pub const NODE_USE_SYSTEM_CA = New(kind.boolean, "NODE_USE_SYSTEM_CA", .{ .default = false });
+pub const NPM_ID_TOKEN = New(kind.string, "NPM_ID_TOKEN", .{});
 pub const npm_lifecycle_event = New(kind.string, "npm_lifecycle_event", .{});
 pub const PATH = New(kind.string, "PATH", .{});
 pub const REPL_ID = New(kind.boolean, "REPL_ID", .{ .default = false });

--- a/test/cli/install/bun-publish-oidc.test.ts
+++ b/test/cli/install/bun-publish-oidc.test.ts
@@ -1,0 +1,294 @@
+import { spawn } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunExe, bunEnv, stderrForInstall, tempDir } from "harness";
+
+// Fake HOME without any .npmrc so global npm credentials
+// don't interfere with the registry URL and auth in our tests.
+using fakeHome = tempDir("oidc-home", {});
+
+async function publish(
+  customEnv: Record<string, string>,
+  cwd: string,
+  ...args: string[]
+): Promise<{ out: string; err: string; exitCode: number }> {
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "publish", "--dry-run", ...args],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: customEnv,
+  });
+
+  const out = await stdout.text();
+  const err = stderrForInstall(await stderr.text());
+  const exitCode = await exited;
+  return { out, err, exitCode };
+}
+
+// Build a clean env from bunEnv with OIDC-related vars stripped,
+// then apply overrides. Ensures no stale vars leak between tests.
+function buildEnv(overrides: Record<string, string> = {}): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(bunEnv)) {
+    if (v != null) result[k] = v;
+  }
+  // Strip OIDC-related vars and npm auth vars to prevent
+  // global ~/.npmrc credentials from leaking into tests
+  for (const key of [
+    "ACTIONS_ID_TOKEN_REQUEST_URL",
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "NPM_ID_TOKEN",
+    "NODE_AUTH_TOKEN",
+    "NPM_TOKEN",
+    "NPM_CONFIG_TOKEN",
+    "BUN_CONFIG_TOKEN",
+  ]) {
+    delete result[key];
+  }
+  // Use a fake HOME to avoid reading global ~/.npmrc credentials.
+  // Set both HOME (Unix) and USERPROFILE (Windows) for cross-platform isolation.
+  result.HOME = String(fakeHome);
+  result.USERPROFILE = String(fakeHome);
+  return { ...result, ...overrides };
+}
+
+describe("oidc trusted publishing", () => {
+  test("successful OIDC auth via GitHub Actions", async () => {
+    const oidcToken = "mock-oidc-identity-token";
+    const npmToken = "mock-npm-short-lived-token";
+
+    // Mock GitHub Actions OIDC endpoint
+    using oidcServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        // Verify audience parameter
+        expect(url.searchParams.get("audience")).toStartWith("npm:");
+        // Verify bearer token
+        expect(req.headers.get("authorization")).toBe("Bearer mock-request-token");
+        return Response.json({ value: oidcToken });
+      },
+    });
+
+    // Mock npm registry that handles both token exchange and publish
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // OIDC token exchange endpoint
+        if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
+          expect(req.method).toBe("POST");
+          expect(req.headers.get("authorization")).toBe(`Bearer ${oidcToken}`);
+          return Response.json({ token: npmToken });
+        }
+
+        // Publish endpoint (PUT /{package})
+        if (req.method === "PUT") {
+          expect(req.headers.get("authorization")).toBe(`Bearer ${npmToken}`);
+          return new Response("OK", { status: 200 });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-test", {
+      "package.json": JSON.stringify({
+        name: "oidc-test-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/" }`,
+    });
+
+    const { err, exitCode } = await publish(
+      buildEnv({
+        CI: "true",
+        GITHUB_ACTIONS: "true",
+        ACTIONS_ID_TOKEN_REQUEST_URL: `http://localhost:${oidcServer.port}/token?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
+      }),
+      String(dir),
+    );
+
+    // dry-run succeeds (exits 0) which means auth passed
+    expect(err).not.toContain("missing authentication");
+    expect(exitCode).toBe(0);
+  });
+
+  test("falls back to NeedAuth when OIDC is not available", async () => {
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch() {
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-noauth", {
+      "package.json": JSON.stringify({
+        name: "oidc-test-noauth",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/" }`,
+    });
+
+    // No OIDC vars, CI disabled — should fail with NeedAuth
+    const { err, exitCode } = await publish(
+      buildEnv({ CI: "false", GITHUB_ACTIONS: "false" }),
+      String(dir),
+    );
+
+    expect(err).toContain("missing authentication");
+    expect(exitCode).toBe(1);
+  });
+
+  test("falls back to NeedAuth when OIDC exchange fails", async () => {
+    // Mock OIDC endpoint that returns a token
+    using oidcServer = Bun.serve({
+      port: 0,
+      async fetch() {
+        return Response.json({ value: "mock-oidc-token" });
+      },
+    });
+
+    // Mock registry that rejects the token exchange
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
+          return new Response("Forbidden", { status: 403 });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-fail", {
+      "package.json": JSON.stringify({
+        name: "oidc-test-fail",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/" }`,
+    });
+
+    // OIDC is available but exchange returns 403 — should fall through to NeedAuth
+    const { err, exitCode } = await publish(
+      buildEnv({
+        CI: "true",
+        GITHUB_ACTIONS: "true",
+        ACTIONS_ID_TOKEN_REQUEST_URL: `http://localhost:${oidcServer.port}/token?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
+      }),
+      String(dir),
+    );
+
+    expect(err).toContain("missing authentication");
+    expect(exitCode).toBe(1);
+  });
+
+  test("uses NPM_ID_TOKEN env var directly", async () => {
+    const oidcToken = "npm-id-token-direct";
+    const npmToken = "mock-npm-token-from-id";
+
+    // Mock registry for token exchange and publish
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
+          expect(req.method).toBe("POST");
+          expect(req.headers.get("authorization")).toBe(`Bearer ${oidcToken}`);
+          return Response.json({ token: npmToken });
+        }
+
+        if (req.method === "PUT") {
+          expect(req.headers.get("authorization")).toBe(`Bearer ${npmToken}`);
+          return new Response("OK", { status: 200 });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-npmid", {
+      "package.json": JSON.stringify({
+        name: "oidc-test-npmid",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/" }`,
+    });
+
+    // NPM_ID_TOKEN bypasses GitHub Actions flow
+    const { err, exitCode } = await publish(
+      buildEnv({
+        CI: "true",
+        GITHUB_ACTIONS: "false",
+        NPM_ID_TOKEN: oidcToken,
+      }),
+      String(dir),
+    );
+
+    expect(err).not.toContain("missing authentication");
+    expect(exitCode).toBe(0);
+  });
+
+  test("skips OIDC when explicit token is configured", async () => {
+    const explicitToken = "explicit-auth-token";
+    let oidcExchangeCalled = false;
+
+    // Separate OIDC server that returns a valid identity token.
+    // If the OIDC gate is broken, the exchange endpoint on the registry
+    // would be hit and flip oidcExchangeCalled to true, failing the test.
+    using oidcServer = Bun.serve({
+      port: 0,
+      async fetch() {
+        return Response.json({ value: "oidc-token-should-not-be-used" });
+      },
+    });
+
+    // Mock registry
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
+          oidcExchangeCalled = true;
+          return Response.json({ token: "should-not-be-used" });
+        }
+
+        if (req.method === "PUT") {
+          // Should use the explicit token, not OIDC
+          expect(req.headers.get("authorization")).toBe(`Bearer ${explicitToken}`);
+          return new Response("OK", { status: 200 });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-explicit", {
+      "package.json": JSON.stringify({
+        name: "oidc-test-explicit",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/", token = "${explicitToken}" }`,
+    });
+
+    // Even with OIDC env vars set, explicit token in bunfig should take precedence
+    const { err, exitCode } = await publish(
+      buildEnv({
+        CI: "true",
+        GITHUB_ACTIONS: "true",
+        ACTIONS_ID_TOKEN_REQUEST_URL: `http://localhost:${oidcServer.port}/token?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
+      }),
+      String(dir),
+    );
+
+    expect(err).not.toContain("missing authentication");
+    expect(oidcExchangeCalled).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/install/bun-publish-oidc.test.ts
+++ b/test/cli/install/bun-publish-oidc.test.ts
@@ -12,7 +12,7 @@ async function publish(
   ...args: string[]
 ): Promise<{ out: string; err: string; exitCode: number }> {
   const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "publish", "--dry-run", ...args],
+    cmd: [bunExe(), "publish", ...args],
     cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -70,23 +70,18 @@ describe("oidc trusted publishing", () => {
       },
     });
 
-    // Mock npm registry that handles both token exchange and publish
+    // Mock npm registry that handles the OIDC token exchange. Under --dry-run,
+    // publish never issues the PUT, so we only need the exchange endpoint here.
+    // PUT-path coverage is in the non-dry-run test below.
     using registryServer = Bun.serve({
       port: 0,
       async fetch(req) {
         const url = new URL(req.url);
 
-        // OIDC token exchange endpoint
         if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
           expect(req.method).toBe("POST");
           expect(req.headers.get("authorization")).toBe(`Bearer ${oidcToken}`);
           return Response.json({ token: npmToken });
-        }
-
-        // Publish endpoint (PUT /{package})
-        if (req.method === "PUT") {
-          expect(req.headers.get("authorization")).toBe(`Bearer ${npmToken}`);
-          return new Response("OK", { status: 200 });
         }
 
         return new Response("Not Found", { status: 404 });
@@ -109,6 +104,7 @@ describe("oidc trusted publishing", () => {
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
       }),
       String(dir),
+      "--dry-run",
     );
 
     // dry-run succeeds (exits 0) which means auth passed
@@ -136,6 +132,7 @@ describe("oidc trusted publishing", () => {
     const { err, exitCode } = await publish(
       buildEnv({ CI: "false", GITHUB_ACTIONS: "false" }),
       String(dir),
+      "--dry-run",
     );
 
     expect(err).toContain("missing authentication");
@@ -180,6 +177,7 @@ describe("oidc trusted publishing", () => {
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
       }),
       String(dir),
+      "--dry-run",
     );
 
     expect(err).toContain("missing authentication");
@@ -190,7 +188,7 @@ describe("oidc trusted publishing", () => {
     const oidcToken = "npm-id-token-direct";
     const npmToken = "mock-npm-token-from-id";
 
-    // Mock registry for token exchange and publish
+    // Mock registry for token exchange only; dry-run never reaches PUT.
     using registryServer = Bun.serve({
       port: 0,
       async fetch(req) {
@@ -200,11 +198,6 @@ describe("oidc trusted publishing", () => {
           expect(req.method).toBe("POST");
           expect(req.headers.get("authorization")).toBe(`Bearer ${oidcToken}`);
           return Response.json({ token: npmToken });
-        }
-
-        if (req.method === "PUT") {
-          expect(req.headers.get("authorization")).toBe(`Bearer ${npmToken}`);
-          return new Response("OK", { status: 200 });
         }
 
         return new Response("Not Found", { status: 404 });
@@ -227,6 +220,7 @@ describe("oidc trusted publishing", () => {
         NPM_ID_TOKEN: oidcToken,
       }),
       String(dir),
+      "--dry-run",
     );
 
     expect(err).not.toContain("missing authentication");
@@ -247,7 +241,8 @@ describe("oidc trusted publishing", () => {
       },
     });
 
-    // Mock registry
+    // Mock registry. OIDC exchange must not be called when an explicit token
+    // is set. Dry-run never reaches PUT, so no PUT handler is needed.
     using registryServer = Bun.serve({
       port: 0,
       async fetch(req) {
@@ -256,12 +251,6 @@ describe("oidc trusted publishing", () => {
         if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
           oidcExchangeCalled = true;
           return Response.json({ token: "should-not-be-used" });
-        }
-
-        if (req.method === "PUT") {
-          // Should use the explicit token, not OIDC
-          expect(req.headers.get("authorization")).toBe(`Bearer ${explicitToken}`);
-          return new Response("OK", { status: 200 });
         }
 
         return new Response("Not Found", { status: 404 });
@@ -285,10 +274,73 @@ describe("oidc trusted publishing", () => {
         ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
       }),
       String(dir),
+      "--dry-run",
     );
 
     expect(err).not.toContain("missing authentication");
     expect(oidcExchangeCalled).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+
+  test("OIDC token is injected into publish PUT request (non-dry-run)", async () => {
+    // End-to-end: runs the real publish PUT so we can assert the OIDC-exchanged
+    // token actually flows through constructPublishHeaders into the PUT's
+    // Authorization header. The dry-run tests above only exercise the OIDC
+    // POST exchange — they return before any PUT is made.
+    const oidcToken = "e2e-oidc-identity-token";
+    const npmToken = "e2e-exchanged-npm-token";
+
+    using oidcServer = Bun.serve({
+      port: 0,
+      async fetch() {
+        return Response.json({ value: oidcToken });
+      },
+    });
+
+    const { promise: putReceived, resolve: resolvePut } =
+      Promise.withResolvers<{ authorization: string | null }>();
+
+    using registryServer = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        if (url.pathname.includes("/-/npm/v1/oidc/token/exchange/package/")) {
+          expect(req.method).toBe("POST");
+          expect(req.headers.get("authorization")).toBe(`Bearer ${oidcToken}`);
+          return Response.json({ token: npmToken });
+        }
+
+        if (req.method === "PUT") {
+          resolvePut({ authorization: req.headers.get("authorization") });
+          return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("oidc-publish-e2e", {
+      "package.json": JSON.stringify({
+        name: "oidc-e2e-pkg",
+        version: "1.0.0",
+      }),
+      "bunfig.toml": `[install]\ncache = false\nregistry = { url = "http://localhost:${registryServer.port}/" }`,
+    });
+
+    const { err, exitCode } = await publish(
+      buildEnv({
+        CI: "true",
+        GITHUB_ACTIONS: "true",
+        ACTIONS_ID_TOKEN_REQUEST_URL: `http://localhost:${oidcServer.port}/token?`,
+        ACTIONS_ID_TOKEN_REQUEST_TOKEN: "mock-request-token",
+      }),
+      String(dir),
+    );
+
+    const put = await putReceived;
+    expect(put.authorization).toBe(`Bearer ${npmToken}`);
+    expect(err).not.toContain("missing authentication");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds OIDC (OpenID Connect) trusted publishing support to `bun publish`, enabling tokenless npm authentication in CI environments. When no explicit auth is configured and the process is running in CI, Bun now attempts to exchange a CI-provided OIDC identity token with the npm registry for a short-lived publish token. This eliminates the need for long-lived `NPM_TOKEN` secrets.

Refs: #15601, #22423, #24855

## What changed

**`src/cli/oidc.zig` (new)** — OIDC token acquisition and exchange module. `attemptOidcAuth()` is the entry point: it first checks the `NPM_ID_TOKEN` env var (works for all CI providers), then falls back to fetching a token from `ACTIONS_ID_TOKEN_REQUEST_URL` (GitHub Actions). The identity token is exchanged with the registry at `/-/npm/v1/oidc/token/exchange/package/{name}` for a short-lived npm auth token. All functions return `null` on failure — OIDC is always best-effort and never prevents publishing when auth is already configured.

**`src/cli/publish_command.zig`** — In `publish()`, before the existing `NeedAuth` check, attempts OIDC if no auth is configured and `isCI()` is true. If OIDC succeeds, creates a stack-local copy of the registry scope with the token injected. All downstream code (`constructPublishHeaders`, etc.) uses the token transparently with no signature changes.

**`src/env_var.zig`** — Adds typed accessors for `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, and `NPM_ID_TOKEN`.

## OIDC flow

```
bun publish
  → no auth token configured? + in CI?
    → GET ${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:${registry_hostname}
      (Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN})
    → POST ${registry}/-/npm/v1/oidc/token/exchange/package/${name}
      (Authorization: Bearer ${oidc_token})
    → registry returns short-lived npm token → use for publish
  → still no auth? → existing NeedAuth error (unchanged)
```

This matches npm CLI's OIDC implementation in `lib/utils/oidc.js`.

## Test plan

- [x] `bun bd test test/cli/install/bun-publish-oidc.test.ts` — 6 tests, all pass
  - Successful OIDC auth via GitHub Actions (mock OIDC + registry servers, `--dry-run`)
  - Falls back to NeedAuth when OIDC not available
  - Falls back to NeedAuth when OIDC exchange fails (403)
  - Uses `NPM_ID_TOKEN` env var directly (bypasses GitHub Actions flow)
  - Skips OIDC when explicit token is already configured
  - **Non-dry-run E2E**: exchanged `Bearer ${npmToken}` actually lands in the publish PUT's Authorization header (verifies `oidc_scope` flows through `constructPublishHeaders`)
- [x] `bun run zig:check` passes
- [ ] CI (this PR)
- [ ] Existing `bun-publish.test.ts` tests unaffected (require verdaccio, tested locally with expected missing-dep skip)

## Session context

**Investigation**: Researched npm CLI's OIDC implementation (`lib/utils/oidc.js`), the GitHub Actions OIDC token request mechanism, and the npm registry token exchange endpoint. Also analyzed the two prior attempts at this feature (#21586, #27263) to understand why they didn't land.

**Architecture decision**: OIDC auth is pure Zig (~170 lines) since it's just 2 HTTP requests following the same `http.AsyncHTTP.initSync` pattern as `checkPackageVersionExists`. The scope-copy approach (`oidc_scope = orig_registry.*`) avoids modifying the const registry pointer while keeping all downstream code unchanged.

**Key constraint**: `scopeForPackageName()` returns `*const Npm.Registry.Scope`, so we can't mutate the token in place. A stack-local copy with the OIDC token injected is pointed to by `registry`, making the change transparent to `constructPublishHeaders` and the publish PUT.

**Provenance (`--provenance`)**: Intentionally deferred to a follow-up PR. This PR is independently valuable — OIDC auth alone eliminates NPM_TOKEN secrets in CI. The proposed provenance approach (sigstore-js via subprocess) is described in [this comment on #15601](https://github.com/oven-sh/bun/issues/15601#issuecomment-4246610476).

**Review feedback addressed** (CodeRabbit, 3a4c7b0):

- *HTTP connect-phase timeout*: `AsyncHTTP.initSync` exposes no connect timeout — a 5-minute timeout applies once the socket is open, but the TCP handshake itself relies on kernel defaults. Documented the caveat at both `initSync` call sites in `oidc.zig`. Adding a configurable connect timeout would mean touching the core HTTP client for a best-effort feature — not worth the blast radius, especially since failure simply returns `null` and falls through to `NeedAuth`.
- *Dead PUT assertions under `--dry-run`*: the original test file had `if (req.method === "PUT") expect(...)` branches that never fired because `--dry-run` returns before the PUT. Dropped the dead branches and added a non-dry-run E2E test that captures the PUT with `Promise.withResolvers` and asserts the injected `Bearer ${npmToken}`. That's now the only test exercising the scope-copy → `constructPublishHeaders` path end-to-end.

<details>
<summary>Timeline</summary>

1. Researched npm OIDC spec + prior PRs → identified that OIDC auth is just 2 HTTP requests, worth doing natively in Zig
2. Explored Bun's publish_command.zig, auth handling, and Registry.Scope type
3. Discovered `scopeForPackageName` returns const pointer → designed stack-local copy pattern
4. Implemented oidc.zig with `fetchIdentityToken` + `exchangeToken`
5. Hit Zig type error: `getStringCloned` returns `OOM!?[]const u8`, needed two-step unwrap
6. Test failures: bunEnv leaks `CI=1` and `NODE_AUTH_TOKEN` from global `~/.npmrc` → fixed with `buildEnv` helper + fake HOME

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
