### PR TITLE
sys(windows): don't panic on unnamed NTSTATUS in openDirAtWindowsNtPath

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1102,7 +1102,7 @@ fn openDirAtWindowsNtPath(
         0,
     );
 
-    if (comptime Environment.allow_assert) {
+    if (Environment.allow_assert and Environment.enable_logs) {
         if (rc == .INVALID_PARAMETER) {
             // Double check what flags you are passing to this
             //
@@ -1113,7 +1113,11 @@ fn openDirAtWindowsNtPath(
         } else if (rc == .OBJECT_PATH_SYNTAX_BAD or rc == .OBJECT_NAME_INVALID) {
             bun.Output.debugWarn("NtCreateFile({f}, {f}) = {s} (dir) = {d}\nYou are calling this function without normalizing the path correctly!!!", .{ dirFd, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(fd) });
         } else {
-            log("NtCreateFile({f}, {f}) = {s} (dir) = {d}", .{ dirFd, bun.fmt.utf16(path), @tagName(rc), @intFromPtr(fd) });
+            // NtCreateFile may return NTSTATUS codes that are not named in Zig's
+            // non-exhaustive NTSTATUS enum (e.g. STATUS_UNTRUSTED_MOUNT_POINT = 0xC00004BC
+            // on newer Windows 11 builds). `@tagName` on an unnamed tag panics with
+            // "invalid enum value", so use the default formatter which handles them.
+            log("NtCreateFile({f}, {f}) = {} (dir) = {d}", .{ dirFd, bun.fmt.utf16(path), rc, @intFromPtr(fd) });
         }
     }
 
@@ -1319,7 +1323,10 @@ pub fn openFileAtWindowsNtPath(
                 if (rc == .SUCCESS) {
                     log("NtCreateFile({f}, {f}) = {s} (file) = {f}", .{ dir, bun.fmt.utf16(path), @tagName(rc), bun.FD.fromNative(result) });
                 } else {
-                    log("NtCreateFile({f}, {f}) = {s} (file) = {}", .{ dir, bun.fmt.utf16(path), @tagName(rc), rc });
+                    // Use the default formatter instead of `@tagName` here: `rc` may
+                    // be an NTSTATUS not named in Zig's non-exhaustive enum, and
+                    // `@tagName` on an unnamed tag panics with "invalid enum value".
+                    log("NtCreateFile({f}, {f}) = {} (file)", .{ dir, bun.fmt.utf16(path), rc });
                 }
             }
         }

--- a/test/js/node/fs/readdir-windows-ntstatus.test.ts
+++ b/test/js/node/fs/readdir-windows-ntstatus.test.ts
@@ -1,0 +1,83 @@
+// On Windows, fs.readdir() goes through openDirAtWindowsNtPath which calls
+// NtCreateFile. NtCreateFile can return NTSTATUS codes that are not named in
+// Zig's (non-exhaustive) NTSTATUS enum — one seen in the wild is
+// STATUS_UNTRUSTED_MOUNT_POINT (0xC00004BC) when traversing certain junctions
+// under newer Windows 11 security policies.
+//
+// Previously a debug-logging branch evaluated `@tagName(rc)` on that status.
+// `@tagName` on an unnamed tag of a non-exhaustive enum panics with
+// "invalid enum value", and because Windows release builds are ReleaseSafe
+// (allow_assert = true), that branch was compiled into shipped binaries.
+//
+// A deterministic unit test would need to force NtCreateFile to return an
+// NTSTATUS outside the Zig enum, which depends on OS version and local
+// security policy and can't be done portably from userspace. Instead this
+// test exercises the same readdir → openDirAtWindowsNtPath path through a
+// junction (the reported trigger) and asserts that any failure surfaces as a
+// catchable Error rather than terminating the process.
+//
+// https://github.com/oven-sh/bun/issues/26496
+// https://github.com/oven-sh/bun/issues/28721
+// https://github.com/oven-sh/bun/issues/29158
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import fs from "node:fs";
+import path from "node:path";
+
+test.skipIf(!isWindows)("fs.readdir through a junction returns or throws, never panics", async () => {
+  using dir = tempDir("readdir-ntstatus", {
+    "target/a.txt": "a",
+    "target/b.txt": "b",
+  });
+  const root = String(dir);
+  const target = path.join(root, "target");
+  const link = path.join(root, "link");
+
+  // Junctions don't require admin rights on Windows.
+  fs.symlinkSync(target, link, "junction");
+
+  // Run in a child so that if the old `@tagName(rc)` panic fires, this test
+  // observes it as a non-zero exit code instead of bringing down the runner.
+  // The child prints JSON describing the outcome on success or caught error.
+  const fixture = `
+    const fs = require("node:fs");
+    const link = process.argv[2];
+    let out;
+    try {
+      const entries = fs.readdirSync(link).sort();
+      out = { ok: true, entries };
+    } catch (err) {
+      out = { ok: false, code: err && err.code, message: String(err && err.message) };
+    }
+    process.stdout.write(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture, link],
+    env: bunEnv,
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(() => JSON.parse(stdout)).not.toThrow();
+
+  const result = JSON.parse(stdout) as
+    | { ok: true; entries: string[] }
+    | { ok: false; code: string | undefined; message: string };
+
+  if (result.ok) {
+    expect(result.entries).toEqual(["a.txt", "b.txt"]);
+  } else {
+    // On hardened Windows configurations the junction may be rejected by
+    // NtCreateFile with a status that maps to a real errno; the important
+    // thing is that it was catchable in JS.
+    expect(typeof result.message).toBe("string");
+  }
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the `invalid enum value` panic in `openDirAtWindowsNtPath` on Windows release builds.

## Root cause

Windows release builds are compiled as **ReleaseSafe** (intentional since Bun 1.1, see `scripts/build/zig.ts`), so `Environment.allow_assert` is **true** in shipped binaries. The `NtCreateFile` debug-log block in `openDirAtWindowsNtPath` was gated only on `allow_assert`:

```zig
if (comptime Environment.allow_assert) {
    ...
    } else {
        log("NtCreateFile(...) = {s} ...", .{ ..., @tagName(rc), ... });
    }
}
```

When `NtCreateFile` returns an NTSTATUS that isn't a *named* tag in Zig's non-exhaustive `NTSTATUS` enum — seen in the wild with `STATUS_UNTRUSTED_MOUNT_POINT` (`0xC00004BC`) when traversing junctions under newer Windows 11 security policies — `@tagName(rc)` panics with `invalid enum value`. The arguments to `log()` are evaluated even though `log()` is a no-op when `enable_logs` is false.

`openFileAtWindowsNtPath` already gated its equivalent block on `allow_assert and enable_logs`, which is why the file path didn't crash.

The actual error path (`Win32Error.fromNTStatus(rc)` → `toSystemErrno()` → fallback to `E.UNKNOWN`) already handles unknown status codes correctly — only the debug logging was panicking.

## Fix

- Gate the `openDirAtWindowsNtPath` debug block on `allow_assert and enable_logs` to match `openFileAtWindowsNtPath`, so it's compiled out of release builds.
- In the fall-through `else` branches of both functions, use the default formatter `{}` (which prints `@enumFromInt(N)` for unnamed tags) instead of `@tagName(rc)`, so debug/`enable_logs` builds don't panic either.

## Testing

A deterministic regression test would need to force `NtCreateFile` to return an NTSTATUS outside Zig's enum, which depends on OS version and local security policy and can't be done portably from userspace. `test/js/node/fs/readdir-windows-ntstatus.test.ts` exercises the same `readdir` → `openDirAtWindowsNtPath` path through a junction (the reported trigger) in a child process and asserts that any failure surfaces as a catchable `Error` rather than a non-zero exit. Verified the change compiles on all targets with `bun run zig:check-all`.

Fixes #26496
Fixes #28721
Fixes #29158
Alternative to #29160