### PR TITLE
install: global virtual store for isolated linker (7x faster warm installs)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,5 +10,11 @@ preload = "./test/preload.ts"
 
 [install]
 linker = "isolated"
+# The CI test runner points BUN_INSTALL_CACHE_DIR at a per-call tmpdir and
+# deletes it between the root and test/ installs. With the global store
+# enabled, `node_modules/.bun/<pkg>` is an absolute symlink into that
+# now-deleted cache, so `test/`'s `file:../node_modules/react` dep dangles.
+# The feature is exercised by test/cli/install/isolated-install.test.ts.
+globalStore = false
 minimumReleaseAge = 259200 # three days
 minimumReleaseAgeExcludes = ["typescript"]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -215,6 +215,7 @@
               "/pm/cli/patch",
               "/pm/filter",
               "/pm/global-cache",
+              "/pm/global-store",
               "/pm/isolated-installs",
               "/pm/lockfile",
               "/pm/lifecycle",

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Global virtual store"
-description: "Share isolated package installs across every project on the machine"
+description: "Install packages once. Every project links to the same copy."
 ---
 
-When using the [isolated linker](/pm/isolated-installs), Bun materializes each package's files **once** into a global virtual store under the package cache and symlinks `node_modules/.bun/<package>@<version>` into it. The store is shared across every project on the machine, so once a `(package, version, resolved-dependency-set)` triple has been installed anywhere, every subsequent install — including a fresh `rm -rf node_modules && bun install` — only creates one symlink per package.
+Every project on your machine depends on the same handful of heavy packages — `typescript`, `next`, `webpack`, `@babel/*`, `react-dom`. Without a shared store, every `node_modules` gets its own copy, and every fresh `bun install` writes them all out again.
 
-That makes warm installs roughly **7× faster** and brings each project's `node_modules` from hundreds of megabytes of copied files down to a directory of symlinks. Ten checkouts that would previously hold ten copies of `typescript`, `webpack`, `next`, and friends now hold one copy in the cache plus ten symlinks.
+The global virtual store changes that to **install once, link everywhere**. Package files live in one shared cache; each project's `node_modules` is a thin tree of symlinks into it. A second checkout, a new branch worktree, a CI workspace — they all point at the copy that's already on disk.
+
+The result: warm installs are roughly **7× faster** (one symlink per package instead of copying every file), and `node_modules` shrinks from hundreds of megabytes per project to a few megabytes of links.
 
 ## Enabling
 

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -97,7 +97,6 @@ The on-disk layout adds one level of indirection compared to [isolated installs]
 │   └── ...package files...
 └── links/                                # Global virtual store
     └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>
-        ├── .bun-ok                       # Completeness stamp
         └── node_modules/
             ├── react/                    # Package files (created once)
             ├── loose-envify -> ../../loose-envify@1.4.0-ea24…/node_modules/loose-envify
@@ -148,7 +147,7 @@ Each unique `(package, version, resolved-dependency-set)` triple gets one direct
 
 ### Concurrency
 
-Multiple `bun install` processes (parallel CI jobs, concurrent workspace builds) may race to populate the same global entry. Population is atomic — clone (or hardlink/copy) into a temp sibling, then `rename` into place — and the loser of the rename treats `EEXIST` as success because both writers were producing identical content-addressed bytes. The `.bun-ok` stamp written after dep symlinks and bin links are in place is what future installs check; an entry whose writer crashed mid-build is rebuilt on the next install.
+Multiple `bun install` processes (parallel CI jobs, concurrent workspace builds) may race to populate the same global entry. Each process builds the entire entry — package files, dependency symlinks, bin links — under a private `<entry>.tmp-<random>/` staging directory and renames it into place as the final step. The loser of the rename sees `EEXIST` and discards its identical staging tree; a writer that crashes mid-build leaves only an unreferenced staging directory that the next install ignores. A published entry is therefore always complete; there is no separate completeness sentinel.
 
 ## Related documentation
 

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -9,7 +9,9 @@ This is the same approach pnpm and aube take, applied to Bun's isolated linker.
 
 ## Enabling
 
-The global virtual store is **on by default** with the isolated linker. It is not used by the hoisted linker.
+The global virtual store is **on by default on macOS and Linux** with the isolated linker. It is not used by the hoisted linker.
+
+On Windows it currently defaults to **off**: Bun's module resolver intermittently misclassifies directory dependency symlinks as files when reached through the two-hop `node_modules/.bun/<pkg>` → `<cache>/links/<pkg>-<hash>/` chain, surfacing as `EISDIR` at require time for some packages. The on-disk symlinks are correctly typed; the bug is in resolver classification and is tracked separately. You can opt in with `globalStore = true` (or `BUN_INSTALL_GLOBAL_STORE=1`) if your project doesn't hit it.
 
 ```bash terminal icon="terminal"
 bun install --linker isolated

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -5,6 +5,8 @@ description: "Share isolated package installs across every project on the machin
 
 When using the [isolated linker](/pm/isolated-installs), Bun materializes each package's files **once** into a global virtual store under the package cache and symlinks `node_modules/.bun/<package>@<version>` into it. The store is shared across every project on the machine, so once a `(package, version, resolved-dependency-set)` triple has been installed anywhere, every subsequent install — including a fresh `rm -rf node_modules && bun install` — only creates one symlink per package.
 
+That makes warm installs roughly **7× faster** and brings each project's `node_modules` from hundreds of megabytes of copied files down to a directory of symlinks. Ten checkouts that would previously hold ten copies of `typescript`, `webpack`, `next`, and friends now hold one copy in the cache plus ten symlinks.
+
 ## Enabling
 
 The global virtual store is **on by default** with the isolated linker on every platform. It is not used by the hoisted linker.
@@ -58,6 +60,20 @@ Warm CI install — lockfile present, package cache warm, `node_modules` deleted
 | **`--linker isolated`, global store**    | **124.8 ms** | **94 ms**   | **0**         | **4,957**      |
 
 **6.6× faster** than the same linker without the global store, **6.6× faster** than hoisted.
+
+### Disk
+
+`node_modules` sizes for the same fixture (`du -sh node_modules` on APFS; clonefile copies are copy-on-write, so the hoisted/per-project numbers are the _logical_ size — on filesystems without CoW that is also the physical size):
+
+|                                          | `node_modules` per project | shared on disk |
+| ---------------------------------------- | -------------------------- | -------------- |
+| `--linker hoisted`                       | 391 MB                     | —              |
+| `--linker isolated`, `globalStore=false` | 391 MB                     | —              |
+| **`--linker isolated`, global store**    | **~5 MB of symlinks**      | 391 MB once    |
+
+Clone the same project five times and the difference is ~2 GB of duplicated package files versus ~400 MB total. The break-even is one project; every additional checkout, branch worktree, or CI workspace after that is free.
+
+### Real-world cold→warm
 
 Cold-to-warm timings on cloned real-world repositories (macOS arm64):
 
@@ -126,7 +142,7 @@ Tools that scan `node_modules` without following symlinks, or that compare file 
 
 ### Disk usage
 
-Each unique `(package, version, resolved-dependency-set)` triple gets one directory in `<cache>/links/`. For a typical project this is one entry per package; projects that resolve the same package with different peer-dependency combinations create one entry per combination. Run `bun pm cache rm` to clear the cache including the global store.
+Each unique `(package, version, resolved-dependency-set)` triple gets one directory in `<cache>/links/`. Across many projects that's a large net win — one copy on disk instead of one per checkout — but the store does grow over time as new versions and new peer-dependency combinations land. Run `bun pm cache rm` to clear the cache including the global store; the next install repopulates only what that project needs.
 
 ### Concurrency
 

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -1,15 +1,13 @@
 ---
 title: "Global virtual store"
-description: "Share isolated installs across projects for fast warm CI installs"
+description: "Share isolated package installs across every project on the machine"
 ---
 
-When using the [isolated linker](/pm/isolated-installs), Bun materializes package contents into a **global virtual store** under the package cache and symlinks `node_modules/.bun/<package>@<version>` into it. The virtual store is shared across every project on the machine, so once a package (and its specific resolved dependency set) has been installed anywhere, every subsequent install — including a fresh `rm -rf node_modules && bun install` — only creates one symlink per package instead of copying the package files again.
-
-This is the same approach pnpm and aube take, applied to Bun's isolated linker.
+When using the [isolated linker](/pm/isolated-installs), Bun materializes each package's files **once** into a global virtual store under the package cache and symlinks `node_modules/.bun/<package>@<version>` into it. The store is shared across every project on the machine, so once a `(package, version, resolved-dependency-set)` triple has been installed anywhere, every subsequent install — including a fresh `rm -rf node_modules && bun install` — only creates one symlink per package.
 
 ## Enabling
 
-The global virtual store is **on by default** with the isolated linker. It is not used by the hoisted linker.
+The global virtual store is **on by default** with the isolated linker on every platform. It is not used by the hoisted linker.
 
 ```bash terminal icon="terminal"
 bun install --linker isolated
@@ -22,7 +20,7 @@ To make isolated the default for a project:
 linker = "isolated"
 ```
 
-To disable the global store and fall back to per-project package copies (the previous behavior), set `globalStore = false` or `BUN_INSTALL_GLOBAL_STORE=0`:
+To opt out and fall back to per-project package copies:
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
@@ -36,7 +34,7 @@ BUN_INSTALL_GLOBAL_STORE=0 bun install --linker isolated
 
 ## Why it's fast
 
-The previous isolated linker called `clonefileat()` (macOS) or `link()`/`copyfile()` (other platforms) for every package on every install, even when the cache was warm and `node_modules` was the only thing missing. Profiling a warm install of a 1,400-package fixture on macOS showed the main thread spending **95.4 % of its time inside `clonefileat`**:
+The previous isolated linker called `clonefileat()` (macOS) or `link()`/`copyfile()` (other platforms) for every package on every install, even when the package cache was warm and `node_modules` was the only thing missing. Profiling a warm install of a 1,400-package fixture on macOS showed the main thread spending **95.4 % of its time inside `clonefileat`**:
 
 ```
 Sort by top of stack (bun install --linker isolated, warm cache):
@@ -51,16 +49,25 @@ With the global store, the warm path is one `access()` (does the global entry ex
 
 ## Benchmarks
 
-Warm CI install (lockfile present, package cache warm, `node_modules` deleted between runs) of a [~1,400-package fixture](https://github.com/endevco/aube/blob/main/benchmarks/fixture.package.json) on Apple Silicon macOS, measured with `hyperfine`:
+Warm CI install — lockfile present, package cache warm, `node_modules` deleted between runs — on a 1,400-package React/webpack/Babel/jest fixture, Apple Silicon macOS, `hyperfine --warmup 3 --runs 10`:
 
-|                                        | wall time    | system time | `clonefileat` | total syscalls |
-| -------------------------------------- | ------------ | ----------- | ------------- | -------------- |
-| `--linker hoisted`                     | 823.9 ms     | 477 ms      | 1,387         | 7,857          |
-| `--linker isolated` (no global store)  | 840.9 ms     | 1,256 ms    | 1,387         | —              |
-| **`--linker isolated` (global store)** | **115.7 ms** | **95 ms**   | **0**         | **4,957**      |
-| aube 1.0.0-beta.5                      | 195.8 ms     | 913 ms      | 0             | 31,445         |
+|                                          | wall time    | system time | `clonefileat` | total syscalls |
+| ---------------------------------------- | ------------ | ----------- | ------------- | -------------- |
+| `--linker hoisted`                       | 823.9 ms     | 477 ms      | 1,387         | 7,857          |
+| `--linker isolated`, `globalStore=false` | 840.9 ms     | 1,256 ms    | 1,387         | —              |
+| **`--linker isolated`, global store**    | **124.8 ms** | **94 ms**   | **0**         | **4,957**      |
 
-The global store is **7.1× faster** than the previous isolated linker on this workload and about **1.7× faster** than aube while issuing roughly **6× fewer syscalls** (Bun's lockfile already carries the package metadata aube has to re-read from disk).
+**6.6× faster** than the same linker without the global store, **6.6× faster** than hoisted.
+
+Cold-to-warm timings on cloned real-world repositories (macOS arm64):
+
+| project                        | packages | cold   | warm       |
+| ------------------------------ | -------- | ------ | ---------- |
+| cal.com                        | ~3,580   | 37.4 s | **4.7 s**  |
+| remix                          | ~1,750   | 23.1 s | **2.0 s**  |
+| excalidraw                     | ~1,332   | 5.9 s  | **1.1 s**  |
+| hono                           | ~790     | 4.5 s  | **1.3 s**  |
+| `next build` (create-next-app) | ~382     | 1.0 s  | **0.35 s** |
 
 ## Directory structure
 
@@ -72,8 +79,9 @@ The on-disk layout adds one level of indirection compared to [isolated installs]
 │   └── ...package files...
 └── links/                                # Global virtual store
     └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>
+        ├── .bun-ok                       # Completeness stamp
         └── node_modules/
-            ├── react/                    # clonefile from cache (created once)
+            ├── react/                    # Package files (created once)
             ├── loose-envify -> ../../loose-envify@1.4.0-ea24…/node_modules/loose-envify
             └── .bin/
                 └── ...
@@ -86,34 +94,33 @@ project/node_modules/
 └── react -> .bun/react@18.3.1/node_modules/react
 ```
 
-The 16-hex `entry_hash` suffix encodes the entry's **resolved dependency closure**: the package's own store path plus the hash of every dependency it links to. Two projects that resolve `react@18.3.1` to the same set of transitive versions share one global directory; a project that resolves a transitive dependency to a different version gets a separate global entry whose dep symlinks point at the right siblings. The hash is stable across installs and machines for the same lockfile.
+The 16-hex `entry_hash` suffix encodes the entry's **resolved dependency closure**: the package's own store path and tarball integrity, plus the hash of every dependency it links to. Two projects that resolve `react@18.3.1` to the same set of transitive versions share one global directory; a project that resolves a transitive dependency to a different version gets a separate global entry whose dep symlinks point at the right siblings. Packages that participate in a dependency cycle share one hash computed over the whole strongly-connected component, so the key is independent of which member a given project's dependency graph happened to reach first.
 
 ## What stays project-local
 
-An entry only lives in the global store when it can be safely shared across projects. Entries fall back to a per-project `node_modules/.bun/<storepath>/` directory (the previous behavior) when:
+An entry only lives in the global store when it can be safely shared. Entries fall back to a per-project `node_modules/.bun/<storepath>/` directory when:
 
 - the package has a **patch** applied via `bun patch` — the patched contents are project-specific;
-- the package has a **trusted lifecycle script** (`preinstall`/`install`/`postinstall`) and scripts are enabled — the script may mutate the install directory;
+- the package is listed in **`trustedDependencies`** (or trusted via `bun add --trust`) — its lifecycle script may mutate the install directory, and a script running through the project symlink would mutate the shared copy;
 - the package, or **any** dependency it links to, is a `workspace:`, `file:`, or `link:` dependency — those resolve to project-local paths that other projects can't see.
 
-The eligibility check propagates upward: if `your-app` depends on `internal-utils` which is a workspace package, `internal-utils` is project-local, and so is every entry that links to it.
+Ineligibility propagates: if `your-app` depends on `internal-utils` which is a workspace package, `internal-utils` is project-local, and so is every entry that links to it. An entry that loses eligibility between installs (newly patched, newly trusted) is detached from the global store and rebuilt project-locally on the next install; the shared entry is left untouched.
+
+## Peer dependencies
+
+Resolved peer dependencies — required and optional — are folded into each global entry as dep symlinks and contribute to its hash. Bun synthesizes an implicit `"*"` optional peer for packages that list a name only in `peerDependenciesMeta` without a matching `peerDependencies` entry (matching pnpm and yarn), so a package like `webpack` that declares `webpack-cli` only in `peerDependenciesMeta` still gets a `webpack-cli` symlink in its global entry when one is installed in the project.
 
 ## Tradeoffs
 
 ### Phantom-dependency fallback
 
-Declared optional peer dependencies (listed in `peerDependencies` with `"optional": true` in `peerDependenciesMeta`) are resolved into each global entry and included in its hash, so they work the same as before.
+When packages live under the project's `node_modules/.bun/`, Node's module resolution walks up through `node_modules/.bun/node_modules/` — the hidden hoisted layer — before reaching the project root. With the global store, packages realpath into `<cache>/links/`, so that layer is no longer on the resolution path from inside a package.
 
-What does change: when a package's files live in the project's `node_modules/.bun/`, Node's module resolution walks up through `node_modules/.bun/node_modules/` — the hidden hoisted layer — before reaching the project root. A small number of packages rely on that fallback to load helpers they never declared as a dependency at all (for example, `webpack/bin/webpack.js` opportunistically does `require('webpack-cli')`; `webpack-cli` appears only in `peerDependenciesMeta`, not `peerDependencies`, so there is no dependency edge to follow).
+In practice this only affects **true phantom dependencies**: a package doing `require('helper')` for something it never declared in `dependencies`, `peerDependencies`, or `peerDependenciesMeta`. If you hit this, add the helper to the consuming package's dependencies (the right fix) or set `globalStore = false`.
 
-With the global store, packages realpath into `<cache>/links/`, so the project's hidden hoisted layer is no longer on the resolution path. Packages that depended on this fallback will fail to resolve their phantom dependency. This matches pnpm and aube. If you hit this:
+Note that [`publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) and [`hoistPattern`](/runtime/bunfig#install-hoistpattern) hoist into the project's `node_modules`, which packages inside the global store can't reach. They still work for resolving hoisted packages from your own source code.
 
-- add the helper to your project's `dependencies` so it becomes a declared dependency of the project (most ecosystems already do this);
-- or set `globalStore = false` for the project.
-
-Note that [`publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) and [`hoistPattern`](/runtime/bunfig#install-hoistpattern) hoist into the _project's_ `node_modules`, which packages inside the global store can't reach (Node walks up from the realpath under `<cache>/links/`, not from the project). They still work for resolving hoisted packages from your own source code.
-
-### `node_modules` is now mostly symlinks
+### `node_modules` is mostly symlinks
 
 Tools that scan `node_modules` without following symlinks, or that compare file paths by string equality, may behave differently. This is the same caveat as any pnpm-style layout.
 
@@ -123,7 +130,7 @@ Each unique `(package, version, resolved-dependency-set)` triple gets one direct
 
 ### Concurrency
 
-Multiple `bun install` processes (parallel CI jobs, concurrent workspace builds) may race to populate the same global entry. Bun treats `EEXIST` from the loser as success because the directory is content-addressed — both writers were producing identical bytes.
+Multiple `bun install` processes (parallel CI jobs, concurrent workspace builds) may race to populate the same global entry. Population is atomic — clone (or hardlink/copy) into a temp sibling, then `rename` into place — and the loser of the rename treats `EEXIST` as success because both writers were producing identical content-addressed bytes. The `.bun-ok` stamp written after dep symlinks and bin links are in place is what future installs check; an entry whose writer crashed mid-build is rebuilt on the next install.
 
 ## Related documentation
 

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -9,9 +9,7 @@ This is the same approach pnpm and aube take, applied to Bun's isolated linker.
 
 ## Enabling
 
-The global virtual store is **on by default on macOS and Linux** with the isolated linker. It is not used by the hoisted linker.
-
-On Windows it currently defaults to **off**: Bun's module resolver intermittently misclassifies directory dependency symlinks as files when reached through the two-hop `node_modules/.bun/<pkg>` → `<cache>/links/<pkg>-<hash>/` chain, surfacing as `EISDIR` at require time for some packages. The on-disk symlinks are correctly typed; the bug is in resolver classification and is tracked separately. You can opt in with `globalStore = true` (or `BUN_INSTALL_GLOBAL_STORE=1`) if your project doesn't hit it.
+The global virtual store is **on by default** with the isolated linker. It is not used by the hoisted linker.
 
 ```bash terminal icon="terminal"
 bun install --linker isolated

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -1,0 +1,132 @@
+---
+title: "Global virtual store"
+description: "Share isolated installs across projects for fast warm CI installs"
+---
+
+When using the [isolated linker](/pm/isolated-installs), Bun materializes package contents into a **global virtual store** under the package cache and symlinks `node_modules/.bun/<package>@<version>` into it. The virtual store is shared across every project on the machine, so once a package (and its specific resolved dependency set) has been installed anywhere, every subsequent install — including a fresh `rm -rf node_modules && bun install` — only creates one symlink per package instead of copying the package files again.
+
+This is the same approach pnpm and aube take, applied to Bun's isolated linker.
+
+## Enabling
+
+The global virtual store is **on by default** with the isolated linker. It is not used by the hoisted linker.
+
+```bash terminal icon="terminal"
+bun install --linker isolated
+```
+
+To make isolated the default for a project:
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+linker = "isolated"
+```
+
+To disable the global store and fall back to per-project package copies (the previous behavior), set `globalStore = false` or `BUN_INSTALL_GLOBAL_STORE=0`:
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+linker = "isolated"
+globalStore = false
+```
+
+```bash terminal icon="terminal"
+BUN_INSTALL_GLOBAL_STORE=0 bun install --linker isolated
+```
+
+## Why it's fast
+
+The previous isolated linker called `clonefileat()` (macOS) or `link()`/`copyfile()` (other platforms) for every package on every install, even when the cache was warm and `node_modules` was the only thing missing. Profiling a warm install of a 1,400-package fixture on macOS showed the main thread spending **95.4 % of its time inside `clonefileat`**:
+
+```
+Sort by top of stack (bun install --linker isolated, warm cache):
+    clonefileat        891 / 934 samples
+    __openat            15
+    __read_nocancel     10
+```
+
+`clonefileat` on APFS holds a volume-wide kernel lock, so spreading the work across more threads barely helps — eight threads only improved a 2,830-directory clone from 959 ms to 743 ms. The fix is to not call it at all on the warm path.
+
+With the global store, the warm path is one `access()` (does the global entry exist?) plus one `symlink()` (point the project at it) per package.
+
+## Benchmarks
+
+Warm CI install (lockfile present, package cache warm, `node_modules` deleted between runs) of a [~1,400-package fixture](https://github.com/endevco/aube/blob/main/benchmarks/fixture.package.json) on Apple Silicon macOS, measured with `hyperfine`:
+
+|                                        | wall time    | system time | `clonefileat` | total syscalls |
+| -------------------------------------- | ------------ | ----------- | ------------- | -------------- |
+| `--linker hoisted`                     | 823.9 ms     | 477 ms      | 1,387         | 7,857          |
+| `--linker isolated` (no global store)  | 840.9 ms     | 1,256 ms    | 1,387         | —              |
+| **`--linker isolated` (global store)** | **115.7 ms** | **95 ms**   | **0**         | **4,957**      |
+| aube 1.0.0-beta.5                      | 195.8 ms     | 913 ms      | 0             | 31,445         |
+
+The global store is **7.1× faster** than the previous isolated linker on this workload and about **1.7× faster** than aube while issuing roughly **6× fewer syscalls** (Bun's lockfile already carries the package metadata aube has to re-read from disk).
+
+## Directory structure
+
+The on-disk layout adds one level of indirection compared to [isolated installs](/pm/isolated-installs#directory-structure):
+
+```bash tree layout icon="list-tree"
+~/.bun/install/cache/
+├── react@18.3.1@@@1/                     # Package cache (unchanged)
+│   └── ...package files...
+└── links/                                # Global virtual store
+    └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>
+        └── node_modules/
+            ├── react/                    # clonefile from cache (created once)
+            ├── loose-envify -> ../../loose-envify@1.4.0-ea24…/node_modules/loose-envify
+            └── .bin/
+                └── ...
+
+project/node_modules/
+├── .bun/
+│   ├── node_modules/                     # Hidden hoisted layer (per project)
+│   │   └── react -> ../react@18.3.1/node_modules/react
+│   └── react@18.3.1 -> ~/.bun/install/cache/links/react@18.3.1-5664d3cd670b3205
+└── react -> .bun/react@18.3.1/node_modules/react
+```
+
+The 16-hex `entry_hash` suffix encodes the entry's **resolved dependency closure**: the package's own store path plus the hash of every dependency it links to. Two projects that resolve `react@18.3.1` to the same set of transitive versions share one global directory; a project that resolves a transitive dependency to a different version gets a separate global entry whose dep symlinks point at the right siblings. The hash is stable across installs and machines for the same lockfile.
+
+## What stays project-local
+
+An entry only lives in the global store when it can be safely shared across projects. Entries fall back to a per-project `node_modules/.bun/<storepath>/` directory (the previous behavior) when:
+
+- the package has a **patch** applied via `bun patch` — the patched contents are project-specific;
+- the package has a **trusted lifecycle script** (`preinstall`/`install`/`postinstall`) and scripts are enabled — the script may mutate the install directory;
+- the package, or **any** dependency it links to, is a `workspace:`, `file:`, or `link:` dependency — those resolve to project-local paths that other projects can't see.
+
+The eligibility check propagates upward: if `your-app` depends on `internal-utils` which is a workspace package, `internal-utils` is project-local, and so is every entry that links to it.
+
+## Tradeoffs
+
+### Phantom-dependency fallback
+
+Declared optional peer dependencies (listed in `peerDependencies` with `"optional": true` in `peerDependenciesMeta`) are resolved into each global entry and included in its hash, so they work the same as before.
+
+What does change: when a package's files live in the project's `node_modules/.bun/`, Node's module resolution walks up through `node_modules/.bun/node_modules/` — the hidden hoisted layer — before reaching the project root. A small number of packages rely on that fallback to load helpers they never declared as a dependency at all (for example, `webpack/bin/webpack.js` opportunistically does `require('webpack-cli')`; `webpack-cli` appears only in `peerDependenciesMeta`, not `peerDependencies`, so there is no dependency edge to follow).
+
+With the global store, packages realpath into `<cache>/links/`, so the project's hidden hoisted layer is no longer on the resolution path. Packages that depended on this fallback will fail to resolve their phantom dependency. This matches pnpm and aube. If you hit this:
+
+- add the helper to your project's `dependencies` so it becomes a declared dependency of the project (most ecosystems already do this);
+- or set `globalStore = false` for the project.
+
+Note that [`publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) and [`hoistPattern`](/runtime/bunfig#install-hoistpattern) hoist into the _project's_ `node_modules`, which packages inside the global store can't reach (Node walks up from the realpath under `<cache>/links/`, not from the project). They still work for resolving hoisted packages from your own source code.
+
+### `node_modules` is now mostly symlinks
+
+Tools that scan `node_modules` without following symlinks, or that compare file paths by string equality, may behave differently. This is the same caveat as any pnpm-style layout.
+
+### Disk usage
+
+Each unique `(package, version, resolved-dependency-set)` triple gets one directory in `<cache>/links/`. For a typical project this is one entry per package; projects that resolve the same package with different peer-dependency combinations create one entry per combination. Run `bun pm cache rm` to clear the cache including the global store.
+
+### Concurrency
+
+Multiple `bun install` processes (parallel CI jobs, concurrent workspace builds) may race to populate the same global entry. Bun treats `EEXIST` from the loser as success because the directory is content-addressed — both writers were producing identical bytes.
+
+## Related documentation
+
+- [Package manager > Isolated installs](/pm/isolated-installs) — The linker the global store builds on
+- [Package manager > Global cache](/pm/global-cache) — Where downloaded packages are stored
+- [Runtime > bunfig](/runtime/bunfig#install-globalstore) — `bunfig.toml` reference

--- a/docs/pm/isolated-installs.mdx
+++ b/docs/pm/isolated-installs.mdx
@@ -122,9 +122,13 @@ node_modules/.bun/package@1.0.0_react@18.2.0/
 
 The directory name encodes both the package version and its peer dependency versions, ensuring each unique combination gets its own installation.
 
+### Global virtual store
+
+By default, store entries are materialized once into a [global virtual store](/pm/global-store) at `<cache>/links/` and `node_modules/.bun/<pkg>@<ver>` is a symlink into it. Warm installs after `rm -rf node_modules` only create one symlink per package instead of copying every package's files again, which is roughly **7× faster** on a typical mid-size project. See the [global store docs](/pm/global-store) for the full layout, benchmarks, and tradeoffs.
+
 ### Backend strategies
 
-Bun uses different file operation strategies for performance:
+When an entry isn't eligible for the global store (or the global store is disabled), Bun materializes it under the project using one of:
 
 - **Clonefile** (macOS) — Copy-on-write filesystem clones for maximum efficiency
 - **Hardlink** (Linux/Windows) — Hardlinks to save disk space

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -671,7 +671,7 @@ Valid values are:
 
 ### `install.globalStore`
 
-When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
+When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true` on macOS and Linux, `false` on Windows (see [the global store docs](/pm/global-store#enabling) for why). Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
 
 For complete documentation refer to [Package manager > Global virtual store](/pm/global-store).
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -669,6 +669,17 @@ Valid values are:
 | `"hoisted"`  | Link dependencies in a shared `node_modules` directory. |
 | `"isolated"` | Link dependencies inside each package installation.     |
 
+### `install.globalStore`
+
+When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
+
+For complete documentation refer to [Package manager > Global virtual store](/pm/global-store).
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+globalStore = false
+```
+
 ### `install.publicHoistPattern`
 
 When using the `"isolated"` linker, packages matching these glob patterns are hoisted to the root `node_modules` directory so they can be resolved by any package in the project. Default `[]`. Similar to pnpm's `public-hoist-pattern`.

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -671,7 +671,7 @@ Valid values are:
 
 ### `install.globalStore`
 
-When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true` on macOS and Linux, `false` on Windows (see [the global store docs](/pm/global-store#enabling) for why). Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
+When using the `"isolated"` linker, share package installations across projects in a global virtual store at `<cache>/links/` and link `node_modules/.bun/<pkg>@<ver>` into it instead of materializing each package into the project. Makes warm installs after `rm -rf node_modules` an order of magnitude faster. Default `true`. Can also be set with the `BUN_INSTALL_GLOBAL_STORE` environment variable.
 
 For complete documentation refer to [Package manager > Global virtual store](/pm/global-store).
 

--- a/src/api/schema.zig
+++ b/src/api/schema.zig
@@ -3068,6 +3068,8 @@ pub const api = struct {
 
         node_linker: ?bun.install.PackageManager.Options.NodeLinker = null,
 
+        global_store: ?bool = null,
+
         security_scanner: ?[]const u8 = null,
 
         minimum_release_age_ms: ?f64 = null,

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -661,6 +661,12 @@ pub const Bunfig = struct {
                         }
                     }
 
+                    if (install_obj.get("globalStore")) |global_store_expr| {
+                        if (global_store_expr.asBool()) |global_store| {
+                            install.global_store = global_store;
+                        }
+                    }
+
                     if (install_obj.get("lockfile")) |lockfile_expr| {
                         if (lockfile_expr.get("print")) |lockfile| {
                             try this.expectString(lockfile);

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -1380,46 +1380,70 @@ pub const FileSystem = struct {
             outpath[entry_path.len + 1] = 0;
             outpath[entry_path.len] = 0;
 
-            var absolute_path_c: [:0]const u8 = outpath[0..entry_path.len :0];
+            const absolute_path_c: [:0]const u8 = outpath[0..entry_path.len :0];
 
             if (comptime bun.Environment.isWindows) {
-                var file = bun.sys.getFileAttributes(absolute_path_c) orelse return error.FileNotFound;
-                var depth: usize = 0;
-                const buf2: *bun.PathBuffer = bun.path_buffer_pool.get();
+                const file = bun.sys.getFileAttributes(absolute_path_c) orelse return error.FileNotFound;
+                // A Windows reparse point carries FILE_ATTRIBUTE_DIRECTORY iff
+                // the link is a directory link (junctions always do; symlinks
+                // do iff created with SYMBOLIC_LINK_FLAG_DIRECTORY; AppExec
+                // links and file symlinks don't), so this is already the
+                // correct `Entry.Kind` without following the chain.
+                cache.kind = if (file.is_directory) .dir else .file;
+                if (!file.is_reparse_point) return cache;
+
+                // For the realpath, open the path and let the kernel follow
+                // every hop, then `GetFinalPathNameByHandle` (same as libuv's
+                // `uv_fs_realpath`). The previous manual readlink+join loop
+                // resolved relative targets against `dirname(absolute_path_c)`,
+                // but that path may itself contain unresolved intermediate
+                // symlinks (e.g. with the isolated linker's global virtual
+                // store, `node_modules/.bun/<pkg>` is a symlink into
+                // `<cache>/links/`, and the dep symlinks inside point at
+                // siblings via `..\..\<dep>-<hash>`). Windows resolves
+                // relative reparse targets against the *real* parent, so the
+                // join landed in the project-side `.bun/` instead of
+                // `<cache>/links/`, the re-stat returned FileNotFound, the
+                // error was swallowed at `Entry.kind`, and a directory symlink
+                // was permanently misclassified as `.file` — surfacing as
+                // EISDIR at module load time.
+                const w = std.os.windows;
+                const wbuf = bun.w_path_buffer_pool.get();
+                defer bun.w_path_buffer_pool.put(wbuf);
+                const wpath = bun.strings.toKernel32Path(wbuf, absolute_path_c);
+                const handle = w.kernel32.CreateFileW(
+                    wpath.ptr,
+                    0,
+                    w.FILE_SHARE_READ | w.FILE_SHARE_WRITE | w.FILE_SHARE_DELETE,
+                    null,
+                    w.OPEN_EXISTING,
+                    // FILE_FLAG_BACKUP_SEMANTICS lets us open directories;
+                    // omitting FILE_FLAG_OPEN_REPARSE_POINT makes Windows
+                    // follow the full reparse chain to the final target.
+                    w.FILE_FLAG_BACKUP_SEMANTICS,
+                    null,
+                );
+                // Dangling link / loop / EACCES: `cache.kind` is already set
+                // from the link's own directory bit, which is correct for all
+                // of those. `Entry.kind`/`Entry.symlink` swallow errors and
+                // fall back to the `.file` placeholder anyway, so returning
+                // the half-populated cache is strictly better than `try`.
+                // Empty `cache.symlink` makes the resolver fall back to
+                // `parent.abs_real_path + base`.
+                if (handle == w.INVALID_HANDLE_VALUE) return cache;
+                defer _ = bun.windows.CloseHandle(handle);
+
+                var info: w.BY_HANDLE_FILE_INFORMATION = undefined;
+                if (bun.windows.GetFileInformationByHandle(handle, &info) != 0) {
+                    cache.kind = if (info.dwFileAttributes & w.FILE_ATTRIBUTE_DIRECTORY != 0) .dir else .file;
+                }
+
+                const buf2 = bun.path_buffer_pool.get();
                 defer bun.path_buffer_pool.put(buf2);
-                const buf3: *bun.PathBuffer = bun.path_buffer_pool.get();
-                defer bun.path_buffer_pool.put(buf3);
-
-                var current_buf: *bun.PathBuffer = buf2;
-                var other_buf: *bun.PathBuffer = &outpath;
-                var joining_buf: *bun.PathBuffer = buf3;
-
-                while (file.is_reparse_point) : (depth += 1) {
-                    var read: [:0]const u8 = try bun.sys.readlink(absolute_path_c, current_buf).unwrap();
-                    if (std.fs.path.isAbsolute(read)) {
-                        std.mem.swap(*bun.PathBuffer, &current_buf, &other_buf);
-                    } else {
-                        read = bun.path.joinAbsStringBufZ(std.fs.path.dirname(absolute_path_c) orelse absolute_path_c, joining_buf, &.{read}, .windows);
-                        std.mem.swap(*bun.PathBuffer, &joining_buf, &other_buf);
-                    }
-                    file = bun.sys.getFileAttributes(read) orelse return error.FileNotFound;
-                    absolute_path_c = read;
-
-                    if (depth > 20) {
-                        return error.TooManySymlinks;
-                    }
+                switch (bun.sys.getFdPath(.fromNative(handle), buf2)) {
+                    .result => |real| cache.symlink = PathString.init(try FilenameStore.instance.append([]const u8, real)),
+                    .err => {},
                 }
-
-                if (depth > 0) {
-                    cache.symlink = PathString.init(try FilenameStore.instance.append([]const u8, absolute_path_c));
-                }
-
-                if (file.is_directory) {
-                    cache.kind = .dir;
-                } else {
-                    cache.kind = .file;
-                }
-
                 return cache;
             }
 

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -745,7 +745,14 @@ pub const Enable = packed struct(u16) {
     /// `<cache>/links/` directory and symlink `node_modules/.bun/<pkg>` into
     /// it, instead of clonefiling every package into every project on every
     /// install. Set BUN_INSTALL_GLOBAL_STORE=0 to disable.
-    global_virtual_store: bool = true,
+    ///
+    /// Off by default on Windows: bun's resolver intermittently misclassifies
+    /// directory dep symlinks as files when reached through the two-hop
+    /// `node_modules/.bun/<pkg>` → `<cache>/links/<pkg>-<hash>/` chain
+    /// (EISDIR on `ReadFile` of the resolved directory). The symlinks
+    /// themselves are correctly typed; the bug is in the Windows directory-
+    /// enumeration classification, not in install. Tracked separately.
+    global_virtual_store: bool = !bun.Environment.isWindows,
     _: u6 = 0,
 };
 

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -394,6 +394,10 @@ pub fn load(
         this.explicit_global_directory = config.global_dir orelse this.explicit_global_directory;
     }
 
+    if (env.get("BUN_INSTALL_GLOBAL_STORE")) |val| {
+        this.enable.global_virtual_store = !strings.eqlComptime(val, "0");
+    }
+
     const default_disable_progress_bar: bool = brk: {
         if (env.get("BUN_INSTALL_PROGRESS")) |prog| {
             break :brk strings.eqlComptime(prog, "0");
@@ -733,7 +737,12 @@ pub const Enable = packed struct(u16) {
 
     exact_versions: bool = false,
     only_missing: bool = false,
-    _: u7 = 0,
+    /// Isolated linker only: materialize package entries once into a shared
+    /// `<cache>/links/` directory and symlink `node_modules/.bun/<pkg>` into
+    /// it, instead of clonefiling every package into every project on every
+    /// install. Set BUN_INSTALL_GLOBAL_STORE=0 to disable.
+    global_virtual_store: bool = true,
+    _: u6 = 0,
 };
 
 const string = []const u8;

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -745,14 +745,7 @@ pub const Enable = packed struct(u16) {
     /// `<cache>/links/` directory and symlink `node_modules/.bun/<pkg>` into
     /// it, instead of clonefiling every package into every project on every
     /// install. Set BUN_INSTALL_GLOBAL_STORE=0 to disable.
-    ///
-    /// Off by default on Windows: bun's resolver intermittently misclassifies
-    /// directory dep symlinks as files when reached through the two-hop
-    /// `node_modules/.bun/<pkg>` → `<cache>/links/<pkg>-<hash>/` chain
-    /// (EISDIR on `ReadFile` of the resolved directory). The symlinks
-    /// themselves are correctly typed; the bug is in the Windows directory-
-    /// enumeration classification, not in install. Tracked separately.
-    global_virtual_store: bool = !bun.Environment.isWindows,
+    global_virtual_store: bool = true,
     _: u6 = 0,
 };
 

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -291,6 +291,10 @@ pub fn load(
             this.node_linker = node_linker;
         }
 
+        if (config.global_store) |global_store| {
+            this.enable.global_virtual_store = global_store;
+        }
+
         if (config.security_scanner) |security_scanner| {
             this.security_scanner = security_scanner;
             this.do.prefetch_resolved_tarballs = false;

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -740,10 +740,12 @@ pub fn preparePatch(manager: *PackageManager) !void {
 fn detachModuleFolderFromSharedStore(module_folder: []const u8) void {
     var path: bun.Path(.{ .sep = .auto }) = .from(module_folder);
     defer path.deinit();
-    var components: usize = 0;
-    {
-        var it = bun.strings.split(module_folder, std.fs.path.sep_str);
-        while (it.next()) |_| components += 1;
+    // `module_folder` is normalised to forward slashes on every platform
+    // before reaching here (see `pathToPosixBuf` in `preparePatch`); count
+    // either separator so the walk covers the full depth on Windows too.
+    var components: usize = 1;
+    for (module_folder) |c| {
+        if (c == '/' or c == '\\') components += 1;
     }
     var depth: usize = 0;
     while (depth < components) : (depth += 1) {

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -766,13 +766,23 @@ fn detachModuleFolderFromSharedStore(module_folder: []const u8) void {
             return;
         if (is_symlink) {
             // Windows directory symlinks/junctions are removed with rmdir,
-            // file symlinks with unlink; on POSIX unlink covers both.
-            if (comptime Environment.isWindows) {
+            // file symlinks with unlink; on POSIX unlink covers both. If
+            // removal fails the symlink is still live, and the caller's
+            // `deleteTree` + `FileCopier` would follow it into the shared
+            // global-store entry — so fail loudly here rather than silently
+            // corrupting the cache.
+            const remove_err: ?bun.sys.Error = if (comptime Environment.isWindows) remove: {
                 if (bun.sys.rmdir(path.sliceZ()).asErr()) |_| {
-                    _ = bun.sys.unlink(path.sliceZ());
+                    if (bun.sys.unlink(path.sliceZ()).asErr()) |e| break :remove if (e.getErrno() == .NOENT) null else e;
                 }
-            } else {
-                _ = bun.sys.unlink(path.sliceZ());
+                break :remove null;
+            } else if (bun.sys.unlink(path.sliceZ()).asErr()) |e|
+                if (e.getErrno() == .NOENT) null else e
+            else
+                null;
+            if (remove_err) |e| {
+                Output.err(e, "failed to detach <b>{s}<r> from the shared package store; refusing to patch through it", .{path.slice()});
+                Global.crash();
             }
             // Re-create the now-missing path segments below the removed
             // symlink so `module_folder`'s parent exists for the copy.

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -706,6 +706,17 @@ pub fn preparePatch(manager: *PackageManager) !void {
     // meaning that changes to the folder will also change the package in the cache.
     //
     // So we will overwrite the folder by directly copying the package in cache into it
+    //
+    // With the isolated linker's global virtual store, `module_folder` is
+    // reached *through* a `node_modules/.bun/<storepath>` symlink that points
+    // into `<cache>/links/`. `deleteTree(module_folder)` would follow that
+    // symlink and wipe the shared global entry (and its dep symlinks)
+    // underneath every other project, then FileCopier would write the user's
+    // edits into the shared cache. Detach first: walk up `module_folder` to
+    // find the first symlink ancestor, replace it with a real directory, and
+    // recreate the path below it so the copy lands in a project-local tree.
+    detachModuleFolderFromSharedStore(module_folder);
+
     overwritePackageInNodeModulesFolder(cache_dir, cache_dir_subpath, module_folder) catch |e| {
         Output.prettyError(
             "<r><red>error<r>: error overwriting folder in node_modules: {s}\n<r>",
@@ -724,6 +735,44 @@ pub fn preparePatch(manager: *PackageManager) !void {
     }
 
     return;
+}
+
+fn detachModuleFolderFromSharedStore(module_folder: []const u8) void {
+    var path: bun.Path(.{ .sep = .auto }) = .from(module_folder);
+    defer path.deinit();
+    var components: usize = 0;
+    {
+        var it = bun.strings.split(module_folder, std.fs.path.sep_str);
+        while (it.next()) |_| components += 1;
+    }
+    var depth: usize = 0;
+    while (depth < components) : (depth += 1) {
+        const is_symlink = if (comptime Environment.isWindows)
+            (bun.sys.getFileAttributes(path.sliceZ()) orelse return).is_reparse_point
+        else if (bun.sys.lstat(path.sliceZ()).asValue()) |st|
+            std.posix.S.ISLNK(@intCast(st.mode))
+        else
+            return;
+        if (is_symlink) {
+            // Windows directory symlinks/junctions are removed with rmdir,
+            // file symlinks with unlink; on POSIX unlink covers both.
+            if (comptime Environment.isWindows) {
+                if (bun.sys.rmdir(path.sliceZ()).asErr()) |_| {
+                    _ = bun.sys.unlink(path.sliceZ());
+                }
+            } else {
+                _ = bun.sys.unlink(path.sliceZ());
+            }
+            // Re-create the now-missing path segments below the removed
+            // symlink so `module_folder`'s parent exists for the copy.
+            const parent = bun.path.dirname(module_folder, .auto);
+            if (parent.len > 0) {
+                FD.cwd().makePath(u8, parent) catch {};
+            }
+            return;
+        }
+        path.undo(1);
+    }
 }
 
 fn overwritePackageInNodeModulesFolder(

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -738,14 +738,23 @@ pub fn preparePatch(manager: *PackageManager) !void {
 }
 
 fn detachModuleFolderFromSharedStore(module_folder: []const u8) void {
-    var path: bun.Path(.{ .sep = .auto }) = .from(module_folder);
+    // `module_folder` reaches here normalised to forward slashes on every
+    // platform (see `pathToPosixBuf` in `preparePatch`). Re-normalise to the
+    // platform separator so `undo()`/`basename()` walk the path correctly on
+    // Windows and the lstat/getFileAttributes calls below see a native path.
+    var native_buf: bun.PathBuffer = undefined;
+    const native = if (comptime Environment.isWindows) native: {
+        @memcpy(native_buf[0..module_folder.len], module_folder);
+        const slice = native_buf[0..module_folder.len];
+        bun.path.posixToPlatformInPlace(u8, slice);
+        break :native slice;
+    } else module_folder;
+
+    var path: bun.Path(.{ .sep = .auto }) = .from(native);
     defer path.deinit();
-    // `module_folder` is normalised to forward slashes on every platform
-    // before reaching here (see `pathToPosixBuf` in `preparePatch`); count
-    // either separator so the walk covers the full depth on Windows too.
     var components: usize = 1;
-    for (module_folder) |c| {
-        if (c == '/' or c == '\\') components += 1;
+    for (native) |c| {
+        if (c == std.fs.path.sep) components += 1;
     }
     var depth: usize = 0;
     while (depth < components) : (depth += 1) {
@@ -767,7 +776,7 @@ fn detachModuleFolderFromSharedStore(module_folder: []const u8) void {
             }
             // Re-create the now-missing path segments below the removed
             // symlink so `module_folder`'s parent exists for the copy.
-            const parent = bun.path.dirname(module_folder, .auto);
+            const parent = bun.path.dirname(native, .auto);
             if (parent.len > 0) {
                 FD.cwd().makePath(u8, parent) catch {};
             }

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -733,7 +733,7 @@ fn overwritePackageInNodeModulesFolder(
 ) !void {
     FD.cwd().deleteTree(node_modules_folder_path) catch {};
 
-    var dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }) = .from(node_modules_folder_path);
+    var dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }) = .from(node_modules_folder_path);
     defer dest_subpath.deinit();
 
     const src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = src_path: {

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -827,12 +827,7 @@ pub const Bin = extern struct {
 
                         switch (bun.sys.symlinkRunningExecutable(rel_target, abs_dest)) {
                             .err => |real_error| {
-                                // EEXIST after we just created `.bin/` means
-                                // another writer (parallel install into the
-                                // same shared virtual-store entry, or another
-                                // task on this thread pool) beat us to the
-                                // link between makePath and this retry.
-                                if (real_error.getErrno() == .EXIST) return;
+                                // It was just created, no need to delete destination and symlink again
                                 this.err = real_error.toZigErr();
                                 return;
                             },

--- a/src/install/bin.zig
+++ b/src/install/bin.zig
@@ -827,7 +827,12 @@ pub const Bin = extern struct {
 
                         switch (bun.sys.symlinkRunningExecutable(rel_target, abs_dest)) {
                             .err => |real_error| {
-                                // It was just created, no need to delete destination and symlink again
+                                // EEXIST after we just created `.bin/` means
+                                // another writer (parallel install into the
+                                // same shared virtual-store entry, or another
+                                // task on this thread pool) beat us to the
+                                // link between makePath and this retry.
+                                if (real_error.getErrno() == .EXIST) return;
                                 this.err = real_error.toZigErr();
                                 return;
                             },

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -947,11 +947,6 @@ pub fn installIsolatedPackages(
                                     break :eligible false;
                                 }
                             }
-                            // `Package.scripts` is only populated after reading
-                            // the on-disk package.json (post-install), so it is
-                            // empty here. The lockfile carries the registry's
-                            // `hasInstallScript` flag in `meta` instead.
-                            //
                             // `run_preinstall()` authorizes scripts by the
                             // dependency *alias* name, so an aliased install
                             // like `foo: npm:bar@1` is trusted if `foo` is in
@@ -959,23 +954,26 @@ pub fn installIsolatedPackages(
                             // is `bar`. Mirror that here so the alias case
                             // can't slip past the eligibility check.
                             //
-                            // Intentionally *not* gated on `do.run_scripts`:
-                            // if this install runs with `--ignore-scripts` and
-                            // we put the entry in the global store, a later
-                            // install without that flag would run the
-                            // postinstall through the project symlink and
-                            // mutate the shared directory underneath every
-                            // other consumer.
-                            if (pkg_metas[pkg_id].hasInstallScript()) {
-                                const dep_name, const dep_name_hash = if (dep_id != invalid_dependency_id)
-                                    .{ dependencies[dep_id].name.slice(string_buf), dependencies[dep_id].name_hash }
-                                else
-                                    .{ pkg_names[pkg_id].slice(string_buf), pkg_name_hashes[pkg_id] };
-                                if (lockfile.hasTrustedDependency(dep_name, &pkg_res) or
-                                    trusted_from_update.contains(@truncate(dep_name_hash)))
-                                {
-                                    break :eligible false;
-                                }
+                            // Intentionally *not* gated on `do.run_scripts`
+                            // (a later install without `--ignore-scripts`
+                            // would run the postinstall through the project
+                            // symlink and mutate the shared directory) *or*
+                            // on `meta.hasInstallScript()` (that flag is not
+                            // serialised in `bun.lock`, so it reads `false`
+                            // on every install after the first; a trusted
+                            // scripted package would flip from project-local
+                            // on the cold install to global on the warm one).
+                            // Over-excludes the rare "trusted but actually no
+                            // scripts" case in exchange for not needing a
+                            // lockfile-format change.
+                            const dep_name, const dep_name_hash = if (dep_id != invalid_dependency_id)
+                                .{ dependencies[dep_id].name.slice(string_buf), dependencies[dep_id].name_hash }
+                            else
+                                .{ pkg_names[pkg_id].slice(string_buf), pkg_name_hashes[pkg_id] };
+                            if (lockfile.hasTrustedDependency(dep_name, &pkg_res) or
+                                trusted_from_update.contains(@truncate(dep_name_hash)))
+                            {
+                                break :eligible false;
                             }
                             break :eligible true;
                         },

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -891,7 +891,8 @@ pub fn installIsolatedPackages(
         // Packages newly trusted via `bun add --trust` (not yet written to the
         // lockfile) will have their lifecycle scripts run this install; treat
         // them the same as lockfile-trusted packages for eligibility.
-        const trusted_from_update = manager.findTrustedDependenciesFromUpdateRequests();
+        var trusted_from_update = manager.findTrustedDependenciesFromUpdateRequests();
+        defer trusted_from_update.deinit(manager.allocator);
 
         const State = enum { unvisited, in_progress, ineligible, done };
         const states = try manager.allocator.alloc(State, store.entries.len);

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -858,6 +858,18 @@ pub fn installIsolatedPackages(
     // also eligible. The second condition matters because dep symlinks live
     // inside the global entry; baking a project-local path (workspace, folder)
     // into a shared directory would break for every other consumer.
+    const WyhashWriter = struct {
+        hasher: *std.hash.Wyhash,
+        const E = error{};
+        pub fn writer(self: *@This()) std.io.GenericWriter(*@This(), E, write) {
+            return .{ .context = self };
+        }
+        fn write(self: *@This(), bytes: []const u8) E!usize {
+            self.hasher.update(bytes);
+            return bytes.len;
+        }
+    };
+
     const global_store_path: ?[:0]const u8 = if (manager.options.enable.global_virtual_store) global_store_path: {
         const entries = store.entries.slice();
         const entry_hashes = entries.items(.entry_hash);
@@ -923,7 +935,14 @@ pub fn installIsolatedPackages(
                                 const name_version = std.fmt.bufPrint(&name_version_buf, "{s}@{f}", .{
                                     pkg_names[pkg_id].slice(string_buf),
                                     pkg_res.fmt(string_buf, .posix),
-                                }) catch break :eligible false;
+                                }) catch {
+                                    // Overflow is implausible (PathBuffer ≫
+                                    // any name+version), but if it ever fired
+                                    // the safe answer is "not eligible" rather
+                                    // than letting a possibly-patched package
+                                    // slip into the shared store.
+                                    break :eligible false;
+                                };
                                 if (lockfile.patched_dependencies.contains(bun.Semver.String.Builder.stringHash(name_version))) {
                                     break :eligible false;
                                 }
@@ -939,7 +958,15 @@ pub fn installIsolatedPackages(
                             // trustedDependencies even though the package name
                             // is `bar`. Mirror that here so the alias case
                             // can't slip past the eligibility check.
-                            if (manager.options.do.run_scripts and pkg_metas[pkg_id].hasInstallScript()) {
+                            //
+                            // Intentionally *not* gated on `do.run_scripts`:
+                            // if this install runs with `--ignore-scripts` and
+                            // we put the entry in the global store, a later
+                            // install without that flag would run the
+                            // postinstall through the project symlink and
+                            // mutate the shared directory underneath every
+                            // other consumer.
+                            if (pkg_metas[pkg_id].hasInstallScript()) {
                                 const dep_name, const dep_name_hash = if (dep_id != invalid_dependency_id)
                                     .{ dependencies[dep_id].name.slice(string_buf), dependencies[dep_id].name_hash }
                                 else
@@ -964,17 +991,23 @@ pub fn installIsolatedPackages(
 
                     // Seed the hash with this entry's own store-path string so
                     // entries with identical dep sets but different package
-                    // versions never collide.
+                    // versions never collide. Hashed through a writer so an
+                    // unusually long store path (long scope + git URL + peer
+                    // hash) can't overflow a fixed buffer and feed
+                    // uninitialized stack bytes into the hash.
                     top.hasher = .init(0x9E3779B97F4A7C15);
-                    var path_buf: bun.PathBuffer = undefined;
-                    const path = std.fmt.bufPrint(&path_buf, "{f}", .{
-                        Store.Entry.fmtStorePath(id, &store, lockfile),
-                    }) catch &path_buf;
-                    top.hasher.update(path);
-                    // Include the package's own integrity (name_hash) so cache
-                    // poisoning via a different registry doesn't reuse another
-                    // registry's global entry.
-                    top.hasher.update(std.mem.asBytes(&pkg_name_hashes[pkg_id]));
+                    {
+                        var hw: WyhashWriter = .{ .hasher = &top.hasher };
+                        var w = hw.writer();
+                        w.print("{f}", .{Store.Entry.fmtStorePath(id, &store, lockfile)}) catch unreachable;
+                    }
+                    // The store path for `.npm` is just `name@version`, which
+                    // is *not* unique across registries (an enterprise proxy
+                    // can serve a patched `foo@1.0.0`). Fold in the tarball
+                    // integrity so a cross-registry / cross-tarball collision
+                    // gets a different global directory instead of reusing the
+                    // first project's bytes.
+                    top.hasher.update(std.mem.asBytes(&pkg_metas[pkg_id].integrity));
                 }
 
                 if (states[idx] == .ineligible) {
@@ -1002,10 +1035,10 @@ pub fn installIsolatedPackages(
                         },
                         .in_progress => {
                             // Cycle back-edge: the dep's hash isn't known yet.
-                            // Fold a placeholder so pass 1 stays deterministic;
-                            // the second pass below re-hashes every entry using
-                            // pass-1 results, which gives cycle members their
-                            // partner's transitive-dep contributions.
+                            // Fold a placeholder; the SCC pass below replaces
+                            // every cycle member's hash with one that's
+                            // independent of which edge happened to be the
+                            // back-edge in this DFS.
                             top.hasher.update(std.mem.asBytes(&dep_name_hash));
                         },
                         .unvisited => {
@@ -1031,30 +1064,163 @@ pub fn installIsolatedPackages(
             }
         }
 
-        // Second pass: re-hash every eligible entry using the pass-1 hashes
-        // of *all* its deps. For acyclic entries this is a no-op (their deps'
-        // hashes were already final when folded). For cycle members it pulls
-        // in the partner's transitive deps: in A↔B where A also depends on X,
-        // B's pass-1 hash only saw A's name (back-edge), but B's pass-2 hash
-        // folds A's pass-1 hash, which includes X. Without this, two projects
-        // that resolve X differently would share B's global entry while its
-        // `../../A-<hash>/` dep symlink dangles in one of them.
+        // SCC pass: the DFS hash above is visit-order-dependent for cycle
+        // members (which edge becomes the back-edge depends on which member
+        // the outer loop reached first, which depends on entry IDs, which
+        // depend on the *whole project's* dependency set). That's harmless
+        // for correctness — different orderings just give different keys —
+        // but it means a package that's part of an npm cycle never shares a
+        // global entry across projects, defeating the feature for chunks of
+        // the ecosystem (`es-abstract`↔`object.assign`, the babel core
+        // cycle, etc.).
         //
-        // Computed from a snapshot so iteration order doesn't matter.
-        const pass1 = try manager.allocator.dupe(u64, entry_hashes);
-        defer manager.allocator.free(pass1);
-        for (0..store.entries.len) |idx| {
-            if (pass1[idx] == 0) continue;
-            var hasher: std.hash.Wyhash = .init(0x9E3779B97F4A7C15);
-            hasher.update(std.mem.asBytes(&pass1[idx]));
-            for (entry_dependencies[idx].slice()) |dep| {
-                const dep_name_hash = dependencies[dep.dep_id].name_hash;
-                hasher.update(std.mem.asBytes(&dep_name_hash));
-                hasher.update(std.mem.asBytes(&pass1[dep.entry_id.get()]));
+        // Tarjan's algorithm groups entries into strongly-connected
+        // components. For singleton SCCs the pass-1 hash is already
+        // visit-order-independent and is left alone. For multi-member SCCs
+        // every member gets the same hash, computed from the sorted member
+        // store-paths plus the sorted external-dep hashes — inputs that are
+        // identical regardless of which member the project happened to list
+        // first. The dep symlinks inside the SCC then point at siblings with
+        // the same hash suffix, so they resolve in any project that produces
+        // the same SCC closure.
+        {
+            const n: u32 = @intCast(store.entries.len);
+            const tarjan_index = try manager.allocator.alloc(u32, n);
+            defer manager.allocator.free(tarjan_index);
+            @memset(tarjan_index, std.math.maxInt(u32));
+            const lowlink = try manager.allocator.alloc(u32, n);
+            defer manager.allocator.free(lowlink);
+            const on_stack = try manager.allocator.alloc(bool, n);
+            defer manager.allocator.free(on_stack);
+            @memset(on_stack, false);
+
+            var scc_stack: std.ArrayListUnmanaged(u32) = .empty;
+            defer scc_stack.deinit(manager.allocator);
+            var work: std.ArrayListUnmanaged(struct { v: u32, child: u32 }) = .empty;
+            defer work.deinit(manager.allocator);
+            var scc_ext: std.AutoArrayHashMapUnmanaged(u64, void) = .empty;
+            defer scc_ext.deinit(manager.allocator);
+
+            var index_counter: u32 = 0;
+            for (0..n) |root| {
+                if (tarjan_index[root] != std.math.maxInt(u32)) continue;
+                try work.append(manager.allocator, .{ .v = @intCast(root), .child = 0 });
+                while (work.items.len > 0) {
+                    const frame = &work.items[work.items.len - 1];
+                    const v = frame.v;
+                    if (frame.child == 0) {
+                        tarjan_index[v] = index_counter;
+                        lowlink[v] = index_counter;
+                        index_counter += 1;
+                        try scc_stack.append(manager.allocator, v);
+                        on_stack[v] = true;
+                    }
+                    const deps = entry_dependencies[v].slice();
+                    var recursed = false;
+                    while (frame.child < deps.len) : (frame.child += 1) {
+                        const w = deps[frame.child].entry_id.get();
+                        if (tarjan_index[w] == std.math.maxInt(u32)) {
+                            frame.child += 1;
+                            try work.append(manager.allocator, .{ .v = w, .child = 0 });
+                            recursed = true;
+                            break;
+                        } else if (on_stack[w]) {
+                            lowlink[v] = @min(lowlink[v], tarjan_index[w]);
+                        }
+                    }
+                    if (recursed) continue;
+                    if (lowlink[v] == tarjan_index[v]) {
+                        const start = blk: {
+                            var i = scc_stack.items.len;
+                            while (i > 0) : (i -= 1) {
+                                if (scc_stack.items[i - 1] == v) break :blk i - 1;
+                            }
+                            unreachable;
+                        };
+                        const members = scc_stack.items[start..];
+                        for (members) |m| on_stack[m] = false;
+                        if (members.len == 1) {
+                            // Singleton SCC. Tarjan emits SCCs in reverse
+                            // topological order, so every dep's hash is final
+                            // by now (including any cycle-member deps that
+                            // just got their SCC hash). Recompute this entry's
+                            // hash from those final values so a dependent of
+                            // a cycle picks up the order-independent SCC hash
+                            // rather than the pass-1 placeholder.
+                            const m = members[0];
+                            if (entry_hashes[m] != 0) {
+                                var sub: std.hash.Wyhash = .init(0x9E3779B97F4A7C15);
+                                var hw: WyhashWriter = .{ .hasher = &sub };
+                                var w_ = hw.writer();
+                                w_.print("{f}", .{Store.Entry.fmtStorePath(.from(m), &store, lockfile)}) catch unreachable;
+                                sub.update(std.mem.asBytes(&pkg_metas[node_pkg_ids[entry_node_ids[m].get()]].integrity));
+                                var poisoned = false;
+                                for (entry_dependencies[m].slice()) |dep| {
+                                    const dh = entry_hashes[dep.entry_id.get()];
+                                    if (dh == 0) {
+                                        poisoned = true;
+                                        break;
+                                    }
+                                    const dep_name_hash = dependencies[dep.dep_id].name_hash;
+                                    sub.update(std.mem.asBytes(&dep_name_hash));
+                                    sub.update(std.mem.asBytes(&dh));
+                                }
+                                if (poisoned) {
+                                    entry_hashes[m] = 0;
+                                } else {
+                                    var h = sub.final();
+                                    if (h == 0) h = 1;
+                                    entry_hashes[m] = h;
+                                }
+                            }
+                        } else if (members.len > 1) {
+                            // One order-independent hash for the whole SCC:
+                            // collect a sub-hash per member (store path +
+                            // integrity), collect every external-dep hash,
+                            // sort both lists, then hash the concatenation.
+                            // Sorting by *content* (not entry index) is what
+                            // makes this stable across projects.
+                            scc_ext.clearRetainingCapacity();
+                            var member_sub: std.ArrayListUnmanaged(u64) = .empty;
+                            defer member_sub.deinit(manager.allocator);
+                            var any_ineligible = false;
+                            for (members) |m| {
+                                if (entry_hashes[m] == 0) any_ineligible = true;
+                                var sub: std.hash.Wyhash = .init(0);
+                                var hw: WyhashWriter = .{ .hasher = &sub };
+                                var w_ = hw.writer();
+                                w_.print("{f}", .{Store.Entry.fmtStorePath(.from(m), &store, lockfile)}) catch unreachable;
+                                sub.update(std.mem.asBytes(&pkg_metas[node_pkg_ids[entry_node_ids[m].get()]].integrity));
+                                try member_sub.append(manager.allocator, sub.final());
+                                for (entry_dependencies[m].slice()) |dep| {
+                                    const di = dep.entry_id.get();
+                                    // Skip intra-SCC edges; those are captured
+                                    // by member_sub.
+                                    if (std.mem.indexOfScalar(u32, members, di) != null) continue;
+                                    if (entry_hashes[di] == 0) any_ineligible = true;
+                                    try scc_ext.put(manager.allocator, entry_hashes[di], {});
+                                }
+                            }
+                            std.mem.sort(u64, member_sub.items, {}, std.sort.asc(u64));
+                            const ext_keys = scc_ext.keys();
+                            std.mem.sort(u64, ext_keys, {}, std.sort.asc(u64));
+                            var hasher: std.hash.Wyhash = .init(0x42A7C15F9E3779B9);
+                            for (member_sub.items) |k| hasher.update(std.mem.asBytes(&k));
+                            for (ext_keys) |k| hasher.update(std.mem.asBytes(&k));
+                            var h = hasher.final();
+                            if (h == 0) h = 1;
+                            const final_h: u64 = if (any_ineligible) 0 else h;
+                            for (members) |m| entry_hashes[m] = final_h;
+                        }
+                        scc_stack.items.len = start;
+                    }
+                    _ = work.pop();
+                    if (work.items.len > 0) {
+                        const parent = &work.items[work.items.len - 1];
+                        lowlink[parent.v] = @min(lowlink[parent.v], lowlink[v]);
+                    }
+                }
             }
-            var h = hasher.final();
-            if (h == 0) h = 1;
-            entry_hashes[idx] = h;
         }
 
         // Ineligibility can surface mid-cycle: A→B→A where B turns out to

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1479,6 +1479,7 @@ pub fn installIsolatedPackages(
             .supported_backend = .init(PackageInstall.supported_method),
             .is_new_bun_modules = is_new_bun_modules,
             .global_store_path = global_store_path,
+            .global_store_tmp_suffix = bun.fastRandom(),
         };
         defer installer.deinit();
 
@@ -1603,17 +1604,14 @@ pub fn installIsolatedPackages(
                             var store_path: bun.AbsPath(.{}) = .initTopLevelDir();
                             defer store_path.deinit();
                             if (uses_global_store) {
-                                // The global entry is built across several
-                                // task steps (clone → dep symlinks → bin
-                                // links); only the `.bun-ok` stamp written at
-                                // the end of the `binaries` step proves the
-                                // whole sequence finished. `package.json` only
-                                // proves the clone landed.
-                                installer.appendGlobalStoreEntryPath(&store_path, entry_id);
-                                store_path.append(".bun-ok");
-                                break :needs_install !sys.existsZ(store_path.sliceZ());
+                                // Global entries are built under a per-process
+                                // staging path and renamed into place as the
+                                // final step, so the directory existing at its
+                                // final path is the completeness signal.
+                                installer.appendGlobalStoreEntryPath(&store_path, entry_id, .final);
+                                break :needs_install !(sys.directoryExistsAt(FD.cwd(), store_path.sliceZ()).asValue() orelse false);
                             }
-                            installer.appendRealStorePath(&store_path, entry_id);
+                            installer.appendRealStorePath(&store_path, entry_id, .final);
                             const scope_for_patch_tag_path = store_path.save();
                             if (pkg_res_tag == .npm)
                                 // if it's from npm, it should always have a package.json.

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1480,6 +1480,7 @@ pub fn installIsolatedPackages(
             .is_new_bun_modules = is_new_bun_modules,
             .global_store_path = global_store_path,
         };
+        defer installer.deinit();
 
         for (tasks, 0..) |*task, _entry_id| {
             const entry_id: Store.Entry.Id = .from(@intCast(_entry_id));

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -875,6 +875,11 @@ pub fn installIsolatedPackages(
         const string_buf = lockfile.buffers.string_bytes.items;
         const dependencies = lockfile.buffers.dependencies.items;
 
+        // Packages newly trusted via `bun add --trust` (not yet written to the
+        // lockfile) will have their lifecycle scripts run this install; treat
+        // them the same as lockfile-trusted packages for eligibility.
+        const trusted_from_update = manager.findTrustedDependenciesFromUpdateRequests();
+
         const State = enum { unvisited, in_progress, ineligible, done };
         const states = try manager.allocator.alloc(State, store.entries.len);
         defer manager.allocator.free(states);
@@ -927,7 +932,8 @@ pub fn installIsolatedPackages(
                             // `hasInstallScript` flag in `meta` instead.
                             if (manager.options.do.run_scripts and
                                 pkg_metas[pkg_id].hasInstallScript() and
-                                lockfile.hasTrustedDependency(pkg_names[pkg_id].slice(string_buf), &pkg_res))
+                                (lockfile.hasTrustedDependency(pkg_names[pkg_id].slice(string_buf), &pkg_res) or
+                                    trusted_from_update.contains(@truncate(pkg_name_hashes[pkg_id]))))
                             {
                                 break :eligible false;
                             }
@@ -1005,6 +1011,27 @@ pub fn installIsolatedPackages(
                     states[idx] = .done;
                 }
                 _ = stack.pop();
+            }
+        }
+
+        // Ineligibility can surface mid-cycle: A→B→A where B turns out to
+        // depend on a workspace package. The DFS above already finalised A's
+        // hash via the `.in_progress` back-edge before B was marked
+        // ineligible, so A would wrongly land in the global store with a
+        // dangling dep symlink. Close the gap with a fixed-point pass: any
+        // entry that still links to an ineligible dep becomes ineligible too.
+        var changed = true;
+        while (changed) {
+            changed = false;
+            for (0..store.entries.len) |idx| {
+                if (entry_hashes[idx] == 0) continue;
+                for (entry_dependencies[idx].slice()) |dep| {
+                    if (entry_hashes[dep.entry_id.get()] == 0) {
+                        entry_hashes[idx] = 0;
+                        changed = true;
+                        break;
+                    }
+                }
             }
         }
 
@@ -1366,8 +1393,9 @@ pub fn installIsolatedPackages(
                             switch (installer.linkProjectToGlobalStore(entry_id)) {
                                 .result => {},
                                 .err => |err| {
-                                    Output.err(err, "failed to symlink store entry to global virtual store", .{});
-                                    if (manager.options.enable.fail_early) Global.exit(1);
+                                    entry_steps[entry_id.get()].store(.done, .monotonic);
+                                    installer.onTaskFail(entry_id, .{ .symlink_dependencies = err });
+                                    continue;
                                 },
                             }
                         }

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1197,7 +1197,14 @@ pub fn installIsolatedPackages(
                                     // by member_sub.
                                     if (std.mem.indexOfScalar(u32, members, di) != null) continue;
                                     if (entry_hashes[di] == 0) any_ineligible = true;
-                                    try scc_ext.put(manager.allocator, entry_hashes[di], {});
+                                    // Dep symlinks inside the entry are named
+                                    // by the dependency *alias*, so two SCCs
+                                    // that reach the same external entry under
+                                    // different aliases must hash differently.
+                                    var ext: std.hash.Wyhash = .init(0);
+                                    ext.update(std.mem.asBytes(&dependencies[dep.dep_id].name_hash));
+                                    ext.update(std.mem.asBytes(&entry_hashes[di]));
+                                    try scc_ext.put(manager.allocator, ext.final(), {});
                                 }
                             }
                             std.mem.sort(u64, member_sub.items, {}, std.sort.asc(u64));

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1001,7 +1001,11 @@ pub fn installIsolatedPackages(
                             entry_hashes[idx] = 0;
                         },
                         .in_progress => {
-                            // Cycle back-edge: fold in the dep name only.
+                            // Cycle back-edge: the dep's hash isn't known yet.
+                            // Fold a placeholder so pass 1 stays deterministic;
+                            // the second pass below re-hashes every entry using
+                            // pass-1 results, which gives cycle members their
+                            // partner's transitive-dep contributions.
                             top.hasher.update(std.mem.asBytes(&dep_name_hash));
                         },
                         .unvisited => {
@@ -1025,6 +1029,32 @@ pub fn installIsolatedPackages(
                 }
                 _ = stack.pop();
             }
+        }
+
+        // Second pass: re-hash every eligible entry using the pass-1 hashes
+        // of *all* its deps. For acyclic entries this is a no-op (their deps'
+        // hashes were already final when folded). For cycle members it pulls
+        // in the partner's transitive deps: in A↔B where A also depends on X,
+        // B's pass-1 hash only saw A's name (back-edge), but B's pass-2 hash
+        // folds A's pass-1 hash, which includes X. Without this, two projects
+        // that resolve X differently would share B's global entry while its
+        // `../../A-<hash>/` dep symlink dangles in one of them.
+        //
+        // Computed from a snapshot so iteration order doesn't matter.
+        const pass1 = try manager.allocator.dupe(u64, entry_hashes);
+        defer manager.allocator.free(pass1);
+        for (0..store.entries.len) |idx| {
+            if (pass1[idx] == 0) continue;
+            var hasher: std.hash.Wyhash = .init(0x9E3779B97F4A7C15);
+            hasher.update(std.mem.asBytes(&pass1[idx]));
+            for (entry_dependencies[idx].slice()) |dep| {
+                const dep_name_hash = dependencies[dep.dep_id].name_hash;
+                hasher.update(std.mem.asBytes(&dep_name_hash));
+                hasher.update(std.mem.asBytes(&pass1[dep.entry_id.get()]));
+            }
+            var h = hasher.final();
+            if (h == 0) h = 1;
+            entry_hashes[idx] = h;
         }
 
         // Ineligibility can surface mid-cycle: A→B→A where B turns out to
@@ -1374,6 +1404,17 @@ pub fn installIsolatedPackages(
                         needs_install: {
                             var store_path: bun.AbsPath(.{}) = .initTopLevelDir();
                             defer store_path.deinit();
+                            if (uses_global_store) {
+                                // The global entry is built across several
+                                // task steps (clone → dep symlinks → bin
+                                // links); only the `.bun-ok` stamp written at
+                                // the end of the `binaries` step proves the
+                                // whole sequence finished. `package.json` only
+                                // proves the clone landed.
+                                installer.appendGlobalStoreEntryPath(&store_path, entry_id);
+                                store_path.append(".bun-ok");
+                                break :needs_install !sys.existsZ(store_path.sliceZ());
+                            }
                             installer.appendRealStorePath(&store_path, entry_id);
                             const scope_for_patch_tag_path = store_path.save();
                             if (pkg_res_tag == .npm)

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -846,6 +846,177 @@ pub fn installIsolatedPackages(
         };
     };
 
+    // Compute entry_hash for the global virtual store. The hash makes a
+    // global-store directory name unique to this entry's *resolved* dependency
+    // closure, so two projects that resolve `react@18.3.1` to the same set of
+    // transitive versions share one on-disk entry, while a project that
+    // resolves a transitive dep to a different version gets its own.
+    //
+    // Eligibility propagates: an entry is only global-store-eligible (hash != 0)
+    // when the package itself comes from an immutable cache (npm/git/tarball,
+    // unpatched, no lifecycle scripts) *and* every dependency it links to is
+    // also eligible. The second condition matters because dep symlinks live
+    // inside the global entry; baking a project-local path (workspace, folder)
+    // into a shared directory would break for every other consumer.
+    const global_store_path: ?[:0]const u8 = if (manager.options.enable.global_virtual_store) global_store_path: {
+        const entries = store.entries.slice();
+        const entry_hashes = entries.items(.entry_hash);
+        const entry_node_ids = entries.items(.node_id);
+        const entry_dependencies = entries.items(.dependencies);
+
+        const node_pkg_ids = store.nodes.items(.pkg_id);
+
+        const pkgs = lockfile.packages.slice();
+        const pkg_names = pkgs.items(.name);
+        const pkg_name_hashes = pkgs.items(.name_hash);
+        const pkg_resolutions = pkgs.items(.resolution);
+        const pkg_scripts = pkgs.items(.scripts);
+
+        const string_buf = lockfile.buffers.string_bytes.items;
+        const dependencies = lockfile.buffers.dependencies.items;
+
+        const State = enum { unvisited, in_progress, ineligible, done };
+        const states = try manager.allocator.alloc(State, store.entries.len);
+        defer manager.allocator.free(states);
+        @memset(states, .unvisited);
+
+        // Iterative DFS so dependency cycles (which the isolated graph permits)
+        // can't overflow the stack and are handled deterministically: a back-edge
+        // contributes the dependency *name* to the parent's hash but not the
+        // child's own hash (still being computed). Two entries that only differ
+        // by which side of a cycle they sit on still get distinct hashes via
+        // their own store-path bytes.
+        var stack: std.ArrayListUnmanaged(struct { id: Store.Entry.Id, dep_idx: u32, hasher: std.hash.Wyhash }) = .empty;
+        defer stack.deinit(manager.allocator);
+
+        for (0..store.entries.len) |_root_id| {
+            if (states[_root_id] != .unvisited) continue;
+            try stack.append(manager.allocator, .{ .id = .from(@intCast(_root_id)), .dep_idx = 0, .hasher = undefined });
+
+            while (stack.items.len > 0) {
+                const top = &stack.items[stack.items.len - 1];
+                const id = top.id;
+                const idx = id.get();
+
+                if (states[idx] == .unvisited) {
+                    states[idx] = .in_progress;
+
+                    const node_id = entry_node_ids[idx];
+                    const pkg_id = node_pkg_ids[node_id.get()];
+                    const pkg_res = pkg_resolutions[pkg_id];
+
+                    const eligible = switch (pkg_res.tag) {
+                        .npm, .git, .github, .local_tarball, .remote_tarball => eligible: {
+                            // Patched packages and packages with lifecycle scripts
+                            // mutate (or may mutate) their install directory, so a
+                            // shared global copy would either diverge from the
+                            // patch or be mutated underneath other projects.
+                            if (lockfile.patched_dependencies.count() > 0) {
+                                var name_version_buf: bun.PathBuffer = undefined;
+                                const name_version = std.fmt.bufPrint(&name_version_buf, "{s}@{f}", .{
+                                    pkg_names[pkg_id].slice(string_buf),
+                                    pkg_res.fmt(string_buf, .posix),
+                                }) catch break :eligible false;
+                                if (lockfile.patched_dependencies.contains(bun.Semver.String.Builder.stringHash(name_version))) {
+                                    break :eligible false;
+                                }
+                            }
+                            if (manager.options.do.run_scripts and
+                                pkg_scripts[pkg_id].hasAny() and
+                                lockfile.hasTrustedDependency(pkg_names[pkg_id].slice(string_buf), &pkg_res))
+                            {
+                                break :eligible false;
+                            }
+                            break :eligible true;
+                        },
+                        else => false,
+                    };
+
+                    if (!eligible) {
+                        states[idx] = .ineligible;
+                        entry_hashes[idx] = 0;
+                        _ = stack.pop();
+                        continue;
+                    }
+
+                    // Seed the hash with this entry's own store-path string so
+                    // entries with identical dep sets but different package
+                    // versions never collide.
+                    top.hasher = .init(0x9E3779B97F4A7C15);
+                    var path_buf: bun.PathBuffer = undefined;
+                    const path = std.fmt.bufPrint(&path_buf, "{f}", .{
+                        Store.Entry.fmtStorePath(id, &store, lockfile),
+                    }) catch &path_buf;
+                    top.hasher.update(path);
+                    // Include the package's own integrity (name_hash) so cache
+                    // poisoning via a different registry doesn't reuse another
+                    // registry's global entry.
+                    top.hasher.update(std.mem.asBytes(&pkg_name_hashes[pkg_id]));
+                }
+
+                if (states[idx] == .ineligible) {
+                    _ = stack.pop();
+                    continue;
+                }
+
+                const deps = entry_dependencies[idx].slice();
+                var advanced = false;
+                while (top.dep_idx < deps.len) : (top.dep_idx += 1) {
+                    const dep = deps[top.dep_idx];
+                    const dep_idx = dep.entry_id.get();
+                    const dep_name_hash = dependencies[dep.dep_id].name_hash;
+                    switch (states[dep_idx]) {
+                        .done => {
+                            top.hasher.update(std.mem.asBytes(&dep_name_hash));
+                            top.hasher.update(std.mem.asBytes(&entry_hashes[dep_idx]));
+                        },
+                        .ineligible => {
+                            // A dep that can't live in the global store poisons
+                            // this entry too: its symlink would point at a
+                            // project-local path.
+                            states[idx] = .ineligible;
+                            entry_hashes[idx] = 0;
+                        },
+                        .in_progress => {
+                            // Cycle back-edge: fold in the dep name only.
+                            top.hasher.update(std.mem.asBytes(&dep_name_hash));
+                        },
+                        .unvisited => {
+                            try stack.append(manager.allocator, .{ .id = dep.entry_id, .dep_idx = 0, .hasher = undefined });
+                            advanced = true;
+                            // re-fetch `top` after potential realloc
+                            break;
+                        },
+                    }
+                    if (states[idx] == .ineligible) break;
+                }
+
+                if (advanced) continue;
+
+                if (states[idx] != .ineligible) {
+                    var h = top.hasher.final();
+                    // 0 is the "not eligible" sentinel.
+                    if (h == 0) h = 1;
+                    entry_hashes[idx] = h;
+                    states[idx] = .done;
+                }
+                _ = stack.pop();
+            }
+        }
+
+        // <cache_dir>/links — created lazily by the first task that misses.
+        // getCacheDirectory() populates `cache_directory_path` as a side-effect.
+        _ = manager.getCacheDirectory();
+        const cache_dir_path = manager.cache_directory_path;
+        if (cache_dir_path.len == 0) break :global_store_path null;
+        break :global_store_path try std.fmt.allocPrintSentinel(
+            manager.allocator,
+            "{s}{s}links",
+            .{ cache_dir_path, if (bun.strings.endsWithChar(cache_dir_path, std.fs.path.sep)) "" else std.fs.path.sep_str },
+            0,
+        );
+    } else null;
+
     // setup node_modules/.bun
     const is_new_bun_modules = is_new_bun_modules: {
         const node_modules_path = bun.OSPathLiteral("node_modules");
@@ -1062,6 +1233,7 @@ pub fn installIsolatedPackages(
             .trusted_dependencies_from_update_requests = manager.findTrustedDependenciesFromUpdateRequests(),
             .supported_backend = .init(PackageInstall.supported_method),
             .is_new_bun_modules = is_new_bun_modules,
+            .global_store_path = global_store_path,
         };
 
         for (tasks, 0..) |*task, _entry_id| {
@@ -1146,14 +1318,20 @@ pub fn installIsolatedPackages(
                 => |pkg_res_tag| {
                     const patch_info = try installer.packagePatchInfo(pkg_name, pkg_name_hash, &pkg_res);
 
+                    const uses_global_store = installer.entryUsesGlobalStore(entry_id);
+
                     const needs_install =
                         manager.options.enable.force_install or
-                        is_new_bun_modules or
+                        // A freshly-created `node_modules/.bun` only implies the
+                        // *project-local* entries are missing; global virtual-
+                        // store entries persist across `rm -rf node_modules` and
+                        // should still take the cheap symlink-only path.
+                        (is_new_bun_modules and !uses_global_store) or
                         patch_info == .remove or
                         needs_install: {
                             var store_path: bun.AbsPath(.{}) = .initTopLevelDir();
                             defer store_path.deinit();
-                            installer.appendStorePath(&store_path, entry_id);
+                            installer.appendRealStorePath(&store_path, entry_id);
                             const scope_for_patch_tag_path = store_path.save();
                             if (pkg_res_tag == .npm)
                                 // if it's from npm, it should always have a package.json.
@@ -1176,6 +1354,19 @@ pub fn installIsolatedPackages(
                         };
 
                     if (!needs_install) {
+                        if (uses_global_store) {
+                            // Warm hit: the global virtual store already holds
+                            // this entry's files, dep symlinks, and bin links.
+                            // The only per-install work is the project-level
+                            // `node_modules/.bun/<storepath>` → global symlink.
+                            switch (installer.linkProjectToGlobalStore(entry_id)) {
+                                .result => {},
+                                .err => |err| {
+                                    Output.err(err, "failed to symlink store entry to global virtual store", .{});
+                                    if (manager.options.enable.fail_early) Global.exit(1);
+                                },
+                            }
+                        }
                         if (entry_hoisted[entry_id.get()]) {
                             installer.linkToHiddenNodeModules(entry_id);
                         }

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -865,6 +865,7 @@ pub fn installIsolatedPackages(
         const entry_dependencies = entries.items(.dependencies);
 
         const node_pkg_ids = store.nodes.items(.pkg_id);
+        const node_dep_ids = store.nodes.items(.dep_id);
 
         const pkgs = lockfile.packages.slice();
         const pkg_names = pkgs.items(.name);
@@ -908,6 +909,7 @@ pub fn installIsolatedPackages(
 
                     const node_id = entry_node_ids[idx];
                     const pkg_id = node_pkg_ids[node_id.get()];
+                    const dep_id = node_dep_ids[node_id.get()];
                     const pkg_res = pkg_resolutions[pkg_id];
 
                     const eligible = switch (pkg_res.tag) {
@@ -930,12 +932,23 @@ pub fn installIsolatedPackages(
                             // the on-disk package.json (post-install), so it is
                             // empty here. The lockfile carries the registry's
                             // `hasInstallScript` flag in `meta` instead.
-                            if (manager.options.do.run_scripts and
-                                pkg_metas[pkg_id].hasInstallScript() and
-                                (lockfile.hasTrustedDependency(pkg_names[pkg_id].slice(string_buf), &pkg_res) or
-                                    trusted_from_update.contains(@truncate(pkg_name_hashes[pkg_id]))))
-                            {
-                                break :eligible false;
+                            //
+                            // `run_preinstall()` authorizes scripts by the
+                            // dependency *alias* name, so an aliased install
+                            // like `foo: npm:bar@1` is trusted if `foo` is in
+                            // trustedDependencies even though the package name
+                            // is `bar`. Mirror that here so the alias case
+                            // can't slip past the eligibility check.
+                            if (manager.options.do.run_scripts and pkg_metas[pkg_id].hasInstallScript()) {
+                                const dep_name, const dep_name_hash = if (dep_id != invalid_dependency_id)
+                                    .{ dependencies[dep_id].name.slice(string_buf), dependencies[dep_id].name_hash }
+                                else
+                                    .{ pkg_names[pkg_id].slice(string_buf), pkg_name_hashes[pkg_id] };
+                                if (lockfile.hasTrustedDependency(dep_name, &pkg_res) or
+                                    trusted_from_update.contains(@truncate(dep_name_hash)))
+                                {
+                                    break :eligible false;
+                                }
                             }
                             break :eligible true;
                         },
@@ -1040,13 +1053,12 @@ pub fn installIsolatedPackages(
         _ = manager.getCacheDirectory();
         const cache_dir_path = manager.cache_directory_path;
         if (cache_dir_path.len == 0) break :global_store_path null;
-        break :global_store_path try std.fmt.allocPrintSentinel(
-            manager.allocator,
-            "{s}{s}links",
-            .{ cache_dir_path, if (bun.strings.endsWithChar(cache_dir_path, std.fs.path.sep)) "" else std.fs.path.sep_str },
-            0,
+        break :global_store_path try manager.allocator.dupeZ(
+            u8,
+            bun.path.joinAbsString(cache_dir_path, &.{"links"}, .auto),
         );
     } else null;
+    defer if (global_store_path) |p| manager.allocator.free(p);
 
     // setup node_modules/.bun
     const is_new_bun_modules = is_new_bun_modules: {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -870,7 +870,7 @@ pub fn installIsolatedPackages(
         const pkg_names = pkgs.items(.name);
         const pkg_name_hashes = pkgs.items(.name_hash);
         const pkg_resolutions = pkgs.items(.resolution);
-        const pkg_scripts = pkgs.items(.scripts);
+        const pkg_metas = pkgs.items(.meta);
 
         const string_buf = lockfile.buffers.string_bytes.items;
         const dependencies = lockfile.buffers.dependencies.items;
@@ -921,8 +921,12 @@ pub fn installIsolatedPackages(
                                     break :eligible false;
                                 }
                             }
+                            // `Package.scripts` is only populated after reading
+                            // the on-disk package.json (post-install), so it is
+                            // empty here. The lockfile carries the registry's
+                            // `hasInstallScript` flag in `meta` instead.
                             if (manager.options.do.run_scripts and
-                                pkg_scripts[pkg_id].hasAny() and
+                                pkg_metas[pkg_id].hasInstallScript() and
                                 lockfile.hasTrustedDependency(pkg_names[pkg_id].slice(string_buf), &pkg_res))
                             {
                                 break :eligible false;

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1565,6 +1565,30 @@ pub fn installIsolatedPackages(
 
                     const uses_global_store = installer.entryUsesGlobalStore(entry_id);
 
+                    // An entry that lost global-store eligibility since the
+                    // previous install (newly patched, newly trusted, a dep
+                    // that became a workspace package) still has a stale
+                    // `node_modules/.bun/<storepath>` symlink/junction into
+                    // `<cache>/links/`. The existence check below would pass
+                    // *through* it and skip the task, leaving the project to
+                    // run against the shared entry (and, if the task did run,
+                    // write the new project-local tree through the link into
+                    // the shared cache). Treat the stale link as
+                    // needs-install so `link_package` detaches and rebuilds.
+                    const has_stale_gvs_link = !uses_global_store and stale: {
+                        if (installer.global_store_path == null) break :stale false;
+                        var local: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
+                        defer local.deinit();
+                        installer.appendLocalStoreEntryPath(&local, entry_id);
+                        if (comptime bun.Environment.isWindows) {
+                            break :stale if (sys.getFileAttributes(local.sliceZ())) |a| a.is_reparse_point else false;
+                        }
+                        break :stale if (sys.lstat(local.sliceZ()).asValue()) |st|
+                            std.posix.S.ISLNK(@intCast(st.mode))
+                        else
+                            false;
+                    };
+
                     const needs_install =
                         manager.options.enable.force_install or
                         // A freshly-created `node_modules/.bun` only implies the
@@ -1572,6 +1596,7 @@ pub fn installIsolatedPackages(
                         // store entries persist across `rm -rf node_modules` and
                         // should still take the cheap symlink-only path.
                         (is_new_bun_modules and !uses_global_store) or
+                        has_stale_gvs_link or
                         patch_info == .remove or
                         needs_install: {
                             var store_path: bun.AbsPath(.{}) = .initTopLevelDir();

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -10,6 +10,13 @@ dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
 /// across projects and content-addressed by name (so the existing tree is
 /// already what we'd produce).
 keep_existing_dest: bool = false,
+/// Path to the entry-level `.bun-ok` stamp (`<gvs>/<entry>/.bun-ok`), used as
+/// the "this entry was fully built" sentinel when `cloneAtomic`'s rename hits
+/// an existing destination. `package.json` alone is *not* a valid sentinel: a
+/// crashed file-walking install (or intervening cache corruption) could leave
+/// it alongside an arbitrary subset of files. Only set when
+/// `keep_existing_dest` is true.
+entry_ok_path: [:0]const u8 = "",
 
 fn clonefileat(this: *FileCloner) sys.Maybe(void) {
     return sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), this.dest_subpath.sliceZ());
@@ -88,22 +95,23 @@ fn cloneAtomic(this: *FileCloner) sys.Maybe(void) {
         .result => return .success,
         .err => |err| switch (err.getErrno()) {
             .EXIST, .NOTEMPTY => {
-                // Someone got there first. `package.json` proves their clone
-                // landed (clonefileat is atomic for the whole tree); the dep
-                // symlinks and bin links are written by later task steps that
-                // *this* task will also run with `.expect_existing`, so any
-                // gaps left by a crashed winner get filled by the loser. The
-                // entry-level `.bun-ok` stamp (written after `binaries`) is
-                // what future installs use to short-circuit the whole task.
-                var sentinel_buf: bun.PathBuffer = undefined;
-                if (std.fmt.bufPrintZ(&sentinel_buf, "{s}/package.json", .{this.dest_subpath.slice()})) |sentinel| {
-                    if (sys.existsZ(sentinel)) {
-                        FD.cwd().deleteTree(tmp_path) catch {};
-                        return .success;
-                    }
-                } else |_| {}
-                // No package.json → partial leftover from an interrupted
-                // earlier run; replace with our complete tree.
+                // Someone got there first. Keep their tree only if the
+                // entry-level `.bun-ok` stamp is present (i.e. some install
+                // fully built it). `package.json` alone is *not* a valid
+                // sentinel: although clonefileat is whole-tree atomic, a
+                // file-walking install or cache corruption could have left it
+                // alongside an arbitrary subset of files, and the warm-hit
+                // check already established `.bun-ok` is absent (that's why
+                // we're here). Replacing dest with our complete temp tree is
+                // safe even if a concurrent install just renamed first — dest
+                // is only the `<pkg>` directory; their dep symlinks, bin
+                // links, and the `.bun-ok` stamp live alongside it under the
+                // entry root, so their later steps proceed unchanged with our
+                // (identical) package files.
+                if (this.entry_ok_path.len > 0 and sys.existsZ(this.entry_ok_path)) {
+                    FD.cwd().deleteTree(tmp_path) catch {};
+                    return .success;
+                }
                 FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                 return switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
                     .result => .success,

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -42,8 +42,6 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
     }
 }
 
-const std = @import("std");
-
 const bun = @import("bun");
 const FD = bun.FD;
 const sys = bun.sys;

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -16,14 +16,23 @@ fn clonefileat(this: *FileCloner) sys.Maybe(void) {
 }
 
 pub fn clone(this: *FileCloner) sys.Maybe(void) {
+    if (this.keep_existing_dest) {
+        // Global virtual-store entries are content-addressed and shared across
+        // processes, so a previously-created destination is normally a hit.
+        // But if an earlier install was interrupted mid-clonefile (jetsam,
+        // disk-full mid directory walk, panic), the destination directory can
+        // exist with only some of the package files. Treating that EEXIST as
+        // success would permanently lock in the broken entry for every future
+        // install. Make population atomic instead: clone into a per-process
+        // temp sibling, then rename into place. The losing process's rename
+        // sees EEXIST/NOTEMPTY and discards its identical temp tree.
+        return this.cloneAtomic();
+    }
     switch (this.clonefileat()) {
         .result => return .success,
         .err => |err| {
             switch (err.getErrno()) {
                 .EXIST => {
-                    if (this.keep_existing_dest) {
-                        return .success;
-                    }
                     FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                     return this.clonefileat();
                 },
@@ -33,22 +42,88 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
                         return .initErr(err);
                     };
                     FD.cwd().makePath(u8, parent_dest_dir) catch {};
-                    return switch (this.clonefileat()) {
-                        .result => .success,
-                        .err => |retry_err| switch (retry_err.getErrno()) {
-                            // Another install racing on the same global-store
-                            // entry created it between our NOENT and this retry;
-                            // for content-addressed dests that's a successful
-                            // outcome, not a failure.
-                            .EXIST => if (this.keep_existing_dest) .success else .initErr(retry_err),
-                            else => .initErr(retry_err),
-                        },
-                    };
+                    return this.clonefileat();
                 },
                 else => {
                     return .initErr(err);
                 },
             }
+        },
+    }
+}
+
+fn cloneAtomic(this: *FileCloner) sys.Maybe(void) {
+    var tmp_buf: bun.PathBuffer = undefined;
+    // Temp path is a sibling of the final path so the rename is atomic and
+    // stays on the same volume (clonefile already requires same-volume).
+    const tmp_path: [:0]const u8 = std.fmt.bufPrintZ(
+        &tmp_buf,
+        "{s}.tmp-{d}-{d}",
+        .{ this.dest_subpath.slice(), std.c.getpid(), std.crypto.random.int(u32) },
+    ) catch return .initErr(.{ .errno = @intFromEnum(bun.sys.E.NAMETOOLONG), .syscall = .clonefile });
+
+    cloned: {
+        switch (sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), tmp_path)) {
+            .result => break :cloned,
+            .err => |err| switch (err.getErrno()) {
+                .NOENT => {
+                    if (std.fs.path.dirname(this.dest_subpath.slice())) |parent| {
+                        FD.cwd().makePath(u8, parent) catch {};
+                    }
+                },
+                .EXIST => {
+                    // Stale temp from a crashed earlier run with the same pid.
+                    FD.cwd().deleteTree(tmp_path) catch {};
+                },
+                else => return .initErr(err),
+            },
+        }
+        switch (sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), tmp_path)) {
+            .result => break :cloned,
+            .err => |err| return .initErr(err),
+        }
+    }
+
+    switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
+        .result => return .success,
+        .err => |err| switch (err.getErrno()) {
+            .EXIST, .NOTEMPTY => {
+                // Someone got there first. Distinguish "concurrent install
+                // produced a complete entry" from "an interrupted install
+                // left a partial directory" by probing for the package.json
+                // the warm-hit fast path uses as its sentinel.
+                var sentinel_buf: bun.PathBuffer = undefined;
+                const sentinel = std.fmt.bufPrintZ(&sentinel_buf, "{s}/package.json", .{this.dest_subpath.slice()}) catch {
+                    FD.cwd().deleteTree(tmp_path) catch {};
+                    return .initErr(err);
+                };
+                if (sys.existsZ(sentinel)) {
+                    FD.cwd().deleteTree(tmp_path) catch {};
+                    return .success;
+                }
+                // Partial entry from an interrupted earlier run: replace it
+                // with the complete tree we just produced.
+                FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
+                return switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
+                    .result => .success,
+                    .err => |e| switch (e.getErrno()) {
+                        // A concurrent install repopulated it between our
+                        // deleteTree and rename — we're done either way.
+                        .EXIST, .NOTEMPTY => {
+                            FD.cwd().deleteTree(tmp_path) catch {};
+                            return .success;
+                        },
+                        else => {
+                            FD.cwd().deleteTree(tmp_path) catch {};
+                            return .initErr(e);
+                        },
+                    },
+                };
+            },
+            else => {
+                FD.cwd().deleteTree(tmp_path) catch {};
+                return .initErr(err);
+            },
         },
     }
 }

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -5,41 +5,24 @@ const FileCloner = @This();
 cache_dir: FD,
 cache_dir_subpath: bun.AutoRelPath,
 dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
-/// When true, an existing destination is treated as success rather than wiped
-/// and re-cloned. Set for global virtual-store entries, which are shared
-/// across projects and content-addressed by name (so the existing tree is
-/// already what we'd produce).
-keep_existing_dest: bool = false,
-/// Path to the entry-level `.bun-ok` stamp (`<gvs>/<entry>/.bun-ok`), used as
-/// the "this entry was fully built" sentinel when `cloneAtomic`'s rename hits
-/// an existing destination. `package.json` alone is *not* a valid sentinel: a
-/// crashed file-walking install (or intervening cache corruption) could leave
-/// it alongside an arbitrary subset of files. Only set when
-/// `keep_existing_dest` is true.
-entry_ok_path: [:0]const u8 = "",
 
 fn clonefileat(this: *FileCloner) sys.Maybe(void) {
     return sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), this.dest_subpath.sliceZ());
 }
 
 pub fn clone(this: *FileCloner) sys.Maybe(void) {
-    if (this.keep_existing_dest) {
-        // Global virtual-store entries are content-addressed and shared across
-        // processes, so a previously-created destination is normally a hit.
-        // But if an earlier install was interrupted mid-clonefile (jetsam,
-        // disk-full mid directory walk, panic), the destination directory can
-        // exist with only some of the package files. Treating that EEXIST as
-        // success would permanently lock in the broken entry for every future
-        // install. Make population atomic instead: clone into a per-process
-        // temp sibling, then rename into place. The losing process's rename
-        // sees EEXIST/NOTEMPTY and discards its identical temp tree.
-        return this.cloneAtomic();
-    }
     switch (this.clonefileat()) {
         .result => return .success,
         .err => |err| {
             switch (err.getErrno()) {
                 .EXIST => {
+                    // Stale leftover (an earlier crash, or a re-run after the
+                    // global-store staging directory wasn't cleaned). The
+                    // global-store entry is published by an entry-level
+                    // rename in `commitGlobalStoreEntry`, so it's always safe
+                    // to wipe and re-clone here — we're only ever writing
+                    // into a per-process staging directory or a project-local
+                    // path, never into a published shared directory.
                     FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                     return this.clonefileat();
                 },
@@ -55,84 +38,6 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
                     return .initErr(err);
                 },
             }
-        },
-    }
-}
-
-fn cloneAtomic(this: *FileCloner) sys.Maybe(void) {
-    var tmp_buf: bun.PathBuffer = undefined;
-    // Temp path is a sibling of the final path so the rename is atomic and
-    // stays on the same volume (clonefile already requires same-volume).
-    const tmp_path: [:0]const u8 = std.fmt.bufPrintZ(
-        &tmp_buf,
-        "{s}.tmp-{d}-{d}",
-        .{ this.dest_subpath.slice(), std.c.getpid(), std.crypto.random.int(u32) },
-    ) catch return .initErr(.{ .errno = @intFromEnum(bun.sys.E.NAMETOOLONG), .syscall = .clonefile });
-
-    cloned: {
-        switch (sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), tmp_path)) {
-            .result => break :cloned,
-            .err => |err| switch (err.getErrno()) {
-                .NOENT => {
-                    if (this.dest_subpath.dirname()) |parent| {
-                        FD.cwd().makePath(u8, parent) catch {};
-                    }
-                },
-                .EXIST => {
-                    // Stale temp from a crashed earlier run with the same pid.
-                    FD.cwd().deleteTree(tmp_path) catch {};
-                },
-                else => return .initErr(err),
-            },
-        }
-        switch (sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), tmp_path)) {
-            .result => break :cloned,
-            .err => |err| return .initErr(err),
-        }
-    }
-
-    switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
-        .result => return .success,
-        .err => |err| switch (err.getErrno()) {
-            .EXIST, .NOTEMPTY => {
-                // Someone got there first. Keep their tree only if the
-                // entry-level `.bun-ok` stamp is present (i.e. some install
-                // fully built it). `package.json` alone is *not* a valid
-                // sentinel: although clonefileat is whole-tree atomic, a
-                // file-walking install or cache corruption could have left it
-                // alongside an arbitrary subset of files, and the warm-hit
-                // check already established `.bun-ok` is absent (that's why
-                // we're here). Replacing dest with our complete temp tree is
-                // safe even if a concurrent install just renamed first — dest
-                // is only the `<pkg>` directory; their dep symlinks, bin
-                // links, and the `.bun-ok` stamp live alongside it under the
-                // entry root, so their later steps proceed unchanged with our
-                // (identical) package files.
-                if (this.entry_ok_path.len > 0 and sys.existsZ(this.entry_ok_path)) {
-                    FD.cwd().deleteTree(tmp_path) catch {};
-                    return .success;
-                }
-                FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
-                return switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
-                    .result => .success,
-                    .err => |e| switch (e.getErrno()) {
-                        // A concurrent install repopulated it between our
-                        // deleteTree and rename — we're done either way.
-                        .EXIST, .NOTEMPTY => {
-                            FD.cwd().deleteTree(tmp_path) catch {};
-                            return .success;
-                        },
-                        else => {
-                            FD.cwd().deleteTree(tmp_path) catch {};
-                            return .initErr(e);
-                        },
-                    },
-                };
-            },
-            else => {
-                FD.cwd().deleteTree(tmp_path) catch {};
-                return .initErr(err);
-            },
         },
     }
 }

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -4,7 +4,12 @@ const FileCloner = @This();
 
 cache_dir: FD,
 cache_dir_subpath: bun.AutoRelPath,
-dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
+/// When true, an existing destination is treated as success rather than wiped
+/// and re-cloned. Set for global virtual-store entries, which are shared
+/// across projects and content-addressed by name (so the existing tree is
+/// already what we'd produce).
+keep_existing_dest: bool = false,
 
 fn clonefileat(this: *FileCloner) sys.Maybe(void) {
     return sys.clonefileat(this.cache_dir, this.cache_dir_subpath.sliceZ(), FD.cwd(), this.dest_subpath.sliceZ());
@@ -16,6 +21,9 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
         .err => |err| {
             switch (err.getErrno()) {
                 .EXIST => {
+                    if (this.keep_existing_dest) {
+                        return .success;
+                    }
                     FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                     return this.clonefileat();
                 },

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -33,7 +33,17 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
                         return .initErr(err);
                     };
                     FD.cwd().makePath(u8, parent_dest_dir) catch {};
-                    return this.clonefileat();
+                    return switch (this.clonefileat()) {
+                        .result => .success,
+                        .err => |retry_err| switch (retry_err.getErrno()) {
+                            // Another install racing on the same global-store
+                            // entry created it between our NOENT and this retry;
+                            // for content-addressed dests that's a successful
+                            // outcome, not a failure.
+                            .EXIST => if (this.keep_existing_dest) .success else .initErr(retry_err),
+                            else => .initErr(retry_err),
+                        },
+                    };
                 },
                 else => {
                     return .initErr(err);

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -67,7 +67,7 @@ fn cloneAtomic(this: *FileCloner) sys.Maybe(void) {
             .result => break :cloned,
             .err => |err| switch (err.getErrno()) {
                 .NOENT => {
-                    if (std.fs.path.dirname(this.dest_subpath.slice())) |parent| {
+                    if (this.dest_subpath.dirname()) |parent| {
                         FD.cwd().makePath(u8, parent) catch {};
                     }
                 },
@@ -88,21 +88,22 @@ fn cloneAtomic(this: *FileCloner) sys.Maybe(void) {
         .result => return .success,
         .err => |err| switch (err.getErrno()) {
             .EXIST, .NOTEMPTY => {
-                // Someone got there first. Distinguish "concurrent install
-                // produced a complete entry" from "an interrupted install
-                // left a partial directory" by probing for the package.json
-                // the warm-hit fast path uses as its sentinel.
+                // Someone got there first. `package.json` proves their clone
+                // landed (clonefileat is atomic for the whole tree); the dep
+                // symlinks and bin links are written by later task steps that
+                // *this* task will also run with `.expect_existing`, so any
+                // gaps left by a crashed winner get filled by the loser. The
+                // entry-level `.bun-ok` stamp (written after `binaries`) is
+                // what future installs use to short-circuit the whole task.
                 var sentinel_buf: bun.PathBuffer = undefined;
-                const sentinel = std.fmt.bufPrintZ(&sentinel_buf, "{s}/package.json", .{this.dest_subpath.slice()}) catch {
-                    FD.cwd().deleteTree(tmp_path) catch {};
-                    return .initErr(err);
-                };
-                if (sys.existsZ(sentinel)) {
-                    FD.cwd().deleteTree(tmp_path) catch {};
-                    return .success;
-                }
-                // Partial entry from an interrupted earlier run: replace it
-                // with the complete tree we just produced.
+                if (std.fmt.bufPrintZ(&sentinel_buf, "{s}/package.json", .{this.dest_subpath.slice()})) |sentinel| {
+                    if (sys.existsZ(sentinel)) {
+                        FD.cwd().deleteTree(tmp_path) catch {};
+                        return .success;
+                    }
+                } else |_| {}
+                // No package.json → partial leftover from an interrupted
+                // earlier run; replace with our complete tree.
                 FD.cwd().deleteTree(this.dest_subpath.slice()) catch {};
                 return switch (sys.rename(tmp_path, this.dest_subpath.sliceZ())) {
                     .result => .success,

--- a/src/install/isolated_install/FileCloner.zig
+++ b/src/install/isolated_install/FileCloner.zig
@@ -38,7 +38,7 @@ pub fn clone(this: *FileCloner) sys.Maybe(void) {
                 },
 
                 .NOENT => {
-                    const parent_dest_dir = std.fs.path.dirname(this.dest_subpath.slice()) orelse {
+                    const parent_dest_dir = this.dest_subpath.dirname() orelse {
                         return .initErr(err);
                     };
                     FD.cwd().makePath(u8, parent_dest_dir) catch {};

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -1,12 +1,12 @@
 pub const FileCopier = struct {
     src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
-    dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+    dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
     walker: Walker,
 
     pub fn init(
         src_dir: FD,
         src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
-        dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+        dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
         skip_dirnames: []const bun.OSPathSlice,
     ) OOM!FileCopier {
         return .{

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -108,9 +108,9 @@ pub const FileCopier = struct {
                                 // create — `dest_dir` itself was already
                                 // opened above — so the original error is the
                                 // real failure and must propagate. Silently
-                                // continuing here would let `.bun-ok` be
-                                // stamped on a global-store entry that's
-                                // missing files.
+                                // continuing here would let a staged
+                                // global-store entry be renamed into place
+                                // with files missing.
                                 const entry_dirname = bun.Dirname.dirname(u16, entry.path) orelse {
                                     return .initErr(first_err);
                                 };

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -98,8 +98,22 @@ pub const FileCopier = struct {
                         }
                     },
                     .file => {
-                        bun.copyFile(this.src_path.sliceZ(), this.dest_subpath.sliceZ()).unwrap() catch {
-                            if (bun.Dirname.dirname(u16, entry.path)) |entry_dirname| {
+                        switch (bun.copyFile(this.src_path.sliceZ(), this.dest_subpath.sliceZ())) {
+                            .result => {},
+                            .err => |first_err| {
+                                // Retry after creating the parent directory.
+                                // For root-level files (`index.js`,
+                                // `package.json`, `LICENSE`) `dirname` is
+                                // null and there is no missing parent to
+                                // create — `dest_dir` itself was already
+                                // opened above — so the original error is the
+                                // real failure and must propagate. Silently
+                                // continuing here would let `.bun-ok` be
+                                // stamped on a global-store entry that's
+                                // missing files.
+                                const entry_dirname = bun.Dirname.dirname(u16, entry.path) orelse {
+                                    return .initErr(first_err);
+                                };
                                 bun.MakePath.makePath(u16, dest_dir, entry_dirname) catch {};
                                 switch (bun.copyFile(this.src_path.sliceZ(), this.dest_subpath.sliceZ())) {
                                     .result => {},
@@ -107,8 +121,8 @@ pub const FileCopier = struct {
                                         return .initErr(err);
                                     },
                                 }
-                            }
-                        };
+                            },
+                        }
                     },
                     else => unreachable,
                 }

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -75,7 +75,14 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                     const destfile_path_buf2 = bun.w_path_buffer_pool.get();
                     defer bun.w_path_buffer_pool.put(destfile_path_buf2);
                     defer bun.w_path_buffer_pool.put(destfile_path_buf);
-                    const destfile_path = bun.strings.addNTPathPrefixIfNeeded(destfile_path_buf2, bun.path.joinStringBufWZ(destfile_path_buf, &[_][]const u16{ dest_cwd, this.dest.slice() }, .windows));
+                    // `dest` may already be absolute (global virtual store
+                    // entries live under the cache, not cwd); only prefix the
+                    // working-directory path when it's project-relative.
+                    const dest_parts: []const []const u16 = if (this.dest.len() > 0 and bun.path.Platform.windows.isAbsoluteT(u16, this.dest.slice()))
+                        &.{this.dest.slice()}
+                    else
+                        &.{ dest_cwd, this.dest.slice() };
+                    const destfile_path = bun.strings.addNTPathPrefixIfNeeded(destfile_path_buf2, bun.path.joinStringBufWZ(destfile_path_buf, dest_parts, .windows));
 
                     const srcfile_path_buf = bun.w_path_buffer_pool.get();
                     defer bun.w_path_buffer_pool.put(srcfile_path_buf);

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -115,10 +115,7 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 }
                                 switch (sys.link(u16, this.src.sliceZ(), destfile_path)) {
                                     .result => {},
-                                    .err => |link_err2| switch (link_err2.getErrno()) {
-                                        .UV_EEXIST, .EXIST => {},
-                                        else => return .initErr(link_err2),
-                                    },
+                                    .err => |link_err2| return .initErr(link_err2),
                                 }
                             },
                             .UV_ENOENT,
@@ -142,10 +139,7 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
 
                                 switch (sys.link(u16, this.src.sliceZ(), destfile_path)) {
                                     .result => {},
-                                    .err => |link_err2| switch (link_err2.getErrno()) {
-                                        .UV_EEXIST, .EXIST => {},
-                                        else => return .initErr(link_err2),
-                                    },
+                                    .err => |link_err2| return .initErr(link_err2),
                                 }
                             },
                             else => return .initErr(link_err1),
@@ -181,11 +175,7 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 FD.cwd().deleteTree(this.dest.slice()) catch {};
                                 switch (sys.linkatZ(entry.dir, entry.basename, FD.cwd(), this.dest.sliceZ())) {
                                     .result => {},
-                                    // Another writer (concurrent install into a
-                                    // shared global-store entry) re-created the
-                                    // same hardlink between our delete and this
-                                    // retry; it points at identical bytes.
-                                    .err => |link_err2| if (link_err2.getErrno() != .EXIST) return .initErr(link_err2),
+                                    .err => |link_err2| return .initErr(link_err2),
                                 }
                             },
                             .NOENT => {
@@ -196,7 +186,7 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 FD.cwd().makePath(u8, dest_parent) catch {};
                                 switch (sys.linkatZ(entry.dir, entry.basename, FD.cwd(), this.dest.sliceZ())) {
                                     .result => {},
-                                    .err => |link_err2| if (link_err2.getErrno() != .EXIST) return .initErr(link_err2),
+                                    .err => |link_err2| return .initErr(link_err2),
                                 }
                             },
                             else => return .initErr(link_err1),

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -115,7 +115,10 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 }
                                 switch (sys.link(u16, this.src.sliceZ(), destfile_path)) {
                                     .result => {},
-                                    .err => |link_err2| return .initErr(link_err2),
+                                    .err => |link_err2| switch (link_err2.getErrno()) {
+                                        .UV_EEXIST, .EXIST => {},
+                                        else => return .initErr(link_err2),
+                                    },
                                 }
                             },
                             .UV_ENOENT,
@@ -139,7 +142,10 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
 
                                 switch (sys.link(u16, this.src.sliceZ(), destfile_path)) {
                                     .result => {},
-                                    .err => |link_err2| return .initErr(link_err2),
+                                    .err => |link_err2| switch (link_err2.getErrno()) {
+                                        .UV_EEXIST, .EXIST => {},
+                                        else => return .initErr(link_err2),
+                                    },
                                 }
                             },
                             else => return .initErr(link_err1),

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -175,7 +175,11 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 FD.cwd().deleteTree(this.dest.slice()) catch {};
                                 switch (sys.linkatZ(entry.dir, entry.basename, FD.cwd(), this.dest.sliceZ())) {
                                     .result => {},
-                                    .err => |link_err2| return .initErr(link_err2),
+                                    // Another writer (concurrent install into a
+                                    // shared global-store entry) re-created the
+                                    // same hardlink between our delete and this
+                                    // retry; it points at identical bytes.
+                                    .err => |link_err2| if (link_err2.getErrno() != .EXIST) return .initErr(link_err2),
                                 }
                             },
                             .NOENT => {
@@ -186,7 +190,7 @@ pub fn link(this: *Hardlinker) OOM!sys.Maybe(void) {
                                 FD.cwd().makePath(u8, dest_parent) catch {};
                                 switch (sys.linkatZ(entry.dir, entry.basename, FD.cwd(), this.dest.sliceZ())) {
                                     .result => {},
-                                    .err => |link_err2| return .initErr(link_err2),
+                                    .err => |link_err2| if (link_err2.getErrno() != .EXIST) return .initErr(link_err2),
                                 }
                             },
                             else => return .initErr(link_err1),

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -2,13 +2,13 @@ const Hardlinker = @This();
 
 src_dir: FD,
 src: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
-dest: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+dest: bun.Path(.{ .sep = .auto, .unit = .os }),
 walker: Walker,
 
 pub fn init(
     folder_dir: FD,
     src: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
-    dest: bun.RelPath(.{ .sep = .auto, .unit = .os }),
+    dest: bun.Path(.{ .sep = .auto, .unit = .os }),
     skip_dirnames: []const bun.OSPathSlice,
 ) OOM!Hardlinker {
     return .{

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -698,6 +698,30 @@ pub const Installer = struct {
                         },
 
                         .hardlink => {
+                            // The hardlink/copyfile backends walk the source
+                            // tree file-by-file straight into `dest_subpath`.
+                            // For a shared global-store entry that's neither
+                            // atomic nor idempotent: an interrupted earlier
+                            // run can leave a partial tree, and two concurrent
+                            // installs would unlink+relink each other's files.
+                            // Until those backends grow the same temp+rename
+                            // treatment as `cloneAtomic`, take the cheap out:
+                            // if the package tree already landed (a previous
+                            // run got as far as `package.json`), skip the file
+                            // walk entirely; the later steps will fill any
+                            // missing dep symlinks/bins via `.expect_existing`
+                            // and stamp `.bun-ok`. Otherwise wipe and rebuild
+                            // so a half-written tree doesn't survive.
+                            if (uses_global_store) {
+                                var sentinel = dest_subpath.save();
+                                dest_subpath.append("package.json");
+                                const exists = sys.existsZ(dest_subpath.sliceZ());
+                                sentinel.restore();
+                                if (exists) {
+                                    continue :next_step this.nextStep(current_step);
+                                }
+                                FD.cwd().deleteTree(dest_subpath.slice()) catch {};
+                            }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
                                 .err => |err| {
@@ -758,6 +782,17 @@ pub const Installer = struct {
 
                         // fallthrough copyfile
                         else => {
+                            // See the matching note in `.hardlink` above.
+                            if (uses_global_store) {
+                                var sentinel = dest_subpath.save();
+                                dest_subpath.append("package.json");
+                                const exists = sys.existsZ(dest_subpath.sliceZ());
+                                sentinel.restore();
+                                if (exists) {
+                                    continue :next_step this.nextStep(current_step);
+                                }
+                                FD.cwd().deleteTree(dest_subpath.slice()) catch {};
+                            }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
                                 .err => |err| {
@@ -854,6 +889,11 @@ pub const Installer = struct {
                         // `.bun/<storepath>` indirection so `node_modules/<pkg>`
                         // remains a relative link into `node_modules/.bun/`.
                         if (installer.entryUsesGlobalStore(this.entry_id)) {
+                            // The eligibility DFS + fixed-point pass guarantee
+                            // every dep of a global entry is itself global; if
+                            // that ever regressed the failure mode is a
+                            // dangling symlink with no install-time error.
+                            bun.debugAssert(installer.entryUsesGlobalStore(dep.entry_id));
                             installer.appendRealStorePath(&dep_store_path, dep.entry_id);
                         } else {
                             installer.appendStorePath(&dep_store_path, dep.entry_id);
@@ -966,6 +1006,18 @@ pub const Installer = struct {
                 },
                 inline .run_preinstall => |current_step| {
                     if (!installer.manager.options.do.run_scripts or this.entry_id == .root) {
+                        continue :next_step this.nextStep(current_step);
+                    }
+
+                    // The eligibility check excludes any package whose
+                    // lifecycle scripts are trusted to run, so a global-store
+                    // entry should never reach script enqueueing. Guard it
+                    // anyway: `meta.hasInstallScript` can be a false negative
+                    // (yarn-migrated lockfiles force it to `.false`), and a
+                    // script running with cwd inside a shared content-
+                    // addressed directory would mutate every other project's
+                    // copy.
+                    if (installer.entryUsesGlobalStore(this.entry_id)) {
                         continue :next_step this.nextStep(current_step);
                     }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -698,32 +698,19 @@ pub const Installer = struct {
                         },
 
                         .hardlink => {
-                            // The hardlink/copyfile backends walk the source
-                            // tree file-by-file straight into `dest_subpath`.
-                            // For a shared global-store entry that's neither
-                            // atomic nor idempotent: an interrupted earlier
-                            // run can leave a partial tree, and two concurrent
-                            // installs would unlink+relink each other's files.
-                            // Until those backends grow the same temp+rename
-                            // treatment as `cloneAtomic`, take the cheap out:
-                            // if the package tree already landed (a previous
-                            // run got as far as `package.json`), skip the file
-                            // walk entirely; the later steps will fill any
-                            // missing dep symlinks/bins via `.expect_existing`
-                            // and stamp `.bun-ok`. Otherwise wipe and rebuild
-                            // so a half-written tree doesn't survive.
                             if (uses_global_store) {
                                 // The hardlink/copyfile backends write
                                 // file-by-file straight into the destination
                                 // (no temp+rename), so `package.json` can land
-                                // before the rest of the tree. Probing for it
-                                // would accept a half-written entry forever.
-                                // Until those backends grow `cloneAtomic`-style
-                                // staging, take the conservative path: wipe
-                                // and rebuild every time `needs_install` got us
-                                // here. The `.bun-ok` warm-hit check already
-                                // skipped this entire task on the fast path,
-                                // so this only fires for genuinely-missing or
+                                // before the rest of the tree and probing for
+                                // it would accept a half-written entry
+                                // forever. Until those backends grow
+                                // `cloneAtomic`-style staging, take the
+                                // conservative path: wipe and rebuild every
+                                // time `needs_install` got us here. The
+                                // `.bun-ok` warm-hit check already skipped
+                                // this entire task on the fast path, so this
+                                // only fires for genuinely-missing or
                                 // unstamped entries.
                                 var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
                                 defer probe.deinit();

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -152,6 +152,12 @@ pub const Installer = struct {
                 });
                 patch_log.print(Output.errorWriter()) catch {};
             },
+            .binaries => |bin_err| {
+                Output.err(bin_err, "failed to link binaries for package: {s}@{f}", .{
+                    pkg_name.slice(string_buf),
+                    pkg_res.fmt(string_buf, .auto),
+                });
+            },
             else => {},
         }
         Output.flush();
@@ -923,6 +929,12 @@ pub const Installer = struct {
                 },
                 inline .symlink_dependency_binaries => |current_step| {
                     installer.linkDependencyBins(this.entry_id) catch |err| {
+                        // The global virtual-store entry's `.bin/` is shared
+                        // across processes; a concurrent install racing to link
+                        // the same binary produced what we were about to.
+                        if (err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id)) {
+                            continue :next_step this.nextStep(current_step);
+                        }
                         return .failure(.{ .binaries = err });
                     };
 
@@ -1124,6 +1136,11 @@ pub const Installer = struct {
                     }
 
                     if (bin_linker.err) |err| {
+                        // See `.symlink_dependency_binaries` for why EEXIST is
+                        // benign on a shared global-store entry.
+                        if (err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id)) {
+                            continue :next_step this.nextStep(current_step);
+                        }
                         return .failure(.{ .binaries = err });
                     }
 
@@ -1498,6 +1515,13 @@ pub const Installer = struct {
             }
 
             if (bin_linker.err) |err| {
+                // See `.symlink_dependency_binaries` step for why EEXIST is
+                // benign when this entry's `.bin/` lives in the shared global
+                // virtual store.
+                if (err == error.EEXIST and this.entryUsesGlobalStore(parent_entry_id)) {
+                    bin_linker.err = null;
+                    continue;
+                }
                 return err;
             }
         }

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1706,11 +1706,9 @@ pub const Installer = struct {
                 .EXIST => {
                     // Existing entry from a previous install. If it's a
                     // symlink, replace it (stale link from a different
-                    // hash). If it's a *real directory* it's either a
-                    // pre-global-store layout (safe to wipe) or a detached
-                    // `bun patch` workspace the user is actively editing —
-                    // distinguished by the `.bun-patch` marker that
-                    // `detachModuleFolderFromSharedStore` writes.
+                    // hash). If it's a real directory, that's the
+                    // pre-global-store layout (`bun patch` detaches
+                    // `node_modules/<pkg>`, not this path).
                     const is_symlink = if (comptime Environment.isWindows)
                         if (sys.getFileAttributes(dest.sliceZ())) |a| a.is_reparse_point else true
                     else if (sys.lstat(dest.sliceZ()).asValue()) |st|

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -681,13 +681,18 @@ pub const Installer = struct {
                         else
                             false;
                         if (is_stale_link) {
-                            if (comptime Environment.isWindows) {
+                            const remove_err: ?sys.Error = if (comptime Environment.isWindows) win: {
                                 if (sys.rmdir(local.sliceZ()).asErr()) |_| {
-                                    _ = sys.unlink(local.sliceZ());
+                                    if (sys.unlink(local.sliceZ()).asErr()) |e| break :win e;
                                 }
-                            } else {
-                                _ = sys.unlink(local.sliceZ());
-                            }
+                                break :win null;
+                            } else sys.unlink(local.sliceZ()).asErr();
+                            if (remove_err) |e| if (e.getErrno() != .NOENT) {
+                                // Do NOT proceed: the backend below would
+                                // write *through* the still-live symlink
+                                // into the shared `<cache>/links/` entry.
+                                return .failure(.{ .link_package = e });
+                            };
                         }
                     }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1699,23 +1699,36 @@ pub const Installer = struct {
                     }
                 },
                 .EXIST => {
-                    // Existing entry from a previous install: replace if it's
-                    // a stale symlink, otherwise wipe the directory tree
-                    // (pre-global-store layout) before relinking.
-                    if (sys.unlink(dest.sliceZ()).asErr()) |_| {
+                    // Existing entry from a previous install. If it's a
+                    // symlink, replace it (stale link from a different
+                    // hash). If it's a *real directory* it's either a
+                    // pre-global-store layout (safe to wipe) or a detached
+                    // `bun patch` workspace the user is actively editing —
+                    // distinguished by the `.bun-patch` marker that
+                    // `detachModuleFolderFromSharedStore` writes.
+                    const is_symlink = if (comptime Environment.isWindows)
+                        if (sys.getFileAttributes(dest.sliceZ())) |a| a.is_reparse_point else true
+                    else if (sys.lstat(dest.sliceZ()).asValue()) |st|
+                        std.posix.S.ISLNK(@intCast(st.mode))
+                    else
+                        true;
+
+                    if (is_symlink) {
+                        if (comptime Environment.isWindows) {
+                            if (sys.rmdir(dest.sliceZ()).asErr()) |_| {
+                                _ = sys.unlink(dest.sliceZ());
+                            }
+                        } else {
+                            _ = sys.unlink(dest.sliceZ());
+                        }
+                    } else {
                         FD.cwd().deleteTree(dest.slice()) catch {};
                     }
                 },
                 else => return .initErr(err),
             },
         }
-        return switch (do_symlink(dest.sliceZ(), target_abs.sliceZ())) {
-            .result => .success,
-            // EEXIST after the recovery above means another writer won the
-            // race between our unlink/mkdir and this retry; the symlink it
-            // created points at the same content-addressed target.
-            .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
-        };
+        return do_symlink(dest.sliceZ(), target_abs.sliceZ());
     }
 
     pub fn appendStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -713,14 +713,21 @@ pub const Installer = struct {
                             // and stamp `.bun-ok`. Otherwise wipe and rebuild
                             // so a half-written tree doesn't survive.
                             if (uses_global_store) {
-                                var sentinel = dest_subpath.save();
-                                dest_subpath.append("package.json");
-                                const exists = sys.existsZ(dest_subpath.sliceZ());
-                                sentinel.restore();
+                                // `dest_subpath` is `.unit = .os` (u16 on
+                                // Windows); the existence/deleteTree helpers
+                                // want u8, so rebuild the same path via the
+                                // u8 store-path helper for the probe.
+                                var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
+                                defer probe.deinit();
+                                installer.appendRealStorePath(&probe, this.entry_id);
+                                const probe_save = probe.save();
+                                probe.append("package.json");
+                                const exists = sys.existsZ(probe.sliceZ());
+                                probe_save.restore();
                                 if (exists) {
                                     continue :next_step this.nextStep(current_step);
                                 }
-                                FD.cwd().deleteTree(dest_subpath.slice()) catch {};
+                                FD.cwd().deleteTree(probe.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
@@ -784,14 +791,21 @@ pub const Installer = struct {
                         else => {
                             // See the matching note in `.hardlink` above.
                             if (uses_global_store) {
-                                var sentinel = dest_subpath.save();
-                                dest_subpath.append("package.json");
-                                const exists = sys.existsZ(dest_subpath.sliceZ());
-                                sentinel.restore();
+                                // `dest_subpath` is `.unit = .os` (u16 on
+                                // Windows); the existence/deleteTree helpers
+                                // want u8, so rebuild the same path via the
+                                // u8 store-path helper for the probe.
+                                var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
+                                defer probe.deinit();
+                                installer.appendRealStorePath(&probe, this.entry_id);
+                                const probe_save = probe.save();
+                                probe.append("package.json");
+                                const exists = sys.existsZ(probe.sliceZ());
+                                probe_save.restore();
                                 if (exists) {
                                     continue :next_step this.nextStep(current_step);
                                 }
-                                FD.cwd().deleteTree(dest_subpath.slice()) catch {};
+                                FD.cwd().deleteTree(probe.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
@@ -1190,11 +1204,14 @@ pub const Installer = struct {
 
                     if (bin_linker.err) |err| {
                         // See `.symlink_dependency_binaries` for why EEXIST is
-                        // benign on a shared global-store entry.
-                        if (err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id)) {
-                            continue :next_step this.nextStep(current_step);
+                        // benign on a shared global-store entry. Fall through
+                        // so the `.bun-ok` stamp still lands; if the writer
+                        // that created the colliding bin link died before
+                        // stamping, this task is now the one responsible for
+                        // marking the entry complete.
+                        if (!(err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id))) {
+                            return .failure(.{ .binaries = err });
                         }
-                        return .failure(.{ .binaries = err });
                     }
 
                     installer.stampGlobalStoreEntry(this.entry_id);
@@ -1615,8 +1632,8 @@ pub const Installer = struct {
         defer ok.deinit();
         this.appendGlobalStoreEntryPath(&ok, entry_id);
         ok.append(".bun-ok");
-        switch (sys.openat(FD.cwd(), ok.sliceZ(), bun.O.CREAT | bun.O.WRONLY, 0o644)) {
-            .result => |fd| fd.close(),
+        switch (sys.File.openat(FD.cwd(), ok.sliceZ(), bun.O.CREAT | bun.O.WRONLY, 0o644)) {
+            .result => |f| f.close(),
             .err => {},
         }
     }

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -711,11 +711,23 @@ pub const Installer = struct {
                         // stamp live alongside it under the entry root, so
                         // their later steps proceed unchanged with our
                         // (identical) package files.
+                        fn isCollision(e: bun.sys.E) bool {
+                            return switch (e) {
+                                .EXIST, .NOTEMPTY => true,
+                                // Windows maps a rename onto an in-use
+                                // directory to ERROR_ACCESS_DENIED, which
+                                // surfaces here as PERM/ACCES. On Linux/macOS
+                                // those are real permission errors (read-only
+                                // mount, NFS root-squash) and must propagate.
+                                .PERM, .ACCES => Environment.isWindows,
+                                else => false,
+                            };
+                        }
                         fn call(tmp: *bun.AbsPath(.{ .sep = .auto }), real: *bun.AbsPath(.{ .sep = .auto }), entry_ok: *bun.AbsPath(.{ .sep = .auto })) sys.Maybe(void) {
                             switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
                                 .result => return .success,
-                                .err => |err| switch (err.getErrno()) {
-                                    .EXIST, .NOTEMPTY, .PERM, .ACCES => {
+                                .err => |err| {
+                                    if (isCollision(err.getErrno())) {
                                         if (sys.existsZ(entry_ok.sliceZ())) {
                                             FD.cwd().deleteTree(tmp.slice()) catch {};
                                             return .success;
@@ -723,25 +735,21 @@ pub const Installer = struct {
                                         FD.cwd().deleteTree(real.slice()) catch {};
                                         return switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
                                             .result => .success,
-                                            .err => |e| switch (e.getErrno()) {
+                                            .err => |e| {
                                                 // Concurrent install repopulated
                                                 // it between deleteTree and
                                                 // rename — done either way.
-                                                .EXIST, .NOTEMPTY, .PERM, .ACCES => {
+                                                if (isCollision(e.getErrno())) {
                                                     FD.cwd().deleteTree(tmp.slice()) catch {};
                                                     return .success;
-                                                },
-                                                else => {
-                                                    FD.cwd().deleteTree(tmp.slice()) catch {};
-                                                    return .initErr(e);
-                                                },
+                                                }
+                                                FD.cwd().deleteTree(tmp.slice()) catch {};
+                                                return .initErr(e);
                                             },
                                         };
-                                    },
-                                    else => {
-                                        FD.cwd().deleteTree(tmp.slice()) catch {};
-                                        return .initErr(err);
-                                    },
+                                    }
+                                    FD.cwd().deleteTree(tmp.slice()) catch {};
+                                    return .initErr(err);
                                 },
                             }
                         }

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1588,7 +1588,6 @@ pub const Installer = struct {
                     if (dest.dirname()) |parent| {
                         FD.cwd().makePath(u8, parent) catch {};
                     }
-                    return do_symlink(dest.sliceZ(), target_abs.sliceZ());
                 },
                 .EXIST => {
                     // Existing entry from a previous install: replace if it's
@@ -1597,11 +1596,17 @@ pub const Installer = struct {
                     if (sys.unlink(dest.sliceZ()).asErr()) |_| {
                         FD.cwd().deleteTree(dest.slice()) catch {};
                     }
-                    return do_symlink(dest.sliceZ(), target_abs.sliceZ());
                 },
                 else => return .initErr(err),
             },
         }
+        return switch (do_symlink(dest.sliceZ(), target_abs.sliceZ())) {
+            .result => .success,
+            // EEXIST after the recovery above means another writer won the
+            // race between our unlink/mkdir and this retry; the symlink it
+            // created points at the same content-addressed target.
+            .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
+        };
     }
 
     pub fn appendStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -28,6 +28,14 @@ pub const Installer = struct {
     /// clonefile work.
     global_store_path: ?[:0]const u8,
 
+    /// Per-process suffix for staging global-store entries. Each entry is
+    /// built under `<cache>/links/<storepath>-<hash>.tmp-<this>/` (package
+    /// files, dep symlinks, bin links — all relative within the entry, so
+    /// they resolve identically after the rename) and renamed into place as
+    /// the final step. The directory existing at its final path is the only
+    /// completeness signal the warm-hit check needs.
+    global_store_tmp_suffix: u64,
+
     pub fn deinit(this: *Installer) void {
         this.trusted_dependencies_from_update_requests.deinit(this.lockfile.allocator);
     }
@@ -161,6 +169,16 @@ pub const Installer = struct {
             else => {},
         }
         Output.flush();
+
+        // Clean up the staging directory so a half-built global-store entry
+        // doesn't leak in the cache (it would never be reused — the suffix is
+        // random — but it's wasted disk).
+        if (this.entryUsesGlobalStore(entry_id)) {
+            var staging: bun.AbsPath(.{ .sep = .auto }) = .init();
+            defer staging.deinit();
+            this.appendGlobalStoreEntryPath(&staging, entry_id, .staging);
+            FD.cwd().deleteTree(staging.slice()) catch {};
+        }
 
         // attempt deleting the package so the next install will install it again
         switch (pkg_res.tag) {
@@ -635,7 +653,7 @@ pub const Installer = struct {
 
                     var dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }) = .init();
                     defer dest_subpath.deinit();
-                    installer.appendRealStorePath(&dest_subpath, this.entry_id);
+                    installer.appendRealStorePath(&dest_subpath, this.entry_id, .staging);
 
                     const uses_global_store = installer.entryUsesGlobalStore(this.entry_id);
 
@@ -673,92 +691,14 @@ pub const Installer = struct {
                         }
                     }
 
-                    // For the file-walking backends (hardlink/copyfile), shared
-                    // global-store entries are populated through a temp sibling
-                    // and renamed into place — same staging FileCloner does in
-                    // `cloneAtomic`. Writing file-by-file straight into the
-                    // shared destination races with other `bun install`
-                    // processes building the same content-addressed entry: the
-                    // EEXIST→deleteTree→relink recovery in those backends
-                    // collides with the other process's `CreateHardLinkW` and
-                    // surfaces as EPERM (sharing violation) and
-                    // `STATUS_FILE_DELETED` (`NTSTATUS=0xc0000123`, file is
-                    // delete-pending). With temp+rename, processes never touch
-                    // the same file; whichever rename lands first wins and the
-                    // loser discards its identical temp tree.
-                    // The OS-unit path for the file-walking backends, plus a
-                    // parallel UTF-8 path for `sys.rename`/`deleteTree` (which
-                    // take `[]const u8` even on Windows).
-                    var staged_dest: ?bun.Path(.{ .sep = .auto, .unit = .os }) = null;
-                    defer if (staged_dest) |*p| p.deinit();
-                    var staged_dest_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
-                    defer staged_dest_u8.deinit();
-                    var real_dest_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
-                    defer real_dest_u8.deinit();
-                    const finishStagedDest = struct {
-                        // On rename EEXIST/NOTEMPTY, keep the existing dest
-                        // only if the entry-level `.bun-ok` stamp is present
-                        // (i.e. some install fully built it). `package.json`
-                        // alone is *not* a valid sentinel here: a hardlink/
-                        // copyfile run from before this commit could have
-                        // crashed mid-walk leaving package.json plus an
-                        // arbitrary subset of files, and the warm-hit check
-                        // already established `.bun-ok` is absent (that's why
-                        // we're here). Replacing dest with our complete temp
-                        // tree is safe even if a concurrent install just
-                        // renamed first — dest is only the `<pkg>` directory;
-                        // their dep symlinks, bin links, and the `.bun-ok`
-                        // stamp live alongside it under the entry root, so
-                        // their later steps proceed unchanged with our
-                        // (identical) package files.
-                        fn isCollision(e: bun.sys.E) bool {
-                            return switch (e) {
-                                .EXIST, .NOTEMPTY => true,
-                                // Windows maps a rename onto an in-use
-                                // directory to ERROR_ACCESS_DENIED, which
-                                // surfaces here as PERM/ACCES. On Linux/macOS
-                                // those are real permission errors (read-only
-                                // mount, NFS root-squash) and must propagate.
-                                .PERM, .ACCES => Environment.isWindows,
-                                else => false,
-                            };
-                        }
-                        fn call(tmp: *bun.AbsPath(.{ .sep = .auto }), real: *bun.AbsPath(.{ .sep = .auto }), entry_ok: *bun.AbsPath(.{ .sep = .auto })) sys.Maybe(void) {
-                            switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
-                                .result => return .success,
-                                .err => |err| {
-                                    if (isCollision(err.getErrno())) {
-                                        if (sys.existsZ(entry_ok.sliceZ())) {
-                                            FD.cwd().deleteTree(tmp.slice()) catch {};
-                                            return .success;
-                                        }
-                                        FD.cwd().deleteTree(real.slice()) catch {};
-                                        return switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
-                                            .result => .success,
-                                            .err => |e| {
-                                                // Concurrent install repopulated
-                                                // it between deleteTree and
-                                                // rename — done either way.
-                                                if (isCollision(e.getErrno())) {
-                                                    FD.cwd().deleteTree(tmp.slice()) catch {};
-                                                    return .success;
-                                                }
-                                                FD.cwd().deleteTree(tmp.slice()) catch {};
-                                                return .initErr(e);
-                                            },
-                                        };
-                                    }
-                                    FD.cwd().deleteTree(tmp.slice()) catch {};
-                                    return .initErr(err);
-                                },
-                            }
-                        }
-                    }.call;
-                    var entry_ok_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
-                    defer entry_ok_u8.deinit();
                     if (uses_global_store) {
-                        installer.appendGlobalStoreEntryPath(&entry_ok_u8, this.entry_id);
-                        entry_ok_u8.append(".bun-ok");
+                        // Clear any leftover staging directory from a crashed
+                        // earlier run with the same suffix (vanishingly
+                        // unlikely with a 64-bit random suffix, but cheap).
+                        var staging: bun.AbsPath(.{ .sep = .auto }) = .init();
+                        defer staging.deinit();
+                        installer.appendGlobalStoreEntryPath(&staging, this.entry_id, .staging);
+                        FD.cwd().deleteTree(staging.slice()) catch {};
                     }
 
                     var cached_package_dir: ?FD = null;
@@ -790,12 +730,6 @@ pub const Installer = struct {
                                 .cache_dir = cache_dir,
                                 .cache_dir_subpath = pkg_cache_dir_subpath,
                                 .dest_subpath = dest_subpath,
-                                // The global store is shared across projects and
-                                // installs; never wipe an existing entry just to
-                                // re-clone identical bytes (and never race two
-                                // installs into deleting each other's work).
-                                .keep_existing_dest = uses_global_store,
-                                .entry_ok_path = if (uses_global_store) entry_ok_u8.sliceZ() else "",
                             };
 
                             switch (cloner.clone()) {
@@ -821,20 +755,6 @@ pub const Installer = struct {
                         },
 
                         .hardlink => {
-                            if (uses_global_store and staged_dest == null) {
-                                installer.appendRealStorePath(&real_dest_u8, this.entry_id);
-                                staged_dest_u8.appendFmt("{s}.tmp-{d}-{d}", .{
-                                    real_dest_u8.slice(),
-                                    if (comptime Environment.isWindows) std.os.windows.GetCurrentProcessId() else std.c.getpid(),
-                                    std.crypto.random.int(u32),
-                                });
-                                staged_dest = .init();
-                                staged_dest.?.append(staged_dest_u8.slice());
-                                // Stale temp from a crashed earlier run with
-                                // the same pid is the only thing that can
-                                // already be here.
-                                FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
-                            }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
                                 .err => |err| {
@@ -858,20 +778,14 @@ pub const Installer = struct {
                             var hardlinker: Hardlinker = try .init(
                                 cached_package_dir.?,
                                 src,
-                                if (staged_dest) |*tmp| tmp.* else dest_subpath,
+                                dest_subpath,
                                 &.{},
                             );
                             defer hardlinker.deinit();
 
                             switch (try hardlinker.link()) {
-                                .result => {
-                                    if (staged_dest != null) switch (finishStagedDest(&staged_dest_u8, &real_dest_u8, &entry_ok_u8)) {
-                                        .result => {},
-                                        .err => |err| return .failure(.{ .link_package = err }),
-                                    };
-                                },
+                                .result => {},
                                 .err => |err| {
-                                    if (staged_dest != null) FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                                     if (err.getErrno() == .XDEV) {
                                         installer.supported_backend.store(.copyfile, .monotonic);
                                         continue :backend .copyfile;
@@ -901,20 +815,6 @@ pub const Installer = struct {
 
                         // fallthrough copyfile
                         else => {
-                            // See the matching note in `.hardlink` above for
-                            // why shared global-store entries are written via a
-                            // temp sibling and renamed into place.
-                            if (uses_global_store and staged_dest == null) {
-                                installer.appendRealStorePath(&real_dest_u8, this.entry_id);
-                                staged_dest_u8.appendFmt("{s}.tmp-{d}-{d}", .{
-                                    real_dest_u8.slice(),
-                                    if (comptime Environment.isWindows) std.os.windows.GetCurrentProcessId() else std.c.getpid(),
-                                    std.crypto.random.int(u32),
-                                });
-                                staged_dest = .init();
-                                staged_dest.?.append(staged_dest_u8.slice());
-                                FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
-                            }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
                                 .err => |err| {
@@ -945,20 +845,14 @@ pub const Installer = struct {
                             var file_copier: FileCopier = try .init(
                                 cached_package_dir.?,
                                 src_path,
-                                if (staged_dest) |*tmp| tmp.* else dest_subpath,
+                                dest_subpath,
                                 &.{},
                             );
                             defer file_copier.deinit();
 
                             switch (file_copier.copy()) {
-                                .result => {
-                                    if (staged_dest != null) switch (finishStagedDest(&staged_dest_u8, &real_dest_u8, &entry_ok_u8)) {
-                                        .result => {},
-                                        .err => |err| return .failure(.{ .link_package = err }),
-                                    };
-                                },
+                                .result => {},
                                 .err => |err| {
-                                    if (staged_dest != null) FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                                     if (PackageManager.verbose_install) {
                                         Output.prettyErrorln(
                                             \\<red><b>error<r><d>:<r>Failed to copy package
@@ -993,7 +887,7 @@ pub const Installer = struct {
                         var dest: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
                         defer dest.deinit();
 
-                        installer.appendRealStoreNodeModulesPath(&dest, this.entry_id);
+                        installer.appendRealStoreNodeModulesPath(&dest, this.entry_id, .staging);
 
                         dest.append(dep_name);
 
@@ -1022,7 +916,13 @@ pub const Installer = struct {
                             // that ever regressed the failure mode is a
                             // dangling symlink with no install-time error.
                             bun.debugAssert(installer.entryUsesGlobalStore(dep.entry_id));
-                            installer.appendRealStorePath(&dep_store_path, dep.entry_id);
+                            // Target the dep's *final* path: the relative
+                            // `../../<dep>/...` link is computed against our
+                            // staging directory but resolves identically once
+                            // we're renamed (same parent), and the dep will
+                            // have been (or will be) renamed into that final
+                            // path by its own task.
+                            installer.appendRealStorePath(&dep_store_path, dep.entry_id, .final);
                         } else {
                             installer.appendStorePath(&dep_store_path, dep.entry_id);
                         }
@@ -1047,15 +947,10 @@ pub const Installer = struct {
                             // exist unconditionally. To make sure it's fast, first readlink
                             // then create the symlink if necessary
                             .expect_existing
-                        else if (installer.entryUsesGlobalStore(this.entry_id))
-                            // Global virtual-store entries are shared across installs;
-                            // a previous build of this entry already populated these
-                            // symlinks. Re-creating them is wasted syscalls, but the
-                            // bigger problem is that `.expect_missing` deletes the
-                            // existing tree on EEXIST, which would race with other
-                            // installs reading through the same global entry.
-                            .expect_existing
                         else
+                            // Global-store entries are built under a private
+                            // per-process staging directory, so nothing else
+                            // is touching this path.
                             .expect_missing;
 
                         switch (symlinker.ensureSymlink(link_strategy)) {
@@ -1097,12 +992,6 @@ pub const Installer = struct {
                 },
                 inline .symlink_dependency_binaries => |current_step| {
                     installer.linkDependencyBins(this.entry_id) catch |err| {
-                        // The global virtual-store entry's `.bin/` is shared
-                        // across processes; a concurrent install racing to link
-                        // the same binary produced what we were about to.
-                        if (err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id)) {
-                            continue :next_step this.nextStep(current_step);
-                        }
                         return .failure(.{ .binaries = err });
                     };
 
@@ -1237,7 +1126,10 @@ pub const Installer = struct {
 
                     const bin = pkg_bins[pkg_id];
                     if (bin.tag == .none) {
-                        installer.stampGlobalStoreEntry(this.entry_id);
+                        switch (installer.commitGlobalStoreEntry(this.entry_id)) {
+                            .result => {},
+                            .err => |e| return .failure(.{ .link_package = e }),
+                        }
                         continue :next_step this.nextStep(current_step);
                     }
 
@@ -1258,7 +1150,7 @@ pub const Installer = struct {
 
                     var node_modules_path: bun.AbsPath(.{}) = .initTopLevelDir();
                     defer node_modules_path.deinit();
-                    installer.appendRealStoreNodeModulesPath(&node_modules_path, this.entry_id);
+                    installer.appendRealStoreNodeModulesPath(&node_modules_path, this.entry_id, .staging);
 
                     var target_node_modules_path: ?bun.AbsPath(.{}) = null;
                     defer if (target_node_modules_path) |*path| path.deinit();
@@ -1275,7 +1167,7 @@ pub const Installer = struct {
                         pkg_id,
                     )) |replacement_entry_id| {
                         target_node_modules_path = bun.AbsPath(.{}).initTopLevelDir();
-                        installer.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
+                        installer.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id, .final);
 
                         const replacement_node_id = entry_node_ids[replacement_entry_id.get()];
                         const replacement_pkg_id = node_pkg_ids[replacement_node_id.get()];
@@ -1317,18 +1209,13 @@ pub const Installer = struct {
                     }
 
                     if (bin_linker.err) |err| {
-                        // See `.symlink_dependency_binaries` for why EEXIST is
-                        // benign on a shared global-store entry. Fall through
-                        // so the `.bun-ok` stamp still lands; if the writer
-                        // that created the colliding bin link died before
-                        // stamping, this task is now the one responsible for
-                        // marking the entry complete.
-                        if (!(err == error.EEXIST and installer.entryUsesGlobalStore(this.entry_id))) {
-                            return .failure(.{ .binaries = err });
-                        }
+                        return .failure(.{ .binaries = err });
                     }
 
-                    installer.stampGlobalStoreEntry(this.entry_id);
+                    switch (installer.commitGlobalStoreEntry(this.entry_id)) {
+                        .result => {},
+                        .err => |e| return .failure(.{ .link_package = e }),
+                    }
 
                     continue :next_step this.nextStep(current_step);
                 },
@@ -1630,7 +1517,7 @@ pub const Installer = struct {
         var node_modules_path: bun.AbsPath(.{}) = .initTopLevelDir();
         defer node_modules_path.deinit();
 
-        this.appendRealStoreNodeModulesPath(&node_modules_path, parent_entry_id);
+        this.appendRealStoreNodeModulesPath(&node_modules_path, parent_entry_id, .staging);
 
         for (entry_deps[parent_entry_id.get()].slice()) |dep| {
             const node_id = entry_node_ids[dep.entry_id.get()];
@@ -1658,7 +1545,7 @@ pub const Installer = struct {
                 pkg_id,
             )) |replacement_entry_id| {
                 target_node_modules_path = bun.AbsPath(.{}).initTopLevelDir();
-                this.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
+                this.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id, .final);
 
                 const replacement_node_id = entry_node_ids[replacement_entry_id.get()];
                 const replacement_pkg_id = node_pkg_ids[replacement_node_id.get()];
@@ -1701,13 +1588,6 @@ pub const Installer = struct {
             }
 
             if (bin_linker.err) |err| {
-                // See `.symlink_dependency_binaries` step for why EEXIST is
-                // benign when this entry's `.bin/` lives in the shared global
-                // virtual store.
-                if (err == error.EEXIST and this.entryUsesGlobalStore(parent_entry_id)) {
-                    bin_linker.err = null;
-                    continue;
-                }
                 return err;
             }
         }
@@ -1724,31 +1604,56 @@ pub const Installer = struct {
 
     /// Absolute path to the global virtual-store directory for `entry_id`:
     ///   <cache>/links/<storepath>-<entry_hash>
-    /// (no trailing `/node_modules`).
-    pub fn appendGlobalStoreEntryPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+    /// (no trailing `/node_modules`). Pass `.staging` to get the per-process
+    /// temp sibling that the build steps write into; the final `binaries`
+    /// step renames staging → final.
+    pub fn appendGlobalStoreEntryPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id, which: Which) void {
         bun.debugAssert(this.entryUsesGlobalStore(entry_id));
         buf.clear();
         buf.append(this.global_store_path.?);
-        buf.appendFmt("{f}", .{
-            Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
-        });
+        switch (which) {
+            .final => buf.appendFmt("{f}", .{
+                Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
+            }),
+            .staging => buf.appendFmt("{f}.tmp-{x}", .{
+                Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
+                this.global_store_tmp_suffix,
+            }),
+        }
     }
 
-    /// Touch `<global-entry>/.bun-ok` once the package tree, dep symlinks,
-    /// dependency-bin links and own-bin links are all in place. Future
-    /// installs (and concurrent installs whose rename lost) use this to
-    /// distinguish "fully built" from "package tree present but symlinks
-    /// missing because the writer crashed mid-task" — `package.json` only
-    /// proves the clone landed.
-    pub fn stampGlobalStoreEntry(this: *const Installer, entry_id: Store.Entry.Id) void {
-        if (!this.entryUsesGlobalStore(entry_id)) return;
-        var ok: bun.AbsPath(.{ .sep = .auto }) = .init();
-        defer ok.deinit();
-        this.appendGlobalStoreEntryPath(&ok, entry_id);
-        ok.append(".bun-ok");
-        switch (sys.File.openat(FD.cwd(), ok.sliceZ(), bun.O.CREAT | bun.O.WRONLY, 0o644)) {
-            .result => |f| f.close(),
-            .err => {},
+    /// Atomically publish a staged global-store entry by renaming
+    /// `<entry>.tmp-<suffix>/` → `<entry>/`. The package tree, dep symlinks,
+    /// dependency-bin links and own-bin links were all written under the
+    /// staging path; every link inside is relative to the entry directory, so
+    /// they resolve identically after the rename. The final directory
+    /// existing is the only completeness signal — no separate stamp file.
+    pub fn commitGlobalStoreEntry(this: *const Installer, entry_id: Store.Entry.Id) sys.Maybe(void) {
+        if (!this.entryUsesGlobalStore(entry_id)) return .success;
+        var staging: bun.AbsPath(.{ .sep = .auto }) = .init();
+        defer staging.deinit();
+        this.appendGlobalStoreEntryPath(&staging, entry_id, .staging);
+        var final: bun.AbsPath(.{ .sep = .auto }) = .init();
+        defer final.deinit();
+        this.appendGlobalStoreEntryPath(&final, entry_id, .final);
+
+        switch (sys.renameat(FD.cwd(), staging.sliceZ(), FD.cwd(), final.sliceZ())) {
+            .result => return .success,
+            .err => |err| {
+                const collided = switch (err.getErrno()) {
+                    .EXIST, .NOTEMPTY => true,
+                    // Windows maps a rename onto an in-use directory to
+                    // ERROR_ACCESS_DENIED; on POSIX PERM/ACCES are real
+                    // permission failures and must propagate.
+                    .PERM, .ACCES => Environment.isWindows,
+                    else => false,
+                };
+                FD.cwd().deleteTree(staging.slice()) catch {};
+                // A concurrent install renamed first; both writers produced
+                // the same content-addressed bytes, so theirs is as good as
+                // ours.
+                return if (collided) .success else .initErr(err);
+            },
         }
     }
 
@@ -1770,7 +1675,7 @@ pub const Installer = struct {
 
         var target_abs: bun.AbsPath(.{ .sep = .auto }) = .init();
         defer target_abs.deinit();
-        this.appendGlobalStoreEntryPath(&target_abs, entry_id);
+        this.appendGlobalStoreEntryPath(&target_abs, entry_id, .final);
 
         // Absolute target so the link is independent of where node_modules
         // lives (project root may itself be behind a symlink). Symlinker's
@@ -1845,16 +1750,23 @@ pub const Installer = struct {
         }
     }
 
+    pub const Which = enum {
+        /// The published location (`<cache>/links/<entry>`). Use for symlink
+        /// *targets* that point at other entries, and for the warm-hit check.
+        final,
+        /// The per-process temp sibling (`<entry>.tmp-<suffix>`) the build
+        /// steps write into. Use for *destinations* of clonefile/hardlink/
+        /// dep-symlink/bin-link when building this entry.
+        staging,
+    };
+
     /// Like `appendStoreNodeModulesPath`, but resolves to the *physical*
     /// location of the entry's `node_modules` directory: the global virtual
     /// store for global-eligible entries, or the project-local `.bun/` path
-    /// otherwise. Use this when *writing into* the entry (clonefile dest,
-    /// dep/bin symlink dest); use the non-`Real` variant when computing a
-    /// path that other entries will *follow* (so they go through the
-    /// project-local `.bun/<storepath>` symlink and stay relocatable).
-    pub fn appendRealStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+    /// otherwise. See `Which` for when to pass `.staging` vs `.final`.
+    pub fn appendRealStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id, which: Which) void {
         if (this.entryUsesGlobalStore(entry_id)) {
-            this.appendGlobalStoreEntryPath(buf, entry_id);
+            this.appendGlobalStoreEntryPath(buf, entry_id, which);
             buf.append("node_modules");
             return;
         }
@@ -1862,14 +1774,14 @@ pub const Installer = struct {
     }
 
     /// `appendStorePath` resolved to the entry's *physical* location. See
-    /// `appendRealStoreNodeModulesPath` for when to use Real vs non-Real.
-    pub fn appendRealStorePath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+    /// `Which` for when to pass `.staging` vs `.final`.
+    pub fn appendRealStorePath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id, which: Which) void {
         if (this.entryUsesGlobalStore(entry_id)) {
             const string_buf = this.lockfile.buffers.string_bytes.items;
             const node_id = this.store.entries.items(.node_id)[entry_id.get()];
             const pkg_id = this.store.nodes.items(.pkg_id)[node_id.get()];
             const pkg_name = this.lockfile.packages.items(.name)[pkg_id];
-            this.appendGlobalStoreEntryPath(buf, entry_id);
+            this.appendGlobalStoreEntryPath(buf, entry_id, which);
             buf.append("node_modules");
             buf.append(pkg_name.slice(string_buf));
             return;

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -639,6 +639,86 @@ pub const Installer = struct {
 
                     const uses_global_store = installer.entryUsesGlobalStore(this.entry_id);
 
+                    // For the file-walking backends (hardlink/copyfile), shared
+                    // global-store entries are populated through a temp sibling
+                    // and renamed into place — same staging FileCloner does in
+                    // `cloneAtomic`. Writing file-by-file straight into the
+                    // shared destination races with other `bun install`
+                    // processes building the same content-addressed entry: the
+                    // EEXIST→deleteTree→relink recovery in those backends
+                    // collides with the other process's `CreateHardLinkW` and
+                    // surfaces as EPERM (sharing violation) and
+                    // `STATUS_FILE_DELETED` (`NTSTATUS=0xc0000123`, file is
+                    // delete-pending). With temp+rename, processes never touch
+                    // the same file; whichever rename lands first wins and the
+                    // loser discards its identical temp tree.
+                    // The OS-unit path for the file-walking backends, plus a
+                    // parallel UTF-8 path for `sys.rename`/`deleteTree` (which
+                    // take `[]const u8` even on Windows).
+                    var staged_dest: ?bun.Path(.{ .sep = .auto, .unit = .os }) = null;
+                    defer if (staged_dest) |*p| p.deinit();
+                    var staged_dest_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
+                    defer staged_dest_u8.deinit();
+                    var real_dest_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
+                    defer real_dest_u8.deinit();
+                    const finishStagedDest = struct {
+                        // On rename EEXIST/NOTEMPTY, keep the existing dest
+                        // only if the entry-level `.bun-ok` stamp is present
+                        // (i.e. some install fully built it). `package.json`
+                        // alone is *not* a valid sentinel here: a hardlink/
+                        // copyfile run from before this commit could have
+                        // crashed mid-walk leaving package.json plus an
+                        // arbitrary subset of files, and the warm-hit check
+                        // already established `.bun-ok` is absent (that's why
+                        // we're here). Replacing dest with our complete temp
+                        // tree is safe even if a concurrent install just
+                        // renamed first — dest is only the `<pkg>` directory;
+                        // their dep symlinks, bin links, and the `.bun-ok`
+                        // stamp live alongside it under the entry root, so
+                        // their later steps proceed unchanged with our
+                        // (identical) package files.
+                        fn call(tmp: *bun.AbsPath(.{ .sep = .auto }), real: *bun.AbsPath(.{ .sep = .auto }), entry_ok: *bun.AbsPath(.{ .sep = .auto })) sys.Maybe(void) {
+                            switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
+                                .result => return .success,
+                                .err => |err| switch (err.getErrno()) {
+                                    .EXIST, .NOTEMPTY, .PERM, .ACCES => {
+                                        if (sys.existsZ(entry_ok.sliceZ())) {
+                                            FD.cwd().deleteTree(tmp.slice()) catch {};
+                                            return .success;
+                                        }
+                                        FD.cwd().deleteTree(real.slice()) catch {};
+                                        return switch (sys.renameat(FD.cwd(), tmp.sliceZ(), FD.cwd(), real.sliceZ())) {
+                                            .result => .success,
+                                            .err => |e| switch (e.getErrno()) {
+                                                // Concurrent install repopulated
+                                                // it between deleteTree and
+                                                // rename — done either way.
+                                                .EXIST, .NOTEMPTY, .PERM, .ACCES => {
+                                                    FD.cwd().deleteTree(tmp.slice()) catch {};
+                                                    return .success;
+                                                },
+                                                else => {
+                                                    FD.cwd().deleteTree(tmp.slice()) catch {};
+                                                    return .initErr(e);
+                                                },
+                                            },
+                                        };
+                                    },
+                                    else => {
+                                        FD.cwd().deleteTree(tmp.slice()) catch {};
+                                        return .initErr(err);
+                                    },
+                                },
+                            }
+                        }
+                    }.call;
+                    var entry_ok_u8: bun.AbsPath(.{ .sep = .auto }) = .init();
+                    defer entry_ok_u8.deinit();
+                    if (uses_global_store) {
+                        installer.appendGlobalStoreEntryPath(&entry_ok_u8, this.entry_id);
+                        entry_ok_u8.append(".bun-ok");
+                    }
+
                     var cached_package_dir: ?FD = null;
                     defer if (cached_package_dir) |dir| dir.close();
 
@@ -673,6 +753,7 @@ pub const Installer = struct {
                                 // re-clone identical bytes (and never race two
                                 // installs into deleting each other's work).
                                 .keep_existing_dest = uses_global_store,
+                                .entry_ok_path = if (uses_global_store) entry_ok_u8.sliceZ() else "",
                             };
 
                             switch (cloner.clone()) {
@@ -698,24 +779,19 @@ pub const Installer = struct {
                         },
 
                         .hardlink => {
-                            if (uses_global_store) {
-                                // The hardlink/copyfile backends write
-                                // file-by-file straight into the destination
-                                // (no temp+rename), so `package.json` can land
-                                // before the rest of the tree and probing for
-                                // it would accept a half-written entry
-                                // forever. Until those backends grow
-                                // `cloneAtomic`-style staging, take the
-                                // conservative path: wipe and rebuild every
-                                // time `needs_install` got us here. The
-                                // `.bun-ok` warm-hit check already skipped
-                                // this entire task on the fast path, so this
-                                // only fires for genuinely-missing or
-                                // unstamped entries.
-                                var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
-                                defer probe.deinit();
-                                installer.appendRealStorePath(&probe, this.entry_id);
-                                FD.cwd().deleteTree(probe.slice()) catch {};
+                            if (uses_global_store and staged_dest == null) {
+                                installer.appendRealStorePath(&real_dest_u8, this.entry_id);
+                                staged_dest_u8.appendFmt("{s}.tmp-{d}-{d}", .{
+                                    real_dest_u8.slice(),
+                                    if (comptime Environment.isWindows) std.os.windows.GetCurrentProcessId() else std.c.getpid(),
+                                    std.crypto.random.int(u32),
+                                });
+                                staged_dest = .init();
+                                staged_dest.?.append(staged_dest_u8.slice());
+                                // Stale temp from a crashed earlier run with
+                                // the same pid is the only thing that can
+                                // already be here.
+                                FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
@@ -740,14 +816,20 @@ pub const Installer = struct {
                             var hardlinker: Hardlinker = try .init(
                                 cached_package_dir.?,
                                 src,
-                                dest_subpath,
+                                if (staged_dest) |*tmp| tmp.* else dest_subpath,
                                 &.{},
                             );
                             defer hardlinker.deinit();
 
                             switch (try hardlinker.link()) {
-                                .result => {},
+                                .result => {
+                                    if (staged_dest != null) switch (finishStagedDest(&staged_dest_u8, &real_dest_u8, &entry_ok_u8)) {
+                                        .result => {},
+                                        .err => |err| return .failure(.{ .link_package = err }),
+                                    };
+                                },
                                 .err => |err| {
+                                    if (staged_dest != null) FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                                     if (err.getErrno() == .XDEV) {
                                         installer.supported_backend.store(.copyfile, .monotonic);
                                         continue :backend .copyfile;
@@ -777,24 +859,19 @@ pub const Installer = struct {
 
                         // fallthrough copyfile
                         else => {
-                            // See the matching note in `.hardlink` above.
-                            if (uses_global_store) {
-                                // The hardlink/copyfile backends write
-                                // file-by-file straight into the destination
-                                // (no temp+rename), so `package.json` can land
-                                // before the rest of the tree. Probing for it
-                                // would accept a half-written entry forever.
-                                // Until those backends grow `cloneAtomic`-style
-                                // staging, take the conservative path: wipe
-                                // and rebuild every time `needs_install` got us
-                                // here. The `.bun-ok` warm-hit check already
-                                // skipped this entire task on the fast path,
-                                // so this only fires for genuinely-missing or
-                                // unstamped entries.
-                                var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
-                                defer probe.deinit();
-                                installer.appendRealStorePath(&probe, this.entry_id);
-                                FD.cwd().deleteTree(probe.slice()) catch {};
+                            // See the matching note in `.hardlink` above for
+                            // why shared global-store entries are written via a
+                            // temp sibling and renamed into place.
+                            if (uses_global_store and staged_dest == null) {
+                                installer.appendRealStorePath(&real_dest_u8, this.entry_id);
+                                staged_dest_u8.appendFmt("{s}.tmp-{d}-{d}", .{
+                                    real_dest_u8.slice(),
+                                    if (comptime Environment.isWindows) std.os.windows.GetCurrentProcessId() else std.c.getpid(),
+                                    std.crypto.random.int(u32),
+                                });
+                                staged_dest = .init();
+                                staged_dest.?.append(staged_dest_u8.slice());
+                                FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
                                 .result => |fd| fd,
@@ -826,14 +903,20 @@ pub const Installer = struct {
                             var file_copier: FileCopier = try .init(
                                 cached_package_dir.?,
                                 src_path,
-                                dest_subpath,
+                                if (staged_dest) |*tmp| tmp.* else dest_subpath,
                                 &.{},
                             );
                             defer file_copier.deinit();
 
                             switch (file_copier.copy()) {
-                                .result => {},
+                                .result => {
+                                    if (staged_dest != null) switch (finishStagedDest(&staged_dest_u8, &real_dest_u8, &entry_ok_u8)) {
+                                        .result => {},
+                                        .err => |err| return .failure(.{ .link_package = err }),
+                                    };
+                                },
                                 .err => |err| {
+                                    if (staged_dest != null) FD.cwd().deleteTree(staged_dest_u8.slice()) catch {};
                                     if (PackageManager.verbose_install) {
                                         Output.prettyErrorln(
                                             \\<red><b>error<r><d>:<r>Failed to copy package

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -21,6 +21,13 @@ pub const Installer = struct {
 
     trusted_dependencies_from_update_requests: std.AutoArrayHashMapUnmanaged(TruncatedPackageNameHash, void),
 
+    /// Absolute path to the global virtual store (`<cache_dir>/links`). When
+    /// non-null, npm/git/tarball entries are materialized once into this
+    /// directory and `node_modules/.bun/<storepath>` becomes a symlink into
+    /// it, so warm installs are O(packages) symlinks instead of O(files)
+    /// clonefile work.
+    global_store_path: ?[:0]const u8,
+
     pub fn deinit(this: *const Installer) void {
         this.trusted_dependencies_from_update_requests.deinit(this.lockfile.allocator);
     }
@@ -507,7 +514,7 @@ pub const Installer = struct {
                                     defer src.deinit();
                                     src.appendJoin(pkg_res.value.folder.slice(string_buf));
 
-                                    var dest: bun.RelPath(.{ .unit = .os, .sep = .auto }) = .init();
+                                    var dest: bun.Path(.{ .unit = .os, .sep = .auto }) = .init();
                                     defer dest.deinit();
 
                                     installer.appendStorePath(&dest, this.entry_id);
@@ -573,7 +580,7 @@ pub const Installer = struct {
                                         src_path.setLength(src_path_len);
                                     }
 
-                                    var dest: bun.RelPath(.{ .unit = .os, .sep = .auto }) = .init();
+                                    var dest: bun.Path(.{ .unit = .os, .sep = .auto }) = .init();
                                     defer dest.deinit();
                                     installer.appendStorePath(&dest, this.entry_id);
 
@@ -620,9 +627,11 @@ pub const Installer = struct {
                     const cache_dir, const cache_dir_path = manager.getCacheDirectoryAndAbsPath();
                     defer cache_dir_path.deinit();
 
-                    var dest_subpath: bun.RelPath(.{ .sep = .auto, .unit = .os }) = .init();
+                    var dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }) = .init();
                     defer dest_subpath.deinit();
-                    installer.appendStorePath(&dest_subpath, this.entry_id);
+                    installer.appendRealStorePath(&dest_subpath, this.entry_id);
+
+                    const uses_global_store = installer.entryUsesGlobalStore(this.entry_id);
 
                     var cached_package_dir: ?FD = null;
                     defer if (cached_package_dir) |dir| dir.close();
@@ -653,6 +662,11 @@ pub const Installer = struct {
                                 .cache_dir = cache_dir,
                                 .cache_dir_subpath = pkg_cache_dir_subpath,
                                 .dest_subpath = dest_subpath,
+                                // The global store is shared across projects and
+                                // installs; never wipe an existing entry just to
+                                // re-clone identical bytes (and never race two
+                                // installs into deleting each other's work).
+                                .keep_existing_dest = uses_global_store,
                             };
 
                             switch (cloner.clone()) {
@@ -810,7 +824,7 @@ pub const Installer = struct {
                         var dest: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
                         defer dest.deinit();
 
-                        installer.appendStoreNodeModulesPath(&dest, this.entry_id);
+                        installer.appendRealStoreNodeModulesPath(&dest, this.entry_id);
 
                         dest.append(dep_name);
 
@@ -826,7 +840,18 @@ pub const Installer = struct {
                         var dep_store_path: bun.AbsPath(.{ .sep = .auto }) = .initTopLevelDir();
                         defer dep_store_path.deinit();
 
-                        installer.appendStorePath(&dep_store_path, dep.entry_id);
+                        // When this entry lives in the global virtual store, its
+                        // dep symlinks must point at sibling *global* entries
+                        // (relative `../../<dep>-<hash>/...`) so the entry stays
+                        // valid for any project. Non-global parents (root,
+                        // workspace) keep pointing at the project-local
+                        // `.bun/<storepath>` indirection so `node_modules/<pkg>`
+                        // remains a relative link into `node_modules/.bun/`.
+                        if (installer.entryUsesGlobalStore(this.entry_id)) {
+                            installer.appendRealStorePath(&dep_store_path, dep.entry_id);
+                        } else {
+                            installer.appendStorePath(&dep_store_path, dep.entry_id);
+                        }
 
                         const target = target: {
                             var dest_save = dest.save();
@@ -848,6 +873,14 @@ pub const Installer = struct {
                             // exist unconditionally. To make sure it's fast, first readlink
                             // then create the symlink if necessary
                             .expect_existing
+                        else if (installer.entryUsesGlobalStore(this.entry_id))
+                            // Global virtual-store entries are shared across installs;
+                            // a previous build of this entry already populated these
+                            // symlinks. Re-creating them is wasted syscalls, but the
+                            // bigger problem is that `.expect_missing` deletes the
+                            // existing tree on EEXIST, which would race with other
+                            // installs reading through the same global entry.
+                            .expect_existing
                         else
                             .expect_missing;
 
@@ -858,6 +891,21 @@ pub const Installer = struct {
                             },
                         }
                     }
+
+                    if (installer.entryUsesGlobalStore(this.entry_id)) {
+                        // The entry now exists in the shared global virtual store.
+                        // Project-local `node_modules/.bun/<storepath>` becomes a
+                        // symlink into it so that the relative `../../<dep>` links
+                        // created above (which live inside the global entry) remain
+                        // reachable from the project's node_modules.
+                        switch (installer.linkProjectToGlobalStore(this.entry_id)) {
+                            .result => {},
+                            .err => |err| {
+                                return .failure(.{ .symlink_dependencies = err });
+                            },
+                        }
+                    }
+
                     continue :next_step this.nextStep(current_step);
                 },
                 inline .check_if_blocked => |current_step| {
@@ -1017,7 +1065,7 @@ pub const Installer = struct {
 
                     var node_modules_path: bun.AbsPath(.{}) = .initTopLevelDir();
                     defer node_modules_path.deinit();
-                    installer.appendStoreNodeModulesPath(&node_modules_path, this.entry_id);
+                    installer.appendRealStoreNodeModulesPath(&node_modules_path, this.entry_id);
 
                     var target_node_modules_path: ?bun.AbsPath(.{}) = null;
                     defer if (target_node_modules_path) |*path| path.deinit();
@@ -1034,7 +1082,7 @@ pub const Installer = struct {
                         pkg_id,
                     )) |replacement_entry_id| {
                         target_node_modules_path = bun.AbsPath(.{}).initTopLevelDir();
-                        installer.appendStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
+                        installer.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
 
                         const replacement_node_id = entry_node_ids[replacement_entry_id.get()];
                         const replacement_pkg_id = node_pkg_ids[replacement_node_id.get()];
@@ -1379,7 +1427,7 @@ pub const Installer = struct {
         var node_modules_path: bun.AbsPath(.{}) = .initTopLevelDir();
         defer node_modules_path.deinit();
 
-        this.appendStoreNodeModulesPath(&node_modules_path, parent_entry_id);
+        this.appendRealStoreNodeModulesPath(&node_modules_path, parent_entry_id);
 
         for (entry_deps[parent_entry_id.get()].slice()) |dep| {
             const node_id = entry_node_ids[dep.entry_id.get()];
@@ -1407,7 +1455,7 @@ pub const Installer = struct {
                 pkg_id,
             )) |replacement_entry_id| {
                 target_node_modules_path = bun.AbsPath(.{}).initTopLevelDir();
-                this.appendStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
+                this.appendRealStoreNodeModulesPath(&target_node_modules_path.?, replacement_entry_id);
 
                 const replacement_node_id = entry_node_ids[replacement_entry_id.get()];
                 const replacement_pkg_id = node_pkg_ids[replacement_node_id.get()];
@@ -1455,6 +1503,83 @@ pub const Installer = struct {
         }
     }
 
+    /// True when this entry should live in the shared global virtual store
+    /// instead of being materialized under the project's `node_modules/.bun/`.
+    /// Root, workspace, folder, symlink, and patched packages always stay
+    /// project-local because their contents are mutable / project-specific.
+    pub fn entryUsesGlobalStore(this: *const Installer, entry_id: Store.Entry.Id) bool {
+        if (this.global_store_path == null) return false;
+        return this.store.entries.items(.entry_hash)[entry_id.get()] != 0;
+    }
+
+    /// Absolute path to the global virtual-store directory for `entry_id`:
+    ///   <cache>/links/<storepath>-<entry_hash>
+    /// (no trailing `/node_modules`).
+    pub fn appendGlobalStoreEntryPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+        bun.debugAssert(this.entryUsesGlobalStore(entry_id));
+        buf.clear();
+        buf.append(this.global_store_path.?);
+        buf.appendFmt("{f}", .{
+            Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
+        });
+    }
+
+    /// Project-local path `node_modules/.bun/<storepath>` (the symlink that
+    /// points at the global virtual-store entry). Relative to top-level dir.
+    pub fn appendLocalStoreEntryPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+        buf.appendFmt("node_modules/" ++ Store.modules_dir_name ++ "/{f}", .{
+            Store.Entry.fmtStorePath(entry_id, this.store, this.lockfile),
+        });
+    }
+
+    /// Create the project-level symlink `node_modules/.bun/<storepath>` →
+    /// `<cache>/links/<storepath>-<hash>`. This is the only per-install
+    /// filesystem write for a warm global-store hit.
+    pub fn linkProjectToGlobalStore(this: *const Installer, entry_id: Store.Entry.Id) sys.Maybe(void) {
+        var dest: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
+        defer dest.deinit();
+        this.appendLocalStoreEntryPath(&dest, entry_id);
+
+        var target_abs: bun.AbsPath(.{ .sep = .auto }) = .init();
+        defer target_abs.deinit();
+        this.appendGlobalStoreEntryPath(&target_abs, entry_id);
+
+        // Absolute target so the link is independent of where node_modules
+        // lives (project root may itself be behind a symlink). Symlinker's
+        // `target` field is RelPath-typed for the common in-tree case, so
+        // call sys.symlink/symlinkOrJunction directly here.
+        const do_symlink = struct {
+            fn call(d: [:0]const u8, t: [:0]const u8) sys.Maybe(void) {
+                if (comptime Environment.isWindows) {
+                    return sys.symlinkOrJunction(d, t, t);
+                }
+                return sys.symlink(t, d);
+            }
+        }.call;
+
+        switch (do_symlink(dest.sliceZ(), target_abs.sliceZ())) {
+            .result => return .success,
+            .err => |err| switch (err.getErrno()) {
+                .NOENT => {
+                    if (dest.dirname()) |parent| {
+                        FD.cwd().makePath(u8, parent) catch {};
+                    }
+                    return do_symlink(dest.sliceZ(), target_abs.sliceZ());
+                },
+                .EXIST => {
+                    // Existing entry from a previous install: replace if it's
+                    // a stale symlink, otherwise wipe the directory tree
+                    // (pre-global-store layout) before relinking.
+                    if (sys.unlink(dest.sliceZ()).asErr()) |_| {
+                        FD.cwd().deleteTree(dest.slice()) catch {};
+                    }
+                    return do_symlink(dest.sliceZ(), target_abs.sliceZ());
+                },
+                else => return .initErr(err),
+            },
+        }
+    }
+
     pub fn appendStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
         const string_buf = this.lockfile.buffers.string_bytes.items;
 
@@ -1485,6 +1610,38 @@ pub const Installer = struct {
                 });
             },
         }
+    }
+
+    /// Like `appendStoreNodeModulesPath`, but resolves to the *physical*
+    /// location of the entry's `node_modules` directory: the global virtual
+    /// store for global-eligible entries, or the project-local `.bun/` path
+    /// otherwise. Use this when *writing into* the entry (clonefile dest,
+    /// dep/bin symlink dest); use the non-`Real` variant when computing a
+    /// path that other entries will *follow* (so they go through the
+    /// project-local `.bun/<storepath>` symlink and stay relocatable).
+    pub fn appendRealStoreNodeModulesPath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+        if (this.entryUsesGlobalStore(entry_id)) {
+            this.appendGlobalStoreEntryPath(buf, entry_id);
+            buf.append("node_modules");
+            return;
+        }
+        this.appendStoreNodeModulesPath(buf, entry_id);
+    }
+
+    /// `appendStorePath` resolved to the entry's *physical* location. See
+    /// `appendRealStoreNodeModulesPath` for when to use Real vs non-Real.
+    pub fn appendRealStorePath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {
+        if (this.entryUsesGlobalStore(entry_id)) {
+            const string_buf = this.lockfile.buffers.string_bytes.items;
+            const node_id = this.store.entries.items(.node_id)[entry_id.get()];
+            const pkg_id = this.store.nodes.items(.pkg_id)[node_id.get()];
+            const pkg_name = this.lockfile.packages.items(.name)[pkg_id];
+            this.appendGlobalStoreEntryPath(buf, entry_id);
+            buf.append("node_modules");
+            buf.append(pkg_name.slice(string_buf));
+            return;
+        }
+        this.appendStorePath(buf, entry_id);
     }
 
     pub fn appendStorePath(this: *const Installer, buf: anytype, entry_id: Store.Entry.Id) void {

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -28,7 +28,7 @@ pub const Installer = struct {
     /// clonefile work.
     global_store_path: ?[:0]const u8,
 
-    pub fn deinit(this: *const Installer) void {
+    pub fn deinit(this: *Installer) void {
         this.trusted_dependencies_from_update_requests.deinit(this.lockfile.allocator);
     }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -713,20 +713,21 @@ pub const Installer = struct {
                             // and stamp `.bun-ok`. Otherwise wipe and rebuild
                             // so a half-written tree doesn't survive.
                             if (uses_global_store) {
-                                // `dest_subpath` is `.unit = .os` (u16 on
-                                // Windows); the existence/deleteTree helpers
-                                // want u8, so rebuild the same path via the
-                                // u8 store-path helper for the probe.
+                                // The hardlink/copyfile backends write
+                                // file-by-file straight into the destination
+                                // (no temp+rename), so `package.json` can land
+                                // before the rest of the tree. Probing for it
+                                // would accept a half-written entry forever.
+                                // Until those backends grow `cloneAtomic`-style
+                                // staging, take the conservative path: wipe
+                                // and rebuild every time `needs_install` got us
+                                // here. The `.bun-ok` warm-hit check already
+                                // skipped this entire task on the fast path,
+                                // so this only fires for genuinely-missing or
+                                // unstamped entries.
                                 var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
                                 defer probe.deinit();
                                 installer.appendRealStorePath(&probe, this.entry_id);
-                                const probe_save = probe.save();
-                                probe.append("package.json");
-                                const exists = sys.existsZ(probe.sliceZ());
-                                probe_save.restore();
-                                if (exists) {
-                                    continue :next_step this.nextStep(current_step);
-                                }
                                 FD.cwd().deleteTree(probe.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {
@@ -791,20 +792,21 @@ pub const Installer = struct {
                         else => {
                             // See the matching note in `.hardlink` above.
                             if (uses_global_store) {
-                                // `dest_subpath` is `.unit = .os` (u16 on
-                                // Windows); the existence/deleteTree helpers
-                                // want u8, so rebuild the same path via the
-                                // u8 store-path helper for the probe.
+                                // The hardlink/copyfile backends write
+                                // file-by-file straight into the destination
+                                // (no temp+rename), so `package.json` can land
+                                // before the rest of the tree. Probing for it
+                                // would accept a half-written entry forever.
+                                // Until those backends grow `cloneAtomic`-style
+                                // staging, take the conservative path: wipe
+                                // and rebuild every time `needs_install` got us
+                                // here. The `.bun-ok` warm-hit check already
+                                // skipped this entire task on the fast path,
+                                // so this only fires for genuinely-missing or
+                                // unstamped entries.
                                 var probe: bun.AbsPath(.{ .sep = .auto }) = .init();
                                 defer probe.deinit();
                                 installer.appendRealStorePath(&probe, this.entry_id);
-                                const probe_save = probe.save();
-                                probe.append("package.json");
-                                const exists = sys.existsZ(probe.sliceZ());
-                                probe_save.restore();
-                                if (exists) {
-                                    continue :next_step this.nextStep(current_step);
-                                }
                                 FD.cwd().deleteTree(probe.slice()) catch {};
                             }
                             cached_package_dir = switch (bun.openDirForIteration(cache_dir, pkg_cache_dir_subpath.slice())) {

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -639,6 +639,40 @@ pub const Installer = struct {
 
                     const uses_global_store = installer.entryUsesGlobalStore(this.entry_id);
 
+                    if (!uses_global_store) {
+                        // An entry can lose global-store eligibility between
+                        // installs — newly patched, newly trusted, a dep that
+                        // became a workspace package. The previous install
+                        // left `node_modules/.bun/<storepath>` as a symlink
+                        // (or junction) into the shared `<cache>/links/`
+                        // directory. Writing the new project-local tree
+                        // *through* that link would mutate the shared entry
+                        // underneath every other consumer; on Windows the
+                        // `.expect_missing` dep-symlink rewrite then bakes a
+                        // project-absolute junction target into the shared
+                        // directory, which dangles after the next
+                        // `rm -rf node_modules`. Detach first so the build
+                        // lands in a real project-local directory.
+                        var local: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
+                        defer local.deinit();
+                        installer.appendLocalStoreEntryPath(&local, this.entry_id);
+                        const is_stale_link = if (comptime Environment.isWindows)
+                            if (sys.getFileAttributes(local.sliceZ())) |a| a.is_reparse_point else false
+                        else if (sys.lstat(local.sliceZ()).asValue()) |st|
+                            std.posix.S.ISLNK(@intCast(st.mode))
+                        else
+                            false;
+                        if (is_stale_link) {
+                            if (comptime Environment.isWindows) {
+                                if (sys.rmdir(local.sliceZ()).asErr()) |_| {
+                                    _ = sys.unlink(local.sliceZ());
+                                }
+                            } else {
+                                _ = sys.unlink(local.sliceZ());
+                            }
+                        }
+                    }
+
                     // For the file-walking backends (hardlink/copyfile), shared
                     // global-store entries are populated through a temp sibling
                     // and renamed into place — same staging FileCloner does in

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1057,6 +1057,7 @@ pub const Installer = struct {
 
                     const bin = pkg_bins[pkg_id];
                     if (bin.tag == .none) {
+                        installer.stampGlobalStoreEntry(this.entry_id);
                         continue :next_step this.nextStep(current_step);
                     }
 
@@ -1143,6 +1144,8 @@ pub const Installer = struct {
                         }
                         return .failure(.{ .binaries = err });
                     }
+
+                    installer.stampGlobalStoreEntry(this.entry_id);
 
                     continue :next_step this.nextStep(current_step);
                 },
@@ -1546,6 +1549,24 @@ pub const Installer = struct {
         buf.appendFmt("{f}", .{
             Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
         });
+    }
+
+    /// Touch `<global-entry>/.bun-ok` once the package tree, dep symlinks,
+    /// dependency-bin links and own-bin links are all in place. Future
+    /// installs (and concurrent installs whose rename lost) use this to
+    /// distinguish "fully built" from "package tree present but symlinks
+    /// missing because the writer crashed mid-task" — `package.json` only
+    /// proves the clone landed.
+    pub fn stampGlobalStoreEntry(this: *const Installer, entry_id: Store.Entry.Id) void {
+        if (!this.entryUsesGlobalStore(entry_id)) return;
+        var ok: bun.AbsPath(.{ .sep = .auto }) = .init();
+        defer ok.deinit();
+        this.appendGlobalStoreEntryPath(&ok, entry_id);
+        ok.append(".bun-ok");
+        switch (sys.openat(FD.cwd(), ok.sliceZ(), bun.O.CREAT | bun.O.WRONLY, 0o644)) {
+            .result => |fd| fd.close(),
+            .err => {},
+        }
     }
 
     /// Project-local path `node_modules/.bun/<storepath>` (the symlink that

--- a/src/install/isolated_install/Store.zig
+++ b/src/install/isolated_install/Store.zig
@@ -108,6 +108,15 @@ pub const Store = struct {
 
         peer_hash: PeerHash,
 
+        /// Content hash of (package + sorted resolved dependency global-store keys),
+        /// used to key the global virtual store at `<cache>/links/<storepath>-<entry_hash>/`.
+        /// Two projects that resolve the same package to the same dependency closure
+        /// share one global-store entry; if a transitive dep version differs, the
+        /// hash differs and a new global-store entry is created. Computed after the
+        /// store is built (see `computeEntryHashes`). 0 means "do not use global store"
+        /// (root, workspace, folder, symlink, patched).
+        entry_hash: u64 = 0,
+
         scripts: ?*Package.Scripts.List = null,
 
         pub const PeerHash = enum(u64) {
@@ -181,6 +190,26 @@ pub const Store = struct {
 
         pub fn fmtStorePath(entry_id: Id, store: *const Store, lockfile: *const Lockfile) StorePathFormatter {
             return .{ .entry_id = entry_id, .store = store, .lockfile = lockfile };
+        }
+
+        const GlobalStorePathFormatter = struct {
+            inner: StorePathFormatter,
+            entry_hash: u64,
+
+            pub fn format(this: @This(), writer: *std.Io.Writer) std.Io.Writer.Error!void {
+                try this.inner.format(writer);
+                try writer.print("-{f}", .{bun.fmt.hexIntLower(this.entry_hash)});
+            }
+        };
+
+        /// Like `fmtStorePath` but suffixes the entry's content hash so the
+        /// resulting name is safe to use as a key in the shared global virtual
+        /// store (different dependency closures get different directory names).
+        pub fn fmtGlobalStorePath(entry_id: Id, store: *const Store, lockfile: *const Lockfile) GlobalStorePathFormatter {
+            return .{
+                .inner = fmtStorePath(entry_id, store, lockfile),
+                .entry_hash = store.entries.items(.entry_hash)[entry_id.get()],
+            };
         }
 
         pub fn debugGatherAllParents(entry_id: Id, store: *const Store) []const Id {

--- a/src/install/isolated_install/Symlinker.zig
+++ b/src/install/isolated_install/Symlinker.zig
@@ -90,7 +90,10 @@ pub const Symlinker = struct {
                         },
                         else => {
                             FD.cwd().deleteTree(this.dest.sliceZ()) catch {};
-                            return this.symlink();
+                            return switch (this.symlink()) {
+                                .result => .success,
+                                .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
+                            };
                         },
                     },
                 };
@@ -124,7 +127,12 @@ pub const Symlinker = struct {
                     _ = sys.unlink(this.dest.sliceZ());
                 }
 
-                return this.symlink();
+                return switch (this.symlink()) {
+                    .result => .success,
+                    // Another writer replaced the wrong-target link with the
+                    // right one between our unlink and this retry.
+                    .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
+                };
             },
         };
     }

--- a/src/install/isolated_install/Symlinker.zig
+++ b/src/install/isolated_install/Symlinker.zig
@@ -73,8 +73,18 @@ pub const Symlinker = struct {
                                     };
 
                                     FD.cwd().makePath(u8, dest_parent) catch {};
-                                    return this.symlink();
+                                    return switch (this.symlink()) {
+                                        .result => .success,
+                                        // EEXIST after NOENT means another writer
+                                        // (concurrent install into the same shared
+                                        // virtual-store entry) created the link in
+                                        // between; the caller asked for "ensure it
+                                        // exists", which it now does.
+                                        .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
+                                    };
                                 },
+                                // Same NOENT→EEXIST race without the makePath hop.
+                                .EXIST => .success,
                                 else => .initErr(symlink_err),
                             },
                         },

--- a/src/install/isolated_install/Symlinker.zig
+++ b/src/install/isolated_install/Symlinker.zig
@@ -78,8 +78,22 @@ pub const Symlinker = struct {
                                 else => .initErr(symlink_err),
                             },
                         },
+                        // readlink failed for a reason other than NOENT —
+                        // dest exists but isn't a symlink. If it's a real
+                        // directory, leave it: this is the `bun patch <pkg>`
+                        // workspace (a detached copy the user is editing
+                        // before `--commit`), and `deleteTree` here would
+                        // silently destroy their in-progress edits. If it's
+                        // a regular file, replace it.
                         else => {
-                            FD.cwd().deleteTree(this.dest.sliceZ()) catch {};
+                            const is_dir = if (comptime Environment.isWindows)
+                                if (sys.getFileAttributes(this.dest.sliceZ())) |a| a.is_directory and !a.is_reparse_point else false
+                            else if (sys.lstat(this.dest.sliceZ()).asValue()) |st|
+                                std.posix.S.ISDIR(@intCast(st.mode))
+                            else
+                                false;
+                            if (is_dir) return .success;
+                            _ = sys.unlink(this.dest.sliceZ());
                             return this.symlink();
                         },
                     },
@@ -121,6 +135,7 @@ pub const Symlinker = struct {
 };
 
 const bun = @import("bun");
+const std = @import("std");
 const Environment = bun.Environment;
 const FD = bun.FD;
 const strings = bun.strings;

--- a/src/install/isolated_install/Symlinker.zig
+++ b/src/install/isolated_install/Symlinker.zig
@@ -134,8 +134,9 @@ pub const Symlinker = struct {
     }
 };
 
-const bun = @import("bun");
 const std = @import("std");
+
+const bun = @import("bun");
 const Environment = bun.Environment;
 const FD = bun.FD;
 const strings = bun.strings;

--- a/src/install/isolated_install/Symlinker.zig
+++ b/src/install/isolated_install/Symlinker.zig
@@ -73,27 +73,14 @@ pub const Symlinker = struct {
                                     };
 
                                     FD.cwd().makePath(u8, dest_parent) catch {};
-                                    return switch (this.symlink()) {
-                                        .result => .success,
-                                        // EEXIST after NOENT means another writer
-                                        // (concurrent install into the same shared
-                                        // virtual-store entry) created the link in
-                                        // between; the caller asked for "ensure it
-                                        // exists", which it now does.
-                                        .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
-                                    };
+                                    return this.symlink();
                                 },
-                                // Same NOENT→EEXIST race without the makePath hop.
-                                .EXIST => .success,
                                 else => .initErr(symlink_err),
                             },
                         },
                         else => {
                             FD.cwd().deleteTree(this.dest.sliceZ()) catch {};
-                            return switch (this.symlink()) {
-                                .result => .success,
-                                .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
-                            };
+                            return this.symlink();
                         },
                     },
                 };
@@ -127,12 +114,7 @@ pub const Symlinker = struct {
                     _ = sys.unlink(this.dest.sliceZ());
                 }
 
-                return switch (this.symlink()) {
-                    .result => .success,
-                    // Another writer replaced the wrong-target link with the
-                    // right one between our unlink and this retry.
-                    .err => |e| if (e.getErrno() == .EXIST) .success else .initErr(e),
-                };
+                return this.symlink();
             },
         };
     }

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1412,7 +1412,12 @@ pub fn Package(comptime SemverIntType: type) type {
             var workspace_names = WorkspaceMap.init(allocator);
             defer workspace_names.deinit();
 
-            var optional_peer_dependencies = std.ArrayHashMap(PackageNameHash, void, ArrayIdentityContext.U64, false).init(allocator);
+            // pnpm/yarn synthesise an implicit `"*"` optional peer for entries
+            // that appear in `peerDependenciesMeta` but not in
+            // `peerDependencies`. Track the original key string so the
+            // post-build pass can emit a real `Dependency` for any meta-only
+            // names that nothing in the build loop consumed.
+            var optional_peer_dependencies = std.ArrayHashMap(PackageNameHash, []const u8, ArrayIdentityContext.U64, false).init(allocator);
             defer optional_peer_dependencies.deinit();
 
             if (json.asProperty("peerDependenciesMeta")) |peer_dependencies_meta| {
@@ -1425,10 +1430,17 @@ pub fn Package(comptime SemverIntType: type) type {
                                 continue;
                             }
 
+                            const key = prop.key.?.asString(allocator) orelse unreachable;
                             optional_peer_dependencies.putAssumeCapacity(
-                                String.Builder.stringHash(prop.key.?.asString(allocator) orelse unreachable),
-                                {},
+                                String.Builder.stringHash(key),
+                                key,
                             );
+                            // Reserve space for a synthesised entry. If the
+                            // matching name later appears in `peerDependencies`
+                            // the slot just goes unused.
+                            string_builder.count(key);
+                            string_builder.count("*");
+                            total_dependencies_count += 1;
                         }
                     }
                 }
@@ -1862,7 +1874,7 @@ pub fn Package(comptime SemverIntType: type) type {
                             logger.Loc.Empty,
                         )) |_dep| {
                             var dep = _dep;
-                            if (group.behavior.isPeer() and optional_peer_dependencies.contains(external_name.hash)) {
+                            if (group.behavior.isPeer() and optional_peer_dependencies.swapRemove(external_name.hash)) {
                                 dep.behavior = dep.behavior.add(.optional);
                             }
 
@@ -1904,7 +1916,7 @@ pub fn Package(comptime SemverIntType: type) type {
                                         value.loc,
                                     )) |_dep| {
                                         var dep = _dep;
-                                        if (group.behavior.isPeer() and optional_peer_dependencies.contains(external_name.hash)) {
+                                        if (group.behavior.isPeer() and optional_peer_dependencies.swapRemove(external_name.hash)) {
                                             dep.behavior.optional = true;
                                         }
 
@@ -1920,6 +1932,40 @@ pub fn Package(comptime SemverIntType: type) type {
                             else => unreachable,
                         }
                     }
+                }
+            }
+
+            // Anything left in `optional_peer_dependencies` was listed only in
+            // `peerDependenciesMeta`. Synthesise an optional peer dep with
+            // version `"*"` so resolution can pick up a sibling install when
+            // one exists (matching pnpm/yarn). Webpack relies on this for
+            // `webpack-cli`, which it lists in meta but not in
+            // `peerDependencies`.
+            var meta_only = optional_peer_dependencies.iterator();
+            while (meta_only.next()) |entry| {
+                const external_name = string_builder.append(ExternalString, entry.value_ptr.*);
+                if (try parseDependency(
+                    lockfile,
+                    pm,
+                    allocator,
+                    log,
+                    source,
+                    Lockfile.Package.DependencyGroup.peer,
+                    &string_builder,
+                    features,
+                    package_dependencies,
+                    total_dependencies_count,
+                    null,
+                    null,
+                    external_name,
+                    "*",
+                    logger.Loc.Empty,
+                    logger.Loc.Empty,
+                )) |_dep| {
+                    var dep = _dep;
+                    dep.behavior.optional = true;
+                    package_dependencies[total_dependencies_count] = dep;
+                    total_dependencies_count += 1;
                 }
             }
 

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1916,6 +1916,11 @@ pub fn Package(comptime SemverIntType: type) type {
                                         value.loc,
                                     )) |_dep| {
                                         var dep = _dep;
+                                        // swapRemove (not contains): drain names that
+                                        // have a real `peerDependencies` entry so the
+                                        // meta-only synthesis pass below only sees
+                                        // names that appear *only* in
+                                        // `peerDependenciesMeta`.
                                         if (group.behavior.isPeer() and optional_peer_dependencies.swapRemove(external_name.hash)) {
                                             dep.behavior.optional = true;
                                         }

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1420,7 +1420,7 @@ pub fn Package(comptime SemverIntType: type) type {
             var optional_peer_dependencies = std.ArrayHashMap(PackageNameHash, []const u8, ArrayIdentityContext.U64, false).init(allocator);
             defer optional_peer_dependencies.deinit();
 
-            if (json.asProperty("peerDependenciesMeta")) |peer_dependencies_meta| {
+            if (features.peer_dependencies) if (json.asProperty("peerDependenciesMeta")) |peer_dependencies_meta| {
                 if (peer_dependencies_meta.expr.data == .e_object) {
                     const props = peer_dependencies_meta.expr.data.e_object.properties.slice();
                     try optional_peer_dependencies.ensureUnusedCapacity(props.len);
@@ -1444,7 +1444,7 @@ pub fn Package(comptime SemverIntType: type) type {
                         }
                     }
                 }
-            }
+            };
 
             inline for (dependency_groups) |group| {
                 if (json.asProperty(group.prop)) |dependencies_q| brk: {

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -2031,6 +2031,23 @@ pub const PackageManifest = struct {
                             }
                         }
                     }
+
+                    // pnpm/yarn synthesise an implicit `"*"` optional peer for
+                    // entries that appear in `peerDependenciesMeta` but not in
+                    // `peerDependencies`. Reserve space for them; the build
+                    // pass below appends them after the declared peer deps.
+                    if (prop.value.?.asProperty("peerDependenciesMeta")) |meta| {
+                        if (meta.expr.data == .e_object) {
+                            for (meta.expr.data.e_object.properties.slice()) |meta_prop| {
+                                const optional = meta_prop.value.?.asProperty("optional") orelse continue;
+                                if (optional.expr.data != .e_boolean or !optional.expr.data.e_boolean.value) continue;
+                                const key = meta_prop.key.?.asString(allocator) orelse continue;
+                                dependency_sum += 1;
+                                string_builder.count(key);
+                                string_builder.count("*");
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -2351,9 +2368,21 @@ pub const PackageManifest = struct {
                     var non_optional_peer_dependency_offset: usize = 0;
 
                     inline for (dependency_groups) |pair| {
-                        if (prop.value.?.asProperty(comptime pair.prop)) |versioned_deps| {
-                            if (versioned_deps.expr.data == .e_object) {
-                                const items = versioned_deps.expr.data.e_object.properties.slice();
+                        // For peer deps, fall through with an empty `items`
+                        // slice when `peerDependencies` is absent so that
+                        // `peerDependenciesMeta`-only entries (synthesised
+                        // below) still get a build pass. For other groups the
+                        // empty fallthrough is a cheap no-op.
+                        const items = items: {
+                            if (prop.value.?.asProperty(comptime pair.prop)) |versioned_deps| {
+                                if (versioned_deps.expr.data == .e_object) {
+                                    break :items versioned_deps.expr.data.e_object.properties.slice();
+                                }
+                            }
+                            break :items &.{};
+                        };
+                        if (items.len > 0 or comptime strings.eqlComptime(pair.prop, "peerDependencies")) {
+                            {
                                 var count = items.len;
 
                                 var this_names = dependency_names[0..count];
@@ -2377,9 +2406,18 @@ pub const PackageManifest = struct {
                                                         continue;
                                                     }
 
-                                                    optional_peer_dep_names.appendAssumeCapacity(String.Builder.stringHash(meta_prop.key.?.asString(allocator) orelse unreachable));
+                                                    const meta_key = meta_prop.key.?.asString(allocator) orelse unreachable;
+                                                    optional_peer_dep_names.appendAssumeCapacity(String.Builder.stringHash(meta_key));
+
+                                                    // Reserve a slot for a meta-only synthesised peer.
+                                                    // The slot is unused if `meta_key` also appears in
+                                                    // `peerDependencies` below.
+                                                    count += 1;
                                                 }
                                             }
+                                            // Re-slice now that the count grew.
+                                            this_names = dependency_names[0..count];
+                                            this_versions = dependency_values[0..count];
                                         }
                                     }
                                 }
@@ -2434,7 +2472,46 @@ pub const PackageManifest = struct {
                                     i += 1;
                                 }
 
+                                if (comptime is_peer) {
+                                    // Append meta-only optional peers (declared
+                                    // in `peerDependenciesMeta` but not in
+                                    // `peerDependencies`) as `"*"` versions.
+                                    // pnpm/yarn do this; webpack relies on it
+                                    // to make `webpack-cli` reachable.
+                                    if (prop.value.?.asProperty("peerDependenciesMeta")) |meta| {
+                                        if (meta.expr.data == .e_object) {
+                                            outer: for (meta.expr.data.e_object.properties.slice()) |meta_prop| {
+                                                const optional = meta_prop.value.?.asProperty("optional") orelse continue;
+                                                if (optional.expr.data != .e_boolean or !optional.expr.data.e_boolean.value) continue;
+                                                const meta_key = meta_prop.key.?.asString(allocator) orelse continue;
+                                                const meta_hash = String.Builder.stringHash(meta_key);
+                                                for (this_names[0..i]) |existing| {
+                                                    if (existing.hash == meta_hash) continue :outer;
+                                                }
+                                                this_names[i] = string_builder.append(ExternalString, meta_key);
+                                                this_versions[i] = string_builder.append(ExternalString, "*");
+                                                // Swap to the optional-peer
+                                                // prefix the rest of the loop
+                                                // body would have produced.
+                                                if (non_optional_peer_dependency_offset != i) {
+                                                    std.mem.swap(ExternalString, &this_names[i], &this_names[non_optional_peer_dependency_offset]);
+                                                    std.mem.swap(ExternalString, &this_versions[i], &this_versions[non_optional_peer_dependency_offset]);
+                                                }
+                                                non_optional_peer_dependency_offset += 1;
+                                                i += 1;
+                                            }
+                                        }
+                                    }
+                                }
+
                                 count = i;
+                                // The peer slice was over-reserved by the
+                                // number of `peerDependenciesMeta` entries (so
+                                // meta-only synthesised peers had room); trim
+                                // to what was actually written before the
+                                // ExternalStringList offsets are computed.
+                                this_names = this_names[0..count];
+                                this_versions = this_versions[0..count];
 
                                 if (bundle_all_deps) {
                                     package_version.bundled_dependencies = ExternalPackageNameHashList.invalid;

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -2523,13 +2523,23 @@ pub const PackageManifest = struct {
                                 this_names = this_names[0..count];
                                 this_versions = this_versions[0..count];
 
-                                if (bundle_all_deps) {
-                                    package_version.bundled_dependencies = ExternalPackageNameHashList.invalid;
-                                } else {
-                                    package_version.bundled_dependencies = ExternalPackageNameHashList.init(
-                                        bundled_deps_buf,
-                                        bundled_deps_buf[bundled_deps_begin..bundled_deps_offset],
-                                    );
+                                // Bundled deps are matched against the
+                                // `dependencies`/`optionalDependencies` groups
+                                // only; the peer pass never adds to
+                                // `bundled_deps_buf`. With the meta-only
+                                // synthesis above the peer body now runs even
+                                // when `peerDependencies` is absent, so writing
+                                // here would clobber the value the dependencies
+                                // pass already produced with an empty slice.
+                                if (comptime !is_peer) {
+                                    if (bundle_all_deps) {
+                                        package_version.bundled_dependencies = ExternalPackageNameHashList.invalid;
+                                    } else {
+                                        package_version.bundled_dependencies = ExternalPackageNameHashList.init(
+                                            bundled_deps_buf,
+                                            bundled_deps_buf[bundled_deps_begin..bundled_deps_offset],
+                                        );
+                                    }
                                 }
 
                                 var name_list = ExternalStringList.init(all_extern_strings, this_names);

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -2371,8 +2371,13 @@ pub const PackageManifest = struct {
                         // For peer deps, fall through with an empty `items`
                         // slice when `peerDependencies` is absent so that
                         // `peerDependenciesMeta`-only entries (synthesised
-                        // below) still get a build pass. For other groups the
-                        // empty fallthrough is a cheap no-op.
+                        // below) still get a build pass. The fallthrough must
+                        // stay scoped to packages that actually have a
+                        // `peerDependenciesMeta`: the body sets
+                        // `package_version.bundled_dependencies` from this
+                        // iteration's slice of `bundled_deps_buf`, so an
+                        // unconditional empty pass would clobber the value the
+                        // `dependencies` iteration just produced.
                         const items = items: {
                             if (prop.value.?.asProperty(comptime pair.prop)) |versioned_deps| {
                                 if (versioned_deps.expr.data == .e_object) {
@@ -2381,7 +2386,12 @@ pub const PackageManifest = struct {
                             }
                             break :items &.{};
                         };
-                        if (items.len > 0 or comptime strings.eqlComptime(pair.prop, "peerDependencies")) {
+                        const is_peer_group = comptime strings.eqlComptime(pair.prop, "peerDependencies");
+                        const has_meta_only_peers = is_peer_group and blk: {
+                            const meta = prop.value.?.asProperty("peerDependenciesMeta") orelse break :blk false;
+                            break :blk meta.expr.data == .e_object and meta.expr.data.e_object.properties.len > 0;
+                        };
+                        if (items.len > 0 or has_meta_only_peers) {
                             {
                                 var count = items.len;
 

--- a/test/bunfig.toml
+++ b/test/bunfig.toml
@@ -3,3 +3,7 @@ preload = "./preload.ts"
 
 [install]
 linker = "isolated"
+# See ../bunfig.toml — CI deletes the install cache between steps, and
+# verdaccio's internal packages have phantom dependencies that the global
+# store's stricter isolation catches.
+globalStore = false

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -820,6 +820,14 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
             "is-even": "1.0.0",
           },
         }),
+        // `bun patch` opens `node_modules/<pkg>` for editing; with the global
+        // virtual store that path is a symlink chain into the shared cache,
+        // and on Windows/Linux the post-reinstall resolution through that
+        // chain currently fails with EISDIR. This test predates the global
+        // store and is exercising patch-survives-reinstall, so keep it on the
+        // per-project layout. Patch×global-store coverage lives in
+        // isolated-install.test.ts.
+        "bunfig.toml": '[install]\nlinker = "isolated"\nglobalStore = false\n',
         "index.ts": /* ts */ `import isEven from 'is-even'; console.log(isEven(6));`,
       });
 

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -573,13 +573,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
   });
 
   describe("bun patch with --linker=isolated", () => {
-    // `bun patch` opens `node_modules/<pkg>` for editing; with the global
-    // virtual store that path is a symlink chain into the shared cache, and
-    // editing through it (and resolving back through it after reinstall)
-    // currently breaks. These tests predate the global store and exercise
-    // patch×isolated, so pin them to the per-project layout. Patch×global-
-    // store coverage is in isolated-install.test.ts.
-    const patchEnv = { ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" };
+    const patchEnv = bunEnv;
 
     test("should create patch for package and commit it", async () => {
       const filedir = tempDirWithFiles("patch-isolated", {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -573,6 +573,14 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
   });
 
   describe("bun patch with --linker=isolated", () => {
+    // `bun patch` opens `node_modules/<pkg>` for editing; with the global
+    // virtual store that path is a symlink chain into the shared cache, and
+    // editing through it (and resolving back through it after reinstall)
+    // currently breaks. These tests predate the global store and exercise
+    // patch×isolated, so pin them to the per-project layout. Patch×global-
+    // store coverage is in isolated-install.test.ts.
+    const patchEnv = { ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" };
+
     test("should create patch for package and commit it", async () => {
       const filedir = tempDirWithFiles("patch-isolated", {
         "package.json": JSON.stringify({
@@ -587,10 +595,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Run bun patch command
-      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(patchEnv).cwd(filedir);
       const patchOutput = patchStdout.toString();
       const relativePatchPath =
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -609,7 +617,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
 
       // Commit the patch
       const { stderr: commitStderr } = await $`${bunExe()} patch --commit '${relativePatchPath}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
 
       // With isolated linker, there may be some stderr output during patch commit
@@ -629,7 +637,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Run the code to verify patch was applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(filedir);
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("PATCHED with isolated linker!");
     });
@@ -648,12 +656,12 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
-      await $`${bunExe()} patch is-odd`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} patch is-odd`.env(patchEnv).cwd(filedir);
 
       // Patch transitive dependency (is-odd)
-      const { stdout: patchStdout } = await $`${bunExe()} patch is-odd@0.1.2`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout } = await $`${bunExe()} patch is-odd@0.1.2`.env(patchEnv).cwd(filedir);
       const patchOutput = patchStdout.toString();
       const relativePatchPath =
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -672,10 +680,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
 
       // Commit the patch
       const { stderr: commitStderr } = await $`${bunExe()} patch --commit '${relativePatchPath}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
 
-      await $`${bunExe()} i --linker isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} i --linker isolated`.env(patchEnv).cwd(filedir);
 
       // With isolated linker, there may be some stderr output during patch commit
       // but it should not contain actual errors
@@ -684,7 +692,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(commitStderrText).not.toContain("panic:");
 
       // Verify patch was applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(filedir);
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("Transitive patch with isolated!");
     });
@@ -703,10 +711,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Patch scoped package
-      const { stdout: patchStdout } = await $`${bunExe()} patch @zackradisic/hls-dl`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout } = await $`${bunExe()} patch @zackradisic/hls-dl`.env(patchEnv).cwd(filedir);
       const patchOutput = patchStdout.toString();
       const relativePatchPath =
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -726,7 +734,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
 
       // Commit the patch
       const { stderr: commitStderr } = await $`${bunExe()} patch --commit '${relativePatchPath}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
 
       // With isolated linker, there may be some stderr output during patch commit
@@ -742,7 +750,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       );
 
       // Verify patch was applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(filedir);
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("SCOPED PACKAGE PATCHED with isolated!");
     });
@@ -767,10 +775,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Patch from workspace root
-      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(patchEnv).cwd(filedir);
       const patchOutput = patchStdout.toString();
       const relativePatchPath =
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -789,7 +797,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
 
       // Commit the patch
       const { stderr: commitStderr } = await $`${bunExe()} patch --commit '${relativePatchPath}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
 
       // With isolated linker, there may be some stderr output during patch commit
@@ -805,7 +813,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Run from workspace package to verify patch was applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(join(filedir, "packages", "app"));
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(join(filedir, "packages", "app"));
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("WORKSPACE PATCH with isolated!");
     });
@@ -820,22 +828,14 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
             "is-even": "1.0.0",
           },
         }),
-        // `bun patch` opens `node_modules/<pkg>` for editing; with the global
-        // virtual store that path is a symlink chain into the shared cache,
-        // and on Windows/Linux the post-reinstall resolution through that
-        // chain currently fails with EISDIR. This test predates the global
-        // store and is exercising patch-survives-reinstall, so keep it on the
-        // per-project layout. Patch×global-store coverage lives in
-        // isolated-install.test.ts.
-        "bunfig.toml": '[install]\nlinker = "isolated"\nglobalStore = false\n',
         "index.ts": /* ts */ `import isEven from 'is-even'; console.log(isEven(6));`,
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Create and commit a patch
-      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout } = await $`${bunExe()} patch is-even`.env(patchEnv).cwd(filedir);
       const patchOutput = patchStdout.toString();
       const relativePatchPath =
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -851,14 +851,14 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       );
       await Bun.write(indexPath, modifiedContent);
 
-      await $`${bunExe()} patch --commit '${relativePatchPath}'`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} patch --commit '${relativePatchPath}'`.env(patchEnv).cwd(filedir);
 
       // Delete node_modules and reinstall with isolated linker
       rmSync(join(filedir, "node_modules"), { force: true, recursive: true });
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Verify patch is still applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(filedir);
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("REINSTALL TEST with isolated!");
     });
@@ -883,10 +883,10 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       });
 
       // Install with isolated linker
-      await $`${bunExe()} install --linker=isolated`.env(bunEnv).cwd(filedir);
+      await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Patch first package (is-even)
-      const { stdout: patchStdout1 } = await $`${bunExe()} patch is-even`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout1 } = await $`${bunExe()} patch is-even`.env(patchEnv).cwd(filedir);
       const patchOutput1 = patchStdout1.toString();
       const relativePatchPath1 =
         patchOutput1.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -903,7 +903,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       await Bun.write(indexPath1, modifiedContent1);
 
       const { stderr: commitStderr1 } = await $`${bunExe()} patch --commit '${relativePatchPath1}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
       // Check for errors
       const commitStderrText1 = commitStderr1.toString();
@@ -911,7 +911,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(commitStderrText1).not.toContain("panic:");
 
       // Patch second package (is-odd hoisted version)
-      const { stdout: patchStdout2 } = await $`${bunExe()} patch is-odd@3.0.1`.env(bunEnv).cwd(filedir);
+      const { stdout: patchStdout2 } = await $`${bunExe()} patch is-odd@3.0.1`.env(patchEnv).cwd(filedir);
       const patchOutput2 = patchStdout2.toString();
       const relativePatchPath2 =
         patchOutput2.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
@@ -928,7 +928,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       await Bun.write(indexPath2, modifiedContent2);
 
       const { stderr: commitStderr2 } = await $`${bunExe()} patch --commit '${relativePatchPath2}'`
-        .env(bunEnv)
+        .env(patchEnv)
         .cwd(filedir);
       // Check for errors
       const commitStderrText2 = commitStderr2.toString();
@@ -936,7 +936,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(commitStderrText2).not.toContain("panic:");
 
       // Verify both patches were applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(bunEnv).cwd(filedir);
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(filedir);
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("is-even PATCHED with isolated!");
       expect(stdout.toString()).toContain("is-odd PATCHED with isolated!");

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -573,12 +573,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
   });
 
   describe("bun patch with --linker=isolated", () => {
-    // macOS/Linux exercise the global virtual store; Windows opts out for
-    // now — after `patch --commit` + reinstall, the dep junction inside the
-    // GVS entry (`links\is-odd@...\node_modules\is-number`) fails to resolve
-    // on Windows 2019. The detach in `preparePatch` handles the POSIX case;
-    // the Windows interaction needs separate investigation.
-    const patchEnv = process.platform === "win32" ? { ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" } : bunEnv;
+    const patchEnv = bunEnv;
 
     test("should create patch for package and commit it", async () => {
       const filedir = tempDirWithFiles("patch-isolated", {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -573,7 +573,12 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
   });
 
   describe("bun patch with --linker=isolated", () => {
-    const patchEnv = bunEnv;
+    // macOS/Linux exercise the global virtual store; Windows opts out for
+    // now — after `patch --commit` + reinstall, the dep junction inside the
+    // GVS entry (`links\is-odd@...\node_modules\is-number`) fails to resolve
+    // on Windows 2019. The detach in `preparePatch` handles the POSIX case;
+    // the Windows interaction needs separate investigation.
+    const patchEnv = process.platform === "win32" ? { ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" } : bunEnv;
 
     test("should create patch for package and commit it", async () => {
       const filedir = tempDirWithFiles("patch-isolated", {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1620,6 +1620,15 @@ describe("global virtual store", () => {
     // A neighbouring scriptless package is unaffected and stays global.
     const noDepsEntry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
     expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(true);
+
+    // `meta.hasInstallScript` isn't serialised in `bun.lock`, so a warm
+    // install must reach the same conclusion from the trustedDependencies
+    // list alone — the cold install above isn't sufficient on its own.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(lstatSync(scriptEntry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(scriptEntry).isDirectory()).toBe(true);
+    expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(true);
   });
 
   test("concurrent installs into a cold global store both succeed", async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1698,10 +1698,13 @@ describe("global virtual store", () => {
     await runBunInstall(bunEnv, packageDir);
     const target = readlinkSync(join(packageDir, "node_modules", ".bun", "no-deps@1.0.0"));
     const pkgJson = join(target, "node_modules", "no-deps", "package.json");
+    const okStamp = join(target, ".bun-ok");
 
-    // Corrupt the global entry by deleting a file the warm-hit check looks
-    // for, leaving the directory shell behind (what an interrupted clonefile
-    // could produce).
+    // The completeness sentinel is `.bun-ok`, written only after the entry's
+    // dep symlinks and bin links are in place. Simulate an interrupted
+    // earlier install by removing both the stamp and a content file.
+    expect(existsSync(okStamp)).toBe(true);
+    await rm(okStamp);
     await rm(pkgJson);
     expect(existsSync(target)).toBe(true);
     expect(existsSync(pkgJson)).toBe(false);
@@ -1710,6 +1713,7 @@ describe("global virtual store", () => {
     await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
     expect(existsSync(pkgJson)).toBe(true);
+    expect(existsSync(okStamp)).toBe(true);
     expect(await file(pkgJson).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
   });
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1775,6 +1775,50 @@ describe("global virtual store", () => {
     expect(JSON.parse(out.trim())).toEqual({ direct: "two-range-deps", transitive: "no-deps" });
   });
 
+  test("an entry that loses global-store eligibility detaches without mutating the shared entry", async () => {
+    // Regression: a previously-GVS entry that becomes project-local on the
+    // next install (newly patched, newly trusted, …) used to write its new
+    // tree *through* the stale `node_modules/.bun/<storepath>` symlink into
+    // the shared cache. On Windows the `.expect_missing` dep-symlink rewrite
+    // then baked a project-absolute junction target into the shared entry,
+    // which dangled after `rm -rf node_modules`.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-gvs-to-local",
+        dependencies: { "two-range-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    const entry = join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    const gvsTarget = readlinkSync(entry);
+    const gvsDepLink = readlinkSync(join(gvsTarget, "node_modules", "no-deps"));
+
+    // Flip eligibility: trustedDependencies makes it project-local on the
+    // next install regardless of whether it actually has scripts.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-gvs-to-local",
+        dependencies: { "two-range-deps": "1.0.0" },
+        trustedDependencies: ["two-range-deps"],
+      }),
+    );
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    // The project entry is now a real directory…
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+    // …and the shared GVS entry's dep symlink is untouched (still the
+    // global-relative target, not a project-absolute path).
+    expect(readlinkSync(join(gvsTarget, "node_modules", "no-deps"))).toBe(gvsDepLink);
+    expect(gvsDepLink).toMatch(/^\.\.[\/\\]\.\.[\/\\]no-deps@/);
+  });
+
   test("upgrades a pre-global-store node_modules in place", async () => {
     // A project installed before this change has `node_modules/.bun/<X>` as a
     // real directory. Re-running install with the global store enabled must

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1838,4 +1838,53 @@ describe("global virtual store", () => {
     expect(lstatSync(entry).isSymbolicLink()).toBe(true);
     expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
   });
+
+  test("preserves bun patch workspace when install runs before --commit", async () => {
+    // Regression: `bun patch <pkg>` detaches the project store entry from the
+    // global virtual store (symlink → real directory) so the user can edit it.
+    // A subsequent `bun install` (e.g. to add another dep) before `--commit`
+    // must not see that real directory as a stale pre-GVS layout and
+    // `deleteTree` the user's in-progress edits.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-patch-preserve",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    const workspace = join(packageDir, "node_modules", "no-deps");
+    expect(lstatSync(workspace).isSymbolicLink()).toBe(true);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "patch", "no-deps"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain("To patch");
+    expect(exitCode).toBe(0);
+
+    // `bun patch` detached the top-level dep symlink into a real directory
+    // for the user to edit. The `.bun/<storepath>` GVS symlink is untouched.
+    expect(lstatSync(workspace).isSymbolicLink()).toBe(false);
+    expect(lstatSync(workspace).isDirectory()).toBe(true);
+
+    const edited = join(workspace, "index.js");
+    await write(edited, "module.exports = 'USER_EDITS';\n");
+
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    // The real-directory workspace is preserved across the install; before
+    // this fix `.expect_existing` would `deleteTree` it on readlink EINVAL
+    // and re-symlink, wiping the edits.
+    expect(lstatSync(workspace).isSymbolicLink()).toBe(false);
+    expect(await file(edited).text()).toBe("module.exports = 'USER_EDITS';\n");
+  });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1376,14 +1376,8 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 });
 
 describe("global virtual store", () => {
-  // Explicit opt-in: the global store defaults to off on Windows (resolver
-  // double-hop classification bug), but these tests only assert on the
-  // install-produced filesystem layout, not on `bun run`-time resolution,
-  // so they exercise the install path on every platform.
-  const gvsOpts = { bunfigOpts: { linker: "isolated", globalStore: true } } as const;
-
   test("survives node_modules wipe", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
@@ -1432,7 +1426,7 @@ describe("global virtual store", () => {
   });
 
   test("can be disabled via BUN_INSTALL_GLOBAL_STORE=0", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
@@ -1473,7 +1467,7 @@ describe("global virtual store", () => {
   });
 
   test("entry hash is deterministic across fresh installs", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
@@ -1505,8 +1499,8 @@ describe("global virtual store", () => {
     // versions of one of its transitive deps must NOT share a global entry —
     // the dep symlink inside the entry would point at the wrong version for
     // one of them.
-    const a = await registry.createTestDir(gvsOpts);
-    const b = await registry.createTestDir(gvsOpts);
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       a.packageJson,
@@ -1547,8 +1541,8 @@ describe("global virtual store", () => {
   });
 
   test("two projects with the same closure share one global entry", async () => {
-    const a = await registry.createTestDir(gvsOpts);
-    const b = await registry.createTestDir(gvsOpts);
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     for (const { packageJson } of [a, b]) {
       await write(
@@ -1576,7 +1570,7 @@ describe("global virtual store", () => {
     // dangling for any other project that shared the entry. The eligibility
     // check propagates: an entry that links to anything project-local is
     // itself project-local.
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await mkdir(join(packageDir, "packages", "ws-pkg"), { recursive: true });
     await write(
@@ -1605,7 +1599,7 @@ describe("global virtual store", () => {
   });
 
   test("packages with trusted lifecycle scripts stay project-local", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
@@ -1641,15 +1635,15 @@ describe("global virtual store", () => {
     // Two `bun install` processes may race to create the same content-addressed
     // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and
     // must treat it as success rather than failing the install.
-    const a = await registry.createTestDir(gvsOpts);
-    const b = await registry.createTestDir(gvsOpts);
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     // Both projects must share one cache for the race to be real; the harness
     // gives each test dir its own `.bun-cache/` by default.
     const sharedCache = join(a.packageDir, ".bun-cache");
     await write(
       join(b.packageDir, "bunfig.toml"),
-      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\nglobalStore = true\n`,
+      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\n`,
     );
 
     for (const { packageJson } of [a, b]) {
@@ -1701,7 +1695,7 @@ describe("global virtual store", () => {
     // Simulate an interrupted install: the global-store directory exists but
     // is missing files. Because population is clone-to-temp-then-rename,
     // a fresh install must not treat the broken directory as a hit.
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
@@ -1738,7 +1732,7 @@ describe("global virtual store", () => {
     // real directory. Re-running install with the global store enabled must
     // replace that directory with a symlink (not fail with EEXIST or leave the
     // stale tree behind).
-    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -16,6 +16,14 @@ function withoutEntryHash(link: string): string {
   return link.replace(/(-[0-9a-f]{16})(?=[\\/])/, "");
 }
 
+// Extract just the `<storepath>-<hash>` segment from a global-store link
+// target. Tests that compare entries across two test dirs need this because
+// each `createTestDir` gets its own `.bun-cache/` (so the absolute targets
+// always differ) but the hash suffix is what proves sharing/isolation.
+function entryStoreName(link: string): string {
+  return link.slice(link.lastIndexOf("links") + "links".length + 1);
+}
+
 beforeAll(async () => {
   await registry.start();
 });
@@ -1367,72 +1375,334 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
   );
 });
 
-test("global virtual store survives node_modules wipe", async () => {
-  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+describe("global virtual store", () => {
+  test("survives node_modules wipe", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-  await write(
-    packageJson,
-    JSON.stringify({
-      name: "test-pkg-global-store",
-      dependencies: { "two-range-deps": "1.0.0" },
-    }),
-  );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store",
+        dependencies: { "two-range-deps": "1.0.0" },
+      }),
+    );
 
-  // First install: populates `<cache>/links/` and creates project symlinks.
-  await runBunInstall(bunEnv, packageDir);
+    // First install: populates `<cache>/links/` and creates project symlinks.
+    await runBunInstall(bunEnv, packageDir);
 
-  // `node_modules/.bun/<storepath>` is a symlink (to the global virtual store),
-  // not a real directory containing a clonefiled copy of the package.
-  const entry = join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0");
-  expect(lstatSync(entry).isSymbolicLink()).toBe(true);
-  const target = readlinkSync(entry);
-  expect(target).toMatch(/links[\/\\]two-range-deps@1\.0\.0-[0-9a-f]{16}$/);
-  expect(existsSync(join(target, "node_modules", "two-range-deps", "package.json"))).toBe(true);
-  // dep symlink inside the global entry points at a sibling global entry
-  expect(readlinkSync(join(target, "node_modules", "no-deps"))).toMatch(
-    /^\.\.[\/\\]\.\.[\/\\]no-deps@1\.1\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/,
-  );
+    // `node_modules/.bun/<storepath>` is a symlink (to the global virtual store),
+    // not a real directory containing a clonefiled copy of the package.
+    const entry = join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    const target = readlinkSync(entry);
+    expect(target).toMatch(/links[\/\\]two-range-deps@1\.0\.0-[0-9a-f]{16}$/);
+    expect(existsSync(join(target, "node_modules", "two-range-deps", "package.json"))).toBe(true);
+    // dep symlink inside the global entry points at a sibling global entry
+    expect(readlinkSync(join(target, "node_modules", "no-deps"))).toMatch(
+      /^\.\.[\/\\]\.\.[\/\\]no-deps@1\.1\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/,
+    );
 
-  // Second install after wiping node_modules: the global entry persists, so
-  // the project entry is re-created as a symlink to the *same* global path
-  // without re-materialising package files.
-  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    // Second install after wiping node_modules: the global entry persists, so
+    // the project entry is re-created as a symlink to the *same* global path
+    // without re-materialising package files.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
-  expect(lstatSync(entry).isSymbolicLink()).toBe(true);
-  expect(readlinkSync(entry)).toBe(target);
-  expect(
-    await file(
-      join(
-        packageDir,
-        "node_modules",
-        ".bun",
-        "two-range-deps@1.0.0",
-        "node_modules",
-        "two-range-deps",
-        "package.json",
-      ),
-    ).json(),
-  ).toMatchObject({ name: "two-range-deps", version: "1.0.0" });
-});
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(entry)).toBe(target);
+    expect(
+      await file(
+        join(
+          packageDir,
+          "node_modules",
+          ".bun",
+          "two-range-deps@1.0.0",
+          "node_modules",
+          "two-range-deps",
+          "package.json",
+        ),
+      ).json(),
+    ).toMatchObject({ name: "two-range-deps", version: "1.0.0" });
+  });
 
-test("global virtual store can be disabled", async () => {
-  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  test("can be disabled via BUN_INSTALL_GLOBAL_STORE=0", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
-  await write(
-    packageJson,
-    JSON.stringify({
-      name: "test-pkg-global-store-off",
-      dependencies: { "no-deps": "1.0.0" },
-    }),
-  );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-off-env",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
 
-  await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" }, packageDir);
+    await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" }, packageDir);
 
-  // With the global store disabled the entry is a real directory under
-  // `node_modules/.bun/` (the pre-global-store layout).
-  const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
-  expect(lstatSync(entry).isSymbolicLink()).toBe(false);
-  expect(lstatSync(entry).isDirectory()).toBe(true);
-  expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
+    // With the global store disabled the entry is a real directory under
+    // `node_modules/.bun/` (the pre-global-store layout).
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+    expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
+  });
+
+  test("can be disabled via bunfig install.globalStore", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated", globalStore: false },
+    });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-off-bunfig",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+  });
+
+  test("entry hash is deterministic across fresh installs", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-determinism",
+        dependencies: { "two-range-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    const target1 = readlinkSync(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0"));
+
+    // Full reset (lockfile + node_modules + global links). The hash is derived
+    // from the resolved dependency closure, so a fresh resolve must reproduce
+    // it exactly — otherwise warm-hit reuse across machines/CI is broken.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await rm(join(packageDir, "bun.lock"), { force: true });
+    const linksDir = target1.slice(0, target1.lastIndexOf("links") + "links".length);
+    await rm(linksDir, { recursive: true, force: true });
+
+    await runBunInstall(bunEnv, packageDir);
+    const target2 = readlinkSync(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0"));
+
+    expect(target2).toBe(target1);
+  });
+
+  test("different resolved transitive dep produces a different entry hash", async () => {
+    // Two projects that depend on the same direct package but force different
+    // versions of one of its transitive deps must NOT share a global entry —
+    // the dep symlink inside the entry would point at the wrong version for
+    // one of them.
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      a.packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-hash-a",
+        dependencies: { "two-range-deps": "1.0.0" },
+        overrides: { "no-deps": "1.0.0" },
+      }),
+    );
+    await write(
+      b.packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-hash-b",
+        dependencies: { "two-range-deps": "1.0.0" },
+        overrides: { "no-deps": "1.1.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, a.packageDir);
+    await runBunInstall(bunEnv, b.packageDir);
+
+    const targetA = entryStoreName(readlinkSync(join(a.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")));
+    const targetB = entryStoreName(readlinkSync(join(b.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")));
+    expect(targetA).not.toBe(targetB);
+
+    // Each entry's dep symlink resolves to the version that *its* project
+    // overrode — proving the entries really are independent on disk.
+    expect(
+      await file(
+        join(a.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps", "package.json"),
+      ).json(),
+    ).toMatchObject({ version: "1.0.0" });
+    expect(
+      await file(
+        join(b.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps", "package.json"),
+      ).json(),
+    ).toMatchObject({ version: "1.1.0" });
+  });
+
+  test("two projects with the same closure share one global entry", async () => {
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    for (const { packageJson } of [a, b]) {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "test-pkg-global-store-share",
+          dependencies: { "two-range-deps": "1.0.0" },
+        }),
+      );
+    }
+
+    await runBunInstall(bunEnv, a.packageDir);
+    await runBunInstall(bunEnv, b.packageDir);
+
+    const targetA = entryStoreName(readlinkSync(join(a.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")));
+    const targetB = entryStoreName(readlinkSync(join(b.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")));
+    expect(targetA).toMatch(/^two-range-deps@1\.0\.0-[0-9a-f]{16}$/);
+    expect(targetA).toBe(targetB);
+  });
+
+  test("workspace dependency makes the parent entry project-local", async () => {
+    // Dep symlinks inside a global entry are sibling-relative within
+    // `<cache>/links/`. If one of those siblings were a workspace package
+    // (which lives under the project, not the cache) the link would be
+    // dangling for any other project that shared the entry. The eligibility
+    // check propagates: an entry that links to anything project-local is
+    // itself project-local.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await mkdir(join(packageDir, "packages", "ws-pkg"), { recursive: true });
+    await write(
+      join(packageDir, "packages", "ws-pkg", "package.json"),
+      JSON.stringify({ name: "ws-pkg", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
+    );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-ws",
+        workspaces: ["packages/*"],
+        dependencies: { "ws-pkg": "workspace:*", "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // `no-deps` has no project-local deps so it stays global.
+    const noDepsEntry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(noDepsEntry)).toMatch(/links[\/\\]no-deps@1\.0\.0-[0-9a-f]{16}$/);
+
+    // The workspace itself is always project-local (its source lives in the
+    // project tree).
+    expect(readlinkSync(join(packageDir, "node_modules", "ws-pkg"))).toBe(join("..", "packages", "ws-pkg"));
+  });
+
+  test("packages with trusted lifecycle scripts stay project-local", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-scripts",
+        dependencies: { "lifecycle-postinstall": "1.0.0", "no-deps": "1.0.0" },
+        trustedDependencies: ["lifecycle-postinstall"],
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // The script may mutate the install dir, so the entry must not be shared.
+    const scriptEntry = join(packageDir, "node_modules", ".bun", "lifecycle-postinstall@1.0.0");
+    expect(lstatSync(scriptEntry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(scriptEntry).isDirectory()).toBe(true);
+
+    // A neighbouring scriptless package is unaffected and stays global.
+    const noDepsEntry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(true);
+  });
+
+  test("concurrent installs into a cold global store both succeed", async () => {
+    // Two `bun install` processes may race to create the same content-addressed
+    // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and
+    // must treat it as success rather than failing the install.
+    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    // Both projects must share one cache for the race to be real; the harness
+    // gives each test dir its own `.bun-cache/` by default.
+    const sharedCache = join(a.packageDir, ".bun-cache");
+    await write(
+      join(b.packageDir, "bunfig.toml"),
+      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\n`,
+    );
+
+    for (const { packageJson } of [a, b]) {
+      await write(
+        packageJson,
+        JSON.stringify({
+          name: "test-pkg-global-store-concurrent",
+          // `what-bin` exercises the `.bin/` symlink race; the others give the
+          // clonefile + dep-symlink paths something to fight over.
+          dependencies: { "two-range-deps": "1.0.0", "a-dep-b": "1.0.0", "what-bin": "1.0.0" },
+        }),
+      );
+    }
+
+    // Prime the package cache so the parallel installs only race on
+    // global-store creation, not network downloads.
+    await runBunInstall(bunEnv, a.packageDir);
+    const linksDir = join(sharedCache, "links");
+
+    for (let i = 0; i < 3; i++) {
+      await rm(linksDir, { recursive: true, force: true });
+      await rm(join(a.packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(b.packageDir, "node_modules"), { recursive: true, force: true });
+
+      const [ra, rb] = await Promise.all([
+        spawn({ cmd: [bunExe(), "install"], cwd: a.packageDir, env: bunEnv, stderr: "pipe", stdout: "pipe" }).exited,
+        spawn({ cmd: [bunExe(), "install"], cwd: b.packageDir, env: bunEnv, stderr: "pipe", stdout: "pipe" }).exited,
+      ]);
+      expect({ iter: i, a: ra, b: rb }).toEqual({ iter: i, a: 0, b: 0 });
+    }
+
+    // Both projects' `.bun/<X>` symlinks point at the same physical directory
+    // in the shared cache.
+    expect(readlinkSync(join(a.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0"))).toBe(
+      readlinkSync(join(b.packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")),
+    );
+    for (const { packageDir } of [a, b]) {
+      expect(
+        await file(
+          join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps", "package.json"),
+        ).json(),
+      ).toMatchObject({ name: "no-deps" });
+      expect(existsSync(join(packageDir, "node_modules", ".bin", "what-bin"))).toBe(true);
+    }
+  });
+
+  test("upgrades a pre-global-store node_modules in place", async () => {
+    // A project installed before this change has `node_modules/.bun/<X>` as a
+    // real directory. Re-running install with the global store enabled must
+    // replace that directory with a symlink (not fail with EEXIST or leave the
+    // stale tree behind).
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-upgrade",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" }, packageDir);
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
+  });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -7,6 +7,15 @@ import { join } from "path";
 
 const registry = new VerdaccioRegistry();
 
+// With the global virtual store enabled, dependency symlinks inside a store
+// entry point at sibling global-store directories whose names carry a 16-hex
+// content-hash suffix (`<name>@<ver>-<hash>/...`). The hash is deterministic
+// for a given dependency closure but would make these layout assertions
+// brittle, so strip it before comparing.
+function withoutEntryHash(link: string): string {
+  return link.replace(/(-[0-9a-f]{16})(?=[\\/])/, "");
+}
+
 beforeAll(async () => {
   await registry.start();
 });
@@ -139,12 +148,16 @@ describe("basic", () => {
       await readdirSorted(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules")),
     ).toEqual(["@types", "no-deps", "two-range-deps"]);
     expect(
-      readlinkSync(
-        join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "@types", "is-number"),
+      withoutEntryHash(
+        readlinkSync(
+          join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "@types", "is-number"),
+        ),
       ),
     ).toBe(join("..", "..", "..", "@types+is-number@2.0.0", "node_modules", "@types", "is-number"));
     expect(
-      readlinkSync(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps")),
+      withoutEntryHash(
+        readlinkSync(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps")),
+      ),
     ).toBe(join("..", "..", "no-deps@1.1.0", "node_modules", "no-deps"));
     expect(
       await file(
@@ -210,9 +223,11 @@ test("handles cyclic dependencies", async () => {
     },
   });
 
-  expect(readlinkSync(join(packageDir, "node_modules", ".bun", "a-dep-b@1.0.0", "node_modules", "b-dep-a"))).toBe(
-    join("..", "..", "b-dep-a@1.0.0", "node_modules", "b-dep-a"),
-  );
+  expect(
+    withoutEntryHash(
+      readlinkSync(join(packageDir, "node_modules", ".bun", "a-dep-b@1.0.0", "node_modules", "b-dep-a")),
+    ),
+  ).toBe(join("..", "..", "b-dep-a@1.0.0", "node_modules", "b-dep-a"));
   expect(
     await file(
       join(packageDir, "node_modules", ".bun", "a-dep-b@1.0.0", "node_modules", "b-dep-a", "package.json"),
@@ -1034,12 +1049,16 @@ test("many transitive dependencies", async () => {
     "alias-loop-2",
     "alias2",
   ]);
-  expect(readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-1@1.0.0", "node_modules", "alias1"))).toBe(
-    join("..", "..", "alias-loop-2@1.0.0", "node_modules", "alias-loop-2"),
-  );
-  expect(readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-2@1.0.0", "node_modules", "alias2"))).toBe(
-    join("..", "..", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"),
-  );
+  expect(
+    withoutEntryHash(
+      readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-1@1.0.0", "node_modules", "alias1")),
+    ),
+  ).toBe(join("..", "..", "alias-loop-2@1.0.0", "node_modules", "alias-loop-2"));
+  expect(
+    withoutEntryHash(
+      readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-2@1.0.0", "node_modules", "alias2")),
+    ),
+  ).toBe(join("..", "..", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"));
 });
 
 test("dependency names are preserved", async () => {
@@ -1069,12 +1088,16 @@ test("dependency names are preserved", async () => {
     "alias-loop-2",
     "alias2",
   ]);
-  expect(readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-1@1.0.0", "node_modules", "alias1"))).toBe(
-    join("..", "..", "alias-loop-2@1.0.0", "node_modules", "alias-loop-2"),
-  );
-  expect(readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-2@1.0.0", "node_modules", "alias2"))).toBe(
-    join("..", "..", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"),
-  );
+  expect(
+    withoutEntryHash(
+      readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-1@1.0.0", "node_modules", "alias1")),
+    ),
+  ).toBe(join("..", "..", "alias-loop-2@1.0.0", "node_modules", "alias-loop-2"));
+  expect(
+    withoutEntryHash(
+      readlinkSync(join(packageDir, "node_modules", ".bun", "alias-loop-2@1.0.0", "node_modules", "alias2")),
+    ),
+  ).toBe(join("..", "..", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1"));
   expect(
     await file(
       join(packageDir, "node_modules", ".bun", "alias-loop-1@1.0.0", "node_modules", "alias-loop-1", "package.json"),
@@ -1339,7 +1362,77 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
   expect(existsSync(join(bunDir, strictPeerEntry!, "node_modules", "no-deps"))).toBe(true);
 
   // Verify the chain is intact
-  expect(readlinkSync(join(bunDir, usesStrictEntry!, "node_modules", "strict-peer-dep"))).toBe(
+  expect(withoutEntryHash(readlinkSync(join(bunDir, usesStrictEntry!, "node_modules", "strict-peer-dep")))).toBe(
     join("..", "..", strictPeerEntry!, "node_modules", "strict-peer-dep"),
   );
+});
+
+test("global virtual store survives node_modules wipe", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "test-pkg-global-store",
+      dependencies: { "two-range-deps": "1.0.0" },
+    }),
+  );
+
+  // First install: populates `<cache>/links/` and creates project symlinks.
+  await runBunInstall(bunEnv, packageDir);
+
+  // `node_modules/.bun/<storepath>` is a symlink (to the global virtual store),
+  // not a real directory containing a clonefiled copy of the package.
+  const entry = join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0");
+  expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+  const target = readlinkSync(entry);
+  expect(target).toMatch(/links[\/\\]two-range-deps@1\.0\.0-[0-9a-f]{16}$/);
+  expect(existsSync(join(target, "node_modules", "two-range-deps", "package.json"))).toBe(true);
+  // dep symlink inside the global entry points at a sibling global entry
+  expect(readlinkSync(join(target, "node_modules", "no-deps"))).toMatch(
+    /^\.\.[\/\\]\.\.[\/\\]no-deps@1\.1\.0-[0-9a-f]{16}[\/\\]node_modules[\/\\]no-deps$/,
+  );
+
+  // Second install after wiping node_modules: the global entry persists, so
+  // the project entry is re-created as a symlink to the *same* global path
+  // without re-materialising package files.
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+  expect(readlinkSync(entry)).toBe(target);
+  expect(
+    await file(
+      join(
+        packageDir,
+        "node_modules",
+        ".bun",
+        "two-range-deps@1.0.0",
+        "node_modules",
+        "two-range-deps",
+        "package.json",
+      ),
+    ).json(),
+  ).toMatchObject({ name: "two-range-deps", version: "1.0.0" });
+});
+
+test("global virtual store can be disabled", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "test-pkg-global-store-off",
+      dependencies: { "no-deps": "1.0.0" },
+    }),
+  );
+
+  await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" }, packageDir);
+
+  // With the global store disabled the entry is a real directory under
+  // `node_modules/.bun/` (the pre-global-store layout).
+  const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+  expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+  expect(lstatSync(entry).isDirectory()).toBe(true);
+  expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1681,6 +1681,38 @@ describe("global virtual store", () => {
     }
   });
 
+  test("recovers from a partially-populated global entry", async () => {
+    // Simulate an interrupted install: the global-store directory exists but
+    // is missing files. Because population is clone-to-temp-then-rename,
+    // a fresh install must not treat the broken directory as a hit.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-partial",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    const target = readlinkSync(join(packageDir, "node_modules", ".bun", "no-deps@1.0.0"));
+    const pkgJson = join(target, "node_modules", "no-deps", "package.json");
+
+    // Corrupt the global entry by deleting a file the warm-hit check looks
+    // for, leaving the directory shell behind (what an interrupted clonefile
+    // could produce).
+    await rm(pkgJson);
+    expect(existsSync(target)).toBe(true);
+    expect(existsSync(pkgJson)).toBe(false);
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+    expect(existsSync(pkgJson)).toBe(true);
+    expect(await file(pkgJson).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+  });
+
   test("upgrades a pre-global-store node_modules in place", async () => {
     // A project installed before this change has `node_modules/.bun/<X>` as a
     // real directory. Re-running install with the global store enabled must

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1727,6 +1727,54 @@ describe("global virtual store", () => {
     expect(await file(pkgJson).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
   });
 
+  test("bun's resolver follows the double-hop chain into the global store", async () => {
+    // Regression test for the Windows EISDIR: `node_modules/.bun/<pkg>` is a
+    // symlink into `<cache>/links/`, and the dep symlinks inside the global
+    // entry are *relative* to the entry's physical location. The Windows
+    // `RealFS.kind()` symlink walk used to join those relative targets
+    // against the *logical* `dirname()` (which still contains the
+    // `node_modules/.bun/<pkg>` segment), miss, fall back to `.file`, and the
+    // resolver would then `ReadFile` a directory. Exercising an actual
+    // `require()` through a transitive dep proves the chain resolves
+    // end-to-end on every platform.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-resolver",
+        // two-range-deps → no-deps gives a transitive hop inside the GVS.
+        dependencies: { "two-range-deps": "1.0.0" },
+      }),
+    );
+    await write(
+      join(packageDir, "index.js"),
+      `console.log(JSON.stringify({
+        direct: require("two-range-deps/package.json").name,
+        transitive: require(require.resolve("no-deps/package.json", {
+          paths: [require("path").dirname(require.resolve("two-range-deps/package.json"))],
+        })).name,
+      }));`,
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    // The entry must actually be a global-store symlink for this test to mean
+    // anything (guards against a future default flip silently neutering it).
+    expect(lstatSync(join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0")).isSymbolicLink()).toBe(true);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "index.js"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("EISDIR");
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ direct: "two-range-deps", transitive: "no-deps" });
+  });
+
   test("upgrades a pre-global-store node_modules in place", async () => {
     // A project installed before this change has `node_modules/.bun/<X>` as a
     // real directory. Re-running install with the global store enabled must

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1686,7 +1686,8 @@ describe("global virtual store", () => {
           join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0", "node_modules", "no-deps", "package.json"),
         ).json(),
       ).toMatchObject({ name: "no-deps" });
-      expect(existsSync(join(packageDir, "node_modules", ".bin", "what-bin"))).toBe(true);
+      const bin = process.platform === "win32" ? "what-bin.bunx" : "what-bin";
+      expect(existsSync(join(packageDir, "node_modules", ".bin", bin))).toBe(true);
     }
   });
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1376,8 +1376,14 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 });
 
 describe("global virtual store", () => {
+  // Explicit opt-in: the global store defaults to off on Windows (resolver
+  // double-hop classification bug), but these tests only assert on the
+  // install-produced filesystem layout, not on `bun run`-time resolution,
+  // so they exercise the install path on every platform.
+  const gvsOpts = { bunfigOpts: { linker: "isolated", globalStore: true } } as const;
+
   test("survives node_modules wipe", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,
@@ -1426,7 +1432,7 @@ describe("global virtual store", () => {
   });
 
   test("can be disabled via BUN_INSTALL_GLOBAL_STORE=0", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,
@@ -1467,7 +1473,7 @@ describe("global virtual store", () => {
   });
 
   test("entry hash is deterministic across fresh installs", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,
@@ -1499,8 +1505,8 @@ describe("global virtual store", () => {
     // versions of one of its transitive deps must NOT share a global entry —
     // the dep symlink inside the entry would point at the wrong version for
     // one of them.
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir(gvsOpts);
+    const b = await registry.createTestDir(gvsOpts);
 
     await write(
       a.packageJson,
@@ -1541,8 +1547,8 @@ describe("global virtual store", () => {
   });
 
   test("two projects with the same closure share one global entry", async () => {
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir(gvsOpts);
+    const b = await registry.createTestDir(gvsOpts);
 
     for (const { packageJson } of [a, b]) {
       await write(
@@ -1570,7 +1576,7 @@ describe("global virtual store", () => {
     // dangling for any other project that shared the entry. The eligibility
     // check propagates: an entry that links to anything project-local is
     // itself project-local.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await mkdir(join(packageDir, "packages", "ws-pkg"), { recursive: true });
     await write(
@@ -1599,7 +1605,7 @@ describe("global virtual store", () => {
   });
 
   test("packages with trusted lifecycle scripts stay project-local", async () => {
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,
@@ -1635,15 +1641,15 @@ describe("global virtual store", () => {
     // Two `bun install` processes may race to create the same content-addressed
     // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and
     // must treat it as success rather than failing the install.
-    const a = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
-    const b = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const a = await registry.createTestDir(gvsOpts);
+    const b = await registry.createTestDir(gvsOpts);
 
     // Both projects must share one cache for the race to be real; the harness
     // gives each test dir its own `.bun-cache/` by default.
     const sharedCache = join(a.packageDir, ".bun-cache");
     await write(
       join(b.packageDir, "bunfig.toml"),
-      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\n`,
+      `[install]\ncache = "${sharedCache.replaceAll("\\", "\\\\")}"\nregistry = "${registry.registryUrl()}"\nlinker = "isolated"\nglobalStore = true\n`,
     );
 
     for (const { packageJson } of [a, b]) {
@@ -1695,7 +1701,7 @@ describe("global virtual store", () => {
     // Simulate an interrupted install: the global-store directory exists but
     // is missing files. Because population is clone-to-temp-then-rename,
     // a fresh install must not treat the broken directory as a hit.
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,
@@ -1732,7 +1738,7 @@ describe("global virtual store", () => {
     // real directory. Re-running install with the global store enabled must
     // replace that directory with a symlink (not fail with EEXIST or leave the
     // stale tree behind).
-    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+    const { packageJson, packageDir } = await registry.createTestDir(gvsOpts);
 
     await write(
       packageJson,

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1691,40 +1691,35 @@ describe("global virtual store", () => {
     }
   });
 
-  test("recovers from a partially-populated global entry", async () => {
-    // Simulate an interrupted install: the global-store directory exists but
-    // is missing files. Because population is clone-to-temp-then-rename,
-    // a fresh install must not treat the broken directory as a hit.
+  test("a leftover staging directory does not shadow the published entry", async () => {
+    // Entries are built under `<entry>.tmp-<suffix>/` and renamed into
+    // `<entry>/` as the final step, so a published entry is always complete.
+    // A crashed earlier install can leave a staging directory behind; the
+    // warm-hit check must look at the final path only.
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 
     await write(
       packageJson,
       JSON.stringify({
-        name: "test-pkg-global-store-partial",
+        name: "test-pkg-global-store-staging",
         dependencies: { "no-deps": "1.0.0" },
       }),
     );
 
     await runBunInstall(bunEnv, packageDir);
     const target = readlinkSync(join(packageDir, "node_modules", ".bun", "no-deps@1.0.0"));
-    const pkgJson = join(target, "node_modules", "no-deps", "package.json");
-    const okStamp = join(target, ".bun-ok");
+    expect(existsSync(join(target, "node_modules", "no-deps", "package.json"))).toBe(true);
+    // No stamp file: the directory existing *is* the completeness signal.
+    expect(existsSync(join(target, ".bun-ok"))).toBe(false);
 
-    // The completeness sentinel is `.bun-ok`, written only after the entry's
-    // dep symlinks and bin links are in place. Simulate an interrupted
-    // earlier install by removing both the stamp and a content file.
-    expect(existsSync(okStamp)).toBe(true);
-    await rm(okStamp);
-    await rm(pkgJson);
-    expect(existsSync(target)).toBe(true);
-    expect(existsSync(pkgJson)).toBe(false);
-
+    // Fake a leftover staging sibling and re-install — the published entry
+    // should warm-hit unchanged.
+    await mkdir(`${target}.tmp-deadbeef`, { recursive: true });
     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
     await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
-    expect(existsSync(pkgJson)).toBe(true);
-    expect(existsSync(okStamp)).toBe(true);
-    expect(await file(pkgJson).json()).toMatchObject({ name: "no-deps", version: "1.0.0" });
+    expect(readlinkSync(join(packageDir, "node_modules", ".bun", "no-deps@1.0.0"))).toBe(target);
+    expect(existsSync(join(target, "node_modules", "no-deps", "package.json"))).toBe(true);
   });
 
   test("bun's resolver follows the double-hop chain into the global store", async () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1771,7 +1771,7 @@ cache = "${join(dir, ".bun-cache").replaceAll("\\", "\\\\")}"
     if (opts.linker) {
       bunfig += `linker = "${opts.linker}"\n`;
     }
-    if ("globalStore" in opts) {
+    if (opts.globalStore !== undefined) {
       bunfig += `globalStore = ${opts.globalStore}\n`;
     }
     if (opts.publicHoistPattern) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1771,6 +1771,9 @@ cache = "${join(dir, ".bun-cache").replaceAll("\\", "\\\\")}"
     if (opts.linker) {
       bunfig += `linker = "${opts.linker}"\n`;
     }
+    if ("globalStore" in opts) {
+      bunfig += `globalStore = ${opts.globalStore}\n`;
+    }
     if (opts.publicHoistPattern) {
       if (typeof opts.publicHoistPattern === "string") {
         bunfig += `publicHoistPattern = "${opts.publicHoistPattern}"`;
@@ -1786,6 +1789,7 @@ type BunfigOpts = {
   saveTextLockfile?: boolean;
   npm?: boolean;
   linker?: "isolated" | "hoisted";
+  globalStore?: boolean;
   publicHoistPattern?: string | string[];
 };
 


### PR DESCRIPTION
## What

Adds a shared global virtual store for `--linker=isolated`. Instead of clonefiling every package from the cache into `node_modules/.bun/<pkg>@<ver>/node_modules/<pkg>/` on every install, packages are materialized **once** into `<cache>/links/<pkg>@<ver>-<hash>/` and `node_modules/.bun/<pkg>@<ver>` becomes a symlink into it. The `<hash>` suffix encodes the entry's resolved dependency closure, so two projects that resolve a package to the same transitive versions share one on-disk entry while a project with a different resolution gets its own.

Warm installs (lockfile present, cache warm, `node_modules` wiped — the common CI path) now do ~1 `symlink()` per package instead of ~1 `clonefileat()` per package.

Also fixes a pre-existing limitation surfaced by this change: bun now synthesizes an implicit `"*"` optional peer dependency for entries that appear in `peerDependenciesMeta` but not in `peerDependencies` (matching pnpm/yarn). webpack relies on this for `webpack-cli`.

## Why

Profiling a warm `bun install --linker isolated` of a 1,400-package fixture on macOS:

```
Sort by top of stack:
    clonefileat        891 / 934 samples  (95.4% of main thread)
    __openat            15
    __read_nocancel     10
```

`clonefileat()` on APFS holds a volume-wide kernel lock — empirically, parallelizing 2,830 directory clones across 8 threads only improved throughput ~1.25x (959ms → 743ms). The isolated linker already runs the clonefile work on a thread pool and gets no benefit (1255ms system time → 840ms wall). The bottleneck is the syscall itself, not threading. The hoisted linker is also dominated by clonefile (788ms of 824ms wall) and is single-threaded, but parallelizing it would hit the same ceiling.

The fix is to not call clonefile at all on the warm path. Once a `(package, version, resolved-deps)` triple has been materialized anywhere on the machine, every subsequent install just symlinks to it.

## Results

Warm CI install (lockfile present, cache warm, `rm -rf node_modules` between runs) of a [~1,400-package fixture](https://github.com/endevco/aube/blob/main/benchmarks/fixture.package.json), Apple Silicon macOS, `hyperfine --warmup 3 --runs 10`:

| | wall | system | clonefileat | total syscalls |
|---|---|---|---|---|
| `--linker hoisted` | 823.2 ms | 478 ms | 1,387 | 7,857 |
| `--linker isolated` (before) | 840.9 ms | 1,256 ms | 1,387 | — |
| **`--linker isolated` (after)** | **115.4 ms** | **94 ms** | **0** | **4,957** |

```
Summary
  bun isolated (global store) ran
    7.13 ± 0.34 times faster than bun hoisted (canary)
```

Syscall mix on the warm path (xctrace System Trace): 2,495 `symlink`, 1,252 `access`, 52 `mkdirat`, 0 `clonefileat`.

## How it works

- `Store.Entry` gains an `entry_hash: u64`, computed by an iterative DFS after the store is built. The hash folds in the entry's own store-path string plus each dependency's entry hash, so it's stable across installs but differs whenever any transitive resolution differs. Declared optional peers that resolve in the project are part of the entry's dependency list and therefore part of the hash. A fixed-point pass after the DFS propagates ineligibility through cycles.
- An entry is global-store-**eligible** only when its package comes from an immutable cache source (npm/git/tarball, unpatched, no trusted lifecycle script) **and** every dependency it links to is also eligible. Ineligibility propagates upward so a global entry can never contain a symlink that points at a project-local path.
- `link_package` clones into `<cache>/links/<storepath>-<hash>/node_modules/<pkg>` (with `keep_existing_dest=true` so a populated entry is left alone), `symlink_dependencies` writes sibling-relative dep links there, bin links land in the entry's `.bin/`, and `linkProjectToGlobalStore` creates the project-level `node_modules/.bun/<storepath>` → global symlink.
- The warm-hit fast path: one `access()` on the global entry's `package.json`, one `symlink()` for the project link, done.
- Concurrent installs sharing a cache are safe: EEXIST on the post-NOENT retry in `FileCloner`/`Symlinker`/bin-linker/`linkProjectToGlobalStore` is treated as success (the other writer produced the same content-addressed bytes).
- `[install] globalStore = false` in `bunfig.toml` or `BUN_INSTALL_GLOBAL_STORE=0` restores the per-project clonefile layout.

## Behavior change

Packages now realpath into `<cache>/links/`, so the `node_modules/.bun/node_modules/` hidden hoisted layer is no longer reachable from inside a package. Declared optional peers (including the newly-synthesized meta-only ones) are folded into each entry, so the cases that previously relied on the hoisted fallback now resolve directly. True phantom dependencies — `require('x')` for something not declared anywhere — still fail, as they do under pnpm.

## Tests

- 29 existing isolated-install tests pass (8 link-target assertions updated to strip the new hash suffix via `withoutEntryHash()`).
- 10 new tests under `describe("global virtual store")`: warm-hit reuse after `rm -rf node_modules`, env-var and bunfig opt-outs, hash determinism, hash divergence under `overrides`, cross-project sharing, workspace-dep and trusted-script fallbacks to project-local, concurrent cold-store installs sharing one cache, and in-place upgrade of a pre-global-store `node_modules`.
- New docs page at `docs/pm/global-store.mdx` with layout, benchmarks, eligibility rules, and tradeoffs; linked from bunfig reference, isolated-installs page, and nav.