### PR TITLE
io: fix WindowsBufferedReader.deinit source handling + ReadableStreamSource Strong cycle

### DIFF
--- a/src/install/lifecycle_script_runner.zig
+++ b/src/install/lifecycle_script_runner.zig
@@ -186,7 +186,10 @@ pub const LifecycleScriptSubprocess = struct {
             combined_script,
             null,
         };
-        if (Environment.isWindows) {
+        const buffer_output = this.manager.options.log_level != .silent and
+            !this.manager.options.log_level.isVerbose() and
+            !this.foreground;
+        if (Environment.isWindows and buffer_output) {
             this.stdout.source = .{ .pipe = bun.new(uv.Pipe, std.mem.zeroes(uv.Pipe)) };
             this.stderr.source = .{ .pipe = bun.new(uv.Pipe, std.mem.zeroes(uv.Pipe)) };
         }
@@ -196,20 +199,16 @@ pub const LifecycleScriptSubprocess = struct {
             else
                 .ignore,
 
-            .stdout = if (this.manager.options.log_level == .silent)
-                .ignore
-            else if (this.manager.options.log_level.isVerbose() or this.foreground)
-                .inherit
+            .stdout = if (!buffer_output)
+                if (this.manager.options.log_level == .silent) .ignore else .inherit
             else if (Environment.isPosix)
                 .buffer
             else
                 .{
                     .buffer = this.stdout.source.?.pipe,
                 },
-            .stderr = if (this.manager.options.log_level == .silent)
-                .ignore
-            else if (this.manager.options.log_level.isVerbose() or this.foreground)
-                .inherit
+            .stderr = if (!buffer_output)
+                if (this.manager.options.log_level == .silent) .ignore else .inherit
             else if (Environment.isPosix)
                 .buffer
             else

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -1053,12 +1053,13 @@ pub const WindowsBufferedReader = struct {
         // Get parent before completing (fs.data may be null if detached)
         const parent_ptr = fs.data;
 
-        // ALWAYS complete the read first (cleans up fs_t, updates state)
+        // ALWAYS complete the read first (cleans up fs_t, updates state).
+        // NOTE: when detached (parent_ptr == null) and close_fd == false,
+        // complete() -> startClose() destroys `file` synchronously, so it must
+        // not be dereferenced past this point on the detached branch.
         file.complete(was_canceled);
 
-        // If detached, file should be closing itself now
         if (parent_ptr == null) {
-            bun.assert(file.state == .closing); // complete should have started close
             return;
         }
 

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -1197,6 +1197,8 @@ pub const WindowsBufferedReader = struct {
             switch (source) {
                 .sync_file, .file => |file| {
                     // Detach - file will close itself after operation completes
+                    // (or just free the struct if the caller owns the fd).
+                    file.close_fd = this.flags.close_handle;
                     file.detach();
                 },
                 .pipe => |pipe| {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -980,11 +980,11 @@ pub const WindowsBufferedReader = struct {
         MaxBuf.removeFromPipereader(&this.maxbuf);
         this.buffer().deinit();
         const source = this.source orelse return;
-        this.source = null;
         if (!source.isClosed()) {
             // closeImpl will take care of freeing the source
             this.closeImpl(false);
         }
+        this.source = null;
     }
 
     pub fn setRawMode(this: *WindowsBufferedReader, value: bool) bun.sys.Maybe(void) {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -937,11 +937,11 @@ pub const WindowsBufferedReader = struct {
         MaxBuf.removeFromPipereader(&this.maxbuf);
         this.buffer().deinit();
         const source = this.source orelse return;
-        this.source = null;
         if (!source.isClosed()) {
             // closeImpl will take care of freeing the source
             this.closeImpl(false);
         }
+        this.source = null;
     }
 
     pub fn setRawMode(this: *WindowsBufferedReader, value: bool) bun.sys.Maybe(void) {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -1054,9 +1054,9 @@ pub const WindowsBufferedReader = struct {
         const parent_ptr = fs.data;
 
         // ALWAYS complete the read first (cleans up fs_t, updates state).
-        // NOTE: when detached (parent_ptr == null) and close_fd == false,
-        // complete() -> startClose() destroys `file` synchronously, so it must
-        // not be dereferenced past this point on the detached branch.
+        // NOTE: when detached (parent_ptr == null), complete() finalizes `file`
+        // (async close or immediate destroy) — must not be dereferenced past
+        // this point on the detached branch.
         file.complete(was_canceled);
 
         if (parent_ptr == null) {

--- a/src/io/source.zig
+++ b/src/io/source.zig
@@ -53,8 +53,8 @@ pub const Source = union(enum) {
         /// When true, file will close itself when the current operation completes.
         close_after_operation: bool = false,
 
-        /// When false, detach()/startClose() free this struct without calling
-        /// uv_fs_close — the caller owns the fd. Mirrors BufferedReader.flags.close_handle.
+        /// When false, finalize() frees this struct without calling uv_fs_close
+        /// — the caller owns the fd. Mirrors BufferedReader.flags.close_handle.
         close_fd: bool = true,
 
         /// Get the File struct from an fs_t pointer using field offset.
@@ -88,9 +88,9 @@ pub const Source = union(enum) {
             }
         }
 
-        /// Detach from parent and schedule automatic cleanup.
-        /// If an operation is in progress, it will complete and then close the file.
-        /// If idle, closes the file immediately.
+        /// Detach from parent and schedule automatic cleanup. After this call,
+        /// `this` may be freed (immediately when idle and `close_fd == false`,
+        /// or via `onCloseComplete` once the async close finishes).
         pub fn detach(this: *File) void {
             this.fs.data = null;
             this.close_after_operation = true;
@@ -98,12 +98,15 @@ pub const Source = union(enum) {
 
             if (this.state == .deinitialized) {
                 this.close_after_operation = false;
-                this.startClose();
+                this.finalize();
             }
         }
 
-        /// Mark the operation as complete and clean up.
-        /// Must be called first in the callback before processing data.
+        /// Mark the operation as complete and clean up. Called first in the
+        /// callback. When detached with an op in flight (`close_after_operation`),
+        /// this frees `this` (immediately when `close_fd == false`, or via the
+        /// async close callback) — callers must not dereference `this` afterward
+        /// on that branch.
         pub fn complete(this: *File, was_canceled: bool) void {
             bun.assert(this.state == .operating or this.state == .canceling);
             if (was_canceled) {
@@ -115,19 +118,21 @@ pub const Source = union(enum) {
 
             if (this.close_after_operation) {
                 this.close_after_operation = false;
-                this.startClose();
+                this.finalize();
             }
         }
 
-        fn startClose(this: *File) void {
+        /// Either start an async close (when `close_fd`) or destroy immediately.
+        /// `this` must not be dereferenced after this returns.
+        fn finalize(this: *File) void {
             bun.assert(this.state == .deinitialized);
-            if (!this.close_fd) {
+            if (this.close_fd) {
+                this.state = .closing;
+                _ = uv.uv_fs_close(uv.Loop.get(), &this.fs, this.file, onCloseComplete);
+            } else {
                 // Caller owns the fd — free this struct without closing.
                 bun.default_allocator.destroy(this);
-                return;
             }
-            this.state = .closing;
-            _ = uv.uv_fs_close(uv.Loop.get(), &this.fs, this.file, onCloseComplete);
         }
 
         fn onCloseComplete(fs: *uv.fs_t) callconv(.c) void {

--- a/src/io/source.zig
+++ b/src/io/source.zig
@@ -294,8 +294,12 @@ pub const Source = union(enum) {
         log("openFile (fd = {f})", .{fd});
         const file = bun.handleOom(bun.default_allocator.create(Source.File));
 
-        file.* = std.mem.zeroes(Source.File);
-        file.file = fd.uv();
+        file.* = .{
+            .fs = std.mem.zeroes(uv.fs_t),
+            .iov = std.mem.zeroes(uv.uv_buf_t),
+            .file = fd.uv(),
+            // state/close_after_operation/close_fd take their declared defaults
+        };
         return file;
     }
 

--- a/src/io/source.zig
+++ b/src/io/source.zig
@@ -53,6 +53,10 @@ pub const Source = union(enum) {
         /// When true, file will close itself when the current operation completes.
         close_after_operation: bool = false,
 
+        /// When false, detach()/startClose() free this struct without calling
+        /// uv_fs_close — the caller owns the fd. Mirrors BufferedReader.flags.close_handle.
+        close_fd: bool = true,
+
         /// Get the File struct from an fs_t pointer using field offset.
         pub fn fromFS(fs: *uv.fs_t) *File {
             return @fieldParentPtr("fs", fs);
@@ -117,6 +121,11 @@ pub const Source = union(enum) {
 
         fn startClose(this: *File) void {
             bun.assert(this.state == .deinitialized);
+            if (!this.close_fd) {
+                // Caller owns the fd — free this struct without closing.
+                bun.default_allocator.destroy(this);
+                return;
+            }
             this.state = .closing;
             _ = uv.uv_fs_close(uv.Loop.get(), &this.fs, this.file, onCloseComplete);
         }

--- a/src/runtime/webcore/FileReader.zig
+++ b/src/runtime/webcore/FileReader.zig
@@ -242,6 +242,11 @@ pub fn onStart(this: *FileReader) streams.Start {
             this.waiting_for_onReaderDone = true;
             _ = this.parent().incrementCount();
         }
+    } else if (comptime Environment.isWindows) {
+        if (this.reader.source != null and !this.reader.isDone()) {
+            this.waiting_for_onReaderDone = true;
+            _ = this.parent().incrementCount();
+        }
     }
 
     if (comptime Environment.isPosix) {
@@ -622,6 +627,11 @@ pub fn onReaderError(this: *FileReader, err: bun.sys.Error) void {
 
     this.pending.result = .{ .err = .{ .Error = err } };
     this.pending.run();
+
+    if (this.waiting_for_onReaderDone) {
+        this.waiting_for_onReaderDone = false;
+        _ = this.parent().decrementCount();
+    }
 }
 
 pub fn setRawMode(this: *FileReader, flag: bool) bun.sys.Maybe(void) {

--- a/src/runtime/webcore/ReadableStream.zig
+++ b/src/runtime/webcore/ReadableStream.zig
@@ -429,7 +429,6 @@ pub fn NewSource(
         pending_err: ?Syscall.Error = null,
         close_handler: ?*const fn (?*anyopaque) void = null,
         close_ctx: ?*anyopaque = null,
-        close_jsvalue: jsc.Strong.Optional = .empty,
         cancel_handler: ?*const fn (?*anyopaque) void = null,
         cancel_ctx: ?*anyopaque = null,
         globalThis: *JSGlobalObject = undefined,
@@ -517,7 +516,6 @@ pub fn NewSource(
 
             this.ref_count -= 1;
             if (this.ref_count == 0) {
-                this.close_jsvalue.deinit();
                 deinit_fn(&this.context);
                 return 0;
             }
@@ -694,7 +692,7 @@ pub fn NewSource(
                 this.globalThis = globalObject;
 
                 if (value.isUndefined()) {
-                    this.close_jsvalue.deinit();
+                    if (this.this_jsvalue != .zero) js.onCloseCallbackSetCached(this.this_jsvalue, globalObject, .js_undefined);
                     return;
                 }
 
@@ -702,7 +700,7 @@ pub fn NewSource(
                     return globalObject.throwInvalidArgumentType("ReadableStreamSource", "onclose", "function");
                 }
                 const cb = value.withAsyncContextIfNeeded(globalObject);
-                this.close_jsvalue.set(globalObject, cb);
+                if (this.this_jsvalue != .zero) js.onCloseCallbackSetCached(this.this_jsvalue, globalObject, cb);
             }
 
             pub fn setOnDrainFromJS(this: *ReadableStreamSourceType, globalObject: *jsc.JSGlobalObject, value: jsc.JSValue) bun.JSError!void {
@@ -726,7 +724,10 @@ pub fn NewSource(
 
                 jsc.markBinding(@src());
 
-                return this.close_jsvalue.get() orelse .js_undefined;
+                if (this.this_jsvalue != .zero) {
+                    if (js.onCloseCallbackGetCached(this.this_jsvalue)) |val| return val;
+                }
+                return .js_undefined;
             }
 
             pub fn getOnDrainFromJS(this: *ReadableStreamSourceType, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
@@ -754,11 +755,12 @@ pub fn NewSource(
             fn onClose(ptr: ?*anyopaque) void {
                 jsc.markBinding(@src());
                 var this = bun.cast(*ReadableStreamSourceType, ptr.?);
-                if (this.close_jsvalue.trySwap()) |cb| {
-                    this.globalThis.queueMicrotask(cb, &.{});
+                if (this.this_jsvalue != .zero) {
+                    if (js.onCloseCallbackGetCached(this.this_jsvalue)) |cb| {
+                        if (!cb.isUndefined()) this.globalThis.queueMicrotask(cb, &.{});
+                        js.onCloseCallbackSetCached(this.this_jsvalue, this.globalThis, .js_undefined);
+                    }
                 }
-
-                this.close_jsvalue.deinit();
             }
 
             pub fn finalize(this: *ReadableStreamSourceType) void {


### PR DESCRIPTION
## Summary

Consolidates the Windows `BufferedReader` fd-ownership fixes with the `ReadableStreamSource` Strong-cycle leak fix (originally #29472, reverted in bf2e2cecf2 because it shifted timing enough to expose the third bug below). They're entangled — fixing the leak makes sources collectable, which exposes paths where `WindowsBufferedReader.deinit` runs with a live source for the first time.

### 1. `WindowsBufferedReader.deinit`: don't null `source` before `closeImpl` (#20198 regression)

`deinit` set `this.source = null` before calling `closeImpl(false)`, but `closeImpl` reads `this.source` — so the call was a no-op. For `.file`: fd + heap `Source.File` leak + uncanceled threadpool read. For `.pipe`/`.tty`: handle leak. Restore the pre-#20198 ordering.

### 2. `lifecycle_script_runner`: only allocate stdio pipes when buffering on Windows

Allocated zero-init `uv.Pipe` handles unconditionally but only `uv_pipe_init`'d them when output is buffered. With (1) restored, `uv_close` on a `type=0` handle aborts inside libuv. Gate the allocation on `buffer_output`.

### 3. `closeImpl`: honor `flags.close_handle` for `.file` sources

The Posix reader checks `close_handle` before closing; Windows didn't — `closeImpl` called `file.detach()→startClose()→uv_fs_close(fd)` unconditionally. `FileResponseStream` sets `close_handle = false` and closes via `Closer.close(this.fd)` itself. With (1) restored, the eof_task path (reader paused with live `.file` source at deinit) double-closed: both `uv_fs_close(fd)` queue to the threadpool back-to-back; with several responses in a row the loser runs after the next response has reused the fd → cascading corruption (the `bun-install.test.ts` "chooses" segfault). Thread `close_handle` through to `Source.File.close_fd`; when false, free the struct without `uv_fs_close`.

### 4. `close_jsvalue` Strong → `onCloseCallback` cached slot (cross-platform)

`setOnCloseFromJS` stored the callback in a `jsc.Strong`, forming a rooted cycle (source → Strong → bound `#onClose` → `NativeReadableStreamSource.$stream` → source). Switch to the codegen-provided `WriteBarrier` slot (mirroring `onDrain`); the cycle becomes a normal intra-heap cycle.

### 5. Windows non-lazy `FileReader.onStart`: hold an across-read ref

`fromPipe` (e.g. `Bun.spawn().stdout`) skipped the `incrementCount()` on Windows. With (4), the source becomes collectable while a `uv_read_start` IOCP read is pending. Add the Windows arm matching POSIX.

### 6. `FileReader.onReaderError`: release the across-read ref

`onReaderDone` decrements; `onReaderError` didn't. Mirror it.

## Verification (Windows)

- `bun-install.test.ts -t "chooses"` (11 tests): all pass, every `uv_fs_close(N) = 0`, no BADF (vs `STATUS_BREAKPOINT` before commit 3).
- Grandchild leak-probe: `*ReadableStreamSource` heap count plateaus at ~15 (= live grandchildren) instead of growing linearly to 31/61/...
- Grandchild uaf-repro: 30 iters, exit 0 (vs `FileReader.deinit src=pipe closed=false` panic with only commit 4).