### PR TITLE
cron: don't report TerminationException as uncaught on worker terminate

### DIFF
--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -926,7 +926,14 @@ pub const CronJob = struct {
     }
 
     fn scheduleNext(this: *CronJob, vm: *jsc.VirtualMachine) void {
-        if (this.stopped) return this.finishDeferredStop(vm);
+        // Every path into here has just returned from user JS (the callback,
+        // an uncaughtException handler, or an unhandledRejection handler). If
+        // that JS called process.exit() / worker.terminate(), don't re-arm
+        // the timer into a VM whose teardown now owns it.
+        if (this.stopped or vm.scriptExecutionStatus() != .running) {
+            this.stopped = true;
+            return this.finishDeferredStop(vm);
+        }
         const next_time = this.computeNextTimespec() orelse
             return this.finishDeferredStop(vm);
         vm.timer.update(&this.event_loop_timer, &next_time);
@@ -975,12 +982,6 @@ pub const CronJob = struct {
                     return;
                 }
                 _ = vm.uncaughtException(vm.global, err, false);
-            }
-            // uncaughtException() may have run a handler that called
-            // process.exit(); don't re-arm the timer into a dying VM.
-            if (vm.scriptExecutionStatus() != .running) {
-                this.selfStop(vm);
-                return;
             }
             this.scheduleNext(vm);
             return;

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -976,6 +976,12 @@ pub const CronJob = struct {
                 }
                 _ = vm.uncaughtException(vm.global, err, false);
             }
+            // uncaughtException() may have run a handler that called
+            // process.exit(); don't re-arm the timer into a dying VM.
+            if (vm.scriptExecutionStatus() != .running) {
+                this.selfStop(vm);
+                return;
+            }
             this.scheduleNext(vm);
             return;
         };

--- a/src/bun.js/api/cron.zig
+++ b/src/bun.js/api/cron.zig
@@ -964,12 +964,29 @@ pub const CronJob = struct {
         this.in_fire = true;
         const result = cb.call(this.global, js_this, &.{}) catch {
             this.in_fire = false;
-            if (this.global.tryTakeException()) |err|
+            if (this.global.tryTakeException()) |err| {
+                // terminate() arriving mid-callback leaves the TerminationException
+                // pending (tryClearException refuses to clear it) while JSC clears
+                // hasTerminationRequest on VMEntryScope exit. Reporting it would
+                // enter a DeferTermination scope and assert; match setTimeout's
+                // Bun__reportUnhandledError and drop it.
+                if (err.isTerminationException()) {
+                    this.selfStop(vm);
+                    return;
+                }
                 _ = vm.uncaughtException(vm.global, err, false);
+            }
             this.scheduleNext(vm);
             return;
         };
         this.in_fire = false;
+
+        // terminate() may have arrived while the callback was running; bail out
+        // without touching the timer heap or JS state the teardown path owns.
+        if (vm.scriptExecutionStatus() != .running) {
+            this.selfStop(vm);
+            return;
+        }
 
         if (result.asAnyPromise()) |promise| {
             switch (promise.status()) {

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2986,10 +2986,14 @@ extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* g
     auto& vm = JSC::getVM(globalObject);
     // Clear the request for the termination exception to be thrown
     vm.clearHasTerminationRequest();
-    // In case it actually has been thrown, clear the exception itself as well
+    // In case it actually has been thrown, clear the exception itself as well.
+    // tryClearException() refuses to clear termination exceptions, so use
+    // TopExceptionScope::clearException() which clears unconditionally —
+    // this function's whole purpose is to clear that specific exception so
+    // execution can resume (e.g. for process.on('exit') after terminate()).
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (scope.exception() && vm.isTerminationException(scope.exception())) {
-        (void)scope.tryClearException();
+        scope.clearException();
     }
 }
 

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -766,11 +766,9 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     }
     if (vm_to_deinit) |vm| {
         // terminate() set the JSC termination flag to interrupt running JS; clear
-        // it (and any already-thrown TerminationException) so process.on('exit')
-        // handlers can run. clearHasTerminationRequest() alone would leave the
-        // exception pending and trip VMTraps::deferTerminationSlow's assertion.
-        // WebWorker__teardownJSCVM re-sets the flag for the JSC VM teardown.
-        vm.global.clearTerminationException();
+        // it so process.on('exit') handlers can run. WebWorker__teardownJSCVM
+        // re-sets it for the JSC VM teardown.
+        vm.jsc_vm.clearHasTerminationRequest();
         vm.is_shutting_down = true;
         vm.onExit();
         jsc.API.cron.CronJob.clearAllForVM(vm, .teardown);

--- a/src/bun.js/web_worker.zig
+++ b/src/bun.js/web_worker.zig
@@ -766,9 +766,11 @@ pub fn exitAndDeinit(this: *WebWorker) noreturn {
     }
     if (vm_to_deinit) |vm| {
         // terminate() set the JSC termination flag to interrupt running JS; clear
-        // it so process.on('exit') handlers can run. WebWorker__teardownJSCVM
-        // re-sets it for the JSC VM teardown.
-        vm.jsc_vm.clearHasTerminationRequest();
+        // it (and any already-thrown TerminationException) so process.on('exit')
+        // handlers can run. clearHasTerminationRequest() alone would leave the
+        // exception pending and trip VMTraps::deferTerminationSlow's assertion.
+        // WebWorker__teardownJSCVM re-sets the flag for the JSC VM teardown.
+        vm.global.clearTerminationException();
         vm.is_shutting_down = true;
         vm.onExit();
         jsc.API.cron.CronJob.clearAllForVM(vm, .teardown);

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -254,6 +254,45 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     expect(exitCode).toBe(0);
   }, 130_000);
 
+  test("worker terminate mid-callback does not report TerminationException as uncaught", async () => {
+    // The callback busy-spins after postMessage so terminate() interrupts
+    // cb.call() with a TerminationException while it's still on the JS stack.
+    // When the VMEntryScope unwinds, JSC clears hasTerminationRequest but
+    // leaves the exception pending; cron's catch block must not hand that to
+    // uncaughtException(), or the lazy process-object init asserts in
+    // VMTraps::deferTerminationSlow. Use several workers so the timing lines
+    // up at least once per minute-boundary.
+    using dir = tempDir("cron-worker-term", {
+      "worker.ts": `
+        Bun.cron("* * * * *", () => {
+          self.postMessage("fired");
+          while (true) { for (let i = 0; i < 1e6; i++); }
+        });
+      `,
+      "main.ts": `
+        const N = 20;
+        let closed = 0;
+        for (let i = 0; i < N; i++) {
+          const w = new Worker("./worker.ts");
+          w.addEventListener("message", () => w.terminate());
+          w.addEventListener("close", () => {
+            if (++closed === N) console.log("ok");
+          });
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  }, 130_000);
+
   test("sync throw in callback emits uncaughtException", async () => {
     // Matches setTimeout: sync throw → uncaughtException. Process exits 1 without a handler.
     await using proc = Bun.spawn({

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -271,12 +271,17 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
       `,
       "main.ts": `
         const N = 20;
-        let closed = 0;
+        let closed = 0, errors = 0;
         for (let i = 0; i < N; i++) {
           const w = new Worker("./worker.ts");
           w.addEventListener("message", () => w.terminate());
+          // Any worker 'error' here means cron routed the TerminationException
+          // through uncaughtException → WebWorker__dispatchError — the
+          // regression this test guards against, independent of whether
+          // VMTraps asserts are compiled in.
+          w.addEventListener("error", () => errors++);
           w.addEventListener("close", () => {
-            if (++closed === N) console.log("ok");
+            if (++closed === N) console.log("errors=" + errors);
           });
         }
       `,
@@ -289,7 +294,7 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     if (exitCode !== 0) console.error(stderr);
-    expect(stdout.trim()).toBe("ok");
+    expect(stdout.trim()).toBe("errors=0");
     expect(exitCode).toBe(0);
   }, 130_000);
 


### PR DESCRIPTION
## Problem

`test/js/bun/cron/in-process-cron.test.ts` crashes on x64-asan with exit 132 in the "worker terminate while async callback pending" test:

```
panic: EventLoop.enqueueTaskConcurrent: VM has terminated
```

## Root cause

When `worker.terminate()` arrives while a `Bun.cron` callback is still executing (on the JS stack inside `cb.call()`):

1. JSC throws the `TerminationException` at a safepoint.
2. As the `VMEntryScope` unwinds, `VM::executeEntryScopeServicesOnExit()` clears `hasTerminationRequest` (the `NeedTermination` trap was handled).
3. Back in Zig, cron's catch block calls `tryTakeException()` — which uses `tryClearException()`, but that **refuses to clear termination exceptions**, so `m_exception` stays set.
4. Cron hands the still-pending termination exception to `vm.uncaughtException()` → `Bun__handleUncaughtException()` → lazy-init of the `process` object.
5. The lazy-init enters a `DeferTermination` scope. `deferTerminationSlow()` sees `hasPendingTerminationException() == true` but `hasTerminationRequest() == false` → `ASSERT(vm.hasTerminationRequest())` → `__builtin_trap()` → SIGILL → exit 132.

Stack at the assert (lldb):
```
#1 VMTraps::deferTerminationSlow
#3 DeferTermination::DeferTermination
#4 LazyProperty<JSGlobalObject, Process>::callFunc      ← lazy process init
#7 Bun__handleUncaughtException
#8 VirtualMachine.uncaughtException
#9 cron.CronJob.onTimerFire                              ← catch block
```

## Fix

- **`src/bun.js/api/cron.zig`**: in `onTimerFire`'s catch block, check `err.isTerminationException()` and just `selfStop()` instead of reporting — matching `setTimeout`'s `Bun__reportUnhandledError`. Re-check `scriptExecutionStatus()` after `cb.call()` returns (and after `uncaughtException()` runs a handler) so a terminate that landed during the callback short-circuits before re-arming the timer or attaching `.then()`.
- **`src/bun.js/bindings/ZigGlobalObject.cpp`**: `JSGlobalObject__clearTerminationException` became a no-op after the WebKit `tryClearException()` refactor (b2e5c6c7d1) — `tryClearException` refuses to clear termination exceptions by design. Use `scope.clearException()` so the function does what its name says. (Independent of the cron fix; benefits the existing repl / bun:test-timeout callers.)

## Verification

New test `worker terminate mid-callback does not report TerminationException as uncaught` spawns 20 workers whose cron callback busy-spins after `postMessage`, so `terminate()` reliably interrupts `cb.call()` with a `TerminationException`. The test asserts `errors=0` via a worker `error` event listener so it has signal on release builds too (where the VMTraps assert is compiled out).

| | baseline (src/ stashed) | with fix |
|---|---|---|
| new test | ❌ crash, stdout empty, `ASSERTION FAILED: vm.hasTerminationRequest()` | ✅ `errors=0`, exit 0 |
| stress (100 workers × 5 runs under `BUN_JSC_validateExceptionChecks=1`) | ❌ every run asserts | ✅ 5/5 clean |
| full `in-process-cron.test.ts` (under `validateExceptionChecks`) | — | ✅ 26/26 pass |
| `test-worker-uncaught-exception-async.js` (under `validateExceptionChecks`) | ✅ | ✅ |

`bun run zig:check-all` passes on all targets.