### PR TITLE
Fix BroadcastChannel channelToContextIdentifier locking and dispatchMessage lifetime

### DIFF
--- a/src/bun.js/bindings/webcore/BroadcastChannel.cpp
+++ b/src/bun.js/bindings/webcore/BroadcastChannel.cpp
@@ -61,7 +61,7 @@ static UncheckedKeyHashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<Broadca
 }
 
 static Lock channelToContextIdentifierLock;
-static UncheckedKeyHashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& channelToContextIdentifier()
+static UncheckedKeyHashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& channelToContextIdentifier() WTF_REQUIRES_LOCK(channelToContextIdentifierLock)
 {
     static NeverDestroyed<UncheckedKeyHashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>> map;
     return map;
@@ -134,6 +134,7 @@ void BroadcastChannel::MainThreadBridge::registerChannel(ScriptExecutionContext&
 
     ScriptExecutionContext::ensureOnMainThread([protectedThis = WTF::move(protectedThis), contextId = context.identifier()](auto& context) mutable {
         context.broadcastChannelRegistry().registerChannel(protectedThis->m_name, protectedThis->identifier());
+        Locker locker { channelToContextIdentifierLock };
         channelToContextIdentifier().add(protectedThis->identifier(), contextId);
     });
 }
@@ -144,6 +145,7 @@ void BroadcastChannel::MainThreadBridge::unregisterChannel()
 
     ScriptExecutionContext::ensureOnMainThread([protectedThis = WTF::move(protectedThis)](auto& context) {
         context.broadcastChannelRegistry().unregisterChannel(protectedThis->m_name, protectedThis->identifier());
+        Locker locker { channelToContextIdentifierLock };
         channelToContextIdentifier().remove(protectedThis->identifier());
     });
 }
@@ -233,7 +235,11 @@ void BroadcastChannel::dispatchMessageTo(BroadcastChannelIdentifier channelIdent
 {
     ASSERT(isMainThread());
 
-    auto contextIdentifier = channelToContextIdentifier().get(channelIdentifier);
+    ScriptExecutionContextIdentifier contextIdentifier;
+    {
+        Locker locker { channelToContextIdentifierLock };
+        contextIdentifier = channelToContextIdentifier().get(channelIdentifier);
+    }
     if (!contextIdentifier)
         return;
 
@@ -256,7 +262,7 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     if (m_isClosed)
         return;
 
-    ScriptExecutionContext::postTaskTo(contextIdForBroadcastChannelId(m_mainThreadBridge->identifier()), [this, message = WTF::move(message)](ScriptExecutionContext& context) mutable {
+    ScriptExecutionContext::postTaskTo(contextIdForBroadcastChannelId(m_mainThreadBridge->identifier()), [this, protectedThis = Ref { *this }, message = WTF::move(message)](ScriptExecutionContext& context) mutable {
         if (m_isClosed)
             return;
 

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -1,5 +1,18 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+
+// Debug/ASAN builds are much slower at spawning workers.
+const timeout = isDebug || isASAN ? 60_000 : 10_000;
+
+// ASAN builds unconditionally print a warning about JSC signal handlers on
+// startup. Strip it so we can still assert the subprocess produced no other
+// stderr output.
+function filterStderr(stderr: string): string {
+  return stderr
+    .split(/\r?\n/)
+    .filter(line => line && !line.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
 
 // Regression test for use-after-free in BroadcastChannel global map.
 // Previously, the global map stored raw BroadcastChannel* pointers. If a Worker
@@ -7,8 +20,10 @@ import { bunEnv, bunExe } from "harness";
 // main thread could race with the Worker's destructor and dereference a dangling
 // pointer. Now the map stores ThreadSafeWeakPtr<BroadcastChannel>, so the lookup
 // returns null if the channel was destroyed.
-test("BroadcastChannel: no UAF when posting to channel after worker terminates", async () => {
-  const script = /* js */ `
+test(
+  "BroadcastChannel: no UAF when posting to channel after worker terminates",
+  async () => {
+    const script = /* js */ `
     const workerCode = \`
       const bc = new BroadcastChannel("worker-gc-test");
       bc.onmessage = (e) => {
@@ -69,22 +84,112 @@ test("BroadcastChannel: no UAF when posting to channel after worker terminates",
     console.log("OK");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
-});
+    expect(filterStderr(stderr)).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
 
-test("BroadcastChannel: repeated worker create/terminate stress", async () => {
-  const script = /* js */ `
+// Regression test for two additional races in BroadcastChannel:
+//  (A) channelToContextIdentifier() HashMap was only locked on the worker-thread
+//      reader, not on the main-thread writers (registerChannel/unregisterChannel/
+//      dispatchMessageTo). A rehash on main concurrent with a worker-side get()
+//      walks a freed bucket array → ASAN heap-use-after-free in WTF::HashTable.
+//  (B) dispatchMessage() posted a task capturing raw `this` without a protecting
+//      Ref. If the worker terminated and GC ran between posting and running the
+//      task, the task dereferenced a freed BroadcastChannel.
+//
+// This test maximises contention: workers post messages (triggering the
+// worker-thread map read in dispatchMessage) while the main thread is churning
+// channel registrations (triggering HashMap rehashes) and terminating workers
+// mid-dispatch (leaving queued tasks with dangling `this`).
+test(
+  "BroadcastChannel: concurrent register/dispatch/terminate does not race channelToContextIdentifier",
+  async () => {
+    const script = /* js */ `
+    const workerCode = \`
+      const bc = new BroadcastChannel("race-test");
+      bc.onmessage = () => {};
+      // Post from the worker so dispatchMessage() runs on OTHER worker threads,
+      // reaching the worker-side channelToContextIdentifier().get() path.
+      for (let i = 0; i < 20; i++) bc.postMessage(i);
+      postMessage("ready");
+    \`;
+    const blobUrl = URL.createObjectURL(new Blob([workerCode], { type: "application/javascript" }));
+
+    const mainChannel = new BroadcastChannel("race-test");
+    mainChannel.onmessage = () => {};
+
+    for (let round = 0; round < 4; round++) {
+      const workers = [];
+      const readyPromises = [];
+
+      // Spawning N workers → N registerChannel() → N .add() calls on main.
+      // Each worker also posts messages that fan out to all other workers,
+      // each fan-out hop reads the map on a worker thread.
+      for (let i = 0; i < 4; i++) {
+        const worker = new Worker(blobUrl);
+        const { promise, resolve } = Promise.withResolvers();
+        worker.onmessage = () => resolve();
+        workers.push(worker);
+        readyPromises.push(promise);
+      }
+
+      // While workers are registering & cross-posting, also create and
+      // immediately drop extra channels on main to force HashMap rehashes.
+      const extraChannels = [];
+      for (let i = 0; i < 16; i++) {
+        extraChannels.push(new BroadcastChannel("race-test"));
+      }
+      for (const c of extraChannels) c.close();
+
+      await Promise.all(readyPromises);
+
+      // Terminate while dispatches are still in flight → queued postTaskTo
+      // lambdas may outlive their BroadcastChannel.
+      for (const worker of workers) {
+        mainChannel.postMessage("x");
+        worker.terminate();
+      }
+
+      Bun.gc(true);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    mainChannel.close();
+    console.log("OK");
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(filterStderr(stderr)).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+test(
+  "BroadcastChannel: repeated worker create/terminate stress",
+  async () => {
+    const script = /* js */ `
     const workerCode = \`
       const bc = new BroadcastChannel("stress-test");
       bc.onmessage = () => {};
@@ -124,16 +229,18 @@ test("BroadcastChannel: repeated worker create/terminate stress", async () => {
     console.log("OK");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("OK");
-  expect(exitCode).toBe(0);
-});
+    expect(filterStderr(stderr)).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -165,7 +165,6 @@ test(
       Bun.gc(true);
     }
 
-    await new Promise(resolve => setTimeout(resolve, 50));
     mainChannel.close();
     console.log("OK");
   `;


### PR DESCRIPTION
## What does this PR do?

Fixes two data races in `BroadcastChannel.cpp` that surface as ASAN heap-use-after-free in `test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts`.

### Bug A — `channelToContextIdentifier` HashMap one-sided locking

The prior `ThreadSafeWeakPtr` fix only covered `allBroadcastChannels()`. The second global, `channelToContextIdentifier()`, has its own lock — but it was taken at only 1 of 4 call sites:

| Site | Thread | Lock? |
| --- | --- | --- |
| `registerChannel` `.add()` | main | ❌ |
| `unregisterChannel` `.remove()` | main | ❌ |
| `dispatchMessageTo` `.get()` | main | ❌ |
| `contextIdForBroadcastChannelId` `.get()` | worker (via `ensureOnContextThread` → `dispatchMessage`) | ✅ |

When main rehashes the HashMap (add/remove during worker spawn/terminate) while a worker reads it, the worker walks a freed bucket array → ASAN heap-UAF inside `WTF::HashTable`. The accessor was also missing `WTF_REQUIRES_LOCK`, so `-Wthread-safety` never flagged this.

**Fix**: add `Locker locker { channelToContextIdentifierLock };` at the three unlocked sites and annotate the accessor with `WTF_REQUIRES_LOCK(channelToContextIdentifierLock)` to match `allBroadcastChannels()`.

### Bug B — `dispatchMessage` captures raw `this` in async task

`dispatchMessage` posts a task with `[this, message = ...]` — raw `this`, no `Ref { *this }`. The caller (`dispatchMessageTo`'s inner lambda) holds a strong `RefPtr` from the `ThreadSafeWeakPtr` lookup, but that ref is dropped when the outer lambda returns. During worker terminate the JS wrapper is destroyed → refcount 0 → `~BroadcastChannel` → the queued task reads freed `this->m_isClosed` and calls `this->dispatchEvent()`.

**Fix**: capture `protectedThis = Ref { *this }` in the `postTaskTo` lambda, matching the pattern in `MessagePort.cpp`, `Performance.cpp`, and `WebSocket.cpp`.

## How did you verify your code works?

- `bun bd test test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts` — 3/3 pass, verified stable across 3 consecutive runs under debug+ASAN
- `bun bd test test/js/web/broadcastchannel/broadcast-channel.test.ts` — 10/11 pass; the one failure (`broadcast channel worker wait`) is pre-existing on `main` under debug+ASAN (it uses `Bun.sleepSync(500)` which isn't enough for an ASAN worker to start) and is unrelated to this change

## Test changes

- Added a stress test that churns channel registrations (forcing HashMap rehashes) while workers cross-post (reaching the worker-side map read), then terminates workers mid-dispatch (leaving queued tasks whose `this` would otherwise dangle).
- Filtered the unconditional ASAN startup warning from child-process `stderr` so `expect(stderr).toBe("")` holds on ASAN builds — same pattern as `fetch-abort-queued.test.ts` / `string-decoder.test.js`.
- Scaled timeouts for `isDebug || isASAN` — worker spawn under debug+ASAN is ~5–10× slower; the existing tests were borderline at the 5s default.

Note: both races are highly timing-dependent (a HashMap rehash must land mid-`get()`); 20 local ASAN runs on macOS did not repro before the fix. The new stress test maximises contention but is not guaranteed to fail without the fix on every platform.