### PR TITLE
ci(binary-size): drop release comparison column

### DIFF
--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -1,12 +1,11 @@
 // Measure stripped binary sizes for every release platform and compare them
-// against (a) the latest finished `main` build ("canary") and (b) a pinned
-// release baseline hardcoded below.
+// against the latest finished `main` build ("canary").
 //
 // Run by the `binary-size` step in .buildkite/ci.mjs after all *-build-bun
 // jobs finish. Always posts an annotation with sizes and deltas. On PR builds
 // it fails if any binary grew by more than --threshold-mb vs canary; on main
 // it never fails (--no-fail) but still shows the comparison against the
-// previous main build and the last release.
+// previous main build.
 //
 // Escape hatch: put `[skip size check]` in the commit message, which makes
 // ci.mjs set soft_fail on this step (it still runs and annotates).
@@ -127,49 +126,12 @@ const canary: Baseline | undefined = await (async () => {
 })().catch(e => ((canaryNote = String(e?.message || e)), undefined));
 console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
-// Release: latest bun-v* tag's commit. Falls back to the hardcoded table
-// until a tagged commit's build carries binary-sizes.json.
-const releaseFallback: Baseline = {
-  label: "bun-v1.3.11",
-  href: "https://github.com/oven-sh/bun/releases/tag/bun-v1.3.11",
-  sizes: {
-    "bun-darwin-aarch64": 61069216,
-    "bun-darwin-x64": 66128448,
-    "bun-linux-aarch64": 98736456,
-    "bun-linux-x64": 99295408,
-    "bun-linux-x64-baseline": 98451632,
-    "bun-linux-aarch64-musl": 93164848,
-    "bun-linux-x64-musl": 94162760,
-    "bun-linux-x64-musl-baseline": 93626184,
-    "bun-windows-x64": 115416576,
-    "bun-windows-x64-baseline": 114743296,
-    "bun-windows-aarch64": 112043008,
-  },
-};
-
-async function fetchReleaseBaseline(): Promise<Baseline | undefined> {
-  const out = Bun.spawnSync(["git", "ls-remote", "--tags", "--sort=-version:refname", "origin", "refs/tags/bun-v*"], {
-    stderr: "inherit",
-  })
-    .stdout.toString()
-    .split("\n")
-    .find(l => l && !l.includes("^{}"));
-  if (!out) return;
-  const [sha, ref] = out.split("\t");
-  const tag = ref.replace("refs/tags/", "");
-  return baselineFromCommit(sha, n => `${tag} (#${n})`);
-}
-
-console.log("--- Fetching release baseline");
-const release: Baseline = (await fetchReleaseBaseline().catch(() => undefined)) ?? releaseFallback;
-console.log(`  ${release.label}`);
-
 // ─── Compare & annotate ───
 
 console.log("--- Results");
 
 type Delta = { base: number; bytes: number };
-type Row = { triplet: string; now: number; canary?: Delta; release?: Delta };
+type Row = { triplet: string; now: number; canary?: Delta };
 
 function delta(now: number, base: number | undefined): Delta | undefined {
   if (!base) return undefined;
@@ -183,7 +145,6 @@ const rows: Row[] = targets
     triplet,
     now: sizes[triplet],
     canary: delta(sizes[triplet], canary?.sizes[triplet]),
-    release: delta(sizes[triplet], release.sizes[triplet]),
   }));
 
 const overThreshold = rows.filter(r => r.canary && r.canary.bytes > thresholdBytes);
@@ -207,7 +168,6 @@ const tableRows = rows
       `<tr><td>${over ? "❌ " : ""}<code>${r.triplet}</code></td>` +
       `<td align="right">${fmtBytes(r.now)}</td>` +
       deltaCells(r.canary, over) +
-      deltaCells(r.release, false) +
       `</tr>`
     );
   })
@@ -228,9 +188,8 @@ const annotation = `
 <tr>
   <th rowspan="2">target</th><th rowspan="2">this build</th>
   <th colspan="2">canary: ${link(canary, "main")}</th>
-  <th colspan="2">release: ${link(release, "latest")}</th>
 </tr>
-<tr><th>size</th><th>Δ</th><th>size</th><th>Δ</th></tr>
+<tr><th>size</th><th>Δ</th></tr>
 ${tableRows}
 </table>
 ${failed ? `<p>Add <code>[skip size check]</code> to the commit message if this increase is intentional.</p>` : ""}
@@ -252,8 +211,7 @@ Bun.spawnSync(
 
 for (const r of rows) {
   const c = r.canary ? `  canary ${fmtDelta(r.canary.bytes).padStart(10)}` : "";
-  const rel = r.release ? `  release ${fmtDelta(r.release.bytes).padStart(10)}` : "";
-  console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}${rel}`);
+  console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
 }
 
 if (failed) {


### PR DESCRIPTION
## What

Removes the "release" comparison column from the binary-size CI annotation. The table now compares only against canary (latest main).

## Why

Tagged release builds are configured differently from canary/PR builds (less debug code baked in), so they come out ~1–2 MB smaller. That makes the release Δ column read as a constant "+1.x MB" on every PR regardless of what the PR actually changed — it's noise that looks like signal. The canary delta is what answers "did this PR grow the binary."

## Details

- Dropped `releaseFallback` hardcoded size table
- Dropped `fetchReleaseBaseline()` (git ls-remote tag lookup)
- Dropped `release` field from `Row` and the corresponding HTML column / console output
- Threshold check was already canary-only — unchanged
- `[skip size check]` escape hatch — unchanged

Net: −42 lines in `scripts/binary-size.ts`.