### PR TITLE
blob: clamp pre-epoch/overflow mtime in toJSTime to avoid @intCast panic

### DIFF
--- a/src/bun.js/jsc.zig
+++ b/src/bun.js/jsc.zig
@@ -243,8 +243,8 @@ pub const Error = @import("ErrorCode").Error;
 pub const init_timestamp = std.math.maxInt(JSTimeType);
 pub const JSTimeType = u52;
 pub fn toJSTime(sec: isize, nsec: isize) JSTimeType {
-    const millisec = @as(u64, @intCast(@divTrunc(nsec, std.time.ns_per_ms)));
-    return @as(JSTimeType, @truncate(@as(u64, @intCast(sec * std.time.ms_per_s)) + millisec));
+    const millisec = @as(i128, sec) * std.time.ms_per_s + @divTrunc(nsec, std.time.ns_per_ms);
+    return @intCast(std.math.clamp(millisec, 0, std.math.maxInt(JSTimeType)));
 }
 
 pub const MAX_SAFE_INTEGER = 9007199254740991;

--- a/test/js/bun/util/bun-file-negative-mtime.test.ts
+++ b/test/js/bun/util/bun-file-negative-mtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { closeSync, openSync, utimesSync } from "fs";
+import { isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// jsc.toJSTime previously used unchecked @intCast to u64 on sec/nsec from
+// fstat mtime. A file with mtime before the Unix epoch (negative seconds)
+// would trip integerOutOfBounds in the ReadFile thread-pool task when
+// resolveSizeAndLastModified stored last_modified. With the fix, the
+// timestamp is clamped to 0 instead of crashing.
+describe.skipIf(isWindows)("Bun.file with pre-epoch mtime", () => {
+  test("text() on a path-backed file with negative mtime does not crash", async () => {
+    using dir = tempDir("bun-file-neg-mtime", { "neg.txt": "hello" });
+    const path = join(String(dir), "neg.txt");
+    utimesSync(path, new Date(-12345678), new Date(-12345678));
+
+    const f = Bun.file(path);
+    expect(await f.text()).toBe("hello");
+    expect(f.lastModified).toBe(0);
+  });
+
+  test("lastModified getter on a file with negative mtime does not crash", async () => {
+    using dir = tempDir("bun-file-neg-mtime", { "neg.txt": "x" });
+    const path = join(String(dir), "neg.txt");
+    utimesSync(path, new Date(-5000), new Date(-5000));
+
+    expect(Bun.file(path).lastModified).toBe(0);
+  });
+
+  test("text() on an fd-backed file with negative mtime does not crash", async () => {
+    using dir = tempDir("bun-file-neg-mtime", { "neg.txt": "from fd" });
+    const path = join(String(dir), "neg.txt");
+    utimesSync(path, new Date(-1000), new Date(-1000));
+
+    const fd = openSync(path, "r");
+    try {
+      const f = Bun.file(fd);
+      expect(await f.text()).toBe("from fd");
+      expect(f.lastModified).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  test("normal mtime is still reported correctly", async () => {
+    using dir = tempDir("bun-file-neg-mtime", { "pos.txt": "ok" });
+    const path = join(String(dir), "pos.txt");
+    const now = Date.now();
+    utimesSync(path, new Date(now), new Date(now));
+
+    const f = Bun.file(path);
+    expect(await f.text()).toBe("ok");
+    expect(Math.abs(f.lastModified - now)).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a Zig safety-check panic in `jsc.toJSTime` when `fstat` reports an mtime before the Unix epoch (negative `sec`) or far enough in the future to overflow `isize * 1000`. All four call sites feed `stat.mtime()` straight into this helper, so any such file crashes `Bun.file(path).text()` / `.lastModified` on a thread-pool worker.

Fuzzer fingerprint: `b576ba5fca6d3710`

## Root cause

```zig
pub fn toJSTime(sec: isize, nsec: isize) JSTimeType {
    const millisec = @as(u64, @intCast(@divTrunc(nsec, std.time.ns_per_ms)));
    return @as(JSTimeType, @truncate(@as(u64, @intCast(sec * std.time.ms_per_s)) + millisec));
}
```

- `@intCast(@divTrunc(nsec, ...))` to `u64` panics if `nsec < 0`.
- `sec * std.time.ms_per_s` panics on `isize` overflow.
- `@intCast(sec * 1000)` to `u64` panics if `sec < 0`.

Reached from `ReadFile.resolveSizeAndLastModified` (line 324) → `runAsyncWithFD`, and from the `Blob.lastModified` getter. The fuzzer trace showed `runAsyncWithFD` as the top frame with the two inner callees inlined in that build; the fingerprint differs from #29355 (which fixed the adjacent `stat.size` `@intCast`) but sits in the same call chain.

Reproduces deterministically with:

```js
utimesSync(path, new Date(-1000), new Date(-1000));
await Bun.file(path).text(); // panic: integer does not fit in destination type
```

## Fix

Compute the millisecond timestamp in `i128` (so `isize * 1000` and the `nsec` addend cannot overflow) and clamp to `[0, maxInt(JSTimeType)]` before the final cast. `JSTimeType` is `u52` so negative times collapse to `0`; this matches the existing storage type rather than changing the field to signed.

## How did you verify your code works?

- New `test/js/bun/util/bun-file-negative-mtime.test.ts` covers path-backed read, fd-backed read, the `lastModified` getter, and a positive-mtime sanity check. Panics on the unfixed binary, passes with the fix.
- `bun bd test test/js/bun/util/bun-file-fd-read.test.ts test/js/bun/util/bun-file.test.ts test/js/bun/util/bun-file-read.test.ts test/js/bun/util/bun-stdin-slice.test.ts` all pass.
- `objdump` of the rebuilt `toJSTime` shows the remaining safety checks are on `i128` arithmetic / post-clamp `@intCast`, all provably unreachable for `isize` inputs.