### PR TITLE
install: parallelize hoisted package linking on fresh node_modules

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -96,9 +96,7 @@ new!(pub BUN_INSPECT_PRELOAD: string, "BUN_INSPECT_PRELOAD", {});
 new!(pub BUN_INSTALL: string, "BUN_INSTALL", {});
 new!(pub BUN_INSTALL_BIN: string, "BUN_INSTALL_BIN", {});
 new!(pub BUN_INSTALL_GLOBAL_DIR: string, "BUN_INSTALL_GLOBAL_DIR", {});
-// Opt out of the parallel hoisted node_modules linker and fall back
-// to linking packages one at a time on the main thread. Escape hatch
-// if the thread-pool fan-out misbehaves on a filesystem.
+// Escape hatch: link hoisted packages serially on the main thread instead of on the thread pool.
 new!(pub BUN_INSTALL_SERIAL_HOISTED: boolean, "BUN_INSTALL_SERIAL_HOISTED", { default: false });
 // Minimum response `Content-Length` (in bytes) for `bun install` to
 // stream a tarball directly into libarchive instead of buffering the
@@ -281,9 +279,7 @@ pub mod feature_flag {
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});
-    // Test-only: emit "[ParallelHoistedInstall] N tasks" to stderr from
-    // the hoisted linker's thread-pool drain so tests can assert the
-    // parallel path was taken without timing.
+    // Test-only: prints "[ParallelHoistedInstall] N tasks" so tests can assert the parallel path ran.
     new_feature_flag!(pub BUN_INTERNAL_PARALLEL_HOISTED_MARKER, "BUN_INTERNAL_PARALLEL_HOISTED_MARKER", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN, "BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT, "BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -96,6 +96,10 @@ new!(pub BUN_INSPECT_PRELOAD: string, "BUN_INSPECT_PRELOAD", {});
 new!(pub BUN_INSTALL: string, "BUN_INSTALL", {});
 new!(pub BUN_INSTALL_BIN: string, "BUN_INSTALL_BIN", {});
 new!(pub BUN_INSTALL_GLOBAL_DIR: string, "BUN_INSTALL_GLOBAL_DIR", {});
+// Opt out of the parallel hoisted node_modules linker and fall back
+// to linking packages one at a time on the main thread. Escape hatch
+// if the thread-pool fan-out misbehaves on a filesystem.
+new!(pub BUN_INSTALL_SERIAL_HOISTED: boolean, "BUN_INSTALL_SERIAL_HOISTED", { default: false });
 // Minimum response `Content-Length` (in bytes) for `bun install` to
 // stream a tarball directly into libarchive instead of buffering the
 // whole body first. Smaller tarballs stay on the buffered path where
@@ -277,6 +281,10 @@ pub mod feature_flag {
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});
+    // Test-only: emit "[ParallelHoistedInstall] N tasks" to stderr from
+    // the hoisted linker's thread-pool drain so tests can assert the
+    // parallel path was taken without timing.
+    new_feature_flag!(pub BUN_INTERNAL_PARALLEL_HOISTED_MARKER, "BUN_INTERNAL_PARALLEL_HOISTED_MARKER", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN, "BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT, "BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB, "BUN_INTERNAL_SUPPRESS_CRASH_ON_UV_STUB", {});

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -41,7 +41,8 @@ pub struct PackageInstall<'a> {
     pub(crate) patch: Option<Patch>,
 
     pub(crate) node_modules: &'a NodeModulesFolder,
-    pub lockfile: &'a Lockfile,
+    /// Needed by `verify()` and by Folder installs; thread-pool workers do neither and pass `None`.
+    pub lockfile: Option<&'a Lockfile>,
 }
 
 #[derive(Clone, Copy)]
@@ -743,6 +744,11 @@ impl UninstallTask {
 // ───────────────────────────── impl PackageInstall ─────────────────────────────
 
 impl<'a> PackageInstall<'a> {
+    fn lockfile(&self) -> &'a Lockfile {
+        self.lockfile
+            .expect("only verify() and Folder installs read the lockfile; workers pass neither")
+    }
+
     ///
     fn verify_patch_hash(&mut self, patch: Patch, root_node_modules_dir: &Dir) -> bool {
         // hash from the .patch file, to be checked against bun tag
@@ -804,7 +810,7 @@ impl<'a> PackageInstall<'a> {
             return false;
         };
         strings::eql_long(
-            repo.resolved.slice(&self.lockfile.buffers.string_bytes),
+            repo.resolved.slice(&self.lockfile().buffers.string_bytes),
             &bun_tag_file.bytes,
             true,
         )
@@ -821,7 +827,7 @@ impl<'a> PackageInstall<'a> {
             resolution::Tag::Root => self.verify_transitive_symlinked_folder(root_node_modules_dir),
             resolution::Tag::Folder => {
                 if self
-                    .lockfile
+                    .lockfile()
                     .is_workspace_tree_id(self.node_modules.tree_id)
                 {
                     self.verify_package_json_name_and_version(root_node_modules_dir, resolution.tag)
@@ -1001,7 +1007,9 @@ impl<'a> PackageInstall<'a> {
 
         // lastly, check the name.
         package_json_checker.found_name()
-            == self.package_name.slice(&self.lockfile.buffers.string_bytes)
+            == self
+                .package_name
+                .slice(&self.lockfile().buffers.string_bytes)
     }
 
     // ───────────────────────────── install backends ─────────────────────────────
@@ -2311,7 +2319,7 @@ impl<'a> PackageInstall<'a> {
 
         if resolution_tag == resolution::Tag::Folder
             && !self
-                .lockfile
+                .lockfile()
                 .is_workspace_tree_id(self.node_modules.tree_id)
         {
             supported_method_to_use = Method::Symlink;

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -396,7 +396,7 @@ pub(crate) struct ParallelHoistedTask {
     pub(crate) package_name: String,
 
     pub(crate) result: package_install::InstallResult,
-    /// Cache ENOENT; `complete_parallel_installs()` reroutes to the download path.
+    /// Entry absent or missing its marker; `complete_parallel_installs()` re-downloads it.
     pub(crate) missing_from_cache: bool,
 }
 
@@ -414,9 +414,15 @@ impl ParallelHoistedTask {
         // before touching it.
         let this = unsafe { &mut *Self::from_task_ptr(task) };
         this.result = this.run();
-        // SAFETY: BACKREF; `PackageInstaller` outlives every task (Drop
-        // waits on the wait group). `WaitGroup::finish()` is `&self`.
-        unsafe { (*this.installer).parallel_wait_group.finish() };
+        // SAFETY: BACKREF. The group is live with this task counted: its owner frees it only
+        // after `wait()` returns, which is what this call permits, so this is `finish_raw`'s
+        // contract, not `finish()`'s. `addr_of!` keeps the worker from forming a reference into
+        // the `PackageInstaller` the main thread holds `&mut` to.
+        unsafe {
+            bun_threading::WaitGroup::finish_raw(core::ptr::addr_of!(
+                (*this.installer).parallel_wait_group
+            ))
+        };
     }
 
     fn run(&mut self) -> package_install::InstallResult {
@@ -429,6 +435,27 @@ impl ParallelHoistedTask {
         let root_node_modules_folder: &Dir =
             unsafe { &*core::ptr::addr_of!((*self.installer).root_node_modules_folder) };
 
+        // SAFETY: `cache_dir_subpath` was copied with its trailing NUL at enqueue time.
+        let cache_z = unsafe {
+            ZStr::from_raw(
+                self.cache_dir_subpath.as_ptr(),
+                self.cache_dir_subpath.len() - 1,
+            )
+        };
+        // The serial cache check, moved here: an entry missing its marker is re-downloaded.
+        if !crate::package_manager::directories::is_package_in_cache_at(
+            self.cache_dir,
+            cache_z,
+            self.resolution_tag,
+        ) {
+            self.missing_from_cache = true;
+            return package_install::InstallResult::fail(
+                crate::Error::Sys(bun_errno::SystemErrno::ENOENT),
+                package_install::Step::OpeningCacheDir,
+                None,
+            );
+        }
+
         // Root tree reuses the open fd; nested trees open (creating if needed) their own.
         let owned_dir: Option<Dir> = if self.tree_id == 0 {
             None
@@ -437,6 +464,7 @@ impl ParallelHoistedTask {
             let opened = match Dir::borrow(&Fd::cwd()).open_at(path) {
                 Ok(d) => d,
                 Err(_) => {
+                    // May pre-create the parent's dir, costing it macOS's whole-dir clonefile.
                     let _ = bun_sys::make_path::make_path(Dir::borrow(&Fd::cwd()), path);
                     match Dir::borrow(&Fd::cwd()).open_at(path) {
                         Ok(d) => d,
@@ -462,17 +490,8 @@ impl ParallelHoistedTask {
         let dest_len = self.destination_dir_subpath.len();
         subpath_buf.as_mut_slice()[..dest_len].copy_from_slice(&self.destination_dir_subpath);
 
-        // SAFETY: `destination_dir_subpath` was copied with its trailing NUL
-        // at enqueue time; len-1 is the NUL, so bytes[..len-1] + \0.
+        // SAFETY: `destination_dir_subpath` was copied with its trailing NUL at enqueue time.
         let dest_z = unsafe { ZStr::from_raw(self.destination_dir_subpath.as_ptr(), dest_len - 1) };
-        // SAFETY: same for `cache_dir_subpath`.
-        let cache_z = unsafe {
-            ZStr::from_raw(
-                self.cache_dir_subpath.as_ptr(),
-                self.cache_dir_subpath.len() - 1,
-            )
-        };
-
         let mut pi = PackageInstall {
             progress: None,
             cache_dir: self.cache_dir,

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -394,6 +394,8 @@ pub(crate) struct ParallelHoistedTask {
     pub(crate) tree_id: lockfile::tree::Id,
     /// Snapshot: `fix_cached_lockfile_package_slices()` may reallocate `names` under workers.
     pub(crate) package_name: String,
+    /// `tree_id` is in `copy_trees`: a self-contained workspace gets real files, not links.
+    copy_tree: bool,
 
     pub(crate) result: package_install::InstallResult,
     /// Entry absent or missing its marker; `complete_parallel_installs()` re-downloads it.
@@ -505,12 +507,12 @@ impl ParallelHoistedTask {
             lockfile: None,
         };
 
-        let result = pi.install(
-            true,
-            destination_dir,
-            pi.get_install_method(),
-            self.resolution_tag,
-        );
+        let method = if self.copy_tree {
+            package_install::Method::Copyfile
+        } else {
+            pi.get_install_method()
+        };
+        let result = pi.install(true, destination_dir, method, self.resolution_tag);
         if let package_install::InstallResult::Failure(f) = &result {
             if f.is_package_missing_from_cache() {
                 self.missing_from_cache = true;
@@ -1287,6 +1289,12 @@ impl<'a> PackageInstaller<'a> {
         }
 
         true
+    }
+
+    /// Packages in this tree are copied rather than linked from the cache.
+    fn is_copy_tree(&self, tree_id: lockfile::tree::Id) -> bool {
+        (tree_id as usize) < self.copy_trees.bit_length()
+            && self.copy_trees.is_set(tree_id as usize)
     }
 
     // `pub fn deinit` dropped. All owned fields (`pending_lifecycle_scripts: Vec`,
@@ -2196,6 +2204,7 @@ impl<'a> PackageInstaller<'a> {
                     package_id,
                     tree_id: self.current_tree_id,
                     package_name: pkg_name,
+                    copy_tree: self.is_copy_tree(self.current_tree_id),
                     result: package_install::InstallResult::Success,
                     missing_from_cache: false,
                 }));
@@ -2513,9 +2522,7 @@ impl<'a> PackageInstaller<'a> {
                         break 'result result;
                     }
 
-                    let method = if (self.current_tree_id as usize) < self.copy_trees.bit_length()
-                        && self.copy_trees.is_set(self.current_tree_id as usize)
-                    {
+                    let method = if self.is_copy_tree(self.current_tree_id) {
                         package_install::Method::Copyfile
                     } else {
                         installer.get_install_method()

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -680,21 +680,23 @@ impl<'a> PackageInstaller<'a> {
                 path: t.node_modules_path.to_vec(),
             };
 
+            let resolution = self.resolutions[t.package_id as usize];
+            // Replay counts as pending: it enqueues no tasks and leaves the drain to the caller.
+            let is_pending_package_install = true;
             if t.missing_from_cache {
                 had_missing = true;
-                let resolution = self.resolutions[t.package_id as usize];
-                // needs_verify = false (the worker already verified), is_pending_package_install = true.
+                // The worker already verified the entry.
+                let needs_verify = false;
                 self.install_package_with_name_and_resolution(
                     t.dependency_id,
                     t.package_id,
                     log_level,
                     t.package_name,
                     &resolution,
-                    false,
-                    true,
+                    needs_verify,
+                    is_pending_package_install,
                 );
             } else {
-                let resolution = self.resolutions[t.package_id as usize];
                 // Root fd suffices for the EACCES fstat: on a fresh tree every nested dir has its mode.
                 self.handle_install_result(
                     t.dependency_id,
@@ -704,7 +706,7 @@ impl<'a> PackageInstaller<'a> {
                     &resolution,
                     t.result,
                     self.root_node_modules_folder.fd(),
-                    true,
+                    is_pending_package_install,
                 );
             }
         }
@@ -2150,7 +2152,7 @@ impl<'a> PackageInstaller<'a> {
             || !installer.verify(resolution, &self.root_node_modules_folder);
 
         if needs_install {
-            // No cache-presence check here: the worker sees ENOENT and the result is rerouted.
+            // The worker checks the cache; a miss comes back as ENOENT and is rerouted on replay.
             #[cfg(unix)]
             if needs_verify
                 && !is_pending_package_install

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -113,17 +113,12 @@ pub struct PackageInstaller<'a> {
 
     pub(crate) seen_bin_links: StringHashMap<()>,
 
-    /// Heap-allocated tasks fanned to `manager.thread_pool` by the
-    /// hoisted linker on POSIX when `node_modules` is being created fresh.
-    /// Drained in `complete_parallel_installs()` on the main thread, where
-    /// each task's stored `InstallResult` is fed through
-    /// `handle_install_result()`. See `ParallelHoistedTask`.
+    /// Joined and replayed by `complete_parallel_installs()`; see `ParallelHoistedTask`.
     #[cfg(unix)]
     pub(crate) parallel_tasks: Vec<*mut ParallelHoistedTask>,
     #[cfg(unix)]
     pub(crate) parallel_wait_group: bun_threading::WaitGroup,
-    /// Accumulates tasks for the current tree; flushed to
-    /// `manager.thread_pool` per tree via `schedule_parallel_batch()`.
+    /// Flushed to the thread pool once per tree by `schedule_parallel_batch()`.
     #[cfg(unix)]
     pub(crate) parallel_batch: bun_threading::thread_pool::Batch,
 }
@@ -379,49 +374,29 @@ fn abs_node_modules_path(
 }
 
 #[cfg(unix)]
-/// A single package's cache→`node_modules` link operation, run on
-/// `manager.thread_pool`. Created by
-/// `install_package_with_name_and_resolution()` when the package is
-/// already cached and the hoisted linker is populating a fresh
-/// `node_modules` on POSIX. Workers call `PackageInstall::install()`
-/// (the expensive hardlink/clonefile walk) and store the result;
-/// `complete_parallel_installs()` then runs the result handling
-/// (summary, bin links, tree counts, lifecycle scripts) serially on
-/// the main thread.
+/// A cache→`node_modules` link on the thread pool; replayed by `complete_parallel_installs()`.
 pub(crate) struct ParallelHoistedTask {
-    /// BACKREF — raw so the worker doesn't hold a `&mut` that the main
-    /// thread's iteration also needs. Workers read only
-    /// `root_node_modules_folder` (shared fd), `lockfile` (for
-    /// `PackageInstall.lockfile: &Lockfile`), and `parallel_wait_group`
-    /// (atomic). They never touch the column slices, `trees`, `summary`,
-    /// or `node_modules` — those belong to the main thread.
+    /// BACKREF; aliasing contract in `run()`'s SAFETY note.
     installer: *mut PackageInstaller<'static>,
     pub(crate) task: bun_threading::thread_pool::Task,
 
-    /// Owned absolute path to this task's `node_modules` directory.
-    /// For `tree_id == 0` this equals the root and the worker reuses
-    /// `installer.root_node_modules_folder` instead of reopening.
     node_modules_path: Box<[u8]>,
-    /// Owned NUL-terminated alias (e.g. `@scope/name\0`).
+    /// NUL-terminated.
     destination_dir_subpath: Box<[u8]>,
-    /// Owned NUL-terminated cache subpath. The cache directory itself
-    /// (`cache_dir`) is a borrowed fd owned by `PackageManager`.
+    /// NUL-terminated.
     cache_dir_subpath: Box<[u8]>,
+    /// Borrowed; owned by `PackageManager`.
     cache_dir: Fd,
 
     pub(crate) resolution_tag: resolution::Tag,
     pub(crate) dependency_id: DependencyID,
     pub(crate) package_id: PackageID,
     pub(crate) tree_id: lockfile::tree::Id,
-    /// Snapshot of `installer.names[package_id]` at enqueue time.
-    /// `fix_cached_lockfile_package_slices()` may rewrite that slice's
-    /// backing storage while workers run.
+    /// Snapshot: `fix_cached_lockfile_package_slices()` may reallocate `names` under workers.
     pub(crate) package_name: String,
 
     pub(crate) result: package_install::InstallResult,
-    /// `result` is a cache-miss `Failure` (ENOENT opening the cache
-    /// subpath). `complete_parallel_installs()` re-routes these through
-    /// the serial download path.
+    /// Cache ENOENT; `complete_parallel_installs()` reroutes to the download path.
     pub(crate) missing_from_cache: bool,
 }
 
@@ -445,13 +420,13 @@ impl ParallelHoistedTask {
     }
 
     fn run(&mut self) -> package_install::InstallResult {
-        // SAFETY: BACKREF — see field doc. Project the two fields we need
-        // via raw place expressions so no `&PackageInstaller` is formed
-        // while the main thread may hold `&mut PackageInstaller`
-        // (`run_tasks(this, &mut installer, ...)` and the next tree's
-        // `install_package(&mut self)` run concurrently with workers).
-        // `root_node_modules_folder` is never mutated during the install
-        // pass; `lockfile` is a stable raw pointer.
+        // SAFETY: BACKREF. The main thread holds `&mut PackageInstaller` while workers run
+        // (`run_tasks(this, &mut installer, ..)`, the next tree's `install_package`), so a worker
+        // must never form `&PackageInstaller`; it projects individual fields with `addr_of!`.
+        // Workers touch exactly three fields: these two, which are not mutated during the install
+        // pass (`root_node_modules_folder` is an open fd, `lockfile` a stable pointer), and the
+        // atomic `parallel_wait_group` in `run_from_thread_pool`. Everything else (column slices,
+        // `trees`, `summary`, `node_modules`, `parallel_tasks`) is main-thread only.
         let (root_node_modules_folder, lockfile): (&Dir, &Lockfile) = unsafe {
             (
                 &*core::ptr::addr_of!((*self.installer).root_node_modules_folder),
@@ -459,9 +434,7 @@ impl ParallelHoistedTask {
             )
         };
 
-        // For nested trees open (and if racing another worker, create)
-        // the destination `node_modules`. The root tree reuses the
-        // already-open `root_node_modules_folder` fd.
+        // Root tree reuses the open fd; nested trees open (creating if needed) their own.
         let owned_dir: Option<Dir> = if self.tree_id == 0 {
             None
         } else {
@@ -626,12 +599,7 @@ impl<'a> PackageInstaller<'a> {
         unsafe { &mut *self.progress }
     }
 
-    /// Whether the hoisted linker should fan per-package
-    /// `PackageInstall::install()` out to `manager.thread_pool` instead
-    /// of running it inline on the main thread. Only enabled on POSIX
-    /// for a fresh `node_modules` (where `skip_delete` is true so there
-    /// is no per-package delete/rename-aside step to serialise).
-    /// Windows already fans out per-file via `HardLinkWindowsInstallTask`.
+    /// Fresh `node_modules` only: `skip_delete` means there is no rename-aside step to serialise.
     #[cfg(unix)]
     pub(crate) fn can_use_parallel_hoisted_install(&self) -> bool {
         if bun_core::env_var::BUN_INSTALL_SERIAL_HOISTED
@@ -643,8 +611,7 @@ impl<'a> PackageInstaller<'a> {
         self.skip_delete
     }
 
-    /// Flush `parallel_batch` to the thread pool. Called once per tree
-    /// so workers start while the main thread continues iterating.
+    /// Called once per tree so workers start before the iteration finishes.
     #[cfg(unix)]
     pub(crate) fn schedule_parallel_batch(&mut self) {
         if self.parallel_batch.len == 0 {
@@ -654,8 +621,7 @@ impl<'a> PackageInstaller<'a> {
         self.manager_mut().thread_pool.schedule(batch);
     }
 
-    /// No-op on Windows so `hoisted_install` can call these
-    /// unconditionally.
+    /// Windows no-ops so `hoisted_install` can call these unconditionally.
     #[cfg(windows)]
     #[inline]
     pub(crate) fn schedule_parallel_batch(&mut self) {}
@@ -665,12 +631,7 @@ impl<'a> PackageInstaller<'a> {
         false
     }
 
-    /// Block on all in-flight `ParallelHoistedTask`s, then feed each
-    /// stored result through `handle_install_result()` on the main
-    /// thread. Tasks whose worker hit a cache miss re-enter the serial
-    /// download path (`install_package_with_name_and_resolution::<false,
-    /// true>()`). Returns `true` if any task re-routed, so
-    /// `hoisted_install` can drain the resulting download tasks.
+    /// Joins the workers and replays their results; `true` means some were rerouted to downloads.
     #[cfg(unix)]
     pub(crate) fn complete_parallel_installs(&mut self, log_level: Options::LogLevel) -> bool {
         self.schedule_parallel_batch();
@@ -720,11 +681,7 @@ impl<'a> PackageInstaller<'a> {
                 );
             } else {
                 let resolution = self.resolutions[t.package_id as usize];
-                // `destination_dir_fd` is only consumed by the EACCES
-                // fstat writability check. The parallel path only runs
-                // on a fresh `node_modules` where bun just created
-                // every nested dir itself (same owner/mode as root), so
-                // root's writability is representative.
+                // Root fd suffices for the EACCES fstat: on a fresh tree every nested dir has its mode.
                 self.handle_install_result(
                     t.dependency_id,
                     t.package_id,
@@ -1310,12 +1267,10 @@ impl<'a> PackageInstaller<'a> {
         true
     }
 
-    // All other owned fields (`pending_lifecycle_scripts: Vec`,
-    // `completed_trees: Bitset`, `trees: Box<[TreeContext]>`,
-    // `tree_ids_to_trees_the_id_depends_on`, `node_modules`,
-    // `trusted_dependencies_from_update_requests`) impl Drop. Borrowed
-    // fields (`manager`, `lockfile`, etc.) are not freed. See `impl Drop`
-    // for the parallel-task drain.
+    // `pub fn deinit` dropped. All owned fields (`pending_lifecycle_scripts: Vec`,
+    // `completed_trees: Bitset`, `trees: Box<[TreeContext]>`, `tree_ids_to_trees_the_id_depends_on`,
+    // `node_modules`, `trusted_dependencies_from_update_requests`) impl Drop. Borrowed fields
+    // (`manager`, `lockfile`, etc.) are not freed.
 
     /// Call when you mutate the length of `lockfile.packages`
     pub(crate) fn fix_cached_lockfile_package_slices(&mut self) {
@@ -1511,10 +1466,7 @@ impl<'a> PackageInstaller<'a> {
         count
     }
 
-    /// Result-handling half of `install_package_with_name_and_resolution()`,
-    /// split out so `complete_parallel_installs()` can feed a worker's
-    /// stored `InstallResult` through the same summary / bin-link /
-    /// tree-count / lifecycle-script path the serial linker uses.
+    /// Shared by the serial path and `complete_parallel_installs()`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn handle_install_result(
         &mut self,
@@ -2178,13 +2130,7 @@ impl<'a> PackageInstaller<'a> {
             || !installer.verify(resolution, &self.root_node_modules_folder);
 
         if needs_install {
-            // Fast path: package is cached, node_modules is fresh, and
-            // the install method is a real link (not a symlink). Hand
-            // the hardlink/clonefile walk to a thread-pool worker and
-            // return; `complete_parallel_installs()` picks up the
-            // result. The cache-presence check here is optimistic —
-            // the worker re-checks on open and sets
-            // `missing_from_cache` for reroute.
+            // No cache-presence check here: the worker sees ENOENT and the result is rerouted.
             #[cfg(unix)]
             if needs_verify
                 && !is_pending_package_install
@@ -2200,13 +2146,10 @@ impl<'a> PackageInstaller<'a> {
                         | resolution::Tag::RemoteTarball
                 )
             {
-                // Copy everything needed from the `PackageInstall` and
-                // end its borrows into `self` (folder_path_buf,
-                // destination_dir_subpath_buf) before `self` is cast
-                // to a raw pointer for the task.
                 let dest = Box::<[u8]>::from(installer.destination_dir_subpath.as_bytes_with_nul());
                 let cache = Box::<[u8]>::from(installer.cache_dir_subpath.as_bytes_with_nul());
                 let cache_dir = installer.cache_dir;
+                // Ends `installer`'s borrows of `self.*_buf` before `self` is cast to a raw pointer.
                 #[allow(clippy::drop_non_drop)]
                 drop(installer);
 
@@ -2864,11 +2807,7 @@ impl<'a> PackageInstaller<'a> {
 #[cfg(unix)]
 impl Drop for PackageInstaller<'_> {
     fn drop(&mut self) {
-        // Any early error return from `hoisted_install` drops the
-        // `PackageInstaller` while workers may still be running. Flush
-        // the current batch so nothing sits un-scheduled, wait for
-        // workers to finish, then free every heap task. After this the
-        // field `Drop`s run safely.
+        // An error return from `hoisted_install` can drop this with workers in flight; join them first.
         self.schedule_parallel_batch();
         if !self.parallel_tasks.is_empty() {
             self.parallel_wait_group.wait();

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -422,17 +422,12 @@ impl ParallelHoistedTask {
     fn run(&mut self) -> package_install::InstallResult {
         // SAFETY: BACKREF. The main thread holds `&mut PackageInstaller` while workers run
         // (`run_tasks(this, &mut installer, ..)`, the next tree's `install_package`), so a worker
-        // must never form `&PackageInstaller`; it projects individual fields with `addr_of!`.
-        // Workers touch exactly three fields: these two, which are not mutated during the install
-        // pass (`root_node_modules_folder` is an open fd, `lockfile` a stable pointer), and the
-        // atomic `parallel_wait_group` in `run_from_thread_pool`. Everything else (column slices,
-        // `trees`, `summary`, `node_modules`, `parallel_tasks`) is main-thread only.
-        let (root_node_modules_folder, lockfile): (&Dir, &Lockfile) = unsafe {
-            (
-                &*core::ptr::addr_of!((*self.installer).root_node_modules_folder),
-                &*core::ptr::addr_of!((*self.installer).lockfile).read(),
-            )
-        };
+        // must never form `&PackageInstaller`; it projects the one field it reads with `addr_of!`.
+        // Workers touch exactly two fields: `root_node_modules_folder`, an open fd that is not
+        // mutated during the install pass, and the atomic `parallel_wait_group` in
+        // `run_from_thread_pool`. Everything else, the lockfile included, is main-thread only.
+        let root_node_modules_folder: &Dir =
+            unsafe { &*core::ptr::addr_of!((*self.installer).root_node_modules_folder) };
 
         // Root tree reuses the open fd; nested trees open (creating if needed) their own.
         let owned_dir: Option<Dir> = if self.tree_id == 0 {
@@ -488,7 +483,7 @@ impl ParallelHoistedTask {
             package_version: b"",
             patch: None,
             node_modules: &local_node_modules,
-            lockfile,
+            lockfile: None,
         };
 
         let result = pi.install(
@@ -1242,6 +1237,12 @@ impl<'a> PackageInstaller<'a> {
         // .monotonic is okay because this value isn't modified from any other thread.
         (deps.subset_of(&self.completed_trees.unmanaged)
             || deps.eql(&self.completed_trees.unmanaged))
+            // Deps may live in any ancestor tree; the parallel linker doesn't install ancestors first.
+            && Self::can_install_package_for_tree(
+                &self.completed_trees,
+                self.lockfile().buffers.trees.as_slice(),
+                scripts_tree_id,
+            )
             && LifecycleScriptSubprocess::alive_count().load(Ordering::Relaxed)
                 < self.manager().options.max_concurrent_lifecycle_scripts
     }
@@ -1953,7 +1954,7 @@ impl<'a> PackageInstaller<'a> {
             // BACKREF accessor — `self.lockfile` is `*mut Lockfile` (never null,
             // outlives `'a`); `lockfile()` centralises the raw deref so this
             // site stays safe.
-            lockfile: self.lockfile(),
+            lockfile: Some(self.lockfile()),
             cache_dir_subpath: ZStr::EMPTY,
         };
         bun_output::scoped_log!(

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -445,9 +445,19 @@ impl ParallelHoistedTask {
     }
 
     fn run(&mut self) -> package_install::InstallResult {
-        // SAFETY: BACKREF — see field doc. `root_node_modules_folder` and
-        // `lockfile` are read-only here; `parallel_wait_group` is atomic.
-        let installer: &PackageInstaller<'_> = unsafe { &*self.installer };
+        // SAFETY: BACKREF — see field doc. Project the two fields we need
+        // via raw place expressions so no `&PackageInstaller` is formed
+        // while the main thread may hold `&mut PackageInstaller`
+        // (`run_tasks(this, &mut installer, ...)` and the next tree's
+        // `install_package(&mut self)` run concurrently with workers).
+        // `root_node_modules_folder` is never mutated during the install
+        // pass; `lockfile` is a stable raw pointer.
+        let (root_node_modules_folder, lockfile): (&Dir, &Lockfile) = unsafe {
+            (
+                &*core::ptr::addr_of!((*self.installer).root_node_modules_folder),
+                &*core::ptr::addr_of!((*self.installer).lockfile).read(),
+            )
+        };
 
         // For nested trees open (and if racing another worker, create)
         // the destination `node_modules`. The root tree reuses the
@@ -474,9 +484,7 @@ impl ParallelHoistedTask {
             };
             Some(opened)
         };
-        let destination_dir: &Dir = owned_dir
-            .as_ref()
-            .unwrap_or(&installer.root_node_modules_folder);
+        let destination_dir: &Dir = owned_dir.as_ref().unwrap_or(root_node_modules_folder);
 
         let local_node_modules = NodeModulesFolder {
             tree_id: self.tree_id,
@@ -507,7 +515,7 @@ impl ParallelHoistedTask {
             package_version: b"",
             patch: None,
             node_modules: &local_node_modules,
-            lockfile: installer.lockfile(),
+            lockfile,
         };
 
         let result = pi.install(
@@ -712,6 +720,11 @@ impl<'a> PackageInstaller<'a> {
                 );
             } else {
                 let resolution = self.resolutions[t.package_id as usize];
+                // `destination_dir_fd` is only consumed by the EACCES
+                // fstat writability check. The parallel path only runs
+                // on a fresh `node_modules` where bun just created
+                // every nested dir itself (same owner/mode as root), so
+                // root's writability is representative.
                 self.handle_install_result(
                     t.dependency_id,
                     t.package_id,

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -112,6 +112,20 @@ pub struct PackageInstaller<'a> {
     pub(crate) trees: Box<[TreeContext]>,
 
     pub(crate) seen_bin_links: StringHashMap<()>,
+
+    /// Heap-allocated tasks fanned to `manager.thread_pool` by the
+    /// hoisted linker on POSIX when `node_modules` is being created fresh.
+    /// Drained in `complete_parallel_installs()` on the main thread, where
+    /// each task's stored `InstallResult` is fed through
+    /// `handle_install_result()`. See `ParallelHoistedTask`.
+    #[cfg(unix)]
+    pub(crate) parallel_tasks: Vec<*mut ParallelHoistedTask>,
+    #[cfg(unix)]
+    pub(crate) parallel_wait_group: bun_threading::WaitGroup,
+    /// Accumulates tasks for the current tree; flushed to
+    /// `manager.thread_pool` per tree via `schedule_parallel_batch()`.
+    #[cfg(unix)]
+    pub(crate) parallel_batch: bun_threading::thread_pool::Batch,
 }
 
 use bun_core::UnwrapOrOom;
@@ -364,6 +378,153 @@ fn abs_node_modules_path(
     abs
 }
 
+#[cfg(unix)]
+/// A single package's cache→`node_modules` link operation, run on
+/// `manager.thread_pool`. Created by
+/// `install_package_with_name_and_resolution()` when the package is
+/// already cached and the hoisted linker is populating a fresh
+/// `node_modules` on POSIX. Workers call `PackageInstall::install()`
+/// (the expensive hardlink/clonefile walk) and store the result;
+/// `complete_parallel_installs()` then runs the result handling
+/// (summary, bin links, tree counts, lifecycle scripts) serially on
+/// the main thread.
+pub(crate) struct ParallelHoistedTask {
+    /// BACKREF — raw so the worker doesn't hold a `&mut` that the main
+    /// thread's iteration also needs. Workers read only
+    /// `root_node_modules_folder` (shared fd), `lockfile` (for
+    /// `PackageInstall.lockfile: &Lockfile`), and `parallel_wait_group`
+    /// (atomic). They never touch the column slices, `trees`, `summary`,
+    /// or `node_modules` — those belong to the main thread.
+    installer: *mut PackageInstaller<'static>,
+    pub(crate) task: bun_threading::thread_pool::Task,
+
+    /// Owned absolute path to this task's `node_modules` directory.
+    /// For `tree_id == 0` this equals the root and the worker reuses
+    /// `installer.root_node_modules_folder` instead of reopening.
+    node_modules_path: Box<[u8]>,
+    /// Owned NUL-terminated alias (e.g. `@scope/name\0`).
+    destination_dir_subpath: Box<[u8]>,
+    /// Owned NUL-terminated cache subpath. The cache directory itself
+    /// (`cache_dir`) is a borrowed fd owned by `PackageManager`.
+    cache_dir_subpath: Box<[u8]>,
+    cache_dir: Fd,
+
+    pub(crate) resolution_tag: resolution::Tag,
+    pub(crate) dependency_id: DependencyID,
+    pub(crate) package_id: PackageID,
+    pub(crate) tree_id: lockfile::tree::Id,
+    /// Snapshot of `installer.names[package_id]` at enqueue time.
+    /// `fix_cached_lockfile_package_slices()` may rewrite that slice's
+    /// backing storage while workers run.
+    pub(crate) package_name: String,
+
+    pub(crate) result: package_install::InstallResult,
+    /// `result` is a cache-miss `Failure` (ENOENT opening the cache
+    /// subpath). `complete_parallel_installs()` re-routes these through
+    /// the serial download path.
+    pub(crate) missing_from_cache: bool,
+}
+
+#[cfg(unix)]
+bun_threading::intrusive_work_task!(ParallelHoistedTask, task);
+
+#[cfg(unix)]
+impl ParallelHoistedTask {
+    unsafe fn run_from_thread_pool(task: *mut bun_threading::thread_pool::Task) {
+        use bun_threading::IntrusiveWorkTask as _;
+        // SAFETY: `task` is the `.task` field of a heap `ParallelHoistedTask`
+        // allocated via `heap::into_raw` and registered with
+        // `intrusive_work_task!`. The main thread holds the only other
+        // pointer (in `parallel_tasks`) and blocks on `parallel_wait_group`
+        // before touching it.
+        let this = unsafe { &mut *Self::from_task_ptr(task) };
+        this.result = this.run();
+        // SAFETY: BACKREF; `PackageInstaller` outlives every task (Drop
+        // waits on the wait group). `WaitGroup::finish()` is `&self`.
+        unsafe { (*this.installer).parallel_wait_group.finish() };
+    }
+
+    fn run(&mut self) -> package_install::InstallResult {
+        // SAFETY: BACKREF — see field doc. `root_node_modules_folder` and
+        // `lockfile` are read-only here; `parallel_wait_group` is atomic.
+        let installer: &PackageInstaller<'_> = unsafe { &*self.installer };
+
+        // For nested trees open (and if racing another worker, create)
+        // the destination `node_modules`. The root tree reuses the
+        // already-open `root_node_modules_folder` fd.
+        let owned_dir: Option<Dir> = if self.tree_id == 0 {
+            None
+        } else {
+            let path = &*self.node_modules_path;
+            let opened = match Dir::borrow(&Fd::cwd()).open_at(path) {
+                Ok(d) => d,
+                Err(_) => {
+                    let _ = bun_sys::make_path::make_path(Dir::borrow(&Fd::cwd()), path);
+                    match Dir::borrow(&Fd::cwd()).open_at(path) {
+                        Ok(d) => d,
+                        Err(err) => {
+                            return package_install::InstallResult::fail(
+                                err.into(),
+                                package_install::Step::OpeningDestDir,
+                                None,
+                            );
+                        }
+                    }
+                }
+            };
+            Some(opened)
+        };
+        let destination_dir: &Dir = owned_dir
+            .as_ref()
+            .unwrap_or(&installer.root_node_modules_folder);
+
+        let local_node_modules = NodeModulesFolder {
+            tree_id: self.tree_id,
+            path: self.node_modules_path.to_vec(),
+        };
+        let mut subpath_buf = PathBuffer::uninit();
+        let dest_len = self.destination_dir_subpath.len();
+        subpath_buf.as_mut_slice()[..dest_len].copy_from_slice(&self.destination_dir_subpath);
+
+        // SAFETY: `destination_dir_subpath` was copied with its trailing NUL
+        // at enqueue time; len-1 is the NUL, so bytes[..len-1] + \0.
+        let dest_z = unsafe { ZStr::from_raw(self.destination_dir_subpath.as_ptr(), dest_len - 1) };
+        // SAFETY: same for `cache_dir_subpath`.
+        let cache_z = unsafe {
+            ZStr::from_raw(
+                self.cache_dir_subpath.as_ptr(),
+                self.cache_dir_subpath.len() - 1,
+            )
+        };
+
+        let mut pi = PackageInstall {
+            progress: None,
+            cache_dir: self.cache_dir,
+            cache_dir_subpath: cache_z,
+            destination_dir_subpath: dest_z,
+            destination_dir_subpath_buf: subpath_buf.as_mut_slice(),
+            package_name: self.package_name,
+            package_version: b"",
+            patch: None,
+            node_modules: &local_node_modules,
+            lockfile: installer.lockfile(),
+        };
+
+        let result = pi.install(
+            true,
+            destination_dir,
+            pi.get_install_method(),
+            self.resolution_tag,
+        );
+        if let package_install::InstallResult::Failure(f) = &result {
+            if f.is_package_missing_from_cache() {
+                self.missing_from_cache = true;
+            }
+        }
+        result
+    }
+}
+
 /// A dependency alias becomes the install destination inside `node_modules`
 /// (the existing entry is renamed aside, deleted, and re-created). Reject
 /// anything that could escape `node_modules`: empty names, `.`/`..`
@@ -455,6 +616,118 @@ impl<'a> PackageInstaller<'a> {
         // `*self`; the install pass is single-threaded so no concurrent `&mut
         // Progress` exists. Same shape as `manager_mut`/`lockfile_mut`.
         unsafe { &mut *self.progress }
+    }
+
+    /// Whether the hoisted linker should fan per-package
+    /// `PackageInstall::install()` out to `manager.thread_pool` instead
+    /// of running it inline on the main thread. Only enabled on POSIX
+    /// for a fresh `node_modules` (where `skip_delete` is true so there
+    /// is no per-package delete/rename-aside step to serialise).
+    /// Windows already fans out per-file via `HardLinkWindowsInstallTask`.
+    #[cfg(unix)]
+    pub(crate) fn can_use_parallel_hoisted_install(&self) -> bool {
+        if bun_core::env_var::BUN_INSTALL_SERIAL_HOISTED
+            .get()
+            .unwrap_or(false)
+        {
+            return false;
+        }
+        self.skip_delete
+    }
+
+    /// Flush `parallel_batch` to the thread pool. Called once per tree
+    /// so workers start while the main thread continues iterating.
+    #[cfg(unix)]
+    pub(crate) fn schedule_parallel_batch(&mut self) {
+        if self.parallel_batch.len == 0 {
+            return;
+        }
+        let batch = core::mem::take(&mut self.parallel_batch);
+        self.manager_mut().thread_pool.schedule(batch);
+    }
+
+    /// No-op on Windows so `hoisted_install` can call these
+    /// unconditionally.
+    #[cfg(windows)]
+    #[inline]
+    pub(crate) fn schedule_parallel_batch(&mut self) {}
+    #[cfg(windows)]
+    #[inline]
+    pub(crate) fn complete_parallel_installs(&mut self, _log_level: Options::LogLevel) -> bool {
+        false
+    }
+
+    /// Block on all in-flight `ParallelHoistedTask`s, then feed each
+    /// stored result through `handle_install_result()` on the main
+    /// thread. Tasks whose worker hit a cache miss re-enter the serial
+    /// download path (`install_package_with_name_and_resolution::<false,
+    /// true>()`). Returns `true` if any task re-routed, so
+    /// `hoisted_install` can drain the resulting download tasks.
+    #[cfg(unix)]
+    pub(crate) fn complete_parallel_installs(&mut self, log_level: Options::LogLevel) -> bool {
+        self.schedule_parallel_batch();
+        if self.parallel_tasks.is_empty() {
+            return false;
+        }
+        self.parallel_wait_group.wait();
+
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_PARALLEL_HOISTED_MARKER
+            .get()
+            .unwrap_or(false)
+        {
+            bun_core::pretty_errorln!(
+                "[ParallelHoistedInstall] {} tasks",
+                self.parallel_tasks.len()
+            );
+            Output::flush();
+        }
+
+        let tasks = core::mem::take(&mut self.parallel_tasks);
+        let saved_tree_id = self.current_tree_id;
+        let saved_nm = core::mem::take(&mut self.node_modules);
+        let mut had_missing = false;
+
+        for raw in &tasks {
+            // SAFETY: every pointer was `heap::into_raw`'d at enqueue; we
+            // hold the only reference now that `wait()` returned.
+            let t: Box<ParallelHoistedTask> = unsafe { bun_core::heap::take(*raw) };
+            self.current_tree_id = t.tree_id;
+            self.node_modules = NodeModulesFolder {
+                tree_id: t.tree_id,
+                path: t.node_modules_path.to_vec(),
+            };
+
+            if t.missing_from_cache {
+                had_missing = true;
+                let resolution = self.resolutions[t.package_id as usize];
+                // needs_verify = false (the worker already verified), is_pending_package_install = true.
+                self.install_package_with_name_and_resolution(
+                    t.dependency_id,
+                    t.package_id,
+                    log_level,
+                    t.package_name,
+                    &resolution,
+                    false,
+                    true,
+                );
+            } else {
+                let resolution = self.resolutions[t.package_id as usize];
+                self.handle_install_result(
+                    t.dependency_id,
+                    t.package_id,
+                    log_level,
+                    t.package_name,
+                    &resolution,
+                    t.result,
+                    self.root_node_modules_folder.fd(),
+                    true,
+                );
+            }
+        }
+
+        self.current_tree_id = saved_tree_id;
+        self.node_modules = saved_nm;
+        had_missing
     }
 
     /// Increments the number of installed packages for a tree id and runs available scripts
@@ -1024,10 +1297,12 @@ impl<'a> PackageInstaller<'a> {
         true
     }
 
-    // `pub fn deinit` dropped. All owned fields (`pending_lifecycle_scripts: Vec`,
-    // `completed_trees: Bitset`, `trees: Box<[TreeContext]>`, `tree_ids_to_trees_the_id_depends_on`,
-    // `node_modules`, `trusted_dependencies_from_update_requests`) impl Drop. Borrowed fields
-    // (`manager`, `lockfile`, etc.) are not freed.
+    // All other owned fields (`pending_lifecycle_scripts: Vec`,
+    // `completed_trees: Bitset`, `trees: Box<[TreeContext]>`,
+    // `tree_ids_to_trees_the_id_depends_on`, `node_modules`,
+    // `trusted_dependencies_from_update_requests`) impl Drop. Borrowed
+    // fields (`manager`, `lockfile`, etc.) are not freed. See `impl Drop`
+    // for the parallel-task drain.
 
     /// Call when you mutate the length of `lockfile.packages`
     pub(crate) fn fix_cached_lockfile_package_slices(&mut self) {
@@ -1221,6 +1496,319 @@ impl<'a> PackageInstaller<'a> {
         }
 
         count
+    }
+
+    /// Result-handling half of `install_package_with_name_and_resolution()`,
+    /// split out so `complete_parallel_installs()` can feed a worker's
+    /// stored `InstallResult` through the same summary / bin-link /
+    /// tree-count / lifecycle-script path the serial linker uses.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn handle_install_result(
+        &mut self,
+        dependency_id: DependencyID,
+        package_id: PackageID,
+        log_level: Options::LogLevel,
+        pkg_name: String,
+        resolution: &Resolution,
+        install_result: package_install::InstallResult,
+        #[allow(unused_variables)] destination_dir_fd: Fd,
+        is_pending_package_install: bool,
+    ) {
+        // SAFETY: `buffers.string_bytes` is append-only and never freed
+        // for the lifetime of this `PackageInstaller`.
+        let string_buf_ptr =
+            bun_ptr::RawSlice::new(self.lockfile().buffers.string_bytes.as_slice());
+        macro_rules! string_buf {
+            () => {
+                string_buf_ptr.slice()
+            };
+        }
+        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize].name;
+        let pkg_name_hash = self.pkg_name_hashes[package_id as usize];
+
+        match install_result {
+            package_install::InstallResult::Success => {
+                let is_duplicate = self.successfully_installed.is_set(package_id as usize);
+                self.summary.success += (!is_duplicate) as u32;
+                self.successfully_installed.set(package_id as usize);
+
+                if log_level.show_progress() {
+                    self.node.complete_one();
+                }
+
+                if self.bins[package_id as usize].tag != bin::Tag::None {
+                    self.trees[self.current_tree_id as usize]
+                        .binaries
+                        .add(dependency_id)
+                        .unwrap_or_oom();
+                }
+
+                let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
+                let dep_behavior = dep.behavior;
+                let truncated_dep_name_hash: TruncatedPackageNameHash =
+                    dep.name_hash as TruncatedPackageNameHash;
+                let (is_trusted, is_trusted_through_update_request) = 'brk: {
+                    if self
+                        .trusted_dependencies_from_update_requests
+                        .contains(&package_id)
+                    {
+                        break 'brk (true, true);
+                    }
+                    if self.lockfile().has_trusted_dependency(
+                        alias.slice(string_buf!()),
+                        pkg_name.slice(string_buf!()),
+                        resolution,
+                    ) {
+                        break 'brk (true, false);
+                    }
+                    break 'brk (false, false);
+                };
+
+                if resolution.tag != resolution::Tag::Root
+                    && (resolution.tag == resolution::Tag::Workspace || is_trusted)
+                {
+                    let mut folder_path =
+                        AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
+                    // `defer folder_path.deinit()` — AbsPath impls Drop.
+                    folder_path
+                        .append(alias.slice(string_buf!()))
+                        .unwrap_or_oom();
+
+                    'enqueue_lifecycle_scripts: {
+                        if self
+                            .manager()
+                            .postinstall_optimizer
+                            .should_ignore_lifecycle_scripts(
+                                &postinstall_optimizer::PkgInfo {
+                                    name_hash: pkg_name_hash,
+                                    version: if resolution.tag == resolution::Tag::Npm {
+                                        Some(resolution.npm().version)
+                                    } else {
+                                        None
+                                    },
+                                    version_buf: string_buf!(),
+                                },
+                                self.lockfile().packages.items_resolutions()[package_id as usize]
+                                    .get(self.lockfile().buffers.resolutions.as_slice()),
+                                self.lockfile().packages.items_meta(),
+                                self.manager().options.cpu,
+                                self.manager().options.os,
+                            )
+                        {
+                            if PackageManager::verbose_install() {
+                                bun_core::pretty_errorln!(
+                                    "<d>[Lifecycle Scripts]<r> ignoring {} lifecycle scripts",
+                                    bstr::BStr::new(pkg_name.slice(string_buf!())),
+                                );
+                            }
+                            break 'enqueue_lifecycle_scripts;
+                        }
+
+                        if self.enqueue_lifecycle_scripts(
+                            alias.slice(string_buf!()),
+                            log_level,
+                            &mut folder_path,
+                            package_id,
+                            dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
+                            resolution,
+                        ) {
+                            if is_trusted_through_update_request {
+                                let (trusted_name, trusted_name_hash) =
+                                    if resolution.tag == resolution::Tag::Npm {
+                                        (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
+                                    } else {
+                                        (alias, truncated_dep_name_hash)
+                                    };
+                                self.manager_mut()
+                                    .trusted_deps_to_add_to_package_json
+                                    .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
+
+                                if self.lockfile().trusted_dependencies.is_none() {
+                                    self.lockfile_mut().trusted_dependencies =
+                                        Some(Default::default());
+                                }
+                                self.lockfile_mut()
+                                    .trusted_dependencies
+                                    .as_mut()
+                                    .unwrap()
+                                    .put(
+                                        trusted_name_hash,
+                                        Box::<[u8]>::from(trusted_name.slice(string_buf!())),
+                                    )
+                                    .unwrap_or_oom();
+                            }
+                        }
+                    }
+                }
+
+                match resolution.tag {
+                    resolution::Tag::Root | resolution::Tag::Workspace => {
+                        // these will never be blocked
+                    }
+                    _ => {
+                        if !is_trusted && self.metas[package_id as usize].has_install_script() {
+                            // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
+                            // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
+                            let mut folder_path =
+                                AutoAbsPath::from(self.node_modules.path.as_slice())
+                                    .unwrap_or_oom();
+                            folder_path
+                                .append(alias.slice(string_buf!()))
+                                .unwrap_or_oom();
+
+                            let count = self.get_installed_package_scripts_count(
+                                alias.slice(string_buf!()),
+                                package_id,
+                                resolution.tag,
+                                &mut folder_path,
+                                log_level,
+                            );
+                            if count > 0 {
+                                if log_level.is_verbose() {
+                                    bun_core::pretty_error!(
+                                        "Blocked {} scripts for: {}@{}\n",
+                                        count,
+                                        bstr::BStr::new(alias.slice(string_buf!())),
+                                        resolution.fmt(string_buf!(), PathSep::Posix),
+                                    );
+                                }
+                                let entry = self
+                                    .summary
+                                    .packages_with_blocked_scripts
+                                    .get_or_put(truncated_dep_name_hash)
+                                    .unwrap_or_oom();
+                                if !entry.found_existing {
+                                    *entry.value_ptr = 0;
+                                }
+                                *entry.value_ptr += count;
+                            }
+                        }
+                    }
+                }
+
+                self.increment_tree_install_count(
+                    !is_pending_package_install,
+                    self.current_tree_id,
+                    log_level,
+                );
+            }
+            package_install::InstallResult::Failure(cause) => {
+                debug_assert!(
+                    !cause.is_package_missing_from_cache()
+                        || (resolution.tag != resolution::Tag::Symlink
+                            && resolution.tag != resolution::Tag::Workspace)
+                );
+
+                // even if the package failed to install, we still need to increment the install
+                // counter for this tree
+                self.increment_tree_install_count(
+                    !is_pending_package_install,
+                    self.current_tree_id,
+                    log_level,
+                );
+
+                if cause.err == crate::Error::DanglingSymlink {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
+                        cause.err.name(),
+                        bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                    );
+                    self.summary.fail += 1;
+                } else if resolution.tag == resolution::Tag::Folder
+                    && cause.is_package_missing_from_cache()
+                {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: Could not find folder \"file:{}\" for dependency \"{}\"",
+                        bstr::BStr::new(resolution.folder().slice(string_buf!())),
+                        bstr::BStr::new(alias.slice(string_buf!())),
+                    );
+                    self.summary.fail += 1;
+                } else if matches!(
+                    cause.err,
+                    crate::Error::Sys(bun_errno::SystemErrno::EACCES) | crate::Error::AccessDenied
+                ) {
+                    // there are two states this can happen
+                    // - Access Denied because node_modules/ is unwritable
+                    // - Access Denied because this specific package is unwritable
+                    // in the case of the former, the logs are extremely noisy, so we
+                    // will exit early, otherwise set a flag to not re-stat
+                    // Static flag since Rust lacks fn-local mutable statics.
+                    static NODE_MODULES_IS_OK: core::sync::atomic::AtomicBool =
+                        core::sync::atomic::AtomicBool::new(false);
+                    if !NODE_MODULES_IS_OK.load(Ordering::Relaxed) {
+                        #[cfg(not(windows))]
+                        {
+                            let dir = destination_dir_fd;
+                            let stat = match bun_sys::fstat(dir) {
+                                Ok(s) => s,
+                                Err(err) => {
+                                    Output::err(
+                                        "EACCES",
+                                        "Permission denied while installing <b>{}<r>",
+                                        (bstr::BStr::new(self.names[package_id as usize].slice(
+                                            self.lockfile().buffers.string_bytes.as_slice(),
+                                        )),),
+                                    );
+                                    if cfg!(debug_assertions) {
+                                        Output::err(err, "Failed to stat node_modules", ());
+                                    }
+                                    Global::exit(1);
+                                }
+                            };
+
+                            // `bun_sys::c::getuid`/`getgid` are local `safe fn`
+                            // redecls (zero args, read kernel process state —
+                            // no preconditions), so no `unsafe` needed.
+                            // `st_mode` is u16 on FreeBSD, u32 elsewhere; widen.
+                            let st_mode = stat.st_mode as u32;
+                            let is_writable = if stat.st_uid == bun_sys::c::getuid() {
+                                st_mode & bun_sys::S::IWUSR > 0
+                            } else if stat.st_gid == bun_sys::c::getgid() {
+                                st_mode & bun_sys::S::IWGRP > 0
+                            } else {
+                                st_mode & bun_sys::S::IWOTH > 0
+                            };
+
+                            if !is_writable {
+                                Output::err_tag(
+                                    "EACCES",
+                                    format_args!(
+                                        "Permission denied while writing packages into node_modules."
+                                    ),
+                                );
+                                Global::exit(1);
+                            }
+                        }
+                        NODE_MODULES_IS_OK.store(true, Ordering::Relaxed);
+                    }
+
+                    Output::err(
+                        "EACCES",
+                        "Permission denied while installing <b>{}<r>",
+                        (bstr::BStr::new(
+                            self.names[package_id as usize].slice(string_buf!()),
+                        ),),
+                    );
+
+                    self.summary.fail += 1;
+                } else {
+                    Output::err(
+                        cause.err,
+                        "failed {} for package <b>{}<r>",
+                        (
+                            bstr::BStr::new(cause.step.name()),
+                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                        ),
+                    );
+                    #[cfg(bun_debug)]
+                    {
+                        let t = cause.debug_trace;
+                        bun_crash_handler::dump_stack_trace(&t.trace(), Default::default());
+                    }
+                    self.summary.fail += 1;
+                }
+            }
+        }
     }
 
     pub(crate) fn install_package_with_name_and_resolution(
@@ -1577,6 +2165,73 @@ impl<'a> PackageInstaller<'a> {
             || !installer.verify(resolution, &self.root_node_modules_folder);
 
         if needs_install {
+            // Fast path: package is cached, node_modules is fresh, and
+            // the install method is a real link (not a symlink). Hand
+            // the hardlink/clonefile walk to a thread-pool worker and
+            // return; `complete_parallel_installs()` picks up the
+            // result. The cache-presence check here is optimistic —
+            // the worker re-checks on open and sets
+            // `missing_from_cache` for reroute.
+            #[cfg(unix)]
+            if needs_verify
+                && !is_pending_package_install
+                && self.can_use_parallel_hoisted_install()
+                && installer.patch.is_none()
+                && installer.get_install_method() != package_install::Method::Symlink
+                && matches!(
+                    resolution.tag,
+                    resolution::Tag::Npm
+                        | resolution::Tag::Git
+                        | resolution::Tag::Github
+                        | resolution::Tag::LocalTarball
+                        | resolution::Tag::RemoteTarball
+                )
+            {
+                // Copy everything needed from the `PackageInstall` and
+                // end its borrows into `self` (folder_path_buf,
+                // destination_dir_subpath_buf) before `self` is cast
+                // to a raw pointer for the task.
+                let dest = Box::<[u8]>::from(installer.destination_dir_subpath.as_bytes_with_nul());
+                let cache = Box::<[u8]>::from(installer.cache_dir_subpath.as_bytes_with_nul());
+                let cache_dir = installer.cache_dir;
+                #[allow(clippy::drop_non_drop)]
+                drop(installer);
+
+                // SAFETY: BACKREF — lifetime-erased raw; workers use it
+                // only until `parallel_wait_group.wait()` returns, and
+                // `Drop for PackageInstaller` waits before any field is
+                // freed. Workers never form a `&mut PackageInstaller`.
+                let this_ptr: *mut PackageInstaller<'static> =
+                    core::ptr::from_mut::<PackageInstaller<'_>>(self).cast();
+                let raw = bun_core::heap::into_raw(Box::new(ParallelHoistedTask {
+                    installer: this_ptr,
+                    task: bun_threading::thread_pool::Task {
+                        node: bun_threading::thread_pool::Node::default(),
+                        callback: ParallelHoistedTask::run_from_thread_pool,
+                    },
+                    node_modules_path: Box::<[u8]>::from(self.node_modules.path.as_slice()),
+                    destination_dir_subpath: dest,
+                    cache_dir_subpath: cache,
+                    cache_dir,
+                    resolution_tag: resolution.tag,
+                    dependency_id,
+                    package_id,
+                    tree_id: self.current_tree_id,
+                    package_name: pkg_name,
+                    result: package_install::InstallResult::Success,
+                    missing_from_cache: false,
+                }));
+                self.parallel_tasks.push(raw);
+                self.parallel_wait_group.add_one();
+                // SAFETY: `raw` is live for the install pass; the Batch
+                // stores only the intrusive `task` node pointer.
+                self.parallel_batch
+                    .push(bun_threading::thread_pool::Batch::from(unsafe {
+                        core::ptr::addr_of_mut!((*raw).task)
+                    }));
+                return;
+            }
+
             if resolution.tag.can_enqueue_install_task()
                 && installer.package_missing_from_cache(
                     self.manager_mut(),
@@ -1896,296 +2551,16 @@ impl<'a> PackageInstaller<'a> {
                 }
             };
 
-            match install_result {
-                package_install::InstallResult::Success => {
-                    let is_duplicate = self.successfully_installed.is_set(package_id as usize);
-                    self.summary.success += (!is_duplicate) as u32;
-                    self.successfully_installed.set(package_id as usize);
-
-                    if log_level.show_progress() {
-                        self.node.complete_one();
-                    }
-
-                    if self.bins[package_id as usize].tag != bin::Tag::None {
-                        self.trees[self.current_tree_id as usize]
-                            .binaries
-                            .add(dependency_id)
-                            .unwrap_or_oom();
-                    }
-
-                    let dep =
-                        &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
-                    let dep_behavior = dep.behavior;
-                    let truncated_dep_name_hash: TruncatedPackageNameHash =
-                        dep.name_hash as TruncatedPackageNameHash;
-                    let (is_trusted, is_trusted_through_update_request) = 'brk: {
-                        if self
-                            .trusted_dependencies_from_update_requests
-                            .contains(&package_id)
-                        {
-                            break 'brk (true, true);
-                        }
-                        if self.lockfile().has_trusted_dependency(
-                            alias.slice(string_buf!()),
-                            pkg_name.slice(string_buf!()),
-                            resolution,
-                        ) {
-                            break 'brk (true, false);
-                        }
-                        break 'brk (false, false);
-                    };
-
-                    if resolution.tag != resolution::Tag::Root
-                        && (resolution.tag == resolution::Tag::Workspace || is_trusted)
-                    {
-                        let mut folder_path =
-                            AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-                        // `defer folder_path.deinit()` — AbsPath impls Drop.
-                        folder_path
-                            .append(alias.slice(string_buf!()))
-                            .unwrap_or_oom();
-
-                        'enqueue_lifecycle_scripts: {
-                            if self
-                                .manager()
-                                .postinstall_optimizer
-                                .should_ignore_lifecycle_scripts(
-                                    &postinstall_optimizer::PkgInfo {
-                                        name_hash: pkg_name_hash,
-                                        version: if resolution.tag == resolution::Tag::Npm {
-                                            Some(resolution.npm().version)
-                                        } else {
-                                            None
-                                        },
-                                        version_buf: string_buf!(),
-                                    },
-                                    self.lockfile().packages.items_resolutions()
-                                        [package_id as usize]
-                                        .get(self.lockfile().buffers.resolutions.as_slice()),
-                                    self.lockfile().packages.items_meta(),
-                                    self.manager().options.cpu,
-                                    self.manager().options.os,
-                                )
-                            {
-                                if PackageManager::verbose_install() {
-                                    bun_core::pretty_errorln!(
-                                        "<d>[Lifecycle Scripts]<r> ignoring {} lifecycle scripts",
-                                        bstr::BStr::new(pkg_name.slice(string_buf!())),
-                                    );
-                                }
-                                break 'enqueue_lifecycle_scripts;
-                            }
-
-                            if self.enqueue_lifecycle_scripts(
-                                alias.slice(string_buf!()),
-                                log_level,
-                                &mut folder_path,
-                                package_id,
-                                dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
-                                resolution,
-                            ) {
-                                if is_trusted_through_update_request {
-                                    let (trusted_name, trusted_name_hash) =
-                                        if resolution.tag == resolution::Tag::Npm {
-                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                                        } else {
-                                            (alias, truncated_dep_name_hash)
-                                        };
-                                    self.manager_mut()
-                                        .trusted_deps_to_add_to_package_json
-                                        .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
-
-                                    if self.lockfile().trusted_dependencies.is_none() {
-                                        self.lockfile_mut().trusted_dependencies =
-                                            Some(Default::default());
-                                    }
-                                    self.lockfile_mut()
-                                        .trusted_dependencies
-                                        .as_mut()
-                                        .unwrap()
-                                        .put(
-                                            trusted_name_hash,
-                                            Box::<[u8]>::from(trusted_name.slice(string_buf!())),
-                                        )
-                                        .unwrap_or_oom();
-                                }
-                            }
-                        }
-                    }
-
-                    match resolution.tag {
-                        resolution::Tag::Root | resolution::Tag::Workspace => {
-                            // these will never be blocked
-                        }
-                        _ => {
-                            if !is_trusted && self.metas[package_id as usize].has_install_script() {
-                                // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
-                                // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
-                                let mut folder_path =
-                                    AutoAbsPath::from(self.node_modules.path.as_slice())
-                                        .unwrap_or_oom();
-                                folder_path
-                                    .append(alias.slice(string_buf!()))
-                                    .unwrap_or_oom();
-
-                                let count = self.get_installed_package_scripts_count(
-                                    alias.slice(string_buf!()),
-                                    package_id,
-                                    resolution.tag,
-                                    &mut folder_path,
-                                    log_level,
-                                );
-                                if count > 0 {
-                                    if log_level.is_verbose() {
-                                        bun_core::pretty_error!(
-                                            "Blocked {} scripts for: {}@{}\n",
-                                            count,
-                                            bstr::BStr::new(alias.slice(string_buf!())),
-                                            resolution.fmt(string_buf!(), PathSep::Posix),
-                                        );
-                                    }
-                                    let entry = self
-                                        .summary
-                                        .packages_with_blocked_scripts
-                                        .get_or_put(truncated_dep_name_hash)
-                                        .unwrap_or_oom();
-                                    if !entry.found_existing {
-                                        *entry.value_ptr = 0;
-                                    }
-                                    *entry.value_ptr += count;
-                                }
-                            }
-                        }
-                    }
-
-                    self.increment_tree_install_count(
-                        !is_pending_package_install,
-                        self.current_tree_id,
-                        log_level,
-                    );
-                }
-                package_install::InstallResult::Failure(cause) => {
-                    debug_assert!(
-                        !cause.is_package_missing_from_cache()
-                            || (resolution.tag != resolution::Tag::Symlink
-                                && resolution.tag != resolution::Tag::Workspace)
-                    );
-
-                    // even if the package failed to install, we still need to increment the install
-                    // counter for this tree
-                    self.increment_tree_install_count(
-                        !is_pending_package_install,
-                        self.current_tree_id,
-                        log_level,
-                    );
-
-                    if cause.err == crate::Error::DanglingSymlink {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
-                            cause.err.name(),
-                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
-                        );
-                        self.summary.fail += 1;
-                    } else if resolution.tag == resolution::Tag::Folder
-                        && cause.is_package_missing_from_cache()
-                    {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error<r>: Could not find folder \"file:{}\" for dependency \"{}\"",
-                            bstr::BStr::new(resolution.folder().slice(string_buf!())),
-                            bstr::BStr::new(alias.slice(string_buf!())),
-                        );
-                        self.summary.fail += 1;
-                    } else if matches!(
-                        cause.err,
-                        crate::Error::Sys(bun_errno::SystemErrno::EACCES)
-                            | crate::Error::AccessDenied
-                    ) {
-                        // there are two states this can happen
-                        // - Access Denied because node_modules/ is unwritable
-                        // - Access Denied because this specific package is unwritable
-                        // in the case of the former, the logs are extremely noisy, so we
-                        // will exit early, otherwise set a flag to not re-stat
-                        // Static flag since Rust lacks fn-local mutable statics.
-                        static NODE_MODULES_IS_OK: core::sync::atomic::AtomicBool =
-                            core::sync::atomic::AtomicBool::new(false);
-                        if !NODE_MODULES_IS_OK.load(Ordering::Relaxed) {
-                            #[cfg(not(windows))]
-                            {
-                                let dir = destination_dir.fd();
-                                let stat = match bun_sys::fstat(dir) {
-                                    Ok(s) => s,
-                                    Err(err) => {
-                                        Output::err(
-                                            "EACCES",
-                                            "Permission denied while installing <b>{}<r>",
-                                            (bstr::BStr::new(
-                                                self.names[package_id as usize].slice(
-                                                    self.lockfile().buffers.string_bytes.as_slice(),
-                                                ),
-                                            ),),
-                                        );
-                                        if cfg!(debug_assertions) {
-                                            Output::err(err, "Failed to stat node_modules", ());
-                                        }
-                                        Global::exit(1);
-                                    }
-                                };
-
-                                // `bun_sys::c::getuid`/`getgid` are local `safe fn`
-                                // redecls (zero args, read kernel process state —
-                                // no preconditions), so no `unsafe` needed.
-                                // `st_mode` is u16 on FreeBSD, u32 elsewhere; widen.
-                                let st_mode = stat.st_mode as u32;
-                                let is_writable = if stat.st_uid == bun_sys::c::getuid() {
-                                    st_mode & bun_sys::S::IWUSR > 0
-                                } else if stat.st_gid == bun_sys::c::getgid() {
-                                    st_mode & bun_sys::S::IWGRP > 0
-                                } else {
-                                    st_mode & bun_sys::S::IWOTH > 0
-                                };
-
-                                if !is_writable {
-                                    Output::err_tag(
-                                        "EACCES",
-                                        format_args!(
-                                            "Permission denied while writing packages into node_modules."
-                                        ),
-                                    );
-                                    Global::exit(1);
-                                }
-                            }
-                            NODE_MODULES_IS_OK.store(true, Ordering::Relaxed);
-                        }
-
-                        Output::err(
-                            "EACCES",
-                            "Permission denied while installing <b>{}<r>",
-                            (bstr::BStr::new(
-                                self.names[package_id as usize].slice(string_buf!()),
-                            ),),
-                        );
-
-                        self.summary.fail += 1;
-                    } else {
-                        Output::err(
-                            cause.err,
-                            "failed {} for package <b>{}<r>",
-                            (
-                                bstr::BStr::new(cause.step.name()),
-                                bstr::BStr::new(
-                                    self.names[package_id as usize].slice(string_buf!()),
-                                ),
-                            ),
-                        );
-                        #[cfg(bun_debug)]
-                        {
-                            let t = cause.debug_trace;
-                            bun_crash_handler::dump_stack_trace(&t.trace(), Default::default());
-                        }
-                        self.summary.fail += 1;
-                    }
-                }
-            }
+            self.handle_install_result(
+                dependency_id,
+                package_id,
+                log_level,
+                pkg_name,
+                resolution,
+                install_result,
+                destination_dir.fd(),
+                is_pending_package_install,
+            );
         } else {
             // Same gate as the `needs_install` branch: a pending parent's
             // `uninstall_before_install` would delete this verified package.
@@ -2470,5 +2845,24 @@ impl<'a> PackageInstaller<'a> {
             needs_verify,
             is_pending_package_install,
         );
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PackageInstaller<'_> {
+    fn drop(&mut self) {
+        // Any early error return from `hoisted_install` drops the
+        // `PackageInstaller` while workers may still be running. Flush
+        // the current batch so nothing sits un-scheduled, wait for
+        // workers to finish, then free every heap task. After this the
+        // field `Drop`s run safely.
+        self.schedule_parallel_batch();
+        if !self.parallel_tasks.is_empty() {
+            self.parallel_wait_group.wait();
+            for raw in self.parallel_tasks.drain(..) {
+                // SAFETY: `heap::into_raw`'d at enqueue, sole owner now.
+                unsafe { bun_core::heap::destroy(raw) };
+            }
+        }
     }
 }

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -478,9 +478,6 @@ pub(crate) fn install_hoisted_packages(
                 installer.install_package(*dependency_id, log_level);
             }
 
-            // Flush any ParallelHoistedTasks accumulated for this tree so
-            // workers start immediately rather than waiting for the full
-            // tree iteration to finish.
             installer.schedule_parallel_batch();
 
             run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
@@ -571,14 +568,7 @@ pub(crate) fn install_hoisted_packages(
         this.tick_lifecycle_scripts();
         this.report_slow_lifecycle_scripts();
 
-        // Wait for any thread-pool package installs kicked off during the
-        // tree iteration above, then run their result handling (summary,
-        // bins, scripts, tree counts) serially. This must happen before the
-        // forced pending-install drain below so bin linking and lifecycle
-        // scripts see a fully populated node_modules. If any worker
-        // discovered a package missing from the cache, the result handler
-        // re-enters the serial path which enqueues a download/extract task;
-        // drain those here.
+        // Must precede the pending-install drain and bin linking below, which need these on disk.
         if installer.complete_parallel_installs(log_level) {
             struct DrainClosure<'a, 'b> {
                 installer: &'a mut PackageInstaller<'b>,
@@ -625,8 +615,7 @@ pub(crate) fn install_hoisted_packages(
                 err: None,
                 manager: mgr,
             };
-            // run_tasks pushes task_batch to the thread pool via
-            // drain_dependency_list, so call it once before sleeping.
+            // is_done() is what submits the rerouted batch; never sleep on work that was not submitted.
             if !DrainClosure::is_done(&mut drain_closure) {
                 // SAFETY: see the sibling `sleep_until` call above.
                 unsafe {

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -420,6 +420,12 @@ pub(crate) fn install_hoisted_packages(
                     }
                     set
                 },
+                #[cfg(unix)]
+                parallel_tasks: Vec::new(),
+                #[cfg(unix)]
+                parallel_wait_group: bun_threading::WaitGroup::init(),
+                #[cfg(unix)]
+                parallel_batch: bun_threading::thread_pool::Batch::default(),
             };
         };
 
@@ -471,6 +477,11 @@ pub(crate) fn install_hoisted_packages(
             for dependency_id in remaining {
                 installer.install_package(*dependency_id, log_level);
             }
+
+            // Flush any ParallelHoistedTasks accumulated for this tree so
+            // workers start immediately rather than waiting for the full
+            // tree iteration to finish.
+            installer.schedule_parallel_batch();
 
             run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
                 this,
@@ -560,6 +571,73 @@ pub(crate) fn install_hoisted_packages(
         this.tick_lifecycle_scripts();
         this.report_slow_lifecycle_scripts();
 
+        // Wait for any thread-pool package installs kicked off during the
+        // tree iteration above, then run their result handling (summary,
+        // bins, scripts, tree counts) serially. This must happen before the
+        // forced pending-install drain below so bin linking and lifecycle
+        // scripts see a fully populated node_modules. If any worker
+        // discovered a package missing from the cache, the result handler
+        // re-enters the serial path which enqueues a download/extract task;
+        // drain those here.
+        if installer.complete_parallel_installs(log_level) {
+            struct DrainClosure<'a, 'b> {
+                installer: &'a mut PackageInstaller<'b>,
+                err: Option<crate::Error>,
+                manager: *mut PackageManager,
+            }
+            impl<'a, 'b> DrainClosure<'a, 'b> {
+                pub(crate) fn is_done(closure: &mut Self) -> bool {
+                    // SAFETY: see the sibling `Closure::is_done` above.
+                    let manager = unsafe { &mut *closure.manager };
+                    let log_level = manager.options.log_level;
+                    if let Err(err) = run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
+                        manager,
+                        closure.installer,
+                        true,
+                        log_level,
+                    ) {
+                        closure.err = Some(err);
+                    }
+                    if closure.err.is_some() {
+                        return true;
+                    }
+
+                    manager.report_slow_lifecycle_scripts();
+
+                    if PackageManager::verbose_install() {
+                        let pending_task_count = manager.pending_task_count();
+                        if pending_task_count > 0
+                            && PackageManager::has_enough_time_passed_between_waiting_messages()
+                        {
+                            bun_core::pretty_errorln!(
+                                "<d>[PackageManager]<r> waiting for {} tasks\n",
+                                pending_task_count
+                            );
+                        }
+                    }
+
+                    manager.pending_task_count() == 0
+                }
+            }
+            let mgr: *mut PackageManager = mgr_ptr;
+            let mut drain_closure = DrainClosure {
+                installer: &mut installer,
+                err: None,
+                manager: mgr,
+            };
+            // run_tasks pushes task_batch to the thread pool via
+            // drain_dependency_list, so call it once before sleeping.
+            if !DrainClosure::is_done(&mut drain_closure) {
+                // SAFETY: see the sibling `sleep_until` call above.
+                unsafe {
+                    PackageManager::sleep_until(mgr, &mut drain_closure, DrainClosure::is_done)
+                };
+            }
+            if let Some(err) = drain_closure.err {
+                return Err(err);
+            }
+        }
+
         // Index instead of `.iter()` so the immutable borrow of
         // `installer.trees` doesn't overlap `&mut self`.
         for tree_idx in 0..installer.trees.len() {
@@ -567,6 +645,11 @@ pub(crate) fn install_hoisted_packages(
             // force = true
             installer.install_available_packages::<true>(log_level);
         }
+        #[cfg(unix)]
+        debug_assert!(
+            installer.parallel_tasks.is_empty() && installer.parallel_batch.len == 0,
+            "a parallel link task was enqueued after complete_parallel_installs() and would never be replayed"
+        );
 
         // .monotonic is okay because this value is only accessed on this thread.
         this.finished_installing.store(true, Ordering::Relaxed);

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -488,7 +488,7 @@ impl PatchTask {
             package_version: &resolution_label,
             // dummy value
             node_modules: &dummy_node_modules,
-            lockfile,
+            lockfile: Some(lockfile),
         };
 
         match pkg_install.install(

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -1,0 +1,268 @@
+import { $, Glob, spawn, write } from "bun";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { lstat, mkdir, readlink, rm } from "fs/promises";
+import { bunEnv, bunExe, isASAN, isDebug, isMusl, isPosix, tempDir } from "harness";
+import { join } from "path";
+
+// Parallel hoisted install is POSIX-only (Windows already fans out
+// per-file via HardLinkWindowsInstallTask).
+
+setDefaultTimeout(1000 * 60 * 5);
+
+/**
+ * Build a set of local tarball packages to exercise the hoisted
+ * installer. Each package has several files and a nested directory so
+ * the hardlink walker has real work to do. local_tarball resolutions go
+ * through the parallel path (see canUseParallelHoistedInstall).
+ */
+async function makeTarballFixture(): Promise<{ dir: string; deps: Record<string, string>; count: number }> {
+  const count = 60;
+  const deps: Record<string, string> = {};
+  const root = tempDir("parallel-hoisted", {});
+  const dir = String(root);
+  await mkdir(join(dir, "tarballs"), { recursive: true });
+
+  for (let i = 0; i < count; i++) {
+    const name = i % 3 === 0 ? `@scope/pkg-${i}` : `pkg-${i}`;
+    // Lay files out under src/<i>/package/... so `tar -C src/<i> package`
+    // works with both GNU and BSD tar (no --transform needed).
+    const pkgRoot = join(dir, "src", String(i));
+    const pkgSrc = join(pkgRoot, "package");
+    await mkdir(join(pkgSrc, "lib", "nested"), { recursive: true });
+    await write(
+      join(pkgSrc, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", bin: i % 5 === 0 ? { [`bin-${i}`]: "./lib/index.js" } : undefined }),
+    );
+    await write(join(pkgSrc, "index.js"), `module.exports = ${i};\n`);
+    await write(join(pkgSrc, "lib", "index.js"), `#!/usr/bin/env node\nconsole.log(${i});\n`);
+    await write(join(pkgSrc, "lib", "nested", "a.js"), `// ${i}\n`);
+    await write(join(pkgSrc, "lib", "nested", "b.js"), `// ${i}\n`);
+    await write(join(pkgSrc, "README.md"), `# ${name}\n`);
+    // Pad with extra files so the per-package hardlink work
+    // dominates process-startup overhead in the parallelism test.
+    // 60 packages × 26 files ≈ 1.5k linkat calls.
+    for (let f = 0; f < 20; f++) {
+      await write(join(pkgSrc, "lib", "nested", `f${f}.js`), `// ${i}.${f}\n`);
+    }
+
+    const tarball = join(dir, "tarballs", `pkg-${i}.tgz`);
+    await $`tar -czf ${tarball} -C ${pkgRoot} package`.quiet();
+    deps[name] = `file:./tarballs/pkg-${i}.tgz`;
+  }
+
+  return { dir, deps, count };
+}
+
+/**
+ * Deterministic fingerprint of node_modules: every regular file, dir
+ * and symlink (with its target), sorted. Both paths call the same
+ * PackageInstall.install() which hardlinks from the same cache
+ * inodes, so file contents are identical by construction; symlink
+ * targets (.bin entries) are compared explicitly.
+ */
+async function fingerprintNodeModules(dir: string): Promise<string[]> {
+  const entries: string[] = [];
+  const glob = new Glob("node_modules/**/*");
+  for await (const entry of glob.scan({ cwd: dir, onlyFiles: false, dot: true, followSymlinks: false })) {
+    const abs = join(dir, entry);
+    const st = await lstat(abs);
+    if (st.isSymbolicLink()) {
+      entries.push(`${entry} -> ${await readlink(abs)}`);
+    } else if (st.isDirectory()) {
+      entries.push(`${entry}/`);
+    } else {
+      entries.push(`${entry} [${st.size}]`);
+    }
+  }
+  entries.sort();
+  return entries;
+}
+
+async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[] = []) {
+  const start = Bun.nanoseconds();
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--ignore-scripts", ...extraArgs],
+    cwd: dir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const wallMicros = (Bun.nanoseconds() - start) / 1000;
+  const usage = proc.resourceUsage();
+  return { stdout, stderr, exitCode, wallMicros, usage };
+}
+
+describe.skipIf(!isPosix)("parallel hoisted install", () => {
+  let fixture: { dir: string; deps: Record<string, string>; count: number };
+  // CI's runner.node.mjs sets BUN_INSTALL_CACHE_DIR which
+  // fetchCacheDirectoryPath() checks BEFORE bunfig's [install] cache,
+  // so override it explicitly to keep the cache local to the fixture.
+  let env: NodeJS.Dict<string>;
+
+  beforeAll(async () => {
+    fixture = await makeTarballFixture();
+    env = {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(fixture.dir, ".bun-cache"),
+      // Enable the "[ParallelHoistedInstall] N tasks" stderr marker
+      // emitted by completeParallelInstalls() — see parallelTaskCount().
+      BUN_INTERNAL_PARALLEL_HOISTED_MARKER: "1",
+    };
+    await write(
+      join(fixture.dir, "package.json"),
+      JSON.stringify({ name: "parallel-hoisted-fixture", version: "1.0.0", dependencies: fixture.deps }),
+    );
+    await write(
+      join(fixture.dir, "bunfig.toml"),
+      `[install]\ncache = "${join(fixture.dir, ".bun-cache")}"\nregistry = "http://localhost:1/invalid/"\n`,
+    );
+  });
+
+  afterAll(async () => {
+    if (fixture) await rm(fixture.dir, { recursive: true, force: true });
+  });
+
+  /**
+   * Parse the test-only "[ParallelHoistedInstall] N tasks" marker that
+   * completeParallelInstalls() emits under
+   * BUN_INTERNAL_PARALLEL_HOISTED_MARKER. Returns 0 if the marker is
+   * absent (i.e. the parallel path was not taken, or doesn't exist).
+   */
+  function parallelTaskCount(stderr: string): number {
+    const m = stderr.match(/\[ParallelHoistedInstall\]\s+(\d+)\s+tasks/);
+    return m ? Number(m[1]) : 0;
+  }
+
+  test("produces identical node_modules to the serial installer", async () => {
+    // Warm the cache + generate the lockfile.
+    const warm = await install(fixture.dir, env);
+    expect(warm.stderr).not.toContain("error:");
+    expect(warm.exitCode).toBe(0);
+
+    // Parallel (default): fresh node_modules, warm cache.
+    await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+    const parallel = await install(fixture.dir, env, ["--frozen-lockfile"]);
+    expect(parallel.stderr).not.toContain("error:");
+    expect(parallel.exitCode).toBe(0);
+    const parallelLayout = await fingerprintNodeModules(fixture.dir);
+
+    // Serial fallback: fresh node_modules, warm cache.
+    await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+    const serial = await install(fixture.dir, { ...env, BUN_INSTALL_SERIAL_HOISTED: "1" }, ["--frozen-lockfile"]);
+    expect(serial.stderr).not.toContain("error:");
+    expect(serial.exitCode).toBe(0);
+    const serialLayout = await fingerprintNodeModules(fixture.dir);
+
+    // Deterministic signal that the parallel path was actually
+    // exercised: completeParallelInstalls() emits a task count under
+    // BUN_INTERNAL_PARALLEL_HOISTED_MARKER (set in env above). Without
+    // the parallel installer, this marker is never printed. The
+    // serial-env run must NOT take the parallel path.
+    expect(parallelTaskCount(parallel.stderr)).toBe(fixture.count);
+    expect(parallelTaskCount(serial.stderr)).toBe(0);
+
+    // every package dir, file and bin link must match exactly.
+    expect(parallelLayout.length).toBeGreaterThan(fixture.count * 5);
+    expect(parallelLayout).toEqual(serialLayout);
+
+    const parallelBins = parallelLayout.filter(p => p.startsWith("node_modules/.bin/"));
+    const serialBins = serialLayout.filter(p => p.startsWith("node_modules/.bin/"));
+    expect(parallelBins.length).toBeGreaterThan(0);
+    expect(parallelBins).toEqual(serialBins);
+
+    // summary counts must match.
+    const countFrom = (s: string) => Number(s.match(/(\d+)\s+packages? installed/)?.[1] ?? "0");
+    expect(countFrom(parallel.stdout)).toBe(countFrom(serial.stdout));
+    expect(countFrom(parallel.stdout)).toBe(fixture.count);
+  });
+
+  test("re-routes to the serial download path when a cache entry is missing", async () => {
+    // Warm the cache if the previous test didn't already.
+    await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+    const warm = await install(fixture.dir, env);
+    expect(warm.exitCode).toBe(0);
+
+    // Delete node_modules and blow away a few packages from the cache
+    // so their parallel workers hit ENOENT opening the cache
+    // directory. The result handler must re-enter the serial path,
+    // re-read the tarball, and install the package anyway. Local
+    // tarballs are cached under "@T@<hash>" (see
+    // cachedTarballFolderNamePrint).
+    await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+    const cacheDir = join(fixture.dir, ".bun-cache");
+    const cacheEntries: string[] = [];
+    for await (const entry of new Glob("@T@*").scan({ cwd: cacheDir, onlyFiles: false })) {
+      cacheEntries.push(entry);
+    }
+    expect(cacheEntries.length).toBe(fixture.count);
+    // Remove three of them so multiple workers exercise the fallback.
+    for (const entry of cacheEntries.slice(0, 3)) {
+      await rm(join(cacheDir, entry), { recursive: true, force: true });
+    }
+
+    const out = await install(fixture.dir, env, ["--frozen-lockfile"]);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+
+    // Every package, including the ones whose cache entries were
+    // deleted, must still end up fully installed.
+    const layout = await fingerprintNodeModules(fixture.dir);
+    const paths = new Set(layout.map(e => e.split(" ")[0].replace(/\/$/, "")));
+    for (let i = 0; i < fixture.count; i++) {
+      const name = i % 3 === 0 ? `@scope/pkg-${i}` : `pkg-${i}`;
+      expect(paths.has(join("node_modules", name, "package.json"))).toBe(true);
+      expect(paths.has(join("node_modules", name, "lib", "nested", "a.js"))).toBe(true);
+    }
+    expect(layout.filter(p => p.startsWith("node_modules/.bin/")).length).toBeGreaterThan(0);
+  });
+
+  // Observable difference between the pre-change serial linker and
+  // the parallel one: parallel linking spreads ~1.5k linkat/mkdirat
+  // syscalls across the thread pool, so (user+sys CPU) / wall time
+  // is well above 1 on a multi-core host. The serial linker does
+  // everything on the main thread, so that ratio stays ≈1.0
+  // (background network/extract threads add a little, but with a
+  // warm cache and frozen lockfile there is essentially none).
+  //
+  // Skip on single-core machines where no fan-out is possible, on
+  // debug/ASAN builds where sanitizer + process-startup overhead
+  // swamps the linking work and compresses the ratio toward 1.0
+  // (observed 1.12 on CI's ASAN runner), and on musl — the Alpine
+  // CI runners are CPU-quota-constrained containers where
+  // `navigator.hardwareConcurrency` reports the host's core count
+  // but the cgroup scheduler hands out slices serially, so the
+  // observed ratio collapses even though tasks ARE fanned out to
+  // the thread pool. The deterministic "[ParallelHoistedInstall] N
+  // tasks" marker in the first test already proves the parallel
+  // code path is taken; this test is a performance canary for
+  // unconstrained hosts only.
+  test.skipIf((navigator.hardwareConcurrency ?? 1) < 2 || isDebug || isASAN || isMusl)(
+    "links packages in parallel on the thread pool",
+    async () => {
+      await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+      const warm = await install(fixture.dir, env);
+      expect(warm.exitCode).toBe(0);
+
+      // Best-of-N to smooth over scheduler noise on a busy CI host.
+      const runs = 5;
+      let best = 0;
+      for (let i = 0; i < runs; i++) {
+        await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
+        const r = await install(fixture.dir, env, ["--frozen-lockfile"]);
+        expect(r.stderr).not.toContain("error:");
+        expect(r.exitCode).toBe(0);
+        const cpu = Number(r.usage?.cpuTime.user ?? 0n) + Number(r.usage?.cpuTime.system ?? 0n);
+        best = Math.max(best, cpu / Math.max(1, r.wallMicros));
+      }
+
+      console.log(`cpu/wall (best of ${runs}): ${best.toFixed(2)}`);
+
+      // With the parallel path on a release build: 1.4–2.7 observed
+      // across Linux/macOS CI. Without it (serial linking on the
+      // main thread), the ratio cannot meaningfully exceed ~1.1 —
+      // verified against bun 1.3.12 (1.10–1.16).
+      expect(best).toBeGreaterThan(1.25);
+    },
+  );
+});

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -1,7 +1,7 @@
 import { $, Glob, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { lstat, mkdir, readlink, rm } from "fs/promises";
-import { bunEnv, bunExe, isASAN, isDebug, isMusl, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { join } from "path";
 
 // Parallel hoisted install is POSIX-only (Windows already fans out
@@ -79,7 +79,6 @@ async function fingerprintNodeModules(dir: string): Promise<string[]> {
 }
 
 async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[] = []) {
-  const start = Bun.nanoseconds();
   await using proc = spawn({
     cmd: [bunExe(), "install", "--ignore-scripts", ...extraArgs],
     cwd: dir,
@@ -88,9 +87,7 @@ async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const wallMicros = (Bun.nanoseconds() - start) / 1000;
-  const usage = proc.resourceUsage();
-  return { stdout, stderr, exitCode, wallMicros, usage };
+  return { stdout, stderr, exitCode };
 }
 
 describe.skipIf(!isPosix)("parallel hoisted install", () => {
@@ -216,53 +213,4 @@ describe.skipIf(!isPosix)("parallel hoisted install", () => {
     }
     expect(layout.filter(p => p.startsWith("node_modules/.bin/")).length).toBeGreaterThan(0);
   });
-
-  // Observable difference between the pre-change serial linker and
-  // the parallel one: parallel linking spreads ~1.5k linkat/mkdirat
-  // syscalls across the thread pool, so (user+sys CPU) / wall time
-  // is well above 1 on a multi-core host. The serial linker does
-  // everything on the main thread, so that ratio stays ≈1.0
-  // (background network/extract threads add a little, but with a
-  // warm cache and frozen lockfile there is essentially none).
-  //
-  // Skip on single-core machines where no fan-out is possible, on
-  // debug/ASAN builds where sanitizer + process-startup overhead
-  // swamps the linking work and compresses the ratio toward 1.0
-  // (observed 1.12 on CI's ASAN runner), and on musl — the Alpine
-  // CI runners are CPU-quota-constrained containers where
-  // `navigator.hardwareConcurrency` reports the host's core count
-  // but the cgroup scheduler hands out slices serially, so the
-  // observed ratio collapses even though tasks ARE fanned out to
-  // the thread pool. The deterministic "[ParallelHoistedInstall] N
-  // tasks" marker in the first test already proves the parallel
-  // code path is taken; this test is a performance canary for
-  // unconstrained hosts only.
-  test.skipIf((navigator.hardwareConcurrency ?? 1) < 2 || isDebug || isASAN || isMusl)(
-    "links packages in parallel on the thread pool",
-    async () => {
-      await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
-      const warm = await install(fixture.dir, env);
-      expect(warm.exitCode).toBe(0);
-
-      // Best-of-N to smooth over scheduler noise on a busy CI host.
-      const runs = 5;
-      let best = 0;
-      for (let i = 0; i < runs; i++) {
-        await rm(join(fixture.dir, "node_modules"), { recursive: true, force: true });
-        const r = await install(fixture.dir, env, ["--frozen-lockfile"]);
-        expect(r.stderr).not.toContain("error:");
-        expect(r.exitCode).toBe(0);
-        const cpu = Number(r.usage?.cpuTime.user ?? 0n) + Number(r.usage?.cpuTime.system ?? 0n);
-        best = Math.max(best, cpu / Math.max(1, r.wallMicros));
-      }
-
-      console.log(`cpu/wall (best of ${runs}): ${best.toFixed(2)}`);
-
-      // With the parallel path on a release build: 1.4–2.7 observed
-      // across Linux/macOS CI. Without it (serial linking on the
-      // main thread), the ratio cannot meaningfully exceed ~1.1 —
-      // verified against bun 1.3.12 (1.10–1.16).
-      expect(best).toBeGreaterThan(1.25);
-    },
-  );
 });

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -270,7 +270,7 @@ describe.skipIf(!isPosix)("parallel hoisted install: lifecycle scripts wait for 
     }
 
     let holdLib: Promise<void> | null = null;
-    let libRequested = Promise.withResolvers<void>();
+    let libRequested = Promise.withResolvers<"requested" | "exited">();
     using server = serve({
       port: 0,
       async fetch(req) {
@@ -278,7 +278,7 @@ describe.skipIf(!isPosix)("parallel hoisted install: lifecycle scripts wait for 
         const tgz = path.match(/^\/tarballs\/(.+)\.tgz$/);
         if (tgz) {
           if (tgz[1] === "lib-1.0.0") {
-            libRequested.resolve();
+            libRequested.resolve("requested");
             if (holdLib) await holdLib;
           }
           return new Response(file(join(tarballs, `${tgz[1]}.tgz`)));
@@ -332,23 +332,30 @@ describe.skipIf(!isPosix)("parallel hoisted install: lifecycle scripts wait for 
     // Fresh install with lib missing from the cache: lib's worker reroutes to a download, which we hold.
     const release = Promise.withResolvers<void>();
     holdLib = release.promise;
-    libRequested = Promise.withResolvers<void>();
+    libRequested = Promise.withResolvers<"requested" | "exited">();
     await using proc = spawnInstall(dir, env, ["--frozen-lockfile"]);
-    await libRequested.promise;
-
-    // bun is now blocked on lib. Result replay (where a buggy build spawns the nested postinstall)
-    // finished before it sent this request, so give any such child a scale-aware chance to run:
-    // two sequential bun startups take at least as long as one postinstall that started earlier.
-    for (let i = 0; i < 2; i++) {
-      await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
-      await ref.exited;
+    // Settle-once: if bun dies before asking for lib, fail now with its output instead of hanging.
+    proc.exited.then(() => libRequested.resolve("exited"));
+    if ((await libRequested.promise) === "exited") {
+      const { exitCode, stderr } = await finish(proc);
+      throw new Error(`bun install exited (${exitCode}) before requesting lib:\n${stderr}`);
     }
-    expect(
-      await file(marker).exists(),
-      "scripted@1's postinstall ran while its ancestor tree (root) was still waiting on lib",
-    ).toBe(false);
 
-    release.resolve();
+    try {
+      // bun is now blocked on lib. Result replay (where a buggy build spawns the nested postinstall)
+      // finished before it sent this request, so give any such child a scale-aware chance to run:
+      // two sequential bun startups take at least as long as one postinstall that started earlier.
+      for (let i = 0; i < 2; i++) {
+        await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
+        await ref.exited;
+      }
+      expect(
+        await file(marker).exists(),
+        "scripted@1's postinstall ran while its ancestor tree (root) was still waiting on lib",
+      ).toBe(false);
+    } finally {
+      release.resolve();
+    }
     const out = await finish(proc);
     expect(out.stderr).not.toContain("error:");
     expect(out.exitCode).toBe(0);

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -1,4 +1,4 @@
-import { $, Glob, spawn, write } from "bun";
+import { $, Glob, file, serve, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { lstat, mkdir, readlink, rm } from "fs/promises";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
@@ -78,16 +78,35 @@ async function fingerprintNodeModules(dir: string): Promise<string[]> {
   return entries;
 }
 
-async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[] = []) {
-  await using proc = spawn({
-    cmd: [bunExe(), "install", "--ignore-scripts", ...extraArgs],
+function spawnInstall(dir: string, env: NodeJS.Dict<string>, args: string[]) {
+  return spawn({
+    cmd: [bunExe(), "install", ...args],
     cwd: dir,
     env,
     stdout: "pipe",
     stderr: "pipe",
   });
+}
+
+async function finish(proc: ReturnType<typeof spawnInstall>) {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
+}
+
+async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[] = []) {
+  await using proc = spawnInstall(dir, env, ["--ignore-scripts", ...extraArgs]);
+  return await finish(proc);
+}
+
+/**
+ * Parse the test-only "[ParallelHoistedInstall] N tasks" marker that
+ * complete_parallel_installs() emits under
+ * BUN_INTERNAL_PARALLEL_HOISTED_MARKER. Returns 0 if the marker is
+ * absent (i.e. the parallel path was not taken, or doesn't exist).
+ */
+function parallelTaskCount(stderr: string): number {
+  const m = stderr.match(/\[ParallelHoistedInstall\]\s+(\d+)\s+tasks/);
+  return m ? Number(m[1]) : 0;
 }
 
 describe.skipIf(!isPosix)("parallel hoisted install", () => {
@@ -119,17 +138,6 @@ describe.skipIf(!isPosix)("parallel hoisted install", () => {
   afterAll(async () => {
     if (fixture) await rm(fixture.dir, { recursive: true, force: true });
   });
-
-  /**
-   * Parse the test-only "[ParallelHoistedInstall] N tasks" marker that
-   * completeParallelInstalls() emits under
-   * BUN_INTERNAL_PARALLEL_HOISTED_MARKER. Returns 0 if the marker is
-   * absent (i.e. the parallel path was not taken, or doesn't exist).
-   */
-  function parallelTaskCount(stderr: string): number {
-    const m = stderr.match(/\[ParallelHoistedInstall\]\s+(\d+)\s+tasks/);
-    return m ? Number(m[1]) : 0;
-  }
 
   test("produces identical node_modules to the serial installer", async () => {
     // Warm the cache + generate the lockfile.
@@ -212,5 +220,142 @@ describe.skipIf(!isPosix)("parallel hoisted install", () => {
       expect(paths.has(join("node_modules", name, "lib", "nested", "a.js"))).toBe(true);
     }
     expect(layout.filter(p => p.startsWith("node_modules/.bin/")).length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * A package's lifecycle scripts may only run once every ancestor tree is
+ * installed, because its dependencies can be hoisted into any ancestor.
+ * The serial linker gets this for free from can_install_package_for_tree();
+ * the parallel linker bypasses that gate, so when a root-tree package is
+ * rerouted to a download, a nested tree must not fire its scripts during
+ * result replay while the root package is still in flight.
+ *
+ * Fixture (served from an in-test registry):
+ *   root: lib, app, scripted@2            -> tree 0
+ *   app -> scripted@1 (conflicts with @2) -> nested under app (tree 1)
+ * scripted@1 is trusted and its postinstall touches a marker. `lib` is
+ * evicted from the cache and its tarball response is held, so the marker
+ * can only legitimately appear after the test releases `lib`.
+ */
+describe.skipIf(!isPosix)("parallel hoisted install: lifecycle scripts wait for ancestor trees", () => {
+  test("nested tree's postinstall is deferred until a rerouted root package is installed", async () => {
+    using root = tempDir("parallel-hoisted-scripts", {});
+    const dir = String(root);
+    const cacheDir = join(dir, ".bun-cache");
+    const marker = join(dir, "scripted-postinstall-ran");
+    const tarballs = join(dir, "tarballs");
+    await mkdir(tarballs, { recursive: true });
+
+    type Version = { dependencies?: Record<string, string>; scripts?: Record<string, string> };
+    const registry: Record<string, Record<string, Version>> = {
+      lib: { "1.0.0": {} },
+      app: { "1.0.0": { dependencies: { scripted: "1.0.0" } } },
+      scripted: {
+        "1.0.0": { scripts: { postinstall: `echo ran > ${JSON.stringify(marker)}` } },
+        "2.0.0": {},
+      },
+    };
+    for (const [name, versions] of Object.entries(registry)) {
+      for (const [version, extra] of Object.entries(versions)) {
+        const pkgRoot = join(dir, "src", `${name}-${version}`);
+        await mkdir(join(pkgRoot, "package"), { recursive: true });
+        await write(join(pkgRoot, "package", "package.json"), JSON.stringify({ name, version, ...extra }));
+        await write(
+          join(pkgRoot, "package", "index.js"),
+          `module.exports = ${JSON.stringify(`${name}@${version}`)};\n`,
+        );
+        await $`tar -czf ${join(tarballs, `${name}-${version}.tgz`)} -C ${pkgRoot} package`.quiet();
+      }
+    }
+
+    let holdLib: Promise<void> | null = null;
+    let libRequested = Promise.withResolvers<void>();
+    using server = serve({
+      port: 0,
+      async fetch(req) {
+        const path = new URL(req.url).pathname;
+        const tgz = path.match(/^\/tarballs\/(.+)\.tgz$/);
+        if (tgz) {
+          if (tgz[1] === "lib-1.0.0") {
+            libRequested.resolve();
+            if (holdLib) await holdLib;
+          }
+          return new Response(file(join(tarballs, `${tgz[1]}.tgz`)));
+        }
+        const name = path.slice(1);
+        const versions = registry[name];
+        if (!versions) return new Response("not found", { status: 404 });
+        const body = Object.fromEntries(
+          Object.entries(versions).map(([version, extra]) => [
+            version,
+            { name, version, ...extra, dist: { tarball: `${server.url}tarballs/${name}-${version}.tgz` } },
+          ]),
+        );
+        return Response.json({ name, versions: body, "dist-tags": { latest: Object.keys(versions).at(-1) } });
+      },
+    });
+
+    await write(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "scripts-wait-for-ancestors",
+        version: "1.0.0",
+        dependencies: { lib: "1.0.0", app: "1.0.0", scripted: "2.0.0" },
+        trustedDependencies: ["scripted"],
+      }),
+    );
+    await write(join(dir, "bunfig.toml"), `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\n`);
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_INTERNAL_PARALLEL_HOISTED_MARKER: "1" };
+
+    // Warm install: proves the fixture nests scripted@1 under app and that its postinstall runs at all.
+    {
+      await using proc = spawnInstall(dir, env, []);
+      const warm = await finish(proc);
+      expect(warm.stderr).not.toContain("error:");
+      expect(warm.exitCode).toBe(0);
+    }
+    expect(await file(join(dir, "node_modules", "app", "node_modules", "scripted", "package.json")).exists()).toBe(
+      true,
+    );
+    expect(await file(marker).exists()).toBe(true);
+
+    await rm(marker);
+    await rm(join(dir, "node_modules"), { recursive: true, force: true });
+    const evicted: string[] = [];
+    for await (const entry of new Glob("lib@*").scan({ cwd: cacheDir, onlyFiles: false })) {
+      evicted.push(entry);
+      await rm(join(cacheDir, entry), { recursive: true, force: true });
+    }
+    expect(evicted.length).toBeGreaterThan(0);
+
+    // Fresh install with lib missing from the cache: lib's worker reroutes to a download, which we hold.
+    const release = Promise.withResolvers<void>();
+    holdLib = release.promise;
+    libRequested = Promise.withResolvers<void>();
+    await using proc = spawnInstall(dir, env, ["--frozen-lockfile"]);
+    await libRequested.promise;
+
+    // bun is now blocked on lib. Result replay (where a buggy build spawns the nested postinstall)
+    // finished before it sent this request, so give any such child a scale-aware chance to run:
+    // two sequential bun startups take at least as long as one postinstall that started earlier.
+    for (let i = 0; i < 2; i++) {
+      await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
+      await ref.exited;
+    }
+    expect(
+      await file(marker).exists(),
+      "scripted@1's postinstall ran while its ancestor tree (root) was still waiting on lib",
+    ).toBe(false);
+
+    release.resolve();
+    const out = await finish(proc);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+    // All four packages went through the parallel path; lib's task was the one rerouted.
+    expect(parallelTaskCount(out.stderr)).toBe(4);
+    expect(await file(join(dir, "node_modules", "lib", "package.json")).exists()).toBe(true);
+    // The postinstall still ran, just after lib landed.
+    expect(await file(marker).exists()).toBe(true);
   });
 });

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -267,9 +267,10 @@ async function until(cond: () => Promise<boolean>): Promise<void> {
  *   root: lib, app, scripted@2            -> tree 0
  *   app -> scripted@1 (conflicts with @2) -> nested under app (tree 1)
  * scripted@1 is trusted; its postinstall touches `marker`. Individual tarball
- * responses can be gated (held until released) or merely observed.
+ * responses can be gated (held until released) or merely observed. With
+ * `patched`, scripted@1 has a patch, which keeps it on the serial path.
  */
-async function scriptsFixture() {
+async function scriptsFixture({ patched = false } = {}) {
   const root = tempDir("parallel-hoisted-scripts", {});
   const dir = String(root);
   const cacheDir = join(dir, ".bun-cache");
@@ -325,6 +326,20 @@ async function scriptsFixture() {
     },
   });
 
+  if (patched) {
+    await write(
+      join(dir, "patches", "scripted@1.0.0.patch"),
+      [
+        "diff --git a/index.js b/index.js",
+        "--- a/index.js",
+        "+++ b/index.js",
+        "@@ -1 +1 @@",
+        '-module.exports = "scripted@1.0.0";',
+        '+module.exports = "scripted@1.0.0 (patched)";',
+        "",
+      ].join("\n"),
+    );
+  }
   await write(
     join(dir, "package.json"),
     JSON.stringify({
@@ -332,6 +347,7 @@ async function scriptsFixture() {
       version: "1.0.0",
       dependencies: { lib: "1.0.0", app: "1.0.0", scripted: "2.0.0" },
       trustedDependencies: ["scripted"],
+      ...(patched ? { patchedDependencies: { "scripted@1.0.0": "patches/scripted@1.0.0.patch" } } : {}),
     }),
   );
   await write(join(dir, "bunfig.toml"), `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\n`);
@@ -482,5 +498,28 @@ describe.concurrent.skipIf(!isPosix)("parallel hoisted install: rerouted downloa
     expect(await file(fx.nested).exists()).toBe(true);
     expect(installedCount(out.stdout)).toBe(expected);
     expect(await file(fx.marker).exists(), "scripted@1 was installed but its result was never handled").toBe(true);
+  });
+
+  /**
+   * A package can also park in pending_installs during the tree walk itself: the patched
+   * scripted@1 takes the serial path while root is still waiting on its parallel tasks. Root then
+   * completes during replay, which (as a pending install) does not drain, so the forced drain that
+   * follows replay has to install, count and run the scripts of the parked package.
+   */
+  test("a package parked during the tree walk is installed after replay", async () => {
+    using fx = await scriptsFixture({ patched: true });
+    const expected = await fx.warmThenEvict();
+
+    await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile"]);
+    const out = await finish(proc);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+    // lib, app and scripted@2; the patched scripted@1 is linked serially.
+    expect(parallelTaskCount(out.stderr)).toBe(3);
+    expect(await file(join(fx.dir, "node_modules", "app", "node_modules", "scripted", "index.js")).text()).toContain(
+      "(patched)",
+    );
+    expect(installedCount(out.stdout)).toBe(expected);
+    expect(await file(fx.marker).exists(), "scripted@1 was parked in pending_installs and never drained").toBe(true);
   });
 });

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -421,6 +421,32 @@ describe.concurrent.skipIf(!isPosix)("parallel hoisted install: rerouted downloa
   });
 
   /**
+   * The serial path treats a cache entry without its completion marker
+   * (package.json for npm) as a miss. The worker must too, rather than
+   * linking whatever partial contents the entry holds.
+   */
+  test("an entry missing its completion marker is re-downloaded, not linked", async () => {
+    using fx = await scriptsFixture();
+    const expected = await fx.warmThenEvict();
+    // Keep lib's entry but strip its marker, leaving the rest of its files in place.
+    let stripped = 0;
+    for await (const entry of new Glob("lib@*").scan({ cwd: fx.cacheDir, onlyFiles: false })) {
+      await rm(join(fx.cacheDir, entry, "package.json"));
+      stripped++;
+    }
+    expect(stripped).toBeGreaterThan(0);
+
+    await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile"]);
+    const out = await finish(proc);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+    expect(parallelTaskCount(out.stderr)).toBe(4);
+    // Re-downloaded: the installed copy has the file the cache entry lacked.
+    expect(await file(join(fx.dir, "node_modules", "lib", "package.json")).exists()).toBe(true);
+    expect(installedCount(out.stdout)).toBe(expected);
+  });
+
+  /**
    * Misses in two trees. The nested package downloads first but cannot
    * install until root is complete, so it parks in pending_installs; when
    * `lib` lands and completes root, the drain re-enters it with

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -104,6 +104,10 @@ async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[
  * BUN_INTERNAL_PARALLEL_HOISTED_MARKER. Returns 0 if the marker is
  * absent (i.e. the parallel path was not taken, or doesn't exist).
  */
+function installedCount(stdout: string): number {
+  return Number(stdout.match(/(\d+)\s+packages? installed/)?.[1] ?? "0");
+}
+
 function parallelTaskCount(stderr: string): number {
   const m = stderr.match(/\[ParallelHoistedInstall\]\s+(\d+)\s+tasks/);
   return m ? Number(m[1]) : 0;
@@ -177,9 +181,8 @@ describe.skipIf(!isPosix)("parallel hoisted install", () => {
     expect(parallelBins).toEqual(serialBins);
 
     // summary counts must match.
-    const countFrom = (s: string) => Number(s.match(/(\d+)\s+packages? installed/)?.[1] ?? "0");
-    expect(countFrom(parallel.stdout)).toBe(countFrom(serial.stdout));
-    expect(countFrom(parallel.stdout)).toBe(fixture.count);
+    expect(installedCount(parallel.stdout)).toBe(installedCount(serial.stdout));
+    expect(installedCount(parallel.stdout)).toBe(fixture.count);
   });
 
   test("re-routes to the serial download path when a cache entry is missing", async () => {
@@ -223,146 +226,213 @@ describe.skipIf(!isPosix)("parallel hoisted install", () => {
   });
 });
 
+const EXITED = Symbol("exited");
+
+/** Await `event`, but if bun exits first, fail immediately with its output instead of hanging. */
+async function orExit<T>(event: Promise<T>, proc: ReturnType<typeof spawnInstall>, what: string): Promise<T> {
+  const r = Promise.withResolvers<T | typeof EXITED>();
+  event.then(r.resolve);
+  proc.exited.then(() => r.resolve(EXITED));
+  const v = await r.promise;
+  if (v === EXITED) {
+    const { exitCode, stderr } = await finish(proc);
+    throw new Error(`bun install exited (${exitCode}) before ${what}:\n${stderr}`);
+  }
+  return v;
+}
+
+/** Let anything bun already spawned or scheduled run: two bun startups outlast one such step. */
+async function settle() {
+  for (let i = 0; i < 2; i++) {
+    await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
+    await ref.exited;
+  }
+}
+
 /**
- * A package's lifecycle scripts may only run once every ancestor tree is
- * installed, because its dependencies can be hoisted into any ancestor.
- * The serial linker gets this for free from can_install_package_for_tree();
- * the parallel linker bypasses that gate, so when a root-tree package is
- * rerouted to a download, a nested tree must not fire its scripts during
- * result replay while the root package is still in flight.
- *
- * Fixture (served from an in-test registry):
+ * Registry served from the test:
  *   root: lib, app, scripted@2            -> tree 0
  *   app -> scripted@1 (conflicts with @2) -> nested under app (tree 1)
- * scripted@1 is trusted and its postinstall touches a marker. `lib` is
- * evicted from the cache and its tarball response is held, so the marker
- * can only legitimately appear after the test releases `lib`.
+ * scripted@1 is trusted; its postinstall touches `marker`. Individual tarball
+ * responses can be gated (held until released) or merely observed.
  */
-describe.skipIf(!isPosix)("parallel hoisted install: lifecycle scripts wait for ancestor trees", () => {
-  test("nested tree's postinstall is deferred until a rerouted root package is installed", async () => {
-    using root = tempDir("parallel-hoisted-scripts", {});
-    const dir = String(root);
-    const cacheDir = join(dir, ".bun-cache");
-    const marker = join(dir, "scripted-postinstall-ran");
-    const tarballs = join(dir, "tarballs");
-    await mkdir(tarballs, { recursive: true });
+async function scriptsFixture() {
+  const root = tempDir("parallel-hoisted-scripts", {});
+  const dir = String(root);
+  const cacheDir = join(dir, ".bun-cache");
+  const marker = join(dir, "scripted-postinstall-ran");
+  const tarballs = join(dir, "tarballs");
+  await mkdir(tarballs, { recursive: true });
 
-    type Version = { dependencies?: Record<string, string>; scripts?: Record<string, string> };
-    const registry: Record<string, Record<string, Version>> = {
-      lib: { "1.0.0": {} },
-      app: { "1.0.0": { dependencies: { scripted: "1.0.0" } } },
-      scripted: {
-        "1.0.0": { scripts: { postinstall: `echo ran > ${JSON.stringify(marker)}` } },
-        "2.0.0": {},
-      },
-    };
-    for (const [name, versions] of Object.entries(registry)) {
-      for (const [version, extra] of Object.entries(versions)) {
-        const pkgRoot = join(dir, "src", `${name}-${version}`);
-        await mkdir(join(pkgRoot, "package"), { recursive: true });
-        await write(join(pkgRoot, "package", "package.json"), JSON.stringify({ name, version, ...extra }));
-        await write(
-          join(pkgRoot, "package", "index.js"),
-          `module.exports = ${JSON.stringify(`${name}@${version}`)};\n`,
-        );
-        await $`tar -czf ${join(tarballs, `${name}-${version}.tgz`)} -C ${pkgRoot} package`.quiet();
-      }
+  type Version = { dependencies?: Record<string, string>; scripts?: Record<string, string> };
+  const registry: Record<string, Record<string, Version>> = {
+    lib: { "1.0.0": {} },
+    app: { "1.0.0": { dependencies: { scripted: "1.0.0" } } },
+    scripted: {
+      "1.0.0": { scripts: { postinstall: `echo ran > ${JSON.stringify(marker)}` } },
+      "2.0.0": {},
+    },
+  };
+  for (const [name, versions] of Object.entries(registry)) {
+    for (const [version, extra] of Object.entries(versions)) {
+      const pkgRoot = join(dir, "src", `${name}-${version}`);
+      await mkdir(join(pkgRoot, "package"), { recursive: true });
+      await write(join(pkgRoot, "package", "package.json"), JSON.stringify({ name, version, ...extra }));
+      await write(join(pkgRoot, "package", "index.js"), `module.exports = ${JSON.stringify(`${name}@${version}`)};\n`);
+      await $`tar -czf ${join(tarballs, `${name}-${version}.tgz`)} -C ${pkgRoot} package`.quiet();
     }
+  }
 
-    let holdLib: Promise<void> | null = null;
-    let libRequested = Promise.withResolvers<"requested" | "exited">();
-    using server = serve({
-      port: 0,
-      async fetch(req) {
-        const path = new URL(req.url).pathname;
-        const tgz = path.match(/^\/tarballs\/(.+)\.tgz$/);
-        if (tgz) {
-          if (tgz[1] === "lib-1.0.0") {
-            libRequested.resolve("requested");
-            if (holdLib) await holdLib;
-          }
-          return new Response(file(join(tarballs, `${tgz[1]}.tgz`)));
+  const gates = new Map<string, { requested: PromiseWithResolvers<void>; release: PromiseWithResolvers<void> }>();
+  const observers = new Map<string, PromiseWithResolvers<void>>();
+  const server = serve({
+    port: 0,
+    async fetch(req) {
+      const path = new URL(req.url).pathname;
+      const tgz = path.match(/^\/tarballs\/(.+)\.tgz$/);
+      if (tgz) {
+        const gate = gates.get(tgz[1]);
+        if (gate) {
+          gate.requested.resolve();
+          await gate.release.promise;
         }
-        const name = path.slice(1);
-        const versions = registry[name];
-        if (!versions) return new Response("not found", { status: 404 });
-        const body = Object.fromEntries(
-          Object.entries(versions).map(([version, extra]) => [
-            version,
-            { name, version, ...extra, dist: { tarball: `${server.url}tarballs/${name}-${version}.tgz` } },
-          ]),
-        );
-        return Response.json({ name, versions: body, "dist-tags": { latest: Object.keys(versions).at(-1) } });
-      },
-    });
+        observers.get(tgz[1])?.resolve();
+        return new Response(file(join(tarballs, `${tgz[1]}.tgz`)));
+      }
+      const name = path.slice(1);
+      const versions = registry[name];
+      if (!versions) return new Response("not found", { status: 404 });
+      const body = Object.fromEntries(
+        Object.entries(versions).map(([version, extra]) => [
+          version,
+          { name, version, ...extra, dist: { tarball: `${server.url}tarballs/${name}-${version}.tgz` } },
+        ]),
+      );
+      return Response.json({ name, versions: body, "dist-tags": { latest: Object.keys(versions).at(-1) } });
+    },
+  });
 
-    await write(
-      join(dir, "package.json"),
-      JSON.stringify({
-        name: "scripts-wait-for-ancestors",
-        version: "1.0.0",
-        dependencies: { lib: "1.0.0", app: "1.0.0", scripted: "2.0.0" },
-        trustedDependencies: ["scripted"],
-      }),
-    );
-    await write(join(dir, "bunfig.toml"), `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\n`);
-    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_INTERNAL_PARALLEL_HOISTED_MARKER: "1" };
+  await write(
+    join(dir, "package.json"),
+    JSON.stringify({
+      name: "scripts-fixture",
+      version: "1.0.0",
+      dependencies: { lib: "1.0.0", app: "1.0.0", scripted: "2.0.0" },
+      trustedDependencies: ["scripted"],
+    }),
+  );
+  await write(join(dir, "bunfig.toml"), `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\n`);
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_INTERNAL_PARALLEL_HOISTED_MARKER: "1" };
 
-    // Warm install: proves the fixture nests scripted@1 under app and that its postinstall runs at all.
-    {
+  return {
+    dir,
+    cacheDir,
+    marker,
+    env,
+    nested: join(dir, "node_modules", "app", "node_modules", "scripted", "package.json"),
+    /** Hold `tarball` once requested; returns when it was requested plus a release() */
+    gate(tarball: string) {
+      const g = { requested: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
+      gates.set(tarball, g);
+      return { requested: g.requested.promise, release: () => g.release.resolve() };
+    },
+    /** Resolves once `tarball` has been handed to bun. */
+    served(tarball: string) {
+      const o = Promise.withResolvers<void>();
+      observers.set(tarball, o);
+      return o.promise;
+    },
+    /** Warm install with scripts on, then clear node_modules + marker and evict the given cache globs. */
+    async warmThenEvict(...globs: string[]) {
       await using proc = spawnInstall(dir, env, []);
       const warm = await finish(proc);
       expect(warm.stderr).not.toContain("error:");
       expect(warm.exitCode).toBe(0);
-    }
-    expect(await file(join(dir, "node_modules", "app", "node_modules", "scripted", "package.json")).exists()).toBe(
-      true,
-    );
-    expect(await file(marker).exists()).toBe(true);
-
-    await rm(marker);
-    await rm(join(dir, "node_modules"), { recursive: true, force: true });
-    const evicted: string[] = [];
-    for await (const entry of new Glob("lib@*").scan({ cwd: cacheDir, onlyFiles: false })) {
-      evicted.push(entry);
-      await rm(join(cacheDir, entry), { recursive: true, force: true });
-    }
-    expect(evicted.length).toBeGreaterThan(0);
-
-    // Fresh install with lib missing from the cache: lib's worker reroutes to a download, which we hold.
-    const release = Promise.withResolvers<void>();
-    holdLib = release.promise;
-    libRequested = Promise.withResolvers<"requested" | "exited">();
-    await using proc = spawnInstall(dir, env, ["--frozen-lockfile"]);
-    // Settle-once: if bun dies before asking for lib, fail now with its output instead of hanging.
-    proc.exited.then(() => libRequested.resolve("exited"));
-    if ((await libRequested.promise) === "exited") {
-      const { exitCode, stderr } = await finish(proc);
-      throw new Error(`bun install exited (${exitCode}) before requesting lib:\n${stderr}`);
-    }
-
-    try {
-      // bun is now blocked on lib. Result replay (where a buggy build spawns the nested postinstall)
-      // finished before it sent this request, so give any such child a scale-aware chance to run:
-      // two sequential bun startups take at least as long as one postinstall that started earlier.
-      for (let i = 0; i < 2; i++) {
-        await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
-        await ref.exited;
+      expect(await file(this.nested).exists()).toBe(true);
+      expect(await file(marker).exists()).toBe(true);
+      await rm(marker);
+      await rm(join(dir, "node_modules"), { recursive: true, force: true });
+      for (const pattern of globs) {
+        let hits = 0;
+        for await (const entry of new Glob(pattern).scan({ cwd: cacheDir, onlyFiles: false })) {
+          hits++;
+          await rm(join(cacheDir, entry), { recursive: true, force: true });
+        }
+        expect(hits, `cache glob ${pattern} matched nothing`).toBeGreaterThan(0);
       }
+      return installedCount(warm.stdout);
+    },
+    [Symbol.dispose]() {
+      server.stop(true);
+      root[Symbol.dispose]();
+    },
+  };
+}
+
+describe.skipIf(!isPosix)("parallel hoisted install: rerouted downloads", () => {
+  /**
+   * A package's lifecycle scripts may only run once every ancestor tree is
+   * installed, because its dependencies can be hoisted into any ancestor.
+   * The serial linker gets this from can_install_package_for_tree(); the
+   * parallel linker bypasses that gate, so a nested tree must not fire its
+   * scripts during result replay while a rerouted root package is still in
+   * flight. `lib`'s tarball is held, so the marker can only legitimately
+   * appear after the test releases it.
+   */
+  test("nested tree's postinstall is deferred until a rerouted root package is installed", async () => {
+    using fx = await scriptsFixture();
+    await fx.warmThenEvict("lib@*");
+
+    const lib = fx.gate("lib-1.0.0");
+    await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile"]);
+    await orExit(lib.requested, proc, "requesting lib");
+    try {
+      // Replay (where a buggy build spawns the postinstall) finished before this request was sent.
+      await settle();
       expect(
-        await file(marker).exists(),
+        await file(fx.marker).exists(),
         "scripted@1's postinstall ran while its ancestor tree (root) was still waiting on lib",
       ).toBe(false);
     } finally {
-      release.resolve();
+      lib.release();
     }
     const out = await finish(proc);
     expect(out.stderr).not.toContain("error:");
     expect(out.exitCode).toBe(0);
-    // All four packages went through the parallel path; lib's task was the one rerouted.
     expect(parallelTaskCount(out.stderr)).toBe(4);
-    expect(await file(join(dir, "node_modules", "lib", "package.json")).exists()).toBe(true);
-    // The postinstall still ran, just after lib landed.
-    expect(await file(marker).exists()).toBe(true);
+    expect(await file(join(fx.dir, "node_modules", "lib", "package.json")).exists()).toBe(true);
+    expect(await file(fx.marker).exists()).toBe(true);
+  });
+
+  /**
+   * Misses in two trees. The nested package downloads first but cannot
+   * install until root is complete, so it parks in pending_installs; when
+   * `lib` lands and completes root, the drain re-enters it with
+   * NEEDS_VERIFY (re-verification since #36298). That re-entry must install
+   * serially: a parallel task created after complete_parallel_installs() is
+   * never replayed, so the package would be linked but never counted, bin
+   * linked, or have its scripts run.
+   */
+  test("a package drained from pending_installs after replay is fully installed", async () => {
+    using fx = await scriptsFixture();
+    const expected = await fx.warmThenEvict("lib@*", "scripted@1.0.0*");
+
+    const lib = fx.gate("lib-1.0.0");
+    const nestedServed = fx.served("scripted-1.0.0");
+    await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile"]);
+    try {
+      await orExit(Promise.all([lib.requested, nestedServed]), proc, "downloading the evicted packages");
+      // Let scripted@1 extract and park in pending_installs before root can complete.
+      await settle();
+    } finally {
+      lib.release();
+    }
+    const out = await finish(proc);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+    expect(parallelTaskCount(out.stderr)).toBe(4);
+    expect(await file(fx.nested).exists()).toBe(true);
+    expect(installedCount(out.stdout)).toBe(expected);
+    expect(await file(fx.marker).exists(), "scripted@1 was installed but its result was never handled").toBe(true);
   });
 });

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -1,6 +1,6 @@
 import { $, Glob, file, serve, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { lstat, mkdir, readlink, rm } from "fs/promises";
+import { lstat, mkdir, readlink, rm, stat } from "fs/promises";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { join } from "path";
 
@@ -268,9 +268,10 @@ async function until(cond: () => Promise<boolean>): Promise<void> {
  *   app -> scripted@1 (conflicts with @2) -> nested under app (tree 1)
  * scripted@1 is trusted; its postinstall touches `marker`. Individual tarball
  * responses can be gated (held until released) or merely observed. With
- * `patched`, scripted@1 has a patch, which keeps it on the serial path.
+ * `patched`, scripted@1 has a patch, which keeps it on the serial path. With
+ * `selfContained`, the workspace apps/desktop (-> lib, tree 2) is self-contained.
  */
-async function scriptsFixture({ patched = false } = {}) {
+async function scriptsFixture({ patched = false, selfContained = false } = {}) {
   const root = tempDir("parallel-hoisted-scripts", {});
   const dir = String(root);
   const cacheDir = join(dir, ".bun-cache");
@@ -340,6 +341,12 @@ async function scriptsFixture({ patched = false } = {}) {
       ].join("\n"),
     );
   }
+  if (selfContained) {
+    await write(
+      join(dir, "apps", "desktop", "package.json"),
+      JSON.stringify({ name: "desktop", version: "1.0.0", dependencies: { lib: "1.0.0" } }),
+    );
+  }
   await write(
     join(dir, "package.json"),
     JSON.stringify({
@@ -348,9 +355,14 @@ async function scriptsFixture({ patched = false } = {}) {
       dependencies: { lib: "1.0.0", app: "1.0.0", scripted: "2.0.0" },
       trustedDependencies: ["scripted"],
       ...(patched ? { patchedDependencies: { "scripted@1.0.0": "patches/scripted@1.0.0.patch" } } : {}),
+      ...(selfContained ? { workspaces: { packages: ["apps/*"], selfContained: ["apps/desktop"] } } : {}),
     }),
   );
-  await write(join(dir, "bunfig.toml"), `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\n`);
+  // Workspaces default to the isolated linker; this file is about the hoisted one.
+  await write(
+    join(dir, "bunfig.toml"),
+    `[install]\ncache = "${cacheDir}"\nregistry = "${server.url}"\nlinker = "hoisted"\n`,
+  );
   const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir, BUN_INTERNAL_PARALLEL_HOISTED_MARKER: "1" };
 
   return {
@@ -359,6 +371,7 @@ async function scriptsFixture({ patched = false } = {}) {
     marker,
     env,
     nested: join(dir, "node_modules", "app", "node_modules", "scripted", "package.json"),
+    workspaceNodeModules: join(dir, "apps", "desktop", "node_modules"),
     async cacheHas(pattern: string): Promise<boolean> {
       for await (const _ of new Glob(pattern).scan({ cwd: cacheDir, onlyFiles: false })) return true;
       return false;
@@ -385,6 +398,7 @@ async function scriptsFixture({ patched = false } = {}) {
       expect(await file(marker).exists()).toBe(true);
       await rm(marker);
       await rm(join(dir, "node_modules"), { recursive: true, force: true });
+      await rm(this.workspaceNodeModules, { recursive: true, force: true });
       for (const pattern of globs) {
         let hits = 0;
         for await (const entry of new Glob(pattern).scan({ cwd: cacheDir, onlyFiles: false })) {
@@ -521,5 +535,27 @@ describe.concurrent.skipIf(!isPosix)("parallel hoisted install: rerouted downloa
     );
     expect(installedCount(out.stdout)).toBe(expected);
     expect(await file(fx.marker).exists(), "scripted@1 was parked in pending_installs and never drained").toBe(true);
+  });
+
+  /**
+   * A self-contained workspace's trees are in `copy_trees`: the serial linker copies their packages
+   * instead of linking them from the cache, so that tools which rewrite that node_modules in place
+   * cannot reach the cache. A worker has to make the same choice for the tree it was enqueued for.
+   * --backend=hardlink makes the link counts meaningful on macOS too, where clonefile also gives 1.
+   */
+  test("a self-contained workspace gets copies, not links, from the parallel path", async () => {
+    using fx = await scriptsFixture({ selfContained: true });
+    const expected = await fx.warmThenEvict();
+
+    await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile", "--backend=hardlink"]);
+    const out = await finish(proc);
+    expect(out.stderr).not.toContain("error:");
+    expect(out.exitCode).toBe(0);
+    // root: lib, app, scripted@2; app: scripted@1; desktop: lib. The workspace link itself is serial.
+    expect(parallelTaskCount(out.stderr)).toBe(5);
+    expect(installedCount(out.stdout)).toBe(expected);
+    // The root's copy is a hardlink from the cache; the workspace's is a real file.
+    expect((await stat(join(fx.dir, "node_modules", "lib", "package.json"))).nlink).toBeGreaterThan(1);
+    expect((await stat(join(fx.workspaceNodeModules, "lib", "package.json"))).nlink).toBe(1);
   });
 });

--- a/test/cli/install/parallel-hoisted-install.test.ts
+++ b/test/cli/install/parallel-hoisted-install.test.ts
@@ -98,16 +98,17 @@ async function install(dir: string, env: NodeJS.Dict<string>, extraArgs: string[
   return await finish(proc);
 }
 
+/** Parse the "N packages installed" summary line from stdout. */
+function installedCount(stdout: string): number {
+  return Number(stdout.match(/(\d+)\s+packages? installed/)?.[1] ?? "0");
+}
+
 /**
  * Parse the test-only "[ParallelHoistedInstall] N tasks" marker that
  * complete_parallel_installs() emits under
  * BUN_INTERNAL_PARALLEL_HOISTED_MARKER. Returns 0 if the marker is
  * absent (i.e. the parallel path was not taken, or doesn't exist).
  */
-function installedCount(stdout: string): number {
-  return Number(stdout.match(/(\d+)\s+packages? installed/)?.[1] ?? "0");
-}
-
 function parallelTaskCount(stderr: string): number {
   const m = stderr.match(/\[ParallelHoistedInstall\]\s+(\d+)\s+tasks/);
   return m ? Number(m[1]) : 0;
@@ -241,12 +242,24 @@ async function orExit<T>(event: Promise<T>, proc: ReturnType<typeof spawnInstall
   return v;
 }
 
-/** Let anything bun already spawned or scheduled run: two bun startups outlast one such step. */
-async function settle() {
+/**
+ * Bounded poll for `path` appearing. From outside, "bun never spawned the script" and "bun spawned
+ * it and it has not written yet" look identical, so the only evidence of a regression is the file
+ * itself. The bound is two bun startups, which outlast an `echo` that was spawned before the poll
+ * began, so it scales with the machine instead of being a wall-clock sleep.
+ */
+async function appearsWithinBound(path: string): Promise<boolean> {
   for (let i = 0; i < 2; i++) {
+    if (await file(path).exists()) return true;
     await using ref = spawn({ cmd: [bunExe(), "-e", "0"], env: bunEnv, stdout: "ignore", stderr: "ignore" });
     await ref.exited;
   }
+  return file(path).exists();
+}
+
+/** Resolve once `cond` holds; callers race this against process exit via orExit(). */
+async function until(cond: () => Promise<boolean>): Promise<void> {
+  while (!(await cond())) await Bun.sleep(5);
 }
 
 /**
@@ -330,6 +343,10 @@ async function scriptsFixture() {
     marker,
     env,
     nested: join(dir, "node_modules", "app", "node_modules", "scripted", "package.json"),
+    async cacheHas(pattern: string): Promise<boolean> {
+      for await (const _ of new Glob(pattern).scan({ cwd: cacheDir, onlyFiles: false })) return true;
+      return false;
+    },
     /** Hold `tarball` once requested; returns when it was requested plus a release() */
     gate(tarball: string) {
       const g = { requested: Promise.withResolvers<void>(), release: Promise.withResolvers<void>() };
@@ -369,7 +386,7 @@ async function scriptsFixture() {
   };
 }
 
-describe.skipIf(!isPosix)("parallel hoisted install: rerouted downloads", () => {
+describe.concurrent.skipIf(!isPosix)("parallel hoisted install: rerouted downloads", () => {
   /**
    * A package's lifecycle scripts may only run once every ancestor tree is
    * installed, because its dependencies can be hoisted into any ancestor.
@@ -388,9 +405,8 @@ describe.skipIf(!isPosix)("parallel hoisted install: rerouted downloads", () => 
     await orExit(lib.requested, proc, "requesting lib");
     try {
       // Replay (where a buggy build spawns the postinstall) finished before this request was sent.
-      await settle();
       expect(
-        await file(fx.marker).exists(),
+        await appearsWithinBound(fx.marker),
         "scripted@1's postinstall ran while its ancestor tree (root) was still waiting on lib",
       ).toBe(false);
     } finally {
@@ -422,8 +438,14 @@ describe.skipIf(!isPosix)("parallel hoisted install: rerouted downloads", () => 
     await using proc = spawnInstall(fx.dir, fx.env, ["--frozen-lockfile"]);
     try {
       await orExit(Promise.all([lib.requested, nestedServed]), proc, "downloading the evicted packages");
-      // Let scripted@1 extract and park in pending_installs before root can complete.
-      await settle();
+      // Once scripted@1 is back in the cache its extraction has completed, so its install attempt is
+      // queued ahead of lib's (which has yet to download and extract): it will park in
+      // pending_installs before root can complete, whenever lib is released after this point.
+      await orExit(
+        until(() => fx.cacheHas("scripted@1.0.0*")),
+        proc,
+        "re-extracting scripted@1",
+      );
     } finally {
       lib.release();
     }


### PR DESCRIPTION
## What

Parallelize the hoisted `node_modules` linker when `node_modules` is being created fresh (the CI / fresh-clone scenario: lockfile present, cache warm, `node_modules` deleted). Previously every package was hardlinked from the cache into `node_modules` **serially on the main thread**; this PR fans each cached package out to the existing thread pool.

> This PR was originally written against the Zig sources; after the Rust rewrite landed on main it was re-implemented 1:1 in `src/install/PackageInstaller.rs` / `hoisted_install.rs`. The design, gating conditions, and test suite are unchanged from the reviewed Zig version. Later rebases folded main's changes to the extracted `handle_install_result()` back in. Rather than hand-patch, each rebase regenerates the method body from main's current inline block (the same verbatim extraction reviewers verified) and diffs it; changes absorbed so far: the transitive `file:`-folder error branch (#33159); the EACCES `err_tag` -> `err` markup conversions (#33245); `trusted_dependencies_from_update_requests` re-keyed by `PackageID` and trusted-dep recording using the package name rather than the alias for npm deps; `should_ignore_lifecycle_scripts` dropping its tree-id argument; and the move to the per-crate `crate::Error` enum (#33909), under which `DanglingSymlink` is a variant and EACCES matches `Sys(EACCES) | AccessDenied`. Upstream drift in this PR's own code was limited to the removed `PackageInstall.file_count` field, `DrainClosure` adopting `crate::Error` like its sibling, and `pub(crate)` narrowing (#36184). The fourth rebase (onto #39597) additionally: removed `LazyPackageDestinationDir`, which main deleted and which a keep-ours resolution had resurrected, so the extracted method now takes the destination fd directly like main's inline code; and absorbed #36298, which made the pending-install drain re-verify (`NEEDS_VERIFY = true`). The parallel enqueue had used `NEEDS_VERIFY` as its entry-point check, so after that change a package drained from `pending_installs` during a reroute would have become a thread-pool task created after `complete_parallel_installs()`, which nothing replays. The enqueue now also requires `!IS_PENDING_PACKAGE_INSTALL` (only the tree loop creates tasks), `hoisted_install` asserts in debug builds that no task survives the replay, and a test covers the two-tree-miss case (it exits 134 on that assertion with the old condition). The fifth rebase absorbed #39770, which turned `install_package_with_name_and_resolution`'s two const generics into runtime `bool` parameters: the enqueue gate is now `needs_verify && !is_pending_package_install` and the reroute replay names both flags with locals, as main's other call sites do; the invariant is unchanged and the two-tree test exercises it. The sixth rebase (onto #40014 and #40010) found one interaction: #40014 gives the hoisted linker a per-tree `copy_trees` set, and packages in a self-contained workspace's trees are copied with the `copyfile` backend instead of linked from the cache. The worker chose its backend alone and would have hardlinked those trees, so each task now records at enqueue whether its tree is a copy tree and the worker picks `Copyfile` for it (`is_copy_tree()` is shared with the serial site); a test warms the cache, clears both `node_modules` and checks the link counts. #40010's `--offline` handling lives in the enqueue helpers that the reroute replay already goes through, so a worker's cache miss under `--offline` reports `--offline: "x" is not in the cache` exactly like the serial path (checked by hand, and main's offline suite passes).


## Why

[aube](https://github.com/endevco/aube)'s published benchmarks show Bun ~3× slower than aube on warm-cache CI install (416ms vs 139ms). Profiling with `strace -c -f` on their fixture (~1,200 packages, ~42,000 files) shows:

| | syscalls | shape |
|---|---|---|
| **bun (before)** | 42,101 `linkat` + 11,576 `getdents64` + 10,233 `openat` + 6,114 `mkdirat` + 8,641 `close` ≈ **80k** | **single-threaded** — wall ≈ sys time |
| **aube** | 2,468 `symlink` + 10,415 `statx` + 3,854 `openat` ≈ **26k** | spread across 6+ rayon workers |

aube's default is a pnpm-style *isolated* layout with a global virtual store: once warm, "installing" is one `symlink` per package into `node_modules/.aube/<dep>` plus one per direct dep — no per-file work. Bun's default is a real *hoisted* `node_modules` (42k files). The outputs aren't equivalent, but the serial loop was the low-hanging fruit either way.

The isolated installer (`nodeLinker=isolated`) already runs per-package tasks on `manager.thread_pool`; this brings the same pattern to hoisted.

## How

- `ParallelHoistedTask` owns copies of `node_modules_path` / `destination_dir_subpath` / `cache_dir_subpath`, opens the tree's `node_modules` dir on a worker, and calls `PackageInstall.install(skip_delete=true, …)`.
- Tasks are batched per tree and flushed via `scheduleParallelBatch()` so workers start as soon as the root tree is enumerated.
- After the tree loop, `completeParallelInstalls()` waits on a `WaitGroup`, then runs the existing result handling (summary, `.bin` linking, lifecycle scripts, tree-install counts) serially on the main thread — extracted into `handleInstallResult()` so both the serial and parallel paths share it.
- The up-front `packageMissingFromCache()` `faccessat` (1,230 calls on the main thread) moves onto the workers: each runs the same `is_package_in_cache_at()` check (npm `package.json` / git `.bun-tag` completion markers, directory existence for other tags) before linking, and an entry that fails it, or that turns out to be gone when opened, is flagged `missing_from_cache` and re-routed through the serial download/extract path on the main thread. Tasks are only ever created from the tree loop (`needs_verify && !is_pending_package_install`); the reroute replay, the post-download path, and the `pending_installs` drain all install serially, since `complete_parallel_installs()` is the only thing that replays tasks.
- `install()` can run on workers and writes the process-wide install method on EXDEV / `OPNOTSUPP` fallback; that global was already an atomic on main by the time of the Rust port, so this PR only relies on it. Workers also never touch the lockfile: `PackageInstall.lockfile` is now `Option`, read only by `verify()` and Folder installs, and workers pass `None`.
- Parallel tasks are enqueued before `can_install_package_for_tree()`, so nested trees no longer wait for their ancestors to be installed first. That gate was only documented as protecting the rename-aside step (irrelevant with `skip_delete`), but it was also what kept a tree from completing, and so running its lifecycle scripts, before the ancestor trees its dependencies may be hoisted into were on disk. `can_run_scripts()` now checks the ancestors explicitly (a no-op for the serial linker), and a test covers the reroute case that exposed it.
- Gated on POSIX + fresh `node_modules` (`skip_delete`). Windows already fans out per-file via `HardLinkWindowsInstallTask`. Workspaces / folder deps / patched packages / `--backend=symlink` fall through to the existing serial path.
- Known cost of releasing trees without a barrier: a nested-tree worker's `make_path()` can create its parent package's directory before the parent's own worker runs. On macOS that package then takes `install_with_clonefile()`'s EEXIST fallback (per-file clones instead of one whole-directory clone); Linux's hardlink path is unaffected, and the result is identical either way. It only affects packages that are hoist points for a nested tree, and only when the race lands. Sequencing the batches per tree would remove it (and would restore the ancestor invariant structurally, making the `can_run_scripts()` check belt-and-braces) at the cost of a join per tree; left as is pending the design review, easy to switch if preferred.
- `BUN_INSTALL_SERIAL_HOISTED=1` forces the old serial path for comparison / debugging.

## Results

6-core Linux (overlayfs), aube's `benchmarks/fixture.package.json`, `hyperfine --warmup 3 --runs 12`:

| Scenario | bun canary | bun (this PR) | aube 1.0.0-beta.5 |
|---|---|---|---|
| CI install, warm cache | 917ms | **271ms** (3.4× faster) | 206ms |
| `add is-odd` | 911ms | **275ms** (3.3× faster) | 439ms (**1.6× slower than bun**) |
| CI install, cold cache | — | — | bun already won in aube's own numbers (935ms vs 1120ms) |

Main-thread strace after the change: `faccessat` drops from 1,230 → 0; main thread is now just task setup + `futex` wait + bin linking. Worker load is balanced across all cores.

On warm-cache CI, aube still edges ahead on overlayfs because it does ~26k syscalls (symlinks into a pre-materialized virtual store) vs bun's ~78k (real 42k-file hoisted tree). Extrapolating from aube's own published ext4 number (bun 416ms → ÷3.4 ≈ **123ms** vs aube **139ms**), this should flip on a native filesystem.

## Correctness

- `test/cli/install/parallel-hoisted-install.test.ts`, seven tests. Parallel and serial installs produce byte-identical `node_modules` (60 scoped/unscoped packages with nested dirs and `.bin` entries; the marker asserts that all 60 took the parallel path). A partial cache (3 entries deleted) still installs every package through the reroute. An entry without its completion marker is re-downloaded rather than linked. With an in-test registry that can hold a tarball: a nested tree's postinstall waits for a rerouted root package; a package parked in `pending_installs` during a reroute is installed, counted and has its scripts run after replay; a package parked during the tree walk itself (a patched nested dependency, which stays on the serial path while root waits on its tasks) is installed by the drain that follows replay; and a self-contained workspace's packages come out as copies (link count 1) while the root's stay hardlinked.
- On recent heads: `bun-install-registry.test.ts` 243/243; the patch, tarball-integrity, bad-workspace and hoist suites all pass; the lifecycle suite matches main's baseline (119/122, the 3 failures are the pre-existing `node`-binary tests); clippy is clean on linux and on the windows target.
- `BUN_INSTALL_SERIAL_HOISTED=1` gives the old behaviour for A/B comparison; the layout test uses it as the reference.

## Related

Possibly addresses (warm-cache / frozen-lockfile install slowness reports):
- #23969
- #28278
- #10371

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 30 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/parallel-hoisted-install.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/parallel-hoisted-install.test.ts:
167 |     // Deterministic signal that the parallel path was actually
168 |     // exercised: completeParallelInstalls() emits a task count under
169 |     // BUN_INTERNAL_PARALLEL_HOISTED_MARKER (set in env above). Without
170 |     // the parallel installer, this marker is never printed. The
171 |     // serial-env run must NOT take the parallel path.
172 |     expect(parallelTaskCount(parallel.stderr)).toBe(fixture.count);
                                                     ^
error: expect(received).toBe(expected)

Expected: 60
Received: 0

      at <anonymous> (/workspace/bun/test/cli/install/parallel-hoisted-install.test.ts:172:48)
(fail) parallel hoisted install > produces identical node_modules to the serial installer [3221.74ms]
(pass) parallel hoisted install > re-routes to the serial download path when a cache entry is missing [1488.79ms]
468 | 
469 |     await using proc = spawnInstall(fx.dir, fx
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (8969f93ed)

test/cli/install/parallel-hoisted-install.test.ts:
(pass) parallel hoisted install > produces identical node_modules to the serial installer [146.21ms]
(pass) parallel hoisted install > re-routes to the serial download path when a cache entry is missing [93.81ms]
(pass) parallel hoisted install: rerouted downloads > a package parked during the tree walk is installed after replay [33.24ms]
(pass) parallel hoisted install: rerouted downloads > an entry missing its completion marker is re-downloaded, not linked [35.41ms]
(pass) parallel hoisted install: rerouted downloads > a package drained from pending_installs after replay is fully installed [35.94ms]
(pass) parallel hoisted install: rerouted downloads > a self-contained workspace gets copies, not links, from the parallel path [36.15ms]
(pass) parallel hoisted install: rerouted downloads > nested tree's postinstall is deferred until a rerouted root package is installed [46.28ms]

 7 pass
 0 fail
 192 expect() calls
Ran 7 tests across 1 file. [714.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/parallel-hoisted-install.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/parallel-hoisted-install.test.ts:
(pass) parallel hoisted install > produces identical node_modules to the serial installer [2692.17ms]
(pass) parallel hoisted install > re-routes to the serial download path when a cache entry is missing [1636.50ms]
(pass) parallel hoisted install: rerouted downloads > a package drained from pending_installs after replay is fully installed [814.05ms]
(pass) parallel hoisted install: rerouted downloads > a package parked during the tree walk is installed after replay [862.84ms]
(pass) parallel hoisted install: rerouted downloads > an entry missing its completion marker is re-downloaded, not linked [919.91ms]
(pass) parallel hoisted install: rerouted downloads > a self-contained workspace gets copies, not links, from the parallel path [889.50ms]
(pass) parallel hoisted install: rerouted downloads > nested tree's postinstall is deferred until a rerouted root package is installed [1545.59ms]

 7 pass
 0 fail
 19
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 748ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8243ms)
Bundle modules (54ms)
Postprocesss modules (27ms)
Bundle Functions (755ms)
Generate Code (26ms)

[9.12s] Bundled "src/js" for production
  2622 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[1/8] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                           |   4 +
 src/install/PackageInstall.rs                     |  18 +-
 src/install/PackageInstaller.rs                   | 963 +++++++++++++++-------
 src/install/hoisted_install.rs                    |  72 ++
 src/install/patch_install.rs                      |   2 +-
 test/cli/install/parallel-hoisted-install.test.ts | 561 +++++++++++++
 6 files changed, 1320 insertions(+), 300 deletions(-)
```

</details>

**gate history** · 11 passed · 0 rejected · iteration 30

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/bun_core/env_var.rs                                3      5     87
src/install/PackageInstall.rs                          3      4     87
src/install/PackageInstaller.rs                       53     67     88
src/install/hoisted_install.rs                         8     10     87
src/install/patch_install.rs                           0      0     87
test/cli/install/parallel-hoisted-install.test.ts     26     51     87
```

</details>

<!-- robobun:evidence:end -->





