### PR TITLE
codegen: drop redundant visitOutputConstraints from generated classes

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1382,11 +1382,19 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
     externs += `extern JSC_CALLCONV size_t ${symbolName(typeName, "estimatedSize")}(void* ptr);` + "\n";
   }
 
+  for (const a of [...Object.values(klass), ...Object.values(proto)]) {
+    if (a.internal === true) {
+      throw new Error(
+        `${typeName}: 'internal: true' on a property is not implemented (no users today; the visitChildren plumbing for it was never wired up consistently). Use 'cache: true' or add it to 'values' instead.`,
+      );
+    }
+  }
   const DECLARE_VISIT_CHILDREN =
     values.length ||
     obj.estimatedSize ||
+    obj.valuesArray ||
     Object.keys(callbacks).length ||
-    [...Object.values(klass), ...Object.values(proto)].find(a => !!a.cache)
+    [...Object.values(klass), ...Object.values(proto)].find(a => a.cache === true)
       ? "DECLARE_VISIT_CHILDREN;\n"
       : "";
   const sizeEstimator = "static size_t estimatedSize(JSCell* cell, VM& vm);";
@@ -1633,7 +1641,7 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
   // WeakHandleOwner calling hasPendingActivity(wrapped()) directly during weak processing.
   // The previous addOpaqueRoot(wrapped()) had no consumer (the Weak's context was nullptr,
   // so containsOpaqueRoot(context) always checked for nullptr, never m_ctx).
-  if (DEFINE_VISIT_CHILDREN_LIST.length || estimatedSize || values.length) {
+  if (DEFINE_VISIT_CHILDREN_LIST.length || estimatedSize || values.length || obj.valuesArray) {
     DEFINE_VISIT_CHILDREN = `
 template<typename Visitor>
 void ${name}::visitChildrenImpl(JSCell* cell, Visitor& visitor)

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1411,7 +1411,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
 
     class Owner final : public JSC::WeakHandleOwner {
       public:
-          bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void* context, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason) final
+          bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor&, ASCIILiteral* reason) final
           {
               auto* controller = JSC::jsCast<${name}*>(handle.slot()->asCell());
               if (${name}::hasPendingActivity(controller->wrapped())) {

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1600,7 +1600,7 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
   const name = className(typeName);
 
   let DEFINE_VISIT_CHILDREN_LIST = [...Object.entries(fields), ...Object.entries(proto)]
-    .filter(([name, { cache = false, internal = false }]) => (cache || internal) === true)
+    .filter(([name, { cache = false }]) => cache === true)
     .map(([name]) => `visitor.append(thisObject->m_${name});`)
     .join("\n");
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1388,7 +1388,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
     Object.keys(callbacks).length ||
     obj.hasPendingActivity ||
     [...Object.values(klass), ...Object.values(proto)].find(a => !!a.cache)
-      ? "DECLARE_VISIT_CHILDREN;\ntemplate<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);\nDECLARE_VISIT_OUTPUT_CONSTRAINTS;\n"
+      ? "DECLARE_VISIT_CHILDREN;\n"
       : "";
   const sizeEstimator = "static size_t estimatedSize(JSCell* cell, VM& vm);";
 
@@ -1608,6 +1608,28 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
     })
     .join("\n");
   var DEFINE_VISIT_CHILDREN = "";
+  // Generated classes intentionally do NOT override visitOutputConstraints (and therefore
+  // do not get enrolled in BunGCOutputConstraint / m_outputConstraintSpaces).
+  //
+  // visitOutputConstraints exists so JSC's incremental GC can re-scan an already-black cell
+  // after the mutator runs, to pick up new outgoing edges that were added without firing a
+  // write barrier. WebCore needs this because edges like EventTarget's listener list or
+  // AbortSignal's algorithm vector live inside the wrapped RefCounted C++ object, not in
+  // WriteBarrier<> fields on the JSCell, so addEventListener() etc. can add an edge from a
+  // black wrapper to a white callback with no barrier firing.
+  //
+  // Generated classes don't have that problem. Every GC-visible edge below is either:
+  //   - a WriteBarrier<Unknown> field on the JSCell, mutated only via .set(vm, thisObject, v)
+  //     (see *SetCachedValue / cached getter paths), which calls vm.writeBarrier(thisObject, v)
+  //     and re-greys thisObject if it was already marked (Heap::addToRememberedSet pushes it
+  //     back onto m_mutatorMarkStack so visitChildren runs again), or
+  //   - jsvalueArray, a FixedVector<WriteBarrier<>> populated before allocateCell() and never
+  //     resized, or
+  //   - addOpaqueRoot(wrapped()), where wrapped() is m_ctx set once at construction.
+  //
+  // In all cases the write barrier (or immutability) guarantees correctness, so re-walking
+  // every live instance of every generated type after each mutator yield is pure overhead.
+  // Only visitChildren is needed.
   if (DEFINE_VISIT_CHILDREN_LIST.length || estimatedSize || values.length || hasPendingActivity) {
     DEFINE_VISIT_CHILDREN = `
 template<typename Visitor>
@@ -1624,35 +1646,13 @@ visitor.reportExtraMemoryVisited(size);
 }`
         : ""
     }
-    thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
-}
-
-DEFINE_VISIT_CHILDREN(${name});
-
-
-
-template<typename Visitor>
-void ${name}::visitAdditionalChildrenInGCThread(Visitor& visitor)
-{
-  ${name}* thisObject = this;
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     ${values}
     ${DEFINE_VISIT_CHILDREN_LIST}
     ${obj.valuesArray ? "for (auto& value : thisObject->jsvalueArray) { visitor.append(value); }" : ""}
-    ${hasPendingActivity ? "visitor.addOpaqueRoot(this->wrapped());" : ""}
+    ${hasPendingActivity ? "visitor.addOpaqueRoot(thisObject->wrapped());" : ""}
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(${name});
-
-template<typename Visitor>
-void ${name}::visitOutputConstraintsImpl(JSCell *cell, Visitor& visitor)
-{
-    ${name}* thisObject = jsCast<${name}*>(cell);
-    ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
-}
-
-DEFINE_VISIT_OUTPUT_CONSTRAINTS(${name});
+DEFINE_VISIT_CHILDREN(${name});
 
 ${renderCallbacksCppImpl(typeName, callbacks)}
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1386,7 +1386,6 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
     values.length ||
     obj.estimatedSize ||
     Object.keys(callbacks).length ||
-    obj.hasPendingActivity ||
     [...Object.values(klass), ...Object.values(proto)].find(a => !!a.cache)
       ? "DECLARE_VISIT_CHILDREN;\n"
       : "";
@@ -1414,7 +1413,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
                   return true;
               }
 
-              return visitor.containsOpaqueRoot(context);
+              return false;
           }
           void finalize(JSC::Handle<JSC::Unknown>, void* context) final {}
       };
@@ -1624,13 +1623,17 @@ function generateClassImpl(typeName, obj: ClassDefinition) {
   //     and re-greys thisObject if it was already marked (Heap::addToRememberedSet pushes it
   //     back onto m_mutatorMarkStack so visitChildren runs again), or
   //   - jsvalueArray, a FixedVector<WriteBarrier<>> populated before allocateCell() and never
-  //     resized, or
-  //   - addOpaqueRoot(wrapped()), where wrapped() is m_ctx set once at construction.
+  //     resized.
   //
   // In all cases the write barrier (or immutability) guarantees correctness, so re-walking
   // every live instance of every generated type after each mutator yield is pure overhead.
   // Only visitChildren is needed.
-  if (DEFINE_VISIT_CHILDREN_LIST.length || estimatedSize || values.length || hasPendingActivity) {
+  //
+  // hasPendingActivity does not need visitChildren at all: liveness is decided by the
+  // WeakHandleOwner calling hasPendingActivity(wrapped()) directly during weak processing.
+  // The previous addOpaqueRoot(wrapped()) had no consumer (the Weak's context was nullptr,
+  // so containsOpaqueRoot(context) always checked for nullptr, never m_ctx).
+  if (DEFINE_VISIT_CHILDREN_LIST.length || estimatedSize || values.length) {
     DEFINE_VISIT_CHILDREN = `
 template<typename Visitor>
 void ${name}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
@@ -1649,7 +1652,6 @@ visitor.reportExtraMemoryVisited(size);
     ${values}
     ${DEFINE_VISIT_CHILDREN_LIST}
     ${obj.valuesArray ? "for (auto& value : thisObject->jsvalueArray) { visitor.append(value); }" : ""}
-    ${hasPendingActivity ? "visitor.addOpaqueRoot(thisObject->wrapped());" : ""}
 }
 
 DEFINE_VISIT_CHILDREN(${name});


### PR DESCRIPTION
## What

Stop emitting `visitOutputConstraints` (and the `visitAdditionalChildrenInGCThread` helper) for classes generated from `*.classes.ts`. Only `visitChildren` is emitted now.

## Why

`BunGCOutputConstraint` exists so JSC's incremental GC can re-scan an already-marked cell after the mutator runs, to pick up edges that were added **without firing a write barrier**. WebCore needs this because `EventTarget`'s listener list, `AbortSignal`'s algorithm vector, `MessagePort` entanglement, etc. live inside the wrapped `RefCounted` C++ object — mutating them doesn't go through `WriteBarrier::set`, so a black wrapper can gain a white edge with no barrier.

Generated classes don't have that problem. Every GC edge they expose is one of:

- a `WriteBarrier<Unknown>` field on the JSCell, mutated only via `.set(vm, thisObject, v)` (the `*SetCachedValue` extern and cached-getter fill paths). `WriteBarrier::set` → `vm.writeBarrier(owner)` → `Heap::addToRememberedSet` → owner re-greyed and pushed onto `m_mutatorMarkStack`, so `visitChildren` runs again. Same mechanism every core JSC type (`JSArray`, `JSPromise`, `JSFunction`, …) relies on — none of which override `visitOutputConstraints`.
- `jsvalueArray`: a `FixedVector<WriteBarrier<>>` populated before `allocateCell()` and never resized.
- `addOpaqueRoot(wrapped())` for `hasPendingActivity`: `wrapped()` is `m_ctx`, set once at construction.

Since no edge can be added without the barrier firing (or is immutable), re-scanning is pure overhead. Before this change, ~63 generated IsoSubspaces were enrolled in `m_outputConstraintSpaces`, so every mutator yield during incremental GC re-walked every live `Request`, `Response`, `Stats`, `Dirent`, `Timeout`, `Subprocess`, etc. to re-append already-barriered fields.

A comment in `generate-classes.ts` records the reasoning so this doesn't get cargo-culted back.

## What's unchanged

Hand-written and WebCore types that genuinely have non-barriered edges (`JSEventTarget`, `JSEventEmitter`, `JSAbortSignal`, `JSMessagePort`, `JSMessageChannel`, `JSCustomEvent`, `JSMessageEvent`, `JSErrorEvent`, `JSPerformanceObserver`, `JSBundlerPlugin`, `JSSQLStatement`, `JSMockFunction`, `ZigGlobalObject`) keep their output constraints.

## Test plan

- [ ] CI builds (codegen output compiles)
- [ ] Existing GC stress tests pass
- [ ] `BUN_JSC_useZombieMode=1` / heap verification on http bench shows no UAF