### PR TITLE
module_loader: remove undefined backing for bun:main source

### DIFF
--- a/src/bun.js/ModuleLoader.zig
+++ b/src/bun.js/ModuleLoader.zig
@@ -1147,7 +1147,7 @@ fn getHardcodedModule(jsc_vm: *VirtualMachine, specifier: bun.String, hardcoded:
     return switch (hardcoded) {
         .@"bun:main" => if (jsc_vm.entry_point.generated) .{
             .allocator = null,
-            .source_code = bun.String.cloneUTF8(jsc_vm.entry_point.source.contents),
+            .source_code = bun.String.cloneUTF8(jsc_vm.entry_point.contents),
             .specifier = specifier,
             .source_url = specifier,
             .tag = .esm,

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1650,7 +1650,7 @@ fn _resolve(
         return;
     } else if (strings.eqlComptime(specifier, main_file_name) and jsc_vm.entry_point.generated) {
         ret.result = null;
-        ret.path = jsc_vm.entry_point.source.path.text;
+        ret.path = main_file_name;
         return;
     } else if (strings.hasPrefixComptime(specifier, js_ast.Macro.namespaceWithColon)) {
         ret.result = null;
@@ -2199,10 +2199,8 @@ pub fn reloadEntryPoint(this: *VirtualMachine, entry_path: []const u8) !*JSInter
 
     if (!this.main_is_html_entrypoint) {
         try this.entry_point.generate(
-            this.allocator,
             this.bun_watcher != .none,
             entry_path,
-            main_file_name,
         );
     }
 

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -2021,6 +2021,7 @@ pub fn deinit(this: *VirtualMachine) void {
     }
     this.proxy_env_storage.deinit();
     this.overridden_main.deinit();
+    this.entry_point.deinit();
     this.has_terminated = true;
 }
 

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -155,6 +155,14 @@ pub const ServerEntryPoint = struct {
     contents: []const u8 = "",
     generated: bool = false,
 
+    pub fn deinit(entry: *ServerEntryPoint) void {
+        if (entry.contents.len > 0) {
+            bun.default_allocator.free(entry.contents);
+        }
+        entry.contents = "";
+        entry.generated = false;
+    }
+
     pub fn generate(
         entry: *ServerEntryPoint,
         is_hot_reload_enabled: bool,

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -149,16 +149,22 @@ pub const ClientEntryPoint = struct {
 };
 
 pub const ServerEntryPoint = struct {
-    source: logger.Source = undefined,
+    /// The generated wrapper source for `bun:main`. Always a valid slice
+    /// (either empty or owned by `bun.default_allocator`) so readers never
+    /// see `undefined` memory regardless of the `generated` flag's state.
+    contents: []const u8 = "",
     generated: bool = false,
 
     pub fn generate(
         entry: *ServerEntryPoint,
-        allocator: std.mem.Allocator,
         is_hot_reload_enabled: bool,
         path_to_use: string,
-        name: string,
     ) !void {
+        // Use the global allocator so this buffer's lifetime is decoupled
+        // from whichever arena the caller's VM happens to be using; the
+        // slice is read later from `getHardcodedModule` which outlives any
+        // per-transpile arena.
+        const allocator = bun.default_allocator;
         const code = brk: {
             if (is_hot_reload_enabled) {
                 break :brk try std.fmt.allocPrint(
@@ -228,9 +234,12 @@ pub const ServerEntryPoint = struct {
             );
         };
 
-        entry.source = logger.Source.initPathString(name, code);
-        entry.source.path.text = name;
-        entry.source.path.namespace = "server-entry";
+        // Free the previous buffer on regenerate (hot reload) instead of
+        // leaking it. `contents` is either "" or a prior allocPrint result.
+        if (entry.contents.len > 0) {
+            allocator.free(entry.contents);
+        }
+        entry.contents = code;
         entry.generated = true;
     }
 };

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -10,7 +10,7 @@
   ".stdDir()": 42,
   ".stdFile()": 16,
   "// autofix": 148,
-  ": [^=]+= undefined,$": 259,
+  ": [^=]+= undefined,$": 258,
   "== alloc.ptr": 0,
   "== allocator.ptr": 0,
   "@import(\"bun\").": 0,

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -12,7 +12,11 @@ import { join } from "node:path";
 // the regenerate path under --hot so ASAN covers the new
 // free-then-reallocate on each reload.
 
-test("dynamic import('bun:main') returns the wrapper module", async () => {
+function stripAsanWarning(stderr: string): string[] {
+  return stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+}
+
+test.concurrent("dynamic import('bun:main') returns the wrapper module", async () => {
   using dir = tempDir("bun-main-dyn", {
     "entry.mjs": `
       const m = await import("bun:main");
@@ -29,11 +33,11 @@ test("dynamic import('bun:main') returns the wrapper module", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("OK\n");
-  expect(stderr.replaceAll(/^WARNING:.*\n/gm, "")).toBe("");
+  expect(stripAsanWarning(stderr)).toEqual([]);
   expect(exitCode).toBe(0);
 });
 
-test("import('bun:main') from a preload (before the module map is populated)", async () => {
+test.concurrent("import('bun:main') from a preload (before the module map is populated)", async () => {
   using dir = tempDir("bun-main-preload", {
     "preload.mjs": `
       const m = await import("bun:main");
@@ -51,53 +55,62 @@ test("import('bun:main') from a preload (before the module map is populated)", a
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("PRELOAD_OK\nENTRY_OK\n");
-  expect(stderr.replaceAll(/^WARNING:.*\n/gm, "")).toBe("");
+  expect(stripAsanWarning(stderr)).toEqual([]);
   expect(exitCode).toBe(0);
 });
 
-test("ServerEntryPoint regenerates cleanly across --hot reloads", async () => {
-  // Each reload calls ServerEntryPoint.generate() again, which now frees the
-  // previous `contents` buffer before allocating a fresh one. Drive several
-  // reloads and verify bun:main is re-fetched and evaluates correctly each
-  // time; under ASAN this catches any use-after-free of the prior buffer.
-  using dir = tempDir("bun-main-hot", {
-    "entry.mjs": `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", 0);\n`,
-  });
-  const entry = join(String(dir), "entry.mjs");
+test.concurrent(
+  "ServerEntryPoint regenerates cleanly across --hot reloads",
+  async () => {
+    // Each reload calls ServerEntryPoint.generate() again, which now frees the
+    // previous `contents` buffer before allocating a fresh one. Drive several
+    // reloads and verify bun:main is re-fetched and evaluates correctly each
+    // time; under ASAN this catches any use-after-free of the prior buffer.
+    using dir = tempDir("bun-main-hot", {
+      "entry.mjs": `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", 0);\n`,
+    });
+    const entry = join(String(dir), "entry.mjs");
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--hot", entry],
-    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--hot", entry],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const reader = proc.stdout.getReader();
-  const decoder = new TextDecoder();
-  let buffered = "";
+    // Drain stderr concurrently so a large sanitizer report can't fill the
+    // pipe buffer and wedge the child while we're blocked on stdout.
+    const stderrPromise = proc.stderr.text();
 
-  const waitForLine = async (needle: string) => {
-    while (!buffered.includes(needle)) {
-      const { value, done } = await reader.read();
-      if (done)
-        throw new Error(`stdout closed before seeing ${JSON.stringify(needle)}; buffer=${JSON.stringify(buffered)}`);
-      buffered += decoder.decode(value, { stream: true });
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+
+    const waitForLine = async (needle: string) => {
+      while (!buffered.includes(needle)) {
+        const { value, done } = await reader.read();
+        if (done)
+          throw new Error(`stdout closed before seeing ${JSON.stringify(needle)}; buffer=${JSON.stringify(buffered)}`);
+        buffered += decoder.decode(value, { stream: true });
+      }
+    };
+
+    await waitForLine("GEN 0\n");
+
+    for (let i = 1; i <= 4; i++) {
+      writeFileSync(entry, `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", ${i});\n`);
+      await waitForLine(`GEN ${i}\n`);
     }
-  };
 
-  await waitForLine("GEN 0\n");
+    proc.kill();
+    reader.releaseLock();
+    await proc.exited;
+    await stderrPromise;
 
-  for (let i = 1; i <= 4; i++) {
-    writeFileSync(entry, `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", ${i});\n`);
-    await waitForLine(`GEN ${i}\n`);
-  }
-
-  proc.kill();
-  reader.releaseLock();
-  await proc.exited;
-
-  // Reaching GEN 4 proves the wrapper was regenerated and re-read via
-  // cloneUTF8 on every reload without faulting on a stale slice.
-  expect(buffered).toContain("GEN 4\n");
-});
+    // Reaching GEN 4 proves the wrapper was regenerated and re-read via
+    // cloneUTF8 on every reload without faulting on a stale slice.
+    expect(buffered).toContain("GEN 4\n");
+  },
+  isDebug ? 60_000 : 30_000,
+);

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// `bun:main` is backed by ServerEntryPoint.contents — a slice that is
+// regenerated on every hot-reload cycle. Previously the backing
+// `logger.Source` defaulted to `undefined`, so any read of
+// `entry_point.source.contents` that wasn't paired with a successful
+// `generate()` dereferenced garbage (high non-null fault in
+// toBunStringComptime). These tests exercise the read path directly and
+// the regenerate path under --hot so ASAN covers the new
+// free-then-reallocate on each reload.
+
+test("dynamic import('bun:main') returns the wrapper module", async () => {
+  using dir = tempDir("bun-main-dyn", {
+    "entry.mjs": `
+      const m = await import("bun:main");
+      if (typeof m !== "object" || m === null) throw new Error("expected module namespace");
+      console.log("OK");
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "./entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("OK\n");
+  expect(stderr.replaceAll(/^WARNING:.*\n/gm, "")).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("import('bun:main') from a preload (before the module map is populated)", async () => {
+  using dir = tempDir("bun-main-preload", {
+    "preload.mjs": `
+      const m = await import("bun:main");
+      if (typeof m !== "object" || m === null) throw new Error("expected module namespace");
+      console.log("PRELOAD_OK");
+    `,
+    "entry.mjs": `console.log("ENTRY_OK");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.mjs", "./entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("PRELOAD_OK\nENTRY_OK\n");
+  expect(stderr.replaceAll(/^WARNING:.*\n/gm, "")).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test("ServerEntryPoint regenerates cleanly across --hot reloads", async () => {
+  // Each reload calls ServerEntryPoint.generate() again, which now frees the
+  // previous `contents` buffer before allocating a fresh one. Drive several
+  // reloads and verify bun:main is re-fetched and evaluates correctly each
+  // time; under ASAN this catches any use-after-free of the prior buffer.
+  using dir = tempDir("bun-main-hot", {
+    "entry.mjs": `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", 0);\n`,
+  });
+  const entry = join(String(dir), "entry.mjs");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--hot", entry],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+
+  const waitForLine = async (needle: string) => {
+    while (!buffered.includes(needle)) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`stdout closed before seeing ${JSON.stringify(needle)}; buffer=${JSON.stringify(buffered)}`);
+      buffered += decoder.decode(value, { stream: true });
+    }
+  };
+
+  await waitForLine("GEN 0\n");
+
+  for (let i = 1; i <= 4; i++) {
+    writeFileSync(entry, `globalThis.__gen = (globalThis.__gen ?? 0) + 1;\nconsole.log("GEN", ${i});\n`);
+    await waitForLine(`GEN ${i}\n`);
+  }
+
+  proc.kill();
+  reader.releaseLock();
+  await proc.exited;
+
+  // Reaching GEN 4 proves the wrapper was regenerated and re-read via
+  // cloneUTF8 on every reload without faulting on a stale slice.
+  expect(buffered).toContain("GEN 4\n");
+});

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 // `bun:main` is backed by ServerEntryPoint.contents — a slice that is
 // regenerated on every hot-reload cycle. Previously the backing
@@ -80,7 +80,8 @@ test("ServerEntryPoint regenerates cleanly across --hot reloads", async () => {
   const waitForLine = async (needle: string) => {
     while (!buffered.includes(needle)) {
       const { value, done } = await reader.read();
-      if (done) throw new Error(`stdout closed before seeing ${JSON.stringify(needle)}; buffer=${JSON.stringify(buffered)}`);
+      if (done)
+        throw new Error(`stdout closed before seeing ${JSON.stringify(needle)}; buffer=${JSON.stringify(buffered)}`);
       buffered += decoder.decode(value, { stream: true });
     }
   };


### PR DESCRIPTION
## What

`ServerEntryPoint` stored its generated wrapper source in a `logger.Source` that defaulted to `undefined`, relying on the `.generated` flag (added in #27027) to guard every read. `getHardcodedModule()` calls `String.cloneUTF8(entry_point.source.contents)` for `bun:main`; if the flag and the source ever disagree the clone reads a garbage `{ptr, len}` and faults inside `toBunStringComptime`:

```
toBunStringComptime                (src/bun.js/webcore/encoding.zig:215)
String.cloneUTF8                   (src/string.zig:208)
ModuleLoader.getHardcodedModule    (src/bun.js/ModuleLoader.zig)
ModuleLoader.fetchBuiltinModule    (src/bun.js/ModuleLoader.zig)
Bun__fetchBuiltinModule            (src/bun.js/ModuleLoader.zig)
fetchESMSourceCode<true>           (src/bun.js/bindings/ModuleLoader.cpp)
GlobalObject::moduleLoaderFetch    (ZigGlobalObject.cpp)
```

(fault address is a high non-null value — consistent with reading an uninitialised slice). Same signature as #27192.

## Fix

Only two fields of the `Source` were ever read: `.contents` and `.path.text` — and `.path.text` is always the constant `"bun:main"`. So:

- Replace `source: logger.Source = undefined` with `contents: []const u8 = ""`. The slice passed to `cloneUTF8` is now always valid (either the empty string or a live heap allocation), independent of `.generated`.
- Allocate the wrapper with `bun.default_allocator` instead of the caller's `vm.allocator` arena so its lifetime is decoupled from whichever arena happens to be active on that VM.
- Free the previous buffer on regenerate so `bun --hot` no longer leaks ~1 KB per reload.
- `_resolve` returns the `main_file_name` constant directly instead of reading it back out of the entry point.

## Verification

- `bun bd test test/js/bun/resolve/bun-main-entry-point.test.ts` — dynamic `import('bun:main')`, preload `import('bun:main')`, and a 4-cycle `--hot` regenerate loop (covers the new free-then-reallocate under ASAN)
- `bun bd test test/js/bun/http/bun-serve-html-entry.test.ts -t bun:main` — existing HTML-entry preload case
- `bun bd test test/regression/issue/440.test.ts test/regression/issue/26142.test.ts` — wrapper behaviour unchanged
- `bun run zig:check-all`

The crash itself isn't deterministically reproducible with the `.generated` guard in place, so the new tests exercise the read and regenerate paths rather than the fault directly.