### PR TITLE
libarchive: keep upstream damaged-block retry semantics on the buffered path

### DIFF
--- a/patches/libarchive/nonblocking-read.patch
+++ b/patches/libarchive/nonblocking-read.patch
@@ -636,7 +636,7 @@
 +					a->read_header_in_progress = 0;
 +					TAR_HEADER_RETURN(ARCHIVE_RETRY);
  				}
-@@ -822,2 +992,55 @@
+@@ -822,2 +992,56 @@
  		header = (const struct archive_entry_header_ustar *)h;
 +
 +		/*
@@ -660,20 +660,21 @@
 +		case 'V': case 'X': case 'x': {
 +			int64_t ext_size = tar_atol(header->size,
 +			    sizeof(header->size));
-+			if (ext_size < 0)
-+				ext_size = 0;
-+			int64_t ext_padded = (ext_size + 511) & ~511;
-+			/* Bound the prebuffer. A corrupted stream can
-+			 * produce garbage that decodes as an extension
-+			 * header with a multi-GB `size`; retrying
-+			 * `ahead(512 + huge)` every chunk would never
-+			 * make progress. Real pax/GNU extension
-+			 * payloads are path-length-bounded (a few KB),
-+			 * so anything beyond this is handed to the
-+			 * handler below, which will fail cleanly on
-+			 * its own `__archive_read_ahead`. */
-+			if (ext_padded > (int64_t)(1u << 20))
++			/* Bound the prebuffer before rounding
++			 * (tar_atol saturates to INT64_MAX on
++			 * overflow, so adding 511 first would be UB).
++			 * A corrupted stream can produce garbage that
++			 * decodes as an extension header with a
++			 * multi-GB `size`; retrying `ahead(512+huge)`
++			 * every chunk would never make progress. Real
++			 * pax/GNU extension payloads are path-length
++			 * bounded (a few KB), so anything beyond this
++			 * is handed to the handler below, which will
++			 * fail cleanly on its own
++			 * `__archive_read_ahead`. */
++			if (ext_size < 0 || ext_size > (int64_t)(1u << 20))
 +				break;
++			int64_t ext_padded = (ext_size + 511) & ~511;
 +			if (__archive_read_ahead(a,
 +			    (size_t)(512 + ext_padded), &bytes) == NULL &&
 +			    bytes == ARCHIVE_RETRY) {
@@ -692,47 +693,47 @@
 +		}
 +
  		switch(header->typeflag[0]) {
-@@ -827,3 +1050,3 @@
+@@ -827,3 +1051,3 @@
  						  "Redundant 'A' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -838,3 +1061,3 @@
+@@ -838,3 +1062,3 @@
  						  "Redundant 'g' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -882,3 +1105,3 @@
+@@ -882,3 +1106,3 @@
  						  "Redundant 'X'/'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -894,3 +1117,3 @@
+@@ -894,3 +1118,3 @@
  						  "Redundant 'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -921,3 +1144,3 @@
+@@ -921,3 +1145,3 @@
  			if (err < ARCHIVE_WARN) {
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -940,3 +1163,3 @@
+@@ -940,3 +1164,3 @@
  				if (err2 < ARCHIVE_WARN) {
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
  				}
-@@ -955,3 +1178,3 @@
+@@ -955,3 +1179,3 @@
  							  "Non-regular file cannot be sparse");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
  				} else if (tar->sparse_gnu_major == 0 &&
-@@ -968,3 +1191,3 @@
+@@ -968,3 +1192,3 @@
  					if (bytes_read < 0)
 -						return ((int)bytes_read);
 +						TAR_HEADER_RETURN((int)bytes_read);
  					tar->entry_bytes_remaining -= bytes_read;
-@@ -974,6 +1197,6 @@
+@@ -974,6 +1198,6 @@
  							  "Unrecognized GNU sparse file format");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
@@ -741,12 +742,12 @@
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  		}
-@@ -983,3 +1206,3 @@
+@@ -983,3 +1207,3 @@
  		if (err == ARCHIVE_FATAL)
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  
-@@ -993,2 +1216,22 @@
+@@ -993,2 +1217,22 @@
  	}
 +
 +bun_retry:

--- a/patches/libarchive/nonblocking-read.patch
+++ b/patches/libarchive/nonblocking-read.patch
@@ -636,7 +636,7 @@
 +					a->read_header_in_progress = 0;
 +					TAR_HEADER_RETURN(ARCHIVE_RETRY);
  				}
-@@ -822,2 +992,56 @@
+@@ -822,2 +992,63 @@
  		header = (const struct archive_entry_header_ustar *)h;
 +
 +		/*
@@ -683,8 +683,15 @@
 +			}
 +			/* Re-establish `h`: the filter may have
 +			 * memmoved its buffer to satisfy the larger
-+			 * request. */
++			 * request. A fatal error from the larger
++			 * read (alloc failure, downstream I/O error)
++			 * leaves `filter->fatal` set, so this read
++			 * can return NULL even though the original
++			 * 512 bytes are still buffered; bail cleanly
++			 * rather than dereferencing `header` below. */
 +			h = __archive_read_ahead(a, 512, NULL);
++			if (h == NULL)
++				TAR_HEADER_RETURN(ARCHIVE_FATAL);
 +			header = (const struct archive_entry_header_ustar *)h;
 +			break;
 +		}
@@ -693,47 +700,47 @@
 +		}
 +
  		switch(header->typeflag[0]) {
-@@ -827,3 +1051,3 @@
+@@ -827,3 +1058,3 @@
  						  "Redundant 'A' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -838,3 +1062,3 @@
+@@ -838,3 +1069,3 @@
  						  "Redundant 'g' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -882,3 +1106,3 @@
+@@ -882,3 +1113,3 @@
  						  "Redundant 'X'/'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -894,3 +1118,3 @@
+@@ -894,3 +1125,3 @@
  						  "Redundant 'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -921,3 +1145,3 @@
+@@ -921,3 +1152,3 @@
  			if (err < ARCHIVE_WARN) {
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -940,3 +1164,3 @@
+@@ -940,3 +1171,3 @@
  				if (err2 < ARCHIVE_WARN) {
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
  				}
-@@ -955,3 +1179,3 @@
+@@ -955,3 +1186,3 @@
  							  "Non-regular file cannot be sparse");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
  				} else if (tar->sparse_gnu_major == 0 &&
-@@ -968,3 +1192,3 @@
+@@ -968,3 +1199,3 @@
  					if (bytes_read < 0)
 -						return ((int)bytes_read);
 +						TAR_HEADER_RETURN((int)bytes_read);
  					tar->entry_bytes_remaining -= bytes_read;
-@@ -974,6 +1198,6 @@
+@@ -974,6 +1205,6 @@
  							  "Unrecognized GNU sparse file format");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
@@ -742,12 +749,12 @@
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  		}
-@@ -983,3 +1207,3 @@
+@@ -983,3 +1214,3 @@
  		if (err == ARCHIVE_FATAL)
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  
-@@ -993,2 +1217,22 @@
+@@ -993,2 +1224,22 @@
  	}
 +
 +bun_retry:

--- a/patches/libarchive/nonblocking-read.patch
+++ b/patches/libarchive/nonblocking-read.patch
@@ -1,20 +1,23 @@
 --- a/libarchive/archive_read_private.h
 +++ b/libarchive/archive_read_private.h
-@@ -182,2 +182,11 @@
+@@ -182,2 +182,14 @@
  
 +	/*
-+	 * BUN PATCH: set by archive_read_next_header2 when the format's
-+	 * read_header callback returns ARCHIVE_RETRY from a non-blocking
-+	 * source. On the next call we skip archive_entry_clear() so that
++	 * BUN PATCH: set by the format's read_header callback when it
++	 * returns ARCHIVE_RETRY from a non-blocking source and wants
++	 * the next call to skip archive_entry_clear() so that
 +	 * attributes already populated by consumed extension headers
-+	 * (pax, GNU long name/link, etc.) survive the resume.
++	 * (pax, GNU long name/link, etc.) survive the resume. Format
++	 * readers that return ARCHIVE_RETRY without setting this —
++	 * e.g. upstream tar's damaged-block skip — get the original
++	 * reset-everything semantics on re-entry.
 +	 */
 +	int		  read_header_in_progress;
 +
  	/* Nodes and offsets of compressed data block */
 --- a/libarchive/archive_read.c
 +++ b/libarchive/archive_read.c
-@@ -616,25 +616,48 @@
+@@ -616,25 +616,58 @@
  
 -	archive_entry_clear(entry);
 -	archive_clear_error(&a->archive);
@@ -77,10 +80,20 @@
 +		++_a->file_count;
 +	}
  	r2 = (a->format->read_header)(a, entry);
-+	/* BUN PATCH: remember whether this header read is mid-flight. */
-+	a->read_header_in_progress = (r2 == ARCHIVE_RETRY);
++	/*
++	 * BUN PATCH: the format reader sets read_header_in_progress
++	 * itself when a non-blocking source yields mid-header (see
++	 * `bun_retry` in the tar reader). Clear it on any terminal
++	 * result so the next call runs the full reset above. An
++	 * ARCHIVE_RETRY that did not set the flag — upstream tar's
++	 * pre-existing damaged-block skip — therefore behaves exactly
++	 * as upstream: the next call re-runs archive_entry_clear /
++	 * archive_clear_error.
++	 */
++	if (r2 != ARCHIVE_RETRY)
++		a->read_header_in_progress = 0;
  
-@@ -1384,2 +1407,29 @@
+@@ -1384,2 +1417,29 @@
  			    &filter->client_buff);
 +			/*
 +			 * BUN PATCH: non-blocking read support.
@@ -110,7 +123,7 @@
 +				return (NULL);
 +			}
  			if (bytes_read < 0) {		/* Read error. */
-@@ -1579,3 +1629,10 @@
+@@ -1579,3 +1639,10 @@
  			filter->client_buff = NULL;
 -			filter->fatal = 1;
 +			/*
@@ -444,18 +457,21 @@
  		}
 -		tar->sconv = tar->sconv_default;
  	}
-@@ -562,2 +638,10 @@
+@@ -562,2 +638,13 @@
  
 +	/*
-+	 * BUN PATCH: on ARCHIVE_RETRY, `tar_read_header` guarantees
-+	 * `*unconsumed == 0` (nothing pending that isn't already
-+	 * flushed) so the caller can yield and re-enter later.
++	 * BUN PATCH: a non-blocking yield leaves `header_in_progress`
++	 * set; in that case `*unconsumed == 0` (nothing pending that
++	 * isn't already flushed) so the caller can yield and re-enter
++	 * later. Upstream's damaged-block ARCHIVE_RETRY clears the
++	 * flag and falls through to the original post-read handling
++	 * below (which is what upstream did).
 +	 */
-+	if (r == ARCHIVE_RETRY)
++	if (r == ARCHIVE_RETRY && tar->header_in_progress)
 +		return (ARCHIVE_RETRY);
 +
  	tar_flush_unconsumed(a, &unconsumed);
-@@ -637,5 +721,16 @@
+@@ -637,5 +724,16 @@
  
 -			if (__archive_read_consume(a, request) != request)
 +			/*
@@ -473,7 +489,7 @@
  			tar->entry_padding = 0;
 +			tar->entry_bytes_remaining = 0;
  			*buff = NULL;
-@@ -648,2 +743,11 @@
+@@ -648,2 +746,11 @@
  		if (*buff == NULL) {
 +			/*
 +			 * BUN PATCH: propagate non-blocking retry. Every
@@ -485,11 +501,11 @@
 +			if (bytes_read == ARCHIVE_RETRY)
 +				return (ARCHIVE_RETRY);
  			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
-@@ -676,2 +780,3 @@
+@@ -676,2 +783,3 @@
  	int64_t request;
 +	int cr;
  	struct tar* tar;
-@@ -683,3 +788,14 @@
+@@ -683,3 +791,14 @@
  
 -	if (__archive_read_consume(a, request) != request)
 +	/*
@@ -505,23 +521,23 @@
 +		return (ARCHIVE_RETRY);
 +	if (cr != ARCHIVE_OK)
  		return (ARCHIVE_FATAL);
-@@ -687,3 +803,2 @@
+@@ -687,3 +806,2 @@
  	tar->entry_bytes_remaining = 0;
 -	tar->entry_bytes_unconsumed = 0;
  	tar->entry_padding = 0;
-@@ -721,4 +836,4 @@
+@@ -721,4 +839,4 @@
  	ssize_t bytes;
 -	int err = ARCHIVE_OK, err2;
 -	int eof_fatal = 0; /* EOF is okay at some points... */
 +	int err, err2;
 +	int eof_fatal; /* EOF is okay at some points... */
  	const char *h;
-@@ -728,3 +843,3 @@
+@@ -728,3 +846,3 @@
  	/* Bitmask of what header types we've seen. */
 -	int32_t seen_headers = 0;
 +	int32_t seen_headers;
  	static const int32_t seen_A_header = 1;
-@@ -737,3 +852,20 @@
+@@ -737,3 +855,20 @@
  
 -	tar_reset_header_state(tar);
 +	/*
@@ -543,7 +559,7 @@
 +	eof_fatal = tar->header_eof_fatal;
 +	err = tar->header_err;
  
-@@ -745,2 +877,13 @@
+@@ -745,2 +880,13 @@
  
 +/*
 + * BUN PATCH: every terminal exit from this function (anything other
@@ -557,12 +573,12 @@
 +	} while (0)
 +
  	/*
-@@ -757,3 +900,3 @@
+@@ -757,3 +903,3 @@
  			if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -762,2 +905,13 @@
+@@ -762,2 +908,13 @@
  			h = __archive_read_ahead(a, 512, &bytes);
 +			if (h == NULL && bytes == ARCHIVE_RETRY) {
 +				/*
@@ -576,7 +592,7 @@
 +				goto bun_retry;
 +			}
  			if (bytes == 0) { /* EOF at a block boundary. */
-@@ -769,5 +923,5 @@
+@@ -769,5 +926,5 @@
  							  "Damaged tar archive (end-of-archive within a sequence of headers)");
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
@@ -584,39 +600,43 @@
 -					return (ARCHIVE_EOF);
 +					TAR_HEADER_RETURN(ARCHIVE_EOF);
  				}
-@@ -779,3 +933,3 @@
+@@ -779,3 +936,3 @@
  				    " detected while reading next header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -799,3 +953,3 @@
+@@ -799,3 +956,3 @@
  				archive_clear_error(&a->archive);
 -				return (ARCHIVE_EOF);
 +				TAR_HEADER_RETURN(ARCHIVE_EOF);
  			}
-@@ -805,3 +959,3 @@
+@@ -805,3 +962,3 @@
  				if (tar_flush_unconsumed(a, unconsumed) != ARCHIVE_OK) {
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
  				}
-@@ -812,5 +966,14 @@
+@@ -812,5 +969,18 @@
  				if (eof_fatal) {
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
  				} else {
 -					return (ARCHIVE_RETRY);
 +					/*
-+					 * BUN PATCH: this RETRY means
-+					 * "skip this block and look for
-+					 * the next valid header", which
-+					 * is also the non-blocking
-+					 * contract: persist state so
-+					 * re-entry does not reset
-+					 * `seen_headers`.
++					 * BUN PATCH: upstream's
++					 * "damaged block, skip and retry
++					 * the next one" — NOT a
++					 * non-blocking yield. The next
++					 * call must re-run the full
++					 * state reset (archive_entry_clear,
++					 * tar_reset_header_state) exactly
++					 * as upstream, so clear both
++					 * in-progress flags instead of
++					 * routing through bun_retry.
 +					 */
-+					goto bun_retry;
++					a->read_header_in_progress = 0;
++					TAR_HEADER_RETURN(ARCHIVE_RETRY);
  				}
-@@ -822,2 +985,55 @@
+@@ -822,2 +992,55 @@
  		header = (const struct archive_entry_header_ustar *)h;
 +
 +		/*
@@ -672,47 +692,47 @@
 +		}
 +
  		switch(header->typeflag[0]) {
-@@ -827,3 +1043,3 @@
+@@ -827,3 +1050,3 @@
  						  "Redundant 'A' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -838,3 +1054,3 @@
+@@ -838,3 +1061,3 @@
  						  "Redundant 'g' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -882,3 +1098,3 @@
+@@ -882,3 +1105,3 @@
  						  "Redundant 'X'/'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -894,3 +1110,3 @@
+@@ -894,3 +1117,3 @@
  						  "Redundant 'x' header");
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -921,3 +1137,3 @@
+@@ -921,3 +1144,3 @@
  			if (err < ARCHIVE_WARN) {
 -				return (ARCHIVE_FATAL);
 +				TAR_HEADER_RETURN(ARCHIVE_FATAL);
  			}
-@@ -940,3 +1156,3 @@
+@@ -940,3 +1163,3 @@
  				if (err2 < ARCHIVE_WARN) {
 -					return (ARCHIVE_FATAL);
 +					TAR_HEADER_RETURN(ARCHIVE_FATAL);
  				}
-@@ -955,3 +1171,3 @@
+@@ -955,3 +1178,3 @@
  							  "Non-regular file cannot be sparse");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
  				} else if (tar->sparse_gnu_major == 0 &&
-@@ -968,3 +1184,3 @@
+@@ -968,3 +1191,3 @@
  					if (bytes_read < 0)
 -						return ((int)bytes_read);
 +						TAR_HEADER_RETURN((int)bytes_read);
  					tar->entry_bytes_remaining -= bytes_read;
-@@ -974,6 +1190,6 @@
+@@ -974,6 +1197,6 @@
  							  "Unrecognized GNU sparse file format");
 -					return (ARCHIVE_WARN);
 +					TAR_HEADER_RETURN(ARCHIVE_WARN);
@@ -721,12 +741,12 @@
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  		}
-@@ -983,3 +1199,3 @@
+@@ -983,3 +1206,3 @@
  		if (err == ARCHIVE_FATAL)
 -			return (err);
 +			TAR_HEADER_RETURN(err);
  
-@@ -993,2 +1209,17 @@
+@@ -993,2 +1216,22 @@
  	}
 +
 +bun_retry:
@@ -736,11 +756,16 @@
 +	 * (either nothing was added this iteration, or we rolled the
 +	 * 512-byte header back above), so
 +	 * `archive_read_format_tar_read_header` can return
-+	 * ARCHIVE_RETRY without flushing.
++	 * ARCHIVE_RETRY without flushing. Setting
++	 * `read_header_in_progress` here (rather than having
++	 * archive_read_next_header2 set it on every RETRY) is what
++	 * lets upstream's damaged-block RETRY keep its original
++	 * reset-everything semantics.
 +	 */
 +	tar->header_seen = seen_headers;
 +	tar->header_eof_fatal = eof_fatal;
 +	tar->header_err = err;
++	a->read_header_in_progress = 1;
 +	return (ARCHIVE_RETRY);
 +#undef TAR_HEADER_RETURN
  }

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -390,8 +390,8 @@ test("buffered extract: damaged-block retry resets header state (upstream semant
   // 'g' header is extracted normally.
   expect(stderr).not.toContain("Fail extracting tarball");
   expect(stderr).not.toContain("failed to resolve");
+  expect(exitCode).toBe(0);
 
   const extracted = readFileSync(join(String(dir), "node_modules", "damaged-pkg", "index.js"));
   expect(extracted.equals(fileBody)).toBe(true);
-  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -368,14 +368,7 @@ test("buffered extract: damaged-block retry resets header state (upstream semant
   const pkgJsonEntry = [tarHeader("package/package.json", pkgJson.length, "0"), pkgJson, pad512(pkgJson.length)];
 
   // [g][damaged][g][package.json][index.js][EOF EOF]
-  const tar = Buffer.concat([
-    ...paxEntry(),
-    damaged,
-    ...paxEntry(),
-    ...pkgJsonEntry,
-    ...file,
-    Buffer.alloc(1024, 0),
-  ]);
+  const tar = Buffer.concat([...paxEntry(), damaged, ...paxEntry(), ...pkgJsonEntry, ...file, Buffer.alloc(1024, 0)]);
   const tgz = gzipSync(tar);
 
   using dir = tempDir("damaged-block-retry", {

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -8,7 +8,7 @@
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
 import { gzipSync } from "node:zlib";
@@ -28,7 +28,7 @@ function octal(n: number, width: number): string {
   return n.toString(8).padStart(width - 1, "0") + "\0";
 }
 
-function tarHeader(name: string, size: number, type: "0" | "5" | "x"): Buffer {
+function tarHeader(name: string, size: number, type: "0" | "5" | "x" | "g"): Buffer {
   const buf = Buffer.alloc(512, 0);
   buf.write(name, 0, 100, "utf8");
   buf.write(octal(0o644, 8), 100); // mode
@@ -327,4 +327,78 @@ describe("streaming tarball extraction", () => {
     expect(stderr).toContain("Integrity check failed");
     expect(exitCode).not.toBe(0);
   });
+});
+
+// -------------------------------------------------------------------
+// Regression: the nonblocking-read patch routed upstream libarchive's
+// pre-existing damaged-block ARCHIVE_RETRY through the same `bun_retry`
+// path as a non-blocking yield, so `seen_headers` / entry state leaked
+// across the retry. A second pax 'g' global header after the damaged
+// block would then trip "Redundant 'g' header" → ARCHIVE_FATAL even
+// though upstream libarchive (and a `tar` CLI) accepts this layout.
+//
+// This test goes through the buffered extractor only: local `file:`
+// tarballs are read fully into memory by PackageManagerTask.readAndExtract
+// and handed to Archiver.extractToDir, which loops on readNextHeader with
+// `.retry => continue`. The streaming reader is never involved, so any
+// behaviour change here is the libarchive patch leaking into the shared
+// buffered codepath.
+// -------------------------------------------------------------------
+test("buffered extract: damaged-block retry resets header state (upstream semantics)", async () => {
+  // One pax 'g' extended-header payload. libarchive's header_pax_global
+  // just skips it, but parsing it sets `seen_headers |= seen_g_header`;
+  // seeing a second one without an intervening state reset is what
+  // triggers the "Redundant 'g' header" FATAL.
+  const pax = Buffer.from("16 comment=test\n", "utf8");
+  expect(pax.length).toBe(16);
+  const paxEntry = () => [tarHeader("pax_global_header", pax.length, "g"), pax, pad512(pax.length)];
+
+  // A 512-byte block that is neither all-zero (would be treated as the
+  // end-of-archive marker) nor has a valid checksum: upstream tar emits
+  // "Damaged tar archive (bad header checksum)" and returns
+  // ARCHIVE_RETRY, which the Zig extract loop handles as `continue`.
+  const damaged = Buffer.alloc(512, 0);
+  damaged.write("junk", 0, "utf8");
+  damaged.fill(" ", 148, 156); // checksum field left as spaces → guaranteed mismatch
+
+  const fileBody = Buffer.from("damaged-block-retry ok\n", "utf8");
+  const file = [tarHeader("package/index.js", fileBody.length, "0"), fileBody, pad512(fileBody.length)];
+
+  const pkgJson = Buffer.from(JSON.stringify({ name: "damaged-pkg", version: "1.0.0", main: "index.js" }) + "\n");
+  const pkgJsonEntry = [tarHeader("package/package.json", pkgJson.length, "0"), pkgJson, pad512(pkgJson.length)];
+
+  // [g][damaged][g][package.json][index.js][EOF EOF]
+  const tar = Buffer.concat([
+    ...paxEntry(),
+    damaged,
+    ...paxEntry(),
+    ...pkgJsonEntry,
+    ...file,
+    Buffer.alloc(1024, 0),
+  ]);
+  const tgz = gzipSync(tar);
+
+  using dir = tempDir("damaged-block-retry", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "damaged-pkg": "file:./damaged-pkg.tgz" },
+    }),
+  });
+  writeFileSync(join(String(dir), "damaged-pkg.tgz"), tgz);
+
+  const { stderr, exitCode } = await runInstall(String(dir));
+
+  // With the broken patch the second 'g' header trips
+  // "Redundant 'g' header" → ARCHIVE_FATAL inside libarchive; the Zig
+  // extract loop surfaces that as `error.Fail` → "Fail extracting
+  // tarball". With upstream semantics restored the damaged block is
+  // skipped, state is fully reset, and the file following the second
+  // 'g' header is extracted normally.
+  expect(stderr).not.toContain("Fail extracting tarball");
+  expect(stderr).not.toContain("failed to resolve");
+
+  const extracted = readFileSync(join(String(dir), "node_modules", "damaged-pkg", "index.js"));
+  expect(extracted.equals(fileBody)).toBe(true);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Follow-up to #29404.

## Problem

`nonblocking-read.patch` routed upstream libarchive's pre-existing damaged-block `ARCHIVE_RETRY` (bad header checksum → skip this block and try the next one) through the same `bun_retry` label as a non-blocking yield. That left both `tar->header_in_progress` and `a->read_header_in_progress` set, so the *next* `archive_read_next_header()` call skipped `archive_entry_clear`, `archive_clear_error`, `++file_count` and `tar_reset_header_state` — a behaviour change on the ordinary **buffered** extract path even when the reader never returns `ARCHIVE_RETRY`.

## Repro

A tarball shaped `[pax 'g' global header][block with bad checksum][pax 'g' global header][regular file]`, installed via `file:./pkg.tgz` (always buffered — `PackageManagerTask.readAndExtract` → `Archiver.extractToDir`):

- **upstream libarchive / this PR**: the damaged block is consumed, state is fully reset, the second `g` header is accepted, the file is extracted.
- **main (64951540d5)**: `seen_headers = seen_g_header` leaks across the retry → the second `g` header trips `"Redundant 'g' header"` → `ARCHIVE_FATAL` → `error: Fail extracting tarball`.

## Fix

Make the format reader the authority on whether a header read is mid-flight:

- `tar_read_header`'s `bun_retry:` label now sets `a->read_header_in_progress = 1` explicitly.
- The damaged-block branch clears it and exits via `TAR_HEADER_RETURN(ARCHIVE_RETRY)` (which also clears `tar->header_in_progress`), so the next call runs the full upstream reset.
- `archive_read_next_header2` now only *clears* the flag on terminal results instead of setting it on every `ARCHIVE_RETRY`.
- `archive_read_format_tar_read_header` only takes the early `return ARCHIVE_RETRY` when `tar->header_in_progress` is still set; a damaged-block retry falls through to the original post-read handling (sparse-list add etc.), matching upstream.

The streaming path is unaffected — the existing drip-feed tests in `bun-install-streaming-extract.test.ts` still pass.

## On the `consume_header` change (point 2 in the report)

Zeroing `next_in`/`avail_in` before `inflateInit2(-15)` is intentionally left as-is: zlib's `inflateInit2_` never reads either field (verified against `vendor/zlib/inflate.c`), and `gzip_filter_read` re-primes them from `__archive_read_filter_ahead` before every `inflate()`. Removing the extra read-ahead is what lets `consume_header` avoid an `ARCHIVE_RETRY` after the header has already been consumed; it's a no-op on the buffered path.

## Verification

Fix is in `patches/`, so the usual `git stash -- src/` gate doesn't cover it. Verified manually:

```
# main's nonblocking-read.patch
bun bd test test/cli/install/bun-install-streaming-extract.test.ts -t damaged-block
(fail) buffered extract: damaged-block retry resets header state (upstream semantics)
  error: expect(received).not.toContain(expected)
  Expected to not contain: "Fail extracting tarball"
  Received: "...error: Fail extracting tarball from damaged-pkg..."

# this PR's patch
bun bd test test/cli/install/bun-install-streaming-extract.test.ts -t damaged-block
(pass) buffered extract: damaged-block retry resets header state (upstream semantics)
```

Full `bun-install-streaming-extract.test.ts` (5 tests, both streaming and buffered paths) and `test/js/bun/archive.test.ts` (99 tests) pass.