### PR TITLE
Fix PathWatcherManager deadlock and UAF in deferred deinit

### DIFF
--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -39,12 +39,18 @@ pub const PathWatcherManager = struct {
     }
 
     fn unrefPendingTask(this: *PathWatcherManager) void {
+        // deinit() may destroy(this). Defer it until after unlock so we don't
+        // unlock() a freed mutex. Zig defers fire LIFO, so registering this
+        // defer before the lock/unlock pair makes it fire last (after unlock).
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
         this.mutex.lock();
         defer this.mutex.unlock();
         this.pending_tasks -= 1;
         if (this.deinit_on_last_task and this.pending_tasks == 0) {
             this.has_pending_tasks.store(false, .release);
-            this.deinit();
+            should_deinit = true;
         }
     }
 
@@ -449,8 +455,13 @@ pub const PathWatcherManager = struct {
 
                 {
                     watcher.mutex.lock();
-                    defer watcher.mutex.unlock();
-                    watcher.file_paths.append(bun.default_allocator, child_path.path) catch |err| {
+                    const append_result = watcher.file_paths.append(bun.default_allocator, child_path.path);
+                    watcher.mutex.unlock();
+                    // On error, drop the ref we took in _fdFromAbsolutePathZ. Must do
+                    // this AFTER releasing watcher.mutex: _decrementPathRef acquires
+                    // manager.mutex, and unregisterWatcher acquires manager.mutex before
+                    // watcher.mutex — inverting here would AB/BA deadlock.
+                    append_result catch |err| {
                         manager._decrementPathRef(entry_path_z);
                         return switch (err) {
                             error.OutOfMemory => .{ .err = .{
@@ -604,17 +615,22 @@ pub const PathWatcherManager = struct {
         this._decrementPathRefNoLock(file_path);
     }
 
-    // unregister is always called form main thread
+    // unregister is always called from main thread
     fn unregisterWatcher(this: *PathWatcherManager, watcher: *PathWatcher) void {
+        // Must defer deinit() to AFTER releasing this.mutex, for two reasons:
+        // 1. deinit() re-acquires this.mutex when hasPendingTasks() is true.
+        //    The mutex is non-recursive, so calling deinit() while holding
+        //    the lock self-deadlocks (observed as __ulock_wait2 hang on macOS).
+        // 2. deinit() may destroy(this). Unlocking a freed mutex is UAF.
+        // Zig defers fire LIFO, so registering this defer before the lock/unlock
+        // pair makes it fire last (after unlock).
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
         this.mutex.lock();
         defer this.mutex.unlock();
 
         var watchers = this.watchers.slice();
-        defer {
-            if (this.deinit_on_last_watcher and this.watcher_count == 0) {
-                this.deinit();
-            }
-        }
 
         for (watchers, 0..) |w, i| {
             if (w) |item| {
@@ -644,6 +660,8 @@ pub const PathWatcherManager = struct {
                 }
             }
         }
+
+        should_deinit = this.deinit_on_last_watcher and this.watcher_count == 0;
     }
 
     fn deinit(this: *PathWatcherManager) void {
@@ -824,12 +842,19 @@ pub const PathWatcher = struct {
     }
 
     pub fn unrefPendingDirectory(this: *PathWatcher) void {
+        // deinit() calls setClosed() which re-locks this.mutex, and may then
+        // proceed to destroy(this). Defer it until after unlock so we don't
+        // self-deadlock or unlock() a freed mutex. Zig defers fire LIFO, so
+        // registering this defer before the lock/unlock pair makes it fire last.
+        var should_deinit = false;
+        defer if (should_deinit) this.deinit();
+
         this.mutex.lock();
         defer this.mutex.unlock();
         this.pending_directories -= 1;
         if (this.isClosed() and this.pending_directories == 0) {
             this.has_pending_directories.store(false, .release);
-            this.deinit();
+            should_deinit = true;
         }
     }
 

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -346,6 +346,14 @@ pub const PathWatcherManager = struct {
             // keep the path alive
             manager._incrementPathRef(path.path);
             errdefer manager._decrementPathRef(path.path);
+
+            // unrefPendingDirectory() may cascade to PathWatcher.deinit()
+            // → manager.unregisterWatcher() which acquires manager.mutex.
+            // Defer it so it runs after manager.mutex is released (defers
+            // fire LIFO). Same pattern as unregisterWatcher/unrefPendingTask.
+            var needs_unref_pending_directory = false;
+            defer if (needs_unref_pending_directory) watcher.unrefPendingDirectory();
+
             var routine: *DirectoryRegisterTask = undefined;
             {
                 manager.mutex.lock();
@@ -357,7 +365,7 @@ pub const PathWatcherManager = struct {
 
                     if (watcher.refPendingDirectory()) {
                         routine.watcher_list.append(bun.default_allocator, watcher) catch |err| {
-                            watcher.unrefPendingDirectory();
+                            needs_unref_pending_directory = true;
                             return err;
                         };
                     } else {
@@ -378,14 +386,14 @@ pub const PathWatcherManager = struct {
                 errdefer routine.deinit();
                 if (watcher.refPendingDirectory()) {
                     routine.watcher_list.append(bun.default_allocator, watcher) catch |err| {
-                        watcher.unrefPendingDirectory();
+                        needs_unref_pending_directory = true;
                         return err;
                     };
                 } else {
                     return error.UnexpectedFailure;
                 }
                 manager.current_fd_task.put(path.fd, routine) catch |err| {
-                    watcher.unrefPendingDirectory();
+                    needs_unref_pending_directory = true;
                     return err;
                 };
             }

--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -343,16 +343,18 @@ pub const PathWatcherManager = struct {
         }
 
         fn schedule(manager: *PathWatcherManager, watcher: *PathWatcher, path: PathInfo) !void {
-            // keep the path alive
-            manager._incrementPathRef(path.path);
-            errdefer manager._decrementPathRef(path.path);
-
-            // unrefPendingDirectory() may cascade to PathWatcher.deinit()
-            // → manager.unregisterWatcher() which acquires manager.mutex.
-            // Defer it so it runs after manager.mutex is released (defers
-            // fire LIFO). Same pattern as unregisterWatcher/unrefPendingTask.
+            // unrefPendingDirectory() may cascade through PathWatcher.deinit()
+            // → manager.unregisterWatcher() → manager.deinit() → destroy(manager).
+            // Register this defer FIRST so it fires LAST (after the errdefer
+            // below and after manager.mutex is released).
             var needs_unref_pending_directory = false;
             defer if (needs_unref_pending_directory) watcher.unrefPendingDirectory();
+
+            // keep the path alive. errdefer registered after the defer above so
+            // LIFO ordering fires _decrementPathRef BEFORE unrefPendingDirectory
+            // — otherwise the latter could destroy(manager) and this would UAF.
+            manager._incrementPathRef(path.path);
+            errdefer manager._decrementPathRef(path.path);
 
             var routine: *DirectoryRegisterTask = undefined;
             {

--- a/test/js/node/watch/fs.watch.deadlock.test.ts
+++ b/test/js/node/watch/fs.watch.deadlock.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression test for PathWatcherManager self-deadlock / UAF.
+//
+// Before the fix, unregisterWatcher() and unrefPendingDirectory() could
+// call deinit() while still holding this.mutex. Since deinit() re-acquires
+// the same non-recursive mutex (and may destroy `this`), this either
+// self-deadlocked in __ulock_wait2 or UAF'd on the deferred unlock().
+//
+// Field report stack trace:
+//   FSWatcher.close → PathWatcher.deinit → PathWatcherManager.unregisterWatcher
+//     → _decrementPathRefNoLock → _os_unfair_lock_lock_slow → __ulock_wait2
+//
+// The trigger is race-condition dependent (close() racing with the work-pool
+// directory scan), so this test exercises the code path repeatedly but may
+// not deadlock on every unpatched run.
+test("rapid create/close of recursive fs.watch does not deadlock", async () => {
+  // Deep directory tree ensures DirectoryRegisterTask runs on the work pool
+  // long enough for close() to race with it.
+  using dir = tempDir("watch-deadlock", {
+    "a/b/c/d/e/f1.txt": "x",
+    "a/b/c/d/e/f2.txt": "x",
+    "a/b/c/d/f3.txt": "x",
+    "a/b/c/f4.txt": "x",
+    "a/b/f5.txt": "x",
+    "g/h/i/j/f6.txt": "x",
+    "g/h/i/f7.txt": "x",
+    "g/h/f8.txt": "x",
+    "k/l/m/f9.txt": "x",
+    "k/l/f10.txt": "x",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const fs = require("fs");
+      const dir = process.argv[1];
+
+      // If we hang, it's a deadlock. Bail after 10s.
+      const timer = setTimeout(() => {
+        process.stderr.write("DEADLOCK: hung for 10 seconds\\n");
+        process.exit(1);
+      }, 10000);
+      timer.unref();
+
+      const total = 50;
+      for (let i = 0; i < total; i++) {
+        const w = fs.watch(dir, { recursive: true }, () => {});
+        // Close immediately — racing with the work-pool directory scan.
+        w.close();
+      }
+
+      console.log("OK " + total);
+      `,
+      String(dir),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("DEADLOCK");
+  expect(stdout).toStartWith("OK");
+  expect(exitCode).toBe(0);
+}, 30000);


### PR DESCRIPTION
## What does this PR do?

Targeted fix for four concurrency bugs in `src/bun.js/node/path_watcher.zig` that cause `fs.watch()` to deadlock or crash. This is the minimal port of #27469 (by @chrislloyd) onto current main — previous attempts (#27957, #28088, #28104) added scope and introduced ASAN regressions. This PR applies only the defer-ordering fix.

## Root causes

### `unregisterWatcher` self-deadlock (primary)

The deinit-on-last-watcher `defer` was registered *after* the `mutex.lock()`/`defer mutex.unlock()` pair:

```zig
this.mutex.lock();
defer this.mutex.unlock();           // fires last
var watchers = this.watchers.slice();
defer {                               // fires BEFORE unlock
    if (this.deinit_on_last_watcher and this.watcher_count == 0) {
        this.deinit();                // called holding this.mutex
    }
}
```

Zig defers fire LIFO, so `deinit()` ran while still holding `this.mutex`. `deinit()` re-acquires `this.mutex` when `hasPendingTasks()` is true. The mutex is non-recursive → self-deadlock (observed as `__ulock_wait2` hang on macOS, debug-build `panic: Deadlock detected` on Linux).

Also UAF: if `deinit()` completes it calls `destroy(this)`, then the deferred `mutex.unlock()` writes to freed memory.

### `unrefPendingTask` UAF

Same shape: `deinit()` called while holding `this.mutex`. If it completes, `destroy(this)` means the deferred `mutex.unlock()` is a UAF.

### `unrefPendingDirectory` self-deadlock

`deinit()` calls `setClosed()` which re-locks `this.mutex`. Called while holding → self-deadlock.

### `processWatcher` AB/BA lock inversion

Worker thread holds `watcher.mutex` → calls `manager._decrementPathRef()` on the OOM error path, which acquires `manager.mutex`. Main thread `unregisterWatcher` holds `manager.mutex` → wants `watcher.mutex`. Classic AB/BA deadlock.

## Fix

All four use the same pattern: set a `should_deinit` flag under the lock, checked by a `defer` registered *before* the lock/unlock pair. LIFO ordering then yields unlock → deinit. For `processWatcher`, capture the append result and release `watcher.mutex` before calling `_decrementPathRef`.

No semantic changes to when the `has_pending_*` atomics are cleared — the conditions remain exactly as before, only `deinit()` is moved outside the lock.

## How did you verify your code works?

- `bun bd test test/js/node/watch/fs.watch.deadlock.test.ts` passes
- Without the fix (src/ stashed), the same test fails with `panic: Deadlock detected` from the debug-build mutex checker
- All Node.js parallel `test-fs-watch-recursive-*.js` tests pass under ASAN (these regressed in #28104)
- `test/regression/issue/3657.test.ts` passes under ASAN
- `test/js/node/watch/fs.watch.test.ts` — 30 pass, 2 pre-existing root-permission failures (same on main)

Supersedes #27469, #27957, #28088, #28104.

---

**Re: duplicate-bot flagging #26385** — that PR fixes a different lock inversion (`PathWatcherManager.mutex` ↔ `Watcher.mutex`, around `main_watcher.remove()`). This PR fixes `PathWatcherManager.mutex` self-deadlock and `PathWatcher.mutex` ↔ `PathWatcherManager.mutex` inversion. They're complementary, not duplicates.

**Re: find-issues-bot flagging #18919** — tested the repro; it hits a separate pre-existing use-after-poison in the File Watcher thread that also reproduces on main without this change. Not claiming that fix here.
