### PR TITLE
deps: bump mimalloc to ac2e0d58 (upstream dev3 + crasher fixes)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -5,7 +5,7 @@
 
 import type { Dependency, NestedCmakeBuild, Provides } from "../source.ts";
 
-const MIMALLOC_COMMIT = "ac2e0d58bd008347ad78d0aae0af829458a2d1de";
+const MIMALLOC_COMMIT = "809f7f32645a8aed84e4e9d343eb75576f133dee";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",
@@ -34,6 +34,13 @@ export const mimalloc: Dependency = {
       // Don't walk all heaps on exit. Bun's shutdown is already complicated
       // enough without mimalloc traversing every live allocation.
       MI_SKIP_COLLECT_ON_EXIT: "ON",
+
+      // Go further: skip mi_process_done entirely. It exists for the
+      // dlopen/dlclose-a-static-mimalloc case (issue #281); Bun is a static
+      // exe that exits via _exit, so the OS reclaims everything. Running it
+      // tears down locks/TLS while other static destructors may still call
+      // free(). MI_SKIP_COLLECT_ON_EXIT only skips the heap walk inside it.
+      MI_NO_PROCESS_DETACH: "ON",
 
       // Disable Transparent Huge Pages. Measured impact:
       //   bun --eval 1:  THP off = 30MB peak,  THP on = 52MB peak

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -5,7 +5,7 @@
 
 import type { Dependency, NestedCmakeBuild, Provides } from "../source.ts";
 
-const MIMALLOC_COMMIT = "809f7f32645a8aed84e4e9d343eb75576f133dee";
+const MIMALLOC_COMMIT = "d56d5b27f8f9bfcd2d2f5f1020ff5e100781b062";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -5,7 +5,7 @@
 
 import type { Dependency, NestedCmakeBuild, Provides } from "../source.ts";
 
-const MIMALLOC_COMMIT = "a29368ef60d5c90bd760ff42a36ad4ad919a9ad7";
+const MIMALLOC_COMMIT = "ac2e0d58bd008347ad78d0aae0af829458a2d1de";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "a29368ef60d5c90bd760ff42a36ad4ad919a9ad7",
+    mimalloc: "ac2e0d58bd008347ad78d0aae0af829458a2d1de",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "ac2e0d58bd008347ad78d0aae0af829458a2d1de",
+    mimalloc: "809f7f32645a8aed84e4e9d343eb75576f133dee",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "809f7f32645a8aed84e4e9d343eb75576f133dee",
+    mimalloc: "d56d5b27f8f9bfcd2d2f5f1020ff5e100781b062",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
## Summary

Bumps `MIMALLOC_COMMIT` to [oven-sh/mimalloc@ac2e0d58](https://github.com/oven-sh/mimalloc/commits/bun-dev3-v2) (`bun-dev3-v2`):

- **Upstream dev3 merge** (52 commits): Windows CRT+TLS init refactor (#1259/#1263), v3.3.0 release prep, `MI_SECURE` level 5, fixes for #1229/#1231/#1236/#1267
- **Reverted** our purge-reschedule patch (`09fed41b`) — preferring upstream's simpler visitor
- **`stats.c`**: fix `mi_subproc_stats_get_json` merge fallout (undeclared `subproc`)
- **`theap.c`**: guard `mi_theap_merge_stats` against concurrent `_mi_theap_free` NULLing `theap->heap`
- **`init.c`**: relax `page_count==0` asserts in `mi_thread_theaps_done` when theap is being concurrently freed; extend `fork_prepare`/`fork_parent` to quiesce all heaps' locks (was `heap_main` only); `fork_child` re-inits all reachable `tld->theaps_lock`
- **`arena.c`**: clear `arena_pages->pages` bit + unregister page-map on the four alloc-fresh failure paths (commit fail, page-map register fail, both `_mi_page_init` fail sites)
- **New tests** with `MI_DEBUG` fault-injection hooks: `test-heap-delete-race`, `test-fork-user-heap`, `test-commit-fail` — all reproduce on the old SHA, all pass on this one

These are crash/deadlock/corruption fixes (heap-delete vs thread-exit race, fork() vs user-heap contention, commit-failure cleanup), not memory-reduction changes. Found while investigating #29412.

## Test plan
- [x] mimalloc `MI_DEBUG=3` build: all 6 tests + stress pass on macOS arm64
- [ ] CI: full Bun build + test on all platforms