### PR TITLE
ci: use spot instances for Linux test shards; auto-retry on agent lost

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -240,15 +240,17 @@ function getImageName(platform, options) {
  * @param {number} [limit]
  * @link https://buildkite.com/docs/pipelines/command-step#retry-attributes
  */
-function getRetry() {
+const retryOnAgentLost = [
+  { exit_status: -1, limit: 3 },
+  { signal_reason: "agent_stop", limit: 3 },
+];
+
+function getRetry(automatic = retryOnAgentLost) {
   return {
     manual: {
       permit_on_passed: true,
     },
-    automatic: [
-      { exit_status: -1, limit: 3 },
-      { signal_reason: "agent_stop", limit: 3 },
-    ],
+    automatic,
   };
 }
 
@@ -811,10 +813,7 @@ function getWindowsSignStep(windowsPlatforms, options) {
     agents: getEc2Agent(signPlatform, options, {
       instanceType: getAzureVmSize("windows", "x64", "test"),
     }),
-    retry: {
-      manual: { permit_on_passed: true },
-      automatic: false,
-    },
+    retry: getRetry(false),
     cancel_on_build_failing: isMergeQueue(),
     command: [
       `powershell -NoProfile -ExecutionPolicy Bypass -File .buildkite/scripts/sign-windows-artifacts.ps1 ` +

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -286,7 +286,7 @@ function getPriority() {
  */
 function getEc2Agent(platform, options, ec2Options) {
   const { os, arch, abi, distro, release } = platform;
-  const { instanceType, cpuCount, threadsPerCore } = ec2Options;
+  const { instanceType, cpuCount, threadsPerCore, preemptible = false } = ec2Options;
   return {
     os,
     arch,
@@ -299,7 +299,7 @@ function getEc2Agent(platform, options, ec2Options) {
     "instance-type": instanceType,
     "cpu-count": cpuCount,
     "threads-per-core": threadsPerCore,
-    "preemptible": true,
+    "preemptible": preemptible,
   };
 }
 
@@ -407,6 +407,7 @@ function getTestAgent(platform, options) {
       instanceType: getAzureVmSize(os, arch, "test"),
       cpuCount: 2,
       threadsPerCore: 1,
+      preemptible: true,
     });
   }
 
@@ -416,12 +417,14 @@ function getTestAgent(platform, options) {
         instanceType: "c8g.2xlarge",
         cpuCount: 2,
         threadsPerCore: 1,
+        preemptible: true,
       });
     }
     return getEc2Agent(platform, options, {
       instanceType: "c8g.xlarge",
       cpuCount: 2,
       threadsPerCore: 1,
+      preemptible: true,
     });
   }
 
@@ -430,12 +433,14 @@ function getTestAgent(platform, options) {
       instanceType: "c7i.2xlarge",
       cpuCount: 2,
       threadsPerCore: 1,
+      preemptible: true,
     });
   }
   return getEc2Agent(platform, options, {
     instanceType: "c7i.xlarge",
     cpuCount: 2,
     threadsPerCore: 1,
+    preemptible: true,
   });
 }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -413,7 +413,6 @@ function getTestAgent(platform, options) {
       instanceType: getAzureVmSize(os, arch, "test"),
       cpuCount: 2,
       threadsPerCore: 1,
-      preemptible: true,
     });
   }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -299,7 +299,7 @@ function getEc2Agent(platform, options, ec2Options) {
     "instance-type": instanceType,
     "cpu-count": cpuCount,
     "threads-per-core": threadsPerCore,
-    "preemptible": false,
+    "preemptible": true,
   };
 }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -236,15 +236,15 @@ function getImageName(platform, options) {
   return `${name}-v${getBootstrapVersion(os)}`;
 }
 
-/**
- * @param {number} [limit]
- * @link https://buildkite.com/docs/pipelines/command-step#retry-attributes
- */
 const retryOnAgentLost = [
-  { exit_status: -1, limit: 3 },
-  { signal_reason: "agent_stop", limit: 3 },
+  { exit_status: -1, limit: 2 },
+  { signal_reason: "agent_stop", limit: 2 },
 ];
 
+/**
+ * @param {false | typeof retryOnAgentLost} [automatic]
+ * @link https://buildkite.com/docs/pipelines/command-step#retry-attributes
+ */
 function getRetry(automatic = retryOnAgentLost) {
   return {
     manual: {
@@ -776,7 +776,7 @@ function getBuildImageStep(platform, options) {
     env: {
       DEBUG: "1",
     },
-    retry: getRetry(),
+    retry: getRetry(false),
     cancel_on_build_failing: isMergeQueue(),
     command: command.filter(Boolean).join(" "),
     timeout_in_minutes: 3 * 60,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -245,7 +245,10 @@ function getRetry() {
     manual: {
       permit_on_passed: true,
     },
-    automatic: false,
+    automatic: [
+      { exit_status: -1, limit: 3 },
+      { signal_reason: "agent_stop", limit: 3 },
+    ],
   };
 }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -279,6 +279,7 @@ function getPriority() {
  * @property {number} cpuCount
  * @property {number} threadsPerCore
  * @property {boolean} dryRun
+ * @property {boolean} [preemptible]
  */
 
 /**

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -811,7 +811,10 @@ function getWindowsSignStep(windowsPlatforms, options) {
     agents: getEc2Agent(signPlatform, options, {
       instanceType: getAzureVmSize("windows", "x64", "test"),
     }),
-    retry: getRetry(),
+    retry: {
+      manual: { permit_on_passed: true },
+      automatic: false,
+    },
     cancel_on_build_failing: isMergeQueue(),
     command: [
       `powershell -NoProfile -ExecutionPolicy Bypass -File .buildkite/scripts/sign-windows-artifacts.ps1 ` +


### PR DESCRIPTION
- Thread `preemptible` through `getEc2Agent`'s options (default `false`); set it `true` in `getTestAgent` for Linux only. Windows and all build/sign/image steps stay on-demand.
- `getRetry()` now defaults to auto-retry on `exit_status: -1` / `signal_reason: agent_stop` (machine died). `windows-sign` and `build-image` opt out via `getRetry(false)`. Real test failures and user cancellation are not retried.

robobun falls back to on-demand when AWS spot capacity is unavailable.