### PR TITLE
bun:test: propagate exceptions from custom asymmetricMatch()

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-custom-asymmetric-matcher-throws.test.ts
+++ b/test/js/bun/test/expect-custom-asymmetric-matcher-throws.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+describe("custom asymmetric matcher that throws", () => {
+  expect.extend({
+    _matcherThatThrows() {
+      // throws an error inside the matcher implementation
+      expect.closeTo(expect as any);
+      return { pass: true };
+    },
+  });
+
+  test("asymmetricMatch() propagates the exception instead of asserting", () => {
+    // @ts-expect-error - custom matcher
+    const matcher = expect._matcherThatThrows();
+    expect(typeof matcher.asymmetricMatch).toBe("function");
+    expect(() => matcher.asymmetricMatch(42)).toThrow("Expected a number value");
+  });
+
+  test("deep equality propagates the exception from the custom matcher", () => {
+    expect(() => {
+      // @ts-expect-error - custom matcher
+      expect({ a: 1 }).toEqual({ a: expect._matcherThatThrows() });
+    }).toThrow("Expected a number value");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`releaseAssertNoException()`) found by Fuzzilli (fingerprint `d1da06da44d3113e`).

`ExpectCustomAsymmetricMatcher.asymmetricMatch()` calls `execute()`, which is a `callconv(.c)` function that swallows `error.JSError` (`catch {}` / `catch false`) and leaves the JS exception pending on the VM. `asymmetricMatch()` then returned `jsBoolean(matched)` without checking for a pending exception, so the generated host function wrapper's `assertExceptionPresenceMatches(false)` hit `releaseAssertNoException()` and aborted.

## Repro

```js
const { expect } = Bun.jest("test.js");
expect.extend({
  myMatcher() {
    expect.closeTo(expect); // throws inside the matcher
    return { pass: true };
  },
});
expect.myMatcher().asymmetricMatch(42);
```

Before:
```
ASSERTION FAILED: Unexpected exception observed ...
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

After: the exception propagates to JS and can be caught normally.

## How did you verify your code works?

- Added regression test `test/js/bun/test/expect-custom-asymmetric-matcher-throws.test.ts` which crashes on the unfixed binary and passes with the fix.
- Existing `expect-extend.test.js` tests still pass (28 pass).
- Original fuzzer script no longer crashes over 15 iterations.