### PR TITLE
Fix assertion failure in Bun.plugin when target coercion throws

### DIFF
--- a/src/bun.js/bindings/BunPlugin.cpp
+++ b/src/bun.js/bindings/BunPlugin.cpp
@@ -301,11 +301,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     if (targetValue) {
         if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};
             }
         }
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
 
     JSObject* builderObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,28 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("throws instead of crashing when 'target' is a Symbol", () => {
+    expect(() => {
+      plugin({
+        setup: () => {},
+        target: Symbol("foo"),
+      } as any);
+    }).toThrow(TypeError);
+  });
+
+  it("propagates errors thrown while coercing 'target' to a string", () => {
+    expect(() => {
+      plugin({
+        setup: () => {},
+        target: {
+          [Symbol.toPrimitive]() {
+            throw new Error("boom");
+          },
+        },
+      } as any);
+    }).toThrow("boom");
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion failure (`assertNoException`) in `Bun.plugin()` when the `target` option is a value whose string coercion throws — e.g. a `Symbol`, or an object with a throwing `Symbol.toPrimitive`.

`toStringOrNull()` returns `nullptr` with a pending exception in these cases. The surrounding code only handled the non-null branch and fell through to `constructEmptyObject()` with the exception still pending, which trips `ExceptionScope::assertNoException()` in debug/ASAN builds.

Found by Fuzzilli (fingerprint `15b3dd05628c2f45`).

## How did you verify your code works?

Minimal repro that asserted before and now throws a clean `TypeError`:

```js
Bun.plugin({
  target: Symbol("foo"),
  setup() {},
});
```

Added regression tests to `test/js/bun/plugin/plugins.test.ts` covering both the `Symbol` case and a throwing `Symbol.toPrimitive`. Full `plugins.test.ts` suite passes (31 pass, 1 todo).