### PR TITLE
Fix YARR JIT SEGV on regex with aliased parenContextHead slots

### DIFF
--- a/test/regression/issue/29547.test.ts
+++ b/test/regression/issue/29547.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29547
+//
+// The YARR JIT's parenContextHead-clearing helper (introduced in upstream
+// WebKit 37465a721d and extended by 2d16551f69) nulled a frame slot that
+// aliased with a different subpattern's returnAddress in a sibling
+// alternative, causing an indirect jump to RIP=0 on backtrack.
+//
+// In the minimal case below, the outer `(?:...)*` has two alternatives:
+//   - alt #0: `[abc]+(?:.|b)` — inner Once subpattern at frame 7-8
+//   - alt #1: `(?:a)*`         — greedy subpattern at frame 5-8
+//
+// Slot 8 is inner Once's returnAddress in alt #0 and (?:a)*'s
+// parenContextHead in alt #1. The unconditional null broke alt #0.
+//
+// Real-world trigger: `bunx --bun jscpd *.tsx` (reprism's JSX tag regex
+// over a typical TSX file) which we reproduce via a Bun.spawn child so
+// the JIT compiles fresh each run.
+test.concurrent("issue/29547: YARR JIT parenContextHead alias SEGV", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const r = /(?:[abc]+(?:.|b)|(?:a)*)*>/;
+        const result = r.exec(' x="c" ');
+        console.log(result === null ? "null" : result[0]);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("null\n");
+  expect(exitCode).toBe(0);
+});
+
+// The original reporter's case: bunx --bun jscpd on TSX files. The specific
+// regex that crashes is Prism's JSX tag pattern applied to the raw TSX
+// source. Distilled to a direct exec call that matches what the tokenizer
+// actually does.
+test.concurrent("issue/29547: Prism JSX tag regex on TSX source", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const pattern = /<\\/?[\\w.:-]+\\s*(?:\\s+(?:[\\w.:-]+(?:=(?:("|')(?:\\\\[\\s\\S]|(?!\\1)[^\\\\])*\\1|[^\\s{'">=]+|\\{(?:\\{[^}]*\\}|[^{}])+\\}))?|\\{\\.{3}[a-z_$][\\w$]*(?:\\.[a-z_$][\\w$]*)*\\}))*\\s*\\/?>/gi;
+        const src = '              <div\\n                className=\"h-full rounded-full bg-blue-400\"\\n                style={{ width: \\\`\\\${barPct}%\\\` }}\\n              />\\n';
+        const m = pattern.exec(src);
+        console.log(m ? m[0].slice(0, 20) : "null");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  expect(stdout.trim()).not.toBe("");
+});

--- a/test/regression/issue/29547.test.ts
+++ b/test/regression/issue/29547.test.ts
@@ -3,21 +3,10 @@ import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/29547
 //
-// The YARR JIT's parenContextHead-clearing helper (introduced in upstream
-// WebKit 37465a721d and extended by 2d16551f69) nulled a frame slot that
-// aliased with a different subpattern's returnAddress in a sibling
-// alternative, causing an indirect jump to RIP=0 on backtrack.
-//
-// In the minimal case below, the outer `(?:...)*` has two alternatives:
-//   - alt #0: `[abc]+(?:.|b)` — inner Once subpattern at frame 7-8
-//   - alt #1: `(?:a)*`         — greedy subpattern at frame 5-8
-//
-// Slot 8 is inner Once's returnAddress in alt #0 and (?:a)*'s
-// parenContextHead in alt #1. The unconditional null broke alt #0.
-//
-// Real-world trigger: `bunx --bun jscpd *.tsx` (reprism's JSX tag regex
-// over a typical TSX file) which we reproduce via a Bun.spawn child so
-// the JIT compiles fresh each run.
+// YARR JIT's parenContextHead-clearing helper nulled a frame slot that
+// aliased a sibling alternative's returnAddress, causing an indirect
+// jump to RIP=0 on backtrack. Spawned as a child so the JIT compiles
+// fresh (crash only reproduces cold).
 test.concurrent("issue/29547: YARR JIT parenContextHead alias SEGV", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -36,35 +25,8 @@ test.concurrent("issue/29547: YARR JIT parenContextHead alias SEGV", async () =>
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
+  // stderr is not asserted empty: ASAN/debug builds can emit signal-handler warnings there.
   expect(stdout).toBe("null\n");
+  if (exitCode !== 0) console.error(stderr);
   expect(exitCode).toBe(0);
-});
-
-// The original reporter's case: bunx --bun jscpd on TSX files. The specific
-// regex that crashes is Prism's JSX tag pattern applied to the raw TSX
-// source. Distilled to a direct exec call that matches what the tokenizer
-// actually does.
-test.concurrent("issue/29547: Prism JSX tag regex on TSX source", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-        const pattern = /<\\/?[\\w.:-]+\\s*(?:\\s+(?:[\\w.:-]+(?:=(?:("|')(?:\\\\[\\s\\S]|(?!\\1)[^\\\\])*\\1|[^\\s{'">=]+|\\{(?:\\{[^}]*\\}|[^{}])+\\}))?|\\{\\.{3}[a-z_$][\\w$]*(?:\\.[a-z_$][\\w$]*)*\\}))*\\s*\\/?>/gi;
-        const src = '              <div\\n                className=\"h-full rounded-full bg-blue-400\"\\n                style={{ width: \\\`\\\${barPct}%\\\` }}\\n              />\\n';
-        const m = pattern.exec(src);
-        console.log(m ? m[0].slice(0, 20) : "null");
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-  expect(stdout.trim()).not.toBe("");
 });

--- a/test/regression/issue/29547.test.ts
+++ b/test/regression/issue/29547.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/29547
@@ -34,11 +34,7 @@ test.concurrent("issue/29547: YARR JIT parenContextHead alias SEGV", async () =>
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(stdout).toBe("null\n");
@@ -66,11 +62,7 @@ test.concurrent("issue/29547: Prism JSX tag regex on TSX source", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #29547.

Real-world trigger: `bunx --bun jscpd *.tsx` (and anything else that runs Prism's JSX tag regex over TSX source) crashes with `panic(main thread): Segmentation fault at address 0x0` on 1.3.13. One-line reproduction:

```js
/(?:[abc]+(?:.|b)|(?:a)*)*>/.exec(' x="c" ');   // RIP=0 → SIGSEGV
```

## Root cause

The WebKit bump in #29294 (`c2010c4` → `4d5e75e`) pulled in `37465a721d` "[YARR] Fix JIT crash on non-greedy ParenthesesSubpattern backtracking", which added `clearInnerParenContextHeadSlots` as a UAF guard: after `restoreParenContext` it walks the disjunction and nulls every Greedy/NonGreedy subpattern's `parenContextHead` frame slot so a later `BEGIN.bt` sees null instead of a possibly-freed ParenContext pointer. (Upstream `2d16551f69` later widened it to `clearParenContextHeadSlotsInRange` walking the full pattern tree.)

Both versions ignore that sibling alternatives of the same disjunction share a base frame offset, so a Greedy subpattern's parenContextHead slot in one alternative can coincide with a Once subpattern's returnAddress slot in a sibling. In the minimal pattern:

```
outer  (?:...)*                frame 0 (slots 0–3)
  alt #0:
    [abc]+                     frame 5 (slots 5–6)
    (?:.|b)  Once              frame 7 (slots 7–8)
  alt #1:
    (?:a)*   Greedy            frame 5 (slots 5–8)
```

Slot 8 is `(?:.|b)`'s `returnAddress` in alt #0 and `(?:a)*`'s `parenContextHead` in alt #1. The unconditional null destroys alt #0's valid returnAddress; the next `NestedAlternativeEnd` backtrack does `loadFromFrameAndJump` on slot 8 and jumps to 0 → `RIP=0` → segfault.

## Fix

The actual code lives in WebKit: https://github.com/oven-sh/WebKit/pull/189.

Before nulling a `parenContextHead` slot, check whether any sibling alternative in the parent disjunction has a term whose frame range covers that slot. If so, skip the null — the sibling alt may have written a valid non-pointer value there. The UAF guard stays active for unambiguous slots, which covers every test case added by `37465a721d` and `2d16551f69` (all still pass).

This PR adds the regression test. The runtime fix ships to users via a `WEBKIT_VERSION` bump once the WebKit PR is merged and autobuilt.

## Verification

- Minimal repro exits cleanly with the fix, SIGSEGVs without.
- `bunx --bun jscpd ComponentOne.tsx ComponentTwo.tsx` from the issue report completes normally.
- All 5 `JSTests/stress/yarr-jit-*.js` tests (including `yarr-jit-paren-context-head-uaf.js` and `yarr-jit-non-greedy-parentheses-backtrack.js`) exit 0.

## Gate note

The fix is entirely in `vendor/WebKit/Source/JavaScriptCore/yarr/YarrJIT.cpp`, not in `src/` or `packages/`. The automatic test-proof gate `git stash push -- src/ packages/` won't revert the WebKit change, so the stashed-build test will pass rather than fail. The before/after split is verifiable directly: run the test with `/tmp/bun-1.3.13/bun` (crashes) vs `bun bd` built against the WebKit PR (passes).