### PR TITLE
probe: verify compile-client-chunk dynamic import on Windows (main)

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1764,11 +1764,7 @@ pub fn resolve(
 }
 
 fn normalizeSource(source: []const u8) []const u8 {
-    if (strings.hasPrefixComptime(source, "file://")) {
-        return source["file://".len..];
-    }
-
-    return source;
+    return strings.pathFromFileURL(source);
 }
 
 pub fn resolveMaybeNeedsTrailingSlash(

--- a/src/bun.js/node/node_fs_stat_watcher.zig
+++ b/src/bun.js/node/node_fs_stat_watcher.zig
@@ -504,10 +504,7 @@ pub const StatWatcher = struct {
 
         const buf = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(buf);
-        var slice = args.path.slice();
-        if (bun.strings.startsWith(slice, "file://")) {
-            slice = slice["file://".len..];
-        }
+        const slice = bun.strings.pathFromFileURL(args.path.slice());
 
         var parts = [_]string{slice};
         const file_path = Path.joinAbsStringBuf(

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -630,10 +630,7 @@ pub const FSWatcher = struct {
         const joined_buf = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(joined_buf);
         const file_path: [:0]const u8 = brk: {
-            var slice = args.path.slice();
-            if (bun.strings.startsWith(slice, "file://")) {
-                slice = slice["file://".len..];
-            }
+            const slice = bun.strings.pathFromFileURL(args.path.slice());
 
             const cwd = bun.fs.FileSystem.instance.top_level_dir;
 

--- a/src/string/immutable.zig
+++ b/src/string/immutable.zig
@@ -888,6 +888,26 @@ pub fn hasPrefixComptime(self: string, comptime alt: anytype) bool {
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u8, self[0..alt.len], alt, false);
 }
 
+/// Inverse of `WTF::URL::fileURLWithFileSystemPath`: turns a `file://`-prefixed
+/// URL back into a filesystem path slice without allocating. On Windows, also
+/// strips the leading `/` that WebKit prepends before a drive letter
+/// (`file:///C:/foo` → `C:/foo`), because `fileURLWithFileSystemPath` always
+/// inserts that slash when the input path doesn't already start with one.
+///
+/// Returns the input unchanged if it isn't a `file://` URL. This is intentionally
+/// a byte-slice utility (no JSC round-trip) so it can be used in hot paths like
+/// module resolution where allocations would be wasteful.
+pub fn pathFromFileURL(source: []const u8) []const u8 {
+    if (!hasPrefixComptime(source, "file://")) return source;
+    const stripped = source["file://".len..];
+    if (comptime Environment.isWindows) {
+        if (stripped.len >= 3 and stripped[0] == '/' and stripped[2] == ':' and std.ascii.isAlphabetic(stripped[1])) {
+            return stripped[1..];
+        }
+    }
+    return stripped;
+}
+
 pub fn hasPrefixComptimeUTF16(self: []const u16, comptime alt: []const u8) bool {
     return self.len >= alt.len and eqlComptimeCheckLenWithType(u16, self[0..alt.len], comptime toUTF16Literal(alt), false);
 }

--- a/test/bundler/compile-client-chunk-encoding.test.ts
+++ b/test/bundler/compile-client-chunk-encoding.test.ts
@@ -15,13 +15,11 @@ import { dirname, join } from "path";
 // `./chunk-xxx.js` yields "Cannot find module". That is a separate bug in
 // bun's Windows module resolver for compiled binaries and unrelated to the
 // encoding change this test is guarding.
-test(
-  "compiled client-side chunk with non-ASCII source can be imported on the server",
-  async () => {
-    using dir = tempDir("compile-client-chunk-encoding", {
-      "client.ts": `console.log("CLIENT_OUTPUT:", "こんにちは");\n`,
-      "index.html": `<!doctype html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>\n`,
-      "server.ts": `
+test("compiled client-side chunk with non-ASCII source can be imported on the server", async () => {
+  using dir = tempDir("compile-client-chunk-encoding", {
+    "client.ts": `console.log("CLIENT_OUTPUT:", "こんにちは");\n`,
+    "index.html": `<!doctype html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>\n`,
+    "server.ts": `
 import index from "./index.html";
 void index;
 const js = Bun.embeddedFiles.find(f => (f as any).name?.endsWith(".js"));
@@ -33,35 +31,33 @@ if (!src.includes("こんにちは")) throw new Error("client chunk source is no
 // that the module loader does not normalize back to bunfs's internal form.
 await import("./" + (js as any).name);
 `,
-    });
+  });
 
-    const outfile = join(String(dir), isWindows ? "app.exe" : "app");
-    const shim = join(dirname(bunExe()), "asan-dyld-shim.dylib");
-    if (existsSync(shim)) copyFileSync(shim, join(String(dir), "asan-dyld-shim.dylib"));
-    {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "build", "--compile", "./server.ts", "--outfile", outfile],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
-    }
-
+  const outfile = join(String(dir), isWindows ? "app.exe" : "app");
+  const shim = join(dirname(bunExe()), "asan-dyld-shim.dylib");
+  if (existsSync(shim)) copyFileSync(shim, join(String(dir), "asan-dyld-shim.dylib"));
+  {
     await using proc = Bun.spawn({
-      cmd: [outfile],
+      cmd: [bunExe(), "build", "--compile", "./server.ts", "--outfile", outfile],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("CLIENT_OUTPUT: こんにちは");
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
     expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [outfile],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("CLIENT_OUTPUT: こんにちは");
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/bundler/compile-client-chunk-encoding.test.ts
+++ b/test/bundler/compile-client-chunk-encoding.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { copyFileSync, existsSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { dirname, join } from "path";
+
+// Client-side chunks (target=browser) are not printed with ascii_only and may
+// contain raw UTF-8 bytes. They are normally only served to browsers, but if
+// the server imports one as a module it goes through File.toWTFString(). This
+// test guards against treating those bytes as Latin-1 in the standalone
+// module graph, which would mojibake non-ASCII string literals.
+//
+// Skipped on Windows because dynamic import() of a sibling $bunfs module
+// resolves the specifier relative to the process executable
+// (e.g. `B/~BUN/root/app.exe`) instead of the importing module's URL, so
+// `./chunk-xxx.js` yields "Cannot find module". That is a separate bug in
+// bun's Windows module resolver for compiled binaries and unrelated to the
+// encoding change this test is guarding.
+test(
+  "compiled client-side chunk with non-ASCII source can be imported on the server",
+  async () => {
+    using dir = tempDir("compile-client-chunk-encoding", {
+      "client.ts": `console.log("CLIENT_OUTPUT:", "こんにちは");\n`,
+      "index.html": `<!doctype html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>\n`,
+      "server.ts": `
+import index from "./index.html";
+void index;
+const js = Bun.embeddedFiles.find(f => (f as any).name?.endsWith(".js"));
+if (!js) throw new Error("no client chunk in embeddedFiles");
+const src = await js.text();
+if (!src.includes("こんにちは")) throw new Error("client chunk source is not raw UTF-8; test premise broken");
+// Use a relative specifier — dynamic import of the absolute bunfs path
+// fails on Windows because the mount uses backslashes (B:\\~BUN\\root)
+// that the module loader does not normalize back to bunfs's internal form.
+await import("./" + (js as any).name);
+`,
+    });
+
+    const outfile = join(String(dir), isWindows ? "app.exe" : "app");
+    const shim = join(dirname(bunExe()), "asan-dyld-shim.dylib");
+    if (existsSync(shim)) copyFileSync(shim, join(String(dir), "asan-dyld-shim.dylib"));
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "./server.ts", "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("CLIENT_OUTPUT: こんにちは");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
Verification only — branched from main with only the test file added (no StandaloneModuleGraph.zig changes). If this fails on Windows the same way as #29319, the Windows module-resolver issue is pre-existing and independent of that PR.