### PR TITLE
build(unified): compile ProcessBindingConstants.cpp standalone

### DIFF
--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -100,6 +100,13 @@ const noUnify: readonly string[] = [
   // which conditional branches fire.
   "src/bun.js/bindings/ProcessBindingUV.cpp",
 
+  // Uses `#ifdef S_IFBLK` / `#ifdef S_IFSOCK` etc. to decide which constants
+  // to expose in `fs.constants` — Node.js omits these on Windows. When
+  // bundled after NodeFSStatBinding.cpp (which `#define`s them for its own
+  // S_IS*() helpers on Windows), the ifdefs fire and the constants leak into
+  // `fs.constants`, breaking Node.js parity and test/js/node/fs/fs.test.ts.
+  "src/bun.js/bindings/ProcessBindingConstants.cpp",
+
   // Defines extern "C" replacements for platform symbols (strncasecmp,
   // fstat64, environ, ...). On Windows an earlier sibling can leak
   // `#define strncasecmp _strnicmp`, turning the definition here into a


### PR DESCRIPTION
## Problem

Since #29545 (unified C++ sources), `test/js/node/fs/fs.test.ts` fails on Windows:

```
error: expect(received).toEqual(expected)
  {
    ...
+   "S_IFBLK": 24576,
    ...
+   "S_IFSOCK": 49152,
    ...
  }
✗ fs.constants
```

Node.js does not expose `S_IFBLK` / `S_IFSOCK` in `fs.constants` on Windows, and neither did Bun before #29545.

## Cause

`ProcessBindingConstants.cpp` decides which constants to expose via `#ifdef`:

```cpp
#ifdef S_IFBLK
    object->putDirect(vm, ..., jsNumber(S_IFBLK));
#endif
```

`NodeFSStatBinding.cpp` `#define`s `S_IFBLK` / `S_IFSOCK` on Windows for its own `S_ISBLK()` / `S_ISSOCK()` helpers. Both files live in `src/bun.js/bindings/`, and with `N` sorted before `P`, `NodeFSStatBinding.cpp` is `#include`d first in the same unified TU — its macros leak into `ProcessBindingConstants.cpp`'s `#ifdef` checks.

`ProcessBindingConstants.cpp` has **251** `#ifdef`/`#ifndef` checks; it is fundamentally sensitive to ambient macro state and should compile in isolation, same as `ProcessBindingUV.cpp` (already in `noUnify` for the identical reason with errno/EAI_* macros).

## Fix

Add `ProcessBindingConstants.cpp` to `noUnify` in `scripts/build/unified.ts`.

## Verification

- `fs.constants` test failure reproduces on Windows in every build based on `main` ≥ `2cf54bf6dd` (e.g. [#47110](https://buildkite.com/bun/bun/builds/47110), windows-2019-x64 / x64-baseline / win11-aarch64)
- Not seen on `main` CI yet only because build #47033 failed at an unrelated aarch64-musl build-cpp step before Windows tests ran
- Linux/macOS unaffected (`S_IFBLK`/`S_IFSOCK` come from `<sys/stat.h>` there regardless)