### PR TITLE
MessagePort: serialize MessagePortChannelRegistry with a Lock (fix worker_threads data race)

### DIFF
--- a/src/bun.js/bindings/webcore/MessagePortChannel.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.cpp
@@ -156,6 +156,8 @@ std::optional<MessageWithMessagePorts> MessagePortChannel::tryTakeMessageForPort
 
     auto message = m_pendingMessages[i].first();
     m_pendingMessages[i].removeAt(0);
+    if (m_pendingMessages[i].isEmpty())
+        m_pendingMessageProtectors[i] = nullptr;
     return WTF::move(message);
 }
 

--- a/src/bun.js/bindings/webcore/MessagePortChannel.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.cpp
@@ -42,8 +42,6 @@ MessagePortChannel::MessagePortChannel(MessagePortChannelRegistry& registry, con
     : m_ports { port1, port2 }
     , m_registry(registry)
 {
-    relaxAdoptionRequirement();
-
     m_processes[0] = port1.processIdentifier;
     m_entangledToProcessProtectors[0] = this;
     m_processes[1] = port2.processIdentifier;
@@ -92,10 +90,7 @@ void MessagePortChannel::disentanglePort(const MessagePortIdentifier& port)
     ASSERT(m_processes[i] || m_isClosed[i]);
     m_processes[i] = std::nullopt;
     m_pendingMessagePortTransfers[i].add(this);
-
-    // This set of steps is to guarantee that the lock is unlocked before the
-    // last ref to this object is released.
-    auto protectedThis = WTF::move(m_entangledToProcessProtectors[i]);
+    m_entangledToProcessProtectors[i] = nullptr;
 }
 
 void MessagePortChannel::closePort(const MessagePortIdentifier& port)
@@ -105,10 +100,6 @@ void MessagePortChannel::closePort(const MessagePortIdentifier& port)
 
     m_processes[i] = std::nullopt;
     m_isClosed[i] = true;
-
-    // This set of steps is to guarantee that the lock is unlocked before the
-    // last ref to this object is released.
-    Ref protectedThis { *this };
 
     m_pendingMessages[i].clear();
     m_pendingMessagePortTransfers[i].clear();
@@ -136,32 +127,23 @@ bool MessagePortChannel::postMessageToRemote(MessageWithMessagePorts&& message, 
     return false;
 }
 
-void MessagePortChannel::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& callback)
+Vector<MessageWithMessagePorts> MessagePortChannel::takeAllMessagesForPort(const MessagePortIdentifier& port)
 {
     // LOG(MessagePorts, "MessagePortChannel %p taking all messages for port %s", this, port.logString().utf8().data());
 
     ASSERT(port == m_ports[0] || port == m_ports[1]);
     size_t i = port == m_ports[0] ? 0 : 1;
 
-    if (m_pendingMessages[i].isEmpty()) {
-        callback({}, [] {});
-        return;
-    }
+    if (m_pendingMessages[i].isEmpty())
+        return {};
 
     ASSERT(m_pendingMessageProtectors[i]);
 
     Vector<MessageWithMessagePorts> result;
     result.swap(m_pendingMessages[i]);
+    m_pendingMessageProtectors[i] = nullptr;
 
-    ++m_messageBatchesInFlight;
-
-    // LOG(MessagePorts, "There are %zu messages to take for port %s. Taking them now, messages in flight is now %" PRIu64, result.size(), port.logString().utf8().data(), m_messageBatchesInFlight);
-
-    callback(WTF::move(result), [this, port, protectedThis = WTF::move(m_pendingMessageProtectors[i])] {
-        UNUSED_PARAM(port);
-        --m_messageBatchesInFlight;
-        // LOG(MessagePorts, "Message port channel %s was notified that a batch of %zu message port messages targeted for port %s just completed dispatch, in flight is now %" PRIu64, logString().utf8().data(), size, port.logString().utf8().data(), m_messageBatchesInFlight);
-    });
+    return result;
 }
 
 std::optional<MessageWithMessagePorts> MessagePortChannel::tryTakeMessageForPort(const MessagePortIdentifier port)

--- a/src/bun.js/bindings/webcore/MessagePortChannel.h
+++ b/src/bun.js/bindings/webcore/MessagePortChannel.h
@@ -30,15 +30,17 @@
 #include "MessageWithMessagePorts.h"
 #include "ProcessIdentifier.h"
 #include <wtf/HashSet.h>
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 
 class MessagePortChannelRegistry;
 
-class MessagePortChannel : public RefCountedAndCanMakeWeakPtr<MessagePortChannel> {
+// In WebKit this is RefCountedAndCanMakeWeakPtr because the registry is main-thread-only.
+// Bun serializes registry/channel access with a Lock instead (MessagePortChannelRegistry::m_lock),
+// so the refcount and weak control block must be atomic — RefPtrs can be released on any thread.
+class MessagePortChannel : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<MessagePortChannel> {
 public:
     static Ref<MessagePortChannel> create(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
@@ -54,12 +56,8 @@ public:
     void closePort(const MessagePortIdentifier&);
     bool postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget);
 
-    void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
+    Vector<MessageWithMessagePorts> takeAllMessagesForPort(const MessagePortIdentifier&);
     std::optional<MessageWithMessagePorts> tryTakeMessageForPort(const MessagePortIdentifier);
-
-    WEBCORE_EXPORT bool hasAnyMessagesPendingOrInFlight() const;
-
-    uint64_t beingTransferredCount();
 
 #if !LOG_DISABLED
     String logString() const
@@ -78,7 +76,6 @@ private:
     Vector<MessageWithMessagePorts> m_pendingMessages[2];
     UncheckedKeyHashSet<RefPtr<MessagePortChannel>> m_pendingMessagePortTransfers[2];
     RefPtr<MessagePortChannel> m_pendingMessageProtectors[2];
-    uint64_t m_messageBatchesInFlight { 0 };
 
     MessagePortChannelRegistry& m_registry;
 };

--- a/src/bun.js/bindings/webcore/MessagePortChannelProvider.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelProvider.cpp
@@ -38,8 +38,6 @@ static MessagePortChannelProviderImpl* globalProvider;
 
 MessagePortChannelProvider& MessagePortChannelProvider::singleton()
 {
-    // TODO: I think this assertion is relevant. Bun will call this on the Worker's thread
-    // ASSERT(isMainThread());
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
         if (!globalProvider)

--- a/src/bun.js/bindings/webcore/MessagePortChannelProviderImpl.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelProviderImpl.cpp
@@ -65,14 +65,8 @@ void MessagePortChannelProviderImpl::postMessageToRemote(MessageWithMessagePorts
         MessagePort::notifyMessageAvailable(remoteTarget);
 }
 
-void MessagePortChannelProviderImpl::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& outerCallback)
+void MessagePortChannelProviderImpl::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& callback)
 {
-    // It is the responsibility of outerCallback to get itself to the appropriate thread (e.g. WebWorker thread)
-    auto callback = [outerCallback = WTF::move(outerCallback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& messageDeliveryCallback) mutable {
-        // ASSERT(isMainThread());
-        outerCallback(WTF::move(messages), WTF::move(messageDeliveryCallback));
-    };
-
     m_registry.takeAllMessagesForPort(port, WTF::move(callback));
 }
 

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
@@ -30,10 +30,7 @@
 
 // #include "Logging.h"
 #include <wtf/CompletionHandler.h>
-#include <wtf/MainThread.h>
-
-// ASSERT(isMainThread()) is used alot here, and I think it may be required, but i'm not 100% sure.
-// we totally are calling these off the main thread in many cases in Bun, so ........
+#include <wtf/Locker.h>
 
 namespace WebCore {
 
@@ -49,14 +46,14 @@ MessagePortChannelRegistry::~MessagePortChannelRegistry()
 void MessagePortChannelRegistry::didCreateMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
 {
     // LOG(MessagePorts, "Registry: Creating MessagePortChannel %p linking %s and %s", this, port1.logString().utf8().data(), port2.logString().utf8().data());
-    // ASSERT(isMainThread());
 
+    // No lock here: the channel constructor calls back into messagePortChannelCreated() which locks.
     MessagePortChannel::create(*this, port1, port2);
 }
 
 void MessagePortChannelRegistry::messagePortChannelCreated(MessagePortChannel& channel)
 {
-    // ASSERT(isMainThread());
+    Locker locker { m_lock };
 
     auto result = m_openChannels.add(channel.port1(), channel);
     ASSERT_UNUSED(result, result.isNewEntry);
@@ -67,10 +64,7 @@ void MessagePortChannelRegistry::messagePortChannelCreated(MessagePortChannel& c
 
 void MessagePortChannelRegistry::messagePortChannelDestroyed(MessagePortChannel& channel)
 {
-    // ASSERT(isMainThread());
-
-    ASSERT(m_openChannels.get(channel.port1()) == &channel);
-    ASSERT(m_openChannels.get(channel.port2()) == &channel);
+    Locker locker { m_lock };
 
     m_openChannels.remove(channel.port1());
     m_openChannels.remove(channel.port2());
@@ -80,43 +74,52 @@ void MessagePortChannelRegistry::messagePortChannelDestroyed(MessagePortChannel&
 
 void MessagePortChannelRegistry::didEntangleLocalToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, ProcessIdentifier process)
 {
-    // ASSERT(isMainThread());
+    // The channel RefPtr must outlive the lock so its destructor (which re-enters
+    // messagePortChannelDestroyed and locks) cannot deadlock.
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_lock };
 
-    // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(local);
-    if (!channel)
-        return;
+        // The channel might be gone if the remote side was closed.
+        channel = m_openChannels.get(local).get();
+        if (!channel)
+            return;
 
-    ASSERT_UNUSED(remote, channel->includesPort(remote));
+        ASSERT_UNUSED(remote, channel->includesPort(remote));
 
-    channel->entanglePortWithProcess(local, process);
+        channel->entanglePortWithProcess(local, process);
+    }
 }
 
 void MessagePortChannelRegistry::didDisentangleMessagePort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_lock };
 
-    // The channel might be gone if the remote side was closed.
-    if (RefPtr channel = m_openChannels.get(port))
+        // The channel might be gone if the remote side was closed.
+        channel = m_openChannels.get(port).get();
+        if (!channel)
+            return;
+
         channel->disentanglePort(port);
+    }
 }
 
 void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: MessagePort %s closed in registry", port.logString().utf8().data());
 
-    RefPtr channel = m_openChannels.get(port);
-    if (!channel)
-        return;
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_lock };
 
-#ifndef NDEBUG
-    // if (channel && channel->hasAnyMessagesPendingOrInFlight())
-    //     LOG(MessagePorts, "Registry: (Note) The channel closed for port %s had messages pending or in flight", port.logString().utf8().data());
-#endif
+        channel = m_openChannels.get(port).get();
+        if (!channel)
+            return;
 
-    channel->closePort(port);
+        channel->closePort(port);
+    }
 
     // FIXME: When making message ports be multi-process, this should probably push a notification
     // to the remaining port to tell it this port closed.
@@ -124,53 +127,59 @@ void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier
 
 bool MessagePortChannelRegistry::didPostMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& remoteTarget)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: Posting message to MessagePort %s in registry", remoteTarget.logString().utf8().data());
 
-    // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(remoteTarget);
-    if (!channel) {
-        // LOG(MessagePorts, "Registry: Could not find MessagePortChannel for port %s; It was probably closed. Message will be dropped.", remoteTarget.logString().utf8().data());
-        return false;
-    }
+    RefPtr<MessagePortChannel> channel;
+    bool result;
+    {
+        Locker locker { m_lock };
 
-    return channel->postMessageToRemote(WTF::move(message), remoteTarget);
+        // The channel might be gone if the remote side was closed.
+        channel = m_openChannels.get(remoteTarget).get();
+        if (!channel) {
+            // LOG(MessagePorts, "Registry: Could not find MessagePortChannel for port %s; It was probably closed. Message will be dropped.", remoteTarget.logString().utf8().data());
+            return false;
+        }
+
+        result = channel->postMessageToRemote(WTF::move(message), remoteTarget);
+    }
+    return result;
 }
 
 void MessagePortChannelRegistry::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& callback)
 {
-    // ASSERT(isMainThread());
+    RefPtr<MessagePortChannel> channel;
+    Vector<MessageWithMessagePorts> messages;
+    {
+        Locker locker { m_lock };
 
-    // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(port);
-    if (!channel) {
-        callback({}, [] {});
-        return;
+        // The channel might be gone if the remote side was closed.
+        channel = m_openChannels.get(port).get();
+        if (channel)
+            messages = channel->takeAllMessagesForPort(port);
     }
 
-    channel->takeAllMessagesForPort(port, WTF::move(callback));
+    // Invoked outside the lock: the callback re-enters the registry via MessagePort::entanglePorts.
+    callback(WTF::move(messages), [] {});
 }
 
 std::optional<MessageWithMessagePorts> MessagePortChannelRegistry::tryTakeMessageForPort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: Trying to take a message for MessagePort %s", port.logString().utf8().data());
 
-    // The channel might be gone if the remote side was closed.
-    auto* channel = m_openChannels.get(port);
-    if (!channel)
-        return std::nullopt;
+    RefPtr<MessagePortChannel> channel;
+    std::optional<MessageWithMessagePorts> result;
+    {
+        Locker locker { m_lock };
 
-    return channel->tryTakeMessageForPort(port);
-}
+        // The channel might be gone if the remote side was closed.
+        channel = m_openChannels.get(port).get();
+        if (!channel)
+            return std::nullopt;
 
-MessagePortChannel* MessagePortChannelRegistry::existingChannelContainingPort(const MessagePortIdentifier& port)
-{
-    // ASSERT(isMainThread());
-
-    return m_openChannels.get(port);
+        result = channel->tryTakeMessageForPort(port);
+    }
+    return result;
 }
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
@@ -31,6 +31,7 @@
 #include "ProcessIdentifier.h"
 #include <wtf/HashMap.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Lock.h>
 
 namespace WebCore {
 
@@ -51,13 +52,16 @@ public:
     WEBCORE_EXPORT void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
     WEBCORE_EXPORT std::optional<MessageWithMessagePorts> tryTakeMessageForPort(const MessagePortIdentifier&);
 
-    WEBCORE_EXPORT MessagePortChannel* existingChannelContainingPort(const MessagePortIdentifier&);
-
     WEBCORE_EXPORT void messagePortChannelCreated(MessagePortChannel&);
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
 private:
-    UncheckedKeyHashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels;
+    // WebKit guarantees single-threaded access via ASSERT(isMainThread()) and routes worker calls through
+    // WorkerMessagePortChannelProvider → callOnMainThread. Bun has no equivalent main-thread runloop and
+    // additionally needs synchronous receiveMessageOnPort() from any thread, so we serialize with a lock
+    // instead. All MessagePortChannel state mutation happens via this registry and is covered by m_lock.
+    Lock m_lock;
+    UncheckedKeyHashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePortChannel>> m_openChannels WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/Performance.cpp
+++ b/src/bun.js/bindings/webcore/Performance.cpp
@@ -136,9 +136,6 @@ MonotonicTime Performance::monotonicTimeFromRelativeTime(DOMHighResTimeStamp rel
 
 PerformanceTiming* Performance::timing()
 {
-    // if (!is<Document>(scriptExecutionContext()))
-    //     return nullptr;
-    // ASSERT(isMainThread());
     if (!m_timing)
         m_timing = PerformanceTiming::create();
     return m_timing.get();

--- a/test/js/web/workers/message-channel-concurrent-fixture.js
+++ b/test/js/web/workers/message-channel-concurrent-fixture.js
@@ -22,7 +22,9 @@ export function hammer() {
       const inner = new MessageChannel();
       // Transfer a port (hits disentangle/entangle in the registry) and post twice.
       port1.postMessage(inner.port1, [inner.port1]);
-      port1.postMessage(j);
+      // Post a truthy payload — receiveMessageOnPort's wrapper currently treats
+      // falsy message values as "no message", which would short-circuit the loop.
+      port1.postMessage({ j });
       // Synchronous registry access from this thread.
       let msg;
       while ((msg = receiveMessageOnPort(port2))) {

--- a/test/js/web/workers/message-channel-concurrent-fixture.js
+++ b/test/js/web/workers/message-channel-concurrent-fixture.js
@@ -1,17 +1,19 @@
 // Stress the MessagePortChannelRegistry from many threads concurrently.
-// Each worker (and the main thread) creates/posts-to/transfers/closes many
-// MessageChannels in a tight loop with no yields, so the registry's HashMap is
-// being rehashed and mutated from several threads at once. Prior to the registry
-// being lock-protected this corrupted the HashMap and crashed.
+// hammer() creates/posts-to/transfers/closes many MessageChannels in a tight
+// loop with no yields, so the registry's HashMap is being rehashed and mutated
+// from several threads at once. Prior to the registry being lock-protected this
+// corrupted the HashMap and crashed.
+//
+// Exported for the test (main thread runs it directly); when loaded as a Worker
+// it runs hammer() and posts the count back.
 
-import { Worker, isMainThread, parentPort, receiveMessageOnPort } from "worker_threads";
+import { isMainThread, parentPort, receiveMessageOnPort } from "worker_threads";
 
-const WORKERS = 6;
-const ITERATIONS = 400;
-const CHANNELS_PER_ITERATION = 8;
-const EXPECTED_PER_HAMMER = ITERATIONS * CHANNELS_PER_ITERATION * 2;
+export const ITERATIONS = 400;
+export const CHANNELS_PER_ITERATION = 8;
+export const EXPECTED_PER_HAMMER = ITERATIONS * CHANNELS_PER_ITERATION * 2;
 
-function hammer() {
+export function hammer() {
   let received = 0;
   for (let i = 0; i < ITERATIONS; i++) {
     const ports = [];
@@ -35,65 +37,7 @@ function hammer() {
   return received;
 }
 
-if (isMainThread) {
-  // Watchdog so deadlock regressions fail fast instead of hanging the outer test.
-  const watchdog = setTimeout(() => {
-    console.error("FAIL: timed out waiting for workers");
-    process.exit(1);
-  }, 30_000);
-  watchdog.unref();
-
-  let exited = 0;
-  let reported = 0;
-  let total = 0;
-
-  for (let w = 0; w < WORKERS; w++) {
-    const worker = new Worker(import.meta.path);
-    worker.on("message", n => {
-      if (n !== EXPECTED_PER_HAMMER) {
-        console.error("FAIL: worker received", n, "messages, expected", EXPECTED_PER_HAMMER);
-        process.exit(1);
-      }
-      reported++;
-      total += n;
-      maybeFinish();
-    });
-    worker.on("error", err => {
-      console.error("worker error:", err);
-      process.exit(1);
-    });
-    worker.on("exit", code => {
-      if (code !== 0) {
-        console.error("worker exited with code", code);
-        process.exit(1);
-      }
-      exited++;
-      maybeFinish();
-    });
-  }
-
-  const mainTotal = hammer();
-  if (mainTotal !== EXPECTED_PER_HAMMER) {
-    console.error("FAIL: main thread received", mainTotal, "messages, expected", EXPECTED_PER_HAMMER);
-    process.exit(1);
-  }
-  total += mainTotal;
-
-  function maybeFinish() {
-    if (exited === WORKERS && reported === WORKERS) finish();
-  }
-
-  function finish() {
-    clearTimeout(watchdog);
-    if (total !== EXPECTED_PER_HAMMER * (WORKERS + 1)) {
-      console.error("FAIL: unexpected total", total);
-      process.exit(1);
-    }
-    console.log("PASS", total);
-    // Workers have all exited; let the main loop drain naturally rather than
-    // racing process.exit() against any in-flight cross-thread tasks.
-  }
-} else {
+if (!isMainThread) {
   parentPort.postMessage(hammer());
   parentPort.close();
 }

--- a/test/js/web/workers/message-channel-concurrent-fixture.js
+++ b/test/js/web/workers/message-channel-concurrent-fixture.js
@@ -1,0 +1,64 @@
+// Stress the MessagePortChannelRegistry from many threads concurrently.
+// Each worker (and the main thread) creates/posts-to/closes many MessageChannels
+// in a tight loop with no yields, so the registry's HashMap is being rehashed and
+// mutated from several threads at once. Prior to the registry being lock-protected
+// this corrupted the HashMap and crashed.
+
+import { Worker, isMainThread, parentPort, receiveMessageOnPort } from "worker_threads";
+
+const WORKERS = 6;
+const ITERATIONS = 400;
+const CHANNELS_PER_ITERATION = 8;
+
+function hammer() {
+  let received = 0;
+  for (let i = 0; i < ITERATIONS; i++) {
+    const channels = [];
+    for (let j = 0; j < CHANNELS_PER_ITERATION; j++) {
+      const { port1, port2 } = new MessageChannel();
+      const inner = new MessageChannel();
+      // Transfer a port (hits disentangle/entangle in the registry) and post twice.
+      port1.postMessage(j, [inner.port1]);
+      port1.postMessage(j);
+      // Synchronous registry access from this thread.
+      while (receiveMessageOnPort(port2)) received++;
+      channels.push(port1, port2, inner.port2);
+    }
+    for (const p of channels) p.close();
+  }
+  return received;
+}
+
+if (isMainThread) {
+  let done = 0;
+  let total = 0;
+  const workers = [];
+
+  for (let w = 0; w < WORKERS; w++) {
+    const worker = new Worker(import.meta.path);
+    worker.on("message", n => {
+      total += n;
+      if (++done === WORKERS + 1) finish();
+    });
+    worker.on("error", err => {
+      console.error("worker error:", err);
+      process.exit(1);
+    });
+    workers.push(worker);
+  }
+
+  total += hammer();
+  if (++done === WORKERS + 1) finish();
+
+  function finish() {
+    if (total === 0) {
+      console.error("FAIL: no messages received");
+      process.exit(1);
+    }
+    console.log("PASS", total);
+    for (const w of workers) w.terminate();
+    process.exit(0);
+  }
+} else {
+  parentPort.postMessage(hammer());
+}

--- a/test/js/web/workers/message-channel-concurrent-fixture.js
+++ b/test/js/web/workers/message-channel-concurrent-fixture.js
@@ -9,6 +9,7 @@ import { Worker, isMainThread, parentPort, receiveMessageOnPort } from "worker_t
 const WORKERS = 6;
 const ITERATIONS = 400;
 const CHANNELS_PER_ITERATION = 8;
+const EXPECTED_PER_HAMMER = ITERATIONS * CHANNELS_PER_ITERATION * 2;
 
 function hammer() {
   let received = 0;
@@ -43,12 +44,19 @@ if (isMainThread) {
   watchdog.unref();
 
   let exited = 0;
+  let reported = 0;
   let total = 0;
 
   for (let w = 0; w < WORKERS; w++) {
     const worker = new Worker(import.meta.path);
     worker.on("message", n => {
+      if (n !== EXPECTED_PER_HAMMER) {
+        console.error("FAIL: worker received", n, "messages, expected", EXPECTED_PER_HAMMER);
+        process.exit(1);
+      }
+      reported++;
       total += n;
+      maybeFinish();
     });
     worker.on("error", err => {
       console.error("worker error:", err);
@@ -59,16 +67,26 @@ if (isMainThread) {
         console.error("worker exited with code", code);
         process.exit(1);
       }
-      if (++exited === WORKERS) finish();
+      exited++;
+      maybeFinish();
     });
   }
 
-  total += hammer();
+  const mainTotal = hammer();
+  if (mainTotal !== EXPECTED_PER_HAMMER) {
+    console.error("FAIL: main thread received", mainTotal, "messages, expected", EXPECTED_PER_HAMMER);
+    process.exit(1);
+  }
+  total += mainTotal;
+
+  function maybeFinish() {
+    if (exited === WORKERS && reported === WORKERS) finish();
+  }
 
   function finish() {
     clearTimeout(watchdog);
-    if (total === 0) {
-      console.error("FAIL: no messages received");
+    if (total !== EXPECTED_PER_HAMMER * (WORKERS + 1)) {
+      console.error("FAIL: unexpected total", total);
       process.exit(1);
     }
     console.log("PASS", total);

--- a/test/js/web/workers/message-channel-concurrent-fixture.js
+++ b/test/js/web/workers/message-channel-concurrent-fixture.js
@@ -1,8 +1,8 @@
 // Stress the MessagePortChannelRegistry from many threads concurrently.
-// Each worker (and the main thread) creates/posts-to/closes many MessageChannels
-// in a tight loop with no yields, so the registry's HashMap is being rehashed and
-// mutated from several threads at once. Prior to the registry being lock-protected
-// this corrupted the HashMap and crashed.
+// Each worker (and the main thread) creates/posts-to/transfers/closes many
+// MessageChannels in a tight loop with no yields, so the registry's HashMap is
+// being rehashed and mutated from several threads at once. Prior to the registry
+// being lock-protected this corrupted the HashMap and crashed.
 
 import { Worker, isMainThread, parentPort, receiveMessageOnPort } from "worker_threads";
 
@@ -13,52 +13,69 @@ const CHANNELS_PER_ITERATION = 8;
 function hammer() {
   let received = 0;
   for (let i = 0; i < ITERATIONS; i++) {
-    const channels = [];
+    const ports = [];
     for (let j = 0; j < CHANNELS_PER_ITERATION; j++) {
       const { port1, port2 } = new MessageChannel();
       const inner = new MessageChannel();
       // Transfer a port (hits disentangle/entangle in the registry) and post twice.
-      port1.postMessage(j, [inner.port1]);
+      port1.postMessage(inner.port1, [inner.port1]);
       port1.postMessage(j);
       // Synchronous registry access from this thread.
-      while (receiveMessageOnPort(port2)) received++;
-      channels.push(port1, port2, inner.port2);
+      let msg;
+      while ((msg = receiveMessageOnPort(port2))) {
+        received++;
+        // Explicitly close the transferred port so it isn't left for GC during teardown.
+        if (msg.message instanceof MessagePort) msg.message.close();
+      }
+      ports.push(port1, port2, inner.port2);
     }
-    for (const p of channels) p.close();
+    for (const p of ports) p.close();
   }
   return received;
 }
 
 if (isMainThread) {
-  let done = 0;
+  // Watchdog so deadlock regressions fail fast instead of hanging the outer test.
+  const watchdog = setTimeout(() => {
+    console.error("FAIL: timed out waiting for workers");
+    process.exit(1);
+  }, 30_000);
+  watchdog.unref();
+
+  let exited = 0;
   let total = 0;
-  const workers = [];
 
   for (let w = 0; w < WORKERS; w++) {
     const worker = new Worker(import.meta.path);
     worker.on("message", n => {
       total += n;
-      if (++done === WORKERS + 1) finish();
     });
     worker.on("error", err => {
       console.error("worker error:", err);
       process.exit(1);
     });
-    workers.push(worker);
+    worker.on("exit", code => {
+      if (code !== 0) {
+        console.error("worker exited with code", code);
+        process.exit(1);
+      }
+      if (++exited === WORKERS) finish();
+    });
   }
 
   total += hammer();
-  if (++done === WORKERS + 1) finish();
 
   function finish() {
+    clearTimeout(watchdog);
     if (total === 0) {
       console.error("FAIL: no messages received");
       process.exit(1);
     }
     console.log("PASS", total);
-    for (const w of workers) w.terminate();
-    process.exit(0);
+    // Workers have all exited; let the main loop drain naturally rather than
+    // racing process.exit() against any in-flight cross-thread tasks.
   }
 } else {
   parentPort.postMessage(hammer());
+  parentPort.close();
 }

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+// Regression test for the MessagePortChannelRegistry data race: the registry's
+// m_openChannels HashMap and per-channel pending-message Vectors were mutated
+// from worker threads with no synchronization (the upstream ASSERT(isMainThread())
+// guards were commented out). This stresses the registry from several threads at
+// once; before the registry was made lock-protected this would crash.
+test("MessageChannel survives concurrent create/post/transfer/close from many workers", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "message-channel-concurrent-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith("PASS ");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -24,4 +24,4 @@ test("MessageChannel survives concurrent create/post/transfer/close from many wo
   expect(filteredStderr).toBe("");
   expect(stdout).toStartWith("PASS ");
   expect(exitCode).toBe(0);
-}, 60_000);
+});

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -16,8 +16,12 @@ test("MessageChannel survives concurrent create/post/transfer/close from many wo
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const filteredStderr = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
 
-  expect(stderr).toBe("");
+  expect(filteredStderr).toBe("");
   expect(stdout).toStartWith("PASS ");
   expect(exitCode).toBe(0);
 }, 60_000);

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -1,22 +1,33 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 import { join } from "path";
+import { Worker } from "worker_threads";
+import { EXPECTED_PER_HAMMER, hammer } from "./message-channel-concurrent-fixture.js";
 
 // Regression test for the MessagePortChannelRegistry data race: the registry's
 // m_openChannels HashMap and per-channel pending-message Vectors were mutated
 // from worker threads with no synchronization (the upstream ASSERT(isMainThread())
 // guards were commented out). This stresses the registry from several threads at
-// once; before the registry was made lock-protected this would crash.
+// once; before the registry was made lock-protected this would crash the process.
 test("MessageChannel survives concurrent create/post/transfer/close from many workers", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "message-channel-concurrent-fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+  const WORKERS = 6;
+  const fixture = join(import.meta.dir, "message-channel-concurrent-fixture.js");
+
+  const workerResults = Array.from({ length: WORKERS }, () => {
+    const worker = new Worker(fixture);
+    return new Promise<number>((resolve, reject) => {
+      worker.on("message", resolve);
+      worker.on("error", reject);
+      worker.on("exit", code => {
+        if (code !== 0) reject(new Error(`worker exited with code ${code}`));
+      });
+    });
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toStartWith("PASS ");
-  if (exitCode !== 0) console.error(stderr);
-  expect(exitCode).toBe(0);
+  // Hammer the registry from the main thread concurrently with the workers.
+  const mainResult = hammer();
+
+  const results = await Promise.all(workerResults);
+
+  expect(mainResult).toBe(EXPECTED_PER_HAMMER);
+  expect(results).toEqual(Array(WORKERS).fill(EXPECTED_PER_HAMMER));
 });

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -20,4 +20,4 @@ test("MessageChannel survives concurrent create/post/transfer/close from many wo
   expect(stderr).toBe("");
   expect(stdout).toStartWith("PASS ");
   expect(exitCode).toBe(0);
-});
+}, 60_000);

--- a/test/js/web/workers/message-channel-concurrent.test.ts
+++ b/test/js/web/workers/message-channel-concurrent.test.ts
@@ -16,12 +16,7 @@ test("MessageChannel survives concurrent create/post/transfer/close from many wo
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const filteredStderr = stderr
-    .split("\n")
-    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-
-  expect(filteredStderr).toBe("");
   expect(stdout).toStartWith("PASS ");
+  if (exitCode !== 0) console.error(stderr);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What

Replaces the commented-out `ASSERT(isMainThread())` guards in `MessagePortChannelRegistry` with a real `WTF::Lock`, and makes `MessagePortChannel` thread-safe-refcounted so the registry can be safely used from worker threads.

Fixes #29458
Fixes #25805
Fixes #22471
Fixes #16186

## Why

WebKit's `MessagePortChannelRegistry` is main-thread-only by design — every method asserts `isMainThread()` and worker access is routed through `WorkerMessagePortChannelProvider` → `callOnMainThread`. Bun stripped the proxy and commented the assertions out (with a `// we totally are calling these off the main thread in many cases in Bun, so ........` note), so worker threads were directly mutating `m_openChannels` (an unguarded `HashMap`) and per-channel `m_pendingMessages` `Vector`s concurrently with the main thread.

The new stress test reproduces this as bmalloc heap corruption (`pas panic: deallocation did fail` / `bitfit allocation error`) on every run against current main.

The linked issues are all the same underlying race surfacing at different points in the call path:

| Issue | Crash site | Faulting address | What was torn |
|---|---|---|---|
| #29458 | `SerializedScriptValue::deserialize` ← `tryTakeMessage` ← `receiveMessageOnPort` | `0x40` | `m_pendingMessages[i].first()` returned a torn slot with a null `RefPtr<SerializedScriptValue>` while another thread reallocated the vector |
| #25805 | MessageChannel transferred between two workers, hammered with `postMessage` | `0x8` | concurrent `m_openChannels` rehash + per-channel state mutation |
| #22471 | `MessagePort::postMessage` | `0x18` | corrupted `m_openChannels.get()` / channel state under `workers_spawned` |
| #16186 | `MessagePort::postMessage` | `0x30` | same as above, 17 workers |

## Why a lock instead of WebKit's thread-hop

WebKit bounces every registry call through `callOnMainThread`. Bun cannot do that directly because Node's synchronous `receiveMessageOnPort()` (`tryTakeMessageForPort`) needs to read the queue from the calling thread without round-tripping through the main loop. A lock gives the same single-writer guarantee WebKit's main-thread invariant provides, while keeping `receiveMessageOnPort` synchronous.

## Details

- `MessagePortChannelRegistry` gains `Lock m_lock`; `m_openChannels` becomes `HashMap<…, ThreadSafeWeakPtr<MessagePortChannel>>` and is `WTF_GUARDED_BY_LOCK`.
- Every registry entry point takes the lock. The looked-up `RefPtr<MessagePortChannel>` is hoisted outside the locked scope so the channel destructor (which re-enters via `messagePortChannelDestroyed`) cannot deadlock.
- `MessagePortChannel` is now `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr` so ref/weak ops are atomic across threads.
- `MessagePortChannel::takeAllMessagesForPort` now returns the message vector instead of invoking the callback directly; the registry invokes the callback **after** releasing the lock (the callback re-enters the registry via `MessagePort::entanglePorts`).
- `MessagePortChannel::tryTakeMessageForPort` now clears `m_pendingMessageProtectors[i]` when it drains the queue (pre-existing self-ref leak on the `receiveMessageOnPort` path).
- Removed dead `m_messageBatchesInFlight` / `hasAnyMessagesPendingOrInFlight` / `existingChannelContainingPort` (declared but never used in Bun).
- `Performance::timing()`'s commented `isMainThread()` guard was a Window-only check in WebKit; in Bun each context has its own `Performance`/`m_timing`, so it's deleted rather than restored.

## Testing

New `test/js/web/workers/message-channel-concurrent.test.ts` spawns 6 workers + main, each creating/transferring/posting/closing 8 channels × 400 iterations in a tight loop with no yields. Against current main this corrupts the heap on every run.
