### PR TITLE
fix(tls): lazy-load system certs for getCACertificates('system')

### DIFF
--- a/packages/bun-usockets/src/crypto/root_certs.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs.cpp
@@ -135,8 +135,7 @@ end:
 
 static void us_internal_init_root_certs(
     X509 *root_cert_instances[root_certs_size],
-    STACK_OF(X509) *&root_extra_cert_instances,
-    STACK_OF(X509) *&root_system_cert_instances) {
+    STACK_OF(X509) *&root_extra_cert_instances) {
   // This used to use an atomic_flag spinlock together with an atomic_bool.
   // The bool was set to true via atomic_exchange BEFORE the certificates were
   // actually parsed, so concurrent callers (e.g. Workers calling
@@ -162,17 +161,6 @@ static void us_internal_init_root_certs(
     if (extra_certs && extra_certs[0]) {
       root_extra_cert_instances = us_ssl_ctx_load_all_certs_from_file(extra_certs);
     }
-
-    // load system certificates if NODE_USE_SYSTEM_CA=1
-    if (us_should_use_system_ca()) {
-#ifdef __APPLE__
-      us_load_system_certificates_macos(&root_system_cert_instances);
-#elif defined(_WIN32)
-      us_load_system_certificates_windows(&root_system_cert_instances);
-#else
-      us_load_system_certificates_linux(&root_system_cert_instances);
-#endif
-    }
   });
 }
 
@@ -184,15 +172,13 @@ extern "C" int us_internal_raw_root_certs(struct us_cert_string_t **out) {
 struct us_default_ca_certificates {
   X509 *root_cert_instances[root_certs_size];
   STACK_OF(X509) *root_extra_cert_instances;
-  STACK_OF(X509) *root_system_cert_instances;
 };
 
 us_default_ca_certificates* us_get_default_ca_certificates() {
-  static us_default_ca_certificates default_ca_certificates = {{NULL}, NULL, NULL};
+  static us_default_ca_certificates default_ca_certificates = {{NULL}, NULL};
 
-  us_internal_init_root_certs(default_ca_certificates.root_cert_instances, 
-                              default_ca_certificates.root_extra_cert_instances,
-                              default_ca_certificates.root_system_cert_instances);
+  us_internal_init_root_certs(default_ca_certificates.root_cert_instances,
+                              default_ca_certificates.root_extra_cert_instances);
 
   return &default_ca_certificates;
 }
@@ -201,10 +187,24 @@ STACK_OF(X509) *us_get_root_extra_cert_instances() {
   return us_get_default_ca_certificates()->root_extra_cert_instances;
 }
 
+// Single source of truth for the OS trust store. Loaded on first demand,
+// independent of --use-system-ca / NODE_USE_SYSTEM_CA, so that
+// tls.getCACertificates('system') matches Node.js (which always reads the
+// system store for 'system'). The flag still gates whether these are merged
+// into the *default* store used for connections — see us_get_default_ca_store.
 STACK_OF(X509) *us_get_root_system_cert_instances() {
-  // Ensure single-path initialization via us_internal_init_root_certs
-  auto certs = us_get_default_ca_certificates();
-  return certs->root_system_cert_instances;
+  static STACK_OF(X509) *system_certs = nullptr;
+  static std::once_flag once;
+  std::call_once(once, []() {
+#ifdef __APPLE__
+    us_load_system_certificates_macos(&system_certs);
+#elif defined(_WIN32)
+    us_load_system_certificates_windows(&system_certs);
+#else
+    us_load_system_certificates_linux(&system_certs);
+#endif
+  });
+  return system_certs;
 }
 
 extern "C" X509_STORE *us_get_default_ca_store() {
@@ -221,7 +221,6 @@ extern "C" X509_STORE *us_get_default_ca_store() {
   us_default_ca_certificates *default_ca_certificates = us_get_default_ca_certificates();
   X509** root_cert_instances = default_ca_certificates->root_cert_instances;
   STACK_OF(X509) *root_extra_cert_instances = default_ca_certificates->root_extra_cert_instances;
-  STACK_OF(X509) *root_system_cert_instances = default_ca_certificates->root_system_cert_instances;
 
   // load all root_cert_instances on the default ca store
   for (size_t i = 0; i < root_certs_size; i++) {
@@ -240,11 +239,14 @@ extern "C" X509_STORE *us_get_default_ca_store() {
     }
   }
 
-  if (us_should_use_system_ca() && root_system_cert_instances) {
-    for (int i = 0; i < sk_X509_num(root_system_cert_instances); i++) {
-      X509 *cert = sk_X509_value(root_system_cert_instances, i);
-      X509_up_ref(cert);
-      X509_STORE_add_cert(store, cert);
+  if (us_should_use_system_ca()) {
+    STACK_OF(X509) *root_system_cert_instances = us_get_root_system_cert_instances();
+    if (root_system_cert_instances) {
+      for (int i = 0; i < sk_X509_num(root_system_cert_instances); i++) {
+        X509 *cert = sk_X509_value(root_system_cert_instances, i);
+        X509_up_ref(cert);
+        X509_STORE_add_cert(store, cert);
+      }
     }
   }
 

--- a/packages/bun-usockets/src/crypto/root_certs_linux.cpp
+++ b/packages/bun-usockets/src/crypto/root_certs_linux.cpp
@@ -10,8 +10,6 @@
 #include <openssl/x509_vfy.h>
 #include <openssl/pem.h>
 
-extern "C" void BUN__warn__extra_ca_load_failed(const char* filename, const char* error_msg);
-
 // Helper function to load certificates from a directory
 static void load_certs_from_directory(const char* dir_path, STACK_OF(X509)* cert_stack) {
   DIR* dir = opendir(dir_path);
@@ -148,21 +146,6 @@ extern "C" void us_load_system_certificates_linux(STACK_OF(X509) **system_certs)
   // Then try loading from directories
   for (const char** path = dir_paths; *path != NULL; path++) {
     load_certs_from_directory(*path, *system_certs);
-  }
-  
-  // Also check NODE_EXTRA_CA_CERTS environment variable
-  const char* extra_ca_certs = getenv("NODE_EXTRA_CA_CERTS");
-  if (extra_ca_certs && strlen(extra_ca_certs) > 0) {
-    FILE* file = fopen(extra_ca_certs, "r");
-    if (file) {
-      X509* cert;
-      while ((cert = PEM_read_X509(file, NULL, NULL, NULL)) != NULL) {
-        sk_X509_push(*system_certs, cert);
-      }
-      fclose(file);
-    } else {
-      BUN__warn__extra_ca_load_failed(extra_ca_certs, "Failed to open file");
-    }
   }
 }
 

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -277,15 +277,15 @@ function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
   if (typeof arg0 === "function") {
     name = arg0.name || kDefaultName;
     fn = arg0 as TestFn;
-    if (arg1 !== null && typeof arg1 === "object") {
-      options = arg1 as TestOptions;
+    if (typeof arg1 === "object") {
+      options = (arg1 ?? kDefaultOptions) as TestOptions;
     } else {
       options = kDefaultOptions;
     }
   } else if (typeof arg0 === "string") {
     name = arg0;
-    if (arg1 !== null && typeof arg1 === "object") {
-      options = arg1 as TestOptions;
+    if (typeof arg1 === "object") {
+      options = (arg1 ?? kDefaultOptions) as TestOptions;
       if (typeof arg2 === "function") {
         fn = arg2 as TestFn;
       } else {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -276,14 +276,14 @@ function parseTestOptions(arg0: unknown, arg1: unknown, arg2: unknown) {
   if (typeof arg0 === "function") {
     name = arg0.name || kDefaultName;
     fn = arg0 as TestFn;
-    if (typeof arg1 === "object") {
+    if (arg1 !== null && typeof arg1 === "object") {
       options = arg1 as TestOptions;
     } else {
       options = kDefaultOptions;
     }
   } else if (typeof arg0 === "string") {
     name = arg0;
-    if (typeof arg1 === "object") {
+    if (arg1 !== null && typeof arg1 === "object") {
       options = arg1 as TestOptions;
       if (typeof arg2 === "function") {
         fn = arg2 as TestFn;

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -215,9 +215,10 @@ describe.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 function test(arg0: unknown, arg1: unknown, arg2: unknown) {
   const { name, fn, options } = createTest(arg0, arg1, arg2);
   const { test } = bunTest();
-  if (options.only) {
-    test.only(name, fn, options);
-  } else if (options.todo) {
+  // Node's {only: true} is intentionally not routed to test.only() here:
+  // in Node it is a no-op unless --test-only is passed, whereas bun:test's
+  // test.only() unconditionally skips siblings.
+  if (options.todo) {
     test.todo(name, fn, options);
   } else if (options.skip) {
     test.skip(name, fn, options);

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -215,7 +215,15 @@ describe.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 function test(arg0: unknown, arg1: unknown, arg2: unknown) {
   const { name, fn, options } = createTest(arg0, arg1, arg2);
   const { test } = bunTest();
-  test(name, fn, options);
+  if (options.only) {
+    test.only(name, fn, options);
+  } else if (options.todo) {
+    test.todo(name, fn, options);
+  } else if (options.skip) {
+    test.skip(name, fn, options);
+  } else {
+    test(name, fn, options);
+  }
 }
 
 test.skip = function (arg0: unknown, arg1: unknown, arg2: unknown) {

--- a/test/regression/issue/19412.test.ts
+++ b/test/regression/issue/19412.test.ts
@@ -15,6 +15,11 @@ test("node:test honours { todo: true }", { todo: true }, () => {
   assert.fail("todo tests may run but failures are not fatal");
 });
 
+let nullOptionsRan = false;
 test("node:test treats null options as no options", null, () => {
-  assert.ok(true);
+  nullOptionsRan = true;
+});
+
+test("node:test ran the previous test's body (fn not dropped)", () => {
+  assert.strictEqual(nullOptionsRan, true);
 });

--- a/test/regression/issue/19412.test.ts
+++ b/test/regression/issue/19412.test.ts
@@ -1,0 +1,20 @@
+// https://github.com/oven-sh/bun/issues/19412
+// The top-level node:test test() ignored {skip, todo, only} options.
+import assert from "node:assert";
+import { test } from "node:test";
+
+test("node:test honours { skip: true }", { skip: true }, () => {
+  assert.fail("should have been skipped");
+});
+
+test("node:test honours { skip: 'reason' }", { skip: "reason" }, () => {
+  assert.fail("should have been skipped");
+});
+
+test("node:test honours { todo: true }", { todo: true }, () => {
+  assert.fail("todo tests may run but failures are not fatal");
+});
+
+test("node:test treats null options as no options", null, () => {
+  assert.ok(true);
+});

--- a/test/regression/issue/24339.test.ts
+++ b/test/regression/issue/24339.test.ts
@@ -1,0 +1,36 @@
+// https://github.com/oven-sh/bun/issues/24339
+//
+// tls.getCACertificates('system') must return the OS trust store regardless
+// of --use-system-ca / NODE_USE_SYSTEM_CA. The flag only controls whether
+// system certs are merged into the 'default' set used for connections.
+//
+// Uses node:test + node:assert and no Bun-specific imports so this file can
+// also be run under Node.js (`node --test`) to verify parity.
+import assert from "node:assert";
+import { test } from "node:test";
+import tls from "node:tls";
+
+// On macOS, Node.js itself often returns an empty 'system' array (Security
+// framework anchor enumeration is environment-dependent), and Node's own
+// test-tls-get-ca-certificates-system.js only asserts non-empty on Windows.
+// The issue this regresses was reported on Linux, so skip on darwin to keep
+// the assertion meaningful where it can be.
+const skip = process.platform === "darwin" ? "Node.js also returns 0 system certs on macOS" : false;
+
+test("tls.getCACertificates('system') returns system certs without --use-system-ca", { skip }, () => {
+  assert.notStrictEqual(process.env.NODE_USE_SYSTEM_CA, "1");
+  assert.ok(!(process.execArgv ?? []).includes("--use-system-ca"));
+
+  const certs = tls.getCACertificates("system");
+  assert.ok(Array.isArray(certs));
+  assert.ok(certs.length > 0, `expected >0 system certs, got ${certs.length}`);
+  for (const cert of certs) {
+    assert.ok(cert.startsWith("-----BEGIN CERTIFICATE-----"), `not PEM: ${cert.slice(0, 40)}`);
+  }
+});
+
+test("tls.getCACertificates('system') is stable across calls", { skip }, () => {
+  const a = tls.getCACertificates("system");
+  const b = tls.getCACertificates("system");
+  assert.strictEqual(a.length, b.length);
+});

--- a/test/regression/issue/24339.test.ts
+++ b/test/regression/issue/24339.test.ts
@@ -10,12 +10,13 @@ import assert from "node:assert";
 import { test } from "node:test";
 import tls from "node:tls";
 
-// On macOS, Node.js itself often returns an empty 'system' array (Security
-// framework anchor enumeration is environment-dependent), and Node's own
-// test-tls-get-ca-certificates-system.js only asserts non-empty on Windows.
-// The issue this regresses was reported on Linux, so skip on darwin to keep
-// the assertion meaningful where it can be.
-const skip = process.platform === "darwin" ? "Node.js also returns 0 system certs on macOS" : false;
+// On macOS, Bun's loader queries the default keychain search list, which does
+// not include SystemRootCertificates.keychain — so the result depends on what
+// is explicitly trusted in login/System.keychain (often nothing on clean/CI
+// Macs). Node v25's loader has the same property on this platform, and Node's
+// own test-tls-get-ca-certificates-system.js only asserts non-empty on
+// Windows. The issue this regresses was reported on Linux.
+const skip = process.platform === "darwin" ? "system cert count is environment-dependent on macOS" : false;
 
 test("tls.getCACertificates('system') returns system certs without --use-system-ca", { skip }, () => {
   assert.notStrictEqual(process.env.NODE_USE_SYSTEM_CA, "1");

--- a/test/regression/issue/24339.test.ts
+++ b/test/regression/issue/24339.test.ts
@@ -30,8 +30,8 @@ test("tls.getCACertificates('system') returns system certs without --use-system-
   }
 });
 
-test("tls.getCACertificates('system') is stable across calls", { skip }, () => {
+test("tls.getCACertificates('system') is cached across calls", { skip }, () => {
   const a = tls.getCACertificates("system");
   const b = tls.getCACertificates("system");
-  assert.strictEqual(a.length, b.length);
+  assert.strictEqual(a, b);
 });

--- a/test/regression/issue/24339.test.ts
+++ b/test/regression/issue/24339.test.ts
@@ -16,7 +16,15 @@ import tls from "node:tls";
 // Macs). Node v25's loader has the same property on this platform, and Node's
 // own test-tls-get-ca-certificates-system.js only asserts non-empty on
 // Windows. The issue this regresses was reported on Linux.
-const skip = process.platform === "darwin" ? "system cert count is environment-dependent on macOS" : false;
+//
+// On Linux, SSL_CERT_FILE / SSL_CERT_DIR override the default search and may
+// legitimately yield zero certs; this test targets default discovery.
+const skip =
+  process.platform === "darwin"
+    ? "system cert count is environment-dependent on macOS"
+    : process.env.SSL_CERT_FILE || process.env.SSL_CERT_DIR
+      ? "SSL_CERT_FILE/SSL_CERT_DIR override default system store discovery"
+      : false;
 
 test("tls.getCACertificates('system') returns system certs without --use-system-ca", { skip }, () => {
   assert.notStrictEqual(process.env.NODE_USE_SYSTEM_CA, "1");


### PR DESCRIPTION
`tls.getCACertificates('system')` returned `[]` unless `--use-system-ca` / `NODE_USE_SYSTEM_CA=1` was set. Node returns the OS trust store unconditionally for `'system'`; the flag only affects `'default'`.

`us_get_root_system_cert_instances()` now lazy-loads on first demand via `std::call_once` — the same primitive #29426 introduced for the bundled/extra certs — independent of the flag. The flag still gates whether system certs are merged into the *default* store used for TLS connections, so there's no startup cost unless `'system'` is actually queried or `--use-system-ca` is set.

Supersedes #29503 (which has merge conflicts with #29426) and #26260, addressing the review on both:

- **Lazy not eager** (Jarred on #26260): only loads when `'system'` is queried or `--use-system-ca` is set.
- **Thread safety** (review bots on #29503): `std::call_once` gives correct happens-before with no hand-rolled DCLP. No premature publication, no torn reads, no leaked allocation.
- **`NODE_EXTRA_CA_CERTS` leaking into `'system'`** (review bot on #29503): the Linux loader no longer appends `NODE_EXTRA_CA_CERTS` — those are already loaded into `root_extra_cert_instances` and exposed via `'extra'`. This was previously double-adding them to the default store on Linux when `--use-system-ca` was set.
- **`node:test` parity** (Jarred on #26260): the regression test uses `node:test`/`node:assert` so it can run under `node --test`. This surfaced that Bun's top-level `node:test` `test()` ignored `{skip, todo, only}` options (the nested `Suite#test` honoured them, top-level didn't); fixed here so the skip works.
- **macOS skip** (review bot on #29503): kept as all-macOS, not CI-only. On macOS the `'system'` count is environment-dependent: `SecItemCopyMatching` only searches the default keychain list (login + System.keychain), not `SystemRootCertificates.keychain`, so it returns 0 on clean/CI Macs but >0 on Macs with user/admin-trusted certs. Node v25's loader behaves the same way, and Node's own `test-tls-get-ca-certificates-system.js` only asserts non-empty on Windows. (Switching the macOS loader to `SecTrustCopyAnchorCertificates()` so it picks up the 159 Apple system roots is a separate follow-up.)

**Verified locally (macOS):**
- `bun bd test test/regression/issue/24339.test.ts` → 2 skip (darwin)
- `node --test test/regression/issue/24339.test.ts` → 2 skip (darwin), parity confirmed
- `bun bd test test/js/node/tls/node-tls-root-certs-concurrent-init.test.ts test/js/node/tls/test-use-system-ca.test.ts test/js/node/tls/test-system-ca-https.test.ts test/js/node/tls/test-node-extra-ca-certs.test.ts test/js/node/tls/node-tls-rootcertificates-immutable.test.ts` → all pass
- `bun bd --use-system-ca test/js/node/test/parallel/test-tls-get-ca-certificates-system.js` → exit 0

Linux/Windows CI will exercise the non-skipped path.

Fixes #24339

Fixes #19412
