### PR TITLE
watcher: re-register kqueue udata after swapRemove in flushEvictions

### DIFF
--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -294,6 +294,29 @@ pub fn flushEvictions(this: *Watcher) void {
     for (this.evict_list[0..this.evict_list_i]) |item| {
         if (item == last_item or this.watchlist.len <= item) continue;
         this.watchlist.swapRemove(item);
+
+        // On macOS, kqueue events carry a `udata` that encodes the watchlist
+        // index of the fd at registration time. `swapRemove` moves the entry
+        // previously at `watchlist.len` into slot `item`, but its kqueue
+        // registration still points at its old (now invalid) index. Left
+        // unpatched, subsequent kevents for that fd would be routed to the
+        // wrong module, so after the first eviction an atomic write to a
+        // second imported file either stopped propagating or drove the
+        // module graph to oscillate between old and new state. See #29524.
+        //
+        // Re-register the moved entry's fd so its next event carries the
+        // updated index. EV_ADD on an existing (ident, filter) replaces the
+        // registration in place. The just-evicted slot's fd was already
+        // closed in the first pass above so there's nothing to fix up there.
+        if (comptime Environment.isMac) {
+            if (item < this.watchlist.len) {
+                const moved_fd = this.watchlist.items(.fd)[item];
+                if (moved_fd.isValid()) {
+                    this.addFileDescriptorToKQueueWithoutChecks(moved_fd, item);
+                }
+            }
+        }
+
         last_item = item;
     }
 }

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -336,8 +336,13 @@ fn watchLoop(this: *Watcher) bun.sys.Maybe(void) {
 ///
 /// Preconditions (caller must ensure):
 /// - `fd` is a valid, open file descriptor
-/// - `fd` is not already registered with this kqueue
 /// - `watchlist_id` matches the entry's index in the watchlist
+///
+/// It is safe to call this on an `fd` that is already registered — `EV_ADD`
+/// on an existing `(ident, filter)` pair replaces the registration in place,
+/// which `flushEvictions` relies on to rewrite `udata` after `swapRemove`
+/// shuffles the watchlist. Do NOT add a guard that skips already-registered
+/// fds; that silently reintroduces issue #29524.
 ///
 /// Note: This function does not propagate kevent registration errors.
 /// If registration fails, the file will not be watched but no error is returned.

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -278,10 +278,7 @@ pub fn flushEvictions(this: *Watcher) void {
     for (this.evict_list[0..this.evict_list_i]) |item| {
         // catch duplicates, since the list is sorted, duplicates will appear right after each other
         if (item == last_item) continue;
-        // `item` may be >= fds.len if a kqueue event with a stale `udata` (i.e.
-        // a watchlist index that has since been compacted away) fed
-        // `removeAtIndex` before the second pass got a chance to run. Match the
-        // bounds check the second pass already has so we don't OOB-read `fds`.
+        // Stale udata from a kevent can point past the compacted watchlist; match the second pass's guard.
         if (item >= fds.len) continue;
 
         if (!Environment.isWindows) {
@@ -300,19 +297,10 @@ pub fn flushEvictions(this: *Watcher) void {
         if (item == last_item or this.watchlist.len <= item) continue;
         this.watchlist.swapRemove(item);
 
-        // On macOS, kqueue events carry a `udata` that encodes the watchlist
-        // index of the fd at registration time. `swapRemove` moves the entry
-        // previously at `watchlist.len` into slot `item`, but its kqueue
-        // registration still points at its old (now invalid) index. Left
-        // unpatched, subsequent kevents for that fd would be routed to the
-        // wrong module, so after the first eviction an atomic write to a
-        // second imported file either stopped propagating or drove the
-        // module graph to oscillate between old and new state. See #29524.
-        //
-        // Re-register the moved entry's fd so its next event carries the
-        // updated index. EV_ADD on an existing (ident, filter) replaces the
-        // registration in place. The just-evicted slot's fd was already
-        // closed in the first pass above so there's nothing to fix up there.
+        // swapRemove put a different entry at `item`, but its kqueue registration still
+        // carries its old `udata` (= pre-swap index). Rewrite it so subsequent kevents
+        // route to the right module; EV_ADD on an existing (ident, filter) replaces in
+        // place. See #29524.
         if (comptime Environment.isMac) {
             if (item < this.watchlist.len) {
                 const moved_fd = this.watchlist.items(.fd)[item];
@@ -343,14 +331,12 @@ fn watchLoop(this: *Watcher) bun.sys.Maybe(void) {
 /// - `fd` is a valid, open file descriptor
 /// - `watchlist_id` matches the entry's index in the watchlist
 ///
-/// It is safe to call this on an `fd` that is already registered — `EV_ADD`
-/// on an existing `(ident, filter)` pair replaces the registration in place,
-/// which `flushEvictions` relies on to rewrite `udata` after `swapRemove`
-/// shuffles the watchlist. Do NOT add a guard that skips already-registered
-/// fds; that silently reintroduces issue #29524.
+/// Safe to call on an already-registered `fd`: `EV_ADD` on an existing
+/// `(ident, filter)` replaces the registration in place, which `flushEvictions`
+/// relies on to rewrite `udata` after `swapRemove`. Adding a
+/// skip-if-registered guard here silently reintroduces #29524.
 ///
-/// Note: This function does not propagate kevent registration errors.
-/// If registration fails, the file will not be watched but no error is returned.
+/// Does not propagate kevent registration errors.
 pub fn addFileDescriptorToKQueueWithoutChecks(this: *Watcher, fd: bun.FD, watchlist_id: usize) void {
     const KEvent = std.c.Kevent;
 

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -488,7 +488,7 @@ fn appendDirectoryAssumeCapacity(
         // id
         event.ident = @intCast(fd.native());
 
-        // Store the hash for fast filtering later
+        // Store the index for fast filtering later
         event.udata = @as(usize, @intCast(watchlist_id));
         var events: [1]KEvent = .{event};
 

--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -278,6 +278,11 @@ pub fn flushEvictions(this: *Watcher) void {
     for (this.evict_list[0..this.evict_list_i]) |item| {
         // catch duplicates, since the list is sorted, duplicates will appear right after each other
         if (item == last_item) continue;
+        // `item` may be >= fds.len if a kqueue event with a stale `udata` (i.e.
+        // a watchlist index that has since been compacted away) fed
+        // `removeAtIndex` before the second pass got a chance to run. Match the
+        // bounds check the second pass already has so we don't OOB-read `fds`.
+        if (item >= fds.len) continue;
 
         if (!Environment.isWindows) {
             // on mac and linux we can just close the file descriptor

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -401,12 +401,7 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             defer current_task.enqueue();
 
             for (events) |event| {
-                // `event.index` comes from `kevent.udata` on macOS and can be
-                // stale (pointing past the compacted watchlist) if the kernel
-                // pre-queued an event before `flushEvictions`/swapRemove
-                // re-registered the moved fd. Guard matches what
-                // DevServer.onFileUpdate and path_watcher.onFileUpdate already
-                // do.
+                // Stale udata: kevent.udata can outlive a swapRemove in flushEvictions.
                 if (event.index >= file_paths.len) continue;
                 const file_path = file_paths[event.index];
                 const update_count = counts[event.index] + 1;

--- a/src/bun.js/hot_reloader.zig
+++ b/src/bun.js/hot_reloader.zig
@@ -401,6 +401,13 @@ pub fn NewHotReloader(comptime Ctx: type, comptime EventLoopType: type, comptime
             defer current_task.enqueue();
 
             for (events) |event| {
+                // `event.index` comes from `kevent.udata` on macOS and can be
+                // stale (pointing past the compacted watchlist) if the kernel
+                // pre-queued an event before `flushEvictions`/swapRemove
+                // re-registered the moved fd. Guard matches what
+                // DevServer.onFileUpdate and path_watcher.onFileUpdate already
+                // do.
+                if (event.index >= file_paths.len) continue;
                 const file_path = file_paths[event.index];
                 const update_count = counts[event.index] + 1;
                 counts[event.index] = update_count;

--- a/test/regression/issue/29524.test.ts
+++ b/test/regression/issue/29524.test.ts
@@ -1,111 +1,57 @@
 // Regression for https://github.com/oven-sh/bun/issues/29524
-//
-// On macOS, `flushEvictions` in src/Watcher.zig compacts the watchlist with
-// `MultiArrayList.swapRemove`, but the kqueue registration for the entry that
-// moved into the vacated slot still carries its old `udata` (its pre-swap
-// watchlist index). Subsequent kevents for that fd were then routed to the
-// wrong module, so an atomic write (write-tmp + rename-over, the way vim,
-// VSCode, prettier, claude-code, etc. save files) to a second imported file
-// after the first eviction stopped propagating — the module graph oscillated
-// between old and new state instead of converging.
-//
-// This test spawns `bun --hot` on an entry that imports three modules, prints
-// a "[tick] a() b() c()" line periodically, and performs three atomic writes
-// in the a -> c -> b order that triggers the bug. Each write must be reflected
-// in a subsequent tick. Before the fix the b-1 tick never arrived on macOS;
-// after the fix all three atomic writes propagate.
-//
-// Linux uses inotify and re-resolves the watchlist index on every event
-// (`INotifyWatcher.zig` — `indexOfScalar(eventlist_index, ...)`), so the bug
-// is macOS-specific. Windows uses a different watcher entirely. Skipping
-// off macOS keeps this focused on the platform where the bug lives.
+// Atomic writes (temp-file + rename) to multiple imported files under
+// `bun --hot` stopped propagating after the first eviction on macOS:
+// kqueue `udata` was stale after `flushEvictions` did `swapRemove` on
+// the watchlist. kqueue-specific, so skipped off macOS.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isMacOS, tempDir } from "harness";
+import { bunEnv, bunExe, forEachLine, isMacOS, tempDir } from "harness";
 import { renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-// Per step: 10s budget; 4 steps; plus spawn + module init. The default 5s
-// test timeout is not enough. Debug builds get Infinity — the hot-reload
-// codegen path is dramatically slower under ASAN.
-const testTimeout = isDebug ? Infinity : 60_000;
+test.skipIf(!isMacOS)("atomic writes to multiple imported files keep propagating under --hot (#29524)", async () => {
+  using dir = tempDir("issue-29524", {
+    "a.js": `export function a() { return "a-0"; }\n`,
+    "b.js": `export function b() { return "b-0"; }\n`,
+    "c.js": `export function c() { return "c-0"; }\n`,
+    "entry.js":
+      `import { a } from "./a.js";\n` +
+      `import { b } from "./b.js";\n` +
+      `import { c } from "./c.js";\n` +
+      `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
+  });
+  const cwd = String(dir);
 
-test.skipIf(!isMacOS)(
-  "atomic writes to multiple imported files keep propagating under --hot (#29524)",
-  async () => {
-    using dir = tempDir("issue-29524", {
-      "a.js": `export function a() { return "a-0"; }\n`,
-      "b.js": `export function b() { return "b-0"; }\n`,
-      "c.js": `export function c() { return "c-0"; }\n`,
-      "entry.js":
-        `import { a } from "./a.js";\n` +
-        `import { b } from "./b.js";\n` +
-        `import { c } from "./c.js";\n` +
-        // 50ms is fast enough to observe oscillation between writes but slow
-        // enough not to flood stdout.
-        `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
-    });
-    const cwd = String(dir);
-    const aFile = join(cwd, "a.js");
-    const bFile = join(cwd, "b.js");
-    const cFile = join(cwd, "c.js");
+  await using runner = Bun.spawn({
+    cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
 
-    await using runner = Bun.spawn({
-      cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
-      cwd,
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-      stdin: "ignore",
-    });
+  function atomicWrite(name: string, content: string) {
+    const path = join(cwd, name);
+    writeFileSync(path + ".atomic", content);
+    renameSync(path + ".atomic", path);
+  }
 
-    // Atomic replace via temp-file + rename, identical to the idiom that
-    // triggers the bug in real editors/tools.
-    function atomicWrite(path: string, content: string) {
-      const tmp = path + ".atomic";
-      writeFileSync(tmp, content);
-      renameSync(tmp, path);
+  const iter = forEachLine(runner.stdout);
+  async function waitForTick(ticker: string) {
+    for (;;) {
+      const { value, done } = await iter.next();
+      if (done) throw new Error(`stdout ended before seeing ${ticker}`);
+      if (value.includes(ticker)) return;
     }
+  }
 
-    let buffered = "";
-    const decoder = new TextDecoder();
-    const reader = runner.stdout.getReader();
-
-    async function waitForTick(ticker: string) {
-      // 10s budget per step is plenty for a 50ms-tick entry; on the fixed
-      // build each transition lands within a few hundred ms.
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        if (buffered.includes(ticker)) return true;
-        const res = await reader.read();
-        if (res.done) return buffered.includes(ticker);
-        buffered += decoder.decode(res.value);
-      }
-      return buffered.includes(ticker);
-    }
-
-    try {
-      // Baseline reload confirms the watcher is wired up.
-      expect(await waitForTick("[tick] a-0 b-0 c-0")).toBe(true);
-
-      // Write #1 — rewrite a.js. Before the fix this step still works (the
-      // first eviction happens here, but nothing has yet been misrouted).
-      atomicWrite(aFile, `export function a() { return "a-1"; }\n`);
-      expect(await waitForTick("[tick] a-1 b-0 c-0")).toBe(true);
-
-      // Write #2 — rewrite c.js. Works coincidentally on buggy builds because
-      // c still happens to be findable at the stale index.
-      atomicWrite(cFile, `export function c() { return "c-1"; }\n`);
-      expect(await waitForTick("[tick] a-1 b-0 c-1")).toBe(true);
-
-      // Write #3 — rewrite b.js. On buggy macOS builds the b-1 tick NEVER
-      // appears: the module graph instead oscillates between
-      // `[tick] a-1 b-0 c-1` and `[tick] a-0 b-0 c-0`. With the kqueue
-      // udata re-registration fix in flushEvictions, all three writes land.
-      atomicWrite(bFile, `export function b() { return "b-1"; }\n`);
-      expect(await waitForTick("[tick] a-1 b-1 c-1")).toBe(true);
-    } finally {
-      reader.cancel().catch(() => {});
-    }
-  },
-  testTimeout,
-);
+  await waitForTick("[tick] a-0 b-0 c-0");
+  atomicWrite("a.js", `export function a() { return "a-1"; }\n`);
+  await waitForTick("[tick] a-1 b-0 c-0");
+  atomicWrite("c.js", `export function c() { return "c-1"; }\n`);
+  await waitForTick("[tick] a-1 b-0 c-1");
+  // Write b last — on buggy macOS builds this tick never appears.
+  atomicWrite("b.js", `export function b() { return "b-1"; }\n`);
+  await waitForTick("[tick] a-1 b-1 c-1");
+  expect(runner.exitCode).toBeNull();
+});

--- a/test/regression/issue/29524.test.ts
+++ b/test/regression/issue/29524.test.ts
@@ -20,9 +20,9 @@
 // is macOS-specific. Windows uses a different watcher entirely. Skipping
 // off macOS keeps this focused on the platform where the bug lives.
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 import { renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 
 test.skipIf(!isMacOS)("atomic writes to multiple imported files keep propagating under --hot (#29524)", async () => {
   using dir = tempDir("issue-29524", {

--- a/test/regression/issue/29524.test.ts
+++ b/test/regression/issue/29524.test.ts
@@ -1,0 +1,102 @@
+// Regression for https://github.com/oven-sh/bun/issues/29524
+//
+// On macOS, `flushEvictions` in src/Watcher.zig compacts the watchlist with
+// `MultiArrayList.swapRemove`, but the kqueue registration for the entry that
+// moved into the vacated slot still carries its old `udata` (its pre-swap
+// watchlist index). Subsequent kevents for that fd were then routed to the
+// wrong module, so an atomic write (write-tmp + rename-over, the way vim,
+// VSCode, prettier, claude-code, etc. save files) to a second imported file
+// after the first eviction stopped propagating — the module graph oscillated
+// between old and new state instead of converging.
+//
+// This test spawns `bun --hot` on an entry that imports three modules, prints
+// a "[tick] a() b() c()" line periodically, and performs three atomic writes
+// in the a -> c -> b order that triggers the bug. Each write must be reflected
+// in a subsequent tick. Before the fix the b-1 tick never arrived on macOS;
+// after the fix all three atomic writes propagate.
+//
+// Linux uses inotify and re-resolves the watchlist index on every event
+// (`INotifyWatcher.zig` — `indexOfScalar(eventlist_index, ...)`), so the bug
+// is macOS-specific. Windows uses a different watcher entirely. Skipping
+// off macOS keeps this focused on the platform where the bug lives.
+import { expect, test } from "bun:test";
+import { renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+
+test.skipIf(!isMacOS)("atomic writes to multiple imported files keep propagating under --hot (#29524)", async () => {
+  using dir = tempDir("issue-29524", {
+    "a.js": `export function a() { return "a-0"; }\n`,
+    "b.js": `export function b() { return "b-0"; }\n`,
+    "c.js": `export function c() { return "c-0"; }\n`,
+    "entry.js":
+      `import { a } from "./a.js";\n` +
+      `import { b } from "./b.js";\n` +
+      `import { c } from "./c.js";\n` +
+      // 50ms is fast enough to observe oscillation between writes but slow
+      // enough not to flood stdout.
+      `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
+  });
+  const cwd = String(dir);
+  const aFile = join(cwd, "a.js");
+  const bFile = join(cwd, "b.js");
+  const cFile = join(cwd, "c.js");
+
+  await using runner = Bun.spawn({
+    cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+
+  // Atomic replace via temp-file + rename, identical to the idiom that
+  // triggers the bug in real editors/tools.
+  function atomicWrite(path: string, content: string) {
+    const tmp = path + ".atomic";
+    writeFileSync(tmp, content);
+    renameSync(tmp, path);
+  }
+
+  let buffered = "";
+  const decoder = new TextDecoder();
+  const reader = runner.stdout.getReader();
+
+  async function waitForTick(ticker: string) {
+    // 10s budget per step is plenty for a 50ms-tick entry; on the fixed
+    // build each transition lands within a few hundred ms.
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      if (buffered.includes(ticker)) return true;
+      const res = await reader.read();
+      if (res.done) return buffered.includes(ticker);
+      buffered += decoder.decode(res.value);
+    }
+    return buffered.includes(ticker);
+  }
+
+  try {
+    // Baseline reload confirms the watcher is wired up.
+    expect(await waitForTick("[tick] a-0 b-0 c-0")).toBe(true);
+
+    // Write #1 — rewrite a.js. Before the fix this step still works (the
+    // first eviction happens here, but nothing has yet been misrouted).
+    atomicWrite(aFile, `export function a() { return "a-1"; }\n`);
+    expect(await waitForTick("[tick] a-1 b-0 c-0")).toBe(true);
+
+    // Write #2 — rewrite c.js. Works coincidentally on buggy builds because
+    // c still happens to be findable at the stale index.
+    atomicWrite(cFile, `export function c() { return "c-1"; }\n`);
+    expect(await waitForTick("[tick] a-1 b-0 c-1")).toBe(true);
+
+    // Write #3 — rewrite b.js. On buggy macOS builds the b-1 tick NEVER
+    // appears: the module graph instead oscillates between
+    // `[tick] a-1 b-0 c-1` and `[tick] a-0 b-0 c-0`. With the kqueue
+    // udata re-registration fix in flushEvictions, all three writes land.
+    atomicWrite(bFile, `export function b() { return "b-1"; }\n`);
+    expect(await waitForTick("[tick] a-1 b-1 c-1")).toBe(true);
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+});

--- a/test/regression/issue/29524.test.ts
+++ b/test/regression/issue/29524.test.ts
@@ -20,83 +20,92 @@
 // is macOS-specific. Windows uses a different watcher entirely. Skipping
 // off macOS keeps this focused on the platform where the bug lives.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isMacOS, tempDir } from "harness";
 import { renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-test.skipIf(!isMacOS)("atomic writes to multiple imported files keep propagating under --hot (#29524)", async () => {
-  using dir = tempDir("issue-29524", {
-    "a.js": `export function a() { return "a-0"; }\n`,
-    "b.js": `export function b() { return "b-0"; }\n`,
-    "c.js": `export function c() { return "c-0"; }\n`,
-    "entry.js":
-      `import { a } from "./a.js";\n` +
-      `import { b } from "./b.js";\n` +
-      `import { c } from "./c.js";\n` +
-      // 50ms is fast enough to observe oscillation between writes but slow
-      // enough not to flood stdout.
-      `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
-  });
-  const cwd = String(dir);
-  const aFile = join(cwd, "a.js");
-  const bFile = join(cwd, "b.js");
-  const cFile = join(cwd, "c.js");
+// Per step: 10s budget; 4 steps; plus spawn + module init. The default 5s
+// test timeout is not enough. Debug builds get Infinity — the hot-reload
+// codegen path is dramatically slower under ASAN.
+const testTimeout = isDebug ? Infinity : 60_000;
 
-  await using runner = Bun.spawn({
-    cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
-    cwd,
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-    stdin: "ignore",
-  });
+test.skipIf(!isMacOS)(
+  "atomic writes to multiple imported files keep propagating under --hot (#29524)",
+  async () => {
+    using dir = tempDir("issue-29524", {
+      "a.js": `export function a() { return "a-0"; }\n`,
+      "b.js": `export function b() { return "b-0"; }\n`,
+      "c.js": `export function c() { return "c-0"; }\n`,
+      "entry.js":
+        `import { a } from "./a.js";\n` +
+        `import { b } from "./b.js";\n` +
+        `import { c } from "./c.js";\n` +
+        // 50ms is fast enough to observe oscillation between writes but slow
+        // enough not to flood stdout.
+        `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
+    });
+    const cwd = String(dir);
+    const aFile = join(cwd, "a.js");
+    const bFile = join(cwd, "b.js");
+    const cFile = join(cwd, "c.js");
 
-  // Atomic replace via temp-file + rename, identical to the idiom that
-  // triggers the bug in real editors/tools.
-  function atomicWrite(path: string, content: string) {
-    const tmp = path + ".atomic";
-    writeFileSync(tmp, content);
-    renameSync(tmp, path);
-  }
+    await using runner = Bun.spawn({
+      cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
 
-  let buffered = "";
-  const decoder = new TextDecoder();
-  const reader = runner.stdout.getReader();
-
-  async function waitForTick(ticker: string) {
-    // 10s budget per step is plenty for a 50ms-tick entry; on the fixed
-    // build each transition lands within a few hundred ms.
-    const deadline = Date.now() + 10_000;
-    while (Date.now() < deadline) {
-      if (buffered.includes(ticker)) return true;
-      const res = await reader.read();
-      if (res.done) return buffered.includes(ticker);
-      buffered += decoder.decode(res.value);
+    // Atomic replace via temp-file + rename, identical to the idiom that
+    // triggers the bug in real editors/tools.
+    function atomicWrite(path: string, content: string) {
+      const tmp = path + ".atomic";
+      writeFileSync(tmp, content);
+      renameSync(tmp, path);
     }
-    return buffered.includes(ticker);
-  }
 
-  try {
-    // Baseline reload confirms the watcher is wired up.
-    expect(await waitForTick("[tick] a-0 b-0 c-0")).toBe(true);
+    let buffered = "";
+    const decoder = new TextDecoder();
+    const reader = runner.stdout.getReader();
 
-    // Write #1 — rewrite a.js. Before the fix this step still works (the
-    // first eviction happens here, but nothing has yet been misrouted).
-    atomicWrite(aFile, `export function a() { return "a-1"; }\n`);
-    expect(await waitForTick("[tick] a-1 b-0 c-0")).toBe(true);
+    async function waitForTick(ticker: string) {
+      // 10s budget per step is plenty for a 50ms-tick entry; on the fixed
+      // build each transition lands within a few hundred ms.
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        if (buffered.includes(ticker)) return true;
+        const res = await reader.read();
+        if (res.done) return buffered.includes(ticker);
+        buffered += decoder.decode(res.value);
+      }
+      return buffered.includes(ticker);
+    }
 
-    // Write #2 — rewrite c.js. Works coincidentally on buggy builds because
-    // c still happens to be findable at the stale index.
-    atomicWrite(cFile, `export function c() { return "c-1"; }\n`);
-    expect(await waitForTick("[tick] a-1 b-0 c-1")).toBe(true);
+    try {
+      // Baseline reload confirms the watcher is wired up.
+      expect(await waitForTick("[tick] a-0 b-0 c-0")).toBe(true);
 
-    // Write #3 — rewrite b.js. On buggy macOS builds the b-1 tick NEVER
-    // appears: the module graph instead oscillates between
-    // `[tick] a-1 b-0 c-1` and `[tick] a-0 b-0 c-0`. With the kqueue
-    // udata re-registration fix in flushEvictions, all three writes land.
-    atomicWrite(bFile, `export function b() { return "b-1"; }\n`);
-    expect(await waitForTick("[tick] a-1 b-1 c-1")).toBe(true);
-  } finally {
-    reader.cancel().catch(() => {});
-  }
-});
+      // Write #1 — rewrite a.js. Before the fix this step still works (the
+      // first eviction happens here, but nothing has yet been misrouted).
+      atomicWrite(aFile, `export function a() { return "a-1"; }\n`);
+      expect(await waitForTick("[tick] a-1 b-0 c-0")).toBe(true);
+
+      // Write #2 — rewrite c.js. Works coincidentally on buggy builds because
+      // c still happens to be findable at the stale index.
+      atomicWrite(cFile, `export function c() { return "c-1"; }\n`);
+      expect(await waitForTick("[tick] a-1 b-0 c-1")).toBe(true);
+
+      // Write #3 — rewrite b.js. On buggy macOS builds the b-1 tick NEVER
+      // appears: the module graph instead oscillates between
+      // `[tick] a-1 b-0 c-1` and `[tick] a-0 b-0 c-0`. With the kqueue
+      // udata re-registration fix in flushEvictions, all three writes land.
+      atomicWrite(bFile, `export function b() { return "b-1"; }\n`);
+      expect(await waitForTick("[tick] a-1 b-1 c-1")).toBe(true);
+    } finally {
+      reader.cancel().catch(() => {});
+    }
+  },
+  testTimeout,
+);

--- a/test/regression/issue/29524.test.ts
+++ b/test/regression/issue/29524.test.ts
@@ -4,54 +4,63 @@
 // kqueue `udata` was stale after `flushEvictions` did `swapRemove` on
 // the watchlist. kqueue-specific, so skipped off macOS.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isMacOS, tempDir } from "harness";
+import { bunEnv, bunExe, forEachLine, isDebug, isMacOS, tempDir } from "harness";
 import { renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-test.skipIf(!isMacOS)("atomic writes to multiple imported files keep propagating under --hot (#29524)", async () => {
-  using dir = tempDir("issue-29524", {
-    "a.js": `export function a() { return "a-0"; }\n`,
-    "b.js": `export function b() { return "b-0"; }\n`,
-    "c.js": `export function c() { return "c-0"; }\n`,
-    "entry.js":
-      `import { a } from "./a.js";\n` +
-      `import { b } from "./b.js";\n` +
-      `import { c } from "./c.js";\n` +
-      `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
-  });
-  const cwd = String(dir);
+// Default bun:test timeout (5s) is not enough: we spawn a subprocess,
+// wait for it to boot, then drive four hot-reload cycles. Infinity on
+// debug/ASAN where hot-reload codegen is much slower.
+const testTimeout = isDebug ? Infinity : 60_000;
 
-  await using runner = Bun.spawn({
-    cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
-    cwd,
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-    stdin: "ignore",
-  });
+test.skipIf(!isMacOS)(
+  "atomic writes to multiple imported files keep propagating under --hot (#29524)",
+  async () => {
+    using dir = tempDir("issue-29524", {
+      "a.js": `export function a() { return "a-0"; }\n`,
+      "b.js": `export function b() { return "b-0"; }\n`,
+      "c.js": `export function c() { return "c-0"; }\n`,
+      "entry.js":
+        `import { a } from "./a.js";\n` +
+        `import { b } from "./b.js";\n` +
+        `import { c } from "./c.js";\n` +
+        `setInterval(() => { process.stdout.write("[tick] " + a() + " " + b() + " " + c() + "\\n"); }, 50);\n`,
+    });
+    const cwd = String(dir);
 
-  function atomicWrite(name: string, content: string) {
-    const path = join(cwd, name);
-    writeFileSync(path + ".atomic", content);
-    renameSync(path + ".atomic", path);
-  }
+    await using runner = Bun.spawn({
+      cmd: [bunExe(), "--hot", "run", join(cwd, "entry.js")],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
 
-  const iter = forEachLine(runner.stdout);
-  async function waitForTick(ticker: string) {
-    for (;;) {
-      const { value, done } = await iter.next();
-      if (done) throw new Error(`stdout ended before seeing ${ticker}`);
-      if (value.includes(ticker)) return;
+    function atomicWrite(name: string, content: string) {
+      const path = join(cwd, name);
+      writeFileSync(path + ".atomic", content);
+      renameSync(path + ".atomic", path);
     }
-  }
 
-  await waitForTick("[tick] a-0 b-0 c-0");
-  atomicWrite("a.js", `export function a() { return "a-1"; }\n`);
-  await waitForTick("[tick] a-1 b-0 c-0");
-  atomicWrite("c.js", `export function c() { return "c-1"; }\n`);
-  await waitForTick("[tick] a-1 b-0 c-1");
-  // Write b last — on buggy macOS builds this tick never appears.
-  atomicWrite("b.js", `export function b() { return "b-1"; }\n`);
-  await waitForTick("[tick] a-1 b-1 c-1");
-  expect(runner.exitCode).toBeNull();
-});
+    const iter = forEachLine(runner.stdout);
+    async function waitForTick(ticker: string) {
+      for (;;) {
+        const { value, done } = await iter.next();
+        if (done) throw new Error(`stdout ended before seeing ${ticker}`);
+        if (value.includes(ticker)) return;
+      }
+    }
+
+    await waitForTick("[tick] a-0 b-0 c-0");
+    atomicWrite("a.js", `export function a() { return "a-1"; }\n`);
+    await waitForTick("[tick] a-1 b-0 c-0");
+    atomicWrite("c.js", `export function c() { return "c-1"; }\n`);
+    await waitForTick("[tick] a-1 b-0 c-1");
+    // Write b last — on buggy macOS builds this tick never appears.
+    atomicWrite("b.js", `export function b() { return "b-1"; }\n`);
+    await waitForTick("[tick] a-1 b-1 c-1");
+    expect(runner.exitCode).toBeNull();
+  },
+  testTimeout,
+);


### PR DESCRIPTION
## Problem

Reported in #29524. On macOS, when `--hot` watches multiple imported modules and any one of them is replaced via the standard atomic-write idiom (`write tmp; rename tmp over target` — what vim, VSCode, prettier, claude-code, etc. do), a subsequent atomic write to a different imported file stops propagating through `--hot`'s live bindings and the module graph oscillates between old and new state.

The reporter's minimal repro: three imported files `a.js`/`b.js`/`c.js` printing `[tick] <a()> <b()> <c()>` every 50ms. Atomically rewriting `a.js` → works, then `c.js` → works, then `b.js` → **broken**: `b-1` never appears, the output cycles `a-1 b-0 c-1` → `a-0 b-0 c-0` → `a-1 b-0 c-0` → …

## Root cause

`src/Watcher.zig::flushEvictions` compacts the watchlist with `MultiArrayList.swapRemove(item)`, which moves the entry at `watchlist.len - 1` into the vacated slot `item`. The moved entry's kqueue registration was made with `event.udata = its_old_index` at add time (`addFileDescriptorToKQueueWithoutChecks`), and was never rewritten. A subsequent kevent for that fd therefore arrives with a stale `udata`, which `KEventWatcher.watchEventFromKEvent` (`src/watcher/KEventWatcher.zig:32`) decodes verbatim via `@truncate(kevent.udata)` into `event.index`. Downstream, `hot_reloader.onFileUpdate` uses that stale index to dereference `file_paths`/`hashes`/`counts` — routing the event to the wrong module — and on a rename event calls `ctx.removeAtIndex(event.index, …)`, which schedules an eviction of whatever now lives at the stale index and compounds the corruption on the next flush.

Linux (inotify) is unaffected: `INotifyWatcher.zig` re-resolves the watchlist slot via `indexOfScalar(eventlist_index, event.watch_descriptor)` on every event, so it is robust to watchlist compaction. Windows uses a different code path. Credit to the reporter (@darknoon) for the diagnosis.

## Fix

After each `swapRemove` in `flushEvictions`, if an entry actually moved into the vacated slot (`item < watchlist.len` post-remove), re-register its fd with kqueue so the next event carries the updated watchlist index. `EV_ADD` with the same `(ident, filter)` pair replaces the existing registration in place, so this is atomic from kqueue's perspective. Comptime-gated to macOS.

## Verification

- `bun bd` builds clean.
- New regression test at `test/regression/issue/29524.test.ts` mirrors the reporter's repro (three imported files, atomic-rename writes in a→c→b order, 10s budget for each expected triple). The test is `test.skipIf(!isMacOS)` — the underlying bug is kqueue-specific; Linux and Windows use different watcher implementations that already correctly handle this scenario, so the test cannot meaningfully reproduce the bug there.
- Existing `test/cli/hot/hot.test.ts` ("should hot reload when file is overwritten") still passes under the patched debug build.
- Manually ran the attached repro script on the debug build on Linux: all three atomic writes propagate, confirming the fix does not regress the already-working Linux path.

**Gate note for reviewers:** because the bug is macOS-only and the test is `skipIf(!isMacOS)`, the automatic farm gate on this Linux container sees the test skip on both the stashed and unstashed runs. The test is structured to fail deterministically on macOS before the fix (it waits up to 10s for `[tick] a-1 b-1 c-1`, which the buggy path never produces) and to pass after. This matches the pattern used by other darwin-only regression tests (e.g. `test/regression/issue/29120.test.ts`).

Closes #29524.