### PR TITLE
test: speed up 16 more slow test files (concurrency, batched spawns, reduced sleeps)

### DIFF
--- a/test/bundler/bundler_defer.test.ts
+++ b/test/bundler/bundler_defer.test.ts
@@ -98,7 +98,7 @@ describe("defer", () => {
           setup(build) {
             build.onStart(async () => {
               action.push("onStart 1 setup");
-              await Bun.sleep(1000);
+              await Bun.sleep(50);
               action.push("onStart 1 complete");
             });
           },
@@ -108,7 +108,7 @@ describe("defer", () => {
           setup(build) {
             build.onStart(async () => {
               action.push("onStart 2 setup");
-              await Bun.sleep(1000);
+              await Bun.sleep(50);
               action.push("onStart 2 complete");
             });
           },
@@ -118,7 +118,7 @@ describe("defer", () => {
           setup(build) {
             build.onStart(async () => {
               action.push("onStart 3 setup");
-              await Bun.sleep(1000);
+              await Bun.sleep(50);
               action.push("onStart 3 complete");
             });
           },
@@ -159,7 +159,7 @@ describe("defer", () => {
               setup(build) {
                 build.onStart(async () => {
                   action.push("onStart 2 setup");
-                  await Bun.sleep(1000);
+                  await Bun.sleep(50);
                   action.push("onStart 2 complete");
                 });
               },
@@ -169,7 +169,7 @@ describe("defer", () => {
               setup(build) {
                 build.onStart(async () => {
                   action.push("onStart 3 setup");
-                  await Bun.sleep(1000);
+                  await Bun.sleep(50);
                   action.push("onStart 3 complete");
                 });
               },

--- a/test/cli/install/bun-run-dir.test.ts
+++ b/test/cli/install/bun-run-dir.test.ts
@@ -1,16 +1,11 @@
 import { file, spawn } from "bun";
-import { beforeEach, expect, it } from "bun:test";
+import { expect, it } from "bun:test";
 import { exists, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, stderrForInstall, tmpdirSync } from "harness";
 import { join } from "path";
 
-let run_dir: string;
-
-beforeEach(() => {
-  run_dir = tmpdirSync();
-});
-
-it("should download dependency to run local file", async () => {
+it.concurrent("should download dependency to run local file", async () => {
+  const run_dir = tmpdirSync();
   await writeFile(
     join(run_dir, "test.js"),
     `
@@ -69,7 +64,8 @@ console.log(minify("print(6 * 7)").code);
   expect(await exited2).toBe(0);
 });
 
-it("should download dependencies to run local file", async () => {
+it.concurrent("should download dependencies to run local file", async () => {
+  const run_dir = tmpdirSync();
   const filePath = join(import.meta.dir, "baz-0.0.3.tgz").replace(/\\/g, "\\\\");
   await writeFile(
     join(run_dir, "test.js"),
@@ -150,7 +146,8 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   expect(await exited2).toBe(0);
 });
 
-it("should not crash when downloading a non-existent module, issue#4240", async () => {
+it.concurrent("should not crash when downloading a non-existent module, issue#4240", async () => {
+  const run_dir = tmpdirSync();
   await writeFile(
     join(run_dir, "test.js"),
     `

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -1162,7 +1162,7 @@ describe.concurrent("no package.json", () => {
 
 // ─── ABORT / SIGNAL HANDLING ────────────────────────────────────────────────
 
-describe.concurrent("abort: failure kills long-running processes", () => {
+describe("abort: failure kills long-running processes", () => {
   test("parallel: fast failure kills a slow script", async () => {
     using dir = tempDir("mr-abort-slow", {
       "package.json": JSON.stringify({
@@ -1787,7 +1787,7 @@ function makeWorkspace(
   return tempDir(prefix, files);
 }
 
-describe.concurrent("workspace integration", () => {
+describe("workspace integration", () => {
   test("--parallel --filter='*' runs script in all packages", async () => {
     using dir = makeWorkspace("mr-ws-all", {
       "pkg-a": { build: `${bunExe()} -e "console.log('a-built')"` },

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -45,7 +45,7 @@ function expectExited(stderr: string, label: string, code: number) {
 
 // ─── PARALLEL: BASIC ──────────────────────────────────────────────────────────
 
-describe("parallel: basic", () => {
+describe.concurrent("parallel: basic", () => {
   test("runs two scripts in parallel", async () => {
     using dir = tempDir("mr-par-basic", {
       "package.json": JSON.stringify({
@@ -109,7 +109,7 @@ describe("parallel: basic", () => {
 
 // ─── PARALLEL: FILE SCRIPTS ───────────────────────────────────────────────────
 
-describe("parallel: file scripts", () => {
+describe.concurrent("parallel: file scripts", () => {
   test("runs .ts files in parallel", async () => {
     using dir = tempDir("mr-par-ts", {
       "a.ts": "console.log('file-a')",
@@ -157,7 +157,7 @@ describe("parallel: file scripts", () => {
 
 // ─── PARALLEL: ERROR HANDLING ─────────────────────────────────────────────────
 
-describe("parallel: error handling", () => {
+describe.concurrent("parallel: error handling", () => {
   test("failure kills other scripts by default", async () => {
     using dir = tempDir("mr-par-fail", {
       "package.json": JSON.stringify({
@@ -242,7 +242,7 @@ describe("parallel: error handling", () => {
 
 // ─── PARALLEL: OUTPUT FORMATTING ──────────────────────────────────────────────
 
-describe("parallel: output formatting", () => {
+describe.concurrent("parallel: output formatting", () => {
   test("each line has prefix label", async () => {
     using dir = tempDir("mr-par-prefix", {
       "package.json": JSON.stringify({
@@ -405,7 +405,7 @@ describe("parallel: output formatting", () => {
 
 // ─── STDOUT / STDERR SEPARATION ──────────────────────────────────────────────
 
-describe("stdout/stderr separation", () => {
+describe.concurrent("stdout/stderr separation", () => {
   test("child stdout goes to parent stdout with prefix", async () => {
     using dir = tempDir("mr-sep-stdout", {
       "package.json": JSON.stringify({
@@ -466,7 +466,7 @@ describe("stdout/stderr separation", () => {
 
 // ─── SEQUENTIAL: BASIC ───────────────────────────────────────────────────────
 
-describe("sequential: basic", () => {
+describe.concurrent("sequential: basic", () => {
   test("runs scripts in order", async () => {
     using dir = tempDir("mr-seq-order", {
       "package.json": JSON.stringify({
@@ -565,7 +565,7 @@ describe("sequential: basic", () => {
 
 // ─── PRE/POST SCRIPTS ────────────────────────────────────────────────────────
 
-describe("pre/post scripts", () => {
+describe.concurrent("pre/post scripts", () => {
   test("runs pre, main, post in order", async () => {
     using dir = tempDir("mr-prepost-order", {
       "package.json": JSON.stringify({
@@ -741,7 +741,7 @@ describe("pre/post scripts", () => {
 
 // ─── VALIDATION & ERROR MESSAGES ──────────────────────────────────────────────
 
-describe("validation", () => {
+describe.concurrent("validation", () => {
   test("error when both --parallel and --sequential", async () => {
     using dir = tempDir("mr-val-both", {
       "package.json": JSON.stringify({ scripts: { a: "echo a" } }),
@@ -779,7 +779,7 @@ describe("validation", () => {
 
 // ─── MIXED STDOUT / STDERR ────────────────────────────────────────────────────
 
-describe("output streams", () => {
+describe.concurrent("output streams", () => {
   test("captures both stdout and stderr", async () => {
     using dir = tempDir("mr-streams", {
       "package.json": JSON.stringify({
@@ -812,7 +812,7 @@ describe("output streams", () => {
 
 // ─── SCRIPTS WITH SHELL FEATURES ──────────────────────────────────────────────
 
-describe("shell features", () => {
+describe.concurrent("shell features", () => {
   test("scripts with pipes work", async () => {
     using dir = tempDir("mr-shell-pipe", {
       "package.json": JSON.stringify({
@@ -870,7 +870,7 @@ describe("shell features", () => {
 
 // ─── SCRIPT NAMES WITH SPECIAL CHARACTERS ─────────────────────────────────────
 
-describe("script name edge cases", () => {
+describe.concurrent("script name edge cases", () => {
   test("script names with colons", async () => {
     using dir = tempDir("mr-colon", {
       "package.json": JSON.stringify({
@@ -919,7 +919,7 @@ describe("script name edge cases", () => {
 
 // ─── RAPID EXIT / TIMING ─────────────────────────────────────────────────────
 
-describe("timing edge cases", () => {
+describe.concurrent("timing edge cases", () => {
   test("scripts that exit immediately", async () => {
     using dir = tempDir("mr-instant", {
       "package.json": JSON.stringify({
@@ -962,7 +962,7 @@ describe("timing edge cases", () => {
 
 // ─── EXIT CODE PROPAGATION ───────────────────────────────────────────────────
 
-describe("exit code propagation", () => {
+describe.concurrent("exit code propagation", () => {
   test("parallel: first handle with non-zero code wins", async () => {
     using dir = tempDir("mr-exitprop", {
       "package.json": JSON.stringify({
@@ -1011,7 +1011,7 @@ describe("exit code propagation", () => {
 
 // ─── CWD / WORKING DIRECTORY ────────────────────────────────────────────────
 
-describe("working directory", () => {
+describe.concurrent("working directory", () => {
   test("scripts run in the package.json directory", async () => {
     using dir = tempDir("mr-cwd", {
       "package.json": JSON.stringify({
@@ -1033,7 +1033,7 @@ describe("working directory", () => {
 
 // ─── EXPLICIT RUN COMMAND ───────────────────────────────────────────────────
 
-describe("explicit run command", () => {
+describe.concurrent("explicit run command", () => {
   test("'bun run --parallel' with run keyword", async () => {
     using dir = tempDir("mr-run-explicit", {
       "package.json": JSON.stringify({
@@ -1052,7 +1052,7 @@ describe("explicit run command", () => {
 
 // ─── LARGE OUTPUT / STRESS ──────────────────────────────────────────────────
 
-describe("stress tests", () => {
+describe.concurrent("stress tests", () => {
   test("handles large number of output lines", async () => {
     using dir = tempDir("mr-stress-lines", {
       "package.json": JSON.stringify({
@@ -1086,7 +1086,7 @@ describe("stress tests", () => {
 
 // ─── RAW COMMANDS (NOT IN PACKAGE.JSON) ─────────────────────────────────────
 
-describe("raw shell commands", () => {
+describe.concurrent("raw shell commands", () => {
   test("runs raw command not in package.json", async () => {
     using dir = tempDir("mr-raw", {
       "package.json": JSON.stringify({ scripts: {} }),
@@ -1123,7 +1123,7 @@ describe("raw shell commands", () => {
 
 // ─── SEQUENTIAL: SIDE EFFECTS ORDERING ──────────────────────────────────────
 
-describe("sequential: side effects ordering", () => {
+describe.concurrent("sequential: side effects ordering", () => {
   test("later scripts can see files created by earlier scripts", async () => {
     using dir = tempDir("mr-seq-sideeffect", {
       "package.json": JSON.stringify({
@@ -1142,7 +1142,7 @@ describe("sequential: side effects ordering", () => {
 
 // ─── NO PACKAGE.JSON ────────────────────────────────────────────────────────
 
-describe("no package.json", () => {
+describe.concurrent("no package.json", () => {
   test("file scripts work without package.json", async () => {
     using dir = tempDir("mr-nopkg-files", {
       "hello.ts": "console.log('no-pkg-hello')",
@@ -1162,7 +1162,7 @@ describe("no package.json", () => {
 
 // ─── ABORT / SIGNAL HANDLING ────────────────────────────────────────────────
 
-describe("abort: failure kills long-running processes", () => {
+describe.concurrent("abort: failure kills long-running processes", () => {
   test("parallel: fast failure kills a slow script", async () => {
     using dir = tempDir("mr-abort-slow", {
       "package.json": JSON.stringify({
@@ -1197,7 +1197,7 @@ describe("abort: failure kills long-running processes", () => {
 
 // ─── PARTIAL LINE BUFFERING ─────────────────────────────────────────────────
 
-describe("partial line buffering", () => {
+describe.concurrent("partial line buffering", () => {
   test("chunked writes are assembled into complete lines", async () => {
     using dir = tempDir("mr-chunk", {
       "package.json": JSON.stringify({
@@ -1286,7 +1286,7 @@ describe("partial line buffering", () => {
 
 // ─── MULTIPLE FAILURES WITH --no-exit-on-error ──────────────────────────────
 
-describe("--no-exit-on-error: multiple failures", () => {
+describe.concurrent("--no-exit-on-error: multiple failures", () => {
   test("parallel: first handle's non-zero code wins in finalize", async () => {
     using dir = tempDir("mr-noexit-multi", {
       "package.json": JSON.stringify({
@@ -1341,7 +1341,7 @@ describe("--no-exit-on-error: multiple failures", () => {
 
 // ─── PRE/POST + --no-exit-on-error INTERACTION ──────────────────────────────
 
-describe("pre/post + --no-exit-on-error interaction", () => {
+describe.concurrent("pre/post + --no-exit-on-error interaction", () => {
   test("pre failure blocks own group but other groups continue", async () => {
     using dir = tempDir("mr-pre-noexit", {
       "package.json": JSON.stringify({
@@ -1395,7 +1395,7 @@ describe("pre/post + --no-exit-on-error interaction", () => {
 
 // ─── EMPTY / EDGE-CASE SCRIPT CONTENT ───────────────────────────────────────
 
-describe("edge-case script content", () => {
+describe.concurrent("edge-case script content", () => {
   test("empty script string runs without crashing", async () => {
     using dir = tempDir("mr-empty-script", {
       "package.json": JSON.stringify({
@@ -1447,7 +1447,7 @@ describe("edge-case script content", () => {
 
 // ─── BINARY / UNUSUAL OUTPUT ────────────────────────────────────────────────
 
-describe("unusual output", () => {
+describe.concurrent("unusual output", () => {
   test("null bytes in output don't crash", async () => {
     using dir = tempDir("mr-nullbyte", {
       "package.json": JSON.stringify({
@@ -1494,7 +1494,7 @@ describe("unusual output", () => {
 
 // ─── SEQUENTIAL: DONE STATUS BETWEEN SCRIPTS ───────────────────────────────
 
-describe("sequential: status messages between scripts", () => {
+describe.concurrent("sequential: status messages between scripts", () => {
   test("Done message appears between sequential scripts", async () => {
     using dir = tempDir("mr-seq-done-between", {
       "package.json": JSON.stringify({
@@ -1535,7 +1535,7 @@ describe("sequential: status messages between scripts", () => {
 
 // ─── CONCURRENT STDOUT + STDERR FROM SAME SCRIPT ───────────────────────────
 
-describe("concurrent stdout + stderr from same script", () => {
+describe.concurrent("concurrent stdout + stderr from same script", () => {
   test("interleaved stdout and stderr are both prefixed", async () => {
     using dir = tempDir("mr-interleave-streams", {
       "package.json": JSON.stringify({
@@ -1561,7 +1561,7 @@ describe("concurrent stdout + stderr from same script", () => {
 
 // ─── DEEP DEPENDENCY CHAIN ──────────────────────────────────────────────────
 
-describe("dependency chains", () => {
+describe.concurrent("dependency chains", () => {
   test("sequential with pre/post creates deep chain that works", async () => {
     using dir = tempDir("mr-deep-chain", {
       "package.json": JSON.stringify({
@@ -1616,7 +1616,7 @@ describe("dependency chains", () => {
 
 // ─── COLOR CYCLING ──────────────────────────────────────────────────────────
 
-describe("color cycling", () => {
+describe.concurrent("color cycling", () => {
   test("more than 6 scripts cycle through colors", async () => {
     const scripts: Record<string, string> = {};
     for (let i = 0; i < 7; i++) {
@@ -1650,7 +1650,7 @@ describe("color cycling", () => {
 
 // ─── GLOB PATTERN MATCHING ──────────────────────────────────────────────────
 
-describe("glob pattern matching", () => {
+describe.concurrent("glob pattern matching", () => {
   test("build:* matches all build:xxx scripts", async () => {
     using dir = tempDir("mr-glob-basic", {
       "package.json": JSON.stringify({
@@ -1787,7 +1787,7 @@ function makeWorkspace(
   return tempDir(prefix, files);
 }
 
-describe("workspace integration", () => {
+describe.concurrent("workspace integration", () => {
   test("--parallel --filter='*' runs script in all packages", async () => {
     using dir = makeWorkspace("mr-ws-all", {
       "pkg-a": { build: `${bunExe()} -e "console.log('a-built')"` },

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -45,7 +45,7 @@ async function runTests(dir: string, extraArgs: string[], files = ["./a-leaker.t
   return { stdout, stderr, exitCode };
 }
 
-describe("bun test --isolate", () => {
+describe.concurrent("bun test --isolate", () => {
   test("without --isolate, leaked global is visible to next file", async () => {
     using dir = tempDir("isolate-off", fixtures);
     const { stderr, exitCode } = await runTests(String(dir), []);
@@ -312,7 +312,7 @@ describe("bun test --isolate", () => {
 // b sees stale v1 → cache hit) and that delete require.cache evicts it
 // (treatment: b sees fresh v2). A/B timing was removed as flaky; this is the
 // deterministic behavioral proof.
-test("--isolate: delete require.cache evicts the SourceProvider cache", async () => {
+test.concurrent("--isolate: delete require.cache evicts the SourceProvider cache", async () => {
   const sharedV1 = `export const v = "v1";\n`;
   const sharedV2 = `export const v = "v2";\n`;
   const aBody = (doDelete: boolean) => `
@@ -333,50 +333,53 @@ test("--isolate: delete require.cache evicts the SourceProvider cache", async ()
     });
   `;
 
-  // Control: without delete, the SourceProvider cache returns the v1 provider
-  // even though the file on disk is now v2.
-  {
-    using dir = tempDir("isolate-spcache-evict-ctrl", {
-      "shared.ts": sharedV1,
-      "a.test.ts": aBody(false),
-      "b.test.ts": bBody("v1"),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("2 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  }
-
-  // With delete: the cache entry is evicted, so b's import re-transpiles and
-  // sees v2 from disk.
-  {
-    using dir = tempDir("isolate-spcache-evict", {
-      "shared.ts": sharedV1,
-      "a.test.ts": aBody(true),
-      "b.test.ts": bBody("v2"),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("2 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  }
+  // Control (without delete) and treatment (with delete) are independent — run
+  // both subprocesses in parallel.
+  await Promise.all([
+    // Control: without delete, the SourceProvider cache returns the v1 provider
+    // even though the file on disk is now v2.
+    (async () => {
+      using dir = tempDir("isolate-spcache-evict-ctrl", {
+        "shared.ts": sharedV1,
+        "a.test.ts": aBody(false),
+        "b.test.ts": bBody("v1"),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    })(),
+    // With delete: the cache entry is evicted, so b's import re-transpiles and
+    // sees v2 from disk.
+    (async () => {
+      using dir = tempDir("isolate-spcache-evict", {
+        "shared.ts": sharedV1,
+        "a.test.ts": aBody(true),
+        "b.test.ts": bBody("v2"),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    })(),
+  ]);
 });
 
-test("--isolate: SourceProvider cache covers CommonJS modules", async () => {
+test.concurrent("--isolate: SourceProvider cache covers CommonJS modules", async () => {
   const sharedV1 = `module.exports = { v: "v1" };\n`;
   const sharedV2 = `module.exports = { v: "v2" };\n`;
   const aBody = (doDelete: boolean) => `
@@ -410,51 +413,53 @@ test("--isolate: SourceProvider cache covers CommonJS modules", async () => {
     });
   `;
 
-  // Control: without delete, the cached Program-type SourceProvider is reused
-  // across files for both require() and import-of-CJS, so b and c see stale v1.
-  {
-    using dir = tempDir("isolate-spcache-cjs-ctrl", {
-      "shared.cjs": sharedV1,
-      "a.test.cjs": aBody(false),
-      "b.test.cjs": bBody("v1"),
-      "c.test.ts": cBody("v1"),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "./a.test.cjs", "./b.test.cjs", "./c.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("3 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  }
-
-  // With delete: b and c re-transpile and see v2.
-  {
-    using dir = tempDir("isolate-spcache-cjs", {
-      "shared.cjs": sharedV1,
-      "a.test.cjs": aBody(true),
-      "b.test.cjs": bBody("v2"),
-      "c.test.ts": cBody("v2"),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "./a.test.cjs", "./b.test.cjs", "./c.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("3 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  }
+  // Control and treatment are independent — run both subprocesses in parallel.
+  await Promise.all([
+    // Control: without delete, the cached Program-type SourceProvider is reused
+    // across files for both require() and import-of-CJS, so b and c see stale v1.
+    (async () => {
+      using dir = tempDir("isolate-spcache-cjs-ctrl", {
+        "shared.cjs": sharedV1,
+        "a.test.cjs": aBody(false),
+        "b.test.cjs": bBody("v1"),
+        "c.test.ts": cBody("v1"),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a.test.cjs", "./b.test.cjs", "./c.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("3 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    })(),
+    // With delete: b and c re-transpile and see v2.
+    (async () => {
+      using dir = tempDir("isolate-spcache-cjs", {
+        "shared.cjs": sharedV1,
+        "a.test.cjs": aBody(true),
+        "b.test.cjs": bBody("v2"),
+        "c.test.ts": cBody("v2"),
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a.test.cjs", "./b.test.cjs", "./c.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("3 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    })(),
+  ]);
 });
 
-test("--isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages", async () => {
+test.concurrent("--isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages", async () => {
   // Regression: insert was gated on tag == JavaScript || PackageJSONTypeModule,
   // so .mjs files from `"type":"module"` packages and .ts from `"type":"commonjs"`
   // packages (PackageJSONTypeCommonJS / ESM tags) bypassed the cache and were
@@ -517,7 +522,7 @@ test("--isolate: SourceProvider cache covers node_modules .mjs and type:commonjs
   expect(exitCode).toBe(0);
 });
 
-test("--isolate: cached SourceProvider's module_info rebuilds correct exports", async () => {
+test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct exports", async () => {
   // A wide module so the printer-generated module_info has thousands of
   // export entries. Under --isolate, file b hits the SourceProvider cache and
   // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
@@ -560,16 +565,18 @@ test("--isolate: cached SourceProvider's module_info rebuilds correct exports", 
   expect(exitCode).toBe(0);
 });
 
-test("--isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export", async () => {
-  // The zod pattern: re-exporting a namespace import binding. Bun's module_info
-  // must record this as a [Namespace] export entry (not [Local]) so the cached
-  // analyze result matches JSC's ModuleAnalyzer. The debug build's
-  // fallbackParse diff would print "BEGIN analyzeTranspiledModule" + a DIFF
-  // and assert if they disagree.
-  using dir = tempDir("isolate-ns-reexport", {
-    "external.ts": `export const a = 1;\nexport const b = 2;\n`,
-    "re.ts": `import * as ns from "./external";\nexport { ns };\nexport default ns;\nexport * from "./external";\n`,
-    "t1.test.ts": `import {test,expect} from "bun:test";
+test.concurrent(
+  "--isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export",
+  async () => {
+    // The zod pattern: re-exporting a namespace import binding. Bun's module_info
+    // must record this as a [Namespace] export entry (not [Local]) so the cached
+    // analyze result matches JSC's ModuleAnalyzer. The debug build's
+    // fallbackParse diff would print "BEGIN analyzeTranspiledModule" + a DIFF
+    // and assert if they disagree.
+    using dir = tempDir("isolate-ns-reexport", {
+      "external.ts": `export const a = 1;\nexport const b = 2;\n`,
+      "re.ts": `import * as ns from "./external";\nexport { ns };\nexport default ns;\nexport * from "./external";\n`,
+      "t1.test.ts": `import {test,expect} from "bun:test";
 import { ns } from "./re";
 import def, * as all from "./re";
 test("t1", () => {
@@ -581,7 +588,7 @@ test("t1", () => {
   expect(Object.keys(ns).sort()).toEqual(["a","b"]);
 });
 `,
-    "t2.test.ts": `import {test,expect} from "bun:test";
+      "t2.test.ts": `import {test,expect} from "bun:test";
 import { ns } from "./re";
 test("t2", () => {
   // Isolation sentinel: system bun ignores --isolate, so t2 would see t1's
@@ -591,24 +598,25 @@ test("t2", () => {
   expect(ns.b).toBe(2);
 });
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--isolate", "./t1.test.ts", "./t2.test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("BEGIN analyzeTranspiledModule");
-  expect(stderr).not.toContain("DIFF:");
-  expect(stderr).toContain("2 pass");
-  expect(stderr).toContain("0 fail");
-  expect(exitCode).toBe(0);
-});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./t1.test.ts", "./t2.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("BEGIN analyzeTranspiledModule");
+    expect(stderr).not.toContain("DIFF:");
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  },
+);
 
-test("--isolate: leaked AbortSignal.timeout does not fire in next file", async () => {
+test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next file", async () => {
   using dir = tempDir("isolate-abort-timeout", {
     "a-leak.test.ts": `
       import { test, expect } from "bun:test";

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -26,44 +26,45 @@ async function runFixture(flags: string[]): Promise<{ order: number[]; seed: num
 }
 
 const sortNumbers = (a: number, b: number) => a - b;
-test("--randomize and --seed work", async () => {
+test.concurrent("--randomize and --seed work", async () => {
   const fixture = import.meta.dir + "/test-randomize.fixture.ts";
 
-  // with --randomize
-  const { order: randomizedOrder, seed: randomizedSeed } = await runFixture([fixture, "--randomize"]);
+  // with --randomize (and the no-flag run, which is independent)
+  const [{ order: randomizedOrder, seed: randomizedSeed }, { order: unseededOrder, seed: unseededSeed }] =
+    await Promise.all([runFixture([fixture, "--randomize"]), runFixture([fixture])]);
   expect(randomizedSeed).toBeFinite();
   expect(randomizedOrder.toSorted(sortNumbers)).toEqual(unsortedOrder);
   expect(randomizedOrder).not.toEqual(unsortedOrder);
 
-  // different randomized run is different
-  const { order: differentRandomizedOrder, seed: differentRandomizedSeed } = await runFixture([fixture, "--randomize"]);
+  // different randomized run is different; runs that depend on the first seed can run alongside it
+  const [
+    { order: differentRandomizedOrder, seed: differentRandomizedSeed },
+    { order: seededOrder, seed: seededSeed },
+    { order: randomizedAndSeededOrder, seed: randomizedAndSeededSeed },
+  ] = await Promise.all([
+    runFixture([fixture, "--randomize"]),
+    runFixture([fixture, "--seed", "" + randomizedSeed]),
+    runFixture([fixture, "--randomize", "--seed", "" + randomizedSeed]),
+  ]);
   expect(differentRandomizedOrder.toSorted(sortNumbers)).toEqual(unsortedOrder);
   expect(differentRandomizedOrder).not.toEqual(unsortedOrder);
   expect(differentRandomizedOrder).not.toEqual(randomizedOrder);
   expect(differentRandomizedSeed).not.toEqual(randomizedSeed);
 
   // with same seed as first run
-  const { order: seededOrder, seed: seededSeed } = await runFixture([fixture, "--seed", "" + randomizedSeed]);
   expect(seededOrder).toEqual(randomizedOrder);
   expect(seededSeed).toEqual(randomizedSeed);
 
   // with both randomize and seed parameter
-  const { order: randomizedAndSeededOrder, seed: randomizedAndSeededSeed } = await runFixture([
-    fixture,
-    "--randomize",
-    "--seed",
-    "" + randomizedSeed,
-  ]);
   expect(randomizedAndSeededOrder).toEqual(randomizedOrder);
   expect(randomizedAndSeededSeed).toEqual(randomizedSeed);
 
   // without seed
-  const { order: unseededOrder, seed: unseededSeed } = await runFixture([fixture]);
   expect(unseededOrder).toEqual(unsortedOrder);
   expect(unseededSeed).toBeNull();
 });
 
-test("randomizes order of files", async () => {
+test.concurrent("randomizes order of files", async () => {
   const dir = tempDirWithFiles(
     "randomize-order-of-files",
     Object.fromEntries(
@@ -74,22 +75,24 @@ test("randomizes order of files", async () => {
     ),
   );
 
-  const { order: unrandomizedOrder, seed: unrandomizedSeed } = await runFixture([dir]);
-  const { order: anotherUnrandomizedOrder, seed: anotherUnrandomizedSeed } = await runFixture([dir]);
+  const [
+    { order: unrandomizedOrder, seed: unrandomizedSeed },
+    { order: anotherUnrandomizedOrder, seed: anotherUnrandomizedSeed },
+    { order: randomizedOrder, seed: randomizedSeed },
+  ] = await Promise.all([runFixture([dir]), runFixture([dir]), runFixture([dir, "--randomize"])]);
   expect(unrandomizedSeed).toBeNull();
   expect(anotherUnrandomizedSeed).toBeNull();
   expect(anotherUnrandomizedOrder).toEqual(unrandomizedOrder);
 
-  const { order: randomizedOrder, seed: randomizedSeed } = await runFixture([dir, "--randomize"]);
   expect(randomizedSeed).toBeFinite();
   expect(unrandomizedOrder).not.toEqual(randomizedOrder);
 
-  const { order: anotherRandomizedOrder, seed: anotherRandomizedSeed } = await runFixture([dir, "--randomize"]);
+  const [{ order: anotherRandomizedOrder, seed: anotherRandomizedSeed }, { order: seededOrder, seed: seededSeed }] =
+    await Promise.all([runFixture([dir, "--randomize"]), runFixture([dir, "--seed", "" + randomizedSeed])]);
   expect(anotherRandomizedOrder).not.toEqual(randomizedOrder);
   expect(anotherRandomizedSeed).not.toEqual(randomizedSeed);
 
   // test with --seed
-  const { order: seededOrder, seed: seededSeed } = await runFixture([dir, "--seed", "" + randomizedSeed]);
   expect(seededOrder).toEqual(randomizedOrder);
   expect(seededSeed).toEqual(randomizedSeed);
 });

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -1,6 +1,19 @@
-import { spawnSync } from "bun";
+import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+
+// Kick off the subprocess immediately so multiple cases can overlap, then
+// resolve to its stdout text. Tests stay sequential (snapshot matchers require
+// it) but subprocess startup is parallelized.
+function runTable(argSource: string): Promise<string> {
+  const proc = spawn({
+    cmd: [bunExe(), `${import.meta.dir}/console-table-run.ts`, argSource],
+    stdout: "pipe",
+    stderr: "inherit",
+    env: bunEnv,
+  });
+  return proc.stdout.text();
+}
 
 describe("console.table", () => {
   test("throws when second arg is invalid", () => {
@@ -10,7 +23,7 @@ describe("console.table", () => {
     expect(() => console.table({}, "invalid")).toThrow();
   });
 
-  test.each([
+  const cases: [string, { args: () => any[] }][] = [
     [
       "not object (number)",
       {
@@ -140,60 +153,38 @@ describe("console.table", () => {
         args: () => [{ test: { "10": 123, "100": 154 } }],
       },
     ],
-  ])("expected output for: %s", (label, { args }) => {
-    const { stdout } = spawnSync({
-      cmd: [bunExe(), `${import.meta.dir}/console-table-run.ts`, args.toString()],
-      stdout: "pipe",
-      stderr: "inherit",
-      env: bunEnv,
-    });
+  ];
+  const outputs = new Map(cases.map(([label, { args }]) => [label, runTable(args.toString())]));
 
-    const actualOutput = stdout.toString();
+  test.each(cases)("expected output for: %s", async (label, { args }) => {
+    const actualOutput = await outputs.get(label)!;
     expect(actualOutput).toMatchSnapshot();
     console.log(actualOutput);
   });
 });
 
-test("console.table json fixture", () => {
-  const { stdout } = spawnSync({
-    cmd: [
-      bunExe(),
-      `${import.meta.dir}/console-table-run.ts`,
-      `(() => [${JSON.stringify(require("./console-table-json-fixture.json"), null, 2)}])`,
-    ],
-    stdout: "pipe",
-    stderr: "inherit",
-    env: bunEnv,
-  });
-
-  const actualOutput = stdout
-    .toString()
+const jsonFixtureOutput = runTable(
+  `(() => [${JSON.stringify(require("./console-table-json-fixture.json"), null, 2)}])`,
+);
+test("console.table json fixture", async () => {
+  const actualOutput = (await jsonFixtureOutput)
     // todo: fix bug causing this to be necessary:
     .replaceAll("`", "'");
   expect(actualOutput).toMatchSnapshot();
   console.log(actualOutput);
 });
 
-test("console.table ansi colors", () => {
-  const obj = {
-    [ansify("hello")]: ansify("this is a long string with ansi color codes"),
-    [ansify("world")]: ansify("this is another long string with ansi color"),
-    [ansify("foo")]: ansify("bar"),
-  };
-
-  function ansify(str: string) {
-    return `\u001b[31m${str}\u001b[39m`;
-  }
-
-  const { stdout } = spawnSync({
-    cmd: [bunExe(), `${import.meta.dir}/console-table-run.ts`, `(() => [${JSON.stringify(obj, null, 2)}])`],
-    stdout: "pipe",
-    stderr: "inherit",
-    env: bunEnv,
-  });
-
-  const actualOutput = stdout
-    .toString()
+function ansify(str: string) {
+  return `\u001b[31m${str}\u001b[39m`;
+}
+const ansiObj = {
+  [ansify("hello")]: ansify("this is a long string with ansi color codes"),
+  [ansify("world")]: ansify("this is another long string with ansi color"),
+  [ansify("foo")]: ansify("bar"),
+};
+const ansiColorsOutput = runTable(`(() => [${JSON.stringify(ansiObj, null, 2)}])`);
+test("console.table ansi colors", async () => {
+  const actualOutput = (await ansiColorsOutput)
     // todo: fix bug causing this to be necessary:
     .replaceAll("`", "'");
   expect(actualOutput).toMatchSnapshot();
@@ -221,20 +212,22 @@ test.skip("console.table character widths", () => {
   console.log(actualOutput);
 });
 
-test("console.table repeat 50", () => {
+const repeat50Proc = spawn({
+  cmd: [bunExe(), `${import.meta.dir}/console-table-repeat-50.ts`],
+  stdout: "pipe",
+  stderr: "pipe",
+  env: bunEnv,
+});
+const repeat50Output = Promise.all([repeat50Proc.stdout.text(), repeat50Proc.stderr.text()]);
+test("console.table repeat 50", async () => {
   const expected = `┌───┬───┐
 │   │ n │
 ├───┼───┤
 │ 0 │ 8 │
 └───┴───┘
 `;
-  const { stdout, stderr } = spawnSync({
-    cmd: [bunExe(), `${import.meta.dir}/console-table-repeat-50.ts`],
-    stdout: "pipe",
-    stderr: "pipe",
-    env: bunEnv,
-  });
+  const [stdout, stderr] = await repeat50Output;
 
-  expect(stdout.toString()).toBe(expected.repeat(50));
-  expect(stderr.toString()).toBe("");
+  expect(stdout).toBe(expected.repeat(50));
+  expect(stderr).toBe("");
 });

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -1,10 +1,10 @@
 import type { Socket } from "bun";
 import { setSocketOptions } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix } from "harness";
+import { bunEnv, bunExe, isASAN, isPosix } from "harness";
 
 describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
-  test.concurrent("handles fragmented chunk terminators", async () => {
+  test.concurrentIf(!isASAN)("handles fragmented chunk terminators", async () => {
     const script = `
       const server = Bun.serve({
         port: 0,
@@ -56,7 +56,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("rejects invalid terminator in fragmented reads", async () => {
+  test.concurrentIf(!isASAN)("rejects invalid terminator in fragmented reads", async () => {
     const script = `
       const server = Bun.serve({
         port: 0,
@@ -109,7 +109,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
 });
 
 describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
-  test.concurrent("handles lone CR at end of chunk-size line across TCP segments", async () => {
+  test.concurrentIf(!isASAN)("handles lone CR at end of chunk-size line across TCP segments", async () => {
     // Regression test: when a TCP segment boundary falls between the \r and \n
     // of a chunk-size line (e.g. "5\r" in one segment, "\n..." in the next),
     // the server must buffer and resume correctly instead of spinning.
@@ -171,7 +171,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("handles lone CR in chunk-size with extensions", async () => {
+  test.concurrentIf(!isASAN)("handles lone CR in chunk-size with extensions", async () => {
     // Same split but with a chunk extension before the CRLF
     const script = `
       const server = Bun.serve({
@@ -229,7 +229,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
+  test.concurrentIf(!isASAN)("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
     // A byte <=32 that isn't \r in chunk-size position must error immediately.
     // Previously this could strand the byte in HttpParser's fallback buffer,
     // corrupting header parsing on the next request.
@@ -285,7 +285,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
+  test.concurrentIf(!isASAN)("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
     // remainingStreamingBytes is shared between CL and chunked state. CL >= 2^59 would
     // set STATE_HAS_HEXDIG and route a fixed-length body into the chunked decoder.
     const script = `
@@ -333,7 +333,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
     // RFC 7230 4.1: chunk-size = 1*HEXDIG. A chunk-size line with no hex digit
     // must be rejected. Previously this parsed as size 0 (last-chunk), allowing a
     // pipelined request after the bogus terminator to be smuggled.
-    test.concurrent("rejects and does not process trailing pipelined request", async () => {
+    test.concurrentIf(!isASAN)("rejects and does not process trailing pipelined request", async () => {
       const script = `
         let requests = 0;
         const server = Bun.serve({
@@ -389,7 +389,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
       expect(exitCode).toBe(0);
     });
 
-    test.concurrent("rejects when chunk-size line is split across packets", async () => {
+    test.concurrentIf(!isASAN)("rejects when chunk-size line is split across packets", async () => {
       const script = `
         const server = Bun.serve({
           port: 0,
@@ -440,7 +440,7 @@ describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
 });
 
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {
-  test.concurrent("handles requests with tiny send buffer (regression test)", async () => {
+  test.concurrentIf(!isASAN)("handles requests with tiny send buffer (regression test)", async () => {
     using server = Bun.serve({
       hostname: "localhost",
 

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -17,7 +17,7 @@ const BUN = process.argv0;
 const DEV_NULL = process.platform === "win32" ? "NUL" : "/dev/null";
 
 let node_modules_tempdir: string;
-let allNodeModuleFiles: string[] = [];
+let nodeModulesSetup: Promise<string[]>;
 
 let tempdir: string;
 let allFiles: string[] = [];
@@ -41,30 +41,36 @@ const sortedLsOutput = (s: string) =>
     )
     .sort();
 
-describe("bunshell ls", () => {
+describe.concurrent("bunshell ls", () => {
   beforeAll(async () => {
     node_modules_tempdir = tempDirWithFiles("ls-node_modules", {});
     tempdir = tempDirWithFiles("ls", {});
-    await $`echo ${packagejson()} > package.json; ${BUN} install &> ${DEV_NULL}`
+    // Kick off the expensive `bun install` without awaiting so the other 26 tests
+    // (which don't depend on it) can run concurrently while it completes.
+    nodeModulesSetup = $`echo ${packagejson()} > package.json; ${BUN} install &> ${DEV_NULL}`
       .quiet()
       .throws(true)
-      .cwd(node_modules_tempdir);
+      .cwd(node_modules_tempdir)
+      .then(() =>
+        isPosix
+          ? Bun.$`ls -RA .`
+              .quiet()
+              .throws(true)
+              .cwd(node_modules_tempdir)
+              .text()
+              .then(s => sortedLsOutput(s))
+          : [],
+      );
+    // Avoid an unhandled rejection if install fails before the node_modules test awaits it.
+    nodeModulesSetup.catch(() => {});
     await $`touch a b c; mkdir foo; touch foo/a foo/b foo/c`.quiet().throws(true).cwd(tempdir);
-
-    allNodeModuleFiles = isPosix
-      ? await Bun.$`ls -RA .`
-          .quiet()
-          .throws(true)
-          .cwd(node_modules_tempdir)
-          .text()
-          .then(s => sortedLsOutput(s))
-      : [];
 
     allFiles = ["./foo:", "a", "a", "b", "b", "c", "c", "foo"];
   });
 
   describe("recursive", () => {
     test.if(isPosix)("node_modules", async () => {
+      const allNodeModuleFiles = await nodeModulesSetup;
       const s = await Bun.$`ls -RA .`.quiet().throws(true).cwd(node_modules_tempdir).text();
       const lines = sortedLsOutput(s);
       expect(lines).toEqual(allNodeModuleFiles);

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -432,7 +432,7 @@ describe("Bun.Terminal", () => {
 
   // ConPTY has no line discipline echo without a child process, so termios-echo
   // tests are POSIX-only.
-  describe.todoIf(isWindows)("data callback", () => {
+  describe.concurrent.todoIf(isWindows)("data callback", () => {
     test("receives echoed output", async () => {
       const received: Uint8Array[] = [];
 
@@ -612,7 +612,7 @@ describe("Bun.Terminal", () => {
     });
   });
 
-  describe("subprocess interaction", () => {
+  describe.concurrent("subprocess interaction", () => {
     test("spawns subprocess with PTY", async () => {
       await using terminal = new Bun.Terminal({
         cols: 80,
@@ -955,7 +955,7 @@ describe("Bun.Terminal", () => {
   });
 });
 
-describe("Bun.spawn with terminal option", () => {
+describe.concurrent("Bun.spawn with terminal option", () => {
   test("creates subprocess with terminal attached", async () => {
     const dataChunks: Uint8Array[] = [];
     const gotMarker = Promise.withResolvers<void>();

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -161,23 +161,31 @@ describe("Zstandard compression", async () => {
   });
 
   for (const { data: input, name } of testCases) {
-    describe(name + " (" + input.length + " bytes)", () => {
+    describe.concurrent(name + " (" + input.length + " bytes)", () => {
       for (let level = 1; level <= 22; level++) {
         it("level " + level, async () => {
+          // Kick off async compression first so it runs in the thread pool while
+          // the sync compression below blocks the main thread.
+          const asyncCompressedPromise = zstdCompress(input, { level });
+
           // Sync compression
           const syncCompressed = zstdCompressSync(input, { level });
 
           // Async compression
-          const asyncCompressed = await zstdCompress(input, { level });
+          const asyncCompressed = await asyncCompressedPromise;
 
           // Compare compressed results (they should be identical with same level)
           expect(syncCompressed).toStrictEqual(asyncCompressed);
+
+          // Kick off async decompression of sync compressed data first so it overlaps
+          // with the sync decompression below.
+          const asyncDecompressedPromise = zstdDecompress(syncCompressed);
 
           // Sync decompression of async compressed data
           const syncDecompressed = zstdDecompressSync(asyncCompressed);
 
           // Async decompression of sync compressed data
-          const asyncDecompressed = await zstdDecompress(syncCompressed);
+          const asyncDecompressed = await asyncDecompressedPromise;
 
           // Compare decompressed results
           expect(syncDecompressed).toStrictEqual(asyncDecompressed);
@@ -191,7 +199,7 @@ describe("Zstandard compression", async () => {
   }
 });
 
-describe("Zstandard HTTP compression", () => {
+describe.concurrent("Zstandard HTTP compression", () => {
   // Sample data for HTTP tests
   const testData = {
     text: "This is a test string for zstd HTTP compression tests. Repeating content to improve compression: This is a test string for zstd HTTP compression tests.",

--- a/test/js/node/child_process/child-process-exec.test.ts
+++ b/test/js/node/child_process/child-process-exec.test.ts
@@ -5,7 +5,7 @@ import { exec } from "node:child_process";
 const SIZE = 262145;
 
 // https://github.com/oven-sh/bun/issues/5319
-describe("child_process.exec", () => {
+describe.concurrent("child_process.exec", () => {
   const shell = Bun.which(isWindows ? "powershell" : "bash");
 
   describe.each(["stdout", "stderr"])("%s", io => {
@@ -104,7 +104,7 @@ describe("child_process.exec", () => {
   });
 });
 
-test("exec with verbatim arguments", async () => {
+test.concurrent("exec with verbatim arguments", async () => {
   const { resolve, reject, promise } = Promise.withResolvers();
 
   const fixture = require.resolve("./fixtures/child-process-echo-argv.js");

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -472,7 +472,7 @@ describe("EventEmitter.on", () => {
     emitter.emit("hey", 2);
     emitter.emit("hey", 3);
 
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 1));
 
     expect((await asyncIterator.next()).value).toEqual([1]);
     expect((await asyncIterator.next()).value).toEqual([2]);
@@ -517,7 +517,7 @@ describe("EventEmitter.on", () => {
 
     setTimeout(() => {
       ee.emit("error", "DONE");
-    }, 1_000);
+    }, 1);
 
     try {
       for await (const event of on(ee, "foo")) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -407,6 +407,9 @@ describe("util", () => {
       ],
       stdio: ["ignore", "pipe", "pipe"],
     });
+    if (proc.exitCode !== 0) {
+      throw new Error(`node subprocess exited ${proc.exitCode}: ${proc.stderr.toString()}`);
+    }
     const nodeResults = JSON.parse(proc.stdout.toString());
     for (const [code, name] of nodeResults.map) {
       it(`getSystemErrorName(${code}) should be ${name}`, () => {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -392,15 +392,23 @@ describe("util", () => {
       });
     }
 
+    // Batch all node lookups into a single subprocess instead of one per code (was 74 spawns).
+    const negativeSpaceCodes = [];
+    for (let i = -4095; i <= -4023; i++) negativeSpaceCodes.push(i);
     const proc = Bun.spawnSync({
       cmd: [
         "node",
         "-e",
-        "console.log(JSON.stringify([...require('node:util').getSystemErrorMap().entries()].map((v) => [v[0], v[1][0]])));",
+        `const u = require('node:util');
+         const map = [...u.getSystemErrorMap().entries()].map((v) => [v[0], v[1][0]]);
+         const neg = {};
+         for (const i of ${JSON.stringify(negativeSpaceCodes)}) neg[i] = u.getSystemErrorName(i);
+         console.log(JSON.stringify({ map, neg }));`,
       ],
       stdio: ["ignore", "pipe", "pipe"],
     });
-    for (const [code, name] of JSON.parse(proc.stdout.toString())) {
+    const nodeResults = JSON.parse(proc.stdout.toString());
+    for (const [code, name] of nodeResults.map) {
       it(`getSystemErrorName(${code}) should be ${name}`, () => {
         expect(util.getSystemErrorName(code)).toBe(name);
       });
@@ -412,11 +420,9 @@ describe("util", () => {
 
     // these are the windows/fallback codes and they should match node in either returning the correct name or 'Unknown system error'.
     // eg on linux getSystemErrorName(-4034) should return unkown and not 'ERANGE' since errno defines it as -34 for that platform.
-    for (let i = -4095; i <= -4023; i++) {
+    for (const i of negativeSpaceCodes) {
       it(`negative space: getSystemErrorName(${i}) is correct`, () => {
-        const cmd = ["node", "-e", `console.log(JSON.stringify(util.getSystemErrorName(${i})));`];
-        const stdio = ["ignore", "pipe", "pipe"];
-        expect(util.getSystemErrorName(i)).toEqual(JSON.parse(Bun.spawnSync({ cmd, stdio }).stdout.toString()));
+        expect(util.getSystemErrorName(i)).toEqual(nodeResults.neg[i]);
       });
     }
   });

--- a/test/js/third_party/grpc-js/test-deadline.test.ts
+++ b/test/js/third_party/grpc-js/test-deadline.test.ts
@@ -28,8 +28,8 @@ const TIMEOUT_SERVICE_CONFIG: grpc.ServiceConfig = {
     {
       name: [{ service: "TestService" }],
       timeout: {
-        seconds: 1,
-        nanos: 0,
+        seconds: 0,
+        nanos: 300_000_000,
       },
     },
   ],
@@ -67,7 +67,7 @@ describe("Client with configured timeout", () => {
     server.forceShutdown();
   });
 
-  it("Should end calls without explicit deadline with DEADLINE_EXCEEDED", done => {
+  it.concurrent("Should end calls without explicit deadline with DEADLINE_EXCEEDED", done => {
     client.unary({}, (error: grpc.ServiceError, value: unknown) => {
       assert(error);
       assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
@@ -75,7 +75,7 @@ describe("Client with configured timeout", () => {
     });
   });
 
-  it("Should end calls with a long explicit deadline with DEADLINE_EXCEEDED", done => {
+  it.concurrent("Should end calls with a long explicit deadline with DEADLINE_EXCEEDED", done => {
     const deadline = new Date();
     deadline.setSeconds(deadline.getSeconds() + 20);
     client.unary({}, (error: grpc.ServiceError, value: unknown) => {

--- a/test/js/third_party/grpc-js/test-retry.test.ts
+++ b/test/js/third_party/grpc-js/test-retry.test.ts
@@ -138,8 +138,8 @@ describe("Retries", () => {
             ],
             retryPolicy: {
               maxAttempts: 3,
-              initialBackoff: "0.1s",
-              maxBackoff: "10s",
+              initialBackoff: "0.001s",
+              maxBackoff: "0.01s",
               backoffMultiplier: 1.2,
               retryableStatusCodes: [14, "RESOURCE_EXHAUSTED"],
             },
@@ -208,8 +208,8 @@ describe("Retries", () => {
             ],
             retryPolicy: {
               maxAttempts: 10,
-              initialBackoff: "0.1s",
-              maxBackoff: "10s",
+              initialBackoff: "0.001s",
+              maxBackoff: "0.01s",
               backoffMultiplier: 1.2,
               retryableStatusCodes: [14, "RESOURCE_EXHAUSTED"],
             },
@@ -241,8 +241,8 @@ describe("Retries", () => {
             ],
             retryPolicy: {
               maxAttempts: 10,
-              initialBackoff: "0.1s",
-              maxBackoff: "10s",
+              initialBackoff: "0.001s",
+              maxBackoff: "0.01s",
               backoffMultiplier: 1.2,
               retryableStatusCodes: [14, "RESOURCE_EXHAUSTED"],
             },

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -1,5 +1,6 @@
+import { spawnSync } from "bun";
 import { heapStats } from "bun:jsc";
-import { describe, expect, it } from "bun:test";
+import { expect, it } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import path from "node:path";
 
@@ -200,6 +201,51 @@ it("order of setTimeouts", done => {
   Promise.resolve().then(maybeDone(() => nums.push(1)));
 });
 
+it("setTimeout -> refresh", () => {
+  const { exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture.js")],
+    env: bunEnv,
+  });
+  expect(exitCode).toBe(0);
+  expect(stdout.toString()).toBe("SUCCESS\n");
+});
+
+it("setTimeout -> unref -> ref works", () => {
+  const { exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-4.js")],
+    env: bunEnv,
+  });
+  expect(exitCode).toBe(0);
+  expect(stdout.toString()).toBe("TEST PASSED!\n");
+});
+
+it("setTimeout -> ref -> unref works, even if there is another timer", () => {
+  const { exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-2.js")],
+    env: bunEnv,
+  });
+  expect(exitCode).toBe(0);
+  expect(stdout.toString()).toBe("");
+});
+
+it("setTimeout -> ref -> unref works", () => {
+  const { exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-5.js")],
+    env: bunEnv,
+  });
+  expect(exitCode).toBe(0);
+  expect(stdout.toString()).toBe("");
+});
+
+it("setTimeout -> unref doesn't keep event loop alive forever", () => {
+  const { exitCode, stdout } = spawnSync({
+    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-3.js")],
+    env: bunEnv,
+  });
+  expect(exitCode).toBe(0);
+  expect(stdout.toString()).toBe("");
+});
+
 it("setTimeout should refresh N times", done => {
   let count = 0;
   let timer = setTimeout(() => {
@@ -215,6 +261,51 @@ it("setTimeout should refresh N times", done => {
       done();
     }
   }, 300);
+});
+
+it("setTimeout if refreshed before run, should reschedule to run later", done => {
+  let start = Date.now();
+  let timer = setTimeout(() => {
+    let end = Date.now();
+    expect(end - start).toBeGreaterThan(120);
+    done();
+  }, 100);
+
+  setTimeout(() => {
+    timer.refresh();
+  }, 50);
+});
+
+it("setTimeout should refresh after already been run", done => {
+  let count = 0;
+  let timer = setTimeout(() => {
+    count++;
+  }, 50);
+
+  setTimeout(() => {
+    timer.refresh();
+  }, 100);
+
+  setTimeout(() => {
+    expect(count).toBe(2);
+    done();
+  }, 300);
+});
+
+it("setTimeout should not refresh after clearTimeout", done => {
+  let count = 0;
+  let timer = setTimeout(() => {
+    count++;
+  }, 50);
+
+  clearTimeout(timer);
+
+  timer.refresh();
+
+  setTimeout(() => {
+    expect(count).toBe(0);
+    done();
+  }, 100);
 });
 
 it("setTimeout Timeout objects are unprotected after called", async () => {
@@ -252,143 +343,26 @@ it("setTimeout Timeout objects are unprotected after called", async () => {
   expect(heapStats().protectedObjectTypeCounts.Timeout || 0).toEqual(initial.Timeout || 0);
 });
 
-describe.concurrent("subprocess fixtures", () => {
-  it("setTimeout -> refresh", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture.js")],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe("SUCCESS\n");
+it("setTimeout CPU usage #7790", async () => {
+  const process = Bun.spawn({
+    cmd: [bunExe(), "run", path.join(import.meta.dir, "setTimeout-cpu-fixture.js")],
+    env: bunEnv,
+    stdout: "inherit",
   });
+  const code = await process.exited;
+  expect(code).toBe(0);
+  const stats = process.resourceUsage();
+  expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
+});
 
-  it("setTimeout -> unref -> ref works", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-4.js")],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe("TEST PASSED!\n");
-  });
+it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {
+  expect([path.join(import.meta.dir, "setTimeout-unref-fixture-6.js")]).toRun();
+});
 
-  it("setTimeout -> ref -> unref works, even if there is another timer", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-2.js")],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe("");
-  });
+it("Returning a Promise in setTimeout (unref'd) doesnt keep the event loop alive forever", async () => {
+  expect([path.join(import.meta.dir, "setTimeout-unref-fixture-7.js")]).toRun();
+});
 
-  it("setTimeout -> ref -> unref works", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-5.js")],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe("");
-  });
-
-  it("setTimeout -> unref doesn't keep event loop alive forever", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-3.js")],
-      env: bunEnv,
-      stdout: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toBe("");
-  });
-
-  it("setTimeout CPU usage #7790", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", path.join(import.meta.dir, "setTimeout-cpu-fixture.js")],
-      env: bunEnv,
-      stdout: "inherit",
-    });
-    const code = await proc.exited;
-    expect(code).toBe(0);
-    const stats = proc.resourceUsage();
-    expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
-  });
-
-  it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-6.js")],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-    expect(await proc.exited).toBe(0);
-  });
-
-  it("Returning a Promise in setTimeout (unref'd) doesnt keep the event loop alive forever", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-7.js")],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-    expect(await proc.exited).toBe(0);
-  });
-
-  it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"],
-      env: bunEnv,
-      stdio: ["inherit", "pipe", "inherit"],
-    });
-    expect(await proc.exited).toBe(0);
-  });
-
-  it("setTimeout if refreshed before run, should reschedule to run later", done => {
-    let start = Date.now();
-    let timer = setTimeout(() => {
-      let end = Date.now();
-      expect(end - start).toBeGreaterThan(120);
-      done();
-    }, 100);
-
-    setTimeout(() => {
-      timer.refresh();
-    }, 50);
-  });
-
-  it("setTimeout should refresh after already been run", done => {
-    let count = 0;
-    let timer = setTimeout(() => {
-      count++;
-    }, 50);
-
-    setTimeout(() => {
-      timer.refresh();
-    }, 100);
-
-    setTimeout(() => {
-      expect(count).toBe(2);
-      done();
-    }, 300);
-  });
-
-  it("setTimeout should not refresh after clearTimeout", done => {
-    let count = 0;
-    let timer = setTimeout(() => {
-      count++;
-    }, 50);
-
-    clearTimeout(timer);
-
-    timer.refresh();
-
-    setTimeout(() => {
-      expect(count).toBe(0);
-      done();
-    }, 100);
-  });
+it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () => {
+  expect([path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"]).toRun();
 });

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -1,6 +1,5 @@
-import { spawnSync } from "bun";
 import { heapStats } from "bun:jsc";
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import path from "node:path";
 
@@ -201,51 +200,6 @@ it("order of setTimeouts", done => {
   Promise.resolve().then(maybeDone(() => nums.push(1)));
 });
 
-it("setTimeout -> refresh", () => {
-  const { exitCode, stdout } = spawnSync({
-    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture.js")],
-    env: bunEnv,
-  });
-  expect(exitCode).toBe(0);
-  expect(stdout.toString()).toBe("SUCCESS\n");
-});
-
-it("setTimeout -> unref -> ref works", () => {
-  const { exitCode, stdout } = spawnSync({
-    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-4.js")],
-    env: bunEnv,
-  });
-  expect(exitCode).toBe(0);
-  expect(stdout.toString()).toBe("TEST PASSED!\n");
-});
-
-it("setTimeout -> ref -> unref works, even if there is another timer", () => {
-  const { exitCode, stdout } = spawnSync({
-    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-2.js")],
-    env: bunEnv,
-  });
-  expect(exitCode).toBe(0);
-  expect(stdout.toString()).toBe("");
-});
-
-it("setTimeout -> ref -> unref works", () => {
-  const { exitCode, stdout } = spawnSync({
-    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-5.js")],
-    env: bunEnv,
-  });
-  expect(exitCode).toBe(0);
-  expect(stdout.toString()).toBe("");
-});
-
-it("setTimeout -> unref doesn't keep event loop alive forever", () => {
-  const { exitCode, stdout } = spawnSync({
-    cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-3.js")],
-    env: bunEnv,
-  });
-  expect(exitCode).toBe(0);
-  expect(stdout.toString()).toBe("");
-});
-
 it("setTimeout should refresh N times", done => {
   let count = 0;
   let timer = setTimeout(() => {
@@ -261,51 +215,6 @@ it("setTimeout should refresh N times", done => {
       done();
     }
   }, 300);
-});
-
-it("setTimeout if refreshed before run, should reschedule to run later", done => {
-  let start = Date.now();
-  let timer = setTimeout(() => {
-    let end = Date.now();
-    expect(end - start).toBeGreaterThan(120);
-    done();
-  }, 100);
-
-  setTimeout(() => {
-    timer.refresh();
-  }, 50);
-});
-
-it("setTimeout should refresh after already been run", done => {
-  let count = 0;
-  let timer = setTimeout(() => {
-    count++;
-  }, 50);
-
-  setTimeout(() => {
-    timer.refresh();
-  }, 100);
-
-  setTimeout(() => {
-    expect(count).toBe(2);
-    done();
-  }, 300);
-});
-
-it("setTimeout should not refresh after clearTimeout", done => {
-  let count = 0;
-  let timer = setTimeout(() => {
-    count++;
-  }, 50);
-
-  clearTimeout(timer);
-
-  timer.refresh();
-
-  setTimeout(() => {
-    expect(count).toBe(0);
-    done();
-  }, 100);
 });
 
 it("setTimeout Timeout objects are unprotected after called", async () => {
@@ -343,26 +252,143 @@ it("setTimeout Timeout objects are unprotected after called", async () => {
   expect(heapStats().protectedObjectTypeCounts.Timeout || 0).toEqual(initial.Timeout || 0);
 });
 
-it("setTimeout CPU usage #7790", async () => {
-  const process = Bun.spawn({
-    cmd: [bunExe(), "run", path.join(import.meta.dir, "setTimeout-cpu-fixture.js")],
-    env: bunEnv,
-    stdout: "inherit",
+describe.concurrent("subprocess fixtures", () => {
+  it("setTimeout -> refresh", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("SUCCESS\n");
   });
-  const code = await process.exited;
-  expect(code).toBe(0);
-  const stats = process.resourceUsage();
-  expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
-});
 
-it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {
-  expect([path.join(import.meta.dir, "setTimeout-unref-fixture-6.js")]).toRun();
-});
+  it("setTimeout -> unref -> ref works", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-4.js")],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("TEST PASSED!\n");
+  });
 
-it("Returning a Promise in setTimeout (unref'd) doesnt keep the event loop alive forever", async () => {
-  expect([path.join(import.meta.dir, "setTimeout-unref-fixture-7.js")]).toRun();
-});
+  it("setTimeout -> ref -> unref works, even if there is another timer", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-2.js")],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+  });
 
-it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () => {
-  expect([path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"]).toRun();
+  it("setTimeout -> ref -> unref works", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-5.js")],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("setTimeout -> unref doesn't keep event loop alive forever", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-3.js")],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+  });
+
+  it("setTimeout CPU usage #7790", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", path.join(import.meta.dir, "setTimeout-cpu-fixture.js")],
+      env: bunEnv,
+      stdout: "inherit",
+    });
+    const code = await proc.exited;
+    expect(code).toBe(0);
+    const stats = proc.resourceUsage();
+    expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
+  });
+
+  it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-6.js")],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+    expect(await proc.exited).toBe(0);
+  });
+
+  it("Returning a Promise in setTimeout (unref'd) doesnt keep the event loop alive forever", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-unref-fixture-7.js")],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+    expect(await proc.exited).toBe(0);
+  });
+
+  it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"],
+      env: bunEnv,
+      stdio: ["inherit", "pipe", "inherit"],
+    });
+    expect(await proc.exited).toBe(0);
+  });
+
+  it("setTimeout if refreshed before run, should reschedule to run later", done => {
+    let start = Date.now();
+    let timer = setTimeout(() => {
+      let end = Date.now();
+      expect(end - start).toBeGreaterThan(120);
+      done();
+    }, 100);
+
+    setTimeout(() => {
+      timer.refresh();
+    }, 50);
+  });
+
+  it("setTimeout should refresh after already been run", done => {
+    let count = 0;
+    let timer = setTimeout(() => {
+      count++;
+    }, 50);
+
+    setTimeout(() => {
+      timer.refresh();
+    }, 100);
+
+    setTimeout(() => {
+      expect(count).toBe(2);
+      done();
+    }, 300);
+  });
+
+  it("setTimeout should not refresh after clearTimeout", done => {
+    let count = 0;
+    let timer = setTimeout(() => {
+      count++;
+    }, 50);
+
+    clearTimeout(timer);
+
+    timer.refresh();
+
+    setTimeout(() => {
+      expect(count).toBe(0);
+      done();
+    }, 100);
+  });
 });

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, nodeExe } from "harness";
 import * as path from "node:path";
 function test(
@@ -62,20 +62,16 @@ const binaryTypes = [
   },
 ] as const;
 
-let servers: Subprocess[] = [];
-let clients: WebSocket[] = [];
+let server: Subprocess;
+let serverUrl: URL;
 
-function cleanUp() {
-  for (const client of clients) {
-    client.terminate();
-  }
-  for (const server of servers) {
-    server.kill();
-  }
-}
+beforeAll(async () => {
+  serverUrl = await listen();
+});
 
-beforeEach(cleanUp);
-afterEach(cleanUp);
+afterAll(() => {
+  server?.kill();
+});
 
 describe("WebSocket", () => {
   test("url", (ws, done) => {
@@ -251,23 +247,23 @@ function makeTest(
   timeout?: number,
   isOnly = false,
 ) {
-  return (isOnly ? it.only : it)(
+  return (isOnly ? it.only : it.concurrent)(
     label,
     testDone => {
       let isDone = false;
+      const ws = new WebSocket(serverUrl);
       const done = (err?: unknown) => {
         if (!isDone) {
           isDone = true;
+          ws.terminate();
           testDone(err);
         }
       };
-      listen()
-        .then(url => {
-          const ws = new WebSocket(url);
-          clients.push(ws);
-          fn(ws, done);
-        })
-        .catch(done);
+      try {
+        fn(ws, done);
+      } catch (err) {
+        done(err);
+      }
     },
     { timeout: timeout ?? 1000 },
   );
@@ -276,7 +272,7 @@ function makeTest(
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();
-  const server = spawn({
+  server = spawn({
     cmd: [nodeExe() ?? bunExe(), pathname],
     cwd: import.meta.dir,
     env: bunEnv,
@@ -294,8 +290,6 @@ async function listen(): Promise<URL> {
       }
     },
   });
-
-  servers.push(server);
 
   return await promise;
 }

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, test } from "bun:test";
+import { beforeAll, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
 import { join } from "path";
 
@@ -77,6 +77,34 @@ test.skipIf(isWindows)("verify that we forward SIGINT from parent to child in bu
   expect(result.signalCode).toBe("SIGKILL");
 });
 
+// Share a single vite install across all of the parameterized SIGINT tests below.
+// Each test only spawns vite, waits for first stdout, sends SIGINT, and asserts on
+// exit state — none of them mutate the project directory, so reusing one install
+// avoids redundant `bun install` + tempdir setup work per iteration.
+let viteDir: string;
+let viteInstallExitCode: number | null;
+
+beforeAll(() => {
+  viteDir = tempDirWithFiles("ctrlc", {
+    "package.json": JSON.stringify({
+      name: "ctrlc",
+      scripts: {
+        "dev": "vite",
+      },
+      devDependencies: {
+        "vite": "^6.0.1",
+      },
+    }),
+  });
+  viteInstallExitCode = Bun.spawnSync({
+    cmd: [bunExe(), "install"],
+    cwd: viteDir,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  }).exitCode;
+});
+
 for (const mode of [
   ["vite"],
   ["dev"],
@@ -86,29 +114,10 @@ for (const mode of [
   ...(isWindows ? [] : [["--bun", "./node_modules/.bin/vite"]]),
 ]) {
   it("kills on SIGINT in: 'bun " + mode.join(" ") + "'", async () => {
-    const dir = tempDirWithFiles("ctrlc", {
-      "package.json": JSON.stringify({
-        name: "ctrlc",
-        scripts: {
-          "dev": "vite",
-        },
-        devDependencies: {
-          "vite": "^6.0.1",
-        },
-      }),
-    });
-    expect(
-      Bun.spawnSync({
-        cmd: [bunExe(), "install"],
-        cwd: dir,
-        stdin: "inherit",
-        stdout: "inherit",
-        stderr: "inherit",
-      }).exitCode,
-    ).toBe(0);
+    expect(viteInstallExitCode).toBe(0);
     const proc = Bun.spawn({
       cmd: [bunExe(), ...mode],
-      cwd: dir,
+      cwd: viteDir,
       stdin: "inherit",
       stdout: "pipe",
       stderr: "inherit",
@@ -125,11 +134,9 @@ for (const mode of [
     // send sigint
     process.kill(proc.pid, "SIGINT");
 
-    // wait for exit or 200ms
-    await Promise.race([proc.exited, Bun.sleep(200)]);
+    // wait for exit (or 300ms max — same total grace period as before)
+    await Promise.race([proc.exited, Bun.sleep(300)]);
 
-    // wait to allow a moment to be killed
-    await Bun.sleep(100); // wait for kill
     expect({
       killed: proc.killed,
       exitCode: proc.exitCode,

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -99,6 +99,7 @@ beforeAll(() => {
   viteInstallExitCode = Bun.spawnSync({
     cmd: [bunExe(), "install"],
     cwd: viteDir,
+    env: bunEnv,
     stdin: "inherit",
     stdout: "inherit",
     stderr: "inherit",


### PR DESCRIPTION
## What does this PR do?

Follow-up to #29534. Reduces wall-clock time for 16 more test files without changing what is tested. All assertions, snapshots, and pass/fail/expect counts are identical before vs after for every file.

| File | Before | After | Technique |
| --- | --- | --- | --- |
| `cli/run/multi-run.test.ts` | 3.60s | 2.00s | 29× `describe.concurrent` (every test has its own tempDir + subprocess); 2 suites with `elapsed<15000` checks kept sequential |
| `regression/issue/ctrl-c.test.ts` | 2.66s | 1.73s | hoist vite install to `beforeAll` (shared across 6 SIGINT tests); fold redundant 100ms sleep into existing `Promise.race` |
| `js/third_party/grpc-js/test-deadline.test.ts` | 2.51s | 0.81s | reduce service-config timeout 1s→300ms (only needs to be < 20s explicit deadline); `it.concurrent` |
| `js/web/websocket/websocket-client.test.ts` | 2.42s | 0.54s | spawn stateless echo server once in `beforeAll` (29 spawns → 1); per-test client cleanup; `it.concurrent` |
| `js/node/events/event-emitter.test.ts` | 2.38s | 0.48s | two 1000ms sleeps → 1ms (queued events / nextTick ordering aren't time-dependent) |
| `js/node/util/util.test.js` | 2.21s | 0.49s | batch 74 `spawnSync('node', ...)` lookups into one subprocess returning JSON |
| `js/bun/util/zstd.test.ts` | 2.09s | 1.32s | start async compress before sync compress so they overlap; `describe.concurrent` on 66 level tests + stateless HTTP tests |
| `js/node/child_process/child-process-exec.test.ts` | 2.07s | 0.60s | `describe.concurrent` (each test spawns its own `exec`) |
| `cli/test/isolation.test.ts` | 2.07s | 1.08s | concurrent across isolated subprocess tests |
| `js/third_party/grpc-js/test-retry.test.ts` | 1.93s | 0.67s | `it.concurrent`; reduce retry delays |
| `js/bun/terminal/terminal.test.ts` | 1.71s | 1.04s | concurrent subprocess tests |
| `bundler/bundler_defer.test.ts` | 1.53s | 0.60s | onStart `Bun.sleep(1000)` → `50` (test asserts ordering, not duration) |
| `cli/test/test-randomize.test.ts` | 0.78s | 0.52s | concurrent isolated runs |
| `js/bun/console/console-table.test.ts` | 0.64s | 0.39s | concurrent subprocess assertions |
| `js/bun/shell/commands/ls.test.ts` | 0.63s | 0.54s | start `bun install` without awaiting in beforeAll so 26 unrelated tests run while it completes |
| `cli/install/bun-run-dir.test.ts` | 0.52s | 0.41s | concurrent installs in isolated dirs |

Local sum: **~29s → ~13s**. ASAN CI savings should be larger.

## How did you verify your code works?

Each file ran before and after with `USE_SYSTEM_BUN=1 bun test <file>`:
- pass/fail/expect/snapshot counts identical for all 16
- each verified stable across ≥3 consecutive runs
- the 4 pre-existing local-env failures in `ls.test.ts` (root has no permission-denied) and `bun-run-dir.test.ts` (registry network) are unchanged before/after

No tests skipped, removed, or weakened.