### PR TITLE
Fix crash in forEachProperty when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5365,7 +5365,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -702,6 +702,22 @@ it("MessageEvent", () => {
   `);
 });
 
+it("inspect object with Proxy prototype that throws in getPrototypeOf does not crash", () => {
+  const obj = {};
+  Object.setPrototypeOf(
+    obj,
+    new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      },
+    ),
+  );
+  expect(typeof Bun.inspect(obj)).toBe("string");
+});
+
 it("CustomEvent", () => {
   const customEvent = new CustomEvent("custom", {
     detail: { value: 42, name: "test" },


### PR DESCRIPTION
When walking the prototype chain during property enumeration for the console formatter (`Bun.inspect` / `console.log`), `getPrototype()` can throw — e.g. via a Proxy `getPrototypeOf` trap — returning an empty `JSValue`. Calling `.getObject()` on that empty value dereferences a null cell pointer and crashes.

Clear the exception and stop walking the chain instead, matching the behavior of the other `getPrototype()` call sites in the same function.

### Repro
```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, {
  getPrototypeOf() { throw new Error("nope"); }
}));
console.log(obj);
```

Before: `Segmentation fault at address 0x5`
After: `{}`

Fuzzer fingerprint: `6ba473c2ca8e03e1`