### PR TITLE
isolate: defer GC across Zig::GlobalObject swap; guard unique_ptr visit

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -21,6 +21,7 @@
 #include "JavaScriptCore/GetterSetter.h"
 #include "JavaScriptCore/GlobalObjectMethodTable.h"
 #include "JavaScriptCore/Heap.h"
+#include "JavaScriptCore/DeferGCInlines.h"
 #include "JavaScriptCore/Identifier.h"
 #include "JavaScriptCore/InitializeThreading.h"
 #include "JavaScriptCore/InternalFieldTuple.h"
@@ -574,6 +575,18 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     JSC::VM& vm = oldGlobal->vm();
     JSC::JSLockHolder locker(vm);
 
+    // `JSGlobalObject::finishCreation` → `init()` performs hundreds of allocations
+    // before every lazy/write-barrier member of the Bun subclass has been wired up.
+    // Unlike the initial VM global (created before any user code can run and
+    // therefore before any concurrent GC is in flight), this one is created while
+    // the previous global's graph is live and the heap is warm, so the concurrent
+    // marker is far more likely to pick the half-initialized object off the stack
+    // and walk it. Deferring GC across the swap keeps the marker from observing the
+    // new global (or the mid-swap pair) until both are in a consistent state; the
+    // deferred collection fires on scope exit, by which point the new global is
+    // gcProtect()'d and the old one is cleanly unprotected.
+    JSC::DeferGC deferGC(vm);
+
     // The new global must inherit the old one's ScriptExecutionContext identifier so that
     // `Bun.isMainThread` (identifier == 1) and cross-thread task dispatch keep working.
     // Move the old context to a fresh identifier first to free the slot.
@@ -740,6 +753,10 @@ using namespace WebCore;
 static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
+    // Same reasoning as Zig__GlobalObject__createForTestIsolation: keep the
+    // concurrent marker from walking the new global while finishCreation/init
+    // is still populating it.
+    JSC::DeferGC deferGC(vm);
     Zig::GlobalObject* shadow = Zig::GlobalObject::create(
         vm,
         Zig::GlobalObject::createStructure(vm),
@@ -2925,7 +2942,15 @@ template<class Visitor, class T> static void visitGlobalObjectMember(Visitor& vi
 
 template<class Visitor, class T> static void visitGlobalObjectMember(Visitor& visitor, std::unique_ptr<T>& ptr)
 {
-    ptr->visit(visitor);
+    // The two unique_ptr members (m_builtinInternalFunctions, m_constructors) are
+    // populated in the constructor initializer list, so in steady state this is
+    // never null. The guard exists because the concurrent marker can visit a
+    // Zig::GlobalObject picked up via conservative stack scan while its own
+    // IsoSubspace slot is being recycled from a previously-destroyed global whose
+    // unique_ptr members were reset to null by ~unique_ptr(); until placement-new
+    // re-initializes them there is a brief window where the pointer reads as null.
+    if (ptr) [[likely]]
+        ptr->visit(visitor);
 }
 
 template<class Visitor, class T, size_t n> static void visitGlobalObjectMember(Visitor& visitor, std::array<WriteBarrier<T>, n>& barriers)

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -1,0 +1,78 @@
+// https://github.com/oven-sh/bun/issues/29519
+//
+// `bun test --isolate` creates a fresh Zig::GlobalObject on the same JSC::VM
+// for every file and gcUnprotect()s the previous one. Prior to this it was
+// never possible for a Zig::GlobalObject to be collected, so the concurrent
+// marker never had a chance to walk one while another was mid-finishCreation.
+// On macOS arm64 this surfaced as a near-null dereference inside
+// JSSegmentedVariableObject::visitChildrenImpl (SlotVisitor walking the
+// half-built new global) and as "marks not empty!" MarkedBlock assertions.
+//
+// This test stresses the swap by running several isolated test files back to
+// back under BUN_JSC_collectContinuously=1 (a dedicated thread that calls
+// Heap::collectSync in a loop) with each file populating global `var`
+// declarations (segmented variable storage) and forcing full GCs. The fix
+// defers GC across the global swap and null-guards the unique_ptr visitor
+// overload; without it this spawn segfaults intermittently.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// collectContinuously is very slow under Windows + ASAN in CI; the failure
+// mode this covers was observed on macOS arm64 and the code path is identical
+// on Linux/macOS, so skip Windows to keep the suite duration reasonable.
+test.skipIf(isWindows)(
+  "bun test --isolate survives concurrent GC while swapping globals",
+  async () => {
+    const files: Record<string, string> = {};
+    // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
+    // a few times even without the collector thread getting lucky on timing.
+    for (let i = 0; i < 6; i++) {
+      files[`gc-${i}.test.js`] = `
+        import { test, expect } from "bun:test";
+        // Top-level 'var' declarations land in JSSegmentedVariableObject::m_variables
+        // on the global, which is exactly the storage the crashing visitChildren
+        // walks.
+        var a${i} = ${i}, b${i} = ${i + 1}, c${i} = ${i + 2}, d${i} = ${i + 3};
+        var e${i} = ${i + 4}, f${i} = ${i + 5}, g${i} = ${i + 6}, h${i} = ${i + 7};
+        test("gc pressure ${i}", () => {
+          globalThis.__isolateLeak${i} = { data: new Array(4000).fill(${i}) };
+          for (let j = 0; j < 4; j++) Bun.gc(true);
+          expect(a${i} + b${i} + c${i} + d${i} + e${i} + f${i} + g${i} + h${i}).toBe(${8 * i + 28});
+        });
+      `;
+    }
+
+    using dir = tempDir("isolate-gc-stress", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "."],
+      env: {
+        ...bunEnv,
+        // Dedicated collector thread running Heap::collectSync in a loop — this
+        // is what makes the "marker visits global mid-finishCreation" window
+        // observable without needing the macOS concurrent-GC scheduler timing.
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // On crash the runner never reaches the summary line and exits non-zero;
+    // checking the pass count first gives a readable diff on failure.
+    expect(stderr).toContain("6 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  },
+  // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
+  // a debug build because the collector thread is constantly preempting the
+  // mutator during JSGlobalObject::init().
+  120_000,
+);

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -57,8 +57,7 @@ describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM u
     expect(stderr).toContain("6 pass");
     expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);
-  }, // mutator during JSGlobalObject::init(). // a debug build because the collector thread is constantly preempting the // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
-  120_000);
+  }, 120_000);
 
   // deriveShadowRealmGlobalObject() is the other path that constructs a
   // Zig::GlobalObject on a warm VM; cover it under the same GC pressure so the

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -1,26 +1,16 @@
 // https://github.com/oven-sh/bun/issues/29519
 //
-// `bun test --isolate` creates a fresh Zig::GlobalObject on the same JSC::VM
-// for every file and gcUnprotect()s the previous one. Prior to this it was
-// never possible for a Zig::GlobalObject to be collected, so the concurrent
-// marker never had a chance to walk one while another was mid-finishCreation.
-// On macOS arm64 this surfaced as a near-null dereference inside
-// JSSegmentedVariableObject::visitChildrenImpl (SlotVisitor walking the
-// half-built new global) and as "marks not empty!" MarkedBlock assertions.
-//
-// This test stresses the swap by running several isolated test files back to
-// back under BUN_JSC_collectContinuously=1 (a dedicated thread that calls
-// Heap::collectSync in a loop). Each file grows the global's segmented
-// variable storage via sloppy-mode indirect eval and forces full GCs. The fix
-// defers GC across the global swap and null-guards the unique_ptr visitor
-// overload; without it this spawn segfaults intermittently.
+// Both --isolate and ShadowRealm construct a fresh Zig::GlobalObject on a
+// warm VM. collectContinuously runs a dedicated collector thread so the
+// marker overlaps finishCreation/init; sloppy-mode indirect eval below grows
+// the global's JSSegmentedVariableObject::m_variables (the storage the
+// crashing visitChildren walks) in each new global.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
-// collectContinuously is very slow under Windows + ASAN in CI; the failure
-// mode this covers was observed on macOS arm64 and the code path is identical
-// on Linux/macOS, so skip Windows to keep the suite duration reasonable.
+// collectContinuously is very slow under Windows + ASAN in CI; the code path
+// is identical on Linux/macOS, so skip Windows to keep duration reasonable.
 test.skipIf(isWindows)(
   "bun test --isolate survives concurrent GC while swapping globals",
   async () => {
@@ -28,12 +18,9 @@ test.skipIf(isWindows)(
     // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
     // a few times even without the collector thread getting lucky on timing.
     for (let i = 0; i < 6; i++) {
-      // Build a sloppy-mode global eval that declares eight vars per file.
       // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
-      // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables
-      // and actually land in the global's m_variables SegmentedVector — the
-      // storage JSSegmentedVariableObject::visitChildrenImpl iterates under
-      // cellLock(). Top-level `var` in an ES module would instead live in
+      // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables.
+      // Top-level `var` in an ES module would instead live in
       // JSModuleEnvironment and never touch the segmented table.
       const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
       const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
@@ -55,9 +42,6 @@ test.skipIf(isWindows)(
       cmd: [bunExe(), "test", "--isolate", "."],
       env: {
         ...bunEnv,
-        // Dedicated collector thread running Heap::collectSync in a loop — this
-        // is what makes the "marker visits global mid-finishCreation" window
-        // observable without needing the macOS concurrent-GC scheduler timing.
         BUN_JSC_collectContinuously: "1",
       },
       cwd: String(dir),
@@ -76,5 +60,40 @@ test.skipIf(isWindows)(
   // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
   // a debug build because the collector thread is constantly preempting the
   // mutator during JSGlobalObject::init().
+  120_000,
+);
+
+// deriveShadowRealmGlobalObject() is the other path that constructs a
+// Zig::GlobalObject on a warm VM; cover it under the same GC pressure so the
+// DeferGC there doesn't silently regress.
+test.skipIf(isWindows)(
+  "ShadowRealm creation survives concurrent GC",
+  async () => {
+    const src = `
+      (0, eval)("var sv0 = 0, sv1 = 1, sv2 = 2, sv3 = 3;");
+      for (let i = 0; i < 40; i++) {
+        const r = new ShadowRealm();
+        r.evaluate("(0, eval)('var a=1,b=2,c=3,d=4'); globalThis.a+globalThis.b");
+        if (i % 8 === 0) Bun.gc(true);
+      }
+      if (globalThis.sv0 + globalThis.sv3 !== 3) throw new Error("segmented vars lost");
+      console.log("ok");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
+    // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is
+    // sufficient — a crash during ShadowRealm creation would hit neither.
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  },
   120_000,
 );

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -14,21 +14,19 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 // Both tests spawn independent subprocesses with no shared state, so run them
 // concurrently to halve wall-clock.
 describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM under concurrent GC", () => {
-  test(
-    "bun test --isolate survives concurrent GC while swapping globals",
-    async () => {
-      const files: Record<string, string> = {};
-      // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
-      // a few times even without the collector thread getting lucky on timing.
-      for (let i = 0; i < 6; i++) {
-        // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
-        // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables.
-        // Top-level `var` in an ES module would instead live in
-        // JSModuleEnvironment and never touch the segmented table.
-        const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
-        const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
-        const sum = names.map(n => `globalThis.${n}`).join(" + ");
-        files[`gc-${i}.test.js`] = `
+  test("bun test --isolate survives concurrent GC while swapping globals", async () => {
+    const files: Record<string, string> = {};
+    // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
+    // a few times even without the collector thread getting lucky on timing.
+    for (let i = 0; i < 6; i++) {
+      // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
+      // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables.
+      // Top-level `var` in an ES module would instead live in
+      // JSModuleEnvironment and never touch the segmented table.
+      const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
+      const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
+      const sum = names.map(n => `globalThis.${n}`).join(" + ");
+      files[`gc-${i}.test.js`] = `
           import { test, expect } from "bun:test";
           (0, eval)(${JSON.stringify(decls)});
           test("gc pressure ${i}", () => {
@@ -37,42 +35,38 @@ describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM u
             expect(${sum}).toBe(${8 * i + 28});
           });
         `;
-      }
+    }
 
-      using dir = tempDir("isolate-gc-stress", files);
+    using dir = tempDir("isolate-gc-stress", files);
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", "--isolate", "."],
-        env: {
-          ...bunEnv,
-          BUN_JSC_collectContinuously: "1",
-        },
-        cwd: String(dir),
-        stderr: "pipe",
-        stdout: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "."],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
 
-      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // On crash the runner never reaches the summary line and exits non-zero;
-      // checking the pass count first gives a readable diff on failure.
-      expect(stderr).toContain("6 pass");
-      expect(stderr).toContain("0 fail");
-      expect(exitCode).toBe(0);
-    },
-    // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
-    // a debug build because the collector thread is constantly preempting the
-    // mutator during JSGlobalObject::init().
-    120_000,
-  );
+    // On crash the runner never reaches the summary line and exits non-zero;
+    // checking the pass count first gives a readable diff on failure.
+    expect(stderr).toContain("6 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  }, // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
+  // a debug build because the collector thread is constantly preempting the
+  // mutator during JSGlobalObject::init().
+  120_000);
 
   // deriveShadowRealmGlobalObject() is the other path that constructs a
   // Zig::GlobalObject on a warm VM; cover it under the same GC pressure so the
   // DeferGC there doesn't silently regress.
-  test(
-    "ShadowRealm creation survives concurrent GC",
-    async () => {
-      const src = `
+  test("ShadowRealm creation survives concurrent GC", async () => {
+    const src = `
         (0, eval)("var sv0 = 0, sv1 = 1, sv2 = 2, sv3 = 3;");
         for (let i = 0; i < 40; i++) {
           const r = new ShadowRealm();
@@ -82,22 +76,20 @@ describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM u
         if (globalThis.sv0 + globalThis.sv3 !== 3) throw new Error("segmented vars lost");
         console.log("ok");
       `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", src],
-        env: {
-          ...bunEnv,
-          BUN_JSC_collectContinuously: "1",
-        },
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
-      // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is
-      // sufficient — a crash during ShadowRealm creation would hit neither.
-      expect(stdout.trim()).toBe("ok");
-      expect(exitCode).toBe(0);
-    },
-    120_000,
-  );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
+    // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is
+    // sufficient — a crash during ShadowRealm creation would hit neither.
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  }, 120_000);
 });

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -10,8 +10,8 @@
 //
 // This test stresses the swap by running several isolated test files back to
 // back under BUN_JSC_collectContinuously=1 (a dedicated thread that calls
-// Heap::collectSync in a loop) with each file populating global `var`
-// declarations (segmented variable storage) and forcing full GCs. The fix
+// Heap::collectSync in a loop). Each file grows the global's segmented
+// variable storage via sloppy-mode indirect eval and forces full GCs. The fix
 // defers GC across the global swap and null-guards the unique_ptr visitor
 // overload; without it this spawn segfaults intermittently.
 
@@ -28,17 +28,23 @@ test.skipIf(isWindows)(
     // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
     // a few times even without the collector thread getting lucky on timing.
     for (let i = 0; i < 6; i++) {
+      // Build a sloppy-mode global eval that declares eight vars per file.
+      // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
+      // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables
+      // and actually land in the global's m_variables SegmentedVector — the
+      // storage JSSegmentedVariableObject::visitChildrenImpl iterates under
+      // cellLock(). Top-level `var` in an ES module would instead live in
+      // JSModuleEnvironment and never touch the segmented table.
+      const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
+      const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
+      const sum = names.map(n => `globalThis.${n}`).join(" + ");
       files[`gc-${i}.test.js`] = `
         import { test, expect } from "bun:test";
-        // Top-level 'var' declarations land in JSSegmentedVariableObject::m_variables
-        // on the global, which is exactly the storage the crashing visitChildren
-        // walks.
-        var a${i} = ${i}, b${i} = ${i + 1}, c${i} = ${i + 2}, d${i} = ${i + 3};
-        var e${i} = ${i + 4}, f${i} = ${i + 5}, g${i} = ${i + 6}, h${i} = ${i + 7};
+        (0, eval)(${JSON.stringify(decls)});
         test("gc pressure ${i}", () => {
           globalThis.__isolateLeak${i} = { data: new Array(4000).fill(${i}) };
           for (let j = 0; j < 4; j++) Bun.gc(true);
-          expect(a${i} + b${i} + c${i} + d${i} + e${i} + f${i} + g${i} + h${i}).toBe(${8 * i + 28});
+          expect(${sum}).toBe(${8 * i + 28});
         });
       `;
     }

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -57,8 +57,7 @@ describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM u
     expect(stderr).toContain("6 pass");
     expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);
-  }, // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
-  // a debug build because the collector thread is constantly preempting the
+  }, // a debug build because the collector thread is constantly preempting the // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
   // mutator during JSGlobalObject::init().
   120_000);
 

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -59,11 +59,7 @@ test.skipIf(isWindows)(
       stdout: "pipe",
     });
 
-    const [, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // On crash the runner never reaches the summary line and exits non-zero;
     // checking the pass count first gives a readable diff on failure.

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -6,94 +6,98 @@
 // the global's JSSegmentedVariableObject::m_variables (the storage the
 // crashing visitChildren walks) in each new global.
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // collectContinuously is very slow under Windows + ASAN in CI; the code path
 // is identical on Linux/macOS, so skip Windows to keep duration reasonable.
-test.skipIf(isWindows)(
-  "bun test --isolate survives concurrent GC while swapping globals",
-  async () => {
-    const files: Record<string, string> = {};
-    // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
-    // a few times even without the collector thread getting lucky on timing.
-    for (let i = 0; i < 6; i++) {
-      // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
-      // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables.
-      // Top-level `var` in an ES module would instead live in
-      // JSModuleEnvironment and never touch the segmented table.
-      const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
-      const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
-      const sum = names.map(n => `globalThis.${n}`).join(" + ");
-      files[`gc-${i}.test.js`] = `
-        import { test, expect } from "bun:test";
-        (0, eval)(${JSON.stringify(decls)});
-        test("gc pressure ${i}", () => {
-          globalThis.__isolateLeak${i} = { data: new Array(4000).fill(${i}) };
-          for (let j = 0; j < 4; j++) Bun.gc(true);
-          expect(${sum}).toBe(${8 * i + 28});
-        });
-      `;
-    }
-
-    using dir = tempDir("isolate-gc-stress", files);
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "."],
-      env: {
-        ...bunEnv,
-        BUN_JSC_collectContinuously: "1",
-      },
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // On crash the runner never reaches the summary line and exits non-zero;
-    // checking the pass count first gives a readable diff on failure.
-    expect(stderr).toContain("6 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  },
-  // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
-  // a debug build because the collector thread is constantly preempting the
-  // mutator during JSGlobalObject::init().
-  120_000,
-);
-
-// deriveShadowRealmGlobalObject() is the other path that constructs a
-// Zig::GlobalObject on a warm VM; cover it under the same GC pressure so the
-// DeferGC there doesn't silently regress.
-test.skipIf(isWindows)(
-  "ShadowRealm creation survives concurrent GC",
-  async () => {
-    const src = `
-      (0, eval)("var sv0 = 0, sv1 = 1, sv2 = 2, sv3 = 3;");
-      for (let i = 0; i < 40; i++) {
-        const r = new ShadowRealm();
-        r.evaluate("(0, eval)('var a=1,b=2,c=3,d=4'); globalThis.a+globalThis.b");
-        if (i % 8 === 0) Bun.gc(true);
+// Both tests spawn independent subprocesses with no shared state, so run them
+// concurrently to halve wall-clock.
+describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM under concurrent GC", () => {
+  test(
+    "bun test --isolate survives concurrent GC while swapping globals",
+    async () => {
+      const files: Record<string, string> = {};
+      // Six files is enough to recycle the Zig::GlobalObject IsoSubspace slot
+      // a few times even without the collector thread getting lucky on timing.
+      for (let i = 0; i < 6; i++) {
+        // Indirect eval (`(0, eval)(…)`) runs in the global scope, so these go
+        // through CreateGlobalVarBinding → JSSegmentedVariableObject::addVariables.
+        // Top-level `var` in an ES module would instead live in
+        // JSModuleEnvironment and never touch the segmented table.
+        const names = ["a", "b", "c", "d", "e", "f", "g", "h"].map(n => `${n}${i}`);
+        const decls = names.map((n, j) => `var ${n} = ${i + j};`).join(" ");
+        const sum = names.map(n => `globalThis.${n}`).join(" + ");
+        files[`gc-${i}.test.js`] = `
+          import { test, expect } from "bun:test";
+          (0, eval)(${JSON.stringify(decls)});
+          test("gc pressure ${i}", () => {
+            globalThis.__isolateLeak${i} = { data: new Array(4000).fill(${i}) };
+            for (let j = 0; j < 4; j++) Bun.gc(true);
+            expect(${sum}).toBe(${8 * i + 28});
+          });
+        `;
       }
-      if (globalThis.sv0 + globalThis.sv3 !== 3) throw new Error("segmented vars lost");
-      console.log("ok");
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", src],
-      env: {
-        ...bunEnv,
-        BUN_JSC_collectContinuously: "1",
-      },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
-    // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is
-    // sufficient — a crash during ShadowRealm creation would hit neither.
-    expect(stdout.trim()).toBe("ok");
-    expect(exitCode).toBe(0);
-  },
-  120_000,
-);
+
+      using dir = tempDir("isolate-gc-stress", files);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "."],
+        env: {
+          ...bunEnv,
+          BUN_JSC_collectContinuously: "1",
+        },
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // On crash the runner never reaches the summary line and exits non-zero;
+      // checking the pass count first gives a readable diff on failure.
+      expect(stderr).toContain("6 pass");
+      expect(stderr).toContain("0 fail");
+      expect(exitCode).toBe(0);
+    },
+    // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
+    // a debug build because the collector thread is constantly preempting the
+    // mutator during JSGlobalObject::init().
+    120_000,
+  );
+
+  // deriveShadowRealmGlobalObject() is the other path that constructs a
+  // Zig::GlobalObject on a warm VM; cover it under the same GC pressure so the
+  // DeferGC there doesn't silently regress.
+  test(
+    "ShadowRealm creation survives concurrent GC",
+    async () => {
+      const src = `
+        (0, eval)("var sv0 = 0, sv1 = 1, sv2 = 2, sv3 = 3;");
+        for (let i = 0; i < 40; i++) {
+          const r = new ShadowRealm();
+          r.evaluate("(0, eval)('var a=1,b=2,c=3,d=4'); globalThis.a+globalThis.b");
+          if (i % 8 === 0) Bun.gc(true);
+        }
+        if (globalThis.sv0 + globalThis.sv3 !== 3) throw new Error("segmented vars lost");
+        console.log("ok");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: {
+          ...bunEnv,
+          BUN_JSC_collectContinuously: "1",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
+      // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is
+      // sufficient — a crash during ShadowRealm creation would hit neither.
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    },
+    120_000,
+  );
+});

--- a/test/regression/issue/29519.test.ts
+++ b/test/regression/issue/29519.test.ts
@@ -57,8 +57,7 @@ describe.skipIf(isWindows).concurrent("Zig::GlobalObject creation on a warm VM u
     expect(stderr).toContain("6 pass");
     expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);
-  }, // a debug build because the collector thread is constantly preempting the // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
-  // mutator during JSGlobalObject::init().
+  }, // mutator during JSGlobalObject::init(). // a debug build because the collector thread is constantly preempting the // collectContinuously + ASAN is slow; each isolated file takes ~5-10s on
   120_000);
 
   // deriveShadowRealmGlobalObject() is the other path that constructs a


### PR DESCRIPTION
## What

`bun test --isolate` (new in #29354) is the first code path that creates a **second** `Zig::GlobalObject` on a warm `JSC::VM` and then `gcUnprotect`s the previous one so it can be collected. Previously the only `Zig::GlobalObject` on a VM was the gc-protected main one, so the concurrent marker never had to walk a `Zig::GlobalObject` while another one was mid-`finishCreation`.

On macOS arm64 this surfaces as:

```
Segmentation fault at address 0x68
JSC::JSSegmentedVariableObject::visitChildrenImpl  JSSegmentedVariableObject.cpp:70
JSC::JSGlobalObject::visitChildrenImpl             JSGlobalObject.cpp:2982
Bun::GlobalScope::visitChildrenImpl                BunGlobalScope.cpp:43
Bun::GlobalScope::visitChildren                    BunGlobalScope.cpp:36
Zig::GlobalObject::visitChildrenImpl               ZigGlobalObject.cpp:2941
JSC::SlotVisitor::visitChildren                    SlotVisitor.cpp:399
```

and as `Block … marks not empty!` MarkedBlock assertions reported in #29519 (1.3.13, macOS Silicon, `bun test --isolate`).

## Cause

`Zig__GlobalObject__createForTestIsolation` runs `Zig::GlobalObject::create` → `finishCreation` → `JSGlobalObject::init()` with **no `DeferGC`**. `init()` performs hundreds of allocations. Unlike the initial global (created before any user code runs, heap cold), the isolation global is created while the previous global's entire module graph is live and the heap is warm, so the concurrent marker is frequently in flight. It picks the half-built global off the stack via conservative scan and walks it through the full `visitChildrenImpl` chain while `init()`/Bun's `finishCreation` is still wiring up members.

Separately, #29542 converted `m_builtinInternalFunctions` / `m_constructors` to `std::unique_ptr`, and the `visitGlobalObjectMember` overload for `unique_ptr` dereferences unconditionally. If the marker ever observes the cell while its IsoSubspace slot is being recycled from a previously-destroyed global (whose `~unique_ptr` reset these to null), that's a straight null deref.

## Fix

- `JSC::DeferGC` around the entire swap in `Zig__GlobalObject__createForTestIsolation`, so no collection fires between `createStructure()` and `gcUnprotect(old)`. The deferred collection runs on scope exit, at which point the new global is `gcProtect()`'d and fully initialized and the old one is cleanly unprotected.
- Same `DeferGC` in `deriveShadowRealmGlobalObject` for parity — `ShadowRealm` is the only other path that constructs `Zig::GlobalObject` on a warm VM.
- Null-guard the `std::unique_ptr<T>&` overload of `visitGlobalObjectMember`. Free in steady state (`[[likely]]`), closes the recycled-slot window regardless of `DeferGC`.

## Reproduction / test

Could not reproduce the segfault on **Linux x64 ASAN** despite `BUN_JSC_collectContinuously=1`, `BUN_JSC_slowPathAllocsBetweenGCs=1`, `BUN_JSC_useZombieMode=1`, `BUN_JSC_numberOfGCMarkers=8`, and dozens of retries — the race depends on macOS arm64's concurrent-GC scheduler timing. `test/regression/issue/29519.test.ts` runs six isolated files under `collectContinuously` with per-file sloppy-mode indirect `eval` `var` declarations (which go through `CreateGlobalVarBinding` → `JSSegmentedVariableObject::addVariables`) and `Bun.gc(true)` loops; it exercises the exact path and should fail intermittently on a macOS arm64 build of unpatched `main`, but passes deterministically on both before/after on Linux.

## Verification

- [x] `bun bd test test/regression/issue/29519.test.ts` — pass
- [x] `bun bd test test/cli/test/isolation.test.ts` — 13 pass, 1 pre-existing unrelated timeout in `cached SourceProvider's module_info rebuilds correct exports` (fails identically on `main`)
- [x] ShadowRealm stress (`new ShadowRealm()` ×200 + `Bun.gc(true)`) under `collectContinuously` — pass
- [ ] CI (macOS arm64 lane is the one that matters here)

Fixes #29519
