### PR TITLE
subprocess: always clean up stdio_pipes in finalizeStreams

### DIFF
--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -767,6 +767,8 @@ pub fn spawnMaybeSync(
                 ctx.* = &subprocess.ipc_data.?;
                 subprocess.ipc_data.?.socket = .{ .open = posix_ipc_info };
             }
+            // uws owns the fd now (owns_fd=1); neutralize the slot so finalizeStreams doesn't double-close.
+            subprocess.stdio_pipes.items[@intCast(ipc_channel)] = bun.invalid_fd;
         } else {
             if (ipc_data.windowsConfigureServer(
                 subprocess.stdio_pipes.items[@intCast(ipc_channel)].buffer,

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -736,22 +736,16 @@ pub fn finalizeStreams(this: *Subprocess) void {
     this.closeIO(.stdout);
     this.closeIO(.stderr);
 
-    close_stdio_pipes: {
-        if (!this.observable_getters.contains(.stdio)) {
-            break :close_stdio_pipes;
-        }
-
-        for (this.stdio_pipes.items) |item| {
-            if (Environment.isWindows) {
-                if (item == .buffer) {
-                    item.buffer.close(onPipeClose);
-                }
-            } else {
-                item.close();
+    for (this.stdio_pipes.items) |item| {
+        if (Environment.isWindows) {
+            if (item == .buffer) {
+                item.buffer.close(onPipeClose);
             }
+        } else {
+            item.close();
         }
-        this.stdio_pipes.clearAndFree(bun.default_allocator);
     }
+    this.stdio_pipes.clearAndFree(bun.default_allocator);
 }
 
 fn deinit(this: *Subprocess) void {

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -473,20 +473,18 @@ pub fn getStdio(this: *Subprocess, global: *JSGlobalObject) bun.JSError!JSValue 
     try array.push(global, .null); // TODO: align this with options
     try array.push(global, .null); // TODO: align this with options
 
-    var pipes = this.stdio_pipes.items;
-    if (this.ipc_data != null) {
-        try array.push(global, .null);
-        pipes = pipes[@min(1, pipes.len)..];
-    }
-
-    for (pipes) |item| {
+    for (this.stdio_pipes.items) |item| {
         if (Environment.isWindows) {
             if (item == .buffer) {
                 const fdno: usize = @intFromPtr(item.buffer.fd().cast());
                 try array.push(global, JSValue.jsNumber(fdno));
+            } else {
+                try array.push(global, .null);
             }
-        } else {
+        } else if (item.isValid()) {
             try array.push(global, JSValue.jsNumber(item.cast()));
+        } else {
+            try array.push(global, .null);
         }
     }
     return array;

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -28,7 +28,6 @@ observable_getters: std.enums.EnumSet(enum {
     stdin,
     stdout,
     stderr,
-    stdio,
 }) = .{},
 closed: std.enums.EnumSet(StdioKind) = .{},
 this_value: jsc.JSRef = jsc.JSRef.empty(),
@@ -474,7 +473,6 @@ pub fn getStdio(this: *Subprocess, global: *JSGlobalObject) bun.JSError!JSValue 
     try array.push(global, .null); // TODO: align this with options
     try array.push(global, .null); // TODO: align this with options
 
-    this.observable_getters.insert(.stdio);
     var pipes = this.stdio_pipes.items;
     if (this.ipc_data != null) {
         try array.push(global, .null);
@@ -741,7 +739,7 @@ pub fn finalizeStreams(this: *Subprocess) void {
             if (item == .buffer) {
                 item.buffer.close(onPipeClose);
             }
-        } else {
+        } else if (item.isValid()) {
             item.close();
         }
     }


### PR DESCRIPTION
## Summary
- `finalizeStreams` skipped the `stdio_pipes` close loop and `clearAndFree()` whenever JS never accessed `subprocess.stdio`, leaking the per-extra-fd `uv.Pipe` heap allocations (Windows) / fds (POSIX) plus the ArrayList backing.
- `getStdio()` only returns raw fd numbers — it never hands ownership of the native handles to JS — so the guard had no ownership-transfer rationale. Removed it; cleanup now runs unconditionally.

## Test plan
- [ ] CI `zig build check` (Windows + POSIX)
- [ ] Existing `test/js/bun/spawn` suite passes
- [ ] Manual: spawn with `stdio: ['inherit','inherit','inherit', 'pipe']`, never read `.stdio`, verify no fd/handle leak across 1000 iterations