### PR TITLE
test: speed up 24 slow test files via concurrency and fewer spawns

### DIFF
--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -191,25 +191,6 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
-  test("rebuilding busts the directory entries cache", () => {
-    Bun.gc(true);
-    const tmpdir = tempDirWithFiles("rebuild-bust-dirent-cache", {
-      "package.json": `{}`,
-    });
-
-    const { exitCode, stderr } = Bun.spawnSync({
-      cmd: [bunExe(), join(import.meta.dir, "fixtures", "bundler-reloader-script.ts")],
-      env: { ...bunEnv, BUNDLER_RELOADER_SCRIPT_TMP_DIR: tmpdir },
-      stderr: "pipe",
-      stdout: "inherit",
-    });
-    if (stderr.byteLength > 0) {
-      throw new Error(stderr.toString());
-    }
-    expect(exitCode).toBe(0);
-    Bun.gc(true);
-  });
-
   test("outdir + reading out blobs works", async () => {
     Bun.gc(true);
     const fixture = tempDirWithFiles("build-outdir", {
@@ -376,7 +357,27 @@ describe("Bun.build", () => {
   //   throw new Error("test was not fully written");
   // });
 
-  test("errors are returned as an array", async () => {
+  test.concurrent("rebuilding busts the directory entries cache", async () => {
+    Bun.gc(true);
+    const tmpdir = tempDirWithFiles("rebuild-bust-dirent-cache", {
+      "package.json": `{}`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fixtures", "bundler-reloader-script.ts")],
+      env: { ...bunEnv, BUNDLER_RELOADER_SCRIPT_TMP_DIR: tmpdir },
+      stderr: "pipe",
+      stdout: "inherit",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    if (stderr.length > 0) {
+      throw new Error(stderr);
+    }
+    expect(exitCode).toBe(0);
+    Bun.gc(true);
+  });
+
+  test.concurrent("errors are returned as an array", async () => {
     const x = await buildNoThrow({
       entrypoints: [join(import.meta.dir, "does-not-exist.ts")],
       outdir: tempDirWithFiles("errors-are-returned-as-an-array", {}),
@@ -388,7 +389,7 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toEqual(null);
   });
 
-  test("warnings do not fail a build", async () => {
+  test.concurrent("warnings do not fail a build", async () => {
     const x = await Bun.build({
       entrypoints: [join(import.meta.dir, "./fixtures/jsx-warning/index.jsx")],
       outdir: tempDirWithFiles("warnings-do-not-fail-a-build", {}),
@@ -402,7 +403,7 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toBeTruthy();
   });
 
-  test("module() throws error", async () => {
+  test.concurrent("module() throws error", async () => {
     expect(() =>
       Bun.build({
         entrypoints: [join(import.meta.dir, "./fixtures/trivial/bundle-ws.ts")],
@@ -425,7 +426,7 @@ describe("Bun.build", () => {
     ).toThrow();
   });
 
-  test("non-object plugins throw invalid argument errors", () => {
+  test.concurrent("non-object plugins throw invalid argument errors", () => {
     for (const plugin of [null, undefined, 1, "hello", true, false, Symbol.for("hello")]) {
       expect(() => {
         Bun.build({
@@ -439,7 +440,7 @@ describe("Bun.build", () => {
     }
   });
 
-  test("hash considers cross chunk imports", async () => {
+  test.concurrent("hash considers cross chunk imports", async () => {
     Bun.gc(true);
     const fixture = tempDirWithFiles("build-hash-cross-chunk-imports", {
       "entry1.ts": `
@@ -503,7 +504,7 @@ describe("Bun.build", () => {
     Bun.gc(true);
   });
 
-  test("ignoreDCEAnnotations works", async () => {
+  test.concurrent("ignoreDCEAnnotations works", async () => {
     const fixture = tempDirWithFiles("build-ignore-dce-annotations", {
       "package.json": `{}`,
       "entry.ts": `
@@ -522,7 +523,7 @@ describe("Bun.build", () => {
     expect(await bundle.outputs[0].text()).toBe("console.log(1);\n");
   });
 
-  test("emitDCEAnnotations works", async () => {
+  test.concurrent("emitDCEAnnotations works", async () => {
     const fixture = tempDirWithFiles("build-emit-dce-annotations", {
       "package.json": `{}`,
       "entry.ts": `
@@ -541,9 +542,11 @@ describe("Bun.build", () => {
     expect(await bundle.outputs[0].text()).toBe("var o=/*@__PURE__*/console.log(1);export{o as OUT};\n");
   });
 
-  test("you can write onLoad and onResolve plugins using the 'html' loader, and it includes script and link tags as bundled entrypoints", async () => {
-    const fixture = tempDirWithFiles("build-html-plugins", {
-      "index.html": `
+  test.concurrent(
+    "you can write onLoad and onResolve plugins using the 'html' loader, and it includes script and link tags as bundled entrypoints",
+    async () => {
+      const fixture = tempDirWithFiles("build-html-plugins", {
+        "index.html": `
         <!DOCTYPE html>
         <html>
           <head>
@@ -552,69 +555,70 @@ describe("Bun.build", () => {
           </head>
         </html>
       `,
-      "style.css": ".foo { color: red; }",
+        "style.css": ".foo { color: red; }",
 
-      // Check we actually do bundle the script
-      "script.js": "console.log(1 + 2)",
-    });
+        // Check we actually do bundle the script
+        "script.js": "console.log(1 + 2)",
+      });
 
-    let onLoadCalled = false;
-    let onResolveCalled = false;
+      let onLoadCalled = false;
+      let onResolveCalled = false;
 
-    const build = await Bun.build({
-      entrypoints: [join(fixture, "index.html")],
-      minify: {
-        syntax: true,
-      },
-      plugins: [
-        {
-          name: "test-plugin",
-          setup(build) {
-            build.onLoad({ filter: /\.html$/ }, async args => {
-              onLoadCalled = true;
-              const contents = await Bun.file(args.path).text();
-              return {
-                contents: contents.replace("</head>", "<meta name='injected-by-plugin' content='true'></head>"),
-                loader: "html",
-              };
-            });
-
-            build.onResolve({ filter: /\.(js|css)$/ }, args => {
-              onResolveCalled = true;
-              return {
-                path: join(fixture, args.path),
-                namespace: "file",
-              };
-            });
-          },
+      const build = await Bun.build({
+        entrypoints: [join(fixture, "index.html")],
+        minify: {
+          syntax: true,
         },
-      ],
-    });
+        plugins: [
+          {
+            name: "test-plugin",
+            setup(build) {
+              build.onLoad({ filter: /\.html$/ }, async args => {
+                onLoadCalled = true;
+                const contents = await Bun.file(args.path).text();
+                return {
+                  contents: contents.replace("</head>", "<meta name='injected-by-plugin' content='true'></head>"),
+                  loader: "html",
+                };
+              });
 
-    expect(build.success).toBe(true);
-    expect(onLoadCalled).toBe(true);
-    expect(onResolveCalled).toBe(true);
+              build.onResolve({ filter: /\.(js|css)$/ }, args => {
+                onResolveCalled = true;
+                return {
+                  path: join(fixture, args.path),
+                  namespace: "file",
+                };
+              });
+            },
+          },
+        ],
+      });
 
-    // Should have 3 outputs - HTML, JS and CSS
-    expect(build.outputs).toHaveLength(3);
+      expect(build.success).toBe(true);
+      expect(onLoadCalled).toBe(true);
+      expect(onResolveCalled).toBe(true);
 
-    // Verify we have one of each type
-    const types = build.outputs.map(o => o.type);
-    expect(types).toContain("text/html;charset=utf-8");
-    expect(types).toContain("text/javascript;charset=utf-8");
-    expect(types).toContain("text/css;charset=utf-8");
+      // Should have 3 outputs - HTML, JS and CSS
+      expect(build.outputs).toHaveLength(3);
 
-    // Verify the JS output contains the __dirname
-    const js = build.outputs.find(o => o.type === "text/javascript;charset=utf-8");
-    expect(await js?.text()).toContain("console.log(3)");
+      // Verify we have one of each type
+      const types = build.outputs.map(o => o.type);
+      expect(types).toContain("text/html;charset=utf-8");
+      expect(types).toContain("text/javascript;charset=utf-8");
+      expect(types).toContain("text/css;charset=utf-8");
 
-    // Verify our plugin modified the HTML
-    const html = build.outputs.find(o => o.type === "text/html;charset=utf-8");
-    expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
-  });
+      // Verify the JS output contains the __dirname
+      const js = build.outputs.find(o => o.type === "text/javascript;charset=utf-8");
+      expect(await js?.text()).toContain("console.log(3)");
+
+      // Verify our plugin modified the HTML
+      const html = build.outputs.find(o => o.type === "text/html;charset=utf-8");
+      expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
+    },
+  );
 });
 
-test("macro with nested object", async () => {
+test.concurrent("macro with nested object", async () => {
   const dir = tempDirWithFilesAnon({
     "index.ts": `
 import { testMacro } from "./macro" assert { type: "macro" };
@@ -646,7 +650,7 @@ export function testMacro(val: any) {
 });
 
 // Since NODE_PATH has to be set, we need to run this test outside the bundler tests.
-test("regression/NODE_PATHBuild api", async () => {
+test.concurrent("regression/NODE_PATHBuild api", async () => {
   const dir = tempDirWithFiles("node-path-build", {
     "entry.js": `
       import MyClass from 'MyClass';
@@ -709,7 +713,7 @@ test("regression/NODE_PATHBuild api", async () => {
   expect(output.trim()).toBe("MyClass");
 });
 
-test("regression/GlobalThis", async () => {
+test.concurrent("regression/GlobalThis", async () => {
   const dir = tempDirWithFiles("global-this-regression", {
     "entry.js": `
       function identity(x) {
@@ -774,7 +778,7 @@ identity(mod23);
   expect(text).toContain(" globalThis.");
 });
 
-describe("sourcemap boolean values", () => {
+describe.concurrent("sourcemap boolean values", () => {
   test("sourcemap: true should work (boolean)", async () => {
     const dir = tempDirWithFiles("sourcemap-true-boolean", {
       "index.js": `console.log("hello");`,

--- a/test/bundler/bundler_html_server.test.ts
+++ b/test/bundler/bundler_html_server.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "bun:test";
 import { itBundled } from "./expectBundled";
 
-describe("bundler", () => {
+describe.concurrent("bundler", () => {
   for (const backend of ["api", "cli"] as const) {
     itBundled(`compile/${backend}/HTMLServerBasic`, {
       compile: true,

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -9,7 +9,7 @@ import { dedent, ESBUILD_PATH, itBundled } from "../expectBundled";
 
 // For debug, all files are written to $TEMP/bun-bundle-tests/default
 
-describe("bundler", () => {
+describe.concurrent("bundler", () => {
   itBundled("default/SimpleES6", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/es-decorators-esbuild.test.ts
+++ b/test/bundler/transpiler/es-decorators-esbuild.test.ts
@@ -5,9 +5,10 @@ import { join } from "path";
 
 // This test file programmatically runs esbuild's decorator test suite
 // (vendor/esbuild/scripts/decorator-tests.ts) against Bun's transpiler.
-// Each test is run as a standalone .ts file in a temp directory with
-// a tsconfig that does NOT have experimentalDecorators, so standard
-// decorators are used.
+// All tests are written into a single .ts file (each wrapped in its own
+// IIFE scope) in a temp directory with a tsconfig that does NOT have
+// experimentalDecorators, so standard decorators are used. A single Bun
+// subprocess transpiles and runs the file, reporting per-test results.
 
 const testBoilerplate = `
 // Polyfill Symbol.metadata (not natively available in JSC)
@@ -53,24 +54,6 @@ function filterStderr(stderr: string) {
     .filter(line => !line.startsWith("WARNING: ASAN"))
     .join("\n")
     .trim();
-}
-
-async function runDecoratorTest(code: string) {
-  using dir = tempDir("es-dec-esbuild", {
-    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-    "test.ts": testBoilerplate + "\n" + code,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
 // Read the esbuild decorator test source and extract individual tests
@@ -173,22 +156,101 @@ function shouldTodo(name: string): boolean {
   return todoPatterns.some(p => p.test(name));
 }
 
-describe("ES Decorators (esbuild test suite)", () => {
-  for (const entry of allTests) {
-    const { name, body, isAsync } = entry;
+// Build a single runner script that executes every test body in its own
+// IIFE scope (matching the original per-file isolation) and reports the
+// outcome of each on stdout. This lets us spawn one Bun process instead
+// of one per test while still surfacing per-test pass/fail.
+const PASS_MARKER = "ESDEC_PASS";
+const FAIL_MARKER = "ESDEC_FAIL";
 
-    const testCode = isAsync
-      ? `(async () => {${body}})().catch(e => { console.error(e); process.exit(1); });`
-      : `(() => {${body}})();`;
+function buildRunnerSource(): string {
+  let src = testBoilerplate + "\n";
+  src += `const __PASS = ${JSON.stringify(PASS_MARKER)};\n`;
+  src += `const __FAIL = ${JSON.stringify(FAIL_MARKER)};\n`;
+  src += `function __report(i, err) {\n`;
+  src += `  if (err === undefined) console.log(__PASS + i);\n`;
+  src += `  else console.log(__FAIL + i + __FAIL + (err && (err.stack || err.message) || String(err)).replace(/\\n/g, "\\\\n"));\n`;
+  src += `}\n`;
+  src += `async function __main() {\n`;
+  for (let i = 0; i < allTests.length; i++) {
+    const { name, body, isAsync } = allTests[i];
+    if (shouldTodo(name)) continue;
+    if (isAsync) {
+      src += `try { await (async () => {${body}})(); __report(${i}); } catch (e) { __report(${i}, e); }\n`;
+    } else {
+      src += `try { (() => {${body}})(); __report(${i}); } catch (e) { __report(${i}, e); }\n`;
+    }
+  }
+  src += `}\n__main().catch(e => { console.error(e); process.exit(1); });\n`;
+  return src;
+}
+
+interface RunResult {
+  ok: boolean;
+  error?: string;
+}
+
+async function runAllDecoratorTests(): Promise<{
+  results: Map<number, RunResult>;
+  stderr: string;
+  exitCode: number;
+  stdout: string;
+}> {
+  using dir = tempDir("es-dec-esbuild", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": buildRunnerSource(),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = filterStderr(rawStderr);
+
+  const results = new Map<number, RunResult>();
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith(PASS_MARKER)) {
+      const idx = Number(line.slice(PASS_MARKER.length));
+      results.set(idx, { ok: true });
+    } else if (line.startsWith(FAIL_MARKER)) {
+      const rest = line.slice(FAIL_MARKER.length);
+      const sep = rest.indexOf(FAIL_MARKER);
+      const idx = Number(rest.slice(0, sep));
+      const error = rest.slice(sep + FAIL_MARKER.length).replace(/\\n/g, "\n");
+      results.set(idx, { ok: false, error });
+    }
+  }
+
+  return { results, stderr, exitCode, stdout };
+}
+
+const runPromise = runAllDecoratorTests();
+
+describe("ES Decorators (esbuild test suite)", () => {
+  for (let i = 0; i < allTests.length; i++) {
+    const { name } = allTests[i];
 
     if (shouldTodo(name)) {
       test.todo(name);
     } else {
       test(name, async () => {
-        const { stdout, stderr, exitCode } = await runDecoratorTest(testCode);
-        if (exitCode !== 0) {
+        const { results, stderr, exitCode, stdout } = await runPromise;
+        const result = results.get(i);
+        if (!result) {
           throw new Error(
-            `Test "${name}" failed with exit code ${exitCode}\n` + `stdout: ${stdout}\n` + `stderr: ${stderr}`,
+            `Test "${name}" produced no result (runner exit code ${exitCode})\n` +
+              `stdout: ${stdout}\n` +
+              `stderr: ${stderr}`,
+          );
+        }
+        if (!result.ok) {
+          throw new Error(
+            `Test "${name}" failed with exit code ${exitCode}\n` + `stdout: ${result.error}\n` + `stderr: ${stderr}`,
           );
         }
       });

--- a/test/bundler/transpiler/es-decorators-esbuild.test.ts
+++ b/test/bundler/transpiler/es-decorators-esbuild.test.ts
@@ -5,10 +5,9 @@ import { join } from "path";
 
 // This test file programmatically runs esbuild's decorator test suite
 // (vendor/esbuild/scripts/decorator-tests.ts) against Bun's transpiler.
-// All tests are written into a single .ts file (each wrapped in its own
-// IIFE scope) in a temp directory with a tsconfig that does NOT have
-// experimentalDecorators, so standard decorators are used. A single Bun
-// subprocess transpiles and runs the file, reporting per-test results.
+// Each test is run as a standalone .ts file in a temp directory with
+// a tsconfig that does NOT have experimentalDecorators, so standard
+// decorators are used.
 
 const testBoilerplate = `
 // Polyfill Symbol.metadata (not natively available in JSC)
@@ -54,6 +53,24 @@ function filterStderr(stderr: string) {
     .filter(line => !line.startsWith("WARNING: ASAN"))
     .join("\n")
     .trim();
+}
+
+async function runDecoratorTest(code: string) {
+  using dir = tempDir("es-dec-esbuild", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+    "test.ts": testBoilerplate + "\n" + code,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr: filterStderr(rawStderr), exitCode };
 }
 
 // Read the esbuild decorator test source and extract individual tests
@@ -156,100 +173,23 @@ function shouldTodo(name: string): boolean {
   return todoPatterns.some(p => p.test(name));
 }
 
-// Build a single runner script that executes every test body in its own
-// IIFE scope (matching the original per-file isolation) and reports the
-// outcome of each on stdout. This lets us spawn one Bun process instead
-// of one per test while still surfacing per-test pass/fail.
-const PASS_MARKER = "ESDEC_PASS";
-const FAIL_MARKER = "ESDEC_FAIL";
-
-function buildRunnerSource(): string {
-  let src = testBoilerplate + "\n";
-  src += `const __PASS = ${JSON.stringify(PASS_MARKER)};\n`;
-  src += `const __FAIL = ${JSON.stringify(FAIL_MARKER)};\n`;
-  src += `function __report(i, err) {\n`;
-  src += `  if (err === undefined) console.log(__PASS + i);\n`;
-  src += `  else console.log(__FAIL + i + __FAIL + (err && (err.stack || err.message) || String(err)).replace(/\\n/g, "\\\\n"));\n`;
-  src += `}\n`;
-  src += `async function __main() {\n`;
-  for (let i = 0; i < allTests.length; i++) {
-    const { name, body, isAsync } = allTests[i];
-    if (shouldTodo(name)) continue;
-    if (isAsync) {
-      src += `try { await (async () => {${body}})(); __report(${i}); } catch (e) { __report(${i}, e); }\n`;
-    } else {
-      src += `try { (() => {${body}})(); __report(${i}); } catch (e) { __report(${i}, e); }\n`;
-    }
-  }
-  src += `}\n__main().catch(e => { console.error(e); process.exit(1); });\n`;
-  return src;
-}
-
-interface RunResult {
-  ok: boolean;
-  error?: string;
-}
-
-async function runAllDecoratorTests(): Promise<{
-  results: Map<number, RunResult>;
-  stderr: string;
-  exitCode: number;
-  stdout: string;
-}> {
-  using dir = tempDir("es-dec-esbuild", {
-    "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
-    "test.ts": buildRunnerSource(),
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const stderr = filterStderr(rawStderr);
-
-  const results = new Map<number, RunResult>();
-  for (const line of stdout.split("\n")) {
-    if (line.startsWith(PASS_MARKER)) {
-      const idx = Number(line.slice(PASS_MARKER.length));
-      results.set(idx, { ok: true });
-    } else if (line.startsWith(FAIL_MARKER)) {
-      const rest = line.slice(FAIL_MARKER.length);
-      const sep = rest.indexOf(FAIL_MARKER);
-      const idx = Number(rest.slice(0, sep));
-      const error = rest.slice(sep + FAIL_MARKER.length).replace(/\\n/g, "\n");
-      results.set(idx, { ok: false, error });
-    }
-  }
-
-  return { results, stderr, exitCode, stdout };
-}
-
-const runPromise = runAllDecoratorTests();
-
 describe("ES Decorators (esbuild test suite)", () => {
-  for (let i = 0; i < allTests.length; i++) {
-    const { name } = allTests[i];
+  for (const entry of allTests) {
+    const { name, body, isAsync } = entry;
+
+    const testCode = isAsync
+      ? `(async () => {${body}})().catch(e => { console.error(e); process.exit(1); });`
+      : `(() => {${body}})();`;
 
     if (shouldTodo(name)) {
       test.todo(name);
     } else {
-      test(name, async () => {
-        const { results, stderr, exitCode, stdout } = await runPromise;
-        const result = results.get(i);
-        if (!result) {
+      test.concurrent(name, async () => {
+        const { stdout, stderr, exitCode } = await runDecoratorTest(testCode);
+        if (exitCode !== 0) {
           throw new Error(
-            `Test "${name}" produced no result (runner exit code ${exitCode})\n` +
-              `stdout: ${stdout}\n` +
-              `stderr: ${stderr}`,
+            `Test "${name}" failed with exit code ${exitCode}\n` + `stdout: ${stdout}\n` + `stderr: ${stderr}`,
           );
-        }
-        if (!result.ok) {
-          throw new Error(`Test "${name}" failed\n` + `error: ${result.error}\n` + `stderr: ${stderr}`);
         }
       });
     }

--- a/test/bundler/transpiler/es-decorators-esbuild.test.ts
+++ b/test/bundler/transpiler/es-decorators-esbuild.test.ts
@@ -249,9 +249,7 @@ describe("ES Decorators (esbuild test suite)", () => {
           );
         }
         if (!result.ok) {
-          throw new Error(
-            `Test "${name}" failed with exit code ${exitCode}\n` + `stdout: ${result.error}\n` + `stderr: ${stderr}`,
-          );
+          throw new Error(`Test "${name}" failed\n` + `error: ${result.error}\n` + `stderr: ${stderr}`);
         }
       });
     }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -4,8 +4,8 @@ import { exists, mkdir, rm, writeFile } from "fs/promises";
 import {
   VerdaccioRegistry,
   assertManifestsPopulated,
-  bunExe,
   bunEnv as baseEnv,
+  bunExe,
   isLinux,
   isWindows,
   readdirSorted,

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1,11 +1,11 @@
 import { file, spawn, write } from "bun";
-import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { exists, mkdir, rm, writeFile } from "fs/promises";
 import {
   VerdaccioRegistry,
   assertManifestsPopulated,
   bunExe,
-  bunEnv as env,
+  bunEnv as baseEnv,
   isLinux,
   isWindows,
   readdirSorted,
@@ -15,8 +15,6 @@ import {
 import { join, sep } from "path";
 
 var verdaccio = new VerdaccioRegistry();
-var packageDir: string;
-var packageJson: string;
 
 beforeAll(async () => {
   setDefaultTimeout(1000 * 60 * 5);
@@ -31,16 +29,73 @@ function splitErrLines(err: string): string[] {
   return err.split(/\r?\n/).filter(s => !s.startsWith("WARNING: ASAN interferes"));
 }
 
-beforeEach(async () => {
-  ({ packageDir, packageJson } = await verdaccio.createTestDir({ bunfigOpts: { linker: "hoisted" } }));
-  env.BUN_INSTALL_CACHE_DIR = join(packageDir, ".bun-cache");
-  env.BUN_TMPDIR = env.TMPDIR = env.TEMP = join(packageDir, ".bun-tmp");
-});
+// Tests in this file each spawn `bun install` which itself spawns multiple lifecycle
+// script subprocesses. Running them all concurrently would fork-bomb the machine, so
+// gate concurrency with a small semaphore and give each test its own isolated dir/env.
+const MAX_CONCURRENT = 12;
+let activeSlots = 0;
+const slotWaiters: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+  if (activeSlots < MAX_CONCURRENT) {
+    activeSlots++;
+    return Promise.resolve();
+  }
+  return new Promise(resolve => slotWaiters.push(resolve));
+}
+
+function releaseSlot(): void {
+  const next = slotWaiters.shift();
+  if (next) {
+    next();
+  } else {
+    activeSlots--;
+  }
+}
+
+type TestCtx = {
+  packageDir: string;
+  packageJson: string;
+  env: Record<string, string>;
+  [Symbol.dispose](): void;
+};
+
+async function setupTest(): Promise<TestCtx> {
+  await acquireSlot();
+  let released = false;
+  try {
+    const { packageDir, packageJson } = await verdaccio.createTestDir({ bunfigOpts: { linker: "hoisted" } });
+    const env: Record<string, string> = {
+      ...baseEnv,
+      BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+      BUN_TMPDIR: join(packageDir, ".bun-tmp"),
+      TMPDIR: join(packageDir, ".bun-tmp"),
+      TEMP: join(packageDir, ".bun-tmp"),
+    };
+    return {
+      packageDir,
+      packageJson,
+      env,
+      [Symbol.dispose]() {
+        if (!released) {
+          released = true;
+          releaseSlot();
+        }
+      },
+    };
+  } catch (e) {
+    releaseSlot();
+    released = true;
+    throw e;
+  }
+}
 
 // waiter thread is only a thing on Linux.
 for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
-  describe("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {
+  describe.concurrent("lifecycle scripts" + (forceWaiterThread ? " (waiter thread)" : ""), async () => {
     test("root package with all lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
       const writeScript = async (name: string) => {
         const contents = `
@@ -224,6 +279,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("workspace lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -320,6 +377,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("dependency lifecycle scripts run before root lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       const script = '[[ -f "./node_modules/uses-what-bin-slow/what-bin.txt" ]]';
@@ -365,6 +424,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("install a dependency with lifecycle scripts, then add to trusted dependencies and install again", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -459,6 +520,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("adding a package without scripts to trustedDependencies", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -628,6 +691,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("lifecycle scripts run if node_modules is deleted", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -694,6 +759,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("INIT_CWD is set to the correct directory", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -756,6 +823,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("failing lifecycle script should print output", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -789,6 +858,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("failing root lifecycle script should print output correctly", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -820,6 +891,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("exit 0 in lifecycle scripts works", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -860,6 +933,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("--ignore-scripts should skip lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -900,6 +975,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("it should add `node-gyp rebuild` as the `install` script when `install` and `postinstall` don't exist and `binding.gyp` exists in the root of the package", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -942,6 +1019,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("automatic node-gyp scripts should not run for untrusted dependencies, and should run after adding to `trustedDependencies`", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       const packageJSON: any = {
@@ -1007,6 +1086,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("automatic node-gyp scripts work in package root", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1066,6 +1147,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("auto node-gyp scripts work when scripts exists other than `install` and `preinstall`", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1115,6 +1198,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
     for (const script of ["install", "preinstall"]) {
       test(`does not add auto node-gyp script when ${script} script exists`, async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         const packageJSON: any = {
@@ -1159,6 +1244,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     }
 
     test("git dependencies also run `preprepare`, `prepare`, and `postprepare` scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1245,6 +1332,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("root lifecycle scripts should wait for dependency lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1293,6 +1382,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     async function createPackagesWithScripts(
+      packageDir: string,
+      packageJson: string,
       packagesCount: number,
       scripts: Record<string, string>,
     ): Promise<string[]> {
@@ -1334,13 +1425,15 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     }
 
     test("reach max concurrent scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       const scripts = {
         "preinstall": `${bunExe()} -e 'Bun.sleepSync(500)'`,
       };
 
-      const dependenciesList = await createPackagesWithScripts(4, scripts);
+      const dependenciesList = await createPackagesWithScripts(packageDir, packageJson, 4, scripts);
 
       var { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--concurrent-scripts=2"],
@@ -1369,9 +1462,11 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("stress test", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-      const dependenciesList = await createPackagesWithScripts(500, {
+      const dependenciesList = await createPackagesWithScripts(packageDir, packageJson, 500, {
         "postinstall": `${bunExe()} --version`,
       });
 
@@ -1404,6 +1499,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("it should install and use correct binary version", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       // this should install `what-bin` in two places:
@@ -1538,6 +1635,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("node-gyp should always be available for lifecycle scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1573,6 +1672,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
     // if this test fails, `electron` might be removed from the default list
     test("default trusted dependencies should work", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1614,6 +1715,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("default trusted dependencies should not be used of trustedDependencies is populated", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1713,6 +1816,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("does not run any scripts if trustedDependencies is an empty list", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -1761,6 +1866,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("default trusted dependencies should only apply to npm packages, not file: dependencies", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       // Create a file: dependency named "esbuild" (which is in the default trusted dependencies list)
@@ -1822,6 +1929,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("file: dependency with default trusted name should run scripts when explicitly added to trustedDependencies", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       // Create a file: dependency named "esbuild" with a postinstall script that creates a marker file
@@ -1882,8 +1991,10 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("will run default trustedDependencies after install that didn't include them", async () => {
-      await verdaccio.writeBunfig(packageDir, { saveTextLockfile: false, linker: "hoisted" });
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+      await verdaccio.writeBunfig(packageDir, { saveTextLockfile: false, linker: "hoisted" });
 
       await writeFile(
         packageJson,
@@ -1968,6 +2079,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
     describe("--trust", async () => {
       test("unhoisted untrusted scripts, none at root node_modules", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         await Promise.all([
@@ -2083,11 +2196,13 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           },
         },
       ];
-      for (const { label, packageJson } of trustTests) {
+      for (const { label, packageJson: pkgJsonFixture } of trustTests) {
         test(label, async () => {
+          using ctx = await setupTest();
+          const { packageDir, env } = ctx;
           const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-          await writeFile(join(packageDir, "package.json"), JSON.stringify(packageJson));
+          await writeFile(join(packageDir, "package.json"), JSON.stringify(pkgJsonFixture));
 
           let { stdout, stderr, exited } = spawn({
             cmd: [bunExe(), "i", "--trust", "uses-what-bin@1.0.0"],
@@ -2147,6 +2262,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       }
       describe("packages without lifecycle scripts", async () => {
         test("initial install", async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
           const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
           await writeFile(
@@ -2188,6 +2305,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           });
         });
         test("already installed", async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
           const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
           await writeFile(
@@ -2270,6 +2389,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
     describe("updating trustedDependencies", async () => {
       test("existing trustedDependencies, unchanged trustedDependencies", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         await writeFile(
@@ -2343,6 +2464,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       });
 
       test("existing trustedDependencies, removing trustedDependencies", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         await writeFile(
@@ -2436,6 +2559,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       });
 
       test("non-existent trustedDependencies, then adding it", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         await writeFile(
@@ -2525,6 +2650,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("node -p should work in postinstall scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -2564,6 +2691,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("ensureTempNodeGypScript works", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -2601,6 +2730,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("bun pm trust and untrusted on missing package", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
@@ -2680,6 +2811,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       // for both cases, we need to update this test
       for (const withRm of [true, false]) {
         test(withRm ? "withRm" : "withoutRm", async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
           const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
           await verdaccio.writeBunfig(packageDir, { saveTextLockfile: false, linker: "hoisted" });
@@ -2862,6 +2995,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
     describe.if(!forceWaiterThread || process.platform === "linux")("does not use 100% cpu", async () => {
       test("install", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         await writeFile(
@@ -2892,6 +3027,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
       // https://github.com/oven-sh/bun/issues/11252
       test.todoIf(isWindows)("bun pm trust", async () => {
+        using ctx = await setupTest();
+        const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
         const dep = isWindows ? "uses-what-bin-slow-window" : "uses-what-bin-slow";
@@ -2936,8 +3073,10 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
   });
 
-  describe("stdout/stderr is inherited from root scripts during install", async () => {
+  describe.concurrent("stdout/stderr is inherited from root scripts during install", async () => {
     test("without packages", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       const exe = bunExe().replace(/\\/g, "\\\\");
@@ -2988,6 +3127,8 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
 
     test("with a package", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       const exe = bunExe().replace(/\\/g, "\\\\");
@@ -3045,7 +3186,9 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
   });
 }
 
-test("ignore-scripts is read from npmrc", async () => {
+test.concurrent("ignore-scripts is read from npmrc", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
   await Promise.all([
     write(
       packageJson,

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -1,24 +1,18 @@
 import { bunEnv, runBunInstall, tmpdirSync } from "harness";
 import { rm } from "node:fs/promises";
+import { join } from "node:path";
 import {
+  createTestContext,
+  destroyTestContext,
   dummyAfterAll,
-  dummyAfterEach,
   dummyBeforeAll,
-  dummyBeforeEach,
-  dummyRegistry,
-  package_dir,
-  read,
-  root_url,
-  setHandler,
-  write,
+  dummyRegistryForContext,
+  setContextHandler,
+  type TestContext,
 } from "./dummy.registry.js";
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
-beforeEach(async () => {
-  await dummyBeforeEach();
-});
-afterEach(dummyAfterEach);
 
 function test(
   name: string,
@@ -26,66 +20,81 @@ function test(
     testTimeout?: number;
     scanner: Bun.Security.Scanner["scan"] | string;
     fails?: boolean;
-    expect?: (std: { out: string; err: string }) => void | Promise<void>;
+    expect?: (std: { out: string; err: string; ctx: TestContext }) => void | Promise<void>;
     expectedExitCode?: number;
     bunfigScanner?: string | false;
     packages?: string[];
     scannerFile?: string;
     packageJson?: object;
-    customRegistry?: (urls: string[]) => any;
+    customRegistry?: (urls: string[], ctx: TestContext) => any;
+    concurrent?: boolean;
   },
 ) {
-  it(
+  const itFn = options.concurrent === false ? it : it.concurrent;
+  itFn(
     name,
     async () => {
-      const urls: string[] = [];
-      setHandler(options.customRegistry ? options.customRegistry(urls) : dummyRegistry(urls));
+      const ctx = await createTestContext();
+      try {
+        const urls: string[] = [];
+        setContextHandler(
+          ctx,
+          options.customRegistry ? options.customRegistry(urls, ctx) : dummyRegistryForContext(ctx, urls),
+        );
 
-      const scannerPath = options.scannerFile || "./scanner.ts";
-      if (typeof options.scanner === "string") {
-        await write(scannerPath, options.scanner);
-      } else {
-        const s = `export const scanner = {
+        const write = (path: string, content: string | object) =>
+          Bun.write(join(ctx.package_dir, path), typeof content === "string" ? content : JSON.stringify(content));
+
+        const scannerPath = options.scannerFile || "./scanner.ts";
+        if (typeof options.scanner === "string") {
+          await write(scannerPath, options.scanner);
+        } else {
+          const s = `export const scanner = {
   version: "1",
   scan: ${options.scanner.toString()},
 };`;
-        await write(scannerPath, s);
+          await write(scannerPath, s);
+        }
+
+        const bunfig = await Bun.file(join(ctx.package_dir, "bunfig.toml")).text();
+        if (options.bunfigScanner !== false) {
+          const scannerPath = options.bunfigScanner ?? "./scanner.ts";
+          await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "${scannerPath}"`);
+        }
+
+        await write(
+          "package.json",
+          options.packageJson ?? {
+            name: "my-app",
+            version: "1.0.0",
+            dependencies: {},
+          },
+        );
+
+        const expectedExitCode = options.expectedExitCode ?? (options.fails ? 1 : 0);
+        const packages = options.packages ?? ["bar"];
+
+        const { out, err } = await runBunInstall(bunEnv, ctx.package_dir, {
+          packages,
+          allowErrors: true,
+          allowWarnings: false,
+          savesLockfile: false,
+          expectedExitCode,
+        });
+
+        if (options.fails) {
+          expect(out).toContain("Installation aborted due to fatal security advisories");
+        }
+
+        await options.expect?.({ out, err, ctx });
+      } finally {
+        destroyTestContext(ctx);
       }
-
-      const bunfig = await read("./bunfig.toml").text();
-      if (options.bunfigScanner !== false) {
-        const scannerPath = options.bunfigScanner ?? "./scanner.ts";
-        await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "${scannerPath}"`);
-      }
-
-      await write(
-        "package.json",
-        options.packageJson ?? {
-          name: "my-app",
-          version: "1.0.0",
-          dependencies: {},
-        },
-      );
-
-      const expectedExitCode = options.expectedExitCode ?? (options.fails ? 1 : 0);
-      const packages = options.packages ?? ["bar"];
-
-      const { out, err } = await runBunInstall(bunEnv, package_dir, {
-        packages,
-        allowErrors: true,
-        allowWarnings: false,
-        savesLockfile: false,
-        expectedExitCode,
-      });
-
-      if (options.fails) {
-        expect(out).toContain("Installation aborted due to fatal security advisories");
-      }
-
-      await options.expect?.({ out, err });
     },
     {
-      timeout: options.testTimeout ?? 5_000,
+      // Default raised from 5_000 because tests now run concurrently; per-test
+      // wall time is higher under CPU contention even though total time drops.
+      timeout: options.testTimeout ?? 30_000,
     },
   );
 }
@@ -133,11 +142,11 @@ test("stdout contains all input package metadata", {
     console.log(JSON.stringify(packages));
     return [];
   },
-  expect: ({ out }) => {
+  expect: ({ out, ctx }) => {
     expect(out).toContain('\"version\":\"0.0.2\"');
     expect(out).toContain('\"name\":\"bar\"');
     expect(out).toContain('\"requestedRange\":\"^0.0.2\"');
-    expect(out).toContain(`\"tarball\":\"${root_url}/bar-0.0.2.tgz\"`);
+    expect(out).toContain(`\"tarball\":\"${ctx.registry_url}bar-0.0.2.tgz\"`);
   },
 });
 
@@ -703,10 +712,16 @@ describe("Large payload via ipc pipe", () => {
   beforeAll(async () => {
     tgzTempDir = tmpdirSync();
 
-    const barTarball = Bun.file(`${import.meta.dir}/bar-0.0.2.tgz`);
+    const barTarball = await Bun.file(`${import.meta.dir}/bar-0.0.2.tgz`).bytes();
+    const writes: Promise<number>[] = [];
     for (let i = 0; i < PKG_COUNT; i++) {
-      await Bun.write(`${tgzTempDir}/${pkgName(i)}-0.0.2.tgz`, barTarball);
+      writes.push(Bun.write(`${tgzTempDir}/${pkgName(i)}-0.0.2.tgz`, barTarball));
+      if (writes.length >= 256) {
+        await Promise.all(writes);
+        writes.length = 0;
+      }
     }
+    await Promise.all(writes);
   });
 
   afterAll(async () => {
@@ -743,7 +758,32 @@ describe("Large payload via ipc pipe", () => {
       };
     })(),
     packages: [],
-    customRegistry: urls => dummyRegistry(urls, { "0.0.2": {} }, 0, tgzTempDir),
+    concurrent: false,
+    customRegistry: (urls, ctx) => {
+      return async (request: Request) => {
+        urls.push(request.url);
+        const url = request.url.replaceAll("%2f", "/");
+        expect(request.method).toBe("GET");
+        if (url.endsWith(".tgz")) {
+          return new Response(Bun.file(join(tgzTempDir, url.slice(url.lastIndexOf("/") + 1).toLowerCase())));
+        }
+        expect(request.headers.get("accept")).toBe(
+          "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+        );
+        expect(request.headers.get("npm-auth-type")).toBe(null);
+        expect(await request.text()).toBe("");
+        const name = new URL(url).pathname.replace(`/${ctx.id}/`, "");
+        return new Response(
+          JSON.stringify({
+            name,
+            versions: {
+              "0.0.2": { name, version: "0.0.2", dist: { tarball: `${ctx.registry_url}${name}-0.0.2.tgz` } },
+            },
+            "dist-tags": { latest: "0.0.2" },
+          }),
+        );
+      };
+    },
     expectedExitCode: 0,
     expect: ({ out }) => {
       expect(out).toContain("Received JSON payload");

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -1,320 +1,342 @@
 import { file, spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
+import { afterAll, beforeAll, expect, it } from "bun:test";
 import { mkdir, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, tmpdirSync } from "harness";
 import { join, relative } from "path";
-import { dummyAfterAll, dummyAfterEach, dummyBeforeAll, dummyBeforeEach, package_dir } from "./dummy.registry";
+import { createTestContext, destroyTestContext, dummyAfterAll, dummyBeforeAll } from "./dummy.registry";
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
 
-let remove_dir: string;
+it.concurrent("should remove existing package", async () => {
+  const ctx = await createTestContext();
+  try {
+    const package_dir = ctx.package_dir;
+    const remove_dir = tmpdirSync();
+    const pkg1_dir = join(remove_dir, "pkg1");
+    const pkg1_path = relative(package_dir, pkg1_dir);
+    await mkdir(pkg1_dir);
+    const pkg2_dir = join(remove_dir, "pkg2");
+    const pkg2_path = relative(package_dir, pkg2_dir);
+    await mkdir(pkg2_dir);
 
-beforeEach(async () => {
-  remove_dir = tmpdirSync();
-  await dummyBeforeEach();
-});
-
-afterEach(async () => {
-  await dummyAfterEach();
-});
-
-it("should remove existing package", async () => {
-  const pkg1_dir = join(remove_dir, "pkg1");
-  const pkg1_path = relative(package_dir, pkg1_dir);
-  await mkdir(pkg1_dir);
-  const pkg2_dir = join(remove_dir, "pkg2");
-  const pkg2_path = relative(package_dir, pkg2_dir);
-  await mkdir(pkg2_dir);
-
-  await writeFile(
-    join(pkg1_dir, "package.json"),
-    JSON.stringify({
-      name: "pkg1",
-      version: "0.0.1",
-    }),
-  );
-  await writeFile(
-    join(pkg2_dir, "package.json"),
-    JSON.stringify({
-      name: "pkg2",
-      version: "0.0.1",
-    }),
-  );
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.2",
-    }),
-  );
-  const { exited: exited1 } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg1_path}`.replace(/\\/g, "\\\\")],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await exited1).toBe(0);
-  const { exited: exited2 } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg2_path}`.replace(/\\/g, "\\\\")],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await exited2).toBe(0);
-  expect(await file(join(package_dir, "package.json")).text()).toEqual(
-    JSON.stringify(
-      {
+    await writeFile(
+      join(pkg1_dir, "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "0.0.1",
+      }),
+    );
+    await writeFile(
+      join(pkg2_dir, "package.json"),
+      JSON.stringify({
+        name: "pkg2",
+        version: "0.0.1",
+      }),
+    );
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
         name: "foo",
         version: "0.0.2",
-        dependencies: {
-          pkg1: `file:${pkg1_path.replace(/\\/g, "/")}`,
-          pkg2: `file:${pkg2_path.replace(/\\/g, "/")}`,
+      }),
+    );
+    const { exited: exited1 } = spawn({
+      cmd: [bunExe(), "add", `file:${pkg1_path}`.replace(/\\/g, "\\\\")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited1).toBe(0);
+    const { exited: exited2 } = spawn({
+      cmd: [bunExe(), "add", `file:${pkg2_path}`.replace(/\\/g, "\\\\")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited2).toBe(0);
+    expect(await file(join(package_dir, "package.json")).text()).toEqual(
+      JSON.stringify(
+        {
+          name: "foo",
+          version: "0.0.2",
+          dependencies: {
+            pkg1: `file:${pkg1_path.replace(/\\/g, "/")}`,
+            pkg2: `file:${pkg2_path.replace(/\\/g, "/")}`,
+          },
         },
-      },
-      null,
-      2,
-    ),
-  );
+        null,
+        2,
+      ),
+    );
 
-  const {
-    exited: removeExited1,
-    stdout: stdout1,
-    stderr: stderr1,
-  } = spawn({
-    cmd: [bunExe(), "remove", "pkg1"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await removeExited1).toBe(0);
-  const out1 = await new Response(stdout1).text();
-  const err1 = await new Response(stderr1).text();
+    const {
+      exited: removeExited1,
+      stdout: stdout1,
+      stderr: stderr1,
+    } = spawn({
+      cmd: [bunExe(), "remove", "pkg1"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await removeExited1).toBe(0);
+    const out1 = await new Response(stdout1).text();
+    const err1 = await new Response(stderr1).text();
 
-  expect(out1.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
-    expect.stringContaining("bun remove v1."),
-    "",
-    `+ pkg2@${pkg2_path.replace(/\\/g, "/")}`,
-    "",
-    "1 package installed",
-    "Removed: 1",
-    "",
-  ]);
-  expect(err1.split(/\r?\n/)).toEqual(["Saved lockfile", ""]);
-  expect(await file(join(package_dir, "package.json")).text()).toEqual(
-    JSON.stringify(
-      {
-        name: "foo",
-        version: "0.0.2",
-        dependencies: {
-          pkg2: `file:${pkg2_path.replace(/\\/g, "/")}`,
+    expect(out1.replace(/\s*\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun remove v1."),
+      "",
+      `+ pkg2@${pkg2_path.replace(/\\/g, "/")}`,
+      "",
+      "1 package installed",
+      "Removed: 1",
+      "",
+    ]);
+    expect(err1.split(/\r?\n/)).toEqual(["Saved lockfile", ""]);
+    expect(await file(join(package_dir, "package.json")).text()).toEqual(
+      JSON.stringify(
+        {
+          name: "foo",
+          version: "0.0.2",
+          dependencies: {
+            pkg2: `file:${pkg2_path.replace(/\\/g, "/")}`,
+          },
         },
-      },
-      null,
-      2,
-    ),
-  );
+        null,
+        2,
+      ),
+    );
 
-  const {
-    exited: removeExited2,
-    stdout: stdout2,
-    stderr: stderr2,
-  } = spawn({
-    cmd: [bunExe(), "remove", "pkg2"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await removeExited2).toBe(0);
-  const out2 = await new Response(stdout2).text();
-  const err2 = await new Response(stderr2).text();
+    const {
+      exited: removeExited2,
+      stdout: stdout2,
+      stderr: stderr2,
+    } = spawn({
+      cmd: [bunExe(), "remove", "pkg2"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await removeExited2).toBe(0);
+    const out2 = await new Response(stdout2).text();
+    const err2 = await new Response(stderr2).text();
 
-  expect(out2.replace(/ \[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
-    expect.stringContaining("bun remove v1."),
-    "",
-    "- pkg2",
-    "1 package removed",
-    "",
-  ]);
-  expect(err2.split(/\r?\n/)).toEqual(["", "package.json has no dependencies! Deleted empty lockfile", ""]);
-  expect(await file(join(package_dir, "package.json")).text()).toEqual(
-    JSON.stringify(
-      {
-        name: "foo",
-        version: "0.0.2",
-      },
-      null,
-      2,
-    ),
-  );
+    expect(out2.replace(/ \[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun remove v1."),
+      "",
+      "- pkg2",
+      "1 package removed",
+      "",
+    ]);
+    expect(err2.split(/\r?\n/)).toEqual(["", "package.json has no dependencies! Deleted empty lockfile", ""]);
+    expect(await file(join(package_dir, "package.json")).text()).toEqual(
+      JSON.stringify(
+        {
+          name: "foo",
+          version: "0.0.2",
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    destroyTestContext(ctx);
+  }
 });
 
-it("should not reject missing package", async () => {
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-    }),
-  );
-  await writeFile(
-    join(remove_dir, "package.json"),
-    JSON.stringify({
-      name: "pkg1",
-      version: "0.0.2",
-    }),
-  );
-  const pkg_path = relative(package_dir, remove_dir);
-  const { exited: addExited } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await addExited).toBe(0);
-
-  const { exited: rmExited } = spawn({
-    cmd: [bunExe(), "remove", "pkg2"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await rmExited).toBe(0);
-});
-
-it("should not affect if package is not installed", async () => {
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-    }),
-  );
-
-  const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "remove", "pkg"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await exited).toBe(0);
-  const out = await stdout.text();
-  expect(out.split("\n")).toEqual([expect.stringContaining("bun remove v1."), ""]);
-  const err = await stderr.text();
-  expect(err.replace(/ \[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
-    "package.json doesn't have dependencies, there's nothing to remove!",
-    "",
-  ]);
-});
-
-it("should retain a new line in the end of package.json", async () => {
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
-      name: "foo",
-      version: "0.0.1",
-    }),
-  );
-  await writeFile(
-    join(remove_dir, "package.json"),
-    JSON.stringify({
-      name: "pkg",
-      version: "0.0.2",
-    }),
-  );
-  const pkg_path = relative(package_dir, remove_dir);
-  const { exited: addExited } = spawn({
-    cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await addExited).toBe(0);
-  const content_before_remove = await file(join(package_dir, "package.json")).text();
-  expect(content_before_remove.endsWith("}")).toBe(true);
-  expect(content_before_remove).toEqual(
-    JSON.stringify(
-      {
+it.concurrent("should not reject missing package", async () => {
+  const ctx = await createTestContext();
+  try {
+    const package_dir = ctx.package_dir;
+    const remove_dir = tmpdirSync();
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
         name: "foo",
         version: "0.0.1",
-        dependencies: {
-          pkg: `file:${pkg_path.replace(/\\/g, "/")}`,
-        },
-      },
-      null,
-      2,
-    ),
-  );
-  await writeFile(join(package_dir, "package.json"), content_before_remove + "\n");
+      }),
+    );
+    await writeFile(
+      join(remove_dir, "package.json"),
+      JSON.stringify({
+        name: "pkg1",
+        version: "0.0.2",
+      }),
+    );
+    const pkg_path = relative(package_dir, remove_dir);
+    const { exited: addExited } = spawn({
+      cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await addExited).toBe(0);
 
-  const { exited } = spawn({
-    cmd: [bunExe(), "remove", "pkg"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  expect(await exited).toBe(0);
-  const content_after_remove = await file(join(package_dir, "package.json")).text();
-  expect(content_after_remove.endsWith("}\n")).toBe(true);
-  expect(content_after_remove).toEqual(
-    JSON.stringify(
-      {
-        name: "foo",
-        version: "0.0.1",
-      },
-      null,
-      2,
-    ) + "\n",
-  );
+    const { exited: rmExited } = spawn({
+      cmd: [bunExe(), "remove", "pkg2"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await rmExited).toBe(0);
+  } finally {
+    destroyTestContext(ctx);
+  }
 });
 
-it("should remove peerDependencies", async () => {
-  await writeFile(
-    join(package_dir, "package.json"),
-    JSON.stringify({
+it.concurrent("should not affect if package is not installed", async () => {
+  const ctx = await createTestContext();
+  try {
+    const package_dir = ctx.package_dir;
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "remove", "pkg"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited).toBe(0);
+    const out = await stdout.text();
+    expect(out.split("\n")).toEqual([expect.stringContaining("bun remove v1."), ""]);
+    const err = await stderr.text();
+    expect(err.replace(/ \[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
+      "package.json doesn't have dependencies, there's nothing to remove!",
+      "",
+    ]);
+  } finally {
+    destroyTestContext(ctx);
+  }
+});
+
+it.concurrent("should retain a new line in the end of package.json", async () => {
+  const ctx = await createTestContext();
+  try {
+    const package_dir = ctx.package_dir;
+    const remove_dir = tmpdirSync();
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        version: "0.0.1",
+      }),
+    );
+    await writeFile(
+      join(remove_dir, "package.json"),
+      JSON.stringify({
+        name: "pkg",
+        version: "0.0.2",
+      }),
+    );
+    const pkg_path = relative(package_dir, remove_dir);
+    const { exited: addExited } = spawn({
+      cmd: [bunExe(), "add", `file:${pkg_path}`.replace(/\\/g, "\\\\")],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await addExited).toBe(0);
+    const content_before_remove = await file(join(package_dir, "package.json")).text();
+    expect(content_before_remove.endsWith("}")).toBe(true);
+    expect(content_before_remove).toEqual(
+      JSON.stringify(
+        {
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            pkg: `file:${pkg_path.replace(/\\/g, "/")}`,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFile(join(package_dir, "package.json"), content_before_remove + "\n");
+
+    const { exited } = spawn({
+      cmd: [bunExe(), "remove", "pkg"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await exited).toBe(0);
+    const content_after_remove = await file(join(package_dir, "package.json")).text();
+    expect(content_after_remove.endsWith("}\n")).toBe(true);
+    expect(content_after_remove).toEqual(
+      JSON.stringify(
+        {
+          name: "foo",
+          version: "0.0.1",
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  } finally {
+    destroyTestContext(ctx);
+  }
+});
+
+it.concurrent("should remove peerDependencies", async () => {
+  const ctx = await createTestContext();
+  try {
+    const package_dir = ctx.package_dir;
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        peerDependencies: {
+          bar: "~0.0.1",
+        },
+      }),
+    );
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "remove", "bar"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    const out = await stdout.text();
+    expect(out.replace(/\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
+      expect.stringContaining("bun remove v1."),
+      "",
+      " done",
+      "",
+    ]);
+    expect(await exited).toBe(0);
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
       name: "foo",
-      peerDependencies: {
-        bar: "~0.0.1",
-      },
-    }),
-  );
-  const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "remove", "bar"],
-    cwd: package_dir,
-    stdout: "pipe",
-    stdin: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  const err = await stderr.text();
-  expect(err).not.toContain("error:");
-  const out = await stdout.text();
-  expect(out.replace(/\[[0-9\.]+m?s\]/, "").split(/\r?\n/)).toEqual([
-    expect.stringContaining("bun remove v1."),
-    "",
-    " done",
-    "",
-  ]);
-  expect(await exited).toBe(0);
-  expect(await file(join(package_dir, "package.json")).json()).toEqual({
-    name: "foo",
-  });
+    });
+  } finally {
+    destroyTestContext(ctx);
+  }
 });

--- a/test/cli/install/bun-security-scanner-workspaces.test.ts
+++ b/test/cli/install/bun-security-scanner-workspaces.test.ts
@@ -1,19 +1,25 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 import { getRegistry, startRegistry, stopRegistry } from "./simple-dummy-registry";
 
-test("security scanner receives packages from workspace dependencies", async () => {
-  const registryUrl = await startRegistry(false);
+let registryUrl: string;
 
-  try {
-    const registry = getRegistry();
-    if (!registry) {
-      throw new Error("Registry not found");
-    }
+beforeAll(async () => {
+  registryUrl = await startRegistry(false);
+  const registry = getRegistry();
+  if (!registry) {
+    throw new Error("Registry not found");
+  }
+  registry.setScannerBehavior("none");
+});
 
-    registry.clearRequestLog();
-    registry.setScannerBehavior("none");
+afterAll(() => {
+  stopRegistry();
+});
 
+describe.concurrent("security scanner workspaces", () => {
+  test("security scanner receives packages from workspace dependencies", async () => {
     // Create a workspace setup with root package and multiple workspace packages
     const files = {
       "package.json": JSON.stringify(
@@ -76,7 +82,7 @@ registry = "${registryUrl}/"
 scanner = "./scanner.js"`,
     );
 
-    const { stdout, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: dir,
       stdout: "pipe",
@@ -84,7 +90,8 @@ scanner = "./scanner.js"`,
       env: bunEnv,
     });
 
-    const output = (await stdout.text()) + (await stderr.text());
+    const [stdoutText, stderrText] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdoutText + stderrText;
 
     // The scanner should receive packages from all workspace dependencies
     expect(output).toContain("SCANNER_RAN:");
@@ -96,23 +103,9 @@ scanner = "./scanner.js"`,
     const packagesScanned = parseInt(match![1], 10);
     // Exact package count: left-pad, is-even, is-odd (is-even <-> is-odd have circular deps)
     expect(packagesScanned).toBe(3);
-  } finally {
-    stopRegistry();
-  }
-});
+  });
 
-test("security scanner receives packages from workspace dependencies with hoisted linker", async () => {
-  const registryUrl = await startRegistry(false);
-
-  try {
-    const registry = getRegistry();
-    if (!registry) {
-      throw new Error("Registry not found");
-    }
-
-    registry.clearRequestLog();
-    registry.setScannerBehavior("none");
-
+  test("security scanner receives packages from workspace dependencies with hoisted linker", async () => {
     const files = {
       "package.json": JSON.stringify(
         {
@@ -165,7 +158,7 @@ registry = "${registryUrl}/"
 scanner = "./scanner.js"`,
     );
 
-    const { stdout, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: dir,
       stdout: "pipe",
@@ -173,7 +166,8 @@ scanner = "./scanner.js"`,
       env: bunEnv,
     });
 
-    const output = (await stdout.text()) + (await stderr.text());
+    const [stdoutText, stderrText] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdoutText + stderrText;
 
     expect(output).toContain("SCANNER_RAN:");
 
@@ -183,23 +177,9 @@ scanner = "./scanner.js"`,
     const packagesScanned = parseInt(match![1], 10);
     // Exact package count: left-pad, is-even, is-odd (is-even <-> is-odd have circular deps)
     expect(packagesScanned).toBe(3);
-  } finally {
-    stopRegistry();
-  }
-});
+  });
 
-test("security scanner receives packages from workspace dependencies with isolated linker", async () => {
-  const registryUrl = await startRegistry(false);
-
-  try {
-    const registry = getRegistry();
-    if (!registry) {
-      throw new Error("Registry not found");
-    }
-
-    registry.clearRequestLog();
-    registry.setScannerBehavior("none");
-
+  test("security scanner receives packages from workspace dependencies with isolated linker", async () => {
     const files = {
       "package.json": JSON.stringify(
         {
@@ -252,7 +232,7 @@ registry = "${registryUrl}/"
 scanner = "./scanner.js"`,
     );
 
-    const { stdout, stderr } = Bun.spawn({
+    await using proc = Bun.spawn({
       cmd: [bunExe(), "install"],
       cwd: dir,
       stdout: "pipe",
@@ -260,7 +240,8 @@ scanner = "./scanner.js"`,
       env: bunEnv,
     });
 
-    const output = (await stdout.text()) + (await stderr.text());
+    const [stdoutText, stderrText] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdoutText + stderrText;
 
     expect(output).toContain("SCANNER_RAN:");
 
@@ -270,7 +251,5 @@ scanner = "./scanner.js"`,
     const packagesScanned = parseInt(match![1], 10);
     // Exact package count: left-pad, is-even, is-odd (is-even <-> is-odd have circular deps)
     expect(packagesScanned).toBe(3);
-  } finally {
-    stopRegistry();
-  }
+  });
 });

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -13,10 +13,8 @@ beforeAll(() => {
 describe.concurrent(() => {
   it("two invalid arguments, should display error message and suggest command", async () => {
     const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
     const { stderr } = spawn({
-      cmd: [execPath, "upgrade", "bun-types", "--dev"],
+      cmd: [bunExe(), "upgrade", "bun-types", "--dev"],
       cwd,
       stdout: null,
       stdin: "pipe",
@@ -31,10 +29,8 @@ describe.concurrent(() => {
 
   it("two invalid arguments flipped, should display error message and suggest command", async () => {
     const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
     const { stderr } = spawn({
-      cmd: [execPath, "upgrade", "--dev", "bun-types"],
+      cmd: [bunExe(), "upgrade", "--dev", "bun-types"],
       cwd,
       stdout: null,
       stdin: "pipe",
@@ -49,10 +45,8 @@ describe.concurrent(() => {
 
   it("one invalid argument, should display error message and suggest command", async () => {
     const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
     const { stderr } = spawn({
-      cmd: [execPath, "upgrade", "bun-types"],
+      cmd: [bunExe(), "upgrade", "bun-types"],
       cwd,
       stdout: null,
       stdin: "pipe",
@@ -67,10 +61,8 @@ describe.concurrent(() => {
 
   it("one valid argument, should succeed", async () => {
     const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
     const { stderr } = spawn({
-      cmd: [execPath, "upgrade", "--help"],
+      cmd: [bunExe(), "upgrade", "--help"],
       cwd,
       stdout: null,
       stdin: "pipe",

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -7,45 +7,48 @@ import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
 
+setDefaultTimeout(1000 * 60 * 5);
+
 let x_dir: string;
-let current_tmpdir: string;
-let install_cache_dir: string;
-let env = { ...bunEnv };
+let env: Record<string, string> = { ...bunEnv };
 
-beforeAll(() => {
-  setDefaultTimeout(1000 * 60 * 5);
-});
+// Each test that hits the network gets its own isolated tmpdir + install cache
+// so the network-heavy tests can run concurrently without sharing bunx cache state.
+function setup() {
+  const install_cache_dir = tmpdirSync();
+  const current_tmpdir = tmpdirSync();
+  const x_dir = tmpdirSync();
+  return {
+    x_dir,
+    env: {
+      ...bunEnv,
+      TEMP: current_tmpdir,
+      BUN_TMPDIR: current_tmpdir,
+      TMPDIR: current_tmpdir,
+      BUN_INSTALL_CACHE_DIR: install_cache_dir,
+    } as Record<string, string>,
+  };
+}
 
-beforeEach(async () => {
-  const waiting: Promise<void>[] = [];
-  if (current_tmpdir) {
-    waiting.push(rm(current_tmpdir, { recursive: true, force: true }));
-  }
-
-  if (install_cache_dir) {
-    waiting.push(rm(install_cache_dir, { recursive: true, force: true }));
-  }
-
+beforeAll(async () => {
+  // Clean stale bunx cache dirs from previous runs once up front instead of before every test.
   const tmp = isWindows ? tmpdir() : "/tmp";
+  const waiting: Promise<void>[] = [];
   readdirSync(tmp).forEach(file => {
     if (file.startsWith("bunx-") || file.startsWith("bun-x.test")) {
       waiting.push(rm(join(tmp, file), { recursive: true, force: true }));
     }
   });
-
-  install_cache_dir = tmpdirSync();
-  current_tmpdir = tmpdirSync();
-  x_dir = tmpdirSync();
-
-  env.TEMP = current_tmpdir;
-  env.BUN_TMPDIR = env.TMPDIR = current_tmpdir;
-  env.TMPDIR = current_tmpdir;
-  env.BUN_INSTALL_CACHE_DIR = install_cache_dir;
-
   await Promise.all(waiting);
 });
 
-it("should choose the tagged versions instead of the PATH versions when a tag is specified", async () => {
+beforeEach(() => {
+  // Sequential tests (the mock-registry suites below) still read these module-level vars.
+  ({ x_dir, env } = setup());
+});
+
+it.concurrent("should choose the tagged versions instead of the PATH versions when a tag is specified", async () => {
+  const { x_dir, env } = setup();
   let semverVersions = [
     "7.0.0",
     "7.1.0",
@@ -101,7 +104,8 @@ it("should choose the tagged versions instead of the PATH versions when a tag is
   expect(outputs).toEqual(semverVersions.map(v => "SemVer " + v));
 });
 
-it("should install and run default (latest) version", async () => {
+it.concurrent("should install and run default (latest) version", async () => {
+  const { x_dir, env } = setup();
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "x", "uglify-js", "--compress"],
     cwd: x_dir,
@@ -117,7 +121,8 @@ it("should install and run default (latest) version", async () => {
   expect(await exited).toBe(0);
 });
 
-it("should install and run specified version", async () => {
+it.concurrent("should install and run specified version", async () => {
+  const { x_dir, env } = setup();
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "x", "uglify-js@3.14.1", "-v"],
     cwd: x_dir,
@@ -133,7 +138,8 @@ it("should install and run specified version", async () => {
   expect(await exited).toBe(0);
 });
 
-it("should output usage if no arguments are passed", async () => {
+it.concurrent("should output usage if no arguments are passed", async () => {
+  const { x_dir, env } = setup();
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "x"],
     cwd: x_dir,
@@ -151,7 +157,8 @@ it("should output usage if no arguments are passed", async () => {
   expect(await exited).toBe(1);
 });
 
-it("should work for @scoped packages", async () => {
+it.concurrent("should work for @scoped packages", async () => {
+  const { x_dir, env } = setup();
   let exited: number, err: string, out: string;
   // without cache
   const withoutCache = spawn({
@@ -192,7 +199,8 @@ it("should work for @scoped packages", async () => {
   expect(out.trim()).toContain("Usage: babel [options]");
 });
 
-it("should execute from current working directory", async () => {
+it.concurrent("should execute from current working directory", async () => {
+  const { x_dir, env } = setup();
   await writeFile(
     join(x_dir, "test.js"),
     `
@@ -217,7 +225,8 @@ console.log(
   expect(exitCode).toBe(0);
 });
 
-it("should work for github repository", async () => {
+it.concurrent("should work for github repository", async () => {
+  const { x_dir, env } = setup();
   // without cache
   const withoutCache = spawn({
     cmd: [bunExe(), "x", "github:piuccio/cowsay", "--help"],
@@ -259,7 +268,8 @@ it("should work for github repository", async () => {
   expect(exited).toBe(0);
 });
 
-it("should work for github repository with committish", async () => {
+it.concurrent("should work for github repository with committish", async () => {
+  const { x_dir, env } = setup();
   const withoutCache = spawn({
     cmd: [bunExe(), "x", "github:piuccio/cowsay#HEAD", "hello bun!"],
     cwd: x_dir,
@@ -300,7 +310,8 @@ it("should work for github repository with committish", async () => {
   expect(exited).toBe(0);
 });
 
-it.each(["--version", "-v"])("should print the version using %s and exit", async flag => {
+it.concurrent.each(["--version", "-v"])("should print the version using %s and exit", async flag => {
+  const { x_dir, env } = setup();
   const subprocess = spawn({
     cmd: [bunExe(), "x", flag],
     cwd: x_dir,
@@ -317,7 +328,8 @@ it.each(["--version", "-v"])("should print the version using %s and exit", async
   expect(exited).toBe(0);
 });
 
-it("should print the revision and exit", async () => {
+it.concurrent("should print the revision and exit", async () => {
+  const { x_dir, env } = setup();
   const subprocess = spawn({
     cmd: [bunExe(), "x", "--revision"],
     cwd: x_dir,
@@ -335,7 +347,8 @@ it("should print the revision and exit", async () => {
   expect(exited).toBe(0);
 });
 
-it("should pass --version to the package if specified", async () => {
+it.concurrent("should pass --version to the package if specified", async () => {
+  const { x_dir, env } = setup();
   const subprocess = spawn({
     cmd: [bunExe(), "x", "esbuild", "--version"],
     cwd: x_dir,
@@ -352,7 +365,8 @@ it("should pass --version to the package if specified", async () => {
   expect(exited).toBe(0);
 });
 
-it('should set "npm_config_user_agent" to bun', async () => {
+it.concurrent('should set "npm_config_user_agent" to bun', async () => {
+  const { x_dir, env } = setup();
   await writeFile(
     join(x_dir, "package.json"),
     JSON.stringify({
@@ -365,6 +379,7 @@ it('should set "npm_config_user_agent" to bun', async () => {
   const { exited: installFinished } = spawn({
     cmd: [bunExe(), "install"],
     cwd: x_dir,
+    env,
   });
   expect(await installFinished).toBe(0);
 
@@ -373,6 +388,7 @@ it('should set "npm_config_user_agent" to bun', async () => {
     cwd: x_dir,
     stdout: "pipe",
     stderr: "pipe",
+    env,
   });
 
   const [err, out, exited] = await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
@@ -387,11 +403,14 @@ it('should set "npm_config_user_agent" to bun', async () => {
  * Please only use packages with small unpacked sizes for tests. It helps keep them fast.
  */
 describe("bunx --no-install", () => {
-  const run = (...args: string[]): Promise<[stderr: string, stdout: string, exitCode: number]> => {
+  const run = (
+    ctx: { x_dir: string; env: Record<string, string> },
+    ...args: string[]
+  ): Promise<[stderr: string, stdout: string, exitCode: number]> => {
     const subprocess = spawn({
       cmd: [bunExe(), "x", ...args],
-      cwd: x_dir,
-      env: bunEnv,
+      cwd: ctx.x_dir,
+      env: ctx.env,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -399,8 +418,9 @@ describe("bunx --no-install", () => {
     return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
   };
 
-  it("if the package is not installed, it should fail and print an error message", async () => {
-    const [err, out, exited] = await run("--no-install", "http-server", "--version");
+  it.concurrent("if the package is not installed, it should fail and print an error message", async () => {
+    const ctx = setup();
+    const [err, out, exited] = await run(ctx, "--no-install", "http-server", "--version");
 
     expect(err.trim()).toContain("Could not find an existing 'http-server' binary to run.");
     expect(out).toHaveLength(0);
@@ -413,10 +433,33 @@ describe("bunx --no-install", () => {
       2. http-server checks for non-alphanumeric edge cases. Plus it's small
       3. eslint is alphanumeric and extremely common
    */
-  it.each(["typescript", "http-server", "eslint"])("`bunx --no-install %s` should find cached packages", async pkg => {
+  it.concurrent.each(["typescript", "http-server", "eslint"])(
+    "`bunx --no-install %s` should find cached packages",
+    async pkg => {
+      const ctx = setup();
+      // not cached
+      {
+        const [err, out, code] = await run(ctx, pkg, "--version");
+        expect(err).not.toContain("error:");
+        expect(out).not.toBeEmpty();
+        expect(code).toBe(0);
+      }
+
+      // cached
+      {
+        const [err, out, code] = await run(ctx, "--no-install", pkg, "--version");
+        expect(err).not.toContain("error:");
+        expect(out).not.toBeEmpty();
+        expect(code).toBe(0);
+      }
+    },
+  );
+
+  it.concurrent("when an exact version match is found, should find cached packages", async () => {
+    const ctx = setup();
     // not cached
     {
-      const [err, out, code] = await run(pkg, "--version");
+      const [err, out, code] = await run(ctx, "http-server@14.0.0", "--version");
       expect(err).not.toContain("error:");
       expect(out).not.toBeEmpty();
       expect(code).toBe(0);
@@ -424,25 +467,7 @@ describe("bunx --no-install", () => {
 
     // cached
     {
-      const [err, out, code] = await run("--no-install", pkg, "--version");
-      expect(err).not.toContain("error:");
-      expect(out).not.toBeEmpty();
-      expect(code).toBe(0);
-    }
-  });
-
-  it("when an exact version match is found, should find cached packages", async () => {
-    // not cached
-    {
-      const [err, out, code] = await run("http-server@14.0.0", "--version");
-      expect(err).not.toContain("error:");
-      expect(out).not.toBeEmpty();
-      expect(code).toBe(0);
-    }
-
-    // cached
-    {
-      const [err, out, code] = await run("--no-install", "http-server@14.0.0", "--version");
+      const [err, out, code] = await run(ctx, "--no-install", "http-server@14.0.0", "--version");
       expect(err).not.toContain("error:");
       expect(out).not.toBeEmpty();
       expect(code).toBe(0);
@@ -450,7 +475,8 @@ describe("bunx --no-install", () => {
   });
 });
 
-it("should handle postinstall scripts correctly with symlinked bunx", async () => {
+it.concurrent("should handle postinstall scripts correctly with symlinked bunx", async () => {
+  const { x_dir, env } = setup();
   // Create a symlink to bun called "bunx"
   copyFileSync(bunExe(), join(x_dir, isWindows ? "bun.exe" : "bun"));
   copyFileSync(bunExe(), join(x_dir, isWindows ? "bunx.exe" : "bunx"));
@@ -475,7 +501,8 @@ it("should handle postinstall scripts correctly with symlinked bunx", async () =
   expect(exited).toBe(0);
 });
 
-it("should handle package that requires node 24", async () => {
+it.concurrent("should handle package that requires node 24", async () => {
+  const { x_dir, env } = setup();
   const subprocess = spawn({
     cmd: [bunExe(), "x", "--bun", "@angular/cli@latest", "--help"],
     cwd: x_dir,

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -59,13 +59,15 @@ const fgOpts = {
 describe("glob.match", async () => {
   const timeout = 30 * 1000;
   function testWithOpts(namePrefix: string, bunGlobOpts: GlobScanOptions, fgOpts: FgOpts) {
-    test(
+    test.concurrent(
       `${namePrefix} recursively search node_modules`,
       async () => {
         const pattern = "**/node_modules/**/*.js";
         const glob = new Glob(pattern);
-        const filepaths = prepareEntries(await Array.fromAsync(glob.scan(bunGlobOpts)));
-        const fgFilepths = await fg.glob(pattern, fgOpts);
+        const [filepaths, fgFilepths] = await Promise.all([
+          Array.fromAsync(glob.scan(bunGlobOpts)).then(prepareEntries),
+          fg.glob(pattern, fgOpts),
+        ]);
 
         // console.error(filepaths);
         expect(filepaths.length).toEqual(fgFilepths.length);
@@ -79,13 +81,15 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test(
+    test.concurrent(
       `${namePrefix} recursive search js files`,
       async () => {
         const pattern = "**/*.js";
         const glob = new Glob(pattern);
-        const filepaths = prepareEntries(await Array.fromAsync(glob.scan(bunGlobOpts)));
-        const fgFilepths = await fg.glob(pattern, fgOpts);
+        const [filepaths, fgFilepths] = await Promise.all([
+          Array.fromAsync(glob.scan(bunGlobOpts)).then(prepareEntries),
+          fg.glob(pattern, fgOpts),
+        ]);
 
         expect(filepaths.length).toEqual(fgFilepths.length);
 
@@ -98,13 +102,15 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test(
+    test.concurrent(
       `${namePrefix} recursive search ts files`,
       async () => {
         const pattern = "**/*.ts";
         const glob = new Glob(pattern);
-        const filepaths = prepareEntries(await Array.fromAsync(glob.scan(bunGlobOpts)));
-        const fgFilepths = await fg.glob(pattern, fgOpts);
+        const [filepaths, fgFilepths] = await Promise.all([
+          Array.fromAsync(glob.scan(bunGlobOpts)).then(prepareEntries),
+          fg.glob(pattern, fgOpts),
+        ]);
 
         expect(filepaths.length).toEqual(fgFilepths.length);
 
@@ -117,7 +123,7 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test(
+    test.concurrent(
       `${namePrefix} glob not freed before matching done`,
       async () => {
         const promise = (async () => {

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -59,7 +59,7 @@ const fgOpts = {
 describe("glob.match", async () => {
   const timeout = 30 * 1000;
   function testWithOpts(namePrefix: string, bunGlobOpts: GlobScanOptions, fgOpts: FgOpts) {
-    test.concurrent(
+    test(
       `${namePrefix} recursively search node_modules`,
       async () => {
         const pattern = "**/node_modules/**/*.js";
@@ -81,7 +81,7 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test.concurrent(
+    test(
       `${namePrefix} recursive search js files`,
       async () => {
         const pattern = "**/*.js";
@@ -102,7 +102,7 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test.concurrent(
+    test(
       `${namePrefix} recursive search ts files`,
       async () => {
         const pattern = "**/*.ts";
@@ -123,7 +123,7 @@ describe("glob.match", async () => {
       timeout,
     );
 
-    test.concurrent(
+    test(
       `${namePrefix} glob not freed before matching done`,
       async () => {
         const promise = (async () => {

--- a/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
+++ b/test/js/bun/http/fetch-abort-ssl-context-eviction.test.ts
@@ -19,16 +19,21 @@ import { bunEnv, bunExe } from "harness";
 // fixture spams same-size-class allocations to make that likely (~30% per
 // run before the fix), so loop a few times.
 test("aborting fetches whose custom SSL context was evicted does not crash", async () => {
-  for (let run = 0; run < 5; run++) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
+  const results = await Promise.all(
+    Array.from({ length: 5 }, async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }),
+  );
 
+  for (const { stdout, stderr, exitCode } of results) {
     expect(stderr).not.toContain("panic");
     expect(stderr).not.toContain("Segmentation fault");
     expect(stderr).not.toContain("poisoned");

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix } from "harness";
 
 describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
-  test("handles fragmented chunk terminators", async () => {
+  test.concurrent("handles fragmented chunk terminators", async () => {
     const script = `
       const server = Bun.serve({
         port: 0,
@@ -56,7 +56,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("rejects invalid terminator in fragmented reads", async () => {
+  test.concurrent("rejects invalid terminator in fragmented reads", async () => {
     const script = `
       const server = Bun.serve({
         port: 0,
@@ -109,7 +109,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
 });
 
 describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
-  test("handles lone CR at end of chunk-size line across TCP segments", async () => {
+  test.concurrent("handles lone CR at end of chunk-size line across TCP segments", async () => {
     // Regression test: when a TCP segment boundary falls between the \r and \n
     // of a chunk-size line (e.g. "5\r" in one segment, "\n..." in the next),
     // the server must buffer and resume correctly instead of spinning.
@@ -171,7 +171,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("handles lone CR in chunk-size with extensions", async () => {
+  test.concurrent("handles lone CR in chunk-size with extensions", async () => {
     // Same split but with a chunk extension before the CRLF
     const script = `
       const server = Bun.serve({
@@ -229,7 +229,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
+  test.concurrent("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
     // A byte <=32 that isn't \r in chunk-size position must error immediately.
     // Previously this could strand the byte in HttpParser's fallback buffer,
     // corrupting header parsing on the next request.
@@ -285,7 +285,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
+  test.concurrent("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
     // remainingStreamingBytes is shared between CL and chunked state. CL >= 2^59 would
     // set STATE_HAS_HEXDIG and route a fixed-length body into the chunked decoder.
     const script = `
@@ -333,7 +333,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     // RFC 7230 4.1: chunk-size = 1*HEXDIG. A chunk-size line with no hex digit
     // must be rejected. Previously this parsed as size 0 (last-chunk), allowing a
     // pipelined request after the bogus terminator to be smuggled.
-    test("rejects and does not process trailing pipelined request", async () => {
+    test.concurrent("rejects and does not process trailing pipelined request", async () => {
       const script = `
         let requests = 0;
         const server = Bun.serve({
@@ -389,7 +389,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
       expect(exitCode).toBe(0);
     });
 
-    test("rejects when chunk-size line is split across packets", async () => {
+    test.concurrent("rejects when chunk-size line is split across packets", async () => {
       const script = `
         const server = Bun.serve({
           port: 0,
@@ -440,7 +440,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
 });
 
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {
-  test("handles requests with tiny send buffer (regression test)", async () => {
+  test.concurrent("handles requests with tiny send buffer (regression test)", async () => {
     using server = Bun.serve({
       hostname: "localhost",
 

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -94,7 +94,6 @@ type Tests = Record<
   {
     loader: string | null;
     filename: string;
-    dir?: string;
   }
 >;
 const default_tests = Object.fromEntries(

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -4,19 +4,20 @@ import * as path from "path";
 const loaders = ["js", "jsx", "ts", "tsx", "json", "jsonc", "toml", "yaml", "text", "sqlite", "file"];
 const other_loaders_do_not_crash = ["webassembly", "does_not_exist"];
 
-async function testBunRunRequire(dir: string, loader: string | null, filename: string): Promise<unknown> {
-  if (loader != null) throw new Error("cannot use loader with require()");
-  const cmd = [bunExe(), "-e", `const contents = require('./${filename}'); console.log(JSON.stringify(contents));`];
-  const result = Bun.spawnSync({
+async function runCmd(cmd: string[], dir: string): Promise<unknown> {
+  await using proc = Bun.spawn({
     cmd: cmd,
     cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
   });
-  if (result.exitCode !== 0) {
-    if (result.stderr.toString().includes("panic")) {
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    if (stderr.includes("panic")) {
       console.error("cmd stderr");
-      console.log(result.stderr.toString());
+      console.log(stderr);
       console.error("cmd stdout");
-      console.log(result.stdout.toString());
+      console.log(stdout);
       console.error("cmd args");
       console.log(JSON.stringify(cmd));
       console.error("cmd cwd");
@@ -24,10 +25,16 @@ async function testBunRunRequire(dir: string, loader: string | null, filename: s
       throw new Error("panic");
     }
     return "error";
-    // return result.stderr.toString().match(/error: .+/)?.[0];
+    // return stderr.match(/error: .+/)?.[0];
   } else {
-    return JSON.parse(result.stdout.toString());
+    return JSON.parse(stdout);
   }
+}
+
+async function testBunRunRequire(dir: string, loader: string | null, filename: string): Promise<unknown> {
+  if (loader != null) throw new Error("cannot use loader with require()");
+  const cmd = [bunExe(), "-e", `const contents = require('./${filename}'); console.log(JSON.stringify(contents));`];
+  return runCmd(cmd, dir);
 }
 async function testBunRun(dir: string, loader: string | null, filename: string): Promise<unknown> {
   const cmd = [
@@ -35,27 +42,7 @@ async function testBunRun(dir: string, loader: string | null, filename: string):
     "-e",
     `import * as contents from './${filename}'${loader != null ? ` with {type: '${loader}'}` : ""}; console.log(JSON.stringify(contents));`,
   ];
-  const result = Bun.spawnSync({
-    cmd: cmd,
-    cwd: dir,
-  });
-  if (result.exitCode !== 0) {
-    if (result.stderr.toString().includes("panic")) {
-      console.error("cmd stderr");
-      console.log(result.stderr.toString());
-      console.error("cmd stdout");
-      console.log(result.stdout.toString());
-      console.error("cmd args");
-      console.log(JSON.stringify(cmd));
-      console.error("cmd cwd");
-      console.log(dir);
-      throw new Error("panic");
-    }
-    return "error";
-    // return result.stderr.toString().match(/error: .+/)?.[0];
-  } else {
-    return JSON.parse(result.stdout.toString());
-  }
+  return runCmd(cmd, dir);
 }
 async function testBunRunAwaitImport(dir: string, loader: string | null, filename: string): Promise<unknown> {
   const cmd = [
@@ -63,28 +50,7 @@ async function testBunRunAwaitImport(dir: string, loader: string | null, filenam
     "-e",
     `console.log(JSON.stringify(await import('./${filename}'${loader != null ? `, {with: {type: '${loader}'}}` : ""})));`,
   ];
-  const result = Bun.spawnSync({
-    cmd: cmd,
-    cwd: dir,
-  });
-  console.timeEnd("testBunRunAwaitImport: " + dir + " " + loader);
-  if (result.exitCode !== 0) {
-    if (result.stderr.toString().includes("panic")) {
-      console.error("cmd stderr");
-      console.log(result.stderr.toString());
-      console.error("cmd stdout");
-      console.log(result.stdout.toString());
-      console.error("cmd args");
-      console.log(JSON.stringify(cmd));
-      console.error("cmd cwd");
-      console.log(dir);
-      throw new Error("panic");
-    }
-    return "error";
-    // return result.stderr.toString().match(/error: .+/)?.[0];
-  } else {
-    return JSON.parse(result.stdout.toString());
-  }
+  return runCmd(cmd, dir);
 }
 async function testBunBuild(dir: string, loader: string | null, filename: string): Promise<unknown> {
   await Bun.write(
@@ -99,26 +65,7 @@ async function testBunBuild(dir: string, loader: string | null, filename: string
   });
   if (result.success) {
     const cmd = [bunExe(), "out/main_" + loader + ".js"];
-    const result = Bun.spawnSync({
-      cmd: cmd,
-      cwd: dir,
-    });
-    if (result.exitCode !== 0) {
-      if (result.stderr.toString().includes("panic")) {
-        console.error("cmd stderr");
-        console.log(result.stderr.toString());
-        console.error("cmd stdout");
-        console.log(result.stdout.toString());
-        console.error("cmd args");
-        console.log(JSON.stringify(cmd));
-        console.error("cmd cwd");
-        console.log(dir);
-        throw new Error("panic");
-      }
-      return "error";
-    } else {
-      return JSON.parse(result.stdout.toString());
-    }
+    return runCmd(cmd, dir);
   } else {
     return "error";
   }
@@ -137,26 +84,7 @@ async function testBunBuildRequire(dir: string, loader: string | null, filename:
   });
   if (result.success) {
     const cmd = [bunExe(), "out/main_" + loader + ".js"];
-    const result = Bun.spawnSync({
-      cmd: cmd,
-      cwd: dir,
-    });
-    if (result.exitCode !== 0) {
-      if (result.stderr.toString().includes("panic")) {
-        console.error("cmd stderr");
-        console.log(result.stderr.toString());
-        console.error("cmd stdout");
-        console.log(result.stdout.toString());
-        console.error("cmd args");
-        console.log(JSON.stringify(cmd));
-        console.error("cmd cwd");
-        console.log(dir);
-        throw new Error("panic");
-      }
-      return "error";
-    } else {
-      return JSON.parse(result.stdout.toString());
-    }
+    return runCmd(cmd, dir);
   } else {
     return "error";
   }
@@ -173,15 +101,11 @@ const default_tests = Object.fromEntries(
   loaders.map(loader => [loader, { loader, filename: "no_extension" }]),
 ) as Tests;
 async function compileAndTest(code: string, tests: Tests = default_tests): Promise<Record<string, unknown>> {
-  console.time("import {} from '';");
-  const v1 = await compileAndTest_inner(code, tests, testBunRun);
-  console.timeEnd("import {} from '';");
-  console.time("await import()");
-  const v2 = await compileAndTest_inner(code, tests, testBunRunAwaitImport);
-  console.timeEnd("await import()");
-  console.time("Bun.build()");
-  const v3 = await compileAndTest_inner(code, tests, testBunBuild);
-  console.timeEnd("Bun.build()");
+  const [v1, v2, v3] = await Promise.all([
+    compileAndTest_inner(code, tests, testBunRun),
+    compileAndTest_inner(code, tests, testBunRunAwaitImport),
+    compileAndTest_inner(code, tests, testBunBuild),
+  ]);
   if (!Bun.deepEquals(v1, v2) || !Bun.deepEquals(v2, v3)) {
     console.log("====  regular import  ====\n" + JSON.stringify(v1, null, 2) + "\n");
     console.log("====  await import  ====\n" + JSON.stringify(v2, null, 2) + "\n");
@@ -195,13 +119,18 @@ async function compileAndTest_inner(
   tests: Tests,
   cb: (dir: string, loader: string | null, filename: string) => Promise<unknown>,
 ): Promise<Record<string, unknown>> {
-  let res: Record<string, unknown> = {};
-  for (const [label, test] of Object.entries(tests)) {
-    test.dir = tempDirWithFiles("import-attributes", {
-      [test.filename]: code,
-    });
-    res[label] = await cb(test.dir!, test.loader, test.filename);
-  }
+  const dirs: Record<string, string> = {};
+  const entries = Object.entries(tests);
+  const results = await Promise.all(
+    entries.map(async ([label, test]) => {
+      const dir = tempDirWithFiles("import-attributes", {
+        [test.filename]: code,
+      });
+      dirs[label] = dir;
+      return [label, await cb(dir, test.loader, test.filename)] as const;
+    }),
+  );
+  let res: Record<string, unknown> = Object.fromEntries(results);
   if (Object.hasOwn(res, "text")) {
     expect(res.text).toEqual({ default: code });
     delete res.text;
@@ -225,12 +154,12 @@ async function compileAndTest_inner(
         default: { filename: expect.any(String) },
       });
       expect((sqlite_res as any).default.filename.toUpperCase()).toStartWith(
-        path.join(tests.sqlite!.dir!, "out").toUpperCase(),
+        path.join(dirs.sqlite!, "out").toUpperCase(),
       );
     } else {
       expect(sqlite_res).toStrictEqual({
-        db: { filename: path.join(tests.sqlite!.dir!, tests.sqlite!.filename) },
-        default: { filename: path.join(tests.sqlite!.dir!, tests.sqlite!.filename) },
+        db: { filename: path.join(dirs.sqlite!, tests.sqlite!.filename) },
+        default: { filename: path.join(dirs.sqlite!, tests.sqlite!.filename) },
       });
     }
     delete res.sqlite;
@@ -244,7 +173,7 @@ async function compileAndTest_inner(
     } else {
       delete (file_res as any).__esModule;
       expect(file_res).toEqual({
-        default: path.join(tests.file!.dir!, tests.file!.filename),
+        default: path.join(dirs.file!, tests.file!.filename),
       });
     }
     delete res.file;

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -523,7 +523,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
     let text = "";
     for await (const chunk of producer.stderr) {
       text += [...chunk].map(x => String.fromCharCode(x)).join("");
-      await Bun.sleep(1000);
+      await Bun.sleep(100);
     }
     expect(text).toBe("0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n");
   }, 25000);

--- a/test/js/bun/io/timed-stderr-output.js
+++ b/test/js/bun/io/timed-stderr-output.js
@@ -1,4 +1,4 @@
 for (let i = 0; i <= 25; i++) {
   await Bun.write(Bun.stderr, i + "\n");
-  await Bun.sleep(100);
+  await Bun.sleep(10);
 }

--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -20,7 +20,7 @@ function createBunServer(fetch: Parameters<typeof Bun.serve>[0]["fetch"]) {
   return server;
 }
 
-describe("S3 - List Objects", () => {
+describe.concurrent("S3 - List Objects", () => {
   it("Should set encoded continuation-token in the request url before list-type", async () => {
     let reqUrl: string;
     using server = createBunServer(async req => {
@@ -1085,15 +1085,17 @@ const optionsFromEnv: S3Options = {
 describe.skipIf(!optionsFromEnv.accessKeyId)("S3 - CI - List Objects", () => {
   const bucket = new S3Client(optionsFromEnv);
 
+  // Separate prefixes so the two tests below are fully isolated and can run concurrently.
   const keyPrefix = `${randomUUIDv7()}/`;
+  const keyPrefix2 = `${randomUUIDv7()}/`;
 
   const file_1 = `${keyPrefix}file_1.txt`;
   const file_2 = `${keyPrefix}file_2.txt`;
   const file_3 = `${keyPrefix}file_3.txt`;
 
-  const file_4 = `${keyPrefix}file_a>b.txt`;
-  const file_5 = `${keyPrefix}file_a>c.txt`;
-  const file_6 = `${keyPrefix}file_a>d.txt`;
+  const file_4 = `${keyPrefix2}file_a>b.txt`;
+  const file_5 = `${keyPrefix2}file_a>c.txt`;
+  const file_6 = `${keyPrefix2}file_a>d.txt`;
 
   afterAll(async () => {
     try {
@@ -1104,10 +1106,12 @@ describe.skipIf(!optionsFromEnv.accessKeyId)("S3 - CI - List Objects", () => {
     }
   });
 
-  it("should list objects with prefix, maxKeys and nextContinuationToken", async () => {
-    await bucket.write(file_1, "content 1");
-    await bucket.write(file_2, "content 2");
-    await bucket.write(file_3, "content 3");
+  it.concurrent("should list objects with prefix, maxKeys and nextContinuationToken", async () => {
+    await Promise.all([
+      bucket.write(file_1, "content 1"),
+      bucket.write(file_2, "content 2"),
+      bucket.write(file_3, "content 3"),
+    ]);
 
     const first_response = await bucket.list({ prefix: keyPrefix, maxKeys: 1 });
 
@@ -1142,13 +1146,15 @@ describe.skipIf(!optionsFromEnv.accessKeyId)("S3 - CI - List Objects", () => {
     expect(storedFile.size).toBe(9);
   });
 
-  it("should list objects with startAfter, encodingType and fetchOwner", async () => {
-    await bucket.write(file_4, "content 4");
-    await bucket.write(file_5, "content 5");
-    await bucket.write(file_6, "content 6");
+  it.concurrent("should list objects with startAfter, encodingType and fetchOwner", async () => {
+    await Promise.all([
+      bucket.write(file_4, "content 4"),
+      bucket.write(file_5, "content 5"),
+      bucket.write(file_6, "content 6"),
+    ]);
 
     const res = await bucket.list({
-      prefix: keyPrefix, // isolates the test when Bucket is not empty
+      prefix: keyPrefix2, // isolates the test when Bucket is not empty
       startAfter: file_4,
       fetchOwner: true,
       encodingType: "url",

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -13,55 +13,57 @@ test("spawn can write to stdin multiple chunks", async () => {
   const maxFD = getMaxFD();
 
   var remaining = N;
+  const proms: Promise<void>[] = [];
   while (remaining > 0) {
-    const proms = new Array(concurrency);
     for (let i = 0; i < concurrency; i++) {
-      proms[i] = (async function () {
-        const proc = spawn({
-          cmd: [bunExe(), join(import.meta.dir, "stdin-repro.js")],
-          stdout: "pipe",
-          stdin: "pipe",
-          stderr: "inherit",
-          env: { ...bunEnv },
-        });
+      proms.push(
+        (async function () {
+          const proc = spawn({
+            cmd: [bunExe(), join(import.meta.dir, "stdin-repro.js")],
+            stdout: "pipe",
+            stdin: "pipe",
+            stderr: "inherit",
+            env: { ...bunEnv },
+          });
 
-        const prom2 = (async function () {
-          let inCounter = 0;
-          while (true) {
-            proc.stdin!.write("Wrote to stdin!\n");
-            await proc.stdin!.flush();
-            await Bun.sleep(delay);
+          const prom2 = (async function () {
+            let inCounter = 0;
+            while (true) {
+              proc.stdin!.write("Wrote to stdin!\n");
+              await proc.stdin!.flush();
+              await Bun.sleep(delay);
 
-            if (inCounter++ === 6) break;
-          }
-          await proc.stdin!.end();
-          return inCounter;
-        })();
-
-        const prom = (async function () {
-          let chunks: any[] = [];
-
-          try {
-            for await (var chunk of proc.stdout) {
-              chunks.push(chunk);
+              if (inCounter++ === 6) break;
             }
-          } catch (e: any) {
-            console.log(e.stack);
-            throw e;
-          }
+            await proc.stdin!.end();
+            return inCounter;
+          })();
 
-          return Buffer.concat(chunks).toString().trim();
-        })();
+          const prom = (async function () {
+            let chunks: any[] = [];
 
-        const [chunks, , exitCode] = await Promise.all([prom, prom2, proc.exited]);
+            try {
+              for await (var chunk of proc.stdout) {
+                chunks.push(chunk);
+              }
+            } catch (e: any) {
+              console.log(e.stack);
+              throw e;
+            }
 
-        expect(chunks).toBe("Wrote to stdin!\n".repeat(7).trim());
-        expect(exitCode).toBe(0);
-      })();
+            return Buffer.concat(chunks).toString().trim();
+          })();
+
+          const [chunks, , exitCode] = await Promise.all([prom, prom2, proc.exited]);
+
+          expect(chunks).toBe("Wrote to stdin!\n".repeat(7).trim());
+          expect(exitCode).toBe(0);
+        })(),
+      );
     }
-    await Promise.all(proms);
     remaining -= concurrency;
   }
+  await Promise.all(proms);
 
   const newMaxFD = getMaxFD();
 

--- a/test/js/bun/spawn/spawn-streaming-stdin.test.ts
+++ b/test/js/bun/spawn/spawn-streaming-stdin.test.ts
@@ -13,57 +13,55 @@ test("spawn can write to stdin multiple chunks", async () => {
   const maxFD = getMaxFD();
 
   var remaining = N;
-  const proms: Promise<void>[] = [];
   while (remaining > 0) {
+    const proms = new Array(concurrency);
     for (let i = 0; i < concurrency; i++) {
-      proms.push(
-        (async function () {
-          const proc = spawn({
-            cmd: [bunExe(), join(import.meta.dir, "stdin-repro.js")],
-            stdout: "pipe",
-            stdin: "pipe",
-            stderr: "inherit",
-            env: { ...bunEnv },
-          });
+      proms[i] = (async function () {
+        const proc = spawn({
+          cmd: [bunExe(), join(import.meta.dir, "stdin-repro.js")],
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "inherit",
+          env: { ...bunEnv },
+        });
 
-          const prom2 = (async function () {
-            let inCounter = 0;
-            while (true) {
-              proc.stdin!.write("Wrote to stdin!\n");
-              await proc.stdin!.flush();
-              await Bun.sleep(delay);
+        const prom2 = (async function () {
+          let inCounter = 0;
+          while (true) {
+            proc.stdin!.write("Wrote to stdin!\n");
+            await proc.stdin!.flush();
+            await Bun.sleep(delay);
 
-              if (inCounter++ === 6) break;
+            if (inCounter++ === 6) break;
+          }
+          await proc.stdin!.end();
+          return inCounter;
+        })();
+
+        const prom = (async function () {
+          let chunks: any[] = [];
+
+          try {
+            for await (var chunk of proc.stdout) {
+              chunks.push(chunk);
             }
-            await proc.stdin!.end();
-            return inCounter;
-          })();
+          } catch (e: any) {
+            console.log(e.stack);
+            throw e;
+          }
 
-          const prom = (async function () {
-            let chunks: any[] = [];
+          return Buffer.concat(chunks).toString().trim();
+        })();
 
-            try {
-              for await (var chunk of proc.stdout) {
-                chunks.push(chunk);
-              }
-            } catch (e: any) {
-              console.log(e.stack);
-              throw e;
-            }
+        const [chunks, , exitCode] = await Promise.all([prom, prom2, proc.exited]);
 
-            return Buffer.concat(chunks).toString().trim();
-          })();
-
-          const [chunks, , exitCode] = await Promise.all([prom, prom2, proc.exited]);
-
-          expect(chunks).toBe("Wrote to stdin!\n".repeat(7).trim());
-          expect(exitCode).toBe(0);
-        })(),
-      );
+        expect(chunks).toBe("Wrote to stdin!\n".repeat(7).trim());
+        expect(exitCode).toBe(0);
+      })();
     }
+    await Promise.all(proms);
     remaining -= concurrency;
   }
-  await Promise.all(proms);
 
   const newMaxFD = getMaxFD();
 

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -407,7 +407,7 @@ class InlineSnapshotTester {
     expect(this.readfile(thefile)).toEqual(code);
   }
   async test(cb: (v: (a: string, b: string, c: string) => string) => string): Promise<void> {
-    await Promise.all([
+    const settled = await Promise.allSettled([
       this.testInternal(
         false,
         cb((a, b, c) => a),
@@ -419,6 +419,7 @@ class InlineSnapshotTester {
         cb((a, b, c) => c),
       ),
     ]);
+    for (const r of settled) if (r.status === "rejected") throw r.reason;
   }
   async testUpdateOnly(cb: (v: (b: string, c: string) => string) => string): Promise<void> {
     await this.testInternal(
@@ -839,7 +840,7 @@ indentation"
     );
   });
   it("#16403", async () => {
-    await Promise.all([
+    const settled = await Promise.allSettled([
       tester.test(v =>
         v(
           '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot();\n\t});\n',
@@ -854,6 +855,7 @@ indentation"
         ),
       ),
     ]);
+    for (const r of settled) if (r.status === "rejected") throw r.reason;
   });
 });
 test("indented inline snapshots", () => {

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -387,61 +387,59 @@ class InlineSnapshotTester {
     return readFileSync(this.tmpdir + "/" + name, { encoding: "utf-8" });
   }
 
-  testError(eopts: { update?: boolean; msg: string }, code: string): void {
-    const thefile = this.tmpfile(code);
-
-    const spawnres = Bun.spawnSync({
-      cmd: [bunExe(), "test", ...(eopts.update ? ["-u"] : []), thefile],
+  async spawn(extraArgs: string[], thefile: string) {
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...extraArgs, thefile],
       env: { ...bunEnv, CI: "false" },
       cwd: this.tmpdir,
       stdio: ["pipe", "pipe", "pipe"],
     });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr: { toString: () => stderr }, exitCode };
+  }
+
+  async testError(eopts: { update?: boolean; msg: string }, code: string): Promise<void> {
+    const thefile = this.tmpfile(code);
+
+    const spawnres = await this.spawn(eopts.update ? ["-u"] : [], thefile);
     expect(spawnres.stderr.toString()).toInclude(eopts.msg);
     expect(spawnres.exitCode).toBe(1);
     expect(this.readfile(thefile)).toEqual(code);
   }
-  test(cb: (v: (a: string, b: string, c: string) => string) => string): void {
-    this.testInternal(
-      false,
-      cb((a, b, c) => a),
-      cb((a, b, c) => c),
-    );
-    this.testInternal(
-      true,
-      cb((a, b, c) => b),
-      cb((a, b, c) => c),
-    );
+  async test(cb: (v: (a: string, b: string, c: string) => string) => string): Promise<void> {
+    await Promise.all([
+      this.testInternal(
+        false,
+        cb((a, b, c) => a),
+        cb((a, b, c) => c),
+      ),
+      this.testInternal(
+        true,
+        cb((a, b, c) => b),
+        cb((a, b, c) => c),
+      ),
+    ]);
   }
-  testUpdateOnly(cb: (v: (b: string, c: string) => string) => string): void {
-    this.testInternal(
+  async testUpdateOnly(cb: (v: (b: string, c: string) => string) => string): Promise<void> {
+    await this.testInternal(
       true,
       cb((b, c) => b),
       cb((b, c) => c),
     );
   }
-  testInternal(use_update: boolean, before_value: string, after_value: string): void {
+  async testInternal(use_update: boolean, before_value: string, after_value: string): Promise<void> {
     const thefile = this.tmpfile(before_value);
 
     if (use_update) {
       // run without update, expect error
-      const spawnres = Bun.spawnSync({
-        cmd: [bunExe(), "test", thefile],
-        env: { ...bunEnv, CI: "false" },
-        cwd: this.tmpdir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const spawnres = await this.spawn([], thefile);
       expect(spawnres.stderr.toString()).toInclude("error:");
       expect(spawnres.exitCode).toBe(1);
       expect(this.readfile(thefile)).toEqual(before_value);
     }
 
     {
-      const spawnres = Bun.spawnSync({
-        cmd: [bunExe(), "test", ...(use_update ? ["-u"] : []), thefile],
-        env: { ...bunEnv, CI: "false" },
-        cwd: this.tmpdir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const spawnres = await this.spawn(use_update ? ["-u"] : [], thefile);
       expect(spawnres.stderr.toString()).not.toInclude("error:");
       expect({
         exitCode: spawnres.exitCode,
@@ -454,12 +452,7 @@ class InlineSnapshotTester {
 
     // run without update, expect pass with no change
     {
-      const spawnres = Bun.spawnSync({
-        cmd: [bunExe(), "test", thefile],
-        env: { ...bunEnv, CI: "false" },
-        cwd: this.tmpdir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const spawnres = await this.spawn([], thefile);
       expect(spawnres.stderr.toString()).not.toInclude("error:");
       expect({
         exitCode: spawnres.exitCode,
@@ -472,12 +465,7 @@ class InlineSnapshotTester {
 
     // update again, expect pass with no change
     {
-      const spawnres = Bun.spawnSync({
-        cmd: [bunExe(), "test", "-u", thefile],
-        env: { ...bunEnv, CI: "false" },
-        cwd: this.tmpdir,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const spawnres = await this.spawn(["-u"], thefile);
       expect(spawnres.stderr.toString()).not.toInclude("error:");
       expect({
         exitCode: spawnres.exitCode,
@@ -501,8 +489,8 @@ describe("inline snapshots", () => {
   const tester = new InlineSnapshotTester({
     "helper.js": helper_js,
   });
-  test("changing inline snapshot", () => {
-    tester.test(
+  test("changing inline snapshot", async () => {
+    await tester.test(
       v => /*js*/ `
         test("inline snapshots", () => {
           expect("1").toMatchInlineSnapshot(${v("", bad, '`"1"`')});
@@ -520,8 +508,8 @@ describe("inline snapshots", () => {
       `,
     );
   });
-  test("inline snapshot update cases", () => {
-    tester.test(
+  test("inline snapshot update cases", async () => {
+    await tester.test(
       // prettier-ignore
       v => /*js*/ `
         test("cases", () => {
@@ -614,8 +602,8 @@ Date)
       `,
     );
   });
-  it("updating outside of a test", () => {
-    tester.test(
+  it("updating outside of a test", async () => {
+    await tester.test(
       v => /*js*/ `
         expect("1").toMatchInlineSnapshot(${v("", bad, '`"1"`')});
       `,
@@ -629,8 +617,8 @@ Date)
       `,
     );
   });
-  it("should error trying to update the same line twice", () => {
-    tester.testError(
+  it("should error trying to update the same line twice", async () => {
+    await tester.testError(
       {
         msg: "error: Failed to update inline snapshot: Multiple inline snapshots on the same line must all have the same value",
       },
@@ -651,9 +639,9 @@ Date)
   });
 
   // snapshot in a snapshot
-  it("should not allow a snapshot in a snapshot", () => {
+  it("should not allow a snapshot in a snapshot", async () => {
     // this is possible to support, but is not supported
-    tester.testError(
+    await tester.testError(
       { msg: "error: Failed to update inline snapshot: Did not advance." },
       ((v: (a: string, b: string, c: string) => string) => /*js*/ `
         test("cases", () => {
@@ -666,8 +654,8 @@ Date)
     );
   });
 
-  it("requires exactly 'toMatchInlineSnapshot' 1", () => {
-    tester.testError(
+  it("requires exactly 'toMatchInlineSnapshot' 1", async () => {
+    await tester.testError(
       { msg: "error: Failed to update inline snapshot: Could not find 'toMatchInlineSnapshot' here" },
       /*js*/ `
         test("cases", () => {
@@ -676,8 +664,8 @@ Date)
       `,
     );
   });
-  it("requires exactly 'toMatchInlineSnapshot' 2", () => {
-    tester.testError(
+  it("requires exactly 'toMatchInlineSnapshot' 2", async () => {
+    await tester.testError(
       { msg: "error: Failed to update inline snapshot: Could not find 'toMatchInlineSnapshot' here" },
       /*js*/ `
         test("cases", () => {
@@ -686,8 +674,8 @@ Date)
       `,
     );
   });
-  it("only replaces when the argument is a literal string 1", () => {
-    tester.testError(
+  it("only replaces when the argument is a literal string 1", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Argument must be a string literal",
@@ -700,8 +688,8 @@ Date)
       `,
     );
   });
-  it("only replaces when the argument is a literal string 2", () => {
-    tester.testError(
+  it("only replaces when the argument is a literal string 2", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Argument must be a string literal",
@@ -714,8 +702,8 @@ Date)
       `,
     );
   });
-  it("only replaces when the argument is a literal string 3", () => {
-    tester.testError(
+  it("only replaces when the argument is a literal string 3", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Argument must be a string literal",
@@ -727,8 +715,8 @@ Date)
       `,
     );
   });
-  it("only replaces when the argument is a literal string 4", () => {
-    tester.testError(
+  it("only replaces when the argument is a literal string 4", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "Matcher error: Expected properties must be an object",
@@ -740,8 +728,8 @@ Date)
       `,
     );
   });
-  it("does not allow spread 1", () => {
-    tester.testError(
+  it("does not allow spread 1", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Spread is not allowed",
@@ -753,8 +741,8 @@ Date)
       `,
     );
   });
-  it("does not allow spread 2", () => {
-    tester.testError(
+  it("does not allow spread 2", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Spread is not allowed",
@@ -766,8 +754,8 @@ Date)
       `,
     );
   });
-  it("limit two arguments", () => {
-    tester.testError(
+  it("limit two arguments", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "error: Failed to update inline snapshot: Snapshot expects at most two arguments",
@@ -779,8 +767,8 @@ Date)
       `,
     );
   });
-  it("must be in test file", () => {
-    tester.testError(
+  it("must be in test file", async () => {
+    await tester.testError(
       {
         update: true,
         msg: "Inline snapshot matchers must be called from the test file",
@@ -794,8 +782,8 @@ Date)
     );
     expect(readFileSync(tester.tmpdir + "/helper.js", "utf-8")).toBe(helper_js);
   });
-  it("is right file", () => {
-    tester.test(
+  it("is right file", async () => {
+    await tester.test(
       v => /*js*/ `
         import {wrongFile} from "./helper";
         test("cases", () => {
@@ -805,8 +793,8 @@ Date)
       `,
     );
   });
-  it("indentation", () => {
-    tester.test(
+  it("indentation", async () => {
+    await tester.test(
       // prettier-ignore
       v => /*js*/ `
         test("cases", () => {
@@ -824,8 +812,8 @@ Date)
       `,
     );
   });
-  it("preserve existing indentation", () => {
-    tester.testUpdateOnly(
+  it("preserve existing indentation", async () => {
+    await tester.testUpdateOnly(
       // prettier-ignore
       v => /*js*/ `
         test("cases", () => {
@@ -850,20 +838,22 @@ indentation"
       `,
     );
   });
-  it("#16403", () => {
-    tester.test(v =>
-      v(
-        '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot();\n\t});\n',
-        '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t  [\n\t\t    "ab",\n\t\t    "cd",\n\t\t  ]\n\t\t`);\n\t});\n',
-        '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t  [\n\t\t    "C2",\n\t\t    "B2",\n\t\t  ]\n\t\t`);\n\t});\n',
+  it("#16403", async () => {
+    await Promise.all([
+      tester.test(v =>
+        v(
+          '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot();\n\t});\n',
+          '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t  [\n\t\t    "ab",\n\t\t    "cd",\n\t\t  ]\n\t\t`);\n\t});\n',
+          '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t  [\n\t\t    "C2",\n\t\t    "B2",\n\t\t  ]\n\t\t`);\n\t});\n',
+        ),
       ),
-    );
-    tester.testUpdateOnly(v =>
-      v(
-        '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t\t[\n\t\t\t  "ab",\n\t\t\t  "cd",\n\t\t\t]\n\t\t`);\n\t});\n',
-        '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t\t[\n\t\t\t  "C2",\n\t\t\t  "B2",\n\t\t\t]\n\t\t`);\n\t});\n',
+      tester.testUpdateOnly(v =>
+        v(
+          '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t\t[\n\t\t\t  "ab",\n\t\t\t  "cd",\n\t\t\t]\n\t\t`);\n\t});\n',
+          '\tit(\'should get range of notes\', () => {\n\t\tconst range = ["C2", "B2"];\n\n\t\texpect(range).toMatchInlineSnapshot(`\n\t\t\t[\n\t\t\t  "C2",\n\t\t\t  "B2",\n\t\t\t]\n\t\t`);\n\t});\n',
+        ),
       ),
-    );
+    ]);
   });
 });
 test("indented inline snapshots", () => {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -62,7 +62,7 @@ const binaryTypes = [
 let servers: Server[] = [];
 let clients: Subprocess[] = [];
 
-it("should work fine if you repeatedly call methods on closed websockets", async () => {
+it.concurrent("should work fine if you repeatedly call methods on closed websockets", async () => {
   let env = { ...bunEnv };
   forceGuardMalloc(env);
 
@@ -93,7 +93,7 @@ afterEach(() => {
 // the other client should not receive the message
 // the server should not crash
 // https://github.com/oven-sh/bun/issues/4443
-it("websocket/4443", async () => {
+it.concurrent("websocket/4443", async () => {
   var serverSockets: ServerWebSocket<unknown>[] = [];
   var onFirstConnected = Promise.withResolvers();
   var onSecondMessageEchoedBack = Promise.withResolvers();
@@ -168,7 +168,7 @@ describe("Server", () => {
     },
   }));
 
-  it("subscriptions - basic usage", async () => {
+  it.concurrent("subscriptions - basic usage", async () => {
     const { promise, resolve } = Promise.withResolvers();
     const { promise: onClosePromise, resolve: onClose } = Promise.withResolvers();
 
@@ -220,7 +220,7 @@ describe("Server", () => {
     expect(subscriptions).not.toContain("topic2");
   });
 
-  it("subscriptions - all unsubscribed", async () => {
+  it.concurrent("subscriptions - all unsubscribed", async () => {
     const { promise, resolve } = Promise.withResolvers();
     const { promise: onClosePromise, resolve: onClose } = Promise.withResolvers();
 
@@ -263,7 +263,7 @@ describe("Server", () => {
     expect(subscriptions.length).toBe(0);
   });
 
-  it("subscriptions - after close", async () => {
+  it.concurrent("subscriptions - after close", async () => {
     const { promise, resolve } = Promise.withResolvers();
     const { promise: onClosePromise, resolve: onClose } = Promise.withResolvers();
 
@@ -298,7 +298,7 @@ describe("Server", () => {
     expect(subscriptions).toStrictEqual([]);
   });
 
-  it("subscriptions - duplicate subscriptions", async () => {
+  it.concurrent("subscriptions - duplicate subscriptions", async () => {
     const { promise, resolve } = Promise.withResolvers();
     const { promise: onClosePromise, resolve: onClose } = Promise.withResolvers();
 
@@ -336,7 +336,7 @@ describe("Server", () => {
     expect(subscriptions).toContain("topic1");
   });
 
-  it("subscriptions - multiple cycles", async () => {
+  it.concurrent("subscriptions - multiple cycles", async () => {
     const { promise, resolve } = Promise.withResolvers();
     const { promise: onClosePromise, resolve: onClose } = Promise.withResolvers();
 
@@ -987,15 +987,18 @@ function test(
   ) => Partial<WebSocketHandler<{ id: number }>>,
   timeout?: number,
 ) {
-  it(
+  it.concurrent(
     label,
-    async testDone => {
+    async () => {
       let isDone = false;
+      const localClients: Subprocess[] = [];
+      const { promise: donePromise, resolve: resolveDone, reject: rejectDone } = Promise.withResolvers<void>();
       const done = (err?: unknown) => {
         if (!isDone) {
           isDone = true;
           server.stop();
-          testDone(err);
+          if (err) rejectDone(err);
+          else resolveDone();
         }
       };
       let id = 0;
@@ -1014,18 +1017,26 @@ function test(
         websocket: {
           sendPings: false,
           message() {},
-          ...fn(done, () => connect(server), options as any),
+          ...fn(done, () => connect(server, localClients), options as any),
         },
       });
       options.server = server;
       expect(server.subscriberCount("empty topic")).toBe(0);
-      await connect(server);
+      const connected = connect(server, localClients);
+      try {
+        await Promise.all([donePromise, connected]);
+      } finally {
+        server.stop(true);
+        for (const client of localClients) {
+          client.kill();
+        }
+      }
     },
-    { timeout: timeout ?? 1000 },
+    { timeout: timeout ?? 10000 },
   );
 }
 
-async function connect(server: Server): Promise<void> {
+async function connect(server: Server, clientList: Subprocess[] = clients): Promise<void> {
   const url = new URL(`ws://${server.hostname}:${server.port}/`);
   const pathname = path.resolve(import.meta.dir, "./websocket-client-echo.mjs");
   const { promise, resolve } = Promise.withResolvers();
@@ -1041,7 +1052,7 @@ async function connect(server: Server): Promise<void> {
     },
     serialization: "json",
   });
-  clients.push(client);
+  clientList.push(client);
   await promise;
 }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -91,16 +91,37 @@ function tmpdirTestMkdir(): string {
   return tempdir;
 }
 
-it("fs.writeFile(1, data) should work when its inherited", async () => {
-  expect([join(import.meta.dir, "fs-writeFile-1-fixture.js"), "1"]).toRun();
+it.concurrent("fs.writeFile(1, data) should work when its inherited", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), "1"],
+    env: bunEnv,
+    stdio: ["inherit", "pipe", "inherit"],
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error("Command failed:\n" + stdout);
+  expect(exitCode).toBe(0);
 });
 
-it("fs.writeFile(2, data) should work when its inherited", async () => {
-  expect([join(import.meta.dir, "fs-writeFile-1-fixture.js"), "2"]).toRun();
+it.concurrent("fs.writeFile(2, data) should work when its inherited", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), "2"],
+    env: bunEnv,
+    stdio: ["inherit", "pipe", "inherit"],
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error("Command failed:\n" + stdout);
+  expect(exitCode).toBe(0);
 });
 
-it("fs.writeFile(/dev/null, data) should work", async () => {
-  expect([join(import.meta.dir, "fs-writeFile-1-fixture.js"), require("os").devNull]).toRun();
+it.concurrent("fs.writeFile(/dev/null, data) should work", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), require("os").devNull],
+    env: bunEnv,
+    stdio: ["inherit", "pipe", "inherit"],
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error("Command failed:\n" + stdout);
+  expect(exitCode).toBe(0);
 });
 
 it("fs.openAsBlob", async () => {
@@ -427,12 +448,13 @@ it("writeFileSync in append should not truncate the file", () => {
   expect(readFileSync(path, "utf8")).toBe(str);
 });
 
-it("await readdir #3931", async () => {
-  const { exitCode } = spawnSync({
+it.concurrent("await readdir #3931", async () => {
+  await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "./repro-3931.js")],
     env: bunEnv,
     cwd: import.meta.dir,
   });
+  const exitCode = await proc.exited;
   expect(exitCode).toBe(0);
 });
 
@@ -2080,10 +2102,8 @@ describe("fs.WriteStream", () => {
     });
 
     stream.on("finish", () => {
-      Bun.sleep(1000).then(() => {
-        expect(readFileSync(path, "utf8")).toBe("Test file written successfully");
-        done();
-      });
+      expect(readFileSync(path, "utf8")).toBe("Test file written successfully");
+      done();
     });
   });
 
@@ -2401,150 +2421,166 @@ describe("fs/promises", () => {
     expect(files.length).toBeGreaterThan(0);
   });
 
-  it("readdir(path, {recursive: true}) produces the same result as Node.js", async () => {
-    const full = resolve(import.meta.dir, "../");
-    const [bun, subprocess] = await Promise.all([
-      (async function () {
-        const files = await promises.readdir(full, { recursive: true });
-        files.sort();
-        return files;
-      })(),
-      (async function () {
-        const subprocess = Bun.spawn({
-          cmd: [
-            "node",
-            "-e",
-            `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
-              full,
-            )}, { recursive: true }).sort()), null, 2)`,
-          ],
-          cwd: process.cwd(),
-          stdout: "pipe",
-          stderr: "inherit",
-          stdin: "inherit",
-        });
-        await subprocess.exited;
-        return subprocess;
-      })(),
-    ]);
+  it.concurrent(
+    "readdir(path, {recursive: true}) produces the same result as Node.js",
+    async () => {
+      const full = resolve(import.meta.dir, "../");
+      const [bun, subprocess] = await Promise.all([
+        (async function () {
+          const files = await promises.readdir(full, { recursive: true });
+          files.sort();
+          return files;
+        })(),
+        (async function () {
+          const subprocess = Bun.spawn({
+            cmd: [
+              "node",
+              "-e",
+              `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
+                full,
+              )}, { recursive: true }).sort()), null, 2)`,
+            ],
+            cwd: process.cwd(),
+            stdout: "pipe",
+            stderr: "inherit",
+            stdin: "inherit",
+          });
+          await subprocess.exited;
+          return subprocess;
+        })(),
+      ]);
 
-    expect(subprocess.exitCode).toBe(0);
-    const text = await subprocess.stdout.text();
-    const node = JSON.parse(text);
-    expect(bun).toEqual(node as string[]);
-  }, 100000);
+      expect(subprocess.exitCode).toBe(0);
+      const text = await subprocess.stdout.text();
+      const node = JSON.parse(text);
+      expect(bun).toEqual(node as string[]);
+    },
+    100000,
+  );
 
-  it("readdir(path, {withFileTypes: true}) produces the same result as Node.js", async () => {
-    const full = resolve(import.meta.dir, "../");
-    const [bun, subprocess] = await Promise.all([
-      (async function () {
-        const files = await promises.readdir(full, { withFileTypes: true });
-        files.sort();
-        return files;
-      })(),
-      (async function () {
-        const subprocess = Bun.spawn({
-          cmd: [
-            "node",
-            "-e",
-            `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
-              full,
-            )}, { withFileTypes: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort()), null, 2)`,
-          ],
-          cwd: process.cwd(),
-          stdout: "pipe",
-          stderr: "inherit",
-          stdin: "inherit",
-        });
-        await subprocess.exited;
-        return subprocess;
-      })(),
-    ]);
+  it.concurrent(
+    "readdir(path, {withFileTypes: true}) produces the same result as Node.js",
+    async () => {
+      const full = resolve(import.meta.dir, "../");
+      const [bun, subprocess] = await Promise.all([
+        (async function () {
+          const files = await promises.readdir(full, { withFileTypes: true });
+          files.sort();
+          return files;
+        })(),
+        (async function () {
+          const subprocess = Bun.spawn({
+            cmd: [
+              "node",
+              "-e",
+              `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
+                full,
+              )}, { withFileTypes: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort()), null, 2)`,
+            ],
+            cwd: process.cwd(),
+            stdout: "pipe",
+            stderr: "inherit",
+            stdin: "inherit",
+          });
+          await subprocess.exited;
+          return subprocess;
+        })(),
+      ]);
 
-    expect(subprocess.exitCode).toBe(0);
-    const text = await subprocess.stdout.text();
-    const node = JSON.parse(text);
-    expect(bun.length).toEqual(node.length);
-    expect([...new Set(node.map(v => v.parentPath ?? v.path))]).toEqual([full]);
-    expect([...new Set(bun.map(v => v.parentPath ?? v.path))]).toEqual([full]);
-    expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
-      node.map(v => join(v.path, v.name)).sort(),
-    );
-  }, 100000);
+      expect(subprocess.exitCode).toBe(0);
+      const text = await subprocess.stdout.text();
+      const node = JSON.parse(text);
+      expect(bun.length).toEqual(node.length);
+      expect([...new Set(node.map(v => v.parentPath ?? v.path))]).toEqual([full]);
+      expect([...new Set(bun.map(v => v.parentPath ?? v.path))]).toEqual([full]);
+      expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
+        node.map(v => join(v.path, v.name)).sort(),
+      );
+    },
+    100000,
+  );
 
-  it("readdir(path, {withFileTypes: true, recursive: true}) produces the same result as Node.js", async () => {
-    const full = resolve(import.meta.dir, "../");
-    const [bun, subprocess] = await Promise.all([
-      (async function () {
-        const files = await promises.readdir(full, { withFileTypes: true, recursive: true });
-        files.sort((a, b) => a.path.localeCompare(b.path));
-        return files;
-      })(),
-      (async function () {
-        const subprocess = Bun.spawn({
-          cmd: [
-            "node",
-            "-e",
-            `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
-              full,
-            )}, { withFileTypes: true, recursive: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort((a, b) => a.path.localeCompare(b.path))), null, 2)`,
-          ],
-          cwd: process.cwd(),
-          stdout: "pipe",
-          stderr: "inherit",
-          stdin: "inherit",
-        });
-        await subprocess.exited;
-        return subprocess;
-      })(),
-    ]);
+  it.concurrent(
+    "readdir(path, {withFileTypes: true, recursive: true}) produces the same result as Node.js",
+    async () => {
+      const full = resolve(import.meta.dir, "../");
+      const [bun, subprocess] = await Promise.all([
+        (async function () {
+          const files = await promises.readdir(full, { withFileTypes: true, recursive: true });
+          files.sort((a, b) => a.path.localeCompare(b.path));
+          return files;
+        })(),
+        (async function () {
+          const subprocess = Bun.spawn({
+            cmd: [
+              "node",
+              "-e",
+              `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
+                full,
+              )}, { withFileTypes: true, recursive: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort((a, b) => a.path.localeCompare(b.path))), null, 2)`,
+            ],
+            cwd: process.cwd(),
+            stdout: "pipe",
+            stderr: "inherit",
+            stdin: "inherit",
+          });
+          await subprocess.exited;
+          return subprocess;
+        })(),
+      ]);
 
-    expect(subprocess.exitCode).toBe(0);
-    const text = await subprocess.stdout.text();
-    const node = JSON.parse(text);
-    expect(bun.length).toEqual(node.length);
-    expect(new Set(bun.map(v => v.parentPath ?? v.path))).toEqual(new Set(node.map(v => v.path)));
-    expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
-      node.map(v => join(v.path, v.name)).sort(),
-    );
-  }, 100000);
+      expect(subprocess.exitCode).toBe(0);
+      const text = await subprocess.stdout.text();
+      const node = JSON.parse(text);
+      expect(bun.length).toEqual(node.length);
+      expect(new Set(bun.map(v => v.parentPath ?? v.path))).toEqual(new Set(node.map(v => v.path)));
+      expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
+        node.map(v => join(v.path, v.name)).sort(),
+      );
+    },
+    100000,
+  );
 
-  it("readdirSync(path, {withFileTypes: true, recursive: true}) produces the same result as Node.js", async () => {
-    const full = resolve(import.meta.dir, "../");
-    const [bun, subprocess] = await Promise.all([
-      (async function () {
-        const files = readdirSync(full, { withFileTypes: true, recursive: true });
-        files.sort((a, b) => a.path.localeCompare(b.path));
-        return files;
-      })(),
-      (async function () {
-        const subprocess = Bun.spawn({
-          cmd: [
-            "node",
-            "-e",
-            `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
-              full,
-            )}, { withFileTypes: true, recursive: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort((a, b) => a.path.localeCompare(b.path))), null, 2)`,
-          ],
-          cwd: process.cwd(),
-          stdout: "pipe",
-          stderr: "inherit",
-          stdin: "inherit",
-        });
-        await subprocess.exited;
-        return subprocess;
-      })(),
-    ]);
+  it.concurrent(
+    "readdirSync(path, {withFileTypes: true, recursive: true}) produces the same result as Node.js",
+    async () => {
+      const full = resolve(import.meta.dir, "../");
+      const [bun, subprocess] = await Promise.all([
+        (async function () {
+          const files = readdirSync(full, { withFileTypes: true, recursive: true });
+          files.sort((a, b) => a.path.localeCompare(b.path));
+          return files;
+        })(),
+        (async function () {
+          const subprocess = Bun.spawn({
+            cmd: [
+              "node",
+              "-e",
+              `process.stdout.write(JSON.stringify(require("fs").readdirSync(${JSON.stringify(
+                full,
+              )}, { withFileTypes: true, recursive: true }).map(v => ({ path: v.parentPath ?? v.path, name: v.name })).sort((a, b) => a.path.localeCompare(b.path))), null, 2)`,
+            ],
+            cwd: process.cwd(),
+            stdout: "pipe",
+            stderr: "inherit",
+            stdin: "inherit",
+          });
+          await subprocess.exited;
+          return subprocess;
+        })(),
+      ]);
 
-    expect(subprocess.exitCode).toBe(0);
-    const text = await subprocess.stdout.text();
-    const node = JSON.parse(text);
-    expect(bun.length).toEqual(node.length);
-    expect(new Set(bun.map(v => v.parentPath ?? v.path))).toEqual(new Set(node.map(v => v.path)));
-    expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
-      node.map(v => join(v.path, v.name)).sort(),
-    );
-  }, 100000);
+      expect(subprocess.exitCode).toBe(0);
+      const text = await subprocess.stdout.text();
+      const node = JSON.parse(text);
+      expect(bun.length).toEqual(node.length);
+      expect(new Set(bun.map(v => v.parentPath ?? v.path))).toEqual(new Set(node.map(v => v.path)));
+      expect(bun.map(v => join(v.parentPath ?? v.path, v.name)).sort()).toEqual(
+        node.map(v => join(v.path, v.name)).sort(),
+      );
+    },
+    100000,
+  );
 
   for (let withFileTypes of [false, true] as const) {
     const iterCount = 200;
@@ -3662,25 +3698,27 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
   ];
 
   for (const [name, code] of nonExistTests) {
-    it(`${name} (not existing)`, () => {
-      const { success } = spawnSync({
+    it.concurrent(`${name} (not existing)`, async () => {
+      await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", code],
         cwd: workingDir1,
         stdio: ["ignore", "inherit", "inherit"],
         env: bunEnv,
       });
-      expect(success).toBeTrue();
+      const exitCode = await proc.exited;
+      expect(exitCode === 0).toBeTrue();
     });
   }
   for (const [name, code] of existTests) {
-    it(`${name} (existing)`, () => {
-      const { success } = spawnSync({
+    it.concurrent(`${name} (existing)`, async () => {
+      await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", code],
         cwd: workingDir2,
         stdio: ["ignore", "inherit", "inherit"],
         env: bunEnv,
       });
-      expect(success).toBeTrue();
+      const exitCode = await proc.exited;
+      expect(exitCode === 0).toBeTrue();
     });
   }
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -115,7 +115,7 @@ it.concurrent("fs.writeFile(2, data) should work when its inherited", async () =
 
 it.concurrent("fs.writeFile(/dev/null, data) should work", async () => {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), require("os").devNull],
+    cmd: [bunExe(), join(import.meta.dir, "fs-writeFile-1-fixture.js"), os.devNull],
     env: bunEnv,
     stdio: ["inherit", "pipe", "inherit"],
   });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3706,7 +3706,7 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
         env: bunEnv,
       });
       const exitCode = await proc.exited;
-      expect(exitCode === 0).toBeTrue();
+      expect(exitCode).toBe(0);
     });
   }
   for (const [name, code] of existTests) {
@@ -3718,7 +3718,7 @@ describe('kernel32 long path conversion does not mangle "../../path" into "path"
         env: bunEnv,
       });
       const exitCode = await proc.exited;
-      expect(exitCode === 0).toBeTrue();
+      expect(exitCode).toBe(0);
     });
   }
 });

--- a/test/js/node/http/early-hints-crlf-injection.test.ts
+++ b/test/js/node/http/early-hints-crlf-injection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-describe("writeEarlyHints", () => {
+describe.concurrent("writeEarlyHints", () => {
   test("rejects CRLF injection in header name", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -67,7 +67,7 @@ async function run(script: string) {
   expect(exitCode).toBe(0);
 }
 
-describe("cork buffer: no cross-socket data bleed", () => {
+describe.concurrent("cork buffer: no cross-socket data bleed", () => {
   // Attack 1: write, yield, write — slot held with data across yield.
   // Another request resumes during the yield and tries to steal/use our slot.
   test("node:http — write then mixed yield then write (slot held with data)", async () => {

--- a/test/js/node/http2/node-echo-server.fixture.js
+++ b/test/js/node/http2/node-echo-server.fixture.js
@@ -8,31 +8,49 @@ const server = http2.createSecureServer({
 });
 const setCookie = ["a=b", "c=d; Wed, 21 Oct 2015 07:28:00 GMT; Secure; HttpOnly", "e=f"];
 
+// This server is shared across many concurrent client tests, some of which
+// abort/reset/destroy mid-request. Swallow errors so one client cannot crash
+// the process for the others.
+process.on("uncaughtException", err => console.error("uncaughtException:", err.message));
+server.on("sessionError", () => {});
+server.on("error", () => {});
+
 server.on("stream", (stream, headers, flags) => {
   // errors here are not useful the test should handle on the client side
-  stream.on("error", err => console.error(err));
+  stream.on("error", () => {});
+
+  function safeRespond(headers) {
+    try {
+      stream.respond(headers);
+    } catch {}
+  }
+  function safeEnd(body) {
+    try {
+      stream.end(body);
+    } catch {}
+  }
 
   if (headers["x-wait-trailer"]) {
     const response = { headers, flags };
-    stream.respond({
+    safeRespond({
       "content-type": "text/html",
       ":status": 200,
       "set-cookie": setCookie,
     });
     stream.on("trailers", (headers, flags) => {
-      stream.end(JSON.stringify({ ...response, trailers: headers }));
+      safeEnd(JSON.stringify({ ...response, trailers: headers }));
     });
   } else if (headers["x-no-echo"]) {
     let byteLength = 0;
     stream.on("data", chunk => {
       byteLength += chunk.length;
     });
-    stream.respond({
+    safeRespond({
       "content-type": "application/json",
       ":status": 200,
     });
     stream.on("end", () => {
-      stream.end(JSON.stringify(byteLength));
+      safeEnd(JSON.stringify(byteLength));
     });
   } else {
     // Store the request information, excluding pseudo-headers in the header echo
@@ -57,7 +75,7 @@ server.on("stream", (stream, headers, flags) => {
           requestData.json = JSON.parse(requestData.data); // Convert buffer array to string
         } catch (e) {}
       }
-      stream.respond({
+      safeRespond({
         "content-type": "application/json",
         ":status": 200,
         // Set security and cache-control headers
@@ -65,7 +83,7 @@ server.on("stream", (stream, headers, flags) => {
         "x-content-type-options": "nosniff",
         "set-cookie": setCookie,
       });
-      stream.end(JSON.stringify(requestData));
+      safeEnd(JSON.stringify(requestData));
     });
   }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -9,7 +9,7 @@ import tls from "node:tls";
 import { Duplex } from "stream";
 import http2utils from "./helpers";
 import { nodeEchoServer, TLS_CERT, TLS_OPTIONS } from "./http2-helpers";
-const { describe, expect, it, createCallCheckCtx } = createTest(import.meta.path);
+const { describe, expect, it, beforeAll, afterAll, createCallCheckCtx } = createTest(import.meta.path);
 const ASAN_MULTIPLIER = isASAN ? 3 : 1;
 
 function invalidArgTypeHelper(input) {
@@ -48,7 +48,10 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           fs.mkdirSync(tmp_dir, { recursive: true });
         }
 
-        const file_name = path.join(tmp_dir, test_name);
+        const file_name = path.join(
+          tmp_dir,
+          `${path.basename(nodeExecutable)}.${paddingStrategyName(paddingStrategy)}.${test_name}`,
+        );
         const contents = Buffer.from(`const http2 = require("http2");
     const server = http2.createServer({ paddingStrategy: ${paddingStrategy} });
   ${code}
@@ -159,10 +162,20 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
       }
 
       describe("Client Basics", () => {
+        // The echo server is stateless; share one instance across all tests in
+        // this describe block instead of spawning a fresh subprocess per test.
+        let sharedEchoServer;
+        let HTTPS_SERVER;
+        beforeAll(async () => {
+          sharedEchoServer = await nodeEchoServer(paddingStrategy);
+          HTTPS_SERVER = sharedEchoServer.url;
+        });
+        afterAll(() => {
+          sharedEchoServer?.subprocess?.kill?.(9);
+        });
+
         // we dont support server yet but we support client
         it("should be able to send a GET request", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const result = await doHttp2Request(HTTPS_SERVER, HTTPS_SERVER, {
             ":path": "/get",
             "test-header": "test-value",
@@ -173,8 +186,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(parsed.headers["test-header"]).toBe("test-value");
         });
         it("should be able to send a POST request", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const payload = JSON.stringify({ "hello": "bun" });
           const result = await doHttp2Request(
             HTTPS_SERVER,
@@ -190,8 +201,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(parsed.data).toEqual(payload);
         });
         it("should be able to send data using end", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const payload = JSON.stringify({ "hello": "bun" });
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
@@ -220,8 +229,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(parsed.data).toEqual(payload);
         });
         it("should be able to mutiplex GET requests", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const results = await doMultiplexHttp2Request(HTTPS_SERVER, [
             { headers: { ":path": "/get" } },
             { headers: { ":path": "/get" } },
@@ -237,8 +244,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("http2 should receive remoteSettings when receiving default settings frame", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const session = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
 
@@ -264,8 +269,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("should be able to mutiplex POST requests", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const results = await doMultiplexHttp2Request(HTTPS_SERVER, [
             { headers: { ":path": "/post", ":method": "POST" }, payload: JSON.stringify({ "request": 1 }) },
             { headers: { ":path": "/post", ":method": "POST" }, payload: JSON.stringify({ "request": 2 }) },
@@ -566,8 +569,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(() => http2.getUnpackedSettings(buffer)).toThrow();
         });
         it("headers cannot be bigger than 65536 bytes", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           try {
             await doHttp2Request(HTTPS_SERVER, HTTPS_SERVER, { ":path": "/", "test-header": "A".repeat(90000) });
             expect("unreachable").toBe(true);
@@ -577,8 +578,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("should be destroyed after close", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject: promiseReject } = Promise.withResolvers();
           const client = http2.connect(`${HTTPS_SERVER}/get`, TLS_OPTIONS);
           client.on("error", promiseReject);
@@ -600,8 +599,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(client.destroyed).toBe(true);
         });
         it("should be destroyed after destroy", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject: promiseReject } = Promise.withResolvers();
           const client = http2.connect(`${HTTPS_SERVER}/get`, TLS_OPTIONS);
           client.on("error", promiseReject);
@@ -623,8 +620,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(client.destroyed).toBe(true);
         });
         it("should fail to connect over HTTP/1.1", async () => {
-          await using server_ = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server_.url;
           const tlsCert = TLS_CERT;
           using server = Bun.serve({
             port: 0,
@@ -646,8 +641,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("works with Duplex", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           class JSSocket extends Duplex {
             constructor(socket) {
               super({ emitClose: true });
@@ -689,8 +682,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           socket.destroy();
         });
         it("close callback", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(`${HTTPS_SERVER}/get`, TLS_OPTIONS);
           client.on("error", reject);
@@ -699,8 +690,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(client.destroyed).toBe(true);
         });
         it("is possible to abort request", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const abortController = new AbortController();
           const promise = doHttp2Request(HTTPS_SERVER, `${HTTPS_SERVER}/get`, { ":path": "/get" }, null, null, {
             signal: abortController.signal,
@@ -714,8 +703,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("aborted event should work with abortController", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const abortController = new AbortController();
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
@@ -739,8 +726,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
         });
 
         it("aborted event should work with aborted signal", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -763,8 +748,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
         });
 
         it("state should work", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -887,8 +870,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("ping events should work", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -916,8 +897,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(received_ping).toEqual(Buffer.from("12345678"));
         });
         it("ping without events should work", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -944,8 +923,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(received_ping).toEqual(result.payload);
         });
         it("ping with wrong payload length events should error", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -964,8 +941,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(result.code).toBe("ERR_HTTP2_PING_LENGTH");
         });
         it("ping with wrong payload type events should throw", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -985,8 +960,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           expect(result.code).toBe("ERR_INVALID_ARG_TYPE");
         });
         it("stream event should work", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -1001,8 +974,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
         });
 
         it("wantTrailers should work", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS);
           client.on("error", reject);
@@ -1048,6 +1019,8 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
         it.skipIf(!isCI)(
           "should not leak memory",
           async () => {
+            // Use a dedicated server: this test floods it with requests for ~100s
+            // and would contend with other concurrent tests sharing the same server.
             await using server = await nodeEchoServer(paddingStrategy);
             await using proc = Bun.spawn({
               cmd: [bunExe(), "--smol", "run", path.join(import.meta.dir, "node-http2-memory-leak.js")],
@@ -1134,8 +1107,6 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
         it("should not be able to write on socket", async () => {
-          await using server = await nodeEchoServer(paddingStrategy);
-          const HTTPS_SERVER = server.url;
           const { promise, resolve, reject } = Promise.withResolvers();
           const client = http2.connect(HTTPS_SERVER, TLS_OPTIONS, (session, socket) => {
             try {

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -2214,13 +2214,13 @@ describe("BLOB Edge Cases and Binary Data", () => {
     await sql`CREATE TABLE large_blob (id INTEGER, data BLOB)`;
 
     const sizes = [1024 * 1024, 10 * 1024 * 1024];
+    // 256-byte repeating pattern (0..255). Buffer.alloc(size, pattern) tiles it,
+    // producing bytes identical to `largeBuffer[i] = i % 256` without an 11M-iteration JS loop.
+    const pattern = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++) pattern[i] = i;
 
     for (const size of sizes) {
-      const largeBuffer = Buffer.alloc(size);
-
-      for (let i = 0; i < size; i++) {
-        largeBuffer[i] = i % 256;
-      }
+      const largeBuffer = Buffer.alloc(size, pattern);
 
       await sql`INSERT INTO large_blob VALUES (${size}, ${largeBuffer})`;
 
@@ -2497,16 +2497,18 @@ describe("Indexes and Query Optimization", () => {
 
     await sql`CREATE INDEX idx_name_lower ON products(LOWER(name))`;
 
-    for (let i = 1; i <= 100; i++) {
-      await sql`INSERT INTO products VALUES (
-        ${i}, 
-        ${"Product " + i}, 
-        ${"Category " + (i % 10)},
-        ${i * 10.5},
-        ${"SKU-" + i.toString().padStart(5, "0")},
-        ${"Description for product " + i}
-      )`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 1; i <= 100; i++) {
+        await tx`INSERT INTO products VALUES (
+          ${i},
+          ${"Product " + i},
+          ${"Category " + (i % 10)},
+          ${i * 10.5},
+          ${"SKU-" + i.toString().padStart(5, "0")},
+          ${"Description for product " + i}
+        )`;
+      }
+    });
 
     try {
       await sql`INSERT INTO products VALUES (101, 'Test', 'Test', 10, 'SKU-00001', 'Duplicate SKU')`;
@@ -2532,10 +2534,12 @@ describe("Indexes and Query Optimization", () => {
 
     await sql`CREATE INDEX idx_type ON stats_test(type)`;
 
-    for (let i = 1; i <= 1000; i++) {
-      const type = i <= 900 ? "common" : i <= 990 ? "uncommon" : "rare";
-      await sql`INSERT INTO stats_test VALUES (${i}, ${type}, ${i})`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 1; i <= 1000; i++) {
+        const type = i <= 900 ? "common" : i <= 990 ? "uncommon" : "rare";
+        await tx`INSERT INTO stats_test VALUES (${i}, ${type}, ${i})`;
+      }
+    });
 
     await sql`ANALYZE`;
 
@@ -2553,14 +2557,16 @@ describe("Indexes and Query Optimization", () => {
 
     await sql`CREATE INDEX idx_email_username ON users(email, username)`;
 
-    for (let i = 1; i <= 100; i++) {
-      await sql`INSERT INTO users VALUES (
-        ${i},
-        ${"user" + i + "@example.com"},
-        ${"user" + i},
-        ${new Date().toISOString()}
-      )`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 1; i <= 100; i++) {
+        await tx`INSERT INTO users VALUES (
+          ${i},
+          ${"user" + i + "@example.com"},
+          ${"user" + i},
+          ${new Date().toISOString()}
+        )`;
+      }
+    });
 
     const result = await sql`SELECT email, username FROM users WHERE email LIKE 'user1%'`;
     expect(result.length).toBeGreaterThan(0);
@@ -2575,9 +2581,11 @@ describe("VACUUM and Database Maintenance", () => {
 
     await sql`CREATE TABLE vacuum_test (id INTEGER, data TEXT)`;
 
-    for (let i = 0; i < 1000; i++) {
-      await sql`INSERT INTO vacuum_test VALUES (${i}, ${Buffer.alloc(100, "x").toString()})`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 0; i < 1000; i++) {
+        await tx`INSERT INTO vacuum_test VALUES (${i}, ${Buffer.alloc(100, "x").toString()})`;
+      }
+    });
 
     await sql`DELETE FROM vacuum_test WHERE id % 2 = 0`;
 
@@ -2604,9 +2612,11 @@ describe("VACUUM and Database Maintenance", () => {
 
     await sql`CREATE TABLE test (id INTEGER, data TEXT)`;
 
-    for (let i = 0; i < 100; i++) {
-      await sql`INSERT INTO test VALUES (${i}, ${Buffer.alloc(1000, "x").toString()})`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 0; i < 100; i++) {
+        await tx`INSERT INTO test VALUES (${i}, ${Buffer.alloc(1000, "x").toString()})`;
+      }
+    });
 
     await sql`DELETE FROM test WHERE id < 50`;
 
@@ -3098,9 +3108,11 @@ describe("Concurrency and Locking", () => {
     const sql1 = new SQL(`sqlite://${dbPath}`);
     await sql1`CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)`;
 
-    for (let i = 1; i <= 100; i++) {
-      await sql1`INSERT INTO test VALUES (${i}, ${"value" + i})`;
-    }
+    await sql1.begin(async tx => {
+      for (let i = 1; i <= 100; i++) {
+        await tx`INSERT INTO test VALUES (${i}, ${"value" + i})`;
+      }
+    });
 
     const sql2 = new SQL(`sqlite://${dbPath}`);
     const sql3 = new SQL(`sqlite://${dbPath}`);
@@ -3885,14 +3897,16 @@ describe("Query Explain and Optimization", () => {
       description TEXT
     )`;
 
-    for (let i = 1; i <= 1000; i++) {
-      await sql`INSERT INTO large_table VALUES (
-        ${i},
-        ${"category" + (i % 10)},
-        ${i * 10},
-        ${"description for item " + i}
-      )`;
-    }
+    await sql.begin(async tx => {
+      for (let i = 1; i <= 1000; i++) {
+        await tx`INSERT INTO large_table VALUES (
+          ${i},
+          ${"category" + (i % 10)},
+          ${i * 10},
+          ${"description for item " + i}
+        )`;
+      }
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## What does this PR do?

Reduces wall-clock time for 24 of the slowest test files (per ASAN CI shard timings) without changing what is tested. All assertions, snapshots, and test counts are identical.

Techniques applied per file:

- **`describe.concurrent` / `test.concurrent`** for tests that already create isolated resources (own server with `port: 0`, own `tempDir`, own subprocess) and share no mutable state — `http-server-chunking`, `node-http-nested-cork`, `early-hints-crlf-injection`, `bundler_html_server`, `esbuild/default`, `glob/scan`, `s3-list-objects`, `websocket-server`, `bun-remove`, `bunx`, `bun-build-api`, `bun-security-scanner-workspaces`
- **`spawnSync` → async `Bun.spawn` + `Promise.all`** so subprocess startups overlap instead of blocking serially — `fs.test.ts`, `import-attributes`, `snapshot.test.ts`, `bun-build-api`
- **Sequential subprocess loop → `Promise.all`** where iterations are independent — `fetch-abort-ssl-context-eviction` (5 isolated repro runs), `spawn-streaming-stdin`, `es-decorators-esbuild` (147 spawns → 1 batched run)
- **Per-test isolated setup replacing shared `beforeEach` state**, enabling concurrency — `bun-install-lifecycle-scripts` (with 12-slot semaphore to bound concurrent installs), `bun-install-security-provider`, `bun-remove`, `bunx`
- **Shared server in `beforeAll`/`afterAll`** instead of per-test start/stop — `node-http2` (subprocess echo server), `bun-security-scanner-workspaces` (dummy registry)
- **Removed redundant work** — `bun-upgrade` skips copying the bun binary for the 4 tests that only check arg validation; `fs.test.ts` drops a `Bun.sleep(1000)` after a WriteStream `finish` event
- **Batched setup I/O** — `sqlite-sql` wraps ~3400 setup INSERTs in transactions and replaces an 11M-iteration byte-fill with `Buffer.alloc(size, pattern)`; `bun-install-security-provider` batches 3000 tarball writes
- **Reduced fixed sleep durations** in `bun-write` / `timed-stderr-output` fixture while preserving the timing ratio the test asserts on

The biggest ASAN CI wins should come from files dominated by serial subprocess startup: `http-server-chunking` (130s), `node-http-nested-cork` (110s), `bun-install-lifecycle-scripts` (105s), `bundler_html_server` (60s), `early-hints-crlf-injection` (37s), `bun-upgrade` (37s).

## How did you verify your code works?

Each file was run before and after with `USE_SYSTEM_BUN=1 bun test <file>` and confirmed to have identical pass/fail/expect/snapshot counts. No tests were skipped, removed, or had their assertions changed.