### PR TITLE
Dedupe extracted embedded native modules in compiled binaries

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -394,9 +394,6 @@ static char* toFileURI(std::span<const char> span)
 
 extern "C" size_t Bun__process_dlopen_count;
 
-// "Fire and forget" wrapper around unlink for c usage that handles EINTR
-extern "C" void Bun__unlink(const char*, size_t);
-
 extern "C" void CrashHandler__setDlOpenAction(const char* action);
 extern "C" bool Bun__VM__allowAddons(void* vm);
 extern "C" int32_t Bun__addonNeedsGlibcOnMusl(const char* path, size_t len, char* soname_out, size_t soname_cap);
@@ -471,54 +468,18 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #else
 #define StandaloneModuleGraph__base_path "/$bunfs/"_s
 #endif
-    bool deleteAfter = false;
     [[maybe_unused]] bool fromEmbedded = false;
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
         BunString bunStr = Bun::toString(filename);
         if (Bun__resolveEmbeddedNodeFile(globalObject->bunVM(), &bunStr)) {
             filename = bunStr.transferToWTFString();
-            deleteAfter = !filename.startsWith("/proc/"_s);
+            // The extracted file is content-hashed and shared across dlopens
+            // and restarts (#29587), so it is never deleted here.
             fromEmbedded = true;
         }
     }
 
     RETURN_IF_EXCEPTION(scope, {});
-
-    // For bun build --compile, we copy the .node file to a temp directory.
-    // It's best to delete it as soon as we can.
-    // https://github.com/oven-sh/bun/issues/19550
-    const auto tryToDeleteIfNecessary = [&]() {
-#if OS(WINDOWS)
-        if (deleteAfter) {
-            // Only call it once
-            deleteAfter = false;
-            if (filename.is8Bit()) {
-                filename.convertTo16Bit();
-            }
-
-            // Convert to 16-bit with a sentinel zero value.
-            auto span = filename.span16();
-            auto dupeZ = new wchar_t[span.size() + 1];
-            if (dupeZ) {
-                memcpy(dupeZ, span.data(), span.size_bytes());
-                dupeZ[span.size()] = L'\0';
-
-                // We can't immediately delete the file on Windows.
-                // Instead, we mark it for deletion on reboot.
-                MoveFileExW(
-                    dupeZ,
-                    NULL, // NULL destination means delete
-                    MOVEFILE_DELAY_UNTIL_REBOOT);
-                delete[] dupeZ;
-            }
-        }
-#else
-        if (deleteAfter) {
-            deleteAfter = false;
-            Bun__unlink(utf8.data(), utf8.length());
-        }
-#endif
-    };
 
     // Handle known yet-to-be-working in Bun
     {
@@ -544,8 +505,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #if OS(WINDOWS)
     BunString filename_str = Bun::toString(filename);
     HMODULE handle = Bun__LoadLibraryBunString(&filename_str);
-
-// On Windows, we use GetLastError() for error messages, so we can only delete after checking for errors
 #else
 #if OS(LINUX)
     // A glibc-linked addon loaded into a musl process segfaults inside the
@@ -568,8 +527,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
     CrashHandler__setDlOpenAction(utf8.data());
     void* handle = dlopen(utf8.data(), RTLD_LAZY);
     CrashHandler__setDlOpenAction(nullptr);
-
-    tryToDeleteIfNecessary();
 #endif
 
     globalObject->m_pendingNapiModuleDlopenHandle = handle;
@@ -604,18 +561,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
         WTF::String msg = errorBuilder.toString();
         if (messageBuffer)
             LocalFree(messageBuffer); // Free the buffer allocated by FormatMessageW
-
-        // Since we're relying on LastError(), we have to delete after checking for errors
-        tryToDeleteIfNecessary();
 #else
         WTF::String msg = WTF::String::fromUTF8(dlerror());
 #endif
         return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED, msg);
     }
-
-#if OS(WINDOWS)
-    tryToDeleteIfNecessary();
-#endif
 
     if (callCountAtStart != globalObject->napiModuleRegisterCallCount) {
         // Module self-registered via static constructor(s).

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4935,19 +4935,15 @@ unsafe fn transpile_virtual_module(
     }
 }
 
-/// Core of `ModuleLoader.resolveEmbeddedFile`:
-/// finds an embedded file in the standalone module graph, materializes it to
-/// a real on-disk temp file with `extname`, and writes the resulting absolute
-/// path into `out_buf`. Returns the number of bytes written.
+/// Materialise an embedded file (`.node`/`.so`/`.dylib`/`.dll` from
+/// `bun build --compile`) to an on-disk path `dlopen(2)` can open. Called
+/// from `resolve_embedded_node_file_hook` (`process.dlopen()`) and
+/// `ffi_body::FFI::open` (`bun:ffi`).
 ///
-/// Called from two paths:
-///   - `resolve_embedded_node_file_hook` (`process.dlopen()` on a compiled
-///     executable; extname = `"node"`).
-///   - `bun:ffi` `dlopen()` on an embedded `with { type: "file" }` shared
-///     library (`ffi_body::FFI::open`; extname = `"so"` / `"dylib"` / `"dll"`).
-///
-/// Returns `None` when the path is empty, not present in the graph, or any
-/// filesystem step fails.
+/// The filename is a hash of the contents, so every `dlopen()` of the same
+/// embedded library — across calls, Worker VMs, and restarts — shares one
+/// file instead of leaking a copy per call (#29585). Returns `None` when the
+/// input is empty, absent from the graph, or a filesystem step fails.
 pub(crate) fn resolve_embedded_file_to_buf(
     input_path: &[u8],
     extname: &[u8],
@@ -4957,69 +4953,100 @@ pub(crate) fn resolve_embedded_file_to_buf(
         return None;
     }
 
-    // Note: do NOT downcast the `&'static dyn StandaloneModuleGraph`
-    // stored on `vm` to `&mut Graph` — that shared-ref provenance is
-    // read-only (instant UB under Stacked Borrows). Reach the concrete graph
-    // via `Graph::get()` which hands out the `UnsafeCell` `*mut` (same path
-    // as `load_standalone_sourcemap` / `node_fs`).
-    let graph = bun_standalone_graph::Graph::get()?;
-    // SAFETY: `graph` is the `UnsafeCell::get()` pointer to the
-    // process-lifetime singleton; this hook runs on the JS thread and `find`
-    // is read-only over the post-init `files` table.
-    let file = (unsafe { &mut *graph }).find(input_path)?;
-    let file_name: &[u8] = file.name;
+    let file = bun_standalone_graph::Graph::get_ref()?.find_ref(input_path)?;
     let file_contents: &[u8] = file.contents.as_bytes();
 
-    let mut tmpname_buf = bun_paths::path_buffer_pool::get();
-    let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
+    // `.bun-{uid}-{wyhash(contents)}.{ext}`: the hash dedupes; the uid keeps
+    // users on a shared `/tmp` from colliding.
+    let content_hash = bun_wyhash::hash(file_contents);
+    let uid = extract_owner_uid();
+    let mut canonical_name_buf = [0u8; 64];
+    let canonical_name = bun_core::fmt::buf_print_z(
+        &mut canonical_name_buf,
+        format_args!(
+            ".bun-{}-{:x}.{}",
+            uid,
+            content_hash,
+            bun_core::fmt::s(extname)
+        ),
+    )
+    .ok()?;
 
-    // SAFETY: `FileSystem::instance()` returns the process-global singleton
-    // pointer (initialized at startup).
+    // Reuse the canonical file from a previous run if it is still ours with
+    // the right size. `lstatat` so a planted symlink fails the ISREG check
+    // instead of being followed.
     let tmpdir = (*Fs::FileSystem::instance()).tmpdir().ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
-
-    let tmpfile = bun_sys::Tmpfile::create(tmpdir_fd, tmpfilename).ok()?;
-    let tmpfile_fd = tmpfile.fd;
-    scopeguard::defer! {
-        let _ = bun_sys::close(tmpfile_fd);
+    if let Ok(st) = bun_sys::lstatat(tmpdir_fd, canonical_name) {
+        let size_ok = st.st_size as usize == file_contents.len();
+        #[cfg(unix)]
+        let ours = st.st_uid == uid && bun_sys::S::ISREG(st.st_mode as u32);
+        #[cfg(windows)]
+        let ours = true;
+        if size_ok && ours {
+            return write_absolute(
+                out_buf,
+                Fs::RealFS::tmpdir_path(),
+                canonical_name.as_bytes(),
+            );
+        }
     }
 
-    let mut scratch = bun_paths::path_buffer_pool::get();
-    if bun_sys::write_file_with_path_buffer(
-        &mut scratch,
-        &bun_sys::WriteFileArgs {
-            data: bun_sys::WriteFileData::Buffer {
-                buffer: file_contents,
-            },
-            encoding: bun_sys::WriteFileEncoding::Buffer,
-            dirfd: tmpdir_fd,
-            file: bun_sys::PathOrFileDescriptor::Fd(tmpfile_fd),
-            ..Default::default()
-        },
-    )
-    .is_err()
-    {
+    // Write to a unique scratch name, then atomically rename it into place.
+    let mut scratch_buf = bun_paths::path_buffer_pool::get();
+    let scratch_name = Fs::FileSystem::tmpname(extname, &mut scratch_buf[..], content_hash).ok()?;
+
+    // 0600: the file persists, only the owning euid ever dlopens it, and the
+    // embedded bytes may come from a binary that is not world-readable.
+    let mut tmpfile = bun_sys::Tmpfile::create_with_mode(tmpdir_fd, scratch_name, 0o600).ok()?;
+    let _close = bun_sys::CloseOnDrop::new(tmpfile.fd);
+
+    let write_ok = bun_sys::File::borrow(&tmpfile.fd)
+        .write_all(file_contents)
+        .is_ok();
+    if !write_ok {
+        let _ = bun_sys::unlinkat(tmpdir_fd, scratch_name);
         return None;
     }
 
-    // `join_abs_string_buf` writes into
-    // `out_buf` and returns a slice pointing into it; capture the length so
-    // the caller knows how many bytes are live.
+    // On sticky `/tmp` the rename fails EACCES/EPERM when another user owns
+    // the destination; fall back to the scratch file.
+    let rename_ok = tmpfile.finish(canonical_name).is_ok();
+
+    let final_name = if rename_ok {
+        canonical_name
+    } else {
+        scratch_name
+    };
+    write_absolute(out_buf, Fs::RealFS::tmpdir_path(), final_name.as_bytes())
+}
+
+/// Writes `{tmpdir}/{name}` into `out_buf` and returns the length.
+fn write_absolute(out_buf: &mut [u8], tmpdir: &[u8], name: &[u8]) -> Option<usize> {
     let result = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-        Fs::RealFS::tmpdir_path(),
+        tmpdir,
         out_buf,
-        &[tmpfilename.as_bytes()],
+        &[name],
     );
     Some(result.len())
 }
 
-/// `LoaderHooks::resolve_embedded_node_file` body —
-/// `ModuleLoader.resolveEmbeddedFile` for the
-/// `process.dlopen()`-on-a-compiled-executable path. Delegates to
+/// euid, not uid: `open(2)` sets the new file's owner to euid, so a
+/// `getuid()` check would never match in a setuid binary.
+#[cfg(unix)]
+fn extract_owner_uid() -> u32 {
+    // SAFETY: `geteuid` takes no arguments and cannot fail.
+    unsafe { libc::geteuid() as u32 }
+}
+
+#[cfg(windows)]
+fn extract_owner_uid() -> u32 {
+    bun_sys::windows::user_unique_id()
+}
+
+/// `LoaderHooks::resolve_embedded_node_file` body: delegates to
 /// [`resolve_embedded_file_to_buf`] with `extname = "node"` and writes the
-/// resulting on-disk path back into `*in_out_str`
-/// (as an owned UTF-8 clone).
+/// on-disk path back into `*in_out_str`.
 ///
 /// # Safety
 /// `vm` is the live per-thread VM; `in_out_str` is a valid in/out

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -989,19 +989,6 @@ pub(crate) extern "C" fn Bun__errnoName(err: core::ffi::c_int) -> *const core::f
     })
 }
 
-/// Small "fire and forget" wrapper around unlink for C usage that handles
-/// EINTR, Windows path conversion, etc.
-///
-/// # Safety
-/// `ptr[0..=len]` must be a valid NUL-terminated path slice for the call.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Bun__unlink(ptr: *const u8, len: usize) {
-    // SAFETY: caller (C++) guarantees `ptr[0..=len]` is a valid NUL-terminated
-    // path slice for the duration of the call.
-    let path = unsafe { ZStr::from_raw(ptr, len) };
-    let _ = unlink(path);
-}
-
 // libuv-style error constants (negated errno on posix, UV_* on Windows). The
 // per-platform `bun_errno` module defines this as `mod uv_e`; re-export under
 // the canonical name so callers can write `bun_sys::UV_E::NOENT`.

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -140,23 +140,30 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
               stderr: "inherit",
             });
             expect(build.success).toBeTrue();
-            await using tmpdir = tempDir("should-be-empty-except", {});
-            const result = spawnSync({
-              cmd: [exe, "self"],
-              env: { ...bunEnv, BUN_TMPDIR: tmpdir },
-              stdin: "inherit",
-              stderr: "inherit",
-              stdout: "pipe",
-            });
+            // Since #29587 each extracted `.node` persists at a content-hashed
+            // path shared across runs (pre-#29587 it was unlinked per load,
+            // see #19550), so a second run must not extract new copies.
+            await using tmpdir = tempDir("napi-compile-extract-" + format, {});
+            const runEnv = { ...bunEnv, BUN_TMPDIR: String(tmpdir), TMPDIR: String(tmpdir) };
+            const runSelf = () =>
+              spawnSync({
+                cmd: [exe, "self"],
+                env: runEnv,
+                stdin: "inherit",
+                stderr: "inherit",
+                stdout: "pipe",
+              });
+            const result = runSelf();
             const stdout = result.stdout.toString().trim();
             expect(stdout).toBe("hello world!");
             expect(result.success).toBeTrue();
-            if (process.platform !== "win32") {
-              expect(readdirSync(tmpdir), "bun should clean up .node files").toBeEmpty();
-            } else {
-              // On Windows, we have to mark it for deletion on reboot.
-              // Not clear how to test for that.
-            }
+            const extractedCount = () => readdirSync(String(tmpdir)).filter(f => f.endsWith(".node")).length;
+            const count = extractedCount();
+            expect(count).toBeGreaterThan(0);
+            const again = runSelf();
+            expect(again.stdout.toString().trim()).toBe("hello world!");
+            expect(again.success).toBeTrue();
+            expect(extractedCount()).toBe(count);
           },
           // CI runs tests under bun-profile (~700 MB on linux with ThinLTO
           // DWARF); --compile copies+reads+rewrites the whole thing to /tmp,

--- a/test/regression/issue/29585.test.ts
+++ b/test/regression/issue/29585.test.ts
@@ -1,0 +1,185 @@
+// https://github.com/oven-sh/bun/issues/29585
+//
+// `bun build --compile` binaries that `dlopen()` an embedded .so used to
+// extract a fresh copy to /tmp for every call, with no dedup or cleanup.
+// Extraction is now content-hashed at `{tmpdir}/.bun-{uid}-{hash}.{ext}`,
+// so repeated dlopens and repeated runs of the same binary share one file.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const cc = isLinux ? (Bun.which("cc") ?? Bun.which("gcc")) : null;
+
+// Paths under `root` whose bytes match `expected`. Content-match (not name
+// pattern) keeps the check robust against any future naming scheme.
+async function findExtractedCopies(root: string, expected: Buffer): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+  const matches: string[] = [];
+  for (const rel of entries) {
+    if (!rel.endsWith(".so")) continue;
+    const p = join(root, rel);
+    try {
+      const f = Bun.file(p);
+      if (f.size !== expected.length) continue;
+      if (expected.equals(Buffer.from(await f.arrayBuffer()))) matches.push(p);
+    } catch {} // raced with deletion / permission — ignore
+  }
+  return matches;
+}
+
+const LIBHELLO_C = "int hello(void) { return 42; }\n";
+
+// Builds `libhello.so` from `libhello.c` and compiles `app.ts` into a
+// standalone binary at `{cwd}/app`. Returns the binary path and the .so bytes
+// for content-matching.
+async function buildFixture(cwd: string): Promise<{ out: string; libBytes: Buffer }> {
+  {
+    // gcc/clang/ld can emit benign notes on success, so only assert exit code.
+    await using proc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", "libhello.so", "libhello.c"],
+      cwd,
+      env: bunEnv,
+    });
+    expect(await proc.exited).toBe(0);
+  }
+
+  const libBytes = Buffer.from(await Bun.file(join(cwd, "libhello.so")).arrayBuffer());
+
+  const out = join(cwd, "app");
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "--outfile", out, "app.ts"],
+      cwd,
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+  return { out, libBytes };
+}
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "compiled binary deduplicates extracted embedded .so across dlopen calls + process restarts (#29585)",
+  async () => {
+    using dir = tempDir("29585", {
+      "libhello.c": LIBHELLO_C,
+
+      // Each dlopen() pre-fix wrote a fresh file to /tmp; post-fix they all
+      // share the content-hashed path `{tmpdir}/.bun-{uid}-{hash}.so`.
+      "app.ts": `
+        import { dlopen, FFIType } from "bun:ffi";
+        import lib from "./libhello.so" with { type: "file" };
+        for (let i = 0; i < 10; i++) {
+          const { symbols, close } = dlopen(lib, { hello: { args: [], returns: FFIType.i32 } });
+          if (symbols.hello() !== 42) { console.error("bad result"); process.exit(1); }
+          close();
+        }
+        console.log("ok");
+      `,
+    });
+    const cwd = String(dir);
+    const { out, libBytes } = await buildFixture(cwd);
+
+    // Isolate extraction so concurrent runs (or anything else in /tmp) can't
+    // interfere. BUN_TMPDIR wins inside bun; TMPDIR covers libc.
+    using extractRoot = tempDir("29585-extract", {});
+    const extractDir = String(extractRoot);
+    const runEnv = { ...bunEnv, BUN_TMPDIR: extractDir, TMPDIR: extractDir };
+
+    const runOnce = async () => {
+      await using proc = Bun.spawn({ cmd: [out], env: runEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // On regression, diagnostics go to stderr — surface them in the failure
+      // message rather than letting the pipe swallow them. Debug+ASAN builds
+      // print benign "ASAN interferes..." and "debug warn:" lines we ignore.
+      expect(stderr).not.toContain("error:");
+      expect(stderr).not.toContain("dlopen");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+    };
+
+    // First run: 10 main-thread dlopens. Pre-fix: 10 files. Post-fix: 1.
+    await runOnce();
+    expect((await findExtractedCopies(extractDir, libBytes)).length).toBe(1);
+
+    // Second run of the same binary: still one file (content-hashed filename is
+    // reused across process restarts).
+    await runOnce();
+    expect((await findExtractedCopies(extractDir, libBytes)).length).toBe(1);
+
+    // Third run: simulate systemd-tmpfiles sweeping the extracted file. The
+    // next run must re-extract (the lstat on the canonical name misses, so it
+    // writes again) instead of handing dlopen a deleted path.
+    for (const p of await findExtractedCopies(extractDir, libBytes)) rmSync(p, { force: true });
+    await runOnce();
+    expect((await findExtractedCopies(extractDir, libBytes)).length).toBe(1);
+  },
+  // `bun build --compile` on debug+ASAN takes ~25s; default 5s isn't enough.
+  180_000,
+);
+
+// The original #29585 report was specifically about `new Worker()` amplifying
+// the leak — each Worker VM had its own `tmpname_id_number` counter that
+// started at 0, so every Worker re-extracted on its first dlopen. This test
+// verifies Workers share the one extracted file: they hash the same embedded
+// bytes to the same content-hashed filename, so all dlopens land on one path.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "compiled binary's Workers share one extracted .so (#29585)",
+  async () => {
+    using dir = tempDir("29585-workers", {
+      "libhello.c": LIBHELLO_C,
+      "app.ts": `
+        import { dlopen, FFIType } from "bun:ffi";
+        import lib from "./libhello.so" with { type: "file" };
+
+        if (Bun.isMainThread) {
+          const workers: Worker[] = [];
+          const done: Promise<void>[] = [];
+          for (let i = 0; i < 5; i++) {
+            const w = new Worker(import.meta.url);
+            workers.push(w);
+            const { promise, resolve, reject } = Promise.withResolvers<void>();
+            w.addEventListener("message", () => resolve(), { once: true });
+            w.addEventListener("error", e => reject(e), { once: true });
+            done.push(promise);
+          }
+          await Promise.all(done);
+          for (const w of workers) w.terminate();
+          console.log("ok");
+        } else {
+          const { symbols, close } = dlopen(lib, { hello: { args: [], returns: FFIType.i32 } });
+          if (symbols.hello() !== 42) { console.error("bad result in worker"); process.exit(1); }
+          postMessage("done");
+          close();
+        }
+      `,
+    });
+    const cwd = String(dir);
+    const { out, libBytes } = await buildFixture(cwd);
+
+    using extractRoot = tempDir("29585-workers-extract", {});
+    const extractDir = String(extractRoot);
+    const runEnv = { ...bunEnv, BUN_TMPDIR: extractDir, TMPDIR: extractDir };
+
+    await using proc = Bun.spawn({ cmd: [out], env: runEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("dlopen");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+
+    // 5 workers each call dlopen(). Pre-fix: 5 files. Post-fix: 1.
+    expect((await findExtractedCopies(extractDir, libBytes)).length).toBe(1);
+  },
+  180_000,
+);


### PR DESCRIPTION
Fixes #29585.

## Problem

A `bun build --compile` binary that loads an embedded native library (`bun:ffi` `dlopen` or `process.dlopen` on a `.node`) extracted a fresh copy to `/tmp` on every call and never cleaned it up. Each Worker re-extracted on its first `dlopen`, so Worker-heavy servers leaked fast (the reporter measured ~14 GB/hour). The cause: `resolve_embedded_file_to_buf` named each tmpfile with `nanoTimestamp()` plus a per-VM counter, so no two calls ever produced the same path.

## Fix

Extraction is now stateless and idempotent. The on-disk file is the cache.

- The name is `{tmpdir}/.bun-{euid}-{wyhash(contents):x}.{ext}`. Same content gives the same path, so all dlopens, Workers, and restarts of the binary share one file. The euid keeps users on a shared `/tmp` apart.
- Reuse check: `lstatat` the canonical name and reuse it if it is a regular file, owned by our euid, with the expected size. `lstatat` (not `fstatat`) makes a planted symlink fail the `ISREG` check instead of being followed.
- Extraction writes a unique scratch file, then `rename(2)`s it onto the canonical name. Racing Workers converge on one valid file. If the rename fails (a foreign owner squats the name on sticky `/tmp`), that call uses its scratch file.
- The post-`dlopen` deletion in `BunProcess.cpp` is removed on both platforms: deleting the shared file would defeat the dedup, and the Windows delete-on-reboot required admin rights and only ever marked the file in active use. The orphaned `Bun__unlink` export is deleted with its last caller.

## Verification

| case | /tmp copies |
|---|---|
| before: 10 dlopens + 5 Workers, 2 runs | 20 |
| after | 1 |

- `test/regression/issue/29585.test.ts`: one file after 10 dlopens, after a second process run, after deleting the file (re-extracts), and across 5 concurrent Workers. Fails pre-fix with `Expected: 1 / Received: 10`.
- `test/napi/napi.test.ts` (`--compile`): the `.node` / `process.dlopen` path keeps a stable extracted count across two runs, on all platforms (verified on Windows Server 2019 x64).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 55 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts test/regression/issue/29585.test.ts

<!-- robobun:evidence:end -->
