### PR TITLE
Propagate exceptions from custom asymmetric matcher asymmetricMatch()

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -247,6 +247,16 @@ describe("invalid matcher implementations errors", () => {
     expect(() => expect(0)._toCustomA()).toThrow("MyError");
   });
 
+  it("propagates exceptions from asymmetricMatch", () => {
+    expect.extend({
+      _toCustomThrow: _received => {
+        throw new Error("MyError");
+      },
+    });
+    const matcher = expect._toCustomThrow();
+    expect(() => matcher.asymmetricMatch({})).toThrow("MyError");
+  });
+
   it("throws when returns undefined", () => {
     expect.extend({
       // @ts-expect-error


### PR DESCRIPTION
When a custom matcher registered via `expect.extend()` throws during `asymmetricMatch()`, `ExpectCustomAsymmetricMatcher.execute()` swallowed the Zig error with `catch false` but left the JSC exception pending on the VM. `asymmetricMatch()` would then return `jsBoolean(false)` with a pending exception, tripping `releaseAssertNoException()` in `toJSHostCall` on debug builds.

```js
const { expect } = Bun.jest(import.meta.path);
expect.extend({
  myMatcher: () => { throw new Error("boom"); },
});
expect.myMatcher().asymmetricMatch({}); // assertion failure in debug builds
```

Fix: check for a pending exception after `execute()` returns and propagate it as `error.JSError`.

Found by Fuzzilli (fingerprint `e1d95239dc9c9401`). The fuzzer hit this via REPRL state where a prior sample registered a throwing function (the native `expect.closeTo`) as a custom matcher.