### PR TITLE
install: add `bun pm fetch`

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3456,6 +3456,12 @@
             }
           }
         },
+        "fetch": {
+          "name": "fetch",
+          "description": "fetch all dependencies into the cache without installing",
+          "flags": [],
+          "positionalArgs": []
+        },
         "migrate": {
           "name": "migrate",
           "description": "migrate another package manager's lockfile without installing anything",

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -208,7 +208,7 @@ _bun_completions() {
         pm)
             _long_short_completion \
                 "${PM_OPTIONS[LONG_OPTIONS]} ${PM_OPTIONS[SHORT_OPTIONS]}";
-            COMPREPLY+=( $(compgen -W "bin ls licenses cache hash hash-print hash-string" -- "${cur_word}") );
+            COMPREPLY+=( $(compgen -W "bin ls licenses cache fetch hash hash-print hash-string" -- "${cur_word}") );
             return;;
         *)
             local replaced_script;

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -173,7 +173,7 @@ complete -c bun \
 	-n "__fish_seen_subcommand_from add" -d 'History' -a '(__history_completions)'
 
 complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls licenses cache hash hash-print hash-string' -f
+	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls licenses cache fetch hash hash-print hash-string' -f
 
 complete -c bun \
 	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -265,6 +265,7 @@ _bun_pm_completion() {
             'hash-string\:"print the string used to hash the lockfile" '
             'hash-print\:"print the hash stored in the current lockfile" '
             'cache\:"print the path to the cache folder" '
+            'fetch\:"fetch all dependencies into the cache without installing" '
             'version\:"bump the version in package.json and create a git tag" '
         )
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -328,6 +328,25 @@ To clear Bun's global module cache:
 bun pm cache rm
 ```
 
+## fetch
+
+To download every dependency into Bun's global module cache without installing anything:
+
+```bash terminal icon="terminal"
+bun pm fetch
+```
+
+```txt
+bun pm fetch v1.3.0 (ca7428e9)
+
+Fetched 42 packages into cache [1.20s]
+Cache: /home/user/.bun/install/cache
+```
+
+Dependencies are resolved the same way `bun install` resolves them, but `node_modules` is not created, lifecycle scripts are not run, and `package.json` and the lockfile are left untouched. With an existing lockfile, only the tarballs missing from the cache are downloaded, using the URLs recorded in the lockfile. This is useful for warming a cache that will be shared between CI jobs, or for downloading everything before going offline; a later `bun install` then installs from the cache. Pass `-g` to fetch the dependencies of globally installed packages instead.
+
+Git dependencies that are already in the lockfile are skipped (a note is printed when this happens); they are downloaded by `bun install`.
+
 ## migrate
 
 To migrate another package manager's lockfile without installing anything:

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -76,6 +76,8 @@ pub mod package_manager_resolution;
 pub mod patch_package;
 #[path = "PackageManager/PopulateManifestCache.rs"]
 pub mod populate_manifest_cache;
+#[path = "PackageManager/PopulatePackageCache.rs"]
+pub mod populate_package_cache;
 #[path = "PackageManager/processDependencyList.rs"]
 pub mod process_dependency_list;
 #[path = "PackageManager/ProgressStrings.rs"]
@@ -158,6 +160,7 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile
   <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder
   <b><green>bun pm<r> <blue>cache rm<r>             clear the cache
+  <b><green>bun pm<r> <blue>fetch<r>                fetch all dependencies into the cache without installing
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -780,6 +780,10 @@ pub fn is_package_in_cache(
 // ─────────────────────────── global directories ───────────────────────────────
 
 pub fn setup_global_dir(manager: &mut PackageManager, ctx: &Command::Context) -> Result<(), Error> {
+    // `bun pm -g fetch` gets here from both the `bun pm` dispatcher and `install_with_manager`.
+    if manager.options.global_bin_dir.is_valid() {
+        return Ok(());
+    }
     manager.options.global_bin_dir = options::open_global_bin_dir(ctx.install.as_deref())?;
     let mut out_buffer = PathBuffer::uninit();
     let result = sys::get_fd_path_z(manager.options.global_bin_dir, &mut out_buffer)?;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -58,7 +58,7 @@ pub struct Options {
     // if set to `false` in bunfig, save a binary lockfile
     pub(crate) save_text_lockfile: Option<bool>,
 
-    pub(crate) lockfile_only: bool,
+    pub lockfile_only: bool,
 
     // `bun pm version` command options
     pub git_tag_version: bool,

--- a/src/install/PackageManager/PopulatePackageCache.rs
+++ b/src/install/PackageManager/PopulatePackageCache.rs
@@ -149,8 +149,10 @@ pub fn populate_package_cache(manager: &mut PackageManager) -> crate::Result<Sum
         match enqueued {
             Ok(()) => {}
             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
-            // Both were already reported: `InvalidURL` by `for_tarball`, `AlreadyFailed` in pass 1.
-            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {}
+            // `for_tarball` already added the error to `manager.log`.
+            Err(ForTarballError::InvalidURL) => {}
+            // Not expected here: downloads that failed during the resolve phase stay `Extracting`.
+            Err(ForTarballError::AlreadyFailed) => {}
         }
     }
 

--- a/src/install/PackageManager/PopulatePackageCache.rs
+++ b/src/install/PackageManager/PopulatePackageCache.rs
@@ -1,0 +1,178 @@
+//! `bun pm fetch`: downloads the lockfile packages the resolve phase did not already cache.
+
+use bun_core::Output;
+
+use super::PackageManager;
+use super::install_with_manager::wait_for_everything_except_peers;
+use super::package_manager_options::LogLevel;
+use crate::network_task::ForTarballError;
+use crate::resolution::Tag as ResolutionTag;
+use crate::{DependencyID, PackageID, PreinstallState, TaskCallbackContext, invalid_dependency_id};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Summary {
+    /// Packages extracted by this process, including the resolve phase's prefetches.
+    pub fetched: u32,
+    /// Packages that were already in the cache.
+    pub already_cached: u32,
+    /// `git:` dependencies missing from the cache that were left alone.
+    pub skipped_git: u32,
+}
+
+/// Failures are reported like `bun install`'s: in `manager.log` and `any_failed_to_install`.
+pub fn populate_package_cache(manager: &mut PackageManager) -> crate::Result<Summary> {
+    let log_level = manager.options.log_level;
+    let cpu = manager.options.cpu;
+    let os = manager.options.os;
+
+    let _ = manager.get_cache_directory();
+    let _ = manager.get_temporary_directory();
+
+    let packages_len = manager.lockfile.packages.len();
+
+    // Enqueueing is keyed by dependency edge; prefer a required one so failures are errors.
+    let dep_ids: Vec<DependencyID> = {
+        let dependencies = manager.lockfile.buffers.dependencies.as_slice();
+        let resolutions = manager.lockfile.buffers.resolutions.as_slice();
+        let mut index = vec![invalid_dependency_id; packages_len];
+        for (dep_id, &pkg_id) in resolutions.iter().enumerate() {
+            let Some(slot) = index.get_mut(pkg_id as usize) else {
+                continue;
+            };
+            let dep_id = dep_id as DependencyID;
+            if *slot == invalid_dependency_id
+                || (!dependencies[*slot as usize].behavior.is_required()
+                    && dependencies[dep_id as usize].behavior.is_required())
+            {
+                *slot = dep_id;
+            }
+        }
+        index
+    };
+
+    let mut summary = Summary::default();
+
+    for (i, &dep_id) in dep_ids.iter().enumerate() {
+        let pkg_id = i as PackageID;
+        let pkg = manager.lockfile.packages.get(i);
+        let resolution = pkg.resolution;
+
+        if !resolution.can_enqueue_install_task() || pkg.is_disabled(cpu, os) {
+            continue;
+        }
+
+        let mut name_and_version_hash: Option<u64> = None;
+        let mut patchfile_hash: Option<u64> = None;
+        match manager.determine_preinstall_state(
+            &pkg,
+            &mut name_and_version_hash,
+            &mut patchfile_hash,
+        ) {
+            PreinstallState::Extract => {}
+            // `ApplyPatch`: the unpatched tarball is cached, which is all this command promises.
+            PreinstallState::Done | PreinstallState::ApplyPatch => {
+                summary.already_cached += 1;
+                continue;
+            }
+            PreinstallState::Unknown
+            | PreinstallState::Extracting
+            | PreinstallState::CalcPatchHash
+            | PreinstallState::CalcingPatchHash
+            | PreinstallState::ApplyingPatch => continue,
+        }
+
+        // Nothing in the lockfile depends on this package.
+        if dep_id == invalid_dependency_id {
+            continue;
+        }
+
+        let task_context = TaskCallbackContext::Dependency(dep_id);
+        let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+
+        let enqueued = match resolution.tag {
+            ResolutionTag::Npm => {
+                let name = pkg.name.slice(string_buf).to_vec();
+                let npm = *resolution.npm();
+                let url = npm.url.slice(string_buf).to_vec();
+                manager.enqueue_package_for_download(
+                    &name,
+                    dep_id,
+                    pkg_id,
+                    npm.version,
+                    &url,
+                    task_context,
+                    name_and_version_hash,
+                )
+            }
+            ResolutionTag::Github => {
+                let url = manager.alloc_github_url(resolution.github());
+                manager.enqueue_tarball_for_download(
+                    dep_id,
+                    pkg_id,
+                    &url,
+                    task_context,
+                    name_and_version_hash,
+                )
+            }
+            ResolutionTag::RemoteTarball => {
+                let url = resolution.remote_tarball().slice(string_buf).to_vec();
+                manager.enqueue_tarball_for_download(
+                    dep_id,
+                    pkg_id,
+                    &url,
+                    task_context,
+                    name_and_version_hash,
+                )
+            }
+            ResolutionTag::LocalTarball => {
+                let alias = manager.lockfile.buffers.dependencies[dep_id as usize]
+                    .name
+                    .slice(string_buf)
+                    .to_vec();
+                manager.enqueue_tarball_for_reading(
+                    dep_id,
+                    pkg_id,
+                    &alias,
+                    &resolution,
+                    task_context,
+                );
+                Ok(())
+            }
+            // `run_tasks` only schedules a checkout after a clone when `IS_PACKAGE_INSTALLER`.
+            ResolutionTag::Git => {
+                summary.skipped_git += 1;
+                continue;
+            }
+            _ => continue,
+        };
+
+        match enqueued {
+            Ok(()) => {}
+            Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
+            // Both were already reported: `InvalidURL` by `for_tarball`, `AlreadyFailed` in pass 1.
+            Err(ForTarballError::InvalidURL | ForTarballError::AlreadyFailed) => {}
+        }
+    }
+
+    let _ = manager.schedule_tasks();
+
+    if manager.pending_task_count() > 0 {
+        if log_level.show_progress() {
+            manager.start_progress_bar();
+        } else if log_level != LogLevel::Silent {
+            bun_core::pretty_errorln!("Fetching packages");
+            Output::flush();
+        }
+
+        let waited = wait_for_everything_except_peers(manager);
+
+        if log_level.show_progress() {
+            manager.end_progress_bar();
+        }
+
+        waited?;
+    }
+
+    summary.fetched = manager.extracted_count;
+    Ok(summary)
+}

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -932,7 +932,8 @@ pub fn install_with_manager(
     // It's unnecessary work to re-save the lockfile if there are no changes.
     // A loaded text lockfile is never re-saved just to bump its version: an
     // existing `bun.lock` keeps the version it was written with.
-    let should_save_lockfile = saves_migrated_lockfile(&load_result, save_format)
+    let should_save_lockfile = (!manager.options.dry_run
+        && saves_migrated_lockfile(&load_result, save_format))
         // check `save_lockfile` after checking if loaded from binary and save format is text
         // because `save_lockfile` is set to false for `--frozen-lockfile`
         || (manager.options.do_.save_lockfile()

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1098,7 +1098,7 @@ impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
 fn wait_for_calcing_patch_hashes(this: &mut PackageManager) -> crate::Result<()> {
     RunAndWaitClosure::<false, true>::run_and_wait(this)
 }
-fn wait_for_everything_except_peers(this: &mut PackageManager) -> crate::Result<()> {
+pub(crate) fn wait_for_everything_except_peers(this: &mut PackageManager) -> crate::Result<()> {
     RunAndWaitClosure::<false, false>::run_and_wait(this)
 }
 fn wait_for_peers(this: &mut PackageManager) -> crate::Result<()> {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1568,6 +1568,9 @@ fn run_tasks_erased(
                     continue;
                 }
 
+                manager.extracted_count += 1;
+                bun_core::analytics::Features::extracted_packages_inc();
+
                 if cb.has_on_extract {
                     // We've populated the cache, package already exists in memory. Call the package installer callback
                     // and don't enqueue dependencies

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -362,6 +362,8 @@ pub mod pm_diff_normalize;
 pub mod pm_diff_profile;
 pub mod pm_diff_relayout;
 pub mod pm_diff_semantic;
+#[path = "pm_fetch_command.rs"]
+pub(crate) mod pm_fetch_command;
 #[path = "pm_licenses_command.rs"]
 pub(crate) mod pm_licenses_command;
 #[path = "pm_pkg_command.rs"]

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -19,6 +19,7 @@ use bun_sys::{self, Dir, Fd, File};
 
 use crate::cli::Command;
 use crate::cli::pm_diff_command as PmDiffCommand;
+use crate::cli::pm_fetch_command::PmFetchCommand;
 use crate::cli::pm_licenses_command::{LicensesFlags, PmLicensesCommand};
 use crate::cli::pm_pkg_command::PmPkgCommand;
 use crate::cli::pm_trusted_command::{DefaultTrustedCommand, TrustCommand, UntrustedCommand};
@@ -217,6 +218,7 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile\n\
   <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder\n\
   <b><green>bun pm<r> <blue>cache rm<r>             clear the cache\n\
+  <b><green>bun pm<r> <blue>fetch<r>                fetch all dependencies into the cache without installing\n\
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything\n\
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts\n\
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`\n\
@@ -779,6 +781,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
         } else if strings::eql_comptime(subcommand, b"pkg") {
             let positionals: &[&[u8]] = pm.options.positionals;
             PmPkgCommand::exec(&&mut *ctx, pm, positionals, &cwd)?;
+            Global::exit(0);
+        } else if strings::eql_comptime(subcommand, b"fetch") {
+            PmFetchCommand::exec(ctx, pm, &cwd)?;
             Global::exit(0);
         }
 

--- a/src/runtime/cli/pm_fetch_command.rs
+++ b/src/runtime/cli/pm_fetch_command.rs
@@ -36,8 +36,9 @@ impl PmFetchCommand {
                 | Do::SAVE_YARN_LOCK
                 | Do::SUMMARY,
         );
-        // Also stops the lockfile format migration, which `Do::SAVE_LOCKFILE` alone does not.
+        // The format migration and `--lockfile-only` write the lockfile without consulting `do_`.
         pm.options.dry_run = true;
+        pm.options.lockfile_only = false;
         // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside `PackageManager::init`
         // (already called by `bun pm` dispatch) on this thread; only read thereafter.
         let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };

--- a/src/runtime/cli/pm_fetch_command.rs
+++ b/src/runtime/cli/pm_fetch_command.rs
@@ -3,8 +3,7 @@ use bstr::BStr;
 use bun_core::{Global, Output};
 use bun_install::package_manager_real::{
     PackageManager, ROOT_PACKAGE_JSON_PATH, get_cache_directory_and_abs_path, install_with_manager,
-    package_manager_options::{Do, LogLevel},
-    populate_package_cache,
+    package_manager_options::Do, populate_package_cache,
 };
 
 use crate::cli::Command;
@@ -17,9 +16,10 @@ impl PmFetchCommand {
         pm: &mut PackageManager,
         original_cwd: &[u8],
     ) -> crate::Result<()> {
-        let log_level = pm.options.log_level;
+        // Off under `--silent` and `--no-summary`; read before the flags are cleared below.
+        let print_summary = pm.options.should_print_command_name();
 
-        if pm.options.should_print_command_name() {
+        if print_summary {
             bun_core::prettyln!(
                 "<r><b>bun pm fetch <r><d>v{}<r>\n\n",
                 Global::package_json_version_with_sha,
@@ -54,7 +54,7 @@ impl PmFetchCommand {
             Global::exit(1);
         }
 
-        if log_level == LogLevel::Silent {
+        if !print_summary {
             return Ok(());
         }
 

--- a/src/runtime/cli/pm_fetch_command.rs
+++ b/src/runtime/cli/pm_fetch_command.rs
@@ -21,7 +21,7 @@ impl PmFetchCommand {
 
         if pm.options.should_print_command_name() {
             bun_core::prettyln!(
-                "<r><b>bun pm fetch <r><d>v{}<r>\n",
+                "<r><b>bun pm fetch <r><d>v{}<r>\n\n",
                 Global::package_json_version_with_sha,
             );
             Output::flush();

--- a/src/runtime/cli/pm_fetch_command.rs
+++ b/src/runtime/cli/pm_fetch_command.rs
@@ -1,0 +1,93 @@
+use bstr::BStr;
+
+use bun_core::{Global, Output};
+use bun_install::package_manager_real::{
+    PackageManager, ROOT_PACKAGE_JSON_PATH, get_cache_directory_and_abs_path, install_with_manager,
+    package_manager_options::{Do, LogLevel},
+    populate_package_cache,
+};
+
+use crate::cli::Command;
+
+pub(crate) struct PmFetchCommand;
+
+impl PmFetchCommand {
+    pub(crate) fn exec(
+        ctx: Command::Context,
+        pm: &mut PackageManager,
+        original_cwd: &[u8],
+    ) -> crate::Result<()> {
+        let log_level = pm.options.log_level;
+
+        if pm.options.should_print_command_name() {
+            bun_core::prettyln!(
+                "<r><b>bun pm fetch <r><d>v{}<r>\n",
+                Global::package_json_version_with_sha,
+            );
+            Output::flush();
+        }
+
+        // Pass 1: resolve, which also downloads whatever the lockfile did not pin yet.
+        pm.options.do_.remove(
+            Do::INSTALL_PACKAGES
+                | Do::RUN_SCRIPTS
+                | Do::WRITE_PACKAGE_JSON
+                | Do::SAVE_LOCKFILE
+                | Do::SAVE_YARN_LOCK
+                | Do::SUMMARY,
+        );
+        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside `PackageManager::init`
+        // (already called by `bun pm` dispatch) on this thread; only read thereafter.
+        let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+        install_with_manager(pm, &mut *ctx, root_package_json_path, original_cwd)?;
+        if pm.any_failed_to_install {
+            Global::exit(1);
+        }
+
+        // Pass 2: download the packages the lockfile already pinned.
+        let summary = populate_package_cache::populate_package_cache(pm)?;
+
+        let _ = pm
+            .log_mut()
+            .print(std::ptr::from_mut(Output::error_writer()));
+        if pm.log_mut().has_errors() || pm.any_failed_to_install {
+            Global::exit(1);
+        }
+
+        if log_level == LogLevel::Silent {
+            return Ok(());
+        }
+
+        if summary.fetched > 0 {
+            bun_core::pretty!(
+                "<green>Fetched {} package{}<r> into cache ",
+                summary.fetched,
+                if summary.fetched == 1 { "" } else { "s" },
+            );
+        } else if summary.already_cached > 0 {
+            bun_core::pretty!(
+                "<green>Done<r>! {} package{} already in cache ",
+                summary.already_cached,
+                if summary.already_cached == 1 { "" } else { "s" },
+            );
+        } else {
+            bun_core::pretty!("<green>Done<r>! No packages to fetch ");
+        }
+        Output::print_start_end_stdout(ctx.start_time, bun_core::time::nano_timestamp());
+        bun_core::pretty!("<r>\n");
+
+        if summary.skipped_git > 0 {
+            bun_core::prettyln!(
+                "<yellow>note<r>: skipped {} git dependenc{} (run <b>bun install<r> to populate)",
+                summary.skipped_git,
+                if summary.skipped_git == 1 { "y" } else { "ies" },
+            );
+        }
+
+        let (_, cache_dir) = get_cache_directory_and_abs_path(pm);
+        bun_core::prettyln!("<d>Cache: {}<r>", BStr::new(cache_dir.slice()));
+        Output::flush();
+
+        Ok(())
+    }
+}

--- a/src/runtime/cli/pm_fetch_command.rs
+++ b/src/runtime/cli/pm_fetch_command.rs
@@ -36,6 +36,8 @@ impl PmFetchCommand {
                 | Do::SAVE_YARN_LOCK
                 | Do::SUMMARY,
         );
+        // Also stops the lockfile format migration, which `Do::SAVE_LOCKFILE` alone does not.
+        pm.options.dry_run = true;
         // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside `PackageManager::init`
         // (already called by `bun pm` dispatch) on this thread; only read thereafter.
         let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { exists, readdir, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env } from "harness";
+import { exists, mkdir, readdir, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env, normalizeBunSnapshot } from "harness";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -21,217 +21,152 @@ beforeEach(async () => {
 });
 afterEach(dummyAfterEach);
 
-async function writeBunfig(dir: string) {
+const packageJson = JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "^0.0.2" } });
+
+// `package_dir` is created per test by dummyBeforeEach, so derive paths lazily.
+const bunfigPath = () => join(package_dir, "bunfig.toml");
+const cacheDir = () => join(package_dir, ".bun-cache");
+
+async function writeProject() {
   // The default dummy.registry bunfig disables the global cache; override it
   // so `bun pm fetch` uses BUN_INSTALL_CACHE_DIR.
-  await writeFile(
-    join(dir, "bunfig.toml"),
-    `
-[install]
-registry = "${root_url}/"
-saveTextLockfile = false
-`,
-  );
+  await writeFile(bunfigPath(), `[install]\nregistry = "${root_url}/"\nsaveTextLockfile = false\n`);
+  await writeFile(join(package_dir, "package.json"), packageJson);
+}
+
+async function runBun(args: string[], extraEnv: Record<string, string> = {}) {
+  await using proc = spawn({
+    cmd: [bunExe(), ...args],
+    cwd: package_dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: { ...env, ...extraEnv },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function fetchIntoCache(cache: string, extraArgs: string[] = [], extraEnv: Record<string, string> = {}) {
+  const { stdout, stderr, exitCode } = await runBun(["pm", ...extraArgs, "fetch"], {
+    ...extraEnv,
+    BUN_INSTALL_CACHE_DIR: cache,
+  });
+  // The cache path is asserted through the cache's contents instead.
+  return { stdout: normalizeBunSnapshot(stdout.replace(/^Cache: .*$/m, "Cache: <cache>")), stderr, exitCode };
+}
+
+async function cachedPackages(cache: string) {
+  return (await readdir(cache)).filter(name => name.startsWith("bar@0.0.2")).length;
 }
 
 it("should fetch dependencies into the cache without installing", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeBunfig(package_dir);
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-      dependencies: {
-        bar: "^0.0.2",
-      },
-    }),
-  );
+  await writeProject();
 
-  const cache_dir = join(package_dir, ".bun-cache");
-  const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "pm", "fetch"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env: {
-      ...env,
-      BUN_INSTALL_CACHE_DIR: cache_dir,
-    },
-  });
-  const out = await stdout.text();
-  const err = await stderr.text();
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir());
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
 
-  expect(err).not.toContain("error:");
-  expect(out).toContain("bun pm fetch");
-  expect(out).toContain("Fetched 1 package");
-  expect(out).toContain("Cache:");
-  expect(await exited).toBe(0);
+    Fetched 1 package into cache
+    Cache: <cache>"
+  `);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
 
-  // The tarball was requested and downloaded.
-  expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
-
-  // The package was extracted into the cache.
-  const cache_contents = await readdir(cache_dir);
-  expect(cache_contents.some(name => name.startsWith("bar@0.0.2"))).toBe(true);
-
-  // node_modules was NOT created, and no lockfile was written.
-  expect(await exists(join(package_dir, "node_modules"))).toBe(false);
-  expect(await exists(join(package_dir, "bun.lock"))).toBe(false);
-  expect(await exists(join(package_dir, "bun.lockb"))).toBe(false);
+  expect(urls).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  expect(await cachedPackages(cacheDir())).toBe(1);
+  expect(
+    await Promise.all(["node_modules", "bun.lock", "bun.lockb"].map(name => exists(join(package_dir, name)))),
+  ).toEqual([false, false, false]);
 }, 30_000);
 
 it("should fetch packages missing from cache when lockfile exists", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeBunfig(package_dir);
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-      dependencies: {
-        bar: "^0.0.2",
-      },
-    }),
-  );
+  await writeProject();
 
-  const cache_dir = join(package_dir, ".bun-cache");
-
-  // First: install normally to generate a lockfile and populate the cache.
   {
-    const { stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        BUN_INSTALL_CACHE_DIR: cache_dir,
-      },
-    });
-    const err = await stderr.text();
-    expect(err).not.toContain("error:");
-    expect(err).toContain("Saved lockfile");
-    expect(await exited).toBe(0);
+    const { stderr, exitCode } = await runBun(["install"], { BUN_INSTALL_CACHE_DIR: cacheDir() });
+    expect(stderr).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
   }
-
-  // Wipe the cache and node_modules, but keep the lockfile.
-  await rm(cache_dir, { recursive: true, force: true });
+  await rm(cacheDir(), { recursive: true, force: true });
   await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
   urls.length = 0;
 
-  // Now: fetch should repopulate the cache from the existing lockfile.
-  {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "pm", "fetch"],
-      cwd: package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        BUN_INSTALL_CACHE_DIR: cache_dir,
-      },
-    });
-    const out = await stdout.text();
-    const err = await stderr.text();
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir());
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
 
-    expect(err).not.toContain("error:");
-    expect(out).toContain("Fetched 1 package");
-    expect(await exited).toBe(0);
-  }
+    Fetched 1 package into cache
+    Cache: <cache>"
+  `);
+  // Nothing needed resolving, so only the second pass (the one that walks the
+  // lockfile) printed anything.
+  expect(stderr).toBe("Fetching packages\n");
+  expect(exitCode).toBe(0);
 
-  // The tarball was downloaded directly from the URL stored in the lockfile.
+  // Downloaded straight from the URL stored in the lockfile, no manifest request.
   expect(urls).toEqual([`${root_url}/bar-0.0.2.tgz`]);
-
-  // The package was extracted into the cache.
-  const cache_contents = await readdir(cache_dir);
-  expect(cache_contents.some(name => name.startsWith("bar@0.0.2"))).toBe(true);
-
-  // node_modules was NOT created.
+  expect(await cachedPackages(cacheDir())).toBe(1);
   expect(await exists(join(package_dir, "node_modules"))).toBe(false);
 }, 30_000);
 
 it("should report when all packages are already cached", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeBunfig(package_dir);
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-      dependencies: {
-        bar: "^0.0.2",
-      },
-    }),
-  );
+  await writeProject();
 
-  const cache_dir = join(package_dir, ".bun-cache");
-
-  // First fetch: populates cache.
-  {
-    const { exited, stderr } = spawn({
-      cmd: [bunExe(), "pm", "fetch"],
-      cwd: package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        BUN_INSTALL_CACHE_DIR: cache_dir,
-      },
-    });
-    const err = await stderr.text();
-    expect(err).not.toContain("error:");
-    expect(await exited).toBe(0);
-  }
-
+  expect((await fetchIntoCache(cacheDir())).exitCode).toBe(0);
   urls.length = 0;
 
-  // Second fetch: everything already cached.
-  const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "pm", "fetch"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env: {
-      ...env,
-      BUN_INSTALL_CACHE_DIR: cache_dir,
-    },
-  });
-  const out = await stdout.text();
-  const err = await stderr.text();
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir());
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
 
-  expect(err).not.toContain("error:");
-  expect(out).toContain("already in cache");
-  expect(await exited).toBe(0);
+    Done! 1 package already in cache
+    Cache: <cache>"
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 
-  // No network requests at all on the second run.
   expect(urls).toEqual([]);
-
-  // node_modules still not created.
   expect(await exists(join(package_dir, "node_modules"))).toBe(false);
 }, 30_000);
 
-// `bun pm` (no subcommand) and `bun pm --help` print separate copies of the
-// subcommand list; both must mention `fetch`.
-it.each([[[]], [["--help"]]])("should appear in bun pm help (%j)", async extraArgs => {
-  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
-  const { stdout, exited } = spawn({
-    cmd: [bunExe(), "pm", ...extraArgs],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
+it("should fetch the global install's dependencies with -g", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeProject();
+  const bunInstall = join(package_dir, "global-install");
+  const globalDir = join(bunInstall, "install", "global");
+  await mkdir(globalDir, { recursive: true });
+  await writeFile(join(globalDir, "package.json"), packageJson);
+
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir(), ["-g", `--config=${bunfigPath()}`], {
+    BUN_INSTALL: bunInstall,
   });
-  const out = await stdout.text();
-  expect(out).toContain("bun pm fetch");
-  expect(await exited).toBe(0);
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
+
+    Fetched 1 package into cache
+    Cache: <cache>"
+  `);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  expect(urls).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  expect(await cachedPackages(cacheDir())).toBe(1);
+  expect(await readdir(globalDir)).toEqual(["package.json"]);
+}, 30_000);
+
+// A bare `bun pm` and `bun pm --help` print separate copies of the subcommand list.
+it.each([[[]], [["--help"]]])("should appear in bun pm help (%j)", async extraArgs => {
+  await writeFile(join(package_dir, "package.json"), packageJson);
+
+  const { stdout, exitCode } = await runBun(["pm", ...extraArgs]);
+  expect(stdout).toMatch(/^\s*bun pm fetch\s+fetch all dependencies into the cache without installing$/m);
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -144,6 +144,23 @@ it("should report when all packages are already cached", async () => {
   expect(await exists(join(package_dir, "node_modules"))).toBe(false);
 }, 30_000);
 
+it.each([
+  ["--no-summary", expect.not.stringContaining("error:")],
+  ["--silent", ""],
+])(
+  "should still fetch but print nothing to stdout with %s",
+  async (flag, stderr) => {
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls));
+    await writeProject();
+
+    expect(await fetchIntoCache(cacheDir(), [flag])).toEqual({ stdout: "", stderr, exitCode: 0 });
+    expect(urls).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+    expect(await cachedPackages(cacheDir())).toBe(1);
+  },
+  30_000,
+);
+
 it("should fetch the global install's dependencies with -g", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -196,6 +196,27 @@ it("should not migrate bun.lockb to bun.lock even when saveTextLockfile is set",
   expect(await projectFiles()).toEqual(before);
 }, 30_000);
 
+it("should ignore --lockfile-only", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeProject();
+  const before = await projectFiles();
+
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir(), ["--lockfile-only"]);
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
+
+    Fetched 1 package into cache
+    Cache: <cache>"
+  `);
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(exitCode).toBe(0);
+
+  expect(urls).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+  expect(await cachedPackages(cacheDir())).toBe(1);
+  expect(await projectFiles()).toEqual(before);
+}, 30_000);
+
 it("should report when all packages are already cached", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -27,11 +27,24 @@ const packageJson = JSON.stringify({ name: "foo", version: "0.0.1", dependencies
 const bunfigPath = () => join(package_dir, "bunfig.toml");
 const cacheDir = () => join(package_dir, ".bun-cache");
 
-async function writeProject() {
-  // The default dummy.registry bunfig disables the global cache; override it
-  // so `bun pm fetch` uses BUN_INSTALL_CACHE_DIR.
-  await writeFile(bunfigPath(), `[install]\nregistry = "${root_url}/"\nsaveTextLockfile = false\n`);
+const binaryLockfile = "saveTextLockfile = false\n";
+const textLockfile = "saveTextLockfile = true\n";
+const defaultLockfileFormat = "";
+
+// The default dummy.registry bunfig disables the global cache; override it
+// so `bun pm fetch` uses BUN_INSTALL_CACHE_DIR.
+async function writeBunfig(lockfileSetting: string) {
+  await writeFile(bunfigPath(), `[install]\nregistry = "${root_url}/"\n${lockfileSetting}`);
+}
+
+async function writeProject(lockfileSetting = binaryLockfile) {
+  await writeBunfig(lockfileSetting);
   await writeFile(join(package_dir, "package.json"), packageJson);
+}
+
+/** Everything in the project directory except the cache the test points BUN_INSTALL_CACHE_DIR at. */
+async function projectFiles() {
+  return (await readdir(package_dir)).filter(name => name !== ".bun-cache").sort();
 }
 
 async function runBun(args: string[], extraEnv: Record<string, string> = {}) {
@@ -120,6 +133,67 @@ it("should fetch packages missing from cache when lockfile exists", async () => 
   expect(urls).toEqual([`${root_url}/bar-0.0.2.tgz`]);
   expect(await cachedPackages(cacheDir())).toBe(1);
   expect(await exists(join(package_dir, "node_modules"))).toBe(false);
+}, 30_000);
+
+it("should not write bun.lock when the lockfile comes from package-lock.json", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeProject(defaultLockfileFormat);
+  await writeFile(
+    join(package_dir, "package-lock.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "foo", version: "0.0.1", dependencies: { bar: "^0.0.2" } },
+        "node_modules/bar": { version: "0.0.2", resolved: `${root_url}/bar-0.0.2.tgz` },
+      },
+    }),
+  );
+  const before = await projectFiles();
+
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir());
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
+
+    Fetched 1 package into cache
+    Cache: <cache>"
+  `);
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(exitCode).toBe(0);
+
+  // Resolved from package-lock.json, so only the tarball was requested.
+  expect(urls).toEqual([`${root_url}/bar-0.0.2.tgz`]);
+  expect(await cachedPackages(cacheDir())).toBe(1);
+  expect(await projectFiles()).toEqual(before);
+}, 30_000);
+
+it("should not migrate bun.lockb to bun.lock even when saveTextLockfile is set", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeProject(binaryLockfile);
+  {
+    const { stderr, exitCode } = await runBun(["install"], { BUN_INSTALL_CACHE_DIR: cacheDir() });
+    expect(stderr).toContain("Saved lockfile");
+    expect(exitCode).toBe(0);
+  }
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+  await writeBunfig(textLockfile);
+  const before = await projectFiles();
+  expect(before).toContain("bun.lockb");
+
+  const { stdout, stderr, exitCode } = await fetchIntoCache(cacheDir());
+  expect(stdout).toMatchInlineSnapshot(`
+    "bun pm fetch <version> (<revision>)
+
+    Done! 1 package already in cache
+    Cache: <cache>"
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  expect(await projectFiles()).toEqual(before);
 }, 30_000);
 
 it("should report when all packages are already cached", async () => {

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -1,0 +1,237 @@
+import { spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { exists, readdir, rm, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "./dummy.registry";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+beforeEach(async () => {
+  await dummyBeforeEach();
+});
+afterEach(dummyAfterEach);
+
+async function writeBunfig(dir: string) {
+  // The default dummy.registry bunfig disables the global cache; override it
+  // so `bun pm fetch` uses BUN_INSTALL_CACHE_DIR.
+  await writeFile(
+    join(dir, "bunfig.toml"),
+    `
+[install]
+registry = "${root_url}/"
+saveTextLockfile = false
+`,
+  );
+}
+
+it("should fetch dependencies into the cache without installing", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeBunfig(package_dir);
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "^0.0.2",
+      },
+    }),
+  );
+
+  const cache_dir = join(package_dir, ".bun-cache");
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "fetch"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      BUN_INSTALL_CACHE_DIR: cache_dir,
+    },
+  });
+  const out = await stdout.text();
+  const err = await stderr.text();
+
+  expect(err).not.toContain("error:");
+  expect(out).toContain("bun pm fetch");
+  expect(out).toContain("Fetched 1 package");
+  expect(out).toContain("Cache:");
+  expect(await exited).toBe(0);
+
+  // The tarball was requested and downloaded.
+  expect(urls.sort()).toEqual([`${root_url}/bar`, `${root_url}/bar-0.0.2.tgz`]);
+
+  // The package was extracted into the cache.
+  const cache_contents = await readdir(cache_dir);
+  expect(cache_contents.some(name => name.startsWith("bar@0.0.2"))).toBe(true);
+
+  // node_modules was NOT created, and no lockfile was written.
+  expect(await exists(join(package_dir, "node_modules"))).toBe(false);
+  expect(await exists(join(package_dir, "bun.lock"))).toBe(false);
+  expect(await exists(join(package_dir, "bun.lockb"))).toBe(false);
+}, 30_000);
+
+it("should fetch packages missing from cache when lockfile exists", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeBunfig(package_dir);
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "^0.0.2",
+      },
+    }),
+  );
+
+  const cache_dir = join(package_dir, ".bun-cache");
+
+  // First: install normally to generate a lockfile and populate the cache.
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: cache_dir,
+      },
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  // Wipe the cache and node_modules, but keep the lockfile.
+  await rm(cache_dir, { recursive: true, force: true });
+  await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+  urls.length = 0;
+
+  // Now: fetch should repopulate the cache from the existing lockfile.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "fetch"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: cache_dir,
+      },
+    });
+    const out = await stdout.text();
+    const err = await stderr.text();
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Fetched 1 package");
+    expect(await exited).toBe(0);
+  }
+
+  // The tarball was downloaded directly from the URL stored in the lockfile.
+  expect(urls).toEqual([`${root_url}/bar-0.0.2.tgz`]);
+
+  // The package was extracted into the cache.
+  const cache_contents = await readdir(cache_dir);
+  expect(cache_contents.some(name => name.startsWith("bar@0.0.2"))).toBe(true);
+
+  // node_modules was NOT created.
+  expect(await exists(join(package_dir, "node_modules"))).toBe(false);
+}, 30_000);
+
+it("should report when all packages are already cached", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeBunfig(package_dir);
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "^0.0.2",
+      },
+    }),
+  );
+
+  const cache_dir = join(package_dir, ".bun-cache");
+
+  // First fetch: populates cache.
+  {
+    const { exited, stderr } = spawn({
+      cmd: [bunExe(), "pm", "fetch"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: cache_dir,
+      },
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+  }
+
+  urls.length = 0;
+
+  // Second fetch: everything already cached.
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "fetch"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      BUN_INSTALL_CACHE_DIR: cache_dir,
+    },
+  });
+  const out = await stdout.text();
+  const err = await stderr.text();
+
+  expect(err).not.toContain("error:");
+  expect(out).toContain("already in cache");
+  expect(await exited).toBe(0);
+
+  // No network requests at all on the second run.
+  expect(urls).toEqual([]);
+
+  // node_modules still not created.
+  expect(await exists(join(package_dir, "node_modules"))).toBe(false);
+}, 30_000);
+
+// `bun pm` (no subcommand) and `bun pm --help` print separate copies of the
+// subcommand list; both must mention `fetch`.
+it.each([[[]], [["--help"]]])("should appear in bun pm help (%j)", async extraArgs => {
+  await writeFile(join(package_dir, "package.json"), JSON.stringify({ name: "foo", version: "0.0.1" }));
+  const { stdout, exited } = spawn({
+    cmd: [bunExe(), "pm", ...extraArgs],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const out = await stdout.text();
+  expect(out).toContain("bun pm fetch");
+  expect(await exited).toBe(0);
+});

--- a/test/cli/install/bun-pm-fetch.test.ts
+++ b/test/cli/install/bun-pm-fetch.test.ts
@@ -80,6 +80,14 @@ it("should fetch dependencies into the cache without installing", async () => {
   expect(
     await Promise.all(["node_modules", "bun.lock", "bun.lockb"].map(name => exists(join(package_dir, name)))),
   ).toEqual([false, false, false]);
+
+  // The point of the command: a following install is served entirely from the cache.
+  urls.length = 0;
+  const install = await runBun(["install"], { BUN_INSTALL_CACHE_DIR: cacheDir() });
+  expect(install.stderr).toContain("Saved lockfile");
+  expect(install.exitCode).toBe(0);
+  expect(urls).toEqual([]);
+  expect(await exists(join(package_dir, "node_modules", "bar", "package.json"))).toBe(true);
 }, 30_000);
 
 it("should fetch packages missing from cache when lockfile exists", async () => {

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -456,6 +456,20 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
 });
 
+test.concurrent("`bun install --dry-run` does not write the bun.lock migrated from package-lock.json", async () => {
+  await using testDir = tempDir("migrate-dry-run", filePlatformFixture("a", "vendor/a", [], []));
+
+  const { stderr, exitCode } = await install(testDir, "--dry-run");
+  expect(stderr).toContain("migrated lockfile from package-lock.json");
+  expect(stderr).not.toContain("Saved lockfile");
+  expect(exitCode).toBe(0);
+  expect(["bun.lock", "bun.lockb", "node_modules"].map(name => fs.existsSync(join(testDir, name)))).toEqual([
+    false,
+    false,
+    false,
+  ]);
+});
+
 test.concurrent.each([
   ["a", "vendor/a"],
   ["@scope/a", "vendor/@scope/a"],


### PR DESCRIPTION
## What

Adds `bun pm fetch`, a new subcommand that resolves all dependencies and downloads them into Bun's install cache **without** writing `node_modules`, running lifecycle scripts, or writing `package.json` / the lockfile.

```sh
$ bun pm fetch
bun pm fetch v1.4.x

Fetched 42 packages into cache [250ms]
Cache: /home/user/.bun/install/cache
```

## Why

Useful for:
- Warming CI caches (fetch once, share the cache directory across jobs)
- Pre-fetching packages before going offline
- Populating a cache without the disk/time cost of materializing `node_modules`

Similar to `pnpm fetch`.

## How

Two passes, both reusing the `bun install` machinery:

1. `src/runtime/cli/pm_fetch_command.rs` (the CLI shim) clears `Do::INSTALL_PACKAGES`, `RUN_SCRIPTS`, `WRITE_PACKAGE_JSON`, `SAVE_LOCKFILE`, `SAVE_YARN_LOCK` and `SUMMARY`, then runs the normal `install_with_manager`. The resolve phase already downloads the tarball of every package it resolves for the first time, so this pass covers everything that was not pinned by the lockfile yet. The shim also marks the run as a dry run: `should_save_lockfile` in `install_with_manager` has a lockfile format-migration branch (`saves_migrated_lockfile`: binary or migrated lockfile loaded, text lockfile to be written) that deliberately ignores `Do::SAVE_LOCKFILE` so `--frozen-lockfile` still migrates. Without this, `bun pm fetch` wrote a `bun.lock` in projects that only have a `package-lock.json`, and replaced a `bun.lockb` with `bun.lock` when `saveTextLockfile` is set. That branch is now gated on `!dry_run`, which also fixes `bun install --dry-run` writing a `bun.lock` in the package-lock.json case. `--lockfile-only` (also a shared `bun pm` flag, acted on before the `Do` flags) is cleared as well.
2. `src/install/PackageManager/PopulatePackageCache.rs` (`populate_package_cache`, next to the existing `PopulateManifestCache.rs`) walks the lockfile and enqueues a download for every package whose `determine_preinstall_state` is `Extract` (npm / github / remote tarball / local tarball), using the URLs stored in the lockfile (no manifest round-trips), then waits with the same `wait_for_everything_except_peers` loop `bun install` uses. It returns a small `Summary` (`fetched`, `already_cached`, `skipped_git`) that the shim prints. Living inside `bun_install` means it uses the crate-internal enqueue APIs directly; the only visibility change is `wait_for_everything_except_peers` becoming `pub(crate)`.

Packages are mapped back to a dependency edge (preferring a required edge) because the enqueue functions and the download-failure reporting are keyed by dependency, not package. `git:` dependencies that are already pinned are skipped with a note: outside of the package installer a finished clone is only used as a resolve result, so there is no checkout step that would populate the cache. Git dependencies resolved for the first time are still cached by pass 1.

`runTasks.rs` now increments `extracted_count` on a successful git checkout, mirroring the npm extract path, so git packages fetched during pass 1 are reflected in the summary (`extracted_count` is otherwise only used for the progress bar total).

`bun pm --help` and a bare `bun pm` print separate copies of the subcommand list (`src/install/PackageManager.rs` and `src/runtime/cli/package_manager_command.rs`); both now list `fetch`.

`setup_global_dir` now returns early once the bin directory is open: `bun pm -g fetch` is the first `bun pm` subcommand to reach `install_with_manager`, which calls it a second time after the `bun pm` dispatcher already did, and each call used to open a fresh directory fd.

Docs: new `## fetch` section in `docs/pm/cli/pm.mdx`. Completions: the subcommand is added to `completions/bun-cli.json` (the entry the generator emits; a full regeneration rewrites ~1300 unrelated lines) and to the bash/fish/zsh `bun pm` lists.

## Verification

`test/cli/install/bun-pm-fetch.test.ts` (every spawn drains stdout/stderr/exit concurrently; stdout is compared against an inline snapshot):
- Fresh project: manifest + tarball requested, cache populated, no `node_modules`, no `bun.lock` / `bun.lockb` written; a `bun install` run afterwards makes zero registry requests
- Existing lockfile + cold cache: the only request is the tarball URL from the lockfile, stderr is exactly `Fetching packages` (only the second pass ran), no `node_modules`
- Warm cache: zero requests, stderr is empty, reports the package as already cached
- Project with only a `package-lock.json`: fetches from the migrated lockfile's URL and leaves the directory listing unchanged (no `bun.lock`)
- `bun.lockb` plus `saveTextLockfile = true`: directory listing unchanged (the lockb is not migrated)
- `--lockfile-only`: ignored; directory listing unchanged, package still fetched
- `--no-summary` and `--silent`: nothing on stdout (and nothing on stderr for `--silent`), but the fetch still happens
- `bun pm -g fetch`: fetches the global install's dependencies (exercises both `setup_global_dir` call sites), leaves the global directory untouched
- Both `bun pm` and `bun pm --help` list the command

`test/cli/install/migration/migrate.test.ts` gains a `bun install --dry-run` case for the package-lock.json migration (no `bun.lock` written).

All of them fail on a bun without this change (`fetch` is an unknown `bun pm` subcommand; the `--dry-run` test fails because a `bun.lock` is written) and pass on this branch. Also run locally: `bun-pm.test.ts` (18/18), `test/internal/source-lints` (98/98), `cargo clippy -p bun_install -p bun_runtime`, `cargo fmt --check`.

Related to #6353
Related to #7956

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 22 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts

<!-- robobun:evidence:end -->
