### PR TITLE
Stop forcing BuiltinFunctions::visit<> instantiation in every TU

### DIFF
--- a/src/bun.js/bindings/BakeAdditionsToGlobalObject.cpp
+++ b/src/bun.js/bindings/BakeAdditionsToGlobalObject.cpp
@@ -3,8 +3,20 @@
 #include "JSBunRequest.h"
 #include "JavaScriptCore/SlotVisitorMacros.h"
 #include "ErrorCode.h"
+#include "WebCoreJSBuiltins.h"
 
 namespace Bun {
+
+JSC::JSFunction* BakeAdditionsToGlobalObject::wrapComponent(JSGlobalObject* globalObject)
+{
+    auto* function = m_wrapComponent.get();
+    if (!function) {
+        auto& vm = globalObject->vm();
+        function = JSC::JSFunction::create(vm, globalObject, WebCore::bakeSSRResponseWrapComponentCodeGenerator(vm), globalObject);
+        m_wrapComponent.set(vm, globalObject, function);
+    }
+    return function;
+}
 
 void createDevServerFrameworkRequestArgsStructure(JSC::LazyClassStructure::Initializer& init)
 {

--- a/src/bun.js/bindings/BakeAdditionsToGlobalObject.h
+++ b/src/bun.js/bindings/BakeAdditionsToGlobalObject.h
@@ -2,7 +2,6 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include "BunBuiltinNames.h"
-#include "WebCoreJSBuiltins.h"
 #include "headers-handwritten.h"
 
 namespace Bun {
@@ -99,16 +98,7 @@ struct BakeAdditionsToGlobalObject {
         return m_asyncLocalStorageInstance.get();
     }
 
-    JSC::JSFunction* wrapComponent(JSGlobalObject* globalObject)
-    {
-        auto* function = m_wrapComponent.get();
-        if (!function) {
-            auto& vm = globalObject->vm();
-            function = JSC::JSFunction::create(vm, globalObject, WebCore::bakeSSRResponseWrapComponentCodeGenerator(vm), globalObject);
-            m_wrapComponent.set(vm, globalObject, function);
-        }
-        return function;
-    }
+    JSC::JSFunction* wrapComponent(JSGlobalObject*);
 
     template<typename T>
     using LazyPropertyOfGlobalObject = LazyProperty<JSGlobalObject, T>;

--- a/src/bun.js/bindings/BunClientData.cpp
+++ b/src/bun.js/bindings/BunClientData.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 
 #include "BunClientData.h"
+#include "WebCoreJSBuiltins.h"
 
 #include "ExtendedDOMClientIsoSubspaces.h"
 #include "ExtendedDOMIsoSubspaces.h"
@@ -50,7 +51,7 @@ JSHeapData::JSHeapData(Heap& heap)
 
 JSVMClientData::JSVMClientData(VM& vm, RefPtr<SourceProvider> sourceProvider)
     : m_builtinNames(vm)
-    , m_builtinFunctions(vm, sourceProvider, m_builtinNames)
+    , m_builtinFunctions(makeUnique<JSBuiltinFunctions>(vm, sourceProvider, m_builtinNames))
     , m_heapData(JSHeapData::ensureHeapData(vm.heap))
     , CLIENT_ISO_SUBSPACE_INIT(m_domBuiltinConstructorSpace)
     , CLIENT_ISO_SUBSPACE_INIT(m_domConstructorSpace)

--- a/src/bun.js/bindings/BunClientData.h
+++ b/src/bun.js/bindings/BunClientData.h
@@ -4,6 +4,7 @@ namespace WebCore {
 
 class ExtendedDOMClientIsoSubspaces;
 class ExtendedDOMIsoSubspaces;
+class JSBuiltinFunctions;
 
 class DOMWrapperWorld;
 }
@@ -23,10 +24,10 @@ class DOMWrapperWorld;
 #include "JSVMClientDataClient.h"
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/StdLibExtras.h>
-#include "WebCoreJSBuiltins.h"
 #include "JSCTaskScheduler.h"
 #include "HTTPHeaderIdentifiers.h"
 namespace Zig {
+class GlobalObject;
 }
 
 namespace WebCore {
@@ -92,7 +93,7 @@ public:
 
     JSHeapData& heapData() { return *m_heapData; }
     BunBuiltinNames& builtinNames() { return m_builtinNames; }
-    JSBuiltinFunctions& builtinFunctions() { return m_builtinFunctions; }
+    JSBuiltinFunctions& builtinFunctions() { return *m_builtinFunctions; }
 
     String overrideSourceURL(const StackFrame&, const String& originalSourceURL) const
     {
@@ -134,7 +135,7 @@ private:
     bool isWebCoreJSClientData() const final { return true; }
 
     BunBuiltinNames m_builtinNames;
-    JSBuiltinFunctions m_builtinFunctions;
+    std::unique_ptr<JSBuiltinFunctions> m_builtinFunctions;
 
     JSHeapData* m_heapData;
 

--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -3,6 +3,7 @@
 
 #include "BunProcess.h"
 #include "DLHandleMap.h"
+#include "WebCoreJSBuiltins.h"
 #include "v8/node.h"
 
 // Include the CMake-generated dependency versions header

--- a/src/bun.js/bindings/JSBakeResponse.h
+++ b/src/bun.js/bindings/JSBakeResponse.h
@@ -3,6 +3,7 @@
 #include "JSCookieMap.h"
 #include "root.h"
 #include "ZigGeneratedClasses.h"
+#include "WebCoreJSBuiltins.h"
 
 namespace Bun {
 using namespace JSC;

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -3,6 +3,7 @@
 #include "root.h"
 
 #include "ZigGlobalObject.h"
+#include "WebCoreJSBuiltins.h"
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/Error.h"

--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/YarrMatchingContextHolder.h>
 #include "ErrorCode.h"
 #include "napi_external.h"
+#include "WebCoreJSBuiltins.h"
 
 #include <JavaScriptCore/JSPromise.h>
 

--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -81,6 +81,7 @@
 #include "JSCommonJSExtensions.h"
 
 #include "ErrorCode.h"
+#include "WebCoreJSBuiltins.h"
 
 extern "C" bool Bun__isBunMain(JSC::JSGlobalObject* global, const BunString*);
 

--- a/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/bun.js/bindings/JSEnvironmentVariableMap.cpp
@@ -13,6 +13,7 @@
 #include "BunClientData.h"
 #include "wtf/Compiler.h"
 #include "wtf/Forward.h"
+#include "WebCoreJSBuiltins.h"
 
 using namespace JSC;
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -829,7 +829,7 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, const JSC::Gl
     , m_constructors(makeUnique<WebCore::DOMConstructors>())
     , m_world(static_cast<JSVMClientData*>(vm.clientData)->normalWorld())
     , m_worldIsNormal(true)
-    , m_builtinInternalFunctions(vm)
+    , m_builtinInternalFunctions(makeUnique<WebCore::JSBuiltinInternalFunctions>(vm))
     , m_scriptExecutionContext(new WebCore::ScriptExecutionContext(&vm, this))
     , globalEventScope(adoptRef(*new Bun::WorkerGlobalScope(m_scriptExecutionContext)))
 {
@@ -844,7 +844,7 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, WebCore::Scri
     , m_constructors(makeUnique<WebCore::DOMConstructors>())
     , m_world(static_cast<JSVMClientData*>(vm.clientData)->normalWorld())
     , m_worldIsNormal(true)
-    , m_builtinInternalFunctions(vm)
+    , m_builtinInternalFunctions(makeUnique<WebCore::JSBuiltinInternalFunctions>(vm))
     , m_scriptExecutionContext(new WebCore::ScriptExecutionContext(&vm, this, contextId))
     , globalEventScope(adoptRef(*new Bun::WorkerGlobalScope(m_scriptExecutionContext)))
 {
@@ -2697,7 +2697,7 @@ JSValue GlobalObject_getGlobalThis(VM& vm, JSObject* globalObject)
 void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    m_builtinInternalFunctions.initialize(*this);
+    m_builtinInternalFunctions->initialize(*this);
 
     auto clientData = WebCore::clientData(vm);
     auto& builtinNames = WebCore::builtinNames(vm);

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -26,6 +26,7 @@ class WorkerGlobalScope;
 class SubtleCrypto;
 class EventTarget;
 class Performance;
+class JSBuiltinInternalFunctions;
 } // namespace WebCore
 
 namespace Bun {
@@ -55,7 +56,6 @@ struct node_module;
 #include "BunPlugin.h"
 #include "JSMockFunction.h"
 #include "InternalModuleRegistry.h"
-#include "WebCoreJSBuiltins.h"
 #include "headers-handwritten.h"
 #include "BunCommonStrings.h"
 #include "BunHttp2CommonStrings.h"
@@ -204,7 +204,7 @@ public:
     static ScriptExecutionStatus scriptExecutionStatus(JSGlobalObject*, JSObject*);
     static void promiseRejectionTracker(JSGlobalObject*, JSC::JSPromise*, JSC::JSPromiseRejectionOperation);
     void setConsole(void* console);
-    WebCore::JSBuiltinInternalFunctions& builtinInternalFunctions() { return m_builtinInternalFunctions; }
+    WebCore::JSBuiltinInternalFunctions& builtinInternalFunctions() { return *m_builtinInternalFunctions; }
     JSC::Structure* FFIFunctionStructure() const { return m_JSFFIFunctionStructure.getInitializedOnMainThread(this); }
     JSC::Structure* NapiClassStructure() const { return m_NapiClassStructure.getInitializedOnMainThread(this); }
 
@@ -530,7 +530,7 @@ public:
     V(public, JSC::LazyClassStructure, m_JSStatFSBigIntClassStructure)                                       \
     V(public, JSC::LazyClassStructure, m_JSDirentClassStructure)                                             \
                                                                                                              \
-    V(private, WebCore::JSBuiltinInternalFunctions, m_builtinInternalFunctions)                              \
+    V(private, std::unique_ptr<WebCore::JSBuiltinInternalFunctions>, m_builtinInternalFunctions)             \
     V(private, std::unique_ptr<WebCore::DOMConstructors>, m_constructors)                                    \
     V(private, Bun::CommonStrings, m_commonStrings)                                                          \
     V(private, Bun::Http2CommonStrings, m_http2CommonStrings)                                                \
@@ -740,7 +740,7 @@ public:
 private:
     void addBuiltinGlobals(JSC::VM&);
 
-    friend void WebCore::JSBuiltinInternalFunctions::initialize(Zig::GlobalObject&);
+    friend class WebCore::JSBuiltinInternalFunctions;
     uint8_t m_worldIsNormal;
     JSDOMStructureMap m_structures WTF_GUARDED_BY_LOCK(m_gcLock);
     Lock m_gcLock;

--- a/src/bun.js/bindings/webcore/InternalWritableStream.cpp
+++ b/src/bun.js/bindings/webcore/InternalWritableStream.cpp
@@ -28,6 +28,7 @@
 
 #include "Exception.h"
 #include "WebCoreJSClientData.h"
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 

--- a/src/bun.js/bindings/webcore/JSByteLengthQueuingStrategy.cpp
+++ b/src/bun.js/bindings/webcore/JSByteLengthQueuingStrategy.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSCountQueuingStrategy.cpp
+++ b/src/bun.js/bindings/webcore/JSCountQueuingStrategy.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableByteStreamController.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableByteStreamController.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableStream.cpp
@@ -41,6 +41,7 @@
 #include "ZigGeneratedClasses.h"
 #include "JavaScriptCore/BuiltinNames.h"
 #include "ZigGlobalObject.h"
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableStreamBYOBReader.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableStreamBYOBReader.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableStreamBYOBRequest.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableStreamBYOBRequest.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableStreamDefaultController.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableStreamDefaultController.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSReadableStreamDefaultReader.cpp
+++ b/src/bun.js/bindings/webcore/JSReadableStreamDefaultReader.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSTextDecoderStream.cpp
+++ b/src/bun.js/bindings/webcore/JSTextDecoderStream.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSTextEncoderStream.cpp
+++ b/src/bun.js/bindings/webcore/JSTextEncoderStream.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSTransformStream.cpp
+++ b/src/bun.js/bindings/webcore/JSTransformStream.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSTransformStreamDefaultController.cpp
+++ b/src/bun.js/bindings/webcore/JSTransformStreamDefaultController.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSWritableStreamDefaultController.cpp
+++ b/src/bun.js/bindings/webcore/JSWritableStreamDefaultController.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/JSWritableStreamDefaultWriter.cpp
+++ b/src/bun.js/bindings/webcore/JSWritableStreamDefaultWriter.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "WebCoreJSBuiltins.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/src/bun.js/bindings/webcore/ReadableStreamDefaultController.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStreamDefaultController.cpp
@@ -31,6 +31,7 @@
 #include "ReadableStreamDefaultController.h"
 
 #include "WebCoreJSClientData.h"
+#include "WebCoreJSBuiltins.h"
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/IdentifierInlines.h>

--- a/src/bun.js/modules/NodeModuleModule.cpp
+++ b/src/bun.js/modules/NodeModuleModule.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include "NodeModuleModule.h"
+#include "WebCoreJSBuiltins.h"
 
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/VM.h>

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -419,6 +419,7 @@ export async function bundleBuiltinFunctions({ requireTransformer }: BundleBuilt
     #include "config.h"
     #include "JSDOMGlobalObject.h"
     #include "WebCoreJSClientData.h"
+    #include "WebCoreJSBuiltins.h"
     #include <JavaScriptCore/JSObjectInlines.h>
     #include "BunBuiltinNames.h"
 
@@ -518,7 +519,17 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
 
     template void JSBuiltinInternalFunctions::visit(AbstractSlotVisitor&);
     template void JSBuiltinInternalFunctions::visit(SlotVisitor&);
+    `;
 
+  for (const { basename, internal } of files) {
+    if (internal) {
+      bundledCPP += `    template void ${basename}BuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
+    template void ${basename}BuiltinFunctions::visit(JSC::SlotVisitor&);
+`;
+    }
+  }
+
+  bundledCPP += `
     SUPPRESS_ASAN void JSBuiltinInternalFunctions::initialize(Zig::GlobalObject& globalObject)
     {
         UNUSED_PARAM(globalObject);
@@ -694,12 +705,13 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
     #undef VISIT_FUNCTION
     }
 
-    template void ${basename}BuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
-    template void ${basename}BuiltinFunctions::visit(JSC::SlotVisitor&);
+    extern template void ${basename}BuiltinFunctions::visit(JSC::AbstractSlotVisitor&);
+    extern template void ${basename}BuiltinFunctions::visit(JSC::SlotVisitor&);
         `;
     }
   }
   bundledHeader += `class JSBuiltinFunctions {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSBuiltinFunctions);
     public:
         explicit JSBuiltinFunctions(JSC::VM& vm, RefPtr<JSC::SourceProvider> provider, BunBuiltinNames &builtinNames);
         void exportNames();
@@ -725,6 +737,7 @@ JSBuiltinInternalFunctions::JSBuiltinInternalFunctions(JSC::VM& vm) : m_vm(vm)
     };
 
     class JSBuiltinInternalFunctions {
+        WTF_DEPRECATED_MAKE_FAST_ALLOCATED(JSBuiltinInternalFunctions);
     public:
         explicit JSBuiltinInternalFunctions(JSC::VM&);
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2635,6 +2635,7 @@ const GENERATED_CLASSES_IMPL_HEADER_PRE = `
 
 #include "JSDOMConvertBufferSource.h"
 #include "ZigGeneratedClasses.h"
+#include "WebCoreJSBuiltins.h"
 #include "ErrorCode+List.h"
 #include "ErrorCode.h"
 #include <JavaScriptCore/HeapAnalyzer.h>


### PR DESCRIPTION
## What

`bundle-functions.ts` was emitting `template void XBuiltinFunctions::visit(...)` — an explicit instantiation **definition** — in `WebCoreJSBuiltins.h`. That header reaches 404 TUs via `BunClientData.h` → `ZigGlobalObject.h`, so every one of them was forced to instantiate the template for both `SlotVisitor` and `AbstractSlotVisitor`. A full-build `-ftime-trace` (release+ASAN, 558 cxx TUs, ClangBuildAnalyzer) put this single template family at **473s of frontend time — ~28% of total build CPU**.

This PR:
- Changes the header emission to `extern template` declarations and moves the explicit instantiation definitions into `WebCoreJSBuiltins.cpp`.
- Breaks the include from `BunClientData.h` and `ZigGlobalObject.h` by holding `JSBuiltinFunctions` / `JSBuiltinInternalFunctions` via `unique_ptr` (both run once at VM/global init; one extra deref is irrelevant). Out-of-lines `BakeAdditionsToGlobalObject::wrapComponent()` for the same reason.
- Adds a direct `#include "WebCoreJSBuiltins.h"` to the ~25 `.cpp` files that actually use the generated `*CodeGenerator()` symbols.

`WebCoreJSBuiltins.h` includers: **404 → 38** (per `ninja -t deps`).

## Test plan

- [x] `bun bd --revision`
- [x] `bun bd test test/js/web/streams/streams.test.js` — 67 pass / 0 fail
- [ ] CI