### PR TITLE
windows: fix fs.writeSync panic when std handle changed after startup

### DIFF
--- a/src/fd.zig
+++ b/src/fd.zig
@@ -152,6 +152,15 @@ pub const FD = packed struct(backing_int) {
             else => fd.value.as_system,
             .windows => switch (fd.decodeWindows()) {
                 .windows => |handle| {
+                    // `.stdin()`/`.stdout()`/`.stderr()` hand out the cached
+                    // `windows_cached_std{in,out,err}` (snapshotted at startup),
+                    // so round-trip against those first. Comparing only against
+                    // the live `GetStdHandle` result panics if the process std
+                    // handle was swapped after startup via `SetStdHandle`,
+                    // `AllocConsole`, `AttachConsole`, etc.
+                    if (fd == windows_cached_stdin) return 0;
+                    if (fd == windows_cached_stdout) return 1;
+                    if (fd == windows_cached_stderr) return 2;
                     if (isStdioHandle(std.os.windows.STD_INPUT_HANDLE, handle)) return 0;
                     if (isStdioHandle(std.os.windows.STD_OUTPUT_HANDLE, handle)) return 1;
                     if (isStdioHandle(std.os.windows.STD_ERROR_HANDLE, handle)) return 2;
@@ -312,14 +321,11 @@ pub const FD = packed struct(backing_int) {
             return null;
         }
         const fd: i32 = @intCast(fd64);
-        if (os == .windows) {
-            return switch (fd) {
-                0 => .stdin(),
-                1 => .stdout(),
-                2 => .stderr(),
-                else => .fromUV(fd),
-            };
-        }
+        // On Windows, JS-visible fds are libuv/CRT fds (see `toJS`). libuv fd
+        // 0/1/2 already map to stdio, so there is no need to substitute the
+        // cached `.system` HANDLE here — doing so forces every `sys_uv` call to
+        // round-trip through `FD.uv()`'s stdio-handle comparison, which panics
+        // if the process std handle was swapped after startup.
         return .fromUV(fd);
     }
     // If a non-number is given, returns null.
@@ -336,11 +342,8 @@ pub const FD = packed struct(backing_int) {
         }
         const int: i64 = @intFromFloat(float);
         const fd: c_int = @intCast(int);
-        if (os == .windows) {
-            if (Stdio.fromInt(fd)) |stdio| {
-                return stdio.fd();
-            }
-        }
+        // See `fromJS` above for why stdio fds are not remapped to the cached
+        // `.system` HANDLE on Windows.
         return .fromUV(fd);
     }
     /// After calling, the input file descriptor is no longer valid and must not be used.

--- a/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
+++ b/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
@@ -1,10 +1,12 @@
-// On Windows, `FD.fromJSValidated(0|1|2)` returns the stdio HANDLE cached at
-// process startup, and `FD.uv()` must map that `.system` FD back to libuv fd
-// 0/1/2 before calling `uv_fs_write`. If `FD.uv()` compares against the *live*
-// `GetStdHandle()` instead of the cached value, a user-space `SetStdHandle`
-// (or `AllocConsole`/`AttachConsole`) makes the round-trip fail and
-// `fs.writeSync(1, ...)` panics with:
+// Regression: on Windows, `FD.fromJSValidated(0|1|2)` used to return the
+// stdio HANDLE cached at process startup, forcing `sys_uv` to map that
+// `.system` FD back to libuv fd 0/1/2 via `FD.uv()`. `FD.uv()` compared the
+// handle against the *live* `GetStdHandle()` result, so a user-space
+// `SetStdHandle` (or `AllocConsole`/`AttachConsole`) made the round-trip fail
+// and `fs.writeSync(1, ...)` panicked with:
 //   "Cast bun.FD.uv(N[handle]) makes closing impossible!"
+// Now `fromJS`/`fromJSValidated` return `.fromUV(0|1|2)` directly, and
+// `FD.uv()` checks the cached stdio handles before `GetStdHandle`.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
@@ -40,7 +42,7 @@ test.skipIf(!isWindows)("fs.writeSync(1, ...) does not panic after SetStdHandle 
       0,
       null,
     );
-    if (nul === null || nul === -1n || nul === BigInt("0xffffffffffffffff")) {
+    if (nul === null) {
       throw new Error("CreateFileW(NUL) failed");
     }
 

--- a/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
+++ b/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
@@ -72,9 +72,7 @@ test.skipIf(!isWindows)("fs.writeSync(1, ...) does not panic after SetStdHandle 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toContain("wrote=19");
-  expect(stderr).not.toContain("makes closing impossible");
-  expect(stderr).not.toContain("panic");
+  expect(stderr).toBe("wrote=19\n");
   expect(stdout).toBe("after-setstdhandle\n");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
+++ b/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
@@ -7,99 +7,104 @@
 //   "Cast bun.FD.uv(N[handle]) makes closing impossible!"
 // Now `fromJS`/`fromJSValidated` return `.fromUV(0|1|2)` directly, and
 // `FD.uv()` checks the cached stdio handles before `GetStdHandle`.
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isArm64, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
-test.skipIf(!isWindows)("fs.writeSync(1, ...) does not panic after SetStdHandle swaps stdout", async () => {
-  const fixture = `
-    const fs = require("node:fs");
-    const { dlopen } = require("bun:ffi");
+describe.concurrent.skipIf(!isWindows)("fs.writeSync on Windows stdio/handles", () => {
+  // bun:ffi (TinyCC) is unavailable on Windows arm64, so this repro can only
+  // run on x64. The second test below covers the plain openSync→writeSync path
+  // on all Windows arches.
+  test.skipIf(isArm64)("fs.writeSync(1, ...) does not panic after SetStdHandle swaps stdout", async () => {
+    const fixture = `
+      const fs = require("node:fs");
+      const { dlopen } = require("bun:ffi");
 
-    const k32 = dlopen("kernel32.dll", {
-      SetStdHandle: { args: ["u32", "ptr"], returns: "i32" },
-      GetStdHandle: { args: ["u32"], returns: "ptr" },
-      CreateFileW: {
-        args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"],
-        returns: "ptr",
-      },
+      const k32 = dlopen("kernel32.dll", {
+        SetStdHandle: { args: ["u32", "ptr"], returns: "i32" },
+        GetStdHandle: { args: ["u32"], returns: "ptr" },
+        CreateFileW: {
+          args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"],
+          returns: "ptr",
+        },
+      });
+
+      const STD_OUTPUT_HANDLE = 0xfffffff5; // (DWORD)-11
+      const GENERIC_WRITE = 0x40000000;
+      const FILE_SHARE_READ = 0x00000001;
+      const FILE_SHARE_WRITE = 0x00000002;
+      const OPEN_EXISTING = 3;
+
+      // Open NUL so we have a real HANDLE distinct from the original stdout.
+      const nulPath = Buffer.from("NUL\\0", "utf16le");
+      const nul = k32.symbols.CreateFileW(
+        nulPath,
+        GENERIC_WRITE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        null,
+        OPEN_EXISTING,
+        0,
+        null,
+      );
+      if (nul === null) {
+        throw new Error("CreateFileW(NUL) failed");
+      }
+
+      const original = k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE);
+      if (k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, nul) === 0) {
+        throw new Error("SetStdHandle failed");
+      }
+      if (k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE) === original) {
+        throw new Error("GetStdHandle did not change after SetStdHandle");
+      }
+
+      // Before the fix this panics: the cached stdout HANDLE no longer equals
+      // the live GetStdHandle(STD_OUTPUT_HANDLE), so FD.uv() falls through to
+      // the "makes closing impossible" panic.
+      const n = fs.writeSync(1, "after-setstdhandle\\n");
+
+      // fs.writeSync(1, ...) maps to libuv fd 1, which is the C runtime's
+      // original stdout — SetStdHandle does not rewire CRT fds — so the write
+      // should land on the parent-observed stdout.
+      k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, original);
+      process.stderr.write("wrote=" + n + "\\n");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const STD_OUTPUT_HANDLE = 0xfffffff5; // (DWORD)-11
-    const GENERIC_WRITE = 0x40000000;
-    const FILE_SHARE_READ = 0x00000001;
-    const FILE_SHARE_WRITE = 0x00000002;
-    const OPEN_EXISTING = 3;
-
-    // Open NUL so we have a real HANDLE distinct from the original stdout.
-    const nulPath = Buffer.from("NUL\\0", "utf16le");
-    const nul = k32.symbols.CreateFileW(
-      nulPath,
-      GENERIC_WRITE,
-      FILE_SHARE_READ | FILE_SHARE_WRITE,
-      null,
-      OPEN_EXISTING,
-      0,
-      null,
-    );
-    if (nul === null) {
-      throw new Error("CreateFileW(NUL) failed");
-    }
-
-    const original = k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE);
-    if (k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, nul) === 0) {
-      throw new Error("SetStdHandle failed");
-    }
-    if (k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE) === original) {
-      throw new Error("GetStdHandle did not change after SetStdHandle");
-    }
-
-    // Before the fix this panics: the cached stdout HANDLE no longer equals
-    // the live GetStdHandle(STD_OUTPUT_HANDLE), so FD.uv() falls through to
-    // the "makes closing impossible" panic.
-    const n = fs.writeSync(1, "after-setstdhandle\\n");
-
-    // fs.writeSync(1, ...) maps to libuv fd 1, which is the C runtime's
-    // original stdout — SetStdHandle does not rewire CRT fds — so the write
-    // should land on the parent-observed stdout.
-    k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, original);
-    process.stderr.write("wrote=" + n + "\\n");
-  `;
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+    expect(stderr).toBe("wrote=19\n");
+    expect(stdout).toBe("after-setstdhandle\n");
+    expect(exitCode).toBe(0);
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("wrote=19\n");
-  expect(stdout).toBe("after-setstdhandle\n");
-  expect(exitCode).toBe(0);
-});
+  test("fs.writeSync on an fd from fs.openSync works", async () => {
+    using dir = tempDir("fs-writeSync-stdio-windows", {});
+    const out = join(String(dir), "out.txt").replaceAll("\\", "/");
 
-test.skipIf(!isWindows)("fs.writeSync on an fd from fs.openSync works", async () => {
-  using dir = tempDir("fs-writeSync-stdio-windows", {});
-  const out = join(String(dir), "out.txt").replaceAll("\\", "/");
+    const fixture = `
+      const fs = require("node:fs");
+      const fd = fs.openSync(${JSON.stringify(out)}, "w");
+      const n = fs.writeSync(fd, "hello from writeSync");
+      fs.closeSync(fd);
+      process.stdout.write("wrote=" + n + " body=" + fs.readFileSync(${JSON.stringify(out)}, "utf8"));
+    `;
 
-  const fixture = `
-    const fs = require("node:fs");
-    const fd = fs.openSync(${JSON.stringify(out)}, "w");
-    const n = fs.writeSync(fd, "hello from writeSync");
-    fs.closeSync(fd);
-    process.stdout.write("wrote=" + n + " body=" + fs.readFileSync(${JSON.stringify(out)}, "utf8"));
-  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+    expect(stderr).toBe("");
+    expect(stdout).toBe("wrote=20 body=hello from writeSync");
+    expect(exitCode).toBe(0);
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout).toBe("wrote=20 body=hello from writeSync");
-  expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
+++ b/test/js/node/fs/fs-writeSync-stdio-windows.test.ts
@@ -1,0 +1,105 @@
+// On Windows, `FD.fromJSValidated(0|1|2)` returns the stdio HANDLE cached at
+// process startup, and `FD.uv()` must map that `.system` FD back to libuv fd
+// 0/1/2 before calling `uv_fs_write`. If `FD.uv()` compares against the *live*
+// `GetStdHandle()` instead of the cached value, a user-space `SetStdHandle`
+// (or `AllocConsole`/`AttachConsole`) makes the round-trip fail and
+// `fs.writeSync(1, ...)` panics with:
+//   "Cast bun.FD.uv(N[handle]) makes closing impossible!"
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
+
+test.skipIf(!isWindows)("fs.writeSync(1, ...) does not panic after SetStdHandle swaps stdout", async () => {
+  const fixture = `
+    const fs = require("node:fs");
+    const { dlopen } = require("bun:ffi");
+
+    const k32 = dlopen("kernel32.dll", {
+      SetStdHandle: { args: ["u32", "ptr"], returns: "i32" },
+      GetStdHandle: { args: ["u32"], returns: "ptr" },
+      CreateFileW: {
+        args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"],
+        returns: "ptr",
+      },
+    });
+
+    const STD_OUTPUT_HANDLE = 0xfffffff5; // (DWORD)-11
+    const GENERIC_WRITE = 0x40000000;
+    const FILE_SHARE_READ = 0x00000001;
+    const FILE_SHARE_WRITE = 0x00000002;
+    const OPEN_EXISTING = 3;
+
+    // Open NUL so we have a real HANDLE distinct from the original stdout.
+    const nulPath = Buffer.from("NUL\\0", "utf16le");
+    const nul = k32.symbols.CreateFileW(
+      nulPath,
+      GENERIC_WRITE,
+      FILE_SHARE_READ | FILE_SHARE_WRITE,
+      null,
+      OPEN_EXISTING,
+      0,
+      null,
+    );
+    if (nul === null || nul === -1n || nul === BigInt("0xffffffffffffffff")) {
+      throw new Error("CreateFileW(NUL) failed");
+    }
+
+    const original = k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE);
+    if (k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, nul) === 0) {
+      throw new Error("SetStdHandle failed");
+    }
+    if (k32.symbols.GetStdHandle(STD_OUTPUT_HANDLE) === original) {
+      throw new Error("GetStdHandle did not change after SetStdHandle");
+    }
+
+    // Before the fix this panics: the cached stdout HANDLE no longer equals
+    // the live GetStdHandle(STD_OUTPUT_HANDLE), so FD.uv() falls through to
+    // the "makes closing impossible" panic.
+    const n = fs.writeSync(1, "after-setstdhandle\\n");
+
+    // fs.writeSync(1, ...) maps to libuv fd 1, which is the C runtime's
+    // original stdout — SetStdHandle does not rewire CRT fds — so the write
+    // should land on the parent-observed stdout.
+    k32.symbols.SetStdHandle(STD_OUTPUT_HANDLE, original);
+    process.stderr.write("wrote=" + n + "\\n");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("wrote=19");
+  expect(stderr).not.toContain("makes closing impossible");
+  expect(stderr).not.toContain("panic");
+  expect(stdout).toBe("after-setstdhandle\n");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!isWindows)("fs.writeSync on an fd from fs.openSync works", async () => {
+  using dir = tempDir("fs-writeSync-stdio-windows", {});
+  const out = join(String(dir), "out.txt").replaceAll("\\", "/");
+
+  const fixture = `
+    const fs = require("node:fs");
+    const fd = fs.openSync(${JSON.stringify(out)}, "w");
+    const n = fs.writeSync(fd, "hello from writeSync");
+    fs.closeSync(fd);
+    process.stdout.write("wrote=" + n + " body=" + fs.readFileSync(${JSON.stringify(out)}, "utf8"));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("wrote=20 body=hello from writeSync");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes `Panic: Cast bun.FD.uv(N[handle]) makes closing impossible!` on Windows when `fs.writeSync(0|1|2, …)` (or any fd-taking `node:fs` operation on stdio) is called after the process std handle has been replaced at runtime.

### Repro

```js
// Windows only
const { dlopen } = require('bun:ffi');
const k32 = dlopen('kernel32.dll', {
  SetStdHandle: { args: ['u32', 'ptr'], returns: 'i32' },
  CreateFileW: { args: ['ptr','u32','u32','ptr','u32','u32','ptr'], returns: 'ptr' },
});
const nul = k32.symbols.CreateFileW(Buffer.from('NUL\\0','utf16le'), 0x40000000, 3, null, 3, 0, null);
k32.symbols.SetStdHandle(0xfffffff5 /* STD_OUTPUT_HANDLE */, nul);
require('fs').writeSync(1, 'boom\n'); // panics before this PR
```

Stack:
```
isStdioHandle  src/fd.zig:629
uv             src/fd.zig
pwritev        src/sys_uv.zig:364
writev         src/sys_uv.zig:494
write          src/sys_uv.zig:537
writeInner     src/bun.js/node/node_fs.zig:4341
write          src/bun.js/node/node_fs.zig:4307
runSync        src/bun.js/node/node_fs_binding.zig:30
NodeJSFSPrototype__writeSync
```

### Root cause

On Windows, `FD.fromJS`/`FD.fromJSValidated` converted JS fd `0/1/2` to the cached stdio `HANDLE` (`windows_cached_std{in,out,err}`, snapshotted in `WindowsStdio.init()`). Every `sys_uv` call then had to map that `.system` FD back to a libuv fd via `FD.uv()`, which compared the handle against the *live* `GetStdHandle()` result. If user code swapped the std handle after startup (native addon calling `SetStdHandle`, `AllocConsole`, `AttachConsole`), the cached handle no longer matched and the cast fell through to the panic.

### Fix

1. **Stop remapping JS fd `0/1/2` to the cached `HANDLE`** in `FD.fromJS`/`FD.fromJSValidated`. JS-visible fds are libuv/CRT fds (that's what `FD.toJS` emits), and libuv fd `0/1/2` already map to stdio. `stdioTag()`/`close()` already handle `.uv` `0/1/2` correctly. This removes the `.system`→`.uv` round-trip from the `node:fs` path entirely.
2. **In `FD.uv()`, check the cached `windows_cached_std{in,out,err}` before the live `GetStdHandle()`** comparison, so any remaining `.system` stdio FD produced by `.stdin()`/`.stdout()`/`.stderr()` still maps back correctly after `SetStdHandle`.

The startup cache itself is kept — Bun's own output/crash-handler writers pin to the startup stderr regardless of what user code does with `SetStdHandle`, which matches Node.js (CRT fd 0/1/2 are pinned at CRT init).

### How did you verify your code works?

- `bun run zig:check-all` — passes on all targets including `x86_64-windows` and `aarch64-windows`.
- New Windows-only regression test `test/js/node/fs/fs-writeSync-stdio-windows.test.ts` that swaps `STD_OUTPUT_HANDLE` via FFI and asserts `fs.writeSync(1, …)` succeeds and writes to the original stdout. Skipped on non-Windows.
- Existing `test/js/node/fs/fs.test.ts` fd-based tests (`open`/`close`/`writeSync`/`readSync`/`fs.write`/`fs.read`/`fstat`) pass unchanged.
