### PR TITLE
Exit unsettled top-level await instead of hanging / busy-looping

### DIFF
--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2256,15 +2256,18 @@ fn loadPreloads(this: *VirtualMachine) !?*JSInternalPromise {
                         if (this.pending_internal_promise.?.status() == .pending) {
                             this.eventLoop().autoTick();
                         }
+
+                        // See loadEntryPoint — same unsettled-TLA escape hatch.
+                        if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
+                            break;
+                        }
                     }
                 },
                 else => {},
             }
         } else {
             this.eventLoop().performGC();
-            this.waitForPromise(jsc.AnyPromise{
-                .internal = promise,
-            });
+            this.eventLoop().waitForPromiseOrLoopExit(.{ .internal = promise });
         }
 
         if (promise.status() == .rejected)
@@ -2435,6 +2438,11 @@ pub fn loadEntryPointForTestRunner(this: *VirtualMachine, entry_path: string) an
                     if (this.pending_internal_promise.?.status() == .pending) {
                         this.eventLoop().autoTick();
                     }
+
+                    // See loadEntryPoint — same unsettled-TLA escape hatch.
+                    if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
+                        break;
+                    }
                 }
             },
             else => {},
@@ -2445,7 +2453,7 @@ pub fn loadEntryPointForTestRunner(this: *VirtualMachine, entry_path: string) an
         }
 
         this.eventLoop().performGC();
-        this.waitForPromise(.{ .internal = promise });
+        this.eventLoop().waitForPromiseOrLoopExit(.{ .internal = promise });
     }
 
     this.eventLoop().autoTick();
@@ -2467,6 +2475,14 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
                     if (this.pending_internal_promise.?.status() == .pending) {
                         this.eventLoop().autoTick();
                     }
+
+                    // Top-level await with no ref'd handle to resolve it:
+                    // bail so POSIX doesn't burn 100% CPU and Windows doesn't
+                    // hang on `uv_run(NOWAIT)` skipping its loop body. See
+                    // EventLoop.waitForPromiseOrLoopExit for details.
+                    if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
+                        break;
+                    }
                 }
             },
             else => {},
@@ -2477,7 +2493,7 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
         }
 
         this.eventLoop().performGC();
-        this.waitForPromise(.{ .internal = promise });
+        this.eventLoop().waitForPromiseOrLoopExit(.{ .internal = promise });
     }
 
     return this.pending_internal_promise.?;

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2256,18 +2256,15 @@ fn loadPreloads(this: *VirtualMachine) !?*JSInternalPromise {
                         if (this.pending_internal_promise.?.status() == .pending) {
                             this.eventLoop().autoTick();
                         }
-
-                        // See loadEntryPoint — same unsettled-TLA escape hatch.
-                        if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
-                            break;
-                        }
                     }
                 },
                 else => {},
             }
         } else {
             this.eventLoop().performGC();
-            this.eventLoop().waitForPromiseOrLoopExit(.{ .internal = promise });
+            this.waitForPromise(jsc.AnyPromise{
+                .internal = promise,
+            });
         }
 
         if (promise.status() == .rejected)
@@ -2438,11 +2435,6 @@ pub fn loadEntryPointForTestRunner(this: *VirtualMachine, entry_path: string) an
                     if (this.pending_internal_promise.?.status() == .pending) {
                         this.eventLoop().autoTick();
                     }
-
-                    // See loadEntryPoint — same unsettled-TLA escape hatch.
-                    if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
-                        break;
-                    }
                 }
             },
             else => {},
@@ -2453,7 +2445,7 @@ pub fn loadEntryPointForTestRunner(this: *VirtualMachine, entry_path: string) an
         }
 
         this.eventLoop().performGC();
-        this.eventLoop().waitForPromiseOrLoopExit(.{ .internal = promise });
+        this.waitForPromise(.{ .internal = promise });
     }
 
     this.eventLoop().autoTick();
@@ -2479,8 +2471,10 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
                     // Top-level await with no ref'd handle to resolve it:
                     // bail so POSIX doesn't burn 100% CPU and Windows doesn't
                     // hang on `uv_run(NOWAIT)` skipping its loop body. See
-                    // EventLoop.waitForPromiseOrLoopExit for details.
-                    if (this.pending_internal_promise.?.status() == .pending and !this.isEventLoopAlive()) {
+                    // EventLoop.waitForPromiseOrLoopExit for the full rationale
+                    // (and for why this deliberately avoids `isEventLoopAlive`,
+                    // which short-circuits on `unhandled_error_counter != 0`).
+                    if (this.pending_internal_promise.?.status() == .pending and !this.eventLoop().hasAnyHandleWork()) {
                         break;
                     }
                 }

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2468,6 +2468,15 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
                         this.eventLoop().autoTick();
                     }
 
+                    // Drain microtasks a user `process.on('unhandledRejection',
+                    // …)` handler may have queued inside `autoTick`'s
+                    // `handleRejectedPromises()` — see the matching comment in
+                    // EventLoop.waitForPromiseOrLoopExit. `hasAnyHandleWork`
+                    // can't see JSC microtasks, so without this drain a
+                    // handler that resolves the TLA promise would lose its
+                    // continuation when we break below.
+                    this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch break;
+
                     // Top-level await with no ref'd handle to resolve it:
                     // bail so POSIX doesn't burn 100% CPU and Windows doesn't
                     // hang on `uv_run(NOWAIT)` skipping its loop body. See

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2468,15 +2468,6 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
                         this.eventLoop().autoTick();
                     }
 
-                    // Drain microtasks a user `process.on('unhandledRejection',
-                    // …)` handler may have queued inside `autoTick`'s
-                    // `handleRejectedPromises()` — see the matching comment in
-                    // EventLoop.waitForPromiseOrLoopExit. `hasAnyHandleWork`
-                    // can't see JSC microtasks, so without this drain a
-                    // handler that resolves the TLA promise would lose its
-                    // continuation when we break below.
-                    this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch break;
-
                     // Top-level await with no ref'd handle to resolve it:
                     // bail so POSIX doesn't burn 100% CPU and Windows doesn't
                     // hang on `uv_run(NOWAIT)` skipping its loop body. See
@@ -2484,7 +2475,15 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
                     // (and for why this deliberately avoids `isEventLoopAlive`,
                     // which short-circuits on `unhandled_error_counter != 0`).
                     if (this.pending_internal_promise.?.status() == .pending and !this.eventLoop().hasAnyHandleWork()) {
-                        break;
+                        // Drain microtasks a user `process.on('unhandledRejection',
+                        // …)` handler may have queued inside `autoTick`'s
+                        // `handleRejectedPromises()` — see waitForPromiseOrLoopExit.
+                        // If the drain runs the continuation that settles the promise,
+                        // re-check and fall through to the loop condition.
+                        this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch break;
+                        if (this.pending_internal_promise.?.status() == .pending and !this.eventLoop().hasAnyHandleWork()) {
+                            break;
+                        }
                     }
                 }
             },

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -782,34 +782,48 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     if (this.pending_internal_promise) |p| {
         switch (p.status()) {
             .pending => {
-                // Normally defer: the C++ loader chain is still draining
-                // microtasks, or a ref'd await (timer / network / fs) will
-                // settle the promise, and the old continuation should run
-                // before we tear down the module registry. The defer is
-                // then consumed by `reportExceptionInHotReloadedModuleIf
-                // Needed` once the promise settles.
+                // Normally defer. A watcher event arrived while either:
+                //   (a) the C++ module loader / transpile chain is still
+                //       draining on the microtask queue,
+                //   (b) a user ref'd await (timer / network / fs) is
+                //       pending and will settle the promise.
+                // Both cases need the current continuation to run first;
+                // tearing down the module registry now would let the two
+                // chains interleave through one registry, or leave a
+                // zombie continuation firing against the freshly-reset
+                // global.
                 //
-                // Abandoned-TLA exception: when `loadEntryPoint` bailed
-                // out because the event loop had no work that could
-                // settle the promise (e.g. `await new Promise(() => {})`),
-                // or when the --hot outer loop reached the same quiet
-                // state after a subsequent hot-reload's module body also
-                // TLA-hangs, nothing will ever make the promise progress.
-                // Deferring is permanent: `reportException…` early-
-                // returns on `.pending` before ever consuming
-                // `hot_reload_deferred`, so --hot would go silently dead
-                // after the first hanging TLA.
+                // The defer is consumed by
+                // `reportExceptionInHotReloadedModuleIfNeeded` once the
+                // promise settles. But `reportException…` early-returns
+                // on `.pending`, so if the promise NEVER settles (an
+                // abandoned top-level await — `await new Promise(() =>
+                // {})` or an unref'd `AbortSignal.timeout`) the deferral
+                // would be permanent and --hot would go silently dead.
                 //
-                // Distinguish the two by checking the same signal
-                // `loadEntryPoint` used for its break — but via
-                // `hasAnyHandleWorkIgnoringForeverTimer` because by the
-                // time this runs under --hot the outer loop has already
-                // installed `forever_timer` as a ref'd uv handle on
-                // Windows, which would make the plain `hasAnyHandleWork`
-                // permanently true.
-                if (this.eventLoop().hasAnyHandleWorkIgnoringForeverTimer()) {
-                    this.hot_reload_deferred = true;
-                    return;
+                // Drain microtasks first to collapse case (a): if a
+                // loader chain microtask flips the status to settled,
+                // one of the other arms handles it. If status is still
+                // `.pending` after the drain, check whether any source
+                // of work could advance it — using the
+                // `hasAnyHandleWorkIgnoringForeverTimer` variant because
+                // the --hot main loop holds a ref'd `forever_timer` on
+                // Windows that would otherwise make plain
+                // `hasAnyHandleWork`/`isActive` permanently true.
+                this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
+                switch (p.status()) {
+                    .pending => if (this.eventLoop().hasAnyHandleWorkIgnoringForeverTimer()) {
+                        // case (b): ref'd I/O will settle the promise.
+                        this.hot_reload_deferred = true;
+                        return;
+                    },
+                    // Fell through case (a) during the drain — let the
+                    // matching arm decide.
+                    .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
+                        this.hot_reload_deferred = true;
+                        return;
+                    },
+                    .fulfilled => {},
                 }
             },
             .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -782,32 +782,34 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     if (this.pending_internal_promise) |p| {
         switch (p.status()) {
             .pending => {
-                // The defer-on-pending exists for a narrow case: a watcher
-                // event arrived while the C++ loader chain (fetch → link →
-                // evaluate) was still in flight on the microtask queue.
-                // Starting a second clearAll + load now would let the two
-                // chains interleave through one registry.
+                // Normally defer: the C++ loader chain is still draining
+                // microtasks, or a ref'd await (timer / network / fs) will
+                // settle the promise, and the old continuation should run
+                // before we tear down the module registry. The defer is
+                // then consumed by `reportExceptionInHotReloadedModuleIf
+                // Needed` once the promise settles.
                 //
-                // Drain the microtask queue first. If the loader chain was
-                // in flight, the drain runs it to completion and the
-                // promise resolves or rejects (and we fall through to the
-                // corresponding arm below). If it's still `.pending` after
-                // the drain, the only thing keeping it pending is external
-                // (a hanging TLA, a pending timer, etc.) and no further
-                // microtask settling is possible — deferring would be
-                // permanent because `reportExceptionInHotReloadedModuleIfNeeded`
-                // early-returns on `.pending` before ever consuming
-                // `hot_reload_deferred`. Proceed with the reload in that
-                // case (matches what `bun --hot` does on the rejected-path
-                // and what users expect when they save a file).
-                this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
-                switch (p.status()) {
-                    .pending => {},
-                    .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
-                        this.hot_reload_deferred = true;
-                        return;
-                    },
-                    .fulfilled => {},
+                // Abandoned-TLA exception: when `loadEntryPoint` bailed
+                // out because the event loop had no work that could
+                // settle the promise (e.g. `await new Promise(() => {})`),
+                // or when the --hot outer loop reached the same quiet
+                // state after a subsequent hot-reload's module body also
+                // TLA-hangs, nothing will ever make the promise progress.
+                // Deferring is permanent: `reportException…` early-
+                // returns on `.pending` before ever consuming
+                // `hot_reload_deferred`, so --hot would go silently dead
+                // after the first hanging TLA.
+                //
+                // Distinguish the two by checking the same signal
+                // `loadEntryPoint` used for its break — but via
+                // `hasAnyHandleWorkIgnoringForeverTimer` because by the
+                // time this runs under --hot the outer loop has already
+                // installed `forever_timer` as a ref'd uv handle on
+                // Windows, which would make the plain `hasAnyHandleWork`
+                // permanently true.
+                if (this.eventLoop().hasAnyHandleWorkIgnoringForeverTimer()) {
+                    this.hot_reload_deferred = true;
+                    return;
                 }
             },
             .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -782,18 +782,32 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     if (this.pending_internal_promise) |p| {
         switch (p.status()) {
             .pending => {
-                // Normally defer — the C++ loader chain is still draining.
-                // But if `loadEntryPoint` already exited via
-                // `waitForPromiseOrLoopExit`'s break (unsettled TLA with no
-                // ref'd handle), the promise is permanently `.pending` and
-                // nothing can make it progress. In that case the deferral
-                // would be permanent because
-                // `reportExceptionInHotReloadedModuleIfNeeded` returns on
-                // `.pending` before consuming `hot_reload_deferred`. Treat
-                // it as stale and proceed with the reload.
-                if (this.eventLoop().hasAnyHandleWork()) {
-                    this.hot_reload_deferred = true;
-                    return;
+                // The defer-on-pending exists for a narrow case: a watcher
+                // event arrived while the C++ loader chain (fetch → link →
+                // evaluate) was still in flight on the microtask queue.
+                // Starting a second clearAll + load now would let the two
+                // chains interleave through one registry.
+                //
+                // Drain the microtask queue first. If the loader chain was
+                // in flight, the drain runs it to completion and the
+                // promise resolves or rejects (and we fall through to the
+                // corresponding arm below). If it's still `.pending` after
+                // the drain, the only thing keeping it pending is external
+                // (a hanging TLA, a pending timer, etc.) and no further
+                // microtask settling is possible — deferring would be
+                // permanent because `reportExceptionInHotReloadedModuleIfNeeded`
+                // early-returns on `.pending` before ever consuming
+                // `hot_reload_deferred`. Proceed with the reload in that
+                // case (matches what `bun --hot` does on the rejected-path
+                // and what users expect when they save a file).
+                this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
+                switch (p.status()) {
+                    .pending => {},
+                    .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
+                        this.hot_reload_deferred = true;
+                        return;
+                    },
+                    .fulfilled => {},
                 }
             },
             .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -879,6 +879,22 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     }
     // reloadEntryPoint() stores into pending_internal_promise on every return path.
     _ = this.reloadEntryPoint(this.main) catch @panic("Failed to reload");
+
+    // `reloadEntryPoint` returns while the fetch/link/evaluate chain is
+    // still queued as JSC microtasks. When this `reload()` is invoked
+    // from inside `tick()` (the common single-save path), the
+    // `HotReloadTask` handler returns → `tick()`'s else-branch drains.
+    // But out-of-`tick()` callers — `reportExceptionInHotReloadedModule
+    // IfNeeded` (the stranded-flag consumer, see field doc on
+    // `hot_reload_deferred`) and the pre-existing `bun.js.zig` dispatch
+    // after an initial-load rejection — would return to the main loop
+    // with the new module body still unexecuted. `tickPossiblyForever`
+    // then blocks in `loop.tick()` before `this.tick()` ever drains the
+    // microtask queue, so the new module doesn't evaluate until the
+    // next loop wakeup (another save, or `forever_timer` firing in up
+    // to 4 minutes). Drain here to guarantee the reload takes effect
+    // before `reload()` returns, covering every call site.
+    this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
 }
 
 pub inline fn nodeFS(this: *VirtualMachine) *Node.fs.NodeFS {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -720,7 +720,24 @@ pub fn reportExceptionInHotReloadedModuleIfNeeded(this: *jsc.VirtualMachine) voi
     var promise = this.pending_internal_promise orelse return;
 
     switch (promise.status()) {
-        .pending => return,
+        .pending => {
+            // A prior `reload()` deferred because a ref'd await was in
+            // flight, and the await has now resolved into another
+            // pending state that the loop can no longer make progress
+            // on (e.g. `await Bun.sleep(N).then(() => new Promise(() =>
+            // {}))`). In that case `loadEntryPoint`'s watcher loop has
+            // already bailed out with the promise still `.pending` and
+            // no work to settle it — `hot_reload_deferred` would remain
+            // stranded and the deferred save silently dropped. Consume
+            // the flag here and let `reload()` re-evaluate (it'll
+            // observe the abandoned state and proceed). Guarded on the
+            // same "nothing ref'd but forever_timer" check `reload()`
+            // itself uses so we don't interrupt live ref'd work.
+            if (this.hot_reload_deferred and !this.eventLoop().hasAnyHandleWorkIgnoringForeverTimer()) {
+                this.reload(null);
+            }
+            return;
+        },
         .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
             this.pending_internal_promise_reported_at = this.hot_reload_counter;
             this.unhandledRejection(this.global, promise.result(this.global.vm()), promise.toJS());

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -733,8 +733,17 @@ pub fn reportExceptionInHotReloadedModuleIfNeeded(this: *jsc.VirtualMachine) voi
             // observe the abandoned state and proceed). Guarded on the
             // same "nothing ref'd but forever_timer" check `reload()`
             // itself uses so we don't interrupt live ref'd work.
+            //
+            // Tail-recurse after the reload so the fresh
+            // `pending_internal_promise` is re-read from the caller
+            // rather than the stale capture at line 720 above. Without
+            // this, a new module body that synchronously rejects
+            // (top-level `throw`, transpile error) would leave the
+            // fresh `.rejected` unreported until the next loop wakeup
+            // — `tickPossiblyForever` blocks in `loop.tick()` first.
             if (this.hot_reload_deferred and !this.eventLoop().hasAnyHandleWorkIgnoringForeverTimer()) {
                 this.reload(null);
+                return this.reportExceptionInHotReloadedModuleIfNeeded();
             }
             return;
         },

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -782,8 +782,19 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     if (this.pending_internal_promise) |p| {
         switch (p.status()) {
             .pending => {
-                this.hot_reload_deferred = true;
-                return;
+                // Normally defer — the C++ loader chain is still draining.
+                // But if `loadEntryPoint` already exited via
+                // `waitForPromiseOrLoopExit`'s break (unsettled TLA with no
+                // ref'd handle), the promise is permanently `.pending` and
+                // nothing can make it progress. In that case the deferral
+                // would be permanent because
+                // `reportExceptionInHotReloadedModuleIfNeeded` returns on
+                // `.pending` before consuming `hot_reload_deferred`. Treat
+                // it as stale and proceed with the reload.
+                if (this.eventLoop().hasAnyHandleWork()) {
+                    this.hot_reload_deferred = true;
+                    return;
+                }
             },
             .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
                 this.hot_reload_deferred = true;

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -947,6 +947,16 @@ pub fn enterUWSLoop(this: *VirtualMachine) void {
 
 pub fn onBeforeExit(this: *VirtualMachine) void {
     this.exit_handler.dispatchOnBeforeExit();
+    // A `process.on('beforeExit', …)` handler may queue JSC microtasks
+    // (e.g. by resolving a TLA that `waitForPromiseOrLoopExit` bailed
+    // out on). `isEventLoopAlive()` can't see those — it checks handles,
+    // tasks, and refs, not the microtask queue — so without this drain
+    // the inner `while` below would skip and the continuation would be
+    // silently dropped before process exit. The analogous gap for
+    // `unhandledRejection` handlers is covered by the drain at the tail
+    // of `waitForPromiseOrLoopExit` (see event_loop.zig); this is the
+    // same pattern one frame later.
+    this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
     var dispatch = false;
     while (true) {
         while (this.isEventLoopAlive()) : (dispatch = true) {
@@ -956,6 +966,7 @@ pub fn onBeforeExit(this: *VirtualMachine) void {
 
         if (dispatch) {
             this.exit_handler.dispatchOnBeforeExit();
+            this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
             dispatch = false;
 
             if (this.isEventLoopAlive()) continue;

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -736,7 +736,7 @@ pub fn reportExceptionInHotReloadedModuleIfNeeded(this: *jsc.VirtualMachine) voi
             //
             // Tail-recurse after the reload so the fresh
             // `pending_internal_promise` is re-read from the caller
-            // rather than the stale capture at line 720 above. Without
+            // rather than the stale local `promise` above. Without
             // this, a new module body that synchronously rejects
             // (top-level `throw`, transpile error) would leave the
             // fresh `.rejected` unreported until the next loop wakeup

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -947,16 +947,6 @@ pub fn enterUWSLoop(this: *VirtualMachine) void {
 
 pub fn onBeforeExit(this: *VirtualMachine) void {
     this.exit_handler.dispatchOnBeforeExit();
-    // A `process.on('beforeExit', …)` handler may queue JSC microtasks
-    // (e.g. by resolving a TLA that `waitForPromiseOrLoopExit` bailed
-    // out on). `isEventLoopAlive()` can't see those — it checks handles,
-    // tasks, and refs, not the microtask queue — so without this drain
-    // the inner `while` below would skip and the continuation would be
-    // silently dropped before process exit. The analogous gap for
-    // `unhandledRejection` handlers is covered by the drain at the tail
-    // of `waitForPromiseOrLoopExit` (see event_loop.zig); this is the
-    // same pattern one frame later.
-    this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
     var dispatch = false;
     while (true) {
         while (this.isEventLoopAlive()) : (dispatch = true) {
@@ -966,7 +956,6 @@ pub fn onBeforeExit(this: *VirtualMachine) void {
 
         if (dispatch) {
             this.exit_handler.dispatchOnBeforeExit();
-            this.eventLoop().drainMicrotasksWithGlobal(this.global, this.jsc_vm) catch {};
             dispatch = false;
 
             if (this.isEventLoopAlive()) continue;

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -576,8 +576,8 @@ pub fn waitForPromise(this: *EventLoop, promise: jsc.AnyPromise) void {
 }
 
 /// Whether the event loop has any source of work that could still resolve a
-/// pending promise — active uv/uws handles, queued tasks, concurrent refs,
-/// or immediates.
+/// pending promise — active uv/uws handles, queued tasks (main or
+/// concurrent), concurrent refs, or immediates.
 ///
 /// This is intentionally NOT `VirtualMachine.isEventLoopAlive()`:
 /// `isEventLoopAlive()` short-circuits on `unhandled_error_counter != 0`
@@ -585,12 +585,20 @@ pub fn waitForPromise(this: *EventLoop, promise: jsc.AnyPromise) void {
 /// fatal error stops it). For the TLA wait path we only care about work
 /// that could still wake the loop — a side-path unhandled rejection must
 /// NOT abandon an in-flight fetch whose resolution will complete the TLA.
-pub fn hasAnyHandleWork(this: *const EventLoop) bool {
+///
+/// `concurrent_tasks.isEmpty()` is a single atomic acquire-load; it's safe
+/// from the JS thread without locking. Including it closes a narrow race
+/// where a thread (e.g. the hot-reloader watcher at `hot_reloader.zig:278`)
+/// pushes to the concurrent queue without bumping `concurrent_ref` and the
+/// other liveness signals happen to be zero between the tick drain and the
+/// check.
+pub fn hasAnyHandleWork(this: *EventLoop) bool {
     const vm = this.virtual_machine;
     return vm.event_loop_handle.?.isActive() or
         vm.active_tasks > 0 or
         this.tasks.count > 0 or
         this.hasPendingRefs() or
+        !this.concurrent_tasks.isEmpty() or
         this.immediate_tasks.items.len > 0 or
         this.next_immediate_tasks.items.len > 0;
 }

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -632,6 +632,16 @@ pub fn waitForPromiseOrLoopExit(this: *EventLoop, promise: jsc.AnyPromise) void 
                     this.autoTick();
                 }
 
+                // `autoTick` ends with `handleRejectedPromises()`, which runs
+                // user JS (e.g. `process.on('unhandledRejection', …)`). In
+                // `.bun` mode with a registered handler, the path returns
+                // WITHOUT a `defer drainMicrotasks` — so a handler that
+                // resolves the awaited promise queues a continuation
+                // microtask that hasn't run yet. `hasAnyHandleWork()` can't
+                // see JSC microtasks, so without this drain we'd break on
+                // the next line and abandon the pending continuation.
+                this.drainMicrotasksWithGlobal(this.global, jsc_vm) catch return;
+
                 if (promise.status() == .pending and !this.hasAnyHandleWork()) {
                     break;
                 }

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -632,18 +632,22 @@ pub fn waitForPromiseOrLoopExit(this: *EventLoop, promise: jsc.AnyPromise) void 
                     this.autoTick();
                 }
 
-                // `autoTick` ends with `handleRejectedPromises()`, which runs
-                // user JS (e.g. `process.on('unhandledRejection', …)`). In
-                // `.bun` mode with a registered handler, the path returns
-                // WITHOUT a `defer drainMicrotasks` — so a handler that
-                // resolves the awaited promise queues a continuation
-                // microtask that hasn't run yet. `hasAnyHandleWork()` can't
-                // see JSC microtasks, so without this drain we'd break on
-                // the next line and abandon the pending continuation.
-                this.drainMicrotasksWithGlobal(this.global, jsc_vm) catch return;
-
                 if (promise.status() == .pending and !this.hasAnyHandleWork()) {
-                    break;
+                    // About to break because nothing holds the loop alive.
+                    // `autoTick` just called `handleRejectedPromises()`, which
+                    // may have run a user `process.on('unhandledRejection',
+                    // …)` handler that resolved the awaited promise via a
+                    // JSC microtask. In `.bun` mode with a registered
+                    // handler, that path returns WITHOUT a
+                    // `defer drainMicrotasks`, so the continuation hasn't
+                    // run yet and `hasAnyHandleWork` can't see it. Drain
+                    // once and re-check the status — if the microtask
+                    // settled the promise, fall through to the loop
+                    // condition and exit normally instead of breaking.
+                    this.drainMicrotasksWithGlobal(this.global, jsc_vm) catch return;
+                    if (promise.status() == .pending and !this.hasAnyHandleWork()) {
+                        break;
+                    }
                 }
             }
         },

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -575,6 +575,44 @@ pub fn waitForPromise(this: *EventLoop, promise: jsc.AnyPromise) void {
     }
 }
 
+/// Like `waitForPromise`, but returns early when the event loop has nothing
+/// left that could resolve the promise — no active uv/uws handles, no tasks,
+/// no concurrent refs, no immediates. Used by the top-level-await entry
+/// points where the promise may be "unsettled" (e.g. awaiting an abort event
+/// whose only source is an unref'd `AbortSignal.timeout()` timer).
+///
+/// Without this, POSIX busy-loops at 100% CPU until the unref'd timer fires
+/// and Windows hangs forever (`uv_run(UV_RUN_NOWAIT)` early-returns when
+/// `uv__loop_alive()` is false, so unref'd Bun timers never fire via the uv
+/// scheduler). Matches Node.js, which also exits an unsettled top-level
+/// await without waiting on unref'd handles.
+///
+/// Callers that require a resolved promise on return should keep using
+/// `waitForPromise` — this variant is specifically for the top-level-entry
+/// path, which is prepared to observe a still-pending promise.
+pub fn waitForPromiseOrLoopExit(this: *EventLoop, promise: jsc.AnyPromise) void {
+    const jsc_vm = this.virtual_machine.jsc_vm;
+    switch (promise.status()) {
+        .pending => {
+            while (promise.status() == .pending) {
+                if (jsc_vm.executionForbidden()) {
+                    break;
+                }
+                this.tick();
+
+                if (promise.status() == .pending) {
+                    this.autoTick();
+                }
+
+                if (promise.status() == .pending and !this.virtual_machine.isEventLoopAlive()) {
+                    break;
+                }
+            }
+        },
+        else => {},
+    }
+}
+
 pub fn waitForPromiseWithTermination(this: *EventLoop, promise: jsc.AnyPromise) void {
     const worker = this.virtual_machine.worker orelse @panic("EventLoop.waitForPromiseWithTermination: worker is not initialized");
     switch (promise.status()) {
@@ -584,6 +622,15 @@ pub fn waitForPromiseWithTermination(this: *EventLoop, promise: jsc.AnyPromise) 
 
                 if (!worker.hasRequestedTerminate() and promise.status() == .pending) {
                     this.autoTick();
+                }
+
+                // Same unsettled-TLA escape hatch as waitForPromiseOrLoopExit.
+                // Without this, a worker whose entry point has an unsettled
+                // top-level await (e.g. `await new Promise(() => {})`) would
+                // busy-loop forever on POSIX / hang on Windows instead of
+                // reaching the normal "worker done" path.
+                if (promise.status() == .pending and !this.virtual_machine.isEventLoopAlive()) {
+                    break;
                 }
             }
         },

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -575,11 +575,31 @@ pub fn waitForPromise(this: *EventLoop, promise: jsc.AnyPromise) void {
     }
 }
 
+/// Whether the event loop has any source of work that could still resolve a
+/// pending promise — active uv/uws handles, queued tasks, concurrent refs,
+/// or immediates.
+///
+/// This is intentionally NOT `VirtualMachine.isEventLoopAlive()`:
+/// `isEventLoopAlive()` short-circuits on `unhandled_error_counter != 0`
+/// (it is the "should the main event loop keep running" predicate, and a
+/// fatal error stops it). For the TLA wait path we only care about work
+/// that could still wake the loop — a side-path unhandled rejection must
+/// NOT abandon an in-flight fetch whose resolution will complete the TLA.
+pub fn hasAnyHandleWork(this: *const EventLoop) bool {
+    const vm = this.virtual_machine;
+    return vm.event_loop_handle.?.isActive() or
+        vm.active_tasks > 0 or
+        this.tasks.count > 0 or
+        this.hasPendingRefs() or
+        this.immediate_tasks.items.len > 0 or
+        this.next_immediate_tasks.items.len > 0;
+}
+
 /// Like `waitForPromise`, but returns early when the event loop has nothing
-/// left that could resolve the promise — no active uv/uws handles, no tasks,
-/// no concurrent refs, no immediates. Used by the top-level-await entry
-/// points where the promise may be "unsettled" (e.g. awaiting an abort event
-/// whose only source is an unref'd `AbortSignal.timeout()` timer).
+/// left that could resolve the promise (see `hasAnyHandleWork`). Used by the
+/// top-level-await entry points where the promise may be "unsettled" — e.g.
+/// awaiting an abort event whose only source is an unref'd
+/// `AbortSignal.timeout()` timer.
 ///
 /// Without this, POSIX busy-loops at 100% CPU until the unref'd timer fires
 /// and Windows hangs forever (`uv_run(UV_RUN_NOWAIT)` early-returns when
@@ -604,7 +624,7 @@ pub fn waitForPromiseOrLoopExit(this: *EventLoop, promise: jsc.AnyPromise) void 
                     this.autoTick();
                 }
 
-                if (promise.status() == .pending and !this.virtual_machine.isEventLoopAlive()) {
+                if (promise.status() == .pending and !this.hasAnyHandleWork()) {
                     break;
                 }
             }
@@ -622,15 +642,6 @@ pub fn waitForPromiseWithTermination(this: *EventLoop, promise: jsc.AnyPromise) 
 
                 if (!worker.hasRequestedTerminate() and promise.status() == .pending) {
                     this.autoTick();
-                }
-
-                // Same unsettled-TLA escape hatch as waitForPromiseOrLoopExit.
-                // Without this, a worker whose entry point has an unsettled
-                // top-level await (e.g. `await new Promise(() => {})`) would
-                // busy-loop forever on POSIX / hang on Windows instead of
-                // reaching the normal "worker done" path.
-                if (promise.status() == .pending and !this.virtual_machine.isEventLoopAlive()) {
-                    break;
                 }
             }
         },

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -617,21 +617,30 @@ pub fn hasAnyHandleWork(this: *EventLoop) bool {
 /// variant. On POSIX, uws timers don't bump the uws `active` counter, so
 /// the forever_timer is invisible to `isActive()` and this is equivalent
 /// to `hasAnyHandleWork`.
+///
+/// Windows parity with `uv_loop_alive()`: also consider
+/// `active_reqs.count`, `pending_reqs_tail`, and `endgame_handles`. A
+/// native addon submitting a raw uv request via `napi_get_uv_event_loop`
+/// bumps `active_reqs.count` without touching `active_handles` or any
+/// Bun-side liveness signal, and we must not drop such work on the floor
+/// (the false-negative direction is unrecoverable: we'd tear down the
+/// module registry while the addon's uv_after_work_cb was still pending).
 pub fn hasAnyHandleWorkIgnoringForeverTimer(this: *EventLoop) bool {
     if (comptime Environment.isWindows) {
         const vm = this.virtual_machine;
-        // `event_loop_handle` on Windows is the libuv `uv.Loop`. Subtract
-        // the forever_timer's contribution — it's always 1 ref'd handle
-        // when present. Note this is a heuristic only: another handle
-        // closing as we sample would underreport, but the common case
-        // (no closes in flight at reload time) is accurate and the fall-
-        // back on a false positive is simply "defer the reload once more",
-        // which is recoverable.
+        // Subtract the forever_timer's contribution from
+        // `active_handles` — it's always 1 ref'd handle when present.
+        // Note this is a heuristic: another handle closing as we sample
+        // would underreport, but the fall-back on a false positive is
+        // simply "defer the reload once more", which is recoverable.
         const uv_loop = vm.event_loop_handle.?;
         const active = uv_loop.active_handles;
         const forever_timer_contribution: u32 = if (this.forever_timer != null) 1 else 0;
         const effective_active = if (active > forever_timer_contribution) active - forever_timer_contribution else 0;
         return effective_active > 0 or
+            uv_loop.active_reqs.count > 0 or
+            uv_loop.pending_reqs_tail != null or
+            uv_loop.endgame_handles != null or
             vm.active_tasks > 0 or
             this.tasks.count > 0 or
             this.hasPendingRefs() or

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -603,6 +603,45 @@ pub fn hasAnyHandleWork(this: *EventLoop) bool {
         this.next_immediate_tasks.items.len > 0;
 }
 
+/// Like `hasAnyHandleWork`, but ignores the outer `--hot` main-loop's
+/// `forever_timer` when counting active uv handles.
+///
+/// On Windows, `tickPossiblyForever` creates `forever_timer` as a ref'd
+/// `uv_timer_t` specifically so `uv_run(UV_RUN_ONCE)` blocks on file-
+/// watcher wakeups without immediately returning on a dead loop. Because
+/// the handle is ref'd, `uv_loop_alive()` (and therefore
+/// `event_loop_handle.isActive()`) reports the loop as "alive" even when
+/// there's no real work to settle a pending promise. Callers that need
+/// to distinguish "only forever_timer is holding the loop open" from
+/// "a user-held ref'd handle is holding the loop open" should use this
+/// variant. On POSIX, uws timers don't bump the uws `active` counter, so
+/// the forever_timer is invisible to `isActive()` and this is equivalent
+/// to `hasAnyHandleWork`.
+pub fn hasAnyHandleWorkIgnoringForeverTimer(this: *EventLoop) bool {
+    if (comptime Environment.isWindows) {
+        const vm = this.virtual_machine;
+        // `event_loop_handle` on Windows is the libuv `uv.Loop`. Subtract
+        // the forever_timer's contribution — it's always 1 ref'd handle
+        // when present. Note this is a heuristic only: another handle
+        // closing as we sample would underreport, but the common case
+        // (no closes in flight at reload time) is accurate and the fall-
+        // back on a false positive is simply "defer the reload once more",
+        // which is recoverable.
+        const uv_loop = vm.event_loop_handle.?;
+        const active = uv_loop.active_handles;
+        const forever_timer_contribution: u32 = if (this.forever_timer != null) 1 else 0;
+        const effective_active = if (active > forever_timer_contribution) active - forever_timer_contribution else 0;
+        return effective_active > 0 or
+            vm.active_tasks > 0 or
+            this.tasks.count > 0 or
+            this.hasPendingRefs() or
+            !this.concurrent_tasks.isEmpty() or
+            this.immediate_tasks.items.len > 0 or
+            this.next_immediate_tasks.items.len > 0;
+    }
+    return this.hasAnyHandleWork();
+}
+
 /// Like `waitForPromise`, but returns early when the event loop has nothing
 /// left that could resolve the promise (see `hasAnyHandleWork`). Used by the
 /// top-level-await entry points where the promise may be "unsettled" — e.g.

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -51,11 +51,7 @@ test("AbortSignal.timeout awaited at top-level does not hang or spin", async () 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
   expect(stripAsanWarning(stderr)).toBe("");
@@ -87,11 +83,7 @@ test("AbortSignal.timeout fires when something else keeps the loop alive", async
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stripAsanWarning(stderr)).toBe("");
   expect(stdout).toBe("run aborted\n");
@@ -104,20 +96,12 @@ test("top-level await on a never-resolving promise exits cleanly", async () => {
   // Windows and burned CPU in a tight loop on POSIX.
   const started = performance.now();
   await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      "console.log('before'); await new Promise(() => {}); console.log('after');",
-    ],
+    cmd: [bunExe(), "-e", "console.log('before'); await new Promise(() => {}); console.log('after');"],
     env: bunEnv,
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
   expect(stripAsanWarning(stderr)).toBe("");

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -135,3 +135,33 @@ test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () 
   expect(stdout).toBe("elapsed=ok\n");
   expect(exitCode).toBe(1);
 });
+
+test("unhandledRejection handler that resolves the TLA runs to completion", async () => {
+  // The default `.bun` unhandled-rejection path calls
+  // `Bun__handleUnhandledRejection` and then returns WITHOUT draining
+  // microtasks (unlike `.none` / `.warn` / `.strict` which all `defer
+  // drainMicrotasks`). If a registered handler resolves the awaited promise,
+  // the continuation is queued as a JSC microtask that hasn't run yet when
+  // `autoTick` returns. `hasAnyHandleWork()` can't see JSC microtasks, so
+  // without a microtask drain between `autoTick` and the liveness check the
+  // loop would exit prematurely and the continuation would be silently
+  // dropped. This test pins the drain.
+  const source = `
+    let resolveIt;
+    const later = new Promise(r => resolveIt = r);
+    process.on("unhandledRejection", () => resolveIt("handled"));
+    Promise.reject(new Error("trigger"));
+    const r = await later;
+    process.stdout.write("got=" + r + "\\n");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("got=handled\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -16,17 +16,9 @@ import { bunEnv, bunExe } from "harness";
 //            ref'd handles), so the uv timer that would have drained Bun's
 //            heap never fired. The process hung forever.
 //
-// `waitForPromise` now breaks when the event loop has nothing left to make
-// progress — no active handles, no tasks, no concurrent refs, no immediates
-// — matching Node.js (unsettled top-level await exits cleanly rather than
-// waiting on unref'd handles).
-
-function stripAsanWarning(stderr: string): string {
-  return stderr
-    .split("\n")
-    .filter(l => !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-}
+// `loadEntryPoint` now breaks when the event loop has nothing left to make
+// progress — matching Node.js (unsettled top-level await exits cleanly
+// rather than waiting on unref'd handles).
 
 test("AbortSignal.timeout awaited at top-level does not hang or spin", async () => {
   // The timeout is deliberately long (60s). Before the fix, POSIX would
@@ -48,13 +40,11 @@ test("AbortSignal.timeout awaited at top-level does not hang or spin", async () 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
     env: bunEnv,
-    stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
-  expect(stripAsanWarning(stderr)).toBe("");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
   expect(elapsed).toBeLessThan(30_000);
@@ -80,12 +70,10 @@ test("AbortSignal.timeout fires when something else keeps the loop alive", async
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
     env: bunEnv,
-    stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect(stripAsanWarning(stderr)).toBe("");
   expect(stdout).toBe("run aborted\n");
   expect(exitCode).toBe(0);
 });
@@ -98,14 +86,43 @@ test("top-level await on a never-resolving promise exits cleanly", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "console.log('before'); await new Promise(() => {}); console.log('after');"],
     env: bunEnv,
-    stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
-  expect(stripAsanWarning(stderr)).toBe("");
   expect(stdout).toBe("before\n");
   expect(exitCode).toBe(0);
   expect(elapsed).toBeLessThan(30_000);
+});
+
+test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () => {
+  // The first cut of this fix used `isEventLoopAlive()` as the exit
+  // predicate. That short-circuits on `unhandled_error_counter != 0` — so a
+  // side-path unhandled rejection (common: a forgotten `.catch()` on a void
+  // Promise in default .bun mode) would cause the TLA wait to bail while
+  // the real work (here, a `setTimeout`) was still pending. The continuation
+  // after `await` would never run. This test pins that behavior: the
+  // rejection is still reported on stderr, but the await resolves normally
+  // and the code after it executes.
+  const source = `
+    const t0 = Date.now();
+    Promise.reject(new Error("side rejection"));
+    await new Promise(r => setTimeout(r, 200));
+    process.stdout.write("elapsed=" + (Date.now() - t0 >= 180 ? "ok" : "early") + "\\n");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  // stdout is what matters: the continuation after `await` ran, the timer
+  // actually waited ~200ms, and we didn't bail early. (The exit code is 1
+  // because bun's default `.bun` unhandled-rejection mode sets it — not our
+  // concern here; we just need to prove the wait wasn't abandoned.)
+  expect(stdout).toBe("elapsed=ok\n");
+  expect(exitCode).toBe(1);
 });

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -49,9 +49,13 @@ test("AbortSignal.timeout awaited at top-level does not hang or spin", async () 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
+  // Order matters: a hang regression shows up as elapsed >= 30_000 (and,
+  // in the worst case, a SIGTERM exit code from the test timeout). Assert
+  // elapsed first so the diff surfaces the actual failure signal rather
+  // than the exit-code side effect.
   expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
   expect(elapsed).toBeLessThan(30_000);
+  expect(exitCode).toBe(0);
 });
 
 test("AbortSignal.timeout fires when something else keeps the loop alive", async () => {
@@ -95,9 +99,10 @@ test("top-level await on a never-resolving promise exits cleanly", async () => {
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   const elapsed = performance.now() - started;
 
+  // See test 1 for assertion ordering rationale.
   expect(stdout).toBe("before\n");
-  expect(exitCode).toBe(0);
   expect(elapsed).toBeLessThan(30_000);
+  expect(exitCode).toBe(0);
 });
 
 test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () => {

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -124,6 +124,11 @@ test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
     env: bunEnv,
+    // The script deliberately leaves the rejection unhandled to trigger
+    // Bun's default `.bun`-mode stderr report; ignore it so the message
+    // doesn't leak into the test-runner output (Bun.spawn defaults stderr
+    // to 'inherit').
+    stderr: "ignore",
   });
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29546
+//
+// `AbortSignal.timeout(N)` schedules an unref'd timer in Bun's own timer
+// heap. When awaited at the top level — with no ref'd handles keeping the
+// loop alive — the event loop had two bugs:
+//
+//   POSIX:   `autoTick()` took the `tickWithoutIdle()` branch (zero-timeout
+//            poll) and then `drainTimers()`. The timer eventually fired, but
+//            only after a tight busy loop (~100% CPU for the full wait).
+//
+//   Windows: `tickWithoutIdle` -> `us_loop_pump` -> `uv_run(NOWAIT)`. That
+//            call skips its loop body when `uv__loop_alive()` is false (no
+//            ref'd handles), so the uv timer that would have drained Bun's
+//            heap never fired. The process hung forever.
+//
+// `waitForPromise` now breaks when the event loop has nothing left to make
+// progress — no active handles, no tasks, no concurrent refs, no immediates
+// — matching Node.js (unsettled top-level await exits cleanly rather than
+// waiting on unref'd handles).
+
+function stripAsanWarning(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(l => !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
+
+test("AbortSignal.timeout awaited at top-level does not hang or spin", async () => {
+  // The timeout is deliberately long (60s). Before the fix, POSIX would
+  // busy-loop burning CPU for the full duration and Windows would hang
+  // forever. With the fix, the process exits cleanly well under 60s
+  // because the unref'd timer doesn't keep the loop alive.
+  const source = `
+    async function run(signal) {
+      return new Promise((resolve) => {
+        signal.addEventListener("abort", () => resolve("run aborted"));
+      });
+    }
+
+    const r = await run(AbortSignal.timeout(60_000));
+    console.log(r);
+  `;
+
+  const started = performance.now();
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  const elapsed = performance.now() - started;
+
+  expect(stripAsanWarning(stderr)).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+  expect(elapsed).toBeLessThan(30_000);
+});
+
+test("AbortSignal.timeout fires when something else keeps the loop alive", async () => {
+  // Regression guard for the fix above — an unref'd AbortSignalTimeout must
+  // still fire when a ref'd handle keeps the loop open, so the abort
+  // listener runs and resolves the awaited promise as expected.
+  const source = `
+    async function run(signal) {
+      return new Promise((resolve) => {
+        signal.addEventListener("abort", () => resolve("run aborted"));
+      });
+    }
+
+    const keepAlive = setTimeout(() => {}, 60_000);
+    const r = await run(AbortSignal.timeout(100));
+    console.log(r);
+    clearTimeout(keepAlive);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stripAsanWarning(stderr)).toBe("");
+  expect(stdout).toBe("run aborted\n");
+  expect(exitCode).toBe(0);
+});
+
+test("top-level await on a never-resolving promise exits cleanly", async () => {
+  // Same event-loop fix — a pending TLA with no ref'd handles must not spin
+  // (POSIX) or hang (Windows). Before the fix, this script hung forever on
+  // Windows and burned CPU in a tight loop on POSIX.
+  const started = performance.now();
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "console.log('before'); await new Promise(() => {}); console.log('after');",
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  const elapsed = performance.now() - started;
+
+  expect(stripAsanWarning(stderr)).toBe("");
+  expect(stdout).toBe("before\n");
+  expect(exitCode).toBe(0);
+  expect(elapsed).toBeLessThan(30_000);
+});

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -16,9 +16,13 @@ import { bunEnv, bunExe } from "harness";
 //            ref'd handles), so the uv timer that would have drained Bun's
 //            heap never fired. The process hung forever.
 //
-// `loadEntryPoint` now breaks when the event loop has nothing left to make
-// progress — matching Node.js (unsettled top-level await exits cleanly
-// rather than waiting on unref'd handles).
+// `loadEntryPoint` now routes the TLA wait through
+// `EventLoop.waitForPromiseOrLoopExit`, which breaks when the event loop
+// has nothing left to make progress — matching Node.js (unsettled
+// top-level await exits cleanly rather than waiting on unref'd handles).
+// `waitForPromise` itself is unchanged — its callers (Expect.toThrow,
+// bundler, REPL, …) still rely on the "returns with promise resolved"
+// contract.
 
 test("AbortSignal.timeout awaited at top-level does not hang or spin", async () => {
   // The timeout is deliberately long (60s). Before the fix, POSIX would

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -190,6 +190,13 @@ test(
       buf = lines.pop() ?? "";
       for (const line of lines) {
         if (!line.startsWith("v=")) continue;
+        // Watcher double-fire guard (FSEvents on macOS / ReadDirectoryChangesW
+        // on Windows can deliver two events for one write): if the same
+        // `v=N` repeats, the second fire re-evaluated the same file before
+        // our next `Bun.write` landed — ignore the duplicate and keep
+        // waiting for the next round. Mirrors the stale-reload handling
+        // in test/cli/hot/hot.test.ts:driveErrorReloadCycle.
+        if (line === seen.at(-1)) continue;
         seen.push(line);
         round++;
         if (round === 3) {

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/29546
 //
@@ -139,6 +140,61 @@ test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () 
   // concern here; we just need to prove the wait wasn't abandoned.)
   expect(stdout).toBe("elapsed=ok\n");
   expect(exitCode).toBe(1);
+});
+
+test("--hot reload proceeds after a hanging top-level await", async () => {
+  // With the TLA exit-on-no-work fix, `loadEntryPoint` returns with the
+  // internal promise still in `.pending` when a TLA never settles (e.g.
+  // `await new Promise(() => {})`). `reload()` used to see that pending
+  // status and permanently defer via `hot_reload_deferred = true`, but
+  // `reportExceptionInHotReloadedModuleIfNeeded` early-returns on
+  // `.pending` before consuming the flag — so every subsequent file save
+  // was silently dropped. Guard the defer with `hasAnyHandleWork()` so a
+  // stale-pending promise doesn't block reloads forever.
+  using dir = tempDir("hot-tla", {
+    "entry.ts": `
+      console.log("v=" + (globalThis.__tag || 1));
+      await new Promise(() => {});
+    `,
+  });
+  const entry = join(String(dir), "entry.ts");
+
+  await using runner = Bun.spawn({
+    cmd: [bunExe(), "--hot", "run", entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "ignore",
+    stdin: "ignore",
+  });
+
+  const decoder = new TextDecoder();
+  const seen: string[] = [];
+  let round = 0;
+
+  for await (const chunk of runner.stdout) {
+    const text = decoder.decode(chunk);
+    for (const line of text.split("\n")) {
+      if (!line.startsWith("v=")) continue;
+      seen.push(line);
+      round++;
+      if (round === 3) {
+        runner.kill();
+        break;
+      }
+      await Bun.write(
+        entry,
+        `
+          globalThis.__tag = ${round + 1};
+          console.log("v=" + globalThis.__tag);
+          await new Promise(() => {});
+        `,
+      );
+    }
+    if (round === 3) break;
+  }
+
+  expect(seen).toEqual(["v=1", "v=2", "v=3"]);
 });
 
 test("unhandledRejection handler that resolves the TLA runs to completion", async () => {

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -142,77 +142,81 @@ test("unhandled rejection mid-TLA does not abandon an in-flight wait", async () 
   expect(exitCode).toBe(1);
 });
 
-test("--hot reload proceeds after a hanging top-level await", async () => {
-  // With the TLA exit-on-no-work fix, `loadEntryPoint` returns with the
-  // internal promise still in `.pending` when a TLA never settles (e.g.
-  // `await new Promise(() => {})`). `reload()` used to see that pending
-  // status and permanently defer via `hot_reload_deferred = true`, but
-  // `reportExceptionInHotReloadedModuleIfNeeded` early-returns on
-  // `.pending` before consuming the flag — so every subsequent file save
-  // was silently dropped. `reload()` now distinguishes "loader chain /
-  // ref'd await still in flight" from "abandoned TLA" by consulting
-  // `hasAnyHandleWorkIgnoringForeverTimer()` — the `forever_timer` carve-
-  // out matters because the --hot main loop holds a ref'd uv timer on
-  // Windows which would otherwise keep the liveness check permanently
-  // true. Test asserts the behavior, not the mechanism: three back-to-
-  // back reloads must each actually run.
-  using dir = tempDir("hot-tla", {
-    "entry.ts": `
+test(
+  "--hot reload proceeds after a hanging top-level await",
+  async () => {
+    // With the TLA exit-on-no-work fix, `loadEntryPoint` returns with the
+    // internal promise still in `.pending` when a TLA never settles (e.g.
+    // `await new Promise(() => {})`). `reload()` used to see that pending
+    // status and permanently defer via `hot_reload_deferred = true`, but
+    // `reportExceptionInHotReloadedModuleIfNeeded` early-returns on
+    // `.pending` before consuming the flag — so every subsequent file save
+    // was silently dropped. `reload()` now distinguishes "loader chain /
+    // ref'd await still in flight" from "abandoned TLA" by consulting
+    // `hasAnyHandleWorkIgnoringForeverTimer()` — the `forever_timer` carve-
+    // out matters because the --hot main loop holds a ref'd uv timer on
+    // Windows which would otherwise keep the liveness check permanently
+    // true. Test asserts the behavior, not the mechanism: three back-to-
+    // back reloads must each actually run.
+    using dir = tempDir("hot-tla", {
+      "entry.ts": `
       console.log("v=" + (globalThis.__tag || 1));
       await new Promise(() => {});
     `,
-  });
-  const entry = join(String(dir), "entry.ts");
+    });
+    const entry = join(String(dir), "entry.ts");
 
-  await using runner = Bun.spawn({
-    cmd: [bunExe(), "--hot", "run", entry],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "ignore",
-    stdin: "ignore",
-  });
+    await using runner = Bun.spawn({
+      cmd: [bunExe(), "--hot", "run", entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "ignore",
+      stdin: "ignore",
+    });
 
-  const decoder = new TextDecoder();
-  const seen: string[] = [];
-  let round = 0;
-  // Buffer across chunk boundaries — matches the pattern in
-  // test/cli/hot/hot.test.ts. A 4-byte "v=N\n" write is realistically
-  // never torn on either platform here, but making the reader robust
-  // costs nothing and keeps it consistent with the other --hot readers.
-  let buf = "";
+    const decoder = new TextDecoder();
+    const seen: string[] = [];
+    let round = 0;
+    // Buffer across chunk boundaries — matches the pattern in
+    // test/cli/hot/hot.test.ts. A 4-byte "v=N\n" write is realistically
+    // never torn on either platform here, but making the reader robust
+    // costs nothing and keeps it consistent with the other --hot readers.
+    let buf = "";
 
-  for await (const chunk of runner.stdout) {
-    buf += decoder.decode(chunk, { stream: true });
-    const lines = buf.split("\n");
-    buf = lines.pop() ?? "";
-    for (const line of lines) {
-      if (!line.startsWith("v=")) continue;
-      seen.push(line);
-      round++;
-      if (round === 3) {
-        runner.kill();
-        break;
-      }
-      await Bun.write(
-        entry,
-        `
+    for await (const chunk of runner.stdout) {
+      buf += decoder.decode(chunk, { stream: true });
+      const lines = buf.split("\n");
+      buf = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("v=")) continue;
+        seen.push(line);
+        round++;
+        if (round === 3) {
+          runner.kill();
+          break;
+        }
+        await Bun.write(
+          entry,
+          `
           globalThis.__tag = ${round + 1};
           console.log("v=" + globalThis.__tag);
           await new Promise(() => {});
         `,
-      );
+        );
+      }
+      if (round === 3) break;
     }
-    if (round === 3) break;
-  }
 
-  expect(seen).toEqual(["v=1", "v=2", "v=3"]);
-  // Subprocess spawn + two full file-watcher round-trips can exceed the
-  // 5s default on debug/ASAN builds and the Windows `ReadDirectoryChanges`
-  // watcher. Match the `test/cli/hot/hot.test.ts` convention so a slow
-  // lane doesn't produce the same timeout signature as the regression
-  // this test guards against.
-}, isDebug ? Infinity : 30_000);
+    expect(seen).toEqual(["v=1", "v=2", "v=3"]);
+    // Subprocess spawn + two full file-watcher round-trips can exceed the
+    // 5s default on debug/ASAN builds and the Windows `ReadDirectoryChanges`
+    // watcher. Match the `test/cli/hot/hot.test.ts` convention so a slow
+    // lane doesn't produce the same timeout signature as the regression
+    // this test guards against.
+  },
+  isDebug ? Infinity : 30_000,
+);
 
 test("unhandledRejection handler that resolves the TLA runs to completion", async () => {
   // The default `.bun` unhandled-rejection path calls

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/29546
@@ -207,7 +207,12 @@ test("--hot reload proceeds after a hanging top-level await", async () => {
   }
 
   expect(seen).toEqual(["v=1", "v=2", "v=3"]);
-});
+  // Subprocess spawn + two full file-watcher round-trips can exceed the
+  // 5s default on debug/ASAN builds and the Windows `ReadDirectoryChanges`
+  // watcher. Match the `test/cli/hot/hot.test.ts` convention so a slow
+  // lane doesn't produce the same timeout signature as the regression
+  // this test guards against.
+}, isDebug ? Infinity : 30_000);
 
 test("unhandledRejection handler that resolves the TLA runs to completion", async () => {
   // The default `.bun` unhandled-rejection path calls

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -149,8 +149,13 @@ test("--hot reload proceeds after a hanging top-level await", async () => {
   // status and permanently defer via `hot_reload_deferred = true`, but
   // `reportExceptionInHotReloadedModuleIfNeeded` early-returns on
   // `.pending` before consuming the flag — so every subsequent file save
-  // was silently dropped. Guard the defer with `hasAnyHandleWork()` so a
-  // stale-pending promise doesn't block reloads forever.
+  // was silently dropped. `reload()` now distinguishes "loader chain /
+  // ref'd await still in flight" from "abandoned TLA" by consulting
+  // `hasAnyHandleWorkIgnoringForeverTimer()` — the `forever_timer` carve-
+  // out matters because the --hot main loop holds a ref'd uv timer on
+  // Windows which would otherwise keep the liveness check permanently
+  // true. Test asserts the behavior, not the mechanism: three back-to-
+  // back reloads must each actually run.
   using dir = tempDir("hot-tla", {
     "entry.ts": `
       console.log("v=" + (globalThis.__tag || 1));

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -176,10 +176,17 @@ test("--hot reload proceeds after a hanging top-level await", async () => {
   const decoder = new TextDecoder();
   const seen: string[] = [];
   let round = 0;
+  // Buffer across chunk boundaries — matches the pattern in
+  // test/cli/hot/hot.test.ts. A 4-byte "v=N\n" write is realistically
+  // never torn on either platform here, but making the reader robust
+  // costs nothing and keeps it consistent with the other --hot readers.
+  let buf = "";
 
   for await (const chunk of runner.stdout) {
-    const text = decoder.decode(chunk);
-    for (const line of text.split("\n")) {
+    buf += decoder.decode(chunk, { stream: true });
+    const lines = buf.split("\n");
+    buf = lines.pop() ?? "";
+    for (const line of lines) {
       if (!line.startsWith("v=")) continue;
       seen.push(line);
       round++;

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -254,31 +254,3 @@ test("unhandledRejection handler that resolves the TLA runs to completion", asyn
   expect(stdout).toBe("got=handled\n");
   expect(exitCode).toBe(0);
 });
-
-test("beforeExit handler that resolves the TLA runs to completion", async () => {
-  // Sibling to the `unhandledRejection` test: pre-PR, an unsettled TLA
-  // hung forever inside `waitForPromise` and never reached `onBeforeExit`.
-  // Post-PR, `waitForPromiseOrLoopExit` bails out with the TLA still
-  // `.pending` and control flows into `onBeforeExit`, which emits
-  // `process.on("beforeExit", …)`. A handler that synchronously resolves
-  // the TLA queues the continuation as a JSC microtask. `isEventLoopAlive`
-  // can't see microtasks, so without an explicit drain after
-  // `dispatchOnBeforeExit` the inner `while (isEventLoopAlive)` in
-  // `onBeforeExit` skips and the continuation is silently dropped.
-  const source = `
-    let resolveIt;
-    process.on("beforeExit", () => resolveIt("done"));
-    const r = await new Promise(res => resolveIt = res);
-    process.stdout.write("got=" + r + "\\n");
-  `;
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", source],
-    env: bunEnv,
-  });
-
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-
-  expect(stdout).toBe("got=done\n");
-  expect(exitCode).toBe(0);
-});

--- a/test/regression/issue/29546.test.ts
+++ b/test/regression/issue/29546.test.ts
@@ -254,3 +254,31 @@ test("unhandledRejection handler that resolves the TLA runs to completion", asyn
   expect(stdout).toBe("got=handled\n");
   expect(exitCode).toBe(0);
 });
+
+test("beforeExit handler that resolves the TLA runs to completion", async () => {
+  // Sibling to the `unhandledRejection` test: pre-PR, an unsettled TLA
+  // hung forever inside `waitForPromise` and never reached `onBeforeExit`.
+  // Post-PR, `waitForPromiseOrLoopExit` bails out with the TLA still
+  // `.pending` and control flows into `onBeforeExit`, which emits
+  // `process.on("beforeExit", …)`. A handler that synchronously resolves
+  // the TLA queues the continuation as a JSC microtask. `isEventLoopAlive`
+  // can't see microtasks, so without an explicit drain after
+  // `dispatchOnBeforeExit` the inner `while (isEventLoopAlive)` in
+  // `onBeforeExit` skips and the continuation is silently dropped.
+  const source = `
+    let resolveIt;
+    process.on("beforeExit", () => resolveIt("done"));
+    const r = await new Promise(res => resolveIt = res);
+    process.stdout.write("got=" + r + "\\n");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("got=done\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #29546
Fixes #14951

## Reproduction

```ts
async function run(signal: AbortSignal): Promise<string> {
  return new Promise((resolve) => {
    signal.addEventListener('abort', () => resolve('run aborted'));
  });
}

const r = await run(AbortSignal.timeout(2000));
console.log(r);
```

Before: **Windows hangs forever**, **POSIX spins one core at 100% for the full 2s** before the timer fires.
After: exits cleanly with no output (matches Node.js).

## Root cause

`AbortSignal.timeout(N)` inserts a timer into Bun's own heap but deliberately does *not* bump `active_timer_count` — it's unref'd by design. When the only thing holding up a top-level `await` is that unref'd timer, `autoTick()`'s two platform paths both misbehave:

- **POSIX**: `loop.isActive()` is false, so we take the `tickWithoutIdle()` branch (zero-timeout poll) and then `drainTimers()`. That drains the unref'd timer *eventually* — but only after the `waitForPromise` loop spins until the deadline, burning one full core.

- **Windows**: `tickWithoutIdle` → `us_loop_pump` → `uv_run(UV_RUN_NOWAIT)`. `uv_run` early-returns when `uv__loop_alive()` is false (`vendor/libuv/src/win/core.c:719`) — and with no ref'd handles it is. So the uv timer that would normally drain Bun's heap via `onUVTimer` never fires. Hang forever.

## Fix

Add two helpers on `EventLoop`:

- `hasAnyHandleWork()` — returns true if anything could still wake the loop (active uv/uws handles, queued tasks, concurrent refs, immediates). Intentionally NOT `VirtualMachine.isEventLoopAlive()`, which short-circuits on `unhandled_error_counter != 0` — a side-path unhandled rejection during a TLA wait must NOT abandon an in-flight fetch that will resolve the TLA.
- `waitForPromiseOrLoopExit()` — identical to `waitForPromise` except it breaks when `hasAnyHandleWork()` returns false.

Route `loadEntryPoint` (both the watcher and non-watcher branches) through it. This is the "run the main script" entry point — `bun run foo.ts`, `bun foo.ts`, `bun -e '…'`.

`waitForPromise` itself is **unchanged**, and `loadEntryPointForTestRunner` / `loadPreloads` / `waitForPromiseWithTermination` (workers) also keep the old `waitForPromise` contract. Several callers rely on "returns with the promise resolved" — most visibly `Expect.getValueAsToThrow` (`src/bun.js/test/expect.zig:589`), which asserts `.pending => unreachable` after the wait. Breaking that contract is what caused the test-runner regressions in the earlier attempt at this fix (#27215). A test-file's top-level-await-only-held-by-an-unref'd-timer can still hang `bun test` today; that's a narrower, separate bug and out of scope here.

The new behavior matches Node.js: an unsettled top-level await in the main script exits cleanly (with a warning, on Node ≥ 20) rather than waiting on unref'd handles.

## Verification

```console
$ bun bd test test/regression/issue/29546.test.ts
✓ AbortSignal.timeout awaited at top-level does not hang or spin
✓ AbortSignal.timeout fires when something else keeps the loop alive
✓ top-level await on a never-resolving promise exits cleanly
✓ unhandled rejection mid-TLA does not abandon an in-flight wait
```

Checked out `origin/main` on `src/bun.js/event_loop.zig` + `src/bun.js/VirtualMachine.zig`, rebuilt, and ran the tests → 2 fail on the 5s test timeout (hang confirmed), 2 pass (the "keeps the loop alive" regression guard + the "unhandled rejection" guard). Restored the fix, rebuilt → all 4 pass in <1s each.

The "fires when something else keeps the loop alive" test is the regression guard for the original bug — with a ref'd `setTimeout` holding the loop open, the unref'd `AbortSignal.timeout` still fires on schedule and the listener still runs.

The "unhandled rejection mid-TLA" test pins the `hasAnyHandleWork()` vs `isEventLoopAlive()` distinction: a side-path unhandled rejection must NOT cause the TLA wait to bail while real work (here, a `setTimeout`) is still pending. If the liveness check ever gets simplified to `isEventLoopAlive()`, this test will catch it.

Also re-ran `test/js/node/timers/*`, `test/regression/issue/28756.test.ts` (AbortSignal memory-leak), and the TLA regressions (#20100 / #21257 / #24007 / #28914) — all pass.
