### PR TITLE
fix(test): propagate exception from custom asymmetric matcher

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-custom-asymmetric-matcher-throw.test.ts
+++ b/test/js/bun/test/expect-custom-asymmetric-matcher-throw.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("asymmetricMatch on a custom matcher that throws propagates the error instead of crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { expect } = Bun.jest();
+      expect.extend({
+        myMatcher() {
+          throw new Error("boom from matcher");
+        },
+      });
+      const m = expect.myMatcher();
+      let caught;
+      try {
+        m.asymmetricMatch({});
+      } catch (e) {
+        caught = e;
+      }
+      if (!(caught instanceof Error) || caught.message !== "boom from matcher") {
+        throw new Error("expected thrown error to propagate, got: " + caught);
+      }
+      console.log("ok");
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

`ExpectCustomAsymmetricMatcher.asymmetricMatch` calls `execute()`, which is a `callconv(.c)` function returning `bool`. When the underlying custom matcher throws, `execute()` swallows the Zig error with `catch false` but leaves the JS exception pending on the VM. `asymmetricMatch` then returns `jsBoolean(false)`, and the host-call wrapper trips `releaseAssertNoException()` in debug builds because a non-empty value was returned while an exception is pending.

Check `globalThis.hasException()` after `execute()` and return `error.JSError` so the exception propagates to the JS caller.

Found by Fuzzilli (fingerprint `3b7c7405d6ae90b5`).

## How did you verify your code works?

Minimal repro that asserts before this change and passes after:

```js
const { expect } = Bun.jest();
expect.extend({
  myMatcher() { throw new Error("boom from matcher"); },
});
expect.myMatcher().asymmetricMatch({});
```

Added a regression test at `test/js/bun/test/expect-custom-asymmetric-matcher-throw.test.ts`. Verified `test/js/bun/test/expect-extend.test.js` still passes.