### PR TITLE
ci: don't compare binary size against release builds

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -827,6 +827,7 @@ function getBinarySizeStep(releasePlatforms, options, { recordOnly = false } = {
   const targets = releasePlatforms.map(p => ({ triplet: getTargetTriplet(p) }));
   const args = [`--targets '${JSON.stringify(targets)}'`, `--threshold-mb ${BINARY_SIZE_THRESHOLD_MB}`];
   if (recordOnly) args.push("--no-fail");
+  if (!options.canary) args.push("--release");
 
   return {
     key: "binary-size",

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -512,11 +512,11 @@ prefer = "online"
 
 Valid values are:
 
-| Value       | Description                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------- |
-| `"online"`  | Default. Check the registry for stale packages as needed.                                         |
+| Value       | Description                                                                                        |
+| ----------- | -------------------------------------------------------------------------------------------------- |
+| `"online"`  | Default. Check the registry for stale packages as needed.                                          |
 | `"offline"` | Skip staleness checks and resolve packages from the local cache. Equivalent to `--prefer-offline`. |
-| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.               |
+| `"latest"`  | Always check npm for the latest matching versions. Equivalent to `--prefer-latest`.                |
 
 ### `install.frozenLockfile`
 

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -14,7 +14,7 @@
 //   bun scripts/binary-size.ts \
 //     --targets '[{"triplet":"bun-darwin-aarch64"},...]' \
 //     --threshold-mb 0.5 \
-//     [--no-fail]
+//     [--no-fail] [--release]
 
 import { mkdirSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
@@ -27,12 +27,14 @@ const { values } = parseArgs({
     targets: { type: "string" },
     "threshold-mb": { type: "string", default: "0.5" },
     "no-fail": { type: "boolean", default: false },
+    release: { type: "boolean", default: false },
   },
 });
 
 const targets: Target[] = JSON.parse(values.targets!);
 const thresholdBytes = parseFloat(values["threshold-mb"]!) * 1024 * 1024;
 const noFail = values["no-fail"];
+const isRelease = values.release;
 
 const org = process.env.BUILDKITE_ORGANIZATION_SLUG || "bun";
 const pipeline = process.env.BUILDKITE_PIPELINE_SLUG || "bun";
@@ -68,7 +70,10 @@ for (const { triplet } of targets) {
   console.log(`  ${triplet.padEnd(30)} ${fmtBytes(sizes[triplet]).padStart(10)}`);
 }
 
-await Bun.write("binary-sizes.json", JSON.stringify({ build: buildNumber, branch, sizes }, null, 2));
+await Bun.write(
+  "binary-sizes.json",
+  JSON.stringify({ build: buildNumber, branch, release: isRelease, sizes }, null, 2),
+);
 agent(["artifact", "upload", "binary-sizes.json"]);
 
 // ─── Baselines ───
@@ -93,7 +98,7 @@ async function buildNumberForCommit(sha: string): Promise<number | undefined> {
   return m ? parseInt(m[1], 10) : undefined;
 }
 
-async function sizesFromBuild(n: number): Promise<Sizes | undefined> {
+async function sizesFromBuild(n: number): Promise<{ sizes: Sizes; release?: boolean } | undefined> {
   const res = await fetch(`https://buildkite.com/${org}/${pipeline}/builds/${n}.json`);
   if (!res.ok) return;
   const { id } = (await res.json()) as { id: string };
@@ -102,18 +107,23 @@ async function sizesFromBuild(n: number): Promise<Sizes | undefined> {
   mkdirSync(dir, { recursive: true });
   const ok = agent(["artifact", "download", "binary-sizes.json", dir, "--build", id], { quiet: true });
   if (ok === undefined) return;
-  return ((await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes }).sizes;
+  return (await Bun.file(`${dir}/binary-sizes.json`).json()) as { sizes: Sizes; release?: boolean };
 }
 
 async function baselineFromCommit(sha: string, label: (n: number) => string): Promise<Baseline | undefined> {
   const n = await buildNumberForCommit(sha);
   if (!n || String(n) === String(buildNumber)) return;
-  const sizes = await sizesFromBuild(n);
-  if (!sizes) return;
-  return { label: label(n), href: `https://buildkite.com/${org}/${pipeline}/builds/${n}`, sizes };
+  const record = await sizesFromBuild(n);
+  if (!record) return;
+  // Only compare like-for-like: canary builds against canary baselines, release
+  // against release. Windows binaries differ by several MB between the two, so
+  // a release build on main would otherwise trip every PR's threshold.
+  if ((record.release ?? false) !== isRelease) return;
+  return { label: label(n), href: `https://buildkite.com/${org}/${pipeline}/builds/${n}`, sizes: record.sizes };
 }
 
-// Canary: walk recent main commits until one whose build has binary-sizes.json.
+// Canary: walk recent main commits until one whose build has a matching
+// (canary vs release) binary-sizes.json.
 console.log("--- Fetching canary baseline");
 let canaryNote = "";
 const canary: Baseline | undefined = await (async () => {
@@ -122,7 +132,7 @@ const canary: Baseline | undefined = await (async () => {
     const b = await baselineFromCommit(sha, n => `main #${n}`);
     if (b) return b;
   }
-  canaryNote = "no recent main build has binary-sizes.json yet";
+  canaryNote = `no recent main ${isRelease ? "release" : "canary"} build has binary-sizes.json yet`;
 })().catch(e => ((canaryNote = String(e?.message || e)), undefined));
 console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 

--- a/scripts/binary-size.ts
+++ b/scripts/binary-size.ts
@@ -35,6 +35,7 @@ const targets: Target[] = JSON.parse(values.targets!);
 const thresholdBytes = parseFloat(values["threshold-mb"]!) * 1024 * 1024;
 const noFail = values["no-fail"];
 const isRelease = values.release;
+const buildKind = isRelease ? "release" : "canary";
 
 const org = process.env.BUILDKITE_ORGANIZATION_SLUG || "bun";
 const pipeline = process.env.BUILDKITE_PIPELINE_SLUG || "bun";
@@ -124,7 +125,7 @@ async function baselineFromCommit(sha: string, label: (n: number) => string): Pr
 
 // Canary: walk recent main commits until one whose build has a matching
 // (canary vs release) binary-sizes.json.
-console.log("--- Fetching canary baseline");
+console.log(`--- Fetching ${buildKind} baseline`);
 let canaryNote = "";
 const canary: Baseline | undefined = await (async () => {
   const commits = await githubJson<{ sha: string }[]>("commits?sha=main&per_page=15");
@@ -132,7 +133,7 @@ const canary: Baseline | undefined = await (async () => {
     const b = await baselineFromCommit(sha, n => `main #${n}`);
     if (b) return b;
   }
-  canaryNote = `no recent main ${isRelease ? "release" : "canary"} build has binary-sizes.json yet`;
+  canaryNote = `no recent main ${buildKind} build has binary-sizes.json yet`;
 })().catch(e => ((canaryNote = String(e?.message || e)), undefined));
 console.log(canary ? `  ${canary.label}` : `  unavailable: ${canaryNote}`);
 
@@ -189,7 +190,7 @@ const header =
     ? `<b>${overThreshold.length}</b> over ${limit}`
     : canary
       ? `all within ${limit}`
-      : `no canary comparison (${canaryNote})`;
+      : `no ${buildKind} comparison (${canaryNote})`;
 
 const annotation = `
 <details${failed ? " open" : ""}>
@@ -197,7 +198,7 @@ const annotation = `
 <table>
 <tr>
   <th rowspan="2">target</th><th rowspan="2">this build</th>
-  <th colspan="2">canary: ${link(canary, "main")}</th>
+  <th colspan="2">${buildKind}: ${link(canary, "main")}</th>
 </tr>
 <tr><th>size</th><th>Δ</th></tr>
 ${tableRows}
@@ -220,12 +221,12 @@ Bun.spawnSync(
 );
 
 for (const r of rows) {
-  const c = r.canary ? `  canary ${fmtDelta(r.canary.bytes).padStart(10)}` : "";
+  const c = r.canary ? `  ${buildKind} ${fmtDelta(r.canary.bytes).padStart(10)}` : "";
   console.log(`  ${r.triplet.padEnd(30)} ${fmtBytes(r.now).padStart(10)}${c}`);
 }
 
 if (failed) {
-  console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs canary`);
+  console.error(`\nerror: ${overThreshold.length} target(s) exceeded ${limit} vs ${buildKind}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## What does this PR do?

The `binary-size` step walks recent `main` commits looking for a build that uploaded `binary-sizes.json` to use as a baseline. Release builds upload that artifact too, so when the most recent `main` build is a release build, every canary PR compares against release-mode sizes. Windows release and canary binaries differ by several MB, so PRs spuriously fail the 0.5 MB threshold.

Fix: pass `--release` to `scripts/binary-size.ts` when `!options.canary` (same release-detection check used for Windows signing), record `release: <bool>` in the uploaded `binary-sizes.json`, and skip any baseline whose `release` flag doesn't match the current build. Canary PRs now only compare against canary baselines.

Release builds will generally show "no release comparison" since prior releases are well outside the 15-commit lookback window — this is intentional and preferable to the previous behavior of showing a misleading several-MB delta vs canary. Release builds are `--no-fail` regardless.

Old artifacts without the `release` field are treated as canary (the common case), so existing baselines remain usable. The currently-stuck release build on main self-resolves once the next canary build lands and is found first in the newest-first commit walk.

## How did you verify your code works?

Syntax/type checked both files, truth-tabled the `(record.release ?? false) !== isRelease` filter for all 6 release/canary/missing-field combinations, and confirmed `!options.canary` matches the existing release-detection pattern in `ci.mjs`. The script talks to Buildkite so it can't be exercised end-to-end locally.