### PR TITLE
fix(windows): fall back to UNKNOWN for unmapped libuv error codes in translateUVErrorToE

### DIFF
--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -2844,7 +2844,10 @@ pub fn translateUVErrorToE(code_in: anytype) bun.sys.E {
         UV_ECHARSET => bun.sys.E.CHARSET,
         UV_EOF => bun.sys.E.EOF,
         UV_UNKNOWN => bun.sys.E.UNKNOWN,
-        else => @enumFromInt(-code),
+        // libuv can return codes not explicitly mapped above (e.g. Windows-specific
+        // codes in the -4000s). `bun.sys.E` is exhaustive, so a strict @enumFromInt
+        // on an unmapped value panics in safe builds. Fall back to UNKNOWN instead.
+        else => std.meta.intToEnum(bun.sys.E, -code) catch bun.sys.E.UNKNOWN,
     };
 }
 

--- a/src/deps/libuv.zig
+++ b/src/deps/libuv.zig
@@ -2847,7 +2847,8 @@ pub fn translateUVErrorToE(code_in: anytype) bun.sys.E {
         // libuv can return codes not explicitly mapped above (e.g. Windows-specific
         // codes in the -4000s). `bun.sys.E` is exhaustive, so a strict @enumFromInt
         // on an unmapped value panics in safe builds. Fall back to UNKNOWN instead.
-        else => std.meta.intToEnum(bun.sys.E, -code) catch bun.sys.E.UNKNOWN,
+        // Wrapping negation so minInt(c_int) maps to UNKNOWN instead of overflowing.
+        else => std.meta.intToEnum(bun.sys.E, -%code) catch bun.sys.E.UNKNOWN,
     };
 }
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -241,9 +241,6 @@ export const hostedGitInfo = {
   fromUrl: $newZigFunction("hosted_git_info.zig", "TestingAPIs.jsFromUrl", 1),
 };
 
-// Windows-only: map a libuv error code to a `bun.sys.E` tag name. Returns
-// `undefined` on other platforms. Used to verify out-of-range codes fall back
-// to UNKNOWN instead of panicking.
 export const translateUVErrorToE: (code: number) => string | undefined = $newZigFunction(
   "sys.zig",
   "TestingAPIs.translateUVErrorToE",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -240,3 +240,12 @@ export const hostedGitInfo = {
   parseUrl: $newZigFunction("hosted_git_info.zig", "TestingAPIs.jsParseUrl", 1),
   fromUrl: $newZigFunction("hosted_git_info.zig", "TestingAPIs.jsFromUrl", 1),
 };
+
+// Windows-only: map a libuv error code to a `bun.sys.E` tag name. Returns
+// `undefined` on other platforms. Used to verify out-of-range codes fall back
+// to UNKNOWN instead of panicking.
+export const translateUVErrorToE: (code: number) => string | undefined = $newZigFunction(
+  "sys.zig",
+  "TestingAPIs.translateUVErrorToE",
+  1,
+);

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -4476,6 +4476,24 @@ pub const umask = switch (Environment.os) {
     .windows => @extern(*const fn (mode: u16) callconv(.c) u16, .{ .name = "_umask" }),
 };
 
+pub const TestingAPIs = struct {
+    /// Exposes libuv -> `bun.sys.E` error-code translation for tests so we can
+    /// feed out-of-range negative values and verify it does not panic.
+    /// Windows-only because `translateUVErrorToE` lives in the libuv bindings.
+    pub fn translateUVErrorToE(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        const arguments = callframe.arguments();
+        if (arguments.len < 1 or !arguments[0].isNumber()) {
+            return globalThis.throw("translateUVErrorToE: expected 1 number argument", .{});
+        }
+        if (comptime !Environment.isWindows) {
+            return .js_undefined;
+        }
+        const code: c_int = @intFromFloat(arguments[0].asNumber());
+        const result = bun.windows.libuv.translateUVErrorToE(code);
+        return bun.String.createUTF8ForJS(globalThis, @tagName(result));
+    }
+};
+
 pub const File = @import("./sys/File.zig");
 
 const builtin = @import("builtin");

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -4487,7 +4487,7 @@ pub const TestingAPIs = struct {
         if (comptime !Environment.isWindows) {
             return .js_undefined;
         }
-        const code: c_int = @intFromFloat(arguments[0].asNumber());
+        const code: c_int = arguments[0].toInt32();
         const result = bun.windows.libuv.translateUVErrorToE(code);
         return bun.String.createUTF8ForJS(globalThis, @tagName(result));
     }

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -4477,9 +4477,8 @@ pub const umask = switch (Environment.os) {
 };
 
 pub const TestingAPIs = struct {
-    /// Exposes libuv -> `bun.sys.E` error-code translation for tests so we can
-    /// feed out-of-range negative values and verify it does not panic.
-    /// Windows-only because `translateUVErrorToE` lives in the libuv bindings.
+    /// Exposes libuv -> `bun.sys.E` translation so tests can feed out-of-range
+    /// negative values and verify it does not panic. Windows-only.
     pub fn translateUVErrorToE(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
         const arguments = callframe.arguments();
         if (arguments.len < 1 or !arguments[0].isNumber()) {

--- a/test/js/node/fs/translate-uv-error-windows.test.ts
+++ b/test/js/node/fs/translate-uv-error-windows.test.ts
@@ -1,0 +1,35 @@
+// On Windows, libuv fs calls (uv_fs_read etc.) can surface negative error codes
+// that are not explicitly listed in translateUVErrorToE's switch. The fallback
+// arm used @enumFromInt(-code) on the exhaustive `bun.sys.E` enum, which panics
+// with "invalid enum value" in safe builds for any code that isn't a named tag.
+// Windows release builds are ReleaseSafe, so this panicked in the wild via
+// fs.readFile -> sys_uv.preadv -> ReturnCodeI64.errEnum -> translateUVErrorToE.
+//
+// This test feeds out-of-range codes directly and asserts we get UNKNOWN
+// instead of a crash.
+
+import { translateUVErrorToE } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { isWindows } from "harness";
+
+test.skipIf(!isWindows)("translateUVErrorToE falls back to UNKNOWN for unmapped libuv codes", () => {
+  // Sanity: known mappings still work.
+  expect(translateUVErrorToE(-4058)).toBe("NOENT"); // UV_ENOENT
+  expect(translateUVErrorToE(-4083)).toBe("BADF"); // UV_EBADF
+  expect(translateUVErrorToE(-4094)).toBe("UNKNOWN"); // UV_UNKNOWN
+
+  // Out-of-range / unmapped codes must not panic; they fall back to UNKNOWN.
+  // -4021 is one past UV_ENOEXEC (-4022), the lowest-magnitude UV_E* constant
+  // on Windows, so nothing maps there.
+  expect(translateUVErrorToE(-4021)).toBe("UNKNOWN");
+  // -4097 is one past UV_ERRNO_MAX (-4096).
+  expect(translateUVErrorToE(-4097)).toBe("UNKNOWN");
+  // Gap inside the -4000s that no UV_E* constant occupies.
+  expect(translateUVErrorToE(-4000)).toBe("UNKNOWN");
+  // A value whose negation is well outside u16 range.
+  expect(translateUVErrorToE(-123456)).toBe("UNKNOWN");
+});
+
+test.skipIf(isWindows)("translateUVErrorToE is a no-op off Windows", () => {
+  expect(translateUVErrorToE(-4058)).toBeUndefined();
+});

--- a/test/js/node/fs/translate-uv-error-windows.test.ts
+++ b/test/js/node/fs/translate-uv-error-windows.test.ts
@@ -20,6 +20,7 @@ test.skipIf(!isWindows)("translateUVErrorToE falls back to UNKNOWN for unmapped 
   expect(translateUVErrorToE(-4097)).toBe("UNKNOWN"); // one past UV_ERRNO_MAX (-4096)
   expect(translateUVErrorToE(-4000)).toBe("UNKNOWN"); // gap no UV_E* constant occupies
   expect(translateUVErrorToE(-123456)).toBe("UNKNOWN"); // negation outside u16 range
+  expect(translateUVErrorToE(-2147483648)).toBe("UNKNOWN"); // INT_MIN: wrapping negation, no overflow
 });
 
 test.skipIf(isWindows)("translateUVErrorToE is a no-op off Windows", () => {

--- a/test/js/node/fs/translate-uv-error-windows.test.ts
+++ b/test/js/node/fs/translate-uv-error-windows.test.ts
@@ -4,9 +4,6 @@
 // with "invalid enum value" in safe builds for any code that isn't a named tag.
 // Windows release builds are ReleaseSafe, so this panicked in the wild via
 // fs.readFile -> sys_uv.preadv -> ReturnCodeI64.errEnum -> translateUVErrorToE.
-//
-// This test feeds out-of-range codes directly and asserts we get UNKNOWN
-// instead of a crash.
 
 import { translateUVErrorToE } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
@@ -18,16 +15,11 @@ test.skipIf(!isWindows)("translateUVErrorToE falls back to UNKNOWN for unmapped 
   expect(translateUVErrorToE(-4083)).toBe("BADF"); // UV_EBADF
   expect(translateUVErrorToE(-4094)).toBe("UNKNOWN"); // UV_UNKNOWN
 
-  // Out-of-range / unmapped codes must not panic; they fall back to UNKNOWN.
-  // -4021 is one past UV_ENOEXEC (-4022), the lowest-magnitude UV_E* constant
-  // on Windows, so nothing maps there.
-  expect(translateUVErrorToE(-4021)).toBe("UNKNOWN");
-  // -4097 is one past UV_ERRNO_MAX (-4096).
-  expect(translateUVErrorToE(-4097)).toBe("UNKNOWN");
-  // Gap inside the -4000s that no UV_E* constant occupies.
-  expect(translateUVErrorToE(-4000)).toBe("UNKNOWN");
-  // A value whose negation is well outside u16 range.
-  expect(translateUVErrorToE(-123456)).toBe("UNKNOWN");
+  // Unmapped codes must not panic; they fall back to UNKNOWN.
+  expect(translateUVErrorToE(-4021)).toBe("UNKNOWN"); // one past UV_ENOEXEC (-4022)
+  expect(translateUVErrorToE(-4097)).toBe("UNKNOWN"); // one past UV_ERRNO_MAX (-4096)
+  expect(translateUVErrorToE(-4000)).toBe("UNKNOWN"); // gap no UV_E* constant occupies
+  expect(translateUVErrorToE(-123456)).toBe("UNKNOWN"); // negation outside u16 range
 });
 
 test.skipIf(isWindows)("translateUVErrorToE is a no-op off Windows", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only `Panic: invalid enum value` in `translateUVErrorToE`.

### Stack
```
Panic: invalid enum value
translateUVErrorToE  src/deps/libuv.zig:2843
errEnum              src/deps/libuv.zig:3013
preadv               src/sys_uv.zig:340
readv                src/sys_uv.zig:422
read                 src/sys_uv.zig:465
readFileWithOptions  src/bun.js/node/node_fs.zig:5092
readFile             src/bun.js/node/node_fs.zig:4975
workPoolCallback     src/bun.js/node/node_fs.zig:380
```

### Cause
`uv_fs_read` can surface a negative error code that is not one of the explicit `UV_E*` switch arms in `translateUVErrorToE`. The `else` arm negates the code and does `@enumFromInt(-code)` into `bun.sys.E`, which on Windows is an **exhaustive** `u16` enum. Any negated value that is not a named tag (e.g. the gaps around `-4085..-4087`, anything outside `-4022..-4096` / `-3000..-3014`, or a value whose negation overflows `u16`) panics in safe builds — and Windows release is ReleaseSafe. This started surfacing after `preadv` in `sys_uv.zig` was changed to read `req.result` directly.

`ReturnCodeI64.errEnum` routes through the same function, so it is fixed by the same change.

### Fix
Replace the strict cast with `std.meta.intToEnum(bun.sys.E, -code) catch bun.sys.E.UNKNOWN` so any unmapped code degrades to `UNKNOWN` instead of aborting the process.

### How did you verify your code works?
- `bun run zig:check-all` — compiles on every target, Windows debug + release included.
- Added `translateUVErrorToE` to `bun:internal-for-testing` (no-op off Windows) and a test at `test/js/node/fs/translate-uv-error-windows.test.ts` that:
  - sanity-checks known mappings (`UV_ENOENT` → `NOENT`, `UV_EBADF` → `BADF`),
  - feeds out-of-range codes (`-4021`, `-4097`, `-4000`, `-123456`) that previously panicked and asserts they now return `"UNKNOWN"`.
