### PR TITLE
linear_fifo: free old buffer when growing while empty

### DIFF
--- a/src/linear_fifo.zig
+++ b/src/linear_fifo.zig
@@ -130,8 +130,8 @@ pub fn LinearFifo(
                     var new_bytes = std.mem.sliceAsBytes(buf);
                     const old_bytes = std.mem.sliceAsBytes(self.readableSlice(0));
                     @memcpy(new_bytes[0..old_bytes.len], old_bytes);
-                    self.allocator.free(self.buf);
                 }
+                self.allocator.free(self.buf);
                 self.head = 0;
                 self.buf = buf;
             } else {


### PR DESCRIPTION
## Summary
- `ensureTotalCapacity` gated `allocator.free(self.buf)` on `self.count > 0`, leaking the previous backing slice whenever the fifo grows while drained.
- Moved the free outside the guard; the memcpy stays conditional. Freeing a zero-length slice is a no-op so first-growth is unchanged.
- Affects the WebSocket client send buffer and other `Dynamic` LinearFifo users that drain fully between writes.

## Test plan
- [x] `zig fmt --check src/linear_fifo.zig`
- [x] `zig ast-check src/linear_fifo.zig`
- [ ] CI