### PR TITLE
Propagate exceptions from custom asymmetric matcher's asymmetricMatch()

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-asymmetric-matcher-throw.test.ts
+++ b/test/js/bun/test/expect-asymmetric-matcher-throw.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+expect.extend({
+  customMatcherThatThrows() {
+    throw new Error("thrown from custom matcher");
+  },
+});
+
+test("asymmetricMatch() propagates exceptions thrown by custom matchers", () => {
+  // @ts-expect-error
+  const matcher = expect.customMatcherThatThrows();
+  expect(() => matcher.asymmetricMatch({})).toThrow("thrown from custom matcher");
+});
+
+test("asymmetric custom matchers that throw surface as failures in deep equality", () => {
+  // @ts-expect-error
+  expect(() => expect({}).toEqual(expect.customMatcherThatThrows())).toThrow("thrown from custom matcher");
+});


### PR DESCRIPTION
Fuzzer fingerprint: `978b8db1aa9c0de9`

## What

`ExpectCustomAsymmetricMatcher.asymmetricMatch()` calls `execute()`, a `callconv(.c)` helper shared with the C++ deep-equality path. `execute()` signals failure by setting a pending JS exception and returning `false` — every error path inside it does `catch return false` or `catch false` without clearing the exception, by design, so that `matchAsymmetricMatcher` in bindings.cpp can observe and propagate it.

The Zig wrapper ignored this and returned `JSValue.jsBoolean(matched)` unconditionally. When the user-provided matcher function threw, the host-function boundary in `toJSHostCall` saw a non-empty return value with a pending exception and hit `releaseAssertNoException()`.

## Repro

```js
const { expect } = Bun.jest();
expect.extend({
  boom() { throw new Error("thrown from custom matcher"); },
});
expect.boom().asymmetricMatch({});
```

The original fuzzer crash was flaky because it depended on a prior REPRL iteration having called `expect.extend({ assertions: ... })` (the jest module object is cached across iterations), after which `expect.assertions(10)` in the crash script produced an asymmetric matcher instead of throwing, and `.asymmetricMatch(this)` on it invoked a matcher that threw.

## Fix

Check for a pending exception after `execute()` and return `error.JSError` so the exception is propagated to JS instead of tripping the assertion.