### PR TITLE
mock.module: validate callback before running resolver

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -512,11 +512,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                         |
+| Value       | Description                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.               |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
 
 ### `install.frozenLockfile`
 

--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -526,6 +526,12 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return {};
     }
 
+    JSC::JSValue callbackValue = callframe->argument(1);
+    if (!callbackValue.isCell() || !callbackValue.isCallable()) {
+        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a function"_s));
+        return {};
+    }
+
     auto resolveSpecifier = [&]() -> void {
         JSC::SourceOrigin sourceOrigin = callframe->callerSourceOrigin(vm);
         if (sourceOrigin.isNull())
@@ -580,12 +586,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     resolveSpecifier();
     RETURN_IF_EXCEPTION(scope, {});
-
-    JSC::JSValue callbackValue = callframe->argument(1);
-    if (!callbackValue.isCell() || !callbackValue.isCallable()) {
-        scope.throwException(lexicalGlobalObject, JSC::createTypeError(lexicalGlobalObject, "mock(module, fn) requires a function"_s));
-        return {};
-    }
 
     JSC::JSObject* callback = callbackValue.getObject();
 

--- a/test/js/bun/test/mock/mock-module-non-string.test.ts
+++ b/test/js/bun/test/mock/mock-module-non-string.test.ts
@@ -1,4 +1,5 @@
 import { expect, mock, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("mock.module throws TypeError for non-string first argument", () => {
   // @ts-expect-error
@@ -35,4 +36,90 @@ test("mock.module does not crash on specifiers that are not valid npm package na
     expect(() => mock.module(specifier)).toThrow("mock(module, fn) requires a function");
   }
   Bun.gc(true);
+});
+
+test("mock.module throws TypeError without resolving when callback is missing", () => {
+  // The resolver can reach the package-manager auto-install path and reentrantly
+  // tick the JS event loop. When the caller forgets the callback, we must throw
+  // before running the resolver at all.
+  const specifiers = [
+    // valid npm package name — bypasses the isNPMPackageName gate in the resolver
+    "PbQ",
+    "some-package-that-does-not-exist",
+    "@scope/pkg",
+    "function f3() {}",
+    "() => 1",
+  ];
+  for (const specifier of specifiers) {
+    // @ts-expect-error missing callback on purpose
+    expect(() => mock.module(specifier)).toThrow("mock(module, fn) requires a function");
+  }
+  for (const specifier of specifiers) {
+    // @ts-expect-error non-callable second argument on purpose
+    expect(() => mock.module(specifier, 123)).toThrow("mock(module, fn) requires a function");
+  }
+  Bun.gc(true);
+});
+
+test("mock.module does not run the resolver when callback is missing", async () => {
+  // When auto-install is enabled and the specifier is a valid npm package name,
+  // the resolver reaches the package-manager path, reentrantly ticks the JS
+  // event loop, and blocks waiting on the registry. If the callback is missing
+  // we must throw before the resolver runs so none of that happens.
+  let requests = 0;
+  const { promise: gotRequest, resolve: onRequest } = Promise.withResolvers<void>();
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      requests++;
+      onRequest();
+      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+
+  using dir = tempDir("mock-module-no-callback-no-resolve", {
+    "index.js": `
+      const { vi } = Bun.jest();
+      try { vi.mock("PbQ"); } catch (e) { console.error("ERR:", e.message); }
+      try { vi.mock("some-valid-pkg-name-abc123"); } catch (e) { console.error("ERR:", e.message); }
+      Bun.gc(true);
+      console.log("done");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=force", "index.js"],
+    env: {
+      ...bunEnv,
+      BUN_CONFIG_REGISTRY: server.url.href,
+      NPM_CONFIG_REGISTRY: server.url.href,
+      BUN_INSTALL_CACHE_DIR: String(dir) + "/.cache",
+    },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Before the fix, the resolver blocks on the registry and the process never
+  // exits on its own. Race the exit against the first registry request so the
+  // test fails fast (instead of timing out) on a regression.
+  const result = await Promise.race([
+    Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]).then(([stdout, stderr, exitCode]) => ({
+      kind: "exited" as const,
+      stdout,
+      stderr,
+      exitCode,
+    })),
+    gotRequest.then(() => ({ kind: "request" as const })),
+  ]);
+
+  if (result.kind === "request") {
+    proc.kill();
+    throw new Error("mock.module ran the resolver and hit the registry when callback was missing");
+  }
+
+  expect(result.stderr).toContain("mock(module, fn) requires a function");
+  expect(result.stdout).toContain("done");
+  expect(requests).toBe(0);
+  expect(result.exitCode).toBe(0);
 });


### PR DESCRIPTION
## Crash

Fuzzilli hit a flaky use-after-poison (fingerprint `Address:use-after-poison:bun-debug+0x8f2ee1e`) from:

```js
const v3 = Bun.jest().vi;
try { v3.mock("PbQ"); } catch (e) {}
Bun.gc(true);
```

`JSMock__jsModuleMock` runs `resolveSpecifier()` before checking whether the second argument is callable. `"PbQ"` is a valid npm package name, so the `isNPMPackageName` gate added in #29255 lets it through to the auto-install path:

```
PackageManager.enqueueDependencyToRoot
-> PackageManager.sleepUntil
-> EventLoop.tick()      // re-entry while still inside JSMock__jsModuleMock
```

That re-entry (plus the `ResolveMessage` thrown by the failed resolution, whose `referrer` field borrows from a stack-temporary `WTF::String`) leaves the process in a state where a later GC can read freed mimalloc memory. The crash reproduces only under fuzzilli's REPRL with specific prior state, which is why it's flaky.

## Fix

Move the callable check for the second argument in front of `resolveSpecifier()`. When the caller omits the callback (or passes something non-callable), `mock.module` / `vi.mock` throw `TypeError: mock(module, fn) requires a function` without ever entering the resolver — no auto-install, no event-loop re-entry, no `ResolveMessage`.

The observable error is unchanged; only its timing moves earlier.

This is the same reorder as the previously-closed #28946. That PR was closed in favour of #29255, which gated auto-install on `isNPMPackageName`; but valid package names like `"PbQ"` pass that gate, so the 1-arg misuse still reaches the resolver on main today.

## Test

`test/js/bun/test/mock/mock-module-non-string.test.ts` gains two cases:

- A direct assertion that `mock.module(specifier)` / `mock.module(specifier, 123)` throw the expected `TypeError` for several specifiers including valid npm package names.
- A subprocess test that runs `vi.mock("PbQ")` under `--install=force` with a local registry. On main the resolver blocks on the registry (the test races against the first request and fails fast with a clear message); with this change the process throws immediately, makes **zero** registry requests, and exits 0.

```
test/js/bun/test/mock/mock-module-non-string.test.ts:
(pass) mock.module throws TypeError for non-string first argument
(pass) mock.module still works with valid string argument
(pass) mock.module does not crash on specifiers that are not valid npm package names
(pass) mock.module throws TypeError without resolving when callback is missing
(pass) mock.module does not run the resolver when callback is missing
```

Also verified `mock-module.test.ts`, `mock-module-resolve-log.test.ts`, and `resolve-autoinstall-invalid-name.test.ts` still pass.

Fingerprint: `Address:use-after-poison:bun-debug+0x8f2ee1e`