### PR TITLE
fs: fix index-out-of-bounds in Windows readdir iterator

### DIFF
--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -218,7 +218,12 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                 while (true) {
                     const w = std.os.windows;
                     if (self.index >= self.end_index) {
-                        var io: w.IO_STATUS_BLOCK = undefined;
+                        // The I/O manager only fills the IO_STATUS_BLOCK on IRP
+                        // completion. When NtQueryDirectoryFile fails with an
+                        // NT_ERROR status (e.g. parameter validation), the block
+                        // is left untouched, so zero-initialize it rather than
+                        // reading uninitialized stack if the call fails.
+                        var io = mem.zeroes(w.IO_STATUS_BLOCK);
                         if (self.first) {
                             // > Any bytes inserted for alignment SHOULD be set to zero, and the receiver MUST ignore them
                             @memset(&self.buf, 0);
@@ -249,12 +254,10 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         );
 
                         self.first = false;
-                        if (io.Information == 0) {
-                            bun.sys.syslog("NtQueryDirectoryFile({f}) = 0", .{self.dir});
-                            return .{ .result = null };
-                        }
-                        self.index = 0;
-                        self.end_index = io.Information;
+
+                        // Check the return status before trusting io.Information;
+                        // the IO_STATUS_BLOCK is not written on NT_ERROR statuses.
+
                         // If the handle is not a directory, we'll get STATUS_INVALID_PARAMETER.
                         if (rc == .INVALID_PARAMETER) {
                             bun.sys.syslog("NtQueryDirectoryFile({f}) = {s}", .{ self.dir, @tagName(rc) });
@@ -270,7 +273,6 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         // matches nothing; NO_MORE_FILES on subsequent calls. Both mean "done".
                         if (rc == .NO_MORE_FILES or rc == .NO_SUCH_FILE) {
                             bun.sys.syslog("NtQueryDirectoryFile({f}) = {s}", .{ self.dir, @tagName(rc) });
-                            self.end_index = self.index;
                             return .{ .result = null };
                         }
 
@@ -294,6 +296,13 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                             };
                         }
 
+                        if (io.Information == 0) {
+                            bun.sys.syslog("NtQueryDirectoryFile({f}) = 0", .{self.dir});
+                            return .{ .result = null };
+                        }
+                        self.index = 0;
+                        self.end_index = io.Information;
+
                         bun.sys.syslog("NtQueryDirectoryFile({f}) = {d}", .{ self.dir, self.end_index });
                     }
 
@@ -304,7 +313,17 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         self.index = self.buf.len;
                     }
 
-                    const dir_info_name = @as([*]const u16, @ptrCast(&dir_info.FileName))[0 .. dir_info.FileNameLength / 2];
+                    // Some filesystem / filter drivers have been observed returning
+                    // FILE_DIRECTORY_INFORMATION entries with an out-of-range
+                    // FileNameLength (well beyond the 255-WCHAR NTFS component
+                    // limit). Clamp to what fits in name_data so a misbehaving
+                    // driver cannot walk us past the end of the destination buffer.
+                    const max_name_u16: usize = if (use_windows_ospath)
+                        self.name_data.len - 1
+                    else
+                        (self.name_data.len - 1) / 2;
+                    const name_len_u16: usize = @min(dir_info.FileNameLength / 2, max_name_u16);
+                    const dir_info_name = @as([*]const u16, @ptrCast(&dir_info.FileName))[0..name_len_u16];
 
                     if (mem.eql(u16, dir_info_name, &[_]u16{'.'}) or mem.eql(u16, dir_info_name, &[_]u16{ '.', '.' }))
                         continue;
@@ -323,10 +342,9 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                     };
 
                     if (use_windows_ospath) {
-                        const length = dir_info.FileNameLength / 2;
-                        @memcpy(self.name_data[0..length], @as([*]u16, @ptrCast(&dir_info.FileName))[0..length]);
-                        self.name_data[length] = 0;
-                        const name_utf16le = self.name_data[0..length :0];
+                        @memcpy(self.name_data[0..name_len_u16], dir_info_name);
+                        self.name_data[name_len_u16] = 0;
+                        const name_utf16le = self.name_data[0..name_len_u16 :0];
 
                         return .{
                             .result = IteratorResultW{

--- a/src/bun.js/node/dir_iterator.zig
+++ b/src/bun.js/node/dir_iterator.zig
@@ -306,9 +306,10 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                         bun.sys.syslog("NtQueryDirectoryFile({f}) = {d}", .{ self.dir, self.end_index });
                     }
 
-                    const dir_info: FILE_DIRECTORY_INFORMATION_PTR = @ptrCast(@alignCast(&self.buf[self.index]));
+                    const entry_offset = self.index;
+                    const dir_info: FILE_DIRECTORY_INFORMATION_PTR = @ptrCast(@alignCast(&self.buf[entry_offset]));
                     if (dir_info.NextEntryOffset != 0) {
-                        self.index += dir_info.NextEntryOffset;
+                        self.index = entry_offset + dir_info.NextEntryOffset;
                     } else {
                         self.index = self.buf.len;
                     }
@@ -316,13 +317,16 @@ pub fn NewIterator(comptime use_windows_ospath: bool) type {
                     // Some filesystem / filter drivers have been observed returning
                     // FILE_DIRECTORY_INFORMATION entries with an out-of-range
                     // FileNameLength (well beyond the 255-WCHAR NTFS component
-                    // limit). Clamp to what fits in name_data so a misbehaving
-                    // driver cannot walk us past the end of the destination buffer.
+                    // limit). Clamp to what fits in name_data (destination) and to
+                    // what remains in buf (source) so a misbehaving driver cannot
+                    // walk us past the end of either buffer.
                     const max_name_u16: usize = if (use_windows_ospath)
                         self.name_data.len - 1
                     else
                         (self.name_data.len - 1) / 2;
-                    const name_len_u16: usize = @min(dir_info.FileNameLength / 2, max_name_u16);
+                    const name_byte_offset = entry_offset + @offsetOf(FILE_DIRECTORY_INFORMATION, "FileName");
+                    const buf_remaining_u16: usize = (self.buf.len -| name_byte_offset) / @sizeOf(u16);
+                    const name_len_u16: usize = @min(dir_info.FileNameLength / 2, max_name_u16, buf_remaining_u16);
                     const dir_info_name = @as([*]const u16, @ptrCast(&dir_info.FileName))[0..name_len_u16];
 
                     if (mem.eql(u16, dir_info_name, &[_]u16{'.'}) or mem.eql(u16, dir_info_name, &[_]u16{ '.', '.' }))


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only panic in `fs.readdir`:

```
panic: index out of bounds: index 524288, len 257

dir_iterator.zig:327    fn next
dir_iterator.zig:428    fn next
node_fs.zig:4491        fn readdirWithEntries
node_fs.zig:4961        fn readdirInner
node_fs.zig:4430        fn readdir
```

### Root cause

The Windows directory iterator copies each entry's name into a fixed-size `name_data` buffer (`[257]u16` for the UTF-16 path, `[513]u8` for the UTF-8 path) using `FileNameLength` from the `FILE_DIRECTORY_INFORMATION` record as the slice bound:

```zig
const length = dir_info.FileNameLength / 2;
@memcpy(self.name_data[0..length], ...);  // <-- panic: index 524288, len 257
```

`FileNameLength` comes from the filesystem driver. In the crash report it was `0x100000` (1 MiB) — far beyond the 255-WCHAR NTFS component limit and well past the 8 KiB result buffer — which is only possible if a third-party filesystem / filter driver (network redirector, virtual FS, AV minifilter, etc.) returned a malformed entry. We trusted it unconditionally and sliced past `name_data`.

### Fix

- **Clamp `FileNameLength / 2`** to what fits in `name_data` (256 WCHARs) before slicing. NTFS caps a path component at 255 WCHARs so legitimate names are unaffected; a malformed entry now yields a truncated name instead of a panic.
- **Check `rc` before reading `io.Information`.** The I/O manager only fills the `IO_STATUS_BLOCK` on IRP completion — on an `NT_ERROR` status the block is left untouched (see the matching comment in `bun_shim_impl.zig`: *"IO_STATUS_BLOCK is filled only if !NT_ERROR(status)"*). Previously `io` was `undefined` and `io.Information` was read/assigned into `self.end_index` before the status check, so a failed call could poison iterator state with stack garbage or silently swallow an error as end-of-directory. The block is now zero-initialized and the status checks run first.

## How did you verify your code works?

This code path is Windows-only and requires a misbehaving filesystem driver to trigger, so it cannot be reproduced in CI. Verified by code tracing: the `@min` bound guarantees `name_len_u16 <= name_data.len - 1`, which makes the `self.name_data[0..name_len_u16]` slice and subsequent null-terminator write provably in-bounds. `zig fmt --check` passes; Windows CI will confirm compilation.