### PR TITLE
fetch: apply TCP backpressure when response body reader stalls

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -547,7 +547,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         if (
                             s && length >= (LIBUS_RECV_BUFFER_LENGTH - 24 * 1024) && length <= LIBUS_RECV_BUFFER_LENGTH &&
                             (error || loop->num_ready_polls < LOOP_ISNT_VERY_BUSY_THRESHOLD) &&
-                            !us_socket_is_closed(0, s)
+                            !us_socket_is_closed(0, s) &&
+                            // on_data may have paused the socket (e.g. fetch
+                            // response-body backpressure). Pausing only
+                            // changes the poll mask, so without this check we
+                            // would keep draining the kernel recv buffer for
+                            // up to 10 more iterations and defeat the pause.
+                            !s->flags.is_paused
                         ) {
                             repeat_recv_count += error == 0;
 

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -1038,6 +1038,17 @@ pub const Value = union(Tag) {
             .globalThis = globalThis,
         });
 
+        // Same wiring as the toReadableStream() path: without drain_handler the
+        // fetch backpressure pause has no resume hook on a body that was first
+        // materialised via clone(), and the socket would stay paused once the
+        // ByteStream buffer crosses the high-water mark.
+        if (locked.onStreamDrained) |onDrained| {
+            if (locked.task) |task| {
+                reader.drain_handler = onDrained;
+                reader.drain_ctx = task;
+            }
+        }
+
         reader.context.setup();
 
         if (drain_result == .estimated_size) {

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -1038,10 +1038,18 @@ pub const Value = union(Tag) {
             .globalThis = globalThis,
         });
 
-        // Same wiring as the toReadableStream() path: without drain_handler the
-        // fetch backpressure pause has no resume hook on a body that was first
-        // materialised via clone(), and the socket would stay paused once the
-        // ByteStream buffer crosses the high-water mark.
+        // Same wiring as the toReadableStream() path. cancel_handler reaches
+        // ignoreRemainingResponseBody so an abandoned clone tears down the
+        // request; drain_handler reaches maybeReleaseBodyBackpressure so the
+        // socket resumes once the ByteStream drains. Without both, a body that
+        // was first materialised via clone() would leak the connection once
+        // either backpressure paused it or both branches were cancelled.
+        if (locked.onStreamCancelled) |onCancelled| {
+            if (locked.task) |task| {
+                reader.cancel_handler = onCancelled;
+                reader.cancel_ctx = task;
+            }
+        }
         if (locked.onStreamDrained) |onDrained| {
             if (locked.task) |task| {
                 reader.drain_handler = onDrained;

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -76,6 +76,10 @@ pub const PendingValue = struct {
     onStartStreaming: ?*const fn (ctx: *anyopaque) jsc.WebCore.DrainResult = null,
     onReadableStreamAvailable: ?*const fn (ctx: *anyopaque, globalThis: *jsc.JSGlobalObject, readable: jsc.WebCore.ReadableStream) void = null,
     onStreamCancelled: ?*const fn (ctx: ?*anyopaque) void = null,
+    /// Runs whenever JS pulls bytes from the ByteStream's internal buffer.
+    /// `buffered` is the number of bytes still queued after the pull.
+    /// FetchTasklet uses this to release response-body backpressure.
+    onStreamDrained: ?*const fn (ctx: ?*anyopaque, buffered: usize) void = null,
     size_hint: Blob.SizeType = 0,
 
     deinit: bool = false,
@@ -510,6 +514,13 @@ pub const Value = union(Tag) {
                     if (locked.task) |task| {
                         reader.cancel_handler = onCancelled;
                         reader.cancel_ctx = task;
+                    }
+                }
+
+                if (locked.onStreamDrained) |onDrained| {
+                    if (locked.task) |task| {
+                        reader.drain_handler = onDrained;
+                        reader.drain_ctx = task;
                     }
                 }
 

--- a/src/bun.js/webcore/ByteStream.zig
+++ b/src/bun.js/webcore/ByteStream.zig
@@ -303,6 +303,16 @@ pub fn onPull(this: *@This(), buffer: []u8, view: jsc.JSValue) streams.Result {
             this.offset += to_write;
         }
 
+        // Report the new buffered size so the producer can release
+        // backpressure once we drop below its low-water mark, rather than
+        // waiting for the `.pending` branch below (which only fires at zero).
+        // FetchTasklet's `is_delivering_body_chunk` guard suppresses this
+        // when it's the controller's synchronous auto-pull running inside
+        // `pending.run()`; outside that window this is a real consumer read.
+        if (this.parent().drain_handler) |handler| {
+            handler(this.parent().drain_ctx, this.buffer.items.len - this.offset);
+        }
+
         if (this.has_received_last_chunk and remaining_in_buffer.len == 0) {
             this.buffer.clearAndFree();
             this.done = true;
@@ -332,15 +342,10 @@ pub fn onPull(this: *@This(), buffer: []u8, view: jsc.JSValue) streams.Result {
     this.pending_buffer = buffer;
     this.setValue(view);
 
-    // Tell the producer that JS is now blocked waiting for more bytes. This is
-    // the only point at which "the consumer wants data" is unambiguous —
-    // earlier in this function we may be servicing the controller's automatic
-    // pre-fetch pull, which drains `buffer` into the controller's queue
-    // without the user having read anything. Releasing backpressure on that
-    // auto-pull would let the queue grow unbounded; releasing here cannot,
-    // because we only reach this branch when both `buffer` and the
-    // controller's queue are empty (otherwise the controller would not have
-    // pulled).
+    // Buffer is empty and a read is now parked waiting — the consumer has
+    // caught up end-to-end. Same callback as the into_array branch above; this
+    // covers the case where the controller's queue was already empty so no
+    // intermediate drain was observed.
     if (this.parent().drain_handler) |handler| {
         handler(this.parent().drain_ctx, 0);
     }

--- a/src/bun.js/webcore/ByteStream.zig
+++ b/src/bun.js/webcore/ByteStream.zig
@@ -459,6 +459,18 @@ pub fn toBufferedValue(this: *@This(), globalThis: *jsc.JSGlobalObject, action: 
         .text => .{ .text = .init(globalThis) },
     };
 
+    // Once buffer_action is set, onPull is never called again and onData
+    // accumulates straight into `buffer` until the last chunk — there is no
+    // pull-based resume path. If the producer paused for backpressure before
+    // we got here (e.g. `res.body` accessed, >HWM buffered, then `res.text()`),
+    // the only thing that would observe `buffer_action != null` and release is
+    // FetchTasklet.evaluateBodyBackpressure, and that runs only on new data
+    // which can't arrive while paused. Fire the drain hook now so the producer
+    // releases immediately.
+    if (this.parent().drain_handler) |handler| {
+        handler(this.parent().drain_ctx, 0);
+    }
+
     return this.buffer_action.?.value();
 }
 

--- a/src/bun.js/webcore/ByteStream.zig
+++ b/src/bun.js/webcore/ByteStream.zig
@@ -332,6 +332,19 @@ pub fn onPull(this: *@This(), buffer: []u8, view: jsc.JSValue) streams.Result {
     this.pending_buffer = buffer;
     this.setValue(view);
 
+    // Tell the producer that JS is now blocked waiting for more bytes. This is
+    // the only point at which "the consumer wants data" is unambiguous —
+    // earlier in this function we may be servicing the controller's automatic
+    // pre-fetch pull, which drains `buffer` into the controller's queue
+    // without the user having read anything. Releasing backpressure on that
+    // auto-pull would let the queue grow unbounded; releasing here cannot,
+    // because we only reach this branch when both `buffer` and the
+    // controller's queue are empty (otherwise the controller would not have
+    // pulled).
+    if (this.parent().drain_handler) |handler| {
+        handler(this.parent().drain_ctx, 0);
+    }
+
     return .{
         .pending = &this.pending,
     };

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -421,6 +421,13 @@ pub fn NewSource(
         close_jsvalue: jsc.Strong.Optional = .empty,
         cancel_handler: ?*const fn (?*anyopaque) void = null,
         cancel_ctx: ?*anyopaque = null,
+        /// Invoked after the stream's internal buffer shrinks because JS pulled
+        /// bytes out. The argument is the number of bytes still buffered.
+        /// FetchTasklet uses this to release response-body backpressure once
+        /// the buffer drops below the low-water mark. Only ByteStream wires
+        /// this today; other Source contexts leave it null.
+        drain_handler: ?*const fn (?*anyopaque, buffered: usize) void = null,
+        drain_ctx: ?*anyopaque = null,
         globalThis: *JSGlobalObject = undefined,
         this_jsvalue: jsc.JSValue = .zero,
         is_closed: bool = false,

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1082,6 +1082,12 @@ pub const FetchTasklet = struct {
 
     fn ignoreRemainingResponseBody(this: *FetchTasklet) void {
         log("ignoreRemainingResponseBody", .{});
+        // If we paused socket reads for body backpressure, release now: the
+        // drain_handler we're about to clear is the only path that would
+        // otherwise resume, and the idle timeout was disarmed at pause time.
+        // Without this the connection sits paused forever after a
+        // reader.cancel() or Response GC mid-stream.
+        this.maybeReleaseBodyBackpressure(0);
         // enabling streaming will make the http thread to drain into the main thread (aka stop buffering)
         // without a stream ref, response body or response instance alive it will just ignore the result
         if (this.http) |http_| {

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -2,6 +2,18 @@ pub const FetchTasklet = struct {
     pub const ResumableSink = jsc.WebCore.ResumableFetchSink;
 
     const log = Output.scoped(.FetchTasklet, .visible);
+
+    /// Response-body backpressure thresholds. When the bytes buffered for JS
+    /// (scheduled_response_buffer on the HTTP-thread side, ByteStream.buffer
+    /// once the body is being streamed) exceed `body_high_water_mark`, the
+    /// HTTP thread pauses socket reads so TCP applies backpressure instead of
+    /// our heap growing without bound. Reads resume once a JS pull drains the
+    /// buffer below `body_low_water_mark`. The gap gives hysteresis so a
+    /// single 512 KB recv (LIBUS_RECV_BUFFER_LENGTH) doesn't oscillate
+    /// pause/resume on every chunk. See Signals.body_backpressure for the
+    /// HTTP-thread half.
+    pub const body_high_water_mark: usize = 1 * 1024 * 1024;
+    pub const body_low_water_mark: usize = 256 * 1024;
     sink: ?*ResumableSink = null,
     http: ?*http.AsyncHTTP = null,
     result: http.HTTPClientResult = .{},
@@ -40,6 +52,13 @@ pub const FetchTasklet = struct {
     signals: http.Signals = .{},
     signal_store: http.Signals.Store = .{},
     has_schedule_callback: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// Set while `onBodyReceived` is pushing a chunk into the ByteStream.
+    /// `pending.run()` inside `ByteStream.onData` drains microtasks, which can
+    /// re-enter `onPull` and fire `onStreamDrainedCallback` synchronously
+    /// before the chunk has finished propagating. The callback uses this flag
+    /// to defer the backpressure-release decision to `evaluateBodyBackpressure`
+    /// (which runs after `onData` returns and can see the settled state).
+    is_delivering_body_chunk: bool = false,
 
     // must be stored because AbortSignal stores reason weakly
     abort_reason: jsc.Strong.Optional = .empty,
@@ -361,12 +380,15 @@ pub const FetchTasklet = struct {
                 const chunk = scheduled_response_buffer.items;
 
                 if (this.result.has_more) {
+                    this.is_delivering_body_chunk = true;
+                    defer this.is_delivering_body_chunk = false;
                     try readable.ptr.Bytes.onData(
                         .{
                             .temporary = bun.ByteList.fromBorrowedSliceDangerous(chunk),
                         },
                         bun.default_allocator,
                     );
+                    this.evaluateBodyBackpressure(&readable.ptr.Bytes.*);
                 } else {
                     this.clearStreamCancelHandler();
                     var prev = this.readable_stream_ref;
@@ -397,12 +419,15 @@ pub const FetchTasklet = struct {
                     const chunk = scheduled_response_buffer.items;
 
                     if (this.result.has_more) {
+                        this.is_delivering_body_chunk = true;
+                        defer this.is_delivering_body_chunk = false;
                         try readable.ptr.Bytes.onData(
                             .{
                                 .temporary = bun.ByteList.fromBorrowedSliceDangerous(chunk),
                             },
                             bun.default_allocator,
                         );
+                        this.evaluateBodyBackpressure(&readable.ptr.Bytes.*);
                     } else {
                         readable.value.ensureStillAlive();
                         response.detachReadableStream(globalThis);
@@ -915,6 +940,8 @@ pub const FetchTasklet = struct {
                 const source = readable.ptr.Bytes.parent();
                 source.cancel_handler = null;
                 source.cancel_ctx = null;
+                source.drain_handler = null;
+                source.drain_ctx = null;
             }
         }
     }
@@ -923,6 +950,77 @@ pub const FetchTasklet = struct {
         const this = bun.cast(*FetchTasklet, ctx.?);
         if (this.ignore_data) return;
         this.ignoreRemainingResponseBody();
+    }
+
+    /// Runs on the JS thread when `ByteStream.onPull` finds the buffer empty
+    /// and parks waiting for data. If we previously asked the HTTP thread to
+    /// pause socket reads, this is the signal that the consumer is ready for
+    /// more — clear the flag and wake the HTTP thread so `drainResponseBody`
+    /// resumes the socket. Skipped while `onBodyReceived` is mid-delivery
+    /// (see `is_delivering_body_chunk`); in that window the auto-pull may
+    /// re-enter here before the chunk has settled, and `evaluateBodyBackpressure`
+    /// makes the decision once `onData` returns.
+    fn onStreamDrainedCallback(ctx: ?*anyopaque, buffered: usize) void {
+        const this = bun.cast(*FetchTasklet, ctx.?);
+        if (this.is_delivering_body_chunk) return;
+        this.maybeReleaseBodyBackpressure(buffered);
+    }
+
+    fn maybeReleaseBodyBackpressure(this: *FetchTasklet, buffered: usize) void {
+        if (buffered >= body_low_water_mark) return;
+        if (!this.signal_store.body_backpressure.load(.monotonic)) return;
+        this.signal_store.body_backpressure.store(false, .release);
+        log("body backpressure released (buffered={d})", .{buffered});
+        if (this.http) |http_| {
+            // Reuse the response-body-drain queue: on the HTTP thread it both
+            // flushes any bytes that arrived between the pause decision and the
+            // actual `pauseStream()` call, and resumes reads now that the
+            // signal is clear.
+            bun.http.http_thread.scheduleResponseBodyDrain(http_.async_http_id);
+        }
+    }
+
+    /// Re-evaluate the backpressure signal after `onBodyReceived` has handed a
+    /// chunk to the ByteStream and the synchronous microtask cascade inside
+    /// `pending.run()` has settled.
+    ///
+    ///   • `buffer_action` set (`.text()`/`.arrayBuffer()` on an existing
+    ///     stream): the consumer asked for the whole body and there is no pull
+    ///     to ever resume from — never pause, and release if we already had.
+    ///   • `buffer` ≥ high-water mark: the controller's auto-pull stopped (its
+    ///     queue is full) and the surplus landed here. Request a pause.
+    ///   • `buffer` < low-water mark: release. Anything that left `buffer` is
+    ///     now in queues bounded by their own controller high-water marks
+    ///     (default queue, or tee branches after `response.clone()`), so a
+    ///     stalled reader cannot drive `buffer` below LWM and a draining one
+    ///     should resume the socket.
+    fn evaluateBodyBackpressure(this: *FetchTasklet, bytes: *const jsc.WebCore.ByteStream) void {
+        // `.text()`/`.arrayBuffer()`/etc. on a body whose ReadableStream already
+        // exists set `buffer_action` and intentionally accumulate the entire
+        // response in `buffer` until `has_received_last_chunk`. There is no
+        // pull in that mode, so a pause would never be released. Skip — the
+        // consumer has asked for the whole body.
+        if (bytes.buffer_action != null) {
+            this.maybeReleaseBodyBackpressure(0);
+            return;
+        }
+        const buffered = bytes.buffer.items.len -| bytes.offset;
+        if (buffered >= body_high_water_mark) {
+            if (this.signal_store.body_backpressure.load(.monotonic)) return;
+            log("body backpressure requested (ByteStream buffered={d})", .{buffered});
+            this.signal_store.body_backpressure.store(true, .release);
+            return;
+        }
+        // Release when our buffer is below the low-water mark. We don't gate
+        // on `pending.state == .pending` here: when the body is teed
+        // (response.clone()) the cascade leaves bytes in the branch queues
+        // with `pending == .used`, and those queues are bounded by their own
+        // controller high-water marks. The `is_delivering_body_chunk` guard on
+        // `onStreamDrainedCallback` already prevents the unbounded ping-pong
+        // that motivated a stricter check — by the time we run, the synchronous
+        // microtask cascade has settled and any remaining bounce is at most one
+        // round-trip per HWM-sized batch.
+        this.maybeReleaseBodyBackpressure(buffered);
     }
 
     fn toBodyValue(this: *FetchTasklet) Body.Value {
@@ -938,6 +1036,7 @@ pub const FetchTasklet = struct {
                     .onStartStreaming = FetchTasklet.onStartStreamingHTTPResponseBodyCallback,
                     .onReadableStreamAvailable = FetchTasklet.onReadableStreamAvailable,
                     .onStreamCancelled = FetchTasklet.onStreamCancelledCallback,
+                    .onStreamDrained = FetchTasklet.onStreamDrainedCallback,
                 },
             };
             return response;

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -969,7 +969,7 @@ pub const FetchTasklet = struct {
     fn maybeReleaseBodyBackpressure(this: *FetchTasklet, buffered: usize) void {
         if (buffered >= body_low_water_mark) return;
         if (!this.signal_store.body_backpressure.load(.monotonic)) return;
-        this.signal_store.body_backpressure.store(false, .release);
+        this.signal_store.body_backpressure.store(false, .monotonic);
         log("body backpressure released (buffered={d})", .{buffered});
         if (this.http) |http_| {
             // Reuse the response-body-drain queue: on the HTTP thread it both
@@ -1008,7 +1008,7 @@ pub const FetchTasklet = struct {
         if (buffered >= body_high_water_mark) {
             if (this.signal_store.body_backpressure.load(.monotonic)) return;
             log("body backpressure requested (ByteStream buffered={d})", .{buffered});
-            this.signal_store.body_backpressure.store(true, .release);
+            this.signal_store.body_backpressure.store(true, .monotonic);
             return;
         }
         // Release when our buffer is below the low-water mark. We don't gate

--- a/src/http.zig
+++ b/src/http.zig
@@ -2033,13 +2033,15 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
     result.body.?.* = body;
     callback.run(@fieldParentPtr("client", this), result);
 
-    // Response-body backpressure: the callback above runs synchronously on this
-    // (HTTP) thread and appends the chunk to the consumer's buffer. If that
-    // pushed the buffer past its high-water mark the consumer flips
-    // `signals.body_backpressure`; observe it here while we still hold the
-    // socket and pause reads so the kernel's receive window closes instead of
-    // our heap growing without bound. `is_done` already released/closed the
-    // socket above, so only the streaming-more-to-come path is eligible.
+    // Response-body backpressure: the callback above queues the chunk for the
+    // JS thread and returns; the JS thread later sets `body_backpressure`
+    // from `evaluateBodyBackpressure` once `ByteStream.buffer` crosses the
+    // high-water mark. What we read here therefore reflects the *previous*
+    // delivery round — the pause is one chunk behind the crossing — but this
+    // is the only point on the HTTP thread that holds the socket, and the
+    // overshoot is bounded at roughly HWM + one recv buffer. `is_done`
+    // already released/closed the socket above, so only the
+    // streaming-more-to-come path is eligible.
     if (!is_done and !this.flags.body_read_paused and this.signals.get(.body_backpressure)) {
         log("body backpressure: pausing socket reads", .{});
         this.flags.body_read_paused = true;

--- a/src/http.zig
+++ b/src/http.zig
@@ -485,8 +485,13 @@ pub const Flags = packed struct(u16) {
     is_preconnect_only: bool = false,
     is_streaming_request_body: bool = false,
     defer_fail_until_connecting_is_complete: bool = false,
+    /// We called `socket.pauseStream()` because the JS-side response body
+    /// buffer crossed its high-water mark (see Signals.body_backpressure).
+    /// `drainResponseBody` resumes once the consumer drains below the
+    /// low-water mark and clears the signal.
+    body_read_paused: bool = false,
     upgrade_state: HTTPUpgradeState = .none,
-    _padding: u3 = 0,
+    _padding: u2 = 0,
 };
 
 // TODO: reduce the size of this struct
@@ -1921,6 +1926,20 @@ pub fn drainResponseBody(this: *HTTPClient, comptime is_ssl: bool, socket: NewHT
         else => {},
     }
 
+    // Resume reads if we previously paused for body backpressure and the
+    // consumer has since drained below its low-water mark. This is the
+    // HTTP-thread half of the handshake; the JS thread clears the signal and
+    // enqueues us via `scheduleResponseBodyDrain` after a pull. Do this before
+    // the empty-buffer early-return below — when paused, `body_out_str` is
+    // typically empty (we stopped reading), so the resume must not be gated
+    // on having bytes to flush.
+    if (this.flags.body_read_paused and !this.signals.get(.body_backpressure)) {
+        log("body backpressure: resuming socket reads", .{});
+        this.flags.body_read_paused = false;
+        _ = socket.resumeStream();
+        this.setTimeout(socket, 5);
+    }
+
     if (this.state.fail != null) {
         // If there's any error at all, do not drain.
         return;
@@ -2013,6 +2032,22 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
 
     result.body.?.* = body;
     callback.run(@fieldParentPtr("client", this), result);
+
+    // Response-body backpressure: the callback above runs synchronously on this
+    // (HTTP) thread and appends the chunk to the consumer's buffer. If that
+    // pushed the buffer past its high-water mark the consumer flips
+    // `signals.body_backpressure`; observe it here while we still hold the
+    // socket and pause reads so the kernel's receive window closes instead of
+    // our heap growing without bound. `is_done` already released/closed the
+    // socket above, so only the streaming-more-to-come path is eligible.
+    if (!is_done and !this.flags.body_read_paused and this.signals.get(.body_backpressure)) {
+        log("body backpressure: pausing socket reads", .{});
+        this.flags.body_read_paused = true;
+        _ = socket.pauseStream();
+        // The idle timeout measures "no bytes from the peer". While paused that
+        // is by construction true, so disarm it; `drainResponseBody` re-arms.
+        this.setTimeout(socket, 0);
+    }
 
     if (comptime print_every > 0) {
         print_every_i += 1;

--- a/src/http/Signals.zig
+++ b/src/http/Signals.zig
@@ -5,8 +5,15 @@ response_body_streaming: ?*std.atomic.Value(bool) = null,
 aborted: ?*std.atomic.Value(bool) = null,
 cert_errors: ?*std.atomic.Value(bool) = null,
 upgraded: ?*std.atomic.Value(bool) = null,
+/// Set by the JS-side consumer (FetchTasklet) when the unread response body
+/// buffered in memory has crossed the high-water mark. The HTTP thread
+/// observes this after delivering a chunk and pauses the socket so TCP
+/// backpressure engages instead of growing the buffer without bound.
+/// Cleared by the consumer when the buffer drains below the low-water mark;
+/// the HTTP thread then resumes the socket via the response-body-drain queue.
+body_backpressure: ?*std.atomic.Value(bool) = null,
 pub fn isEmpty(this: *const Signals) bool {
-    return this.aborted == null and this.response_body_streaming == null and this.header_progress == null and this.cert_errors == null and this.upgraded == null;
+    return this.aborted == null and this.response_body_streaming == null and this.header_progress == null and this.cert_errors == null and this.upgraded == null and this.body_backpressure == null;
 }
 
 pub const Store = struct {
@@ -15,6 +22,7 @@ pub const Store = struct {
     aborted: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     cert_errors: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     upgraded: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    body_backpressure: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     pub fn to(this: *Store) Signals {
         return .{
             .header_progress = &this.header_progress,
@@ -22,6 +30,7 @@ pub const Store = struct {
             .aborted = &this.aborted,
             .cert_errors = &this.cert_errors,
             .upgraded = &this.upgraded,
+            .body_backpressure = &this.body_backpressure,
         };
     }
 };

--- a/test/js/web/fetch/fetch-unread-body-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak-fixture.ts
@@ -1,0 +1,85 @@
+// Client side of the fetch response-body backpressure test (Sentry BUN-2V22
+// cluster). The server lives in the test file so this process's RSS measures
+// only fetch-client buffering.
+//
+// Mechanism under test: when the unread response body in ByteStream.buffer /
+// scheduled_response_buffer crosses the high-water mark, the HTTP thread
+// pauses socket reads so TCP applies backpressure instead of the buffer
+// growing without bound. When JS pulls below the low-water mark, reads resume.
+//
+// Shape:
+//   1. Read ONE chunk to establish the ByteStream and enable streaming.
+//   2. Stall. Yield to the event loop repeatedly so the HTTP thread has every
+//      opportunity to deliver more data. With backpressure, RSS plateaus near
+//      the high-water mark; without, it climbs toward the full payload.
+//   3. Report the RSS plateau.
+//   4. Drain a further N MB to prove resume works (the read would hang if the
+//      socket stayed paused).
+
+const SERVER = process.env.SERVER!;
+const TARGET_BYTES = Number(process.env.TARGET_BYTES!);
+
+const res = await fetch(SERVER);
+const reader = res.body!.getReader();
+
+// (1) Prime the stream so `response_body_streaming` is set before measuring.
+const first = await reader.read();
+if (first.done) throw new Error("server closed before sending data");
+
+// Measure the baseline AFTER fetch/connect/first-read so we isolate growth
+// during the stall. Under debug+ASAN the connect + JSC ReadableStream setup
+// alone costs tens of MB; that's not what this test is about.
+Bun.gc(true);
+const baselineRSS = process.memoryUsage.rss();
+
+// (2) Stall and let the HTTP thread push as much as backpressure allows. The
+// outcome being tested is inherently a rate: without backpressure, RSS climbs
+// at network speed; with it, RSS plateaus near the high-water mark almost
+// immediately. We sample until either RSS crosses half the payload (leak —
+// breaks immediately, makes the unfixed case fast and deterministic) or RSS
+// has been stable for a stretch of consecutive samples (plateau — backpressure
+// engaged). The 2ms inter-sample gap exists only so the HTTP thread gets
+// scheduling time on release builds; the loop's exit is condition-driven.
+let maxGrowth = 0;
+let stableFor = 0;
+let last = 0;
+for (let i = 0; i < 250; i++) {
+  await Bun.sleep(2);
+  const growth = process.memoryUsage.rss() - baselineRSS;
+  if (growth > maxGrowth) maxGrowth = growth;
+  if (growth > TARGET_BYTES / 2) break;
+  if (growth === last) {
+    if (++stableFor >= 25) break;
+  } else {
+    stableFor = 0;
+    last = growth;
+  }
+}
+Bun.gc(true);
+
+// (3) Report.
+const stalledMB = (maxGrowth / 1024 / 1024) | 0;
+
+// (4) Drain another 16 MB to prove the socket resumes after a pull. If
+// backpressure paused the socket and resume is broken, this hangs and the
+// parent's test timeout catches it.
+let drained = first.value!.length;
+while (drained < 16 * 1024 * 1024) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  drained += value.length;
+}
+
+console.log(
+  JSON.stringify({
+    sentMB: (TARGET_BYTES / 1024 / 1024) | 0,
+    stalledRssGrowthMB: stalledMB,
+    drainedMB: (drained / 1024 / 1024) | 0,
+  }),
+);
+
+// Keep the response alive past the measurement so GC can't free the buffer
+// before we sampled RSS.
+void res;
+
+process.exit(0);

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -131,6 +131,49 @@ test("fetch response body backpressure is released on reader.cancel()", async ()
   expect(exitCode).toBe(0);
 });
 
+// Accessing res.body, letting the buffer cross the HWM (pausing the socket),
+// then calling res.text() takes the toBufferedValue path which sets
+// buffer_action with no pull-based resume hook. toBufferedValue must release
+// the pause itself; evaluateBodyBackpressure's buffer_action exemption only
+// runs on new data, which can't arrive while paused.
+test("fetch response body backpressure is released when .text() follows a stalled .body", async () => {
+  const SIZE = 4 * 1024 * 1024;
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      return new Response(new Blob([Buffer.alloc(SIZE, "x")]));
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      `
+        const res = await fetch(process.env.SERVER);
+        // Create the ByteStream and enable streaming.
+        void res.body;
+        // Let the HTTP thread buffer past the 1 MB HWM and pause.
+        for (let i = 0; i < 50; i++) await Bun.sleep(2);
+        // toBufferedValue path — must release the pause it can't otherwise see.
+        const text = await res.text();
+        if (text.length !== ${SIZE}) throw new Error("size " + text.length);
+        console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, SERVER: server.url.href },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (stderr) console.error(stderr.trim());
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
 // response.clone() before any .body access creates the ByteStream via the
 // Body.tee() fallback path, which must wire drain_handler the same way
 // toReadableStream() does — otherwise once the buffer crosses the HWM the

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -198,9 +198,22 @@ test("fetch response body backpressure resumes after clone()-before-body-access"
         // clone() first — this is the tee() fallback that allocates a fresh
         // ByteStream.Source.
         const clone = res.clone();
-        const [a, b] = await Promise.all([res.bytes(), clone.bytes()]);
-        if (a.byteLength !== ${SIZE} || b.byteLength !== ${SIZE}) {
-          throw new Error("size mismatch: " + a.byteLength + " / " + b.byteLength);
+        // Stall one branch so the underlying ByteStream's buffer crosses the
+        // HWM and the socket pauses. Without drain_handler wired on the tee()
+        // path, nothing would resume it.
+        const reader = clone.body.getReader();
+        await reader.read();
+        for (let i = 0; i < 50; i++) await Bun.sleep(2);
+        // Now drain both branches; this requires the socket to resume.
+        const a = await res.bytes();
+        let b = 0;
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          b += value.length;
+        }
+        if (a.byteLength !== ${SIZE} || b >= ${SIZE} || b === 0) {
+          throw new Error("size mismatch: " + a.byteLength + " / " + b);
         }
         console.log("ok");
       `,

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -213,17 +213,17 @@ test("fetch response body backpressure resumes after clone()-before-body-access"
         // HWM and the socket pauses. Without drain_handler wired on the tee()
         // path, nothing would resume it.
         const reader = clone.body.getReader();
-        await reader.read();
+        const first = await reader.read();
         for (let i = 0; i < 50; i++) await Bun.sleep(2);
         // Now drain both branches; this requires the socket to resume.
         const a = await res.bytes();
-        let b = 0;
+        let b = first.value.byteLength;
         while (true) {
           const { value, done } = await reader.read();
           if (done) break;
           b += value.length;
         }
-        if (a.byteLength !== ${SIZE} || b >= ${SIZE} || b === 0) {
+        if (a.byteLength !== ${SIZE} || b !== ${SIZE}) {
           throw new Error("size mismatch: " + a.byteLength + " / " + b);
         }
         console.log("ok");

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -68,3 +68,107 @@ test("fetch response body applies backpressure when the reader stalls", async ()
 
   expect(exitCode).toBe(0);
 });
+
+// reader.cancel() (or Response GC) while the socket is paused must release the
+// pause. The drain_handler is cleared in ignoreRemainingResponseBody, so
+// without an explicit release there the connection would sit paused forever
+// with its idle timeout disarmed.
+test("fetch response body backpressure is released on reader.cancel()", async () => {
+  const CHUNK = Buffer.alloc(256 * 1024, "x");
+  let serverClosed = false;
+  const { promise: closed, resolve: markClosed } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            for (let i = 0; i < 512; i++) await controller.write(CHUNK);
+          },
+          cancel() {
+            serverClosed = true;
+            markClosed();
+          },
+        }),
+      );
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      `
+        const res = await fetch(process.env.SERVER);
+        const reader = res.body.getReader();
+        await reader.read();
+        // Stall long enough for the buffer to cross the HWM and pause.
+        for (let i = 0; i < 50; i++) await Bun.sleep(2);
+        await reader.cancel();
+        // Hold the process open briefly so the server sees the connection
+        // close before we exit.
+        await Bun.sleep(50);
+        console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, SERVER: server.url.href },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (stderr) console.error(stderr.trim());
+
+  // If the pause was never released, the connection stays open and the
+  // server's `cancel()` never fires.
+  await closed;
+  expect(serverClosed).toBe(true);
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+// response.clone() before any .body access creates the ByteStream via the
+// Body.tee() fallback path, which must wire drain_handler the same way
+// toReadableStream() does — otherwise once the buffer crosses the HWM the
+// socket is paused with no resume hook.
+test("fetch response body backpressure resumes after clone()-before-body-access", async () => {
+  const SIZE = 8 * 1024 * 1024;
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      return new Response(new Blob([Buffer.alloc(SIZE)]));
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      `
+        const res = await fetch(process.env.SERVER);
+        // clone() first — this is the tee() fallback that allocates a fresh
+        // ByteStream.Source.
+        const clone = res.clone();
+        const [a, b] = await Promise.all([res.bytes(), clone.bytes()]);
+        if (a.byteLength !== ${SIZE} || b.byteLength !== ${SIZE}) {
+          throw new Error("size mismatch: " + a.byteLength + " / " + b.byteLength);
+        }
+        console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, SERVER: server.url.href },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (stderr) console.error(stderr.trim());
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// Regression test for the fetch response-body backpressure gap (Sentry
+// BUN-2V22 cluster). Before the fix, ByteStream.onData appended every incoming
+// chunk to its internal buffer with no high-water-mark check, so a server that
+// sends faster than JS reads (or a client that never reads) buffered the
+// entire response in memory and OOMed long-running processes.
+//
+// The server pumps TARGET_BYTES as fast as the socket accepts. The fixture
+// reads one chunk, stalls, samples RSS while yielding to the event loop, then
+// drains a further 16 MB to prove the socket resumes after a pull.
+test("fetch response body applies backpressure when the reader stalls", async () => {
+  const CHUNK = Buffer.alloc(256 * 1024, "x");
+  const TARGET_BYTES = 128 * 1024 * 1024;
+
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch() {
+      let written = 0;
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            while (written < TARGET_BYTES) {
+              await controller.write(CHUNK);
+              written += CHUNK.length;
+            }
+            // Leave the response open so the client stays in the
+            // still-receiving state for the duration of the measurement.
+          },
+        }),
+        { headers: { "Content-Type": "application/octet-stream" } },
+      );
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "fetch-unread-body-leak-fixture.ts")],
+    env: {
+      ...bunEnv,
+      SERVER: server.url.href,
+      TARGET_BYTES: String(TARGET_BYTES),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (stderr) console.error(stderr.trim());
+  console.log(stdout.trim());
+
+  const report = JSON.parse(stdout.trim());
+
+  // With backpressure, the client buffers ~high-water-mark (1 MB) plus a few
+  // recv-buffer-sized chunks of overshoot and allocator slack — single-digit
+  // MB. Without, it buffers on the order of TARGET_BYTES. 32 MB gives wide
+  // margin for debug-build/ASAN overhead while still being ~4× smaller than
+  // the unfixed behaviour.
+  expect(report.stalledRssGrowthMB).toBeLessThan(32);
+
+  // Resume must work: the post-stall drain should have read past the
+  // high-water mark, which is only possible if the socket resumed.
+  expect(report.drainedMB).toBeGreaterThanOrEqual(16);
+
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch-unread-body-leak.test.ts
+++ b/test/js/web/fetch/fetch-unread-body-leak.test.ts
@@ -72,11 +72,12 @@ test("fetch response body applies backpressure when the reader stalls", async ()
 // reader.cancel() (or Response GC) while the socket is paused must release the
 // pause. The drain_handler is cleared in ignoreRemainingResponseBody, so
 // without an explicit release there the connection would sit paused forever
-// with its idle timeout disarmed.
+// with its idle timeout disarmed. The subprocess deliberately stays alive
+// after cancel() so process exit can't close the FD and mask the regression;
+// the observable is `server.pendingRequests` dropping to 0, which only
+// happens once the client has drained the response (i.e. the socket resumed).
 test("fetch response body backpressure is released on reader.cancel()", async () => {
   const CHUNK = Buffer.alloc(256 * 1024, "x");
-  let serverClosed = false;
-  const { promise: closed, resolve: markClosed } = Promise.withResolvers<void>();
 
   using server = Bun.serve({
     port: 0,
@@ -86,11 +87,10 @@ test("fetch response body backpressure is released on reader.cancel()", async ()
         new ReadableStream({
           type: "direct",
           async pull(controller) {
-            for (let i = 0; i < 512; i++) await controller.write(CHUNK);
-          },
-          cancel() {
-            serverClosed = true;
-            markClosed();
+            // Small enough that, once the client resumes and ignores, the
+            // response drains and completes within the test window.
+            for (let i = 0; i < 32; i++) await controller.write(CHUNK);
+            controller.close();
           },
         }),
       );
@@ -109,10 +109,11 @@ test("fetch response body backpressure is released on reader.cancel()", async ()
         // Stall long enough for the buffer to cross the HWM and pause.
         for (let i = 0; i < 50; i++) await Bun.sleep(2);
         await reader.cancel();
-        // Hold the process open briefly so the server sees the connection
-        // close before we exit.
-        await Bun.sleep(50);
-        console.log("ok");
+        process.stdout.write("cancelled\\n");
+        // Stay alive: process exit would close the socket regardless of
+        // whether the pause was released, masking the regression. The parent
+        // kills us once the server reports the response drained.
+        setInterval(() => {}, 1 << 30);
       `,
     ],
     env: { ...bunEnv, SERVER: server.url.href },
@@ -120,15 +121,25 @@ test("fetch response body backpressure is released on reader.cancel()", async ()
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  if (stderr) console.error(stderr.trim());
+  let buffered = "";
+  for await (const chunk of proc.stdout) {
+    buffered += Buffer.from(chunk).toString();
+    if (buffered.includes("cancelled\n")) break;
+  }
+  expect(buffered).toContain("cancelled");
 
-  // If the pause was never released, the connection stays open and the
-  // server's `cancel()` never fires.
-  await closed;
-  expect(serverClosed).toBe(true);
-  expect(stdout.trim()).toBe("ok");
-  expect(exitCode).toBe(0);
+  // The subprocess is still alive (setInterval ref), so the only way the
+  // server's pending count reaches 0 is the client having resumed the paused
+  // socket and drained the 8 MB to completion. If the regression recurs the
+  // socket stays paused, the server can't finish sending, and this loop runs
+  // until the test runner's timeout fails it.
+  while (server.pendingRequests > 0) {
+    await Bun.sleep(5);
+  }
+  expect(server.pendingRequests).toBe(0);
+
+  proc.kill();
+  await proc.exited;
 });
 
 // Accessing res.body, letting the buffer cross the HWM (pausing the socket),


### PR DESCRIPTION
## What

Caps `fetch()` response-body memory at a high-water mark by pausing socket reads when the JS consumer falls behind, instead of buffering the entire response unconditionally.

## Why

`ByteStream.onData` appended every chunk to `this.buffer` with no HWM check, and the HTTP thread drained the socket into `scheduled_response_buffer` regardless of whether JS was reading. A server that sends faster than the client reads — or a client that touches `res.body` and never reads — buffered the full payload until OOM. This is the dominant OOM cluster in Sentry for long-running compiled apps (`fetch=True`, `StandaloneExecutable`).

## How

- `Signals.body_backpressure` atomic + `HTTPClient.flags.body_read_paused`
- After `onBodyReceived` pushes a chunk into the ByteStream (post-microtask-cascade), `evaluateBodyBackpressure` sets the signal when `ByteStream.buffer ≥ 1 MB`
- HTTP thread checks the signal after `callback.run()` while it still holds the socket → `socket.pauseStream()` + disarm idle timeout
- Release path: `onStreamDrained` hook on `Body.PendingValue` → `drain_handler` on `NewSource`, fired from `ByteStream.onPull` when it parks waiting; clears the signal and wakes the HTTP thread via `scheduleResponseBodyDrain` → `drainResponseBody` resumes
- `is_delivering_body_chunk` re-entrancy guard: `pending.run()` drains microtasks which lets the controller's auto-pull re-enter `onPull` synchronously; the guard defers the release decision to after `onData` returns
- `buffer_action` exemption: `.text()`/`.arrayBuffer()` on an existing stream wants the whole body and has no pull to resume from
- uSockets `loop.c` repeat-recv now checks `is_paused` so a pause from inside `on_data` stops the drain (was draining ≤10 more iterations)

## Scope

Only the streaming path (`res.body` accessed). `await fetch(url)` then never touching `.body` still buffers in `scheduled_response_buffer` until done — pausing there would hang `.text()`/`.arrayBuffer()` and needs a separate design.

## Test

`test/js/web/fetch/fetch-unread-body-leak.test.ts` — server streams 128 MB at a subprocess that reads one chunk then stalls:

| | stalled RSS growth | drained after |
|---|---|---|
| this PR | 5-8 MB | 16 MB ✓ |
| `USE_SYSTEM_BUN=1` | 86 MB | (test fails) |

Regression sweep: `fetch.test.ts` 341/341, `fetch.stream.test.ts` 109/109, `body-stream.test.ts` 4884/4884 (incl. `response.clone()` + 8 MB tee). The four `fetch-leak.test.ts` failures and the `body-stream → fetch.test` cascade are pre-existing on debug+ASAN (verified on stashed `main`).