### PR TITLE
Fix null deref in esmRegistryMap when globalThis.Loader is overwritten

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2222,14 +2222,12 @@ void GlobalObject::finishCreation(VM& vm)
 
             JSMap* registry = nullptr;
             auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            scope.assertNoExceptionExceptTermination();
             RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                scope.assertNoExceptionExceptTermination();
+            if (auto* loaderObject = loaderValue ? loaderValue.getObject() : nullptr) {
+                auto registryValue = loaderObject->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
                 RETURN_IF_EXCEPTION(scope, setEmpty());
                 if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
                 }
             }
 

--- a/test/js/bun/resolve/loader-overwrite.test.ts
+++ b/test/js/bun/resolve/loader-overwrite.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// globalThis.Loader is user-writable. The lazy esmRegistryMap initializer reads
+// Loader.registry off the global and must not assume it is an object (or that
+// registry is a JSMap) since user code may have replaced or deleted it.
+
+async function run(name: string, entry: string) {
+  using dir = tempDir(name, {
+    "target.mjs": "export const x = 1;\n",
+    "entry.js": entry,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+test.concurrent("globalThis.Loader replaced with a primitive", async () => {
+  const { stdout, signalCode, exitCode } = await run(
+    "loader-overwrite-primitive",
+    `
+      globalThis.Loader = 1;
+      import("./target.mjs").then(() => console.log("ok")).catch(e => console.log("err", e.message));
+    `,
+  );
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe("ok\n");
+});
+
+test.concurrent("globalThis.Loader set to undefined", async () => {
+  const { stdout, signalCode, exitCode } = await run(
+    "loader-overwrite-undefined",
+    `
+      globalThis.Loader = undefined;
+      import("./target.mjs").then(() => console.log("ok")).catch(e => console.log("err", e.message));
+    `,
+  );
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe("ok\n");
+});
+
+test.concurrent("globalThis.Loader.registry replaced with a non-Map", async () => {
+  const { stdout, signalCode, exitCode } = await run(
+    "loader-overwrite-registry",
+    `
+      globalThis.Loader = { registry: 1 };
+      import("./target.mjs").then(() => console.log("ok")).catch(e => console.log("err", e.message));
+    `,
+  );
+  expect(signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe("ok\n");
+});
+
+test.concurrent("globalThis.Loader with a throwing registry getter", async () => {
+  const { stderr, signalCode } = await run(
+    "loader-overwrite-throwing",
+    `
+      globalThis.Loader = new Proxy({}, { get() { throw new Error("boom"); }, has() { return true; } });
+      import("./target.mjs").then(() => console.log("ok")).catch(e => console.log("err", e.message));
+    `,
+  );
+  expect(signalCode).toBeNull();
+  expect(stderr).not.toContain("panic");
+  expect(stderr).toContain("boom");
+});


### PR DESCRIPTION
The lazy initializer for `m_esmRegistryMap` reads `globalThis.Loader.registry` to reuse the module loader's registry map. Since `globalThis.Loader` is a writable property, user code can replace it with a non-object value (or delete it and redefine it), which caused `loaderValue.getObject()` to return `nullptr` followed by a member call on null.

This also fixes two adjacent issues in the same block:
- `jsCast<JSMap*>(registryValue)` asserted when `Loader.registry` was not a `JSMap` — now uses `jsDynamicCast` and falls back to a fresh map.
- `scope.assertNoExceptionExceptTermination()` fired when a user-defined getter/Proxy for `Loader` or `Loader.registry` threw — removed since arbitrary exceptions are possible here and already handled by `RETURN_IF_EXCEPTION`.

Minimal repro:
```js
globalThis.Loader = 1;
import("./target.mjs");
```

Found by Fuzzilli.