### PR TITLE
node:module: avoid ThrowScope in builtinModules/globalPaths callbacks

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -653,6 +653,11 @@ static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
     return zigGlobalObject->JSSourceMapConstructor();
 }
 
+// PropertyCallbacks reified by reifyAllStaticProperties run back-to-back with
+// no exception check between them, so they must not call helpers that open a
+// ThrowScope (constructArray / constructEmptyArray). Use JSArray::tryCreate*
+// instead. See test/integration/bun-types/bun-types.test.ts (tsgo case) which
+// ESM-imports node:module under the JSC exception-scope validator.
 static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -655,15 +655,25 @@ static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
 
 static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)
 {
+    auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
+
     MarkedArgumentBuffer args;
     args.ensureCapacity(countof(builtinModuleNames));
-
     for (unsigned i = 0; i < countof(builtinModuleNames); ++i) {
         args.append(JSC::jsOwnedString(vm, String(builtinModuleNames[i])));
     }
 
-    auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    return JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList(args));
+    JSC::ObjectInitializationScope initializationScope(vm);
+    auto* array = JSC::JSArray::tryCreateUninitializedRestricted(
+        initializationScope,
+        globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+        countof(builtinModuleNames));
+    if (!array) [[unlikely]]
+        return {};
+    for (unsigned i = 0; i < countof(builtinModuleNames); ++i) {
+        array->initializeIndex(initializationScope, i, args.at(i));
+    }
+    return array;
 }
 
 static JSValue getConstantsObject(VM& vm, JSObject* moduleObject)
@@ -691,9 +701,9 @@ static JSValue getConstantsObject(VM& vm, JSObject* moduleObject)
 
 static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
 {
-    return JSC::constructEmptyArray(
-        moduleObject->globalObject(),
-        static_cast<ArrayAllocationProfile*>(nullptr), 0);
+    auto* globalObject = moduleObject->globalObject();
+    return JSC::JSArray::tryCreate(
+        vm, globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), 0);
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSetCJSWrapperItem, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))


### PR DESCRIPTION
## Summary
- `reifyAllStaticProperties` calls each `PropertyCallback` in the `node:module` LUT back-to-back with no exception check between them. `getBuiltinModulesObject` (via `constructArray`) and `getGlobalPathsObject` (via `constructEmptyArray`) each open an internal `ThrowScope`, whose dtor `simulateThrow()`s — so under `BUN_JSC_validateExceptionChecks=1` the second callback trips the validator on first `import("node:module")`.
- Surfaced on x64-asan as `test/integration/bun-types/bun-types.test.ts > tsgo (TypeScript 7 native preview)` once 33356e8b13 added a test that spawns Bun (with `bunEnv`, which forwards the validator env var) to run `tsgo.js`, which ESM-imports `node:module`.
- Replace both with `JSArray::tryCreate` / `tryCreateUninitializedRestricted` + `initializeIndex`, which produce identical arrays without opening any `ThrowScope`. Strings are filled into the `MarkedArgumentBuffer` before the `ObjectInitializationScope` opens since allocation is disallowed inside it.

## Test plan
- [x] `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 bun-debug --print 'import("node:module").then(m => [m.builtinModules.length, Array.isArray(m.globalPaths)])'` — was aborting, now prints `[ 76, true ]`
- [x] `BUN_JSC_validateExceptionChecks=1 ... bun-debug node_modules/@typescript/native-preview/bin/tsgo.js --version` — was aborting, now prints the version
- [x] `bun bd test test/integration/bun-types/bun-types.test.ts -t "tsgo"` with `BUN_JSC_validateExceptionChecks=1` + `ASAN_OPTIONS=allow_user_segv_handler=1` — passes
- [x] `bun bd test test/js/node/module/node-module-module.test.js` — 28 pass (run without exception checks; that file is in `no-validate-exceptions.txt` for an unrelated `jsFunctionWrap` issue)
- [ ] CI x64-asan shard for `bun-types.test.ts` goes green