### PR TITLE
docs(CLAUDE.md): only use test/regression/ for numbered regressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,7 @@ This is an explicit exception to the "never use `bun test` directly" rule. There
 
 ### Test Organization
 
-If the bug has a GitHub Issue number **and** is a regression (it worked in a previous release and broke), the test goes in `test/regression/issue/${issueNumber}.test.ts`. Ensure the issue number is **REAL** and not a placeholder!
-
-Otherwise, add the test to the **existing test file** for the code you're changing rather than creating a new file. Look in:
+**Default: add your test to the existing test file for the code you're changing.** Do not create a new file. A fetch bug goes in `test/js/web/fetch/fetch.test.ts`, a `Bun.serve` bug goes in `test/js/bun/http/serve.test.ts`, and so on. Keeping tests next to related coverage is what makes them discoverable and prevents duplicated setup.
 
 - `test/js/bun/` - Bun-specific API tests (http, crypto, ffi, shell, etc.)
 - `test/js/node/` - Node.js compatibility tests
@@ -64,6 +62,8 @@ Otherwise, add the test to the **existing test file** for the code you're changi
 - `test/integration/` - End-to-end integration tests
 - `test/napi/` - N-API compatibility tests
 - `test/v8/` - V8 C++ API compatibility tests
+
+**Exception:** `test/regression/issue/${issueNumber}.test.ts` is reserved for bugs that have a GitHub issue number **and** are true regressions (worked in a previous release, then broke). An issue number alone is not enough — if the behavior was never correct, it's not a regression and the test belongs in the existing file for that module. The issue number must be **REAL**, not a placeholder.
 
 ### Writing Tests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,9 +52,9 @@ This is an explicit exception to the "never use `bun test` directly" rule. There
 
 ### Test Organization
 
-If a test is for a specific numbered GitHub Issue, it should be placed in `test/regression/issue/${issueNumber}.test.ts`. Ensure the issue number is **REAL** and not a placeholder!
+If the bug has a GitHub Issue number **and** is a regression (it worked in a previous release and broke), the test goes in `test/regression/issue/${issueNumber}.test.ts`. Ensure the issue number is **REAL** and not a placeholder!
 
-If no valid issue number is provided, find the best existing file to modify instead, such as;
+Otherwise, add the test to the **existing test file** for the code you're changing rather than creating a new file. Look in:
 
 - `test/js/bun/` - Bun-specific API tests (http, crypto, ffi, shell, etc.)
 - `test/js/node/` - Node.js compatibility tests

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -149,8 +149,8 @@ To create a repetitive string, use `Buffer.alloc(count, fill).toString()` instea
 ### Test Organization
 
 - Use `describe` blocks for grouping related tests
-- Regression tests for specific issues go in `/test/regression/issue/${issueNumber}.test.ts`. If there's no issue number, do not put them in the regression directory.
-- Unit tests for specific features are organized by module (e.g., `/test/js/bun/`, `/test/js/node/`)
+- **Add tests to the existing test file for the code you're changing** — do not create a new file. Tests are organized by module (e.g., `/test/js/bun/`, `/test/js/node/`, `/test/js/web/`).
+- `/test/regression/issue/${issueNumber}.test.ts` is **only** for bugs that have a GitHub issue number **and** are true regressions (worked in a previous release, then broke). An issue number alone does not qualify — if it was never correct, put the test in the module's existing test file instead.
 - Integration tests are in `/test/integration/`
 
 ### Nested/complex object equality

--- a/test/README.md
+++ b/test/README.md
@@ -50,7 +50,7 @@ describe("TextEncoder", () => {
 });
 ```
 
-If you are fixing a bug that was reported from a GitHub issue, remember to add a test in the `test/regression/` directory.
+When fixing a bug, add the test to the existing test file for that code (e.g. a fetch bug → `test/js/web/fetch/fetch.test.ts`). Only use `test/regression/` when the bug has a GitHub issue number **and** is a true regression — it worked in a previous release and then broke.
 
 ```ts
 // test/regression/issue/02005.test.ts


### PR DESCRIPTION
Clarifies test placement guidance across `CLAUDE.md`, `test/CLAUDE.md`, and `test/README.md`:

- **Default:** add your test to the **existing test file** for the code you're changing. Do not create a new file. A fetch bug goes in `test/js/web/fetch/fetch.test.ts`, a `Bun.serve` bug goes in `test/js/bun/http/serve.test.ts`, etc.
- **Exception:** `test/regression/issue/${N}.test.ts` is reserved for bugs that have a GitHub issue number **and** are true regressions (worked in a previous release, then broke). An issue number alone is not enough.

Previously the wording implied any numbered issue → regression dir, which scatters tests away from the code they cover (e.g. #29198 added `test/regression/issue/29195.test.ts` for a fetch bug that belonged in `fetch.test.ts`). All three docs now agree.