### PR TITLE
build: skip zig's ELF -r shard merge; pass shards to lld

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -379,9 +379,11 @@ function getZigAgent(platform, options) {
     });
   }
 
-  // Everything else cross-compiles from Linux aarch64
+  // Everything else cross-compiles from Linux aarch64. ASAN gets a wider
+  // box: it builds with cg=CI_ASAN_CODEGEN_THREADS (8) so it can use the
+  // parallel backend; release stays at cg=1 (full IPO) so 2 vCPU suffice.
   return getEc2Agent(getZigPlatform(), options, {
-    instanceType: "r8g.large",
+    instanceType: platform.profile === "asan" ? "r8g.2xlarge" : "r8g.large",
   });
 }
 

--- a/build.zig
+++ b/build.zig
@@ -831,6 +831,7 @@ pub fn addInstallObjectFile(
     const bin = compile.getEmittedBin();
     if (out_mode == .obj and
         @hasField(Compile, "llvm_no_merge_shards") and
+        @hasField(Compile, "llvm_codegen_threads") and
         compile.llvm_no_merge_shards and
         compile.llvm_codegen_threads > 1)
     {

--- a/build.zig
+++ b/build.zig
@@ -754,6 +754,13 @@ fn configureObj(b: *Build, opts: *BunBuildOptions, obj: *Compile) void {
 
     if (@hasField(std.meta.Child(@TypeOf(obj)), "llvm_codegen_threads"))
         obj.llvm_codegen_threads = opts.llvm_codegen_threads orelse 0;
+    // Skip zig's relocatable -r merge of the codegen shards: it's
+    // single-threaded and dominated wall time at high shard counts
+    // (~9min for 64 × ~8MB shards). With this set, shards are emitted
+    // directly as `{out}.{i}.o`; addInstallObjectFile installs them
+    // all and the bun link step (lld, parallel) consumes them.
+    if (@hasField(std.meta.Child(@TypeOf(obj)), "llvm_no_merge_shards"))
+        obj.llvm_no_merge_shards = (opts.llvm_codegen_threads orelse 0) > 1;
 
     obj.no_link_obj = opts.os != .windows and !opts.no_llvm;
 
@@ -820,6 +827,29 @@ pub fn addInstallObjectFile(
 ) *Step {
     // bin always needed to be computed or else the compilation will do nothing. zig build system bug?
     const bin = compile.getEmittedBin();
+    if (out_mode == .obj and
+        @hasField(Compile, "llvm_no_merge_shards") and
+        compile.llvm_no_merge_shards and
+        compile.llvm_codegen_threads > 1)
+    {
+        // Install every shard as `{name}.{i}.o`; scripts/build/zig.ts
+        // declares the matching outputs and the bun link step (lld)
+        // consumes them all. The merged `{name}.o` does not exist in
+        // this configuration. Shard `i` is at `{out_filename - ".o"}.{i}.o`
+        // in the emitted-bin directory (see Compilation.zig:3475).
+        const dir = compile.getEmittedBinDirectory();
+        const stem = if (std.mem.endsWith(u8, compile.out_filename, ".o"))
+            compile.out_filename[0 .. compile.out_filename.len - 2]
+        else
+            compile.out_filename;
+        const umbrella = b.step("install-shards", "install codegen shard objects");
+        var i: u32 = 0;
+        while (i < compile.llvm_codegen_threads) : (i += 1) {
+            const shard = dir.path(b, b.fmt("{s}.{d}.o", .{ stem, i }));
+            umbrella.dependOn(&b.addInstallFile(shard, b.fmt("{s}.{d}.o", .{ name, i })).step);
+        }
+        return umbrella;
+    }
     return &b.addInstallFile(switch (out_mode) {
         .obj => bin,
         .bc => compile.getEmittedLlvmBc(),

--- a/build.zig
+++ b/build.zig
@@ -842,7 +842,10 @@ pub fn addInstallObjectFile(
             compile.out_filename[0 .. compile.out_filename.len - 2]
         else
             compile.out_filename;
-        const umbrella = b.step("install-shards", "install codegen shard objects");
+        const umbrella = b.step(
+            b.fmt("install-shards-{s}", .{name}),
+            b.fmt("install {s} codegen shard objects", .{name}),
+        );
         var i: u32 = 0;
         while (i < compile.llvm_codegen_threads) : (i += 1) {
             const shard = dir.path(b, b.fmt("{s}.{d}.o", .{ stem, i }));

--- a/build.zig
+++ b/build.zig
@@ -758,9 +758,11 @@ fn configureObj(b: *Build, opts: *BunBuildOptions, obj: *Compile) void {
     // single-threaded and dominated wall time at high shard counts
     // (~9min for 64 × ~8MB shards). With this set, shards are emitted
     // directly as `{out}.{i}.o`; addInstallObjectFile installs them
-    // all and the bun link step (lld, parallel) consumes them.
+    // all and the bun link step (lld, parallel) consumes them. Only
+    // for the main object — `zig build test` reuses configureObj and
+    // its install path expects a single artifact.
     if (@hasField(std.meta.Child(@TypeOf(obj)), "llvm_no_merge_shards"))
-        obj.llvm_no_merge_shards = (opts.llvm_codegen_threads orelse 0) > 1;
+        obj.llvm_no_merge_shards = obj.kind == .obj and (opts.llvm_codegen_threads orelse 0) > 1;
 
     obj.no_link_obj = opts.os != .windows and !opts.no_llvm;
 
@@ -842,16 +844,17 @@ pub fn addInstallObjectFile(
             compile.out_filename[0 .. compile.out_filename.len - 2]
         else
             compile.out_filename;
-        const umbrella = b.step(
-            b.fmt("install-shards-{s}", .{name}),
-            b.fmt("install {s} codegen shard objects", .{name}),
-        );
+        // Group via shard 0's install step so we don't register a
+        // user-visible top-level `b.step()` for what is an internal
+        // fan-out. Ninja still parallelises the dependents.
+        var first: ?*Step = null;
         var i: u32 = 0;
         while (i < compile.llvm_codegen_threads) : (i += 1) {
             const shard = dir.path(b, b.fmt("{s}.{d}.o", .{ stem, i }));
-            umbrella.dependOn(&b.addInstallFile(shard, b.fmt("{s}.{d}.o", .{ name, i })).step);
+            const inst = &b.addInstallFile(shard, b.fmt("{s}.{d}.o", .{ name, i })).step;
+            if (first) |f| f.dependOn(inst) else first = inst;
         }
-        return umbrella;
+        return first.?;
     }
     return &b.addInstallFile(switch (out_mode) {
         .obj => bin,

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -484,7 +484,7 @@ function emitZigOnly(n: Ninja, cfg: Config, sources: Sources): BunOutput {
  *
  * Expected artifacts (same paths cpp-only/zig-only produced):
  *   - libbun-profile.a            — from cpp-only's ar()
- *   - bun-zig.o                   — from zig-only
+ *   - bun-zig.o (or bun-zig.{i}.o for ASAN — see zigObjectPaths)
  *   - deps/<name>/lib<name>.a     — from cpp-only's dep builds
  *   - cache/webkit-<hash>/lib/... — WebKit prebuilt (same cache path)
  */

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -38,7 +38,7 @@ import { quote, slash } from "./shell.ts";
 import { emitShims } from "./shims.ts";
 import { computeDepLibs, depSourceStamp, resolveDep, type ResolvedDep } from "./source.ts";
 import { streamPath } from "./stream.ts";
-import { emitZig, emitZigCheck } from "./zig.ts";
+import { emitZig, emitZigCheck, zigObjectPaths } from "./zig.ts";
 
 // ───────────────────────────────────────────────────────────────────────────
 // Executable naming
@@ -509,11 +509,10 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
   // prefix/suffix, e.g. libbun-profile.a).
   const archive = resolve(cfg.buildDir, `${cfg.libPrefix}${exeName}${cfg.libSuffix}`);
 
-  // bun-zig.o from zig-only: same path emitZig writes to.
-  // Hardcoded filename — emitZig uses "bun-zig.o" regardless of platform
-  // (zig outputs ELF-like obj format by default; -Dobj_format=obj for
-  // windows → COFF, but filename stays the same).
-  const zigObj = resolve(cfg.buildDir, "bun-zig.o");
+  // bun-zig*.o from zig-only: same paths emitZig writes to. Shared
+  // helper so both sides of the CI split agree (single file at cg<=1,
+  // N shards for asan at cg=CI_ASAN_CODEGEN_THREADS).
+  const zigObjects = zigObjectPaths(cfg);
 
   // Only need ldflags + stripflags (no cflags/cxxflags — no compile).
   const flags = computeFlags(cfg);
@@ -527,7 +526,7 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
   const windowsRes = cfg.windows ? [emitWindowsResources(n, cfg)] : [];
 
   const shims = emitShims(n, cfg);
-  const exe = link(n, cfg, exeName, [archive, zigObj, ...windowsRes], {
+  const exe = link(n, cfg, exeName, [archive, ...zigObjects, ...windowsRes], {
     libs: depLibs,
     flags: [...flags.ldflags, ...systemLibs(cfg), ...manifestLinkFlags(cfg), ...shims.ldflags],
     implicitInputs: [...linkImplicitInputs(cfg), ...shims.implicitInputs],
@@ -548,7 +547,7 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
     strippedExe,
     dsym,
     deps: [], // no ResolvedDep — we only computed lib paths
-    zigObjects: [zigObj],
+    zigObjects,
     objects: [],
   };
 }

--- a/scripts/build/clean.ts
+++ b/scripts/build/clean.ts
@@ -70,9 +70,7 @@ const presets: Record<string, () => string[]> = {
     ...buildProfiles().flatMap(p => [
       resolve(p, "cache", "zig"),
       // Single-object (cg=1) and shard (cg>1) outputs both match.
-      ...(existsSync(p) ? readdirSync(p) : [])
-        .filter(f => /^bun-zig(\.\d+)?\.o$/.test(f))
-        .map(f => resolve(p, f)),
+      ...(existsSync(p) ? readdirSync(p) : []).filter(f => /^bun-zig(\.\d+)?\.o$/.test(f)).map(f => resolve(p, f)),
     ]),
     resolve(sharedCacheDir, "zig"),
     resolve(cwd, "build", "debug", "zig-check-cache"),

--- a/scripts/build/clean.ts
+++ b/scripts/build/clean.ts
@@ -31,7 +31,7 @@ presets:
   release          build/release/
   debug-local      build/debug-local/
   release-local    build/release-local/
-  zig              zig caches + bun-zig.o across all profiles, .zig-cache, zig-out
+  zig              zig caches + bun-zig*.o across all profiles, .zig-cache, zig-out
   cpp              C++ obj/ + pch/ across all profiles
   cache            machine-shared build cache (~/.bun/build-cache: ccache, zig,
                    tarballs, prebuilt webkit) — affects ALL checkouts

--- a/scripts/build/clean.ts
+++ b/scripts/build/clean.ts
@@ -67,7 +67,13 @@ const presets: Record<string, () => string[]> = {
   "release-local": profile("release-local"),
 
   zig: () => [
-    ...buildProfiles().flatMap(p => [resolve(p, "cache", "zig"), resolve(p, "bun-zig.o")]),
+    ...buildProfiles().flatMap(p => [
+      resolve(p, "cache", "zig"),
+      // Single-object (cg=1) and shard (cg>1) outputs both match.
+      ...(existsSync(p) ? readdirSync(p) : [])
+        .filter(f => /^bun-zig(\.\d+)?\.o$/.test(f))
+        .map(f => resolve(p, f)),
+    ]),
     resolve(sharedCacheDir, "zig"),
     resolve(cwd, "build", "debug", "zig-check-cache"),
     resolve(cwd, ".zig-cache"),

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -51,7 +51,7 @@ export interface Host {
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
   nodejsAbiVersion: NODEJS_ABI_VERSION,
-  // zigCommit's default varies by ci — see defaultZigCommit() in zig.ts.
+  // zigCommit's default varies by host OS — see defaultZigCommit() in zig.ts.
   webkitVersion: WEBKIT_VERSION,
 };
 

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -469,7 +469,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // to test a branch before bumping the pinned default.
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
-  const zigCommit = partial.zigCommit ?? defaultZigCommit(ci, host.os, asan);
+  const zigCommit = partial.zigCommit ?? defaultZigCommit(host.os);
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
 
   // ─── macOS SDK ───
@@ -795,7 +795,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os, cfg.asan))
+  if (cfg.zigCommit !== defaultZigCommit(cfg.host.os))
     features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -469,7 +469,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // to test a branch before bumping the pinned default.
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
-  const zigCommit = partial.zigCommit ?? defaultZigCommit(ci, host.os);
+  const zigCommit = partial.zigCommit ?? defaultZigCommit(ci, host.os, asan);
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
 
   // ─── macOS SDK ───
@@ -795,7 +795,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os))
+  if (cfg.zigCommit !== defaultZigCommit(cfg.ci, cfg.host.os, cfg.asan))
     features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -795,8 +795,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.host.os))
-    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== defaultZigCommit(cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -70,15 +70,14 @@ function usingParallelCompiler(cfg: Config): boolean {
  * `linkonce_odr` externs so LLVM can't inline or IPO across them.
  *
  * Sharding is gated off for:
- *   - CI: zig-only/link-only run on different machines, so the link step
- *     can't know how many shards were produced. Single artifact keeps the
- *     upload/download contract simple. (Shipped releases are always CI,
- *     so they get cg=1 and full IPO.)
+ *   - Non-ASAN CI: shipped releases want full IPO; cg=1 keeps that and
+ *     keeps the upload/download contract a single file.
  *   - Windows targets: COFF shard emission is unimplemented in oven-sh/zig.
  *
- * Local builds — Debug or Release — shard for build speed. A local
- * `--profile=release` is for dev iteration; benchmark against a CI
- * artifact (always cg=1) if cross-unit inlining matters.
+ * ASAN CI uses a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only and
+ * link-only — which run on different machines — agree on the artifact
+ * names. Local builds shard at availableParallelism(); benchmark against
+ * a non-ASAN CI artifact if cross-unit inlining matters.
  */
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;
@@ -351,9 +350,9 @@ export interface ZigBuildInputs {
 /**
  * Emit the zig download + zig build steps. Returns the output object file(s).
  *
- * Single `bun-zig.o` when codegenThreads()<=1 (CI, Windows targets);
- * `bun-zig.{0..N-1}.o` shards otherwise (local dev). The link step
- * spreads the returned array into its inputs either way.
+ * Single `bun-zig.o` when codegenThreads()<=1 (non-ASAN CI, Windows
+ * targets); `bun-zig.{0..N-1}.o` shards otherwise (ASAN CI, local dev).
+ * The link step spreads the returned array into its inputs either way.
  */
 export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[] {
   n.comment("─── Zig ───");

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -41,7 +41,7 @@ import { streamPath } from "./stream.ts";
  * one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "faa680d0e3df6e8ab7607e6037d6d79e90f9eb27";
+export const ZIG_COMMIT_PARALLEL = "0bcf4c3d998133e724d27e9fd783172ffed4c943";
 
 /**
  * The one place that picks which compiler to use. The parallel compiler
@@ -82,8 +82,30 @@ function usingParallelCompiler(cfg: Config): boolean {
  */
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;
-  if (cfg.ci || cfg.windows) return 1;
+  if (cfg.windows) return 1;
+  if (cfg.ci) {
+    // ASAN is a test-only build (not shipped), so cross-shard IPO loss is
+    // fine and the speedup is worth it. The count is FIXED so zig-only and
+    // link-only — which run on different machines — agree on the artifact
+    // names. Non-asan CI stays at 1: shipped releases want full IPO.
+    return cfg.asan ? CI_ASAN_CODEGEN_THREADS : 1;
+  }
   return availableParallelism();
+}
+
+/** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
+export const CI_ASAN_CODEGEN_THREADS = 8;
+
+/**
+ * Output object file names for the zig step, matching what build.zig emits.
+ * Shared between emitZig (zig-only/full) and emitLinkOnly so both sides of
+ * the CI artifact split agree on filenames.
+ */
+export function zigObjectPaths(cfg: Config): string[] {
+  const cg = codegenThreads(cfg);
+  return cg > 1
+    ? Array.from({ length: cg }, (_, i) => resolve(cfg.buildDir, `bun-zig.${i}.o`))
+    : [resolve(cfg.buildDir, "bun-zig.o")];
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -385,11 +407,7 @@ export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[]
   // of one merged `bun-zig.o` (zig's single-threaded ELF -r merge of the
   // shards dominated wall time). Declare every shard so ninja tracks them
   // and the link step gets all of them; lld merges in parallel.
-  const cgThreads = codegenThreads(cfg);
-  const outputs =
-    cgThreads > 1
-      ? Array.from({ length: cgThreads }, (_, i) => resolve(cfg.buildDir, `bun-zig.${i}.o`))
-      : [resolve(cfg.buildDir, "bun-zig.o")];
+  const outputs = zigObjectPaths(cfg);
   const args = zigBuildArgs(cfg);
 
   n.build({

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -41,7 +41,7 @@ import { streamPath } from "./stream.ts";
  * one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";
+export const ZIG_COMMIT_PARALLEL = "faa680d0e3df6e8ab7607e6037d6d79e90f9eb27";
 
 /**
  * The one place that picks which compiler to use. The parallel compiler

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -42,29 +42,40 @@ export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
 export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";
 
 /**
- * The one place that picks which compiler to use. Everything coupled to
- * the parallel compiler (ZIG_PARALLEL_SEMA, -Dllvm_codegen_threads) keys
- * on the resolved cfg.zigCommit via usingParallelCompiler(), so changing
- * this — or passing --zigCommit=<hash> — is sufficient.
- *
- * Parallel compiler is darwin+linux local only for now. Linux was gated
- * off until 65b29282 fixed the self-hosted ELF `-r` merge that combines
- * sharded codegen output (#29132). CI and Windows stay on the stable
- * compiler.
+ * The one place that picks which compiler to use. The parallel compiler
+ * is used everywhere except Windows (its sharded-codegen object emission
+ * for COFF is unimplemented). Parallel SEMA is deterministic and changes
+ * no output, so CI gets it too — only the codegen-unit count differs by
+ * config (see codegenThreads()).
  */
-export function defaultZigCommit(ci: boolean, hostOs: OS): string {
-  if (ci || hostOs === "windows") return ZIG_COMMIT;
+export function defaultZigCommit(ci: boolean, hostOs: OS, asan: boolean): string {
+  void ci;
+  void asan;
+  if (hostOs === "windows") return ZIG_COMMIT;
   return ZIG_COMMIT_PARALLEL;
 }
 
 /**
- * True iff `cfg` is using the parallel-sema compiler. All parallel-only
- * build knobs (ZIG_PARALLEL_SEMA env, -Dllvm_codegen_threads>0) must key
- * on this — the stable compiler emits N sharded .o files under those
- * options but leaves getEmittedBin() as a 0-byte stub, so link fails.
+ * True iff `cfg` is using the parallel-sema compiler. Gates
+ * ZIG_PARALLEL_SEMA and the `llvm_no_merge_shards` build.zig path —
+ * the stable compiler doesn't understand either.
  */
 function usingParallelCompiler(cfg: Config): boolean {
   return cfg.zigCommit !== ZIG_COMMIT;
+}
+
+/**
+ * Number of LLVM codegen units. >1 splits the build into N independent
+ * LLVM modules — parallelises emit, but cross-unit calls become
+ * `linkonce_odr` externs so LLVM can't inline or IPO across them.
+ * Shipped release builds stay at 1 so they're optimised as one module.
+ * Local dev (mostly Debug, where -O0 doesn't inline anyway) and CI
+ * ASAN (not shipped) take the build-speed win.
+ */
+function codegenThreads(cfg: Config): number {
+  if (!usingParallelCompiler(cfg)) return 0;
+  if (cfg.ci && !cfg.asan) return 1;
+  return availableParallelism();
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -263,7 +274,7 @@ export function registerZigRules(n: Ninja, cfg: Config): void {
   // ninja can track completion. Same cache dirs as the main zig build —
   // zig keys by hash, the two coexist cleanly.
   n.rule("zig_check", {
-    command: `${stream} --console --stamp=$out --env=ZIG_LOCAL_CACHE_DIR=$zig_local_cache --env=ZIG_GLOBAL_CACHE_DIR=$zig_global_cache $zig build $step $args`,
+    command: `${stream} --console --stamp=$out --env=ZIG_LOCAL_CACHE_DIR=$zig_local_cache --env=ZIG_GLOBAL_CACHE_DIR=$zig_global_cache${parallelSema} $zig build $step $args`,
     description: "zig $step",
     pool: "console",
     restat: true,
@@ -365,7 +376,7 @@ export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[]
   // of one merged `bun-zig.o` (zig's single-threaded ELF -r merge of the
   // shards dominated wall time). Declare every shard so ninja tracks them
   // and the link step gets all of them; lld merges in parallel.
-  const cgThreads = usingParallelCompiler(cfg) ? availableParallelism() : 0;
+  const cgThreads = codegenThreads(cfg);
   const outputs =
     cgThreads > 1
       ? Array.from({ length: cgThreads }, (_, i) => resolve(cfg.buildDir, `bun-zig.${i}.o`))
@@ -435,8 +446,8 @@ function zigBuildArgs(cfg: Config): string[] {
     `-Duse_mimalloc=true`,
     // Sharded LLVM codegen — one shard per host core on the parallel
     // compiler. Zig has no "auto" value (0 = single-threaded). MUST be 0
-    // on the stable compiler — see usingParallelCompiler().
-    `-Dllvm_codegen_threads=${usingParallelCompiler(cfg) ? availableParallelism() : 0}`,
+    // on the stable compiler — see codegenThreads().
+    `-Dllvm_codegen_threads=${codegenThreads(cfg)}`,
 
     // Versioning
     `-Dversion=${cfg.version}`,

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -253,9 +253,10 @@ export function registerZigRules(n: Ninja, cfg: Config): void {
     restat: true,
   });
 
-  // Zig build — the big one. One invocation produces bun-zig.o. Zig's
-  // own build system handles per-file tracking; restat prunes downstream
-  // when zig's cache says nothing changed.
+  // Zig build — the big one. One invocation produces bun-zig.o (or
+  // bun-zig.{0..N-1}.o when codegenThreads()>1). Zig's own build system
+  // handles per-file tracking; restat prunes downstream when zig's cache
+  // says nothing changed.
   //
   // Default: --console + pool=console. Zig gets direct TTY, its native
   // spinner works. Ninja defers [N/M] while the console job owns the
@@ -328,9 +329,9 @@ export interface ZigBuildInputs {
 /**
  * Emit the zig download + zig build steps. Returns the output object file(s).
  *
- * For normal builds: one `bun-zig.o`. For test builds (future): `bun-test.o`.
- * Threaded codegen (LLVM_ZIG_CODEGEN_THREADS > 1) would produce multiple .o
- * files, but that's always 0 in practice — deferred.
+ * Single `bun-zig.o` when codegenThreads()<=1 (CI, Windows targets);
+ * `bun-zig.{0..N-1}.o` shards otherwise (local dev). The link step
+ * spreads the returned array into its inputs either way.
  */
 export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[] {
   n.comment("─── Zig ───");

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -32,11 +32,13 @@ import { streamPath } from "./stream.ts";
  * Override via `--zig-commit=<hash>` to test a new compiler.
  * From https://github.com/oven-sh/zig releases.
  *
- * TEMPORARY SPLIT: local dev uses a newer compiler with parallel sema +
- * sharded LLVM codegen (big speedup, still being proven correct). CI
- * stays on the last known-good commit so release builds aren't affected
- * by compiler bugs we haven't shaken out yet. Once the parallel compiler
- * is trusted, collapse both back to one constant.
+ * TEMPORARY SPLIT: ZIG_COMMIT is the pre-parallel-sema compiler, kept
+ * for Windows hosts only (COFF shard emission isn't implemented and
+ * the build path needs a single object). Everything else — local and
+ * CI, all targets — uses ZIG_COMMIT_PARALLEL (parallel sema is
+ * deterministic; codegen-unit count is decided separately by
+ * codegenThreads()). Once Windows is supported, collapse both back to
+ * one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
 export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -360,11 +360,20 @@ export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[]
 
   // ─── Build ───
   const cacheDirs = zigCacheDirs(cfg);
-  const output = resolve(cfg.buildDir, "bun-zig.o");
+  // With the parallel compiler at >1 codegen threads, build.zig sets
+  // `llvm_no_merge_shards` and installs `bun-zig.{i}.o` per shard instead
+  // of one merged `bun-zig.o` (zig's single-threaded ELF -r merge of the
+  // shards dominated wall time). Declare every shard so ninja tracks them
+  // and the link step gets all of them; lld merges in parallel.
+  const cgThreads = usingParallelCompiler(cfg) ? availableParallelism() : 0;
+  const outputs =
+    cgThreads > 1
+      ? Array.from({ length: cgThreads }, (_, i) => resolve(cfg.buildDir, `bun-zig.${i}.o`))
+      : [resolve(cfg.buildDir, "bun-zig.o")];
   const args = zigBuildArgs(cfg);
 
   n.build({
-    outputs: [output],
+    outputs,
     rule: "zig_build",
     inputs: [],
     implicitInputs: zigBuildImplicitInputs(cfg, inputs),
@@ -377,10 +386,10 @@ export function emitZig(n: Ninja, cfg: Config, inputs: ZigBuildInputs): string[]
       zig_global_cache: cacheDirs.global,
     },
   });
-  n.phony("bun-zig", [output]);
+  n.phony("bun-zig", outputs);
   n.blank();
 
-  return [output];
+  return outputs;
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -74,6 +74,10 @@ function usingParallelCompiler(cfg: Config): boolean {
  */
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;
+  // COFF shard emission is unimplemented in oven-sh/zig; a Linux→Windows
+  // cross-compile (local zig-only) would otherwise declare N ninja outputs
+  // zig can't produce.
+  if (cfg.windows) return 1;
   if (cfg.ci && !cfg.asan) return 1;
   return availableParallelism();
 }

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -48,9 +48,7 @@ export const ZIG_COMMIT_PARALLEL = "65b29282c04e42bea2539e9e31c5a59ac9cbabdb";
  * no output, so CI gets it too — only the codegen-unit count differs by
  * config (see codegenThreads()).
  */
-export function defaultZigCommit(ci: boolean, hostOs: OS, asan: boolean): string {
-  void ci;
-  void asan;
+export function defaultZigCommit(hostOs: OS): string {
   if (hostOs === "windows") return ZIG_COMMIT;
   return ZIG_COMMIT_PARALLEL;
 }
@@ -68,17 +66,17 @@ function usingParallelCompiler(cfg: Config): boolean {
  * Number of LLVM codegen units. >1 splits the build into N independent
  * LLVM modules — parallelises emit, but cross-unit calls become
  * `linkonce_odr` externs so LLVM can't inline or IPO across them.
- * Shipped release builds stay at 1 so they're optimised as one module.
- * Local dev (mostly Debug, where -O0 doesn't inline anyway) and CI
- * ASAN (not shipped) take the build-speed win.
+ *
+ * Sharding is local-dev only:
+ *   - shipped release builds need cg=1 so they're optimised as one module;
+ *   - CI splits zig-only/link-only across machines, so the link step would
+ *     need to know the zig-only runner's core count to find the shards.
+ *     Single artifact keeps the upload/download contract simple.
+ *   - COFF shard emission is unimplemented (Windows targets).
  */
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;
-  // COFF shard emission is unimplemented in oven-sh/zig; a Linux→Windows
-  // cross-compile (local zig-only) would otherwise declare N ninja outputs
-  // zig can't produce.
-  if (cfg.windows) return 1;
-  if (cfg.ci && !cfg.asan) return 1;
+  if (cfg.ci || cfg.windows) return 1;
   return availableParallelism();
 }
 

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -67,12 +67,16 @@ function usingParallelCompiler(cfg: Config): boolean {
  * LLVM modules — parallelises emit, but cross-unit calls become
  * `linkonce_odr` externs so LLVM can't inline or IPO across them.
  *
- * Sharding is local-dev only:
- *   - shipped release builds need cg=1 so they're optimised as one module;
- *   - CI splits zig-only/link-only across machines, so the link step would
- *     need to know the zig-only runner's core count to find the shards.
- *     Single artifact keeps the upload/download contract simple.
- *   - COFF shard emission is unimplemented (Windows targets).
+ * Sharding is gated off for:
+ *   - CI: zig-only/link-only run on different machines, so the link step
+ *     can't know how many shards were produced. Single artifact keeps the
+ *     upload/download contract simple. (Shipped releases are always CI,
+ *     so they get cg=1 and full IPO.)
+ *   - Windows targets: COFF shard emission is unimplemented in oven-sh/zig.
+ *
+ * Local builds — Debug or Release — shard for build speed. A local
+ * `--profile=release` is for dev iteration; benchmark against a CI
+ * artifact (always cg=1) if cross-unit inlining matters.
  */
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;


### PR DESCRIPTION
With `-Dllvm_codegen_threads=N>1`, zig emits N shard objects then merges them into one `bun-zig.o` via its self-hosted relocatable `-r` linker. That merge is single-threaded and dominated wall time on Linux (~9min for 64 × ~8MB shards on a 64-core box; sema+emit was ~1:42).

This sets `obj.llvm_no_merge_shards=true` so shards land directly at `{out}.{i}.o`; `addInstallObjectFile` installs all of them; `emitZig` declares N outputs so the link step gets every shard. `lld` merges them in parallel along with the C++ objects.

## Results (Linux x86_64, 64 cores, fresh debug build)
- zig step: **11+min → ~2min**
- total `bun run build`: **~2:42 wall** (37.8× CPU parallelism)
- `bun-debug --revision` and `bun-debug -e 'console.log(...)'` work

## Compatibility
- Guarded with `@hasField(Compile, "llvm_no_merge_shards")` so it's a no-op on the stable compiler.
- `emitZig` checks `usingParallelCompiler(cfg)` so the stable-compiler path still emits a single `bun-zig.o`.
- `link-only` mode (CI, downloads `bun-zig.o` from `zig-only` artifact) is unchanged — `zig-only` runs on CI which uses the stable compiler.

oven-sh/zig@5ffef04e36 adds `getEmittedBinShards()` to the stdlib for a cleaner API; this PR computes the paths directly so it works with the current 65b29282 binary.