### PR TITLE
Sync bun-vscode packageManager schema with SchemaStore

### DIFF
--- a/packages/bun-vscode/assets/package.json
+++ b/packages/bun-vscode/assets/package.json
@@ -655,7 +655,14 @@
     "packageManager": {
       "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
       "type": "string",
-      "pattern": "^((npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?|bun)$"
+      "oneOf": [
+        {
+          "pattern": "(npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?"
+        },
+        {
+          "const": "bun"
+        }
+      ]
     },
     "engines": {
       "type": "object",

--- a/packages/bun-vscode/assets/package.json
+++ b/packages/bun-vscode/assets/package.json
@@ -655,7 +655,7 @@
     "packageManager": {
       "description": "Defines which package manager is expected to be used when working on the current project. This field is currently experimental and needs to be opted-in; see https://nodejs.org/api/corepack.html",
       "type": "string",
-      "pattern": "(bun|npm|pnpm|yarn)@\\d+\\.\\d+\\.\\d+(-.+)?"
+      "pattern": "^((npm|pnpm|yarn|bun)@\\d+\\.\\d+\\.\\d+(-.+)?|bun)$"
     },
     "engines": {
       "type": "object",


### PR DESCRIPTION
### What does this PR do?

I've changed the pattern for `package.json`'s `packageManager` field to make Bun's version optional.

Bun is the runtime; forcing version here is not a good choice. And Corepack does not support Bun, so whether or not there is a version of Bun doesn't really matter for Corepack users.

### How did you verify your code works?

The SchemaStore already applied the new schema, and it works. See:

- https://github.com/SchemaStore/schemastore/pull/5613