### PR TITLE
inspect: handle circular references in JSX elements

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,35 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    props: {},
+  };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+
+  const el2 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    props: { foo: null },
+  };
+  el2.props.foo = el2;
+  expect(Bun.inspect(el2)).toBe("<div foo=[Circular] />");
+
+  const el3 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    props: { children: null },
+  };
+  el3.props.children = el3;
+  expect(Bun.inspect(el3)).toBe("<div>\n  [Circular]\n</div>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

`Bun.inspect()` on a React element whose `key`, `props`, or `children` referenced itself (directly or indirectly) would recurse until the stack overflowed and the process segfaulted.

The `.JSX` tag was missing from `canHaveCircularReferences()`, so the visited-set check and stack guard at the top of `printAs` were skipped for React elements. Formatting the `key` (or any prop/child) would re-enter the `.JSX` branch with the same value forever.

### Repro

```js
const el = {
  $$typeof: Symbol.for("react.element"),
  type: "div",
  key: null,
  props: {},
};
el.key = el;
Bun.inspect(el); // segfault (stack overflow)
```

Now prints `<div key=[Circular] />`.

## How did you verify your code works?

- Fuzzer repro no longer crashes
- Added regression test in `test/js/bun/util/inspect.test.js` covering circular `key`, prop value, and `children`
- Existing JSX inspect tests still pass

Found by Fuzzilli (fingerprint `6e718886f45af13a`).