### PR TITLE
expect: propagate exception from asymmetricMatch on custom matcher

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-asymmetric-match-throw.test.ts
+++ b/test/js/bun/test/expect-asymmetric-match-throw.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("asymmetricMatch propagates exception from throwing custom matcher instead of crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { expect } = Bun.jest();
+      expect.extend({
+        myMatcher: () => {
+          throw new Error("boom");
+        },
+      });
+      let thrown;
+      try {
+        expect.myMatcher().asymmetricMatch({});
+      } catch (e) {
+        thrown = e;
+      }
+      if (!(thrown instanceof Error) || thrown.message !== "boom") {
+        console.error("expected thrown Error('boom'), got:", thrown);
+        process.exit(1);
+      }
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzer found a debug assertion failure (fingerprint `20255103bd1708c1`).

## What happened

`ExpectCustomAsymmetricMatcher.asymmetricMatch` calls `execute()`, a C-callconv function that returns `bool` and leaves a pending JS exception on the VM when the user-provided matcher function throws. `asymmetricMatch` then returned `jsBoolean(false)` — a valid non-zero JSValue — with the exception still pending, tripping the host function assertion `(value == .zero) == globalThis.hasException()`.

## Repro

```js
const { expect } = Bun.jest();
expect.extend({ myMatcher: () => { throw new Error("boom"); } });
expect.myMatcher().asymmetricMatch({});
```

Before:
```
ASSERTION FAILED: Unexpected exception observed ...
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

After: the `Error: boom` propagates to JS as a catchable exception.

## Fix

Check for a pending exception after `execute()` and return `error.JSError` so the binding layer reports it correctly.