### PR TITLE
Bump WebKit: align V8 heap snapshot output with Chrome DevTools expectations

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "59188212cf11248f0cd3578b62207664c4f7adbd";
+export const WEBKIT_VERSION = "c1fc04865a915e0ef7ab2c8724025caac2665336";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
+export const WEBKIT_VERSION = "ce78f86a3ec34a178a672250e9045e807811eb7e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c1fc04865a915e0ef7ab2c8724025caac2665336";
+export const WEBKIT_VERSION = "b173a72ad7224b637988c0b9d006ee374e5fbdcd";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c9f26a68b86ca8a52e3920eab67d0cf0043d89a9";
+export const WEBKIT_VERSION = "59188212cf11248f0cd3578b62207664c4f7adbd";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ce78f86a3ec34a178a672250e9045e807811eb7e";
+export const WEBKIT_VERSION = "c9f26a68b86ca8a52e3920eab67d0cf0043d89a9";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/bundler/transpiler/es-decorators-esbuild.test.ts
+++ b/test/bundler/transpiler/es-decorators-esbuild.test.ts
@@ -184,7 +184,7 @@ describe("ES Decorators (esbuild test suite)", () => {
     if (shouldTodo(name)) {
       test.todo(name);
     } else {
-      test(name, async () => {
+      test.concurrent(name, async () => {
         const { stdout, stderr, exitCode } = await runDecoratorTest(testCode);
         if (exitCode !== 0) {
           throw new Error(


### PR DESCRIPTION
Bumps WebKit to [`b173a72ad722`](https://github.com/oven-sh/WebKit/commit/b173a72ad7225e0ef7ab2c8724025caac2665336) — four commits to `BunV8HeapSnapshotBuilder` that bring the `.heapsnapshot` output into line with what Chrome DevTools actually parses, found by auditing against V8's [`heap-snapshot-generator.cc`](https://github.com/v8/v8/blob/main/src/profiler/heap-snapshot-generator.cc).

## Why

Bun's `v8.writeHeapSnapshot()` and the inspector's `HeapProfiler.takeHeapSnapshot` produce a V8-format JSON file. DevTools is the only real consumer of that format and it makes a lot of structural assumptions that aren't in any spec — node-type semantics drive shallow-size attribution, the `system /` name prefix drives styling, root topology drives the Distance column, and node IDs drive snapshot diffing. Several of those assumptions were silently violated, so snapshots loaded but showed misleading data.

## User-visible fixes in DevTools

| Symptom before | Cause | Fix |
|---|---|---|
| Every JS `Array` shows **0 shallow size**; bytes reattributed to whatever references it | We emitted `kArray`, which V8 reserves for internal FixedArray backing stores; DevTools' `calculateShallowSizes()` zeroes those and reassigns | JSArray → `kObject`, name `"Array"` |
| Arrays don't appear in the **Statistics pie chart** "JS arrays" bucket; Summary fragments by length | Name was `"Array (123)"`; DevTools matches `kObject && rawName()==='Array'` exactly | Name is now the constructor name |
| Lexical environments / module scopes show as **compiled code** | `kCode` for `LexicalEnvironment`, `ModuleEnvironment`, `WithScope`, etc. | `kObject` with `"system / <ClassName>"` names — DevTools greys them out as internals while still showing them in retainer chains. Captured variables continue to render as named children via the existing `analyzeVariableNameEdge` path |
| Retainers view shows GC roots as **"\<varname\> in system / Context"** with an empty varname, as if a closure were retaining the object | `ConservativeScan`, `StrongHandles`, `JITStubRoutines` etc. were emitted as `kContextVariable` edges, which V8 reserves strictly for closure-captured locals | Those root edges are now `kInternal` |
| Promises **fragment** across many Summary rows: `Promise (pending)`, `Promise (fulfilled: Object)`, `Promise (rejected)`… | Name embedded status + recursed into the fulfilled value | Name is just `"Promise"`; status/result are visible by expanding the node's properties like in V8 |
| **Distance** column shows `1` for everything | Root referenced objects directly with no `(GC roots)` intermediary and no `shortcut` edge to the global; DevTools' BFS couldn't distinguish user roots from system roots | Added a synthetic `(GC roots)` node; `from==nullptr` edges route through it; each `JSGlobalObject` gets a `root → shortcut → global` edge |
| **Snapshot diff** and **"Objects allocated between A and B"** return garbage | Node IDs were a 24-bit pointer hash (birthday-collides at ~5k objects) and weren't stable across snapshots | IDs now come from JSC's `HeapProfiler` `HeapSnapshot` chain — same cell keeps the same ID across snapshots, new cells get monotone-increasing IDs from the shared `getNextObjectIdentifier()` counter, and `Heap::removeDeadHeapSnapshotNodes` prunes dead entries via `forEachDeadCell` on every GC so address reuse doesn't alias |
| Long strings bloat the snapshot file | No truncation | Strings capped at 1024 chars (V8's `--heap-snapshot-string-limit` default), no ellipsis, dedup on truncated content |
| Taking a snapshot of a heap with large rope strings was slow | Ropes were resolved to flat strings just to get the node name | Ropes >16K chars are named `"(concatenated string)"`; smaller ropes are resolved so the first 1024 chars show as the node name |

## Correctness / robustness fixes

- **`analyzeNode` TOCTOU under parallel marking**: the old check-`m_cellToNodeId`-then-release-then-insert sequence let two GC marking threads each append a `Node` for the same cell. `analyzeNode` now just calls `getOrCreateNodeId`, which holds `m_cellToNodeIdMutex` across the entire find-or-insert.
- **JSON key order**: `trace_tree` is now emitted immediately after `trace_function_infos` (before `samples`/`locations`) to match V8's serializer. DevTools' streaming loader is positional once `trace_function_count > 0`; we hard-code 0 today so this was latent, but it's a one-line landmine to leave in.
- **`ShadowRealm`, `WebAssembly.Module`, `WebAssembly.Instance`** are now `kObject` (were `kCode`).

## Cost

The cross-snapshot ID chain pins ~**16 bytes per live object** (`{JSCell*, unsigned}`) in `HeapProfiler` for the duration of the profiling session — same footprint as V8's `HeapObjectsMap`. Each cell lives in exactly one snapshot in the chain (the one where it first appeared) and dead entries are swept on every GC, so the bound is *live-object count*, not *objects-ever-seen*. One-off `v8.writeHeapSnapshot()` calls pay this until the `HeapProfiler` is torn down.

## Commits

- oven-sh/WebKit@ce78f86a3ec3 — 1024-char string truncation in `addString` and string node names
- oven-sh/WebKit@c9f26a68b86c — node/edge classification, `system /` scope names, Promise/Array naming, rope literal, `kInternal` root edges, JSON key order
- oven-sh/WebKit@59188212cf11 — sequential node IDs, `(GC roots)` subtree + shortcut-to-global, `analyzeNode` TOCTOU
- oven-sh/WebKit@b173a72ad722 — cross-snapshot ID persistence via the `HeapSnapshot` chain; `getNextObjectIdentifier` made public

Full range: https://github.com/oven-sh/WebKit/compare/4d5e75ebd84a...b173a72ad722

> CI will fail until the WebKit `autobuild-b173a72ad7225e0ef7ab2c8724025caac2665336` release artifacts are published.
