### PR TITLE
Propagate exceptions from custom asymmetric matcher in asymmetricMatch

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-asymmetric-matcher-throw.test.ts
+++ b/test/js/bun/test/expect-asymmetric-matcher-throw.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("asymmetricMatch propagates exceptions thrown by custom matcher", async () => {
+  const src = `
+    const { expect } = Bun.jest(import.meta.path);
+    expect.extend({
+      _throwingMatcher() {
+        throw new Error("boom from matcher");
+      },
+    });
+    const matcher = expect._throwingMatcher();
+    try {
+      matcher.asymmetricMatch(1);
+      console.log("FAIL: did not throw");
+    } catch (e) {
+      console.log("caught:", e.message);
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(stdout.trim()).toBe("caught: boom from matcher");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzer found a debug assertion crash (`releaseAssertNoException`) with fingerprint `3a4e9ec87daf2145`.

## Root cause

`ExpectCustomAsymmetricMatcher.execute()` is a `callconv(.c) bool` entry point (also called from C++), so when the user-supplied matcher throws it swallows the error with `catch false` and leaves the JSC exception pending for the caller's `ThrowScope` to observe.

`asymmetricMatch()` (the JS-visible `matcher.asymmetricMatch(value)` method) calls `execute()` and then unconditionally returns `JSValue.jsBoolean(matched)`. When the matcher threw, this returns a non-empty value through `toJSHostCall` while an exception is still pending, which trips `ExceptionValidationScope.assertExceptionPresenceMatches` → `releaseAssertNoException()`.

## Repro

```js
const { expect } = Bun.jest(import.meta.path);
expect.extend({ m() { throw new Error("boom"); } });
expect.m().asymmetricMatch(1);
```

## Fix

Check for a pending exception after `execute()` and return `error.JSError` so the exception propagates to JS instead of being masked by a boolean return.