### PR TITLE
Fix use-after-free when HTMLRewriter document end handler throws

### DIFF
--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -44,6 +44,32 @@ describe("HTMLRewriter", () => {
     ).toThrow("test");
   });
 
+  it("error inside document end handler", () => {
+    expect(() =>
+      new HTMLRewriter()
+        .onDocument({
+          end() {
+            throw new Error("test");
+          },
+        })
+        .transform(new Response("<div>hello</div>")),
+    ).toThrow("test");
+    Bun.gc(true);
+  });
+
+  it("error inside document end handler (string)", () => {
+    expect(() =>
+      new HTMLRewriter()
+        .onDocument({
+          end() {
+            throw new Error("test");
+          },
+        })
+        .transform("<div>hello</div>"),
+    ).toThrow("test");
+    Bun.gc(true);
+  });
+
   it("fast async error inside element handler", () => {
     let caught = false;
     try {


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in `HTMLRewriter` found by Fuzzilli.

When a document `end` handler throws synchronously during `transform()`, `BufferOutputSink.runOutputSink` was calling `response.finalize()` on the output `Response`. However, by the time `runOutputSink` runs, that `Response` has already been wrapped in a JS object via `toJS()` (in `BufferOutputSink.init`), so its single ref is owned by the JS wrapper. Calling `finalize()` here destroyed the native `Response` while the JS wrapper still pointed at it; the next GC would invoke `JSResponse::~JSResponse` → `Response.finalize()` on freed memory.

The adjacent `write()` error path already handled this correctly (it doesn't finalize). This change makes the `end()` error path match.

### Repro

```js
const rewriter = new HTMLRewriter();
rewriter.onDocument({ end() { throw new Error("boom"); } });
try { rewriter.transform(""); } catch {}
Bun.gc(true);
```

Before: ASAN `use-after-poison` in `JSRef.deinit` → `Response.finalize`.
After: throws `Error: boom` cleanly.

## How did you verify your code works?

- Verified the Fuzzilli crash script no longer crashes under ASAN
- Added regression tests for `onDocument({ end })` throwing with both `Response` and string input
- Ran the full `html-rewriter.test.js` suite (43 pass, 2 todo, 0 fail)
- Ran related regression tests (`htmlrewriter-additional-bugs`, `19219`, `html-rewriter-doctype`)