### PR TITLE
build: bump ZIG_COMMIT_PARALLEL to 65b29282c0

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -512,11 +512,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                         |
+| Value       | Description                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.               |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
 
 ### `install.frozenLockfile`
 

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,7 @@ import { streamPath } from "./stream.ts";
  * is trusted, collapse both back to one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "445fc0cbba4eea579e5c846f2b8be7c9bdc4e1cc";
+export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";
 
 /**
  * The one place that picks which compiler to use. Everything coupled to


### PR DESCRIPTION
Picks up oven-sh/zig#19 (psema: shard unit_claims, drop sema_lock under non-incremental).

## Perf (Linux x86_64, 64 cores)
- zig behavior.zig sema-only: ~18s serial → ~2.2s at j=16 (8.1x), 1.14× CPU overhead
- behavior.zig with `-fllvm --llvm-codegen-threads=32`: 9.9s → 2.15s
- bun `zig build obj -ODebug` (sema to first error, stale codegen): 47s serial → 12.8s parallel (3.7x)

## Correctness
- 0/120 sema-only stress runs across j=8/16/32/64
- 0/10 full-exec runs at j=64
- behavior tests identical serial vs parallel: 2091 passed; 24 skipped; 0 failed
- LLVM codegen sharding: 1983/32/0

Note: parallel compiler is still darwin-local-only per `defaultZigCommit` (Linux ELF -r merge gating in #29132 unchanged). This bump only affects darwin local dev.