### PR TITLE
fix(tls): race in root certificate initialization causing segfault

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -1,9 +1,7 @@
-// MSVC doesn't support C11 stdatomic.h propertly yet.
-// so we use C++ std::atomic instead.
 #include "./root_certs.h"
 #include "./root_certs_header.h"
 #include "./internal/internal.h"
-#include <atomic>
+#include <mutex>
 #include <string.h>
 #include "./default_ciphers.h"
 
@@ -139,17 +137,21 @@ static void us_internal_init_root_certs(
     X509 *root_cert_instances[root_certs_size],
     STACK_OF(X509) *&root_extra_cert_instances,
     STACK_OF(X509) *&root_system_cert_instances) {
-  static std::atomic_flag root_cert_instances_lock = ATOMIC_FLAG_INIT;
-  static std::atomic_bool root_cert_instances_initialized = 0;
-
-  if (std::atomic_load(&root_cert_instances_initialized) == 1)
-    return;
-
-  while (atomic_flag_test_and_set_explicit(&root_cert_instances_lock,
-                                           std::memory_order_acquire))
-    ;
-
-  if (!atomic_exchange(&root_cert_instances_initialized, 1)) {
+  // This used to use an atomic_flag spinlock together with an atomic_bool.
+  // The bool was set to true via atomic_exchange BEFORE the certificates were
+  // actually parsed, so concurrent callers (e.g. Workers calling
+  // tls.getCACertificates() or opening a TLS connection) observed
+  // "initialized" and returned early while the STACK_OF(X509) pointers were
+  // still being pushed to and realloc'd by this thread. That's a data race
+  // which at best yields truncated/stale certificate lists and at worst
+  // crashes inside BoringSSL (e.g. when a torn read hands a freed/garbage
+  // pointer to PEM encode, or heap corruption from the concurrent access
+  // lands in the middle of X509 parsing).
+  //
+  // std::call_once does exactly what we want: initialization runs exactly
+  // once and every other caller blocks until it has fully completed.
+  static std::once_flag root_cert_instances_once;
+  std::call_once(root_cert_instances_once, [&]() {
     for (size_t i = 0; i < root_certs_size; i++) {
       root_cert_instances[i] =
           us_ssl_ctx_get_X509_without_callback_from(root_certs[i]);
@@ -171,10 +173,7 @@ static void us_internal_init_root_certs(
       us_load_system_certificates_linux(&root_system_cert_instances);
 #endif
     }
-  }
-
-  atomic_flag_clear_explicit(&root_cert_instances_lock,
-                             std::memory_order_release);
+  });
 }
 
 extern "C" int us_internal_raw_root_certs(struct us_cert_string_t **out) {

--- a/test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts
+++ b/test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts
@@ -31,15 +31,18 @@ describe("root certificate initialization", () => {
 
     using dir = tempDir("tls-root-certs-race", {
       "extra-ca-bundle.pem": bundle,
-      "fixture.mjs": `
+      "concurrent-init.fixture.ts": `
         import { Worker } from "node:worker_threads";
 
         const N = 16;
-        const results = [];
-        let done = 0;
+        const results: Array<{ extra: number; def: number }> = [];
+        let messaged = 0;
+        let exited = 0;
 
-        function finish() {
-          process.stdout.write(JSON.stringify(results));
+        function maybeFinish() {
+          if (messaged === N && exited === N) {
+            process.stdout.write(JSON.stringify(results));
+          }
         }
 
         for (let i = 0; i < N; i++) {
@@ -57,18 +60,27 @@ describe("root certificate initialization", () => {
           );
           w.on("message", m => {
             results.push(m);
-            if (++done === N) finish();
+            messaged++;
+            maybeFinish();
           });
           w.on("error", err => {
-            console.error(err);
+            console.error("worker error:", err);
             process.exit(1);
+          });
+          w.on("exit", code => {
+            if (code !== 0) {
+              console.error("worker exited with code", code);
+              process.exit(1);
+            }
+            exited++;
+            maybeFinish();
           });
         }
       `,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(String(dir), "fixture.mjs")],
+      cmd: [bunExe(), path.join(String(dir), "concurrent-init.fixture.ts")],
       env: {
         ...bunEnv,
         NODE_EXTRA_CA_CERTS: path.join(String(dir), "extra-ca-bundle.pem"),
@@ -79,7 +91,10 @@ describe("root certificate initialization", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    // On unpatched builds this segfaults and writes the crash panel to stderr,
+    // so surface that first for a readable failure diff.
     expect(stderr).toBe("");
+    expect(stdout).not.toBe("");
 
     const results = JSON.parse(stdout) as Array<{ extra: number; def: number }>;
     expect(results.length).toBe(16);

--- a/test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts
+++ b/test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+import tls from "node:tls";
+
+// us_internal_init_root_certs() used to publish "initialized" (via
+// atomic_exchange) BEFORE it finished parsing the bundled root certs and
+// populating the extra/system STACK_OF(X509)*. Concurrent callers (Workers,
+// or the first TLS connection) would observe the flag, skip initialization,
+// and read the certificate stacks while they were still being mutated /
+// realloc'd by the initializing thread. That showed up as tls.getCACertificates()
+// returning different (truncated) lists depending on timing, and in some
+// environments as a segfault inside BoringSSL's X509/EC parsing when a torn
+// read handed a freed or garbage pointer down the call chain.
+//
+// This test races many Workers against a large NODE_EXTRA_CA_CERTS bundle so
+// there is a wide window during initialization, and asserts that every Worker
+// observes the exact same, fully-populated certificate list.
+
+describe("root certificate initialization", () => {
+  test("concurrent Workers all see the same CA certificate lists", async () => {
+    // Build a big extra-CA bundle out of the bundled root certs so that the
+    // initialization path has a lot of parsing work to do. This widens the
+    // race window without depending on what system certs happen to exist on
+    // the CI machine.
+    const bundled = tls.rootCertificates;
+    expect(bundled.length).toBeGreaterThan(50);
+    // Repeat the bundle a few times so there's plenty of work.
+    const bundle = (bundled.join("\n") + "\n").repeat(3);
+    const expectedExtraCount = bundled.length * 3;
+
+    using dir = tempDir("tls-root-certs-race", {
+      "extra-ca-bundle.pem": bundle,
+      "fixture.mjs": `
+        import { Worker } from "node:worker_threads";
+
+        const N = 16;
+        const results = [];
+        let done = 0;
+
+        function finish() {
+          process.stdout.write(JSON.stringify(results));
+        }
+
+        for (let i = 0; i < N; i++) {
+          const w = new Worker(
+            \`
+              const tls = require("node:tls");
+              const extra = tls.getCACertificates("extra");
+              const def = tls.getCACertificates("default");
+              require("node:worker_threads").parentPort.postMessage({
+                extra: extra.length,
+                def: def.length,
+              });
+            \`,
+            { eval: true },
+          );
+          w.on("message", m => {
+            results.push(m);
+            if (++done === N) finish();
+          });
+          w.on("error", err => {
+            console.error(err);
+            process.exit(1);
+          });
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(dir), "fixture.mjs")],
+      env: {
+        ...bunEnv,
+        NODE_EXTRA_CA_CERTS: path.join(String(dir), "extra-ca-bundle.pem"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+
+    const results = JSON.parse(stdout) as Array<{ extra: number; def: number }>;
+    expect(results.length).toBe(16);
+
+    // Every Worker must see the full extra-CA list. Before the fix, threads
+    // that raced past the early "initialized" check would observe a partial
+    // (or empty) list.
+    for (const r of results) {
+      expect(r.extra).toBe(expectedExtraCount);
+    }
+
+    // And every Worker must agree on the default list as well.
+    const firstDefault = results[0].def;
+    expect(firstDefault).toBeGreaterThanOrEqual(bundled.length + expectedExtraCount);
+    for (const r of results) {
+      expect(r.def).toBe(firstDefault);
+    }
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a data race in `us_internal_init_root_certs()` that could segfault or return truncated CA certificate lists when multiple threads (e.g. Workers) hit the initialization path concurrently.

## How did you verify your code works?

New test `test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts` — 16 Workers concurrently call `tls.getCACertificates()` while `NODE_EXTRA_CA_CERTS` points at a ~435-cert bundle.

**Before** — segfaults on every run:
```
panic: Segmentation fault at address 0x29A3A2C
```
and when it didn't segfault, workers observed wildly different counts (0 / 83 / 145 / 303 / …).

**After** — all 16 Workers see the exact same, fully-populated list.

## Root cause

```c
if (std::atomic_load(&root_cert_instances_initialized) == 1)
  return;                                          // (3) reader skips here

while (atomic_flag_test_and_set_explicit(&lock, …)) ;

if (!atomic_exchange(&root_cert_instances_initialized, 1)) {   // (1) flag set TRUE here
  // (2) …but all the parsing / sk_X509_push / realloc happens AFTER
  for (…) root_cert_instances[i] = parse(root_certs[i]);
  root_extra_cert_instances = load_from_file(NODE_EXTRA_CA_CERTS);
  us_load_system_certificates_*(&root_system_cert_instances);
}
```

Thread A sets `initialized = 1` at (1), then starts the slow work at (2). Thread B checks (3), sees `initialized == 1`, returns immediately, and reads the `STACK_OF(X509)*` while thread A is still pushing to it. `sk_X509_push` reallocs the backing array as it grows — thread B reads through a freed pointer, or gets a torn `num`/`data` pair, and hands garbage to `PEM_write_bio_X509` → deep BoringSSL X509/EC codepaths → segfault at a near-null address.

The reported stack trace on `linux-x64-baseline`:
```
Segmentation fault at address 0x00000049
  oct.cc.inc:80     bssl::ec_point_from_uncompressed
  …
  root_certs.cpp:69   us_ssl_ctx_get_X509_without_callback_from
  root_certs.cpp:155  us_internal_init_root_certs
  root_certs.cpp:207  us_get_root_system_cert_instances
  NodeTLS.cpp:89      Bun::getSystemCACertificates
```

The race also meant `tls.getCACertificates("extra" | "system" | "default")` could return a truncated snapshot that then got cached forever at the JS level.

## Fix

Replace the hand-rolled spinlock + premature flag with `std::call_once`, which is exactly the primitive for one-time init: the first caller runs the body, every concurrent caller blocks until it *completes*, and there is a proper happens-before edge on return.