### PR TITLE
parser: accept `accessor` keyword under `experimentalDecorators: true`

### DIFF
--- a/src/ast/parse.zig
+++ b/src/ast/parse.zig
@@ -200,6 +200,26 @@ pub fn Parse(
             try p.lexer.expect(.t_close_brace);
 
             const has_any_decorators = has_decorators or class_opts.ts_decorators.len > 0;
+
+            // Auto-accessor fields always need the standard-decorator lowering
+            // (WeakMap + getter/setter) because JavaScriptCore doesn't parse
+            // `accessor` natively. When `standard_decorators` is off (i.e. the
+            // file is in `experimentalDecorators` mode), we still route a class
+            // with an auto-accessor through that path so the accessor gets
+            // lowered — see #29553.
+            //
+            // Mixing auto-accessors with TS legacy decorators in the same class
+            // would route the legacy decorators through the standard-proposal
+            // runtime, which is wrong semantically. Reject that combination
+            // explicitly rather than silently changing decorator semantics.
+            if (has_auto_accessor and !p.options.features.standard_decorators and has_any_decorators) {
+                try p.log.addError(
+                    p.source,
+                    class_keyword.loc,
+                    "Cannot mix the `accessor` keyword with `experimentalDecorators: true` decorators in the same class. Use standard decorators (leave `experimentalDecorators` unset or false) to combine them.",
+                );
+            }
+
             return G.Class{
                 .class_name = name,
                 .extends = extends,
@@ -209,7 +229,7 @@ pub fn Parse(
                 .body_loc = body_loc,
                 .properties = properties.items,
                 .has_decorators = has_any_decorators,
-                .should_lower_standard_decorators = p.options.features.standard_decorators and (has_any_decorators or has_auto_accessor),
+                .should_lower_standard_decorators = has_auto_accessor or (p.options.features.standard_decorators and has_any_decorators),
             };
         }
 

--- a/src/ast/parse.zig
+++ b/src/ast/parse.zig
@@ -201,23 +201,12 @@ pub fn Parse(
 
             const has_any_decorators = has_decorators or class_opts.ts_decorators.len > 0;
 
-            // Auto-accessor fields always need the standard-decorator lowering
-            // (WeakMap + getter/setter) because JavaScriptCore doesn't parse
-            // `accessor` natively. When `standard_decorators` is off (i.e. the
-            // file is in `experimentalDecorators` mode), we still route a class
-            // with an auto-accessor through that path so the accessor gets
-            // lowered — see #29553.
-            //
-            // Mixing auto-accessors with TS legacy decorators in the same class
-            // would route the legacy decorators through the standard-proposal
-            // runtime, which is wrong semantically. Reject that combination
-            // explicitly rather than silently changing decorator semantics.
+            // JSC doesn't parse `accessor` natively, so any class with auto-accessors must go
+            // through the standard-decorator lowering (WeakMap + getter/setter) regardless of
+            // mode. But mixing auto-accessors with legacy TS decorators would silently reroute
+            // those decorators through the standard-proposal runtime — reject that combination.
             if (has_auto_accessor and !p.options.features.standard_decorators and has_any_decorators) {
-                try p.log.addError(
-                    p.source,
-                    class_keyword.loc,
-                    "Cannot mix the `accessor` keyword with `experimentalDecorators: true` decorators in the same class. Use standard decorators (leave `experimentalDecorators` unset or false) to combine them.",
-                );
+                try p.log.addError(p.source, class_keyword.loc, "Cannot mix the `accessor` keyword with `experimentalDecorators: true` in the same class. Use standard decorators instead.");
             }
 
             return G.Class{

--- a/src/ast/parseProperty.zig
+++ b/src/ast/parseProperty.zig
@@ -300,8 +300,10 @@ pub fn ParseProperty(
                                             }
                                         },
                                         .p_accessor => {
-                                            // "accessor" keyword for auto-accessor fields (TC39 standard decorators)
-                                            if (opts.is_class and p.options.features.standard_decorators and
+                                            // "accessor" keyword for auto-accessor fields (TC39 proposal).
+                                            // TypeScript supports this under both decorator modes, so don't
+                                            // gate it on `standard_decorators` — see #29553.
+                                            if (opts.is_class and
                                                 (js_lexer.PropertyModifierKeyword.List.get(raw) orelse .p_static) == .p_accessor)
                                             {
                                                 kind = .auto_accessor;

--- a/test/regression/issue/29553.test.ts
+++ b/test/regression/issue/29553.test.ts
@@ -7,53 +7,16 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // syntax error when a project's tsconfig.json had `experimentalDecorators: true`.
 // The keyword should be accepted under either decorator mode.
 
-test.concurrent("accessor keyword parses and runs under experimentalDecorators: true", async () => {
-  using dir = tempDir("issue-29553-exp", {
-    "tsconfig.json": JSON.stringify({
-      compilerOptions: {
-        target: "ES2022",
-        module: "ESNext",
-        moduleResolution: "Bundler",
-        experimentalDecorators: true,
-        emitDecoratorMetadata: true,
-        strict: true,
-        skipLibCheck: true,
-      },
-    }),
-    "test/TEST1.ts": `export class Test1 {
-  public accessor computed: number;
-  constructor(c: number) {
-    this.computed = c;
-  }
-}
-`,
-    "test/TEST1.test.ts": `import { test, expect, describe } from "bun:test";
-import { Test1 } from "./TEST1";
-
-describe("TEST", () => {
-  test("asd", () => {
-    const t = new Test1(42);
-    expect(t.computed).toBe(42);
-  });
-});
-`,
-  });
-
+async function runBun(cwd: string, ...args: string[]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "./test"],
+    cmd: [bunExe(), ...args],
     env: bunEnv,
-    cwd: String(dir),
+    cwd,
     stderr: "pipe",
     stdout: "pipe",
   });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // `bun test` writes most of its output to stderr.
-  const combined = stdout + stderr;
-  expect(combined).toContain("1 pass");
-  expect(combined).not.toContain("Expected");
-  expect(exitCode).toBe(0);
-});
+  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+}
 
 test.concurrent("accessor with various modifiers under experimentalDecorators: true", async () => {
   using dir = tempDir("issue-29553-modifiers", {
@@ -75,16 +38,7 @@ console.log(f.a, f.b, f.getC(), f.getD(), Foo.e, f.f);
 `,
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("Expected");
+  const [stdout, , exitCode] = await runBun(String(dir), "main.ts");
   expect(stdout).toBe("1 2 3 4 5 6\n");
   expect(exitCode).toBe(0);
 });
@@ -98,16 +52,7 @@ console.log(new Foo().x);
 `,
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("Expected");
+  const [stdout, , exitCode] = await runBun(String(dir), "main.ts");
   expect(stdout).toBe("42\n");
   expect(exitCode).toBe(0);
 });
@@ -127,28 +72,17 @@ console.log(new Foo().x);
 `,
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("Expected");
+  const [stdout, , exitCode] = await runBun(String(dir), "main.ts");
   expect(stdout).toBe("dec x accessor\n7\n");
   expect(exitCode).toBe(0);
 });
 
-test.concurrent(
-  "mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics",
-  async () => {
-    using dir = tempDir("issue-29553-mixed", {
-      "tsconfig.json": JSON.stringify({
-        compilerOptions: { experimentalDecorators: true },
-      }),
-      "main.ts": `function legacyDec(target: any, key: string) {}
+test.concurrent("mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics", async () => {
+  using dir = tempDir("issue-29553-mixed", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true },
+    }),
+    "main.ts": `function legacyDec(target: any, key: string) {}
 
 class Foo {
   @legacyDec
@@ -157,18 +91,9 @@ class Foo {
   accessor x: number = 0;
 }
 `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
-    expect(exitCode).not.toBe(0);
-  },
-);
+  const [, stderr, exitCode] = await runBun(String(dir), "main.ts");
+  expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/regression/issue/29553.test.ts
+++ b/test/regression/issue/29553.test.ts
@@ -77,12 +77,14 @@ console.log(new Foo().x);
   expect(exitCode).toBe(0);
 });
 
-test.concurrent("mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics", async () => {
-  using dir = tempDir("issue-29553-mixed", {
-    "tsconfig.json": JSON.stringify({
-      compilerOptions: { experimentalDecorators: true },
-    }),
-    "main.ts": `function legacyDec(target: any, key: string) {}
+test.concurrent(
+  "mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics",
+  async () => {
+    using dir = tempDir("issue-29553-mixed", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { experimentalDecorators: true },
+      }),
+      "main.ts": `function legacyDec(target: any, key: string) {}
 
 class Foo {
   @legacyDec
@@ -91,9 +93,10 @@ class Foo {
   accessor x: number = 0;
 }
 `,
-  });
+    });
 
-  const [, stderr, exitCode] = await runBun(String(dir), "main.ts");
-  expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
-  expect(exitCode).not.toBe(0);
-});
+    const [, stderr, exitCode] = await runBun(String(dir), "main.ts");
+    expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
+    expect(exitCode).not.toBe(0);
+  },
+);

--- a/test/regression/issue/29553.test.ts
+++ b/test/regression/issue/29553.test.ts
@@ -141,12 +141,14 @@ console.log(new Foo().x);
   expect(exitCode).toBe(0);
 });
 
-test.concurrent("mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics", async () => {
-  using dir = tempDir("issue-29553-mixed", {
-    "tsconfig.json": JSON.stringify({
-      compilerOptions: { experimentalDecorators: true },
-    }),
-    "main.ts": `function legacyDec(target: any, key: string) {}
+test.concurrent(
+  "mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics",
+  async () => {
+    using dir = tempDir("issue-29553-mixed", {
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { experimentalDecorators: true },
+      }),
+      "main.ts": `function legacyDec(target: any, key: string) {}
 
 class Foo {
   @legacyDec
@@ -155,17 +157,18 @@ class Foo {
   accessor x: number = 0;
 }
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "main.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
-  expect(exitCode).not.toBe(0);
-});
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
+    expect(exitCode).not.toBe(0);
+  },
+);

--- a/test/regression/issue/29553.test.ts
+++ b/test/regression/issue/29553.test.ts
@@ -1,0 +1,171 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/29553
+//
+// The `accessor` keyword (TC39 auto-accessors / TS 4.9+) was rejected as a
+// syntax error when a project's tsconfig.json had `experimentalDecorators: true`.
+// The keyword should be accepted under either decorator mode.
+
+test.concurrent("accessor keyword parses and runs under experimentalDecorators: true", async () => {
+  using dir = tempDir("issue-29553-exp", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+        strict: true,
+        skipLibCheck: true,
+      },
+    }),
+    "test/TEST1.ts": `export class Test1 {
+  public accessor computed: number;
+  constructor(c: number) {
+    this.computed = c;
+  }
+}
+`,
+    "test/TEST1.test.ts": `import { test, expect, describe } from "bun:test";
+import { Test1 } from "./TEST1";
+
+describe("TEST", () => {
+  test("asd", () => {
+    const t = new Test1(42);
+    expect(t.computed).toBe(42);
+  });
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./test"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // `bun test` writes most of its output to stderr.
+  const combined = stdout + stderr;
+  expect(combined).toContain("1 pass");
+  expect(combined).not.toContain("Expected");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("accessor with various modifiers under experimentalDecorators: true", async () => {
+  using dir = tempDir("issue-29553-modifiers", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true },
+    }),
+    "main.ts": `class Foo {
+  accessor a = 1;
+  public accessor b = 2;
+  private accessor c = 3;
+  protected accessor d = 4;
+  static accessor e = 5;
+  readonly accessor f = 6;
+  getC() { return this.c; }
+  getD() { return this.d; }
+}
+const f = new Foo();
+console.log(f.a, f.b, f.getC(), f.getD(), Foo.e, f.f);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Expected");
+  expect(stdout).toBe("1 2 3 4 5 6\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("accessor without tsconfig (TS file, no decorator flags)", async () => {
+  using dir = tempDir("issue-29553-plain", {
+    "main.ts": `class Foo {
+  accessor x: number = 42;
+}
+console.log(new Foo().x);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Expected");
+  expect(stdout).toBe("42\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("accessor still works under standard decorators mode", async () => {
+  using dir = tempDir("issue-29553-std", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: false },
+    }),
+    "main.ts": `function dec(value: any, context: any) {
+  console.log("dec", context.name, context.kind);
+}
+class Foo {
+  @dec accessor x: number = 7;
+}
+console.log(new Foo().x);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("Expected");
+  expect(stdout).toBe("dec x accessor\n7\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("mixing accessor with experimentalDecorators legacy @dec is a clear error, not silent wrong semantics", async () => {
+  using dir = tempDir("issue-29553-mixed", {
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: { experimentalDecorators: true },
+    }),
+    "main.ts": `function legacyDec(target: any, key: string) {}
+
+class Foo {
+  @legacyDec
+  doThing() {}
+
+  accessor x: number = 0;
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Cannot mix the `accessor` keyword with `experimentalDecorators: true`");
+  expect(exitCode).not.toBe(0);
+});


### PR DESCRIPTION
## What

Fixes #29553. Fixes #27335. The `accessor` keyword (TC39 auto-accessors, TypeScript 4.9+) was gated behind the internal `standard_decorators` feature flag in the parser, so any class field written as `public accessor foo: number` failed to parse when a project's `tsconfig.json` had `experimentalDecorators: true` — a common default, especially in Angular-style projects.

```
# Reproduced at test/TEST1.ts:2 with v1.3.13-canary.1 (bf2e2cec)
2 |     public accessor computed: number;
                        ^
error: Expected ";" but found "computed"
```

## Why

TypeScript accepts `accessor` in both decorator modes — they're independent proposals. The lowering path in `lowerDecorators.zig` already handles undecorated `auto_accessor` properties (WeakMap + getter/setter pair). All that was missing was the parser gate and the `should_lower_standard_decorators` condition.

## How

- **src/ast/parseProperty.zig**: drop the `p.options.features.standard_decorators` guard on the `p_accessor` keyword branch. Always recognise `accessor` in class bodies.
- **src/ast/parse.zig**: set `should_lower_standard_decorators` whenever an auto-accessor is present (not only when `standard_decorators` is already on), so the accessor gets lowered correctly. JavaScriptCore doesn't parse `accessor` natively, so the rewrite is what makes it run.
- **src/ast/parse.zig**: if a class mixes `accessor` with TS legacy `@dec` members under `experimentalDecorators: true`, emit a clear compile error. Otherwise the legacy decorators would be routed through the standard-proposal runtime (wrong signature), which is worse than a clear error.

## Verification

`test/regression/issue/29553.test.ts` — 5 tests covering:
- The issue's exact repro (`bun test ./test` with `experimentalDecorators: true`).
- `accessor` with all TS modifiers (`public`, `private`, `protected`, `static`, `readonly`) under `experimentalDecorators: true`.
- `accessor` in a plain TS file (no tsconfig).
- `accessor` under standard decorators (regression guard).
- The new error for legacy-`@dec` + `accessor` combined.

Before-fix: tests fail with the `Expected ";"` parse error. After-fix: 5 pass.

Nearby decorator regression suites (`test/bundler/transpiler/es-decorators.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts`, `issue/27526.test.ts`, `issue/27575.test.ts`) all still pass — 209 tests across those files, no regressions.

## Related (not closed by this PR)

- #29197 (`@decorator accessor x` parse error) — this PR fixes it under the default (standard-decorators) mode, but under `experimentalDecorators: true` it now raises a clear "can't mix" error instead of silently producing wrong decorator semantics. Fully supporting legacy `@dec` + `accessor` in the same class requires a separate lowering pass (desugar `accessor` to `#storage` + getter/setter before the legacy-decorator loop) — out of scope here.
- #28118 (`this.#field` not rewritten in initializers under `@decorated accessor`) — unrelated private-field rewrite bug in the decorator-lowering path; still reproduces after this PR.