### PR TITLE
Handle tampered globalThis.Loader in ESM registry map init

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2222,14 +2222,12 @@ void GlobalObject::finishCreation(VM& vm)
 
             JSMap* registry = nullptr;
             auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            scope.assertNoExceptionExceptTermination();
             RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                scope.assertNoExceptionExceptTermination();
+            if (auto* loaderObject = loaderValue ? loaderValue.getObject() : nullptr) {
+                auto registryValue = loaderObject->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
                 RETURN_IF_EXCEPTION(scope, setEmpty());
                 if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
                 }
             }
 

--- a/test/js/bun/resolve/esm-registry-loader-tampered.test.ts
+++ b/test/js/bun/resolve/esm-registry-loader-tampered.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The ESM registry map lazy initializer reads `globalThis.Loader.registry`.
+// User code can replace or delete `Loader`, and `globalThis` can have a Proxy
+// in its prototype chain whose `has` trap throws. These used to hit a debug
+// assertion / null deref / bad jsCast instead of propagating a JS error.
+
+test.concurrent("require() when globalThis prototype has a throwing `has` trap", async () => {
+  using dir = tempDir("esm-registry-proxy-has", {
+    "mod.js": "module.exports = 1;",
+    "entry.js": `
+      const orig = Object.getPrototypeOf(globalThis);
+      Object.setPrototypeOf(globalThis, new Proxy(orig, {
+        has(target, key) { throw new TypeError("has trap threw"); },
+      }));
+      delete globalThis.Loader;
+      try {
+        require("./mod.js");
+        process.stdout.write("OK\\n");
+      } catch (e) {
+        process.stdout.write("caught: " + e.message + "\\n");
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("caught: has trap threw\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() when globalThis.Loader is overwritten with a non-object", async () => {
+  using dir = tempDir("esm-registry-loader-primitive", {
+    "mod.js": "module.exports = 1;",
+    "entry.js": `
+      globalThis.Loader = 5;
+      require("./mod.js");
+      process.stdout.write("OK\\n");
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() when globalThis.Loader.registry is not a Map", async () => {
+  using dir = tempDir("esm-registry-not-a-map", {
+    "mod.js": "module.exports = 1;",
+    "entry.js": `
+      globalThis.Loader = { registry: 5 };
+      require("./mod.js");
+      process.stdout.write("OK\\n");
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("require() when globalThis.Loader has a throwing `registry` getter", async () => {
+  using dir = tempDir("esm-registry-throwing-getter", {
+    "mod.js": "module.exports = 1;",
+    "entry.js": `
+      globalThis.Loader = { get registry() { throw new TypeError("getter threw"); } };
+      try {
+        require("./mod.js");
+        process.stdout.write("OK\\n");
+      } catch (e) {
+        process.stdout.write("caught: " + e.message + "\\n");
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("caught: getter threw\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
The `m_esmRegistryMap` lazy initializer reads `globalThis.Loader.registry` via `getIfPropertyExists`, which walks the prototype chain and can invoke Proxy traps or user getters that throw arbitrary exceptions. The existing code asserted that only a termination exception could be pending after these lookups, and assumed the results were always an object / `JSMap`.

When `globalThis` had a Proxy prototype with a throwing `has` trap (and `Loader` had been deleted so the lookup reached the prototype chain), the debug build hit:

```
ASSERTION FAILED: !exception() || m_vm.hasPendingTerminationException()
ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

Related cases in the same block also crashed: `globalThis.Loader = 5` caused a null deref on `loaderValue.getObject()->...`, and `globalThis.Loader = { registry: 5 }` tripped the `jsCast<JSMap*>` assertion.

### Fix
- Remove the two `assertNoExceptionExceptTermination()` calls — the existing `RETURN_IF_EXCEPTION(scope, setEmpty())` already propagates the exception and sets a fallback map.
- Only dereference `Loader` when it is actually an object.
- Use `jsDynamicCast<JSMap*>` for `registry` so a non-Map value falls through to the fresh-map fallback instead of asserting.

### Tests
Added `test/js/bun/resolve/esm-registry-loader-tampered.test.ts` covering all four scenarios (throwing proxy `has` trap on globalThis prototype, non-object `Loader`, non-Map `Loader.registry`, throwing `Loader.registry` getter). All four fail on the previous build and pass with this change.

Found by fuzzer (fingerprint `a88b69673dd3ec7e`).