### PR TITLE
build: test WebKit preview autobuild-preview-pr-187-0c3c8e5a

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
+export const WEBKIT_VERSION = "autobuild-preview-pr-187-0c3c8e5a";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
CI run against the latest preview build of oven-sh/WebKit#187 (`CachedTypes: borrow CachedBytecode bytes for InstructionStream and ExpressionInfo`, head `0c3c8e5a`).

Do not merge — this is for surfacing breakage only. If green, the WebKit PR can land and a real bump will follow with the merged commit hash.