### PR TITLE
test: deflake install/cron tests; move bun-types check to GH Actions

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -705,6 +705,9 @@ function getTestBunStep(platform, options, testOptions = {}) {
 
   if (testFiles) {
     args.push(...testFiles.map(testFile => `--include=${testFile}`));
+  } else {
+    // platform-independent tsc check; runs in .github/workflows/bun-types.yml instead
+    args.push("--exclude=integration/bun-types");
   }
 
   const depends = [];

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -703,7 +703,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
     args.push(`--build-id=${buildId}`);
   }
 
-  if (testFiles) {
+  if (testFiles?.length) {
     args.push(...testFiles.map(testFile => `--include=${testFile}`));
   } else {
     // platform-independent tsc check; runs in .github/workflows/bun-types.yml instead

--- a/.github/workflows/bun-types.yml
+++ b/.github/workflows/bun-types.yml
@@ -11,12 +11,14 @@ on:
       - "packages/bun-types/**"
       - "packages/@types/bun/**"
       - "test/integration/bun-types/**"
+      - "src/cli/init/tsconfig.default.json"
       - ".github/workflows/bun-types.yml"
   pull_request:
     paths:
       - "packages/bun-types/**"
       - "packages/@types/bun/**"
       - "test/integration/bun-types/**"
+      - "src/cli/init/tsconfig.default.json"
       - ".github/workflows/bun-types.yml"
 
 env:

--- a/.github/workflows/bun-types.yml
+++ b/.github/workflows/bun-types.yml
@@ -1,0 +1,41 @@
+name: bun-types
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "packages/bun-types/**"
+      - "packages/@types/bun/**"
+      - "test/integration/bun-types/**"
+      - ".github/workflows/bun-types.yml"
+  pull_request:
+    paths:
+      - "packages/bun-types/**"
+      - "packages/@types/bun/**"
+      - "test/integration/bun-types/**"
+      - ".github/workflows/bun-types.yml"
+
+env:
+  BUN_VERSION: "canary"
+
+jobs:
+  typecheck:
+    name: "TypeScript types"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: |
+          bun install
+          bun install --cwd test
+      - name: Check types
+        run: bun test test/integration/bun-types/bun-types.test.ts

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
-import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import { readlinkSync } from "fs";
+import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
   bunExe,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
+import { readlinkSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -30,20 +31,13 @@ expect.extend({
   toBeWorkspaceLink,
   toBeValidBin,
   toHaveBins,
-  toHaveWorkspaceLink: async function (package_dir: string, [link, real]: [string, string]) {
-    if (!isWindows) {
-      return expect(await readlink(join(package_dir, "node_modules", link))).toBeWorkspaceLink(join("..", real));
-    } else {
-      return expect(await readlink(join(package_dir, "node_modules", link))).toBeWorkspaceLink(join(package_dir, real));
-    }
+  toHaveWorkspaceLink: function (package_dir: string, [link, real]: [string, string]) {
+    const target = readlinkSync(join(package_dir, "node_modules", link));
+    return toBeWorkspaceLink(target, isWindows ? join(package_dir, real) : join("..", real));
   },
-  toHaveWorkspaceLink2: async function (package_dir: string, [link, realPosix, realWin]: [string, string, string]) {
-    if (!isWindows) {
-      return expect(await readlink(join(package_dir, "node_modules", link))).toBeWorkspaceLink(join("..", realPosix));
-    } else {
-      // prettier-ignore
-      return expect(await readlink(join(package_dir, "node_modules", link))).toBeWorkspaceLink(join(package_dir, realWin));
-    }
+  toHaveWorkspaceLink2: function (package_dir: string, [link, realPosix, realWin]: [string, string, string]) {
+    const target = readlinkSync(join(package_dir, "node_modules", link));
+    return toBeWorkspaceLink(target, isWindows ? join(package_dir, realWin) : join("..", realPosix));
   },
 });
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -9,7 +9,7 @@ import { gc as bunGC, sleepSync, spawnSync, unsafe, which, write } from "bun";
 import { heapStats } from "bun:jsc";
 import { beforeAll, describe, expect } from "bun:test";
 import { ChildProcess, execSync, fork } from "child_process";
-import { readdir, readFile, readlink, rm, writeFile } from "fs/promises";
+import { readdir, rm, writeFile } from "fs/promises";
 import fs, { closeSync, openSync, rmSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";
@@ -762,7 +762,7 @@ Received ${JSON.stringify({ name: onDisk.name, version: onDisk.version })}`,
   };
 }
 
-export async function toHaveBins(actual: string[], expectedBins: string[]) {
+export function toHaveBins(actual: string[], expectedBins: string[]) {
   const message = () => `Expected ${actual} to be package bins ${expectedBins}`;
 
   if (isWindows) {
@@ -777,19 +777,19 @@ export async function toHaveBins(actual: string[], expectedBins: string[]) {
   return { pass: actual.every((bin, i) => bin === expectedBins[i]), message };
 }
 
-export async function toBeValidBin(actual: string, expectedLinkPath: string) {
+export function toBeValidBin(actual: string, expectedLinkPath: string) {
   const message = () => `Expected ${actual} to be a link to ${expectedLinkPath}`;
 
   if (isWindows) {
-    const contents = await readFile(actual + ".bunx", "utf16le");
+    const contents = fs.readFileSync(actual + ".bunx", "utf16le");
     const expected = expectedLinkPath.slice(3);
     return { pass: contents.includes(expected), message };
   }
 
-  return { pass: (await readlink(actual)) === expectedLinkPath, message };
+  return { pass: fs.readlinkSync(actual) === expectedLinkPath, message };
 }
 
-export async function toBeWorkspaceLink(actual: string, expectedLinkPath: string) {
+export function toBeWorkspaceLink(actual: string, expectedLinkPath: string) {
   const message = () => `Expected ${actual} to be a link to ${expectedLinkPath}`;
 
   if (isWindows) {

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -231,25 +231,28 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
         });
       `,
     });
+    // Wait for "close" before forcing GC so main-VM destruct-on-exit (ASAN
+    // CI sets BUN_DESTRUCT_VM_ON_EXIT=1) does not race the worker thread's
+    // own teardown — terminate() returns before the worker finishes.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
         const w = new Worker("./worker.ts");
-        w.onmessage = () => {
-          w.terminate();
+        w.onmessage = () => w.terminate();
+        w.addEventListener("close", () => {
           Bun.gc(true);
           console.log("ok");
-          process.exit(0);
-        };
+        });
       `,
       ],
       env: bunEnv,
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
   }, 130_000);

--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -252,7 +252,7 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    if (exitCode !== 0) console.error(stderr);
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
   }, 130_000);


### PR DESCRIPTION
## Deflake bun-install async matchers

`test/harness.ts`: make `toHaveBins` / `toBeValidBin` / `toBeWorkspaceLink` synchronous (`readlinkSync` / `readFileSync`).
`test/cli/install/bun-install.test.ts`: make `toHaveWorkspaceLink` / `toHaveWorkspaceLink2` synchronous and have them return a real `{pass, message}` by calling `toBeWorkspaceLink` directly instead of `return expect(...).toBeWorkspaceLink(...)`.

The file was intermittently failing on x64-asan with
```
InvalidMatcherError: Unexpected return from matcher function `toBeValidBin`.
'"Resolving dependencies\nResolved, downloaded and extracted [8]\nSaved lockfile\n"' was returned
```
The stack traces show `runTest:306` (a `toBeValidBin` call) at both the top **and** bottom of the stack — async custom matchers under `describe.concurrent` enter `waitForPromise`, which ticks the event loop and runs other concurrent tests' matchers reentrantly inside the first one. Making the matchers sync removes the event-loop pump entirely. The `toHaveWorkspaceLink` rewrite also fixes a latent bug: it was returning the `Expect` object (whose `.pass` property is the truthy `expect().pass()` matcher function), so it silently passed regardless of the link target.

## Deflake cron worker terminate

`test/js/bun/cron/in-process-cron.test.ts`: in the "worker terminate while async callback pending" subprocess, wait for the worker `"close"` event instead of calling `process.exit(0)` immediately after `terminate()`; print stderr on non-zero exit so ASAN dumps are visible.

The test was exiting 132 on x64-asan after printing "ok". ASAN CI sets `BUN_DESTRUCT_VM_ON_EXIT=1`, which `bunEnv` inherits via `...process.env`, so the spawned child's `process.exit(0)` destructs the main VM while the worker thread (`terminate()` is fire-and-forget) is still running its own teardown. The adjacent "TerminationException" test already uses the `"close"` event for exactly this reason. The previous version also captured stderr into `_stderr` and never printed it, so the ASAN report was invisible in CI logs.

## Move bun-types typecheck out of BuildKite

`test/integration/bun-types/bun-types.test.ts` packs `packages/bun-types` and runs the TypeScript compiler API against fixtures. It's platform-independent and only depends on `.d.ts` files, but currently runs on every BuildKite shard for ~240s each.

`.buildkite/ci.mjs` now passes `--exclude=integration/bun-types` to the test runner, and `.github/workflows/bun-types.yml` runs it once on ubuntu with canary bun via the internal `setup-bun` action — path-filtered to `packages/bun-types/**`, `packages/@types/bun/**`, and the test directory.

## Test plan

- [x] `bun bd test test/cli/install/bun-install.test.ts -t "should handle workspaces|chooses"` — exercises all five matchers
- [x] `BUN_DESTRUCT_VM_ON_EXIT=1 bun bd test test/js/bun/cron/in-process-cron.test.ts -t "worker terminate"` — both pass
- [x] `bun test test/integration/bun-types/bun-types.test.ts` with system bun — 12 pass
- [x] `node --check .buildkite/ci.mjs`
- [ ] new `bun-types` GH workflow green on this PR
- [ ] CI x64-asan green