### PR TITLE
install: stop reading dangling dependency pointer in enqueueDependencyToRoot

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.zig
+++ b/src/install/PackageManager/PackageManagerEnqueue.zig
@@ -318,9 +318,13 @@ pub fn enqueueDependencyToRoot(
     }));
 
     if (this.lockfile.buffers.resolutions.items[dep_id] == invalid_package_id) {
+        // Copy to the stack: `enqueueDependencyWithMainAndSuccessFn` can call
+        // `Lockfile.Package.fromNPM`, which grows `buffers.dependencies` and
+        // would invalidate a pointer taken directly into it.
+        const dependency = this.lockfile.buffers.dependencies.items[dep_id];
         this.enqueueDependencyWithMainAndSuccessFn(
             dep_id,
-            &this.lockfile.buffers.dependencies.items[dep_id],
+            &dependency,
             invalid_package_id,
             false,
             assignRootResolution,
@@ -1517,7 +1521,7 @@ fn getOrPutResolvedPackageWithFindResult(
                     .network_task = try this.generateNetworkTaskForTarball(
                         task_id,
                         manifest.str(&find_result.package.tarball_url),
-                        dependency.behavior.isRequired(),
+                        behavior.isRequired(),
                         dependency_id,
                         package,
                         name_and_version_hash,

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -367,8 +367,7 @@ pub fn installWithManager(
                     // ever reads through a pointer into the old backing storage.
                     if (manager.summary.overrides_changed and all_name_hashes.len > 0) {
                         const dependencies_len = manager.lockfile.buffers.dependencies.items.len;
-                        var dependency_i: usize = 0;
-                        while (dependency_i < dependencies_len) : (dependency_i += 1) {
+                        for (0..dependencies_len) |dependency_i| {
                             const dependency = manager.lockfile.buffers.dependencies.items[dependency_i];
                             if (std.mem.indexOfScalar(PackageNameHash, all_name_hashes, dependency.name_hash)) |_| {
                                 manager.lockfile.buffers.resolutions.items[dependency_i] = invalid_package_id;
@@ -386,8 +385,7 @@ pub fn installWithManager(
 
                     if (manager.summary.catalogs_changed) {
                         const dependencies_len = manager.lockfile.buffers.dependencies.items.len;
-                        var _dep_id: usize = 0;
-                        while (_dep_id < dependencies_len) : (_dep_id += 1) {
+                        for (0..dependencies_len) |_dep_id| {
                             const dep_id: DependencyID = @intCast(_dep_id);
                             const dep = manager.lockfile.buffers.dependencies.items[dep_id];
                             if (dep.version.tag != .catalog) continue;

--- a/src/install/PackageManager/install_with_manager.zig
+++ b/src/install/PackageManager/install_with_manager.zig
@@ -360,35 +360,46 @@ pub fn installWithManager(
 
                     builder.clamp();
 
+                    // `enqueueDependencyWithMain` can reach `Lockfile.Package.fromNPM`,
+                    // which grows `buffers.dependencies` and may reallocate it.
+                    // Iterate by index against a snapshot of the original length and
+                    // copy each entry to the stack so neither the loop nor the callee
+                    // ever reads through a pointer into the old backing storage.
                     if (manager.summary.overrides_changed and all_name_hashes.len > 0) {
-                        for (manager.lockfile.buffers.dependencies.items, 0..) |*dependency, dependency_i| {
+                        const dependencies_len = manager.lockfile.buffers.dependencies.items.len;
+                        var dependency_i: usize = 0;
+                        while (dependency_i < dependencies_len) : (dependency_i += 1) {
+                            const dependency = manager.lockfile.buffers.dependencies.items[dependency_i];
                             if (std.mem.indexOfScalar(PackageNameHash, all_name_hashes, dependency.name_hash)) |_| {
                                 manager.lockfile.buffers.resolutions.items[dependency_i] = invalid_package_id;
                                 manager.enqueueDependencyWithMain(
                                     @truncate(dependency_i),
-                                    dependency,
+                                    &dependency,
                                     invalid_package_id,
                                     false,
                                 ) catch |err| {
-                                    addDependencyError(manager, dependency, err);
+                                    addDependencyError(manager, &dependency, err);
                                 };
                             }
                         }
                     }
 
                     if (manager.summary.catalogs_changed) {
-                        for (manager.lockfile.buffers.dependencies.items, 0..) |*dep, _dep_id| {
+                        const dependencies_len = manager.lockfile.buffers.dependencies.items.len;
+                        var _dep_id: usize = 0;
+                        while (_dep_id < dependencies_len) : (_dep_id += 1) {
                             const dep_id: DependencyID = @intCast(_dep_id);
+                            const dep = manager.lockfile.buffers.dependencies.items[dep_id];
                             if (dep.version.tag != .catalog) continue;
 
                             manager.lockfile.buffers.resolutions.items[dep_id] = invalid_package_id;
                             manager.enqueueDependencyWithMain(
                                 dep_id,
-                                dep,
+                                &dep,
                                 invalid_package_id,
                                 false,
                             ) catch |err| {
-                                addDependencyError(manager, dep, err);
+                                addDependencyError(manager, &dep, err);
                             };
                         }
                     }

--- a/test/cli/run/autoinstall-cached-manifest.test.ts
+++ b/test/cli/run/autoinstall-cached-manifest.test.ts
@@ -46,11 +46,15 @@ test("auto-install with cached manifest but missing tarball does not read a dang
   }
 
   // Keep the `.npm` manifest files, drop every extracted tarball so the next
-  // run hits the `.extract` path with a warm manifest cache.
+  // run hits the `.extract` path with a warm manifest cache. Assert both
+  // kinds actually exist first so this test doesn't silently become a no-op
+  // if the first run's auto-install didn't reach the registry.
   const entries = readdirSync(cacheDir);
-  expect(entries.some(e => e.endsWith(".npm"))).toBe(true);
-  for (const entry of entries) {
-    if (entry.endsWith(".npm")) continue;
+  const manifests = entries.filter(e => e.endsWith(".npm"));
+  const extracted = entries.filter(e => !e.endsWith(".npm"));
+  expect(manifests.length).toBeGreaterThan(0);
+  expect(extracted.length).toBeGreaterThan(0);
+  for (const entry of extracted) {
     rmSync(join(cacheDir, entry), { recursive: true, force: true });
   }
 

--- a/test/cli/run/autoinstall-cached-manifest.test.ts
+++ b/test/cli/run/autoinstall-cached-manifest.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression: when runtime auto-install (`enqueueDependencyToRoot`) finds a
 // cached manifest on disk but not the extracted tarball, it calls

--- a/test/cli/run/autoinstall-cached-manifest.test.ts
+++ b/test/cli/run/autoinstall-cached-manifest.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Regression: when runtime auto-install (`enqueueDependencyToRoot`) finds a
+// cached manifest on disk but not the extracted tarball, it calls
+// `Lockfile.Package.fromNPM` which grows `lockfile.buffers.dependencies`.
+// The `dependency` argument was a pointer directly into that buffer, so the
+// subsequent `.extract` branch read `dependency.behavior` from freed memory
+// (ASAN: use-after-poison).
+//
+// This test uses real npm like the neighbouring run-autoinstall.test.ts; the
+// package only needs to have at least one dependency of its own so that
+// `fromNPM` reallocates the single-entry dependencies buffer.
+test("auto-install with cached manifest but missing tarball does not read a dangling dependency pointer", async () => {
+  using dir = tempDir("autoinstall-cached-manifest", {});
+  const cacheDir = join(String(dir), ".bun-cache");
+
+  const env = {
+    ...bunEnv,
+    BUN_INSTALL_CACHE_DIR: cacheDir,
+  };
+
+  // Use `-e` so the `require()` is resolved at runtime through
+  // `Bun__resolveSync` → `enqueueDependencyToRoot` (the code path that was
+  // passing a pointer directly into the lockfile buffer). Loading from a
+  // file instead lets the transpiler resolve the import through a
+  // different path that already used a stack copy.
+  const script = `try { require("is-even"); } catch {} console.log("ok");`;
+
+  // First run: downloads manifests and tarballs into the cache. The manifest
+  // isn't cached yet, so the safe `processDependencyListItem` path (stack
+  // copy) is taken.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--install=force", "-e", script],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("ok");
+    expect(exitCode).toBe(0);
+  }
+
+  // Keep the `.npm` manifest files, drop every extracted tarball so the next
+  // run hits the `.extract` path with a warm manifest cache.
+  const entries = readdirSync(cacheDir);
+  expect(entries.some(e => e.endsWith(".npm"))).toBe(true);
+  for (const entry of entries) {
+    if (entry.endsWith(".npm")) continue;
+    rmSync(join(cacheDir, entry), { recursive: true, force: true });
+  }
+
+  // Second run: manifest is loaded from disk, `fromNPM` appends the package's
+  // dependencies (reallocating the buffer), then the tarball download path
+  // runs. Previously this read `dependency.behavior` from the freed buffer.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--install=force", "-e", script],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("ok");
+    expect(exitCode).toBe(0);
+  }
+});


### PR DESCRIPTION
Fuzzilli found a use-after-poison in the runtime auto-install path.

`enqueueDependencyToRoot` passed `&lockfile.buffers.dependencies.items[dep_id]` into `enqueueDependencyWithMainAndSuccessFn`. When the manifest for the requested package is already cached (on disk or in memory) but the extracted tarball is not, control reaches `getOrPutResolvedPackageWithFindResult`, which calls `Lockfile.Package.fromNPM`. That grows `buffers.dependencies` via `ensureUnusedCapacity` to make room for the package's own dependencies, reallocating the backing storage. The subsequent `.extract` branch then read `dependency.behavior.isRequired()` from the freed buffer.

```
#0 getOrPutResolvedPackageWithFindResult   PackageManagerEnqueue.zig:1520  dependency.behavior.isRequired()
#1 getOrPutResolvedPackage                 PackageManagerEnqueue.zig:1778
#2 enqueueDependencyWithMainAndSuccessFn   PackageManagerEnqueue.zig:523
#3 enqueueDependencyToRoot                 PackageManagerEnqueue.zig:321
#4 Resolver.enqueueDependencyToResolve     resolver.zig:2356
...
#14 Bun__resolveSync
#15 functionImportMeta__resolveSyncPrivate  (runtime require() path)
```

Two changes:

- `enqueueDependencyToRoot` now copies the `Dependency` to the stack before taking its address, matching every other caller of `enqueueDependencyWithMainAndSuccessFn` (`processDependencyListItem`, `processPeerDependencyList`, etc.).
- The one read that ran after `fromNPM` now uses the `behavior` parameter that was already passed by value, instead of re-dereferencing `dependency`.

Repro (debug/ASAN only): auto-install a package with a warm on-disk manifest but no extracted tarball — `fromNPM` appending even a single dependency forces a realloc of the one-entry buffer. The new test warms the cache, removes the extracted tarballs, and runs `require()` via `-e` so it goes through `Bun__resolveSync` → `enqueueDependencyToRoot`.