### PR TITLE
test --changed: let tsconfig paths win over packages=external

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -598,6 +598,13 @@ pub const Resolver = struct {
         if (r.opts.packages == .external and isPackagePath(import_path)) {
             return true;
         }
+        return r.matchesUserExternalPattern(import_path);
+    }
+
+    /// True if `import_path` matches one of the user-supplied `--external`
+    /// patterns. Does NOT consider `packages = external`; use
+    /// `isExternalPattern` for the combined check.
+    pub fn matchesUserExternalPattern(r: *ThisResolver, import_path: string) bool {
         for (r.opts.external.patterns) |pattern| {
             if (import_path.len >= pattern.prefix.len + pattern.suffix.len and (strings.startsWith(
                 import_path,
@@ -606,6 +613,39 @@ pub const Resolver = struct {
                 import_path,
                 pattern.suffix,
             ))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Cheap pattern-only check: would the enclosing tsconfig.json's `paths`
+    /// remap this import? Returns true if any `paths` key matches `import_path`
+    /// exactly or via a `*` glob.
+    ///
+    /// The full match inside `matchTSConfigPaths` also requires the target file
+    /// to exist on disk; this helper deliberately stops at the pattern so that
+    /// callers (notably the `packages=external` short-circuit) can hand off to
+    /// the normal resolver instead of marking a path-aliased local import as
+    /// an external package.
+    pub fn hasTSConfigPathsMatch(r: *ThisResolver, source_dir: string, import_path: string) bool {
+        const dir_info = (r.dirInfoCached(source_dir) catch null) orelse return false;
+        const tsconfig = dir_info.enclosing_tsconfig_json orelse return false;
+        if (tsconfig.paths.count() == 0) return false;
+
+        var iter = tsconfig.paths.iterator();
+        while (iter.next()) |entry| {
+            const key = entry.key_ptr.*;
+            if (strings.indexOfChar(key, '*')) |star| {
+                const prefix = if (star == 0) "" else key[0..star];
+                const suffix = if (star == key.len - 1) "" else key[star + 1 ..];
+                if (strings.startsWith(import_path, prefix) and
+                    strings.endsWith(import_path, suffix) and
+                    import_path.len >= prefix.len + suffix.len)
+                {
+                    return true;
+                }
+            } else if (strings.eqlLong(key, import_path, true)) {
                 return true;
             }
         }
@@ -701,8 +741,20 @@ pub const Resolver = struct {
 
         // Certain types of URLs default to being external for convenience,
         // while these rules should not be applied to the entrypoint as it is never external (#12734)
+        //
+        // A tsconfig.json `paths` alias whose key looks bare (e.g. "@/*")
+        // would otherwise be caught by `packages = external + isPackagePath`
+        // even though it remaps to a local file. Consult tsconfig paths first
+        // so the resolver follows the alias into the project source instead
+        // of silently marking it external (issue #29590). User-supplied
+        // `--external` patterns and URL-style specifiers still win.
+        const is_packages_external_match =
+            r.opts.packages == .external and
+            isPackagePath(import_path) and
+            !r.hasTSConfigPathsMatch(source_dir, import_path);
         if (kind != .entry_point_build and kind != .entry_point_run and
-            (r.isExternalPattern(import_path) or
+            (is_packages_external_match or
+                r.matchesUserExternalPattern(import_path) or
                 // "fill: url(#filter);"
                 (kind.isFromCSS() and strings.startsWith(import_path, "#")) or
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -598,13 +598,6 @@ pub const Resolver = struct {
         if (r.opts.packages == .external and isPackagePath(import_path)) {
             return true;
         }
-        return r.matchesUserExternalPattern(import_path);
-    }
-
-    /// True if `import_path` matches one of the user-supplied `--external`
-    /// patterns. Does NOT consider `packages = external`; use
-    /// `isExternalPattern` for the combined check.
-    pub fn matchesUserExternalPattern(r: *ThisResolver, import_path: string) bool {
         for (r.opts.external.patterns) |pattern| {
             if (import_path.len >= pattern.prefix.len + pattern.suffix.len and (strings.startsWith(
                 import_path,
@@ -619,37 +612,27 @@ pub const Resolver = struct {
         return false;
     }
 
-    /// Cheap pattern-only check: would the enclosing tsconfig.json's `paths`
-    /// remap this import? Returns true if any `paths` key matches `import_path`
-    /// exactly or via a `*` glob.
+    /// Full tsconfig.json `paths` resolution for the enclosing tsconfig of
+    /// `source_dir`. Returns the resolved `MatchResult` iff a key matches
+    /// AND the mapped target exists on disk; returns null otherwise.
     ///
-    /// The full match inside `matchTSConfigPaths` also requires the target file
-    /// to exist on disk; this helper deliberately stops at the pattern so that
-    /// callers (notably the `packages=external` short-circuit) can hand off to
-    /// the normal resolver instead of marking a path-aliased local import as
-    /// an external package.
-    pub fn hasTSConfigPathsMatch(r: *ThisResolver, source_dir: string, import_path: string) bool {
-        const dir_info = (r.dirInfoCached(source_dir) catch null) orelse return false;
-        const tsconfig = dir_info.enclosing_tsconfig_json orelse return false;
-        if (tsconfig.paths.count() == 0) return false;
-
-        var iter = tsconfig.paths.iterator();
-        while (iter.next()) |entry| {
-            const key = entry.key_ptr.*;
-            if (strings.indexOfChar(key, '*')) |star| {
-                const prefix = if (star == 0) "" else key[0..star];
-                const suffix = if (star == key.len - 1) "" else key[star + 1 ..];
-                if (strings.startsWith(import_path, prefix) and
-                    strings.endsWith(import_path, suffix) and
-                    import_path.len >= prefix.len + suffix.len)
-                {
-                    return true;
-                }
-            } else if (strings.eqlLong(key, import_path, true)) {
-                return true;
-            }
-        }
-        return false;
+    /// Used by the `packages=external` short-circuit so that a path-aliased
+    /// local file is followed into the project source instead of being
+    /// mistaken for a bare package specifier, while a bare specifier whose
+    /// alias target does not exist (e.g. a catch-all `"*"` paths entry used
+    /// for ambient type stubs) still falls through to the external path.
+    pub fn resolveViaTSConfigPaths(
+        r: *ThisResolver,
+        source_dir: string,
+        import_path: string,
+        kind: ast.ImportKind,
+    ) ?MatchResult {
+        if (source_dir.len == 0) return null;
+        if (!std.fs.path.isAbsolute(source_dir)) return null;
+        const dir_info = (r.dirInfoCached(source_dir) catch null) orelse return null;
+        const tsconfig = dir_info.enclosing_tsconfig_json orelse return null;
+        if (tsconfig.paths.count() == 0) return null;
+        return r.matchTSConfigPaths(tsconfig, import_path, kind);
     }
 
     pub fn flushDebugLogs(r: *ThisResolver, flush_mode: DebugLogs.FlushMode) !void {
@@ -739,22 +722,41 @@ pub const Resolver = struct {
             }
         }
 
-        // Certain types of URLs default to being external for convenience,
-        // while these rules should not be applied to the entrypoint as it is never external (#12734)
-        //
         // A tsconfig.json `paths` alias whose key looks bare (e.g. "@/*")
         // would otherwise be caught by `packages = external + isPackagePath`
-        // even though it remaps to a local file. Consult tsconfig paths first
-        // so the resolver follows the alias into the project source instead
-        // of silently marking it external (issue #29590). User-supplied
-        // `--external` patterns and URL-style specifiers still win.
-        const is_packages_external_match =
-            r.opts.packages == .external and
-            isPackagePath(import_path) and
-            !r.hasTSConfigPathsMatch(source_dir, import_path);
+        // even though it remaps to a local file. Try the alias first, and
+        // only when it actually resolves to a file on disk do we follow it
+        // into the project source; otherwise fall through to the normal
+        // `packages = external` short-circuit so bare specifiers that
+        // happen to be covered by a catch-all paths entry (e.g.
+        // `"*": ["./types/*"]` for ambient .d.ts stubs) still get marked
+        // external (issue #29590).
         if (kind != .entry_point_build and kind != .entry_point_run and
-            (is_packages_external_match or
-                r.matchesUserExternalPattern(import_path) or
+            r.opts.packages == .external and isPackagePath(import_path))
+        {
+            if (r.resolveViaTSConfigPaths(source_dir, import_path, kind)) |res| {
+                if (r.debug_logs) |*debug| {
+                    debug.addNote("Resolved via tsconfig.json \"paths\" before applying packages=external");
+                    r.flushDebugLogs(.success) catch {};
+                }
+                return .{
+                    .success = Result{
+                        .import_kind = kind,
+                        .path_pair = res.path_pair,
+                        .diff_case = res.diff_case,
+                        .package_json = res.package_json,
+                        .dirname_fd = res.dirname_fd,
+                        .file_fd = res.file_fd,
+                        .jsx = r.opts.jsx,
+                    },
+                };
+            }
+        }
+
+        // Certain types of URLs default to being external for convenience,
+        // while these rules should not be applied to the entrypoint as it is never external (#12734)
+        if (kind != .entry_point_build and kind != .entry_point_run and
+            (r.isExternalPattern(import_path) or
                 // "fill: url(#filter);"
                 (kind.isFromCSS() and strings.startsWith(import_path, "#")) or
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -619,15 +619,11 @@ pub const Resolver = struct {
         return false;
     }
 
-    /// Full tsconfig.json `paths` resolution for the enclosing tsconfig of
-    /// `source_dir`. Returns the resolved `MatchResult` iff a key matches
-    /// AND the mapped target exists on disk; returns null otherwise.
-    ///
-    /// Used by the `packages=external` short-circuit so that a path-aliased
-    /// local file is followed into the project source instead of being
-    /// mistaken for a bare package specifier, while a bare specifier whose
-    /// alias target does not exist (e.g. a catch-all `"*"` paths entry used
-    /// for ambient type stubs) still falls through to the external path.
+    /// Resolves `import_path` via the enclosing tsconfig's `paths`. Returns
+    /// the `MatchResult` iff a key matches AND the mapped target exists on
+    /// disk. Used to let path-aliased local files win over `packages=external`
+    /// without breaking catch-all `"*"` paths entries that only cover ambient
+    /// type stubs.
     pub fn resolveViaTSConfigPaths(
         r: *ThisResolver,
         source_dir: string,
@@ -729,20 +725,11 @@ pub const Resolver = struct {
             }
         }
 
-        // A tsconfig.json `paths` alias whose key looks bare (e.g. "@/*")
-        // would otherwise be caught by `packages = external + isPackagePath`
-        // even though it remaps to a local file. Try the alias first, and
-        // only when it actually resolves to a file on disk do we follow it
-        // into the project source; otherwise fall through to the normal
-        // `packages = external` short-circuit so bare specifiers that
-        // happen to be covered by a catch-all paths entry (e.g.
-        // `"*": ["./types/*"]` for ambient .d.ts stubs) still get marked
-        // external (issue #29590).
-        //
-        // A user-supplied `--external` wildcard still wins: the block
-        // below only fires when the import would otherwise be externalised
-        // by `packages=external + isPackagePath`, never by an explicit
-        // user pattern.
+        // #29590: a tsconfig `paths` key can look bare (e.g. "@/*") and
+        // otherwise collide with `packages=external + isPackagePath`. Try
+        // the alias first, but only follow it when it actually resolves to
+        // a file on disk — a catch-all `"*": ["./types/*"]` for ambient
+        // .d.ts stubs must still let real bare imports stay external.
         if (kind != .entry_point_build and kind != .entry_point_run and
             r.opts.packages == .external and isPackagePath(import_path) and
             !r.matchesUserExternalPattern(import_path))

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -598,6 +598,13 @@ pub const Resolver = struct {
         if (r.opts.packages == .external and isPackagePath(import_path)) {
             return true;
         }
+        return r.matchesUserExternalPattern(import_path);
+    }
+
+    /// True iff `import_path` matches a user-supplied `--external` wildcard
+    /// pattern. Does NOT consider `packages = external`; use
+    /// `isExternalPattern` for the combined check.
+    pub fn matchesUserExternalPattern(r: *ThisResolver, import_path: string) bool {
         for (r.opts.external.patterns) |pattern| {
             if (import_path.len >= pattern.prefix.len + pattern.suffix.len and (strings.startsWith(
                 import_path,
@@ -731,8 +738,14 @@ pub const Resolver = struct {
         // happen to be covered by a catch-all paths entry (e.g.
         // `"*": ["./types/*"]` for ambient .d.ts stubs) still get marked
         // external (issue #29590).
+        //
+        // A user-supplied `--external` wildcard still wins: the block
+        // below only fires when the import would otherwise be externalised
+        // by `packages=external + isPackagePath`, never by an explicit
+        // user pattern.
         if (kind != .entry_point_build and kind != .entry_point_run and
-            r.opts.packages == .external and isPackagePath(import_path))
+            r.opts.packages == .external and isPackagePath(import_path) and
+            !r.matchesUserExternalPattern(import_path))
         {
             if (r.resolveViaTSConfigPaths(source_dir, import_path, kind)) |res| {
                 if (r.debug_logs) |*debug| {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1364,10 +1364,8 @@ describe("bundler", () => {
       `,
     },
   });
-  // A catch-all tsconfig `paths` entry (common for ambient .d.ts stubs)
-  // must not defeat `packages=external`: if the alias doesn't resolve to a
-  // real file, the bare specifier still gets marked external. Related to
-  // the follow-up fix for #29590.
+  // #29590: a catch-all `paths` entry (common for ambient .d.ts stubs)
+  // whose target doesn't exist must not defeat `packages=external`.
   itBundled("edgecase/PackageExternalStarPathsDoesNotBundleNodeModules#29590", {
     files: {
       "/entry.ts": /* ts */ `
@@ -1396,9 +1394,7 @@ describe("bundler", () => {
       `,
     },
     onAfterBundle(api) {
-      // `foo` must stay external — a catch-all paths entry whose target
-      // does not exist on disk cannot claim the import. If this regresses,
-      // `foo` gets inlined via `require_foo = __commonJS(...)` instead.
+      // If this regresses, `foo` gets inlined via __commonJS(...) instead.
       api.expectFile("/out.js").toContain(`from "foo"`);
     },
     run: {
@@ -1407,10 +1403,8 @@ describe("bundler", () => {
       `,
     },
   });
-  // Explicit --external wildcards must win over a tsconfig `paths` alias
-  // that resolves to a real local file. Without this guard the #29590 fix
-  // would silently bundle `@/src/*` when the user asked for it to stay
-  // external on top of `--packages=external`.
+  // #29590: an explicit --external wildcard must win over a tsconfig `paths`
+  // alias, even when the alias resolves to a real local file.
   itBundled("edgecase/ExternalWildcardBeatsTSConfigPaths#29590", {
     files: {
       "/entry.ts": /* ts */ `
@@ -1433,8 +1427,7 @@ describe("bundler", () => {
     external: ["@/src/*"],
     target: "bun",
     onAfterBundle(api) {
-      // The import must stay external. If it regresses, `add` gets
-      // inlined from src/adder.ts into the output bundle.
+      // If this regresses, `add` gets inlined from src/adder.ts.
       api.expectFile("/out.js").toContain(`from "@/src/adder"`);
       api.expectFile("/out.js").not.toContain(`= (a, b) => a + b`);
     },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1364,6 +1364,49 @@ describe("bundler", () => {
       `,
     },
   });
+  // A catch-all tsconfig `paths` entry (common for ambient .d.ts stubs)
+  // must not defeat `packages=external`: if the alias doesn't resolve to a
+  // real file, the bare specifier still gets marked external. Related to
+  // the follow-up fix for #29590.
+  itBundled("edgecase/PackageExternalStarPathsDoesNotBundleNodeModules#29590", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { a } from "foo";
+        console.log(a);
+      `,
+      "/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": { "*": ["./types/*"] }
+          }
+        }
+      `,
+    },
+    packages: "external",
+    target: "bun",
+    runtimeFiles: {
+      "/node_modules/foo/index.js": `export const a = "Hello World";`,
+      "/node_modules/foo/package.json": /* json */ `
+        {
+          "name": "foo",
+          "version": "2.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    onAfterBundle(api) {
+      // `foo` must stay external — a catch-all paths entry whose target
+      // does not exist on disk cannot claim the import. If this regresses,
+      // `foo` gets inlined via `require_foo = __commonJS(...)` instead.
+      api.expectFile("/out.js").toContain(`from "foo"`);
+    },
+    run: {
+      stdout: `
+        Hello World
+      `,
+    },
+  });
   itBundled("edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal#12734", {
     files: {
       "/src/entry.ts": /* ts */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1407,6 +1407,38 @@ describe("bundler", () => {
       `,
     },
   });
+  // Explicit --external wildcards must win over a tsconfig `paths` alias
+  // that resolves to a real local file. Without this guard the #29590 fix
+  // would silently bundle `@/src/*` when the user asked for it to stay
+  // external on top of `--packages=external`.
+  itBundled("edgecase/ExternalWildcardBeatsTSConfigPaths#29590", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { add } from "@/src/adder";
+        console.log(add(1, 2));
+      `,
+      "/src/adder.ts": /* ts */ `
+        export const add = (a: number, b: number) => a + b;
+      `,
+      "/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "baseUrl": ".",
+            "paths": { "@/*": ["./*"] }
+          }
+        }
+      `,
+    },
+    packages: "external",
+    external: ["@/src/*"],
+    target: "bun",
+    onAfterBundle(api) {
+      // The import must stay external. If it regresses, `add` gets
+      // inlined from src/adder.ts into the output bundle.
+      api.expectFile("/out.js").toContain(`from "@/src/adder"`);
+      api.expectFile("/out.js").not.toContain(`= (a, b) => a + b`);
+    },
+  });
   itBundled("edgecase/EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal#12734", {
     files: {
       "/src/entry.ts": /* ts */ `

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -372,12 +372,8 @@ describe.concurrent("bun test --changed", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Regression for https://github.com/oven-sh/bun/issues/29590: a test that
-  // reaches a shared source file via a tsconfig `paths` alias whose key
-  // looks bare (e.g. "@/*") must still be selected when that source file
-  // changes. The scan bundler runs with packages=external so bare
-  // specifiers aren't followed into node_modules; the path-alias key
-  // must not be mistaken for one of those bare specifiers.
+  // https://github.com/oven-sh/bun/issues/29590: a tsconfig `paths` alias
+  // like "@/*" must be followed when building the module graph.
   test("tsconfig paths alias is followed when computing the module graph", async () => {
     using dir = tempDir("test-changed-tsconfig-paths", {
       "package.json": JSON.stringify({ name: "aliasrepro", type: "module" }),
@@ -385,24 +381,15 @@ describe.concurrent("bun test --changed", () => {
         compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } },
       }),
       "src/adder.ts": `export const add = (a: number, b: number) => a + b;\n`,
-      "tests/alias.test.ts":
-        `import { test, expect } from "bun:test";\n` +
-        `import { add } from "@/src/adder";\n` +
-        `test("alias", () => expect(add(1, 2)).toBe(3));\n`,
-      "tests/relative.test.ts":
-        `import { test, expect } from "bun:test";\n` +
-        `import { add } from "../src/adder";\n` +
-        `test("relative", () => expect(add(1, 2)).toBe(3));\n`,
-      "tests/unrelated.test.ts":
-        `import { test, expect } from "bun:test";\n` + `test("unrelated", () => expect(1).toBe(1));\n`,
+      "tests/alias.test.ts": `import { test, expect } from "bun:test";\nimport { add } from "@/src/adder";\ntest("alias", () => expect(add(1, 2)).toBe(3));\n`,
+      "tests/relative.test.ts": `import { test, expect } from "bun:test";\nimport { add } from "../src/adder";\ntest("relative", () => expect(add(1, 2)).toBe(3));\n`,
+      "tests/unrelated.test.ts": `import { test, expect } from "bun:test";\ntest("unrelated", () => expect(1).toBe(1));\n`,
     });
     initRepo(String(dir));
     appendFileSync(join(String(dir), "src", "adder.ts"), "// touched\n");
 
     const { stderr, exitCode } = await runTestChanged(String(dir));
     const testNames = ["alias.test.ts", "relative.test.ts", "unrelated.test.ts"];
-    // Both importers of src/adder.ts are selected — the aliased one must
-    // not be silently dropped. The unrelated test stays filtered out.
     expect(ranFiles(stderr, testNames)).toEqual(["alias.test.ts", "relative.test.ts"]);
     expect(exitCode).toBe(0);
   });

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -371,6 +371,42 @@ describe.concurrent("bun test --changed", () => {
     expect(stderr).not.toContain("bad.test.ts:");
     expect(exitCode).toBe(0);
   });
+
+  // Regression for https://github.com/oven-sh/bun/issues/29590: a test that
+  // reaches a shared source file via a tsconfig `paths` alias whose key
+  // looks bare (e.g. "@/*") must still be selected when that source file
+  // changes. The scan bundler runs with packages=external so bare
+  // specifiers aren't followed into node_modules; the path-alias key
+  // must not be mistaken for one of those bare specifiers.
+  test("tsconfig paths alias is followed when computing the module graph", async () => {
+    using dir = tempDir("test-changed-tsconfig-paths", {
+      "package.json": JSON.stringify({ name: "aliasrepro", type: "module" }),
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } },
+      }),
+      "src/adder.ts": `export const add = (a: number, b: number) => a + b;\n`,
+      "tests/alias.test.ts":
+        `import { test, expect } from "bun:test";\n` +
+        `import { add } from "@/src/adder";\n` +
+        `test("alias", () => expect(add(1, 2)).toBe(3));\n`,
+      "tests/relative.test.ts":
+        `import { test, expect } from "bun:test";\n` +
+        `import { add } from "../src/adder";\n` +
+        `test("relative", () => expect(add(1, 2)).toBe(3));\n`,
+      "tests/unrelated.test.ts":
+        `import { test, expect } from "bun:test";\n` +
+        `test("unrelated", () => expect(1).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+    appendFileSync(join(String(dir), "src", "adder.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    const testNames = ["alias.test.ts", "relative.test.ts", "unrelated.test.ts"];
+    // Both importers of src/adder.ts are selected — the aliased one must
+    // not be silently dropped. The unrelated test stays filtered out.
+    expect(ranFiles(stderr, testNames)).toEqual(["alias.test.ts", "relative.test.ts"]);
+    expect(exitCode).toBe(0);
+  });
 });
 
 // On Windows, `bun test --watch` runs as a parent watcher-manager that

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -394,8 +394,7 @@ describe.concurrent("bun test --changed", () => {
         `import { add } from "../src/adder";\n` +
         `test("relative", () => expect(add(1, 2)).toBe(3));\n`,
       "tests/unrelated.test.ts":
-        `import { test, expect } from "bun:test";\n` +
-        `test("unrelated", () => expect(1).toBe(1));\n`,
+        `import { test, expect } from "bun:test";\n` + `test("unrelated", () => expect(1).toBe(1));\n`,
     });
     initRepo(String(dir));
     appendFileSync(join(String(dir), "src", "adder.ts"), "// touched\n");


### PR DESCRIPTION
Fixes #29590

## Bug

`bun test --changed` silently skips tests whose only path to a changed
source file goes through a tsconfig `paths` alias whose key looks bare.

```jsonc
// tsconfig.json
{ "compilerOptions": { "baseUrl": ".", "paths": { "@/*": ["./*"] } } }
```

```ts
// tests/alias.test.ts
import { add } from "@/src/adder";
```

Edit `src/adder.ts`, run `bun test --changed`, and `tests/alias.test.ts`
is absent from the selected set. The sibling `tests/relative.test.ts`
(same import, relative path) runs.

## Cause

`src/cli/test/ChangedFilesFilter.zig` builds the module graph with
`scan_transpiler.options.packages = .external` so bare specifiers
aren't followed into `node_modules`. In the resolver, the
`packages = external` check fires before tsconfig `paths`:

```zig
// resolver.zig — old
pub fn isExternalPattern(r: *ThisResolver, import_path: string) bool {
    if (r.opts.packages == .external and isPackagePath(import_path)) {
        return true; // ← catches "@/src/adder" before paths runs
    }
    …
}
```

`isPackagePath("@/src/adder")` is true (not absolute, no `./`/`../`
prefix), so the import is marked external before
`matchTSConfigPaths` (resolver.zig ≈1716) ever runs. No import edge
is recorded, and the reverse-BFS in `ChangedFilesFilter` can't see
that the test file is affected. The same happens for any bare-looking
alias key — `@/*`, `~/*`, `components/*`, etc.

## Fix

Consult the enclosing tsconfig's `paths` before the
`packages = external` short-circuit. Only the
`packages = external + isPackagePath` path is gated on tsconfig;
user-supplied `--external` patterns and URL-style specifiers
(`http://`, `//`, CSS `#id`) still win, and nothing changes for
projects without tsconfig paths.

A new `hasTSConfigPathsMatch` helper does a cheap pattern-only check
(exact or `*` glob on the paths keys). The full `matchTSConfigPaths`
also verifies the target file exists on disk, which would make this
hot-path check stat every aliased import; we only need to know
whether tsconfig *would* claim the specifier, so the existence check
is left to the regular resolver when control falls through.

## Verification

```console
$ bun bd test test/cli/test/test-changed.test.ts
 19 pass
 0 fail
```

New regression test `tsconfig paths alias is followed when computing
the module graph` covers both the aliased importer and the sibling
relative importer; it fails on `main` and passes with this change.

All 112 tests in `test/bundler/bundler_edgecase.test.ts` (incl. the
existing `PackageExternalDoNotBundleNodeModules` and
`EntrypointWithoutPrefixSlashOrDotIsNotConsideredExternal#12734`
cases) still pass.