### PR TITLE
fix: add cgroup memory awareness to prevent OOM kills in containers

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3091,9 +3091,15 @@ static Process* getProcessObject(JSC::JSGlobalObject* lexicalGlobalObject, JSVal
     return process;
 }
 
+extern "C" uint64_t Bun__cgroup__getMemoryLimit();
 JSC_DEFINE_HOST_FUNCTION(Process_functionConstrainedMemory, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    return JSValue::encode(jsNumber(WTF::ramSize()));
+    // Issue #17723: Return the actual cgroup memory limit when running inside
+    // a Docker/Kubernetes container, instead of the total system RAM.
+    // Frameworks like Next.js call this to auto-size their caches.
+    uint64_t limit = Bun__cgroup__getMemoryLimit();
+    if (limit == 0) limit = WTF::ramSize();
+    return JSValue::encode(jsNumber(limit));
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -30,6 +30,13 @@ gc_timer_interval: i32 = 0,
 gc_repeating_timer_fast: bool = true,
 disabled: bool = false,
 
+/// Container memory awareness (Issue #17723)
+/// When running inside a Docker/Kubernetes container with a cgroup memory limit,
+/// these fields enable RSS-based GC pressure thresholds that prevent OOM kills.
+cgroup_memory_limit: ?usize = null,
+cgroup_pressure_threshold: usize = 0, // 75% of limit — trigger async GC
+cgroup_critical_threshold: usize = 0, // 85% of limit — trigger sync full GC
+
 pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     const actual = uws.Loop.get();
     this.gc_timer = uws.Timer.createFallthrough(actual, this);
@@ -61,6 +68,21 @@ pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     }
 
     this.disabled = vm.transpiler.env.has("BUN_GC_TIMER_DISABLE");
+
+    // Container memory awareness (Issue #17723)
+    // Detect cgroup memory limit to enable RSS-based GC pressure thresholds.
+    if (bun.cgroup.getCachedMemoryLimit()) |limit| {
+        this.cgroup_memory_limit = limit;
+        this.cgroup_pressure_threshold = limit * 3 / 4; // 75%
+        this.cgroup_critical_threshold = limit * 85 / 100; // 85%
+
+        // In containers, force mimalloc to return freed pages to the OS immediately
+        // instead of caching them for 1000ms (default). This prevents RSS from
+        // staying elevated after GC, which would cause Kubernetes to OOM-kill.
+        if (comptime bun.use_mimalloc) {
+            bun.mimalloc.mi_option_set(.purge_delay, 0);
+        }
+    }
 
     if (!this.disabled)
         this.gc_repeating_timer.set(this, onGCRepeatingTimer, gc_timer_interval, gc_timer_interval);
@@ -98,6 +120,10 @@ pub fn onGCTimer(timer: *uws.Timer) callconv(.c) void {
 // When the heap size is increasing, we always switch to fast mode
 // When the heap size has been the same or less for 30 seconds, we switch to slow mode
 pub fn updateGCRepeatTimer(this: *GarbageCollectionController, comptime setting: @Type(.enum_literal)) void {
+    // Never switch to slow mode inside containers — we need frequent RSS checks
+    // to prevent OOM kills (Issue #17723).
+    if (this.cgroup_memory_limit != null and setting == .slow) return;
+
     if (setting == .fast and !this.gc_repeating_timer_fast) {
         this.gc_repeating_timer_fast = true;
         this.gc_repeating_timer.set(this, onGCRepeatingTimer, this.gc_timer_interval, this.gc_timer_interval);
@@ -111,6 +137,12 @@ pub fn updateGCRepeatTimer(this: *GarbageCollectionController, comptime setting:
 
 pub fn onGCRepeatingTimer(timer: *uws.Timer) callconv(.c) void {
     var this = timer.as(*GarbageCollectionController);
+
+    // Container-aware RSS pressure check (Issue #17723)
+    if (this.cgroup_memory_limit != null) {
+        this.checkContainerMemoryPressure();
+    }
+
     const prev_heap_size = this.gc_last_heap_size_on_repeating_timer;
     this.performGC();
     this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
@@ -172,6 +204,38 @@ pub fn performGC(this: *GarbageCollectionController) void {
     var vm = this.bunVM().jsc_vm;
     vm.collectAsync();
     this.gc_last_heap_size = vm.blockBytesAllocated();
+}
+
+/// Check RSS against container memory thresholds and trigger aggressive GC
+/// when approaching the cgroup limit. This is the core fix for Issue #17723.
+///
+/// At 75% of the limit: trigger async GC + partial mimalloc purge
+/// At 85% of the limit: trigger synchronous full GC + forced mimalloc purge
+fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
+    const rss = bun.cgroup.getCurrentRSS();
+    if (rss == 0) return;
+
+    if (rss > this.cgroup_critical_threshold) {
+        // CRITICAL: RSS is above 85% of the container limit.
+        // Run a synchronous full GC immediately and force mimalloc to
+        // return all freed pages to the OS.
+        var vm = this.bunVM().jsc_vm;
+        _ = vm.runGC(true);
+        vm.shrinkFootprint();
+        if (comptime bun.use_mimalloc) {
+            bun.mimalloc.mi_collect(true);
+        }
+        this.gc_last_heap_size = vm.blockBytesAllocated();
+    } else if (rss > this.cgroup_pressure_threshold) {
+        // PRESSURE: RSS is above 75% of the container limit.
+        // Run an async GC and do a partial mimalloc purge.
+        var vm = this.bunVM().jsc_vm;
+        vm.collectAsync();
+        if (comptime bun.use_mimalloc) {
+            bun.mimalloc.mi_collect(false);
+        }
+        this.gc_last_heap_size = vm.blockBytesAllocated();
+    }
 }
 
 pub const GCTimerState = enum {

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -36,6 +36,7 @@ disabled: bool = false,
 cgroup_memory_limit: ?usize = null,
 cgroup_pressure_threshold: usize = 0, // 75% of limit — trigger async GC
 cgroup_critical_threshold: usize = 0, // 85% of limit — trigger sync full GC
+    cgroup_last_critical_gc: i64 = 0, // timestamp of last critical GC (5s cooldown)
 
 pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     const actual = uws.Loop.get();
@@ -79,8 +80,9 @@ pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
         // In containers, force mimalloc to return freed pages to the OS immediately
         // instead of caching them for 1000ms (default). This prevents RSS from
         // staying elevated after GC, which would cause Kubernetes to OOM-kill.
+        // Uses std.once to set this process-wide exactly once, even with Workers.
         if (comptime bun.use_mimalloc) {
-            bun.mimalloc.mi_option_set(.purge_delay, 0);
+            mimalloc_purge_once.call();
         }
     }
 
@@ -211,6 +213,10 @@ pub fn performGC(this: *GarbageCollectionController) void {
 ///
 /// At 75% of the limit: trigger async GC + partial mimalloc purge
 /// At 85% of the limit: trigger synchronous full GC + forced mimalloc purge
+///
+/// Note: Each Worker has its own VirtualMachine with its own GarbageCollectionController.
+/// RSS is process-wide, so multiple Workers may detect pressure simultaneously.
+/// The 5-second cooldown on the critical path prevents compounding pause time.
 fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
     const rss = bun.cgroup.getCurrentRSS();
     if (rss == 0) return;
@@ -219,6 +225,12 @@ fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
         // CRITICAL: RSS is above 85% of the container limit.
         // Run a synchronous full GC immediately and force mimalloc to
         // return all freed pages to the OS.
+        // Cooldown: skip if we already ran a critical GC within the last 5 seconds
+        // to avoid compounding event-loop pause time.
+        const now = std.time.milliTimestamp();
+        if (now - this.cgroup_last_critical_gc < 5000) return;
+        this.cgroup_last_critical_gc = now;
+
         var vm = this.bunVM().jsc_vm;
         _ = vm.runGC(true);
         vm.shrinkFootprint();
@@ -237,6 +249,12 @@ fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
         this.gc_last_heap_size = vm.blockBytesAllocated();
     }
 }
+
+var mimalloc_purge_once = std.once(struct {
+    fn set() void {
+        bun.mimalloc.mi_option_set(.purge_delay, 0);
+    }
+}.set);
 
 pub const GCTimerState = enum {
     pending,

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -14,6 +14,8 @@
 //! - Adaptive timing based on heap growth patterns
 //! - Configurable intervals via BUN_GC_TIMER_INTERVAL environment variable
 //! - Can be disabled via BUN_GC_TIMER_DISABLE for debugging/testing
+//! - Reports mimalloc committed memory to JSC so the GC doubling heuristic
+//!   accounts for native allocations (Issue #17723)
 //!
 //! Thread Safety: This type must be unique per JavaScript thread and is not
 //! thread-safe. Each VirtualMachine instance should have its own controller.
@@ -29,14 +31,6 @@ gc_repeating_timer: *uws.Timer = undefined,
 gc_timer_interval: i32 = 0,
 gc_repeating_timer_fast: bool = true,
 disabled: bool = false,
-
-/// Container memory awareness (Issue #17723)
-/// When running inside a Docker/Kubernetes container with a cgroup memory limit,
-/// these fields enable RSS-based GC pressure thresholds that prevent OOM kills.
-cgroup_memory_limit: ?usize = null,
-cgroup_pressure_threshold: usize = 0, // 75% of limit — trigger async GC
-cgroup_critical_threshold: usize = 0, // 85% of limit — trigger sync full GC
-    cgroup_last_critical_gc: i64 = 0, // timestamp of last critical GC (5s cooldown)
 
 pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     const actual = uws.Loop.get();
@@ -71,16 +65,11 @@ pub fn init(this: *GarbageCollectionController, vm: *VirtualMachine) void {
     this.disabled = vm.transpiler.env.has("BUN_GC_TIMER_DISABLE");
 
     // Container memory awareness (Issue #17723)
-    // Detect cgroup memory limit to enable RSS-based GC pressure thresholds.
-    if (bun.cgroup.getCachedMemoryLimit()) |limit| {
-        this.cgroup_memory_limit = limit;
-        this.cgroup_pressure_threshold = limit * 3 / 4; // 75%
-        this.cgroup_critical_threshold = limit * 85 / 100; // 85%
-
-        // In containers, force mimalloc to return freed pages to the OS immediately
-        // instead of caching them for 1000ms (default). This prevents RSS from
-        // staying elevated after GC, which would cause Kubernetes to OOM-kill.
-        // Uses std.once to set this process-wide exactly once, even with Workers.
+    // When running in a cgroup-constrained container, force mimalloc to return
+    // freed pages to the OS immediately instead of caching them for 1000ms.
+    // This prevents RSS from staying elevated after GC, which would cause
+    // Kubernetes/Docker to OOM-kill the process.
+    if (bun.cgroup.getCachedMemoryLimit() != null) {
         if (comptime bun.use_mimalloc) {
             mimalloc_purge_once.call();
         }
@@ -100,58 +89,69 @@ pub fn scheduleGCTimer(this: *GarbageCollectionController) void {
     this.gc_timer.set(this, onGCTimer, 16, 0);
 }
 
-pub fn bunVM(this: *GarbageCollectionController) *VirtualMachine {
-    return @alignCast(@fieldParentPtr("gc_controller", this));
+pub fn updateGCRepeatTimer(this: *GarbageCollectionController, comptime which: enum { fast, slow }) void {
+    const interval = switch (which) {
+        .fast => this.gc_timer_interval,
+        .slow => this.gc_timer_interval * 4,
+    };
+
+    if (this.gc_repeating_timer_fast != (which == .fast)) {
+        this.gc_repeating_timer_fast = (which == .fast);
+        this.gc_repeating_timer.set(this, onGCRepeatingTimer, interval, interval);
+    }
 }
 
 pub fn onGCTimer(timer: *uws.Timer) callconv(.c) void {
-    var this = timer.as(*GarbageCollectionController);
-    if (this.disabled) return;
-    this.gc_timer_state = .run_on_next_tick;
+    timer.as(*GarbageCollectionController).processGCTimer();
 }
 
-// We want to always run GC once in awhile
-// But if you have a long-running instance of Bun, you don't want the
-// program constantly using CPU doing GC for no reason
-//
-// So we have two settings for this GC timer:
-//
-//    - Fast: GC runs every 1 second
-//    - Slow: GC runs every 30 seconds
-//
-// When the heap size is increasing, we always switch to fast mode
-// When the heap size has been the same or less for 30 seconds, we switch to slow mode
-pub fn updateGCRepeatTimer(this: *GarbageCollectionController, comptime setting: @Type(.enum_literal)) void {
-    // Never switch to slow mode inside containers — we need frequent RSS checks
-    // to prevent OOM kills (Issue #17723).
-    if (this.cgroup_memory_limit != null and setting == .slow) return;
+/// Get the effective heap size by combining JSC's blockBytesAllocated with
+/// mimalloc's committed memory. This is the core fix for Issue #17723:
+/// without this, JSC only sees its own managed heap, so the GC doubling
+/// heuristic never triggers even when native/mimalloc memory is consuming
+/// most of the container's memory budget.
+fn getEffectiveHeapSize(vm: *jsc.VM) usize {
+    var heap_size = vm.blockBytesAllocated();
 
-    if (setting == .fast and !this.gc_repeating_timer_fast) {
-        this.gc_repeating_timer_fast = true;
-        this.gc_repeating_timer.set(this, onGCRepeatingTimer, this.gc_timer_interval, this.gc_timer_interval);
-        this.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
-    } else if (setting == .slow and this.gc_repeating_timer_fast) {
-        this.gc_repeating_timer_fast = false;
-        this.gc_repeating_timer.set(this, onGCRepeatingTimer, 30_000, 30_000);
-        this.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
+    if (comptime bun.use_mimalloc) {
+        // mi_process_info gives us committed bytes which reflects the actual
+        // virtual memory mimalloc has committed (backed by physical pages).
+        // This is the most accurate measure of mimalloc's memory footprint.
+        var elapsed_msecs: usize = 0;
+        var user_msecs: usize = 0;
+        var system_msecs: usize = 0;
+        var current_rss: usize = 0;
+        var peak_rss: usize = 0;
+        var current_commit: usize = 0;
+        var peak_commit: usize = 0;
+        var page_faults: usize = 0;
+
+        bun.mimalloc.mi_process_info(
+            &elapsed_msecs,
+            &user_msecs,
+            &system_msecs,
+            &current_rss,
+            &peak_rss,
+            &current_commit,
+            &peak_commit,
+            &page_faults,
+        );
+
+        // Use the larger of JSC's reported heap and mimalloc's committed memory.
+        // This ensures the GC doubling heuristic sees the true memory pressure.
+        if (current_commit > heap_size) {
+            heap_size = current_commit;
+        }
     }
+
+    return heap_size;
 }
 
 pub fn onGCRepeatingTimer(timer: *uws.Timer) callconv(.c) void {
     var this = timer.as(*GarbageCollectionController);
 
-    // Container-aware RSS pressure check (Issue #17723)
-    // If pressure was detected and GC was already triggered, skip the normal
-    // performGC() to avoid running GC twice on the same tick.
-    const pressure_gc_ran = if (this.cgroup_memory_limit != null)
-        this.checkContainerMemoryPressure()
-    else
-        false;
-
     const prev_heap_size = this.gc_last_heap_size_on_repeating_timer;
-    if (!pressure_gc_ran) {
-        this.performGC();
-    }
+    this.performGC();
     this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
     if (prev_heap_size == this.gc_last_heap_size_on_repeating_timer) {
         this.heap_size_didnt_change_for_repeating_timer_ticks_count +|= 1;
@@ -168,7 +168,7 @@ pub fn onGCRepeatingTimer(timer: *uws.Timer) callconv(.c) void {
 pub fn processGCTimer(this: *GarbageCollectionController) void {
     if (this.disabled) return;
     var vm = this.bunVM().jsc_vm;
-    this.processGCTimerWithHeapSize(vm, vm.blockBytesAllocated());
+    this.processGCTimerWithHeapSize(vm, getEffectiveHeapSize(vm));
 }
 
 fn processGCTimerWithHeapSize(this: *GarbageCollectionController, vm: *jsc.VM, this_heap_size: usize) void {
@@ -210,53 +210,7 @@ pub fn performGC(this: *GarbageCollectionController) void {
     if (this.disabled) return;
     var vm = this.bunVM().jsc_vm;
     vm.collectAsync();
-    this.gc_last_heap_size = vm.blockBytesAllocated();
-}
-
-/// Check RSS against container memory thresholds and trigger aggressive GC
-/// when approaching the cgroup limit. This is the core fix for Issue #17723.
-///
-/// At 75% of the limit: trigger async GC + partial mimalloc purge
-/// At 85% of the limit: trigger synchronous full GC + forced mimalloc purge
-///
-/// Note: Each Worker has its own VirtualMachine with its own GarbageCollectionController.
-/// RSS is process-wide, so multiple Workers may detect pressure simultaneously.
-/// The 5-second cooldown on the critical path prevents compounding pause time.
-/// Returns true if GC was triggered (so the caller can skip its own performGC).
-fn checkContainerMemoryPressure(this: *GarbageCollectionController) bool {
-    const rss = bun.cgroup.getCurrentRSS();
-    if (rss == 0) return false;
-
-    if (rss > this.cgroup_critical_threshold) {
-        // CRITICAL: RSS is above 85% of the container limit.
-        // Run a synchronous full GC immediately and force mimalloc to
-        // return all freed pages to the OS.
-        // Cooldown: skip if we already ran a critical GC within the last 5 seconds
-        // to avoid compounding event-loop pause time.
-        const now = std.time.milliTimestamp();
-        if (now - this.cgroup_last_critical_gc < 5000) return false;
-        this.cgroup_last_critical_gc = now;
-
-        var vm = this.bunVM().jsc_vm;
-        _ = vm.runGC(true);
-        vm.shrinkFootprint();
-        if (comptime bun.use_mimalloc) {
-            bun.mimalloc.mi_collect(true);
-        }
-        this.gc_last_heap_size = vm.blockBytesAllocated();
-        return true;
-    } else if (rss > this.cgroup_pressure_threshold) {
-        // PRESSURE: RSS is above 75% of the container limit.
-        // Run an async GC and do a partial mimalloc purge.
-        var vm = this.bunVM().jsc_vm;
-        vm.collectAsync();
-        if (comptime bun.use_mimalloc) {
-            bun.mimalloc.mi_collect(false);
-        }
-        this.gc_last_heap_size = vm.blockBytesAllocated();
-        return true;
-    }
-    return false;
+    this.gc_last_heap_size = getEffectiveHeapSize(vm);
 }
 
 var mimalloc_purge_once = std.once(struct {

--- a/src/bun.js/event_loop/GarbageCollectionController.zig
+++ b/src/bun.js/event_loop/GarbageCollectionController.zig
@@ -141,12 +141,17 @@ pub fn onGCRepeatingTimer(timer: *uws.Timer) callconv(.c) void {
     var this = timer.as(*GarbageCollectionController);
 
     // Container-aware RSS pressure check (Issue #17723)
-    if (this.cgroup_memory_limit != null) {
-        this.checkContainerMemoryPressure();
-    }
+    // If pressure was detected and GC was already triggered, skip the normal
+    // performGC() to avoid running GC twice on the same tick.
+    const pressure_gc_ran = if (this.cgroup_memory_limit != null)
+        this.checkContainerMemoryPressure()
+    else
+        false;
 
     const prev_heap_size = this.gc_last_heap_size_on_repeating_timer;
-    this.performGC();
+    if (!pressure_gc_ran) {
+        this.performGC();
+    }
     this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
     if (prev_heap_size == this.gc_last_heap_size_on_repeating_timer) {
         this.heap_size_didnt_change_for_repeating_timer_ticks_count +|= 1;
@@ -217,9 +222,10 @@ pub fn performGC(this: *GarbageCollectionController) void {
 /// Note: Each Worker has its own VirtualMachine with its own GarbageCollectionController.
 /// RSS is process-wide, so multiple Workers may detect pressure simultaneously.
 /// The 5-second cooldown on the critical path prevents compounding pause time.
-fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
+/// Returns true if GC was triggered (so the caller can skip its own performGC).
+fn checkContainerMemoryPressure(this: *GarbageCollectionController) bool {
     const rss = bun.cgroup.getCurrentRSS();
-    if (rss == 0) return;
+    if (rss == 0) return false;
 
     if (rss > this.cgroup_critical_threshold) {
         // CRITICAL: RSS is above 85% of the container limit.
@@ -228,7 +234,7 @@ fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
         // Cooldown: skip if we already ran a critical GC within the last 5 seconds
         // to avoid compounding event-loop pause time.
         const now = std.time.milliTimestamp();
-        if (now - this.cgroup_last_critical_gc < 5000) return;
+        if (now - this.cgroup_last_critical_gc < 5000) return false;
         this.cgroup_last_critical_gc = now;
 
         var vm = this.bunVM().jsc_vm;
@@ -238,6 +244,7 @@ fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
             bun.mimalloc.mi_collect(true);
         }
         this.gc_last_heap_size = vm.blockBytesAllocated();
+        return true;
     } else if (rss > this.cgroup_pressure_threshold) {
         // PRESSURE: RSS is above 75% of the container limit.
         // Run an async GC and do a partial mimalloc purge.
@@ -247,7 +254,9 @@ fn checkContainerMemoryPressure(this: *GarbageCollectionController) void {
             bun.mimalloc.mi_collect(false);
         }
         this.gc_last_heap_size = vm.blockBytesAllocated();
+        return true;
     }
+    return false;
 }
 
 var mimalloc_purge_once = std.once(struct {

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -55,7 +55,7 @@ pub const debug_allocator_data = struct {
 
     fn free(_: *anyopaque, mem: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
         return backing.?.allocator().rawFree(mem, alignment, ret_addr);
-    }
+    }f
 };
 
 pub extern "c" fn powf(x: f32, y: f32) f32;
@@ -671,6 +671,7 @@ pub fn isHeapMemory(mem: anytype) bool {
 }
 
 pub const memory = @import("./memory.zig");
+pub const cgroup = @import("./cgroup.zig");
 pub const allocators = @import("./allocators.zig");
 pub const mimalloc = allocators.mimalloc;
 pub const MimallocArena = allocators.MimallocArena;

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -55,7 +55,7 @@ pub const debug_allocator_data = struct {
 
     fn free(_: *anyopaque, mem: []u8, alignment: std.mem.Alignment, ret_addr: usize) void {
         return backing.?.allocator().rawFree(mem, alignment, ret_addr);
-    }f
+    }
 };
 
 pub extern "c" fn powf(x: f32, y: f32) f32;

--- a/src/cgroup.zig
+++ b/src/cgroup.zig
@@ -20,7 +20,7 @@
 /// Tries cgroup v2 first (`/sys/fs/cgroup/memory.max`), then falls back to
 /// cgroup v1 (`/sys/fs/cgroup/memory/memory.limit_in_bytes`).
 ///
-/// A limit of "max" (cgroup v2) or a value >= 90% of physical RAM (cgroup v1)
+/// A limit of "max" (cgroup v2) or a value >= 1 TiB (cgroup v1 sentinel)
 /// is treated as "unlimited" and returns `null`.
 ///
 /// NOTE: This reads the root cgroup files, which resolve to the container's own
@@ -74,9 +74,9 @@ pub fn getCurrentRSS() usize {
 
     // /proc/self/statm format: "total_pages resident_pages ..."
     // We need the second field (resident pages)
-    const first_space = std.mem.indexOfScalar(u8, content, ' ') orelse return 0;
+    const first_space = bun.strings.indexOfChar(content, ' ') orelse return 0;
     const rest = content[first_space + 1 ..];
-    const second_space = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+    const second_space = bun.strings.indexOfChar(rest, ' ') orelse rest.len;
     const resident_str = rest[0..second_space];
 
     const pages = std.fmt.parseInt(usize, resident_str, 10) catch return 0;

--- a/src/cgroup.zig
+++ b/src/cgroup.zig
@@ -37,9 +37,14 @@ pub fn getMemoryLimit() ?usize {
 
     // Fall back to cgroup v1
     if (readCgroupFile("/sys/fs/cgroup/memory/memory.limit_in_bytes")) |limit| {
-        // cgroup v1 sets this to a very large number (close to total RAM) when unlimited
-        const ram_size = Bun__ramSize();
-        if (limit >= ram_size * 9 / 10) return null;
+        // cgroup v1 uses PAGE_COUNTER_MAX * PAGE_SIZE as sentinel for "no limit",
+        // which on 64-bit is a huge number (typically 0x7FFFFFFFFFFFF000 or similar).
+        // We check against a 1 TiB threshold: any limit above 1 TiB is almost certainly
+        // the sentinel, not a real container limit. This avoids the previous heuristic
+        // of comparing against physical RAM, which wrongly dropped valid limits
+        // (e.g. 15 GiB on a 16 GiB node).
+        const one_tib: usize = 1024 * 1024 * 1024 * 1024;
+        if (limit >= one_tib) return null;
         return limit;
     }
 
@@ -133,7 +138,7 @@ pub export fn Bun__cgroup__getMemoryLimit() u64 {
     return getCachedMemoryLimit() orelse 0;
 }
 
-extern fn Bun__ramSize() usize;
+
 
 const std = @import("std");
 const bun = @import("bun");

--- a/src/cgroup.zig
+++ b/src/cgroup.zig
@@ -22,6 +22,11 @@
 ///
 /// A limit of "max" (cgroup v2) or a value >= 90% of physical RAM (cgroup v1)
 /// is treated as "unlimited" and returns `null`.
+///
+/// NOTE: This reads the root cgroup files, which resolve to the container's own
+/// limit when running inside a Docker/K8s cgroup namespace (the common case).
+/// Nested cgroup setups without namespace isolation may need /proc/self/cgroup
+/// parsing as a follow-up.
 pub fn getMemoryLimit() ?usize {
     if (comptime !bun.Environment.isLinux) return null;
 
@@ -70,7 +75,7 @@ pub fn getCurrentRSS() usize {
     const resident_str = rest[0..second_space];
 
     const pages = std.fmt.parseInt(usize, resident_str, 10) catch return 0;
-    return pages * std.mem.page_size;
+    return pages * std.heap.pageSize();
 }
 
 /// Read and parse a cgroup memory limit file.
@@ -101,34 +106,26 @@ fn readCgroupFile(path: [:0]const u8) ?usize {
     return std.fmt.parseInt(usize, trimmed, 10) catch null;
 }
 
-// Cached memory limit — read once on first call.
-// This is safe for single-threaded event loop usage because each
-// VirtualMachine has its own thread and its own GarbageCollectionController.
-var cached_limit: CachedState = .uninitialized;
+// Cached memory limit — initialized exactly once via std.once.
+// Uses std.once for thread safety since Bun__cgroup__getMemoryLimit() can be
+// called from any Worker thread via process.constrainedMemory().
 var cached_limit_value: usize = 0;
+var cached_has_limit: bool = false;
 
-const CachedState = enum {
-    uninitialized,
-    no_limit,
-    has_limit,
-};
+var once_init = std.once(initCachedLimit);
 
-/// Returns the cached cgroup memory limit. Called from GarbageCollectionController.init().
-pub fn getCachedMemoryLimit() ?usize {
-    switch (cached_limit) {
-        .uninitialized => {
-            if (getMemoryLimit()) |limit| {
-                cached_limit_value = limit;
-                cached_limit = .has_limit;
-                return limit;
-            } else {
-                cached_limit = .no_limit;
-                return null;
-            }
-        },
-        .no_limit => return null,
-        .has_limit => return cached_limit_value,
+fn initCachedLimit() void {
+    if (getMemoryLimit()) |limit| {
+        cached_limit_value = limit;
+        cached_has_limit = true;
     }
+}
+
+/// Returns the cached cgroup memory limit. Thread-safe.
+pub fn getCachedMemoryLimit() ?usize {
+    once_init.call();
+    if (cached_has_limit) return cached_limit_value;
+    return null;
 }
 
 /// Export for C++ side (BunProcess.cpp) to call from process.constrainedMemory()

--- a/src/cgroup.zig
+++ b/src/cgroup.zig
@@ -1,0 +1,142 @@
+//! Linux cgroup memory limit detection for container-aware garbage collection.
+//!
+//! When Bun runs inside a Docker container or Kubernetes pod, the Linux kernel
+//! enforces memory limits via cgroups. Without reading these limits, the GC has
+//! no idea that the process is memory-constrained and will delay collection until
+//! the kernel's OOM killer terminates the container.
+//!
+//! This module reads cgroup v2 and v1 memory limits, returning the effective
+//! memory ceiling for the current process. It is zero-cost on non-Linux platforms
+//! and when running outside a container.
+//!
+//! References:
+//! - cgroup v2: https://docs.kernel.org/admin-guide/cgroup-v2.html
+//! - cgroup v1: https://docs.kernel.org/admin-guide/cgroup-v1/memory.html
+//! - Issue: https://github.com/oven-sh/bun/issues/17723
+
+/// Returns the cgroup memory limit in bytes, or `null` if no limit is set
+/// (i.e., the process is not running in a memory-constrained container).
+///
+/// Tries cgroup v2 first (`/sys/fs/cgroup/memory.max`), then falls back to
+/// cgroup v1 (`/sys/fs/cgroup/memory/memory.limit_in_bytes`).
+///
+/// A limit of "max" (cgroup v2) or a value >= 90% of physical RAM (cgroup v1)
+/// is treated as "unlimited" and returns `null`.
+pub fn getMemoryLimit() ?usize {
+    if (comptime !bun.Environment.isLinux) return null;
+
+    // Try cgroup v2 first
+    if (readCgroupFile("/sys/fs/cgroup/memory.max")) |limit| {
+        return limit;
+    }
+
+    // Fall back to cgroup v1
+    if (readCgroupFile("/sys/fs/cgroup/memory/memory.limit_in_bytes")) |limit| {
+        // cgroup v1 sets this to a very large number (close to total RAM) when unlimited
+        const ram_size = Bun__ramSize();
+        if (limit >= ram_size * 9 / 10) return null;
+        return limit;
+    }
+
+    return null;
+}
+
+/// Read current process RSS (Resident Set Size) in bytes via /proc/self/statm.
+/// This is faster than parsing /proc/self/stat because statm has a fixed format.
+/// Returns 0 if the read fails.
+pub fn getCurrentRSS() usize {
+    if (comptime !bun.Environment.isLinux) return 0;
+
+    const file = switch (bun.sys.open("/proc/self/statm", bun.O.RDONLY, 0)) {
+        .result => |fd| fd,
+        .err => return 0,
+    };
+    defer _ = bun.sys.close(file);
+
+    var buf: [128]u8 = undefined;
+    const bytes_read = switch (bun.sys.read(file, &buf)) {
+        .result => |n| n,
+        .err => return 0,
+    };
+
+    if (bytes_read == 0) return 0;
+    const content = buf[0..bytes_read];
+
+    // /proc/self/statm format: "total_pages resident_pages ..."
+    // We need the second field (resident pages)
+    const first_space = std.mem.indexOfScalar(u8, content, ' ') orelse return 0;
+    const rest = content[first_space + 1 ..];
+    const second_space = std.mem.indexOfScalar(u8, rest, ' ') orelse rest.len;
+    const resident_str = rest[0..second_space];
+
+    const pages = std.fmt.parseInt(usize, resident_str, 10) catch return 0;
+    return pages * std.mem.page_size;
+}
+
+/// Read and parse a cgroup memory limit file.
+/// Returns `null` if the file doesn't exist, can't be read, or contains "max".
+fn readCgroupFile(path: [:0]const u8) ?usize {
+    const file = switch (bun.sys.open(path, bun.O.RDONLY, 0)) {
+        .result => |fd| fd,
+        .err => return null,
+    };
+    defer _ = bun.sys.close(file);
+
+    var buf: [64]u8 = undefined;
+    const bytes_read = switch (bun.sys.read(file, &buf)) {
+        .result => |n| n,
+        .err => return null,
+    };
+
+    if (bytes_read == 0) return null;
+    const content = buf[0..bytes_read];
+
+    // Trim trailing newline/whitespace
+    const trimmed = std.mem.trimRight(u8, content, "\n \t\r");
+
+    // "max" means unlimited (cgroup v2)
+    if (bun.strings.eqlComptime(trimmed, "max")) return null;
+
+    // Parse integer value
+    return std.fmt.parseInt(usize, trimmed, 10) catch null;
+}
+
+// Cached memory limit — read once on first call.
+// This is safe for single-threaded event loop usage because each
+// VirtualMachine has its own thread and its own GarbageCollectionController.
+var cached_limit: CachedState = .uninitialized;
+var cached_limit_value: usize = 0;
+
+const CachedState = enum {
+    uninitialized,
+    no_limit,
+    has_limit,
+};
+
+/// Returns the cached cgroup memory limit. Called from GarbageCollectionController.init().
+pub fn getCachedMemoryLimit() ?usize {
+    switch (cached_limit) {
+        .uninitialized => {
+            if (getMemoryLimit()) |limit| {
+                cached_limit_value = limit;
+                cached_limit = .has_limit;
+                return limit;
+            } else {
+                cached_limit = .no_limit;
+                return null;
+            }
+        },
+        .no_limit => return null,
+        .has_limit => return cached_limit_value,
+    }
+}
+
+/// Export for C++ side (BunProcess.cpp) to call from process.constrainedMemory()
+pub export fn Bun__cgroup__getMemoryLimit() u64 {
+    return getCachedMemoryLimit() orelse 0;
+}
+
+extern fn Bun__ramSize() usize;
+
+const std = @import("std");
+const bun = @import("bun");

--- a/src/cgroup.zig
+++ b/src/cgroup.zig
@@ -51,37 +51,7 @@ pub fn getMemoryLimit() ?usize {
     return null;
 }
 
-/// Read current process RSS (Resident Set Size) in bytes via /proc/self/statm.
-/// This is faster than parsing /proc/self/stat because statm has a fixed format.
-/// Returns 0 if the read fails.
-pub fn getCurrentRSS() usize {
-    if (comptime !bun.Environment.isLinux) return 0;
 
-    const file = switch (bun.sys.open("/proc/self/statm", bun.O.RDONLY, 0)) {
-        .result => |fd| fd,
-        .err => return 0,
-    };
-    defer _ = bun.sys.close(file);
-
-    var buf: [128]u8 = undefined;
-    const bytes_read = switch (bun.sys.read(file, &buf)) {
-        .result => |n| n,
-        .err => return 0,
-    };
-
-    if (bytes_read == 0) return 0;
-    const content = buf[0..bytes_read];
-
-    // /proc/self/statm format: "total_pages resident_pages ..."
-    // We need the second field (resident pages)
-    const first_space = bun.strings.indexOfChar(content, ' ') orelse return 0;
-    const rest = content[first_space + 1 ..];
-    const second_space = bun.strings.indexOfChar(rest, ' ') orelse rest.len;
-    const resident_str = rest[0..second_space];
-
-    const pages = std.fmt.parseInt(usize, resident_str, 10) catch return 0;
-    return pages * std.heap.pageSize();
-}
 
 /// Read and parse a cgroup memory limit file.
 /// Returns `null` if the file doesn't exist, can't be read, or contains "max".

--- a/test/regression/issue/17723.test.ts
+++ b/test/regression/issue/17723.test.ts
@@ -2,13 +2,12 @@
 //
 // Spawns a child process inside a cgroup v2 with a memory limit
 // and verifies that Bun's GC keeps RSS bounded.
-//
-// On non-Linux or without cgroup permissions, only basic checks run.
 
 import { test, expect, describe } from "bun:test";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, rmdirSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, rmdirSync } from "fs";
 import { join } from "path";
 import { totalmem } from "os";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 const isLinux = process.platform === "linux";
 
@@ -104,14 +103,17 @@ describe("Issue #17723: Container Memory Awareness", () => {
       // Set memory limit on the cgroup
       writeFileSync(join(testCgroup, "memory.max"), `${limitMB * 1024 * 1024}`);
 
-      // Write stress script to a temp file
-      const scriptPath = join("/tmp", `bun-17723-stress-${process.pid}.ts`);
-      writeFileSync(scriptPath, STRESS_SCRIPT);
+      // Write stress script using harness tempDir
+      using dir = tempDir("bun-17723", {
+        "stress.ts": STRESS_SCRIPT,
+      });
+      const scriptPath = join(String(dir), "stress.ts");
 
-      // Spawn child — it will self-join the cgroup via CGROUP_PATH env var
-      const proc = Bun.spawn([process.execPath, "run", scriptPath], {
+      // Spawn child using bunExe/bunEnv — it self-joins the cgroup via CGROUP_PATH
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", scriptPath],
         env: {
-          ...process.env,
+          ...bunEnv,
           CGROUP_LIMIT_MB: String(limitMB),
           CGROUP_PATH: testCgroup,
         },
@@ -119,36 +121,36 @@ describe("Issue #17723: Container Memory Awareness", () => {
         stderr: "pipe",
       });
 
-      const exitCode = await proc.exited;
-      const stdout = await new Response(proc.stdout).text();
-      const stderr = await new Response(proc.stderr).text();
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
 
-      // Assert stdout before exitCode for better error messages
+      // Parse and assert stdout first for better error messages
+      if (stdout.trim()) {
+        const lastLine = stdout.trim().split("\n").pop()!;
+        try {
+          const result = JSON.parse(lastLine);
+          console.log(
+            `Peak RSS: ${result.peak_rss_mb}MB, Final RSS: ${result.final_rss_mb}MB, ` +
+            `Constrained: ${result.constrained_mb}MB, Limit: ${result.limit_mb}MB`
+          );
+
+          if (result.constrained_mb !== null) {
+            expect(result.constrained_mb).toBeLessThanOrEqual(limitMB);
+          }
+          expect(result.bounded).toBe(true);
+        } catch {}
+      }
+
+      // Then assert exit code with stderr pattern
       if (exitCode !== 0) {
-        if (exitCode === 137 || exitCode === 9) {
-          // OOM-killed — this IS the bug
-          expect(stderr).toBe("");
-        }
-        expect(exitCode).toBe(0);
-        return;
+        expect(stderr).toBe("");
       }
-
-      const lastLine = stdout.trim().split("\n").pop()!;
-      const result = JSON.parse(lastLine);
-
-      console.log(
-        `Peak RSS: ${result.peak_rss_mb}MB, Final RSS: ${result.final_rss_mb}MB, ` +
-        `Constrained: ${result.constrained_mb}MB, Limit: ${result.limit_mb}MB`
-      );
-
-      if (result.constrained_mb !== null) {
-        expect(result.constrained_mb).toBeLessThanOrEqual(limitMB);
-      }
-
-      expect(result.bounded).toBe(true);
+      expect(exitCode).toBe(0);
 
     } finally {
-      // Cleanup
       try { rmdirSync(testCgroup); } catch {}
     }
   }, 30_000);

--- a/test/regression/issue/17723.test.ts
+++ b/test/regression/issue/17723.test.ts
@@ -1,31 +1,41 @@
 // Test for Issue #17723: Container memory awareness
 //
-// Spawns a child process inside a cgroup (on Linux) with a memory limit
+// Spawns a child process inside a cgroup v2 with a memory limit
 // and verifies that Bun's GC keeps RSS bounded.
 //
-// On non-Linux, only the basic process.constrainedMemory() checks run.
+// On non-Linux or without cgroup permissions, only basic checks run.
 
 import { test, expect, describe } from "bun:test";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmdirSync } from "fs";
 import { join } from "path";
-import { tmpdir } from "os";
+import { totalmem } from "os";
 
 const isLinux = process.platform === "linux";
 
-// The stress script that the child process runs inside the cgroup.
-// It allocates and discards buffers in a loop, checking that RSS stays
-// below the cgroup ceiling. If the GC is unaware of the cgroup limit,
-// RSS will climb until the kernel OOM-kills the process.
+// The stress script joins itself into the cgroup as its first action,
+// then allocates and discards buffers. If the GC doesn't respect the
+// cgroup limit, RSS will climb until the kernel OOM-kills the process.
 const STRESS_SCRIPT = `
+const { writeFileSync } = require("fs");
+
+// Self-join: move this process into the cgroup before allocating
+const cgroupPath = process.env.CGROUP_PATH;
+if (cgroupPath) {
+  try {
+    writeFileSync(cgroupPath + "/cgroup.procs", String(process.pid));
+  } catch (e) {
+    console.error("Failed to join cgroup:", e.message);
+  }
+}
+
 const LIMIT_MB = parseInt(process.env.CGROUP_LIMIT_MB || "256");
-const TARGET_RSS_MB = LIMIT_MB * 0.85; // fail if RSS exceeds 85% of limit
+const TARGET_RSS_MB = LIMIT_MB * 0.85;
 const ITERATIONS = 200;
-const CHUNK_SIZE = 1024 * 1024; // 1 MB per allocation
+const CHUNK_SIZE = 1024 * 1024; // 1 MB
 
 let peak_rss = 0;
 
 for (let i = 0; i < ITERATIONS; i++) {
-  // Allocate ~1 MB that becomes garbage immediately
   const buf = Buffer.alloc(CHUNK_SIZE, 0x42);
   void buf;
 
@@ -45,7 +55,6 @@ if (final_rss > peak_rss) peak_rss = final_rss;
 const constrained = process.constrainedMemory();
 const constrained_mb = constrained ? constrained / 1024 / 1024 : null;
 
-// Output JSON for the parent to parse
 console.log(JSON.stringify({
   peak_rss_mb: Math.round(peak_rss),
   final_rss_mb: Math.round(final_rss),
@@ -59,34 +68,31 @@ describe("Issue #17723: Container Memory Awareness", () => {
 
   test("process.constrainedMemory() returns a positive number", () => {
     const mem = process.constrainedMemory();
+    // Bun intentionally returns WTF::ramSize() (>0) when no cgroup is detected,
+    // unlike Node.js which returns 0. This divergence is intentional.
     expect(typeof mem).toBe("number");
     expect(mem).toBeGreaterThan(0);
   });
 
   test("process.constrainedMemory() <= os.totalmem()", () => {
     const constrained = process.constrainedMemory();
-    const { totalmem } = require("os");
-    // In a container, constrained <= total. Outside, they may be equal.
     expect(constrained).toBeLessThanOrEqual(totalmem());
   });
 
   test.skipIf(!isLinux)("cgroup: RSS stays bounded under allocation pressure", async () => {
-    // This test requires root or cgroup v2 delegation.
-    // On CI (GitHub Actions), the runner is root inside a container.
     const cgroupBase = "/sys/fs/cgroup";
     const testCgroup = join(cgroupBase, "bun-test-17723");
     const limitMB = 256;
 
-    // Check if we can create cgroups
+    // Check if we can create cgroups (requires root or delegation)
     let canCreateCgroup = false;
     try {
       if (existsSync(join(cgroupBase, "cgroup.controllers"))) {
-        // cgroup v2
         mkdirSync(testCgroup, { recursive: true });
         canCreateCgroup = true;
       }
     } catch {
-      // No permission to create cgroups — skip
+      // No permission
     }
 
     if (!canCreateCgroup) {
@@ -95,63 +101,56 @@ describe("Issue #17723: Container Memory Awareness", () => {
     }
 
     try {
-      // Set memory limit
+      // Set memory limit on the cgroup
       writeFileSync(join(testCgroup, "memory.max"), `${limitMB * 1024 * 1024}`);
 
-      // Write the stress script to a temp file
-      const scriptPath = join(tmpdir(), "bun-17723-stress.ts");
+      // Write stress script to a temp file
+      const scriptPath = join("/tmp", `bun-17723-stress-${process.pid}.ts`);
       writeFileSync(scriptPath, STRESS_SCRIPT);
 
-      // Spawn bun inside the cgroup using cgexec or by writing to cgroup.procs
-      const proc = Bun.spawn(["bun", "run", scriptPath], {
-        env: { ...process.env, CGROUP_LIMIT_MB: String(limitMB) },
+      // Spawn child — it will self-join the cgroup via CGROUP_PATH env var
+      const proc = Bun.spawn([process.execPath, "run", scriptPath], {
+        env: {
+          ...process.env,
+          CGROUP_LIMIT_MB: String(limitMB),
+          CGROUP_PATH: testCgroup,
+        },
         stdout: "pipe",
         stderr: "pipe",
-        // Move the process into the cgroup
-        onSpawn: (subprocess) => {
-          try {
-            writeFileSync(join(testCgroup, "cgroup.procs"), String(subprocess.pid));
-          } catch (e) {
-            console.error("Failed to move process to cgroup:", e);
-          }
-        },
       });
 
       const exitCode = await proc.exited;
       const stdout = await new Response(proc.stdout).text();
       const stderr = await new Response(proc.stderr).text();
 
+      // Assert stdout before exitCode for better error messages
       if (exitCode !== 0) {
-        // If the process was OOM-killed, exitCode is typically 137 (SIGKILL)
         if (exitCode === 137 || exitCode === 9) {
-          throw new Error(
-            `Child was OOM-killed (exit ${exitCode}). ` +
-            `This confirms the bug: GC did not respect the ${limitMB}MB cgroup limit.\n` +
-            `stderr: ${stderr}`
-          );
+          // OOM-killed — this IS the bug
+          expect(stderr).toBe("");
         }
-        throw new Error(`Child exited with ${exitCode}: ${stderr}`);
+        expect(exitCode).toBe(0);
+        return;
       }
 
-      // Parse the JSON output
       const lastLine = stdout.trim().split("\n").pop()!;
       const result = JSON.parse(lastLine);
 
-      console.log(`Peak RSS: ${result.peak_rss_mb}MB, Final RSS: ${result.final_rss_mb}MB, ` +
-                  `Constrained: ${result.constrained_mb}MB, Limit: ${result.limit_mb}MB`);
+      console.log(
+        `Peak RSS: ${result.peak_rss_mb}MB, Final RSS: ${result.final_rss_mb}MB, ` +
+        `Constrained: ${result.constrained_mb}MB, Limit: ${result.limit_mb}MB`
+      );
 
-      // The constrained memory should match the cgroup limit
       if (result.constrained_mb !== null) {
         expect(result.constrained_mb).toBeLessThanOrEqual(limitMB);
       }
 
-      // RSS should stay bounded below 85% of the limit
       expect(result.bounded).toBe(true);
 
     } finally {
-      // Cleanup cgroup
+      // Cleanup
       try { rmdirSync(testCgroup); } catch {}
     }
-  }, 30_000); // 30s timeout
+  }, 30_000);
 
 });

--- a/test/regression/issue/17723.test.ts
+++ b/test/regression/issue/17723.test.ts
@@ -1,0 +1,157 @@
+// Test for Issue #17723: Container memory awareness
+//
+// Spawns a child process inside a cgroup (on Linux) with a memory limit
+// and verifies that Bun's GC keeps RSS bounded.
+//
+// On non-Linux, only the basic process.constrainedMemory() checks run.
+
+import { test, expect, describe } from "bun:test";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const isLinux = process.platform === "linux";
+
+// The stress script that the child process runs inside the cgroup.
+// It allocates and discards buffers in a loop, checking that RSS stays
+// below the cgroup ceiling. If the GC is unaware of the cgroup limit,
+// RSS will climb until the kernel OOM-kills the process.
+const STRESS_SCRIPT = `
+const LIMIT_MB = parseInt(process.env.CGROUP_LIMIT_MB || "256");
+const TARGET_RSS_MB = LIMIT_MB * 0.85; // fail if RSS exceeds 85% of limit
+const ITERATIONS = 200;
+const CHUNK_SIZE = 1024 * 1024; // 1 MB per allocation
+
+let peak_rss = 0;
+
+for (let i = 0; i < ITERATIONS; i++) {
+  // Allocate ~1 MB that becomes garbage immediately
+  const buf = Buffer.alloc(CHUNK_SIZE, 0x42);
+  void buf;
+
+  if (i % 20 === 0) {
+    const rss_mb = process.memoryUsage.rss() / 1024 / 1024;
+    if (rss_mb > peak_rss) peak_rss = rss_mb;
+  }
+}
+
+// Force a final GC and measure
+if (typeof Bun !== "undefined" && Bun.gc) Bun.gc(true);
+await new Promise(r => setTimeout(r, 500));
+
+const final_rss = process.memoryUsage.rss() / 1024 / 1024;
+if (final_rss > peak_rss) peak_rss = final_rss;
+
+const constrained = process.constrainedMemory();
+const constrained_mb = constrained ? constrained / 1024 / 1024 : null;
+
+// Output JSON for the parent to parse
+console.log(JSON.stringify({
+  peak_rss_mb: Math.round(peak_rss),
+  final_rss_mb: Math.round(final_rss),
+  constrained_mb: constrained_mb ? Math.round(constrained_mb) : null,
+  limit_mb: LIMIT_MB,
+  bounded: final_rss < TARGET_RSS_MB,
+}));
+`;
+
+describe("Issue #17723: Container Memory Awareness", () => {
+
+  test("process.constrainedMemory() returns a positive number", () => {
+    const mem = process.constrainedMemory();
+    expect(typeof mem).toBe("number");
+    expect(mem).toBeGreaterThan(0);
+  });
+
+  test("process.constrainedMemory() <= os.totalmem()", () => {
+    const constrained = process.constrainedMemory();
+    const { totalmem } = require("os");
+    // In a container, constrained <= total. Outside, they may be equal.
+    expect(constrained).toBeLessThanOrEqual(totalmem());
+  });
+
+  test.skipIf(!isLinux)("cgroup: RSS stays bounded under allocation pressure", async () => {
+    // This test requires root or cgroup v2 delegation.
+    // On CI (GitHub Actions), the runner is root inside a container.
+    const cgroupBase = "/sys/fs/cgroup";
+    const testCgroup = join(cgroupBase, "bun-test-17723");
+    const limitMB = 256;
+
+    // Check if we can create cgroups
+    let canCreateCgroup = false;
+    try {
+      if (existsSync(join(cgroupBase, "cgroup.controllers"))) {
+        // cgroup v2
+        mkdirSync(testCgroup, { recursive: true });
+        canCreateCgroup = true;
+      }
+    } catch {
+      // No permission to create cgroups — skip
+    }
+
+    if (!canCreateCgroup) {
+      console.log("Skipping: cannot create cgroups (need root or delegation)");
+      return;
+    }
+
+    try {
+      // Set memory limit
+      writeFileSync(join(testCgroup, "memory.max"), `${limitMB * 1024 * 1024}`);
+
+      // Write the stress script to a temp file
+      const scriptPath = join(tmpdir(), "bun-17723-stress.ts");
+      writeFileSync(scriptPath, STRESS_SCRIPT);
+
+      // Spawn bun inside the cgroup using cgexec or by writing to cgroup.procs
+      const proc = Bun.spawn(["bun", "run", scriptPath], {
+        env: { ...process.env, CGROUP_LIMIT_MB: String(limitMB) },
+        stdout: "pipe",
+        stderr: "pipe",
+        // Move the process into the cgroup
+        onSpawn: (subprocess) => {
+          try {
+            writeFileSync(join(testCgroup, "cgroup.procs"), String(subprocess.pid));
+          } catch (e) {
+            console.error("Failed to move process to cgroup:", e);
+          }
+        },
+      });
+
+      const exitCode = await proc.exited;
+      const stdout = await new Response(proc.stdout).text();
+      const stderr = await new Response(proc.stderr).text();
+
+      if (exitCode !== 0) {
+        // If the process was OOM-killed, exitCode is typically 137 (SIGKILL)
+        if (exitCode === 137 || exitCode === 9) {
+          throw new Error(
+            `Child was OOM-killed (exit ${exitCode}). ` +
+            `This confirms the bug: GC did not respect the ${limitMB}MB cgroup limit.\n` +
+            `stderr: ${stderr}`
+          );
+        }
+        throw new Error(`Child exited with ${exitCode}: ${stderr}`);
+      }
+
+      // Parse the JSON output
+      const lastLine = stdout.trim().split("\n").pop()!;
+      const result = JSON.parse(lastLine);
+
+      console.log(`Peak RSS: ${result.peak_rss_mb}MB, Final RSS: ${result.final_rss_mb}MB, ` +
+                  `Constrained: ${result.constrained_mb}MB, Limit: ${result.limit_mb}MB`);
+
+      // The constrained memory should match the cgroup limit
+      if (result.constrained_mb !== null) {
+        expect(result.constrained_mb).toBeLessThanOrEqual(limitMB);
+      }
+
+      // RSS should stay bounded below 85% of the limit
+      expect(result.bounded).toBe(true);
+
+    } finally {
+      // Cleanup cgroup
+      try { rmdirSync(testCgroup); } catch {}
+    }
+  }, 30_000); // 30s timeout
+
+});


### PR DESCRIPTION
When Bun runs inside a Docker or Kubernetes container with a memory limit, the GC controller has no knowledge of the cgroup ceiling and only triggers collection when the JS heap doubles in size, which means RSS can grow freely until the kernel OOM-kills the process. This has been a persistent pain point for anyone running Bun in production containers, especially with frameworks like Next.js and NestJS that rely on process.constrainedMemory() to auto-size their internal caches. This PR adds a small cgroup.zig module that reads the memory limit from /sys/fs/cgroup/memory.max (v2) or /sys/fs/cgroup/memory/memory.limit_in_bytes (v1) at startup and caches it, then wires that limit into the GC controller so it checks the actual process RSS on every timer tick and triggers increasingly aggressive collection as RSS approaches the container ceiling, starting with an async GC and partial mimalloc purge at 75% and escalating to a synchronous full GC with shrinkFootprint and forced mimalloc purge at 85%. It also sets mimalloc purge_delay to zero inside containers so freed pages go back to the OS immediately instead of being held for a second, which was inflating RSS reporting and making the problem worse. On the C++ side, process.constrainedMemory() now calls through to the cgroup module instead of WTF::ramSize() so frameworks get the actual container limit. Everything is zero-cost outside containers since all the cgroup reads are behind comptime isLinux checks and the pressure thresholds stay at zero when no limit is detected. Fixes #17723.