### PR TITLE
fix(inspect): stack overflow when inspecting JSX element with circular reference

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,18 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular key", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, props: {} };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+});
+
+it("jsx with circular children", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, props: {} };
+  el.props.children = el;
+  expect(Bun.inspect(el)).toBe("<div>\n  [Circular]\n</div>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
Fixes a stack overflow crash in `Bun.inspect` / `console.log` when a React element contains a circular reference through its `key`, `props`, or `children`.

## Repro

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {} };
el.key = el;
Bun.inspect(el); // segfault (stack overflow)
```

## Cause

The JSX branch of the formatter recursively formats `key`, `props`, and `children`, but `.JSX` was not included in `canHaveCircularReferences()`, so the visited-map cycle check was skipped. A self-referential element recursed until the native stack was exhausted.

## Fix

Add `.JSX` to `canHaveCircularReferences()` in both `ConsoleObject.zig` and `pretty_format.zig` so the existing `[Circular]` handling and stack guard apply.

Found by Fuzzilli (fingerprint `6e718886f45af13a`).