### PR TITLE
Fix Segfaults from JSBundlerPlugin

### DIFF
--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -541,7 +541,7 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, const
                 context,
                 plugin,
                 JSC::JSValue::encode(exception),
-                JSValue::encode(jsNumber(0)));
+                JSValue::encode(jsNumber(1)));
         }
     }
 }
@@ -584,7 +584,7 @@ extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, co
                 context,
                 plugin,
                 JSC::JSValue::encode(exception),
-                JSValue::encode(jsNumber(1)));
+                JSValue::encode(jsNumber(0)));
         }
         return;
     }

--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -539,7 +539,7 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, const
         if (!plugin->plugin.tombstoned) {
             plugin->plugin.addError(
                 context,
-                plugin->plugin.config,
+                plugin,
                 JSC::JSValue::encode(exception),
                 JSValue::encode(jsNumber(0)));
         }


### PR DESCRIPTION
### What does this PR do?

This PR has two commits that each fix an issue related to a segfault I came across while testing the FreeBSD port here: https://github.com/8ff/bun-freebsd/issues/1. 

The first commit fixes the segfault, because a pointer of the incorrect type is being passed (see commit message for details.)

The second fixes a typo, where a 0/1 is flipped by the caller as compared to what the callee expects (see commit message for details.)