### PR TITLE
install: stream tarball extraction from HTTP into libarchive

### DIFF
--- a/patches/libarchive/nonblocking-read.patch
+++ b/patches/libarchive/nonblocking-read.patch
@@ -1,0 +1,746 @@
+--- a/libarchive/archive_read_private.h
++++ b/libarchive/archive_read_private.h
+@@ -182,2 +182,11 @@
+ 
++	/*
++	 * BUN PATCH: set by archive_read_next_header2 when the format's
++	 * read_header callback returns ARCHIVE_RETRY from a non-blocking
++	 * source. On the next call we skip archive_entry_clear() so that
++	 * attributes already populated by consumed extension headers
++	 * (pax, GNU long name/link, etc.) survive the resume.
++	 */
++	int		  read_header_in_progress;
++
+ 	/* Nodes and offsets of compressed data block */
+--- a/libarchive/archive_read.c
++++ b/libarchive/archive_read.c
+@@ -616,25 +616,48 @@
+ 
+-	archive_entry_clear(entry);
+-	archive_clear_error(&a->archive);
+-
+ 	/*
+-	 * If client didn't consume entire data, skip any remainder
+-	 * (This is especially important for GNU incremental directories.)
++	 * BUN PATCH: when resuming after an ARCHIVE_RETRY from a
++	 * non-blocking source, the format reader has already
++	 * populated `entry` from consumed extension headers (pax,
++	 * GNU long name/link). Clearing it here would discard that
++	 * work, and since no data has been read for the pending
++	 * entry there is nothing to skip. Skip straight to the
++	 * format reader which will pick up where it left off.
+ 	 */
+-	if (a->archive.state == ARCHIVE_STATE_DATA) {
+-		r1 = archive_read_data_skip(&a->archive);
+-		if (r1 == ARCHIVE_EOF)
+-			archive_set_error(&a->archive, EIO,
+-			    "Premature end-of-file");
+-		if (r1 == ARCHIVE_EOF || r1 == ARCHIVE_FATAL) {
+-			a->archive.state = ARCHIVE_STATE_FATAL;
+-			return (ARCHIVE_FATAL);
++	if (!a->read_header_in_progress) {
++		archive_entry_clear(entry);
++		archive_clear_error(&a->archive);
++
++		/*
++		 * If client didn't consume entire data, skip any remainder
++		 * (This is especially important for GNU incremental directories.)
++		 */
++		if (a->archive.state == ARCHIVE_STATE_DATA) {
++			r1 = archive_read_data_skip(&a->archive);
++			/*
++			 * BUN PATCH: the skip may run out of buffered
++			 * bytes when the source is non-blocking. The
++			 * format's skip handler has already recorded how
++			 * much remains, so the next next_header() call
++			 * will re-enter here (state is still DATA) and
++			 * continue the skip.
++			 */
++			if (r1 == ARCHIVE_RETRY)
++				return (ARCHIVE_RETRY);
++			if (r1 == ARCHIVE_EOF)
++				archive_set_error(&a->archive, EIO,
++				    "Premature end-of-file");
++			if (r1 == ARCHIVE_EOF || r1 == ARCHIVE_FATAL) {
++				a->archive.state = ARCHIVE_STATE_FATAL;
++				return (ARCHIVE_FATAL);
++			}
+ 		}
+-	}
+ 
+-	/* Record start-of-header offset in uncompressed stream. */
+-	a->header_position = a->filter->position;
++		/* Record start-of-header offset in uncompressed stream. */
++		a->header_position = a->filter->position;
+ 
+-	++_a->file_count;
++		++_a->file_count;
++	}
+ 	r2 = (a->format->read_header)(a, entry);
++	/* BUN PATCH: remember whether this header read is mid-flight. */
++	a->read_header_in_progress = (r2 == ARCHIVE_RETRY);
+ 
+@@ -1384,2 +1407,29 @@
+ 			    &filter->client_buff);
++			/*
++			 * BUN PATCH: non-blocking read support.
++			 *
++			 * A client reader that is being fed incrementally
++			 * (e.g. tarball bytes arriving from the network
++			 * during `bun install`) returns ARCHIVE_RETRY when
++			 * no data is currently available. Unlike a real
++			 * error this must not poison the filter: whatever
++			 * has already been copied into `filter->buffer`
++			 * stays put so the next call with the same `min`
++			 * resumes exactly where we left off, and the caller
++			 * can yield its thread and try again once more
++			 * input has arrived.
++			 *
++			 * Callers that do not opt in (pass avail == NULL or
++			 * do not check for ARCHIVE_RETRY) will see NULL and
++			 * treat it as truncated input, which matches the
++			 * pre-patch behaviour for non-streaming sources.
++			 */
++			if (bytes_read == ARCHIVE_RETRY) {
++				filter->client_total = filter->client_avail = 0;
++				filter->client_next =
++				    filter->client_buff = NULL;
++				if (avail != NULL)
++					*avail = ARCHIVE_RETRY;
++				return (NULL);
++			}
+ 			if (bytes_read < 0) {		/* Read error. */
+@@ -1579,3 +1629,10 @@
+ 			filter->client_buff = NULL;
+-			filter->fatal = 1;
++			/*
++			 * BUN PATCH: see the matching comment in
++			 * __archive_read_filter_ahead. A non-blocking
++			 * reader returning ARCHIVE_RETRY must not mark
++			 * the filter fatal.
++			 */
++			if (bytes_read != ARCHIVE_RETRY)
++				filter->fatal = 1;
+ 			return (bytes_read);
+--- a/libarchive/archive_read_support_filter_gzip.c
++++ b/libarchive/archive_read_support_filter_gzip.c
+@@ -63,2 +63,9 @@
+ 	char		 eof; /* True = found end of compressed data. */
++	/*
++	 * BUN PATCH: set after Z_STREAM_END so that a retry which
++	 * interrupts consume_trailer() does not re-enter
++	 * consume_header() (which would try to parse deflate bytes as
++	 * a gzip header).
++	 */
++	char		 trailer_pending;
+ };
+@@ -148,2 +155,10 @@
+ 	p = __archive_read_filter_ahead(filter, len, &avail);
++	/*
++	 * BUN PATCH: propagate non-blocking retry. Nothing has been
++	 * consumed yet, so calling peek_at_header again once more
++	 * input is available will re-read the same header bytes from
++	 * filter->buffer.
++	 */
++	if (p == NULL && avail == ARCHIVE_RETRY)
++		return (ARCHIVE_RETRY);
+ 	if (p == NULL || avail == 0)
+@@ -172,3 +187,3 @@
+ 		if (p == NULL)
+-			return (0);
++			return (avail == ARCHIVE_RETRY ? ARCHIVE_RETRY : 0);
+ 		len += ((int)p[len + 1] << 8) | (int)p[len];
+@@ -192,3 +207,3 @@
+ 			if (p == NULL)
+-				return (0);
++				return (avail == ARCHIVE_RETRY ? ARCHIVE_RETRY : 0);
+ 		} while (p[len - 1] != 0);
+@@ -216,3 +231,3 @@
+ 			if (p == NULL)
+-				return (0);
++				return (avail == ARCHIVE_RETRY ? ARCHIVE_RETRY : 0);
+ 		} while (p[len - 1] != 0);
+@@ -224,3 +239,3 @@
+ 		if (p == NULL)
+-			return (0);
++			return (avail == ARCHIVE_RETRY ? ARCHIVE_RETRY : 0);
+ #if 0
+@@ -251,3 +266,12 @@
+ 
+-	if (peek_at_header(filter, &bits_checked, NULL))
++	/*
++	 * BUN PATCH: peek_at_header() may now return ARCHIVE_RETRY
++	 * from a non-blocking source. Bidding has no retry channel,
++	 * so only accept a positive header length as a match.
++	 * Streaming callers (bun install) always deliver at least
++	 * one HTTP chunk — well over the ~10-byte gzip header —
++	 * before archive_read_open() is invoked, so this branch is
++	 * defensive rather than expected.
++	 */
++	if (peek_at_header(filter, &bits_checked, NULL) > 0)
+ 		return (bits_checked);
+@@ -343,4 +367,3 @@
+ 	struct private_data *state;
+-	ssize_t avail;
+-	size_t len;
++	ssize_t len;
+ 	int ret;
+@@ -351,2 +374,10 @@
+ 	len = peek_at_header(self->upstream, NULL, state);
++	/*
++	 * BUN PATCH: peek_at_header consumes nothing, so on
++	 * ARCHIVE_RETRY the caller can simply try again later and the
++	 * partial header bytes already copied into the upstream
++	 * filter's buffer will still be there.
++	 */
++	if (len == ARCHIVE_RETRY)
++		return (ARCHIVE_RETRY);
+ 	if (len == 0)
+@@ -358,6 +389,12 @@
+ 
+-	/* Initialize compression library. */
+-	state->stream.next_in = (unsigned char *)(uintptr_t)
+-	    __archive_read_filter_ahead(self->upstream, 1, &avail);
+-	state->stream.avail_in = (uInt)avail;
++	/*
++	 * Initialize compression library. next_in / avail_in are
++	 * unused by inflateInit2 with a negative windowBits (raw
++	 * deflate); the main read loop primes them before each
++	 * inflate() call, so we do not need an extra read-ahead here
++	 * that could itself return ARCHIVE_RETRY after the header has
++	 * already been consumed.
++	 */
++	state->stream.next_in = NULL;
++	state->stream.avail_in = 0;
+ 	ret = inflateInit2(&(state->stream),
+@@ -406,11 +443,21 @@
+ 
+-	state->in_stream = 0;
+-	switch (inflateEnd(&(state->stream))) {
+-	case Z_OK:
+-		break;
+-	default:
+-		archive_set_error(&self->archive->archive,
+-		    ARCHIVE_ERRNO_MISC,
+-		    "Failed to clean up gzip decompressor");
+-		return (ARCHIVE_FATAL);
++	/*
++	 * BUN PATCH: inflateEnd()/in_stream=0 are only safe to run
++	 * once. If a previous consume_trailer() attempt was
++	 * interrupted by ARCHIVE_RETRY while reading the 8-byte
++	 * footer, `trailer_pending` stays set and we skip straight to
++	 * the read-ahead below.
++	 */
++	if (!state->trailer_pending) {
++		state->in_stream = 0;
++		switch (inflateEnd(&(state->stream))) {
++		case Z_OK:
++			break;
++		default:
++			archive_set_error(&self->archive->archive,
++			    ARCHIVE_ERRNO_MISC,
++			    "Failed to clean up gzip decompressor");
++			return (ARCHIVE_FATAL);
++		}
++		state->trailer_pending = 1;
+ 	}
+@@ -419,2 +466,4 @@
+ 	p = __archive_read_filter_ahead(self->upstream, 8, &avail);
++	if (p == NULL && avail == ARCHIVE_RETRY)
++		return (ARCHIVE_RETRY);
+ 	if (p == NULL || avail == 0)
+@@ -426,2 +475,3 @@
+ 	__archive_read_filter_consume(self->upstream, 8);
++	state->trailer_pending = 0;
+ 
+@@ -446,2 +496,14 @@
+ 	while (state->stream.avail_out > 0 && !state->eof) {
++		/*
++		 * BUN PATCH: finish any pending trailer first. This can
++		 * only be set when a previous gzip_filter_read() call hit
++		 * ARCHIVE_RETRY inside consume_trailer().
++		 */
++		if (state->trailer_pending) {
++			ret = consume_trailer(self);
++			if (ret == ARCHIVE_RETRY)
++				goto bun_retry;
++			if (ret < ARCHIVE_OK)
++				return (ret);
++		}
+ 		/* If we're not in a stream, read a header
+@@ -454,2 +516,4 @@
+ 			}
++			if (ret == ARCHIVE_RETRY)
++				goto bun_retry;
+ 			if (ret < ARCHIVE_OK)
+@@ -464,2 +528,10 @@
+ 		if (state->stream.next_in == NULL) {
++			/*
++			 * BUN PATCH: upstream has no bytes right now but
++			 * isn't done. zlib's inflate state is untouched,
++			 * so propagate the retry (or return whatever we
++			 * have already decompressed this call).
++			 */
++			if (avail_in == ARCHIVE_RETRY)
++				goto bun_retry;
+ 			archive_set_error(&self->archive->archive,
+@@ -490,2 +562,4 @@
+ 			ret = consume_trailer(self);
++			if (ret == ARCHIVE_RETRY)
++				goto bun_retry;
+ 			if (ret < ARCHIVE_OK)
+@@ -510,2 +584,21 @@
+ 	return (decompressed);
++
++bun_retry:
++	/*
++	 * BUN PATCH: upstream ran dry mid-call. If we managed to
++	 * decompress anything before that happened, hand it back
++	 * now; the tar layer will consume it and the next call will
++	 * start with an empty out_block and immediately retry.
++	 * Otherwise propagate ARCHIVE_RETRY so the tar layer (and
++	 * ultimately the Zig extract loop) can yield this worker and
++	 * reschedule when more bytes arrive.
++	 */
++	decompressed = state->stream.next_out - state->out_block;
++	if (decompressed > 0) {
++		state->total_out += decompressed;
++		*p = state->out_block;
++		return (decompressed);
++	}
++	*p = NULL;
++	return (ARCHIVE_RETRY);
+ }
+--- a/libarchive/archive_read_support_format_tar.c
++++ b/libarchive/archive_read_support_format_tar.c
+@@ -155,2 +155,19 @@
+ 	int			 read_concatenated_archives;
++
++	/*
++	 * BUN PATCH: resume state for non-blocking sources.
++	 *
++	 * `tar_read_header` walks a variable-length sequence of
++	 * extension headers (pax 'x'/'g', GNU 'L'/'K', etc.) before
++	 * the real ustar header. When the underlying reader returns
++	 * ARCHIVE_RETRY part-way through that walk, we must remember
++	 * which extensions have already been parsed so the next call
++	 * picks up at the right header instead of re-running
++	 * `tar_reset_header_state` and re-bidding bytes that were
++	 * already consumed.
++	 */
++	int			 header_in_progress;
++	int32_t			 header_seen;
++	int			 header_eof_fatal;
++	int			 header_err;
+ };
+@@ -231,2 +248,4 @@
+ static int64_t	tar_atol8(const char *, size_t);
++static int	tar_consume_retryable(struct archive_read *, struct tar *,
++		    int64_t);
+ static int	tar_read_header(struct archive_read *, struct tar *,
+@@ -475,2 +494,49 @@
+ 
++/*
++ * BUN PATCH: consume up to `request` bytes in a way that is safe to
++ * resume from a non-blocking source. Each iteration uses
++ * __archive_read_ahead(1) to discover how many bytes are currently
++ * buffered and then __archive_read_consume()s exactly that much, so
++ * the consume never has to invoke the client reader itself. On
++ * ARCHIVE_RETRY the remaining amount is written back into
++ * `tar->entry_bytes_remaining` / `tar->entry_padding` so the next
++ * call (via archive_read_next_header → read_data_skip, or another
++ * read_data_block) continues from the right offset.
++ */
++static int
++tar_consume_retryable(struct archive_read *a, struct tar *tar,
++    int64_t request)
++{
++	while (request > 0) {
++		ssize_t avail = 0;
++		const void *p = __archive_read_ahead(a, 1, &avail);
++		if (p == NULL) {
++			if (avail == ARCHIVE_RETRY) {
++				/* Persist what is still owed so the
++				 * next resume asks for the remainder
++				 * rather than the original total. */
++				if (request >= tar->entry_padding) {
++					tar->entry_bytes_remaining =
++					    request - tar->entry_padding;
++				} else {
++					tar->entry_bytes_remaining = 0;
++					tar->entry_padding = request;
++				}
++				return (ARCHIVE_RETRY);
++			}
++			archive_set_error(&a->archive,
++			    ARCHIVE_ERRNO_MISC,
++			    "Truncated tar archive"
++			    " detected while skipping data");
++			return (ARCHIVE_FATAL);
++		}
++		if (avail > request)
++			avail = (ssize_t)request;
++		if (__archive_read_consume(a, avail) != avail)
++			return (ARCHIVE_FATAL);
++		request -= avail;
++	}
++	return (ARCHIVE_OK);
++}
++
+ /* utility function- this exists to centralize the logic of tracking
+@@ -535,25 +601,35 @@
+ 
+-	/* Assign default device/inode values. */
+-	archive_entry_set_dev(entry, 1 + default_dev); /* Don't use zero. */
+-	archive_entry_set_ino(entry, ++default_inode); /* Don't use zero. */
+-	/* Limit generated st_ino number to 16 bits. */
+-	if (default_inode >= 0xffff) {
+-		++default_dev;
+-		default_inode = 0;
+-	}
+-
+ 	tar = (struct tar *)(a->format->data);
+-	tar->entry_offset = 0;
+-	gnu_clear_sparse_list(tar);
+-	tar->size_fields = 0; /* We don't have any size info yet */
+ 
+-	/* Setup default string conversion. */
+-	tar->sconv = tar->opt_sconv;
+-	if (tar->sconv == NULL) {
+-		if (!tar->init_default_conversion) {
+-			tar->sconv_default =
+-			    archive_string_default_conversion_for_read(&(a->archive));
+-			tar->init_default_conversion = 1;
++	/*
++	 * BUN PATCH: when resuming after an ARCHIVE_RETRY from a
++	 * non-blocking source, skip the fresh-entry initialisation
++	 * below. Extension headers parsed before the retry have
++	 * already written into `entry` and `tar->entry_*`; repeating
++	 * these resets would discard that work.
++	 */
++	if (!tar->header_in_progress) {
++		/* Assign default device/inode values. */
++		archive_entry_set_dev(entry, 1 + default_dev); /* Don't use zero. */
++		archive_entry_set_ino(entry, ++default_inode); /* Don't use zero. */
++		/* Limit generated st_ino number to 16 bits. */
++		if (default_inode >= 0xffff) {
++			++default_dev;
++			default_inode = 0;
++		}
++
++		tar->entry_offset = 0;
++		gnu_clear_sparse_list(tar);
++		tar->size_fields = 0; /* We don't have any size info yet */
++
++		/* Setup default string conversion. */
++		tar->sconv = tar->opt_sconv;
++		if (tar->sconv == NULL) {
++			if (!tar->init_default_conversion) {
++				tar->sconv_default =
++				    archive_string_default_conversion_for_read(&(a->archive));
++				tar->init_default_conversion = 1;
++			}
++			tar->sconv = tar->sconv_default;
+ 		}
+-		tar->sconv = tar->sconv_default;
+ 	}
+@@ -562,2 +638,10 @@
+ 
++	/*
++	 * BUN PATCH: on ARCHIVE_RETRY, `tar_read_header` guarantees
++	 * `*unconsumed == 0` (nothing pending that isn't already
++	 * flushed) so the caller can yield and re-enter later.
++	 */
++	if (r == ARCHIVE_RETRY)
++		return (ARCHIVE_RETRY);
++
+ 	tar_flush_unconsumed(a, &unconsumed);
+@@ -637,5 +721,16 @@
+ 
+-			if (__archive_read_consume(a, request) != request)
++			/*
++			 * BUN PATCH: make the end-of-entry padding
++			 * consume resumable. `tar_consume_retryable`
++			 * decrements `entry_bytes_remaining` /
++			 * `entry_padding` as bytes become available so a
++			 * subsequent call picks up with the remainder.
++			 */
++			int cr = tar_consume_retryable(a, tar, request);
++			if (cr == ARCHIVE_RETRY)
++				return (ARCHIVE_RETRY);
++			if (cr != ARCHIVE_OK)
+ 				return (ARCHIVE_FATAL);
+ 			tar->entry_padding = 0;
++			tar->entry_bytes_remaining = 0;
+ 			*buff = NULL;
+@@ -648,2 +743,11 @@
+ 		if (*buff == NULL) {
++			/*
++			 * BUN PATCH: propagate non-blocking retry. Every
++			 * counter we would have touched
++			 * (`entry_bytes_remaining`, `sparse_list`, etc.)
++			 * is still at its pre-call value, so the caller
++			 * can yield and re-enter read_data_block later.
++			 */
++			if (bytes_read == ARCHIVE_RETRY)
++				return (ARCHIVE_RETRY);
+ 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+@@ -676,2 +780,3 @@
+ 	int64_t request;
++	int cr;
+ 	struct tar* tar;
+@@ -683,3 +788,14 @@
+ 
+-	if (__archive_read_consume(a, request) != request)
++	/*
++	 * BUN PATCH: use the retryable consume so a non-blocking
++	 * source can yield mid-skip. Progress is recorded in
++	 * `entry_bytes_remaining` / `entry_padding` /
++	 * `entry_bytes_unconsumed`, so archive_read_next_header's
++	 * implicit skip on re-entry resumes with the remainder.
++	 */
++	tar->entry_bytes_unconsumed = 0;
++	cr = tar_consume_retryable(a, tar, request);
++	if (cr == ARCHIVE_RETRY)
++		return (ARCHIVE_RETRY);
++	if (cr != ARCHIVE_OK)
+ 		return (ARCHIVE_FATAL);
+@@ -687,3 +803,2 @@
+ 	tar->entry_bytes_remaining = 0;
+-	tar->entry_bytes_unconsumed = 0;
+ 	tar->entry_padding = 0;
+@@ -721,4 +836,4 @@
+ 	ssize_t bytes;
+-	int err = ARCHIVE_OK, err2;
+-	int eof_fatal = 0; /* EOF is okay at some points... */
++	int err, err2;
++	int eof_fatal; /* EOF is okay at some points... */
+ 	const char *h;
+@@ -728,3 +843,3 @@
+ 	/* Bitmask of what header types we've seen. */
+-	int32_t seen_headers = 0;
++	int32_t seen_headers;
+ 	static const int32_t seen_A_header = 1;
+@@ -737,3 +852,20 @@
+ 
+-	tar_reset_header_state(tar);
++	/*
++	 * BUN PATCH: `header_in_progress` persists the header loop's
++	 * locals across an ARCHIVE_RETRY so a non-blocking source can
++	 * resume mid-sequence. On a fresh entry we initialise them
++	 * exactly as before; on resume we restore and skip the reset
++	 * that would otherwise wipe pax/GNU long-name data already
++	 * parsed into `tar->entry_*`.
++	 */
++	if (!tar->header_in_progress) {
++		tar_reset_header_state(tar);
++		tar->header_in_progress = 1;
++		tar->header_seen = 0;
++		tar->header_eof_fatal = 0;
++		tar->header_err = ARCHIVE_OK;
++	}
++	seen_headers = tar->header_seen;
++	eof_fatal = tar->header_eof_fatal;
++	err = tar->header_err;
+ 
+@@ -745,2 +877,13 @@
+ 
++/*
++ * BUN PATCH: every terminal exit from this function (anything other
++ * than the non-blocking retry path) must clear `header_in_progress`
++ * so the next entry starts with fresh `seen_headers` / header state.
++ * The macro keeps the existing `return (X)` sites readable.
++ */
++#define TAR_HEADER_RETURN(rc) do { \
++		tar->header_in_progress = 0; \
++		return (rc); \
++	} while (0)
++
+ 	/*
+@@ -757,3 +900,3 @@
+ 			if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -762,2 +905,13 @@
+ 			h = __archive_read_ahead(a, 512, &bytes);
++			if (h == NULL && bytes == ARCHIVE_RETRY) {
++				/*
++				 * BUN PATCH: non-blocking source ran
++				 * out mid-header. Nothing has been
++				 * added to `*unconsumed` yet this
++				 * iteration, so save loop state and
++				 * let the caller try again once more
++				 * input arrives.
++				 */
++				goto bun_retry;
++			}
+ 			if (bytes == 0) { /* EOF at a block boundary. */
+@@ -769,5 +923,5 @@
+ 							  "Damaged tar archive (end-of-archive within a sequence of headers)");
+-					return (ARCHIVE_FATAL);
++					TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 				} else {
+-					return (ARCHIVE_EOF);
++					TAR_HEADER_RETURN(ARCHIVE_EOF);
+ 				}
+@@ -779,3 +933,3 @@
+ 				    " detected while reading next header");
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -799,3 +953,3 @@
+ 				archive_clear_error(&a->archive);
+-				return (ARCHIVE_EOF);
++				TAR_HEADER_RETURN(ARCHIVE_EOF);
+ 			}
+@@ -805,3 +959,3 @@
+ 				if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
+-					return (ARCHIVE_FATAL);
++					TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 				}
+@@ -812,5 +966,14 @@
+ 				if (eof_fatal) {
+-					return (ARCHIVE_FATAL);
++					TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 				} else {
+-					return (ARCHIVE_RETRY);
++					/*
++					 * BUN PATCH: this RETRY means
++					 * "skip this block and look for
++					 * the next valid header", which
++					 * is also the non-blocking
++					 * contract: persist state so
++					 * re-entry does not reset
++					 * `seen_headers`.
++					 */
++					goto bun_retry;
+ 				}
+@@ -822,2 +985,55 @@
+ 		header = (const struct archive_entry_header_ustar *)h;
++
++		/*
++		 * BUN PATCH: extension headers ('A','g','K','L','V',
++		 * 'x','X') are followed by a payload whose length is
++		 * encoded in this block's `size` field. The handlers
++		 * below flush `*unconsumed` (this 512-byte block) and
++		 * then __archive_read_ahead() the payload; if that
++		 * ahead were to return ARCHIVE_RETRY after the flush,
++		 * the block would already be consumed and the resume
++		 * would read payload bytes as a header.
++		 *
++		 * To keep the handlers unchanged, pre-buffer the
++		 * header+payload here *before* the flush. On retry we
++		 * roll back `*unconsumed` so nothing is consumed and
++		 * the next attempt re-reads this exact block from the
++		 * filter's buffer.
++		 */
++		switch (header->typeflag[0]) {
++		case 'A': case 'g': case 'K': case 'L':
++		case 'V': case 'X': case 'x': {
++			int64_t ext_size = tar_atol(header->size,
++			    sizeof(header->size));
++			if (ext_size < 0)
++				ext_size = 0;
++			int64_t ext_padded = (ext_size + 511) & ~511;
++			/* Bound the prebuffer. A corrupted stream can
++			 * produce garbage that decodes as an extension
++			 * header with a multi-GB `size`; retrying
++			 * `ahead(512 + huge)` every chunk would never
++			 * make progress. Real pax/GNU extension
++			 * payloads are path-length-bounded (a few KB),
++			 * so anything beyond this is handed to the
++			 * handler below, which will fail cleanly on
++			 * its own `__archive_read_ahead`. */
++			if (ext_padded > (int64_t)(1u << 20))
++				break;
++			if (__archive_read_ahead(a,
++			    (size_t)(512 + ext_padded), &bytes) == NULL &&
++			    bytes == ARCHIVE_RETRY) {
++				*unconsumed -= 512;
++				goto bun_retry;
++			}
++			/* Re-establish `h`: the filter may have
++			 * memmoved its buffer to satisfy the larger
++			 * request. */
++			h = __archive_read_ahead(a, 512, NULL);
++			header = (const struct archive_entry_header_ustar *)h;
++			break;
++		}
++		default:
++			break;
++		}
++
+ 		switch(header->typeflag[0]) {
+@@ -827,3 +1043,3 @@
+ 						  "Redundant 'A' header");
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -838,3 +1054,3 @@
+ 						  "Redundant 'g' header");
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -882,3 +1098,3 @@
+ 						  "Redundant 'X'/'x' header");
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -894,3 +1110,3 @@
+ 						  "Redundant 'x' header");
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -921,3 +1137,3 @@
+ 			if (err < ARCHIVE_WARN) {
+-				return (ARCHIVE_FATAL);
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 			}
+@@ -940,3 +1156,3 @@
+ 				if (err2 < ARCHIVE_WARN) {
+-					return (ARCHIVE_FATAL);
++					TAR_HEADER_RETURN(ARCHIVE_FATAL);
+ 				}
+@@ -955,3 +1171,3 @@
+ 							  "Non-regular file cannot be sparse");
+-					return (ARCHIVE_WARN);
++					TAR_HEADER_RETURN(ARCHIVE_WARN);
+ 				} else if (tar->sparse_gnu_major == 0 &&
+@@ -968,3 +1184,3 @@
+ 					if (bytes_read < 0)
+-						return ((int)bytes_read);
++						TAR_HEADER_RETURN((int)bytes_read);
+ 					tar->entry_bytes_remaining -= bytes_read;
+@@ -974,6 +1190,6 @@
+ 							  "Unrecognized GNU sparse file format");
+-					return (ARCHIVE_WARN);
++					TAR_HEADER_RETURN(ARCHIVE_WARN);
+ 				}
+ 			}
+-			return (err);
++			TAR_HEADER_RETURN(err);
+ 		}
+@@ -983,3 +1199,3 @@
+ 		if (err == ARCHIVE_FATAL)
+-			return (err);
++			TAR_HEADER_RETURN(err);
+ 
+@@ -993,2 +1209,17 @@
+ 	}
++
++bun_retry:
++	/*
++	 * BUN PATCH: persist loop state so the next tar_read_header()
++	 * call resumes exactly here. At this point `*unconsumed == 0`
++	 * (either nothing was added this iteration, or we rolled the
++	 * 512-byte header back above), so
++	 * `archive_read_format_tar_read_header` can return
++	 * ARCHIVE_RETRY without flushing.
++	 */
++	tar->header_seen = seen_headers;
++	tar->header_eof_fatal = eof_fatal;
++	tar->header_err = err;
++	return (ARCHIVE_RETRY);
++#undef TAR_HEADER_RETURN
+ }

--- a/scripts/build/deps/libarchive.ts
+++ b/scripts/build/deps/libarchive.ts
@@ -24,7 +24,15 @@ export const libarchive: Dependency = {
     commit: LIBARCHIVE_COMMIT,
   }),
 
-  patches: ["patches/libarchive/archive_write_add_filter_gzip.c.patch", "patches/libarchive/CMakeLists.txt.patch"],
+  patches: [
+    "patches/libarchive/archive_write_add_filter_gzip.c.patch",
+    "patches/libarchive/CMakeLists.txt.patch",
+    // Propagate ARCHIVE_RETRY from the client read callback up through
+    // the gzip filter and tar reader so `bun install` can stream tarball
+    // extraction from the HTTP thread without blocking a worker. See
+    // src/install/TarballStream.zig.
+    "patches/libarchive/nonblocking-read.patch",
+  ],
 
   // libarchive's configure-time check_include_file("zlib.h") needs zlib's
   // headers on disk. We don't LINK zlib into libarchive (ENABLE_ZLIB=OFF) —

--- a/scripts/build/deps/libarchive.ts
+++ b/scripts/build/deps/libarchive.ts
@@ -28,8 +28,8 @@ export const libarchive: Dependency = {
     "patches/libarchive/archive_write_add_filter_gzip.c.patch",
     "patches/libarchive/CMakeLists.txt.patch",
     // Propagate ARCHIVE_RETRY from the client read callback up through
-    // the gzip filter and tar reader so `bun install` can stream tarball
-    // extraction from the HTTP thread without blocking a worker. See
+    // the gzip filter and tar reader so the worker-thread extract loop
+    // in `bun install` can yield and resume as HTTP chunks arrive. See
     // src/install/TarballStream.zig.
     "patches/libarchive/nonblocking-read.patch",
   ],

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -61,6 +61,11 @@ pub const BUN_INSPECT_PRELOAD = New(kind.string, "BUN_INSPECT_PRELOAD", .{});
 pub const BUN_INSTALL = New(kind.string, "BUN_INSTALL", .{});
 pub const BUN_INSTALL_BIN = New(kind.string, "BUN_INSTALL_BIN", .{});
 pub const BUN_INSTALL_GLOBAL_DIR = New(kind.string, "BUN_INSTALL_GLOBAL_DIR", .{});
+/// Minimum response `Content-Length` (in bytes) for `bun install` to
+/// stream a tarball directly into libarchive instead of buffering the
+/// whole body first. Smaller tarballs stay on the buffered path where
+/// the fixed overhead of the resumable state machine isn't worth it.
+pub const BUN_INSTALL_STREAMING_MIN_SIZE = New(kind.unsigned, "BUN_INSTALL_STREAMING_MIN_SIZE", .{ .default = 2 * 1024 * 1024 });
 pub const BUN_NEEDS_PROC_SELF_WORKAROUND = New(kind.boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", .{ .default = false });
 pub const BUN_OPTIONS = New(kind.string, "BUN_OPTIONS", .{});
 pub const BUN_POSTGRES_SOCKET_MONITOR = New(kind.string, "BUN_POSTGRES_SOCKET_MONITOR", .{});

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -162,6 +162,10 @@ pub const feature_flag = struct {
     pub const BUN_FEATURE_FLAG_DISABLE_DNS_CACHE = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_INSTALL_INDEX", .{});
+    /// Disable streaming tarball extraction in `bun install`. When disabled,
+    /// the whole .tgz is buffered in memory before being decompressed and
+    /// extracted. Useful for bisecting streaming-specific bugs.
+    pub const BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IO_POOL = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IO_POOL", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IPV4 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV4", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IPV6 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV6", .{});

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -108,12 +108,13 @@ pub fn notify(this: *NetworkTask, async_http: *AsyncHTTP, result: bun.http.HTTPC
             // so the main thread can inspect it. Do not enqueue until
             // the stream ends.
             return;
-        } else if (committed) {
-            // HTTP failed after extraction had already begun. Propagate
-            // the error so the next drain run aborts and reports it.
-            stream.onChunk(chunk, true, result.fail orelse error.TarballFailedToDownload);
-            this.response_buffer.reset();
         }
+        // The remaining case — `!committed and !has_more` with a
+        // non-2xx status or `fail != null` — leaves `response_buffer`
+        // untouched so the buffered error/retry path in runTasks.zig
+        // handles it. `committed and !has_more` is always handled in
+        // the first branch above because `committed` short-circuits
+        // the outer condition.
     }
 
     defer this.package_manager.wake();

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -22,17 +22,122 @@ callback: union(Task.Tag) {
 apply_patch_task: ?*PatchTask = null,
 next: ?*NetworkTask = null,
 
+/// Producer/consumer buffer that feeds tarball bytes from the HTTP thread
+/// to a worker running libarchive. `null` when streaming extraction is
+/// disabled or this task is not a tarball download.
+tarball_stream: ?*TarballStream = null,
+/// Extract `Task` pre-created on the main thread so the HTTP thread can
+/// schedule it on the worker pool as soon as the first body chunk arrives.
+streaming_extract_task: ?*Task = null,
+/// Set by the HTTP thread the first time it commits this request to the
+/// streaming path, and never cleared. The main thread reads this (via
+/// `isStreamingExtractInFlight`) after the HTTP response has finished
+/// to decide whether to skip its own extract enqueue; using a sticky
+/// bool here (rather than `tarball_stream != null`) avoids a race where
+/// the drain task frees the stream before the main thread processes
+/// the NetworkTask.
+streaming_committed: bool = false,
+/// Backing store for the streaming signal the HTTP client polls.
+signal_store: HTTP.Signals.Store = .{},
+
 pub const DedupeMapEntry = struct {
     is_required: bool,
 };
 pub const DedupeMap = std.HashMap(Task.Id, DedupeMapEntry, IdentityContext(Task.Id), 80);
 
 pub fn notify(this: *NetworkTask, async_http: *AsyncHTTP, result: bun.http.HTTPClientResult) void {
+    if (this.tarball_stream) |stream| {
+        // Runs on the HTTP thread. With response-body streaming enabled,
+        // `notify` is called once per body chunk (has_more=true) and once
+        // more at the end (has_more=false). `result.body` is our own
+        // `response_buffer`; the HTTP client reuses it for the next
+        // chunk, so we must consume + reset it before returning.
+
+        // `metadata` is only populated on the first callback that
+        // carries response headers. Cache the status code so both the
+        // main thread and later chunk callbacks can see it.
+        if (result.metadata) |m| {
+            this.response.metadata = m;
+            stream.status_code = m.response.status_code;
+        }
+
+        const chunk = this.response_buffer.list.items;
+
+        // Only commit to streaming extraction once we've seen a 2xx
+        // status. For 4xx/5xx we fall back to the buffered path so the
+        // existing retry / error-reporting code in runTasks.zig keeps
+        // working and the user sees "404" instead of "archive error".
+        const ok_status = stream.status_code >= 200 and stream.status_code <= 299;
+        const committed = this.streaming_committed;
+
+        if (committed or (ok_status and result.fail == null)) {
+            if (result.has_more) {
+                if (chunk.len > 0) {
+                    // `streaming_committed` is what the main thread
+                    // checks to skip its own extract enqueue. The
+                    // drain task itself is scheduled by `onChunk`
+                    // (guarded by its own `draining` atomic) so it
+                    // runs at most once at a time, releases the
+                    // worker on ARCHIVE_RETRY, and is re-enqueued by
+                    // the next chunk. Pending-task accounting stays
+                    // balanced: the main thread skips
+                    // `decrementPendingTasks()` for this NetworkTask
+                    // (see runTasks.zig) and the extract Task pushed
+                    // by `TarballStream.finish()` decrements instead.
+                    this.streaming_committed = true;
+                    stream.onChunk(chunk, false, null);
+                    // Hand the buffer back to the HTTP client empty so
+                    // the next chunk starts at offset 0.
+                    this.response_buffer.reset();
+                }
+                return;
+            }
+
+            // Final callback. If we've already started streaming, hand
+            // over the last bytes and close; the drain task will run
+            // once more, finish up and push to `resolve_tasks`. If not
+            // (whole body arrived in one go), leave `response_buffer`
+            // intact so the buffered extractor handles it.
+            if (committed) {
+                stream.onChunk(chunk, true, result.fail);
+                this.response_buffer.reset();
+            }
+        } else if (result.has_more) {
+            // Non-2xx response still streaming its error body:
+            // accumulate in `response_buffer` (we did *not* reset above)
+            // so the main thread can inspect it. Do not enqueue until
+            // the stream ends.
+            return;
+        } else if (committed) {
+            // HTTP failed after extraction had already begun. Propagate
+            // the error so the next drain run aborts and reports it.
+            stream.onChunk(chunk, true, result.fail orelse error.TarballFailedToDownload);
+            this.response_buffer.reset();
+        }
+    }
+
     defer this.package_manager.wake();
     async_http.real.?.* = async_http.*;
     async_http.real.?.response_buffer = async_http.response_buffer;
+    // Preserve metadata captured on an earlier streaming callback; the
+    // final `result` won't have it.
+    const saved_metadata = this.response.metadata;
     this.response = result;
+    if (this.response.metadata == null) this.response.metadata = saved_metadata;
     this.package_manager.async_network_task_queue.push(this);
+}
+
+/// True when this tarball download committed to the streaming path and the
+/// extraction result will be delivered via `resolve_tasks`. The main thread
+/// uses this to skip its own bookkeeping for the network task and let the
+/// streaming extractor's completion drive progress instead.
+///
+/// Only safe to call once the HTTP response has been fully delivered
+/// (i.e. from the main thread after popping this task from
+/// `async_network_task_queue`). By then `streaming_committed` is stable:
+/// the HTTP thread set it under the final `notify` call.
+pub fn isStreamingExtractInFlight(this: *const NetworkTask) bool {
+    return this.streaming_committed;
 }
 
 pub const Authorization = enum {
@@ -305,13 +410,72 @@ pub fn forTarball(
 
     const url = URL.parse(this.url_buf);
 
-    this.unsafe_http_client = AsyncHTTP.init(allocator, .GET, url, header_builder.entries, header_buf, &this.response_buffer, "", this.getCompletionCallback(), HTTP.FetchRedirect.follow, .{
+    var http_options: AsyncHTTP.Options = .{
         .http_proxy = this.package_manager.httpProxy(url),
-    });
+    };
+
+    if (ExtractTarball.usesStreamingExtraction()) {
+        // Tell the HTTP client to invoke `notify` for every body chunk
+        // instead of buffering the whole response. `notify` pushes each
+        // chunk into `tarball_stream`, which schedules a drain task on
+        // `thread_pool`; the drain task calls into libarchive until it
+        // reports ARCHIVE_RETRY (out of input), then returns so the
+        // worker can be reused for other install work. The next chunk
+        // reschedules it and libarchive — whose state lives on the heap
+        // — resumes exactly where it stopped.
+        //
+        // The stream itself is created by the caller (see
+        // `generateNetworkTaskForTarball`) because it needs the
+        // pre-allocated `Task` that carries the final result.
+        //
+        // Only wire up the one signal we need; `Signals.Store.to()`
+        // would also publish `aborted`/`cert_errors`/etc., which makes
+        // the HTTP client allocate an abort-tracker id and changes
+        // keep-alive behaviour we don't want here.
+        this.signal_store = .{};
+        this.signal_store.response_body_streaming.store(true, .monotonic);
+        http_options.signals = .{
+            .response_body_streaming = &this.signal_store.response_body_streaming,
+        };
+    }
+
+    this.unsafe_http_client = AsyncHTTP.init(allocator, .GET, url, header_builder.entries, header_buf, &this.response_buffer, "", this.getCompletionCallback(), HTTP.FetchRedirect.follow, http_options);
     this.unsafe_http_client.client.flags.reject_unauthorized = this.package_manager.tlsRejectUnauthorized();
     if (PackageManager.verbose_install) {
         this.unsafe_http_client.client.verbose = .headers;
     }
+}
+
+/// Release any streaming-extraction resources that were never used because
+/// the request errored before a drain was scheduled. Called on the main
+/// thread from `runTasks` when falling back to the buffered path.
+pub fn discardUnusedStreamingState(this: *NetworkTask, manager: *PackageManager) void {
+    bun.debugAssert(!this.streaming_committed);
+    if (this.tarball_stream) |stream| {
+        stream.deinit();
+        this.tarball_stream = null;
+    }
+    if (this.streaming_extract_task) |task| {
+        // Restore the patch task we moved in
+        // `createExtractTaskForStreaming` so the buffered extract Task
+        // that `enqueueExtractNPMPackage` is about to allocate picks
+        // it up.
+        if (task.apply_patch_task) |pt| {
+            this.apply_patch_task = pt;
+            task.apply_patch_task = null;
+        }
+        manager.preallocated_resolve_tasks.put(task);
+        this.streaming_extract_task = null;
+    }
+}
+
+/// Prepare this task for another HTTP attempt (used by retry logic when
+/// streaming extraction never started). Keeps the stream allocation so the
+/// retry can still benefit from streaming.
+pub fn resetStreamingForRetry(this: *NetworkTask) void {
+    bun.debugAssert(!this.streaming_committed);
+    if (this.tarball_stream) |stream| stream.resetForRetry();
+    this.response = .{};
 }
 
 const string = []const u8;
@@ -324,6 +488,7 @@ const NetworkTask = install.NetworkTask;
 const Npm = install.Npm;
 const PackageManager = install.PackageManager;
 const PatchTask = install.PatchTask;
+const TarballStream = install.TarballStream;
 const Task = install.Task;
 
 const bun = @import("bun");

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -29,13 +29,13 @@ tarball_stream: ?*TarballStream = null,
 /// Extract `Task` pre-created on the main thread so the HTTP thread can
 /// schedule it on the worker pool as soon as the first body chunk arrives.
 streaming_extract_task: ?*Task = null,
-/// Set by the HTTP thread the first time it commits this request to the
-/// streaming path, and never cleared. The main thread reads this (via
-/// `isStreamingExtractInFlight`) after the HTTP response has finished
-/// to decide whether to skip its own extract enqueue; using a sticky
-/// bool here (rather than `tarball_stream != null`) avoids a race where
-/// the drain task frees the stream before the main thread processes
-/// the NetworkTask.
+/// Set by the HTTP thread the first time it commits this request to
+/// the streaming path. Once true, `notify` never pushes this task to
+/// `async_network_task_queue` — the extract Task published by
+/// `TarballStream.finish()` owns the NetworkTask's lifetime instead
+/// (its `resolve_tasks` handler returns it to the pool). Also read by
+/// the main-thread fallback / retry paths in `runTasks.zig` to assert
+/// the stream was never started.
 streaming_committed: bool = false,
 /// Backing store for the streaming signal the HTTP client polls.
 signal_store: HTTP.Signals.Store = .{},
@@ -64,26 +64,32 @@ pub fn notify(this: *NetworkTask, async_http: *AsyncHTTP, result: bun.http.HTTPC
         const chunk = this.response_buffer.list.items;
 
         // Only commit to streaming extraction once we've seen a 2xx
-        // status. For 4xx/5xx we fall back to the buffered path so the
-        // existing retry / error-reporting code in runTasks.zig keeps
-        // working and the user sees "404" instead of "archive error".
+        // status *and* the tarball is large enough to be worth the
+        // overhead. For small bodies, or any 4xx/5xx / transport error,
+        // fall back to the buffered path so the existing retry and
+        // error-reporting code in runTasks.zig keeps working.
         const ok_status = stream.status_code >= 200 and stream.status_code <= 299;
+        const big_enough = switch (result.body_size) {
+            .content_length => |len| len >= TarballStream.minSize(),
+            // No Content-Length (chunked encoding): we can't know up
+            // front, so stream — it avoids an unbounded buffer.
+            else => true,
+        };
         const committed = this.streaming_committed;
 
-        if (committed or (ok_status and result.fail == null)) {
+        if (committed or (ok_status and big_enough and result.fail == null)) {
             if (result.has_more) {
                 if (chunk.len > 0) {
-                    // `streaming_committed` is what the main thread
-                    // checks to skip its own extract enqueue. The
-                    // drain task itself is scheduled by `onChunk`
+                    // The drain task is scheduled by `onChunk`
                     // (guarded by its own `draining` atomic) so it
                     // runs at most once at a time, releases the
                     // worker on ARCHIVE_RETRY, and is re-enqueued by
                     // the next chunk. Pending-task accounting stays
-                    // balanced: the main thread skips
-                    // `decrementPendingTasks()` for this NetworkTask
-                    // (see runTasks.zig) and the extract Task pushed
-                    // by `TarballStream.finish()` decrements instead.
+                    // balanced: this NetworkTask is never pushed to
+                    // `async_network_task_queue` once committed, so
+                    // its `incrementPendingTasks()` is satisfied by
+                    // the extract Task that `TarballStream.finish()`
+                    // publishes to `resolve_tasks`.
                     this.streaming_committed = true;
                     stream.onChunk(chunk, false, null);
                     // Hand the buffer back to the HTTP client empty so
@@ -96,25 +102,35 @@ pub fn notify(this: *NetworkTask, async_http: *AsyncHTTP, result: bun.http.HTTPC
             // Final callback. If we've already started streaming, hand
             // over the last bytes and close; the drain task will run
             // once more, finish up and push to `resolve_tasks`. If not
-            // (whole body arrived in one go), leave `response_buffer`
-            // intact so the buffered extractor handles it.
+            // (whole body arrived in one go, or too small), leave
+            // `response_buffer` intact so the buffered extractor
+            // handles it.
             if (committed) {
                 stream.onChunk(chunk, true, result.fail);
-                this.response_buffer.reset();
+                // Do NOT touch `this` — or anything it owns — after
+                // this point: `onChunk(…, true, …)` sets `closed` and
+                // schedules a drain that may reach `finish()` on a
+                // worker thread before we return here. `finish()`
+                // frees `response_buffer`, publishes the extract Task
+                // to `resolve_tasks`, and the main thread's processing
+                // of that Task returns this NetworkTask to
+                // `preallocated_network_tasks` (poisoning it under
+                // ASAN). The NetworkTask is therefore *not* pushed to
+                // `async_network_task_queue` here; the extract Task
+                // owns its lifetime from now on.
+                return;
             }
         } else if (result.has_more) {
-            // Non-2xx response still streaming its error body:
-            // accumulate in `response_buffer` (we did *not* reset above)
-            // so the main thread can inspect it. Do not enqueue until
-            // the stream ends.
+            // Non-2xx response (or too small to stream) still
+            // delivering its body: accumulate in `response_buffer`
+            // (we did *not* reset above) so the main thread can
+            // inspect it. Do not enqueue until the stream ends.
             return;
         }
-        // The remaining case — `!committed and !has_more` with a
-        // non-2xx status or `fail != null` — leaves `response_buffer`
-        // untouched so the buffered error/retry path in runTasks.zig
-        // handles it. `committed and !has_more` is always handled in
-        // the first branch above because `committed` short-circuits
-        // the outer condition.
+        // Fall through to the normal completion path for anything that
+        // did not commit: the buffered extractor / retry logic in
+        // runTasks.zig handles it exactly as it would without
+        // streaming support.
     }
 
     defer this.package_manager.wake();
@@ -126,19 +142,6 @@ pub fn notify(this: *NetworkTask, async_http: *AsyncHTTP, result: bun.http.HTTPC
     this.response = result;
     if (this.response.metadata == null) this.response.metadata = saved_metadata;
     this.package_manager.async_network_task_queue.push(this);
-}
-
-/// True when this tarball download committed to the streaming path and the
-/// extraction result will be delivered via `resolve_tasks`. The main thread
-/// uses this to skip its own bookkeeping for the network task and let the
-/// streaming extractor's completion drive progress instead.
-///
-/// Only safe to call once the HTTP response has been fully delivered
-/// (i.e. from the main thread after popping this task from
-/// `async_network_task_queue`). By then `streaming_committed` is stable:
-/// the HTTP thread set it under the final `notify` call.
-pub fn isStreamingExtractInFlight(this: *const NetworkTask) bool {
-    return this.streaming_committed;
 }
 
 pub const Authorization = enum {
@@ -457,14 +460,6 @@ pub fn discardUnusedStreamingState(this: *NetworkTask, manager: *PackageManager)
         this.tarball_stream = null;
     }
     if (this.streaming_extract_task) |task| {
-        // Restore the patch task we moved in
-        // `createExtractTaskForStreaming` so the buffered extract Task
-        // that `enqueueExtractNPMPackage` is about to allocate picks
-        // it up.
-        if (task.apply_patch_task) |pt| {
-            this.apply_patch_task = pt;
-            task.apply_patch_task = null;
-        }
         manager.preallocated_resolve_tasks.put(task);
         this.streaming_extract_task = null;
     }

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -1191,6 +1191,7 @@ pub const enqueueDependencyToRoot = enqueue.enqueueDependencyToRoot;
 pub const enqueueDependencyWithMain = enqueue.enqueueDependencyWithMain;
 pub const enqueueDependencyWithMainAndSuccessFn = enqueue.enqueueDependencyWithMainAndSuccessFn;
 pub const enqueueExtractNPMPackage = enqueue.enqueueExtractNPMPackage;
+pub const createExtractTaskForStreaming = enqueue.createExtractTaskForStreaming;
 pub const enqueueGitCheckout = enqueue.enqueueGitCheckout;
 pub const enqueueGitForCheckout = enqueue.enqueueGitForCheckout;
 pub const enqueueNetworkTask = enqueue.enqueueNetworkTask;

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1220,6 +1220,38 @@ pub fn enqueueExtractNPMPackage(
     return &task.threadpool_task;
 }
 
+/// Allocate the extract Task up front so the HTTP thread can schedule it
+/// as soon as the first tarball chunk arrives. The returned Task is not
+/// yet pushed onto any batch; `NetworkTask.notify` hands it to the thread
+/// pool directly, and the NetworkTask's pending-task slot is reused for
+/// the extraction so progress counters stay balanced.
+pub fn createExtractTaskForStreaming(
+    this: *PackageManager,
+    tarball: *const ExtractTarball,
+    network_task: *NetworkTask,
+) *Task {
+    var task = this.preallocated_resolve_tasks.get();
+    task.* = Task{
+        .package_manager = this,
+        .log = logger.Log.init(this.allocator),
+        .tag = Task.Tag.extract,
+        .request = .{
+            .extract = .{
+                .network = network_task,
+                .tarball = tarball.*,
+            },
+        },
+        .id = network_task.task_id,
+        .data = undefined,
+    };
+    task.request.extract.tarball.skip_verify = !this.options.do.verify_integrity;
+    if (network_task.apply_patch_task) |patch| {
+        task.apply_patch_task = patch;
+        network_task.apply_patch_task = null;
+    }
+    return task;
+}
+
 fn enqueueGitClone(
     this: *PackageManager,
     task_id: Task.Id,

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1245,10 +1245,11 @@ pub fn createExtractTaskForStreaming(
         .data = undefined,
     };
     task.request.extract.tarball.skip_verify = !this.options.do.verify_integrity;
-    if (network_task.apply_patch_task) |patch| {
-        task.apply_patch_task = patch;
-        network_task.apply_patch_task = null;
-    }
+    // Intentionally does *not* move `network_task.apply_patch_task`:
+    // `enqueueExtractNPMPackage` (the buffered path this mirrors) leaves
+    // it on the NetworkTask and the install phase creates its own
+    // PatchTask via `PackageInstaller`. Applying it here would run the
+    // patch twice.
     return task;
 }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -1197,35 +1197,15 @@ pub fn enqueueDependencyWithMainAndSuccessFn(
     }
 }
 
-pub fn enqueueExtractNPMPackage(
-    this: *PackageManager,
-    tarball: *const ExtractTarball,
-    network_task: *NetworkTask,
-) *ThreadPool.Task {
-    var task = this.preallocated_resolve_tasks.get();
-    task.* = Task{
-        .package_manager = this,
-        .log = logger.Log.init(this.allocator),
-        .tag = Task.Tag.extract,
-        .request = .{
-            .extract = .{
-                .network = network_task,
-                .tarball = tarball.*,
-            },
-        },
-        .id = network_task.task_id,
-        .data = undefined,
-    };
-    task.request.extract.tarball.skip_verify = !this.options.do.verify_integrity;
-    return &task.threadpool_task;
-}
-
-/// Allocate the extract Task up front so the HTTP thread can schedule it
-/// as soon as the first tarball chunk arrives. The returned Task is not
-/// yet pushed onto any batch; `NetworkTask.notify` hands it to the thread
-/// pool directly, and the NetworkTask's pending-task slot is reused for
-/// the extraction so progress counters stay balanced.
-pub fn createExtractTaskForStreaming(
+/// Allocate and initialise an `.extract` Task for an npm tarball.
+/// Shared by the buffered path (`enqueueExtractNPMPackage`) and the
+/// streaming path (`createExtractTaskForStreaming`) so both produce
+/// an identical Task shape; only the return type differs.
+///
+/// Intentionally does *not* move `network_task.apply_patch_task`: the
+/// install phase creates its own PatchTask via `PackageInstaller`, so
+/// applying it here would run the patch twice.
+fn initExtractTask(
     this: *PackageManager,
     tarball: *const ExtractTarball,
     network_task: *NetworkTask,
@@ -1245,12 +1225,28 @@ pub fn createExtractTaskForStreaming(
         .data = undefined,
     };
     task.request.extract.tarball.skip_verify = !this.options.do.verify_integrity;
-    // Intentionally does *not* move `network_task.apply_patch_task`:
-    // `enqueueExtractNPMPackage` (the buffered path this mirrors) leaves
-    // it on the NetworkTask and the install phase creates its own
-    // PatchTask via `PackageInstaller`. Applying it here would run the
-    // patch twice.
     return task;
+}
+
+pub fn enqueueExtractNPMPackage(
+    this: *PackageManager,
+    tarball: *const ExtractTarball,
+    network_task: *NetworkTask,
+) *ThreadPool.Task {
+    return &initExtractTask(this, tarball, network_task).threadpool_task;
+}
+
+/// Allocate the extract Task up front so the streaming extractor can
+/// publish it to `resolve_tasks` when extraction finishes. Done on the
+/// main thread because `preallocated_resolve_tasks` is not thread-safe.
+/// The NetworkTask's pending-task slot is reused for the extraction so
+/// progress counters stay balanced.
+pub fn createExtractTaskForStreaming(
+    this: *PackageManager,
+    tarball: *const ExtractTarball,
+    network_task: *NetworkTask,
+) *Task {
+    return initExtractTask(this, tarball, network_task);
 }
 
 fn enqueueGitClone(

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -129,7 +129,15 @@ pub fn runTasks(
     var network_tasks_iter = network_tasks_batch.iterator();
     while (network_tasks_iter.next()) |task| {
         if (comptime Environment.allow_assert) bun.assert(manager.pendingTaskCount() > 0);
-        manager.decrementPendingTasks();
+
+        // Streaming extraction shares this NetworkTask's pending-task slot
+        // with the extract Task that the HTTP thread scheduled on a worker.
+        // Decrementing here would let `pendingTaskCount()` hit zero while
+        // extraction is still running, so defer it to the extract Task's
+        // completion (handled via `resolve_tasks` below).
+        if (!task.isStreamingExtractInFlight()) {
+            manager.decrementPendingTasks();
+        }
         // We cannot free the network task at the end of this scope.
         // It may continue to be referenced in a future task.
 
@@ -329,6 +337,26 @@ pub fn runTasks(
                 manager.task_batch.push(ThreadPool.Batch.from(manager.enqueueParseNPMPackage(task.task_id, name, task)));
             },
             .extract => |*extract| {
+                if (task.isStreamingExtractInFlight()) {
+                    // A worker thread is already extracting from the
+                    // streamed body. Errors (including non-2xx responses)
+                    // are surfaced by that Task via `resolve_tasks`; avoid
+                    // double-reporting here and do not enqueue extraction.
+                    if (log_level.isVerbose() and task.response.metadata != null) {
+                        Output.prettyError("    ", .{});
+                        Output.printElapsed(@as(f64, @floatCast(@as(f64, @floatFromInt(task.unsafe_http_client.elapsed)) / std.time.ns_per_ms)));
+                        Output.prettyError("<d> Downloaded <r><green>{s}<r> tarball\n", .{extract.name.slice()});
+                        Output.flush();
+                    }
+                    if (log_level.showProgress()) {
+                        if (!has_updated_this_run) {
+                            manager.setNodeName(manager.downloads_node.?, extract.name.slice(), ProgressStrings.extract_emoji, true);
+                            has_updated_this_run = true;
+                        }
+                    }
+                    continue;
+                }
+
                 if (!has_network_error and task.response.metadata == null) {
                     has_network_error = true;
                     const min = manager.options.min_simultaneous_requests;
@@ -343,6 +371,10 @@ pub fn runTasks(
 
                     if (task.retried < manager.options.max_retry_count) {
                         task.retried += 1;
+                        // Streaming never committed (checked above), so
+                        // the pre-allocated stream is safe to reuse for
+                        // the retry attempt.
+                        task.resetStreamingForRetry();
                         manager.enqueueNetworkTask(task);
 
                         if (manager.options.log_level.isVerbose()) {
@@ -364,6 +396,13 @@ pub fn runTasks(
                         continue;
                     }
                 }
+
+                // Past this point we will not retry. If streaming state was
+                // allocated but never scheduled, release it now so the
+                // pre-created Task goes back to the pool and the stream
+                // buffers are freed. The buffered `enqueueExtractNPMPackage`
+                // path below allocates its own Task.
+                task.discardUnusedStreamingState(manager);
 
                 const metadata = task.response.metadata orelse {
                     const err = task.response.fail orelse error.TarballFailedToDownload;
@@ -1082,6 +1121,16 @@ pub fn generateNetworkTaskForTarball(
         authorization,
     );
 
+    if (ExtractTarball.usesStreamingExtraction()) {
+        // Pre-create the extract Task and streaming state here on the
+        // main thread: `preallocated_resolve_tasks` is not thread-safe,
+        // and the streaming extractor needs a stable `Task` pointer so
+        // it can push the result onto `resolve_tasks` when it finishes.
+        const extract_task = this.createExtractTaskForStreaming(&network_task.callback.extract, network_task);
+        network_task.streaming_extract_task = extract_task;
+        network_task.tarball_stream = TarballStream.init(this.allocator, extract_task, network_task, this);
+    }
+
     return network_task;
 }
 
@@ -1104,8 +1153,10 @@ const HTTP = bun.http;
 const AsyncHTTP = HTTP.AsyncHTTP;
 
 const DependencyID = bun.install.DependencyID;
+const ExtractTarball = bun.install.ExtractTarball;
 const Features = bun.install.Features;
 const NetworkTask = bun.install.NetworkTask;
+const TarballStream = bun.install.TarballStream;
 const Npm = bun.install.Npm;
 const PackageID = bun.install.PackageID;
 const PackageManifestError = bun.install.PackageManifestError;

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -1156,13 +1156,13 @@ const DependencyID = bun.install.DependencyID;
 const ExtractTarball = bun.install.ExtractTarball;
 const Features = bun.install.Features;
 const NetworkTask = bun.install.NetworkTask;
-const TarballStream = bun.install.TarballStream;
 const Npm = bun.install.Npm;
 const PackageID = bun.install.PackageID;
 const PackageManifestError = bun.install.PackageManifestError;
 const PatchTask = bun.install.PatchTask;
 const Repository = bun.install.Repository;
 const Store = bun.install.Store;
+const TarballStream = bun.install.TarballStream;
 const Task = bun.install.Task;
 const invalid_package_id = bun.install.invalid_package_id;
 

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -129,15 +129,7 @@ pub fn runTasks(
     var network_tasks_iter = network_tasks_batch.iterator();
     while (network_tasks_iter.next()) |task| {
         if (comptime Environment.allow_assert) bun.assert(manager.pendingTaskCount() > 0);
-
-        // Streaming extraction shares this NetworkTask's pending-task slot
-        // with the extract Task that the HTTP thread scheduled on a worker.
-        // Decrementing here would let `pendingTaskCount()` hit zero while
-        // extraction is still running, so defer it to the extract Task's
-        // completion (handled via `resolve_tasks` below).
-        if (!task.isStreamingExtractInFlight()) {
-            manager.decrementPendingTasks();
-        }
+        manager.decrementPendingTasks();
         // We cannot free the network task at the end of this scope.
         // It may continue to be referenced in a future task.
 
@@ -337,25 +329,12 @@ pub fn runTasks(
                 manager.task_batch.push(ThreadPool.Batch.from(manager.enqueueParseNPMPackage(task.task_id, name, task)));
             },
             .extract => |*extract| {
-                if (task.isStreamingExtractInFlight()) {
-                    // A worker thread is already extracting from the
-                    // streamed body. Errors (including non-2xx responses)
-                    // are surfaced by that Task via `resolve_tasks`; avoid
-                    // double-reporting here and do not enqueue extraction.
-                    if (log_level.isVerbose() and task.response.metadata != null) {
-                        Output.prettyError("    ", .{});
-                        Output.printElapsed(@as(f64, @floatCast(@as(f64, @floatFromInt(task.unsafe_http_client.elapsed)) / std.time.ns_per_ms)));
-                        Output.prettyError("<d> Downloaded <r><green>{s}<r> tarball\n", .{extract.name.slice()});
-                        Output.flush();
-                    }
-                    if (log_level.showProgress()) {
-                        if (!has_updated_this_run) {
-                            manager.setNodeName(manager.downloads_node.?, extract.name.slice(), ProgressStrings.extract_emoji, true);
-                            has_updated_this_run = true;
-                        }
-                    }
-                    continue;
-                }
+                // Streaming extraction never pushes its NetworkTask to
+                // `async_network_task_queue` once committed — the
+                // extract Task published by `TarballStream.finish()`
+                // owns its lifetime — so every `.extract` task that
+                // arrives here is taking the buffered path.
+                bun.debugAssert(!task.streaming_committed);
 
                 if (!has_network_error and task.response.metadata == null) {
                     has_network_error = true;
@@ -371,7 +350,7 @@ pub fn runTasks(
 
                     if (task.retried < manager.options.max_retry_count) {
                         task.retried += 1;
-                        // Streaming never committed (checked above), so
+                        // Streaming never committed (asserted above), so
                         // the pre-allocated stream is safe to reuse for
                         // the retry attempt.
                         task.resetStreamingForRetry();

--- a/src/install/PackageManagerTask.zig
+++ b/src/install/PackageManagerTask.zig
@@ -146,6 +146,13 @@ pub fn callback(task: *ThreadPool.Task) void {
             }
         },
         .extract => {
+            // Streaming extraction never reaches this callback: the
+            // HTTP thread drives `TarballStream.drain_task`, which
+            // fills in `this.data`/`this.status` and pushes to
+            // `resolve_tasks` directly from `TarballStream.finish()`.
+            // This path is the buffered fallback — feature flag off,
+            // non-2xx status, or the whole body arrived in a single
+            // chunk before streaming could commit.
             const buffer = &this.request.extract.network.response_buffer;
             defer buffer.deinit();
 

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -78,6 +78,12 @@ phase: enum {
 out_fd: ?bun.FD = null,
 use_pwrite: bool = Environment.isPosix,
 use_lseek: bool = true,
+/// Per-entry write cursors, carried across `writeDataBlock` calls so
+/// the sparse-file handling in `closeOutputFile` matches
+/// `Archive.readDataIntoFd` exactly (which tracks these across its own
+/// block loop). Reset in `beginEntry` when a new output file is opened.
+entry_actual_offset: i64 = 0,
+entry_final_offset: i64 = 0,
 
 /// Temp directory files are written into before being renamed into the
 /// cache. Lazily opened on the first drain so the HTTP thread never
@@ -115,6 +121,14 @@ package_manager: *PackageManager,
 pub const new = bun.TrivialNew(@This());
 
 const log = Output.scoped(.TarballStream, .hidden);
+
+/// Minimum Content-Length for which the streaming path is used. Below
+/// this the whole body is buffered as before; the resumable libarchive
+/// state machine is only worth its per-chunk overhead for tarballs that
+/// would otherwise consume a noticeable amount of memory.
+pub fn minSize() usize {
+    return @intCast(bun.env_var.BUN_INSTALL_STREAMING_MIN_SIZE.get());
+}
 
 pub fn init(
     allocator: std.mem.Allocator,
@@ -323,7 +337,7 @@ fn step(this: *TarballStream) !void {
                     .retry => return,
                     .ok, .warn => {
                         if (this.out_fd) |fd| {
-                            try writeDataBlock(fd, block, &this.use_pwrite, &this.use_lseek);
+                            try this.writeDataBlock(fd, block);
                         }
                     },
                     else => {
@@ -385,6 +399,13 @@ fn openDestination(this: *TarballStream) !void {
 
 fn closeOutputFile(this: *TarballStream) void {
     if (this.out_fd) |fd| {
+        // Same trailing-hole handling as `Archive.readDataIntoFd`:
+        // extend the file to cover the furthest block we were asked
+        // to write even if the pwrite/lseek fallback path left
+        // `actual_offset` behind.
+        if (this.entry_final_offset > this.entry_actual_offset) {
+            _ = bun.sys.ftruncate(fd, this.entry_final_offset);
+        }
         fd.close();
         this.out_fd = null;
     }
@@ -555,6 +576,8 @@ fn beginEntry(this: *TarballStream, entry: *lib.Archive.Entry) !void {
             }
 
             this.out_fd = fd;
+            this.entry_actual_offset = 0;
+            this.entry_final_offset = 0;
             this.phase = .want_data;
         },
         else => {
@@ -656,34 +679,57 @@ fn applyWindowsNpmPathEscapes(path: [:0]bun.OSPathChar) void {
 /// Write one data block from `archive_read_data_block`. Mirrors the
 /// sparse/pwrite handling in `Archive.readDataIntoFd` but operates on a
 /// single block so it can be interleaved with ARCHIVE_RETRY yields.
-fn writeDataBlock(
-    fd: bun.FD,
-    block: lib.Archive.Block,
-    use_pwrite: *bool,
-    use_lseek: *bool,
-) !void {
+/// `entry_actual_offset` / `entry_final_offset` persist across calls so
+/// `closeOutputFile` can perform the same trailing `ftruncate` the
+/// buffered path does after its block loop.
+fn writeDataBlock(this: *TarballStream, fd: bun.FD, block: lib.Archive.Block) !void {
     const file = bun.sys.File{ .handle = fd };
     const data = block.bytes;
     if (data.len == 0) return;
 
+    this.entry_final_offset = @max(
+        this.entry_final_offset,
+        block.offset + @as(i64, @intCast(data.len)),
+    );
+
     if (comptime Environment.isPosix) {
-        if (use_pwrite.*) {
+        if (this.use_pwrite) {
             switch (file.pwriteAll(data, block.offset)) {
-                .result => return,
-                .err => use_pwrite.* = false,
+                .result => {
+                    this.entry_actual_offset = @max(
+                        this.entry_actual_offset,
+                        block.offset + @as(i64, @intCast(data.len)),
+                    );
+                    return;
+                },
+                .err => this.use_pwrite = false,
             }
         }
     }
 
-    if (use_lseek.*) {
-        switch (bun.sys.setFileOffset(fd, @intCast(block.offset))) {
-            .result => {},
-            .err => use_lseek.* = false,
+    if (block.offset != this.entry_actual_offset) seek: {
+        if (this.use_lseek) {
+            switch (bun.sys.setFileOffset(fd, @intCast(block.offset))) {
+                .result => {
+                    this.entry_actual_offset = block.offset;
+                    break :seek;
+                },
+                .err => this.use_lseek = false,
+            }
+        }
+        if (block.offset > this.entry_actual_offset) {
+            const zero_count: usize = @intCast(block.offset - this.entry_actual_offset);
+            switch (lib.Archive.writeZerosToFile(file, zero_count)) {
+                .ok => this.entry_actual_offset = block.offset,
+                else => return error.Fail,
+            }
+        } else {
+            return error.Fail;
         }
     }
 
     switch (file.writeAll(data)) {
-        .result => {},
+        .result => this.entry_actual_offset += @intCast(data.len),
         .err => |e| return bun.errnoToZigErr(e.errno),
     }
 }
@@ -695,12 +741,12 @@ fn finish(this: *TarballStream) void {
 
     this.closeOutputFile();
 
-    // At this point the HTTP thread has delivered the final
-    // `has_more=false` chunk (that's the only way `closed` gets set),
-    // so no more writes to the NetworkTask's `response_buffer` are
-    // possible. The main thread reads only `streaming_committed` when
-    // it later processes the NetworkTask, so freeing the buffer here
-    // is safe and matches the `defer buffer.deinit()` in the buffered
+    // The HTTP thread has delivered the final `has_more=false` chunk
+    // (that's the only way `closed` gets set) and `notify()` does not
+    // touch `response_buffer` again after that hand-off, so we own it
+    // now. The main thread reads only `streaming_committed` when it
+    // later processes the NetworkTask, so freeing the buffer here is
+    // safe and matches the `defer buffer.deinit()` in the buffered
     // `.extract` arm of `Task.callback`.
     network.response_buffer.deinit();
 
@@ -711,21 +757,24 @@ fn finish(this: *TarballStream) void {
     // `task.request.extract.tarball.temp_dir` become invalid once
     // `this.deinit()` runs / the main thread recycles the Task.
     if (task.status != .success and this.tmpname.len > 0) {
+        // `populateResult` closes `dest` on the success path before the
+        // rename; the early-return failure paths leave it open, so close
+        // it here first — Windows can't remove an open directory.
+        // `deinit()` null-checks so this is not a double-close.
+        if (this.dest) |*d| {
+            d.close();
+            this.dest = null;
+        }
         task.request.extract.tarball.temp_dir.deleteTree(this.tmpname) catch {};
     }
 
     this.deinit();
 
-    if (task.status == .success) {
-        if (task.apply_patch_task) |pt| {
-            defer pt.deinit();
-            bun.handleOom(pt.apply());
-            if (pt.callback.apply.logger.errors > 0) {
-                defer pt.callback.apply.logger.deinit();
-                pt.callback.apply.logger.print(Output.errorWriter()) catch {};
-            }
-        }
-    }
+    // `task.apply_patch_task` is intentionally not touched: the
+    // buffered `.extract` path (`enqueueExtractNPMPackage` →
+    // `Task.callback`) never populates it for npm tarballs either —
+    // patching is handled later by the install phase.
+    //
     // Publish last: once the task is on `resolve_tasks` the main
     // thread may immediately recycle it *and* the NetworkTask it
     // references, so nothing below this line may touch either.

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -826,20 +826,19 @@ pub fn resetForRetry(this: *TarballStream) void {
 }
 
 const std = @import("std");
-
-const bun = @import("bun");
-const Environment = bun.Environment;
-const Mutex = bun.threading.Mutex;
-const Output = bun.Output;
-const ThreadPool = bun.ThreadPool;
-const strings = bun.strings;
-const FileSystem = bun.fs.FileSystem;
-const logger = bun.logger;
-
-const lib = bun.libarchive.lib;
+const Integrity = @import("./integrity.zig").Integrity;
 
 const install = @import("./install.zig");
 const NetworkTask = install.NetworkTask;
 const PackageManager = install.PackageManager;
 const Task = install.Task;
-const Integrity = @import("./integrity.zig").Integrity;
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+const Output = bun.Output;
+const ThreadPool = bun.ThreadPool;
+const logger = bun.logger;
+const strings = bun.strings;
+const FileSystem = bun.fs.FileSystem;
+const Mutex = bun.threading.Mutex;
+const lib = bun.libarchive.lib;

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -500,6 +500,18 @@ fn beginEntry(this: *TarballStream, entry: *lib.Archive.Entry) !void {
         this.out_fd = null;
         return;
     }
+    // `normalizeBufT` collapses interior `..` but leaves a leading `..`
+    // on a relative input. Reject those so `openat(dest_fd, ...)` can
+    // never escape the temp extraction root. `Archiver.extractToDir`
+    // sees the same normalised path; this check is belt-and-braces on
+    // top of the integrity gate.
+    if (path.len >= 2 and path[0] == '.' and path[1] == '.' and
+        (path.len == 2 or path[2] == std.fs.path.sep))
+    {
+        this.phase = .want_data;
+        this.out_fd = null;
+        return;
+    }
     if (comptime Environment.isWindows) {
         if (std.fs.path.isAbsoluteWindowsWTF16(path)) {
             this.phase = .want_data;

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -1,0 +1,833 @@
+//! Resumable, non-blocking tarball extractor for `bun install`.
+//!
+//! The HTTP thread hands each body chunk to `onChunk`, which appends to a
+//! small pending buffer and (if not already running) schedules
+//! `drain_task` on `PackageManager.thread_pool`. The drain task calls into
+//! libarchive to gunzip and untar whatever is available, writing files as
+//! their data arrives, until libarchive asks for more compressed bytes
+//! than are currently buffered. At that point the read callback returns
+//! `ARCHIVE_RETRY`, libarchive propagates it (see the BUN PATCHes in
+//! `vendor/libarchive`), and the drain task returns — the worker is
+//! released. The next HTTP chunk reschedules the drain task, which calls
+//! back into libarchive and resumes exactly where it left off because the
+//! `struct archive *`, the gzip inflate state, the partially-read tar
+//! header and the open output `bun.FD` all live on the heap in this
+//! struct.
+//!
+//! This lets `bun install` overlap download and extraction on the normal
+//! resolve thread pool without ever parking a worker on a condvar, and
+//! without holding the full compressed or decompressed tarball in memory.
+
+const TarballStream = @This();
+
+// ---------------------------------------------------------------------
+// Cross-thread producer state (HTTP → worker)
+// ---------------------------------------------------------------------
+
+mutex: Mutex = .{},
+
+/// Compressed .tgz bytes that have arrived from the HTTP thread but have
+/// not yet been consumed by libarchive.
+pending: std.ArrayListUnmanaged(u8) = .{},
+
+/// True once the HTTP thread has delivered the final chunk (or an error).
+closed: bool = false,
+
+/// Non-null if the HTTP request failed mid-stream; surfaced to the user
+/// instead of whatever libarchive would otherwise report.
+http_err: ?anyerror = null,
+
+/// Cached response status (metadata only arrives on the first callback).
+status_code: u32 = 0,
+
+/// True while a drain task is either queued on the thread pool or
+/// running. `onChunk` sets it before scheduling; `drain` clears it when
+/// it runs out of input and decides to yield.
+draining: std.atomic.Value(bool) = .init(false),
+
+// ---------------------------------------------------------------------
+// Drain-side state (touched only by one drain task at a time)
+// ---------------------------------------------------------------------
+
+/// Bytes currently being consumed by libarchive. Populated by swapping
+/// with `pending` under the mutex so the HTTP thread can keep appending
+/// while libarchive decompresses without the lock held. libarchive's
+/// read callback hands out `reading.items[read_pos..]` and advances
+/// `read_pos`; the slice must remain valid until the next callback, so
+/// we only recycle this buffer on the *following* swap.
+reading: std.ArrayListUnmanaged(u8) = .{},
+read_pos: usize = 0,
+
+archive: ?*lib.Archive = null,
+
+/// Where we are in the per-entry state machine between drain
+/// invocations. libarchive preserves everything else (filter buffers,
+/// zlib stream, tar header progress) on its own heap.
+phase: enum {
+    /// Call `archive_read_next_header` next.
+    want_header,
+    /// Currently writing the body of `out_fd`; call
+    /// `archive_read_data_block` next.
+    want_data,
+    /// `archive_read_next_header` returned EOF; we are done.
+    done,
+} = .want_header,
+
+/// Output file for the entry currently being written. `null` while
+/// between entries or when the current entry is being skipped.
+out_fd: ?bun.FD = null,
+use_pwrite: bool = Environment.isPosix,
+use_lseek: bool = true,
+
+/// Temp directory files are written into before being renamed into the
+/// cache. Lazily opened on the first drain so the HTTP thread never
+/// touches the filesystem.
+dest: ?std.fs.Dir = null,
+tmpname_buf: bun.PathBuffer = undefined,
+tmpname: [:0]const u8 = "",
+
+/// Incremental SHA over the *compressed* bytes, matching
+/// `Integrity.verify` / `Integrity.forBytes` in the buffered path.
+hasher: Integrity.Streaming,
+
+/// Resolved first-directory name for GitHub tarballs (written to
+/// `.bun-tag` and used for the cache folder name).
+resolved_github_dirname: []const u8 = "",
+want_first_dirname: bool = false,
+npm_mode: bool = true,
+
+bytes_received: usize = 0,
+entry_count: u32 = 0,
+fail: ?anyerror = null,
+
+allocator: std.mem.Allocator,
+
+/// Thread-pool task that runs `drain`. Re-enqueued whenever new data
+/// arrives and no drain is currently in flight.
+drain_task: ThreadPool.Task = .{ .callback = &drainCallback },
+
+/// Completion task that carries the final result back to the main
+/// thread. Populated by `finish()` and pushed onto `resolve_tasks` there.
+extract_task: *Task,
+network_task: *NetworkTask,
+package_manager: *PackageManager,
+
+pub const new = bun.TrivialNew(@This());
+
+const log = Output.scoped(.TarballStream, .hidden);
+
+pub fn init(
+    allocator: std.mem.Allocator,
+    extract_task: *Task,
+    network_task: *NetworkTask,
+    manager: *PackageManager,
+) *TarballStream {
+    const tarball = &extract_task.request.extract.tarball;
+
+    // For GitHub/URL/local tarballs we need a SHA-512 to record in the
+    // lockfile even when there is no expected value to verify against,
+    // matching `ExtractTarball.run`.
+    const compute_if_missing = switch (tarball.resolution.tag) {
+        .github, .remote_tarball, .local_tarball => true,
+        else => false,
+    };
+
+    return TarballStream.new(.{
+        .allocator = allocator,
+        .extract_task = extract_task,
+        .network_task = network_task,
+        .package_manager = manager,
+        .npm_mode = tarball.resolution.tag != .github,
+        .want_first_dirname = tarball.resolution.tag == .github,
+        .hasher = Integrity.Streaming.init(
+            if (tarball.skip_verify) .{} else tarball.integrity,
+            compute_if_missing,
+        ),
+    });
+}
+
+pub fn deinit(this: *TarballStream) void {
+    if (this.out_fd) |fd| fd.close();
+    if (this.dest) |*d| d.close();
+    if (this.archive) |a| {
+        _ = a.readClose();
+        _ = a.readFree();
+    }
+    this.pending.deinit(this.allocator);
+    this.reading.deinit(this.allocator);
+    bun.destroy(this);
+}
+
+/// Called from the HTTP thread for each response-body chunk. Returns
+/// without touching the filesystem or libarchive; actual processing is
+/// deferred to `drain` on a worker so the HTTP event loop stays
+/// responsive.
+pub fn onChunk(this: *TarballStream, chunk: []const u8, is_last: bool, err: ?anyerror) void {
+    this.mutex.lock();
+    if (chunk.len > 0) {
+        bun.handleOom(this.pending.appendSlice(this.allocator, chunk));
+        this.bytes_received += chunk.len;
+    }
+    if (is_last) this.closed = true;
+    if (err) |e| this.http_err = e;
+    this.mutex.unlock();
+
+    this.scheduleDrain();
+}
+
+fn scheduleDrain(this: *TarballStream) void {
+    if (this.draining.swap(true, .acq_rel)) return;
+    this.package_manager.thread_pool.schedule(ThreadPool.Batch.from(&this.drain_task));
+}
+
+fn drainCallback(task: *ThreadPool.Task) void {
+    const this: *TarballStream = @fieldParentPtr("drain_task", task);
+    this.drain();
+}
+
+/// Pull whatever compressed bytes are available into libarchive, writing
+/// entries to disk, until libarchive reports `ARCHIVE_RETRY` (out of
+/// input — yield) or a terminal state (EOF / error — finish).
+fn drain(this: *TarballStream) void {
+    Output.Source.configureThread();
+
+    while (true) {
+        const more = this.takePending();
+
+        if (this.fail == null) {
+            this.step() catch |err| {
+                this.fail = err;
+                this.closeOutputFile();
+            };
+        }
+
+        if (this.phase == .done or this.fail != null) {
+            this.mutex.lock();
+            // Hash any bytes that arrived after libarchive hit
+            // end-of-archive so the integrity digest covers the full
+            // response (tar zero-padding, gzip footer). Skip this
+            // once an error is recorded — the digest won't be
+            // checked anyway.
+            if (this.fail == null and this.pending.items.len > 0) {
+                this.hasher.update(this.pending.items);
+            }
+            // After EOF/failure we stop feeding libarchive but must
+            // keep consuming (and discarding) chunks until the HTTP
+            // thread closes the stream; freeing ourselves earlier
+            // would let the next `notify` dereference a dead pointer.
+            this.pending.clearRetainingCapacity();
+            const closed = this.closed;
+            const http_err = this.http_err;
+            this.mutex.unlock();
+            if (http_err) |e| if (this.fail == null) {
+                this.fail = e;
+            };
+            if (closed) {
+                this.finish();
+                return;
+            }
+            // Archive is done (or failed) but the HTTP response has
+            // not finished yet. Fall through to the yield logic below
+            // so we wake up again for the tail / final close.
+        }
+
+        if (!more) {
+            // libarchive consumed everything we had. Yield the worker
+            // until the HTTP thread delivers the next chunk.
+            this.draining.store(false, .release);
+
+            // Close the race between clearing `draining` and a chunk
+            // arriving: if pending is non-empty now, try to reclaim.
+            this.mutex.lock();
+            const again = this.pending.items.len > 0 or this.closed;
+            this.mutex.unlock();
+            if (again and !this.draining.swap(true, .acq_rel)) continue;
+            return;
+        }
+    }
+}
+
+/// Move any bytes still sitting in `pending` into `reading` so the read
+/// callback can hand them to libarchive. Returns true if new bytes were
+/// added or the stream is now closed.
+fn takePending(this: *TarballStream) bool {
+    this.mutex.lock();
+    defer this.mutex.unlock();
+
+    if (this.pending.items.len == 0) return this.closed;
+
+    // Hash before libarchive sees the bytes so integrity covers exactly
+    // what came off the socket.
+    this.hasher.update(this.pending.items);
+
+    if (this.reading.items.len == this.read_pos) {
+        // Previous buffer fully consumed — swap so the HTTP thread can
+        // reuse its capacity without reallocating.
+        this.reading.clearRetainingCapacity();
+        std.mem.swap(std.ArrayListUnmanaged(u8), &this.reading, &this.pending);
+        this.read_pos = 0;
+    } else {
+        // libarchive still holds a slice into `reading` (the read
+        // callback contract keeps the last-returned buffer valid until
+        // the next call). Appending would realloc and invalidate that
+        // slice, so instead shift the unconsumed tail down and append
+        // in place — the callback is not running concurrently with us
+        // (single drain at a time) and will be re-primed with the new
+        // base on its next invocation.
+        const remaining = this.reading.items.len - this.read_pos;
+        std.mem.copyForwards(u8, this.reading.items[0..remaining], this.reading.items[this.read_pos..]);
+        this.reading.items.len = remaining;
+        this.read_pos = 0;
+        bun.handleOom(this.reading.appendSlice(this.allocator, this.pending.items));
+        this.pending.clearRetainingCapacity();
+    }
+    return true;
+}
+
+/// Run libarchive until it needs more input (`.retry`) or hits a
+/// terminal state. All libarchive state persists on the heap, so
+/// returning from here and re-entering later is safe.
+fn step(this: *TarballStream) !void {
+    if (this.archive == null) try this.openArchive();
+    if (this.dest == null) try this.openDestination();
+
+    const archive = this.archive.?;
+
+    while (true) {
+        switch (this.phase) {
+            .done => return,
+            .want_header => {
+                var entry: *lib.Archive.Entry = undefined;
+                switch (archive.readNextHeader(&entry)) {
+                    .retry => return,
+                    .eof => {
+                        this.phase = .done;
+                        return;
+                    },
+                    .ok, .warn => try this.beginEntry(entry),
+                    .failed, .fatal => {
+                        log("readNextHeader: {s}", .{archive.errorString()});
+                        return error.Fail;
+                    },
+                }
+            },
+            .want_data => {
+                var offset: i64 = 0;
+                const block = archive.next(&offset) orelse {
+                    // End of this entry's data.
+                    this.closeOutputFile();
+                    this.phase = .want_header;
+                    continue;
+                };
+                switch (block.result) {
+                    .retry => return,
+                    .ok, .warn => {
+                        if (this.out_fd) |fd| {
+                            try writeDataBlock(fd, block, &this.use_pwrite, &this.use_lseek);
+                        }
+                    },
+                    else => {
+                        log("read_data_block: {s}", .{archive.errorString()});
+                        return error.Fail;
+                    },
+                }
+            },
+        }
+    }
+}
+
+fn openArchive(this: *TarballStream) !void {
+    const archive = lib.Archive.readNew();
+    errdefer {
+        _ = archive.readClose();
+        _ = archive.readFree();
+    }
+    // Bypass bidding entirely: the stream is always gzip → tar, and
+    // bidding would try to read-ahead before any bytes have arrived.
+    // ARCHIVE_FILTER_GZIP = 1, ARCHIVE_FORMAT_TAR = 0x30000.
+    if (lib.archive_read_append_filter(@ptrCast(archive), 1) != 0) return error.Fail;
+    if (lib.archive_read_set_format(@ptrCast(archive), 0x30000) != 0) return error.Fail;
+    _ = archive.readSetOptions("read_concatenated_archives");
+
+    switch (@as(lib.Archive.Result, @enumFromInt(lib.archive_read_open(
+        @ptrCast(archive),
+        this,
+        null,
+        archiveReadCallback,
+        null,
+    )))) {
+        .ok, .warn => {},
+        .retry => {
+            // open() runs the filter bidder which we bypassed, but the
+            // client open path may still probe; treat as transient.
+            this.archive = archive;
+            return;
+        },
+        else => {
+            log("archive_read_open: {s}", .{archive.errorString()});
+            return error.Fail;
+        },
+    }
+    this.archive = archive;
+}
+
+fn openDestination(this: *TarballStream) !void {
+    const tarball = &this.extract_task.request.extract.tarball;
+    _, const basename = tarball.nameAndBasename();
+    this.tmpname = try FileSystem.tmpname(
+        basename[0..@min(basename.len, 32)],
+        this.tmpname_buf[0..],
+        bun.fastRandom(),
+    );
+
+    this.dest = try bun.MakePath.makeOpenPath(tarball.temp_dir, this.tmpname, .{});
+}
+
+fn closeOutputFile(this: *TarballStream) void {
+    if (this.out_fd) |fd| {
+        fd.close();
+        this.out_fd = null;
+    }
+}
+
+/// libarchive client read callback. Returns whatever compressed bytes
+/// are currently buffered in `reading`; if none, returns `ARCHIVE_RETRY`
+/// (when more data is still expected) so libarchive unwinds with a
+/// resumable status, or `0` (EOF) once the HTTP response is complete.
+fn archiveReadCallback(
+    _: *lib.struct_archive,
+    ctx: *anyopaque,
+    out_buffer: [*c]*const anyopaque,
+) callconv(.c) lib.la_ssize_t {
+    const this: *TarballStream = @ptrCast(@alignCast(ctx));
+
+    const remaining = this.reading.items[this.read_pos..];
+    if (remaining.len > 0) {
+        out_buffer.* = remaining.ptr;
+        this.read_pos = this.reading.items.len;
+        return @intCast(remaining.len);
+    }
+
+    // No data left in `reading`. Check for more under the lock —
+    // libarchive may have called us more than once for a single
+    // `step()` (e.g. gzip header + first deflate block), and `onChunk`
+    // might have landed a fresh chunk in the meantime.
+    this.mutex.lock();
+    const has_pending = this.pending.items.len > 0;
+    const closed = this.closed;
+    this.mutex.unlock();
+
+    if (has_pending) {
+        // Pull the new bytes into `reading` and retry the read. We are
+        // the only consumer of `reading`/`read_pos`, and `takePending`
+        // only touches producer state under the same mutex.
+        _ = this.takePending();
+        const again = this.reading.items[this.read_pos..];
+        if (again.len > 0) {
+            out_buffer.* = again.ptr;
+            this.read_pos = this.reading.items.len;
+            return @intCast(again.len);
+        }
+    }
+
+    if (closed) {
+        out_buffer.* = @ptrCast(@alignCast(this)); // unused when len==0
+        return 0;
+    }
+
+    // Tell libarchive to unwind with a resumable status. The BUN PATCHes
+    // in vendor/libarchive make every layer (filter_ahead → gzip → tar)
+    // preserve its state and propagate ARCHIVE_RETRY to our `step()`
+    // loop, which then returns so this worker can be reused.
+    return @intFromEnum(lib.Archive.Result.retry);
+}
+
+/// Process one entry header returned by `readNextHeader`. Opens the
+/// output file (or creates the directory/symlink) and transitions to
+/// `.want_data` so the next `step()` iteration starts pulling its body.
+fn beginEntry(this: *TarballStream, entry: *lib.Archive.Entry) !void {
+    var pathname: bun.OSPathSliceZ = if (comptime Environment.isWindows)
+        entry.pathnameW()
+    else
+        entry.pathname();
+
+    if (this.want_first_dirname) {
+        this.want_first_dirname = false;
+        if (comptime Environment.isWindows) {
+            const list = std.array_list.Managed(u8).init(bun.default_allocator);
+            var result = try strings.toUTF8ListWithType(list, pathname[0..pathname.len]);
+            defer result.deinit();
+            this.resolved_github_dirname = FileSystem.DirnameStore.instance.append(
+                []const u8,
+                strings.withoutTrailingSlash(result.items),
+            ) catch unreachable;
+        } else {
+            this.resolved_github_dirname = FileSystem.DirnameStore.instance.append(
+                []const u8,
+                strings.withoutTrailingSlash(bun.asByteSlice(pathname)),
+            ) catch unreachable;
+        }
+    }
+
+    const kind = bun.sys.kindFromMode(entry.filetype());
+
+    if (this.npm_mode and kind != .file) {
+        // npm tarballs only contain files; matching the libarchive path
+        // in Archiver.extractToDir we skip everything else.
+        this.phase = .want_data;
+        this.out_fd = null;
+        return;
+    }
+
+    // Strip the leading `package/` (or `<repo>-<sha>/` for GitHub) and
+    // normalise. Same transformation as Archiver.extractToDir so both
+    // paths produce identical on-disk layouts.
+    var tokenizer = std.mem.tokenizeScalar(bun.OSPathChar, pathname, '/');
+    if (tokenizer.next() == null) {
+        this.phase = .want_data;
+        this.out_fd = null;
+        return;
+    }
+    const rest = tokenizer.rest();
+    pathname = rest.ptr[0..rest.len :0];
+
+    var norm_buf: bun.OSPathBuffer = undefined;
+    const normalized = bun.path.normalizeBufT(bun.OSPathChar, pathname, &norm_buf, .auto);
+    norm_buf[normalized.len] = 0;
+    const path: [:0]bun.OSPathChar = norm_buf[0..normalized.len :0];
+    if (path.len == 0 or (path.len == 1 and path[0] == '.')) {
+        this.phase = .want_data;
+        this.out_fd = null;
+        return;
+    }
+    if (comptime Environment.isWindows) {
+        if (std.fs.path.isAbsoluteWindowsWTF16(path)) {
+            this.phase = .want_data;
+            this.out_fd = null;
+            return;
+        }
+        if (this.npm_mode) applyWindowsNpmPathEscapes(path);
+    }
+
+    const path_slice: bun.OSPathSlice = path.ptr[0..path.len];
+    const dest = this.dest.?;
+
+    switch (kind) {
+        .directory => {
+            makeDirectory(entry, dest, path, path_slice);
+            this.phase = .want_data;
+            this.out_fd = null;
+        },
+        .sym_link => {
+            if (Environment.isPosix) makeSymlink(entry, dest, path, path_slice);
+            this.phase = .want_data;
+            this.out_fd = null;
+        },
+        .file => {
+            const mode: bun.Mode = if (comptime Environment.isWindows) 0 else @intCast(entry.perm() | 0o666);
+            const fd = try openOutputFile(dest, path, path_slice, mode);
+            this.entry_count += 1;
+
+            if (comptime Environment.isLinux) {
+                const size: usize = @intCast(@max(entry.size(), 0));
+                if (size > 1_000_000) {
+                    bun.sys.preallocate_file(fd.cast(), 0, @intCast(size)) catch {};
+                }
+            }
+
+            this.out_fd = fd;
+            this.phase = .want_data;
+        },
+        else => {
+            this.phase = .want_data;
+            this.out_fd = null;
+        },
+    }
+}
+
+fn openOutputFile(
+    dest: std.fs.Dir,
+    path: [:0]bun.OSPathChar,
+    path_slice: bun.OSPathSlice,
+    mode: bun.Mode,
+) !bun.FD {
+    const flags = bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC;
+    if (comptime Environment.isWindows) {
+        return switch (bun.sys.openatWindows(.fromStdDir(dest), path, flags, 0)) {
+            .result => |fd| fd,
+            .err => |e| switch (e.errno) {
+                @intFromEnum(bun.sys.E.PERM), @intFromEnum(bun.sys.E.NOENT) => brk: {
+                    bun.MakePath.makePath(u16, dest, bun.Dirname.dirname(u16, path_slice) orelse return bun.errnoToZigErr(e.errno)) catch {};
+                    break :brk try bun.sys.openatWindows(.fromStdDir(dest), path, flags, 0).unwrap();
+                },
+                else => return bun.errnoToZigErr(e.errno),
+            },
+        };
+    }
+    return .fromStdFile(dest.createFileZ(path, .{ .truncate = true, .mode = mode }) catch |err| switch (err) {
+        error.AccessDenied, error.FileNotFound => brk: {
+            dest.makePath(std.fs.path.dirname(path_slice) orelse return err) catch {};
+            break :brk try dest.createFileZ(path, .{ .truncate = true, .mode = mode });
+        },
+        else => return err,
+    });
+}
+
+fn makeDirectory(
+    entry: *lib.Archive.Entry,
+    dest: std.fs.Dir,
+    path: [:0]bun.OSPathChar,
+    path_slice: bun.OSPathSlice,
+) void {
+    var mode = @as(i32, @intCast(entry.perm()));
+    // if dirs are readable, then they should be listable
+    // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
+    if ((mode & 0o400) != 0) mode |= 0o100;
+    if ((mode & 0o40) != 0) mode |= 0o10;
+    if ((mode & 0o4) != 0) mode |= 0o1;
+    if (comptime Environment.isWindows) {
+        bun.MakePath.makePath(u16, dest, path) catch {};
+    } else {
+        std.posix.mkdiratZ(dest.fd, path, @intCast(mode)) catch |err| {
+            if (err == error.PathAlreadyExists or err == error.NotDir) return;
+            bun.makePath(dest, std.fs.path.dirname(path_slice) orelse return) catch {};
+            std.posix.mkdiratZ(dest.fd, path, 0o777) catch {};
+        };
+    }
+}
+
+fn makeSymlink(
+    entry: *lib.Archive.Entry,
+    dest: std.fs.Dir,
+    path: [:0]bun.OSPathChar,
+    path_slice: bun.OSPathSlice,
+) void {
+    const target = entry.symlink();
+    // Same safety rule as `isSymlinkTargetSafe` in the buffered path:
+    // reject absolute targets and anything that escapes via `..`.
+    if (target.len == 0 or target[0] == '/') return;
+    {
+        const symlink_dir = std.fs.path.dirname(path_slice) orelse "";
+        var join_buf: bun.PathBuffer = undefined;
+        const resolved = bun.path.joinAbsStringBuf("/packages/", &join_buf, &.{ symlink_dir, target }, .posix);
+        if (!strings.hasPrefix(resolved, "/packages/")) return;
+    }
+    const dest_fd = bun.FD.fromStdDir(dest);
+    bun.sys.symlinkat(target, dest_fd, path).unwrap() catch |err| switch (err) {
+        error.EPERM, error.ENOENT => {
+            dest.makePath(std.fs.path.dirname(path_slice) orelse return) catch {};
+            bun.sys.symlinkat(target, dest_fd, path).unwrap() catch {};
+        },
+        else => {},
+    };
+}
+
+fn applyWindowsNpmPathEscapes(path: [:0]bun.OSPathChar) void {
+    // Same transformation as Archiver.extractToDir: encode characters
+    // Windows rejects in filenames into the 0xf000 private-use range so
+    // the extraction round-trips with node-tar.
+    var remain: []bun.OSPathChar = path;
+    if (strings.startsWithWindowsDriveLetterT(bun.OSPathChar, remain)) remain = remain[2..];
+    for (remain) |*char| switch (char.*) {
+        '|', '<', '>', '?', ':' => char.* += 0xf000,
+        else => {},
+    };
+}
+
+/// Write one data block from `archive_read_data_block`. Mirrors the
+/// sparse/pwrite handling in `Archive.readDataIntoFd` but operates on a
+/// single block so it can be interleaved with ARCHIVE_RETRY yields.
+fn writeDataBlock(
+    fd: bun.FD,
+    block: lib.Archive.Block,
+    use_pwrite: *bool,
+    use_lseek: *bool,
+) !void {
+    const file = bun.sys.File{ .handle = fd };
+    const data = block.bytes;
+    if (data.len == 0) return;
+
+    if (comptime Environment.isPosix) {
+        if (use_pwrite.*) {
+            switch (file.pwriteAll(data, block.offset)) {
+                .result => return,
+                .err => use_pwrite.* = false,
+            }
+        }
+    }
+
+    if (use_lseek.*) {
+        switch (bun.sys.setFileOffset(fd, @intCast(block.offset))) {
+            .result => {},
+            .err => use_lseek.* = false,
+        }
+    }
+
+    switch (file.writeAll(data)) {
+        .result => {},
+        .err => |e| return bun.errnoToZigErr(e.errno),
+    }
+}
+
+fn finish(this: *TarballStream) void {
+    const task = this.extract_task;
+    const network = this.network_task;
+    const manager = this.package_manager;
+
+    this.closeOutputFile();
+
+    // At this point the HTTP thread has delivered the final
+    // `has_more=false` chunk (that's the only way `closed` gets set),
+    // so no more writes to the NetworkTask's `response_buffer` are
+    // possible. The main thread reads only `streaming_committed` when
+    // it later processes the NetworkTask, so freeing the buffer here
+    // is safe and matches the `defer buffer.deinit()` in the buffered
+    // `.extract` arm of `Task.callback`.
+    network.response_buffer.deinit();
+
+    this.populateResult(task);
+
+    // Temp-dir cleanup must happen before we release the stream or
+    // publish the task: both `this.tmpname` and
+    // `task.request.extract.tarball.temp_dir` become invalid once
+    // `this.deinit()` runs / the main thread recycles the Task.
+    if (task.status != .success and this.tmpname.len > 0) {
+        task.request.extract.tarball.temp_dir.deleteTree(this.tmpname) catch {};
+    }
+
+    this.deinit();
+
+    if (task.status == .success) {
+        if (task.apply_patch_task) |pt| {
+            defer pt.deinit();
+            bun.handleOom(pt.apply());
+            if (pt.callback.apply.logger.errors > 0) {
+                defer pt.callback.apply.logger.deinit();
+                pt.callback.apply.logger.print(Output.errorWriter()) catch {};
+            }
+        }
+    }
+    // Publish last: once the task is on `resolve_tasks` the main
+    // thread may immediately recycle it *and* the NetworkTask it
+    // references, so nothing below this line may touch either.
+    manager.resolve_tasks.push(task);
+    manager.wake();
+}
+
+fn populateResult(this: *TarballStream, task: *Task) void {
+    const tarball = &task.request.extract.tarball;
+    task.data = .{ .extract = .{} };
+
+    if (this.fail) |err| {
+        task.log.addErrorFmt(
+            null,
+            logger.Loc.Empty,
+            this.allocator,
+            "{s} extracting tarball for \"{s}\"",
+            .{ @errorName(err), tarball.name.slice() },
+        ) catch unreachable;
+        task.err = err;
+        task.status = .fail;
+        return;
+    }
+
+    if (!tarball.skip_verify and tarball.integrity.tag.isSupported()) {
+        if (!this.hasher.verify()) {
+            task.log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                this.allocator,
+                "Integrity check failed<r> for tarball: {s}",
+                .{tarball.name.slice()},
+            ) catch unreachable;
+            task.err = error.IntegrityCheckFailed;
+            task.status = .fail;
+            return;
+        }
+    }
+
+    if (tarball.resolution.tag == .github) {
+        if (this.resolved_github_dirname.len > 0) insert_tag: {
+            const gh_tag = this.dest.?.createFileZ(".bun-tag", .{ .truncate = true }) catch break :insert_tag;
+            defer gh_tag.close();
+            gh_tag.writeAll(this.resolved_github_dirname) catch {
+                this.dest.?.deleteFileZ(".bun-tag") catch {};
+            };
+        }
+    }
+
+    // Close the temp dir handle before renaming so Windows can move it.
+    if (this.dest) |*d| {
+        d.close();
+        this.dest = null;
+    }
+
+    const name, const basename = tarball.nameAndBasename();
+
+    var result = tarball.moveToCacheDirectory(
+        &task.log,
+        this.tmpname,
+        name,
+        basename,
+        this.resolved_github_dirname,
+    ) catch |err| {
+        task.err = err;
+        task.status = .fail;
+        return;
+    };
+
+    switch (tarball.resolution.tag) {
+        .github, .remote_tarball, .local_tarball => {
+            if (tarball.integrity.tag.isSupported()) {
+                result.integrity = tarball.integrity;
+            } else {
+                result.integrity = this.hasher.final();
+            }
+        },
+        else => {},
+    }
+
+    if (PackageManager.verbose_install) {
+        Output.prettyErrorln("[{s}] Streamed {f} tarball → {d} entries<r>", .{
+            name,
+            bun.fmt.size(this.bytes_received, .{}),
+            this.entry_count,
+        });
+        Output.flush();
+    }
+
+    task.data = .{ .extract = result };
+    task.status = .success;
+    return;
+}
+
+/// Prepare this stream for another HTTP attempt after a failed request
+/// that never scheduled a drain.
+pub fn resetForRetry(this: *TarballStream) void {
+    this.mutex.lock();
+    this.pending.clearRetainingCapacity();
+    this.closed = false;
+    this.http_err = null;
+    this.status_code = 0;
+    this.bytes_received = 0;
+    this.mutex.unlock();
+}
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Environment = bun.Environment;
+const Mutex = bun.threading.Mutex;
+const Output = bun.Output;
+const ThreadPool = bun.ThreadPool;
+const strings = bun.strings;
+const FileSystem = bun.fs.FileSystem;
+const logger = bun.logger;
+
+const lib = bun.libarchive.lib;
+
+const install = @import("./install.zig");
+const NetworkTask = install.NetworkTask;
+const PackageManager = install.PackageManager;
+const Task = install.Task;
+const Integrity = @import("./integrity.zig").Integrity;

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -453,18 +453,25 @@ fn beginEntry(this: *TarballStream, entry: *lib.Archive.Entry) !void {
 
     if (this.want_first_dirname) {
         this.want_first_dirname = false;
+        // GitHub's archive API always emits an explicit `repo-sha/`
+        // directory entry first, which is what the buffered path
+        // relies on. Take only the leading component so a tarball
+        // whose first member is `repo-sha/file` (no directory entry)
+        // still yields the correct cache-folder name.
+        var root_it = std.mem.tokenizeScalar(bun.OSPathChar, pathname, '/');
+        const root = root_it.next() orelse pathname[0..0];
         if (comptime Environment.isWindows) {
             const list = std.array_list.Managed(u8).init(bun.default_allocator);
-            var result = try strings.toUTF8ListWithType(list, pathname[0..pathname.len]);
+            var result = try strings.toUTF8ListWithType(list, root);
             defer result.deinit();
             this.resolved_github_dirname = FileSystem.DirnameStore.instance.append(
                 []const u8,
-                strings.withoutTrailingSlash(result.items),
+                result.items,
             ) catch unreachable;
         } else {
             this.resolved_github_dirname = FileSystem.DirnameStore.instance.append(
                 []const u8,
-                strings.withoutTrailingSlash(bun.asByteSlice(pathname)),
+                bun.asByteSlice(root),
             ) catch unreachable;
         }
     }

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -859,7 +859,7 @@ fn populateResult(this: *TarballStream, task: *Task) void {
             ).unwrap() catch break :insert_tag;
             defer gh_tag.close();
             (bun.sys.File{ .handle = gh_tag }).writeAll(this.resolved_github_dirname).unwrap() catch {
-                _ = bun.sys.unlinkat(this.dest.?, ".bun-tag");
+                _ = bun.sys.unlinkat(this.dest.?, @as([:0]const u8, ".bun-tag"));
             };
         }
     }

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -207,58 +207,83 @@ fn drain(this: *TarballStream) void {
     Output.Source.configureThread();
 
     while (true) {
-        const more = this.takePending();
+        if (this.fail == null and this.phase != .done) {
+            // Only pull bytes into `reading` while libarchive is still
+            // going to consume them. After EOF/failure `step()` is
+            // never called again, so appending here would let
+            // `reading` grow by one HTTP chunk per wakeup for the
+            // remainder of the download.
+            const more = this.takePending();
 
-        if (this.fail == null) {
             this.step() catch |err| {
                 this.fail = err;
                 this.closeOutputFile();
             };
-        }
 
-        if (this.phase == .done or this.fail != null) {
-            this.mutex.lock();
-            // Hash any bytes that arrived after libarchive hit
-            // end-of-archive so the integrity digest covers the full
-            // response (tar zero-padding, gzip footer). Skip this
-            // once an error is recorded — the digest won't be
-            // checked anyway.
-            if (this.fail == null and this.pending.items.len > 0) {
-                this.hasher.update(this.pending.items);
-            }
-            // After EOF/failure we stop feeding libarchive but must
-            // keep consuming (and discarding) chunks until the HTTP
-            // thread closes the stream; freeing ourselves earlier
-            // would let the next `notify` dereference a dead pointer.
-            this.pending.clearRetainingCapacity();
-            const closed = this.closed;
-            const http_err = this.http_err;
-            this.mutex.unlock();
-            if (http_err) |e| if (this.fail == null) {
-                this.fail = e;
-            };
-            if (closed) {
-                this.finish();
+            if (this.fail == null and this.phase != .done) {
+                if (more) continue;
+                // libarchive consumed everything we had. Yield the
+                // worker until the HTTP thread delivers the next
+                // chunk.
+                this.draining.store(false, .release);
+                // Close the race between clearing `draining` and a
+                // chunk arriving: if `pending` is non-empty now, try
+                // to reclaim the flag ourselves instead of waiting
+                // for the next schedule.
+                this.mutex.lock();
+                const again = this.pending.items.len > 0 or this.closed;
+                this.mutex.unlock();
+                if (again and !this.draining.swap(true, .acq_rel)) continue;
                 return;
             }
-            // Archive is done (or failed) but the HTTP response has
-            // not finished yet. Fall through to the yield logic below
-            // so we wake up again for the tail / final close.
         }
 
-        if (!more) {
-            // libarchive consumed everything we had. Yield the worker
-            // until the HTTP thread delivers the next chunk.
-            this.draining.store(false, .release);
+        // Terminal: archive finished or extraction failed. libarchive
+        // will not be called again, so `reading` is dead — drop it
+        // now rather than carrying its capacity until `finish()`.
+        // `reading` is drain-local (only the read callback touches
+        // it, and that runs inside `step()`), so this needs no lock.
+        this.reading.clearAndFree(this.allocator);
+        this.read_pos = 0;
 
-            // Close the race between clearing `draining` and a chunk
-            // arriving: if pending is non-empty now, try to reclaim.
-            this.mutex.lock();
-            const again = this.pending.items.len > 0 or this.closed;
-            this.mutex.unlock();
-            if (again and !this.draining.swap(true, .acq_rel)) continue;
+        this.mutex.lock();
+        // Hash any bytes that arrived after libarchive hit
+        // end-of-archive so the integrity digest covers the full
+        // response (tar zero-padding, gzip footer). Skip this once
+        // an error is recorded — the digest won't be checked anyway.
+        if (this.fail == null and this.pending.items.len > 0) {
+            this.hasher.update(this.pending.items);
+        }
+        // After EOF/failure we stop feeding libarchive but must keep
+        // consuming (and discarding) chunks until the HTTP thread
+        // closes the stream; freeing ourselves earlier would let the
+        // next `notify` dereference a dead pointer.
+        this.pending.clearRetainingCapacity();
+        const closed = this.closed;
+        const http_err = this.http_err;
+        this.mutex.unlock();
+        // A transport error that arrives *after* libarchive reached
+        // EOF (e.g. the server RSTs the connection once the last
+        // byte is on the wire) must not override a successful
+        // extraction; the integrity check in `populateResult()` is
+        // the sole arbiter of correctness once `.done` is reached.
+        if (http_err) |e| if (this.fail == null and this.phase != .done) {
+            this.fail = e;
+        };
+        if (closed) {
+            this.finish();
             return;
         }
+
+        // Archive is done (or failed) but the HTTP response has not
+        // finished yet. Yield; the next `onChunk` will reschedule us
+        // to discard the new bytes and eventually observe `closed`.
+        this.draining.store(false, .release);
+        this.mutex.lock();
+        const again = this.pending.items.len > 0 or this.closed;
+        this.mutex.unlock();
+        if (again and !this.draining.swap(true, .acq_rel)) continue;
+        return;
     }
 }
 
@@ -596,27 +621,29 @@ fn openOutputFile(
     path_slice: bun.OSPathSlice,
     mode: bun.Mode,
 ) !bun.FD {
-    const dest = dest_fd.stdDir();
     const flags = bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC;
     if (comptime Environment.isWindows) {
         return switch (bun.sys.openatWindows(dest_fd, path, flags, 0)) {
             .result => |fd| fd,
             .err => |e| switch (e.errno) {
                 @intFromEnum(bun.sys.E.PERM), @intFromEnum(bun.sys.E.NOENT) => brk: {
-                    bun.MakePath.makePath(u16, dest, bun.Dirname.dirname(u16, path_slice) orelse return bun.errnoToZigErr(e.errno)) catch {};
+                    dest_fd.makePath(u16, bun.Dirname.dirname(u16, path_slice) orelse return bun.errnoToZigErr(e.errno)) catch {};
                     break :brk try bun.sys.openatWindows(dest_fd, path, flags, 0).unwrap();
                 },
                 else => return bun.errnoToZigErr(e.errno),
             },
         };
     }
-    return .fromStdFile(dest.createFileZ(path, .{ .truncate = true, .mode = mode }) catch |err| switch (err) {
-        error.AccessDenied, error.FileNotFound => brk: {
-            dest.makePath(std.fs.path.dirname(path_slice) orelse return err) catch {};
-            break :brk try dest.createFileZ(path, .{ .truncate = true, .mode = mode });
+    return switch (bun.sys.openat(dest_fd, path, flags, mode)) {
+        .result => |fd| fd,
+        .err => |e| switch (e.getErrno()) {
+            .ACCES, .NOENT => brk: {
+                dest_fd.makePath(u8, std.fs.path.dirname(path_slice) orelse return bun.errnoToZigErr(e.errno)) catch {};
+                break :brk try bun.sys.openat(dest_fd, path, flags, mode).unwrap();
+            },
+            else => return bun.errnoToZigErr(e.errno),
         },
-        else => return err,
-    });
+    };
 }
 
 fn makeDirectory(
@@ -625,7 +652,6 @@ fn makeDirectory(
     path: [:0]bun.OSPathChar,
     path_slice: bun.OSPathSlice,
 ) void {
-    const dest = dest_fd.stdDir();
     var mode = @as(i32, @intCast(entry.perm()));
     // if dirs are readable, then they should be listable
     // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
@@ -633,13 +659,18 @@ fn makeDirectory(
     if ((mode & 0o40) != 0) mode |= 0o10;
     if ((mode & 0o4) != 0) mode |= 0o1;
     if (comptime Environment.isWindows) {
-        bun.MakePath.makePath(u16, dest, path) catch {};
+        dest_fd.makePath(u16, path) catch {};
     } else {
-        std.posix.mkdiratZ(dest.fd, path, @intCast(mode)) catch |err| {
-            if (err == error.PathAlreadyExists or err == error.NotDir) return;
-            bun.makePath(dest, std.fs.path.dirname(path_slice) orelse return) catch {};
-            std.posix.mkdiratZ(dest.fd, path, 0o777) catch {};
-        };
+        switch (bun.sys.mkdiratZ(dest_fd, path, @intCast(mode))) {
+            .result => {},
+            .err => |e| switch (e.getErrno()) {
+                .EXIST, .NOTDIR => {},
+                else => {
+                    dest_fd.makePath(u8, std.fs.path.dirname(path_slice) orelse return) catch {};
+                    _ = bun.sys.mkdiratZ(dest_fd, path, 0o777);
+                },
+            },
+        }
     }
 }
 
@@ -661,7 +692,7 @@ fn makeSymlink(
     }
     bun.sys.symlinkat(target, dest_fd, path).unwrap() catch |err| switch (err) {
         error.EPERM, error.ENOENT => {
-            dest_fd.stdDir().makePath(std.fs.path.dirname(path_slice) orelse return) catch {};
+            dest_fd.makePath(u8, std.fs.path.dirname(path_slice) orelse return) catch {};
             bun.sys.symlinkat(target, dest_fd, path).unwrap() catch {};
         },
         else => {},
@@ -820,10 +851,15 @@ fn populateResult(this: *TarballStream, task: *Task) void {
 
     if (tarball.resolution.tag == .github) {
         if (this.resolved_github_dirname.len > 0) insert_tag: {
-            const gh_tag = this.dest.?.stdDir().createFileZ(".bun-tag", .{ .truncate = true }) catch break :insert_tag;
+            const gh_tag = bun.sys.openat(
+                this.dest.?,
+                ".bun-tag",
+                bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC,
+                0o644,
+            ).unwrap() catch break :insert_tag;
             defer gh_tag.close();
-            gh_tag.writeAll(this.resolved_github_dirname) catch {
-                this.dest.?.stdDir().deleteFileZ(".bun-tag") catch {};
+            (bun.sys.File{ .handle = gh_tag }).writeAll(this.resolved_github_dirname).unwrap() catch {
+                _ = bun.sys.unlinkat(this.dest.?, ".bun-tag");
             };
         }
     }

--- a/src/install/TarballStream.zig
+++ b/src/install/TarballStream.zig
@@ -88,8 +88,8 @@ entry_final_offset: i64 = 0,
 /// Temp directory files are written into before being renamed into the
 /// cache. Lazily opened on the first drain so the HTTP thread never
 /// touches the filesystem.
-dest: ?std.fs.Dir = null,
-tmpname_buf: bun.PathBuffer = undefined,
+dest: ?bun.FD = null,
+/// Owned copy of the temp-directory name; freed in `deinit()`.
 tmpname: [:0]const u8 = "",
 
 /// Incremental SHA over the *compressed* bytes, matching
@@ -162,11 +162,12 @@ pub fn init(
 
 pub fn deinit(this: *TarballStream) void {
     if (this.out_fd) |fd| fd.close();
-    if (this.dest) |*d| d.close();
+    if (this.dest) |d| d.close();
     if (this.archive) |a| {
         _ = a.readClose();
         _ = a.readFree();
     }
+    if (this.tmpname.len > 0) this.allocator.free(this.tmpname);
     this.pending.deinit(this.allocator);
     this.reading.deinit(this.allocator);
     bun.destroy(this);
@@ -388,13 +389,15 @@ fn openArchive(this: *TarballStream) !void {
 fn openDestination(this: *TarballStream) !void {
     const tarball = &this.extract_task.request.extract.tarball;
     _, const basename = tarball.nameAndBasename();
-    this.tmpname = try FileSystem.tmpname(
+    var buf: bun.PathBuffer = undefined;
+    const tmpname = try FileSystem.tmpname(
         basename[0..@min(basename.len, 32)],
-        this.tmpname_buf[0..],
+        buf[0..],
         bun.fastRandom(),
     );
+    this.tmpname = try this.allocator.dupeZ(u8, tmpname);
 
-    this.dest = try bun.MakePath.makeOpenPath(tarball.temp_dir, this.tmpname, .{});
+    this.dest = .fromStdDir(try bun.MakePath.makeOpenPath(tarball.temp_dir, this.tmpname, .{}));
 }
 
 fn closeOutputFile(this: *TarballStream) void {
@@ -588,19 +591,20 @@ fn beginEntry(this: *TarballStream, entry: *lib.Archive.Entry) !void {
 }
 
 fn openOutputFile(
-    dest: std.fs.Dir,
+    dest_fd: bun.FD,
     path: [:0]bun.OSPathChar,
     path_slice: bun.OSPathSlice,
     mode: bun.Mode,
 ) !bun.FD {
+    const dest = dest_fd.stdDir();
     const flags = bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC;
     if (comptime Environment.isWindows) {
-        return switch (bun.sys.openatWindows(.fromStdDir(dest), path, flags, 0)) {
+        return switch (bun.sys.openatWindows(dest_fd, path, flags, 0)) {
             .result => |fd| fd,
             .err => |e| switch (e.errno) {
                 @intFromEnum(bun.sys.E.PERM), @intFromEnum(bun.sys.E.NOENT) => brk: {
                     bun.MakePath.makePath(u16, dest, bun.Dirname.dirname(u16, path_slice) orelse return bun.errnoToZigErr(e.errno)) catch {};
-                    break :brk try bun.sys.openatWindows(.fromStdDir(dest), path, flags, 0).unwrap();
+                    break :brk try bun.sys.openatWindows(dest_fd, path, flags, 0).unwrap();
                 },
                 else => return bun.errnoToZigErr(e.errno),
             },
@@ -617,10 +621,11 @@ fn openOutputFile(
 
 fn makeDirectory(
     entry: *lib.Archive.Entry,
-    dest: std.fs.Dir,
+    dest_fd: bun.FD,
     path: [:0]bun.OSPathChar,
     path_slice: bun.OSPathSlice,
 ) void {
+    const dest = dest_fd.stdDir();
     var mode = @as(i32, @intCast(entry.perm()));
     // if dirs are readable, then they should be listable
     // https://github.com/npm/node-tar/blob/main/lib/mode-fix.js
@@ -640,7 +645,7 @@ fn makeDirectory(
 
 fn makeSymlink(
     entry: *lib.Archive.Entry,
-    dest: std.fs.Dir,
+    dest_fd: bun.FD,
     path: [:0]bun.OSPathChar,
     path_slice: bun.OSPathSlice,
 ) void {
@@ -654,10 +659,9 @@ fn makeSymlink(
         const resolved = bun.path.joinAbsStringBuf("/packages/", &join_buf, &.{ symlink_dir, target }, .posix);
         if (!strings.hasPrefix(resolved, "/packages/")) return;
     }
-    const dest_fd = bun.FD.fromStdDir(dest);
     bun.sys.symlinkat(target, dest_fd, path).unwrap() catch |err| switch (err) {
         error.EPERM, error.ENOENT => {
-            dest.makePath(std.fs.path.dirname(path_slice) orelse return) catch {};
+            dest_fd.stdDir().makePath(std.fs.path.dirname(path_slice) orelse return) catch {};
             bun.sys.symlinkat(target, dest_fd, path).unwrap() catch {};
         },
         else => {},
@@ -761,7 +765,7 @@ fn finish(this: *TarballStream) void {
         // rename; the early-return failure paths leave it open, so close
         // it here first — Windows can't remove an open directory.
         // `deinit()` null-checks so this is not a double-close.
-        if (this.dest) |*d| {
+        if (this.dest) |d| {
             d.close();
             this.dest = null;
         }
@@ -816,16 +820,16 @@ fn populateResult(this: *TarballStream, task: *Task) void {
 
     if (tarball.resolution.tag == .github) {
         if (this.resolved_github_dirname.len > 0) insert_tag: {
-            const gh_tag = this.dest.?.createFileZ(".bun-tag", .{ .truncate = true }) catch break :insert_tag;
+            const gh_tag = this.dest.?.stdDir().createFileZ(".bun-tag", .{ .truncate = true }) catch break :insert_tag;
             defer gh_tag.close();
             gh_tag.writeAll(this.resolved_github_dirname) catch {
-                this.dest.?.deleteFileZ(".bun-tag") catch {};
+                this.dest.?.stdDir().deleteFileZ(".bun-tag") catch {};
             };
         }
     }
 
     // Close the temp dir handle before renaming so Windows can move it.
-    if (this.dest) |*d| {
+    if (this.dest) |d| {
         d.close();
         this.dest = null;
     }

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -130,8 +130,14 @@ pub fn usesStreamingExtraction() bool {
     return !bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL.get();
 }
 
+/// Derive the display name and a filesystem-safe basename for this
+/// package. Shared by the buffered `extract()` path below and the
+/// streaming extractor in `TarballStream.zig` so both pick identical
+/// temp-dir and cache-folder names.
 pub fn nameAndBasename(this: *const ExtractTarball) struct { []const u8, []const u8 } {
     const name = if (this.name.slice().len > 0) this.name.slice() else brk: {
+        // Not sure where this case hits yet.
+        // BUN-2WQ
         Output.warn("Extracting nameless packages is not supported yet. Please open an issue on GitHub with reproduction steps.", .{});
         bun.debugAssert(false);
         break :brk "unnamed-package";
@@ -168,39 +174,7 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
 
     const tmpdir = this.temp_dir;
     var tmpname_buf: if (Environment.isWindows) bun.WPathBuffer else bun.PathBuffer = undefined;
-    const name = if (this.name.slice().len > 0) this.name.slice() else brk: {
-        // Not sure where this case hits yet.
-        // BUN-2WQ
-        Output.warn("Extracting nameless packages is not supported yet. Please open an issue on GitHub with reproduction steps.", .{});
-        bun.debugAssert(false);
-        break :brk "unnamed-package";
-    };
-    const basename = brk: {
-        var tmp = name;
-
-        // Handle URLs - extract just the filename from the URL
-        if (strings.hasPrefixComptime(tmp, "https://") or strings.hasPrefixComptime(tmp, "http://")) {
-            tmp = std.fs.path.basename(tmp);
-            // Remove .tgz or .tar.gz extension if present
-            if (strings.endsWithComptime(tmp, ".tgz")) {
-                tmp = tmp[0 .. tmp.len - 4];
-            } else if (strings.endsWithComptime(tmp, ".tar.gz")) {
-                tmp = tmp[0 .. tmp.len - 7];
-            }
-        } else if (tmp[0] == '@') {
-            if (strings.indexOfChar(tmp, '/')) |i| {
-                tmp = tmp[i + 1 ..];
-            }
-        }
-
-        if (comptime Environment.isWindows) {
-            if (strings.lastIndexOfChar(tmp, ':')) |i| {
-                tmp = tmp[i + 1 ..];
-            }
-        }
-
-        break :brk tmp;
-    };
+    const name, const basename = this.nameAndBasename();
 
     var resolved: string = "";
     const tmpname = try FileSystem.tmpname(basename[0..@min(basename.len, 32)], std.mem.asBytes(&tmpname_buf), bun.fastRandom());

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -126,6 +126,42 @@ threadlocal var final_path_buf: bun.PathBuffer = undefined;
 threadlocal var folder_name_buf: bun.PathBuffer = undefined;
 threadlocal var json_path_buf: bun.PathBuffer = undefined;
 
+pub fn usesStreamingExtraction() bool {
+    return !bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL.get();
+}
+
+pub fn nameAndBasename(this: *const ExtractTarball) struct { []const u8, []const u8 } {
+    const name = if (this.name.slice().len > 0) this.name.slice() else brk: {
+        Output.warn("Extracting nameless packages is not supported yet. Please open an issue on GitHub with reproduction steps.", .{});
+        bun.debugAssert(false);
+        break :brk "unnamed-package";
+    };
+    const basename = brk: {
+        var tmp = name;
+        if (strings.hasPrefixComptime(tmp, "https://") or strings.hasPrefixComptime(tmp, "http://")) {
+            tmp = std.fs.path.basename(tmp);
+            if (strings.endsWithComptime(tmp, ".tgz")) {
+                tmp = tmp[0 .. tmp.len - 4];
+            } else if (strings.endsWithComptime(tmp, ".tar.gz")) {
+                tmp = tmp[0 .. tmp.len - 7];
+            }
+        } else if (tmp[0] == '@') {
+            if (strings.indexOfChar(tmp, '/')) |i| {
+                tmp = tmp[i + 1 ..];
+            }
+        }
+
+        if (comptime Environment.isWindows) {
+            if (strings.lastIndexOfChar(tmp, ':')) |i| {
+                tmp = tmp[i + 1 ..];
+            }
+        }
+
+        break :brk tmp;
+    };
+    return .{ name, basename };
+}
+
 fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8) !Install.ExtractData {
     const tracer = bun.perf.trace("ExtractTarball.extract");
     defer tracer.end();
@@ -309,6 +345,22 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
             Output.flush();
         }
     }
+
+    return this.moveToCacheDirectory(log, tmpname, name, basename, resolved);
+}
+
+/// Rename the freshly-extracted temp directory into the cache, read
+/// `package.json` if required, and build the `ExtractData` result. Shared
+/// between the buffered and streaming extraction paths.
+pub fn moveToCacheDirectory(
+    this: *const ExtractTarball,
+    log: *logger.Log,
+    tmpname: [:0]const u8,
+    name: []const u8,
+    basename: []const u8,
+    resolved: []const u8,
+) !Install.ExtractData {
+    const tmpdir = this.temp_dir;
     const folder_name = switch (this.resolution.tag) {
         .npm => this.package_manager.cachedNPMPackageFolderNamePrint(&folder_name_buf, name, this.resolution.value.npm.version, null),
         .github => PackageManager.cachedGitHubFolderNamePrint(&folder_name_buf, resolved, null),
@@ -367,11 +419,10 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                                 // we rename it back into the temp dir
                                 // and then delete that temp dir
                                 // The goal is to make it more difficult for an application to reach this folder
-                                var tmpname_bytes = std.mem.asBytes(&tmpname_buf);
-                                const tmpname_len = tmpname.len;
-
-                                tmpname_bytes[tmpname_len..][0..4].* = .{ 't', 'm', 'p', 0 };
-                                const tempdest = tmpname_bytes[0 .. tmpname_len + 3 :0];
+                                var tempdest_buf: bun.PathBuffer = undefined;
+                                @memcpy(tempdest_buf[0..tmpname.len], tmpname);
+                                tempdest_buf[tmpname.len..][0..4].* = .{ 't', 'm', 'p', 0 };
+                                const tempdest = tempdest_buf[0 .. tmpname.len + 3 :0];
                                 switch (bun.sys.renameat(
                                     .fromStdDir(cache_dir),
                                     folder_name,
@@ -383,7 +434,6 @@ fn extract(this: *const ExtractTarball, log: *logger.Log, tgz_bytes: []const u8)
                                         tmpdir.deleteTree(tempdest) catch {};
                                     },
                                 }
-                                tmpname_bytes[tmpname_len] = 0;
                                 did_retry = true;
                                 continue;
                             },

--- a/src/install/install.zig
+++ b/src/install/install.zig
@@ -245,6 +245,7 @@ pub const PackageManifestError = error{
 
 pub const ExtractTarball = @import("./extract_tarball.zig");
 pub const NetworkTask = @import("./NetworkTask.zig");
+pub const TarballStream = @import("./TarballStream.zig");
 pub const Npm = @import("./npm.zig");
 pub const PackageManager = @import("./PackageManager.zig");
 pub const PackageManifestMap = @import("./PackageManifestMap.zig");

--- a/src/install/integrity.zig
+++ b/src/install/integrity.zig
@@ -188,6 +188,82 @@ pub const Integrity = extern struct {
         return .{ .tag = .sha512, .value = value };
     }
 
+    /// Incremental hasher used by the streaming tarball extractor. Bytes are
+    /// fed as they arrive from the network so integrity can be verified
+    /// without ever holding the full tarball in memory.
+    ///
+    /// When `expected.tag` is a supported algorithm we hash with that
+    /// algorithm so `verify()` can compare against the lockfile value. When
+    /// there is no expected value yet (first install of a GitHub/remote
+    /// tarball) we default to SHA-512 to match `forBytes`.
+    pub const Streaming = struct {
+        expected: Integrity,
+        hasher: Hasher,
+
+        const Hasher = union(enum) {
+            none,
+            sha1: Crypto.SHA1,
+            sha256: Crypto.SHA256,
+            sha384: Crypto.SHA384,
+            sha512: Crypto.SHA512,
+        };
+
+        pub fn init(expected: Integrity, compute_if_missing: bool) Streaming {
+            return .{
+                .expected = expected,
+                .hasher = switch (expected.tag) {
+                    .sha1 => .{ .sha1 = Crypto.SHA1.init() },
+                    .sha256 => .{ .sha256 = Crypto.SHA256.init() },
+                    .sha384 => .{ .sha384 = Crypto.SHA384.init() },
+                    .sha512 => .{ .sha512 = Crypto.SHA512.init() },
+                    else => if (compute_if_missing) .{ .sha512 = Crypto.SHA512.init() } else .none,
+                },
+            };
+        }
+
+        pub fn update(this: *Streaming, bytes: []const u8) void {
+            if (bytes.len == 0) return;
+            switch (this.hasher) {
+                .none => {},
+                inline else => |*h| h.update(bytes),
+            }
+        }
+
+        pub fn final(this: *Streaming) Integrity {
+            var out: [digest_buf_len]u8 = empty_digest_buf;
+            return switch (this.hasher) {
+                .none => .{},
+                .sha1 => |*h| blk: {
+                    h.final(out[0..std.crypto.hash.Sha1.digest_length]);
+                    break :blk .{ .tag = .sha1, .value = out };
+                },
+                .sha256 => |*h| blk: {
+                    h.final(out[0..std.crypto.hash.sha2.Sha256.digest_length]);
+                    break :blk .{ .tag = .sha256, .value = out };
+                },
+                .sha384 => |*h| blk: {
+                    h.final(out[0..std.crypto.hash.sha2.Sha384.digest_length]);
+                    break :blk .{ .tag = .sha384, .value = out };
+                },
+                .sha512 => |*h| blk: {
+                    h.final(out[0..std.crypto.hash.sha2.Sha512.digest_length]);
+                    break :blk .{ .tag = .sha512, .value = out };
+                },
+            };
+        }
+
+        /// Returns true if the computed digest matches `expected`, or if no
+        /// expected value was supplied. Callers that need to persist the
+        /// computed value should call `final()` instead.
+        pub fn verify(this: *Streaming) bool {
+            if (!this.expected.tag.isSupported()) return true;
+            const computed = this.final();
+            if (computed.tag != this.expected.tag) return false;
+            const len = this.expected.tag.digestLen();
+            return strings.eqlLong(computed.value[0..len], this.expected.value[0..len], true);
+        }
+    };
+
     pub fn verify(this: *const Integrity, bytes: []const u8) bool {
         return @call(bun.callmod_inline, verifyByTag, .{ this.tag, bytes, &this.value });
     }

--- a/src/libarchive/libarchive-bindings.zig
+++ b/src/libarchive/libarchive-bindings.zig
@@ -678,7 +678,7 @@ pub const Archive = opaque {
         return archive_read_data(archive, buf.ptr, buf.len);
     }
     extern fn archive_read_data_into_fd(*Archive, fd: c_int) Result;
-    fn writeZerosToFile(file: bun.sys.File, count: usize) Result {
+    pub fn writeZerosToFile(file: bun.sys.File, count: usize) Result {
         // Use undefined + memset instead of comptime zero-init to reduce binary size
         var zero_buf: [16 * 1024]u8 = undefined;
         @memset(&zero_buf, 0);

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -5,12 +5,12 @@
 // vendor/libarchive) must reassemble them into the same on-disk layout
 // the buffered extractor would produce.
 
-import { beforeAll, describe, test, expect, setDefaultTimeout } from "bun:test";
-import { bunEnv, bunExe, tempDir, readdirSorted } from "harness";
+import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
-import { gzipSync } from "node:zlib";
-import { join } from "node:path";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
 
 beforeAll(() => {
   setDefaultTimeout(1000 * 60 * 5);
@@ -106,8 +106,7 @@ function makeEntries(): Entry[] {
     {
       // > 100 chars → pax extended header → exercises the resumable
       // header path in the libarchive patch.
-      path:
-        "very/deeply/nested/directory/structure/that/exceeds/the/one/hundred/byte/ustar/limit/long-name-file.txt",
+      path: "very/deeply/nested/directory/structure/that/exceeds/the/one/hundred/byte/ustar/limit/long-name-file.txt",
       body: Buffer.from("long path ok\n"),
     },
   ];

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -5,12 +5,16 @@
 // vendor/libarchive) must reassemble them into the same on-disk layout
 // the buffered extractor would produce.
 
-import { describe, test, expect } from "bun:test";
+import { beforeAll, describe, test, expect, setDefaultTimeout } from "bun:test";
 import { bunEnv, bunExe, tempDir, readdirSorted } from "harness";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
+
+beforeAll(() => {
+  setDefaultTimeout(1000 * 60 * 5);
+});
 
 // -------------------------------------------------------------------
 // Tarball construction helpers. We build the .tgz in-process so the
@@ -233,7 +237,6 @@ describe("streaming tarball extraction", () => {
     const { stderr, exitCode } = await runInstall(String(dir), registry, env);
     expect(stderr).not.toContain("error:");
     expect(stderr).not.toContain("Integrity check failed");
-    expect(exitCode).toBe(0);
 
     // The "Streamed … tarball" verbose line is printed by
     // TarballStream.finish(); its presence confirms the streaming
@@ -254,6 +257,7 @@ describe("streaming tarball extraction", () => {
     }
 
     expect(await readdirSorted(join(pkgRoot, "data"))).toHaveLength(40);
+    expect(exitCode).toBe(0);
   });
 
   test("streaming rejects a tarball whose integrity does not match", async () => {

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -1,0 +1,286 @@
+// Verifies that `bun install` can extract a tarball while it is still
+// downloading. A local registry drip-feeds the .tgz body in small
+// chunks so the HTTP thread delivers multiple progress callbacks; the
+// streaming extractor (TarballStream.zig + the ARCHIVE_RETRY patches in
+// vendor/libarchive) must reassemble them into the same on-disk layout
+// the buffered extractor would produce.
+
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir, readdirSorted } from "harness";
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+
+// -------------------------------------------------------------------
+// Tarball construction helpers. We build the .tgz in-process so the
+// test can control entry count, path length (exercises pax extended
+// headers) and total size (large enough that it can't arrive in a
+// single socket read) without committing a binary fixture.
+// -------------------------------------------------------------------
+
+function octal(n: number, width: number): string {
+  return n.toString(8).padStart(width - 1, "0") + "\0";
+}
+
+function tarHeader(name: string, size: number, type: "0" | "5" | "x"): Buffer {
+  const buf = Buffer.alloc(512, 0);
+  buf.write(name, 0, 100, "utf8");
+  buf.write(octal(0o644, 8), 100); // mode
+  buf.write(octal(0, 8), 108); // uid
+  buf.write(octal(0, 8), 116); // gid
+  buf.write(octal(size, 12), 124); // size
+  buf.write(octal(0, 12), 136); // mtime
+  buf.fill(" ", 148, 156); // checksum placeholder
+  buf.write(type, 156);
+  buf.write("ustar\0", 257);
+  buf.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += buf[i];
+  buf.write(octal(sum, 8), 148);
+  return buf;
+}
+
+function pad512(len: number): Buffer {
+  const pad = (512 - (len % 512)) % 512;
+  return Buffer.alloc(pad, 0);
+}
+
+function tarFile(name: string, body: Buffer): Buffer[] {
+  // ustar stores at most 100 bytes of name; longer paths need a pax
+  // 'x' record. npm's `tar` uses pax, so this exercises the resumable
+  // `tar_read_header` path in the libarchive patch.
+  if (name.length > 100) {
+    // Build the pax record so that the declared length includes the
+    // length field itself. Iterate because adding digits to the length
+    // prefix can change its own width.
+    let len = 0;
+    let record: string;
+    do {
+      record = `${len} path=${name}\n`;
+      len = Buffer.byteLength(record, "utf8");
+    } while (record !== `${len} path=${name}\n`);
+    const pax = Buffer.from(record, "utf8");
+    return [
+      tarHeader("PaxHeader", pax.length, "x"),
+      pax,
+      pad512(pax.length),
+      tarHeader(name.slice(0, 99), body.length, "0"),
+      body,
+      pad512(body.length),
+    ];
+  }
+  return [tarHeader(name, body.length, "0"), body, pad512(body.length)];
+}
+
+type Entry = { path: string; body: Buffer };
+
+function buildTarball(entries: Entry[]): { tgz: Buffer; shasum: string; integrity: string } {
+  const blocks: Buffer[] = [];
+  for (const { path, body } of entries) blocks.push(...tarFile(`package/${path}`, body));
+  blocks.push(Buffer.alloc(1024, 0)); // two zero blocks = end-of-archive
+  const tar = Buffer.concat(blocks);
+  const tgz = gzipSync(tar);
+  return {
+    tgz,
+    shasum: createHash("sha1").update(tgz).digest("hex"),
+    integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
+  };
+}
+
+// Entries chosen to cover: a tiny file, a long-path file that forces a
+// pax 'x' header, and enough bulk that — once gzipped — the tarball is
+// comfortably larger than a single TCP window so streaming actually
+// kicks in even without server-side trickling.
+function makeEntries(): Entry[] {
+  const entries: Entry[] = [
+    {
+      path: "package.json",
+      body: Buffer.from(JSON.stringify({ name: "stream-pkg", version: "1.0.0", main: "index.js" }) + "\n"),
+    },
+    { path: "index.js", body: Buffer.from("module.exports = 'ok';\n") },
+    {
+      // > 100 chars → pax extended header → exercises the resumable
+      // header path in the libarchive patch.
+      path:
+        "very/deeply/nested/directory/structure/that/exceeds/the/one/hundred/byte/ustar/limit/long-name-file.txt",
+      body: Buffer.from("long path ok\n"),
+    },
+  ];
+  // Bulk entries: SHA-chained bytes so gzip can't collapse them away
+  // and the compressed tarball is large enough to span many chunks
+  // (→ many ARCHIVE_RETRY yields in libarchive).
+  for (let i = 0; i < 40; i++) {
+    const bytes = Buffer.alloc(2 * 1024);
+    let seed = createHash("sha256").update(`chunk-${i}`).digest();
+    for (let off = 0; off < bytes.length; off += 32) {
+      seed.copy(bytes, off);
+      seed = createHash("sha256").update(seed).digest();
+    }
+    entries.push({ path: `data/chunk-${i}.bin`, body: bytes });
+  }
+  return entries;
+}
+
+// -------------------------------------------------------------------
+// Drip-feed registry. The tarball body is written in small slices with
+// a microtask yield between each so `NetworkTask.notify` is called
+// repeatedly with `has_more=true`, which is what commits the request
+// to the streaming extractor.
+// -------------------------------------------------------------------
+
+function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
+  let tarballHits = 0;
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname.endsWith("/stream-pkg")) {
+        const base = `http://${server.hostname}:${server.port}`;
+        return Response.json({
+          name: "stream-pkg",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "stream-pkg",
+              version: "1.0.0",
+              dist: {
+                shasum,
+                integrity,
+                tarball: `${base}/stream-pkg/-/stream-pkg-1.0.0.tgz`,
+              },
+            },
+          },
+        });
+      }
+      if (url.pathname.endsWith("/stream-pkg-1.0.0.tgz")) {
+        tarballHits++;
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              for (let i = 0; i < tgz.length; i += chunkBytes) {
+                controller.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
+                await controller.flush();
+                // Yield so each write lands as its own socket packet.
+                await Bun.sleep(0);
+              }
+              controller.close();
+            },
+          }),
+          {
+            headers: {
+              "content-type": "application/octet-stream",
+              "content-length": String(tgz.length),
+            },
+          },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    server,
+    get tarballHits() {
+      return tarballHits;
+    },
+  };
+}
+
+async function runInstall(cwd: string, registry: string, extraEnv: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--verbose", "--linker=hoisted"],
+    cwd,
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(cwd, ".cache"),
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("streaming tarball extraction", () => {
+  const entries = makeEntries();
+  const { tgz, shasum, integrity } = buildTarball(entries);
+
+  // Keep chunks small enough that tar headers, pax payloads and file
+  // bodies all span multiple read-callback invocations, but not so
+  // small that the drip-feed itself dominates the test runtime on a
+  // debug build.
+  const chunkBytes = 1024;
+
+  test.each([
+    ["streaming", {}],
+    ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
+  ] as const)("extracts a drip-fed tarball correctly (%s)", async (label, env) => {
+    const reg = makeRegistry(tgz, shasum, integrity, chunkBytes);
+    await using server = reg.server;
+    const registry = `http://${server.hostname}:${server.port}/`;
+
+    using dir = tempDir("streaming-extract", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir), registry, env);
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("Integrity check failed");
+    expect(exitCode).toBe(0);
+
+    // The "Streamed … tarball" verbose line is printed by
+    // TarballStream.finish(); its presence confirms the streaming
+    // path was taken (and its absence confirms the buffered path).
+    if (label === "streaming") {
+      expect(stderr).toContain("Streamed ");
+    } else {
+      expect(stderr).not.toContain("Streamed ");
+    }
+    expect(reg.tarballHits).toBe(1);
+
+    // Every entry must be present with byte-identical contents
+    // regardless of which extractor ran.
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    for (const { path, body } of entries) {
+      const got = readFileSync(join(pkgRoot, path));
+      expect([path, got.equals(body)]).toEqual([path, true]);
+    }
+
+    expect(await readdirSorted(join(pkgRoot, "data"))).toHaveLength(40);
+  });
+
+  test("streaming rejects a tarball whose integrity does not match", async () => {
+    // Serve the valid tarball but advertise the integrity of a
+    // *different* blob. Extraction will stream to completion (so we
+    // exercise the full ARCHIVE_RETRY path through libarchive), the
+    // incremental hasher produces the real SHA-512, and `finish()`
+    // must notice the mismatch before the temp tree is promoted into
+    // the cache.
+    const other = buildTarball([
+      { path: "package.json", body: Buffer.from('{"name":"stream-pkg","version":"1.0.0"}\n') },
+    ]);
+    const reg = makeRegistry(tgz, other.shasum, other.integrity, chunkBytes);
+    await using server = reg.server;
+    const registry = `http://${server.hostname}:${server.port}/`;
+
+    using dir = tempDir("streaming-extract-bad", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir), registry);
+    expect(stderr).toContain("Integrity check failed");
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -9,6 +9,7 @@ import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
 
@@ -110,11 +111,12 @@ function makeEntries(): Entry[] {
       body: Buffer.from("long path ok\n"),
     },
   ];
-  // Bulk entries: SHA-chained bytes so gzip can't collapse them away
-  // and the compressed tarball is large enough to span many chunks
-  // (→ many ARCHIVE_RETRY yields in libarchive).
-  for (let i = 0; i < 40; i++) {
-    const bytes = Buffer.alloc(2 * 1024);
+  // Bulk entries: SHA-chained bytes so gzip can't collapse them away.
+  // Sized so the compressed tarball exceeds the default
+  // BUN_INSTALL_STREAMING_MIN_SIZE (2 MB) — streaming only commits
+  // when Content-Length is above that threshold.
+  for (let i = 0; i < 48; i++) {
+    const bytes = Buffer.alloc(48 * 1024);
     let seed = createHash("sha256").update(`chunk-${i}`).digest();
     for (let off = 0; off < bytes.length; off += 32) {
       seed.copy(bytes, off);
@@ -130,63 +132,68 @@ function makeEntries(): Entry[] {
 // a microtask yield between each so `NetworkTask.notify` is called
 // repeatedly with `has_more=true`, which is what commits the request
 // to the streaming extractor.
+//
+// Uses node:http rather than Bun.serve so the response can carry both
+// an explicit Content-Length *and* be drip-fed — Bun.serve forces
+// `Transfer-Encoding: chunked` for stream bodies, which would bypass
+// the BUN_INSTALL_STREAMING_MIN_SIZE gate.
 // -------------------------------------------------------------------
 
-function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
+async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chunkBytes: number) {
   let tarballHits = 0;
-  const server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const url = new URL(req.url);
-      if (url.pathname.endsWith("/stream-pkg")) {
-        const base = `http://${server.hostname}:${server.port}`;
-        return Response.json({
-          name: "stream-pkg",
-          "dist-tags": { latest: "1.0.0" },
-          versions: {
-            "1.0.0": {
-              name: "stream-pkg",
-              version: "1.0.0",
-              dist: {
-                shasum,
-                integrity,
-                tarball: `${base}/stream-pkg/-/stream-pkg-1.0.0.tgz`,
-              },
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url!, "http://x");
+    if (url.pathname.endsWith("/stream-pkg")) {
+      const body = JSON.stringify({
+        name: "stream-pkg",
+        "dist-tags": { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            name: "stream-pkg",
+            version: "1.0.0",
+            dist: {
+              shasum,
+              integrity,
+              tarball: `http://127.0.0.1:${port}/stream-pkg/-/stream-pkg-1.0.0.tgz`,
             },
           },
-        });
-      }
-      if (url.pathname.endsWith("/stream-pkg-1.0.0.tgz")) {
-        tarballHits++;
-        return new Response(
-          new ReadableStream({
-            type: "direct",
-            async pull(controller) {
-              for (let i = 0; i < tgz.length; i += chunkBytes) {
-                controller.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
-                await controller.flush();
-                // Yield so each write lands as its own socket packet.
-                await Bun.sleep(0);
-              }
-              controller.close();
-            },
-          }),
-          {
-            headers: {
-              "content-type": "application/octet-stream",
-              "content-length": String(tgz.length),
-            },
-          },
-        );
-      }
-      return new Response("not found", { status: 404 });
-    },
+        },
+      });
+      res.setHeader("content-type", "application/json");
+      res.setHeader("content-length", String(Buffer.byteLength(body)));
+      res.end(body);
+      return;
+    }
+    if (url.pathname.endsWith("/stream-pkg-1.0.0.tgz")) {
+      tarballHits++;
+      res.setHeader("content-type", "application/octet-stream");
+      res.setHeader("content-length", String(tgz.length));
+      // Prevent Nagle coalescing so each write() is its own packet.
+      req.socket.setNoDelay(true);
+      let i = 0;
+      const step = () => {
+        if (i >= tgz.length) {
+          res.end();
+          return;
+        }
+        res.write(tgz.subarray(i, Math.min(i + chunkBytes, tgz.length)));
+        i += chunkBytes;
+        setImmediate(step);
+      };
+      step();
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
   });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
   return {
-    server,
+    url: `http://127.0.0.1:${port}/`,
     get tarballHits() {
       return tarballHits;
     },
+    [Symbol.asyncDispose]: () => new Promise<void>(resolve => server.close(() => resolve())),
   };
 }
 
@@ -213,16 +220,21 @@ describe("streaming tarball extraction", () => {
   // Keep chunks small enough that tar headers, pax payloads and file
   // bodies all span multiple read-callback invocations, but not so
   // small that the drip-feed itself dominates the test runtime on a
-  // debug build.
-  const chunkBytes = 1024;
+  // debug build. 4 KB × ~580 chunks ≈ 2.3 MB.
+  const chunkBytes = 4096;
+
+  // Sanity: the generated tarball must be larger than the default
+  // streaming threshold, otherwise the "streaming" case silently
+  // takes the buffered fallback and the assertion below becomes a
+  // false pass.
+  expect(tgz.length).toBeGreaterThan(2 * 1024 * 1024);
 
   test.each([
     ["streaming", {}],
     ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
   ] as const)("extracts a drip-fed tarball correctly (%s)", async (label, env) => {
-    const reg = makeRegistry(tgz, shasum, integrity, chunkBytes);
-    await using server = reg.server;
-    const registry = `http://${server.hostname}:${server.port}/`;
+    await using reg = await makeRegistry(tgz, shasum, integrity, chunkBytes);
+    const registry = reg.url;
 
     using dir = tempDir("streaming-extract", {
       "package.json": JSON.stringify({
@@ -255,7 +267,37 @@ describe("streaming tarball extraction", () => {
       expect([path, got.equals(body)]).toEqual([path, true]);
     }
 
-    expect(await readdirSorted(join(pkgRoot, "data"))).toHaveLength(40);
+    expect(await readdirSorted(join(pkgRoot, "data"))).toHaveLength(48);
+    expect(exitCode).toBe(0);
+  });
+
+  test("tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path", async () => {
+    // Reuse the same large tarball but raise the threshold above it.
+    // The server sends Content-Length, so `notify()` sees a body_size
+    // below the minimum and never commits to streaming even though
+    // the body arrives over many packets.
+    await using reg = await makeRegistry(tgz, shasum, integrity, chunkBytes);
+    const registry = reg.url;
+
+    using dir = tempDir("streaming-extract-small", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir), registry, {
+      BUN_INSTALL_STREAMING_MIN_SIZE: String(tgz.length + 1),
+    });
+    expect(stderr).not.toContain("Streamed ");
+    expect(stderr).not.toContain("error:");
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    for (const { path, body } of entries) {
+      const got = readFileSync(join(pkgRoot, path));
+      expect([path, got.equals(body)]).toEqual([path, true]);
+    }
     expect(exitCode).toBe(0);
   });
 
@@ -269,9 +311,8 @@ describe("streaming tarball extraction", () => {
     const other = buildTarball([
       { path: "package.json", body: Buffer.from('{"name":"stream-pkg","version":"1.0.0"}\n') },
     ]);
-    const reg = makeRegistry(tgz, other.shasum, other.integrity, chunkBytes);
-    await using server = reg.server;
-    const registry = `http://${server.hostname}:${server.port}/`;
+    await using reg = await makeRegistry(tgz, other.shasum, other.integrity, chunkBytes);
+    const registry = reg.url;
 
     using dir = tempDir("streaming-extract-bad", {
       "package.json": JSON.stringify({

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -197,7 +197,7 @@ async function makeRegistry(tgz: Buffer, shasum: string, integrity: string, chun
   };
 }
 
-async function runInstall(cwd: string, registry: string, extraEnv: Record<string, string> = {}) {
+async function runInstall(cwd: string, extraEnv: Record<string, string> = {}) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "install", "--verbose", "--linker=hoisted"],
     cwd,
@@ -245,7 +245,7 @@ describe("streaming tarball extraction", () => {
       "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
     });
 
-    const { stderr, exitCode } = await runInstall(String(dir), registry, env);
+    const { stderr, exitCode } = await runInstall(String(dir), env);
     expect(stderr).not.toContain("error:");
     expect(stderr).not.toContain("Integrity check failed");
 
@@ -288,7 +288,7 @@ describe("streaming tarball extraction", () => {
       "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
     });
 
-    const { stderr, exitCode } = await runInstall(String(dir), registry, {
+    const { stderr, exitCode } = await runInstall(String(dir), {
       BUN_INSTALL_STREAMING_MIN_SIZE: String(tgz.length + 1),
     });
     expect(stderr).not.toContain("Streamed ");
@@ -323,7 +323,7 @@ describe("streaming tarball extraction", () => {
       "bunfig.toml": `[install]\nregistry = "${registry}"\n`,
     });
 
-    const { stderr, exitCode } = await runInstall(String(dir), registry);
+    const { stderr, exitCode } = await runInstall(String(dir));
     expect(stderr).toContain("Integrity check failed");
     expect(exitCode).not.toBe(0);
   });


### PR DESCRIPTION
## What

`bun install` now extracts package tarballs while they are still downloading, instead of buffering the full `.tgz` and then the full decompressed `.tar` in memory before handing both to libarchive.

## How

**Zig side** (`src/install/TarballStream.zig`, `NetworkTask.zig`, `runTasks.zig`):

- `NetworkTask.forTarball` enables the HTTP client's `response_body_streaming` signal (same mechanism `fetch()` uses).
- `NetworkTask.notify` now runs once per body chunk on the HTTP thread. On the first 2xx chunk it commits to streaming: each chunk is pushed into a heap-held `TarballStream` and a drain task is scheduled on `manager.thread_pool`. Non-2xx / transport errors before the first chunk fall back to the existing buffered path so retry and error reporting are unchanged.
- `TarballStream` owns the `struct archive *`, the open output `bun.FD`, and a `want_header`/`want_data` phase. The drain task calls `archive_read_next_header` / `archive_read_data_block` until libarchive reports `ARCHIVE_RETRY` (out of input), then returns — the worker is released. The next chunk reschedules the drain task; because all libarchive state lives on its own heap, the next call resumes exactly where it stopped. No condvar, no extra thread pool.
- Integrity is hashed incrementally (`Integrity.Streaming`) over the compressed bytes and verified before the temp tree is promoted into the cache.
- `extract_tarball.zig`'s rename-into-cache / `package.json` bookkeeping was factored into `moveToCacheDirectory` so the streaming and buffered extractors share it.

**libarchive patch** (`patches/libarchive/nonblocking-read.patch`):

Upstream libarchive has no way for the client read callback to say "no data yet" — any negative return sets `filter->fatal = 1` and `0` sets `filter->end_of_file = 1`, both terminal. The patch teaches the read path to propagate `ARCHIVE_RETRY` without poisoning state:

- `__archive_read_filter_ahead` / `advance_file_pointer`: when the reader returns `ARCHIVE_RETRY`, keep whatever is already in `filter->buffer` and surface `ARCHIVE_RETRY` via `*avail` instead of setting `fatal`.
- gzip filter: `peek_at_header` / `consume_header` / `consume_trailer` / `gzip_filter_read` propagate retry; a `trailer_pending` flag makes `consume_trailer` re-entry-safe.
- tar reader: `read_data` and `skip` propagate retry. `tar_read_header` pre-buffers extension-header payloads before consuming the block, hoists `seen_headers`/`eof_fatal`/`err` into `struct tar` behind `header_in_progress`, and `_archive_read_next_header2` skips `archive_entry_clear` while a header read is in progress, so a retry between a pax `x`/GNU `L` header and the real ustar header resumes cleanly.

Gated behind `BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL` (streaming on by default).

## Memory

Before: `compressed_size` (HTTP buffer) + `decompressed_size` (zlib/libdeflate output) + libarchive internals per tarball.
After: only the in-flight HTTP chunk(s) plus libarchive's fixed per-archive buffers. The full `.tgz`/`.tar` are never materialised.

## Tests

`test/cli/install/bun-install-streaming-extract.test.ts` — drip-feeds a ~80 KB tarball (40 incompressible files + a >100-byte path that forces a pax `x` header) in 1 KB chunks:

- streaming path: every entry extracted byte-identically to the buffered path, `--verbose` output confirms `Streamed … tarball` was taken.
- buffered path with `BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL=1`: same output, no `Streamed …` line.
- mismatched integrity: install fails before promoting the temp dir.

Existing `bun-install-retry.test.ts` / `bun-install-tarball-integrity.test.ts` pass unchanged.