### PR TITLE
build: WebKit bump for bytecode-cache source-string fix

### DIFF
--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -236,14 +236,18 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   const cFlagsFull = [...flags.cflags, ...includeFlags, ...defineFlags];
 
   // ─── Step 5: PCH ───
-  // In CI, only the cpp-only job uses PCH — full mode skips it since the
-  // cpp-only artifacts are what actually get used downstream.
+  // PCH wherever we compile bun's own C++ ("full" and "cpp-only").
+  // link-only/zig-only never reach here. The PCH wrapper applies
+  // `#pragma clang system_header` to JSC headers, which is what suppresses
+  // -Wundefined-var-template on JSGenericTypedArrayView::s_info — without it
+  // a `mode=full --ci=on` build (e.g. `bun run build:ci`) fails. Real CI
+  // uses cpp-only so the previous `!cfg.ci` gate happened to work there.
   //
   // Not on Windows: matches cmake (BuildBun.cmake:868 gated on NOT WIN32).
   // clang-cl's /Yc//Yu flags exist but the wrapper+stub mechanism here
   // is built around clang's -emit-pch model. If Windows PCH is wanted
   // later, see compile.ts TODO(windows) for what needs wiring.
-  const usePch = !cfg.windows && (!cfg.ci || cfg.mode === "cpp-only");
+  const usePch = !cfg.windows && (cfg.mode === "full" || cfg.mode === "cpp-only");
   let pchOut: { pch: string; wrapperHeader: string } | undefined;
 
   if (usePch) {

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-186-d3a08965";
+export const WEBKIT_VERSION = "4b07413c2d0b3bcc0bf393f2105c33e2739026ec";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
+export const WEBKIT_VERSION = "autobuild-preview-pr-186-d3a08965";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -32,9 +32,14 @@ test.concurrent("dynamic import('bun:main') returns the wrapper module", async (
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("OK\n");
-  expect(stripAsanWarning(stderr)).toEqual([]);
-  expect(exitCode).toBe(0);
+  // Surface child diagnostics on failure: a bare stdout assertion hides why
+  // the child exited (ASAN report / unhandled rejection / signal).
+  expect({ stdout, stderr: stripAsanWarning(stderr), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "OK\n",
+    stderr: [],
+    exitCode: 0,
+    signalCode: null,
+  });
 });
 
 test.concurrent("import('bun:main') from a preload (before the module map is populated)", async () => {


### PR DESCRIPTION
## Summary

Pins WebKit to the preview build of https://github.com/oven-sh/WebKit/pull/186 so CI can run against it.

That PR stops `CachedStringSourceProvider` from encoding the bundled source text into the bytecode cache and from heap-allocating a copy of it during decode. Under `BUN_JSC_ADDITIONS`, `SourceCodeKey::operator==` already skips the source-bytes comparison, so the encoded copy was never read — but it was still:

- written verbatim into every `.jsc` blob (≈15-18% of the file)
- heap-allocated as an `AtomStringImpl` during `decodeCodeBlockImpl`
- pinned by a `Decoder` finalizer for the lifetime of every `UnlinkedFunctionExecutable` with a lazy body — i.e. effectively process-lifetime, since cold functions in the bundle never drop their `m_decoder` ref

The source bytes that runtime features (`Function.prototype.toString`, `Error.stack`, lazy-reparse) read are unaffected: they come from `ScriptExecutable::m_source` → the runtime `ZigSourceProvider`, which is a separate object set before `decodeCodeBlock` runs.

Cross-version `.jsc` files self-invalidate via `m_cacheVersion = hash(BUN_WEBKIT_VERSION)`, which changes with this pin.

**Draft:** the version string is a preview tag; will be replaced with the merged commit hash once oven-sh/WebKit#186 lands.

## Test plan
- [ ] CI green
- [x] `test/bundler/bundler_compile.test.ts` 54/54 (release, local-WebKit)
- [x] `test/bundler/bundler_banner.test.ts` 11/11
- [x] `test/bundler/bun-build-api.test.ts -t bytecode` 1/1
- [x] Debug-local (assertions on): `Function.prototype.toString`, `Error.stack`, nested-lazy-decode, async, `eval`, `new Function` all pass with `[Disk Cache] Cache hit`
- [x] Old-format `.jsc` (system bun) + new decoder → `[Disk Cache] Cache miss`, falls back to parse, output correct