### PR TITLE
fetch: hold tasklet mutex through derefFromThread so HTTP thread never drops last ref

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -144,6 +144,20 @@ export const setSyntheticAllocationLimitForTesting: (limit: number) => number = 
   1,
 );
 
+export const fetchTestingInternals = {
+  /**
+   * Returns `{ statusText: boolean, url: boolean }` — whether each native
+   * backing string on a fetch `Response` is an atom `StringImpl`. Atom
+   * strings live in a per-thread table; the `Response` can be destroyed
+   * from the HTTP thread during VM shutdown (FetchTasklet.derefFromThread),
+   * so these MUST both be `false` or the process trips
+   * `RELEASE_ASSERT(wasRemoved)` in `AtomStringImpl::remove()`.
+   */
+  responseAtomFlags: $newZigFunction("webcore/Response.zig", "jsResponseAtomFlagsForTesting", 1) as (
+    response: Response,
+  ) => { statusText: boolean; url: boolean },
+};
+
 export const npm_manifest_test_helpers = $zig("npm.zig", "PackageManifest.bindings.generate") as {
   /**
    * Returns the parsed manifest file. Currently only returns an array of available versions.

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -148,10 +148,10 @@ export const fetchTestingInternals = {
   /**
    * Returns `{ statusText: boolean, url: boolean }` — whether each native
    * backing string on a fetch `Response` is an atom `StringImpl`. Atom
-   * strings live in a per-thread table; the `Response` can be destroyed
-   * from the HTTP thread during VM shutdown (FetchTasklet.derefFromThread),
-   * so these MUST both be `false` or the process trips
-   * `RELEASE_ASSERT(wasRemoved)` in `AtomStringImpl::remove()`.
+   * strings live in a per-thread table, so `Response.destroy()` must run
+   * on the JS thread that created them. `FetchTasklet.callback()` holds
+   * the tasklet mutex through `derefFromThread()` so the HTTP thread is
+   * never the last ref; see `fetch-response-shutdown-atom.test.ts`.
    */
   responseAtomFlags: $newZigFunction("webcore/Response.zig", "jsResponseAtomFlagsForTesting", 1) as (
     response: Response,

--- a/src/runtime/webcore/Response.zig
+++ b/src/runtime/webcore/Response.zig
@@ -181,15 +181,15 @@ pub inline fn setSizeHint(this: *Response, size_hint: Blob.SizeType) void {
 }
 
 /// Testing helper: returns `{ statusText: bool, url: bool }` indicating
-/// whether each backing `bun.String` is an atom StringImpl. These must be
-/// `false` for fetch responses — atom strings live in a per-thread table,
-/// and `FetchTasklet.derefFromThread()` can run `Response.destroy()` on the
-/// HTTP thread during VM shutdown, which would trip
-/// `RELEASE_ASSERT(wasRemoved)` in `AtomStringImpl::remove()`. Exposed via
-/// `bun:internal-for-testing` as `fetchTestingInternals.responseAtomFlags`.
+/// whether each backing `bun.String` is an atom StringImpl. fetch responses
+/// atomize both for dedup; atom strings live in a per-thread table, so
+/// `Response.destroy()` must run on the JS thread that created them.
+/// `FetchTasklet.callback()` holds the tasklet mutex through
+/// `derefFromThread()` to guarantee the HTTP thread is never the last ref.
+/// Exposed via `bun:internal-for-testing` as
+/// `fetchTestingInternals.responseAtomFlags`.
 pub fn jsResponseAtomFlagsForTesting(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-    const arguments = callframe.arguments_old(1);
-    const this_value = arguments.ptr[0];
+    const this_value = callframe.argument(0);
     const response = this_value.as(Response) orelse {
         return globalObject.throwInvalidArgumentTypeValue("response", "Response", this_value);
     };

--- a/src/runtime/webcore/Response.zig
+++ b/src/runtime/webcore/Response.zig
@@ -180,6 +180,31 @@ pub inline fn setSizeHint(this: *Response, size_hint: Blob.SizeType) void {
     }
 }
 
+/// Testing helper: returns `{ statusText: bool, url: bool }` indicating
+/// whether each backing `bun.String` is an atom StringImpl. These must be
+/// `false` for fetch responses — atom strings live in a per-thread table,
+/// and `FetchTasklet.derefFromThread()` can run `Response.destroy()` on the
+/// HTTP thread during VM shutdown, which would trip
+/// `RELEASE_ASSERT(wasRemoved)` in `AtomStringImpl::remove()`. Exposed via
+/// `bun:internal-for-testing` as `fetchTestingInternals.responseAtomFlags`.
+pub fn jsResponseAtomFlagsForTesting(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const arguments = callframe.arguments_old(1);
+    const this_value = arguments.ptr[0];
+    const response = this_value.as(Response) orelse {
+        return globalObject.throwInvalidArgumentTypeValue("response", "Response", this_value);
+    };
+
+    const status_is_atom = response.#init.status_text.tag == .WTFStringImpl and
+        response.#init.status_text.value.WTFStringImpl.isAtom();
+    const url_is_atom = response.#url.tag == .WTFStringImpl and
+        response.#url.value.WTFStringImpl.isAtom();
+
+    const obj = jsc.JSValue.createEmptyObject(globalObject, 2);
+    obj.put(globalObject, ZigString.static("statusText"), jsc.JSValue.jsBoolean(status_is_atom));
+    obj.put(globalObject, ZigString.static("url"), jsc.JSValue.jsBoolean(url_is_atom));
+    return obj;
+}
+
 pub export fn jsFunctionRequestOrResponseHasBodyValue(_: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) callconv(jsc.conv) jsc.JSValue {
     const arguments = callframe.arguments_old(1);
     const this_value = arguments.ptr[0];

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -76,15 +76,21 @@ pub const FetchTasklet = struct {
     pub fn derefFromThread(this: *FetchTasklet) void {
         const count = this.ref_count.fetchSub(1, .monotonic);
         bun.debugAssert(count > 0);
+        // The only caller is callback(), which holds task.mutex during this
+        // deref. The JS-side baseline deref is in onProgressUpdate, which
+        // needs that mutex — so it can't have run yet and count must be ≥2
+        // here. That means the branch below is unreachable from callback()
+        // today; it's kept as a defensive enqueue for any future caller.
+        bun.debugAssert(count > 1);
 
         if (count == 1) {
             if (this.javascript_vm.isShuttingDown()) {
-                this.deinit() catch |err| switch (err) {};
+                // deinit() touches JS-thread-only state (Response holds
+                // per-thread atom strings, jsc.Weak, jsc.Strong). Leak
+                // rather than crash — the process is exiting.
                 return;
             }
-            // this is really unlikely to happen, but can happen
             // lets make sure that we always call deinit from main thread
-
             this.javascript_vm.eventLoop().enqueueTaskConcurrent(jsc.ConcurrentTask.fromCallback(this, FetchTasklet.deinit));
         }
     }
@@ -977,22 +983,20 @@ pub const FetchTasklet = struct {
         const metadata = this.metadata.?;
         const http_response = metadata.response;
         this.is_waiting_body = this.result.has_more;
-        // status_text and url must NOT be atomized: the Response can be
-        // destroyed from the HTTP thread via derefFromThread() -> deinit()
-        // when the VM is shutting down (see isShuttingDown() branch), and
-        // atom strings are per-thread — deref'ing them off-thread trips
-        // the `wasRemoved` RELEASE_ASSERT in AtomStringImpl::remove().
-        // Regular WTFStringImpl refcounts are atomic so cloneUTF8 is safe.
+        // status_text and url are atomized for dedup (many responses share
+        // "OK"). Atom strings live in a per-thread table, so Response.destroy
+        // must run on this thread — see the defer-order note in callback()
+        // for why derefFromThread() can never drop the last ref.
         return Response.init(
             .{
                 .headers = FetchHeaders.createFromPicoHeaders(http_response.headers),
                 .status_code = @as(u16, @truncate(http_response.status_code)),
-                .status_text = bun.String.cloneUTF8(http_response.status),
+                .status_text = bun.String.createAtomIfPossible(http_response.status),
             },
             Body{
                 .value = this.toBodyValue(),
             },
-            bun.String.cloneUTF8(metadata.url),
+            bun.String.createAtomIfPossible(metadata.url),
             this.result.redirected,
         );
     }
@@ -1407,13 +1411,25 @@ pub const FetchTasklet = struct {
     pub fn callback(task: *FetchTasklet, async_http: *http.AsyncHTTP, result: http.HTTPClientResult) void {
         // at this point only this thread is accessing result to is no race condition
         const is_done = !result.has_more;
-        // we are done with the http client so we can deref our side
-        // this is a atomic operation and will enqueue a task to deinit on the main thread
-        defer if (is_done) task.derefFromThread();
 
         task.mutex.lock();
-        // we need to unlock before task.deref();
         defer task.mutex.unlock();
+        // derefFromThread() runs BEFORE the mutex is released (inner defer
+        // runs first). The JS-side baseline deref lives in onProgressUpdate,
+        // which must acquire this mutex, so while we hold it the JS side
+        // cannot have dropped its ref yet — our deref is therefore always
+        // N→N-1 with N≥2, never the last ref. That guarantees deinit()
+        // (and with it Response.destroy(), which derefs per-thread atom
+        // strings for status_text/url) only ever runs on the JS thread.
+        // Previously derefFromThread ran after unlock; if the JS thread
+        // fully processed the request and started VM teardown in that gap,
+        // the isShuttingDown() branch in derefFromThread() would deinit on
+        // the HTTP thread and trip AtomStringImpl::remove()'s wasRemoved
+        // assert. poll_ref is unref'd inside onProgressUpdate, so holding
+        // the mutex through our deref also keeps the VM alive until the
+        // HTTP thread is done with this tasklet.
+        defer if (is_done) task.derefFromThread();
+
         task.http.?.* = async_http.*;
         task.http.?.response_buffer = async_http.response_buffer;
 

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -977,16 +977,22 @@ pub const FetchTasklet = struct {
         const metadata = this.metadata.?;
         const http_response = metadata.response;
         this.is_waiting_body = this.result.has_more;
+        // status_text and url must NOT be atomized: the Response can be
+        // destroyed from the HTTP thread via derefFromThread() -> deinit()
+        // when the VM is shutting down (see isShuttingDown() branch), and
+        // atom strings are per-thread — deref'ing them off-thread trips
+        // the `wasRemoved` RELEASE_ASSERT in AtomStringImpl::remove().
+        // Regular WTFStringImpl refcounts are atomic so cloneUTF8 is safe.
         return Response.init(
             .{
                 .headers = FetchHeaders.createFromPicoHeaders(http_response.headers),
                 .status_code = @as(u16, @truncate(http_response.status_code)),
-                .status_text = bun.String.createAtomIfPossible(http_response.status),
+                .status_text = bun.String.cloneUTF8(http_response.status),
             },
             Body{
                 .value = this.toBodyValue(),
             },
-            bun.String.createAtomIfPossible(metadata.url),
+            bun.String.cloneUTF8(metadata.url),
             this.result.redirected,
         );
     }

--- a/src/string/wtf.zig
+++ b/src/string/wtf.zig
@@ -38,7 +38,7 @@ pub const WTFStringImplStruct = extern struct {
     }
 
     pub fn isStatic(this: WTFStringImpl) bool {
-        return this.m_refCount & s_refCountIncrement != 0;
+        return this.m_refCount & s_refCountFlagIsStaticString != 0;
     }
 
     pub fn byteLength(this: WTFStringImpl) usize {

--- a/src/string/wtf.zig
+++ b/src/string/wtf.zig
@@ -59,8 +59,9 @@ pub const WTFStringImplStruct = extern struct {
 
     /// Atom strings live in a per-thread AtomStringTable — last-deref from
     /// a different thread trips RELEASE_ASSERT(wasRemoved) in
-    /// AtomStringImpl::remove(). Used by tests to assert that strings which
-    /// may be destroyed off the creating thread are NOT atoms.
+    /// AtomStringImpl::remove(). Holders of atom strings must guarantee
+    /// destruction on the creating thread (see e.g. the defer-order note
+    /// in FetchTasklet.callback() for Response.status_text/url).
     pub inline fn isAtom(self: WTFStringImpl) bool {
         return (self.m_hashAndFlags & s_hashFlagStringKindIsAtom) != 0;
     }

--- a/src/string/wtf.zig
+++ b/src/string/wtf.zig
@@ -14,10 +14,10 @@ pub const WTFStringImplStruct = extern struct {
     const s_flagMask: u32 = (1 << s_flagCount) - 1;
     const s_flagStringKindCount: u32 = 4;
     const s_hashZeroValue: u32 = 0;
-    const s_hashFlagStringKindIsAtom: u32 = @as(1, u32) << (s_flagStringKindCount);
-    const s_hashFlagStringKindIsSymbol: u32 = @as(1, u32) << (s_flagStringKindCount + 1);
+    const s_hashFlagStringKindIsAtom: u32 = @as(u32, 1) << s_flagStringKindCount;
+    const s_hashFlagStringKindIsSymbol: u32 = @as(u32, 1) << (s_flagStringKindCount + 1);
     const s_hashMaskStringKind: u32 = s_hashFlagStringKindIsAtom | s_hashFlagStringKindIsSymbol;
-    const s_hashFlagDidReportCost: u32 = @as(1, u32) << 3;
+    const s_hashFlagDidReportCost: u32 = @as(u32, 1) << 3;
     const s_hashFlag8BitBuffer: u32 = 1 << 2;
     const s_hashMaskBufferOwnership: u32 = (1 << 0) | (1 << 1);
 
@@ -55,6 +55,14 @@ pub const WTFStringImplStruct = extern struct {
 
     pub inline fn is8Bit(self: WTFStringImpl) bool {
         return (self.m_hashAndFlags & s_hashFlag8BitBuffer) != 0;
+    }
+
+    /// Atom strings live in a per-thread AtomStringTable — last-deref from
+    /// a different thread trips RELEASE_ASSERT(wasRemoved) in
+    /// AtomStringImpl::remove(). Used by tests to assert that strings which
+    /// may be destroyed off the creating thread are NOT atoms.
+    pub inline fn isAtom(self: WTFStringImpl) bool {
+        return (self.m_hashAndFlags & s_hashFlagStringKindIsAtom) != 0;
     }
 
     pub inline fn length(self: WTFStringImpl) u32 {

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -49,15 +49,23 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
       resp.headers.get("x-proxy-used");
     `;
 
+    // Reproduce the original report's environment: proxy resolution runs,
+    // NO_PROXY matches so the request goes direct. Set BOTH casings for
+    // the proxy vars — env_loader.getHttpProxy / isNoProxy read lowercase
+    // first, so an inherited lowercase value from bunEnv would otherwise
+    // win over our uppercase one and send the subprocess at the dead proxy.
+    const noProxy = `example.com, localhost:1, localhost:${server.port}, 127.0.0.1`;
     const env = {
       ...bunEnv,
       // Force VM teardown + full GC at exit so the JS Response wrapper is
       // finalized before bun.Global.exit(). The ASAN CI lane sets this.
       BUN_DESTRUCT_VM_ON_EXIT: "1",
-      // Reproduce the original report's environment: proxy resolution runs,
-      // NO_PROXY matches so the request goes direct.
       http_proxy: `http://127.0.0.1:1`,
-      NO_PROXY: `example.com, localhost:1, localhost:${server.port}, 127.0.0.1`,
+      HTTP_PROXY: `http://127.0.0.1:1`,
+      https_proxy: "",
+      HTTPS_PROXY: "",
+      NO_PROXY: noProxy,
+      no_proxy: noProxy,
     };
 
     const iterations = 40;

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -1,6 +1,6 @@
+import { fetchTestingInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { fetchTestingInternals } from "bun:internal-for-testing";
 
 // Regression test for a flaky RELEASE_ASSERT observed in proxy.test.js under
 // the x64 ASAN lane:

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -68,7 +68,7 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
       no_proxy: noProxy,
     };
 
-    const iterations = 40;
+    const iterations = 16;
     const concurrency = 8;
     const failures: string[] = [];
 
@@ -90,5 +90,5 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
     }
 
     expect(failures).toEqual([]);
-  }, 90_000);
+  });
 });

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -9,27 +9,34 @@ import { bunEnv, bunExe } from "harness";
 //   WTF/wtf/text/AtomStringImpl.cpp(409) : static void WTF::AtomStringImpl::remove(AtomStringImpl *)
 //   "The string being removed is an atom in the string table of an other thread!"
 //
-// Root cause: FetchTasklet.toResponse() used bun.String.createAtomIfPossible
-// for Response.status_text and Response.url. Atom strings live in a
-// per-thread table. If the process exits while the HTTP thread is between
-// releasing the callback mutex and running derefFromThread(), and
-// BUN_DESTRUCT_VM_ON_EXIT is set (as the CI ASAN lane does), the HTTP
-// thread ends up holding the last FetchTasklet ref after the JS thread has
-// already finalized the JS Response wrapper. derefFromThread()'s
-// isShuttingDown() branch then runs FetchTasklet.deinit() on the HTTP
-// thread, which drops the last native Response ref and derefs the atom
-// strings from the wrong thread -> assert.
+// Root cause: FetchTasklet.toResponse() atomizes Response.status_text and
+// Response.url for dedup (many responses share "OK"). Atom strings live in
+// a per-thread table. In FetchTasklet.callback() (HTTP thread), the defer
+// order used to be: enqueue onProgressUpdate -> unlock mutex ->
+// derefFromThread(). In the gap between unlock and derefFromThread(), the
+// JS thread could run onProgressUpdate (which derefs the tasklet 2->1 and
+// unrefs poll_ref), finish the user script, and — with
+// BUN_DESTRUCT_VM_ON_EXIT=1 as the ASAN CI lane sets — run destructOnExit's
+// full GC, finalizing the JS Response wrapper. Then the HTTP thread's
+// derefFromThread() would see count==1 + isShuttingDown() and run deinit()
+// on the HTTP thread, dropping the last native Response ref and deref'ing
+// the atom strings from the wrong thread -> assert.
 //
-// The fix uses bun.String.cloneUTF8 (plain WTFStringImpl, atomic refcount,
-// no per-thread table) for status_text / url. The race itself is a handful
-// of instructions wide and not reproducible via timing alone, so this test
-// directly asserts the invariant that makes the race harmless: the backing
-// strings are NOT atoms. A stress loop under the same CI conditions
-// (BUN_DESTRUCT_VM_ON_EXIT + parallel subprocesses) additionally exercises
-// the shutdown path end-to-end.
+// Fix: callback() now runs derefFromThread() BEFORE releasing the mutex.
+// onProgressUpdate needs that mutex, so while the HTTP thread holds it the
+// JS side cannot have dropped its baseline ref — the HTTP deref is always
+// N->N-1 with N>=2, never the last ref. poll_ref (unref'd inside
+// onProgressUpdate) therefore keeps the VM alive until the HTTP thread is
+// done with the tasklet, and deinit() only ever runs on the JS thread where
+// the atom strings were registered.
+//
+// The race window was a handful of instructions and not reproducible via
+// timing alone. This test documents the intent (status_text/url remain
+// atomized for memory dedup — deliberately, since the race is now closed
+// structurally) and exercises the shutdown path end-to-end.
 
-describe("fetch Response status_text/url are safe to destroy off-thread", () => {
-  test("backing strings are not atom StringImpls", async () => {
+describe("fetch Response status_text/url atom strings are JS-thread-owned", () => {
+  test("backing strings are atomized (dedup) and survive a round-trip", async () => {
     await using server = Bun.serve({
       port: 0,
       fetch() {
@@ -37,17 +44,16 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
       },
     });
 
-    // Use a short URL so it would have been atomized under the old
-    // `createAtomIfPossible` (< 64 bytes, ASCII).
     const resp = await fetch(server.url);
     expect(resp.statusText).toBe("OK");
     expect(resp.url).toBe(String(server.url));
 
-    // The actual invariant: neither backing string may be an atom, because
-    // Response.destroy() can run on the HTTP thread during VM shutdown and
-    // atom strings are per-thread — destroying one off-thread asserts.
+    // status_text and url are intentionally atomized for memory dedup.
+    // This is safe because callback() holds the tasklet mutex through
+    // derefFromThread(), guaranteeing the HTTP thread is never the last
+    // ref and Response.destroy() runs on the JS thread that owns the atoms.
     const flags = fetchTestingInternals.responseAtomFlags(resp);
-    expect(flags).toEqual({ statusText: false, url: false });
+    expect(flags).toEqual({ statusText: true, url: true });
   });
 
   test("parallel fetch-then-exit under BUN_DESTRUCT_VM_ON_EXIT does not trip AtomStringImpl::remove", async () => {
@@ -55,14 +61,14 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
       port: 0,
       fetch() {
         // Tiny body so headers + body arrive in a single HTTP callback —
-        // that's the path where derefFromThread() can be the last ref.
+        // that's the path where derefFromThread() is the HTTP-side deref.
         return new Response("x");
       },
     });
 
     const script = `
       const resp = await fetch(${JSON.stringify(String(server.url))});
-      // Touch the formerly-atomized fields so they're materialized.
+      // Touch the atomized fields so they're materialized.
       resp.statusText;
       resp.url;
       resp.headers.get("x-proxy-used");
@@ -88,7 +94,7 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
     };
 
     // One parallel batch is enough to document the end-to-end shutdown
-    // path — the deterministic invariant is covered by the test above.
+    // path — the invariant is guaranteed structurally by the defer order.
     const batch = Array.from({ length: 8 }, () =>
       Bun.spawn({
         cmd: [bunExe(), "-e", script],

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { fetchTestingInternals } from "bun:internal-for-testing";
 
 // Regression test for a flaky RELEASE_ASSERT observed in proxy.test.js under
 // the x64 ASAN lane:
@@ -12,25 +13,43 @@ import { bunEnv, bunExe } from "harness";
 // for Response.status_text and Response.url. Atom strings live in a
 // per-thread table. If the process exits while the HTTP thread is between
 // releasing the callback mutex and running derefFromThread(), and
-// BUN_DESTRUCT_VM_ON_EXIT is set (as the CI ASAN lane does), the
-// HTTP thread ends up holding the last FetchTasklet ref after the JS
-// thread has already finalized the JS Response wrapper. derefFromThread()'s
+// BUN_DESTRUCT_VM_ON_EXIT is set (as the CI ASAN lane does), the HTTP
+// thread ends up holding the last FetchTasklet ref after the JS thread has
+// already finalized the JS Response wrapper. derefFromThread()'s
 // isShuttingDown() branch then runs FetchTasklet.deinit() on the HTTP
 // thread, which drops the last native Response ref and derefs the atom
 // strings from the wrong thread -> assert.
 //
 // The fix uses bun.String.cloneUTF8 (plain WTFStringImpl, atomic refcount,
-// no per-thread table) for status_text / url.
-//
-// This test recreates the CI conditions: BUN_DESTRUCT_VM_ON_EXIT=1 so the
-// JS Response wrapper is finalized during the shutdown GC, http_proxy +
-// NO_PROXY set so the env-proxy resolution path runs, and a batch of
-// subprocesses spawned in parallel so the HTTP thread is contending for
-// CPU at exit time. Before the fix this trips the assert intermittently
-// on ASAN builds; after the fix it cannot, since the strings are no
-// longer atoms.
+// no per-thread table) for status_text / url. The race itself is a handful
+// of instructions wide and not reproducible via timing alone, so this test
+// directly asserts the invariant that makes the race harmless: the backing
+// strings are NOT atoms. A stress loop under the same CI conditions
+// (BUN_DESTRUCT_VM_ON_EXIT + parallel subprocesses) additionally exercises
+// the shutdown path end-to-end.
 
 describe("fetch Response status_text/url are safe to destroy off-thread", () => {
+  test("backing strings are not atom StringImpls", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("x", { status: 200, statusText: "OK" });
+      },
+    });
+
+    // Use a short URL so it would have been atomized under the old
+    // `createAtomIfPossible` (< 64 bytes, ASCII).
+    const resp = await fetch(server.url);
+    expect(resp.statusText).toBe("OK");
+    expect(resp.url).toBe(String(server.url));
+
+    // The actual invariant: neither backing string may be an atom, because
+    // Response.destroy() can run on the HTTP thread during VM shutdown and
+    // atom strings are per-thread — destroying one off-thread asserts.
+    const flags = fetchTestingInternals.responseAtomFlags(resp);
+    expect(flags).toEqual({ statusText: false, url: false });
+  });
+
   test("parallel fetch-then-exit under BUN_DESTRUCT_VM_ON_EXIT does not trip AtomStringImpl::remove", async () => {
     await using server = Bun.serve({
       port: 0,
@@ -68,24 +87,21 @@ describe("fetch Response status_text/url are safe to destroy off-thread", () => 
       no_proxy: noProxy,
     };
 
-    const iterations = 16;
-    const concurrency = 8;
+    // One parallel batch is enough to document the end-to-end shutdown
+    // path — the deterministic invariant is covered by the test above.
+    const batch = Array.from({ length: 8 }, () =>
+      Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env,
+        stdout: "ignore",
+        stderr: "pipe",
+      }),
+    );
     const failures: string[] = [];
-
-    for (let i = 0; i < iterations; i += concurrency) {
-      const batch = Array.from({ length: Math.min(concurrency, iterations - i) }, () =>
-        Bun.spawn({
-          cmd: [bunExe(), "-e", script],
-          env,
-          stdout: "ignore",
-          stderr: "pipe",
-        }),
-      );
-      for (const proc of batch) {
-        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-        if (exitCode !== 0) {
-          failures.push(`exit ${exitCode}: ${stderr.slice(0, 500)}`);
-        }
+    for (const proc of batch) {
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) {
+        failures.push(`exit ${exitCode}: ${stderr.slice(0, 500)}`);
       }
     }
 

--- a/test/js/bun/http/fetch-response-shutdown-atom.test.ts
+++ b/test/js/bun/http/fetch-response-shutdown-atom.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for a flaky RELEASE_ASSERT observed in proxy.test.js under
+// the x64 ASAN lane:
+//
+//   ASSERTION FAILED: wasRemoved
+//   WTF/wtf/text/AtomStringImpl.cpp(409) : static void WTF::AtomStringImpl::remove(AtomStringImpl *)
+//   "The string being removed is an atom in the string table of an other thread!"
+//
+// Root cause: FetchTasklet.toResponse() used bun.String.createAtomIfPossible
+// for Response.status_text and Response.url. Atom strings live in a
+// per-thread table. If the process exits while the HTTP thread is between
+// releasing the callback mutex and running derefFromThread(), and
+// BUN_DESTRUCT_VM_ON_EXIT is set (as the CI ASAN lane does), the
+// HTTP thread ends up holding the last FetchTasklet ref after the JS
+// thread has already finalized the JS Response wrapper. derefFromThread()'s
+// isShuttingDown() branch then runs FetchTasklet.deinit() on the HTTP
+// thread, which drops the last native Response ref and derefs the atom
+// strings from the wrong thread -> assert.
+//
+// The fix uses bun.String.cloneUTF8 (plain WTFStringImpl, atomic refcount,
+// no per-thread table) for status_text / url.
+//
+// This test recreates the CI conditions: BUN_DESTRUCT_VM_ON_EXIT=1 so the
+// JS Response wrapper is finalized during the shutdown GC, http_proxy +
+// NO_PROXY set so the env-proxy resolution path runs, and a batch of
+// subprocesses spawned in parallel so the HTTP thread is contending for
+// CPU at exit time. Before the fix this trips the assert intermittently
+// on ASAN builds; after the fix it cannot, since the strings are no
+// longer atoms.
+
+describe("fetch Response status_text/url are safe to destroy off-thread", () => {
+  test("parallel fetch-then-exit under BUN_DESTRUCT_VM_ON_EXIT does not trip AtomStringImpl::remove", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch() {
+        // Tiny body so headers + body arrive in a single HTTP callback —
+        // that's the path where derefFromThread() can be the last ref.
+        return new Response("x");
+      },
+    });
+
+    const script = `
+      const resp = await fetch(${JSON.stringify(String(server.url))});
+      // Touch the formerly-atomized fields so they're materialized.
+      resp.statusText;
+      resp.url;
+      resp.headers.get("x-proxy-used");
+    `;
+
+    const env = {
+      ...bunEnv,
+      // Force VM teardown + full GC at exit so the JS Response wrapper is
+      // finalized before bun.Global.exit(). The ASAN CI lane sets this.
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      // Reproduce the original report's environment: proxy resolution runs,
+      // NO_PROXY matches so the request goes direct.
+      http_proxy: `http://127.0.0.1:1`,
+      NO_PROXY: `example.com, localhost:1, localhost:${server.port}, 127.0.0.1`,
+    };
+
+    const iterations = 40;
+    const concurrency = 8;
+    const failures: string[] = [];
+
+    for (let i = 0; i < iterations; i += concurrency) {
+      const batch = Array.from({ length: Math.min(concurrency, iterations - i) }, () =>
+        Bun.spawn({
+          cmd: [bunExe(), "-e", script],
+          env,
+          stdout: "ignore",
+          stderr: "pipe",
+        }),
+      );
+      for (const proc of batch) {
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        if (exitCode !== 0) {
+          failures.push(`exit ${exitCode}: ${stderr.slice(0, 500)}`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 90_000);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky `RELEASE_ASSERT` in the x64 ASAN lane, observed in `test/js/bun/http/proxy.test.js`:

```
ASSERTION FAILED: wasRemoved
vendor/WebKit/Source/WTF/wtf/text/AtomStringImpl.cpp(409) : static void WTF::AtomStringImpl::remove(AtomStringImpl *)
```

The failing subprocess was `NO_PROXY port handling > should handle NO_PROXY with multiple entries including port`, exiting with code 132 (SIGILL from the `RELEASE_ASSERT`).

## Root cause

`FetchTasklet.toResponse()` atomizes `Response.status_text` and `Response.url` for dedup (many responses share `"OK"`). Atom strings live in a **per-thread** table, so `Response.destroy()` must run on the thread that created them.

`FetchTasklet.callback()` runs on the HTTP thread with this defer order:
```zig
defer if (is_done) task.derefFromThread();  // runs LAST (after unlock)
task.mutex.lock();
defer task.mutex.unlock();                   // runs second-to-last
```

So on the HTTP thread: enqueue `onProgressUpdate` → **unlock mutex** → **derefFromThread()**. In the gap between unlock and `derefFromThread()`, the JS thread can:

1. Run `onProgressUpdate` → `onResolve` → create the `Response` with atomized strings, resolve the fetch promise, unref `poll_ref`, deref the tasklet (2→1).
2. Finish the user script, set `is_shutting_down=true`, and — with `BUN_DESTRUCT_VM_ON_EXIT=1` (set by the ASAN CI lane via `scripts/runner.node.mjs`) — run `destructOnExit` → full GC → `Response.finalize` → `Response.ref_count` 2→1.

Then the HTTP thread resumes at `derefFromThread()` → tasklet 1→0 → sees `isShuttingDown()` → runs `deinit()` on the HTTP thread (branch added in #27385) → `native_response.unref()` → `Response` 1→0 → `Response.destroy()` derefs the atom strings from the **HTTP thread** → `AtomStringImpl::remove()` looks in the HTTP thread's table, doesn't find them, asserts.

The `NO_PROXY` parsing is unrelated — the bug is a generic fetch-vs-shutdown race that surfaced during that test run.

## Fix

Swap the defer order in `callback()` so `derefFromThread()` runs **while holding the mutex**:

```zig
task.mutex.lock();
defer task.mutex.unlock();                   // runs LAST
defer if (is_done) task.derefFromThread();   // runs BEFORE unlock
```

`onProgressUpdate` (the only path that drops the other baseline ref) needs the mutex, so while the HTTP thread holds it the JS side cannot have deref'd yet. The HTTP thread's deref is therefore always N→N-1 with N≥2 — **never** the last ref. Since `poll_ref` is unref'd inside `onProgressUpdate`, the VM stays alive until the HTTP thread is done with the tasklet, and `deinit()` only ever runs on the JS thread that owns the atom strings.

This keeps the atom-string dedup (memory savings for repeated `"OK"` etc.) while closing the race structurally.

Secondary changes:
- `derefFromThread()`: `bun.debugAssert(count > 1)` to document the invariant. The `count == 1` branch is now unreachable from `callback()`; its `isShuttingDown()` arm is changed from `deinit()` to leak (defensive — `deinit()` touches `jsc.Weak`/`jsc.Strong` and atom strings that are JS-thread-only).
- `src/string/wtf.zig`: add `WTFStringImplStruct.isAtom()`; fix pre-existing `@as(1, u32)` arg-order typos in the atom-flag constants (dead code until now) and the `isStatic()` mask (was checking `s_refCountIncrement` 0x2 instead of `s_refCountFlagIsStaticString` 0x1 — verified against WebKit `StringImpl.h:381`).
- `bun:internal-for-testing`: add `fetchTestingInternals.responseAtomFlags(response)` returning `{statusText, url}` bools for whether each backing string is an atom.

## How did you verify your code works?

New `test/js/bun/http/fetch-response-shutdown-atom.test.ts`:
- Asserts the backing strings **are** atoms (documenting that dedup is intentional and the race is closed by defer ordering, not by dropping atoms).
- A parallel batch of subprocesses with `BUN_DESTRUCT_VM_ON_EXIT=1`, `http_proxy` + `NO_PROXY` set as in the original report, exercises the shutdown path end-to-end.

Also:
- `bun bd test test/js/bun/http/proxy.test.js` — 16/16 pass, 8 skip.
- `bun bd test test/js/web/fetch/response.test.ts` — 14/14 pass.
- `bun bd test test/internal/ban-words.test.ts` — 119/119 pass.
- Smoke test: 50 concurrent fetches + streaming body — `debugAssert(count > 1)` holds.

**Note on reproduction:** the race window is a handful of instructions; I was unable to trigger it via timing in ~500 attempts. The fix is correct by construction — with the mutex held through `derefFromThread()`, the HTTP thread categorically cannot observe `count == 1`.
