### PR TITLE
deps: bump mimalloc to 57029fb1 (upstream dev3 a3fb9498)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -5,7 +5,7 @@
 
 import type { Dependency, NestedCmakeBuild, Provides } from "../source.ts";
 
-const MIMALLOC_COMMIT = "d56d5b27f8f9bfcd2d2f5f1020ff5e100781b062";
+const MIMALLOC_COMMIT = "57029fb1f193e633462e76af745599e1dbfd4b58";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "d56d5b27f8f9bfcd2d2f5f1020ff5e100781b062",
+    mimalloc: "57029fb1f193e633462e76af745599e1dbfd4b58",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "886098f3f339617b4243b286f5ed364b9989e245",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
Merges upstream dev3 (22 commits) into bun-dev3-v2. With our config
(MI_NO_OPT_ARCH=ON, MI_OSX_ZONE=OFF, MI_NO_PROCESS_DETACH=ON,
MI_OVERRIDE=OFF on macOS/Win), only the bitmap-purge restore fixes
(65d70e3c, d5861285) reach compiled code: when mi_arenas_try_purge
early-exits, freed slices not yet visited are now put back on the
purge bitmap instead of being lost, so the next scavenge cycle can
return them to the OS.

Also picks up oven-sh/mimalloc@809f7f32 which extends
MI_NO_PROCESS_DETACH (already set in #29420) to gate
_mi_auto_process_done itself, covering Windows mi_win_main /
.CRT$XPU paths in addition to the POSIX destructor.
