### PR TITLE
Propagate exceptions from custom asymmetric matcher `asymmetricMatch()`

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -512,11 +512,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                         |
+| Value       | Description                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.               |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
 
 ### `install.frozenLockfile`
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -294,6 +294,23 @@ describe("invalid matcher implementations errors", () => {
     });
     expect(() => expect(0)._toCustomA()).toThrow("MyError");
   });
+
+  it("throws when invalid matcher is called via asymmetricMatch", () => {
+    expect.extend({
+      // @ts-expect-error
+      _toCustomA: _expected => undefined,
+    });
+    expect(() => expect._toCustomA().asymmetricMatch(0)).toThrow(buildErrorMsg("undefined"));
+  });
+
+  it("throws when matcher that throws is called via asymmetricMatch", () => {
+    expect.extend({
+      _toCustomA: _expected => {
+        throw new Error("MyError");
+      },
+    });
+    expect(() => expect._toCustomA().asymmetricMatch(0)).toThrow("MyError");
+  });
 });
 
 describe("async support", () => {


### PR DESCRIPTION
Fuzzer fingerprint: `bf9d10ef9c71ff80`

## What

`ExpectCustomAsymmetricMatcher.asymmetricMatch()` calls into `execute()`, which is a `callconv(.c) bool` function shared with the C++ deep-equals path. `execute()` swallows Zig errors with `catch false` / `catch {}` but leaves the underlying JS exception pending on the VM.

`asymmetricMatch()` would then return `JSValue.jsBoolean(false)` — a valid non-empty value — while an exception was still pending. In debug builds this trips `toJSHostCall`'s `assertExceptionPresenceMatches` → `releaseAssertNoException()`.

## Repro

```js
const { expect } = Bun.jest();
expect.extend({ myMatcher: () => undefined });
expect.myMatcher().asymmetricMatch(1);
```

```
ASSERTION FAILED: Unexpected exception observed
...
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

## Fix

Check for a pending exception after `execute()` returns and propagate `error.JSError` so the exception surfaces to JS properly (as an `InvalidMatcherError` or the user-thrown error) instead of tripping the assertion.

## How did you verify your code works?

Added two regression tests to `test/js/bun/test/expect-extend.test.js` covering both the invalid-return and thrown-error paths via `asymmetricMatch()`:

- Pre-fix debug build: assertion failure on the new "throws when invalid matcher is called via asymmetricMatch" test
- Post-fix debug build: all 30 tests in `expect-extend.test.js` pass
- Release build: all 30 tests pass (exception was already surfacing there by accident)
