### PR TITLE
Fix segfault in Bun.pathToFileURL when URL construction fails on Windows

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -797,6 +797,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPathToFileURL, (JSC::JSGlobalObject * lexicalGl
         jsValue = WebCore::toJSNewlyCreated<IDLInterface<DOMURL>>(*lexicalGlobalObject, globalObject, throwScope, WTF::move(object));
     }
 
+    RETURN_IF_EXCEPTION(throwScope, {});
     auto* jsDOMURL = jsCast<JSDOMURL*>(jsValue.asCell());
     vm.heap.reportExtraMemoryAllocated(jsDOMURL, jsDOMURL->wrapped().memoryCostForGC());
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(jsValue));

--- a/test/js/bun/util/pathToFileURL-invalid.test.ts
+++ b/test/js/bun/util/pathToFileURL-invalid.test.ts
@@ -42,9 +42,7 @@ describe("Bun.pathToFileURL with inputs that fail URL construction", () => {
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     // One line per input: either a valid URL or a thrown TypeError — never a crash.
-    expect(stdout.trim().split("\n")).toEqual(
-      inputs.map(() => expect.stringMatching(/^(ok ".*"|threw TypeError)$/)),
-    );
+    expect(stdout.trim().split("\n")).toEqual(inputs.map(() => expect.stringMatching(/^(ok ".*"|threw TypeError)$/)));
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/util/pathToFileURL-invalid.test.ts
+++ b/test/js/bun/util/pathToFileURL-invalid.test.ts
@@ -1,0 +1,58 @@
+import { pathToFileURL } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// On Windows, UNC paths map the first segment to the URL host. When that
+// segment is not a valid URL host (e.g. `\\?\C:\foo` → host `%3F`, or
+// `\\@\share` → host `@`), DOMURL::create throws and toJSNewlyCreated returns
+// an empty JSValue. Without an exception check, the subsequent
+// jsCast<JSDOMURL*>(...)->wrapped() dereferences null and crashes.
+//
+// On POSIX, fileURLWithFileSystemPath always produces an empty host so
+// construction never fails; these inputs just resolve to paths under cwd.
+describe("Bun.pathToFileURL with inputs that fail URL construction", () => {
+  const inputs = [
+    "\\\\?\\C:\\Windows\\System32", // Windows extended-length path prefix
+    "\\\\@\\share",
+    "\\\\<\\share",
+    "\\\\a b\\share",
+    "\\\\a:b\\share",
+  ];
+
+  test("does not crash in a subprocess", async () => {
+    const src = `
+      const inputs = ${JSON.stringify(inputs)};
+      for (const input of inputs) {
+        try {
+          const url = Bun.pathToFileURL(input);
+          console.log("ok", JSON.stringify(url.href));
+        } catch (e) {
+          console.log("threw", e?.constructor?.name);
+        }
+      }
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    // One line per input: either a valid URL or a thrown TypeError — never a crash.
+    expect(stdout.trim().split("\n")).toEqual(
+      inputs.map(() => expect.stringMatching(/^(ok ".*"|threw TypeError)$/)),
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  // On Windows these inputs cannot produce a valid file URL, so they must
+  // throw cleanly instead of segfaulting.
+  test.skipIf(!isWindows)("throws TypeError on Windows for UNC paths with invalid hosts", () => {
+    for (const input of inputs) {
+      expect(() => pathToFileURL(input)).toThrow(TypeError);
+    }
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a segfault in `Bun.pathToFileURL` on Windows when given a UNC path whose first segment is not a valid URL host.

```
RawPtrTraits<DOMURL>::unwrap (wtf/RawPtrTraits.h:44)
JSDOMWrapper<DOMURL>::wrapped (src/bun.js/bindings/JSDOMWrapper.h:86)
functionPathToFileURL (src/bun.js/bindings/BunObject.cpp:801)
```

On Windows, `WTF::URL::fileURLWithFileSystemPath` maps the first segment of a UNC path (`\\server\share`) to the URL host. When that segment is not a valid host — e.g. the common extended-length prefix `\\?\C:\...` (host `%3F`), or `\\@\share`, `\\a b\share`, etc. — the resulting URL string fails to parse. `DOMURL::create` then returns an `Exception`, and `toJSNewlyCreated` propagates it and returns an **empty** `JSValue`. `functionPathToFileURL` did not check for this and proceeded to `jsCast<JSDOMURL*>(jsValue.asCell())->wrapped()`, dereferencing null at offset 0x18.

On POSIX this path is unreachable because the host is always empty (`file:///…`).

The fix adds `RETURN_IF_EXCEPTION(throwScope, {})` before the cast — the same pattern already used in `BunString__toJSDOMURL`. After the fix these inputs throw a `TypeError` instead of crashing.

### How did you verify your code works?

Added `test/js/bun/util/pathToFileURL-invalid.test.ts`:
- Spawns a subprocess that feeds the problematic UNC paths to `Bun.pathToFileURL` and asserts each either returns a URL or throws `TypeError`, and that the process exits 0 (on Windows without this fix the process crashes → non-zero exit + truncated stdout).
- Windows-gated in-process assertion that each input throws `TypeError`.

Ran `bun bd test test/js/bun/util/pathToFileURL-invalid.test.ts` and `bun bd test test/js/bun/util/fileUrl.test.js` locally — both pass. The crash is Windows-only, so the behavioural change is observable on Windows CI.
