### PR TITLE
Fix panic in ResolveMessage.getSpecifier when metadata is .build

### DIFF
--- a/src/jsc/ResolveMessage.zig
+++ b/src/jsc/ResolveMessage.zig
@@ -203,14 +203,20 @@ pub const ResolveMessage = struct {
         this: *ResolveMessage,
         globalThis: *jsc.JSGlobalObject,
     ) jsc.JSValue {
-        return ZigString.init(this.msg.metadata.resolve.specifier.slice(this.msg.data.text)).toJS(globalThis);
+        switch (this.msg.metadata) {
+            .resolve => |resolve| return ZigString.init(resolve.specifier.slice(this.msg.data.text)).toJS(globalThis),
+            else => return ZigString.Empty.toJS(globalThis),
+        }
     }
 
     pub fn getImportKind(
         this: *ResolveMessage,
         globalThis: *jsc.JSGlobalObject,
     ) jsc.JSValue {
-        return ZigString.init(this.msg.metadata.resolve.import_kind.label()).toJS(globalThis);
+        switch (this.msg.metadata) {
+            .resolve => |resolve| return ZigString.init(resolve.import_kind.label()).toJS(globalThis),
+            else => return ZigString.Empty.toJS(globalThis),
+        }
     }
 
     pub fn getReferrer(

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1902,13 +1902,17 @@ pub fn resolveMaybeNeedsTrailingSlash(
             // This Msg is wrapped in a ResolveMessage JS object below; without
             // `.resolve` metadata here, accessing `err.specifier` / `err.importKind`
             // or calling `JSON.stringify(err)` from JS would read the inactive
-            // union field and panic in safe builds. The specifier is left empty:
-            // on Windows it always exceeds what `BabyString` (u16 offset/len) can
-            // encode here, and on other platforms it may — the full specifier is
-            // in the message text regardless.
+            // union field and panic in safe builds. `BabyString` uses u16
+            // offset/len, so encode the specifier only when it fits (it always
+            // does on macOS/Linux at this threshold; on Windows the threshold
+            // itself exceeds u16 so it never does). When it doesn't fit the
+            // full specifier is still in the message text.
             .metadata = .{
                 .resolve = .{
-                    .specifier = .{ .offset = 0, .len = 0 },
+                    .specifier = if (specifier_utf8.slice().len <= std.math.maxInt(u16))
+                        logger.BabyString.in(printed, specifier_utf8.slice())
+                    else
+                        .{ .offset = 0, .len = 0 },
                     .import_kind = import_kind,
                     .err = error.NameTooLong,
                 },

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1902,9 +1902,10 @@ pub fn resolveMaybeNeedsTrailingSlash(
             // This Msg is wrapped in a ResolveMessage JS object below; without
             // `.resolve` metadata here, accessing `err.specifier` / `err.importKind`
             // or calling `JSON.stringify(err)` from JS would read the inactive
-            // union field and panic in safe builds. The specifier itself is left
-            // empty because it is longer than `BabyString` (u16 offset/len) can
-            // encode on this path.
+            // union field and panic in safe builds. The specifier is left empty:
+            // on Windows it always exceeds what `BabyString` (u16 offset/len) can
+            // encode here, and on other platforms it may — the full specifier is
+            // in the message text regardless.
             .metadata = .{
                 .resolve = .{
                     .specifier = .{ .offset = 0, .len = 0 },

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1885,12 +1885,13 @@ pub fn resolveMaybeNeedsTrailingSlash(
         defer specifier_utf8.deinit();
         const source_utf8 = source.toUTF8(bun.default_allocator);
         defer source_utf8.deinit();
+        const import_kind: bun.ImportKind = if (is_esm) .stmt else if (is_user_require_resolve) .require_resolve else .require;
         const printed = bun.api.ResolveMessage.fmt(
             bun.default_allocator,
             specifier_utf8.slice(),
             source_utf8.slice(),
             error.NameTooLong,
-            if (is_esm) .stmt else if (is_user_require_resolve) .require_resolve else .require,
+            import_kind,
         ) catch |err| bun.handleOom(err);
         const msg = logger.Msg{
             .data = logger.rangeData(
@@ -1898,6 +1899,19 @@ pub fn resolveMaybeNeedsTrailingSlash(
                 logger.Range.None,
                 printed,
             ),
+            // This Msg is wrapped in a ResolveMessage JS object below; without
+            // `.resolve` metadata here, accessing `err.specifier` / `err.importKind`
+            // or calling `JSON.stringify(err)` from JS would read the inactive
+            // union field and panic in safe builds. The specifier itself is left
+            // empty because it is longer than `BabyString` (u16 offset/len) can
+            // encode on this path.
+            .metadata = .{
+                .resolve = .{
+                    .specifier = .{ .offset = 0, .len = 0 },
+                    .import_kind = import_kind,
+                    .err = error.NameTooLong,
+                },
+            },
         };
         res.* = ErrorableString.err(error.NameTooLong, (try bun.api.ResolveMessage.create(global, VirtualMachine.get().allocator, msg, source_utf8.slice())));
         return;

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -109,6 +109,40 @@ describe("ResolveMessage", () => {
     }
     expect().pass();
   });
+
+  // The NameTooLong fast-path in the resolver previously constructed a
+  // ResolveMessage backed by a logger.Msg with `.build` metadata. Reading
+  // `.specifier` / `.importKind` (or JSON.stringify, which reads both via
+  // toJSON) then accessed the inactive `.resolve` union field — garbage in
+  // release, a hard panic in safe/debug builds. Run in a subprocess so the
+  // panic (if it regresses) doesn't take down the test runner.
+  it("NameTooLong error has .resolve metadata (specifier/importKind/toJSON are safe)", async () => {
+    const src = `
+      // Exceeds MAX_PATH_BYTES * 1.5 on every platform (Windows' is largest at ~98302).
+      const long = Buffer.alloc(150000, "a").toString();
+      try {
+        await import("./" + long + ".js");
+        console.log("FAIL: import unexpectedly succeeded");
+      } catch (e) {
+        console.log(e.name);
+        console.log(typeof e.specifier);
+        console.log(e.importKind);
+        JSON.stringify(e);
+        console.log("ok");
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+    expect(stderrLines).toEqual([]);
+    expect(stdout.trim().split("\n")).toEqual(["ResolveMessage", "string", "import-statement", "ok"]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 // These tests reproduce panics where the module resolver wrote past fixed-size

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -116,7 +116,7 @@ describe("ResolveMessage", () => {
   // toJSON) then accessed the inactive `.resolve` union field — garbage in
   // release, a hard panic in safe/debug builds. Run in a subprocess so the
   // panic (if it regresses) doesn't take down the test runner.
-  it("NameTooLong error has .resolve metadata (specifier/importKind/toJSON are safe)", async () => {
+  it.concurrent("NameTooLong error has .resolve metadata (specifier/importKind/toJSON are safe)", async () => {
     const src = `
       // Exceeds MAX_PATH_BYTES * 1.5 on every platform (Windows' is largest at ~98302).
       const long = Buffer.alloc(150000, "a").toString();
@@ -150,7 +150,7 @@ describe("ResolveMessage", () => {
   // both triggers the fast-path and fits — verify `.specifier` is populated
   // via `BabyString.in` there. Skipped on Windows: the threshold (~147k)
   // itself exceeds u16, so no length can hit both conditions.
-  it.skipIf(isWindows)("NameTooLong error populates .specifier when it fits in u16", async () => {
+  it.concurrent.skipIf(isWindows)("NameTooLong error populates .specifier when it fits in u16", async () => {
     const src = `
       const long = Buffer.alloc(10000, "a").toString();
       const spec = "./" + long + ".js";

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 describe("ResolveMessage", () => {
   it("position object does not segfault", async () => {
@@ -141,6 +141,39 @@ describe("ResolveMessage", () => {
     const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
     expect(stderrLines).toEqual([]);
     expect(stdout.trim().split("\n")).toEqual(["ResolveMessage", "string", "import-statement", "ok"]);
+    expect(exitCode).toBe(0);
+  });
+
+  // The previous test's 150k specifier exceeds BabyString's u16 range and so
+  // only exercises the empty-specifier fallback. On macOS/Linux the
+  // NameTooLong threshold (1536 / 6144) is well under u16, so a ~10k specifier
+  // both triggers the fast-path and fits — verify `.specifier` is populated
+  // via `BabyString.in` there. Skipped on Windows: the threshold (~147k)
+  // itself exceeds u16, so no length can hit both conditions.
+  it.skipIf(isWindows)("NameTooLong error populates .specifier when it fits in u16", async () => {
+    const src = `
+      const long = Buffer.alloc(10000, "a").toString();
+      const spec = "./" + long + ".js";
+      try {
+        await import(spec);
+        console.log("FAIL: import unexpectedly succeeded");
+      } catch (e) {
+        console.log(e.name);
+        console.log(e.importKind);
+        console.log(e.specifier === spec);
+        console.log(e.code);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+    expect(stderrLines).toEqual([]);
+    expect(stdout.trim().split("\n")).toEqual(["ResolveMessage", "import-statement", "true", "ERR_MODULE_NOT_FOUND"]);
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What

Fixes `Panic: access of union field 'resolve' while field 'build' is active` in `ResolveMessage.getSpecifier` (and `getImportKind` / `toJSON`).

Stack:
```
Panic: access of union field 'resolve' while field 'build' is active
slice                              src/logger.zig:383
getSpecifier                       src/bun.js/ResolveMessage.zig:206
toJSON                             src/bun.js/ResolveMessage.zig:160
ResolveMessagePrototype__toJSON    codegen/ZigGeneratedClasses.zig
```

## Root cause

The `NameTooLong` fast-path in `resolveMaybeNeedsTrailingSlash` (hit when an import specifier exceeds `MAX_PATH_BYTES * 1.5`) constructed a `logger.Msg` **without** setting `.metadata`, so it defaulted to `.build` — and then wrapped it in a `ResolveMessage` JS object.

`ResolveMessage.getSpecifier` and `getImportKind` read `this.msg.metadata.resolve` unconditionally. When the active tag was `.build`:
- **Safe/debug builds**: Zig's union safety check panics.
- **Release builds**: reads garbage — `err.importKind` comes back as `"entry-point-run"` (enum index 0 from zeroed memory).

Every other `ResolveMessage.create` call site either switches on `msg.metadata` first or constructs the `Msg` with explicit `.resolve` metadata; this was the one exception.

## Fix

1. **`VirtualMachine.zig`** — give the `NameTooLong` `Msg` proper `.metadata = .resolve` with the correct `import_kind` and `err`. The `specifier` `BabyString` is left empty because on this path the specifier is by definition longer than `BabyString`'s u16 offset/len can encode; the full specifier is still in the message text.
2. **`ResolveMessage.zig`** — make `getSpecifier` and `getImportKind` switch on `metadata` (matching the existing pattern in `getCode`), returning an empty string for the non-`.resolve` case so any future call site that gets this wrong degrades gracefully instead of panicking.

## Verification

New test in `test/js/bun/resolve/resolve-error.test.ts` imports a 150 000-char specifier (exceeds the threshold on all platforms) in a subprocess, then reads `.specifier`, `.importKind`, and `JSON.stringify`s the caught error.

- System bun (release): fails — `importKind` is `"entry-point-run"` instead of `"import-statement"`.
- Debug build without fix: subprocess panics, test fails.
- Debug build with fix: passes, `importKind` is `"import-statement"`.

`bun run zig:check-all` passes on all targets including Windows.