### PR TITLE
Fix `bunx @scope/name` matching unrelated system binaries in $PATH

### DIFF
--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -578,7 +578,6 @@ pub const BunxCommand = struct {
                 // system binaries. Only search node_modules/.bin directories.
                 const search_path = if (initial_bin_name_is_a_guess and
                     ORIGINAL_PATH.len > 0 and
-                    ORIGINAL_PATH.len < PATH_FOR_BIN_DIRS.len and
                     strings.endsWith(PATH_FOR_BIN_DIRS, ORIGINAL_PATH))
                     PATH_FOR_BIN_DIRS[0 .. PATH_FOR_BIN_DIRS.len - ORIGINAL_PATH.len]
                 else

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -382,6 +382,17 @@ pub const BunxCommand = struct {
             update_request.name;
         debug("initial_bin_name: {s}", .{initial_bin_name});
 
+        // When the user types a scoped package like `@foo/bar`, the initial bin
+        // name ("bar") is only a guess — the package's actual bin may be named
+        // something else entirely. In that case we must not search the original
+        // system $PATH with the guessed name, or we may match an unrelated system
+        // binary (e.g. `bunx @uidotsh/install` would otherwise run /usr/bin/install).
+        // We still search local node_modules/.bin directories, since many scoped
+        // packages do link their bin under the unscoped name.
+        const initial_bin_name_is_a_guess = opts.binary_name == null and
+            update_request.name.len > 0 and
+            update_request.name[0] == '@';
+
         // fast path: they're actually using this interchangeably with `bun run`
         // so we use Bun.which to check
         // SAFETY: initialized by Run.configureEnvForRun
@@ -561,9 +572,20 @@ pub const BunxCommand = struct {
 
             // Only use the system-installed version if there is no version specified
             if (update_request.version.literal.isEmpty()) {
+                // If the bin name is a guess derived from a scoped package name,
+                // exclude the original system $PATH so we don't match unrelated
+                // system binaries. Only search node_modules/.bin directories.
+                const search_path = if (initial_bin_name_is_a_guess and
+                    ORIGINAL_PATH.len > 0 and
+                    ORIGINAL_PATH.len < PATH_FOR_BIN_DIRS.len and
+                    strings.endsWith(PATH_FOR_BIN_DIRS, ORIGINAL_PATH))
+                    PATH_FOR_BIN_DIRS[0 .. PATH_FOR_BIN_DIRS.len - ORIGINAL_PATH.len]
+                else
+                    PATH_FOR_BIN_DIRS;
+
                 destination_ = bun.which(
                     &path_buf,
-                    PATH_FOR_BIN_DIRS,
+                    search_path,
                     if (ignore_cwd.len > 0) "" else this_transpiler.fs.top_level_dir,
                     initial_bin_name,
                 );
@@ -644,7 +666,7 @@ pub const BunxCommand = struct {
             const root_dir_fd = root_dir_info.getFileDescriptor();
             bun.assert(root_dir_fd.isValid());
             if (opts.binary_name == null) {
-                if (getBinName(&this_transpiler, root_dir_fd, bunx_cache_dir, initial_bin_name)) |package_name_for_bin| {
+                if (getBinName(&this_transpiler, root_dir_fd, bunx_cache_dir, result_package_name)) |package_name_for_bin| {
                     // if we check the bin name and its actually the same, we don't need to check $PATH here again
                     if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
                         absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, bun.pathLiteral("{s}/node_modules/.bin/{s}{s}"), .{ bunx_cache_dir, package_name_for_bin, bun.exe_suffix }) catch unreachable;

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -433,6 +433,19 @@ pub const BunxCommand = struct {
         }
 
         var PATH = this_transpiler.env.get("PATH").?;
+
+        // `configurePathForRun` builds PATH by appending ORIGINAL_PATH to a set of
+        // `*/node_modules/.bin` directories (plus the bun-node shim dir). Capture just
+        // that prepended portion here — it is used below to search for guessed bin
+        // names without risking a collision with an unrelated binary in the user's
+        // system $PATH. A trailing delimiter may remain; `bun.which` tokenizes on the
+        // delimiter so empty segments are ignored.
+        const local_bin_dirs: []const u8 = if (ORIGINAL_PATH.len > 0 and
+            strings.endsWith(PATH, ORIGINAL_PATH))
+            PATH[0 .. PATH.len - ORIGINAL_PATH.len]
+        else
+            PATH;
+
         const display_version = if (update_request.version.literal.isEmpty())
             "latest"
         else
@@ -575,17 +588,10 @@ pub const BunxCommand = struct {
             if (update_request.version.literal.isEmpty()) {
                 // If the bin name is a guess derived from a scoped package name,
                 // exclude the original system $PATH so we don't match unrelated
-                // system binaries. Only search node_modules/.bin directories.
-                const search_path = if (initial_bin_name_is_a_guess and
-                    ORIGINAL_PATH.len > 0 and
-                    strings.endsWith(PATH_FOR_BIN_DIRS, ORIGINAL_PATH))
-                    PATH_FOR_BIN_DIRS[0 .. PATH_FOR_BIN_DIRS.len - ORIGINAL_PATH.len]
-                else
-                    PATH_FOR_BIN_DIRS;
-
+                // system binaries. Only search local node_modules/.bin directories.
                 destination_ = bun.which(
                     &path_buf,
-                    search_path,
+                    if (initial_bin_name_is_a_guess) local_bin_dirs else PATH_FOR_BIN_DIRS,
                     if (ignore_cwd.len > 0) "" else this_transpiler.fs.top_level_dir,
                     initial_bin_name,
                 );
@@ -673,14 +679,15 @@ pub const BunxCommand = struct {
 
                         // Only use the system-installed version if there is no version specified.
                         // `package_name_for_bin` is the real bin name from the target package's
-                        // own package.json (not a guess), so it is safe to search the full
-                        // configured $PATH for it. The local node_modules/.bin directories are
-                        // at the front of PATH_FOR_BIN_DIRS, so a locally-installed package wins
-                        // over any same-named system binary.
+                        // own package.json. Search only local node_modules/.bin directories for
+                        // it — not the system $PATH, because the real bin name may itself collide
+                        // with an unrelated system binary when the package lives only in the bunx
+                        // cache (handled by the `orelse` absolute-path probe below) and not in a
+                        // local node_modules.
                         if (update_request.version.literal.isEmpty()) {
                             destination_ = bun.which(
                                 &path_buf,
-                                PATH_FOR_BIN_DIRS,
+                                local_bin_dirs,
                                 if (ignore_cwd.len > 0) "" else this_transpiler.fs.top_level_dir,
                                 package_name_for_bin,
                             );

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -368,6 +368,18 @@ pub const BunxCommand = struct {
             }
         }
 
+        // When the user types a scoped package like `@foo/bar`, the initial bin
+        // name ("bar") is only a guess — the package's actual bin may be named
+        // something else entirely. In that case we must not search the original
+        // system $PATH with the guessed name, or we may match an unrelated system
+        // binary (e.g. `bunx @uidotsh/install` would otherwise run /usr/bin/install).
+        // We still search local node_modules/.bin directories, since many scoped
+        // packages do link their bin under the unscoped name.
+        //
+        // Only the branch that strips the scope from the package name is a guess;
+        // explicit `--package` bins and hardcoded aliases like `tsc`/`claude` are
+        // known-good bin names and should still be searchable in the system $PATH.
+        var initial_bin_name_is_a_guess = false;
         const initial_bin_name = if (opts.binary_name) |bin_name|
             bin_name
         else if (strings.eqlComptime(update_request.name, "typescript"))
@@ -376,22 +388,11 @@ pub const BunxCommand = struct {
             "claude"
         else if (update_request.version.tag == .github)
             update_request.version.value.github.repo.slice(update_request.version_buf)
-        else if (strings.lastIndexOfChar(update_request.name, '/')) |index|
-            update_request.name[index + 1 ..]
-        else
-            update_request.name;
+        else if (strings.lastIndexOfChar(update_request.name, '/')) |index| blk: {
+            initial_bin_name_is_a_guess = true;
+            break :blk update_request.name[index + 1 ..];
+        } else update_request.name;
         debug("initial_bin_name: {s}", .{initial_bin_name});
-
-        // When the user types a scoped package like `@foo/bar`, the initial bin
-        // name ("bar") is only a guess — the package's actual bin may be named
-        // something else entirely. In that case we must not search the original
-        // system $PATH with the guessed name, or we may match an unrelated system
-        // binary (e.g. `bunx @uidotsh/install` would otherwise run /usr/bin/install).
-        // We still search local node_modules/.bin directories, since many scoped
-        // packages do link their bin under the unscoped name.
-        const initial_bin_name_is_a_guess = opts.binary_name == null and
-            update_request.name.len > 0 and
-            update_request.name[0] == '@';
 
         // fast path: they're actually using this interchangeably with `bun run`
         // so we use Bun.which to check
@@ -671,11 +672,16 @@ pub const BunxCommand = struct {
                     if (!strings.eqlLong(package_name_for_bin, initial_bin_name, true)) {
                         absolute_in_cache_dir = std.fmt.bufPrint(&absolute_in_cache_dir_buf, bun.pathLiteral("{s}/node_modules/.bin/{s}{s}"), .{ bunx_cache_dir, package_name_for_bin, bun.exe_suffix }) catch unreachable;
 
-                        // Only use the system-installed version if there is no version specified
+                        // Only use the system-installed version if there is no version specified.
+                        // `package_name_for_bin` is the real bin name from the target package's
+                        // own package.json (not a guess), so it is safe to search the full
+                        // configured $PATH for it. The local node_modules/.bin directories are
+                        // at the front of PATH_FOR_BIN_DIRS, so a locally-installed package wins
+                        // over any same-named system binary.
                         if (update_request.version.literal.isEmpty()) {
                             destination_ = bun.which(
                                 &path_buf,
-                                bunx_cache_dir,
+                                PATH_FOR_BIN_DIRS,
                                 if (ignore_cwd.len > 0) "" else this_transpiler.fs.top_level_dir,
                                 package_name_for_bin,
                             );

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -988,6 +988,95 @@ describe("scoped packages should not match unrelated system binaries", () => {
     expect(err).not.toContain("error:");
     expect(exited).toBe(0);
   });
+
+  // When a scoped package lives only in the bunx cache (not locally
+  // installed) and its real bin name — discovered by reading its
+  // package.json — collides with a system binary, bunx must run the
+  // cached bin via the absolute-path probe, not the system binary.
+  it("bunx-cache-only `@scope/name` whose real bin collides with a system binary runs the cached bin", async () => {
+    // Create a scoped package with a bin name that differs from the
+    // unscoped portion AND collides with a system binary we control.
+    const pkgRoot = tmpdirSync();
+    const packageDir = join(pkgRoot, "package");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@cacheonly/pkg",
+        version: "1.0.0",
+        bin: { "colliding-tool": "cli.js" },
+      }),
+    );
+    await writeFile(
+      join(packageDir, "cli.js"),
+      `#!/usr/bin/env node\nconsole.log("CORRECT: ran the cached package's bin");\n`,
+    );
+    const tgzDir = tmpdirSync();
+    await Bun.$`tar -czf ${join(tgzDir, "pkg-1.0.0.tgz")} -C ${pkgRoot} package`;
+
+    // Put a decoy "colliding-tool" (the REAL bin name) in $PATH.
+    const fakeBinDir = tmpdirSync();
+    if (isWindows) {
+      await writeFile(join(fakeBinDir, "colliding-tool.cmd"), `@echo WRONG: ran a system binary from PATH\r\n`);
+    } else {
+      const fakeBin = join(fakeBinDir, "colliding-tool");
+      await writeFile(fakeBin, `#!/bin/sh\necho "WRONG: ran a system binary from PATH"\n`);
+      chmodSync(fakeBin, 0o755);
+    }
+
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "1.0.0": { bin: { "colliding-tool": "cli.js" }, as: "1.0.0" } }, 0, tgzDir));
+
+    const runEnv = {
+      ...env,
+      npm_config_registry: `http://localhost:${port}/`,
+      PATH: `${fakeBinDir}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
+    };
+
+    // First run: installs into the bunx cache (no local node_modules).
+    {
+      const subprocess = spawn({
+        cmd: [bunExe(), "x", "@cacheonly/pkg"],
+        cwd: x_dir,
+        stdout: "pipe",
+        stdin: "inherit",
+        stderr: "pipe",
+        env: runEnv,
+      });
+      const [err, out, exited] = await Promise.all([
+        subprocess.stderr.text(),
+        subprocess.stdout.text(),
+        subprocess.exited,
+      ]);
+      expect(out).not.toContain("WRONG");
+      expect(err).not.toContain("WRONG");
+      expect(out).toContain("CORRECT: ran the cached package's bin");
+      expect(exited).toBe(0);
+    }
+
+    // Second run with --no-install: must resolve the real bin name from
+    // the cached package.json and run the cached bin, NOT the colliding
+    // system binary.
+    {
+      const subprocess = spawn({
+        cmd: [bunExe(), "x", "--no-install", "@cacheonly/pkg"],
+        cwd: x_dir,
+        stdout: "pipe",
+        stdin: "inherit",
+        stderr: "pipe",
+        env: runEnv,
+      });
+      const [err, out, exited] = await Promise.all([
+        subprocess.stderr.text(),
+        subprocess.stdout.text(),
+        subprocess.exited,
+      ]);
+      expect(out).not.toContain("WRONG");
+      expect(err).not.toContain("WRONG");
+      expect(out).toContain("CORRECT: ran the cached package's bin");
+      expect(exited).toBe(0);
+    }
+  });
 });
 
 describe("package name aliases", () => {

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { copyFileSync, readdirSync } from "node:fs";
+import { chmodSync, copyFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -882,8 +882,6 @@ describe("scoped packages should not match unrelated system binaries", () => {
   // full scoped name) to discover the real bin name, instead of guessing
   // the unscoped basename and tripping over a system binary.
   it("locally installed `@scope/name` resolves the real bin from its package.json", async () => {
-    const { chmodSync } = await import("node:fs");
-
     await mkdir(join(x_dir, "node_modules", "@myscope", "collide"), { recursive: true });
     await mkdir(join(x_dir, "node_modules", ".bin"), { recursive: true });
     await writeFile(
@@ -947,8 +945,6 @@ describe("scoped packages should not match unrelated system binaries", () => {
   // which excludes the system $PATH for scoped packages but still searches
   // node_modules/.bin — should find the locally-linked bin.
   it("locally installed `@scope/foo` whose bin is also named `foo` is still found", async () => {
-    const { chmodSync } = await import("node:fs");
-
     await mkdir(join(x_dir, "node_modules", "@myscope", "samebin"), { recursive: true });
     await mkdir(join(x_dir, "node_modules", ".bin"), { recursive: true });
     await writeFile(

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,10 +1,10 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { rm, writeFile } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
 import { copyFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "os";
-import { join, resolve } from "path";
+import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
 
 let x_dir: string;
@@ -790,6 +790,90 @@ console.log("EXECUTED: multi-tool-alt (alternate binary)");
       expect(out).not.toContain("EXECUTED: multi-tool (main binary)");
       expect(exited).toBe(0);
     });
+  });
+});
+
+// Regression: `bunx @scope/name` guesses the bin name as `name` (the
+// unscoped portion), then searched the full system $PATH with it. When
+// `name` happened to match an unrelated system binary — e.g.
+// `bunx @uidotsh/install` matching /usr/bin/install — the system binary
+// was executed instead of the package's actual bin.
+describe("scoped packages should not match unrelated system binaries", () => {
+  let port: number;
+
+  beforeAll(() => {
+    dummyBeforeAll();
+    port = getPort()!;
+  });
+
+  afterAll(() => {
+    dummyAfterAll();
+  });
+
+  beforeEach(async () => {
+    await dummyBeforeEach();
+  });
+
+  it("`bunx @scope/install` runs the package's bin, not a system binary named `install`", async () => {
+    // Create a scoped package whose bin name does NOT match the unscoped
+    // portion of the package name, mirroring @uidotsh/install whose bin is
+    // "uidotsh-installer".
+    const pkgRoot = tmpdirSync();
+    const packageDir = join(pkgRoot, "package");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "@scope/install",
+        version: "1.0.0",
+        bin: { "scoped-tool": "cli.js" },
+      }),
+    );
+    await writeFile(
+      join(packageDir, "cli.js"),
+      `#!/usr/bin/env node\nconsole.log("CORRECT: ran the scoped package's bin");\n`,
+    );
+    const tgzDir = tmpdirSync();
+    // The dummy registry serves the tarball by basename of the request URL,
+    // which for `@scope/install` + version 1.0.0 is `install-1.0.0.tgz`.
+    await Bun.$`tar -czf ${join(tgzDir, "install-1.0.0.tgz")} -C ${pkgRoot} package`;
+
+    // Create a fake "install" binary in $PATH to simulate /usr/bin/install.
+    const fakeBinDir = tmpdirSync();
+    if (isWindows) {
+      await writeFile(join(fakeBinDir, "install.cmd"), `@echo WRONG: ran a system binary from PATH\r\n`);
+    } else {
+      const fakeBin = join(fakeBinDir, "install");
+      await writeFile(fakeBin, `#!/bin/sh\necho "WRONG: ran a system binary from PATH"\n`);
+      await Bun.$`chmod +x ${fakeBin}`;
+    }
+
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "1.0.0": { bin: { "scoped-tool": "cli.js" }, as: "1.0.0" } }, 0, tgzDir));
+
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", "@scope/install"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: {
+        ...env,
+        npm_config_registry: `http://localhost:${port}/`,
+        PATH: `${fakeBinDir}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
+      },
+    });
+
+    const [err, out, exited] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+
+    expect(out).not.toContain("WRONG");
+    expect(err).not.toContain("WRONG");
+    expect(out).toContain("CORRECT: ran the scoped package's bin");
+    expect(exited).toBe(0);
   });
 });
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -875,6 +875,123 @@ describe("scoped packages should not match unrelated system binaries", () => {
     expect(out).toContain("CORRECT: ran the scoped package's bin");
     expect(exited).toBe(0);
   });
+
+  // Also covers https://github.com/oven-sh/bun/issues/19458 and
+  // https://github.com/oven-sh/bun/issues/17904: when a scoped package is
+  // already installed locally, bunx must read its package.json (under the
+  // full scoped name) to discover the real bin name, instead of guessing
+  // the unscoped basename and tripping over a system binary.
+  it("locally installed `@scope/name` resolves the real bin from its package.json", async () => {
+    const { chmodSync } = await import("node:fs");
+
+    await mkdir(join(x_dir, "node_modules", "@myscope", "collide"), { recursive: true });
+    await mkdir(join(x_dir, "node_modules", ".bin"), { recursive: true });
+    await writeFile(
+      join(x_dir, "node_modules", "@myscope", "collide", "package.json"),
+      JSON.stringify({ name: "@myscope/collide", version: "1.0.0", bin: { "real-bin": "./real.js" } }),
+    );
+    await writeFile(
+      join(x_dir, "node_modules", "@myscope", "collide", "real.js"),
+      `#!/usr/bin/env node\nconsole.log("REAL_BIN_RAN");\n`,
+    );
+    if (isWindows) {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "real-bin.cmd"),
+        `@echo off\r\nnode "%~dp0..\\@myscope\\collide\\real.js" %*\r\n`,
+      );
+    } else {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "real-bin"),
+        `#!/usr/bin/env node\nrequire("../@myscope/collide/real.js");\n`,
+      );
+      chmodSync(join(x_dir, "node_modules", "@myscope", "collide", "real.js"), 0o755);
+      chmodSync(join(x_dir, "node_modules", ".bin", "real-bin"), 0o755);
+    }
+
+    // Put a decoy named after the unscoped basename ("collide") in $PATH.
+    const fakeBinDir = tmpdirSync();
+    if (isWindows) {
+      await writeFile(join(fakeBinDir, "collide.cmd"), `@echo off\r\necho DECOY_RAN\r\n`);
+    } else {
+      const fakeBin = join(fakeBinDir, "collide");
+      await writeFile(fakeBin, `#!/bin/sh\necho DECOY_RAN\n`);
+      chmodSync(fakeBin, 0o755);
+    }
+
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", "--no-install", "@myscope/collide"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: {
+        ...env,
+        PATH: `${fakeBinDir}${delimiter}${env.PATH ?? process.env.PATH ?? ""}`,
+      },
+    });
+
+    const [err, out, exited] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+
+    expect(out.trim()).toBe("REAL_BIN_RAN");
+    expect(out).not.toContain("DECOY_RAN");
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
+
+  // When a scoped package's bin name happens to match its unscoped
+  // basename (e.g. `@scope/foo` with bin `foo`), the first $PATH probe —
+  // which excludes the system $PATH for scoped packages but still searches
+  // node_modules/.bin — should find the locally-linked bin.
+  it("locally installed `@scope/foo` whose bin is also named `foo` is still found", async () => {
+    const { chmodSync } = await import("node:fs");
+
+    await mkdir(join(x_dir, "node_modules", "@myscope", "samebin"), { recursive: true });
+    await mkdir(join(x_dir, "node_modules", ".bin"), { recursive: true });
+    await writeFile(
+      join(x_dir, "node_modules", "@myscope", "samebin", "package.json"),
+      JSON.stringify({ name: "@myscope/samebin", version: "1.0.0", bin: { samebin: "./real.js" } }),
+    );
+    await writeFile(
+      join(x_dir, "node_modules", "@myscope", "samebin", "real.js"),
+      `#!/usr/bin/env node\nconsole.log("SAMEBIN_RAN");\n`,
+    );
+    if (isWindows) {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "samebin.cmd"),
+        `@echo off\r\nnode "%~dp0..\\@myscope\\samebin\\real.js" %*\r\n`,
+      );
+    } else {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "samebin"),
+        `#!/usr/bin/env node\nrequire("../@myscope/samebin/real.js");\n`,
+      );
+      chmodSync(join(x_dir, "node_modules", "@myscope", "samebin", "real.js"), 0o755);
+      chmodSync(join(x_dir, "node_modules", ".bin", "samebin"), 0o755);
+    }
+
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", "--no-install", "@myscope/samebin"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env,
+    });
+
+    const [err, out, exited] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+
+    expect(out.trim()).toBe("SAMEBIN_RAN");
+    expect(err).not.toContain("error:");
+    expect(exited).toBe(0);
+  });
 });
 
 describe("package name aliases", () => {


### PR DESCRIPTION
## Problem

```console
$ bunx @uidotsh/install
/usr/bin/install: missing file operand
Try '/usr/bin/install --help' for more information.
```

`npx @uidotsh/install` works correctly.

## Cause

For scoped packages, `bunx` strips the scope to derive an initial guess at the bin name (`@uidotsh/install` → `install`), then searches the full system `$PATH` with that guess. Since `install` is a standard Unix binary at `/usr/bin/install`, it matched and was executed instead of the package's actual bin (`uidotsh-installer`).

Any scoped package whose unscoped portion collides with a system binary is affected — `@paretools/git`, `@foo/find`, `@foo/which`, etc.

Additionally, the pre-install `getBinName` lookup passed the stripped name (`install`) when looking for `node_modules/<name>/package.json`, so a locally-installed `@scope/name` was never found by its real bin name.

## Fix

- When the initial bin name was derived by stripping the scope (a guess), exclude the original system `$PATH` from the `which()` search. Only the `node_modules/.bin` directories prepended by `configurePathForRun` are searched, so locally-installed scoped packages are still found via their linked bins. Hardcoded aliases (`tsc`, `claude`) and explicit `--package` bins are not guesses and still search the full `$PATH`.
- `getBinName` now reads `node_modules/@scope/name/package.json` (the full package name) instead of `node_modules/name/package.json`, so a locally-installed scoped package's real bin name is discovered before falling through to install.
- After the real bin name is resolved from the package's own `package.json`, search `PATH_FOR_BIN_DIRS` (which has local `node_modules/.bin` at the front) instead of just the bunx cache dir, so the locally-linked bin is found.

## Verification

Three regression tests in `test/cli/install/bunx.test.ts`:
1. `bunx @scope/install` against a mock registry, with a decoy `install` in `$PATH` — verifies the package's bin runs instead of the decoy.
2. Locally-installed `@myscope/collide` with bin `real-bin`, decoy `collide` in `$PATH`, `--no-install` — verifies the real bin is resolved via the package's `package.json`.
3. Locally-installed `@myscope/samebin` with bin `samebin` — verifies a scoped package whose bin name matches its basename is still found (guards against over-restriction).

```console
$ ./build/debug/bun-debug x @uidotsh/install
┌  ui.sh installer…
│
◆  What's your ui.sh token?
```

Supersedes #28951.

Fixes #28950
Fixes #19458
Fixes #17191
Fixes #17904
