### PR TITLE
deps(mimalloc): set MI_OVERRIDE=OFF on Windows

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -83,9 +83,14 @@ export const mimalloc: Dependency = {
       args.MI_OVERRIDE = "ON";
       args.MI_OSX_ZONE = "OFF";
       args.MI_OSX_INTERPOSE = "OFF";
+    } else if (cfg.windows) {
+      // Bun links the static CRT and calls mi_* directly; nothing routes
+      // through CRT malloc. With override ON, dev3's alloc-override.c
+      // emits _expand/_msize/free into the static lib and lld-link
+      // duplicates against libucrt(d). mimalloc's *default* is ON, so
+      // this must be explicit.
+      args.MI_OVERRIDE = "OFF";
     }
-    // Windows: use mimalloc's defaults (no override; Windows has its own
-    // mechanism via the static CRT we link).
 
     if (cfg.debug) {
       // Heavy debug checks: guard bytes, freed-memory poisoning, double-free

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -59,13 +59,16 @@ export const mimalloc: Dependency = {
 
     // ─── Override behavior (global malloc replacement) ───
     // The decision matrix:
-    //   ASAN:  always OFF — ASAN interceptors must see the real malloc.
-    //   macOS: OFF — macOS's malloc zones are sufficient and overriding
-    //          causes issues with system frameworks (SecureTransport, etc.)
-    //          that have their own allocator expectations.
-    //   Linux: ON — this is the main win. All malloc/free goes through
-    //          mimalloc, including WebKit's bmalloc when it falls back
-    //          to system malloc.
+    //   ASAN:    always OFF — ASAN interceptors must see the real malloc.
+    //   macOS:   OFF — macOS's malloc zones are sufficient and overriding
+    //            causes issues with system frameworks (SecureTransport, etc.)
+    //            that have their own allocator expectations.
+    //   Linux:   ON — this is the main win. All malloc/free goes through
+    //            mimalloc, including WebKit's bmalloc when it falls back
+    //            to system malloc.
+    //   Windows: OFF — Bun links the static CRT and calls mi_* directly;
+    //            dev3's alloc-override.c emits _expand/_msize/free which
+    //            duplicate against libucrt(d) at link time.
     if (cfg.asan) {
       args.MI_TRACK_ASAN = "ON";
       args.MI_OVERRIDE = "OFF";
@@ -84,11 +87,7 @@ export const mimalloc: Dependency = {
       args.MI_OSX_ZONE = "OFF";
       args.MI_OSX_INTERPOSE = "OFF";
     } else if (cfg.windows) {
-      // Bun links the static CRT and calls mi_* directly; nothing routes
-      // through CRT malloc. With override ON, dev3's alloc-override.c
-      // emits _expand/_msize/free into the static lib and lld-link
-      // duplicates against libucrt(d). mimalloc's *default* is ON, so
-      // this must be explicit.
+      // mimalloc's *default* is ON, so this must be explicit.
       args.MI_OVERRIDE = "OFF";
     }
 


### PR DESCRIPTION
## Summary

Windows debug builds fail to link since the dev3 mimalloc bump (#29420 / #29435):

```
lld-link: error: duplicate symbol: _expand
>>> defined at mimalloc-debug.lib(alloc.c.obj)
>>> defined at libucrtd.lib(expand.obj)
```

**Root cause:** `mimalloc.ts` never set `MI_OVERRIDE` for Windows — only a comment claiming the upstream default was "no override". The actual default is `ON`. Pre-dev3 this was harmless because `alloc-override.c`'s `_MSC_VER` block was an empty comment ("cannot override malloc unless using a dll"). Upstream [microsoft/mimalloc#1259](https://github.com/microsoft/mimalloc/pull/1259) / #1263 filled it with real CRT symbol definitions (`_expand`, `_msize`, `_msize_base`, `_free_base`, `free`), so the static lib now exports them and collides with the debug CRT.

**Fix:** explicit `MI_OVERRIDE=OFF` on Windows. Bun links the static CRT and calls `mi_*` directly; nothing routes through CRT malloc, so override has no benefit there. This restores the effective pre-dev3 behavior.

**Not stale cache:** `dep_configure` already uses `cmake --fresh`, so the cache was correctly regenerated — it got `ON` because that's the real default.

**Why CI didn't catch it:** all `ci-*` profiles use `buildType: "Release"` (`/MT` → `libucrt.lib`). The duplicate only fires under `/MTd` because `libucrtd.lib`'s `expand.obj` is pulled in for its debug-heap symbols. CI never builds Windows debug.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `bun scripts/build.ts --configure-only`
- [x] Windows debug: `bun bd --version` → `1.3.13-debug` (previously failed at link)
- [x] Verified `build/debug/deps/mimalloc/CMakeCache.txt` shows `MI_OVERRIDE:BOOL=OFF` after reconfigure
- [ ] CI (release Windows — also flips ON→OFF; expected no-op since pre-dev3 override did nothing on Windows static)