### PR TITLE
sys: cache memfd_create ENOSYS + BUN_FEATURE_FLAG_DISABLE_MEMFD

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -21,7 +21,7 @@ Bun ships as a single, dependency-free executable. You can install it via script
 
     </CodeGroup>
     <Note>
-      **Linux users**  The `unzip` package is required to install Bun. Use `sudo apt install unzip` to install the unzip package. Kernel version 5.6 or higher is strongly recommended, but the minimum is 5.1. Use `uname -r` to check Kernel version.
+      **Linux users**  The `unzip` package is required to install Bun. Use `sudo apt install unzip` to install the unzip package. Kernel version 5.6 or higher is recommended; Bun runs on kernels as old as 3.10 (RHEL 7) with graceful degradation of newer syscalls. Use `uname -r` to check your kernel version.
       </Note>
 
   </Tab>

--- a/src/allocators/LinuxMemFdAllocator.zig
+++ b/src/allocators/LinuxMemFdAllocator.zig
@@ -114,6 +114,8 @@ pub fn shouldUse(bytes: []const u8) bool {
         return false;
     }
 
+    if (!bun.sys.canUseMemfd()) return false;
+
     if (bun.jsc.VirtualMachine.is_smol_mode) {
         return bytes.len >= 1024 * 1024 * 1;
     }

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1388,7 +1388,7 @@ pub fn spawnProcessPosix(
             },
             .buffer => {
                 if (Environment.isLinux) use_memfd: {
-                    if (!options.stream and i > 0) {
+                    if (!options.stream and i > 0 and bun.sys.canUseMemfd()) {
                         // use memfd if we can
                         const label = switch (i) {
                             0 => "spawn_stdio_stdin",

--- a/src/bun.js/api/bun/spawn/stdio.zig
+++ b/src/bun.js/api/bun/spawn/stdio.zig
@@ -93,6 +93,7 @@ pub const Stdio = union(enum) {
         if (comptime !Environment.isLinux) {
             return false;
         }
+        if (!bun.sys.canUseMemfd()) return false;
         const label = switch (index) {
             0 => "spawn_stdio_stdin",
             1 => "spawn_stdio_stdout",

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -175,6 +175,7 @@ pub const feature_flag = struct {
     pub const BUN_FEATURE_FLAG_DISABLE_IO_POOL = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IO_POOL", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IPV4 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV4", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_IPV6 = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_IPV6", .{});
+    pub const BUN_FEATURE_FLAG_DISABLE_MEMFD = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_MEMFD", .{});
     /// The RedisClient supports auto-pipelining by default. This flag disables that behavior.
     pub const BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_REDIS_AUTO_PIPELINING", .{});
     pub const BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK = newFeatureFlag("BUN_FEATURE_FLAG_DISABLE_RWF_NONBLOCK", .{});

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3120,8 +3120,19 @@ pub const MemfdFlags = enum(u32) {
     const MFD_ALLOW_SEALING: u32 = std.os.linux.MFD.ALLOW_SEALING;
 };
 
+/// Set on first ENOSYS so callers can short-circuit without retrying the
+/// syscall on every Blob/spawn. memfd_create requires kernel ≥ 3.17; all
+/// callers already fall back to a heap buffer / pipe / socketpair when this
+/// returns an error.
+var memfd_unsupported = std.atomic.Value(bool).init(false);
+
 pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
     if (comptime !Environment.isLinux) @compileError("linux only!");
+
+    if (memfd_unsupported.load(.monotonic) or bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_MEMFD.get()) {
+        return .{ .err = .{ .errno = @intFromEnum(bun.sys.E.NOSYS), .syscall = .memfd_create } };
+    }
+
     var flags: u32 = @intFromEnum(flags_);
     while (true) {
         const rc = std.os.linux.memfd_create(name, flags);
@@ -3138,6 +3149,7 @@ pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
                         continue;
                     }
                 },
+                .NOSYS => memfd_unsupported.store(true, .monotonic),
                 else => {},
             }
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3120,25 +3120,15 @@ pub const MemfdFlags = enum(u32) {
     const MFD_ALLOW_SEALING: u32 = std.os.linux.MFD.ALLOW_SEALING;
 };
 
-/// memfd_create requires kernel ≥ 3.17. Tristate: 0 = unknown, 1 = supported,
-/// -1 = unsupported (ENOSYS seen, or disabled). Callers should check
-/// canUseMemfd() first and take their existing fallback (heap buffer / pipe /
-/// socketpair) when it returns false.
-var can_use_memfd = std.atomic.Value(i32).init(0);
+/// memfd_create requires kernel ≥ 3.17. Latched true on first ENOSYS so
+/// callers can take their existing fallback (heap buffer / pipe / socketpair)
+/// without retrying the syscall on every Blob/spawn.
+var memfd_enosys = std.atomic.Value(bool).init(false);
 
 pub fn canUseMemfd() bool {
     if (comptime !Environment.isLinux) return false;
-    const result = can_use_memfd.load(.monotonic);
-    if (result == 0) {
-        if (bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_MEMFD.get()) {
-            can_use_memfd.store(-1, .monotonic);
-            return false;
-        }
-        // Optimistically allow; first ENOSYS flips to -1.
-        can_use_memfd.store(1, .monotonic);
-        return true;
-    }
-    return result == 1;
+    if (bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_MEMFD.get()) return false;
+    return !memfd_enosys.load(.monotonic);
 }
 
 pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
@@ -3159,7 +3149,7 @@ pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
                         continue;
                     }
                 },
-                .NOSYS => can_use_memfd.store(-1, .monotonic),
+                .NOSYS => memfd_enosys.store(true, .monotonic),
                 else => {},
             }
 

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3120,19 +3120,29 @@ pub const MemfdFlags = enum(u32) {
     const MFD_ALLOW_SEALING: u32 = std.os.linux.MFD.ALLOW_SEALING;
 };
 
-/// Set on first ENOSYS so callers can short-circuit without retrying the
-/// syscall on every Blob/spawn. memfd_create requires kernel ≥ 3.17; all
-/// callers already fall back to a heap buffer / pipe / socketpair when this
-/// returns an error.
-var memfd_unsupported = std.atomic.Value(bool).init(false);
+/// memfd_create requires kernel ≥ 3.17. Tristate: 0 = unknown, 1 = supported,
+/// -1 = unsupported (ENOSYS seen, or disabled). Callers should check
+/// canUseMemfd() first and take their existing fallback (heap buffer / pipe /
+/// socketpair) when it returns false.
+var can_use_memfd = std.atomic.Value(i32).init(0);
+
+pub fn canUseMemfd() bool {
+    if (comptime !Environment.isLinux) return false;
+    const result = can_use_memfd.load(.monotonic);
+    if (result == 0) {
+        if (bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_MEMFD.get()) {
+            can_use_memfd.store(-1, .monotonic);
+            return false;
+        }
+        // Optimistically allow; first ENOSYS flips to -1.
+        can_use_memfd.store(1, .monotonic);
+        return true;
+    }
+    return result == 1;
+}
 
 pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
     if (comptime !Environment.isLinux) @compileError("linux only!");
-
-    if (memfd_unsupported.load(.monotonic) or bun.feature_flag.BUN_FEATURE_FLAG_DISABLE_MEMFD.get()) {
-        return .{ .err = .{ .errno = @intFromEnum(bun.sys.E.NOSYS), .syscall = .memfd_create } };
-    }
-
     var flags: u32 = @intFromEnum(flags_);
     while (true) {
         const rc = std.os.linux.memfd_create(name, flags);
@@ -3149,7 +3159,7 @@ pub fn memfd_create(name: [:0]const u8, flags_: MemfdFlags) Maybe(bun.FD) {
                         continue;
                     }
                 },
-                .NOSYS => memfd_unsupported.store(true, .monotonic),
+                .NOSYS => can_use_memfd.store(-1, .monotonic),
                 else => {},
             }
 

--- a/test/js/bun/memfd-disabled.test.ts
+++ b/test/js/bun/memfd-disabled.test.ts
@@ -1,0 +1,63 @@
+// Verifies that consumers of memfd_create degrade gracefully when the syscall
+// is unavailable (kernel < 3.17, or seccomp-filtered). bun.sys.memfd_create
+// returns ENOSYS when BUN_FEATURE_FLAG_DISABLE_MEMFD is set, exercising the
+// same fallback paths an old kernel would hit.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+
+const env = { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" };
+
+test.skipIf(process.platform !== "linux")("Bun.spawn stdin from Blob falls back when memfd is disabled", async () => {
+  const payload = Buffer.alloc(64 * 1024, "x").toString();
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const proc = Bun.spawn({
+          cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+          stdin: new Blob([${JSON.stringify(payload)}]),
+          stdout: "pipe",
+        });
+        const out = await proc.stdout.text();
+        console.log(out.length, out === ${JSON.stringify(payload)});
+        process.exit(await proc.exited);
+      `,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toBe(`${payload.length} true`);
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(process.platform !== "linux")("large Response body Blob falls back when memfd is disabled", async () => {
+  // LinuxMemFdAllocator.shouldUse triggers at ≥ 1 MiB (smol) / larger otherwise;
+  // sending a body well past that ensures the memfd path is attempted.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const body = Buffer.alloc(8 * 1024 * 1024, 0x61);
+        const blob = await new Response(body).blob();
+        const buf = new Uint8Array(await blob.arrayBuffer());
+        if (buf.length !== body.length) throw new Error("length mismatch: " + buf.length);
+        for (let i = 0; i < buf.length; i += 4096) {
+          if (buf[i] !== 0x61) throw new Error("byte mismatch at " + i);
+        }
+        console.log("ok", buf.length);
+      `,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toBe("ok 8388608");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`memfd_create` requires kernel ≥ 3.17. A binary-level syscall audit (in #29461) found that every Bun caller already falls back on error — Blob → heap, spawn stdio → pipe, process IPC → socketpair — so kernel 3.10 (RHEL 7) works today, but every call retries the failing syscall.

This PR:
- Caches ENOSYS in `bun.sys.memfd_create` so subsequent calls return immediately
- Adds `BUN_FEATURE_FLAG_DISABLE_MEMFD` to force the fallback (seccomp environments, testing)
- Tests that Blob and spawn-stdin work with the flag set
- Fixes `docs/installation.mdx`: "minimum kernel 5.1" was never true (the io_uring check it referenced has zero callers). Actual floor is ~3.10 with degraded atomicity.

Complements #29461 (glibc 2.17).

## Test plan

- [ ] CI: linux test suite passes with new `memfd-disabled.test.ts`
- [ ] CI: zig check on all platforms