### PR TITLE
fix(bundler): `longestCommonPathGeneric` breaks for 9+ entrypoints

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -239,21 +239,21 @@ pub fn longestCommonPathGeneric(input: []const []const u8, comptime platform: Pl
                 }
             }
 
-            var string_index: usize = 1;
-            while (string_index < input.len) : (string_index += 1) {
-                while (index < min_length) : (index += 1) {
-                    if (platform == .windows) {
-                        if (std.ascii.toLower(input[0][index]) != std.ascii.toLower(input[string_index][index])) {
-                            break;
-                        }
-                    } else {
-                        if (input[0][index] != input[string_index][index]) {
-                            break;
-                        }
+            while (index < min_length) : (index += 1) {
+                const c = input[0][index];
+                var all_equal = true;
+                for (input[1..]) |str| {
+                    const matches = if (platform == .windows)
+                        std.ascii.toLower(c) == std.ascii.toLower(str[index])
+                    else
+                        c == str[index];
+                    if (!matches) {
+                        all_equal = false;
+                        break;
                     }
                 }
-                if (index == min_length) index -= 1;
-                if (@call(bun.callmod_inline, isPathSeparator, .{input[0][index]})) {
+                if (!all_equal) break;
+                if (@call(bun.callmod_inline, isPathSeparator, .{c})) {
                     last_common_separator = index;
                 }
             }

--- a/test/bundler/outdir-common-path.test.ts
+++ b/test/bundler/outdir-common-path.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync } from "fs";
+import { join } from "path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("bun build --outdir common path stripping", () => {
+  for (const count of [2, 7, 8, 9, 10, 16]) {
+    test(`${count} entrypoints from same directory produce flat output`, async () => {
+      const names = Array.from({ length: count }, (_, i) => `entry${i}`);
+      const files: Record<string, string> = {};
+      for (const name of names) {
+        files[`src/deep/nested/${name}.ts`] = `console.log("${name}");`;
+      }
+
+      using dir = tempDir(`outdir-common-${count}`, files);
+      const entrypoints = names.map((n) => join(String(dir), "src", "deep", "nested", `${n}.ts`));
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", ...entrypoints, "--target=bun", "--format=esm", "--outdir", join(String(dir), "out")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+
+      const outputFiles = readdirSync(join(String(dir), "out"));
+      const expected = names.map((n) => `${n}.js`).sort();
+      expect(outputFiles.sort()).toEqual(expected);
+    });
+  }
+});


### PR DESCRIPTION
`bun build --outdir` with 9+ entrypoints preserves the full input directory structure instead of stripping the longest common prefix. Works correctly for 2-8 entrypoints.

## Root cause

`longestCommonPathGeneric` in `src/resolver/resolve_path.zig` has two code paths:
- **Inline branch** (2-8 inputs, compile-time unrolled): single loop over character positions, checks all strings at each position, tracks `last_common_separator` inside the loop. Correct.
- **Else branch** (9+ inputs, runtime loop): nested loop — outer over string pairs, inner over characters. Only checks for separators at the *divergence point*, which is outside the inner loop. For paths like `src/deep/nested/one.ts` vs `src/deep/nested/two.ts`, divergence is at `o`/`t` — not a separator — so `last_common_separator` stays 0.

## Fix

Replace the else branch's nested loop with a single-pass loop matching the inline branch: iterate character positions, compare all strings at each position, track separators inside the loop.

## Test

`test/bundler/outdir-common-path.test.ts` — parameterized over 2/7/8/9/10/16 entrypoints from a shared directory, asserts flat output.

:clown: [Clown](https://github.com/amarbel-llc/clown)