### PR TITLE
uws/usockets: passphrase_cb overflow, chunked 1*HEXDIG, SSM, sweep iterator

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -468,7 +468,7 @@ static int bsd_socket_set_source_specific_membership4(LIBUS_SOCKET_DESCRIPTOR fd
     mreq.imr_sourceaddr.s_addr = source->sin_addr.s_addr;
     mreq.imr_multiaddr.s_addr = group->sin_addr.s_addr;
 
-    int option = drop? IP_ADD_SOURCE_MEMBERSHIP : IP_DROP_SOURCE_MEMBERSHIP;
+    int option = drop? IP_DROP_SOURCE_MEMBERSHIP : IP_ADD_SOURCE_MEMBERSHIP;
 
     return setsockopt(fd, IPPROTO_IP, option, &mreq, sizeof(mreq));
 }
@@ -484,13 +484,13 @@ static int bsd_socket_set_source_specific_membership6(LIBUS_SOCKET_DESCRIPTOR fd
     memcpy(&mreq.gsr_source, source, sizeof(mreq.gsr_source));
     memcpy(&mreq.gsr_group, group, sizeof(mreq.gsr_group));
 
-    int option = drop? MCAST_JOIN_SOURCE_GROUP : MCAST_LEAVE_SOURCE_GROUP;
+    int option = drop? MCAST_LEAVE_SOURCE_GROUP : MCAST_JOIN_SOURCE_GROUP;
 
     return setsockopt(fd, IPPROTO_IPV6, option, &mreq, sizeof(mreq));
 }
 
 int bsd_socket_set_source_specific_membership(LIBUS_SOCKET_DESCRIPTOR fd, const struct sockaddr_storage *source, const struct sockaddr_storage *group, const struct sockaddr_storage *iface, int drop) {
-    if (source->ss_family == group->ss_family && group->ss_family == iface->ss_family) {
+    if (source->ss_family == group->ss_family && (iface == NULL || group->ss_family == iface->ss_family)) {
         if (source->ss_family == AF_INET) {
             return bsd_socket_set_source_specific_membership4(fd, (const struct sockaddr_in*) source, (const struct sockaddr_in*) group, (const struct sockaddr_in*) iface, drop);
         } else if (source->ss_family == AF_INET6) {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -112,8 +112,10 @@ struct us_internal_ssl_socket_t {
 int passphrase_cb(char *buf, int size, int rwflag, void *u) {
   const char *passphrase = (const char *)u;
   size_t passphrase_length = strlen(passphrase);
+  // BoringSSL calls us with a stack buf[PEM_BUFSIZE]; copying past `size`
+  // overflows it. Match Node's PasswordCallback: fail rather than truncate.
+  if (passphrase_length > (size_t)size) return -1;
   memcpy(buf, passphrase, passphrase_length);
-  // put null at end? no?
   return (int)passphrase_length;
 }
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -111,6 +111,12 @@ void us_internal_loop_link(struct us_loop_t *loop, struct us_socket_context_t *c
 
 /* Unlink is called before free */
 void us_internal_loop_unlink(struct us_loop_t *loop, struct us_socket_context_t *context) {
+    /* If a timeout callback in us_internal_timer_sweep frees the current context,
+     * advance the sweep iterator before context->next is repointed into the closed
+     * list — otherwise the sweep walks into freed contexts and skips active ones. */
+    if (context == loop->data.iterator) {
+        loop->data.iterator = context->next;
+    }
     if (loop->data.head == context) {
         loop->data.head = context->next;
         if (loop->data.head) {
@@ -128,7 +134,8 @@ void us_internal_loop_unlink(struct us_loop_t *loop, struct us_socket_context_t 
 void us_internal_timer_sweep(struct us_loop_t *loop) {
     struct us_internal_loop_data_t *loop_data = &loop->data;
     /* For all socket contexts in this loop */
-    for (loop_data->iterator = loop_data->head; loop_data->iterator; loop_data->iterator = loop_data->iterator->next) {
+    loop_data->iterator = loop_data->head;
+    while (loop_data->iterator) {
 
         struct us_socket_context_t *context = loop_data->iterator;
 
@@ -177,6 +184,11 @@ void us_internal_timer_sweep(struct us_loop_t *loop) {
         /* We always store a 0 to context->iterator here since we are no longer iterating this context */
         next_context:
         context->iterator = 0;
+        /* Advance, accounting for us_internal_loop_unlink having moved the iterator
+         * if a timeout callback freed this context. */
+        if (loop_data->iterator == context) {
+            loop_data->iterator = context->next;
+        }
     }
 }
 

--- a/packages/bun-uws/src/ChunkedEncoding.h
+++ b/packages/bun-uws/src/ChunkedEncoding.h
@@ -33,12 +33,16 @@ namespace uWS {
     constexpr uint64_t STATE_IS_CHUNKED = 1ull << (sizeof(uint64_t) * 8 - 2);//0x4000000000000000;
     constexpr uint64_t STATE_IS_CHUNKED_EXTENSION = 1ull << (sizeof(uint64_t) * 8 - 3);//0x2000000000000000;
     constexpr uint64_t STATE_WAITING_FOR_LF = 1ull << (sizeof(uint64_t) * 8 - 4);//0x1000000000000000;
-    constexpr uint64_t STATE_SIZE_MASK = ~(STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_IS_CHUNKED_EXTENSION | STATE_WAITING_FOR_LF);//0x0FFFFFFFFFFFFFFF;
+    /* RFC 7230 4.1: chunk-size = 1*HEXDIG. Tracks that at least one hex digit has
+     * been consumed for the current chunk-size line, across packet boundaries.
+     * Without this a bare "\r\n" or ";ext\r\n" would parse as size 0. */
+    constexpr uint64_t STATE_HAS_HEXDIG = 1ull << (sizeof(uint64_t) * 8 - 5);//0x0800000000000000;
+    constexpr uint64_t STATE_SIZE_MASK = ~(STATE_HAS_SIZE | STATE_IS_CHUNKED | STATE_IS_CHUNKED_EXTENSION | STATE_WAITING_FOR_LF | STATE_HAS_HEXDIG);//0x07FFFFFFFFFFFFFF;
     constexpr uint64_t STATE_IS_ERROR = ~0ull;//0xFFFFFFFFFFFFFFFF;
-    /* Overflow guard: if any of bits 55-59 are set before the next *16, one more
+    /* Overflow guard: if any of bits 54-58 are set before the next *16, one more
      * hex digit (plus the +2 for the trailing CRLF of chunk-data) would carry into
-     * STATE_WAITING_FOR_LF at bit 60. Limits chunk size to 14 hex digits (~72 PB). */
-    constexpr uint64_t STATE_SIZE_OVERFLOW = 0x1Full << (sizeof(uint64_t) * 8 - 9);//0x0F80000000000000;
+     * STATE_HAS_HEXDIG at bit 59. Limits chunk size to 14 hex digits (~72 PB). */
+    constexpr uint64_t STATE_SIZE_OVERFLOW = 0x1Full << (sizeof(uint64_t) * 8 - 10);//0x07C0000000000000;
 
     inline uint64_t chunkSize(uint64_t state) {
         return state & STATE_SIZE_MASK;
@@ -72,8 +76,9 @@ namespace uWS {
         if (state & STATE_WAITING_FOR_LF) [[unlikely]] {
             if (!data.length()) return state;
             if (data[0] != '\n') return STATE_IS_ERROR;
+            if (!(state & STATE_HAS_HEXDIG)) return STATE_IS_ERROR;
             data.remove_prefix(1);
-            return ((state & ~(STATE_WAITING_FOR_LF | STATE_IS_CHUNKED_EXTENSION)) + 2)
+            return ((state & ~(STATE_WAITING_FOR_LF | STATE_IS_CHUNKED_EXTENSION | STATE_HAS_HEXDIG)) + 2)
                    | STATE_HAS_SIZE | STATE_IS_CHUNKED;
         }
 
@@ -96,7 +101,7 @@ namespace uWS {
                 else if ((unsigned)(d - 'a') < 6)            n = d - 'a' + 10;
                 else return STATE_IS_ERROR;
                 if (chunkSize(state) & STATE_SIZE_OVERFLOW) [[unlikely]] return STATE_IS_ERROR;
-                state = ((state & STATE_SIZE_MASK) * 16ull + n) | STATE_IS_CHUNKED;
+                state = ((state & STATE_SIZE_MASK) * 16ull + n) | STATE_IS_CHUNKED | STATE_HAS_HEXDIG;
                 ++p; --len;
             }
         }
@@ -114,9 +119,10 @@ namespace uWS {
                     return state | STATE_WAITING_FOR_LF;
                 }
                 if (*p != '\n') return STATE_IS_ERROR;
+                if (!(state & STATE_HAS_HEXDIG)) return STATE_IS_ERROR;
                 ++p; --len;
                 data = std::string_view(p, len);
-                return ((state & ~STATE_IS_CHUNKED_EXTENSION) + 2)
+                return ((state & ~(STATE_IS_CHUNKED_EXTENSION | STATE_HAS_HEXDIG)) + 2)
                        | STATE_HAS_SIZE | STATE_IS_CHUNKED;
             }
             if (c <= 32) return STATE_IS_ERROR;

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -910,8 +910,12 @@ namespace uWS
             // lets check if content len is valid before calling requestHandler
             if(contentLengthStringLen) {
                 remainingStreamingBytes = toUnsignedInteger(contentLengthString);
-                if (remainingStreamingBytes == UINT64_MAX) [[unlikely]] {
-                    /* Parser error */
+                /* remainingStreamingBytes is overloaded: for Content-Length it holds the raw byte
+                 * count, for Transfer-Encoding: chunked it holds the ChunkedEncoding state word.
+                 * isParsingChunkedEncoding() distinguishes the two by testing the flag bits, so a
+                 * Content-Length value must never reach a flag bit. UINT64_MAX (parse error) is
+                 * also caught by this since UINT64_MAX > STATE_SIZE_MASK. */
+                if (remainingStreamingBytes > STATE_SIZE_MASK) [[unlikely]] {
                     return HttpParserResult::error(HTTP_ERROR_400_BAD_REQUEST, HTTP_PARSER_ERROR_INVALID_CONTENT_LENGTH);
                 }
             }

--- a/src/deps/uws/socket.zig
+++ b/src/deps/uws/socket.zig
@@ -1140,7 +1140,7 @@ pub const InternalSocket = union(enum) {
                 .connected, .connecting, .detached, .pipe => false,
             },
             .pipe => switch (other) {
-                .pipe => if (Environment.isWindows) other.pipe == other.pipe else false,
+                .pipe => if (Environment.isWindows) this.pipe == other.pipe else false,
                 .connected, .connecting, .detached, .upgradedDuplex => false,
             },
         };

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -284,6 +284,159 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(stdout).toContain("400");
     expect(exitCode).toBe(0);
   });
+
+  test("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
+    // remainingStreamingBytes is shared between CL and chunked state. CL >= 2^59 would
+    // set STATE_HAS_HEXDIG and route a fixed-length body into the chunked decoder.
+    const script = `
+      let urls = [];
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) { urls.push(new URL(req.url).pathname); return new Response("OK"); },
+      });
+      const { promise, resolve } = Promise.withResolvers();
+      let received = "";
+      const socket = await Bun.connect({
+        hostname: "localhost",
+        port: server.port,
+        socket: {
+          data(s, d) { received += d.toString(); },
+          async open(s) {
+            s.write("GET /first HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 576460752303423488\\r\\n\\r\\n");
+            s.flush();
+            await Bun.sleep(20);
+            s.write("\\r\\n\\r\\nGET /smuggled HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+            s.flush();
+          },
+          error() {},
+          close() { console.log(JSON.stringify({ received, urls })); resolve(); },
+        },
+      });
+      await promise;
+      server.stop();
+    `;
+
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const { received, urls } = JSON.parse(stdout);
+    expect(received).toContain("400");
+    expect(urls).not.toContain("/smuggled");
+    expect(exitCode).toBe(0);
+  });
+
+  describe.each([
+    ["bare CRLF", "\\r\\n"],
+    ["extension only", ";a=b\\r\\n"],
+  ])("rejects chunk-size with zero hex digits (%s)", (_, chunkSizeLine) => {
+    // RFC 7230 4.1: chunk-size = 1*HEXDIG. A chunk-size line with no hex digit
+    // must be rejected. Previously this parsed as size 0 (last-chunk), allowing a
+    // pipelined request after the bogus terminator to be smuggled.
+    test("rejects and does not process trailing pipelined request", async () => {
+      const script = `
+        let requests = 0;
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            requests++;
+            try {
+              await req.text();
+              return new Response("OK " + req.url);
+            } catch {
+              return new Response("Body error", { status: 400 });
+            }
+          },
+        });
+        const { promise, resolve } = Promise.withResolvers();
+        let received = "";
+        const socket = await Bun.connect({
+          hostname: "localhost",
+          port: server.port,
+          socket: {
+            data(socket, data) { received += data.toString(); },
+            open(socket) {
+              socket.write(
+                "PUT /first HTTP/1.1\\r\\nHost: x\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n" +
+                "${chunkSizeLine}\\r\\n" +
+                "GET /smuggled HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n"
+              );
+              socket.flush();
+            },
+            error() {},
+            close() { console.log(JSON.stringify({ received, requests })); resolve(); },
+          },
+        });
+        await promise;
+        server.stop();
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      const { received, requests } = JSON.parse(stdout);
+      expect(received).toContain("400");
+      expect(received).not.toContain("/smuggled");
+      // The smuggled request must never reach the handler.
+      expect(requests).toBeLessThanOrEqual(1);
+      expect(exitCode).toBe(0);
+    });
+
+    test("rejects when chunk-size line is split across packets", async () => {
+      const script = `
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            try { await req.text(); return new Response("OK"); }
+            catch { return new Response("Body error", { status: 400 }); }
+          },
+        });
+        const { promise, resolve } = Promise.withResolvers();
+        let received = "";
+        const socket = await Bun.connect({
+          hostname: "localhost",
+          port: server.port,
+          socket: {
+            data(socket, data) { received += data.toString(); },
+            async open(socket) {
+              socket.write("PUT / HTTP/1.1\\r\\nHost: x\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
+              socket.flush();
+              await Bun.sleep(20);
+              socket.write("${chunkSizeLine}");
+              socket.flush();
+              await Bun.sleep(20);
+              socket.write("\\r\\n");
+              socket.flush();
+            },
+            error() {},
+            close() { console.log(received); resolve(); },
+          },
+        });
+        await promise;
+        server.stop();
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toContain("400");
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -241,6 +241,30 @@ describe("tls.createServer listen", () => {
     server.listen(0, "0.0.0.0", closeAndFail);
   });
 
+  it("should reject passphrase longer than PEM_BUFSIZE without crashing", done => {
+    // BoringSSL invokes the passphrase callback with a 1024-byte stack buffer.
+    // A longer passphrase must fail key decryption rather than overflow that buffer.
+    const { mustCall, mustNotCall } = createCallCheckCtx(done);
+
+    const server: Server = createServer({
+      key: passKey,
+      passphrase: Buffer.alloc(2000, "A").toString(),
+      cert: cert,
+    });
+
+    server.on("error", mustCall());
+    let timeout: Timer;
+    function closeAndFail() {
+      clearTimeout(timeout);
+      server.close();
+      mustNotCall()();
+    }
+
+    timeout = setTimeout(closeAndFail, 100);
+
+    server.listen(0, "0.0.0.0", closeAndFail);
+  });
+
   it("should not listen without cert", done => {
     const { mustCall, mustNotCall } = createCallCheckCtx(done);
 


### PR DESCRIPTION
## Summary

Six fixes from auditing `bun-usockets` / `bun-uws`:

- **`crypto/openssl.c` — `passphrase_cb` stack buffer overflow.** The PEM password callback copied `strlen(passphrase)` bytes into BoringSSL's `buf` without checking the `size` argument. BoringSSL invokes it with a 1024-byte (`PEM_BUFSIZE`) stack buffer, so a `tls.passphrase` > 1024 bytes overflowed the stack in `PEM_do_header` / `d2i_PKCS8PrivateKey_bio`. Now returns `-1` when the passphrase exceeds `size`, matching Node's `PasswordCallback`.

- **`ChunkedEncoding.h` — chunk-size with zero hex digits accepted as size 0.** RFC 7230 §4.1 requires `chunk-size = 1*HEXDIG`, but a body of `\r\n\r\n` or `;ext\r\n\r\n` (no hex digit) parsed identically to `0\r\n\r\n`. Behind a stricter proxy this is a request-smuggling differential. Adds `STATE_HAS_HEXDIG` (bit 59) to track that at least one hex digit was consumed for the current chunk-size line, persisting across packet boundaries; the transition to `STATE_HAS_SIZE` now requires it. `STATE_SIZE_MASK` and `STATE_SIZE_OVERFLOW` shift down one bit to make room.

- **`HttpParser.h` — cap Content-Length at `STATE_SIZE_MASK`.** `remainingStreamingBytes` is shared between Content-Length and the chunked state word; `isParsingChunkedEncoding()` distinguishes them by testing the flag bits. With bit 59 now a flag, an 18-digit Content-Length ≥ 2⁵⁹ would alias `STATE_HAS_HEXDIG` and route a fixed-length body into the chunked decoder. The cap keeps every accepted CL strictly below the flag region (and is still ~576 PB).

- **`loop.c` — timer-sweep iterator not patched on context unlink.** `us_internal_timer_sweep` iterates contexts via `loop_data->iterator`, but `us_internal_loop_unlink` never updated it. If a timeout callback dropped the last ref on the current context, the for-loop's `iterator->next` followed it into the closed-context list and skipped the remaining active contexts for that tick. Now patches the iterator in `unlink` and checks for it after each context body, mirroring the existing socket-level iterator pattern.

- **`bsd.c` — source-specific multicast add/drop inverted; NULL `iface` deref.** The ternary was `drop ? ADD : DROP` for both v4 and v6, so `addSourceSpecificMembership` dropped and vice versa. The wrapper also dereferenced `iface->ss_family` unconditionally even though the v4/v6 helpers explicitly handle `iface == NULL`.

- **`src/deps/uws/socket.zig` — `InternalSocket.eq` self-compare.** `.pipe` arm compared `other.pipe == other.pipe` (always true on Windows) instead of `this.pipe == other.pipe`.

## Node.js parity

23-case side-by-side against Node 25.2.1 (`node:http`): all valid chunked bodies (`0\r\n\r\n`, leading zeros, upper/lower hex, extensions) remain accepted; all previously-rejected cases (whitespace, bare LF, `0x` prefix, signs, NUL, double-CR) remain rejected. Only the three zero-hex-digit cases move from 200 → 400, now matching Node.

## Test plan

- [x] `bun bd test test/js/bun/http/http-server-chunking.test.ts` — 11 pass (5 new: zero-hex-digit ×4, CL flag-bit aliasing ×1)
- [x] New zero-hex-digit tests fail on system bun (`USE_SYSTEM_BUN=1`), pass on debug build
- [x] `bun bd test test/js/node/tls/node-tls-server.test.ts` — 22 pass (1 new: 2000-byte passphrase rejected without crash; system bun segfaults at `0x4141414141414149`)
- [x] `bun bd test test/js/bun/http/serve.test.ts` — 189 pass / 1 skip / 0 fail
- [x] `bun bd test test/js/web/fetch/chunked-trailing.test.js` — 23 pass
- [x] `bun run zig:check`