### PR TITLE
build: WebKit-style unified C++ sources + PCH expansion (~5× faster build-cpp)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -432,7 +432,8 @@ Options:
                           on/off/true/false/yes/no/1/0.
                           Fields: asan, lto, assertions, logs, baseline,
                                   canary, valgrind, webkit (prebuilt|local),
-                                  buildDir, mode (full|cpp-only|link-only)
+                                  buildDir, mode (full|cpp-only|link-only),
+                                  unifiedSources, timeTrace
   --target=<name>         Build a specific ninja target (repeatable)
   --configure-only        Emit build.ninja, don't run it
   -j<N>, -v, -k<N>        Passed through to ninja

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -297,6 +297,8 @@ function parseArgs(argv: string[]): CliArgs {
     "tinycc",
     "valgrind",
     "fuzzilli",
+    "unifiedSources",
+    "timeTrace",
     "ci",
     "buildkite",
   ]);

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -157,7 +157,7 @@ For `mode: "full"` (the normal case):
 2. **Codegen** — `emitCodegen(n, cfg, sources)` emits ~20 generation steps (bindgen, `.classes.ts` → C++, bundled modules, LUTs). Returns grouped outputs.
 3. **Zig** — `emitZig(n, cfg, {...})` emits zig download + `zig build obj` → `bun-zig.o`.
 4. **Flags** — `computeFlags(cfg)` evaluates flag tables → cflags/cxxflags/defines/ldflags/stripflags.
-5. **PCH** — compile `root.h` → PCH (skipped on Windows, skipped in CI full mode).
+5. **PCH** — compile `root-pch.h` → PCH (skipped on Windows, skipped in CI full mode).
 6. **Compile** — loop sources, `cxx()`/`cc()` per file.
 7. **Link** — `emitShims(n, cfg)` for platform workaround dylibs, then `link(n, cfg, exeName, objects, {libs, flags})`.
 8. **Post-link** — strip (release only), dsymutil (darwin release only).

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -183,6 +183,7 @@ Split CI modes: `zig-only` (zstd+codegen+zig), `cpp-only` (deps+codegen+compile 
 | `ninja.ts`                     | `Ninja` class — the build-file writer                                              |
 | `rules.ts`                     | `registerAllRules()` — calls each module's `registerXxxRules()`                    |
 | `compile.ts`                   | `cc`/`cxx`/`pch`/`link`/`ar` + `registerCompileRules()`                            |
+| `unified.ts`                   | WebKit-style unified-source bundling, `generateUnifiedSources()`                   |
 | `source.ts`                    | `Dependency` types, `resolveDep()`, fetch/configure/build emission                 |
 | `codegen.ts`                   | Code generation steps, `emitCodegen()`, `CodegenOutputs`                           |
 | `zig.ts`                       | Zig download + `zig build`, `emitZig()`                                            |

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -5,7 +5,7 @@
  *   - resolve all deps → lib paths + include dirs
  *   - emit codegen → generated .cpp/.h/.zig
  *   - emit zig build → bun-zig.o
- *   - build PCH from root.h (implicit deps: WebKit libs + all codegen)
+ *   - build PCH from root-pch.h (implicit deps: WebKit libs + all codegen)
  *   - compile all C/C++ with the PCH
  *   - link everything → bun-debug (or bun-profile, bun-asan, etc.)
  *   - smoke test: run `<exe> --revision` to catch load-time failures

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -275,8 +275,8 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   n.blank();
 
   // Source lists: from the pre-globbed snapshot + platform extras.
-  // Unified sources: bundle the globbed .cpp into ~8-per-TU wrappers (see
-  // unified.ts). Generated at configure time; depfiles track the underlying
+  // Unified sources: bundle the globbed .cpp into N-per-TU wrappers (see
+  // unified.ts for N). Generated at configure time; depfiles track the underlying
   // .cpp files so editing one rebuilds its bundle. Codegen .cpp are kept
   // separate — those are already large single TUs (ZigGeneratedClasses.cpp
   // is 3.3 MB) and bundling them would serialize work. Always called so

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -37,6 +37,7 @@ import type { Ninja } from "./ninja.ts";
 import { quote, slash } from "./shell.ts";
 import { emitShims } from "./shims.ts";
 import { computeDepLibs, depSourceStamp, resolveDep, type ResolvedDep } from "./source.ts";
+import { generateUnifiedSources } from "./unified.ts";
 import { streamPath } from "./stream.ts";
 import { emitZig, emitZigCheck, zigObjectPaths } from "./zig.ts";
 
@@ -274,7 +275,15 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   n.blank();
 
   // Source lists: from the pre-globbed snapshot + platform extras.
-  const cxxSources = [...sources.cxx];
+  // Unified sources: bundle the globbed .cpp into ~8-per-TU wrappers (see
+  // unified.ts). Generated at configure time; depfiles track the underlying
+  // .cpp files so editing one rebuilds its bundle. Codegen .cpp are kept
+  // separate — those are already large single TUs (ZigGeneratedClasses.cpp
+  // is 3.3 MB) and bundling them would serialize work.
+  const split = cfg.unifiedSources
+    ? generateUnifiedSources(cfg, sources.cxx)
+    : { unified: [], standalone: [...sources.cxx], bundled: [] };
+  const cxxSources = [...split.unified, ...split.standalone];
   const cSources = [...sources.c];
 
   // Windows-only cpp sources (rescle — PE resource editor for --compile).
@@ -312,6 +321,18 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   const codegenOrderOnly = codegen.cppAll;
 
   // Compile all .cpp with PCH.
+  // Emit compile_commands.json entries for the ORIGINAL bundled .cpp files
+  // too — clangd looks up flags by the file you opened, and a bundled source
+  // has no ninja edge of its own. Same flags as the bundle (no PCH listed —
+  // clangd parses standalone, and the PCH path is build-internal).
+  for (const src of split.bundled) {
+    n.addCompileCommand({
+      directory: cfg.buildDir,
+      file: src,
+      arguments: [cfg.cxx, ...cxxFlagsFull, "-c", src],
+    });
+  }
+
   const cxxObjects: string[] = [];
   for (const src of cxxSources) {
     const relSrc = relative(cfg.cwd, src);

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -279,10 +279,9 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
   // unified.ts). Generated at configure time; depfiles track the underlying
   // .cpp files so editing one rebuilds its bundle. Codegen .cpp are kept
   // separate — those are already large single TUs (ZigGeneratedClasses.cpp
-  // is 3.3 MB) and bundling them would serialize work.
-  const split = cfg.unifiedSources
-    ? generateUnifiedSources(cfg, sources.cxx)
-    : { unified: [], standalone: [...sources.cxx], bundled: [] };
+  // is 3.3 MB) and bundling them would serialize work. Always called so
+  // stale bundles are pruned even with --unifiedSources=false.
+  const split = generateUnifiedSources(cfg, sources.cxx);
   const cxxSources = [...split.unified, ...split.standalone];
   const cSources = [...sources.c];
 

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -37,8 +37,8 @@ import type { Ninja } from "./ninja.ts";
 import { quote, slash } from "./shell.ts";
 import { emitShims } from "./shims.ts";
 import { computeDepLibs, depSourceStamp, resolveDep, type ResolvedDep } from "./source.ts";
-import { generateUnifiedSources } from "./unified.ts";
 import { streamPath } from "./stream.ts";
+import { generateUnifiedSources } from "./unified.ts";
 import { emitZig, emitZigCheck, zigObjectPaths } from "./zig.ts";
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -263,7 +263,7 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
     // mode where it fails on the pinned bun version (see cppAll docstring).
     // Scripts that emit undeclared .h also emit a .cpp/.h in cppAll, so they
     // still run. cxx transitively waits: cxx → PCH → deps+cppAll.
-    pchOut = pch(n, cfg, "src/bun.js/bindings/root.h", {
+    pchOut = pch(n, cfg, "src/bun.js/bindings/root-pch.h", {
       flags: cxxFlagsFull,
       implicitInputs: depHeaderSignal,
       orderOnlyInputs: codegen.cppAll,

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -120,6 +120,10 @@ export interface Config {
   tinycc: boolean;
   valgrind: boolean;
   fuzzilli: boolean;
+  /** Bundle small .cpp files into unified TUs (WebKit-style). See unified.ts. */
+  unifiedSources: boolean;
+  /** Emit clang -ftime-trace .json next to each .o for build profiling. */
+  timeTrace: boolean;
 
   // ─── Environment ───
   ci: boolean;
@@ -226,6 +230,8 @@ export interface PartialConfig {
   tinycc?: boolean;
   valgrind?: boolean;
   fuzzilli?: boolean;
+  unifiedSources?: boolean;
+  timeTrace?: boolean;
   ci?: boolean;
   buildkite?: boolean;
   webkit?: WebKitMode;
@@ -517,6 +523,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     tinycc,
     valgrind,
     fuzzilli,
+    unifiedSources: partial.unifiedSources ?? true,
+    timeTrace: partial.timeTrace ?? false,
     ci,
     buildkite,
     webkit: partial.webkit ?? "prebuilt",

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -371,6 +371,7 @@ export const bunOnlyFlags: Flag[] = [
   {
     flag: "-ftime-trace",
     when: c => c.timeTrace,
+    lang: "cxx",
     desc: "Emit per-TU Chrome-trace JSON next to each .o (analyze with ClangBuildAnalyzer)",
   },
 

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -367,6 +367,13 @@ export const globalFlags: Flag[] = [
 // ═══════════════════════════════════════════════════════════════════════════
 
 export const bunOnlyFlags: Flag[] = [
+  // ─── Build profiling ───
+  {
+    flag: "-ftime-trace",
+    when: c => c.timeTrace,
+    desc: "Emit per-TU Chrome-trace JSON next to each .o (analyze with ClangBuildAnalyzer)",
+  },
+
   // ─── Language standard ───
   // WebKit uses gnu++ extensions on Linux; if we don't match, the first
   // memory allocation crashes (ABI mismatch in sized delete).

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -76,7 +76,8 @@ export interface BuildNode {
 export interface CompileCommand {
   directory: string;
   file: string;
-  output: string;
+  /** Optional per the JSON Compilation Database spec; omitted for entries that exist only for clangd (unified-source originals). */
+  output?: string;
   arguments: string[];
 }
 

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -112,11 +112,21 @@ const noUnify: readonly string[] = [
 ];
 
 /**
- * How many .cpp files per bundle. WebKit defaults to 8; we use 16 — frontend
- * parsing dominates and ~80 TUs still saturates CI's cores. Measured faster
- * than 8 for both release and ASAN on CI.
+ * How many .cpp files per bundle. WebKit defaults to 8.
+ *
+ * Release (incl. release-asan): 32. Measured 701s vs 866s @ 16 vs 1532s @ 8
+ * release cpp-only — frontend parsing dominates, so more dedup wins. ~70 TUs
+ * still keeps CI's 16–32 cores saturated.
+ *
+ * Debug: 8. Local iteration cares about incremental blast radius — editing
+ * one .cpp recompiles its 7 siblings, not 31.
+ *
+ * Fixed per profile rather than host-core-derived so bundle composition is
+ * identical across machines (ccache, reproducible builds).
  */
-const bundleSize = 16;
+function bundleSizeFor(cfg: Config): number {
+  return cfg.release ? 32 : 8;
+}
 
 export interface UnifiedSplit {
   /** Generated UnifiedSource-*.cpp absolute paths to compile. */
@@ -144,6 +154,7 @@ export interface UnifiedSplit {
 export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[]): UnifiedSplit {
   const outDir = resolve(cfg.buildDir, "unified");
   mkdirSync(outDir, { recursive: true });
+  const bundleSize = bundleSizeFor(cfg);
 
   // Files with active per-file flag overrides (flags.ts) can't share a TU
   // with files that need different flags. Computed here so the override's

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -1,0 +1,183 @@
+/**
+ * Unified source bundling — WebKit-style.
+ *
+ * Concatenates N small .cpp files into one translation unit by writing
+ * `UnifiedSource-<dir>-<n>.cpp` files that contain only `#include "abs.cpp"`
+ * lines, then compiling those instead of the originals.
+ *
+ * Why: Bun has ~550 .cpp files, ~330 of them under 200 lines. Each compile
+ * spends most of its time re-parsing the same JSC/WebCore headers. Bundling
+ * 8 files into one TU means 1 header parse instead of 8 — same code, 1/8th
+ * the redundant frontend work. WebKit reports a 3–4× clean-build speedup
+ * from this technique alone.
+ *
+ * Algorithm (matches WebKit's generate-unified-source-bundles):
+ *   - Group sources by parent directory. Files from different directories
+ *     never share a bundle — keeps `using namespace WebCore` in webcore/
+ *     from leaking into bindings/ etc.
+ *   - Sort each group by basename for determinism.
+ *   - Walk each group filling bundles of `bundleSize` (default 8).
+ *   - Files in `noUnify` compile standalone (large enough to saturate a
+ *     core alone, or have per-file flag overrides, or are known to conflict).
+ *
+ * Pitfalls (handled by convention, not by this script — fix at the source):
+ *   - File-static names from N files now share a TU. On collision, wrap the
+ *     statics in an anonymous or `namespace FILENAME { }` block, or rename.
+ *   - `using namespace X;` at file scope leaks into later includes in the
+ *     same bundle.
+ *   - A file may build only because an earlier sibling already pulled a
+ *     header. When bundle composition shifts (file added/removed), the
+ *     missing include surfaces. Fix the include; don't reorder bundles.
+ *
+ * Incremental builds: editing one .cpp recompiles its whole bundle (8 files).
+ * Acceptable — the bundle compile is still fast, and ccache handles the
+ * common case of unchanged bundles. Set `cfg.unifiedSources = false` for
+ * fine-grained incremental during heavy single-file iteration.
+ */
+
+import { mkdirSync, readdirSync, rmSync } from "node:fs";
+import { basename, dirname, relative, resolve } from "node:path";
+import type { Config } from "./config.ts";
+import { writeIfChanged } from "./fs.ts";
+import { slash } from "./shell.ts";
+
+/**
+ * Directories whose files all compile standalone. Reasons inline.
+ * Matched as a prefix of `relative(cwd, abs)`.
+ */
+const noUnifyDirs: readonly string[] = [
+  // Each V8*.cpp invokes ASSERT_V8_TYPE_LAYOUT_MATCHES which expands a
+  // `__LINE__`-named namespace containing `using BunType = ...`. Two files
+  // hitting the same source line collide. Also `using Isolate = ...` aliases
+  // differ per file. Only ~30 small files; not worth restructuring.
+  "src/bun.js/bindings/v8/",
+
+  // WebKit-derived crypto algorithm files each define file-static helpers
+  // with the same names (`aesAlgorithm`, `cryptEncrypt`, `ALG128`, `IVSIZE`,
+  // ...). ~85 files; the alternative is wrapping ~15 files' statics in
+  // named namespaces and qualifying every call site, which diverges from
+  // upstream for marginal gain.
+  "src/bun.js/bindings/webcrypto/",
+];
+
+/**
+ * Files that must compile standalone. Reasons inline.
+ * Paths are repo-root-relative; matched against `relative(cwd, abs)`.
+ */
+const noUnify = new Set<string>([
+  // Has per-file flag override (see flags.ts fileOverrides) — can't share
+  // a TU with files that need different flags.
+  "src/bun.js/bindings/workaround-missing-symbols.cpp",
+
+  // Heavy single-file TUs that already saturate a core. Bundling them with
+  // siblings would serialize work that should run in parallel.
+  "src/bun.js/bindings/ZigGlobalObject.cpp",
+  "src/bun.js/bindings/BunObject.cpp",
+  "src/bun.js/bindings/bindings.cpp",
+  "src/bun.js/bindings/BunProcess.cpp",
+  "src/bun.js/bindings/JSBuffer.cpp",
+  "src/bun.js/bindings/KeyObject.cpp",
+  "src/bun.js/bindings/napi.cpp",
+  "src/bun.js/bindings/webcore/SerializedScriptValue.cpp",
+  "src/bun.js/bindings/webcore/HTTPParsers.cpp",
+
+  // Duplicates static MIME-parsing helpers from JSMIMEParams.cpp verbatim;
+  // both end up in the same bundle. TODO: extract helpers to a shared header.
+  "src/bun.js/bindings/webcore/JSMIMEType.cpp",
+
+  // Wraps JSC::Wasm::StreamingCompiler. Its wrapperKey()/toJSNewlyCreated()
+  // overloads live in namespace WebCore but the wrapped type is in JSC::Wasm,
+  // so two-phase lookup only finds them via ordinary lookup at template
+  // definition time — which fails if JSDOMWrapperCache.h was already parsed
+  // by an earlier file in the bundle.
+  "src/bun.js/bindings/webcore/JSWasmStreamingCompiler.cpp",
+  "src/bun.js/bindings/sqlite/JSSQLStatement.cpp",
+]);
+
+/** How many .cpp files per bundle. WebKit uses 8. */
+const bundleSize = 8;
+
+export interface UnifiedSplit {
+  /** Generated UnifiedSource-*.cpp absolute paths to compile. */
+  unified: string[];
+  /** Sources that compile standalone (no-unify list, or alone in their dir). */
+  standalone: string[];
+  /**
+   * Original .cpp paths that were bundled (i.e. NOT in `standalone`). Used to
+   * emit per-file compile_commands.json entries so clangd works when the user
+   * opens an individual source instead of the bundle.
+   */
+  bundled: string[];
+}
+
+/**
+ * Generate unified-source bundle files under `<buildDir>/unified/` and return
+ * the split. Idempotent — `writeIfChanged` preserves mtimes, so a no-op
+ * configure produces no rebuilds.
+ *
+ * `cxxSources` must be absolute paths (the glob output). Generated codegen
+ * .cpp files should NOT be passed here — those are already large single TUs
+ * (ZigGeneratedClasses.cpp etc.) and are added to the compile list separately
+ * in bun.ts.
+ */
+export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[]): UnifiedSplit {
+  const outDir = resolve(cfg.buildDir, "unified");
+  mkdirSync(outDir, { recursive: true });
+
+  const standalone: string[] = [];
+  const byDir = new Map<string, string[]>();
+
+  for (const abs of cxxSources) {
+    // slash(): noUnify keys and the dir tag below are posix-style.
+    const rel = slash(relative(cfg.cwd, abs));
+    if (noUnify.has(rel) || noUnifyDirs.some(d => rel.startsWith(d))) {
+      standalone.push(abs);
+      continue;
+    }
+    const dir = dirname(rel);
+    let arr = byDir.get(dir);
+    if (arr === undefined) byDir.set(dir, (arr = []));
+    arr.push(abs);
+  }
+
+  const unified: string[] = [];
+  const bundled: string[] = [];
+  // Stable iteration: sort directory keys so bundle numbering is deterministic
+  // across glob-order changes (globSync order can vary by filesystem).
+  for (const dir of [...byDir.keys()].sort()) {
+    const files = byDir.get(dir)!.sort((a, b) => basename(a).localeCompare(basename(b)));
+
+    // Single file in a directory: no point wrapping it. Compile directly so
+    // compiler diagnostics point at the real path.
+    if (files.length === 1) {
+      standalone.push(files[0]!);
+      continue;
+    }
+
+    const tag = dir.replace(/[^A-Za-z0-9]+/g, "_");
+    for (let i = 0; i < files.length; i += bundleSize) {
+      const chunk = files.slice(i, i + bundleSize);
+      const n = i / bundleSize;
+      const out = resolve(outDir, `UnifiedSource-${tag}-${n}.cpp`);
+      // Absolute include paths: the bundle lives in buildDir but the sources
+      // are in src/. -I doesn't help for #include "foo.cpp"; absolute is
+      // simplest and matches what compile_commands.json consumers expect.
+      // slash(): clang accepts forward slashes everywhere; native backslashes
+      // in `#include "C:\..."` are escape sequences.
+      const body = chunk.map(f => `#include "${slash(f)}"`).join("\n") + "\n";
+      writeIfChanged(out, body);
+      unified.push(out);
+      bundled.push(...chunk);
+    }
+  }
+
+  // Prune stale bundles from previous configures (e.g. a directory shrank
+  // from 3 bundles to 1). They're not in the ninja graph so they wouldn't be
+  // built, but leaving them confuses grep/clangd indexing.
+  const live = new Set(unified.map(p => basename(p)));
+  for (const f of readdirSync(outDir)) {
+    if (f.endsWith(".cpp") && !live.has(f)) rmSync(resolve(outDir, f));
+  }
+
+  return { unified, standalone, bundled };
+}

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -101,12 +101,6 @@ const noUnify: readonly string[] = [
   // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
-  // Includes <sys/sysinfo.h> → linux/sysinfo.h → linux/types.h. On the CI
-  // sysroot the kernel headers error on __kernel_long_t when something
-  // earlier in the TU has already pulled a conflicting libc/kernel type
-  // header. Platform-specific system headers are fragile in shared TUs.
-  "src/bun.js/bindings/OsBinding.cpp",
-
   // Platform cert loaders include OS crypto headers (<wincrypt.h>,
   // <Security/Security.h>) and deliberately avoid OpenSSL. wincrypt
   // macro-defines X509_NAME etc., poisoning BoringSSL headers in any

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -217,12 +217,12 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
       const chunk = files.slice(i, i + bundleSize);
       const n = i / bundleSize;
       const out = resolve(outDir, `UnifiedSource-${tag}-${n}.cpp`);
-      // Absolute include paths: the bundle lives in buildDir but the sources
-      // are in src/. -I doesn't help for #include "foo.cpp"; absolute is
-      // simplest and matches what compile_commands.json consumers expect.
-      // slash(): clang accepts forward slashes everywhere; native backslashes
-      // in `#include "C:\..."` are escape sequences.
-      const body = chunk.map(f => `#include "${slash(f)}"`).join("\n") + "\n";
+      // Paths relative to the bundle file: ccache hashes source content
+      // verbatim (CCACHE_BASEDIR only rewrites command-line args), so an
+      // absolute checkout root in the body would defeat cache sharing
+      // across worktrees. slash(): clang accepts forward slashes everywhere;
+      // native backslashes in `#include "C:\..."` are escape sequences.
+      const body = chunk.map(f => `#include "${slash(relative(outDir, f))}"`).join("\n") + "\n";
       writeIfChanged(out, body);
       unified.push(out);
       bundled.push(...chunk);

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -157,7 +157,11 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
   // .sort()) so bundle composition is identical regardless of glob order or
   // host LC_COLLATE.
   for (const dir of [...byDir.keys()].sort()) {
-    const files = byDir.get(dir)!.sort((a, b) => (basename(a) < basename(b) ? -1 : 1));
+    const files = byDir.get(dir)!.sort((a, b) => {
+      const x = basename(a);
+      const y = basename(b);
+      return x < y ? -1 : x > y ? 1 : 0;
+    });
 
     // Single file in a directory: no point wrapping it. Compile directly so
     // compiler diagnostics point at the real path.

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -38,15 +38,10 @@
 import { mkdirSync, readdirSync, rmSync } from "node:fs";
 import { basename, dirname, relative, resolve } from "node:path";
 import type { Config } from "./config.ts";
+import { assert } from "./error.ts";
 import { fileOverrides } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
 import { slash } from "./shell.ts";
-
-/**
- * Directories whose files all compile standalone. Reasons inline.
- * Matched as a prefix of `relative(cwd, abs)`.
- */
-const noUnifyDirs: readonly string[] = [];
 
 /**
  * Files that must compile standalone. Reasons inline.
@@ -141,7 +136,7 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
   for (const abs of cxxSources) {
     // slash(): noUnify keys and the dir tag below are posix-style.
     const rel = slash(relative(cfg.cwd, abs));
-    if (noUnify.has(rel) || noUnifyDirs.some(d => rel.startsWith(d))) {
+    if (noUnify.has(rel)) {
       standalone.push(abs);
       continue;
     }
@@ -153,6 +148,7 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
 
   const unified: string[] = [];
   const bundled: string[] = [];
+  const tagToDir = new Map<string, string>();
   // Stable iteration: sort directory keys and basenames by code unit (default
   // .sort()) so bundle composition is identical regardless of glob order or
   // host LC_COLLATE.
@@ -171,6 +167,13 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
     }
 
     const tag = dir.replace(/[^A-Za-z0-9]+/g, "_");
+    // The tag is lossy (foo-bar and foo_bar both → foo_bar). Our directory
+    // set doesn't hit this today; fail loudly if it ever does so the second
+    // dir's bundles don't silently overwrite the first's.
+    const prior = tagToDir.get(tag);
+    assert(prior === undefined, `unified-source tag collision: '${dir}' and '${prior}' both sanitize to '${tag}'`);
+    tagToDir.set(tag, dir);
+
     for (let i = 0; i < files.length; i += bundleSize) {
       const chunk = files.slice(i, i + bundleSize);
       const n = i / bundleSize;

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -95,10 +95,10 @@ const noUnify: readonly string[] = [
   "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp",
   "src/bun.js/bindings/webcrypto/SubtleCrypto.cpp",
 
-  // Conditionally redefines ~80 errno/EAI_* macros based on which system
-  // headers were already included, then uses them to build a switch. Any
-  // earlier sibling that pulls <netdb.h> changes which branch the
-  // `#if !defined` takes, and the redefinitions leak forward too.
+  // Redefines ~80 errno/EAI_* macros (the EAI_* ones unconditionally, the
+  // rest via `#if !defined`) and uses them to build a switch. The defines
+  // leak forward; an earlier sibling pulling <netdb.h>/<errno.h> changes
+  // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
   // Platform cert loaders include OS crypto headers (<wincrypt.h>,

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -2,8 +2,8 @@
  * Unified source bundling — WebKit-style.
  *
  * Concatenates N small .cpp files into one translation unit by writing
- * `UnifiedSource-<dir>-<n>.cpp` files that contain only `#include "abs.cpp"`
- * lines, then compiling those instead of the originals.
+ * `UnifiedSource-<dir>-<n>.cpp` files that contain only `#include` lines
+ * pointing at the originals, then compiling those instead.
  *
  * Why: Bun has ~550 .cpp files, ~330 of them under 200 lines. Each compile
  * spends most of its time re-parsing the same JSC/WebCore headers. Bundling

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -38,6 +38,7 @@
 import { mkdirSync, readdirSync, rmSync } from "node:fs";
 import { basename, dirname, relative, resolve } from "node:path";
 import type { Config } from "./config.ts";
+import { fileOverrides } from "./flags.ts";
 import { writeIfChanged } from "./fs.ts";
 import { slash } from "./shell.ts";
 
@@ -45,29 +46,16 @@ import { slash } from "./shell.ts";
  * Directories whose files all compile standalone. Reasons inline.
  * Matched as a prefix of `relative(cwd, abs)`.
  */
-const noUnifyDirs: readonly string[] = [
-  // Each V8*.cpp invokes ASSERT_V8_TYPE_LAYOUT_MATCHES which expands a
-  // `__LINE__`-named namespace containing `using BunType = ...`. Two files
-  // hitting the same source line collide. Also `using Isolate = ...` aliases
-  // differ per file. Only ~30 small files; not worth restructuring.
-  "src/bun.js/bindings/v8/",
-
-  // WebKit-derived crypto algorithm files each define file-static helpers
-  // with the same names (`aesAlgorithm`, `cryptEncrypt`, `ALG128`, `IVSIZE`,
-  // ...). ~85 files; the alternative is wrapping ~15 files' statics in
-  // named namespaces and qualifying every call site, which diverges from
-  // upstream for marginal gain.
-  "src/bun.js/bindings/webcrypto/",
-];
+const noUnifyDirs: readonly string[] = [];
 
 /**
  * Files that must compile standalone. Reasons inline.
  * Paths are repo-root-relative; matched against `relative(cwd, abs)`.
  */
 const noUnify = new Set<string>([
-  // Has per-file flag override (see flags.ts fileOverrides) — can't share
-  // a TU with files that need different flags.
-  "src/bun.js/bindings/workaround-missing-symbols.cpp",
+  // Files with per-file flag overrides can't share a TU with files that
+  // need different flags. Pulled from flags.ts so the two lists can't drift.
+  ...fileOverrides.map(o => o.file),
 
   // Heavy single-file TUs that already saturate a core. Bundling them with
   // siblings would serialize work that should run in parallel.
@@ -85,17 +73,40 @@ const noUnify = new Set<string>([
   // both end up in the same bundle. TODO: extract helpers to a shared header.
   "src/bun.js/bindings/webcore/JSMIMEType.cpp",
 
-  // Wraps JSC::Wasm::StreamingCompiler. Its wrapperKey()/toJSNewlyCreated()
-  // overloads live in namespace WebCore but the wrapped type is in JSC::Wasm,
-  // so two-phase lookup only finds them via ordinary lookup at template
-  // definition time — which fails if JSDOMWrapperCache.h was already parsed
-  // by an earlier file in the bundle.
+  // These instantiate JSDOMConvert templates with JSC::* types whose toJS()
+  // overloads live in namespace WebCore — ADL can't find them, so they rely
+  // on ordinary lookup at template definition time. That fails if an earlier
+  // file in the bundle already parsed JSDOMConvertInterface.h /
+  // JSDOMWrapperCache.h before the overload was visible.
   "src/bun.js/bindings/webcore/JSWasmStreamingCompiler.cpp",
+  "src/bun.js/bindings/webcore/JSDOMPromiseDeferred.cpp",
+  "src/bun.js/bindings/webcore/JSMessageEventCustom.cpp",
   "src/bun.js/bindings/sqlite/JSSQLStatement.cpp",
+
+  // WebKit-derived crypto algorithm impls share file-static helper names
+  // (`aesAlgorithm`, `cryptEncrypt`, `ALG128`, `IVSIZE`, ...) — upstream
+  // also compiles these outside unified sources. The remaining ~70
+  // webcrypto files (JS bindings, key types) bundle cleanly.
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CBCOpenSSL.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CFBOpenSSL.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_CTROpenSSL.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_GCMOpenSSL.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmECDSA.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmHMAC.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp",
+  "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp",
+  "src/bun.js/bindings/webcrypto/SubtleCrypto.cpp",
 ]);
 
-/** How many .cpp files per bundle. WebKit uses 8. */
-const bundleSize = 8;
+/** How many .cpp files per bundle. WebKit defaults to 8; we use 16. */
+const bundleSize = 16;
 
 export interface UnifiedSplit {
   /** Generated UnifiedSource-*.cpp absolute paths to compile. */
@@ -142,10 +153,11 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
 
   const unified: string[] = [];
   const bundled: string[] = [];
-  // Stable iteration: sort directory keys so bundle numbering is deterministic
-  // across glob-order changes (globSync order can vary by filesystem).
+  // Stable iteration: sort directory keys and basenames by code unit (default
+  // .sort()) so bundle composition is identical regardless of glob order or
+  // host LC_COLLATE.
   for (const dir of [...byDir.keys()].sort()) {
-    const files = byDir.get(dir)!.sort((a, b) => basename(a).localeCompare(basename(b)));
+    const files = byDir.get(dir)!.sort((a, b) => (basename(a) < basename(b) ? -1 : 1));
 
     // Single file in a directory: no point wrapping it. Compile directly so
     // compiler diagnostics point at the real path.

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -7,7 +7,7 @@
  *
  * Why: Bun has ~550 .cpp files, ~330 of them under 200 lines. Each compile
  * spends most of its time re-parsing the same JSC/WebCore headers. Bundling
- * 8 files into one TU means 1 header parse instead of 8 — same code, 1/8th
+ * N files into one TU means 1 header parse instead of N — same code, 1/Nth
  * the redundant frontend work. WebKit reports a 3–4× clean-build speedup
  * from this technique alone.
  *
@@ -16,7 +16,7 @@
  *     never share a bundle — keeps `using namespace WebCore` in webcore/
  *     from leaking into bindings/ etc.
  *   - Sort each group by basename for determinism.
- *   - Walk each group filling bundles of `bundleSize` (default 8).
+ *   - Walk each group filling bundles of `bundleSizeFor(cfg)`.
  *   - Files in `noUnify` compile standalone (large enough to saturate a
  *     core alone, or have per-file flag overrides, or are known to conflict).
  *
@@ -29,7 +29,7 @@
  *     header. When bundle composition shifts (file added/removed), the
  *     missing include surfaces. Fix the include; don't reorder bundles.
  *
- * Incremental builds: editing one .cpp recompiles its whole bundle (8 files).
+ * Incremental builds: editing one .cpp recompiles its whole bundle.
  * Acceptable — the bundle compile is still fast, and ccache handles the
  * common case of unchanged bundles. Set `cfg.unifiedSources = false` for
  * fine-grained incremental during heavy single-file iteration.

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -47,11 +47,7 @@ import { slash } from "./shell.ts";
  * Files that must compile standalone. Reasons inline.
  * Paths are repo-root-relative; matched against `relative(cwd, abs)`.
  */
-const noUnify = new Set<string>([
-  // Files with per-file flag overrides can't share a TU with files that
-  // need different flags. Pulled from flags.ts so the two lists can't drift.
-  ...fileOverrides.map(o => o.file),
-
+const noUnify: readonly string[] = [
   // Heavy single-file TUs that already saturate a core. Bundling them with
   // siblings would serialize work that should run in parallel.
   "src/bun.js/bindings/ZigGlobalObject.cpp",
@@ -107,7 +103,7 @@ const noUnify = new Set<string>([
   // assuming TU isolation — keep it that way.
   "packages/bun-usockets/src/crypto/root_certs_windows.cpp",
   "packages/bun-usockets/src/crypto/root_certs_darwin.cpp",
-]);
+];
 
 /**
  * How many .cpp files per bundle. WebKit defaults to 8.
@@ -152,13 +148,26 @@ export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[
   mkdirSync(outDir, { recursive: true });
   const bundleSize = bundleSizeFor(cfg);
 
+  // Files with active per-file flag overrides (flags.ts) can't share a TU
+  // with files that need different flags. Computed here so the override's
+  // `when` predicate is honored — a file only excluded on linux+lto can
+  // still bundle on macOS.
+  const skip = new Set(noUnify);
+  for (const o of fileOverrides) {
+    if (o.when === undefined || o.when(cfg)) skip.add(o.file);
+  }
+
   const standalone: string[] = [];
   const byDir = new Map<string, string[]>();
 
   for (const abs of cxxSources) {
+    if (!cfg.unifiedSources) {
+      standalone.push(abs);
+      continue;
+    }
     // slash(): noUnify keys and the dir tag below are posix-style.
     const rel = slash(relative(cfg.cwd, abs));
-    if (noUnify.has(rel)) {
+    if (skip.has(rel)) {
       standalone.push(abs);
       continue;
     }

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -95,6 +95,12 @@ const noUnify: readonly string[] = [
   "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp",
   "src/bun.js/bindings/webcrypto/SubtleCrypto.cpp",
 
+  // Conditionally redefines ~80 errno/EAI_* macros based on which system
+  // headers were already included, then uses them to build a switch. Any
+  // earlier sibling that pulls <netdb.h> changes which branch the
+  // `#if !defined` takes, and the redefinitions leak forward too.
+  "src/bun.js/bindings/ProcessBindingUV.cpp",
+
   // Platform cert loaders include OS crypto headers (<wincrypt.h>,
   // <Security/Security.h>) and deliberately avoid OpenSSL. wincrypt
   // macro-defines X509_NAME etc., poisoning BoringSSL headers in any

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -101,6 +101,12 @@ const noUnify: readonly string[] = [
   // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
+  // Includes <sys/sysinfo.h> → linux/sysinfo.h → linux/types.h. On the CI
+  // sysroot the kernel headers error on __kernel_long_t when something
+  // earlier in the TU has already pulled a conflicting libc/kernel type
+  // header. Platform-specific system headers are fragile in shared TUs.
+  "src/bun.js/bindings/OsBinding.cpp",
+
   // Platform cert loaders include OS crypto headers (<wincrypt.h>,
   // <Security/Security.h>) and deliberately avoid OpenSSL. wincrypt
   // macro-defines X509_NAME etc., poisoning BoringSSL headers in any

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -55,7 +55,6 @@ const noUnify: readonly string[] = [
   "src/bun.js/bindings/bindings.cpp",
   "src/bun.js/bindings/BunProcess.cpp",
   "src/bun.js/bindings/JSBuffer.cpp",
-  "src/bun.js/bindings/KeyObject.cpp",
   "src/bun.js/bindings/napi.cpp",
   "src/bun.js/bindings/webcore/SerializedScriptValue.cpp",
   "src/bun.js/bindings/webcore/HTTPParsers.cpp",

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -101,6 +101,13 @@ const noUnify: readonly string[] = [
   // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
+  // Defines extern "C" replacements for platform symbols (strncasecmp,
+  // fstat64, environ, ...). On Windows an earlier sibling can leak
+  // `#define strncasecmp _strnicmp`, turning the definition here into a
+  // duplicate of the CRT's _strnicmp. Independent of the flags-override
+  // exclusion, which is linux-lto-only.
+  "src/bun.js/bindings/workaround-missing-symbols.cpp",
+
   // Platform cert loaders include OS crypto headers (<wincrypt.h>,
   // <Security/Security.h>) and deliberately avoid OpenSSL. wincrypt
   // macro-defines X509_NAME etc., poisoning BoringSSL headers in any

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -112,19 +112,11 @@ const noUnify: readonly string[] = [
 ];
 
 /**
- * How many .cpp files per bundle. WebKit defaults to 8.
- *
- * Release non-ASAN: 16. Frontend dominates and ~80 TUs still saturates CI's
- * cores; the extra header dedup nearly halves CPU vs 8.
- *
- * Debug / ASAN: 8. ASAN inflates backend time per TU, so the slowest bundle
- * becomes the wall-clock bottleneck — smaller bundles keep more cores busy
- * on the tail. For local debug, 8 also halves the blast radius when editing
- * a single .cpp (7 siblings recompile, not 15).
+ * How many .cpp files per bundle. WebKit defaults to 8; we use 16 — frontend
+ * parsing dominates and ~80 TUs still saturates CI's cores. Measured faster
+ * than 8 for both release and ASAN on CI.
  */
-function bundleSizeFor(cfg: Config): number {
-  return cfg.release && !cfg.asan ? 16 : 8;
-}
+const bundleSize = 16;
 
 export interface UnifiedSplit {
   /** Generated UnifiedSource-*.cpp absolute paths to compile. */
@@ -152,7 +144,6 @@ export interface UnifiedSplit {
 export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[]): UnifiedSplit {
   const outDir = resolve(cfg.buildDir, "unified");
   mkdirSync(outDir, { recursive: true });
-  const bundleSize = bundleSizeFor(cfg);
 
   // Files with active per-file flag overrides (flags.ts) can't share a TU
   // with files that need different flags. Computed here so the override's

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -98,10 +98,31 @@ const noUnify = new Set<string>([
   "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp",
   "src/bun.js/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp",
   "src/bun.js/bindings/webcrypto/SubtleCrypto.cpp",
+
+  // Platform cert loaders include OS crypto headers (<wincrypt.h>,
+  // <Security/Security.h>) and deliberately avoid OpenSSL. wincrypt
+  // macro-defines X509_NAME etc., poisoning BoringSSL headers in any
+  // sibling that includes them; the darwin file defines errSecSuccess /
+  // SecCertificateRef that clash with the real framework header. Written
+  // assuming TU isolation — keep it that way.
+  "packages/bun-usockets/src/crypto/root_certs_windows.cpp",
+  "packages/bun-usockets/src/crypto/root_certs_darwin.cpp",
 ]);
 
-/** How many .cpp files per bundle. WebKit defaults to 8; we use 16. */
-const bundleSize = 16;
+/**
+ * How many .cpp files per bundle. WebKit defaults to 8.
+ *
+ * Release non-ASAN: 16. Frontend dominates and ~80 TUs still saturates CI's
+ * cores; the extra header dedup nearly halves CPU vs 8.
+ *
+ * Debug / ASAN: 8. ASAN inflates backend time per TU, so the slowest bundle
+ * becomes the wall-clock bottleneck — smaller bundles keep more cores busy
+ * on the tail. For local debug, 8 also halves the blast radius when editing
+ * a single .cpp (7 siblings recompile, not 15).
+ */
+function bundleSizeFor(cfg: Config): number {
+  return cfg.release && !cfg.asan ? 16 : 8;
+}
 
 export interface UnifiedSplit {
   /** Generated UnifiedSource-*.cpp absolute paths to compile. */
@@ -129,6 +150,7 @@ export interface UnifiedSplit {
 export function generateUnifiedSources(cfg: Config, cxxSources: readonly string[]): UnifiedSplit {
   const outDir = resolve(cfg.buildDir, "unified");
   mkdirSync(outDir, { recursive: true });
+  const bundleSize = bundleSizeFor(cfg);
 
   const standalone: string[] = [];
   const byDir = new Map<string, string[]>();

--- a/src/bun.js/bindings/AsymmetricKeyValue.h
+++ b/src/bun.js/bindings/AsymmetricKeyValue.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "root.h"
 
 #include "openssl/evp.h"

--- a/src/bun.js/bindings/AsyncContextFrame.cpp
+++ b/src/bun.js/bindings/AsyncContextFrame.cpp
@@ -134,7 +134,7 @@ JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, 
 
     ASYNCCONTEXTFRAME_CALL_IMPL(global, ProfilingReason::API, functionObject, JSC::getCallData(functionObject), thisValue, args);
 }
-JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<Exception>& returnedException)
+JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<JSC::Exception>& returnedException)
 {
 #if ASSERT_ENABLED
     auditEverything(global, functionObject, thisValue, args);
@@ -150,7 +150,7 @@ JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue function
 {
     return AsyncContextFrame::call(global, functionObject, thisValue, args);
 }
-JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<Exception>& returnedException)
+JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args, NakedPtr<JSC::Exception>& returnedException)
 {
     return AsyncContextFrame::call(global, functionObject, thisValue, args, returnedException);
 }

--- a/src/bun.js/bindings/BunClientData.cpp
+++ b/src/bun.js/bindings/BunClientData.cpp
@@ -47,6 +47,8 @@ JSHeapData::JSHeapData(Heap& heap)
 {
 }
 
+JSHeapData::~JSHeapData() = default;
+
 #define CLIENT_ISO_SUBSPACE_INIT(subspace) subspace(m_heapData->subspace)
 
 JSVMClientData::JSVMClientData(VM& vm, RefPtr<JSC::SourceProvider> sourceProvider)

--- a/src/bun.js/bindings/BunClientData.cpp
+++ b/src/bun.js/bindings/BunClientData.cpp
@@ -49,7 +49,7 @@ JSHeapData::JSHeapData(Heap& heap)
 
 #define CLIENT_ISO_SUBSPACE_INIT(subspace) subspace(m_heapData->subspace)
 
-JSVMClientData::JSVMClientData(VM& vm, RefPtr<SourceProvider> sourceProvider)
+JSVMClientData::JSVMClientData(VM& vm, RefPtr<JSC::SourceProvider> sourceProvider)
     : m_builtinNames(vm)
     , m_builtinFunctions(makeUnique<JSBuiltinFunctions>(vm, sourceProvider, m_builtinNames))
     , m_heapData(JSHeapData::ensureHeapData(vm.heap))

--- a/src/bun.js/bindings/BunClientData.h
+++ b/src/bun.js/bindings/BunClientData.h
@@ -44,6 +44,7 @@ class JSHeapData {
 
 public:
     JSHeapData(JSC::Heap&);
+    ~JSHeapData();
 
     static JSHeapData* ensureHeapData(JSC::Heap&);
 

--- a/src/bun.js/bindings/BunInspector.cpp
+++ b/src/bun.js/bindings/BunInspector.cpp
@@ -11,18 +11,18 @@ extern "C" void Bun__tickWhilePaused(bool*);
 namespace Bun {
 using namespace JSC;
 template<bool isSSL>
-class BunInspectorConnection : public Inspector::FrontendChannel {
+class WebSocketInspectorConnection : public Inspector::FrontendChannel {
 public:
-    using BunInspectorSocket = uWS::WebSocket<isSSL, true, BunInspectorConnection*>;
+    using BunInspectorSocket = uWS::WebSocket<isSSL, true, WebSocketInspectorConnection*>;
 
-    BunInspectorConnection(BunInspectorSocket* ws, JSC::JSGlobalObject* globalObject)
+    WebSocketInspectorConnection(BunInspectorSocket* ws, JSC::JSGlobalObject* globalObject)
         : ws(ws)
         , globalObject(globalObject)
         , pendingMessages()
     {
     }
 
-    ~BunInspectorConnection()
+    ~WebSocketInspectorConnection()
     {
     }
 
@@ -98,14 +98,14 @@ public:
     BunInspectorSocket* ws;
 };
 
-using BunInspectorConnectionNoSSL = BunInspectorConnection<false>;
-using SSLBunInspectorConnection = BunInspectorConnection<true>;
+using WebSocketInspectorConnectionNoSSL = WebSocketInspectorConnection<false>;
+using SSLWebSocketInspectorConnection = WebSocketInspectorConnection<true>;
 
 template<bool isSSL>
 static void addInspector(void* app, JSC::JSGlobalObject* globalObject)
 {
     if constexpr (isSSL) {
-        auto handler = uWS::SSLApp::WebSocketBehavior<SSLBunInspectorConnection*> {
+        auto handler = uWS::SSLApp::WebSocketBehavior<SSLWebSocketInspectorConnection*> {
             /* Settings */
             .compression = uWS::DISABLED,
             .maxPayloadLength = 16 * 1024 * 1024,
@@ -118,14 +118,14 @@ static void addInspector(void* app, JSC::JSGlobalObject* globalObject)
             .upgrade = nullptr,
             .open = [globalObject](auto* ws) {
                 globalObject->setInspectable(true);
-                *ws->getUserData() = new SSLBunInspectorConnection(ws, globalObject);
-                SSLBunInspectorConnection* inspector = *ws->getUserData();
+                *ws->getUserData() = new SSLWebSocketInspectorConnection(ws, globalObject);
+                SSLWebSocketInspectorConnection* inspector = *ws->getUserData();
                 inspector->onOpen(globalObject); },
             .message = [](auto* ws, std::string_view message, uWS::OpCode opCode) {
-                SSLBunInspectorConnection* inspector = *(SSLBunInspectorConnection**)ws->getUserData();
+                SSLWebSocketInspectorConnection* inspector = *(SSLWebSocketInspectorConnection**)ws->getUserData();
                 inspector->onMessage(message); },
             .drain = [](auto* ws) {
-                SSLBunInspectorConnection* inspector = *(SSLBunInspectorConnection**)ws->getUserData();
+                SSLWebSocketInspectorConnection* inspector = *(SSLWebSocketInspectorConnection**)ws->getUserData();
                 inspector->drain(); },
             .ping = [](auto* /*ws*/, std::string_view) {
         /* Not implemented yet */ },
@@ -133,15 +133,15 @@ static void addInspector(void* app, JSC::JSGlobalObject* globalObject)
         /* Not implemented yet */ },
 
             .close = [](auto* ws, int /*code*/, std::string_view /*message*/) {
-            SSLBunInspectorConnection* inspector = *(SSLBunInspectorConnection**)ws->getUserData();
+            SSLWebSocketInspectorConnection* inspector = *(SSLWebSocketInspectorConnection**)ws->getUserData();
             inspector->onClose();
             delete inspector; }
         };
 
-        ((uWS::SSLApp*)app)->ws<SSLBunInspectorConnection*>("/bun:inspect", WTF::move(handler));
+        ((uWS::SSLApp*)app)->ws<SSLWebSocketInspectorConnection*>("/bun:inspect", WTF::move(handler));
     } else {
 
-        auto handler = uWS::App::WebSocketBehavior<BunInspectorConnectionNoSSL*> {
+        auto handler = uWS::App::WebSocketBehavior<WebSocketInspectorConnectionNoSSL*> {
             /* Settings */
             .compression = uWS::DISABLED,
             .maxPayloadLength = 16 * 1024 * 1024,
@@ -154,14 +154,14 @@ static void addInspector(void* app, JSC::JSGlobalObject* globalObject)
             .upgrade = nullptr,
             .open = [globalObject](auto* ws) {
                 globalObject->setInspectable(true);
-                *ws->getUserData() = new BunInspectorConnectionNoSSL(ws, globalObject);
-                BunInspectorConnectionNoSSL* inspector = *ws->getUserData();
+                *ws->getUserData() = new WebSocketInspectorConnectionNoSSL(ws, globalObject);
+                WebSocketInspectorConnectionNoSSL* inspector = *ws->getUserData();
                 inspector->onOpen(globalObject); },
             .message = [](auto* ws, std::string_view message, uWS::OpCode opCode) {
-                    BunInspectorConnectionNoSSL* inspector = *(BunInspectorConnectionNoSSL**)ws->getUserData();
+                    WebSocketInspectorConnectionNoSSL* inspector = *(WebSocketInspectorConnectionNoSSL**)ws->getUserData();
                     inspector->onMessage(message); },
             .drain = [](auto* ws) {
-                        BunInspectorConnectionNoSSL* inspector = *(BunInspectorConnectionNoSSL**)ws->getUserData();
+                        WebSocketInspectorConnectionNoSSL* inspector = *(WebSocketInspectorConnectionNoSSL**)ws->getUserData();
                         inspector->drain(); },
             .ping = [](auto* /*ws*/, std::string_view) {
         /* Not implemented yet */ },
@@ -169,12 +169,12 @@ static void addInspector(void* app, JSC::JSGlobalObject* globalObject)
         /* Not implemented yet */ },
 
             .close = [](auto* ws, int /*code*/, std::string_view /*message*/) {
-            BunInspectorConnectionNoSSL* inspector = *(BunInspectorConnectionNoSSL**)ws->getUserData();
+            WebSocketInspectorConnectionNoSSL* inspector = *(WebSocketInspectorConnectionNoSSL**)ws->getUserData();
             inspector->onClose();
             delete inspector; }
         };
 
-        ((uWS::App*)app)->ws<BunInspectorConnectionNoSSL*>("/bun:inspect", WTF::move(handler));
+        ((uWS::App*)app)->ws<WebSocketInspectorConnectionNoSSL*>("/bun:inspect", WTF::move(handler));
     }
 }
 

--- a/src/bun.js/bindings/ErrorCode.h
+++ b/src/bun.js/bindings/ErrorCode.h
@@ -3,8 +3,13 @@
 
 #include "root.h"
 #include <JavaScriptCore/JSInternalFieldObjectImpl.h>
+#include "BunClientData.h"
 #include "ErrorCode+List.h"
 #include "CryptoKeyType.h"
+
+namespace Zig {
+class GlobalObject;
+}
 
 #define RELEASE_RETURN_IF_EXCEPTION(scope__, value__)                                                              \
     do {                                                                                                           \

--- a/src/bun.js/bindings/ErrorCode.h
+++ b/src/bun.js/bindings/ErrorCode.h
@@ -1,11 +1,8 @@
 // To add a new error code, put it in ErrorCode.ts
 #pragma once
 
-#include "ZigGlobalObject.h"
 #include "root.h"
 #include <JavaScriptCore/JSInternalFieldObjectImpl.h>
-#include <JavaScriptCore/JSInternalFieldObjectImplInlines.h>
-#include "BunClientData.h"
 #include "ErrorCode+List.h"
 #include "CryptoKeyType.h"
 

--- a/src/bun.js/bindings/ErrorCode.h
+++ b/src/bun.js/bindings/ErrorCode.h
@@ -1,15 +1,13 @@
 // To add a new error code, put it in ErrorCode.ts
 #pragma once
 
+#include "ZigGlobalObject.h"
 #include "root.h"
 #include <JavaScriptCore/JSInternalFieldObjectImpl.h>
+#include <JavaScriptCore/JSInternalFieldObjectImplInlines.h>
 #include "BunClientData.h"
 #include "ErrorCode+List.h"
 #include "CryptoKeyType.h"
-
-namespace Zig {
-class GlobalObject;
-}
 
 #define RELEASE_RETURN_IF_EXCEPTION(scope__, value__)                                                              \
     do {                                                                                                           \

--- a/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/bun.js/bindings/ExposeNodeModuleGlobals.cpp
@@ -14,6 +14,7 @@
 #include "ZigGlobalObject.h"
 #include "InternalModuleRegistry.h"
 
+#pragma push_macro("assert")
 #undef assert
 
 #define FOREACH_EXPOSED_BUILTIN_IMR(v)     \
@@ -131,3 +132,5 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void Bun__REPL__setupGlobalRequire(
     globalObject->putDirect(vm, Identifier::fromString(vm, "__filename"_s), filename, 0);
     globalObject->putDirect(vm, Identifier::fromString(vm, "__dirname"_s), dirname, 0);
 }
+
+#pragma pop_macro("assert")

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -1391,8 +1391,8 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionWithImplementation, (JSC::JSGlobalObject 
     thisObject->tail.clear();
 
     MarkedArgumentBuffer args;
-    NakedPtr<Exception> exception;
-    JSValue returnValue = call(globalObject, callback, callData, jsUndefined(), args, exception);
+    NakedPtr<JSC::Exception> exception;
+    JSValue returnValue = JSC::call(globalObject, callback, callData, jsUndefined(), args, exception);
 
     if (auto promise = tryJSDynamicCast<JSC::JSPromise*>(returnValue)) {
         auto capability = JSC::JSPromise::createNewPromiseCapability(globalObject, globalObject->promiseConstructor());

--- a/src/bun.js/bindings/JSStringDecoder.cpp
+++ b/src/bun.js/bindings/JSStringDecoder.cpp
@@ -8,6 +8,7 @@
 #include "JSDOMAttribute.h"
 #include "headers.h"
 #include "JSDOMConvertEnumeration.h"
+#include "JSBufferEncodingType.h"
 #include <JavaScriptCore/JSArrayBufferView.h>
 #include "BunClientData.h"
 #include "wtf/text/ASCIILiteral.h"

--- a/src/bun.js/bindings/NodeFSStatBinding.cpp
+++ b/src/bun.js/bindings/NodeFSStatBinding.cpp
@@ -35,6 +35,8 @@ using namespace WebCore;
 
 #if OS(WINDOWS)
 #ifndef mode_t
+#pragma push_macro("mode_t")
+#define BUN_PUSHED_MODE_T
 #define mode_t int32_t
 #endif
 
@@ -944,3 +946,8 @@ void initJSBigIntStatsClassStructure(JSC::LazyClassStructure::Initializer& init)
 }
 
 } // namespace Bun
+
+#ifdef BUN_PUSHED_MODE_T
+#pragma pop_macro("mode_t")
+#undef BUN_PUSHED_MODE_T
+#endif

--- a/src/bun.js/bindings/NodeFSStatBinding.cpp
+++ b/src/bun.js/bindings/NodeFSStatBinding.cpp
@@ -20,6 +20,10 @@
 #include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/DateInstance.h"
+#if !OS(WINDOWS)
+#include <sys/stat.h>
+#endif
+
 namespace Bun {
 
 class JSStatsPrototype;
@@ -29,9 +33,7 @@ class JSBigIntStatsConstructor;
 using namespace JSC;
 using namespace WebCore;
 
-#if !OS(WINDOWS)
-#include <sys/stat.h>
-#else
+#if OS(WINDOWS)
 #ifndef mode_t
 #define mode_t int32_t
 #endif

--- a/src/bun.js/bindings/NodeVMSourceTextModule.h
+++ b/src/bun.js/bindings/NodeVMSourceTextModule.h
@@ -38,7 +38,7 @@ public:
     JSValue instantiate(JSGlobalObject* globalObject);
     RefPtr<CachedBytecode> bytecode(JSGlobalObject* globalObject);
     JSUint8Array* cachedData(JSGlobalObject* globalObject);
-    Exception* evaluationException() const { return m_evaluationException.get(); }
+    JSC::Exception* evaluationException() const { return m_evaluationException.get(); }
     void initializeImportMeta(JSGlobalObject* globalObject);
 
     const SourceCode& sourceCode() const { return m_sourceCode; }
@@ -52,7 +52,7 @@ private:
     WriteBarrier<JSArray> m_moduleRequestsArray;
     WriteBarrier<ModuleProgramExecutable> m_cachedExecutable;
     WriteBarrier<JSUint8Array> m_cachedBytecodeBuffer;
-    WriteBarrier<Exception> m_evaluationException;
+    WriteBarrier<JSC::Exception> m_evaluationException;
     WriteBarrier<Unknown> m_initializeImportMeta;
     RefPtr<CachedBytecode> m_bytecode;
     SourceCode m_sourceCode;

--- a/src/bun.js/bindings/ProcessBindingBuffer.cpp
+++ b/src/bun.js/bindings/ProcessBindingBuffer.cpp
@@ -157,3 +157,5 @@ void ProcessBindingBuffer::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 DEFINE_VISIT_CHILDREN(ProcessBindingBuffer);
 
 } // namespace Bun
+
+#undef PROCESS_BINDING_NOT_IMPLEMENTED

--- a/src/bun.js/bindings/ProcessBindingFs.cpp
+++ b/src/bun.js/bindings/ProcessBindingFs.cpp
@@ -212,3 +212,5 @@ void ProcessBindingFs::finishCreation(JSC::VM& vm)
 }
 
 } // namespace Bun
+
+#undef PROCESS_BINDING_NOT_IMPLEMENTED

--- a/src/bun.js/bindings/ProcessBindingUV.cpp
+++ b/src/bun.js/bindings/ProcessBindingUV.cpp
@@ -27,48 +27,39 @@
 #if !defined(EAGAIN)
 #define EAGAIN 35
 #endif
-#if !defined(EAI_ADDRFAMILY)
+// EAI_* are libuv's fixed UV__EAI_* values (uv/errno.h), NOT the host's
+// getaddrinfo codes. Unconditionally redefine — if <netdb.h> was included
+// earlier (directly or via a unified-build sibling) its values are wrong
+// here: e.g. glibc's EAI_NODATA is -5, so `err == -EAI_NODATA` would
+// match 5 instead of -3007.
+#undef EAI_ADDRFAMILY
 #define EAI_ADDRFAMILY 3000
-#endif
-#if !defined(EAI_AGAIN)
+#undef EAI_AGAIN
 #define EAI_AGAIN 3001
-#endif
-#if !defined(EAI_BADFLAGS)
+#undef EAI_BADFLAGS
 #define EAI_BADFLAGS 3002
-#endif
-#if !defined(EAI_BADHINTS)
+#undef EAI_BADHINTS
 #define EAI_BADHINTS 3013
-#endif
-#if !defined(EAI_CANCELED)
+#undef EAI_CANCELED
 #define EAI_CANCELED 3003
-#endif
-#if !defined(EAI_FAIL)
+#undef EAI_FAIL
 #define EAI_FAIL 3004
-#endif
-#if !defined(EAI_FAMILY)
+#undef EAI_FAMILY
 #define EAI_FAMILY 3005
-#endif
-#if !defined(EAI_MEMORY)
+#undef EAI_MEMORY
 #define EAI_MEMORY 3006
-#endif
-#if !defined(EAI_NODATA)
+#undef EAI_NODATA
 #define EAI_NODATA 3007
-#endif
-#if !defined(EAI_NONAME)
+#undef EAI_NONAME
 #define EAI_NONAME 3008
-#endif
-#if !defined(EAI_OVERFLOW)
+#undef EAI_OVERFLOW
 #define EAI_OVERFLOW 3009
-#endif
-#if !defined(EAI_PROTOCOL)
+#undef EAI_PROTOCOL
 #define EAI_PROTOCOL 3014
-#endif
-#if !defined(EAI_SERVICE)
+#undef EAI_SERVICE
 #define EAI_SERVICE 3010
-#endif
-#if !defined(EAI_SOCKTYPE)
+#undef EAI_SOCKTYPE
 #define EAI_SOCKTYPE 3011
-#endif
 #if !defined(EALREADY)
 #define EALREADY 37
 #endif

--- a/src/bun.js/bindings/node/http/JSConnectionsListConstructor.h
+++ b/src/bun.js/bindings/node/http/JSConnectionsListConstructor.h
@@ -1,4 +1,4 @@
-#pragma std::once_flag
+#pragma once
 
 #include "root.h"
 #include <JavaScriptCore/InternalFunction.h>

--- a/src/bun.js/bindings/node/http/JSHTTPParserConstructor.h
+++ b/src/bun.js/bindings/node/http/JSHTTPParserConstructor.h
@@ -1,4 +1,4 @@
-#pragma std::once_flag
+#pragma once
 
 #include "root.h"
 #include <JavaScriptCore/InternalFunction.h>

--- a/src/bun.js/bindings/root-pch.h
+++ b/src/bun.js/bindings/root-pch.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// PCH source — see scripts/build/bun.ts. This is what actually gets
+// precompiled; .cpp files include "root.h", and the build force-includes
+// this via -Xclang -include so the PCH covers it.
+//
+// Kept separate from root.h so the heavy headers below are only pulled when
+// root.h is guaranteed to be the first thing parsed (the PCH wrapper
+// force-includes it). If they lived in root.h itself, a TU whose first
+// explicit include is BunClientData.h would re-enter root.h mid-parse and
+// reach ZigGlobalObject.h before WebCore::clientData() is declared. The PCH
+// path is fine; Windows (no PCH yet) and --unifiedSources=false would not be.
+
+#include "root.h"
+
+// #include'd by the vast majority of TUs and cost ~1.1s each to parse
+// (-ftime-trace). Editing either already triggers a near-full rebuild via
+// depfiles, so precompiling them costs nothing extra incrementally.
+#include "BunClientData.h"
+#include "ZigGlobalObject.h"

--- a/src/bun.js/bindings/root.h
+++ b/src/bun.js/bindings/root.h
@@ -102,13 +102,4 @@
 #define ZIG_EXPORT(...)
 #define ZIG_NONNULL
 
-#ifdef __cplusplus
-// These two are #include'd by the vast majority of TUs and cost ~1.1s each
-// to parse (-ftime-trace). Editing either already triggers a near-full
-// rebuild via depfiles, so precompiling them costs nothing extra
-// incrementally. Kept at the very end — they expect the macros above.
-#include "BunClientData.h"
-#include "ZigGlobalObject.h"
-#endif
-
 #endif

--- a/src/bun.js/bindings/root.h
+++ b/src/bun.js/bindings/root.h
@@ -102,4 +102,13 @@
 #define ZIG_EXPORT(...)
 #define ZIG_NONNULL
 
+#ifdef __cplusplus
+// These two are #include'd by the vast majority of TUs and cost ~1.1s each
+// to parse (-ftime-trace). Editing either already triggers a near-full
+// rebuild via depfiles, so precompiling them costs nothing extra
+// incrementally. Kept at the very end — they expect the macros above.
+#include "BunClientData.h"
+#include "ZigGlobalObject.h"
+#endif
+
 #endif

--- a/src/bun.js/bindings/v8/V8Context.h
+++ b/src/bun.js/bindings/v8/V8Context.h
@@ -5,9 +5,7 @@
 
 namespace v8 {
 
-namespace shim {
 class Isolate;
-}
 
 // Context is always a reinterpret pointer to Zig::GlobalObject, so that functions accepting a
 // Context can quickly access JSC data

--- a/src/bun.js/bindings/v8/v8_compatibility_assertions.h
+++ b/src/bun.js/bindings/v8/v8_compatibility_assertions.h
@@ -13,7 +13,7 @@
 
 // usage: [*outside* namespace v8] ASSERT_V8_TYPE_LAYOUT_MATCHES(v8::SomeTemplate<v8::SomeParam>)
 #define ASSERT_V8_TYPE_LAYOUT_MATCHES(TYPENAME)                                       \
-    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                           \
+    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                        \
     namespace DeclareBunType {                                                        \
     namespace v8 = ::v8;                                                              \
     using BunType = TYPENAME;                                                         \
@@ -32,7 +32,7 @@
 
 // usage: [*outside* namespace v8] ASSERT_V8_TYPE_FIELD_OFFSET_MATCHES(v8::Maybe<int>, m_hasValue, has_value_)
 #define ASSERT_V8_TYPE_FIELD_OFFSET_MATCHES(TYPENAME, BUN_FIELD_NAME, V8_FIELD_NAME)       \
-    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                                \
+    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                             \
     namespace DeclareBunType {                                                             \
     namespace v8 = ::v8;                                                                   \
     using BunType = TYPENAME;                                                              \

--- a/src/bun.js/bindings/v8/v8_compatibility_assertions.h
+++ b/src/bun.js/bindings/v8/v8_compatibility_assertions.h
@@ -13,7 +13,7 @@
 
 // usage: [*outside* namespace v8] ASSERT_V8_TYPE_LAYOUT_MATCHES(v8::SomeTemplate<v8::SomeParam>)
 #define ASSERT_V8_TYPE_LAYOUT_MATCHES(TYPENAME)                                       \
-    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__LINE__) {                           \
+    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                           \
     namespace DeclareBunType {                                                        \
     namespace v8 = ::v8;                                                              \
     using BunType = TYPENAME;                                                         \
@@ -32,7 +32,7 @@
 
 // usage: [*outside* namespace v8] ASSERT_V8_TYPE_FIELD_OFFSET_MATCHES(v8::Maybe<int>, m_hasValue, has_value_)
 #define ASSERT_V8_TYPE_FIELD_OFFSET_MATCHES(TYPENAME, BUN_FIELD_NAME, V8_FIELD_NAME)       \
-    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__LINE__) {                                \
+    namespace V8_TYPE_ASSERTIONS_NAMESPACE_NAME(__COUNTER__) {                                \
     namespace DeclareBunType {                                                             \
     namespace v8 = ::v8;                                                                   \
     using BunType = TYPENAME;                                                              \

--- a/src/bun.js/bindings/webcore/JSDOMOperation.cpp
+++ b/src/bun.js/bindings/webcore/JSDOMOperation.cpp
@@ -4,6 +4,12 @@
 #include "JSDOMOperation.h"
 #include "BunBuiltinNames.h"
 
+// JSDOMOperation.h #defines createNotEnoughArgumentsError → our wrapper.
+// Suspend it here so the wrapper can call the real JSC function, then
+// restore it — under unified builds the suspended macro would otherwise
+// leak into later siblings (JSDOMURL.cpp etc.) and they'd silently lose
+// the ERR_MISSING_ARGS code on the thrown error.
+#pragma push_macro("createNotEnoughArgumentsError")
 #undef createNotEnoughArgumentsError
 
 namespace WebCore {
@@ -19,6 +25,8 @@ JSC::JSObject* createNotEnoughArgumentsErrorBun(JSC::JSGlobalObject* globalObjec
 
     return error;
 }
+
+#pragma pop_macro("createNotEnoughArgumentsError")
 
 void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, const String& message)
 {

--- a/src/bun.js/bindings/webcore/JSValueInWrappedObject.h
+++ b/src/bun.js/bindings/webcore/JSValueInWrappedObject.h
@@ -82,9 +82,6 @@ inline void JSValueInWrappedObject::visit(Visitor& visitor) const
     visitor.append(m_cell);
 }
 
-template void JSValueInWrappedObject::visit(JSC::AbstractSlotVisitor&) const;
-template void JSValueInWrappedObject::visit(JSC::SlotVisitor&) const;
-
 inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
 {
     if (!value.isCell()) {


### PR DESCRIPTION
## What

Adds WebKit-style unified-source bundling to the C++ build and expands the precompiled header. At configure time, `scripts/build/unified.ts` writes `UnifiedSource-<dir>-<n>.cpp` wrappers that `#include` 16 sibling `.cpp` files each, then compiles those instead of the originals. Combined with adding `ZigGlobalObject.h` + `BunClientData.h` to the PCH and dropping a pair of bogus header-level explicit template instantiations, this collapses **547 → 82** translation units.

## Why

`-ftime-trace` + ClangBuildAnalyzer on a release `cpp-only` build showed **83 % of compile time is frontend parsing** — every tiny `.cpp` re-parses `ZigGlobalObject.h`, `BunClientData.h`, and the JSDOM converter headers. JSC builds in ~3 min in CI with far more C++ because it bundles 8 files per TU; we were compiling each file standalone.

## Numbers

Release `cpp-only`, deps cached, 64-core Linux:

|                       | TUs | CPU time | wall |
| --------------------- | --- | -------- | ---- |
| main                  | 547 | 3613 s   | —    |
| `--unifiedSources=off`| 547 | 3464 s   | 1:24 |
| **this PR**           | **82** | **866 s** | **0:40** |

ClangBuildAnalyzer: frontend 3004 s → 1260 s → ~550 s; backend 609 s → 407 s. The `JSValueInWrappedObject::visit` template (previously the #1 instantiation at 234 s) no longer appears.

## Knobs

- `--unifiedSources=false` restores per-file compilation (useful when iterating on a single `.cpp` and you don't want its 15 bundle-mates recompiling).
- `--timeTrace=true` adds `-ftime-trace` so you can re-profile with ClangBuildAnalyzer.
- `compile_commands.json` still has an entry per original `.cpp`, so clangd keeps working on individual files.

## Source changes exposed by bundling

- `JSValueInWrappedObject.h` — drop `template void ...visit(...)` explicit instantiations from the header (re-instantiated by every includer at ~3.2 s each; upstream WebKit doesn't have them).
- `root.h` — add `BunClientData.h` + `ZigGlobalObject.h` to the PCH (parsed once instead of ~130×).
- `v8_compatibility_assertions.h` — `__LINE__` → `__COUNTER__` so the namespace-rebinding macro generates unique names per TU.
- `V8Context.h` — fix bogus `namespace shim { class Isolate; }` forward decl that was creating a phantom `v8::shim::Isolate` shadowing `v8::Isolate` (real bug, only became visible when shim/ files shared a TU).
- Two `#pragma std::once_flag` typos → `#pragma once`; one missing `#pragma once`.
- Qualify a handful of `Exception`/`SourceProvider`/`call` references with `JSC::` so they don't become ambiguous when bundled with files that pull in `WebCore::Exception`.
- `JSStringDecoder.cpp` — include `JSBufferEncodingType.h` directly instead of relying on a sibling.
- `ProcessBindingBuffer.cpp` — `#undef PROCESS_BINDING_NOT_IMPLEMENTED` at EOF so it doesn't leak into the next file in its bundle.

## Excluded from bundling

- 16 `webcrypto/CryptoAlgorithm*.cpp` files that share file-static helper names (`aesAlgorithm`, `cryptEncrypt`, `ALG128`, …) — upstream WebKit also compiles these standalone.
- `webcore/JSWasmStreamingCompiler.cpp`, `JSDOMPromiseDeferred.cpp`, `JSMessageEventCustom.cpp`, `JSMIMEType.cpp` — wrap types whose `toJS`/`wrapperKey` overloads aren't ADL-reachable, so they rely on ordinary lookup at template-def time.
- A handful of large TUs (`ZigGlobalObject.cpp`, `bindings.cpp`, …) that already saturate a core and shouldn't be serialized with siblings.

No runtime behaviour change — same code, fewer redundant header parses.

## Follow-ups (not in this PR)

- Windows PCH (`/Yc`/`/Yu` plumbing in `compile.ts` is TODO'd).
- `ErrorCode.h` pulls in all of `ZigGlobalObject.h` for ~170 TUs that only need forward decls — only matters for `--unifiedSources=false` now.
- `BunClientData.h`'s `unique_ptr<ExtendedDOMIsoSubspaces>` instantiates a heavy destructor in every includer; an out-of-line dtor would cut another ~30 s.