### PR TITLE
process(windows): free SyncWindowsPipeReader chunks backing

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1992,6 +1992,7 @@ pub const sync = struct {
             remain = remain[chunk.len..];
             chunks_allocator.free(chunk);
         }
+        chunks_allocator.free(chunks);
 
         return result;
     }


### PR DESCRIPTION
## Summary
- `SyncWindowsPipeReader.onClose` borrows `chunks.items` and destroys the reader, but the `ArrayList([]u8)` backing storage is never freed after `flattenOwnedChunks` consumes the inner chunks
- `flattenOwnedChunks` now frees the outer `[][]u8` slice via `chunks_allocator` after copying, matching its owned-chunks contract
- Leak was per-pipe per `bun.spawn.sync` on Windows (capacity × 16 bytes)

## Test plan
- [x] `bun run build` (debug) compiles clean
- [ ] Windows CI: `bun.spawn.sync` test suite