### PR TITLE
Fix debug assertion in spyOn on non-callable indexed properties

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1562,7 +1562,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
                 // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, mock, attributes & ~PropertyAttribute::Accessor, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1011,6 +1011,38 @@ describe("spyOn", () => {
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    test("spyOn on a missing indexed property does not crash", () => {
+      const o = {};
+      const fn = spyOn(o, 12);
+      expect(Object.getOwnPropertyDescriptor(o, 12)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      fn.mockRestore();
+      expect(Object.getOwnPropertyDescriptor(o, 12)).toEqual({
+        value: undefined,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    });
+
+    test("spyOn on a non-callable indexed property does not crash", () => {
+      const arr = ["hello"];
+      const fn = spyOn(arr, 0);
+      expect(Object.getOwnPropertyDescriptor(arr, 0)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(arr[0]).toBe(fn);
+      fn.mockRestore();
+      expect(arr[0]).toBe("hello");
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
When `spyOn` is called on an indexed property that is missing or non-callable, the mock function is stored directly via `putDirectIndex` rather than wrapped in a `GetterSetter`. The `PropertyAttribute::Accessor` bit was still being set on the sparse array entry, which later triggers an assertion in `PropertySlot::setValue` when the property is read (e.g. via `Object.getOwnPropertyDescriptor`):

```
ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)
JavaScriptCore/PropertySlot.h(219) : void JSC::PropertySlot::setValue(JSObject *, unsigned int, JSValue)
```

Deterministic repro:
```js
const { spyOn } = Bun.jest();
const o = {};
spyOn(o, 12);
Object.getOwnPropertyDescriptor(o, 12); // assert
```

Since we are storing the mock as a plain value in this branch, mask off the `Accessor` bit before calling `putDirectIndex`.