### PR TITLE
install: support `--filter` for `bun add` and `bun remove`

### DIFF
--- a/docs/pm/cli/add.mdx
+++ b/docs/pm/cli/add.mdx
@@ -77,6 +77,23 @@ To view a complete list of options for this command:
 bun add --help
 ```
 
+## `--filter`
+
+<Note>**Alias** — `-F`</Note>
+
+In a monorepo, `bun add` from the root writes to the root `package.json`. Use `--filter` to add the dependency to one or more workspace packages instead.
+
+```bash terminal icon="terminal"
+# add zod to the "api" workspace package
+bun add zod --filter api
+
+# match by relative path
+bun add zod --filter ./packages/api
+
+# add to every workspace package
+bun add zod --filter '*'
+```
+
 ## `--global`
 
 <Note>

--- a/docs/pm/cli/remove.mdx
+++ b/docs/pm/cli/remove.mdx
@@ -11,6 +11,20 @@ import Remove from "/snippets/cli/remove.mdx";
 bun remove ts-node
 ```
 
+## `--filter`
+
+<Note>**Alias** — `-F`</Note>
+
+In a monorepo, use `--filter` to remove a dependency from one or more workspace packages instead of the root `package.json`.
+
+```bash terminal icon="terminal"
+# remove zod from the "api" workspace package
+bun remove zod --filter api
+
+# remove from every workspace package
+bun remove zod --filter '*'
+```
+
 ---
 
 <Remove />

--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -34,6 +34,11 @@ bun add <package> <@version>
   Add the exact version instead of the <code>^</code> range. Alias: <code>-E</code>
 </ParamField>
 
+<ParamField path="--filter" type="string">
+  Add packages to the matching workspaces instead of the root <code>package.json</code>. Accepts a workspace name, a
+  glob like <code>@scope/*</code>, or a relative path like <code>./packages/api</code>. Alias: <code>-F</code>
+</ParamField>
+
 <ParamField path="--only-missing" type="boolean">
   Only add dependencies to <code>package.json</code> if they are not already present
 </ParamField>

--- a/docs/snippets/cli/remove.mdx
+++ b/docs/snippets/cli/remove.mdx
@@ -30,6 +30,11 @@ bun remove <package>
   Add to <code>trustedDependencies</code> in the project's <code>package.json</code> and install the package(s)
 </ParamField>
 
+<ParamField path="--filter" type="string">
+  Remove packages from the matching workspaces instead of the root <code>package.json</code>. Accepts a workspace name,
+  a glob like <code>@scope/*</code>, or a relative path like <code>./packages/api</code>. Alias: <code>-F</code>
+</ParamField>
+
 ### Lockfile Behavior
 
 <ParamField path="--yarn" type="boolean">

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -177,8 +177,9 @@ pub const Subcommand = enum {
             .outdated => true,
             .install => true,
             .update => true,
+            .add => true,
+            .remove => true,
             // .pack => true,
-            // .add => true,
             else => false,
         };
     }

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -99,12 +99,14 @@ pub const add_params: []const ParamType = &(shared_params ++ [_]ParamType{
     clap.parseParam("--optional                        Add dependency to \"optionalDependencies\"") catch unreachable,
     clap.parseParam("--peer                        Add dependency to \"peerDependencies\"") catch unreachable,
     clap.parseParam("-E, --exact                  Add the exact version instead of the ^range") catch unreachable,
+    clap.parseParam("-F, --filter <STR>...                 Add packages to the matching workspaces") catch unreachable,
     clap.parseParam("-a, --analyze                   Recursively analyze & install dependencies of files passed as arguments (using Bun's bundler)") catch unreachable,
     clap.parseParam("--only-missing                  Only add dependencies to package.json if they are not already present") catch unreachable,
     clap.parseParam("<POS> ...                         \"name\" or \"name@version\" of package(s) to install") catch unreachable,
 });
 
 pub const remove_params: []const ParamType = &(shared_params ++ [_]ParamType{
+    clap.parseParam("-F, --filter <STR>...                 Remove packages from the matching workspaces") catch unreachable,
     clap.parseParam("<POS> ...                         \"name\" of package(s) to remove from package.json") catch unreachable,
 });
 
@@ -445,6 +447,10 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <b><green>bun add<r> <cyan>-d<r> <blue>typescript<r>
                 \\  <b><green>bun add<r> <cyan>--optional<r> <blue>lodash<r>
                 \\  <b><green>bun add<r> <cyan>--peer<r> <blue>esbuild<r>
+                \\
+                \\  <d>Add to a specific workspace package<r>
+                \\  <b><green>bun add<r> <cyan>--filter=api<r> <blue>zod<r>
+                \\  <b><green>bun add<r> <cyan>--filter='./packages/*'<r> <blue>zod<r>
                 \\
                 \\Full documentation is available at <magenta>https://bun.com/docs/cli/add<r>.
                 \\

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -477,6 +477,9 @@ pub fn printHelp(subcommand: Subcommand) void {
                 \\  <d>Remove a dependency<r>
                 \\  <b><green>bun remove<r> <blue>ts-node<r>
                 \\
+                \\  <d>Remove from a specific workspace package<r>
+                \\  <b><green>bun remove<r> <cyan>--filter=api<r> <blue>zod<r>
+                \\
                 \\Full documentation is available at <magenta>https://bun.com/docs/cli/remove<r>.
                 \\
             ;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -71,6 +71,16 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
         Global.crash();
     }
 
+    if ((subcommand == .add or subcommand == .remove) and manager.options.filter_patterns.len > 0) {
+        return try updatePackageJSONAndInstallWithFilter(
+            manager,
+            ctx,
+            updates,
+            subcommand,
+            original_cwd,
+        );
+    }
+
     var current_package_json = switch (manager.workspace_package_json_cache.getWithPath(
         manager.allocator,
         manager.log,
@@ -486,6 +496,441 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
     }
 }
 
+const FilteredWorkspace = struct {
+    /// Absolute, null-terminated path to the workspace's package.json (owned).
+    package_json_path: [:0]const u8,
+    /// Workspace package name (owned).
+    name: []const u8,
+    name_hash: PackageNameHash,
+    indentation: JSPrinter.Options.Indentation,
+    preserve_trailing_newline: bool,
+    /// Serialized package.json contents after the pre-install edit.
+    before_install_source: []const u8,
+};
+
+/// Enumerate workspace packages declared in the root `package.json` and
+/// return those matching `--filter` patterns. Must be run from the workspace
+/// root (PackageManager.init has already chdir'd there).
+fn findFilteredWorkspaces(
+    manager: *PackageManager,
+    original_cwd: string,
+    root_package_json_path: [:0]const u8,
+) ![]FilteredWorkspace {
+    const allocator = manager.allocator;
+
+    // Parse --filter patterns.
+    const filter_path_buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(filter_path_buf);
+
+    var filters: std.ArrayListUnmanaged(WorkspaceFilter) = .{};
+    defer {
+        for (filters.items) |f| f.deinit(allocator);
+        filters.deinit(allocator);
+    }
+    try filters.ensureUnusedCapacity(allocator, manager.options.filter_patterns.len);
+    for (manager.options.filter_patterns) |pattern| {
+        filters.appendAssumeCapacity(try WorkspaceFilter.init(allocator, pattern, original_cwd, filter_path_buf[0..]));
+    }
+
+    // Load the root package.json so we can read its "workspaces" array.
+    const root_entry = switch (manager.workspace_package_json_cache.getWithPath(
+        allocator,
+        manager.log,
+        root_package_json_path,
+        .{ .guess_indentation = true },
+    )) {
+        .parse_err => |err| {
+            manager.log.print(Output.errorWriter()) catch {};
+            Output.errGeneric("failed to parse package.json \"{s}\": {s}", .{ root_package_json_path, @errorName(err) });
+            Global.crash();
+        },
+        .read_err => |err| {
+            Output.errGeneric("failed to read package.json \"{s}\": {s}", .{ root_package_json_path, @errorName(err) });
+            Global.crash();
+        },
+        .entry => |e| e,
+    };
+
+    const workspaces_array: ?*JSAst.E.Array = brk: {
+        const prop = root_entry.root.asProperty("workspaces") orelse break :brk null;
+        switch (prop.expr.data) {
+            .e_array => |arr| break :brk arr,
+            .e_object => |obj| {
+                if (obj.get("packages")) |packages| {
+                    if (packages.data == .e_array) break :brk packages.data.e_array;
+                }
+                break :brk null;
+            },
+            else => break :brk null,
+        }
+    };
+
+    if (workspaces_array == null) {
+        Output.errGeneric("<b>--filter<r> requires a <b>\"workspaces\"<r> field in the root package.json", .{});
+        Global.exit(1);
+    }
+
+    // Enumerate workspace members.
+    var workspace_map = Package.WorkspaceMap.init(allocator);
+    defer workspace_map.map.deinit();
+
+    var log = logger.Log.init(allocator);
+    defer log.deinit();
+
+    _ = workspace_map.processNamesArray(
+        allocator,
+        &manager.workspace_package_json_cache,
+        &log,
+        workspaces_array.?,
+        &root_entry.source,
+        logger.Loc.Empty,
+        null,
+    ) catch {};
+
+    // Match workspaces against filters.
+    const top_level_dir = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
+    const match_path_buf = bun.path_buffer_pool.get();
+    defer bun.path_buffer_pool.put(match_path_buf);
+
+    var matched: std.ArrayListUnmanaged(FilteredWorkspace) = .{};
+    errdefer matched.deinit(allocator);
+
+    for (workspace_map.keys(), workspace_map.values()) |rel_path, entry| {
+        const abs_workspace_dir = abs_dir: {
+            const abs = bun.path.joinAbsStringBuf(top_level_dir, match_path_buf, &.{rel_path}, .posix);
+            break :abs_dir strings.withoutTrailingSlash(abs);
+        };
+
+        const is_match = is_match: {
+            var any_positive = false;
+            var matched_positive = false;
+
+            for (filters.items) |filter| {
+                const pattern, const target = switch (filter) {
+                    .name => |pattern| .{ pattern, entry.name },
+                    .path => |pattern| .{ pattern, abs_workspace_dir },
+                    .all => {
+                        any_positive = true;
+                        matched_positive = true;
+                        continue;
+                    },
+                };
+
+                switch (bun.glob.match(pattern, target)) {
+                    .match => {
+                        any_positive = true;
+                        matched_positive = true;
+                    },
+                    .no_match => {
+                        any_positive = true;
+                    },
+                    .negate_no_match => {
+                        // Excluded by a "!pattern". Skip this workspace.
+                        break :is_match false;
+                    },
+                    .negate_match => {},
+                }
+            }
+
+            // If only negative filters were given (e.g. --filter '!api'), match everything
+            // that wasn't excluded.
+            break :is_match if (any_positive) matched_positive else true;
+        };
+
+        if (!is_match) continue;
+
+        const out_path_buf = bun.path_buffer_pool.get();
+        defer bun.path_buffer_pool.put(out_path_buf);
+        const abs_package_json_path = bun.path.joinAbsStringBufZ(
+            top_level_dir,
+            out_path_buf,
+            &.{ rel_path, "package.json" },
+            .auto,
+        );
+
+        try matched.append(allocator, .{
+            .package_json_path = try allocator.dupeZ(u8, abs_package_json_path),
+            .name = try allocator.dupe(u8, entry.name),
+            .name_hash = String.Builder.stringHash(entry.name),
+            .indentation = .{},
+            .preserve_trailing_newline = false,
+            .before_install_source = "",
+        });
+    }
+
+    return matched.toOwnedSlice(allocator);
+}
+
+fn editPackageJSONForRemove(
+    current_package_json: *JSAst.Expr,
+    updates: []const UpdateRequest,
+    subcommand: Subcommand,
+) bool {
+    if (current_package_json.data != .e_object) {
+        Output.errGeneric("package.json is not an Object {{}}, so there's nothing to {s}!", .{@tagName(subcommand)});
+        Global.crash();
+    }
+
+    var any_changes = false;
+    for (updates) |request| {
+        inline for ([_]string{ "dependencies", "devDependencies", "optionalDependencies", "peerDependencies" }) |list| {
+            if (current_package_json.asProperty(list)) |query| {
+                if (query.expr.data == .e_object) {
+                    var dependencies = query.expr.data.e_object.properties.slice();
+                    var i: usize = 0;
+                    var new_len = dependencies.len;
+                    while (i < dependencies.len) : (i += 1) {
+                        if (dependencies[i].key.?.data == .e_string) {
+                            if (dependencies[i].key.?.data.e_string.eql(string, request.name)) {
+                                if (new_len > 1) {
+                                    dependencies[i] = dependencies[new_len - 1];
+                                    new_len -= 1;
+                                } else {
+                                    new_len = 0;
+                                }
+                                any_changes = true;
+                            }
+                        }
+                    }
+
+                    if (new_len != dependencies.len) {
+                        query.expr.data.e_object.properties.len = @as(u32, @truncate(new_len));
+                        if (query.expr.data.e_object.properties.len == 0) {
+                            _ = current_package_json.data.e_object.properties.swapRemove(query.i);
+                            current_package_json.data.e_object.packageJSONSort();
+                        } else {
+                            var obj = query.expr.data.e_object;
+                            obj.alphabetizeProperties();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return any_changes;
+}
+
+fn updatePackageJSONAndInstallWithFilter(
+    manager: *PackageManager,
+    ctx: Command.Context,
+    updates: *[]UpdateRequest,
+    subcommand: Subcommand,
+    original_cwd: string,
+) !void {
+    if (manager.options.global) {
+        Output.errGeneric("<b>--filter<r> is not supported with <b>--global<r>", .{});
+        Global.exit(1);
+    }
+
+    const top_level_dir_without_trailing_slash = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
+
+    var root_package_json_path_buf: bun.PathBuffer = undefined;
+    const root_package_json_path: [:0]const u8 = root_package_json_path: {
+        @memcpy(root_package_json_path_buf[0..top_level_dir_without_trailing_slash.len], top_level_dir_without_trailing_slash);
+        @memcpy(root_package_json_path_buf[top_level_dir_without_trailing_slash.len..][0.."/package.json".len], "/package.json");
+        const root_package_json_path = root_package_json_path_buf[0 .. top_level_dir_without_trailing_slash.len + "/package.json".len];
+        root_package_json_path_buf[root_package_json_path.len] = 0;
+        break :root_package_json_path root_package_json_path_buf[0..root_package_json_path.len :0];
+    };
+
+    const workspaces = try findFilteredWorkspaces(manager, original_cwd, root_package_json_path);
+
+    if (workspaces.len == 0) {
+        Output.errGeneric("<b>--filter<r> did not match any workspace", .{});
+        for (manager.options.filter_patterns) |pattern| {
+            Output.prettyErrorln("  <d>pattern:<r> {s}", .{pattern});
+        }
+        Global.exit(1);
+    }
+
+    const dependency_list = if (manager.options.update.development)
+        "devDependencies"
+    else if (manager.options.update.optional)
+        "optionalDependencies"
+    else if (manager.options.update.peer)
+        "peerDependencies"
+    else
+        "dependencies";
+
+    var any_remove_changes = false;
+
+    // Pre-install: edit each matching workspace's package.json in memory.
+    for (workspaces) |*workspace| {
+        // `PackageJSONEditor.edit` uses `request.e_string` as a sentinel for
+        // "already handled"; reset it between workspaces so every workspace
+        // actually gets the dependency added.
+        for (updates.*) |*request| request.e_string = null;
+
+        var entry = switch (manager.workspace_package_json_cache.getWithPath(
+            manager.allocator,
+            manager.log,
+            workspace.package_json_path,
+            .{ .guess_indentation = true },
+        )) {
+            .parse_err => |err| {
+                manager.log.print(Output.errorWriter()) catch {};
+                Output.errGeneric("failed to parse package.json \"{s}\": {s}", .{ workspace.package_json_path, @errorName(err) });
+                Global.crash();
+            },
+            .read_err => |err| {
+                Output.errGeneric("failed to read package.json \"{s}\": {s}", .{ workspace.package_json_path, @errorName(err) });
+                Global.crash();
+            },
+            .entry => |e| e,
+        };
+
+        workspace.indentation = entry.indentation;
+        workspace.preserve_trailing_newline = entry.source.contents.len > 0 and
+            entry.source.contents[entry.source.contents.len - 1] == '\n';
+
+        switch (subcommand) {
+            .add => {
+                try PackageJSONEditor.edit(
+                    manager,
+                    updates,
+                    &entry.root,
+                    dependency_list,
+                    .{
+                        .exact_versions = manager.options.enable.exact_versions,
+                        .before_install = true,
+                    },
+                );
+            },
+            .remove => {
+                if (editPackageJSONForRemove(&entry.root, updates.*, subcommand)) {
+                    any_remove_changes = true;
+                }
+            },
+            else => unreachable,
+        }
+
+        var buffer_writer = JSPrinter.BufferWriter.init(manager.allocator);
+        try buffer_writer.buffer.list.ensureTotalCapacity(manager.allocator, entry.source.contents.len + 1);
+        buffer_writer.append_newline = workspace.preserve_trailing_newline;
+        var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
+
+        _ = JSPrinter.printJSON(
+            @TypeOf(&package_json_writer),
+            &package_json_writer,
+            entry.root,
+            &entry.source,
+            .{
+                .indent = workspace.indentation,
+                .mangled_props = null,
+            },
+        ) catch |err| {
+            Output.prettyErrorln("package.json failed to write due to error {s}", .{@errorName(err)});
+            Global.crash();
+        };
+
+        const new_source = try manager.allocator.dupe(u8, package_json_writer.ctx.writtenWithoutTrailingZero());
+        entry.source.contents = new_source;
+        workspace.before_install_source = new_source;
+    }
+
+    // The install step resolves update requests by looking at the dependency list of
+    // `manager.workspace_name_hash`'s package. Point it at one of the workspaces we
+    // edited so the resolved version gets populated on the UpdateRequests.
+    manager.workspace_name_hash = workspaces[0].name_hash;
+    manager.root_package_id.id = null;
+    manager.original_package_json_path = workspaces[0].package_json_path;
+
+    manager.to_update = false;
+    {
+        const cloned = updates.*;
+        manager.update_requests = cloned;
+    }
+
+    // Ensure the root package.json is cached (installWithManager expects it).
+    _ = manager.workspace_package_json_cache.getWithPath(
+        manager.allocator,
+        manager.log,
+        root_package_json_path,
+        .{ .guess_indentation = true },
+    );
+
+    try manager.installWithManager(ctx, root_package_json_path, original_cwd);
+
+    if (subcommand == .add) {
+        for (updates.*) |request| {
+            if (request.failed) {
+                Global.exit(1);
+                return;
+            }
+        }
+    }
+
+    if (!manager.options.do.write_package_json) {
+        return;
+    }
+
+    // Post-install: for `add`, rewrite each workspace's package.json with the
+    // resolved version. For `remove`, the pre-install edit is already final.
+    for (workspaces) |*workspace| {
+        const final_source = switch (subcommand) {
+            .add => blk: {
+                for (updates.*) |*request| request.e_string = null;
+
+                const source = &logger.Source.initPathString("package.json", workspace.before_install_source);
+                var new_root = JSON.parsePackageJSONUTF8(source, manager.log, manager.allocator) catch |err| {
+                    Output.prettyErrorln("package.json failed to parse due to error {s}", .{@errorName(err)});
+                    Global.crash();
+                };
+
+                try PackageJSONEditor.edit(
+                    manager,
+                    updates,
+                    &new_root,
+                    dependency_list,
+                    .{
+                        .exact_versions = manager.options.enable.exact_versions,
+                        .add_trusted_dependencies = manager.options.do.trust_dependencies_from_args,
+                    },
+                );
+
+                var buffer_writer = JSPrinter.BufferWriter.init(manager.allocator);
+                try buffer_writer.buffer.list.ensureTotalCapacity(manager.allocator, source.contents.len + 1);
+                buffer_writer.append_newline = workspace.preserve_trailing_newline;
+                var package_json_writer = JSPrinter.BufferPrinter.init(buffer_writer);
+
+                _ = JSPrinter.printJSON(
+                    @TypeOf(&package_json_writer),
+                    &package_json_writer,
+                    new_root,
+                    source,
+                    .{
+                        .indent = workspace.indentation,
+                        .mangled_props = null,
+                    },
+                ) catch |err| {
+                    Output.prettyErrorln("package.json failed to write due to error {s}", .{@errorName(err)});
+                    Global.crash();
+                };
+
+                break :blk try manager.allocator.dupe(u8, package_json_writer.ctx.writtenWithoutTrailingZero());
+            },
+            .remove => workspace.before_install_source,
+            else => unreachable,
+        };
+
+        const file = (try bun.sys.File.openat(
+            .cwd(),
+            workspace.package_json_path,
+            bun.O.RDWR,
+            0,
+        ).unwrap()).handle.stdFile();
+
+        try file.pwriteAll(final_source, 0);
+        std.posix.ftruncate(file.handle, final_source.len) catch {};
+        file.close();
+    }
+
+    if (subcommand == .remove and !any_remove_changes) {
+        Global.exit(0);
+    }
+}
+
 pub fn updatePackageJSONAndInstallCatchError(
     ctx: Command.Context,
     subcommand: Subcommand,
@@ -758,4 +1203,9 @@ const PackageJSONEditor = PackageManager.PackageJSONEditor;
 const PatchCommitResult = PackageManager.PatchCommitResult;
 const Subcommand = PackageManager.Subcommand;
 const UpdateRequest = PackageManager.UpdateRequest;
+const WorkspaceFilter = PackageManager.WorkspaceFilter;
 const attemptToCreatePackageJSON = PackageManager.attemptToCreatePackageJSON;
+
+const Lockfile = bun.install.Lockfile;
+const Package = Lockfile.Package;
+const JSAst = bun.ast;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -933,13 +933,12 @@ fn updatePackageJSONAndInstallWithFilter(
         const file = try bun.sys.File.openat(
             .cwd(),
             workspace.package_json_path,
-            bun.O.RDWR,
+            bun.O.WRONLY | bun.O.TRUNC,
             0,
         ).unwrap();
         defer file.close();
 
-        try file.pwriteAll(final_source, 0).unwrap();
-        _ = bun.sys.ftruncate(file.handle, @intCast(final_source.len));
+        try file.writeAll(final_source).unwrap();
     }
 
     if (subcommand == .remove) {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -740,17 +740,20 @@ fn updatePackageJSONAndInstallWithFilter(
 
     var any_remove_changes = false;
 
-    // `PackageJSONEditor.edit` can shrink `updates` in place (e.g. with
-    // `--only-missing` when the dependency already exists). Remember the
-    // original slice so each workspace sees the full set of requests.
-    const original_updates = updates.*;
+    // `PackageJSONEditor.edit` can shrink and reorder `updates` in place
+    // (e.g. with `--only-missing` when the dependency already exists it
+    // swap-removes from the slice). Take a deep copy of the elements so each
+    // workspace starts from the same set of requests, unaffected by any
+    // in-place mutation the previous workspace's edit performed.
+    const original_updates = bun.handleOom(manager.allocator.dupe(UpdateRequest, updates.*));
 
     // Pre-install: edit each matching workspace's package.json in memory.
     for (workspaces) |*workspace| {
         // `PackageJSONEditor.edit` uses `request.e_string` as a sentinel for
         // "already handled"; reset it between workspaces so every workspace
         // actually gets the dependency added.
-        updates.* = original_updates;
+        @memcpy(updates.*.ptr[0..original_updates.len], original_updates);
+        updates.*.len = original_updates.len;
         for (updates.*) |*request| request.e_string = null;
 
         var entry = switch (manager.workspace_package_json_cache.getWithPath(
@@ -828,10 +831,14 @@ fn updatePackageJSONAndInstallWithFilter(
     manager.original_package_json_path = workspaces[0].package_json_path;
 
     manager.to_update = false;
-    {
-        const cloned = updates.*;
-        manager.update_requests = cloned;
-    }
+    // Always give the install step the full request list. The pre-install loop
+    // may have left `updates.*` shrunk (if the last workspace already had every
+    // requested dependency with `--only-missing`), which would cause
+    // `cleanWithLogger` to skip populating `package_id` on the requests.
+    @memcpy(updates.*.ptr[0..original_updates.len], original_updates);
+    updates.*.len = original_updates.len;
+    for (updates.*) |*request| request.e_string = null;
+    manager.update_requests = updates.*;
 
     // Ensure the root package.json is cached (installWithManager expects it).
     _ = manager.workspace_package_json_cache.getWithPath(
@@ -862,6 +869,11 @@ fn updatePackageJSONAndInstallWithFilter(
         return;
     }
 
+    // Snapshot the post-install request state (with `package_id` populated by
+    // `cleanWithLogger`). Each workspace's post-install edit may swap-remove
+    // from `updates` again, so restore from this snapshot between iterations.
+    const resolved_updates = bun.handleOom(manager.allocator.dupe(UpdateRequest, updates.*));
+
     // Post-install: for `add`, rewrite each workspace's package.json with the
     // resolved version. For `remove`, the pre-install edit is already final.
     for (workspaces) |*workspace| {
@@ -872,7 +884,8 @@ fn updatePackageJSONAndInstallWithFilter(
 
         const final_source = switch (subcommand) {
             .add => blk: {
-                updates.* = original_updates;
+                @memcpy(updates.*.ptr[0..resolved_updates.len], resolved_updates);
+                updates.*.len = resolved_updates.len;
                 for (updates.*) |*request| request.e_string = null;
 
                 const source = &logger.Source.initPathString("package.json", workspace.before_install_source);
@@ -917,16 +930,16 @@ fn updatePackageJSONAndInstallWithFilter(
             else => unreachable,
         };
 
-        const file = (try bun.sys.File.openat(
+        const file = try bun.sys.File.openat(
             .cwd(),
             workspace.package_json_path,
             bun.O.RDWR,
             0,
-        ).unwrap()).handle.stdFile();
+        ).unwrap();
         defer file.close();
 
-        try file.pwriteAll(final_source, 0);
-        std.posix.ftruncate(file.handle, final_source.len) catch {};
+        try file.pwriteAll(final_source, 0).unwrap();
+        _ = bun.sys.ftruncate(file.handle, @intCast(final_source.len));
     }
 
     if (subcommand == .remove) {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -1181,6 +1181,7 @@ const std = @import("std");
 const bun = @import("bun");
 const Environment = bun.Environment;
 const Global = bun.Global;
+const JSAst = bun.ast;
 const JSON = bun.json;
 const JSPrinter = bun.js_printer;
 const Output = bun.Output;
@@ -1197,6 +1198,9 @@ const String = Semver.String;
 const Fs = bun.fs;
 const FileSystem = Fs.FileSystem;
 
+const Lockfile = bun.install.Lockfile;
+const Package = Lockfile.Package;
+
 const PackageManager = bun.install.PackageManager;
 const CommandLineArguments = PackageManager.CommandLineArguments;
 const PackageJSONEditor = PackageManager.PackageJSONEditor;
@@ -1205,7 +1209,3 @@ const Subcommand = PackageManager.Subcommand;
 const UpdateRequest = PackageManager.UpdateRequest;
 const WorkspaceFilter = PackageManager.WorkspaceFilter;
 const attemptToCreatePackageJSON = PackageManager.attemptToCreatePackageJSON;
-
-const Lockfile = bun.install.Lockfile;
-const Package = Lockfile.Package;
-const JSAst = bun.ast;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -488,12 +488,19 @@ fn findFilteredWorkspaces(
     var log = logger.Log.init(allocator);
     defer log.deinit();
 
+    // `root_entry` points into `workspace_package_json_cache`'s HashMapUnmanaged value
+    // storage. `processNamesArray` inserts into that same map (via `processWorkspaceName`
+    // -> `json_cache.getWithPath`) for every workspace it discovers, so a rehash would
+    // leave `&root_entry.source` dangling mid-enumeration. Take a stack copy first.
+    // https://github.com/oven-sh/bun/issues/12288
+    const root_source = root_entry.source;
+
     _ = workspace_map.processNamesArray(
         allocator,
         &manager.workspace_package_json_cache,
         &log,
         workspaces_array.?,
-        &root_entry.source,
+        &root_source,
         logger.Loc.Empty,
         null,
     ) catch |err| {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -758,18 +758,17 @@ fn updatePackageJSONAndInstallWithFilter(
 
     var any_remove_changes = false;
 
-    // `PackageJSONEditor.edit` can shrink and reorder `updates` in place
-    // (e.g. with `--only-missing` when the dependency already exists it
-    // swap-removes from the slice). Take a deep copy of the elements so each
-    // workspace starts from the same set of requests, unaffected by any
-    // in-place mutation the previous workspace's edit performed.
+    // `PackageJSONEditor.edit` mutates `UpdateRequest` entries in place
+    // (currently `request.e_string`, used as an "already handled" sentinel
+    // pointing into the edited workspace's AST). Take a deep copy so each
+    // workspace and the install step start from the same pristine request
+    // set, insulated from any per-request state the previous edit left behind.
     const original_updates = bun.handleOom(manager.allocator.dupe(UpdateRequest, updates.*));
 
     // Pre-install: edit each matching workspace's package.json in memory.
     for (workspaces) |*workspace| {
-        // `PackageJSONEditor.edit` uses `request.e_string` as a sentinel for
-        // "already handled"; reset it between workspaces so every workspace
-        // actually gets the dependency added.
+        // Reset per-request state between workspaces so `edit` treats every
+        // request as unhandled for this workspace.
         @memcpy(updates.*.ptr[0..original_updates.len], original_updates);
         updates.*.len = original_updates.len;
         for (updates.*) |*request| request.e_string = null;
@@ -849,10 +848,10 @@ fn updatePackageJSONAndInstallWithFilter(
     manager.original_package_json_path = workspaces[0].package_json_path;
 
     manager.to_update = false;
-    // Always give the install step the full request list. The pre-install loop
-    // may have left `updates.*` shrunk (if the last workspace already had every
-    // requested dependency with `--only-missing`), which would cause
-    // `cleanWithLogger` to skip populating `package_id` on the requests.
+    // Restore the pristine request list for the install step: the per-workspace
+    // edit loop above left each request's `e_string` pointing into the last
+    // workspace's AST, and `cleanWithLogger` needs fresh requests to populate
+    // `package_id` from the resolved lockfile.
     @memcpy(updates.*.ptr[0..original_updates.len], original_updates);
     updates.*.len = original_updates.len;
     for (updates.*) |*request| request.e_string = null;

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -483,7 +483,7 @@ fn findFilteredWorkspaces(
 
     // Enumerate workspace members.
     var workspace_map = Package.WorkspaceMap.init(allocator);
-    defer workspace_map.map.deinit();
+    defer workspace_map.deinit();
 
     var log = logger.Log.init(allocator);
     defer log.deinit();
@@ -705,6 +705,17 @@ fn updatePackageJSONAndInstallWithFilter(
 ) !void {
     if (manager.options.global) {
         Output.errGeneric("<b>--filter<r> is not supported with <b>--global<r>", .{});
+        Global.exit(1);
+    }
+
+    if (manager.options.enable.only_missing) {
+        // `--only-missing` shrinks the update-request slice in place when a
+        // dependency already exists. With multiple matched workspaces, each
+        // workspace may already have a different subset of the requested
+        // packages, which makes the post-install resolved-version rewrite
+        // ambiguous (it could overwrite versions `--only-missing` was meant to
+        // preserve). Reject the combination until someone needs it.
+        Output.errGeneric("<b>--filter<r> is not supported with <b>--only-missing<r>", .{});
         Global.exit(1);
     }
 

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -414,6 +414,9 @@ const FilteredWorkspace = struct {
     preserve_trailing_newline: bool,
     /// Serialized package.json contents after the pre-install edit.
     before_install_source: []const u8,
+    /// For `.remove`: whether this workspace's package.json actually had a
+    /// matching dependency removed. Unchanged workspaces are not rewritten.
+    remove_changed: bool,
 };
 
 /// Enumerate workspace packages declared in the root `package.json` and
@@ -574,6 +577,7 @@ fn findFilteredWorkspaces(
             .indentation = .{},
             .preserve_trailing_newline = false,
             .before_install_source = "",
+            .remove_changed = false,
         });
     }
 
@@ -785,9 +789,8 @@ fn updatePackageJSONAndInstallWithFilter(
                 );
             },
             .remove => {
-                if (editPackageJSONForRemove(&entry.root, updates.*, subcommand)) {
-                    any_remove_changes = true;
-                }
+                workspace.remove_changed = editPackageJSONForRemove(&entry.root, updates.*, subcommand);
+                if (workspace.remove_changed) any_remove_changes = true;
             },
             else => unreachable,
         }
@@ -853,9 +856,20 @@ fn updatePackageJSONAndInstallWithFilter(
         return;
     }
 
+    if (subcommand == .remove and !any_remove_changes) {
+        // Nothing was removed from any matched workspace; don't touch any files.
+        Global.exit(0);
+        return;
+    }
+
     // Post-install: for `add`, rewrite each workspace's package.json with the
     // resolved version. For `remove`, the pre-install edit is already final.
     for (workspaces) |*workspace| {
+        if (subcommand == .remove and !workspace.remove_changed) {
+            // This workspace didn't have the dependency; leave its package.json alone.
+            continue;
+        }
+
         const final_source = switch (subcommand) {
             .add => blk: {
                 updates.* = original_updates;
@@ -916,11 +930,6 @@ fn updatePackageJSONAndInstallWithFilter(
     }
 
     if (subcommand == .remove) {
-        if (!any_remove_changes) {
-            Global.exit(0);
-            return;
-        }
-
         cleanupNodeModulesAfterRemove(manager, updates.*);
     }
 }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -144,51 +144,7 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
     var not_in_workspace_root: ?PatchCommitResult = null;
     switch (subcommand) {
         .remove => {
-            // if we're removing, they don't have to specify where it is installed in the dependencies list
-            // they can even put it multiple times and we will just remove all of them
-            for (updates.*) |request| {
-                inline for ([_]string{ "dependencies", "devDependencies", "optionalDependencies", "peerDependencies" }) |list| {
-                    if (current_package_json.root.asProperty(list)) |query| {
-                        if (query.expr.data == .e_object) {
-                            var dependencies = query.expr.data.e_object.properties.slice();
-                            var i: usize = 0;
-                            var new_len = dependencies.len;
-                            while (i < dependencies.len) : (i += 1) {
-                                if (dependencies[i].key.?.data == .e_string) {
-                                    if (dependencies[i].key.?.data.e_string.eql(string, request.name)) {
-                                        if (new_len > 1) {
-                                            dependencies[i] = dependencies[new_len - 1];
-                                            new_len -= 1;
-                                        } else {
-                                            new_len = 0;
-                                        }
-
-                                        any_changes = true;
-                                    }
-                                }
-                            }
-
-                            const changed = new_len != dependencies.len;
-                            if (changed) {
-                                query.expr.data.e_object.properties.len = @as(u32, @truncate(new_len));
-
-                                // If the dependencies list is now empty, remove it from the package.json
-                                // since we're swapRemove, we have to re-sort it
-                                if (query.expr.data.e_object.properties.len == 0) {
-                                    // TODO: Theoretically we could change these two lines to
-                                    // `.orderedRemove(query.i)`, but would that change user-facing
-                                    // behavior?
-                                    _ = current_package_json.root.data.e_object.properties.swapRemove(query.i);
-                                    current_package_json.root.data.e_object.packageJSONSort();
-                                } else {
-                                    var obj = query.expr.data.e_object;
-                                    obj.alphabetizeProperties();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            any_changes = editPackageJSONForRemove(&current_package_json.root, updates.*, subcommand);
         },
 
         .link, .add, .update => {
@@ -443,55 +399,7 @@ fn updatePackageJSONAndInstallWithManagerWithUpdates(
                 return;
             }
 
-            var cwd = std.fs.cwd();
-            // This is not exactly correct
-            var node_modules_buf: bun.PathBuffer = undefined;
-            bun.copy(u8, &node_modules_buf, "node_modules" ++ std.fs.path.sep_str);
-            const offset_buf = node_modules_buf["node_modules/".len..];
-            const name_hashes = manager.lockfile.packages.items(.name_hash);
-            for (updates.*) |request| {
-                // If the package no longer exists in the updated lockfile, delete the directory
-                // This is not thorough.
-                // It does not handle nested dependencies
-                // This is a quick & dirty cleanup intended for when deleting top-level dependencies
-                if (std.mem.indexOfScalar(PackageNameHash, name_hashes, String.Builder.stringHash(request.name)) == null) {
-                    bun.copy(u8, offset_buf, request.name);
-                    cwd.deleteTree(node_modules_buf[0 .. "node_modules/".len + request.name.len]) catch {};
-                }
-            }
-
-            // This is where we clean dangling symlinks
-            // This could be slow if there are a lot of symlinks
-            if (bun.openDir(cwd, manager.options.bin_path)) |node_modules_bin_handle| {
-                var node_modules_bin: std.fs.Dir = node_modules_bin_handle;
-                defer node_modules_bin.close();
-                var iter: std.fs.Dir.Iterator = node_modules_bin.iterate();
-                iterator: while (iter.next() catch null) |entry| {
-                    switch (entry.kind) {
-                        std.fs.Dir.Entry.Kind.sym_link => {
-
-                            // any symlinks which we are unable to open are assumed to be dangling
-                            // note that using access won't work here, because access doesn't resolve symlinks
-                            bun.copy(u8, &node_modules_buf, entry.name);
-                            node_modules_buf[entry.name.len] = 0;
-                            const buf: [:0]u8 = node_modules_buf[0..entry.name.len :0];
-
-                            var file = node_modules_bin.openFileZ(buf, .{ .mode = .read_only }) catch {
-                                node_modules_bin.deleteFileZ(buf) catch {};
-                                continue :iterator;
-                            };
-
-                            file.close();
-                        },
-                        else => {},
-                    }
-                }
-            } else |err| {
-                if (err != error.ENOENT) {
-                    Output.err(err, "while reading node_modules/.bin", .{});
-                    Global.crash();
-                }
-            }
+            cleanupNodeModulesAfterRemove(manager, updates.*);
         }
     }
 }
@@ -585,7 +493,18 @@ fn findFilteredWorkspaces(
         &root_entry.source,
         logger.Loc.Empty,
         null,
-    ) catch {};
+    ) catch |err| {
+        log.print(Output.errorWriter()) catch {};
+        Output.errGeneric("failed to enumerate workspaces: {s}", .{@errorName(err)});
+        Global.crash();
+    };
+
+    // Surface per-workspace discovery errors (missing package.json, missing name, ...).
+    // Don't hard-fail: the install step will re-enumerate and report these with full
+    // context, but we want them visible before the "no match" message if nothing matched.
+    if (log.errors > 0) {
+        log.print(Output.errorWriter()) catch {};
+    }
 
     // Match workspaces against filters.
     const top_level_dir = strings.withoutTrailingSlash(FileSystem.instance.top_level_dir);
@@ -661,6 +580,11 @@ fn findFilteredWorkspaces(
     return matched.toOwnedSlice(allocator);
 }
 
+/// Remove each requested package from every dependency group in `current_package_json`.
+/// Returns true if anything was removed.
+///
+/// If we're removing, the user doesn't have to specify where it is installed in the
+/// dependencies list — they can even put it multiple times and we remove all of them.
 fn editPackageJSONForRemove(
     current_package_json: *JSAst.Expr,
     updates: []const UpdateRequest,
@@ -695,6 +619,8 @@ fn editPackageJSONForRemove(
 
                     if (new_len != dependencies.len) {
                         query.expr.data.e_object.properties.len = @as(u32, @truncate(new_len));
+                        // If the dependencies list is now empty, remove it from the package.json.
+                        // Since we swapRemove, we have to re-sort it.
                         if (query.expr.data.e_object.properties.len == 0) {
                             _ = current_package_json.data.e_object.properties.swapRemove(query.i);
                             current_package_json.data.e_object.packageJSONSort();
@@ -709,6 +635,61 @@ fn editPackageJSONForRemove(
     }
 
     return any_changes;
+}
+
+/// Best-effort cleanup after `bun remove`: delete `node_modules/<pkg>` for packages
+/// that no longer appear in the lockfile, and prune dangling symlinks from
+/// `node_modules/.bin`. Runs relative to cwd (which is the workspace root).
+fn cleanupNodeModulesAfterRemove(manager: *PackageManager, updates: []const UpdateRequest) void {
+    var cwd = std.fs.cwd();
+    // This is not exactly correct
+    var node_modules_buf: bun.PathBuffer = undefined;
+    bun.copy(u8, &node_modules_buf, "node_modules" ++ std.fs.path.sep_str);
+    const offset_buf = node_modules_buf["node_modules/".len..];
+    const name_hashes = manager.lockfile.packages.items(.name_hash);
+    for (updates) |request| {
+        // If the package no longer exists in the updated lockfile, delete the directory
+        // This is not thorough.
+        // It does not handle nested dependencies
+        // This is a quick & dirty cleanup intended for when deleting top-level dependencies
+        if (std.mem.indexOfScalar(PackageNameHash, name_hashes, String.Builder.stringHash(request.name)) == null) {
+            bun.copy(u8, offset_buf, request.name);
+            cwd.deleteTree(node_modules_buf[0 .. "node_modules/".len + request.name.len]) catch {};
+        }
+    }
+
+    // This is where we clean dangling symlinks
+    // This could be slow if there are a lot of symlinks
+    if (bun.openDir(cwd, manager.options.bin_path)) |node_modules_bin_handle| {
+        var node_modules_bin: std.fs.Dir = node_modules_bin_handle;
+        defer node_modules_bin.close();
+        var iter: std.fs.Dir.Iterator = node_modules_bin.iterate();
+        iterator: while (iter.next() catch null) |entry| {
+            switch (entry.kind) {
+                std.fs.Dir.Entry.Kind.sym_link => {
+
+                    // any symlinks which we are unable to open are assumed to be dangling
+                    // note that using access won't work here, because access doesn't resolve symlinks
+                    bun.copy(u8, &node_modules_buf, entry.name);
+                    node_modules_buf[entry.name.len] = 0;
+                    const buf: [:0]u8 = node_modules_buf[0..entry.name.len :0];
+
+                    var file = node_modules_bin.openFileZ(buf, .{ .mode = .read_only }) catch {
+                        node_modules_bin.deleteFileZ(buf) catch {};
+                        continue :iterator;
+                    };
+
+                    file.close();
+                },
+                else => {},
+            }
+        }
+    } else |err| {
+        if (err != error.ENOENT) {
+            Output.err(err, "while reading node_modules/.bin", .{});
+            Global.crash();
+        }
+    }
 }
 
 fn updatePackageJSONAndInstallWithFilter(
@@ -755,11 +736,17 @@ fn updatePackageJSONAndInstallWithFilter(
 
     var any_remove_changes = false;
 
+    // `PackageJSONEditor.edit` can shrink `updates` in place (e.g. with
+    // `--only-missing` when the dependency already exists). Remember the
+    // original slice so each workspace sees the full set of requests.
+    const original_updates = updates.*;
+
     // Pre-install: edit each matching workspace's package.json in memory.
     for (workspaces) |*workspace| {
         // `PackageJSONEditor.edit` uses `request.e_string` as a sentinel for
         // "already handled"; reset it between workspaces so every workspace
         // actually gets the dependency added.
+        updates.* = original_updates;
         for (updates.*) |*request| request.e_string = null;
 
         var entry = switch (manager.workspace_package_json_cache.getWithPath(
@@ -830,8 +817,9 @@ fn updatePackageJSONAndInstallWithFilter(
     }
 
     // The install step resolves update requests by looking at the dependency list of
-    // `manager.workspace_name_hash`'s package. Point it at one of the workspaces we
-    // edited so the resolved version gets populated on the UpdateRequests.
+    // `manager.workspace_name_hash`'s package. After the pre-install edit above, every
+    // matched workspace has every requested dependency (either newly added or already
+    // present), so any one of them is a valid lookup target. Use the first.
     manager.workspace_name_hash = workspaces[0].name_hash;
     manager.root_package_id.id = null;
     manager.original_package_json_path = workspaces[0].package_json_path;
@@ -870,6 +858,7 @@ fn updatePackageJSONAndInstallWithFilter(
     for (workspaces) |*workspace| {
         const final_source = switch (subcommand) {
             .add => blk: {
+                updates.* = original_updates;
                 for (updates.*) |*request| request.e_string = null;
 
                 const source = &logger.Source.initPathString("package.json", workspace.before_install_source);
@@ -920,14 +909,19 @@ fn updatePackageJSONAndInstallWithFilter(
             bun.O.RDWR,
             0,
         ).unwrap()).handle.stdFile();
+        defer file.close();
 
         try file.pwriteAll(final_source, 0);
         std.posix.ftruncate(file.handle, final_source.len) catch {};
-        file.close();
     }
 
-    if (subcommand == .remove and !any_remove_changes) {
-        Global.exit(0);
+    if (subcommand == .remove) {
+        if (!any_remove_changes) {
+            Global.exit(0);
+            return;
+        }
+
+        cleanupNodeModulesAfterRemove(manager, updates.*);
     }
 }
 

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -3,7 +3,7 @@
 // matching workspace's package.json, not the root package.json.
 
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env } from "harness";
 import { join } from "path";
@@ -16,8 +16,9 @@ import {
   package_dir,
   root_url,
   setHandler,
-} from "../../cli/install/dummy.registry.js";
+} from "./dummy.registry";
 
+beforeAll(() => setDefaultTimeout(1000 * 60 * 5));
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
 beforeEach(async () => {
@@ -130,6 +131,64 @@ it("bun add --filter='*' adds to every workspace", async () => {
 
   // Even with two matched workspaces, there should be exactly one install
   // (one metadata request, one tarball fetch).
+  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
+});
+
+it("bun add --filter='*' adds to every workspace in a large monorepo", async () => {
+  // Enough workspaces to force the workspace_package_json_cache HashMap to
+  // rehash mid-enumeration (minimal_capacity = 8, ~80% load factor). Guards
+  // against passing a pointer into the map's value storage across inserts.
+  // https://github.com/oven-sh/bun/issues/12288
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  const names = Array.from({ length: 12 }, (_, i) => `pkg-${String.fromCharCode(97 + i)}`);
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "monorepo",
+      version: "0.0.0",
+      workspaces: ["packages/*"],
+    }),
+  );
+  for (const name of names) {
+    await mkdir(join(package_dir, "packages", name), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", name, "package.json"),
+      JSON.stringify({ name, version: "1.0.0" }),
+    );
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter", "*"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  const out = await stdout.text();
+  expect(err).not.toContain("error:");
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  // Root package.json should be untouched.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+
+  // Every workspace should have the dependency with the resolved version.
+  for (const name of names) {
+    expect(await file(join(package_dir, "packages", name, "package.json")).json()).toEqual({
+      name,
+      version: "1.0.0",
+      dependencies: { baz: "^0.0.3" },
+    });
+  }
+
+  // Still a single install run.
   expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
 });
 

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -152,10 +152,7 @@ it("bun add --filter='*' adds to every workspace in a large monorepo", async () 
   );
   for (const name of names) {
     await mkdir(join(package_dir, "packages", name), { recursive: true });
-    await writeFile(
-      join(package_dir, "packages", name, "package.json"),
-      JSON.stringify({ name, version: "1.0.0" }),
-    );
+    await writeFile(join(package_dir, "packages", name, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
   }
 
   const { stdout, stderr, exited } = spawn({

--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -18,7 +18,10 @@ import {
   setHandler,
 } from "./dummy.registry";
 
-beforeAll(() => setDefaultTimeout(1000 * 60 * 5));
+// Must be module-scope: setDefaultTimeout inside beforeAll is a no-op because
+// it() calls register with the default 5s before any beforeAll hook runs.
+setDefaultTimeout(1000 * 60 * 5);
+
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
 beforeEach(async () => {

--- a/test/regression/issue/14719.test.ts
+++ b/test/regression/issue/14719.test.ts
@@ -276,12 +276,14 @@ it("bun add --filter works when run from inside a workspace directory", async ()
 it("bun remove --filter removes from the matching workspace only", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  // Root also depends on baz — --filter should never touch the root manifest.
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
       name: "monorepo",
       version: "0.0.0",
       workspaces: ["packages/*"],
+      dependencies: { baz: "^0.0.3" },
     }),
   );
   await mkdir(join(package_dir, "packages", "api"), { recursive: true });
@@ -306,6 +308,14 @@ it("bun remove --filter removes from the matching workspace only", async () => {
   const err = await stderr.text();
   expect(err).not.toContain("error:");
   expect(await exited).toBe(0);
+
+  // Root still has baz.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+    dependencies: { baz: "^0.0.3" },
+  });
 
   expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
     name: "api",

--- a/test/regression/issue/14719.test.ts
+++ b/test/regression/issue/14719.test.ts
@@ -1,0 +1,291 @@
+// https://github.com/oven-sh/bun/issues/14719
+// `bun add <pkg> --filter=<workspace>` should add the package to the
+// matching workspace's package.json, not the root package.json.
+
+import { file, spawn } from "bun";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { mkdir, writeFile } from "fs/promises";
+import { bunExe, bunEnv as env } from "harness";
+import { join } from "path";
+import {
+  dummyAfterAll,
+  dummyAfterEach,
+  dummyBeforeAll,
+  dummyBeforeEach,
+  dummyRegistry,
+  package_dir,
+  root_url,
+  setHandler,
+} from "../../cli/install/dummy.registry.js";
+
+beforeAll(dummyBeforeAll);
+afterAll(dummyAfterAll);
+beforeEach(async () => {
+  await dummyBeforeEach();
+});
+afterEach(dummyAfterEach);
+
+async function setupMonorepo() {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "monorepo",
+      version: "0.0.0",
+      workspaces: ["packages/*"],
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "api"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "web"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "api", "package.json"),
+    JSON.stringify({ name: "api", version: "1.0.0" }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "web", "package.json"),
+    JSON.stringify({ name: "web", version: "1.0.0" }),
+  );
+}
+
+it("bun add --filter=<name> adds to the matching workspace, not the root", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter=api"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  const out = await stdout.text();
+  expect(err).not.toContain("error:");
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  // Root package.json should be untouched.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+
+  // api should have the dependency with the resolved version.
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+    dependencies: {
+      baz: "^0.0.3",
+    },
+  });
+
+  // web should be untouched.
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+  });
+
+  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
+});
+
+it("bun add --filter='*' adds to every workspace", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter", "*"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  const out = await stdout.text();
+  expect(err).not.toContain("error:");
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  // Root package.json should be untouched.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+});
+
+it("bun add -d --filter puts the dependency in devDependencies", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "-d", "baz", "--filter=web"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  const out = await stdout.text();
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+    devDependencies: { baz: "^0.0.3" },
+  });
+
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+  });
+});
+
+it("bun add --filter with a path pattern matches by workspace directory", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter", "./packages/api"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  const out = await stdout.text();
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+  });
+});
+
+it("bun remove --filter removes from the matching workspace only", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "monorepo",
+      version: "0.0.0",
+      workspaces: ["packages/*"],
+    }),
+  );
+  await mkdir(join(package_dir, "packages", "api"), { recursive: true });
+  await mkdir(join(package_dir, "packages", "web"), { recursive: true });
+  await writeFile(
+    join(package_dir, "packages", "api", "package.json"),
+    JSON.stringify({ name: "api", version: "1.0.0", dependencies: { baz: "^0.0.3" } }),
+  );
+  await writeFile(
+    join(package_dir, "packages", "web", "package.json"),
+    JSON.stringify({ name: "web", version: "1.0.0", dependencies: { baz: "^0.0.3" } }),
+  );
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "remove", "baz", "--filter=api"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+  });
+
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+});
+
+it("bun add --filter errors when no workspace matches", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter=does-not-exist"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).toContain("did not match any workspace");
+  expect(await exited).toBe(1);
+
+  // Nothing should have been written anywhere.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+  });
+});
+
+it("bun add --filter errors when there is no workspaces field", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "not-a-monorepo",
+      version: "0.0.0",
+    }),
+  );
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter=api"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).toContain('requires a "workspaces" field');
+  expect(await exited).toBe(1);
+});

--- a/test/regression/issue/14719.test.ts
+++ b/test/regression/issue/14719.test.ts
@@ -300,7 +300,7 @@ it("bun remove --filter removes from the matching workspace only", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "remove", "baz", "--filter=api"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "ignore",
     stderr: "pipe",
     env,
@@ -352,7 +352,7 @@ it("bun remove --filter with a glob removes from every matching workspace", asyn
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "remove", "baz", "--filter", "pkg-*"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "ignore",
     stderr: "pipe",
     env,
@@ -385,7 +385,7 @@ it("bun add --filter errors when no workspace matches", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "add", "baz", "--filter=does-not-exist"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "ignore",
     stderr: "pipe",
     env,
@@ -420,7 +420,7 @@ it("bun add --filter errors when there is no workspaces field", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "add", "baz", "--filter=api"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "ignore",
     stderr: "pipe",
     env,

--- a/test/regression/issue/14719.test.ts
+++ b/test/regression/issue/14719.test.ts
@@ -127,6 +127,10 @@ it("bun add --filter='*' adds to every workspace", async () => {
     version: "1.0.0",
     dependencies: { baz: "^0.0.3" },
   });
+
+  // Even with two matched workspaces, there should be exactly one install
+  // (one metadata request, one tarball fetch).
+  expect(urls.sort()).toEqual([`${root_url}/baz`, `${root_url}/baz-0.0.3.tgz`]);
 });
 
 it("bun add -d --filter puts the dependency in devDependencies", async () => {
@@ -310,6 +314,54 @@ it("bun remove --filter removes from the matching workspace only", async () => {
 
   expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
     name: "web",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+});
+
+it("bun remove --filter with a glob removes from every matching workspace", async () => {
+  // https://github.com/oven-sh/bun/issues/27897
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "monorepo",
+      version: "0.0.0",
+      workspaces: ["packages/*"],
+    }),
+  );
+  for (const name of ["pkg-a", "pkg-b", "other"]) {
+    await mkdir(join(package_dir, "packages", name), { recursive: true });
+    await writeFile(
+      join(package_dir, "packages", name, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", dependencies: { baz: "^0.0.3" } }),
+    );
+  }
+
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "remove", "baz", "--filter", "pkg-*"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exited).toBe(0);
+
+  expect(await file(join(package_dir, "packages", "pkg-a", "package.json")).json()).toEqual({
+    name: "pkg-a",
+    version: "1.0.0",
+  });
+  expect(await file(join(package_dir, "packages", "pkg-b", "package.json")).json()).toEqual({
+    name: "pkg-b",
+    version: "1.0.0",
+  });
+  // "other" doesn't match the glob, so it keeps the dependency.
+  expect(await file(join(package_dir, "packages", "other", "package.json")).json()).toEqual({
+    name: "other",
     version: "1.0.0",
     dependencies: { baz: "^0.0.3" },
   });

--- a/test/regression/issue/14719.test.ts
+++ b/test/regression/issue/14719.test.ts
@@ -191,6 +191,84 @@ it("bun add --filter with a path pattern matches by workspace directory", async 
   });
 });
 
+it("bun add -F '*' --filter '!api' combines the short alias with negation", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "-F", "*", "--filter", "!api"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  const out = await stdout.text();
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  // Root untouched.
+  expect(await file(join(package_dir, "package.json")).json()).toEqual({
+    name: "monorepo",
+    version: "0.0.0",
+    workspaces: ["packages/*"],
+  });
+
+  // api was negated, so unchanged.
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+  });
+
+  // web matched '*' and wasn't negated.
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+});
+
+it("bun add --filter works when run from inside a workspace directory", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {} }));
+  await setupMonorepo();
+  await writeFile(
+    join(package_dir, "packages", "api", "bunfig.toml"),
+    await file(join(package_dir, "bunfig.toml")).text(),
+  );
+
+  // Run from packages/api, but target web via --filter.
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "baz", "--filter=web"],
+    cwd: join(package_dir, "packages", "api"),
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  const out = await stdout.text();
+  expect(out).toContain("installed baz@0.0.3");
+  expect(await exited).toBe(0);
+
+  // api (where we ran from) should be untouched.
+  expect(await file(join(package_dir, "packages", "api", "package.json")).json()).toEqual({
+    name: "api",
+    version: "1.0.0",
+  });
+
+  // web got the dependency.
+  expect(await file(join(package_dir, "packages", "web", "package.json")).json()).toEqual({
+    name: "web",
+    version: "1.0.0",
+    dependencies: { baz: "^0.0.3" },
+  });
+});
+
 it("bun remove --filter removes from the matching workspace only", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls, { "0.0.3": {} }));


### PR DESCRIPTION
## What does this PR do?

Adds `--filter` / `-F` to `bun add` and `bun remove` so you can target specific workspace packages from the monorepo root:

```sh
# add zod to the "api" workspace package, not the root package.json
bun add zod --filter api

# match by relative path
bun add zod --filter ./packages/api

# add to every workspace package
bun add zod --filter '*'

# remove from one workspace
bun remove zod --filter api
```

Previously the only way to add a dependency to a workspace package was to `cd` into that directory first. Running `bun add` from the root always wrote to the root `package.json`.

The `--filter` flag accepts the same pattern syntax as `bun install --filter` / `bun outdated --filter`:

- workspace package name (`--filter=api`)
- name glob (`--filter='@scope/*'`)
- relative path (`--filter=./packages/api`)
- wildcard (`--filter='*'`)
- negation (`--filter='!api'`)

Multiple `--filter` flags can be passed. When more than one workspace matches, the dependency is written to each matching workspace's `package.json` and a single install runs at the root. When positive and negative patterns are combined, a workspace must match at least one positive pattern and none of the negative ones (pnpm semantics) — since `add`/`remove` write to `package.json`, the selection errs on the side of not touching workspaces you didn't explicitly target.

Fixes #14719
Fixes #27897

## How did you verify your code works?

New tests in `test/cli/install/bun-add-filter.test.ts`:

- `bun add --filter=<name>` adds to the matching workspace, not the root
- `bun add --filter='*'` adds to every workspace and runs a single install
- `bun add --filter='*'` adds to every workspace in a large (12-package) monorepo — exercises the workspace-cache rehash path
- `bun add -d --filter` puts the dependency in `devDependencies`
- `bun add --filter ./packages/api` matches by workspace directory
- `bun add -F '*' --filter '!api'` excludes a workspace by negation
- `bun add --filter` from inside a workspace subdir targets a sibling workspace
- `bun remove --filter` removes from the matching workspace only (root manifest untouched)
- `bun remove --filter 'pkg-*'` removes from every workspace matching the glob
- `bun add --filter` errors when no workspace matches
- `bun add --filter` errors when there is no `workspaces` field

All 11 pass with this build and fail on current `main`. Existing `bun-add.test.ts` still passes. `zig:check-all` passes on all targets.
