### PR TITLE
captureStackTrace: don't abort when Error.stackTraceLimit is non-numeric

### DIFF
--- a/src/bun.js/bindings/FormatStackTraceForJS.cpp
+++ b/src/bun.js/bindings/FormatStackTraceForJS.cpp
@@ -735,7 +735,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
     JSC::JSObject* errorObject = objectArg.asCell()->getObject();
     JSC::JSValue caller = callFrame->argument(1);
 
-    size_t stackTraceLimit = globalObject->stackTraceLimit().value();
+    size_t stackTraceLimit = globalObject->stackTraceLimit().value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT);
     if (stackTraceLimit == 0) {
         stackTraceLimit = DEFAULT_ERROR_STACK_TRACE_LIMIT;
     }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -889,3 +889,20 @@ test("Error.captureStackTrace applies stackTraceLimit after caller removal", () 
     Error.stackTraceLimit = origLimit;
   }
 });
+
+test("captureStackTrace does not crash when stackTraceLimit is non-numeric", () => {
+  const origLimit = Error.stackTraceLimit;
+  try {
+    Error.stackTraceLimit = "foo";
+    const obj = {};
+    expect(() => Error.captureStackTrace(obj)).not.toThrow();
+    expect(typeof obj.stack).toBe("string");
+
+    delete Error.stackTraceLimit;
+    const obj2 = {};
+    expect(() => Error.captureStackTrace(obj2)).not.toThrow();
+    expect(typeof obj2.stack).toBe("string");
+  } finally {
+    Error.stackTraceLimit = origLimit;
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a SIGABRT when `Error.captureStackTrace()` is called after `Error.stackTraceLimit` has been set to a non-numeric value (or deleted).

```js
Error.stackTraceLimit = "foo";
Error.captureStackTrace({}); // SIGABRT
```

When `Error.stackTraceLimit` is assigned a value that isn't a number, JSC's `ErrorConstructor::put` stores `std::nullopt` in `m_stackTraceLimit`. `errorConstructorFuncCaptureStackTrace` was calling `.value()` on that optional unconditionally, and since Bun is built with `-fno-exceptions`, `std::bad_optional_access` turns straight into `abort()`.

Changed to `.value_or(DEFAULT_ERROR_STACK_TRACE_LIMIT)`, which matches how `BunProcess.cpp` and `bindings.cpp` already read the same optional.

Found by Fuzzilli (fingerprint `dd0298a12ccb7c64`).