### PR TITLE
build: add $BUN_DEP_TARBALLS to stage github-archive tarballs locally

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -156,6 +156,35 @@ export async function extractZip(zipPath: string, dest: string): Promise<void> {
 }
 
 /**
+ * Look up a prestaged tarball for `$BUN_DEP_TARBALLS` mode.
+ *
+ * Returns the absolute path when the env var is set and the file exists.
+ * Returns `null` when the env var is unset — callers fall through to their
+ * normal download path. Throws when the env var IS set but the expected
+ * file is missing: the whole point of the contract is to fail loudly
+ * rather than silently fall back to network.
+ *
+ * @param key Per-fetch identifier that goes into the filename — a commit
+ *   for github-archive fetches, an identity string for prebuilts. The
+ *   semantic difference doesn't matter here; this helper only cares that
+ *   it's a filename-safe token (callers assert that at configure time).
+ * @param sourceUrl The URL that would have been downloaded. Surfaced in
+ *   the error hint so a consumer can grep/curl it directly instead of
+ *   cross-referencing the dep definition.
+ */
+export function resolvePrestagedTarball(name: string, key: string, sourceUrl: string): string | null {
+  const dir = process.env.BUN_DEP_TARBALLS;
+  if (!dir) return null;
+  const path = resolve(dir, `${name}-${key}.tar.gz`);
+  if (!existsSync(path)) {
+    throw new BuildError(`BUN_DEP_TARBALLS='${dir}' but no prestaged tarball for ${name}`, {
+      hint: `Expected file: ${path}\n         Source URL: ${sourceUrl}`,
+    });
+  }
+  return path;
+}
+
+/**
  * Fetch a prebuilt tarball: download + extract + write identity stamp.
  *
  * Generic mechanism for the `{ kind: "prebuilt" }` Source variant. Download a
@@ -198,11 +227,22 @@ export async function fetchPrebuilt(
   // checkouts) can't stomp each other's download/extraction.
   const suffix = `.${process.pid}.${Date.now().toString(36)}`;
 
-  // ─── Download ───
+  // ─── Locate tarball ───
+  // Default: download to a process-unique temp path alongside dest.
+  // $BUN_DEP_TARBALLS: consume a prestaged tarball instead (see
+  // resolvePrestagedTarball above). Same contract as fetchDep.
   const destParent = resolve(dest, "..");
   await mkdir(destParent, { recursive: true });
-  const tarballPath = `${dest}${suffix}.tar.gz`;
-  await downloadWithRetry(url, tarballPath, name);
+
+  const staged = resolvePrestagedTarball(name, identity, url);
+  const isPrestaged = staged !== null;
+  let tarballPath: string;
+  if (staged !== null) {
+    tarballPath = staged;
+  } else {
+    tarballPath = `${dest}${suffix}.tar.gz`;
+    await downloadWithRetry(url, tarballPath, name);
+  }
 
   // ─── Extract ───
   // Extract to a private staging dir, then hoist. We don't extract directly
@@ -214,7 +254,9 @@ export async function fetchPrebuilt(
   try {
     // stripComponents=0: keep top-level dir for hoisting.
     await extractTarGz(tarballPath, stagingDir, 0);
-    await rm(tarballPath, { force: true });
+    // Don't delete a user-staged tarball — the env var is a "use this file"
+    // contract, not "consume it".
+    if (!isPrestaged) await rm(tarballPath, { force: true });
 
     // Hoist: if single top-level dir, promote its contents to dest.
     // If multiple entries (unusual), the staging dir becomes dest.
@@ -249,6 +291,6 @@ export async function fetchPrebuilt(
     console.log(`extracted to ${dest}`);
   } finally {
     await rm(stagingDir, { recursive: true, force: true });
-    await rm(tarballPath, { force: true });
+    if (!isPrestaged) await rm(tarballPath, { force: true });
   }
 }

--- a/scripts/build/fetch-cli.ts
+++ b/scripts/build/fetch-cli.ts
@@ -25,7 +25,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { downloadWithRetry, extractTarGz, fetchPrebuilt } from "./download.ts";
+import { downloadWithRetry, extractTarGz, fetchPrebuilt, resolvePrestagedTarball } from "./download.ts";
 import { BuildError, assert } from "./error.ts";
 import { fetchZig } from "./zig.ts";
 
@@ -150,15 +150,24 @@ async function fetchDep(
 
   console.log(`fetching ${repo}@${commit.slice(0, 8)}`);
 
-  // ─── Download (with cache) ───
+  // ─── Locate tarball ───
+  // Default: cache at `${cache}/${name}-${urlHash}.tar.gz`, download if missing.
+  // $BUN_DEP_TARBALLS: consume a prestaged tarball instead (see
+  // resolvePrestagedTarball in download.ts). Keyed on commit, not urlHash,
+  // so consumers don't have to reimplement our URL scheme.
   const url = `https://github.com/${repo}/archive/${commit}.tar.gz`;
-  const urlHash = createHash("sha256").update(url).digest("hex").slice(0, 16);
-  const tarballPath = join(cache, `${name}-${urlHash}.tar.gz`);
+  const staged = resolvePrestagedTarball(name, commit, url);
 
-  await mkdir(cache, { recursive: true });
-
-  if (!existsSync(tarballPath)) {
-    await downloadWithRetry(url, tarballPath, name);
+  let tarballPath: string;
+  if (staged !== null) {
+    tarballPath = staged;
+  } else {
+    const urlHash = createHash("sha256").update(url).digest("hex").slice(0, 16);
+    tarballPath = join(cache, `${name}-${urlHash}.tar.gz`);
+    await mkdir(cache, { recursive: true });
+    if (!existsSync(tarballPath)) {
+      await downloadWithRetry(url, tarballPath, name);
+    }
   }
 
   // ─── Extract ───

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -831,6 +831,22 @@ export function computeDepLibs(cfg: Config, dep: Dependency): string[] {
 }
 
 /**
+ * Assert that a dep's filename-relevant ref (`commit` for github-archive,
+ * `identity` for prebuilt) is safe to interpolate into a tarball filename.
+ * Enforced at configure time regardless of BUN_DEP_TARBALLS — the invariant
+ * is about dep-definition validity, not tarball lookup. The default cache
+ * path uses a URL hash and isn't affected by this check; the guard matters
+ * once someone stages tarballs (see fetch-cli.ts / download.ts).
+ */
+function assertFilenameSafeRef(depName: string, field: "commit" | "identity", value: string): void {
+  assert(
+    /^[A-Za-z0-9._-]+$/.test(value),
+    `${depName}: ${field}='${value}' contains characters unsafe in a filename`,
+    { hint: "Use a value without slashes, spaces, or other path-unsafe characters" },
+  );
+}
+
+/**
  * Emit a ninja fetch rule. Returns absolute path to the .ref stamp.
  *
  * The .ref stamp contains the "source identity": hash(commit + patch contents).
@@ -845,6 +861,8 @@ function emitFetch(
   patches: string[],
   compiledSources: string[],
 ): string {
+  assertFilenameSafeRef(name, "commit", source.commit);
+
   const srcDir = depSourceDir(cfg, name);
   const refStamp = resolve(srcDir, ".ref");
   const patchPaths = patches.map(p => resolve(cfg.cwd, p));
@@ -908,6 +926,8 @@ function emitPrebuilt(
   source: Extract<Source, { kind: "prebuilt" }>,
   provides: Provides,
 ): ResolvedDep {
+  assertFilenameSafeRef(name, "identity", source.identity);
+
   // Dest dir: default to vendor/<name>/, but deps like WebKit override to
   // a shared cache location (WebKit's ~200MB, you don't want it per-buildDir).
   const destDir = source.destDir ?? depSourceDir(cfg, name);


### PR DESCRIPTION
### What does this PR do?

Sandboxed builds (e.g. distro packaging) need a way to say "fetching is my job, not yours — here are the tarballs I already downloaded; use them and fail loudly if I missed any" so that a silent network fetch can't slip past the package recipe's audit.

When `$BUN_DEP_TARBALLS=<dir>` is set, `fetch-cli.ts::fetchDep` looks for `<dir>/<name>-<commit>.tar.gz` for each github-archive dep. If the file exists, it's extracted and patched as usual; if it's missing, the build errors with the expected filename and the source URL the recipe needs to fetch. `downloadWithRetry()` is never called on this path — the env var turns the network fetch off, not just redirects it.

Default behavior (env unset) is unchanged: tarballs are cached at `${cache}/${name}-${urlHash}.tar.gz` and downloaded on miss.

The `$BUN_DEP_TARBALLS` path keys on `<commit>` rather than the URL hash the default cache uses — consumers shouldn't have to reimplement the archive URL scheme, and the filename stays stable if that scheme ever changes.

Also: assert at configure time that each github-archive dep's `commit` matches `[A-Za-z0-9._-]+`, since it's now interpolated into a filename. Current deps (sha hashes plus brotli's `v1.1.0` tag) all satisfy this; the check just forbids future entries with slashes, spaces, or other path-unsafe refs from landing silently.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>

### How did you verify your code works?

Verified scenarios:
1. No env var — 14 fetch edges emitted, default behavior unchanged.
2. Env set, dir empty — ninja clone-picohttpparser fails with expected-file + source-URL hint.
3. Env set, tarball staged — clone-picohttpparser extracts and populates vendor/, .ref written.
4. Invalid commit format (release/v0.5) — configure errors at the assert, points at the fix.