### PR TITLE
Fix crash inspecting WeakMap/WeakSet with user-set .size

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,14 +2757,17 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakMap;
+                const length: i32 = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = if (is_weak) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2867,17 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakSet;
+                const length: i32 = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = if (is_weak) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                if (this.globalThis.hasException()) this.globalThis.clearException();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                if (this.globalThis.hasException()) this.globalThis.clearException();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -44,7 +44,7 @@ pub const DiffFormatter = struct {
                 &received_buf.writer,
                 fmt_options,
             ) catch {
-                if (this.globalThis.hasException()) this.globalThis.clearException();
+                _ = this.globalThis.clearExceptionExceptTermination();
             };
 
             JestPrettyFormat.format(
@@ -55,7 +55,7 @@ pub const DiffFormatter = struct {
                 &expected_buf.writer,
                 fmt_options,
             ) catch {
-                if (this.globalThis.hasException()) this.globalThis.clearException();
+                _ = this.globalThis.clearExceptionExceptTermination();
             };
         }
 

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,14 +1307,17 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakMap;
+                    const length: i32 = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const map_name = if (is_weak) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,8 +1338,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakSet;
+                    const length: i32 = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
@@ -1344,7 +1350,7 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const set_name = if (is_weak) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect-weak-collections.test.ts
+++ b/test/js/bun/util/inspect-weak-collections.test.ts
@@ -49,6 +49,13 @@ describe("Bun.inspect WeakMap/WeakSet", () => {
     expect(() => expect(wm).toEqual([1, 2])).toThrow();
   });
 
+  test("toEqual diff with WeakSet that has size does not crash", () => {
+    const ws = new WeakSet();
+    // @ts-expect-error
+    ws.size = 2;
+    expect(() => expect(ws).toEqual([1, 2])).toThrow();
+  });
+
   test("normal Map still shows entries", () => {
     const m = new Map([["a", 1]]);
     expect(Bun.inspect(m)).toContain("Map(1)");

--- a/test/js/bun/util/inspect-weak-collections.test.ts
+++ b/test/js/bun/util/inspect-weak-collections.test.ts
@@ -28,6 +28,19 @@ describe("Bun.inspect WeakMap/WeakSet", () => {
     expect(called).toBe(false);
   });
 
+  test("WeakSet with size getter does not invoke it", () => {
+    const ws = new WeakSet();
+    let called = false;
+    Object.defineProperty(ws, "size", {
+      get() {
+        called = true;
+        throw new Error("should not be called");
+      },
+    });
+    expect(Bun.inspect(ws)).toBe("WeakSet {}");
+    expect(called).toBe(false);
+  });
+
   test("toMatchObject diff with WeakMap that has size does not crash", () => {
     const wm = new WeakMap();
     // @ts-expect-error

--- a/test/js/bun/util/inspect-weak-collections.test.ts
+++ b/test/js/bun/util/inspect-weak-collections.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.inspect WeakMap/WeakSet", () => {
+  test("WeakMap with user-defined size property does not throw", () => {
+    const wm = new WeakMap();
+    // @ts-expect-error
+    wm.size = 1000;
+    expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  });
+
+  test("WeakSet with user-defined size property does not throw", () => {
+    const ws = new WeakSet();
+    // @ts-expect-error
+    ws.size = 1000;
+    expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  });
+
+  test("WeakMap with size getter does not invoke it", () => {
+    const wm = new WeakMap();
+    let called = false;
+    Object.defineProperty(wm, "size", {
+      get() {
+        called = true;
+        throw new Error("should not be called");
+      },
+    });
+    expect(Bun.inspect(wm)).toBe("WeakMap {}");
+    expect(called).toBe(false);
+  });
+
+  test("toMatchObject diff with WeakMap that has size does not crash", () => {
+    const wm = new WeakMap();
+    // @ts-expect-error
+    wm.size = 2;
+    expect(() => expect(wm).toMatchObject([1, 2])).toThrow();
+  });
+
+  test("toMatchObject diff with WeakSet that has size does not crash", () => {
+    const ws = new WeakSet();
+    // @ts-expect-error
+    ws.size = 2;
+    expect(() => expect(ws).toMatchObject([1, 2])).toThrow();
+  });
+
+  test("toEqual diff with WeakMap that has size does not crash", () => {
+    const wm = new WeakMap();
+    // @ts-expect-error
+    wm.size = 2;
+    expect(() => expect(wm).toEqual([1, 2])).toThrow();
+  });
+
+  test("normal Map still shows entries", () => {
+    const m = new Map([["a", 1]]);
+    expect(Bun.inspect(m)).toContain("Map(1)");
+    expect(Bun.inspect(m)).toContain('"a"');
+  });
+
+  test("normal Set still shows entries", () => {
+    const s = new Set(["a"]);
+    expect(Bun.inspect(s)).toContain("Set(1)");
+    expect(Bun.inspect(s)).toContain('"a"');
+  });
+});


### PR DESCRIPTION
Fuzzilli found a debug assertion crash (fingerprint `b70df657956fedff`) with:

```js
const wm = new WeakMap();
wm.size = 1000;
Bun.jest().expect(wm).toMatchObject([1, 2]);
```

### What was happening

The console formatter and the jest pretty-formatter share a `.Map` / `.Set` format tag for both `Map`/`WeakMap` and `Set`/`WeakSet`. To decide whether to iterate entries, they read the value's `.size` property. A real `WeakMap`/`WeakSet` has no `size`, so this normally falls through to the `length == 0` early-return and prints `WeakMap {}`.

If a user assigns a `.size` property to a `WeakMap`/`WeakSet`, the early-return is skipped and `value.forEach(...)` → `JSC::forEachInIterable` is called, which throws a `TypeError` because weak collections have no iterator.

In `expect().toMatchObject` / `toEqual`, the `DiffFormatter` calls the pretty-formatter and catches the Zig error with `catch {}`, but leaves the pending JSC exception set. A subsequent `ExceptionScope` check trips the `assertNoExceptionExceptTermination` assertion.

### Fix

- Skip the `.size` lookup and iteration entirely for `WeakMap`/`WeakSet` in both formatters — their contents aren't observable anyway, so `WeakMap {}` / `WeakSet {}` is always correct. This also avoids invoking a user-defined `size` getter on a weak collection.
- When `DiffFormatter` swallows a format error, also clear any pending JSC exception so we don't trip the scope assertion on the next JSC call.

### Before

```
const wm = new WeakMap();
wm.size = 2;
Bun.inspect(wm);       // TypeError: Type error
expect(wm).toEqual([]); // ASSERTION FAILED (debug)
```

### After

```
Bun.inspect(wm);        // "WeakMap {}"
expect(wm).toEqual([]);  // proper jest diff error
```

### How did you verify your code works?

- Reproduced the original fuzzer crash with the debug+ASAN build, applied the fix, and confirmed the crash script now produces a normal jest diff error instead of an assertion abort.
- Added `test/js/bun/util/inspect-weak-collections.test.ts` covering `Bun.inspect`, `toMatchObject`, and `toEqual` for both `WeakMap` and `WeakSet` with a user-set `.size` (including a throwing getter), plus sanity checks that normal `Map`/`Set` still show their entries. The new tests fail on `main` and pass with this change.
- Ran the existing `test/js/bun/util/inspect.test.js` suite to confirm no regressions.
