### PR TITLE
build: add $BUN_ZIG_PATH to override the vendored zig compiler

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -17,8 +17,8 @@
 
 import { existsSync, readFileSync, symlinkSync } from "node:fs";
 import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
-import { availableParallelism } from "node:os";
-import { resolve } from "node:path";
+import { availableParallelism, homedir } from "node:os";
+import { join, resolve } from "node:path";
 import type { Config, OS } from "./config.ts";
 import { downloadWithRetry, extractZip } from "./download.ts";
 import { assert } from "./error.ts";
@@ -160,11 +160,23 @@ export function codegenEmbed(cfg: Config): boolean {
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Where zig lives. In vendor/ (gitignored), shared across profiles — the
- * commit pin is global and changing it affects everything.
+ * Where zig lives. Defaults to vendor/zig (gitignored), shared across
+ * profiles — the commit pin is global and changing it affects everything.
+ *
+ * Override via $BUN_ZIG_PATH to point at an existing zig install (e.g.
+ * share one compiler across worktrees, test a zig fork build, or pre-fetch
+ * in an air-gapped environment). When set, the fetch edge is skipped and
+ * the path must already contain a zig/ + lib/ layout. Mirrors the
+ * $BUN_WEBKIT_PATH override.
  */
 function zigPath(cfg: Config): string {
-  return resolve(cfg.vendorDir, "zig");
+  const env = process.env.BUN_ZIG_PATH;
+  if (!env) return resolve(cfg.vendorDir, "zig");
+  // Shells don't expand ~ inside quotes; handle it here so a quoted export works.
+  if (env === "~" || env.startsWith("~/") || env.startsWith("~\\")) return join(homedir(), env.slice(1));
+  // Anchor relative paths to the repo root so ninja's regen rule (which runs
+  // from buildDir) resolves the same path as the initial configure.
+  return resolve(cfg.cwd, env);
 }
 
 function zigExecutable(cfg: Config): string {
@@ -310,29 +322,42 @@ export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[]
   // ─── Download compiler ───
   const zigDest = zigPath(cfg);
   const zigExe = zigExecutable(cfg);
-  const safe = zigCompilerSafe(cfg);
-  const url = zigDownloadUrl(cfg, safe);
-  // Commit + safe go into the stamp content, so switching either retriggers.
-  const stamp = resolve(zigDest, ".zig-commit");
+  const envOverride = process.env.BUN_ZIG_PATH;
+  if (envOverride) {
+    // User-provided compiler — no fetch edge. Validate at configure time
+    // that the path has a usable layout; commit mismatch is the user's
+    // problem. zig build will error loudly if the compiler is too old.
+    assert(existsSync(zigExe), `BUN_ZIG_PATH='${envOverride}' but no zig executable at ${zigExe}`, {
+      hint: "Point $BUN_ZIG_PATH at an extracted zig install (the dir containing zig + lib/), or unset it to use the bundled compiler",
+    });
+    assert(existsSync(resolve(zigDest, "lib")), `BUN_ZIG_PATH='${envOverride}' but no lib/ dir at ${zigDest}`, {
+      hint: "zig needs its bundled stdlib at <path>/lib/ — make sure the extract wasn't partial",
+    });
+  } else {
+    const safe = zigCompilerSafe(cfg);
+    const url = zigDownloadUrl(cfg, safe);
+    // Commit + safe go into the stamp content, so switching either retriggers.
+    const stamp = resolve(zigDest, ".zig-commit");
 
-  n.build({
-    outputs: [stamp],
-    implicitOutputs: [zigExe],
-    rule: "zig_fetch",
-    inputs: [],
-    // Only fetch-cli.ts. This file (zig.ts) has emitZig and other logic
-    // unrelated to download — editing those shouldn't re-download the
-    // compiler. The URL/commit are in the rule's vars so changing those
-    // already retriggers via ninja's command tracking.
-    implicitInputs: [fetchCliPath],
-    vars: {
-      url,
-      dest: zigDest,
-      // Safe is encoded in the commit stamp (not just URL) so the CLI
-      // can short-circuit correctly when safe doesn't change.
-      commit: `${cfg.zigCommit}${safe ? "-safe" : ""}`,
-    },
-  });
+    n.build({
+      outputs: [stamp],
+      implicitOutputs: [zigExe],
+      rule: "zig_fetch",
+      inputs: [],
+      // Only fetch-cli.ts. This file (zig.ts) has emitZig and other logic
+      // unrelated to download — editing those shouldn't re-download the
+      // compiler. The URL/commit are in the rule's vars so changing those
+      // already retriggers via ninja's command tracking.
+      implicitInputs: [fetchCliPath],
+      vars: {
+        url,
+        dest: zigDest,
+        // Safe is encoded in the commit stamp (not just URL) so the CLI
+        // can short-circuit correctly when safe doesn't change.
+        commit: `${cfg.zigCommit}${safe ? "-safe" : ""}`,
+      },
+    });
+  }
   n.phony("zig-compiler", [zigExe]);
 
   // ─── Build ───


### PR DESCRIPTION
### What does this PR do?

Mirrors the existing $BUN_WEBKIT_PATH env override: when set, points at an existing zig install (containing zig + lib/) and the zig_fetch ninja edge is skipped. Path resolution handles ~ expansion and anchors relative paths to the repo root so ninja's regen rule resolves the same path as the initial configure.

I'm primarily interested in this for Arch Linux's bun package [1], which does this today on 1.3.12 via a patch [2]. However, one can imagine other use cases:

- Worktree sharing (one compiler build across N worktrees, same reason $BUN_WEBKIT_PATH exists).

- Testing zig compiler forks/patches without cutting a release or touching ZIG_COMMIT.

- Air-gapped / restricted-network dev environments where the compiler is pre-staged.

Configure-time validation checks that $BUN_ZIG_PATH/zig and $BUN_ZIG_PATH/lib/ both exist, and emits a hint pointing at the likely fix when they don't. Commit mismatch (user's zig differs from ZIG_COMMIT) is the user's problem — build.zig will error loudly if the compiler is too old for the options it receives.

[1] https://archlinux.org/packages/extra/x86_64/bun/
[2] https://gitlab.archlinux.org/archlinux/packaging/packages/bun/-/raw/main/bun-add-cmake-option-zig-local.patch

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>

### How did you verify your code works?

Verified by regenerating `build.ninja` via `bun scripts/build.ts --configure-only` in three scenarios on Linux x64:

1. `BUN_ZIG_PATH` unset (default) — `build.ninja` still contains the `zig_fetch` edge (`build ../../vendor/zig/.zig-commit | ../../vendor/zig/zig: zig_fetch …`). Regression check — default behavior is unchanged.
2. `BUN_ZIG_PATH=/tmp/nonexistent-zig` — configure errors with `BUN_ZIG_PATH='/tmp/nonexistent-zig' but no zig executable at /tmp/nonexistent-zig/zig` plus the hint pointing at the likely fix.
3. `BUN_ZIG_PATH=vendor/zig` (after pre-fetching the compiler via `ninja -C build/debug zig-compiler`) — no `zig_fetch` edge in `build.ninja`, but `bun-zig.o` still lists `../../vendor/zig/zig` as an implicit input, and ninja treats the existing file as a source.

Re-ran scenario 1 after scenario 3 to confirm the fetch edge is re-emitted once the env var is unset — no sticky state.

Also typechecked with `bunx tsc --noEmit -p scripts/build/tsconfig.json`: no new errors introduced in `zig.ts`.

Did not run a full `bun bd` end-to-end with `BUN_ZIG_PATH` set; the `zig_build` ninja edge is unchanged by this patch (it only references `zigExecutable`, which both code paths produce), so the risk surface is configure-time only.
