### PR TITLE
http: fail-fast aborted fetches queued behind max_simultaneous_requests

### DIFF
--- a/src/http/AsyncHTTP.zig
+++ b/src/http/AsyncHTTP.zig
@@ -408,7 +408,7 @@ pub fn onAsyncHTTPCallback(this: *AsyncHTTP, async_http: *AsyncHTTP, result: HTT
         assert(active_requests > 0);
     }
 
-    if (!bun.http.http_thread.queued_tasks.isEmpty() and AsyncHTTP.active_requests_count.load(.monotonic) < AsyncHTTP.max_simultaneous_requests.load(.monotonic)) {
+    if ((!bun.http.http_thread.queued_tasks.isEmpty() or bun.http.http_thread.deferred_tasks.items.len > 0) and AsyncHTTP.active_requests_count.load(.monotonic) < AsyncHTTP.max_simultaneous_requests.load(.monotonic)) {
         bun.http.http_thread.loop.loop.wakeup();
     }
 }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -18,6 +18,11 @@ http_context: NewHTTPContext(false),
 https_context: NewHTTPContext(true),
 
 queued_tasks: Queue = Queue{},
+/// Tasks popped from `queued_tasks` that couldn't start because
+/// `active_requests_count >= max_simultaneous_requests`. Kept in FIFO order
+/// and processed before `queued_tasks` on the next `drainEvents`. Owned by
+/// the HTTP thread; never accessed concurrently.
+deferred_tasks: std.ArrayListUnmanaged(*AsyncHTTP) = .{},
 
 queued_shutdowns: std.ArrayListUnmanaged(ShutdownMessage) = std.ArrayListUnmanaged(ShutdownMessage){},
 queued_writes: std.ArrayListUnmanaged(WriteMessage) = std.ArrayListUnmanaged(WriteMessage){},
@@ -477,7 +482,6 @@ fn drainEvents(this: *@This()) void {
     var count: usize = 0;
     var active = AsyncHTTP.active_requests_count.load(.monotonic);
     const max = AsyncHTTP.max_simultaneous_requests.load(.monotonic);
-    if (active >= max) return;
     defer {
         if (comptime Environment.allow_assert) {
             if (count > 0)
@@ -485,25 +489,63 @@ fn drainEvents(this: *@This()) void {
         }
     }
 
-    while (this.queued_tasks.pop()) |http| {
-        var cloned = bun.http.ThreadlocalAsyncHTTP.new(.{
-            .async_http = http.*,
-        });
-        cloned.async_http.real = http;
-        // Clear stale queue pointers - the clone inherited http.next and http.task.node.next
-        // which may point to other AsyncHTTP structs that could be freed before the callback
-        // copies data back to the original. If not cleared, retrying a failed request would
-        // re-queue with stale pointers causing use-after-free.
-        cloned.async_http.next = null;
-        cloned.async_http.task.node.next = null;
-        cloned.async_http.onStart();
-        if (comptime Environment.allow_assert) {
-            count += 1;
+    // Deferred tasks are ones we previously popped from the MPSC queue but
+    // couldn't start because we were at max. They stay in FIFO order ahead of
+    // anything still in `queued_tasks`.
+    //
+    // Already-aborted tasks are started regardless of `max`: `start_()` will
+    // observe the `aborted` signal and fail immediately with
+    // `error.AbortedBeforeConnecting`, and `onAsyncHTTPCallback` decrements
+    // `active_requests_count` in the same turn — so they never hold a slot.
+    // Without this, an aborted fetch that was queued behind `max` would sit
+    // there until some unrelated request completed; if every active request
+    // is itself hung, the aborted one never settles and its promise hangs
+    // forever even though the user called `controller.abort()`.
+    {
+        var kept: usize = 0;
+        var i: usize = 0;
+        while (i < this.deferred_tasks.items.len) : (i += 1) {
+            const http = this.deferred_tasks.items[i];
+            const aborted = http.client.signals.get(.aborted);
+            if (aborted or active < max) {
+                startQueuedTask(http);
+                if (comptime Environment.allow_assert) count += 1;
+                if (!aborted) active += 1;
+            } else {
+                this.deferred_tasks.items[kept] = http;
+                kept += 1;
+            }
         }
-
-        active += 1;
-        if (active >= max) break;
+        this.deferred_tasks.items.len = kept;
     }
+
+    while (this.queued_tasks.pop()) |http| {
+        const aborted = http.client.signals.get(.aborted);
+        if (!aborted and active >= max) {
+            // Can't start this one yet. Defer it (preserves FIFO relative to
+            // later pops) and keep draining — there may be aborted tasks
+            // behind it that we can fail-fast right now.
+            bun.handleOom(this.deferred_tasks.append(bun.default_allocator, http));
+            continue;
+        }
+        startQueuedTask(http);
+        if (comptime Environment.allow_assert) count += 1;
+        if (!aborted) active += 1;
+    }
+}
+
+fn startQueuedTask(http: *AsyncHTTP) void {
+    var cloned = bun.http.ThreadlocalAsyncHTTP.new(.{
+        .async_http = http.*,
+    });
+    cloned.async_http.real = http;
+    // Clear stale queue pointers - the clone inherited http.next and http.task.node.next
+    // which may point to other AsyncHTTP structs that could be freed before the callback
+    // copies data back to the original. If not cleared, retrying a failed request would
+    // re-queue with stale pointers causing use-after-free.
+    cloned.async_http.next = null;
+    cloned.async_http.task.node.next = null;
+    cloned.async_http.onStart();
 }
 
 fn processEvents(this: *@This()) noreturn {

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -23,6 +23,13 @@ queued_tasks: Queue = Queue{},
 /// and processed before `queued_tasks` on the next `drainEvents`. Owned by
 /// the HTTP thread; never accessed concurrently.
 deferred_tasks: std.ArrayListUnmanaged(*AsyncHTTP) = .{},
+/// Set by `drainQueuedShutdowns` when a shutdown's `async_http_id` wasn't in
+/// `socket_async_http_abort_tracker` — the request is either not yet started
+/// (still in `queued_tasks`/`deferred_tasks`) or already done. `drainEvents`
+/// uses this to decide whether it must scan the queued/deferred lists for
+/// aborted tasks when `active >= max`; without it the common at-capacity
+/// path stays O(1). Owned by the HTTP thread.
+has_pending_queued_abort: bool = false,
 
 queued_shutdowns: std.ArrayListUnmanaged(ShutdownMessage) = std.ArrayListUnmanaged(ShutdownMessage){},
 queued_writes: std.ArrayListUnmanaged(WriteMessage) = std.ArrayListUnmanaged(WriteMessage){},
@@ -384,6 +391,13 @@ fn drainQueuedShutdowns(this: *@This()) void {
                         socket.close(.failure);
                     },
                 }
+            } else {
+                // No socket for this id: the request either hasn't started
+                // yet (still in `queued_tasks`/`deferred_tasks`) or has
+                // already completed. Flag it so `drainEvents` knows to scan
+                // the queue for aborted-but-unstarted tasks even when
+                // `active >= max` would otherwise short-circuit.
+                this.has_pending_queued_abort = true;
             }
         }
         if (queued_shutdowns.items.len == 0) {
@@ -489,6 +503,14 @@ fn drainEvents(this: *@This()) void {
         }
     }
 
+    // Fast path: at capacity and no queued/deferred task could possibly be
+    // aborted. A queued task can only become aborted via `scheduleShutdown`,
+    // which we just drained — `drainQueuedShutdowns` sets
+    // `has_pending_queued_abort` for any id it couldn't find in the socket
+    // tracker. If that's clear, there's nothing to fail-fast and nothing can
+    // start, so don't walk the lists.
+    if (active >= max and !this.has_pending_queued_abort) return;
+
     // Deferred tasks are ones we previously popped from the MPSC queue but
     // couldn't start because we were at max. They stay in FIFO order ahead of
     // anything still in `queued_tasks`.
@@ -501,27 +523,32 @@ fn drainEvents(this: *@This()) void {
     // there until some unrelated request completed; if every active request
     // is itself hung, the aborted one never settles and its promise hangs
     // forever even though the user called `controller.abort()`.
+    //
+    // `startQueuedTask` can re-enter `onAsyncHTTPCallback` synchronously (for
+    // aborted tasks, or when connect() fails immediately), which reads both
+    // `active_requests_count` and `deferred_tasks.items.len` to decide whether
+    // to wake the loop. To keep those reads accurate we swap the deferred list
+    // out before iterating so the field reflects only tasks still waiting, and
+    // reload `active` from the atomic after every start rather than tracking
+    // it locally.
+    this.has_pending_queued_abort = false;
     {
-        var kept: usize = 0;
-        var i: usize = 0;
-        while (i < this.deferred_tasks.items.len) : (i += 1) {
-            const http = this.deferred_tasks.items[i];
-            const aborted = http.client.signals.get(.aborted);
-            if (aborted or active < max) {
+        var pending = this.deferred_tasks;
+        this.deferred_tasks = .{};
+        defer pending.deinit(bun.default_allocator);
+        for (pending.items) |http| {
+            if (http.client.signals.get(.aborted) or active < max) {
                 startQueuedTask(http);
                 if (comptime Environment.allow_assert) count += 1;
-                if (!aborted) active += 1;
+                active = AsyncHTTP.active_requests_count.load(.monotonic);
             } else {
-                this.deferred_tasks.items[kept] = http;
-                kept += 1;
+                bun.handleOom(this.deferred_tasks.append(bun.default_allocator, http));
             }
         }
-        this.deferred_tasks.items.len = kept;
     }
 
     while (this.queued_tasks.pop()) |http| {
-        const aborted = http.client.signals.get(.aborted);
-        if (!aborted and active >= max) {
+        if (!http.client.signals.get(.aborted) and active >= max) {
             // Can't start this one yet. Defer it (preserves FIFO relative to
             // later pops) and keep draining — there may be aborted tasks
             // behind it that we can fail-fast right now.
@@ -530,7 +557,7 @@ fn drainEvents(this: *@This()) void {
         }
         startQueuedTask(http);
         if (comptime Environment.allow_assert) count += 1;
-        if (!aborted) active += 1;
+        active = AsyncHTTP.active_requests_count.load(.monotonic);
     }
 }
 

--- a/test/js/web/fetch/fetch-abort-queued.test.ts
+++ b/test/js/web/fetch/fetch-abort-queued.test.ts
@@ -79,15 +79,8 @@ test("aborting a fetch that is queued behind max_simultaneous_requests rejects t
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim().split("\n")).toEqual([
-    "OK: queued fetch rejected with AbortError",
-    "hung request is pending",
-  ]);
+  expect(stdout.trim().split("\n")).toEqual(["OK: queued fetch rejected with AbortError", "hung request is pending"]);
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/fetch-abort-queued.test.ts
+++ b/test/js/web/fetch/fetch-abort-queued.test.ts
@@ -1,0 +1,93 @@
+// When `active_requests_count >= max_simultaneous_requests`, new fetch()
+// requests sit in the HTTP thread's queue without a socket. Their
+// `async_http_id` is therefore not in `socket_async_http_abort_tracker`, so
+// `drainQueuedShutdowns` used to silently drop the abort and `drainEvents`
+// would early-return without touching the queue. If every active request was
+// itself hung, the aborted request's promise never settled even though
+// `controller.abort()` had fired.
+//
+// The fix makes `drainEvents` fail-fast any queued task whose `aborted` signal
+// is already set, regardless of whether a slot is free.
+//
+// Runs in a child process so we can set BUN_CONFIG_MAX_HTTP_REQUESTS without
+// affecting the rest of the test suite.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const fixture = /* js */ `
+  import { createServer } from "net";
+  import { once } from "events";
+
+  // Server that accepts connections and never responds.
+  const sockets = [];
+  const server = createServer(socket => { sockets.push(socket); });
+  server.listen(0);
+  await once(server, "listening");
+  const port = server.address().port;
+
+  // Fill the single available slot with a request that will hang forever.
+  const hung = fetch("http://127.0.0.1:" + port + "/hung").catch(e => e);
+
+  // Wait until the server has actually seen the connection so we know the
+  // slot is occupied before queueing the next request.
+  while (sockets.length === 0) await new Promise(r => setImmediate(r));
+
+  // This request is queued behind max_simultaneous_requests; it has no socket.
+  const controller = new AbortController();
+  const queued = fetch("http://127.0.0.1:" + port + "/queued", {
+    signal: controller.signal,
+  });
+
+  let settled = false;
+  queued.catch(() => { settled = true; });
+
+  // Give the HTTP thread a chance to pick it up (it can't — slot is full).
+  await new Promise(r => setImmediate(r));
+  await new Promise(r => setImmediate(r));
+
+  controller.abort();
+
+  try {
+    await queued;
+    console.log("FAIL: queued fetch resolved");
+  } catch (e) {
+    if (e?.name === "AbortError") {
+      console.log("OK: queued fetch rejected with AbortError");
+    } else {
+      console.log("FAIL: queued fetch rejected with", e?.name, e?.message);
+    }
+  }
+
+  // The hung request should still be pending — aborting the queued one must
+  // not have disturbed it.
+  const hungState = await Promise.race([
+    hung.then(() => "settled"),
+    new Promise(r => setImmediate(() => r("pending"))),
+  ]);
+  console.log("hung request is", hungState);
+
+  for (const s of sockets) s.destroy();
+  server.close();
+  await hung;
+`;
+
+test("aborting a fetch that is queued behind max_simultaneous_requests rejects the promise", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_CONFIG_MAX_HTTP_REQUESTS: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stdout.trim().split("\n")).toEqual([
+    "OK: queued fetch rejected with AbortError",
+    "hung request is pending",
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch-abort-queued.test.ts
+++ b/test/js/web/fetch/fetch-abort-queued.test.ts
@@ -38,9 +38,8 @@ const fixture = /* js */ `
   const queued = fetch("http://127.0.0.1:" + port + "/queued", {
     signal: controller.signal,
   });
-
-  let settled = false;
-  queued.catch(() => { settled = true; });
+  // Suppress unhandled-rejection noise while we wait below.
+  queued.catch(() => {});
 
   // Give the HTTP thread a chance to pick it up (it can't — slot is full).
   await new Promise(r => setImmediate(r));
@@ -79,8 +78,15 @@ test("aborting a fetch that is queued behind max_simultaneous_requests rejects t
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  // ASAN debug builds unconditionally print a signal-handler warning to
+  // stderr at startup; ignore that line.
+  const stderrLines = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderrLines).toBe("");
   expect(stdout.trim().split("\n")).toEqual(["OK: queued fetch rejected with AbortError", "hung request is pending"]);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Follow-up to #29406.

## What

When `AsyncHTTP.active_requests_count >= max_simultaneous_requests`, new `fetch()` requests sit in the HTTP thread's MPSC `queued_tasks` without a socket. Their `async_http_id` is therefore not in `socket_async_http_abort_tracker`, so when the user calls `controller.abort()`:

- `abortTask` sets the `aborted` atomic and posts a `scheduleShutdown`
- `drainQueuedShutdowns` looks up the id, finds nothing, silently drops it
- `drainEvents` sees `active >= max` and returns without touching `queued_tasks`

The aborted request just sits in the queue until some other request completes and frees a slot. If every active request is itself hung (unresponsive server, dead route, etc.), the aborted request's promise **never** settles even though the abort event fired.

## Repro

```ts
// BUN_CONFIG_MAX_HTTP_REQUESTS=1
const hung = fetch(`http://${hangServer}/`);      // occupies the only slot
const ac = new AbortController();
const queued = fetch(`http://${hangServer}/`, { signal: ac.signal });
ac.abort();
await queued;   // <- never resolves or rejects on current main
```

## Fix

`drainEvents` no longer early-returns when `active >= max`. It now:
1. Processes a new HTTP-thread-local `deferred_tasks` list (tasks previously popped but unable to start) in FIFO order.
2. Drains `queued_tasks` fully.

In both phases, a task whose `aborted` signal is already set is started regardless of `max` — `start_()` observes the flag and fails immediately with `error.AbortedBeforeConnecting`, and `onAsyncHTTPCallback` decrements `active_requests_count` in the same turn, so aborted tasks never hold a slot. Non-aborted tasks that can't start go into `deferred_tasks` (preserving FIFO relative to later pops).

`onAsyncHTTPCallback`'s wakeup check now also considers `deferred_tasks`.

## Verification

`test/js/web/fetch/fetch-abort-queued.test.ts` spawns a child with `BUN_CONFIG_MAX_HTTP_REQUESTS=1`, fills the slot with a hung request, queues a second request with an `AbortSignal`, aborts it, and asserts it rejects with `AbortError` while the hung request stays pending.

```
# system bun: times out after 5s
# bun bd:
(pass) aborting a fetch that is queued behind max_simultaneous_requests rejects the promise
```

Also spot-checked FIFO ordering is preserved for non-aborted deferred tasks and that aborting a mid-queue request doesn't disturb its neighbours.