### PR TITLE
build: bump parallel zig to 65b29282, enable on Linux

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,7 @@ import { streamPath } from "./stream.ts";
  * is trusted, collapse both back to one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "445fc0cbba4eea579e5c846f2b8be7c9bdc4e1cc";
+export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";
 
 /**
  * The one place that picks which compiler to use. Everything coupled to
@@ -47,15 +47,13 @@ export const ZIG_COMMIT_PARALLEL = "445fc0cbba4eea579e5c846f2b8be7c9bdc4e1cc";
  * on the resolved cfg.zigCommit via usingParallelCompiler(), so changing
  * this — or passing --zigCommit=<hash> — is sufficient.
  *
- * Parallel compiler is darwin-local only for now. Linux is gated off
- * because oven-sh/zig's self-hosted ELF `-r` merge (used to combine
- * sharded codegen output when no_link_obj=true) currently emits an
- * incomplete bun-zig.o — link fails with every Zig symbol undefined on
- * a fresh build. macOS's Mach-O merge path works. See #29132. CI and
- * Windows stay on the stable compiler regardless.
+ * Parallel compiler is darwin+linux local only for now. Linux was gated
+ * off until 65b29282 fixed the self-hosted ELF `-r` merge that combines
+ * sharded codegen output (#29132). CI and Windows stay on the stable
+ * compiler.
  */
 export function defaultZigCommit(ci: boolean, hostOs: OS): string {
-  if (ci || hostOs !== "darwin") return ZIG_COMMIT;
+  if (ci || hostOs === "windows") return ZIG_COMMIT;
   return ZIG_COMMIT_PARALLEL;
 }
 


### PR DESCRIPTION
## Summary

- Bump `ZIG_COMMIT_PARALLEL` from `445fc0cb` → `65b29282` ([oven-sh/zig@65b29282](https://github.com/oven-sh/zig/commit/65b29282c04e42bea2539e9e31c5a59ac9cbabdb))
- Ungate Linux local builds from the parallel compiler now that the self-hosted ELF `-r` merge produces a complete `bun-zig.o` (closes #29132)
- CI and Windows stay on the stable compiler

The new commit also brings sharded `unit_claims` + dropped `sema_lock` under non-incremental for parallel sema, which speeds up darwin builds too.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `bun scripts/build.ts --configure-only` — generated URL points at `autobuild-65b29282…`, all 12 platform assets present in the release
- [x] `defaultZigCommit()` returns PARALLEL for local darwin+linux, STABLE for CI and windows
- [x] `bun bd --revision` — clean build with the new compiler on darwin-arm64
- [x] `bun bd test test/js/bun/util/which.test.ts` — sanity test passes
- [ ] Fresh `bun run build` on a Linux host (verifies the #29132 fix end-to-end)