### PR TITLE
fix(sql/mysql): wait for all result sets before resolving prepared queries

### DIFF
--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -31,13 +31,13 @@ initMySQL(
 
     // CALL <proc>() and multi-statement strings can yield several result sets.
     // Accumulate until the server clears SERVER_MORE_RESULTS_EXISTS (is_last).
-    const last_result = query[_results];
-    if (!last_result) {
+    const lastResult = query[_results];
+    if (!lastResult) {
       query[_results] = result;
-    } else if (last_result instanceof SQLResultArray) {
-      query[_results] = [last_result, result];
+    } else if (lastResult instanceof SQLResultArray) {
+      query[_results] = [lastResult, result];
     } else {
-      last_result.push(result);
+      lastResult.push(result);
     }
 
     if (!is_last) {

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -41,8 +41,9 @@ initMySQL(
     }
 
     if (!is_last) {
-      // The Zig side clears the pending value after each callback; re-prime it
-      // so the follow-up result set lands in a fresh array.
+      // The Zig side swaps the pending value out for js_undefined before
+      // invoking this callback; re-prime so the follow-up result set lands in
+      // a fresh array.
       query[_handle].setPendingValue(new SQLResultArray());
       return;
     }

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -5,7 +5,7 @@ const { SQLHelper, SSLMode, SQLResultArray, buildDefinedColumnsAndQuery } = requ
 const {
   Query,
   SQLQueryFlags,
-  symbols: { _strings, _values, _flags, _results, _handle },
+  symbols: { _strings, _values, _results, _handle },
 } = require("internal/sql/query");
 const { MySQLError } = require("internal/sql/errors");
 
@@ -23,47 +23,30 @@ function wrapError(error: Error | MySQLErrorOptions) {
 }
 initMySQL(
   function onResolveMySQLQuery(query, result, commandTag, count, queries, is_last, last_insert_rowid, affected_rows) {
-    /// simple queries
-    if (query[_flags] & SQLQueryFlags.simple) {
-      $assert(result instanceof SQLResultArray, "Invalid result array");
-      // prepare for next query
-      query[_handle].setPendingValue(new SQLResultArray());
-
-      result.count = count || 0;
-      result.lastInsertRowid = last_insert_rowid;
-      result.affectedRows = affected_rows || 0;
-      const last_result = query[_results];
-
-      if (!last_result) {
-        query[_results] = result;
-      } else {
-        if (last_result instanceof SQLResultArray) {
-          // multiple results
-          query[_results] = [last_result, result];
-        } else {
-          // 3 or more results
-          last_result.push(result);
-        }
-      }
-      if (is_last) {
-        if (queries) {
-          const queriesIndex = queries.indexOf(query);
-          if (queriesIndex !== -1) {
-            queries.splice(queriesIndex, 1);
-          }
-        }
-        try {
-          query.resolve(query[_results]);
-        } catch {}
-      }
-      return;
-    }
-    /// prepared statements
     $assert(result instanceof SQLResultArray, "Invalid result array");
 
     result.count = count || 0;
     result.lastInsertRowid = last_insert_rowid;
     result.affectedRows = affected_rows || 0;
+
+    // CALL <proc>() and multi-statement strings can yield several result sets.
+    // Accumulate until the server clears SERVER_MORE_RESULTS_EXISTS (is_last).
+    const last_result = query[_results];
+    if (!last_result) {
+      query[_results] = result;
+    } else if (last_result instanceof SQLResultArray) {
+      query[_results] = [last_result, result];
+    } else {
+      last_result.push(result);
+    }
+
+    if (!is_last) {
+      // The Zig side clears the pending value after each callback; re-prime it
+      // so the follow-up result set lands in a fresh array.
+      query[_handle].setPendingValue(new SQLResultArray());
+      return;
+    }
+
     if (queries) {
       const queriesIndex = queries.indexOf(query);
       if (queriesIndex !== -1) {
@@ -71,7 +54,7 @@ initMySQL(
       }
     }
     try {
-      query.resolve(result);
+      query.resolve(query[_results]);
     } catch {}
   },
 

--- a/test/regression/issue/24850.test.ts
+++ b/test/regression/issue/24850.test.ts
@@ -32,8 +32,9 @@ describeWithContainer(
     });
 
     afterAll(async () => {
-      await sql?.unsafe(`DROP PROCEDURE IF EXISTS bun_24850`).catch(() => {});
-      await sql?.close();
+      if (!sql) return;
+      await sql.unsafe(`DROP PROCEDURE IF EXISTS bun_24850`).catch(() => {});
+      await sql.close();
     });
 
     test("CALL via prepared statement returns rows without leaking an error", async () => {

--- a/test/regression/issue/24850.test.ts
+++ b/test/regression/issue/24850.test.ts
@@ -56,11 +56,15 @@ describeWithContainer(
       expect(x).toBe(1);
     });
 
-    test("CALL via sql.unsafe (text protocol) still returns multi-result", async () => {
-      const result = await sql.unsafe(`CALL bun_24850('{"id": 3, "value": "world"}')`);
+    test("CALL via sql.unsafe with params (prepared) returns rows without leaking an error", async () => {
+      const result = await sql.unsafe(`CALL bun_24850(?)`, [JSON.stringify({ id: 3, value: "world" })]);
       expect(result.length).toBe(2);
-      const [rows] = result as any;
+      const [rows, ok] = result as any;
       expect(rows[0]).toEqual({ id: 3, value: "world" });
+      expect(ok.length).toBe(0);
+
+      const [{ x }] = await sql`SELECT 1 AS x`;
+      expect(x).toBe(1);
     });
   },
 );

--- a/test/regression/issue/24850.test.ts
+++ b/test/regression/issue/24850.test.ts
@@ -1,0 +1,65 @@
+// https://github.com/oven-sh/bun/issues/24850
+//
+// Calling a MySQL stored procedure via the prepared-statement path returned
+// the first result set and then leaked an error for the trailing OK packet,
+// because the prepared branch of onResolveMySQLQuery resolved on the first
+// result instead of waiting for SERVER_MORE_RESULTS_EXISTS to clear.
+
+import { SQL } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer(
+  "MySQL stored procedure multi-result (#24850)",
+  { image: "mysql_plain", concurrent: true },
+  container => {
+    let sql: SQL;
+
+    beforeAll(async () => {
+      await container.ready;
+      sql = new SQL({
+        url: `mysql://root:@${container.host}:${container.port}/bun_sql_test`,
+        max: 1,
+      });
+
+      await sql.unsafe(`DROP PROCEDURE IF EXISTS bun_24850`);
+      await sql.unsafe(`
+        CREATE PROCEDURE bun_24850(IN p JSON)
+        BEGIN
+          SELECT JSON_VALUE(p, '$.id') + 0 AS id, JSON_VALUE(p, '$.value') AS value;
+        END
+      `);
+    });
+
+    afterAll(async () => {
+      await sql?.unsafe(`DROP PROCEDURE IF EXISTS bun_24850`).catch(() => {});
+      await sql?.close();
+    });
+
+    test("CALL via prepared statement returns rows without leaking an error", async () => {
+      const param = JSON.stringify({ id: 7, value: "hello" });
+      const result = await sql`CALL bun_24850(${param})`;
+
+      // CALL produces the SELECT result set followed by a final OK packet, so
+      // the resolved value is an array of result sets.
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(2);
+
+      const [rows, ok] = result as any;
+      expect(rows[0]).toEqual({ id: 7, value: "hello" });
+      expect(ok.length).toBe(0);
+
+      // Connection must remain usable; before the fix the leaked second result
+      // desynchronised the request queue and the next query observed the error.
+      const [{ x }] = await sql`SELECT 1 AS x`;
+      expect(x).toBe(1);
+    });
+
+    test("CALL via sql.unsafe (text protocol) still returns multi-result", async () => {
+      const result = await sql.unsafe(`CALL bun_24850('{"id": 3, "value": "world"}')`);
+      expect(result.length).toBe(2);
+      const [rows] = result as any;
+      expect(rows[0]).toEqual({ id: 3, value: "world" });
+    });
+  },
+);


### PR DESCRIPTION
Calling a MySQL stored procedure via the prepared-statement path (tagged template, or `sql.unsafe(..., params)`) returned the first result set, then the trailing OK packet arrived for a query that had already been resolved and removed from the queue — surfacing as an unhandled `TypeError: undefined is not an object` *outside* the caller's `catch`.

`onResolveMySQLQuery` already accumulated results and waited for `is_last` on the simple-query branch; the prepared branch resolved immediately. Unified the two so both honour `SERVER_MORE_RESULTS_EXISTS`. The pending result array is now only re-primed when more results are actually coming, so the common single-result case (INSERT/UPDATE/DELETE/SELECT) doesn't pay an extra allocation.

Verified the Zig side (`MySQLConnection.zig:962`) computes `is_last` correctly for both text and binary protocol from the OK/EOF status flags, so no native change is needed.

Supersedes #24906 (auto-closed for inactivity) — same root cause, but this unifies the two branches instead of duplicating the accumulation logic, and avoids the per-query allocation when `is_last`.

**Verified locally:**
- `USE_SYSTEM_BUN=1 bun test test/regression/issue/24850.test.ts` → **fails** with `Expected: 2, Received: 1` plus the unhandled `TypeError` from the issue
- `bun bd test test/regression/issue/24850.test.ts` → **2 pass**
- `bun bd test test/js/sql/sql-mysql.test.ts test/js/sql/sql-mysql.helpers.test.ts test/js/sql/sql-mysql.transactions.test.ts` → **222 pass**

Fixes #24850