### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -1617,7 +1617,7 @@ pub fn handleOnDataHeaders(
     while (true) {
         var amount_read: usize = 0;
 
-        // we reset the pending_response each time wich means that on parse error this will be always be empty
+        // we reset the pending_response each time which means that on parse error this will be always be empty
         this.state.pending_response = picohttp.Response{};
 
         // minimal http/1.1 response is 16 bytes ("HTTP/1.1 200\r\n\r\n")

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1776,7 +1776,7 @@ pub fn Package(comptime SemverIntType: type) type {
                         // workspace names from their package jsons. duplicates not allowed
                         const gop = try seen_workspace_names.getOrPut(allocator, @truncate(String.Builder.stringHash(entry.name)));
                         if (gop.found_existing) {
-                            // this path does alot of extra work to format the error message
+                            // this path does a lot of extra work to format the error message
                             // but this is ok because the install is going to fail anyways, so this
                             // has zero effect on the happy path.
                             var cwd_buf: bun.PathBuffer = undefined;

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -204,7 +204,7 @@ interface JSCommonJSModule {
  * Binding files are located in `src/bun.js/bindings`
  *
  * @see {@link $zig} for native zig bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename name of the c++ file containing the function. Do not pass a path.
  * @param symbol   The name of the binding function to call. Use `dot.notation` to access
@@ -223,7 +223,7 @@ declare function $cpp<T = any>(filename: NativeFilenameCPP, symbol: string): T;
  * Binding files are located in `src/bun.js/bindings`
  *
  * @see {@link $cpp} for native c++ bindings.
- * @see `src/codegen/replacements.ts` for the script that performs replacement of this funciton.
+ * @see `src/codegen/replacements.ts` for the script that performs replacement of this function.
  *
  * @param filename name of the zig file containing the function. Do not pass a path.
  * @param symbol   The name of the binding function. Use `dot.notation` to access


### PR DESCRIPTION

**Repo:** oven-sh/bun (⭐ 72000)
**Type:** docs
**Files changed:** 3
**Lines:** +4/-4

## What
Fix three small spelling typos in source-code comments: `wich` → `which`
in `src/http.zig`, `alot` → `a lot` in `src/install/lockfile/Package.zig`,
and `funciton` → `function` (two occurrences) in `src/js/private.d.ts`.
Comments only — no behavior change, no public API change.

## Why
Tiny readability/polish improvement. The `funciton` typo in
`src/js/private.d.ts` is in a `@see` reference doc-comment that contributors
read when learning the codegen replacement system, so getting it right has
mild documentation value.

## Testing
No code paths changed; no tests required. Verified via `git diff` that
only comment text was modified. A full `bun bd` build is unnecessary for
comment-only edits.

## Risk
Low — comment-only edits in three unrelated files; no logic, types, or
public surface affected.
