### PR TITLE
Fix assertion in spyOn with numeric key on non-callable value

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1555,8 +1555,6 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
             if (hasValue)
                 attributes = slot.attributes();
 
-            attributes |= PropertyAttribute::Accessor;
-
             if (JSModuleNamespaceObject* moduleNamespaceObject = tryJSDynamicCast<JSModuleNamespaceObject*>(object)) {
                 moduleNamespaceObject->overrideExportValue(globalObject, propertyKey, mock);
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
@@ -1564,6 +1562,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 // For indexed properties, set the mock directly instead of wrapping in GetterSetter
                 object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
             } else {
+                attributes |= PropertyAttribute::Accessor;
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }
 

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1011,6 +1011,35 @@ describe("spyOn", () => {
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    test("spyOn works with indexed properties that do not exist", () => {
+      const obj = {};
+      const fn = spyOn(obj, 512);
+      expect(obj[512]).toBe(fn);
+      expect(Object.getOwnPropertyDescriptor(obj, 512)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      fn.mockRestore();
+      expect(obj[512]).toBeUndefined();
+    });
+
+    test("spyOn works with indexed properties that are not callable", () => {
+      const obj = {};
+      obj[5] = "hello";
+      const fn = spyOn(obj, 5);
+      expect(obj[5]).toBe(fn);
+      expect(Object.getOwnPropertyDescriptor(obj, 5)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      fn.mockRestore();
+      expect(obj[5]).toBe("hello");
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
When `spyOn` is called with a numeric property key and the target value is not callable (either missing or not a function), the mock function is stored directly on the object via `putDirectIndex` rather than being wrapped in a `GetterSetter`. However, `PropertyAttribute::Accessor` was still being OR'd into the attributes before this call, producing a sparse array entry that is tagged as an accessor but holds a plain value.

Reading the property back (or GC visiting it) then trips this debug assertion in JSC:

```
ASSERTION FAILED: attributes == attributesForStructure(attributes) && !(attributes & PropertyAttribute::Accessor)
JavaScriptCore/PropertySlot.h(219) : void JSC::PropertySlot::setValue(JSObject *, unsigned int, JSValue)
```

Repro:
```js
const { spyOn } = Bun.jest("");
const obj = {};
spyOn(obj, 512);
obj[512]; // assert
```

Fix: only set `PropertyAttribute::Accessor` on the `putDirectAccessor` path where a `GetterSetter` is actually installed. The indexed and module-namespace paths store plain values and don't need it.

Found by Fuzzilli.