### PR TITLE
webcore: fix ReadableStreamSource Strong cycle + Windows fromPipe ref

### DIFF
--- a/src/bun.js/webcore/FileReader.zig
+++ b/src/bun.js/webcore/FileReader.zig
@@ -623,6 +623,11 @@ pub fn onReaderError(this: *FileReader, err: bun.sys.Error) void {
 
     this.pending.result = .{ .err = .{ .Error = err } };
     this.pending.run();
+
+    if (this.waiting_for_onReaderDone) {
+        this.waiting_for_onReaderDone = false;
+        _ = this.parent().decrementCount();
+    }
 }
 
 pub fn setRawMode(this: *FileReader, flag: bool) bun.sys.Maybe(void) {

--- a/src/bun.js/webcore/FileReader.zig
+++ b/src/bun.js/webcore/FileReader.zig
@@ -242,6 +242,11 @@ pub fn onStart(this: *FileReader) streams.Start {
             this.waiting_for_onReaderDone = true;
             _ = this.parent().incrementCount();
         }
+    } else if (comptime Environment.isWindows) {
+        if (this.reader.source != null and !this.reader.isDone()) {
+            this.waiting_for_onReaderDone = true;
+            _ = this.parent().incrementCount();
+        }
     }
 
     if (comptime Environment.isPosix) {

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -418,7 +418,6 @@ pub fn NewSource(
         pending_err: ?Syscall.Error = null,
         close_handler: ?*const fn (?*anyopaque) void = null,
         close_ctx: ?*anyopaque = null,
-        close_jsvalue: jsc.Strong.Optional = .empty,
         cancel_handler: ?*const fn (?*anyopaque) void = null,
         cancel_ctx: ?*anyopaque = null,
         globalThis: *JSGlobalObject = undefined,
@@ -506,7 +505,6 @@ pub fn NewSource(
 
             this.ref_count -= 1;
             if (this.ref_count == 0) {
-                this.close_jsvalue.deinit();
                 deinit_fn(&this.context);
                 return 0;
             }
@@ -683,7 +681,7 @@ pub fn NewSource(
                 this.globalThis = globalObject;
 
                 if (value.isUndefined()) {
-                    this.close_jsvalue.deinit();
+                    if (this.this_jsvalue != .zero) js.onCloseCallbackSetCached(this.this_jsvalue, globalObject, .js_undefined);
                     return;
                 }
 
@@ -691,7 +689,7 @@ pub fn NewSource(
                     return globalObject.throwInvalidArgumentType("ReadableStreamSource", "onclose", "function");
                 }
                 const cb = value.withAsyncContextIfNeeded(globalObject);
-                this.close_jsvalue.set(globalObject, cb);
+                if (this.this_jsvalue != .zero) js.onCloseCallbackSetCached(this.this_jsvalue, globalObject, cb);
             }
 
             pub fn setOnDrainFromJS(this: *ReadableStreamSourceType, globalObject: *jsc.JSGlobalObject, value: jsc.JSValue) bun.JSError!void {
@@ -715,7 +713,10 @@ pub fn NewSource(
 
                 jsc.markBinding(@src());
 
-                return this.close_jsvalue.get() orelse .js_undefined;
+                if (this.this_jsvalue != .zero) {
+                    if (js.onCloseCallbackGetCached(this.this_jsvalue)) |val| return val;
+                }
+                return .js_undefined;
             }
 
             pub fn getOnDrainFromJS(this: *ReadableStreamSourceType, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
@@ -743,11 +744,12 @@ pub fn NewSource(
             fn onClose(ptr: ?*anyopaque) void {
                 jsc.markBinding(@src());
                 var this = bun.cast(*ReadableStreamSourceType, ptr.?);
-                if (this.close_jsvalue.trySwap()) |cb| {
-                    this.globalThis.queueMicrotask(cb, &.{});
+                if (this.this_jsvalue != .zero) {
+                    if (js.onCloseCallbackGetCached(this.this_jsvalue)) |cb| {
+                        if (!cb.isUndefined()) this.globalThis.queueMicrotask(cb, &.{});
+                        js.onCloseCallbackSetCached(this.this_jsvalue, this.globalThis, .js_undefined);
+                    }
                 }
-
-                this.close_jsvalue.deinit();
             }
 
             pub fn finalize(this: *ReadableStreamSourceType) void {


### PR DESCRIPTION
## Summary

Three related fixes; the second and third are required by the first.

### 1. `close_jsvalue` Strong → `onCloseCallback` cached slot (cross-platform)

`setOnCloseFromJS` stored the callback in a `jsc.Strong`, which forms a rooted cycle: source-wrapper → `close_jsvalue` Strong → bound `#onClose` → `NativeReadableStreamSource` (`ReadableStreamInternals.ts:1972`) → `$stream` private prop (`:1959`) → source-wrapper. Because a Strong is a global GC root, the source survives even after every JS reference (including the outer `ReadableStream`) is dropped. It only becomes collectable when EOF/close runs the JS-side `callClose` (which clears `$stream`) or at VM shutdown.

The codegen already declares `onCloseCallback` in `streams.classes.ts` `values`; `onDrain` already uses its cached slot. Switch `onClose` to the same `WriteBarrier`-backed storage and delete the Strong field. The cycle becomes an ordinary intra-heap cycle that mark-sweep collects.

### 2. Windows non-lazy `FileReader` across-read ref

`FileReader.onStart` holds an `incrementCount()` until `onReaderDone` only on the lazy path (always) or the POSIX non-lazy path. The Windows non-lazy path — `fromPipe`, reached via `Bun.spawn().stdout`/`.stderr` — did not. With the cycle fix above, the source is now collectable while a `uv_read_start` IOCP read is pending, and `WindowsBufferedReader.deinit` would run with a live `.pipe` source whose `data` ptr is then dereferenced by the queued `onStreamRead`. Add a Windows arm matching the POSIX one.

### 3. Release the across-read ref in `onReaderError` too

`onReaderDone` checks `waiting_for_onReaderDone` and decrements; `onReaderError` did not, so a read that ends in error (rather than EOF) leaked the ref taken in `onStart`. Pre-existing on the lazy and POSIX paths; commit 2 adds a Windows arm that would inherit the same gap. Mirror the release after `pending.run()`.

## Verification

On Windows, with a child that spawns a detached grandchild inheriting stdout (so the pipe stays open after the direct child exits), repeatedly accessing `proc.stdout`, dropping it, and forcing GC:

| | `*ReadableStreamSource` heap count after 30 iters | `WindowsBufferedReader.deinit` reached with live `.pipe` source |
|---|---|---|
| baseline | 31 (linear growth; 61 at 60 iters) | no — leak masks it |
| commit 1 only | ~14 (plateaus at live-grandchild count) | **yes** — `FileReader.deinit` sees `src=pipe`, `closed=false` |
| commits 1–3 | ~15 (plateaus; freed as pipes EOF; flat through 80 iters) | no |

## Relation to #29440

Found while verifying the review comment on #29440 about `WindowsBufferedReader.deinit` ordering. That comment correctly identified the buffer-free-before-detach as theoretical; this PR explains why (the Strong cycle pinned the source) and fixes the underlying leak plus the UAF that fixing the leak would have exposed.