### PR TITLE
test --parallel: set JEST_WORKER_ID and BUN_TEST_WORKER_ID per worker

### DIFF
--- a/src/cli/test/parallel/Coordinator.zig
+++ b/src/cli/test/parallel/Coordinator.zig
@@ -9,7 +9,9 @@ pub const Coordinator = struct {
     files: []const PathString,
     cwd: [:0]const u8,
     argv: [:null]?[*:0]const u8,
-    envp: [*:null]?[*:0]const u8,
+    /// One envp per worker slot — same base, with that slot's JEST_WORKER_ID
+    /// and BUN_TEST_WORKER_ID appended.
+    envps: []const [:null]?[*:0]const u8,
 
     workers: []Worker,
     /// retries[i] counts how many times files[i] has been re-queued after a

--- a/src/cli/test/parallel/Worker.zig
+++ b/src/cli/test/parallel/Worker.zig
@@ -84,7 +84,7 @@ pub fn start(this: *Worker) !void {
             .new_process_group = true,
             .linux_pdeathsig = if (Environment.isLinux) std.posix.SIG.KILL else null,
         };
-        var spawned = try (try bun.spawn.spawnProcess(&options, coord.argv.ptr, coord.envp)).unwrap();
+        var spawned = try (try bun.spawn.spawnProcess(&options, coord.argv.ptr, coord.envps[this.idx].ptr)).unwrap();
         defer spawned.extra_pipes.deinit();
         this.process = spawned.toProcess(coord.vm.eventLoop(), false);
         if (spawned.stdout) |fd| try this.out.reader.start(fd, true).unwrap();
@@ -117,7 +117,7 @@ pub fn start(this: *Worker) !void {
             .windows = .{ .loop = jsc.EventLoopHandle.init(coord.vm) },
             .stream = true,
         };
-        var spawned = try (try bun.spawn.spawnProcess(&options, coord.argv.ptr, coord.envp)).unwrap();
+        var spawned = try (try bun.spawn.spawnProcess(&options, coord.argv.ptr, coord.envps[this.idx].ptr)).unwrap();
         defer spawned.extra_pipes.deinit();
         this.process = spawned.toProcess(coord.vm.eventLoop(), false);
 

--- a/src/cli/test/parallel/runner.zig
+++ b/src/cli/test/parallel/runner.zig
@@ -59,18 +59,17 @@ pub fn runAsCoordinator(
             reporter.reporters.junit = null;
         }
     }
-    const base_envp = try vm.transpiler.env.map.createNullDelimitedEnvMap(arena.allocator());
-    // Each worker gets the shared environment plus a unique JEST_WORKER_ID and
-    // BUN_TEST_WORKER_ID (1-indexed, matching Jest) so tests can pick distinct
-    // ports/databases.
+    // Each worker gets a unique JEST_WORKER_ID / BUN_TEST_WORKER_ID (1-indexed,
+    // matching Jest) so tests can pick distinct ports/databases. Serialize the
+    // env map once per worker after .put() — appending after the fact would
+    // create duplicate entries when the parent already has the variable set,
+    // and POSIX getenv() returns the first match.
     const envps = try arena.allocator().alloc([:null]?[*:0]const u8, K);
     for (envps, 0..) |*envp, i| {
-        const id = try std.fmt.allocPrintSentinel(arena.allocator(), "{d}", .{i + 1}, 0);
-        const slot = try arena.allocator().allocSentinel(?[*:0]const u8, base_envp.len + 2, null);
-        @memcpy(slot[0..base_envp.len], base_envp);
-        slot[base_envp.len] = try std.fmt.allocPrintSentinel(arena.allocator(), "JEST_WORKER_ID={s}", .{id}, 0);
-        slot[base_envp.len + 1] = try std.fmt.allocPrintSentinel(arena.allocator(), "BUN_TEST_WORKER_ID={s}", .{id}, 0);
-        envp.* = slot;
+        const id = try std.fmt.allocPrint(arena.allocator(), "{d}", .{i + 1});
+        bun.handleOom(vm.transpiler.env.map.put("JEST_WORKER_ID", id));
+        bun.handleOom(vm.transpiler.env.map.put("BUN_TEST_WORKER_ID", id));
+        envp.* = try vm.transpiler.env.map.createNullDelimitedEnvMap(arena.allocator());
     }
     const argv = try buildWorkerArgv(arena.allocator(), ctx);
 

--- a/src/cli/test/parallel/runner.zig
+++ b/src/cli/test/parallel/runner.zig
@@ -22,6 +22,10 @@ pub fn runAsCoordinator(
     const N: u32 = @intCast(files.len);
     const K: u32 = @min(ctx.test_options.parallel, N);
     if (K <= 1) {
+        // Jest sets JEST_WORKER_ID=1 even with --maxWorkers=1; match that so
+        // tests can rely on the var whenever --parallel is passed.
+        bun.handleOom(vm.transpiler.env.map.put("JEST_WORKER_ID", "1"));
+        bun.handleOom(vm.transpiler.env.map.put("BUN_TEST_WORKER_ID", "1"));
         TestCommand.runAllTests(reporter, vm, files, allocator);
         return false;
     }

--- a/src/cli/test/parallel/runner.zig
+++ b/src/cli/test/parallel/runner.zig
@@ -55,7 +55,19 @@ pub fn runAsCoordinator(
             reporter.reporters.junit = null;
         }
     }
-    const envp = try vm.transpiler.env.map.createNullDelimitedEnvMap(arena.allocator());
+    const base_envp = try vm.transpiler.env.map.createNullDelimitedEnvMap(arena.allocator());
+    // Each worker gets the shared environment plus a unique JEST_WORKER_ID and
+    // BUN_TEST_WORKER_ID (1-indexed, matching Jest) so tests can pick distinct
+    // ports/databases.
+    const envps = try arena.allocator().alloc([:null]?[*:0]const u8, K);
+    for (envps, 0..) |*envp, i| {
+        const id = try std.fmt.allocPrintSentinel(arena.allocator(), "{d}", .{i + 1}, 0);
+        const slot = try arena.allocator().allocSentinel(?[*:0]const u8, base_envp.len + 2, null);
+        @memcpy(slot[0..base_envp.len], base_envp);
+        slot[base_envp.len] = try std.fmt.allocPrintSentinel(arena.allocator(), "JEST_WORKER_ID={s}", .{id}, 0);
+        slot[base_envp.len + 1] = try std.fmt.allocPrintSentinel(arena.allocator(), "BUN_TEST_WORKER_ID={s}", .{id}, 0);
+        envp.* = slot;
+    }
     const argv = try buildWorkerArgv(arena.allocator(), ctx);
 
     // Sort lexicographically so adjacent indices share parent directories.
@@ -83,7 +95,7 @@ pub fn runAsCoordinator(
         .files = sorted,
         .cwd = bun.fs.FileSystem.instance.top_level_dir,
         .argv = argv,
-        .envp = envp,
+        .envps = envps,
         .workers = workers,
         .retries = retries,
         .pending_retry = pending_retry,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,6 +1,34 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
+test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
+  // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
+  // remaining files; otherwise one fast worker handles all three.
+  const fixture = `import {test} from "bun:test"; test("t", async () => { await Bun.sleep(200); console.log("WID="+process.env.JEST_WORKER_ID+" "+process.env.BUN_TEST_WORKER_ID); });`;
+  using dir = tempDir("parallel-worker-id", {
+    "a.test.js": fixture,
+    "b.test.js": fixture,
+    "c.test.js": fixture,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=3"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = stdout + stderr;
+  expect(out).not.toContain("WID=undefined");
+  // 1-indexed; JEST_WORKER_ID and BUN_TEST_WORKER_ID always match.
+  const seen = [...out.matchAll(/WID=(\d+) (\d+)/g)].map(m => {
+    expect(m[1]).toBe(m[2]);
+    return m[1];
+  });
+  expect(seen.sort()).toEqual(["1", "2", "3"]);
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel runs files across workers and aggregates totals", async () => {
   using dir = tempDir("parallel-basic", {
     "a.test.js": `import {test,expect} from "bun:test"; test("a1",()=>expect(1).toBe(1)); test("a2",()=>expect(1).toBe(1));`,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -27,6 +27,21 @@ test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID
   });
   expect(seen.sort()).toEqual(["1", "2", "3"]);
   expect(exitCode).toBe(0);
+
+  // K<=1 serial-fallback (single file, or --parallel=1) still sets WORKER_ID=1
+  // so tests can rely on it whenever --parallel is passed (matches Jest).
+  using single = tempDir("parallel-worker-id-single", { "a.test.js": fixture });
+  await using p2 = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=5"],
+    env: bunEnv,
+    cwd: String(single),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [o2, e2, c2] = await Promise.all([p2.stdout.text(), p2.stderr.text(), p2.exited]);
+  expect(o2 + e2).toContain("WID=1 1");
+  expect(o2 + e2).not.toContain("WID=undefined");
+  expect(c2).toBe(0);
 });
 
 test("--parallel runs files across workers and aggregates totals", async () => {


### PR DESCRIPTION
Closes #9352.
Fixes #23179


Each `bun test --parallel` worker now gets `JEST_WORKER_ID` and `BUN_TEST_WORKER_ID` set to its 1-indexed slot, matching Jest's behaviour. The serial-fallback path (`--parallel=1` or `--parallel` with a single file) sets both to `"1"` so tests can rely on the variable whenever `--parallel` is passed. A pre-existing `JEST_WORKER_ID` in the parent environment is overridden in both paths. Non-parallel `bun test` is unchanged (the variable stays unset).

Implementation: `runAsCoordinator` builds a per-worker `envp` (`base + JEST_WORKER_ID=<n> + BUN_TEST_WORKER_ID=<n>`) and `Coordinator` indexes into the slice by worker slot.

## Test plan

- [x] `bun bd test test/cli/test/parallel.test.ts -t WORKER_ID` — covers 3-worker spread, 1-indexing, JEST/BUN match, K≤1 serial-fallback
- [x] `bun bd test test/cli/test/isolation.test.ts test/cli/test/parallel.test.ts` — 40/0
- [x] `bun run zig:check-all`