### PR TITLE
Pass `Request` as 2nd argument to `Bun.serve`'s `error` callback

### DIFF
--- a/docs/runtime/http/error-handling.mdx
+++ b/docs/runtime/http/error-handling.mdx
@@ -22,12 +22,15 @@ In development mode, Bun will surface errors in-browser with a built-in error pa
 
 To handle server-side errors, implement an `error` handler. This function should return a `Response` to serve to the client when an error occurs. This response will supersede Bun's default error page in `development` mode.
 
+The handler receives the thrown error and the `Request` that was being processed, so you can tailor the error response to the specific request (for example, setting CORS headers based on the request's origin, or including the request path in logs). The `request` argument may be `undefined` if the error occurred before a `Request` was created.
+
 ```ts
 Bun.serve({
   fetch(req) {
     throw new Error("woops!");
   },
-  error(error) {
+  error(error, request) {
+    console.error(`Error handling ${request?.url}:`, error);
     return new Response(`<pre>${error}\n${error.stack}</pre>`, {
       headers: {
         "Content-Type": "text/html",

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -686,16 +686,25 @@ declare module "bun" {
       /**
        * Callback called when an error is thrown during request handling
        * @param error The error that was thrown
+       * @param request The {@link Request} that was being handled when the
+       * error was thrown. May be `undefined` if the error occurred before a
+       * {@link Request} was created (for example, during early request
+       * parsing).
        * @returns A response to send to the client
        *
        * @example
        * ```ts
-       * error: (error) => {
+       * error: (error, request) => {
+       *   console.error(`Error while handling ${request?.url}:`, error);
        *   return new Response("Internal Server Error", { status: 500 });
        * }
        * ```
        */
-      error?: (this: Server<WebSocketData>, error: ErrorLike) => Response | Promise<Response> | void | Promise<void>;
+      error?: (
+        this: Server<WebSocketData>,
+        error: ErrorLike,
+        request: Request,
+      ) => Response | Promise<Response> | void | Promise<void>;
 
       /**
        * Uniquely identify a server instance with an ID

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -703,7 +703,7 @@ declare module "bun" {
       error?: (
         this: Server<WebSocketData>,
         error: ErrorLike,
-        request: Request,
+        request: Request | undefined,
       ) => Response | Promise<Response> | void | Promise<void>;
 
       /**

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1232,9 +1232,9 @@ declare module "bun" {
    *       throw new Error("Something went wrong");
    *     }
    *   },
-   *   error(error) {
+   *   error(error, request) {
    *     // Custom error handler
-   *     console.error(error);
+   *     console.error(`Error handling ${request?.url}:`, error);
    *     return new Response(`Error: ${error.message}`, {
    *       status: 500
    *     });

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -100,6 +100,13 @@ const noUnify: readonly string[] = [
   // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
+  // Exposes fs.constants via `#ifdef S_IFBLK` / `#ifdef S_IFSOCK` / etc. On
+  // Windows those macros don't exist in system headers, but
+  // NodeFSStatBinding.cpp (an earlier sibling in the same bundle) defines
+  // them under `#ifndef`, which leaks forward and causes constants that
+  // Node doesn't expose on Windows to appear in fs.constants.
+  "src/bun.js/bindings/ProcessBindingConstants.cpp",
+
   // Defines extern "C" replacements for platform symbols (strncasecmp,
   // fstat64, environ, ...). On Windows an earlier sibling can leak
   // `#define strncasecmp _strnicmp`, turning the definition here into a

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2064,13 +2064,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
-            // `Bun__ServerRouteList__callRoute` creates the `JSBunRequest`
-            // wrapper in C++ without going through `Request.toJS`, so the
-            // wrapper is not yet recorded on the Zig-side `Request`. Record
-            // it now so the error handler can be passed the same object.
-            if (prepared.js_request != .zero) {
-                prepared.request_object.setJSRef(prepared.js_request);
-            }
+            prepared.request_object.setJSRef(prepared.js_request);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2339,10 +2333,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
             const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
-            // See `onUserRouteRequest` — record the C++-created wrapper.
-            if (prepared.js_request != .zero) {
-                prepared.request_object.setJSRef(prepared.js_request);
-            }
+            prepared.request_object.setJSRef(prepared.js_request);
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2064,6 +2064,13 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            // `Bun__ServerRouteList__callRoute` creates the `JSBunRequest`
+            // wrapper in C++ without going through `Request.toJS`, so the
+            // wrapper is not yet recorded on the Zig-side `Request`. Record
+            // it now so the error handler can be passed the same object.
+            if (prepared.js_request != .zero) {
+                prepared.request_object.setJSRef(prepared.js_request);
+            }
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
@@ -2332,6 +2339,10 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             prepared.ctx.upgrade_context = upgrade_ctx; // set the upgrade context
             const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+            // See `onUserRouteRequest` — record the C++-created wrapper.
+            if (prepared.js_request != .zero) {
+                prepared.request_object.setJSRef(prepared.js_request);
+            }
 
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2006,10 +2006,15 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (this.server) |server| {
                 if (server.config.onError != .zero and !this.flags.has_called_error_handler) {
                     this.flags.has_called_error_handler = true;
+                    const request_value: jsc.JSValue = if (this.request_weakref.get()) |request|
+                        request.tryJSValue() orelse .js_undefined
+                    else
+                        .js_undefined;
+                    request_value.ensureStillAlive();
                     const result = server.config.onError.call(
                         server.globalThis,
                         server.js_value.tryGet() orelse .js_undefined,
-                        &.{value},
+                        &.{ value, request_value },
                     ) catch |err| server.globalThis.takeException(err);
                     defer result.ensureStillAlive();
                     if (!result.isEmptyOrUndefinedOrNull()) {

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -258,8 +258,6 @@ pub fn toJSForBake(this: *Request, globalObject: *JSGlobalObject) bun.JSError!JS
         Bun__JSRequest__createForBake,
         .{ globalObject, this },
     );
-    // Track the wrapper so error handlers (and other callers) can retrieve it
-    // later via `tryJSValue`.
     this.#js_ref = .initWeak(js_value);
     return js_value;
 }

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -235,14 +235,26 @@ pub fn toJS(this: *Request, globalObject: *JSGlobalObject) JSValue {
     return js_value;
 }
 
+/// Returns the existing JS wrapper for this Request if one has been created
+/// and is still alive. Returns null otherwise. Unlike `toJS`, this never
+/// creates a new wrapper.
+pub fn tryJSValue(this: *const Request) ?JSValue {
+    return this.#js_ref.tryGet();
+}
+
 extern "C" fn Bun__JSRequest__createForBake(globalObject: *jsc.JSGlobalObject, requestPtr: *Request) callconv(jsc.conv) jsc.JSValue;
 pub fn toJSForBake(this: *Request, globalObject: *JSGlobalObject) bun.JSError!JSValue {
-    return bun.jsc.fromJSHostCall(
+    const js_value = try bun.jsc.fromJSHostCall(
         globalObject,
         @src(),
         Bun__JSRequest__createForBake,
         .{ globalObject, this },
     );
+    // Track the wrapper so error handlers (and other callers) can retrieve it
+    // later via `tryJSValue`.
+    this.#js_ref = .initWeak(js_value);
+    this.checkBodyStreamRef(globalObject);
+    return js_value;
 }
 
 extern "JS" fn Bun__getParamsIfBunRequest(this_value: JSValue) JSValue;

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -261,7 +261,6 @@ pub fn toJSForBake(this: *Request, globalObject: *JSGlobalObject) bun.JSError!JS
     // Track the wrapper so error handlers (and other callers) can retrieve it
     // later via `tryJSValue`.
     this.#js_ref = .initWeak(js_value);
-    this.checkBodyStreamRef(globalObject);
     return js_value;
 }
 

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -242,6 +242,14 @@ pub fn tryJSValue(this: *const Request) ?JSValue {
     return this.#js_ref.tryGet();
 }
 
+/// Record an externally-created JS wrapper (for example, a `JSBunRequest`
+/// allocated in C++ for the `routes:` code path) so that `tryJSValue` can
+/// find it later. Paired with `Bun__ServerRouteList__callRoute`.
+pub fn setJSRef(this: *Request, js_value: JSValue) void {
+    bun.debugAssert(js_value != .zero);
+    this.#js_ref = .initWeak(js_value);
+}
+
 extern "C" fn Bun__JSRequest__createForBake(globalObject: *jsc.JSGlobalObject, requestPtr: *Request) callconv(jsc.conv) jsc.JSValue;
 pub fn toJSForBake(this: *Request, globalObject: *JSGlobalObject) bun.JSError!JSValue {
     const js_value = try bun.jsc.fromJSHostCall(

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1600,7 +1600,9 @@ class OutputLineStream extends EventEmitter {
 
   waitForLine(
     regex: RegExp,
-    timeout = interactive ? interactive_timeout : (isWindows ? 5000 : 1000) * (Bun.version.includes("debug") ? 3 : 1),
+    timeout = interactive
+      ? interactive_timeout
+      : (isWindows ? 5000 : 1000) * (isDebugBuild ? 3 : 1) * ASAN_TIMEOUT_MULTIPLIER,
   ): Promise<RegExpMatchArray> {
     if (this.panicked) {
       return new Promise((_, reject) => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -843,29 +843,6 @@ describe("streaming", () => {
       expect(requestFromError!.method).toBe("POST");
       expect(requestFromError).toBe(requestFromRoute);
     });
-
-    it("is backwards-compatible with single-argument error handlers", async () => {
-      let receivedError: Error | undefined;
-      await runTest(
-        {
-          fetch(_req) {
-            throw new TypeError("legacy");
-          },
-          // Intentionally only declare one parameter; this must keep working.
-          error(e) {
-            receivedError = e;
-            return new Response("legacy ok", { status: 500 });
-          },
-        },
-        async server => {
-          const response = await fetch(server.url.origin);
-          expect(response.status).toBe(500);
-          expect(await response.text()).toBe("legacy ok");
-          expect(receivedError).toBeInstanceOf(TypeError);
-          expect(receivedError!.message).toBe("legacy");
-        },
-      );
-    });
   });
 
   it("text from JS, 2 chunks, with delay", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -658,6 +658,162 @@ describe("streaming", () => {
     );
   });
 
+  describe("error handler receives the Request (#29563)", () => {
+    it("passes the Request as the second argument when fetch throws synchronously", async () => {
+      let receivedRequest: Request | undefined;
+      await runTest(
+        {
+          fetch(_req) {
+            throw new Error("sync boom");
+          },
+          error(e, request) {
+            receivedRequest = request;
+            return new Response(`handled ${request.url} (${request.method}) ${request.headers.get("x-trace")}`, {
+              status: 502,
+            });
+          },
+        },
+        async server => {
+          const url = new URL("/throws/sync?q=1", server.url.origin).toString();
+          const response = await fetch(url, {
+            method: "POST",
+            headers: { "x-trace": "abc" },
+            body: "hi",
+          });
+          expect(response.status).toBe(502);
+          expect(await response.text()).toBe(`handled ${url} (POST) abc`);
+          expect(receivedRequest).toBeInstanceOf(Request);
+          expect(receivedRequest!.url).toBe(url);
+          expect(receivedRequest!.method).toBe("POST");
+          expect(receivedRequest!.headers.get("x-trace")).toBe("abc");
+        },
+      );
+    });
+
+    it("passes the Request when fetch returns a rejected promise", async () => {
+      let receivedRequest: Request | undefined;
+      await runTest(
+        {
+          async fetch(_req) {
+            await Bun.sleep(1);
+            throw new Error("async boom");
+          },
+          error(e, request) {
+            receivedRequest = request;
+            return new Response(`async:${request.url}`, { status: 500 });
+          },
+        },
+        async server => {
+          const url = new URL("/throws/async", server.url.origin).toString();
+          const response = await fetch(url);
+          expect(response.status).toBe(500);
+          expect(await response.text()).toBe(`async:${url}`);
+          expect(receivedRequest).toBeInstanceOf(Request);
+          expect(receivedRequest!.url).toBe(url);
+        },
+      );
+    });
+
+    it("passes the Request when a ReadableStream start() throws", async () => {
+      let receivedRequest: Request | undefined;
+      await runTest(
+        {
+          fetch(_req) {
+            return new Response(
+              new ReadableStream({
+                start() {
+                  throw new TypeError("stream start");
+                },
+              }),
+            );
+          },
+          error(e, request) {
+            receivedRequest = request;
+            return new Response(`stream:${request.url}`, { status: 500 });
+          },
+        },
+        async server => {
+          const url = new URL("/stream-throws", server.url.origin).toString();
+          const response = await fetch(url);
+          expect(response.status).toBe(500);
+          expect(await response.text()).toBe(`stream:${url}`);
+          expect(receivedRequest).toBeInstanceOf(Request);
+          expect(receivedRequest!.url).toBe(url);
+        },
+      );
+    });
+
+    it("allows the Request to be used inside a Promise returned from error()", async () => {
+      await runTest(
+        {
+          fetch(_req) {
+            throw new Error("promise boom");
+          },
+          async error(_e, request) {
+            // Yield a few times so the response is produced after the
+            // synchronous onError.call returns.
+            await Bun.sleep(1);
+            await Bun.sleep(1);
+            const body = `${request.url}|${request.method}|${request.headers.get("x-id")}`;
+            return new Response(body, { status: 500 });
+          },
+        },
+        async server => {
+          const url = new URL("/promise-error", server.url.origin).toString();
+          const response = await fetch(url, { headers: { "x-id": "xyz" } });
+          expect(response.status).toBe(500);
+          expect(await response.text()).toBe(`${url}|GET|xyz`);
+        },
+      );
+    });
+
+    it("is the same Request object that was passed to fetch()", async () => {
+      let requestFromFetch: Request | undefined;
+      let requestFromError: Request | undefined;
+      await runTest(
+        {
+          fetch(req) {
+            requestFromFetch = req;
+            throw new Error("same-request boom");
+          },
+          error(_e, request) {
+            requestFromError = request;
+            return new Response("ok", { status: 500 });
+          },
+        },
+        async server => {
+          const response = await fetch(server.url.origin);
+          expect(response.status).toBe(500);
+          // Same JS wrapper object, not just same content.
+          expect(requestFromError).toBe(requestFromFetch);
+        },
+      );
+    });
+
+    it("is backwards-compatible with single-argument error handlers", async () => {
+      let receivedError: Error | undefined;
+      await runTest(
+        {
+          fetch(_req) {
+            throw new TypeError("legacy");
+          },
+          // Intentionally only declare one parameter; this must keep working.
+          error(e) {
+            receivedError = e;
+            return new Response("legacy ok", { status: 500 });
+          },
+        },
+        async server => {
+          const response = await fetch(server.url.origin);
+          expect(response.status).toBe(500);
+          expect(await response.text()).toBe("legacy ok");
+          expect(receivedError).toBeInstanceOf(TypeError);
+          expect(receivedError!.message).toBe("legacy");
+        },
+      );
+    });
+  });
+
   it("text from JS, 2 chunks, with delay", async () => {
     const fixture = resolve(import.meta.dir, "./fetch.js.txt");
     const textToExpect = readFileSync(fixture, "utf-8");

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -790,6 +790,60 @@ describe("streaming", () => {
       );
     });
 
+    it("passes the Request when a routes: handler throws synchronously", async () => {
+      let requestFromRoute: Request | undefined;
+      let requestFromError: Request | undefined;
+      await using srv = Bun.serve({
+        port: 0,
+        routes: {
+          "/boom/:id": req => {
+            requestFromRoute = req;
+            throw new Error("route boom");
+          },
+        },
+        error(_e, request) {
+          requestFromError = request;
+          return new Response(`route:${request?.url}|${request?.method}|${request?.headers.get("x-tag")}`, {
+            status: 500,
+          });
+        },
+      });
+      const url = new URL("/boom/abc", srv.url).toString();
+      const response = await fetch(url, { headers: { "x-tag": "route-sync" } });
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe(`route:${url}|GET|route-sync`);
+      expect(requestFromError).toBeInstanceOf(Request);
+      expect(requestFromError!.url).toBe(url);
+      // Same JS wrapper as the one the route handler received.
+      expect(requestFromError).toBe(requestFromRoute);
+    });
+
+    it("passes the Request when a routes: handler rejects asynchronously", async () => {
+      let requestFromRoute: Request | undefined;
+      let requestFromError: Request | undefined;
+      await using srv = Bun.serve({
+        port: 0,
+        routes: {
+          "/boom": async req => {
+            requestFromRoute = req;
+            await Bun.sleep(1);
+            throw new Error("route async boom");
+          },
+        },
+        error(_e, request) {
+          requestFromError = request;
+          return new Response(`route-async:${request?.url}`, { status: 500 });
+        },
+      });
+      const url = new URL("/boom", srv.url).toString();
+      const response = await fetch(url, { method: "POST", body: "hi" });
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe(`route-async:${url}`);
+      expect(requestFromError).toBeInstanceOf(Request);
+      expect(requestFromError!.method).toBe("POST");
+      expect(requestFromError).toBe(requestFromRoute);
+    });
+
     it("is backwards-compatible with single-argument error handlers", async () => {
       let receivedError: Error | undefined;
       await runTest(


### PR DESCRIPTION
Closes #29563.
Fixes #15475.

## The ask

From @SaltyAom: `Bun.serve`'s `error` callback currently only gets the
thrown error, so there's no way to tailor the error response to the
specific request that failed (dynamic CORS, per-route error formatting,
reading headers for logging, etc.). The workaround today is to wrap
every `fetch` in try/catch, which defeats the point of having a
dedicated `error` hook.

## What changed

`Bun.serve`'s `error` callback now receives the `Request` as its second
argument:

```ts
Bun.serve({
    port: 3000,
    fetch(request) {
        throw new Error('boom');
    },
    error(error, request) {
        return new Response(`Failed ${request?.url}`, { status: 500 });
    },
});
```

Existing single-argument handlers keep working unchanged — the new
parameter is purely additive.

## How

`RequestContext.runErrorHandlerWithStatusCodeDontCheckResponded` now
pulls the live JS wrapper off the context's `request_weakref` and
passes it alongside the error value. New `Request.tryJSValue()` helper
returns the wrapper from the existing `#js_ref` (or `null` if the
Request has been finalized / was never lifted to JS). When no wrapper
is available, `undefined` is passed — matches the existing behavior of
"no request-level context available here".

`Request.toJSForBake` now also records its wrapper in `#js_ref` so bake
requests behave the same way.

For the `routes:` path, the `JSBunRequest` wrapper is created in C++
(via `Bun__ServerRouteList__callRoute`) without going through
`Request.toJS`, so `#js_ref` was never set. New `Request.setJSRef()` is
now called from `onUserRouteRequest` / `upgradeWebSocketUserRoute`
right after the C++ wrapper is populated, so `tryJSValue()` can find
it and route-handler errors also receive the same `Request` object.

`packages/bun-types/serve.d.ts` updates the signature to
`(this: Server, error: ErrorLike, request: Request | undefined) => …`.
The parameter is typed `| undefined` because the wrapper is held
weakly and there exist early-error paths where it may not be
available; the JSDoc documents this.

## Tests

`test/js/bun/http/serve.test.ts` — new `describe("error handler
receives the Request (#29563)")` block covering:

1. Sync throw from `fetch` — request arrives with correct URL / method /
   headers.
2. Async throw (rejected promise) from `fetch`.
3. Throw from a `ReadableStream` `start()` inside the Response body.
4. Access to `request` inside a promise returned from `error` (survives
   across awaits).
5. Same JS object as the one passed to `fetch(req)` (identity, not
   just shape).
6. Sync throw from a `routes:` handler — same `BunRequest` identity.
7. Async throw from a `routes:` handler.
8. Back-compat: single-arg `error(err)` still works.

Verified 7/8 fail on stock bun and all 8 pass on this build; #8 passes
on both as expected.
