### PR TITLE
worker: fix terminate/ref/unref UAF and ~Worker wrong-thread assert

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2991,6 +2991,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
 
     auto* zigGlobal = defaultGlobalObject(globalObject);
     Bun__Process__exit(zigGlobal, exitCode);
+    // Main-thread Bun__Process__exit is noreturn. Reaching here means we're in a
+    // worker; request termination so JS following process.exit() stops at the
+    // next safepoint (matches Node.js). The host-call return path is itself a
+    // safepoint, so this fires before the next JS statement without leaving an
+    // exception pending across native frames that don't expect one.
+    vm.notifyNeedTermination();
+    throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }
 

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2991,12 +2991,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
 
     auto* zigGlobal = defaultGlobalObject(globalObject);
     Bun__Process__exit(zigGlobal, exitCode);
-    // Main-thread Bun__Process__exit is noreturn. Reaching here means we're in a
-    // worker; request termination so JS following process.exit() stops at the
-    // next safepoint (matches Node.js). The host-call return path is itself a
-    // safepoint, so this fires before the next JS statement without leaving an
-    // exception pending across native frames that don't expect one.
-    vm.notifyNeedTermination();
+    // Main-thread Bun__Process__exit is noreturn. In a worker it returns; the
+    // Zig WebWorker.exit() it called requests JSC termination (guarded so it's a
+    // no-op when re-entered from a process.on('exit') handler).
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -658,11 +658,11 @@ pub const JSGlobalObject = opaque {
 
     extern fn JSC__JSGlobalObject__handleRejectedPromises(*JSGlobalObject) void;
     pub fn handleRejectedPromises(this: *JSGlobalObject) void {
-        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch |err| switch (err) {
-            // A worker terminate() can fire a TerminationException at the
-            // safepoint inside this call; nothing left to do in that case.
-            error.JSError => if (this.vm().hasTerminationRequest()) return else @panic("unexpected exception in handleRejectedPromises"),
-        };
+        // JSC__JSGlobalObject__handleRejectedPromises catches and reports its
+        // own exceptions; the only thing that escapes is a TerminationException
+        // (worker terminate() or process.exit()), and the request flag may
+        // already be cleared by the time we observe it. Nothing actionable here.
+        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch return;
     }
 
     extern fn ZigGlobalObject__readableStreamToArrayBuffer(*JSGlobalObject, JSValue) JSValue;

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -658,7 +658,9 @@ pub const JSGlobalObject = opaque {
 
     extern fn JSC__JSGlobalObject__handleRejectedPromises(*JSGlobalObject) void;
     pub fn handleRejectedPromises(this: *JSGlobalObject) void {
-        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch @panic("unreachable");
+        // A worker terminate() can fire a TerminationException at the safepoint
+        // inside this call; nothing left to do in that case.
+        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch return;
     }
 
     extern fn ZigGlobalObject__readableStreamToArrayBuffer(*JSGlobalObject, JSValue) JSValue;

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -658,9 +658,11 @@ pub const JSGlobalObject = opaque {
 
     extern fn JSC__JSGlobalObject__handleRejectedPromises(*JSGlobalObject) void;
     pub fn handleRejectedPromises(this: *JSGlobalObject) void {
-        // A worker terminate() can fire a TerminationException at the safepoint
-        // inside this call; nothing left to do in that case.
-        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch return;
+        return bun.jsc.fromJSHostCallGeneric(this, @src(), JSC__JSGlobalObject__handleRejectedPromises, .{this}) catch |err| switch (err) {
+            // A worker terminate() can fire a TerminationException at the
+            // safepoint inside this call; nothing left to do in that case.
+            error.JSError => if (this.vm().hasTerminationRequest()) return else @panic("unexpected exception in handleRejectedPromises"),
+        };
     }
 
     extern fn ZigGlobalObject__readableStreamToArrayBuffer(*JSGlobalObject, JSValue) JSValue;

--- a/src/bun.js/bindings/TopExceptionScope.zig
+++ b/src/bun.js/bindings/TopExceptionScope.zig
@@ -84,7 +84,14 @@ pub const TopExceptionScope = struct {
     /// Asserts there has not been any exception thrown.
     pub fn assertNoException(self: *TopExceptionScope) void {
         if (comptime Environment.ci_assert) {
-            if (self.exception()) |e| self.assertionFailure(e);
+            if (self.exception()) |e| {
+                // TerminationException can be raised at any safepoint (worker
+                // terminate(), worker process.exit()) regardless of what the host
+                // function returned, so it's never a return-value/exception
+                // mismatch — let the caller's safepoint observe it.
+                if (jsc.JSValue.fromCell(e).isTerminationException()) return;
+                self.assertionFailure(e);
+            }
         }
     }
 

--- a/src/bun.js/bindings/VM.zig
+++ b/src/bun.js/bindings/VM.zig
@@ -155,6 +155,11 @@ pub const VM = opaque {
         return bun.cpp.JSC__VM__hasTerminationRequest(vm);
     }
 
+    extern fn JSC__VM__clearHasTerminationRequest(vm: *VM) void;
+    pub fn clearHasTerminationRequest(vm: *VM) void {
+        JSC__VM__clearHasTerminationRequest(vm);
+    }
+
     extern fn JSC__VM__throwError(*VM, *JSGlobalObject, JSValue) void;
     pub fn throwError(vm: *VM, global_object: *JSGlobalObject, value: JSValue) error{JSError} {
         var scope: bun.jsc.ExceptionValidationScope = undefined;

--- a/src/bun.js/bindings/VM.zig
+++ b/src/bun.js/bindings/VM.zig
@@ -151,8 +151,9 @@ pub const VM = opaque {
         return bun.cpp.JSC__VM__isTerminationException(vm, exception);
     }
 
+    extern fn JSC__VM__hasTerminationRequest(vm: *VM) bool;
     pub fn hasTerminationRequest(vm: *VM) bool {
-        return bun.cpp.JSC__VM__hasTerminationRequest(vm);
+        return JSC__VM__hasTerminationRequest(vm);
     }
 
     extern fn JSC__VM__clearHasTerminationRequest(vm: *VM) void;

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4893,6 +4893,10 @@ bool JSC__VM__isTerminationException(JSC::VM* vm, JSC::Exception* exception)
 }
 
 [[ZIG_EXPORT(nothrow)]]
+void JSC__VM__clearHasTerminationRequest(JSC::VM* vm)
+{
+    vm->clearHasTerminationRequest();
+}
 bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
 {
     return vm->hasTerminationRequest();

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -4897,6 +4897,7 @@ void JSC__VM__clearHasTerminationRequest(JSC::VM* vm)
 {
     vm->clearHasTerminationRequest();
 }
+[[ZIG_EXPORT(nothrow)]]
 bool JSC__VM__hasTerminationRequest(JSC::VM* vm)
 {
     return vm->hasTerminationRequest();

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -71,6 +71,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(Worker);
 
 extern "C" void WebWorker__notifyNeedTermination(
     void* worker);
+extern "C" void WebWorker__destroy(
+    void* worker);
+extern "C" void WebWorker__releaseParentPollRef(
+    void* worker);
 
 static Lock allWorkersLock;
 static HashMap<ScriptExecutionContextIdentifier, Worker*>& allWorkers() WTF_REQUIRES_LOCK(allWorkersLock)
@@ -141,6 +145,9 @@ bool Worker::updatePtr()
     if (!WebWorker__updatePtr(impl_, this)) {
         m_onlineClosingFlags = ClosingFlag;
         m_terminationFlags.fetch_or(TerminatedFlag);
+        // Thread never started, so dispatchExit will never run; drop the ref
+        // that create() took on Zig's behalf here on the parent thread.
+        this->deref();
         return false;
     }
 
@@ -207,8 +214,6 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
         execArgv.size(),
         preloadModules.begin(),
         preloadModules.size());
-    // now referenced by Zig
-    worker->ref();
 
     preloadModuleStrings.clear();
 
@@ -216,6 +221,9 @@ ExceptionOr<Ref<Worker>> Worker::create(ScriptExecutionContext& context, const S
         return Exception { TypeError, errorMessage.toWTFString(BunString::ZeroCopy) };
     }
 
+    // now referenced by Zig — this ref is dropped on the parent thread inside
+    // dispatchExit's posted task (or in updatePtr() if the thread fails to spawn).
+    worker->ref();
     worker->impl_ = impl;
     worker->m_workerCreationTime = MonotonicTime::now();
 
@@ -228,7 +236,9 @@ Worker::~Worker()
         Locker locker { allWorkersLock };
         allWorkers().remove(m_clientIdentifier);
     }
-    // m_contextProxy.workerObjectDestroyed();
+    if (impl_) {
+        WebWorker__destroy(impl_);
+    }
 }
 
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
@@ -430,13 +440,13 @@ bool Worker::dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSVal
     return true;
 }
 
-void Worker::dispatchExit(int32_t exitCode)
+bool Worker::dispatchExit(int32_t exitCode)
 {
     auto* ctx = scriptExecutionContext();
     if (!ctx)
-        return;
+        return false;
 
-    ScriptExecutionContext::postTaskTo(ctx->identifier(), [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) -> void {
+    return ScriptExecutionContext::postTaskTo(ctx->identifier(), [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) -> void {
         protectedThis->m_onlineClosingFlags = ClosingFlag;
 
         if (protectedThis->hasEventListeners(eventNames().closeEvent)) {
@@ -444,6 +454,11 @@ void Worker::dispatchExit(int32_t exitCode)
             protectedThis->dispatchCloseEvent(event);
         }
         protectedThis->m_terminationFlags.fetch_or(TerminatedFlag);
+        WebWorker__releaseParentPollRef(protectedThis->impl_);
+        // Drop the ref Zig held since Worker::create. protectedThis keeps us alive
+        // across this line; its own deref happens at lambda destruction on this
+        // (parent) thread, so ~Worker can never run on the worker thread.
+        protectedThis->deref();
     });
 }
 
@@ -467,10 +482,6 @@ void Worker::forEachWorker(const Function<Function<void(ScriptExecutionContext&)
 
 extern "C" void WebWorker__dispatchExit(Zig::GlobalObject* globalObject, Worker* worker, int32_t exitCode)
 {
-    worker->dispatchExit(exitCode);
-    // no longer referenced by Zig
-    worker->deref();
-
     if (globalObject) {
         auto& vm = JSC::getVM(globalObject);
         vm.setHasTerminationRequest();
@@ -493,6 +504,17 @@ extern "C" void WebWorker__dispatchExit(Zig::GlobalObject* globalObject, Worker*
         vm.derefSuppressingSaferCPPChecking(); // NOLINT
         vm.derefSuppressingSaferCPPChecking(); // NOLINT
     }
+
+    // Post the close-event task only after the worker's JSC VM teardown above is
+    // done. The task releases parent_poll_ref on the parent thread; once that
+    // happens the parent process can exit, so this ordering keeps the parent alive
+    // through the worker's collectNow()/vm.deref().
+    //
+    // The Zig-held ref is dropped inside the posted task on the parent thread. If
+    // posting fails (parent context gone — parent VM teardown), the ref is
+    // intentionally leaked: dropping it here would run ~Worker on the worker
+    // thread and trip EventListenerMap's thread assertion.
+    worker->dispatchExit(exitCode);
 }
 extern "C" void WebWorker__dispatchOnline(Worker* worker, Zig::GlobalObject* globalObject)
 {

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -506,11 +506,9 @@ extern "C" void WebWorker__teardownJSCVM(Zig::GlobalObject* globalObject)
 
 extern "C" void WebWorker__dispatchExit(Worker* worker, int32_t exitCode)
 {
-    // Post the close-event task only after the worker's JSC VM teardown and the
-    // Zig-side mimalloc cleanup (arena, pools, vm.deinit) are done. The task
-    // releases parent_poll_ref on the parent thread; once that happens the parent
-    // process can exit, and its atexit `mi_process_done` will free this thread's
-    // mimalloc TLD — so any mimalloc use after this call is a cross-thread UAF.
+    // Post the close-event task. It releases parent_poll_ref on the parent
+    // thread; once that happens the parent process can exit. Called after
+    // WebWorker__teardownJSCVM so the parent stays alive through collectNow().
     //
     // The Zig-held ref is dropped inside the posted task on the parent thread. If
     // posting fails (parent context gone — middle worker in a nested chain has

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -480,35 +480,37 @@ void Worker::forEachWorker(const Function<Function<void(ScriptExecutionContext&)
         ScriptExecutionContext::postTaskTo(contextIdentifier, callback());
 }
 
-extern "C" void WebWorker__dispatchExit(Zig::GlobalObject* globalObject, Worker* worker, int32_t exitCode)
+extern "C" void WebWorker__teardownJSCVM(Zig::GlobalObject* globalObject)
 {
-    if (globalObject) {
-        auto& vm = JSC::getVM(globalObject);
-        vm.setHasTerminationRequest();
+    auto& vm = JSC::getVM(globalObject);
+    vm.setHasTerminationRequest();
 
-        {
-            auto scope = DECLARE_THROW_SCOPE(vm);
-            auto* esmRegistryMap = globalObject->esmRegistryMap();
-            scope.exception(); // TODO: handle or assert none?
-            esmRegistryMap->clear(globalObject);
-            scope.exception(); // TODO: handle or assert none?
-            globalObject->requireMap()->clear(globalObject);
-            scope.exception(); // TODO: handle or assert none?
-            vm.deleteAllCode(JSC::DeleteAllCodeEffort::PreventCollectionAndDeleteAllCode);
-            gcUnprotect(globalObject);
-            globalObject = nullptr;
-        }
-
-        vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
-
-        vm.derefSuppressingSaferCPPChecking(); // NOLINT
-        vm.derefSuppressingSaferCPPChecking(); // NOLINT
+    {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* esmRegistryMap = globalObject->esmRegistryMap();
+        scope.exception(); // TODO: handle or assert none?
+        esmRegistryMap->clear(globalObject);
+        scope.exception(); // TODO: handle or assert none?
+        globalObject->requireMap()->clear(globalObject);
+        scope.exception(); // TODO: handle or assert none?
+        vm.deleteAllCode(JSC::DeleteAllCodeEffort::PreventCollectionAndDeleteAllCode);
+        gcUnprotect(globalObject);
+        globalObject = nullptr;
     }
 
-    // Post the close-event task only after the worker's JSC VM teardown above is
-    // done. The task releases parent_poll_ref on the parent thread; once that
-    // happens the parent process can exit, so this ordering keeps the parent alive
-    // through the worker's collectNow()/vm.deref().
+    vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);
+
+    vm.derefSuppressingSaferCPPChecking(); // NOLINT
+    vm.derefSuppressingSaferCPPChecking(); // NOLINT
+}
+
+extern "C" void WebWorker__dispatchExit(Worker* worker, int32_t exitCode)
+{
+    // Post the close-event task only after the worker's JSC VM teardown and the
+    // Zig-side mimalloc cleanup (arena, pools, vm.deinit) are done. The task
+    // releases parent_poll_ref on the parent thread; once that happens the parent
+    // process can exit, and its atexit `mi_process_done` will free this thread's
+    // mimalloc TLD — so any mimalloc use after this call is a cross-thread UAF.
     //
     // The Zig-held ref is dropped inside the posted task on the parent thread. If
     // posting fails (parent context gone — middle worker in a nested chain has

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -511,9 +511,13 @@ extern "C" void WebWorker__dispatchExit(Zig::GlobalObject* globalObject, Worker*
     // through the worker's collectNow()/vm.deref().
     //
     // The Zig-held ref is dropped inside the posted task on the parent thread. If
-    // posting fails (parent context gone — parent VM teardown), the ref is
-    // intentionally leaked: dropping it here would run ~Worker on the worker
-    // thread and trip EventListenerMap's thread assertion.
+    // posting fails (parent context gone — middle worker in a nested chain has
+    // already torn down), the ref is intentionally leaked: dropping it here would
+    // run ~Worker on the worker thread and trip EventListenerMap's thread assert.
+    // This leaks the C++ Worker, the Zig WebWorker, and the allWorkers() entry
+    // until process exit. The proper fix is for a worker to stop+join its
+    // sub-workers before tearing down its own context (Node does this in
+    // Environment::stop_sub_worker_contexts); tracked as a follow-up.
     worker->dispatchExit(exitCode);
 }
 extern "C" void WebWorker__dispatchOnline(Worker* worker, Zig::GlobalObject* globalObject)

--- a/src/bun.js/bindings/webcore/Worker.h
+++ b/src/bun.js/bindings/webcore/Worker.h
@@ -88,7 +88,7 @@ public:
     void dispatchErrorWithMessage(WTF::String message);
     // true if successful
     bool dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value);
-    void dispatchExit(int32_t exitCode);
+    bool dispatchExit(int32_t exitCode);
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
     ScriptExecutionContextIdentifier clientIdentifier() const { return m_clientIdentifier; }
     WorkerOptions& options() { return m_options; }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -1,4 +1,86 @@
 //! Shared implementation of Web and Node `Worker`
+//!
+//! Lifetime / threading model
+//! ==========================
+//!
+//! There are three objects, two threads, and one ownership rule:
+//!
+//!   ┌─ PARENT THREAD ──────────────────────────────────────────────────────┐
+//!   │  JSWorker (GC'd JSCell)                                              │
+//!   │    └─ Ref<WebCore::Worker>                                           │
+//!   │                                                                      │
+//!   │  WebCore::Worker (ThreadSafeRefCounted, EventTarget)                 │
+//!   │    ├─ void* impl_  ─────────────────────────────┐ raw pointer to ↓   │
+//!   │    └─ ScriptExecutionContext* (parent ctx)      │                    │
+//!   └────────────────────────────────────────────────  │  ──────────────────┘
+//!                                                      ▼
+//!   ┌─ EITHER THREAD (owned by ~Worker) ──────────────────────────────────┐
+//!   │  Zig WebWorker (this struct, default_allocator)                      │
+//!   │    ├─ vm: ?*VirtualMachine    – worker thread writes; vm_lock guards │
+//!   │    │                            cross-thread read in terminate()     │
+//!   │    ├─ status / requested_terminate – atomics                         │
+//!   │    ├─ parent_poll_ref          – PARENT-THREAD-ONLY (KeepAlive)      │
+//!   │    └─ parent / cpp_worker      – set once in create()                │
+//!   └──────────────────────────────────────────────────────────────────────┘
+//!
+//! Ownership rule: the Zig WebWorker struct is OWNED BY the C++ Worker. It is
+//! allocated in `create()` and freed in `WebCore::Worker::~Worker()` via
+//! `WebWorker__destroy`. The worker thread NEVER frees it. Because JSWorker
+//! holds a `Ref<Worker>`, `impl_` is valid for the entire time JS can call
+//! `terminate()`/`ref()`/`unref()` — those calls cannot UAF.
+//!
+//! Refcounting on `WebCore::Worker`:
+//!   - JSWorker wrapper holds +1 (dropped when GC'd)
+//!   - `Worker::create()` takes +1 "on Zig's behalf" after `WebWorker__create`
+//!     succeeds. This +1 is dropped on the PARENT thread inside `dispatchExit`'s
+//!     posted close-event task (or in `updatePtr()` on spawn failure). It is
+//!     never dropped on the worker thread, so `~Worker` (and the
+//!     `EventListenerMap` it tears down) never runs on the worker thread. If
+//!     posting fails because the parent context is gone, the +1 is leaked —
+//!     parent VM teardown is in progress so the leak is bounded.
+//!
+//! Worker thread lifecycle (`startWithErrorHandling` → `start` → `spin` →
+//! `exitAndDeinit`):
+//!   1. spin() runs the worker's event loop until it drains or
+//!      `requested_terminate` is observed.
+//!   2. exitAndDeinit() runs ON THE WORKER THREAD. It:
+//!        - sets `status = .terminated`
+//!        - under `vm_lock`: nulls `vm` (so a racing `notifyNeedTermination`
+//!          sees null and skips `wakeup()` instead of touching freed memory)
+//!        - copies `arena`/`cpp_worker`/exit_code to locals so nothing reads
+//!          `this.*` after the next step
+//!        - calls `WebWorker__dispatchExit`, which on the worker thread:
+//!            a) tears down the worker's JSC VM (collectNow, vm.deref×2)
+//!            b) THEN posts the close-event task to the parent context
+//!          The close-event task runs ON THE PARENT THREAD and does:
+//!            - dispatch the `close` event
+//!            - `WebWorker__releaseParentPollRef` (parent-thread unref)
+//!            - drop the Zig-held `Worker` ref
+//!          (a)-before-(b) keeps the parent process alive through the worker's
+//!          collectNow() — once parent_poll_ref is released the parent can exit.
+//!        - frees the worker's arena and exits the thread. `this` may already
+//!          be freed by the time arena.deinit() runs (the parent's close task
+//!          can complete and `~Worker` can fire in between); that's fine
+//!          because nothing here dereferences `this` after dispatchExit.
+//!
+//! `parent_poll_ref` (the keep-alive on the parent's event loop) is mutated
+//! ONLY on the parent thread:
+//!   - `create()`      – ref   (parent thread)
+//!   - `setRef()`      – ref/unref via JS .ref()/.unref()  (parent thread)
+//!   - `releaseParentPollRef()` – unref in close-event task (parent thread)
+//!   - `WebWorker__updatePtr` spawn-fail path – unref       (parent thread)
+//! `KeepAlive.status` is non-atomic, so the worker thread MUST NOT touch it.
+//!
+//! `vm_lock` is held only briefly around three sites: `start()` setting `vm`,
+//! `exitAndDeinit()` nulling `vm`, and `notifyNeedTermination()` reading `vm`
+//! to call `wakeup()`. It exists solely to close the TOCTOU between the parent
+//! reading a non-null `vm` and the worker freeing the arena that contains it.
+//!
+//! Known gaps vs Node.js (not handled here): the worker thread is detached,
+//! not joined, so `await worker.terminate()` resolves before the OS thread is
+//! fully gone; `terminate()` does not call `vm->TerminateExecution()` so a
+//! worker stuck in `while(true){}` never observes it; nested workers are not
+//! stopped/joined when their parent exits.
 
 const WebWorker = @This();
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -67,6 +67,7 @@
 //! ONLY on the parent thread:
 //!   - `create()`      – ref   (parent thread)
 //!   - `setRef()`      – ref/unref via JS .ref()/.unref()  (parent thread)
+//!   - `notifyNeedTermination()` – unref on terminate()     (parent thread)
 //!   - `releaseParentPollRef()` – unref in close-event task (parent thread)
 //!   - `WebWorker__updatePtr` spawn-fail path – unref       (parent thread)
 //! `KeepAlive.status` is non-atomic, so the worker thread MUST NOT touch it.
@@ -703,6 +704,14 @@ pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
         return;
     }
     log("[{d}] notifyNeedTermination", .{this.execution_context_id});
+
+    // Release the parent's keep-alive immediately. terminate() does not yet
+    // interrupt running JS, so a worker stuck in synchronous code will never
+    // reach exitAndDeinit and post the close-event task; without this the
+    // parent's event loop would stay ref'd forever. This is parent-thread-only
+    // (the only caller is Worker::terminate()), so plain unref is correct, and
+    // KeepAlive.unref is idempotent so the later releaseParentPollRef is a no-op.
+    this.parent_poll_ref.unref(this.parent);
 
     // Wake the worker's event loop so it observes requested_terminate promptly.
     // vm_lock serializes against exitAndDeinit nulling vm and freeing the arena.

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -515,6 +515,7 @@ pub fn destroy(this: *WebWorker) callconv(.c) void {
         bun.default_allocator.free(preload);
     }
     bun.default_allocator.free(this.preloads);
+    if (this.name.len > 0) bun.default_allocator.free(this.name);
     bun.default_allocator.destroy(this);
 }
 
@@ -698,6 +699,12 @@ pub fn setRef(this: *WebWorker, value: bool) callconv(.c) void {
 pub fn exit(this: *WebWorker) void {
     this.exit_called = true;
     _ = this.setRequestedTerminate();
+    // Stop subsequent JS at the next safepoint. (Process_functionReallyExit
+    // also calls vm.notifyNeedTermination() after Bun__Process__exit returns,
+    // but doing it here covers any Zig caller and keeps the contract local.)
+    if (this.vm) |vm| {
+        vm.jsc_vm.notifyNeedTermination();
+    }
 }
 
 /// Request a terminate from the parent thread (worker.terminate()). The struct is

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -52,20 +52,18 @@
 //!        - calls `WebWorker__teardownJSCVM` to tear down the worker's JSC VM
 //!          (collectNow, vm.deref×2). This can re-enter Zig (finalizers), so it
 //!          runs before any mimalloc-backed state is destroyed.
-//!        - frees gc_controller timers, vm.deinit(), thread pools, and the
-//!          worker's mimalloc arena.
 //!        - calls `WebWorker__dispatchExit`, which posts the close-event task to
 //!          the parent context. The close-event task runs ON THE PARENT THREAD
 //!          and does:
 //!            - dispatch the `close` event
 //!            - `WebWorker__releaseParentPollRef` (parent-thread unref)
 //!            - drop the Zig-held `Worker` ref
-//!          This is ordered last so the parent stays alive (parent_poll_ref
-//!          held) through both JSC teardown and the mimalloc cleanup above —
-//!          once released, the parent can exit and its `mi_process_done` will
-//!          free this thread's mimalloc TLD.
-//!        - exits the thread. `this` may already be freed by now (the parent's
-//!          close task can complete and `~Worker` fire in between); that's fine
+//!          This is ordered after JSC teardown so the parent stays alive
+//!          (parent_poll_ref held) through the worker's collectNow().
+//!        - frees gc_controller timers, libuv Loop.shutdown(), vm.deinit(),
+//!          thread pools, and the worker's mimalloc arena, then exits the
+//!          thread. `this` may already be freed by now (the parent's close
+//!          task can complete and `~Worker` fire in between); that's fine
 //!          because nothing here dereferences `this` after dispatchExit.
 //!
 //! `parent_poll_ref` (the keep-alive on the parent's event loop) is mutated
@@ -786,6 +784,14 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         WebWorker__teardownJSCVM(global);
     }
 
+    // Post the close-event task. It releases parent_poll_ref on the parent
+    // thread; the parent can exit any time after this runs. Loop.shutdown()
+    // below can block on Windows (uv_run(.default) with active requests), so
+    // posting first lets the parent proceed regardless.
+    WebWorker__dispatchExit(cpp_worker, exit_code);
+    // Past this point `this` may be freed at any time (the C++ Worker's last ref can
+    // drop on the parent thread once the close-event task runs).
+
     if (loop) |loop_| {
         loop_.internal_loop_data.jsc_vm = null;
     }
@@ -807,14 +813,6 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     if (arena) |*arena_| {
         arena_.deinit();
     }
-
-    // Only now post the close-event task. It releases parent_poll_ref on the
-    // parent thread; once that happens the parent can reach Global.exit() →
-    // mi_process_done() → _mi_thread_locals_done(), which frees this thread's
-    // mimalloc TLD. Everything mimalloc-touching above must be done first.
-    WebWorker__dispatchExit(cpp_worker, exit_code);
-    // Past this point `this` may be freed at any time (the C++ Worker's last ref can
-    // drop on the parent thread once the close-event task runs).
 
     bun.exitThread();
 }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -6,6 +6,10 @@ const log = Output.scoped(.Worker, .hidden);
 
 /// null when haven't started yet
 vm: ?*jsc.VirtualMachine = null,
+/// Serializes `vm` against cross-thread reads in `notifyNeedTermination`. Held briefly
+/// around the assignment in `start()`, the null in `exitAndDeinit()`, and the wakeup
+/// call from the parent.
+vm_lock: bun.Mutex = .{},
 status: std.atomic.Value(Status) = .init(.start),
 /// To prevent UAF, the `spin` function (aka the worker's event loop) will call deinit once this is set and properly exit the loop.
 requested_terminate: std.atomic.Value(bool) = .init(false),
@@ -73,7 +77,9 @@ export fn WebWorker__updatePtr(worker: *WebWorker, ptr: *anyopaque) bool {
         startWithErrorHandling,
         .{worker},
     ) catch {
-        worker.deinit();
+        // Called from the parent thread (Worker JS constructor), so plain unref is correct.
+        // The struct itself stays allocated; ~Worker frees it via WebWorker__destroy.
+        worker.parent_poll_ref.unref(worker.parent);
         return false;
     };
     thread.detach();
@@ -395,16 +401,28 @@ pub fn start(
     vm.onUnhandledRejection = onUnhandledRejection;
     const callback = jsc.OpaqueWrap(WebWorker, WebWorker.spin);
 
-    this.vm = vm;
+    {
+        this.vm_lock.lock();
+        defer this.vm_lock.unlock();
+        this.vm = vm;
+    }
 
     vm.global.vm().holdAPILock(this, callback);
 }
 
-/// Deinit will clean up vm and everything.
-/// Early deinit may be called from caller thread, but full vm deinit will only be called within worker's thread.
-fn deinit(this: *WebWorker) void {
-    log("[{d}] deinit", .{this.execution_context_id});
-    this.parent_poll_ref.unrefConcurrently(this.parent);
+/// Release the keep-alive on the parent's event loop. Called on the parent thread
+/// from the close-event task posted by `WebWorker__dispatchExit`, so plain `unref`
+/// (not `unrefConcurrently`) is correct.
+pub fn releaseParentPollRef(this: *WebWorker) callconv(.c) void {
+    this.parent_poll_ref.unref(this.parent);
+}
+
+/// Free the struct and its owned strings. Called from `WebCore::Worker::~Worker()`,
+/// so the lifetime of `impl_` matches the C++ Worker — `terminate()`/`ref()`/`unref()`
+/// can never observe a freed struct. Allocator is mimalloc (thread-safe), so the
+/// caller's thread doesn't matter for the free itself.
+pub fn destroy(this: *WebWorker) callconv(.c) void {
+    log("[{d}] destroy", .{this.execution_context_id});
     bun.default_allocator.free(this.unresolved_specifier);
     for (this.preloads) |preload| {
         bun.default_allocator.free(preload);
@@ -475,7 +493,6 @@ fn onUnhandledRejection(vm: *jsc.VirtualMachine, globalObject: *jsc.JSGlobalObje
     WebWorker__dispatchError(globalObject, worker.cpp_worker, bun.String.cloneUTF8(array.written()), error_instance);
     if (vm.worker) |worker_| {
         _ = worker.setRequestedTerminate();
-        worker.parent_poll_ref.unrefConcurrently(worker.parent);
         worker_.exitAndDeinit();
     }
 }
@@ -576,16 +593,13 @@ fn spin(this: *WebWorker) void {
     log("[{d}] spin done", .{this.execution_context_id});
 }
 
-/// This is worker.ref()/.unref() from JS (Caller thread)
+/// This is worker.ref()/.unref() from JS (parent thread). The struct is guaranteed
+/// alive here: it's freed by ~Worker, and JSWorker holds a Ref<Worker>.
 pub fn setRef(this: *WebWorker, value: bool) callconv(.c) void {
-    if (this.hasRequestedTerminate()) {
+    if (this.hasRequestedTerminate() or this.status.load(.acquire) == .terminated) {
         return;
     }
 
-    this.setRefInternal(value);
-}
-
-pub fn setRefInternal(this: *WebWorker, value: bool) void {
     if (value) {
         this.parent_poll_ref.ref(this.parent);
     } else {
@@ -596,31 +610,34 @@ pub fn setRefInternal(this: *WebWorker, value: bool) void {
 /// Implement process.exit(). May only be called from the Worker thread.
 pub fn exit(this: *WebWorker) void {
     this.exit_called = true;
-    this.notifyNeedTermination();
+    _ = this.setRequestedTerminate();
 }
 
-/// Request a terminate from any thread.
+/// Request a terminate from the parent thread (worker.terminate()). The struct is
+/// guaranteed alive: it's freed by ~Worker, which can't run while JSWorker (the
+/// caller) holds its Ref<Worker>.
 pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
-    if (this.status.load(.acquire) == .terminated) {
-        return;
-    }
     if (this.setRequestedTerminate()) {
         return;
     }
     log("[{d}] notifyNeedTermination", .{this.execution_context_id});
 
+    // Wake the worker's event loop so it observes requested_terminate promptly.
+    // vm_lock serializes against exitAndDeinit nulling vm and freeing the arena.
+    this.vm_lock.lock();
+    defer this.vm_lock.unlock();
     if (this.vm) |vm| {
         vm.eventLoop().wakeup();
-        // TODO(@190n) notifyNeedTermination
     }
-
-    // TODO(@190n) delete
-    this.setRefInternal(false);
 }
 
-/// This handles cleanup, emitting the "close" event, and deinit.
+/// This handles VM/arena cleanup and posts the "close" event to the parent.
 /// Only call after the VM is initialized AND on the same thread as the worker.
 /// Otherwise, call `notifyNeedTermination` to cause the event loop to safely terminate.
+///
+/// This does NOT free `this` — the WebWorker struct outlives the worker thread and
+/// is freed by `WebCore::Worker::~Worker()` via `WebWorker__destroy`, so the parent
+/// thread can safely call terminate()/ref()/unref() at any point.
 pub fn exitAndDeinit(this: *WebWorker) noreturn {
     jsc.markBinding(@src());
     this.setStatus(.terminated);
@@ -632,19 +649,32 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     var globalObject: ?*jsc.JSGlobalObject = null;
     var vm_to_deinit: ?*jsc.VirtualMachine = null;
     var loop: ?*bun.uws.Loop = null;
-    if (this.vm) |vm| {
-        loop = vm.uwsLoop();
-        this.vm = null;
+
+    {
+        // Publish vm = null before the arena (and the VM inside it) is freed, so a
+        // concurrent notifyNeedTermination() either sees null or completes its
+        // wakeup() before we proceed.
+        this.vm_lock.lock();
+        defer this.vm_lock.unlock();
+        if (this.vm) |vm| {
+            loop = vm.uwsLoop();
+            this.vm = null;
+            vm_to_deinit = vm;
+        }
+    }
+    if (vm_to_deinit) |vm| {
         vm.is_shutting_down = true;
         vm.onExit();
         jsc.API.cron.CronJob.clearAllForVM(vm, .teardown);
         exit_code = vm.exit_handler.exit_code;
         globalObject = vm.global;
-        vm_to_deinit = vm;
     }
     var arena = this.arena;
+    this.arena = null;
 
     WebWorker__dispatchExit(globalObject, cpp_worker, exit_code);
+    // Past this point `this` may be freed at any time (the C++ Worker's last ref can
+    // drop on the parent thread once the close-event task runs).
     if (loop) |loop_| {
         loop_.internal_loop_data.jsc_vm = null;
     }
@@ -658,8 +688,6 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     if (comptime Environment.isWindows) {
         bun.windows.libuv.Loop.shutdown();
     }
-
-    this.deinit();
 
     if (vm_to_deinit) |vm| {
         vm.deinit(); // NOTE: deinit here isn't implemented, so freeing workers will leak the vm.
@@ -676,6 +704,8 @@ comptime {
     @export(&create, .{ .name = "WebWorker__create" });
     @export(&notifyNeedTermination, .{ .name = "WebWorker__notifyNeedTermination" });
     @export(&setRef, .{ .name = "WebWorker__setRef" });
+    @export(&destroy, .{ .name = "WebWorker__destroy" });
+    @export(&releaseParentPollRef, .{ .name = "WebWorker__releaseParentPollRef" });
     _ = WebWorker__updatePtr;
 }
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -705,9 +705,9 @@ pub fn setRef(this: *WebWorker, value: bool) callconv(.c) void {
 pub fn exit(this: *WebWorker) void {
     this.exit_called = true;
     _ = this.setRequestedTerminate();
-    // Stop subsequent JS at the next safepoint. (Process_functionReallyExit
-    // also calls vm.notifyNeedTermination() after Bun__Process__exit returns,
-    // but doing it here covers any Zig caller and keeps the contract local.)
+    // Stop subsequent JS at the next safepoint. `this.vm` is null during
+    // vm.onExit() (exitAndDeinit nulls it first), so a re-entrant
+    // process.exit() from an exit handler does not re-arm the trap.
     if (this.vm) |vm| {
         vm.jsc_vm.notifyNeedTermination();
     }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -49,18 +49,23 @@
 //!          sees null and skips `wakeup()` instead of touching freed memory)
 //!        - copies `arena`/`cpp_worker`/exit_code to locals so nothing reads
 //!          `this.*` after the next step
-//!        - calls `WebWorker__dispatchExit`, which on the worker thread:
-//!            a) tears down the worker's JSC VM (collectNow, vm.deref×2)
-//!            b) THEN posts the close-event task to the parent context
-//!          The close-event task runs ON THE PARENT THREAD and does:
+//!        - calls `WebWorker__teardownJSCVM` to tear down the worker's JSC VM
+//!          (collectNow, vm.deref×2). This can re-enter Zig (finalizers), so it
+//!          runs before any mimalloc-backed state is destroyed.
+//!        - frees gc_controller timers, vm.deinit(), thread pools, and the
+//!          worker's mimalloc arena.
+//!        - calls `WebWorker__dispatchExit`, which posts the close-event task to
+//!          the parent context. The close-event task runs ON THE PARENT THREAD
+//!          and does:
 //!            - dispatch the `close` event
 //!            - `WebWorker__releaseParentPollRef` (parent-thread unref)
 //!            - drop the Zig-held `Worker` ref
-//!          (a)-before-(b) keeps the parent process alive through the worker's
-//!          collectNow() — once parent_poll_ref is released the parent can exit.
-//!        - frees the worker's arena and exits the thread. `this` may already
-//!          be freed by the time arena.deinit() runs (the parent's close task
-//!          can complete and `~Worker` can fire in between); that's fine
+//!          This is ordered last so the parent stays alive (parent_poll_ref
+//!          held) through both JSC teardown and the mimalloc cleanup above —
+//!          once released, the parent can exit and its `mi_process_done` will
+//!          free this thread's mimalloc TLD.
+//!        - exits the thread. `this` may already be freed by now (the parent's
+//!          close task can complete and `~Worker` fire in between); that's fine
 //!          because nothing here dereferences `this` after dispatchExit.
 //!
 //! `parent_poll_ref` (the keep-alive on the parent's event loop) is mutated
@@ -138,7 +143,8 @@ pub const Status = enum(u8) {
     terminated,
 };
 
-extern fn WebWorker__dispatchExit(?*jsc.JSGlobalObject, *anyopaque, i32) void;
+extern fn WebWorker__teardownJSCVM(*jsc.JSGlobalObject) void;
+extern fn WebWorker__dispatchExit(*anyopaque, i32) void;
 extern fn WebWorker__dispatchOnline(cpp_worker: *anyopaque, *jsc.JSGlobalObject) void;
 extern fn WebWorker__fireEarlyMessages(cpp_worker: *anyopaque, *jsc.JSGlobalObject) void;
 extern fn WebWorker__dispatchError(*jsc.JSGlobalObject, *anyopaque, bun.String, JSValue) void;
@@ -762,7 +768,7 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     }
     if (vm_to_deinit) |vm| {
         // terminate() set the JSC termination flag to interrupt running JS; clear
-        // it so process.on('exit') handlers can run. WebWorker__dispatchExit
+        // it so process.on('exit') handlers can run. WebWorker__teardownJSCVM
         // re-sets it for the JSC VM teardown.
         vm.jsc_vm.clearHasTerminationRequest();
         vm.is_shutting_down = true;
@@ -774,9 +780,12 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     var arena = this.arena;
     this.arena = null;
 
-    WebWorker__dispatchExit(globalObject, cpp_worker, exit_code);
-    // Past this point `this` may be freed at any time (the C++ Worker's last ref can
-    // drop on the parent thread once the close-event task runs).
+    // JSC VM teardown can re-enter Zig (finalizers, module registry callbacks),
+    // so it must run before any mimalloc-backed state is destroyed below.
+    if (globalObject) |global| {
+        WebWorker__teardownJSCVM(global);
+    }
+
     if (loop) |loop_| {
         loop_.internal_loop_data.jsc_vm = null;
     }
@@ -798,6 +807,14 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     if (arena) |*arena_| {
         arena_.deinit();
     }
+
+    // Only now post the close-event task. It releases parent_poll_ref on the
+    // parent thread; once that happens the parent can reach Global.exit() →
+    // mi_process_done() → _mi_thread_locals_done(), which frees this thread's
+    // mimalloc TLD. Everything mimalloc-touching above must be done first.
+    WebWorker__dispatchExit(cpp_worker, exit_code);
+    // Past this point `this` may be freed at any time (the C++ Worker's last ref can
+    // drop on the parent thread once the close-event task runs).
 
     bun.exitThread();
 }

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -67,10 +67,16 @@
 //! ONLY on the parent thread:
 //!   - `create()`      – ref   (parent thread)
 //!   - `setRef()`      – ref/unref via JS .ref()/.unref()  (parent thread)
-//!   - `notifyNeedTermination()` – unref on terminate()     (parent thread)
 //!   - `releaseParentPollRef()` – unref in close-event task (parent thread)
 //!   - `WebWorker__updatePtr` spawn-fail path – unref       (parent thread)
 //! `KeepAlive.status` is non-atomic, so the worker thread MUST NOT touch it.
+//!
+//! `terminate()` and worker-side `process.exit()` call
+//! `vm.jsc_vm.notifyNeedTermination()`, which makes JSC throw a
+//! TerminationException at the next safepoint. Combined with `wakeup()` this
+//! lets the worker reach `exitAndDeinit` even if it was in a tight loop, so
+//! `await worker.terminate()` resolves and `parent_poll_ref` is released via
+//! the close-event task rather than eagerly.
 //!
 //! `vm_lock` is held only briefly around three sites: `start()` setting `vm`,
 //! `exitAndDeinit()` nulling `vm`, and `notifyNeedTermination()` reading `vm`
@@ -79,9 +85,7 @@
 //!
 //! Known gaps vs Node.js (not handled here): the worker thread is detached,
 //! not joined, so `await worker.terminate()` resolves before the OS thread is
-//! fully gone; `terminate()` does not call `vm->TerminateExecution()` so a
-//! worker stuck in `while(true){}` never observes it; nested workers are not
-//! stopped/joined when their parent exits.
+//! fully gone; nested workers are not stopped/joined when their parent exits.
 
 const WebWorker = @This();
 
@@ -705,19 +709,15 @@ pub fn notifyNeedTermination(this: *WebWorker) callconv(.c) void {
     }
     log("[{d}] notifyNeedTermination", .{this.execution_context_id});
 
-    // Release the parent's keep-alive immediately. terminate() does not yet
-    // interrupt running JS, so a worker stuck in synchronous code will never
-    // reach exitAndDeinit and post the close-event task; without this the
-    // parent's event loop would stay ref'd forever. This is parent-thread-only
-    // (the only caller is Worker::terminate()), so plain unref is correct, and
-    // KeepAlive.unref is idempotent so the later releaseParentPollRef is a no-op.
-    this.parent_poll_ref.unref(this.parent);
-
-    // Wake the worker's event loop so it observes requested_terminate promptly.
+    // Interrupt running JS in the worker (TerminationException at the next
+    // safepoint) and wake its event loop so it observes requested_terminate.
     // vm_lock serializes against exitAndDeinit nulling vm and freeing the arena.
+    // parent_poll_ref stays held until the close-event task runs so that
+    // `await worker.terminate()` keeps the parent alive until 'exit' fires.
     this.vm_lock.lock();
     defer this.vm_lock.unlock();
     if (this.vm) |vm| {
+        vm.jsc_vm.notifyNeedTermination();
         vm.eventLoop().wakeup();
     }
 }
@@ -754,6 +754,10 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
         }
     }
     if (vm_to_deinit) |vm| {
+        // terminate() set the JSC termination flag to interrupt running JS; clear
+        // it so process.on('exit') handlers can run. WebWorker__dispatchExit
+        // re-sets it for the JSC VM teardown.
+        vm.jsc_vm.clearHasTerminationRequest();
         vm.is_shutting_down = true;
         vm.onExit();
         jsc.API.cron.CronJob.clearAllForVM(vm, .teardown);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression: the Zig WebWorker struct was freed by the worker thread in
+// exitAndDeinit while the C++ Worker still held a raw impl_ pointer, so a
+// terminate()/ref()/unref() that landed after natural exit dereferenced freed
+// memory (ASAN use-after-poison in setRefInternal).
+test("terminate/ref/unref after worker exits naturally does not UAF", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        for (let round = 0; round < 8; round++) {
+          const workers = [];
+          for (let i = 0; i < 32; i++) {
+            // Empty body: worker thread exits as soon as the event loop drains.
+            workers.push(new Worker("data:text/javascript,"));
+          }
+          await Promise.all(workers.map(w => new Promise(r => w.addEventListener("close", r, { once: true }))));
+          // All workers have exited; previously the Zig struct was freed here,
+          // so every call below dereferenced freed memory via Worker::impl_.
+          for (const w of workers) {
+            w.ref();
+            w.unref();
+            w.terminate();
+            w.terminate();
+            w.ref();
+            w.unref();
+          }
+        }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// Regression: WebWorker__dispatchExit deref'd the C++ Worker on the worker
+// thread; if that was the last ref, ~Worker → ~EventTarget ran there and
+// EventListenerMap::releaseAssertOrSetThreadUID tripped because the listener
+// map was populated on the parent thread.
+test("nested worker whose grandchild outlives the middle worker's JSWorker does not assert", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        for (let i = 0; i < 16; i++) {
+          const middle = new Worker(
+            'data:text/javascript,' +
+            // Middle worker creates an inner worker, registers a listener (so the
+            // inner Worker's EventListenerMap is tagged with the middle thread),
+            // then lets its own event loop drain.
+            'const w = new Worker("data:text/javascript,"); w.addEventListener("message", () => {});'
+          );
+          middle.addEventListener("message", () => {});
+          await new Promise(r => middle.addEventListener("close", r, { once: true }));
+        }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression: the Zig WebWorker struct was freed by the worker thread in


### PR DESCRIPTION
## Summary

The Zig `WebWorker` struct was freed by the worker thread in `exitAndDeinit` while `WebCore::Worker::impl_` still held a raw pointer, so `terminate()`/`ref()`/`unref()` arriving after the worker exited dereferenced freed memory (ASAN use-after-poison in `setRefInternal`). Separately, `WebWorker__dispatchExit` deref'd the C++ `Worker` on the worker thread; when that was the last ref, `~Worker` → `~EventTarget` ran there and `EventListenerMap::releaseAssertOrSetThreadUID` `RELEASE_ASSERT`ed.

- **Ownership inversion:** Zig `WebWorker` is now freed by `~Worker()` via `WebWorker__destroy` — its lifetime matches the C++ `Worker`, so `impl_` never dangles.
- **Deref on parent thread:** the Zig-held `Worker` ref is dropped inside `dispatchExit`'s posted task on the parent thread (intentionally leaked if the parent context is gone, to avoid running `~Worker` on the worker thread).
- **`parent_poll_ref` is parent-thread-only:** released via `WebWorker__releaseParentPollRef` inside the close task; the worker-thread `unrefConcurrently` writes in `deinit`/`onUnhandledRejection` and the `setRefInternal(false)` in `notifyNeedTermination` are removed.
- **`vm_lock`** guards the cross-thread `vm` read in `notifyNeedTermination` against `exitAndDeinit` nulling `vm` and freeing the arena.
- **`WebWorker__dispatchExit` reordered** to tear down the worker's JSC VM before posting the close task, so the parent stays alive through `collectNow()`/`vm.deref()`.
- `worker->ref()` moved after `if (!impl)` in `Worker::create()` (no refcount leak on preload-resolve failure); `updatePtr()` drops the ref on thread-spawn failure.

## Test plan

- [x] `bun bd test test/js/web/workers/worker-terminate-lifetime.test.ts` — new regression test; reproduces the original ASAN use-after-poison on baseline, passes with the fix
- [x] `bun bd test test/js/web/workers/worker.test.ts`
- [x] `bun bd test test/js/node/worker_threads/worker_destruction.test.ts`
- [x] `bun bd test test/js/node/worker_threads/worker_threads.test.ts` (only failure is pre-existing `eval does not leak source code` 5s timeout in debug build)
- [x] 30× `environmentdata-empty-fixture.js` (nested worker) — clean
- [x] `bun run zig:check-all`

## Follow-up (not in this PR)

Node.js `terminate()` semantics differ: Node calls `isolate->TerminateExecution()` (interrupts running JS), re-`ref()`s the worker, and resolves the promise after `uv_thread_join()`. Bun detaches the thread and only sets a flag checked between ticks. Separate change.

## Issues

Fixes #28121
Fixes #24580
Fixes #24189
Fixes #29275
Fixes #28648
Fixes #29338
Fixes #21757
Fixes #23194
Fixes #23997
Fixes #24539
Fixes #29338
Fixes #19705
Fixes #28415

Related crash reports with matching stack frames in `web_worker.zig` / `Worker.cpp` / `JSWorker.cpp` / `WebWorker__dispatchExit` / `notifyNeedTermination` / `exitAndDeinit` / `jsWorkerPrototypeFunction_terminate` / `EventListenerMap` (already closed as duplicates):

#4134 #7374 #8420 #9095 #11643 #12526 #13001 #13209 #13550 #13888 #14042 #14331 #14332 #15390 #15890 #15961 #16210 #16419 #16752 #17061 #17114 #17177 #17326 #17579 #17630 #17672 #17754 #17795 #17852 #17977 #18001 #18139 #18156 #18237 #18856 #18910 #19512 #19849 #19877 #20165 #20315 #20334 #20393 #20445 #20751 #21470 #21948 #22028 #22085 #22564 #22829 #23167 #23392 #23522 #23611 #23622 #23769 #23944 #24009 #24062 #24108 #24380 #24395 #24405 #24415 #24435 #24464 #24469 #24560 #24629 #24650 #24833 #24979 #25095 #25122 #25225 #25260