### PR TITLE
zig: hoist try out of tagged-union literals to avoid partial writes

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1725,40 +1725,49 @@ pub const JSBundler = struct {
             switch (which.to(i32)) {
                 0 => {
                     const resolve: *JSBundler.Resolve = bun.cast(*Resolve, ctx);
-                    const msg = logger.Msg.fromJS(
-                        bun.default_allocator,
-                        plugin.globalObject(),
-                        resolve.import_record.source_file,
-                        exception,
-                    ) catch |err| switch (err) {
-                        error.OutOfMemory => bun.outOfMemory(),
-                        error.JSError, error.JSTerminated => {
-                            plugin.globalObject().reportActiveExceptionAsUnhandled(err);
-                            return;
-                        },
-                    };
+                    const msg = msgFromJS(plugin, resolve.import_record.source_file, exception);
                     resolve.value = .{ .err = msg };
                     resolve.bv2.onResolveAsync(resolve);
                 },
                 1 => {
                     const load: *Load = bun.cast(*Load, ctx);
-                    const msg = logger.Msg.fromJS(
-                        bun.default_allocator,
-                        plugin.globalObject(),
-                        load.path,
-                        exception,
-                    ) catch |err| switch (err) {
-                        error.OutOfMemory => bun.outOfMemory(),
-                        error.JSError, error.JSTerminated => {
-                            plugin.globalObject().reportActiveExceptionAsUnhandled(err);
-                            return;
-                        },
-                    };
+                    const msg = msgFromJS(plugin, load.path, exception);
                     load.value = .{ .err = msg };
                     load.bv2.onLoadAsync(load);
                 },
                 else => @panic("invalid error type"),
             }
+        }
+
+        /// Convert a JS exception value into a `logger.Msg`. If the conversion itself throws
+        /// (e.g. `Symbol.toPrimitive` on the thrown object throws), clear that secondary
+        /// exception and return a generic fallback message so `onResolveAsync`/`onLoadAsync`
+        /// is still called and the bundler's pending-item counter is decremented. Returning
+        /// early here would cause `Bun.build` to hang forever waiting on the counter.
+        fn msgFromJS(plugin: *Plugin, file: []const u8, exception: JSValue) logger.Msg {
+            return logger.Msg.fromJS(
+                bun.default_allocator,
+                plugin.globalObject(),
+                file,
+                exception,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => bun.outOfMemory(),
+                error.JSError, error.JSTerminated => {
+                    // We are already producing a build error for the original plugin
+                    // exception; the secondary exception from string conversion is not
+                    // useful to the user and should not be treated as unhandled.
+                    _ = plugin.globalObject().clearExceptionExceptTermination();
+                    return .{
+                        .data = .{
+                            .text = bun.handleOom(bun.default_allocator.dupe(
+                                u8,
+                                "A bundler plugin threw a value that could not be converted to a string",
+                            )),
+                            .location = .{ .file = file, .line = 0, .column = 0 },
+                        },
+                    };
+                },
+            };
         }
     };
 };

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1763,7 +1763,7 @@ pub const JSBundler = struct {
                                 u8,
                                 "A bundler plugin threw a value that could not be converted to a string",
                             )),
-                            .location = .{ .file = file, .line = 0, .column = 0 },
+                            .location = .{ .file = file, .line = -1, .column = -1 },
                         },
                     };
                 },

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -1725,38 +1725,36 @@ pub const JSBundler = struct {
             switch (which.to(i32)) {
                 0 => {
                     const resolve: *JSBundler.Resolve = bun.cast(*Resolve, ctx);
-                    resolve.value = .{
-                        .err = logger.Msg.fromJS(
-                            bun.default_allocator,
-                            plugin.globalObject(),
-                            resolve.import_record.source_file,
-                            exception,
-                        ) catch |err| switch (err) {
-                            error.OutOfMemory => bun.outOfMemory(),
-                            error.JSError, error.JSTerminated => {
-                                plugin.globalObject().reportActiveExceptionAsUnhandled(err);
-                                return;
-                            },
+                    const msg = logger.Msg.fromJS(
+                        bun.default_allocator,
+                        plugin.globalObject(),
+                        resolve.import_record.source_file,
+                        exception,
+                    ) catch |err| switch (err) {
+                        error.OutOfMemory => bun.outOfMemory(),
+                        error.JSError, error.JSTerminated => {
+                            plugin.globalObject().reportActiveExceptionAsUnhandled(err);
+                            return;
                         },
                     };
+                    resolve.value = .{ .err = msg };
                     resolve.bv2.onResolveAsync(resolve);
                 },
                 1 => {
                     const load: *Load = bun.cast(*Load, ctx);
-                    load.value = .{
-                        .err = logger.Msg.fromJS(
-                            bun.default_allocator,
-                            plugin.globalObject(),
-                            load.path,
-                            exception,
-                        ) catch |err| switch (err) {
-                            error.OutOfMemory => bun.outOfMemory(),
-                            error.JSError, error.JSTerminated => {
-                                plugin.globalObject().reportActiveExceptionAsUnhandled(err);
-                                return;
-                            },
+                    const msg = logger.Msg.fromJS(
+                        bun.default_allocator,
+                        plugin.globalObject(),
+                        load.path,
+                        exception,
+                    ) catch |err| switch (err) {
+                        error.OutOfMemory => bun.outOfMemory(),
+                        error.JSError, error.JSTerminated => {
+                            plugin.globalObject().reportActiveExceptionAsUnhandled(err);
+                            return;
                         },
                     };
+                    load.value = .{ .err = msg };
                     load.bv2.onLoadAsync(load);
                 },
                 else => @panic("invalid error type"),

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -147,7 +147,17 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
             this.* = socket;
             // TODO: server_name is not supported on named pipes, I belive its , lets wait for
             // someone to ask for it
-            errdefer this.deinit();
+
+            // On error, clean up everything `this` owns *except* `this.handlers`: the outer
+            // `errdefer handlers.deinit()` already unprotects those JSValues, and `this.handlers`
+            // is a by-value copy of the same struct, so calling `this.deinit()` here would
+            // unprotect the same callbacks a second time.
+            errdefer {
+                this.strong_data.deinit();
+                this.connection.deinit();
+                if (this.protos) |protos| bun.default_allocator.free(protos);
+                handlers.vm.allocator.destroy(this);
+            }
 
             // we need to add support for the backlog parameter on listen here we use the
             // default value of nodejs
@@ -993,6 +1003,13 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
             .vm = globalThis.bunVM(),
             .listener = listener,
         });
+        var pipe_initialized = false;
+        errdefer {
+            // Once the uv pipe handle is registered with the loop it must be closed via
+            // uv_close; before that point we can free the struct directly. `deinit()` also
+            // frees the SSL context if one was created.
+            if (pipe_initialized) this.closePipeAndDeinit() else this.deinit();
+        }
 
         if (ssl_config) |ssl_options| {
             bun.BoringSSL.load();
@@ -1008,6 +1025,7 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
         if (initResult == .err) {
             return error.FailedToInitPipe;
         }
+        pipe_initialized = true;
         if (path[path.len - 1] == 0) {
             // is already null terminated
             const slice_z = path[0 .. path.len - 1 :0];

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -149,20 +149,19 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
             // someone to ask for it
             errdefer this.deinit();
 
-            this.listener = .{
-                // we need to add support for the backlog parameter on listen here we use the
-                // default value of nodejs
-                .namedPipe = WindowsNamedPipeListeningContext.listen(
-                    globalObject,
-                    pipe_name,
-                    511,
-                    ssl,
-                    this,
-                ) catch return globalObject.throwInvalidArguments(
-                    "Failed to listen at {s}",
-                    .{pipe_name},
-                ),
-            };
+            // we need to add support for the backlog parameter on listen here we use the
+            // default value of nodejs
+            const named_pipe = WindowsNamedPipeListeningContext.listen(
+                globalObject,
+                pipe_name,
+                511,
+                ssl,
+                this,
+            ) catch return globalObject.throwInvalidArguments(
+                "Failed to listen at {s}",
+                .{pipe_name},
+            );
+            this.listener = .{ .namedPipe = named_pipe };
 
             const this_value = this.toJS(globalObject);
             this.strong_self.set(globalObject, this_value);

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -470,9 +470,10 @@ pub const Value = union(Tag) {
                 blob.resolveSize();
                 const value = try jsc.WebCore.ReadableStream.fromBlobCopyRef(globalThis, &blob, blob.size);
 
+                const stream = (try jsc.WebCore.ReadableStream.fromJS(value, globalThis)).?;
                 this.* = .{
                     .Locked = .{
-                        .readable = jsc.WebCore.ReadableStream.Strong.init((try jsc.WebCore.ReadableStream.fromJS(value, globalThis)).?, globalThis),
+                        .readable = jsc.WebCore.ReadableStream.Strong.init(stream, globalThis),
                         .global = globalThis,
                     },
                 };

--- a/src/http/Decompressor.zig
+++ b/src/http/Decompressor.zig
@@ -22,43 +22,40 @@ pub const Decompressor = union(enum) {
         if (this.* == .none) {
             switch (encoding) {
                 .gzip, .deflate => {
-                    this.* = .{
-                        .zlib = try Zlib.ZlibReaderArrayList.initWithOptionsAndListAllocator(
-                            buffer,
-                            &body_out_str.list,
-                            body_out_str.allocator,
-                            bun.http.default_allocator,
-                            .{
-                                // zlib.MAX_WBITS = 15
-                                // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
-                                // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
-                                // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
-                                .windowBits = if (encoding == Encoding.gzip) Zlib.MAX_WBITS | 16 else (if (buffer.len > 1 and buffer[0] == 120) 0 else -Zlib.MAX_WBITS),
-                            },
-                        ),
-                    };
+                    const reader = try Zlib.ZlibReaderArrayList.initWithOptionsAndListAllocator(
+                        buffer,
+                        &body_out_str.list,
+                        body_out_str.allocator,
+                        bun.http.default_allocator,
+                        .{
+                            // zlib.MAX_WBITS = 15
+                            // to (de-)compress deflate format, use wbits = -zlib.MAX_WBITS
+                            // to (de-)compress deflate format with headers we use wbits = 0 (we can detect the first byte using 120)
+                            // to (de-)compress gzip format, use wbits = zlib.MAX_WBITS | 16
+                            .windowBits = if (encoding == Encoding.gzip) Zlib.MAX_WBITS | 16 else (if (buffer.len > 1 and buffer[0] == 120) 0 else -Zlib.MAX_WBITS),
+                        },
+                    );
+                    this.* = .{ .zlib = reader };
                     return;
                 },
                 .brotli => {
-                    this.* = .{
-                        .brotli = try Brotli.BrotliReaderArrayList.newWithOptions(
-                            buffer,
-                            &body_out_str.list,
-                            body_out_str.allocator,
-                            .{},
-                        ),
-                    };
+                    const reader = try Brotli.BrotliReaderArrayList.newWithOptions(
+                        buffer,
+                        &body_out_str.list,
+                        body_out_str.allocator,
+                        .{},
+                    );
+                    this.* = .{ .brotli = reader };
                     return;
                 },
                 .zstd => {
-                    this.* = .{
-                        .zstd = try zstd.ZstdReaderArrayList.initWithListAllocator(
-                            buffer,
-                            &body_out_str.list,
-                            body_out_str.allocator,
-                            bun.http.default_allocator,
-                        ),
-                    };
+                    const reader = try zstd.ZstdReaderArrayList.initWithListAllocator(
+                        buffer,
+                        &body_out_str.list,
+                        body_out_str.allocator,
+                        bun.http.default_allocator,
+                    );
+                    this.* = .{ .zstd = reader };
                     return;
                 },
                 else => @panic("Invalid encoding. This code should not be reachable"),

--- a/test/bundler/plugin-error-nested-throw.test.ts
+++ b/test/bundler/plugin-error-nested-throw.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression test: when a bundler plugin throws a non-Error value whose string
+// conversion also throws, `logger.Msg.fromJS` fails with a JS exception. Prior
+// to the fix, `JSBundlerPlugin__addError` would return early without calling
+// `onLoadAsync`/`onResolveAsync`, so the bundler's pending-item counter was
+// never decremented and `Bun.build` would hang forever.
+describe("Bun.build plugin throws value whose toString also throws", () => {
+  const fixture = (hook: "onLoad" | "onResolve") => /* js */ `
+    const { join } = require("path");
+    const result = await Bun.build({
+      entrypoints: [join(import.meta.dir, "entry.ts")],
+      throw: false,
+      plugins: [
+        {
+          name: "bad-plugin",
+          setup(build) {
+            build.${hook}({ filter: ${hook === "onLoad" ? "/entry\\.ts$/" : "/^virtual:thing$/"} }, async () => {
+              // force the rejection to go through the promise path so addError() is hit
+              await Promise.resolve();
+              // Not an Error instance, so Msg.fromJS falls back to toBunString(),
+              // which invokes ToPrimitive -> Symbol.toPrimitive -> throws again.
+              throw {
+                [Symbol.toPrimitive]() {
+                  throw new Error("nested throw during error conversion");
+                },
+                toString() {
+                  throw new Error("nested throw during error conversion");
+                },
+              };
+            });
+          },
+        },
+      ],
+    });
+    console.log(JSON.stringify({
+      success: result.success,
+      logs: result.logs.map(l => String(l.message ?? l)),
+    }));
+  `;
+
+  for (const hook of ["onLoad", "onResolve"] as const) {
+    test.concurrent(`${hook}: build completes instead of hanging`, async () => {
+      using dir = tempDir(`plugin-nested-throw-${hook}`, {
+        "entry.ts": hook === "onLoad" ? `console.log("hi");` : `import "virtual:thing"; console.log("hi");`,
+        "build.ts": fixture(hook),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", join(String(dir), "build.ts")],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        // If the build hangs (the bug), kill it so the assertion below can report
+        // a useful diff instead of the test runner just timing out.
+        timeout: 10_000,
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // If the subprocess was killed by the spawn timeout, the build hung.
+      expect({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+        signalCode: proc.signalCode ?? null,
+      }).toMatchObject({
+        exitCode: 0,
+        signalCode: null,
+      });
+
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.success).toBe(false);
+      expect(parsed.logs.length).toBeGreaterThan(0);
+    }, 15_000);
+  }
+});

--- a/test/bundler/plugin-error-nested-throw.test.ts
+++ b/test/bundler/plugin-error-nested-throw.test.ts
@@ -42,39 +42,43 @@ describe("Bun.build plugin throws value whose toString also throws", () => {
   `;
 
   for (const hook of ["onLoad", "onResolve"] as const) {
-    test.concurrent(`${hook}: build completes instead of hanging`, async () => {
-      using dir = tempDir(`plugin-nested-throw-${hook}`, {
-        "entry.ts": hook === "onLoad" ? `console.log("hi");` : `import "virtual:thing"; console.log("hi");`,
-        "build.ts": fixture(hook),
-      });
+    test.concurrent(
+      `${hook}: build completes instead of hanging`,
+      async () => {
+        using dir = tempDir(`plugin-nested-throw-${hook}`, {
+          "entry.ts": hook === "onLoad" ? `console.log("hi");` : `import "virtual:thing"; console.log("hi");`,
+          "build.ts": fixture(hook),
+        });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", join(String(dir), "build.ts")],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-        // If the build hangs (the bug), kill it so the assertion below can report
-        // a useful diff instead of the test runner just timing out.
-        timeout: 10_000,
-      });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", join(String(dir), "build.ts")],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+          // If the build hangs (the bug), kill it so the assertion below can report
+          // a useful diff instead of the test runner just timing out.
+          timeout: 10_000,
+        });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // If the subprocess was killed by the spawn timeout, the build hung.
-      expect({
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        exitCode,
-        signalCode: proc.signalCode ?? null,
-      }).toMatchObject({
-        exitCode: 0,
-        signalCode: null,
-      });
+        // If the subprocess was killed by the spawn timeout, the build hung.
+        expect({
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+          exitCode,
+          signalCode: proc.signalCode ?? null,
+        }).toMatchObject({
+          exitCode: 0,
+          signalCode: null,
+        });
 
-      const parsed = JSON.parse(stdout.trim());
-      expect(parsed.success).toBe(false);
-      expect(parsed.logs.length).toBeGreaterThan(0);
-    }, 15_000);
+        const parsed = JSON.parse(stdout.trim());
+        expect(parsed.success).toBe(false);
+        expect(parsed.logs.length).toBeGreaterThan(0);
+      },
+      15_000,
+    );
   }
 });

--- a/test/bundler/plugin-error-nested-throw.test.ts
+++ b/test/bundler/plugin-error-nested-throw.test.ts
@@ -9,7 +9,7 @@ import { join } from "path";
 // never decremented and `Bun.build` would hang forever.
 describe("Bun.build plugin throws value whose toString also throws", () => {
   const fixture = (hook: "onLoad" | "onResolve") => /* js */ `
-    const { join } = require("path");
+    import { join } from "path";
     const result = await Bun.build({
       entrypoints: [join(import.meta.dir, "entry.ts")],
       throw: false,
@@ -42,43 +42,39 @@ describe("Bun.build plugin throws value whose toString also throws", () => {
   `;
 
   for (const hook of ["onLoad", "onResolve"] as const) {
-    test.concurrent(
-      `${hook}: build completes instead of hanging`,
-      async () => {
-        using dir = tempDir(`plugin-nested-throw-${hook}`, {
-          "entry.ts": hook === "onLoad" ? `console.log("hi");` : `import "virtual:thing"; console.log("hi");`,
-          "build.ts": fixture(hook),
-        });
+    test.concurrent(`${hook}: build completes instead of hanging`, async () => {
+      using dir = tempDir(`plugin-nested-throw-${hook}`, {
+        "entry.ts": hook === "onLoad" ? `console.log("hi");` : `import "virtual:thing"; console.log("hi");`,
+        "build.ts": fixture(hook),
+      });
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "run", join(String(dir), "build.ts")],
-          env: bunEnv,
-          cwd: String(dir),
-          stdout: "pipe",
-          stderr: "pipe",
-          // If the build hangs (the bug), kill it so the assertion below can report
-          // a useful diff instead of the test runner just timing out.
-          timeout: 10_000,
-        });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", join(String(dir), "build.ts")],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        // If the build hangs (the bug), kill it so the assertion below can report
+        // a useful diff instead of the test runner just timing out.
+        timeout: 10_000,
+      });
 
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-        // If the subprocess was killed by the spawn timeout, the build hung.
-        expect({
-          stdout: stdout.trim(),
-          stderr: stderr.trim(),
-          exitCode,
-          signalCode: proc.signalCode ?? null,
-        }).toMatchObject({
-          exitCode: 0,
-          signalCode: null,
-        });
+      // If the subprocess was killed by the spawn timeout, the build hung.
+      expect({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+        signalCode: proc.signalCode ?? null,
+      }).toMatchObject({
+        exitCode: 0,
+        signalCode: null,
+      });
 
-        const parsed = JSON.parse(stdout.trim());
-        expect(parsed.success).toBe(false);
-        expect(parsed.logs.length).toBeGreaterThan(0);
-      },
-      15_000,
-    );
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.success).toBe(false);
+      expect(parsed.logs.length).toBeGreaterThan(0);
+    });
   }
 });

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// When `Bun.listen()` on a Windows named pipe fails (e.g. the pipe name is
+// already in use), the cleanup path must:
+//   - not double-unprotect the socket handler callbacks (previously both
+//     `errdefer this.deinit()` and `errdefer handlers.deinit()` unprotected the
+//     same JSValues, tripping a debug assertion)
+//   - free the heap-allocated `WindowsNamedPipeListeningContext` and close the
+//     libuv pipe handle, so the event loop can drain and the process exits
+describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
+  test("failed listen on in-use pipe throws, cleans up, and does not hang", async () => {
+    const src = /* js */ `
+      const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-named-pipe-" + Math.random().toString(36).slice(2);
+
+      const first = Bun.listen({
+        unix: pipe,
+        socket: { data() {}, open() {}, close() {}, error() {} },
+      });
+
+      let threw = false;
+      try {
+        Bun.listen({
+          unix: pipe,
+          socket: { data() {}, open() {}, close() {}, error() {} },
+        });
+      } catch (e) {
+        threw = true;
+      }
+
+      first.stop(true);
+
+      if (!threw) {
+        console.error("expected second Bun.listen to throw");
+        process.exit(1);
+      }
+
+      Bun.gc(true);
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      // If the libuv pipe handle leaks, the event loop never drains and the
+      // process hangs; bound it so we get a useful failure instead of a test
+      // runner timeout.
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      stdout: "OK",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 30_000);
+});

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -62,5 +62,5 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
       exitCode: 0,
       signalCode: null,
     });
-  }, 30_000);
+  });
 });


### PR DESCRIPTION
## What

Fixes four sites where a tagged-union assignment of the form `lhs = .{ .tag = <expr> }` has early-exit control flow (`try`, `catch return`) inside `<expr>`. Zig writes the union tag to the result location *before* evaluating the payload expression, so if the early-exit fires the union is left with the new tag and the old/garbage payload bytes.

Minimal repro of the underlying Zig behavior:

```zig
const Data = union(enum) { f1: u32, f2: u64 };
fn bar() !u64 { return error.Oops; }
fn foo(l: *Data) void {
    l.* = .{ .f2 = bar() catch return };
}
// l before: .{ .f1 = 0xDEADBEEF }
// l after:  .{ .f2 = <0xDEADBEEF reinterpreted as u64> }
```

The fix everywhere is to hoist the fallible expression into a temporary before assigning the union literal.

## Sites fixed

- **`src/http/Decompressor.zig`** — `this.* = .{ .zlib = try Zlib.init(...) }` (and brotli/zstd). On init failure the tag flips with a garbage `*Reader` pointer; `InternalState.reset()` later calls `decompressor.deinit()` which dereferences it.
- **`src/bun.js/webcore/Body.zig`** — `this.* = .{ .Locked = .{ .readable = ...(try ReadableStream.fromJS(...)).?, ... } }`. If `fromJS` throws, `Body.Value` (heap state on Request/Response) is left as `.Locked` with garbage `Strong`/`*JSGlobalObject`; later body access or GC finalize reads it.
- **`src/bun.js/api/bun/socket/Listener.zig`** (Windows) — `this.listener = .{ .namedPipe = listen(...) catch return throw(...) }` with `errdefer this.deinit()` registered. On listen failure `errdefer` runs `deinit()`, which hits `bun.assert(this.listener == .none)` — but the tag was already flipped to `.namedPipe`.
- **`src/bun.js/api/JSBundler.zig`** — `resolve.value = .{ .err = Msg.fromJS(...) catch { ...; return; } }`. On JS exception the heap `*Resolve`/`*Load` is left with `.err` tag and garbage `Msg`.

## Test plan

- [ ] `bun bd` builds
- [ ] `bun run zig:check-all` passes (Listener.zig change is Windows-only)
- [ ] CI green