### PR TITLE
docs: Update bun setup version key in CI/CD guide

### DIFF
--- a/docs/guides/install/cicd.mdx
+++ b/docs/guides/install/cicd.mdx
@@ -35,7 +35,7 @@ jobs:
       # ...
       - uses: oven-sh/setup-bun@v2
          with: # [!code ++]
-          version: "latest" # or "canary" # [!code ++]
+          bun-version: "latest" # or "canary" # [!code ++]
 ```
 
 ---


### PR DESCRIPTION
### What does this PR do?

Update the `version` key of `oven-sh/setup-bun@v2` to the correct `bun-version` in the CI/CD guide.

### How did you verify your code works?

N/A