### PR TITLE
shell: fd/memory leak sweep — 70+ fixes across interpreter, IO, states, builtins

### DIFF
--- a/src/shell/Builtin.zig
+++ b/src/shell/Builtin.zig
@@ -440,7 +440,9 @@ fn initRedirections(
                     if (node.redirect.stdin) {
                         break :redirfd switch (ShellSyscall.openat(cmd.base.shell.cwd_fd, path, node.redirect.toFlags(), perm)) {
                             .err => |e| {
-                                return cmd.writeFailingError("bun: {f}: {s}", .{ e.toShellSystemError().message, path });
+                                const sys_err = e.toShellSystemError();
+                                defer sys_err.deref();
+                                return cmd.writeFailingError("bun: {f}: {s}", .{ sys_err.message, path });
                             },
                             .result => |f| f,
                         };
@@ -466,13 +468,17 @@ fn initRedirections(
 
                     break :redirfd switch (result) {
                         .err => |e| {
-                            return cmd.writeFailingError("bun: {f}: {s}", .{ e.toShellSystemError().message, path });
+                            const sys_err = e.toShellSystemError();
+                            defer sys_err.deref();
+                            return cmd.writeFailingError("bun: {f}: {s}", .{ sys_err.message, path });
                         },
                         .result => |f| {
                             if (bun.Environment.isWindows) {
                                 switch (f.makeLibUVOwnedForSyscall(.open, .close_on_fail)) {
                                     .err => |e| {
-                                        return cmd.writeFailingError("bun: {f}: {s}", .{ e.toShellSystemError().message, path });
+                                        const sys_err = e.toShellSystemError();
+                                        defer sys_err.deref();
+                                        return cmd.writeFailingError("bun: {f}: {s}", .{ sys_err.message, path });
                                     },
                                     .result => |f2| break :redirfd f2,
                                 }
@@ -517,24 +523,30 @@ fn initRedirections(
                 }
 
                 if (interpreter.jsobjs[file.jsbuf.idx].asArrayBuffer(globalObject)) |buf| {
-                    const arraybuf: BuiltinIO.ArrayBuf = .{ .buf = jsc.ArrayBuffer.Strong{
-                        .array_buffer = buf,
-                        .held = .create(buf.value, globalObject),
-                    }, .i = 0 };
-
+                    // Each slot gets its own Strong; sharing one across stdin/stdout/stderr
+                    // would double-free the heap *Impl in Builtin.deinit().
                     if (node.redirect.stdin) {
                         cmd.exec.bltn.stdin.deref();
-                        cmd.exec.bltn.stdin = .{ .arraybuf = arraybuf };
+                        cmd.exec.bltn.stdin = .{ .arraybuf = .{ .buf = .{
+                            .array_buffer = buf,
+                            .held = .create(buf.value, globalObject),
+                        }, .i = 0 } };
                     }
 
                     if (node.redirect.stdout) {
                         cmd.exec.bltn.stdout.deref();
-                        cmd.exec.bltn.stdout = .{ .arraybuf = arraybuf };
+                        cmd.exec.bltn.stdout = .{ .arraybuf = .{ .buf = .{
+                            .array_buffer = buf,
+                            .held = .create(buf.value, globalObject),
+                        }, .i = 0 } };
                     }
 
                     if (node.redirect.stderr) {
                         cmd.exec.bltn.stderr.deref();
-                        cmd.exec.bltn.stderr = .{ .arraybuf = arraybuf };
+                        cmd.exec.bltn.stderr = .{ .arraybuf = .{ .buf = .{
+                            .array_buffer = buf,
+                            .held = .create(buf.value, globalObject),
+                        }, .i = 0 } };
                     }
                 } else if (interpreter.jsobjs[file.jsbuf.idx].as(jsc.WebCore.Body.Value)) |body| {
                     if ((node.redirect.stdout or node.redirect.stderr) and !(body.* == .Blob and !body.Blob.needsToReadFile())) {

--- a/src/shell/IOReader.zig
+++ b/src/shell/IOReader.zig
@@ -19,6 +19,7 @@ evtloop: jsc.EventLoopHandle,
 concurrent_task: jsc.EventLoopTask,
 async_deinit: AsyncDeinitReader,
 is_reading: if (bun.Environment.isWindows) bool else u0 = if (bun.Environment.isWindows) false else 0,
+started: bool = false,
 
 pub const ChildPtr = IOReaderChildPtr;
 pub const ReaderImpl = bun.io.BufferedReader;
@@ -79,6 +80,7 @@ pub fn init(fd: bun.FD, evtloop: jsc.EventLoopHandle) *IOReader {
 
 /// Idempotent function to start the reading
 pub fn start(this: *IOReader) Yield {
+    this.started = true;
     if (bun.Environment.isPosix) {
         if (this.reader.handle == .closed or !this.reader.handle.poll.isRegistered()) {
             if (this.reader.start(this.fd, true).asErr()) |e| {
@@ -197,11 +199,7 @@ fn asyncDeinit(this: *@This()) void {
     // The async hop guards against being deref'd from inside a read callback while
     // BufferedReader is still iterating. If we never started reading, no callback can be
     // in flight, so close synchronously to avoid holding the fd until the next tick.
-    const never_started = if (bun.Environment.isWindows)
-        !this.is_reading and this.readers.len() == 0
-    else
-        this.reader.handle == .closed;
-    if (never_started) {
+    if (!this.started) {
         this.asyncDeinitCallback();
         return;
     }

--- a/src/shell/IOReader.zig
+++ b/src/shell/IOReader.zig
@@ -198,7 +198,7 @@ fn asyncDeinit(this: *@This()) void {
     // BufferedReader is still iterating. If we never started reading, no callback can be
     // in flight, so close synchronously to avoid holding the fd until the next tick.
     const never_started = if (bun.Environment.isWindows)
-        this.reader.source == null
+        !this.is_reading and this.readers.len() == 0
     else
         this.reader.handle == .closed;
     if (never_started) {
@@ -216,10 +216,18 @@ fn asyncDeinitCallback(this: *@This()) void {
                 this.reader.closeImpl(false);
             }
         } else {
+            // We set reader.flags.close_handle=false in init(), so reader.deinit() will not
+            // return the FilePoll to its pool. Do it explicitly (without closing the fd —
+            // we own that and close it ourselves below).
+            if (this.reader.handle == .poll) {
+                this.reader.handle.closeImpl(null, {}, false);
+            }
             log("IOReader(0x{x}) __deinit fd={f}", .{ @intFromPtr(this), this.fd });
             this.fd.close();
         }
     }
+    if (this.err) |*e| e.deref();
+    this.readers.deinit();
     this.buf.deinit(bun.default_allocator);
     this.reader.disableKeepingProcessAlive({});
     this.reader.deinit();

--- a/src/shell/IOReader.zig
+++ b/src/shell/IOReader.zig
@@ -194,6 +194,17 @@ pub fn onReaderDone(this: *IOReader) void {
 
 fn asyncDeinit(this: *@This()) void {
     log("IOReader(0x{x}) asyncDeinit", .{@intFromPtr(this)});
+    // The async hop guards against being deref'd from inside a read callback while
+    // BufferedReader is still iterating. If we never started reading, no callback can be
+    // in flight, so close synchronously to avoid holding the fd until the next tick.
+    const never_started = if (bun.Environment.isWindows)
+        this.reader.source == null
+    else
+        this.reader.handle == .closed;
+    if (never_started) {
+        this.asyncDeinitCallback();
+        return;
+    }
     this.async_deinit.enqueue(); // calls `asyncDeinitCallback`
 }
 

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -488,6 +488,9 @@ pub fn onError(this: *IOWriter, err__: bun.sys.Error) void {
         }
 
         bun.handleOom(seen.append(@intFromPtr(ptr)));
+        // Callee consumes the error (derefs it). Ref before each pass so deinitOnMainThread's
+        // deref of this.err is balanced and multiple callees don't over-deref. Matches IOReader.
+        if (this.err) |*e| e.ref();
         // TODO: This probably shouldn't call .run()
         w.ptr.onIOWriterChunk(0, this.err).run();
     }

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -591,6 +591,11 @@ fn enqueueFile(this: *IOWriter) Yield {
     if (this.is_writing) {
         return .suspended;
     }
+    // The pollable path sets `started` in write(); the non-pollable file path bypasses
+    // write() entirely, so set it here. asyncDeinit's never-started fast-path must not
+    // fire for a writer that actually wrote — bump()'s onIOWriterChunk callback can deref
+    // us while doFileWrite is still on the stack.
+    this.started = true;
     this.setWriting(true);
 
     return this.doFileWrite();

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -206,11 +206,13 @@ fn write(this: *IOWriter) enum {
 
     if (!this.started) {
         log("IOWriter(0x{x}, fd={f}) starting", .{ @intFromPtr(this), this.fd });
+        // Set before onError: the callback chain may deref to 0 and asyncDeinit's
+        // never-started fast-path would synchronously destroy us mid-onError.
+        this.started = true;
         if (this.__start().asErr()) |e| {
             this.onError(e);
             return .failed;
         }
-        this.started = true;
         if (comptime bun.Environment.isPosix) {
             // if `handle == .fd` it means it's a file which does not
             // support polling for writeability and we should just

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -128,6 +128,7 @@ pub fn __start(this: *IOWriter) Maybe(void) {
                 this.flags.pollable = false;
                 this.flags.nonblocking = false;
                 this.flags.is_socket = false;
+                if (this.writer.handle == .poll) this.writer.handle.closeImpl(null, {}, false);
                 this.writer.handle = .{ .closed = {} };
                 return __start(this);
             }
@@ -139,6 +140,7 @@ pub fn __start(this: *IOWriter) Maybe(void) {
                     this.flags.pollable = false;
                     this.flags.nonblocking = false;
                     this.flags.is_socket = false;
+                    if (this.writer.handle == .poll) this.writer.handle.closeImpl(null, {}, false);
                     this.writer.handle = .{ .closed = {} };
                     return __start(this);
                 }
@@ -350,6 +352,7 @@ pub fn doFileWrite(this: *IOWriter) Yield {
         const written_slice = this.buf.items[this.total_bytes_written .. this.total_bytes_written + amt];
         bun.handleOom(bl.appendSlice(bun.default_allocator, written_slice));
     }
+    this.total_bytes_written += amt;
     child.written += amt;
     if (!child.wroteEverything()) {
         bun.assert(writeResult == .done);
@@ -467,7 +470,9 @@ pub fn onError(this: *IOWriter, err__: bun.sys.Error) void {
     var seen_alloc = std.heap.stackFallback(@sizeOf(usize) * 64, bun.default_allocator);
     var seen = bun.handleOom(std.array_list.Managed(usize).initCapacity(seen_alloc.get(), 64));
     defer seen.deinit();
-    writer_loop: for (this.writers.slice()) |w| {
+    // Writers before writer_idx have already had their onIOWriterChunk callback fired and may
+    // have been freed; only notify the still-pending ones.
+    writer_loop: for (this.writers.slice()[this.writer_idx..]) |w| {
         if (w.isDead()) continue;
         const ptr = w.ptr.ptr.ptr();
         if (seen.items.len < 8) {
@@ -677,6 +682,13 @@ pub fn enqueueFmt(
 fn asyncDeinit(this: *@This()) void {
     debug("IOWriter(0x{x}, fd={f}) asyncDeinit", .{ @intFromPtr(this), this.fd });
     bun.assert(!this.is_writing);
+    // The async hop guards against being deref'd from inside a write callback while
+    // PipeWriter is still on the stack. If we never started, no callback can be in
+    // flight, so close synchronously to avoid holding the fd until the next tick.
+    if (!this.started) {
+        this.deinitOnMainThread();
+        return;
+    }
     this.async_deinit.enqueue();
 }
 
@@ -684,8 +696,10 @@ pub fn deinitOnMainThread(this: *IOWriter) void {
     debug("IOWriter(0x{x}, fd={f}) deinit", .{ @intFromPtr(this), this.fd });
     if (bun.Environment.allow_assert) this.ref_count.assertNoRefs();
     this.buf.deinit(bun.default_allocator);
+    this.writers.deinit();
+    if (this.err) |*e| e.deref();
     if (comptime bun.Environment.isPosix) {
-        if (this.writer.handle == .poll and this.writer.handle.poll.isRegistered()) {
+        if (this.writer.handle == .poll) {
             this.writer.handle.closeImpl(null, {}, false);
         }
     } else {

--- a/src/shell/ParsedShellScript.zig
+++ b/src/shell/ParsedShellScript.zig
@@ -76,6 +76,7 @@ pub fn setCwd(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: 
         return globalThis.throw("$`...`.cwd(): expected a string argument", .{});
     };
     const str = try bun.String.fromJS(str_js, globalThis);
+    if (this.cwd) |*prev| prev.deref();
     this.cwd = str;
     return .js_undefined;
 }
@@ -98,16 +99,18 @@ pub fn setEnv(this: *ParsedShellScript, globalThis: *JSGlobalObject, callframe: 
     defer object_iter.deinit();
 
     var env: EnvMap = EnvMap.init(bun.default_allocator);
+    errdefer env.deinit();
     env.ensureTotalCapacity(object_iter.len);
 
     // If the env object does not include a $PATH, it must disable path lookup for argv[0]
     // PATH = "";
 
     while (try object_iter.next()) |key| {
-        const keyslice = bun.handleOom(key.toOwnedSlice(bun.default_allocator));
         var value = object_iter.value;
         if (value.isUndefined()) continue;
 
+        const keyslice = bun.handleOom(key.toOwnedSlice(bun.default_allocator));
+        errdefer bun.default_allocator.free(keyslice);
         const value_str = try value.getZigString(globalThis);
         const slice = bun.handleOom(value_str.toOwnedSlice(bun.default_allocator));
         const keyref = EnvStr.initRefCounted(keyslice);

--- a/src/shell/builtin/cat.zig
+++ b/src/shell/builtin/cat.zig
@@ -91,7 +91,10 @@ pub fn next(this: *Cat) Yield {
                 return this.bltn().done(0);
             }
 
-            if (exec.reader) |r| r.deref();
+            if (exec.reader) |r| {
+                r.deref();
+                exec.reader = null;
+            }
 
             const arg = std.mem.span(exec.args[exec.idx]);
             exec.idx += 1;
@@ -108,6 +111,8 @@ pub fn next(this: *Cat) Yield {
             const reader = IOReader.init(fd, this.bltn().eventLoop());
             exec.chunks_done = 0;
             exec.chunks_queued = 0;
+            exec.in_done = false;
+            exec.out_done = false;
             exec.reader = reader;
             exec.reader.?.addReader(this);
             return exec.reader.?.start();
@@ -119,13 +124,10 @@ pub fn next(this: *Cat) Yield {
 
 pub fn onIOWriterChunk(this: *Cat, _: usize, err: ?jsc.SystemError) Yield {
     debug("onIOWriterChunk(0x{x}, {s}, had_err={})", .{ @intFromPtr(this), @tagName(this.state), err != null });
-    const errno: ExitCode = if (err) |e| brk: {
-        defer e.deref();
-        break :brk @as(ExitCode, @intCast(@intFromEnum(e.getErrno())));
-    } else 0;
     // Writing to stdout errored, cancel everything and write error
     if (err) |e| {
         defer e.deref();
+        const errno: ExitCode = @intCast(@intFromEnum(e.getErrno()));
         switch (this.state) {
             .exec_stdin => {
                 this.state.exec_stdin.errno = errno;

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -225,12 +225,14 @@ pub fn onShellCpTaskDone(this: *Cp, task: *ShellCpTask) void {
                 return;
             }
         } else {
-            const tgt_absolute = task.tgt_absolute;
-            task.tgt_absolute = null;
-            if (tgt_absolute) |tgt| this.state.exec.ebusy.absolute_targets.put(bun.default_allocator, tgt, {}) catch |err| bun.handleOom(err);
-            const src_absolute = task.src_absolute;
-            task.src_absolute = null;
-            if (src_absolute) |tgt| this.state.exec.ebusy.absolute_srcs.put(bun.default_allocator, tgt, {}) catch |err| bun.handleOom(err);
+            if (bun.take(&task.tgt_absolute)) |tgt| {
+                const gop = bun.handleOom(this.state.exec.ebusy.absolute_targets.getOrPut(bun.default_allocator, tgt));
+                if (gop.found_existing) bun.default_allocator.free(tgt);
+            }
+            if (bun.take(&task.src_absolute)) |src| {
+                const gop = bun.handleOom(this.state.exec.ebusy.absolute_srcs.getOrPut(bun.default_allocator, src));
+                if (gop.found_existing) bun.default_allocator.free(src);
+            }
         }
     }
 
@@ -249,8 +251,14 @@ pub fn printShellCpTask(this: *Cp, task: *ShellCpTask) Yield {
         .state = .waiting_write_err,
     });
     if (bun.take(&task.err)) |err| {
-        this.state.exec.err = err;
-        const error_string = this.bltn().taskErrorToString(.cp, this.state.exec.err.?);
+        const error_string = this.bltn().taskErrorToString(.cp, err);
+        if (this.state == .exec) {
+            if (this.state.exec.err) |*prev| prev.deinit(bun.default_allocator);
+            this.state.exec.err = err;
+        } else {
+            var e = err;
+            e.deinit(bun.default_allocator);
+        }
         return output_task.start(error_string);
     }
     return output_task.start(null);
@@ -266,7 +274,7 @@ pub const ShellCpOutputTask = OutputTask(Cp, .{
 
 const ShellCpOutputTaskVTable = struct {
     pub fn writeErr(this: *Cp, childptr: anytype, errbuf: []const u8) ?Yield {
-        this.state.exec.output_waiting += 1;
+        if (this.state == .exec) this.state.exec.output_waiting += 1;
         if (this.bltn().stderr.needsIO()) |safeguard| {
             return this.bltn().stderr.enqueue(childptr, errbuf, safeguard);
         }
@@ -275,11 +283,11 @@ const ShellCpOutputTaskVTable = struct {
     }
 
     pub fn onWriteErr(this: *Cp) void {
-        this.state.exec.output_done += 1;
+        if (this.state == .exec) this.state.exec.output_done += 1;
     }
 
     pub fn writeOut(this: *Cp, childptr: anytype, output: *OutputSrc) ?Yield {
-        this.state.exec.output_waiting += 1;
+        if (this.state == .exec) this.state.exec.output_waiting += 1;
         if (this.bltn().stdout.needsIO()) |safeguard| {
             return this.bltn().stdout.enqueue(childptr, output.slice(), safeguard);
         }
@@ -288,7 +296,7 @@ const ShellCpOutputTaskVTable = struct {
     }
 
     pub fn onWriteOut(this: *Cp) void {
-        this.state.exec.output_done += 1;
+        if (this.state == .exec) this.state.exec.output_done += 1;
     }
 
     pub fn onDone(this: *Cp) Yield {

--- a/src/shell/builtin/mkdir.zig
+++ b/src/shell/builtin/mkdir.zig
@@ -112,6 +112,7 @@ pub fn onShellMkdirTaskDone(this: *Mkdir, task: *ShellMkdirTask) void {
 
     if (err) |e| {
         const error_string = this.bltn().taskErrorToString(.mkdir, e);
+        if (this.state.exec.err) |prev| prev.deref();
         this.state.exec.err = e;
         output_task.start(error_string).run();
         return;
@@ -256,7 +257,7 @@ pub const ShellMkdirTask = struct {
             switch (node_fs.mkdirRecursiveImpl(args, *MkdirVerboseVTable, &vtable)) {
                 .result => {},
                 .err => |e| {
-                    this.err = e.withPath(bun.handleOom(bun.default_allocator.dupe(u8, filepath))).toShellSystemError();
+                    this.err = e.withPath(filepath).toShellSystemError();
                     std.mem.doNotOptimizeAway(&node_fs);
                 },
             }
@@ -274,7 +275,7 @@ pub const ShellMkdirTask = struct {
                     }
                 },
                 .err => |e| {
-                    this.err = e.withPath(bun.handleOom(bun.default_allocator.dupe(u8, filepath))).toShellSystemError();
+                    this.err = e.withPath(filepath).toShellSystemError();
                     std.mem.doNotOptimizeAway(&node_fs);
                 },
             }

--- a/src/shell/builtin/mv.zig
+++ b/src/shell/builtin/mv.zig
@@ -21,6 +21,7 @@ state: union(enum) {
         error_signal: std.atomic.Value(bool),
         tasks: []ShellMvBatchedTask,
         err: ?Syscall.Error = null,
+        err_path_owned: bool = false,
     },
     done,
     waiting_write_err: struct {
@@ -76,6 +77,9 @@ pub const ShellMvBatchedTask = struct {
     error_signal: *std.atomic.Value(bool),
 
     err: ?Syscall.Error = null,
+    /// True iff err.?.path was heap-allocated by this task (moveInDir's dupeZ); false when
+    /// it borrows this.target / argv or is empty.
+    err_path_owned: bool = false,
 
     task: ShellTask(@This(), runFromThreadPool, runFromMainThread, debug),
     event_loop: jsc.EventLoopHandle,
@@ -121,6 +125,7 @@ pub const ShellMvBatchedTask = struct {
                 }, .auto);
 
                 this.err = e.withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, target_path[0..])));
+                this.err_path_owned = true;
                 return false;
             },
             else => {},
@@ -352,8 +357,9 @@ pub fn batchedMoveTaskDone(this: *Mv, task: *ShellMvBatchedTask) void {
         exec.error_signal.store(true, .seq_cst);
         if (exec.err == null) {
             exec.err = err.*;
-        } else {
-            err.deinit();
+            exec.err_path_owned = task.err_path_owned;
+        } else if (task.err_path_owned) {
+            bun.default_allocator.free(err.path);
         }
     }
 
@@ -363,6 +369,8 @@ pub fn batchedMoveTaskDone(this: *Mv, task: *ShellMvBatchedTask) void {
             const e = err.toShellSystemError();
             defer e.deref();
             const buf = this.bltn().fmtErrorArena(.mv, "{f}: {f}\n", .{ e.path, e.message });
+            if (exec.err_path_owned) bun.default_allocator.free(err.path);
+            exec.err = null;
             _ = this.writeFailingError(buf, err.errno);
             return;
         }
@@ -374,6 +382,11 @@ pub fn batchedMoveTaskDone(this: *Mv, task: *ShellMvBatchedTask) void {
 
 pub fn deinit(this: *Mv) void {
     if (this.args.target_fd) |fd| fd.toOptional().close();
+    if (this.state == .executing) {
+        if (this.state.executing.err) |err| {
+            if (this.state.executing.err_path_owned) bun.default_allocator.free(err.path);
+        }
+    }
 }
 
 const Opts = struct {

--- a/src/shell/builtin/mv.zig
+++ b/src/shell/builtin/mv.zig
@@ -232,6 +232,7 @@ pub fn next(this: *Mv) Yield {
                             },
                             else => {
                                 const sys_err = e.toShellSystemError();
+                                defer sys_err.deref();
                                 const buf = this.bltn().fmtErrorArena(.mv, "{s}: {s}\n", .{ sys_err.path.byteSlice(), sys_err.message.byteSlice() });
                                 return this.writeFailingError(buf, 1);
                             },
@@ -360,6 +361,7 @@ pub fn batchedMoveTaskDone(this: *Mv, task: *ShellMvBatchedTask) void {
     if (exec.tasks_done >= exec.task_count) {
         if (exec.err) |err| {
             const e = err.toShellSystemError();
+            defer e.deref();
             const buf = this.bltn().fmtErrorArena(.mv, "{f}: {f}\n", .{ e.path, e.message });
             _ = this.writeFailingError(buf, err.errno);
             return;

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -403,9 +403,9 @@ fn parseFlag(this: *Opts, _: *Builtin, flag: []const u8) ParseFlagsResult {
 }
 
 pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
-    // In verbose mode the embedded root_task may still be queued for writeVerbose on the main
-    // thread; freeing the ShellRmTask here would UAF it. Non-verbose has no such alias.
-    defer if (!task.opts.verbose) task.deinit();
+    // In verbose mode the root DirTask may also be queued for writeVerbose; both callbacks
+    // hold a pending count and the last one to run frees the ShellRmTask.
+    defer task.decrPendingAndMaybeDeinit();
     var exec = &this.state.exec;
     const tasks_done = switch (exec.state) {
         .idle => @panic("Invalid state"),
@@ -413,7 +413,11 @@ pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
             exec.state.waiting.tasks_done += 1;
             const amt = exec.state.waiting.tasks_done;
             if (task.err) |err| {
+                // Ownership of err.path stays with the task (freed in ShellRmTask.deinit);
+                // exec.err is only used as a did-anything-fail flag after this point, so
+                // drop the soon-to-be-dangling path slice from our copy.
                 exec.err = err;
+                exec.err.?.path = "";
                 const error_string = this.bltn().taskErrorToString(.rm, err);
                 if (this.bltn().stderr.needsIO()) |safeguard| {
                     log("Rm(0x{x}) task=0x{x} ERROR={s}", .{ @intFromPtr(this), @intFromPtr(task), error_string });
@@ -440,9 +444,11 @@ pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
 
 fn writeVerbose(this: *Rm, verbose: *ShellRmTask.DirTask) Yield {
     defer {
-        // Root DirTask is embedded in ShellRmTask; freeing it is handled when the ShellRmTask
-        // itself is freed (which in verbose mode is currently leaked — see onShellRmTaskDone).
+        const tm = verbose.task_manager;
         if (verbose.parent_task != null) verbose.deinit();
+        // Release the pending count taken in postRun(); the ShellRmTask is freed once every
+        // queued writeVerbose and onShellRmTaskDone have run.
+        tm.decrPendingAndMaybeDeinit();
     }
     if (this.bltn().stdout.needsIO()) |safeguard| {
         const buf = verbose.takeDeletedEntries();
@@ -472,6 +478,10 @@ pub const ShellRmTask = struct {
 
     error_signal: *std.atomic.Value(bool),
     err_mutex: bun.Mutex = .{},
+    /// Main-thread callbacks that must complete before this task can be freed:
+    /// always one for onShellRmTaskDone (via finishConcurrently), plus one per DirTask whose
+    /// verbose output was queued. Decremented by decrPendingAndMaybeDeinit.
+    pending_main_callbacks: std.atomic.Value(u32) = std.atomic.Value(u32).init(1),
     err: ?Syscall.Error = null,
 
     event_loop: jsc.EventLoopHandle,
@@ -606,15 +616,22 @@ pub const ShellRmTask = struct {
 
             // We have executed all the children of this task
             if (this.subtask_count.fetchSub(1, .seq_cst) == 1) {
-                defer {
-                    if (this.task_manager.opts.verbose)
-                        this.queueForWrite()
-                    else
-                        this.deinit();
+                // If a verbose write will be queued, take a pending count on the ShellRmTask now —
+                // before decrementing the parent (children) or calling finishConcurrently (root) —
+                // so the main thread can't free it out from under writeVerbose.
+                const will_queue_verbose = this.task_manager.opts.verbose and this.deleted_entries.items.len > 0;
+                if (will_queue_verbose) {
+                    _ = this.task_manager.pending_main_callbacks.fetchAdd(1, .seq_cst);
                 }
 
                 // If we have a parent and we are the last child, now we can delete the parent
                 if (this.parent_task != null) {
+                    defer {
+                        if (will_queue_verbose)
+                            this.queueForWrite()
+                        else
+                            this.deinit();
+                    }
                     // It's possible that we queued this subdir task and it finished, while the parent
                     // was still in the `removeEntryDir` function
                     const tasks_left_before_decrement = this.parent_task.?.subtask_count.fetchSub(1, .seq_cst);
@@ -625,8 +642,13 @@ pub const ShellRmTask = struct {
                     return;
                 }
 
-                // Otherwise we are root task
+                // Root task. After finishConcurrently() the task may be freed at any time unless
+                // we hold a pending count, so don't touch `this`/task_manager afterwards unless
+                // will_queue_verbose kept it alive.
                 this.task_manager.finishConcurrently();
+                if (will_queue_verbose) {
+                    this.queueForWrite();
+                }
             }
 
             // Otherwise need to wait
@@ -1182,6 +1204,12 @@ pub const ShellRmTask = struct {
         this.rm.onShellRmTaskDone(this);
     }
 
+    pub fn decrPendingAndMaybeDeinit(this: *ShellRmTask) void {
+        if (this.pending_main_callbacks.fetchSub(1, .seq_cst) == 1) {
+            this.deinit();
+        }
+    }
+
     pub fn deinit(this: *ShellRmTask) void {
         if (bun.Environment.isWindows) {
             if (this.cwd_path) |p| bun.default_allocator.free(p);
@@ -1189,6 +1217,7 @@ pub const ShellRmTask = struct {
         if (this.err) |*e| {
             if (e.path.len > 0) bun.default_allocator.free(e.path);
         }
+        this.root_task.deleted_entries.deinit();
         bun.default_allocator.destroy(this);
     }
 };

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -297,6 +297,7 @@ pub noinline fn next(this: *Rm) Yield {
 
 pub fn onIOWriterChunk(this: *Rm, _: usize, e: ?jsc.SystemError) Yield {
     log("Rm(0x{x}).onIOWriterChunk()", .{@intFromPtr(this)});
+    defer if (e) |err| err.deref();
     if (comptime bun.Environment.allow_assert) {
         assert((this.state == .parse_opts and this.state.parse_opts.state == .wait_write_err) or
             (this.state == .exec and this.state.exec.state == .waiting and this.state.exec.output_count.load(.seq_cst) > 0) or
@@ -314,7 +315,6 @@ pub fn onIOWriterChunk(this: *Rm, _: usize, e: ?jsc.SystemError) Yield {
     }
 
     if (e != null) {
-        defer e.?.deref();
         this.state = .{ .err = @intFromEnum(e.?.getErrno()) };
         return this.bltn().done(e.?.getErrno());
     }
@@ -403,6 +403,9 @@ fn parseFlag(this: *Opts, _: *Builtin, flag: []const u8) ParseFlagsResult {
 }
 
 pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
+    // In verbose mode the embedded root_task may still be queued for writeVerbose on the main
+    // thread; freeing the ShellRmTask here would UAF it. Non-verbose has no such alias.
+    defer if (!task.opts.verbose) task.deinit();
     var exec = &this.state.exec;
     const tasks_done = switch (exec.state) {
         .idle => @panic("Invalid state"),
@@ -436,6 +439,11 @@ pub fn onShellRmTaskDone(this: *Rm, task: *ShellRmTask) void {
 }
 
 fn writeVerbose(this: *Rm, verbose: *ShellRmTask.DirTask) Yield {
+    defer {
+        // Root DirTask is embedded in ShellRmTask; freeing it is handled when the ShellRmTask
+        // itself is freed (which in verbose mode is currently leaked — see onShellRmTaskDone).
+        if (verbose.parent_task != null) verbose.deinit();
+    }
     if (this.bltn().stdout.needsIO()) |safeguard| {
         const buf = verbose.takeDeletedEntries();
         defer buf.deinit();
@@ -658,7 +666,10 @@ pub const ShellRmTask = struct {
 
         pub fn queueForWrite(this: *DirTask) void {
             log("DirTask(0x{x}, path={s}) queueForWrite to_write={d}", .{ @intFromPtr(this), this.path, this.deleted_entries.items.len });
-            if (this.deleted_entries.items.len == 0) return;
+            if (this.deleted_entries.items.len == 0) {
+                if (this.parent_task != null) this.deinit();
+                return;
+            }
             if (this.task_manager.event_loop == .js) {
                 this.task_manager.event_loop.js.enqueueTaskConcurrent(this.concurrent_task.js.from(this, .manual_deinit));
             } else {
@@ -721,10 +732,12 @@ pub const ShellRmTask = struct {
         this.enqueueNoJoin(parent_dir, new_path, kind_hint);
     }
 
+    /// Takes ownership of `path`; freed via the spawned DirTask's deinit (or here on early return).
     pub fn enqueueNoJoin(this: *ShellRmTask, parent_task: *DirTask, path: [:0]const u8, kind_hint: DirTask.EntryKindHint) void {
         defer debug("enqueue: {s} {s}", .{ path, @tagName(kind_hint) });
 
         if (this.error_signal.load(.seq_cst)) {
+            bun.default_allocator.free(path);
             return;
         }
 
@@ -814,7 +827,7 @@ pub const ShellRmTask = struct {
                             .NOTDIR => {
                                 delete_state.treat_as_dir = false;
                                 if (this.removeEntryFile(dir_task, dir_task.path, is_absolute, buf, &delete_state).asErr()) |err| {
-                                    return .{ .err = this.errorWithPath(err, path) };
+                                    return .{ .err = err };
                                 }
                                 if (!delete_state.treat_as_dir) return .success;
                                 if (delete_state.treat_as_dir) break :out_to_iter;
@@ -899,7 +912,7 @@ pub const ShellRmTask = struct {
                     };
 
                     switch (this.removeEntryFile(dir_task, file_path, is_absolute, buf, &remove_child_vtable)) {
-                        .err => |e| return .{ .err = this.errorWithPath(e, current.name.sliceAssumeZ()) },
+                        .err => |e| return .{ .err = e },
                         .result => {},
                     }
                 },
@@ -1012,7 +1025,7 @@ pub const ShellRmTask = struct {
 
             this.treat_as_dir = true;
             if (this.allow_enqueue) {
-                this.task.enqueueNoJoin(parent_dir_task, path, .dir);
+                this.task.enqueueNoJoin(parent_dir_task, bun.handleOom(bun.default_allocator.dupeZ(u8, path)), .dir);
                 this.enqueued = true;
             }
             return .success;
@@ -1170,6 +1183,12 @@ pub const ShellRmTask = struct {
     }
 
     pub fn deinit(this: *ShellRmTask) void {
+        if (bun.Environment.isWindows) {
+            if (this.cwd_path) |p| bun.default_allocator.free(p);
+        }
+        if (this.err) |*e| {
+            if (e.path.len > 0) bun.default_allocator.free(e.path);
+        }
         bun.default_allocator.destroy(this);
     }
 };

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -756,7 +756,7 @@ pub const ShellRmTask = struct {
 
     /// Takes ownership of `path`; freed via the spawned DirTask's deinit (or here on early return).
     pub fn enqueueNoJoin(this: *ShellRmTask, parent_task: *DirTask, path: [:0]const u8, kind_hint: DirTask.EntryKindHint) void {
-        defer debug("enqueue: {s} {s}", .{ path, @tagName(kind_hint) });
+        debug("enqueue: {s} {s}", .{ path, @tagName(kind_hint) });
 
         if (this.error_signal.load(.seq_cst)) {
             bun.default_allocator.free(path);

--- a/src/shell/builtin/touch.zig
+++ b/src/shell/builtin/touch.zig
@@ -58,6 +58,7 @@ pub fn next(this: *Touch) Yield {
             if (exec.started) {
                 if (this.state.exec.tasks_done >= this.state.exec.tasks_count and this.state.exec.output_done >= this.state.exec.output_waiting) {
                     const exit_code: ExitCode = if (this.state.exec.err != null) 1 else 0;
+                    if (this.state.exec.err) |e| e.deref();
                     this.state = .done;
                     return this.bltn().done(exit_code);
                 }
@@ -80,11 +81,11 @@ pub fn next(this: *Touch) Yield {
 }
 
 pub fn onIOWriterChunk(this: *Touch, _: usize, e: ?jsc.SystemError) Yield {
+    if (e) |err| err.deref();
+
     if (this.state == .waiting_write_err) {
         return this.bltn().done(1);
     }
-
-    if (e) |err| err.deref();
 
     return this.next();
 }
@@ -114,6 +115,7 @@ pub fn onShellTouchTaskDone(this: *Touch, task: *ShellTouchTask) void {
             .state = .waiting_write_err,
         });
         const error_string = this.bltn().taskErrorToString(.touch, e);
+        if (this.state.exec.err) |prev| prev.deref();
         this.state.exec.err = e;
         output_task.start(error_string).run();
         return;
@@ -249,12 +251,12 @@ pub const ShellTouchTask = struct {
                         break :out;
                     },
                     .err => |e| {
-                        this.err = e.withPath(bun.handleOom(bun.default_allocator.dupe(u8, filepath))).toShellSystemError();
+                        this.err = e.withPath(filepath).toShellSystemError();
                         break :out;
                     },
                 }
             }
-            this.err = err.withPath(bun.handleOom(bun.default_allocator.dupe(u8, filepath))).toShellSystemError();
+            this.err = err.withPath(filepath).toShellSystemError();
         }
 
         if (this.event_loop == .js) {

--- a/src/shell/builtin/which.zig
+++ b/src/shell/builtin/which.zig
@@ -35,6 +35,7 @@ pub fn start(this: *Which) Yield {
         const path_buf = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(path_buf);
         const PATH = this.bltn().parentCmd().base.shell.export_env.get(EnvStr.initSlice("PATH")) orelse EnvStr.initSlice("");
+        defer PATH.deref();
         var had_not_found = false;
         for (args) |arg_raw| {
             const arg = arg_raw[0..std.mem.len(arg_raw)];
@@ -73,6 +74,7 @@ pub fn next(this: *Which) Yield {
     const path_buf = bun.path_buffer_pool.get();
     defer bun.path_buffer_pool.put(path_buf);
     const PATH = this.bltn().parentCmd().base.shell.export_env.get(EnvStr.initSlice("PATH")) orelse EnvStr.initSlice("");
+    defer PATH.deref();
 
     const resolved = which(path_buf, PATH.slice(), this.bltn().parentCmd().base.shell.cwdZ(), arg) orelse {
         multiargs.had_not_found = true;
@@ -112,9 +114,9 @@ pub fn onIOWriterChunk(this: *Which, _: usize, e: ?jsc.SystemError) Yield {
             (this.state == .multi_args and this.state.multi_args.state == .waiting_write));
     }
 
-    if (e != null) {
-        this.state = .{ .err = e.? };
-        return this.bltn().done(e.?.getErrno());
+    if (e) |err| {
+        defer err.deref();
+        return this.bltn().done(err.getErrno());
     }
 
     if (this.state == .one_arg) {
@@ -127,7 +129,7 @@ pub fn onIOWriterChunk(this: *Which, _: usize, e: ?jsc.SystemError) Yield {
 
 pub fn deinit(this: *Which) void {
     log("({s}) deinit", .{@tagName(.which)});
-    _ = this;
+    if (this.state == .err) this.state.err.deref();
 }
 
 pub inline fn bltn(this: *Which) *Builtin {

--- a/src/shell/builtin/which.zig
+++ b/src/shell/builtin/which.zig
@@ -17,7 +17,6 @@ state: union(enum) {
         },
     },
     done,
-    err: jsc.SystemError,
 } = .idle,
 
 pub fn start(this: *Which) Yield {
@@ -129,7 +128,7 @@ pub fn onIOWriterChunk(this: *Which, _: usize, e: ?jsc.SystemError) Yield {
 
 pub fn deinit(this: *Which) void {
     log("({s}) deinit", .{@tagName(.which)});
-    if (this.state == .err) this.state.err.deref();
+    _ = this;
 }
 
 pub inline fn bltn(this: *Which) *Builtin {

--- a/src/shell/builtin/yes.zig
+++ b/src/shell/builtin/yes.zig
@@ -74,9 +74,10 @@ pub fn start(this: *@This()) Yield {
         return this.bltn().stdout.enqueue(this, this.buffer[0..this.buffer_used], safeguard);
     }
 
+    const evtloop = this.bltn().eventLoop();
     this.task = .{
-        .evtloop = this.bltn().eventLoop(),
-        .concurrent_task = jsc.EventLoopTask.fromEventLoop(this.task.evtloop),
+        .evtloop = evtloop,
+        .concurrent_task = jsc.EventLoopTask.fromEventLoop(evtloop),
     };
     return this.writeNoIO();
 }

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -294,6 +294,58 @@ pub const Interpreter = struct {
     __alloc_scope: if (bun.Environment.enableAllocScopes) bun.AllocationScope else void,
     estimated_size_for_gc: usize = 0,
 
+    /// Side-channel for `try_()`: lets init/setup paths use `try`/`errdefer` for cleanup
+    /// while still surfacing the rich syscall error (errno+path+syscall) at the boundary.
+    last_err: ?Syscall.Error = null,
+
+    /// Unwrap a `Maybe(T)` into `error{Sys}!T`, stashing the syscall error on `last_err`.
+    /// Use with `try` so `errdefer` fires for resources acquired earlier in the function.
+    /// The boundary `catch`es and reads `takeErr()` to surface it.
+    ///
+    /// The stashed `Syscall.Error.path` is borrowed; the catch boundary must be inside the
+    /// scope that owns any path buffer passed to the failing syscall. In practice keep the
+    /// `try_` calls and the `catch` in the same function.
+    ///
+    /// Main-thread only — thread-pool task bodies must keep using `Maybe` directly.
+    pub fn try_(this: *ThisInterpreter, m: anytype) error{Sys}!@TypeOf(m).ReturnType {
+        return switch (m) {
+            .result => |r| r,
+            .err => |e| {
+                this.last_err = e;
+                return error.Sys;
+            },
+        };
+    }
+
+    pub fn takeErr(this: *ThisInterpreter) Syscall.Error {
+        const e = this.last_err.?;
+        this.last_err = null;
+        return e;
+    }
+
+    /// Standalone error sink for code paths where `*ThisInterpreter` isn't available yet
+    /// (e.g. `ThisInterpreter.init` before the struct is constructed). Same path-lifetime
+    /// caveat as `ThisInterpreter.try_`.
+    pub const Catch = struct {
+        err: ?Syscall.Error = null,
+
+        pub fn try_(this: *Catch, m: anytype) error{Sys}!@TypeOf(m).ReturnType {
+            return switch (m) {
+                .result => |r| r,
+                .err => |e| {
+                    this.err = e;
+                    return error.Sys;
+                },
+            };
+        }
+
+        pub fn take(this: *Catch) Syscall.Error {
+            const e = this.err.?;
+            this.err = null;
+            return e;
+        }
+    };
+
     // Here are all the state nodes:
     pub const State = @import("./states/Base.zig");
     pub const Script = @import("./states/Script.zig");
@@ -1088,20 +1140,20 @@ pub const Interpreter = struct {
     }
 
     fn setupIOBeforeRun(this: *ThisInterpreter) Maybe(void) {
+        return if (this.setupIOBeforeRunImpl()) |_| .success else |_| .{ .err = this.takeErr() };
+    }
+
+    fn setupIOBeforeRunImpl(this: *ThisInterpreter) error{Sys}!void {
         if (!this.flags.quiet) {
             const event_loop = this.event_loop;
 
             log("Duping stdout", .{});
-            const stdout_fd = switch (if (bun.Output.Source.Stdio.isStdoutNull()) bun.sys.openNullDevice() else ShellSyscall.dup(.stdout())) {
-                .result => |fd| fd,
-                .err => |err| return .{ .err = err },
-            };
+            const stdout_fd = try this.try_(if (bun.Output.Source.Stdio.isStdoutNull()) bun.sys.openNullDevice() else ShellSyscall.dup(.stdout()));
+            errdefer stdout_fd.close();
 
             log("Duping stderr", .{});
-            const stderr_fd = switch (if (bun.Output.Source.Stdio.isStderrNull()) bun.sys.openNullDevice() else ShellSyscall.dup(.stderr())) {
-                .result => |fd| fd,
-                .err => |err| return .{ .err = err },
-            };
+            const stderr_fd = try this.try_(if (bun.Output.Source.Stdio.isStderrNull()) bun.sys.openNullDevice() else ShellSyscall.dup(.stderr()));
+            errdefer stderr_fd.close();
 
             const stdout_writer = IOWriter.init(
                 stdout_fd,
@@ -1133,8 +1185,6 @@ pub const Interpreter = struct {
                 this.root_io.stderr.fd.captured = &this.root_shell._buffered_stderr.owned;
             }
         }
-
-        return .success;
     }
 
     pub fn run(this: *ThisInterpreter) !Maybe(void) {

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -804,7 +804,7 @@ pub const Interpreter = struct {
             .result => |i| i,
             .err => |*e| {
                 jsobjs.deinit();
-                if (export_env) |*ee| ee.deinit();
+                // export_env is consumed by init() on both success and failure.
                 shargs.deinit();
                 return try throwShellErr(e, .{ .js = globalThis.bunVM().event_loop });
             },
@@ -894,18 +894,24 @@ pub const Interpreter = struct {
         export_env_: ?EnvMap,
         cwd_: ?[]const u8,
     ) shell.Result(*ThisInterpreter) {
+        // Hoisted so the catch boundary's toShellSystemError() can read err.path
+        // (which borrows from this buffer) before it's returned to the pool.
+        const pathbuf = bun.path_buffer_pool.get();
+        defer bun.path_buffer_pool.put(pathbuf);
+
         var sys: Catch = .{};
-        const interpreter = initImpl(&sys, ctx, event_loop, allocator, shargs, jsobjs, export_env_) catch {
+        const interpreter = initImpl(&sys, ctx, event_loop, allocator, shargs, jsobjs, export_env_, pathbuf) catch {
             return .{ .err = .{ .sys = sys.take().toShellSystemError() } };
         };
 
         if (cwd_) |c| {
             if (interpreter.root_shell.changeCwdImpl(interpreter, c, true).asErr()) |e| {
+                const sys_err = e.toShellSystemError();
                 interpreter.root_io.deref();
                 interpreter.root_shell.deinitImpl(false, true);
                 if (comptime bun.Environment.enableAllocScopes) interpreter.__alloc_scope.deinit();
                 allocator.destroy(interpreter);
-                return .{ .err = .{ .sys = e.toShellSystemError() } };
+                return .{ .err = .{ .sys = sys_err } };
             }
         }
 
@@ -922,6 +928,7 @@ pub const Interpreter = struct {
         shargs: *ShellArgs,
         jsobjs: []JSValue,
         export_env_: ?EnvMap,
+        pathbuf: *bun.PathBuffer,
     ) error{Sys}!*ThisInterpreter {
         var export_env = brk: {
             if (event_loop == .js) break :brk if (export_env_) |e| e else EnvMap.init(allocator);
@@ -947,12 +954,9 @@ pub const Interpreter = struct {
 
             break :brk export_env;
         };
-        // Only deinit if we built it ourselves; a caller-supplied map stays caller-owned on error.
-        errdefer if (export_env_ == null) export_env.deinit();
+        // init() consumes export_env_ regardless of outcome; callers must not free it.
+        errdefer export_env.deinit();
 
-        // Avoid the large stack allocation on Windows.
-        const pathbuf = bun.path_buffer_pool.get();
-        defer bun.path_buffer_pool.put(pathbuf);
         const cwd: [:0]const u8 = try sys.try_(Syscall.getcwdZ(pathbuf));
 
         const cwd_fd = try sys.try_(Syscall.open(cwd, bun.O.DIRECTORY | bun.O.RDONLY, 0));

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -534,7 +534,10 @@ pub const Interpreter = struct {
             const duped = bun.handleOom(alloc.create(ShellExecEnv));
 
             const dupedfd = switch (Syscall.dup(this.cwd_fd)) {
-                .err => |err| return .{ .err = err },
+                .err => |err| {
+                    alloc.destroy(duped);
+                    return .{ .err = err };
+                },
                 .result => |fd| fd,
             };
 
@@ -783,6 +786,7 @@ pub const Interpreter = struct {
             &export_env,
         );
 
+        defer if (cwd) |*cc| cc.deref();
         const cwd_string: ?bun.jsc.ZigString.Slice = if (cwd) |c| brk: {
             break :brk c.toUTF8(bun.default_allocator);
         } else null;
@@ -801,7 +805,6 @@ pub const Interpreter = struct {
             .err => |*e| {
                 jsobjs.deinit();
                 if (export_env) |*ee| ee.deinit();
-                if (cwd) |*cc| cc.deref();
                 shargs.deinit();
                 return try throwShellErr(e, .{ .js = globalThis.bunVM().event_loop });
             },
@@ -809,8 +812,7 @@ pub const Interpreter = struct {
 
         if (globalThis.hasException()) {
             jsobjs.deinit();
-            if (export_env) |*ee| ee.deinit();
-            if (cwd) |*cc| cc.deref();
+            // Note: export_env is now owned by interpreter.root_shell; finalize() will deinit it.
             // Note: Don't call shargs.deinit() here - interpreter.finalize() will do it
             // since interpreter.args points to shargs after init() succeeds.
             interpreter.finalize();
@@ -892,7 +894,36 @@ pub const Interpreter = struct {
         export_env_: ?EnvMap,
         cwd_: ?[]const u8,
     ) shell.Result(*ThisInterpreter) {
-        const export_env = brk: {
+        var sys: Catch = .{};
+        const interpreter = initImpl(&sys, ctx, event_loop, allocator, shargs, jsobjs, export_env_) catch {
+            return .{ .err = .{ .sys = sys.take().toShellSystemError() } };
+        };
+
+        if (cwd_) |c| {
+            if (interpreter.root_shell.changeCwdImpl(interpreter, c, true).asErr()) |e| {
+                interpreter.root_io.deref();
+                interpreter.root_shell.deinitImpl(false, true);
+                if (comptime bun.Environment.enableAllocScopes) interpreter.__alloc_scope.deinit();
+                allocator.destroy(interpreter);
+                return .{ .err = .{ .sys = e.toShellSystemError() } };
+            }
+        }
+
+        interpreter.root_shell.__alloc_scope = if (bun.Environment.enableAllocScopes) &interpreter.__alloc_scope else {};
+
+        return .{ .result = interpreter };
+    }
+
+    fn initImpl(
+        sys: *Catch,
+        ctx: bun.cli.Command.Context,
+        event_loop: jsc.EventLoopHandle,
+        allocator: Allocator,
+        shargs: *ShellArgs,
+        jsobjs: []JSValue,
+        export_env_: ?EnvMap,
+    ) error{Sys}!*ThisInterpreter {
+        var export_env = brk: {
             if (event_loop == .js) break :brk if (export_env_) |e| e else EnvMap.init(allocator);
 
             var env_loader: *bun.DotEnv.Loader = env_loader: {
@@ -916,38 +947,30 @@ pub const Interpreter = struct {
 
             break :brk export_env;
         };
+        // Only deinit if we built it ourselves; a caller-supplied map stays caller-owned on error.
+        errdefer if (export_env_ == null) export_env.deinit();
 
         // Avoid the large stack allocation on Windows.
         const pathbuf = bun.path_buffer_pool.get();
         defer bun.path_buffer_pool.put(pathbuf);
-        const cwd: [:0]const u8 = switch (Syscall.getcwdZ(pathbuf)) {
-            .result => |cwd| cwd,
-            .err => |err| {
-                return .{ .err = .{ .sys = err.toShellSystemError() } };
-            },
-        };
+        const cwd: [:0]const u8 = try sys.try_(Syscall.getcwdZ(pathbuf));
 
-        const cwd_fd = switch (Syscall.open(cwd, bun.O.DIRECTORY | bun.O.RDONLY, 0)) {
-            .result => |fd| fd,
-            .err => |err| {
-                return .{ .err = .{ .sys = err.toShellSystemError() } };
-            },
-        };
+        const cwd_fd = try sys.try_(Syscall.open(cwd, bun.O.DIRECTORY | bun.O.RDONLY, 0));
+        errdefer cwd_fd.close();
 
         var cwd_arr = bun.handleOom(std.array_list.Managed(u8).initCapacity(bun.default_allocator, cwd.len + 1));
         bun.handleOom(cwd_arr.appendSlice(cwd[0 .. cwd.len + 1]));
+        errdefer cwd_arr.deinit();
 
         if (comptime bun.Environment.isDebug) {
             assert(cwd_arr.items[cwd_arr.items.len -| 1] == 0);
         }
 
         log("Duping stdin", .{});
-        const stdin_fd = switch (if (bun.Output.Source.Stdio.isStdinNull()) bun.sys.openNullDevice() else ShellSyscall.dup(shell.STDIN_FD)) {
-            .result => |fd| fd,
-            .err => |err| return .{ .err = .{ .sys = err.toShellSystemError() } },
-        };
+        const stdin_fd = try sys.try_(if (bun.Output.Source.Stdio.isStdinNull()) bun.sys.openNullDevice() else ShellSyscall.dup(shell.STDIN_FD));
 
         const stdin_reader = IOReader.init(stdin_fd, event_loop);
+        errdefer stdin_reader.deref();
 
         const interpreter = bun.handleOom(allocator.create(ThisInterpreter));
         interpreter.* = .{
@@ -987,13 +1010,7 @@ pub const Interpreter = struct {
             .globalThis = undefined,
         };
 
-        if (cwd_) |c| {
-            if (interpreter.root_shell.changeCwdImpl(interpreter, c, true).asErr()) |e| return .{ .err = .{ .sys = e.toShellSystemError() } };
-        }
-
-        interpreter.root_shell.__alloc_scope = if (bun.Environment.enableAllocScopes) &interpreter.__alloc_scope else {};
-
-        return .{ .result = interpreter };
+        return interpreter;
     }
 
     pub fn initAndRunFromFile(ctx: bun.cli.Command.Context, mini: *jsc.MiniEventLoop, path: []const u8) !bun.shell.ExitCode {
@@ -1329,6 +1346,10 @@ pub const Interpreter = struct {
 
         this.keep_alive.disable();
         this.args.deinit();
+        for (this.vm_args_utf8.items[0..]) |str| {
+            str.deinit();
+        }
+        this.vm_args_utf8.deinit();
         this.allocator.destroy(this);
     }
 
@@ -1355,6 +1376,7 @@ pub const Interpreter = struct {
     pub fn setCwd(this: *ThisInterpreter, globalThis: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
         const value = callframe.argument(0);
         const str = try bun.String.fromJS(value, globalThis);
+        defer str.deref();
 
         const slice = str.toUTF8(bun.default_allocator);
         defer slice.deinit();
@@ -1386,9 +1408,9 @@ pub const Interpreter = struct {
         // PATH = "";
 
         while (object_iter.next()) |key| {
-            const keyslice = bun.handleOom(key.toOwnedSlice(bun.default_allocator));
             var value = object_iter.value;
             if (value.isUndefined()) continue;
+            const keyslice = bun.handleOom(key.toOwnedSlice(bun.default_allocator));
 
             const value_str = value.getZigString(globalThis);
             const slice = bun.handleOom(value_str.toOwnedSlice(bun.default_allocator));
@@ -1828,7 +1850,7 @@ pub const ShellSyscall = struct {
             };
 
             return switch (Syscall.stat(path)) {
-                .err => |e| .{ .err = e.clone(bun.default_allocator) },
+                .err => |e| .{ .err = e.withPath(path_) },
                 .result => |s| .{ .result = s },
             };
         }

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -4372,11 +4372,19 @@ pub fn SmolList(comptime T: type, comptime INLINED_MAX: comptime_int) type {
             }
 
             pub fn pop(this: *Inlined) T {
-                const ret = this.items[this.items.len - 1];
+                const ret = this.items[this.len - 1];
                 this.len -= 1;
                 return ret;
             }
         };
+
+        pub fn deinit(this: *@This()) void {
+            switch (this.*) {
+                .inlined => {},
+                .heap => |*heap| heap.deinit(bun.default_allocator),
+            }
+            this.* = zeroes;
+        }
 
         pub inline fn len(this: *const @This()) usize {
             return switch (this.*) {

--- a/src/shell/states/Assigns.zig
+++ b/src/shell/states/Assigns.zig
@@ -31,8 +31,10 @@ pub const ChildPtr = StatePtrUnion(.{
 });
 
 pub inline fn deinit(this: *Assigns) void {
-    if (this.state == .expanding) {
-        this.state.expanding.current_expansion_result.deinit();
+    switch (this.state) {
+        .expanding => |*e| e.current_expansion_result.deinit(),
+        .err => |*e| e.deinit(bun.default_allocator),
+        .idle, .done => {},
     }
     this.io.deinit();
     this.base.endScope();
@@ -127,11 +129,12 @@ pub fn childDone(this: *Assigns, child: ChildPtr, exit_code: ExitCode) Yield {
         bun.assert(this.state == .expanding);
         const expansion = child.ptr.as(Expansion);
         if (exit_code != 0) {
+            // `expansion` points into `this.state.expanding.expansion`; capture the error
+            // and deinit it before switching the union variant or we operate on garbage.
+            const err = expansion.state.err;
             this.state.expanding.current_expansion_result.clearAndFree();
-            this.state = .{
-                .err = expansion.state.err,
-            };
             expansion.deinit();
+            this.state = .{ .err = err };
             return .failed;
         }
         var expanding = &this.state.expanding;

--- a/src/shell/states/Async.zig
+++ b/src/shell/states/Async.zig
@@ -144,7 +144,8 @@ pub fn deinit(this: *Async) void {
 
 pub fn actuallyDeinit(this: *Async) void {
     this.io.deref();
-    bun.destroy(this);
+    this.base.endScope();
+    this.parent.destroy(this);
 }
 
 pub fn runFromMainThread(this: *Async) void {

--- a/src/shell/states/Base.zig
+++ b/src/shell/states/Base.zig
@@ -99,6 +99,16 @@ pub fn throw(this: *const Base, err: *const bun.shell.ShellErr) void {
     throwShellErr(err, this.eventLoop()) catch {}; //TODO:
 }
 
+/// Unwrap a `Maybe(T)` into `error{Sys}!T`, stashing the rich error on the interpreter.
+/// See `ThisInterpreter.try_` — this is sugar for `this.interpreter.try_(m)`.
+pub inline fn try_(this: *Base, m: anytype) error{Sys}!@TypeOf(m).ReturnType {
+    return this.interpreter.try_(m);
+}
+
+pub inline fn takeErr(this: *Base) bun.sys.Error {
+    return this.interpreter.takeErr();
+}
+
 pub fn rootIO(this: *const Base) *const IO {
     return this.interpreter.rootIO();
 }

--- a/src/shell/states/Cmd.zig
+++ b/src/shell/states/Cmd.zig
@@ -112,10 +112,11 @@ const BufferedIoClosed = struct {
             open,
             closed: bun.ByteList,
         } = .open,
-        owned: bool = false,
 
         pub fn deinit(this: *BufferedIoState) void {
-            if (this.state == .closed and this.owned) {
+            // The closed buffer was taken via PipeReader.takeBuffer(); we own it
+            // regardless of the original stdio variant.
+            if (this.state == .closed) {
                 this.state.closed.clearAndFree(bun.default_allocator);
             }
         }
@@ -186,8 +187,8 @@ const BufferedIoClosed = struct {
     fn fromStdio(io: *const [3]bun.shell.subproc.Stdio) BufferedIoClosed {
         return .{
             .stdin = if (io[stdin_no].isPiped()) false else null,
-            .stdout = if (io[stdout_no].isPiped()) .{ .owned = io[stdout_no] == .pipe } else null,
-            .stderr = if (io[stderr_no].isPiped()) .{ .owned = io[stderr_no] == .pipe } else null,
+            .stdout = if (io[stdout_no].isPiped()) .{} else null,
+            .stderr = if (io[stderr_no].isPiped()) .{} else null,
         };
     }
 };
@@ -522,6 +523,7 @@ fn initSubproc(this: *Cmd) Yield {
     const subproc = switch (Subprocess.spawnAsync(this.base.eventLoop(), &shellio, spawn_args, &this.exec.subproc.child, &did_exit_immediately)) {
         .result => this.exec.subproc.child,
         .err => |*e| {
+            defer e.deinit(bun.default_allocator);
             this.exec = .none;
             return this.writeFailingError("{f}\n", .{e});
         },
@@ -605,7 +607,9 @@ fn initRedirections(this: *Cmd, spawn_args: *Subprocess.SpawnArgs) bun.JSError!?
                 const flags = this.node.redirect.toFlags();
                 const redirfd = switch (ShellSyscall.openat(this.base.shell.cwd_fd, path, flags, perm)) {
                     .err => |e| {
-                        return this.writeFailingError("bun: {f}: {s}", .{ e.toShellSystemError().message, path });
+                        const sys_err = e.toShellSystemError();
+                        defer sys_err.deref();
+                        return this.writeFailingError("bun: {f}: {s}", .{ sys_err.message, path });
                     },
                     .result => |f| f,
                 };
@@ -701,13 +705,11 @@ pub fn deinit(this: *Cmd) void {
     if (this.exec != .none) {
         if (this.exec == .subproc) {
             var cmd = this.exec.subproc.child;
-            if (cmd.hasExited()) {
-                cmd.unref(true);
-            } else {
+            if (!cmd.hasExited()) {
                 _ = cmd.tryKill(9);
-                cmd.unref(true);
-                cmd.deinit();
             }
+            cmd.unref(true);
+            cmd.deinit();
 
             this.exec.subproc.buffered_closed.deinit();
         } else {
@@ -765,6 +767,7 @@ pub fn bufferedOutputCloseStdout(this: *Cmd, err: ?jsc.SystemError) void {
     }
     log("cmd ({x}) close buffered stdout", .{@intFromPtr(this)});
     if (err) |e| {
+        defer e.deref();
         this.exit_code = @as(ExitCode, @intCast(@intFromEnum(e.getErrno())));
     }
     if (this.io.stdout == .fd and this.io.stdout.fd.captured != null and !this.node.redirect.redirectsElsewhere(.stdout)) {
@@ -782,6 +785,7 @@ pub fn bufferedOutputCloseStderr(this: *Cmd, err: ?jsc.SystemError) void {
     }
     log("cmd ({x}) close buffered stderr", .{@intFromPtr(this)});
     if (err) |e| {
+        defer e.deref();
         this.exit_code = @as(ExitCode, @intCast(@intFromEnum(e.getErrno())));
     }
     if (this.io.stderr == .fd and this.io.stderr.fd.captured != null and !this.node.redirect.redirectsElsewhere(.stderr)) {

--- a/src/shell/states/Cmd.zig
+++ b/src/shell/states/Cmd.zig
@@ -563,12 +563,23 @@ fn initRedirections(this: *Cmd, spawn_args: *Subprocess.SpawnArgs) bun.JSError!?
                 }
 
                 if (this.base.interpreter.jsobjs[val.idx].asArrayBuffer(global)) |buf| {
-                    const stdio: bun.shell.subproc.Stdio = .{ .array_buffer = jsc.ArrayBuffer.Strong{
-                        .array_buffer = buf,
-                        .held = .create(buf.value, global),
-                    } };
-
-                    setStdioFromRedirect(&spawn_args.stdio, this.node.redirect, stdio);
+                    // Each slot needs its own Strong; copying one Stdio into multiple slots
+                    // (e.g. for &>) would alias the same *Impl and double-free in deinit.
+                    const flags = this.node.redirect;
+                    if (flags.stdin) {
+                        spawn_args.stdio[stdin_no] = .{ .array_buffer = .{ .array_buffer = buf, .held = .create(buf.value, global) } };
+                    }
+                    if (flags.duplicate_out) {
+                        spawn_args.stdio[stdout_no] = .{ .array_buffer = .{ .array_buffer = buf, .held = .create(buf.value, global) } };
+                        spawn_args.stdio[stderr_no] = .{ .array_buffer = .{ .array_buffer = buf, .held = .create(buf.value, global) } };
+                    } else {
+                        if (flags.stdout) {
+                            spawn_args.stdio[stdout_no] = .{ .array_buffer = .{ .array_buffer = buf, .held = .create(buf.value, global) } };
+                        }
+                        if (flags.stderr) {
+                            spawn_args.stdio[stderr_no] = .{ .array_buffer = .{ .array_buffer = buf, .held = .create(buf.value, global) } };
+                        }
+                    }
                 } else if (this.base.interpreter.jsobjs[val.idx].as(jsc.WebCore.Blob)) |blob__| {
                     const blob = blob__.dupe();
                     if (this.node.redirect.stdin) {

--- a/src/shell/states/Expansion.zig
+++ b/src/shell/states/Expansion.zig
@@ -322,6 +322,8 @@ fn transitionToGlobState(this: *Expansion) Yield {
     ) catch |err| bun.handleOom(err)) {
         .result => {},
         .err => |e| {
+            arena.deinit();
+            this.child_state = .idle;
             this.state = .{ .err = bun.shell.ShellErr.newSys(e) };
             return .{ .expansion = this };
         },
@@ -337,7 +339,7 @@ pub fn expandVarAndCmdSubst(this: *Expansion, start_word_idx: u32) ?Yield {
         .simple => |*simp| {
             const is_cmd_subst = this.expandSimpleNoIO(simp, &this.current_out, true);
             if (is_cmd_subst) {
-                const io: IO = .{
+                var io: IO = .{
                     .stdin = this.base.rootIO().stdin.ref(),
                     .stdout = .pipe,
                     .stderr = this.base.rootIO().stderr.ref(),
@@ -345,6 +347,7 @@ pub fn expandVarAndCmdSubst(this: *Expansion, start_word_idx: u32) ?Yield {
                 const shell_state = switch (this.base.shell.dupeForSubshell(this.base.allocScope(), this.base.allocator(), io, .cmd_subst)) {
                     .result => |s| s,
                     .err => |e| {
+                        io.deref();
                         this.base.throw(&bun.shell.ShellErr.newSys(e));
                         return .failed;
                     },
@@ -369,7 +372,7 @@ pub fn expandVarAndCmdSubst(this: *Expansion, start_word_idx: u32) ?Yield {
             for (cmp.atoms[start_word_idx + starting_offset ..]) |*simple_atom| {
                 const is_cmd_subst = this.expandSimpleNoIO(simple_atom, &this.current_out, true);
                 if (is_cmd_subst) {
-                    const io: IO = .{
+                    var io: IO = .{
                         .stdin = this.base.rootIO().stdin.ref(),
                         .stdout = .pipe,
                         .stderr = this.base.rootIO().stderr.ref(),
@@ -377,6 +380,7 @@ pub fn expandVarAndCmdSubst(this: *Expansion, start_word_idx: u32) ?Yield {
                     const shell_state = switch (this.base.shell.dupeForSubshell(this.base.allocScope(), this.base.allocator(), io, .cmd_subst)) {
                         .result => |s| s,
                         .err => |e| {
+                            io.deref();
                             this.base.throw(&bun.shell.ShellErr.newSys(e));
                             return .failed;
                         },

--- a/src/shell/states/Pipeline.zig
+++ b/src/shell/states/Pipeline.zig
@@ -97,7 +97,11 @@ fn setupCommands(this: *Pipeline) ?Yield {
 
     this.cmds = if (cmd_count >= 1) bun.handleOom(this.base.allocator().alloc(CmdOrResult, cmd_count)) else null;
     if (this.cmds == null) return null;
+    // Pre-fill so a mid-loop failure leaves cmds[i..] in a state deinit() can skip safely.
+    for (this.cmds.?) |*c| c.* = .{ .result = 0 };
+
     var pipes = bun.handleOom(this.base.allocator().alloc(Pipe, if (cmd_count > 1) cmd_count - 1 else 1));
+    this.pipes = pipes;
 
     if (cmd_count > 1) {
         var pipes_set: u32 = 0;
@@ -107,6 +111,7 @@ fn setupCommands(this: *Pipeline) ?Yield {
                 closefd(pipe[1]);
             }
             const system_err = err.toShellSystemError();
+            defer system_err.deref();
             return this.writeFailingError("bun: {f}\n", .{system_err.message});
         }
     }
@@ -125,7 +130,16 @@ fn setupCommands(this: *Pipeline) ?Yield {
                 const subshell_state = switch (this.base.shell.dupeForSubshell(this.base.allocScope(), this.base.allocator(), cmd_io, .pipeline)) {
                     .result => |s| s,
                     .err => |err| {
+                        cmd_io.deref();
+                        if (cmd_count > 1) {
+                            // Close pipe ends not yet wrapped in an IOReader/IOWriter; the
+                            // wrapped ones are owned by cmds[0..i]/cmd_io and close on deref.
+                            for (pipes[i..]) |p| closefd(p[0]);
+                            const w_start = @min(i + 1, @as(u32, @intCast(pipes.len)));
+                            for (pipes[w_start..]) |p| closefd(p[1]);
+                        }
                         const system_err = err.toShellSystemError();
+                        defer system_err.deref();
                         return this.writeFailingError("bun: {f}\n", .{system_err.message});
                     },
                 };
@@ -144,8 +158,6 @@ fn setupCommands(this: *Pipeline) ?Yield {
             .assigns => {},
         }
     }
-
-    this.pipes = pipes;
 
     return null;
 }
@@ -201,8 +213,7 @@ pub fn onIOWriterChunk(this: *Pipeline, _: usize, err: ?jsc.SystemError) Yield {
         return .failed;
     }
 
-    this.state = .{ .done = .{} };
-    return .done;
+    return this.parent.childDone(this, 1);
 }
 
 pub fn childDone(this: *Pipeline, child: ChildPtr, exit_code: ExitCode) Yield {
@@ -261,18 +272,16 @@ pub fn childDone(this: *Pipeline, child: ChildPtr, exit_code: ExitCode) Yield {
 }
 
 pub fn deinit(this: *Pipeline) void {
-    // If commands was zero then we didn't allocate anything
-    if (this.cmds == null) return;
-    for (this.cmds.?) |*cmd_or_result| {
-        if (cmd_or_result.* == .cmd) {
-            cmd_or_result.cmd.call("deinit", .{}, void);
+    if (this.cmds) |cmds| {
+        for (cmds) |*cmd_or_result| {
+            if (cmd_or_result.* == .cmd) {
+                cmd_or_result.cmd.call("deinit", .{}, void);
+            }
         }
+        this.base.allocator().free(cmds);
     }
     if (this.pipes) |pipes| {
         this.base.allocator().free(pipes);
-    }
-    if (this.cmds) |cmds| {
-        this.base.allocator().free(cmds);
     }
     this.io.deref();
     this.base.endScope();

--- a/src/shell/states/Subshell.zig
+++ b/src/shell/states/Subshell.zig
@@ -69,6 +69,9 @@ pub fn initDupeShellState(
     subshell.base.shell = switch (shell_state.dupeForSubshell(subshell.base.allocScope(), subshell.base.allocator(), io, .subshell)) {
         .result => |s| s,
         .err => |e| {
+            // Callee-consumes-on-failure: we own the io refs the caller passed in.
+            subshell.io.deref();
+            subshell.base.endScope();
             parent.destroy(subshell);
             return .{ .err = e };
         },

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -587,6 +587,26 @@ pub const ShellSubprocess = struct {
         bun.default_allocator.destroy(this);
     }
 
+    /// Tear down a subprocess whose stdio start() failed. Marks pending pipe readers as
+    /// errored so PipeReader.deinit's done-assert passes, drops the exit handler so a
+    /// later onProcessExit doesn't touch the freed Subprocess, then deinits.
+    ///
+    /// Windows: PipeReader.deinit asserts the libuv source is closed. Whether the source
+    /// is uv-initialized depends on how far startWithCurrentPipe got, so a blind close or
+    /// destroy is unsafe. Fall back to leaking the Subprocess (pre-existing behavior)
+    /// rather than risk closing an uninitialized handle.
+    fn abortAfterFailedStart(this: *@This()) void {
+        if (Environment.isWindows) return;
+        inline for (.{ .stdout, .stderr }) |tag| {
+            const r: *Readable = &@field(this, @tagName(tag));
+            if (r.* == .pipe and r.pipe.state == .pending) {
+                r.pipe.state = .{ .err = null };
+            }
+        }
+        this.process.exit_handler = .{};
+        this.deinit();
+    }
+
     pub const SpawnArgs = struct {
         arena: *bun.ArenaAllocator,
         cmd_parent: *ShellCmd,
@@ -787,33 +807,35 @@ pub const ShellSubprocess = struct {
 
         const no_sigpipe = if (shellio.stdout) |iowriter| !iowriter.flags.is_socket else true;
 
+        // Hoist asSpawnOption results so a later one failing doesn't strand an earlier
+        // Windows *uv.Pipe in an unbound temporary inside the struct initializer.
+        const stdin_opt = switch (spawn_args.stdio[0].asSpawnOption(0)) {
+            .result => |opt| opt,
+            .err => |e| return .{ .err = .{ .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())) } },
+        };
+        const stdout_opt = switch (spawn_args.stdio[1].asSpawnOption(1)) {
+            .result => |opt| opt,
+            .err => |e| {
+                if (Environment.isWindows) stdin_opt.deinit();
+                return .{ .err = .{ .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())) } };
+            },
+        };
+        const stderr_opt = switch (spawn_args.stdio[2].asSpawnOption(2)) {
+            .result => |opt| opt,
+            .err => |e| {
+                if (Environment.isWindows) {
+                    stdin_opt.deinit();
+                    stdout_opt.deinit();
+                }
+                return .{ .err = .{ .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())) } };
+            },
+        };
+
         var spawn_options = bun.spawn.SpawnOptions{
             .cwd = spawn_args.cwd,
-            .stdin = switch (spawn_args.stdio[0].asSpawnOption(0)) {
-                .result => |opt| opt,
-                .err => |e| {
-                    return .{ .err = .{
-                        .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())),
-                    } };
-                },
-            },
-            .stdout = switch (spawn_args.stdio[1].asSpawnOption(1)) {
-                .result => |opt| opt,
-                .err => |e| {
-                    return .{ .err = .{
-                        .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())),
-                    } };
-                },
-            },
-            .stderr = switch (spawn_args.stdio[2].asSpawnOption(2)) {
-                .result => |opt| opt,
-                .err => |e| {
-                    return .{ .err = .{
-                        .custom = bun.handleOom(bun.default_allocator.dupe(u8, e.toStr())),
-                    } };
-                },
-            },
-
+            .stdin = stdin_opt,
+            .stdout = stdout_opt,
+            .stderr = stderr_opt,
             .windows = if (Environment.isWindows) bun.spawn.WindowsSpawnOptions.WindowsOptions{
                 .hide_window = true,
                 .loop = event_loop,
@@ -893,15 +915,19 @@ pub const ShellSubprocess = struct {
 
         if (subprocess.stdin == .buffer) {
             if (subprocess.stdin.buffer.start().asErr()) |err| {
+                const sys_err = err.toShellSystemError();
                 _ = subprocess.tryKill(@intFromEnum(bun.SignalCode.SIGTERM));
-                return .{ .err = .{ .sys = err.toShellSystemError() } };
+                subprocess.abortAfterFailedStart();
+                return .{ .err = .{ .sys = sys_err } };
             }
         }
 
         if (subprocess.stdout == .pipe) {
             if (subprocess.stdout.pipe.start(subprocess, event_loop).asErr()) |err| {
+                const sys_err = err.toShellSystemError();
                 _ = subprocess.tryKill(@intFromEnum(bun.SignalCode.SIGTERM));
-                return .{ .err = .{ .sys = err.toShellSystemError() } };
+                subprocess.abortAfterFailedStart();
+                return .{ .err = .{ .sys = sys_err } };
             }
             if (!spawn_args.lazy and subprocess.stdout == .pipe) {
                 subprocess.stdout.pipe.readAll();
@@ -910,8 +936,10 @@ pub const ShellSubprocess = struct {
 
         if (subprocess.stderr == .pipe) {
             if (subprocess.stderr.pipe.start(subprocess, event_loop).asErr()) |err| {
+                const sys_err = err.toShellSystemError();
                 _ = subprocess.tryKill(@intFromEnum(bun.SignalCode.SIGTERM));
-                return .{ .err = .{ .sys = err.toShellSystemError() } };
+                subprocess.abortAfterFailedStart();
+                return .{ .err = .{ .sys = sys_err } };
             }
 
             if (!spawn_args.lazy and subprocess.stderr == .pipe) {

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -396,9 +396,14 @@ pub const ShellSubprocess = struct {
 
         pub fn close(this: *Readable) void {
             switch (this.*) {
-                inline .memfd, .fd => |fd| {
+                .memfd => |fd| {
                     this.* = .{ .closed = {} };
                     fd.close();
+                },
+                // .fd is borrowed from the shell's IOWriter (see IO.OutKind.to_subproc_stdio) or
+                // a CowFd redirect; the owner closes it.
+                .fd => {
+                    this.* = .{ .closed = {} };
                 },
                 .pipe => {
                     this.pipe.close();
@@ -409,9 +414,14 @@ pub const ShellSubprocess = struct {
 
         pub fn finalize(this: *Readable) void {
             switch (this.*) {
-                inline .memfd, .fd => |fd| {
+                .memfd => |fd| {
                     this.* = .{ .closed = {} };
                     fd.close();
+                },
+                // .fd is borrowed from the shell's IOWriter (see IO.OutKind.to_subproc_stdio) or
+                // a CowFd redirect; the owner closes it.
+                .fd => {
+                    this.* = .{ .closed = {} };
                 },
                 .pipe => |pipe| {
                     defer pipe.detach();
@@ -530,7 +540,7 @@ pub const ShellSubprocess = struct {
     pub fn finalizeSync(this: *@This()) void {
         this.closeProcess();
 
-        // this.closeIO(.stdin);
+        this.closeIO(.stdin);
         this.closeIO(.stdout);
         this.closeIO(.stderr);
     }
@@ -767,18 +777,13 @@ pub const ShellSubprocess = struct {
             spawn_args.env_array.capacity = spawn_args.env_array.items.len;
         }
 
-        var should_close_memfd = Environment.isLinux;
-
-        defer {
-            if (should_close_memfd) {
-                inline for (0..spawn_args.stdio.len) |fd_index| {
-                    if (spawn_args.stdio[fd_index] == .memfd) {
-                        spawn_args.stdio[fd_index].memfd.close();
-                        spawn_args.stdio[fd_index] = .ignore;
-                    }
-                }
-            }
-        }
+        // Until ownership transfers into Writable/Readable, deinit any caller-provided
+        // stdio resources (memfd, ArrayBuffer.Strong, Blob) on early return so they
+        // aren't leaked.
+        var stdio_consumed = false;
+        defer if (!stdio_consumed) {
+            for (&spawn_args.stdio) |*s| s.deinit();
+        };
 
         const no_sigpipe = if (shellio.stdout) |iowriter| !iowriter.flags.is_socket else true;
 
@@ -819,10 +824,12 @@ pub const ShellSubprocess = struct {
         }
 
         spawn_args.cmd_parent.args.append(null) catch {
+            spawn_options.deinit();
             return .{ .err = .{ .custom = bun.handleOom(bun.default_allocator.dupe(u8, "out of memory")) } };
         };
 
         spawn_args.env_array.append(allocator, null) catch {
+            spawn_options.deinit();
             return .{ .err = .{ .custom = bun.handleOom(bun.default_allocator.dupe(u8, "out of memory")) } };
         };
 
@@ -831,9 +838,13 @@ pub const ShellSubprocess = struct {
             @ptrCast(spawn_args.cmd_parent.args.items.ptr),
             @ptrCast(spawn_args.env_array.items.ptr),
         ) catch |err| {
+            spawn_options.deinit();
             return .{ .err = .{ .custom = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "Failed to spawn process: {s}", .{@errorName(err)})) } };
         }) {
-            .err => |err| return .{ .err = .{ .sys = err.toShellSystemError() } },
+            .err => |err| {
+                spawn_options.deinit();
+                return .{ .err = .{ .sys = err.toShellSystemError() } };
+            },
             .result => |result| result,
         };
 
@@ -866,6 +877,7 @@ pub const ShellSubprocess = struct {
             .cmd_parent = spawn_args.cmd_parent,
         };
         subprocess.process.setExitHandler(subprocess);
+        stdio_consumed = true;
 
         if (subprocess.stdin == .pipe) {
             subprocess.stdin.pipe.signal = bun.webcore.streams.Signal.init(&subprocess.stdin);
@@ -906,8 +918,6 @@ pub const ShellSubprocess = struct {
                 subprocess.stderr.pipe.readAll();
             }
         }
-
-        should_close_memfd = false;
 
         log("returning", .{});
 
@@ -1217,8 +1227,14 @@ pub const PipeReader = struct {
         if (this.process) |proc| {
             const cmd = proc.cmd_parent;
             if (this.captured_writer.err) |e| {
+                // Transfer ownership of the error out of captured_writer so
+                // PipeReader.deinit doesn't deref the same SystemError twice.
+                this.captured_writer.err = null;
+                if (this.state == .done) bun.default_allocator.free(this.state.done);
                 if (this.state != .err) {
                     this.state = .{ .err = e };
+                } else {
+                    e.deref();
                 }
             }
             const e: ?jsc.SystemError = brk: {

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -57,16 +57,24 @@ describe.concurrent("fd leak", () => {
       const testcode = await Bun.file(join(import.meta.dirname, "./test_builder.ts")).text();
 
       const impl = /* ts */ `
-              import { openSync, closeSync } from "node:fs";
+              import { openSync, closeSync, readdirSync } from "node:fs";
               import { devNull } from "os";
               const TestBuilder = createTestBuilder(import.meta.path);
 
               const runs = ${runs};
               const threshold = ${threshold};
 
+              function getFDCount(): number {
+                if (process.platform === "darwin" || process.platform === "linux") {
+                  return readdirSync(process.platform === "darwin" ? "/dev/fd" : "/proc/self/fd").length;
+                }
+                const maxFD = openSync(devNull, "r");
+                closeSync(maxFD);
+                return maxFD;
+              }
+
               Bun.gc(true);
-              const baseline = openSync(devNull, "r");
-              closeSync(baseline);
+              const baseline = getFDCount();
 
               for (let i = 0; i < runs; i++) {
                 await ${builder.toString().slice("() =>".length)}.quiet().run();
@@ -74,10 +82,9 @@ describe.concurrent("fd leak", () => {
               // Run the GC, because the interpreter closes file descriptors when it
               // deinitializes when its finalizer is called
               Bun.gc(true);
-              const fd = openSync(devNull, "r");
-              closeSync(fd);
-              if (fd - baseline > threshold) {
-                console.error('FD leak detected:', fd - baseline, 'leaked (threshold:', threshold, ')');
+              const after = getFDCount();
+              if (after - baseline > threshold) {
+                console.error('FD leak detected:', after - baseline, 'leaked (threshold:', threshold, ')');
                 process.exit(1);
               }
             `;


### PR DESCRIPTION
## What

Systematic sweep of file-descriptor and memory leaks in `src/shell/`. Started by refactoring `leak.test.ts` to count actual open fds via `readdirSync(/dev/fd)` instead of probing the next-allocated fd number — the old check kept returning the same recycled fd before/after and was masking real accumulation. That immediately exposed an fd held past `await` by every `` $`...` `` invocation, which led to a broader audit.

Adds a small `try_()`/`takeErr()` primitive on `ThisInterpreter`/`State` that lets init/setup code use `try` + `errdefer` over `Maybe(T)` while keeping the rich `Syscall.Error` payload, then applies it (and direct fixes where the shape doesn't fit) across the interpreter, IO layer, state machines, subprocess plumbing, and builtins.

## Highlights (happy-path bugs that fired on normal use)

- Every shell invocation held its stdin `IOReader` fd until the next event-loop tick (now closes synchronously when never started; same for `IOWriter`)
- Every started `IOReader` on POSIX leaked a `FilePoll` (`close_handle=false` skipped pool return)
- `rm` leaked one `ShellRmTask` per file argument (deinit defined, never called) — now freed in both verbose and non-verbose modes
- `Cmd.deinit` skipped `Subprocess.deinit()` when the process had already exited
- `cat a b` could deref the second file's `IOReader` while it was still reading
- `cmd &> ${arrayBuffer}` shared one `Strong` `*Impl` across stdout+stderr → double-free in deinit (both builtin and subprocess paths)
- `SmolList.Inlined.pop()` returned `items[INLINED_MAX-1]` instead of `items[len-1]`
- `.cwd(path)` leaked a `bun.String` ref on every call; `setEnv` leaked keyslices for undefined values
- `which` leaked a PATH `EnvStr` ref per argument
- `yes` no-IO branch read an undefined `task.evtloop`

Plus ~50 error-path leaks (resource acquired → fallible step → return without close/deref) across `ThisInterpreter.init`, `setupIOBeforeRun`, `dupeForSubshell`, `Pipeline.setupCommands`, `Subshell.initDupeShellState`, `Expansion`, `mv` path ownership, and the per-builtin `exec.err` overwrite/transition paths. `subproc` now tears down the heap `Subprocess` when stdio `start()` fails (POSIX), and frees Windows `uv.Pipe`s on mid-init failure. See individual commits for the full per-file breakdown.

## Remaining known limitations

- `subproc.abortAfterFailedStart()` is POSIX-only — Windows still leaks the Subprocess on `start()` failure because `PipeReader.deinit` asserts the libuv source is closed and whether it's initialized depends on how far `startWithCurrentPipe` got.
- `Assigns.deinit` while in `.expanding` doesn't deinit the nested `Expansion` (may be `undefined` pre-init); only matters on mid-expansion abort.

## Tests

- `bun bd test test/js/bun/shell/` — 756 pass / 10 fail. The 7 `memleak_*` and 3 `shell-leak-args.test.ts` failures reproduce identically on `main` (debug-build RSS thresholds); not regressions from this PR.
- All 6 `fdleak_*` tests pass with the new accurate fd-count check.
- `zig:check-all` passes on all platforms.

May supersede parts of #25916 and #26857.