### PR TITLE
Fix assertion failure when spyOn is used on non-callable indexed property

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1562,7 +1562,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
                 mock->spyAttributes |= JSMockFunction::SpyAttributeESModuleNamespace;
             } else if (auto index = parseIndex(propertyKey)) {
                 // For indexed properties, set the mock directly instead of wrapping in GetterSetter
-                object->putDirectIndex(globalObject, *index, mock, attributes, PutDirectIndexLikePutDirect);
+                object->putDirectIndex(globalObject, *index, mock, attributes & ~PropertyAttribute::Accessor, PutDirectIndexLikePutDirect);
             } else {
                 object->putDirectAccessor(globalObject, propertyKey, JSC::GetterSetter::create(vm, globalObject, mock, mock), attributes);
             }

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -1011,6 +1011,27 @@ describe("spyOn", () => {
       expect(arr[14]()).toBe(456);
       expect(fn).not.toHaveBeenCalled();
     });
+
+    test("spyOn works with non-callable indexed properties", () => {
+      const obj = {};
+      const fn = spyOn(obj, 1);
+      expect(() => obj[1]).not.toThrow();
+      expect(obj[1]).toBe(fn);
+      expect(Object.getOwnPropertyDescriptor(obj, 1)).toEqual({
+        value: fn,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+
+      const obj2 = {};
+      obj2[3] = "hello";
+      const fn2 = spyOn(obj2, 3);
+      expect(() => obj2[3]).not.toThrow();
+      expect(() => Object.getOwnPropertyDescriptor(obj2, 3)).not.toThrow();
+      fn2.mockRestore();
+      expect(obj2[3]).toBe("hello");
+    });
   }
 
   // spyOn does not work with getters/setters yet.


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion in `PropertySlot::setValue` triggered after calling `spyOn(obj, <numeric index>)` on a non-callable (or missing) value.

```js
const obj = {};
Bun.jest().spyOn(obj, 1);
obj[1]; // ASSERTION FAILED: ... !(attributes & PropertyAttribute::Accessor)
```

When spying on a non-callable value at a numeric index, `spyOn` stores the mock directly via `putDirectIndex` rather than wrapping it in a `GetterSetter`. However it was still passing `PropertyAttribute::Accessor` in the attributes. This left the indexed storage with a plain value carrying the `Accessor` attribute, so the next lookup on that index hit the `PropertySlot::setValue` assertion that forbids `Accessor` on plain values.

The fix masks out `PropertyAttribute::Accessor` for the `putDirectIndex` call.

Found by Fuzzilli. Fingerprint: `PropertySlot.h(219)`

## How did you verify your code works?

Added a regression test in `test/js/bun/test/mock-fn.test.js` covering `spyOn` on missing and existing non-callable numeric indices, including subsequent reads and `Object.getOwnPropertyDescriptor`. The full `mock-fn.test.js` suite (73 tests) passes.