### PR TITLE
build: skip libuv compilation on POSIX

### DIFF
--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -3,11 +3,12 @@
  * event loop and file I/O (Windows' IOCP model needs a proper abstraction
  * layer). On unix, bun's event loop is custom (kqueue/epoll direct).
  *
- * Built everywhere despite being windows-only at runtime, because node-api
- * addons may reference libuv symbols and expect them to link.
+ * On POSIX, node-api addons that reference libuv symbols are served by
+ * src/bun.js/bindings/uv-posix-stubs.c + uv-posix-polyfills*.c, with headers
+ * from src/bun.js/bindings/libuv/ (see flags.ts) — vendor libuv is not built.
  */
 
-import type { Dependency, NestedCmakeBuild } from "../source.ts";
+import type { Dependency } from "../source.ts";
 
 // Tip of oven-sh/libuv's `bun` branch — upstream f3ce527e + the win-pipe
 // CancelIoEx race fix + ConPTY support in uv_spawn. To bump upstream, rebase
@@ -17,38 +18,32 @@ const LIBUV_COMMIT = "4dcfac4780d394e0dc2d3fb30335ca01b553eb46";
 export const libuv: Dependency = {
   name: "libuv",
 
+  enabled: cfg => cfg.windows,
+
   source: () => ({
     kind: "github-archive",
     repo: "oven-sh/libuv",
     commit: LIBUV_COMMIT,
   }),
 
-  build: cfg => {
-    const spec: NestedCmakeBuild = {
-      kind: "nested-cmake",
-      targets: ["uv_a"],
-      args: {
-        LIBUV_BUILD_SHARED: "OFF",
-        LIBUV_BUILD_TESTS: "OFF",
-        LIBUV_BUILD_BENCH: "OFF",
-      },
-    };
+  build: () => ({
+    kind: "nested-cmake",
+    targets: ["uv_a"],
+    args: {
+      LIBUV_BUILD_SHARED: "OFF",
+      LIBUV_BUILD_TESTS: "OFF",
+      LIBUV_BUILD_BENCH: "OFF",
+    },
+    // libuv's windows code has a handful of int-conversion warnings that
+    // clang-cl elevates. /DWIN32 /D_WINDOWS are what MSVC's cmake preset
+    // would add automatically; libuv's headers gate win32 paths on them.
+    extraCFlags: ["/DWIN32", "/D_WINDOWS", "-Wno-int-conversion"],
+  }),
 
-    if (cfg.windows) {
-      // libuv's windows code has a handful of int-conversion warnings that
-      // clang-cl elevates. /DWIN32 /D_WINDOWS are what MSVC's cmake preset
-      // would add automatically; libuv's headers gate win32 paths on them.
-      spec.extraCFlags = ["/DWIN32", "/D_WINDOWS", "-Wno-int-conversion"];
-    }
-
-    return spec;
-  },
-
-  provides: cfg => ({
-    // uv_a → libuv.lib on windows (the cmake target sets OUTPUT_NAME=libuv),
-    // libuv's cmake sets OUTPUT_NAME=libuv on Windows to avoid conflicts
-    // with system uv.lib. Unix uses the bare name.
-    libs: [cfg.windows ? "libuv" : "uv"],
+  provides: () => ({
+    // uv_a → libuv.lib (the cmake target sets OUTPUT_NAME=libuv on Windows
+    // to avoid conflicts with system uv.lib).
+    libs: ["libuv"],
     includes: ["include"],
   }),
 };


### PR DESCRIPTION
## Summary

libuv is only used at runtime on Windows. On POSIX, node-api addons that reference `uv_*` symbols are served by `src/bun.js/bindings/uv-posix-stubs.c` + `uv-posix-polyfills*.c`, and `#include <uv.h>` resolves to `src/bun.js/bindings/libuv/uv.h` (which already comes first in the include order, shadowing `vendor/libuv/include`). The vendored `libuv.a` was being fetched, cmake-configured, compiled, and linked on every POSIX build without contributing any referenced symbols.

This gates the dep behind `enabled: cfg => cfg.windows` so `resolveDep()` skips it entirely on darwin/linux, and drops the now-dead `cfg.windows` branches in `build()`/`provides()`. The `enabled` field's docstring at `source.ts:397` already cited "libuv is windows-only" as its example — the field just wasn't actually set.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `bun scripts/build.ts --configure-only` — 16 deps (down from 17), no `deps/libuv/*` or `vendor/libuv/include` in `build.ninja`
- [x] `bun bd --revision` — links and smoke-tests clean on darwin-arm64
- [x] `bun bd test test/napi/napi.test.ts` — 88 pass / 7 fail, identical to main (pre-existing failures, unrelated)
- [ ] CI: linux x64/arm64, linux-musl, darwin x64
- [ ] CI: windows x64 (libuv should still build and link)