### PR TITLE
install: ignore `patchedDependencies` from folder dependency's package.json

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2213,11 +2213,13 @@ impl Package<u64> {
             }
         }
 
-        if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
-            if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
-                for (_, value, _) in rows {
-                    if let Some(value) = value {
-                        string_builder.count(value);
+        if FEATURES.patched_dependencies {
+            if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
+                if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
+                    for (_, value, _) in rows {
+                        if let Some(value) = value {
+                            string_builder.count(value);
+                        }
                     }
                 }
             }
@@ -2565,28 +2567,30 @@ impl Package<u64> {
             self.resolution = Resolution::<u64>::init(TaggedValue::Root);
         }
 
-        if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
-            if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
-                lockfile
-                    .patched_dependencies
-                    .ensure_total_capacity(rows.len())
-                    .expect("unreachable");
-                for (key, value, _) in rows {
-                    let Some(value) = value else {
-                        continue;
-                    };
-                    let keyhash = semver::string::Builder::string_hash(key);
-                    let patch_path = string_builder.append::<String>(value);
+        if FEATURES.patched_dependencies {
+            if let Some(patched_deps) = json.as_property(b"patchedDependencies") {
+                if let Some(rows) = JsonObjectStringRows::new(&patched_deps.expr, &bump) {
                     lockfile
                         .patched_dependencies
-                        .put(
-                            keyhash,
-                            PatchedDep {
-                                path: patch_path,
-                                ..Default::default()
-                            },
-                        )
+                        .ensure_total_capacity(rows.len())
                         .expect("unreachable");
+                    for (key, value, _) in rows {
+                        let Some(value) = value else {
+                            continue;
+                        };
+                        let keyhash = semver::string::Builder::string_hash(key);
+                        let patch_path = string_builder.append::<String>(value);
+                        lockfile
+                            .patched_dependencies
+                            .put(
+                                keyhash,
+                                PatchedDep {
+                                    path: patch_path,
+                                    ..Default::default()
+                                },
+                            )
+                            .expect("unreachable");
+                    }
                 }
             }
         }

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -570,6 +570,108 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     }
   });
 
+  // https://github.com/oven-sh/bun/issues/13531
+  it("should ignore patchedDependencies from a folder dependency's package.json", async () => {
+    const patchFilename = filepathEscape("is-even@1.0.0.patch");
+    const filedir = tempDirWithFiles("patch-folder-dep", {
+      "pkgA": {
+        "package.json": JSON.stringify({
+          "name": "pkg-a",
+          "version": "1.0.0",
+          "patchedDependencies": {
+            "is-even@1.0.0": `patches/${patchFilename}`,
+          },
+          "dependencies": {
+            "is-even": "1.0.0",
+          },
+        }),
+        "patches": {
+          [patchFilename]: is_even_patch,
+        },
+      },
+      "pkgB": {
+        "package.json": JSON.stringify({
+          "name": "pkg-b",
+          "version": "1.0.0",
+          "dependencies": {
+            "pkg-a": "../pkgA",
+          },
+        }),
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: join(filedir, "pkgB"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // patchedDependencies from pkgA should be ignored, not resolved relative to pkgB
+    expect(stderr).not.toContain("Couldn't find patch file");
+    expect(stderr).not.toContain("patches/");
+    expect({ stdout, exitCode }).toMatchObject({ exitCode: 0 });
+
+    // lockfile should not contain pkgA's patchedDependencies
+    const lockfile = await Bun.file(join(filedir, "pkgB", "bun.lock")).text();
+    expect(lockfile).toContain("pkg-a");
+    expect(lockfile).not.toContain("patchedDependencies");
+  });
+
+  // https://github.com/oven-sh/bun/issues/13531 (workspace variant, see also #27894)
+  it("should ignore patchedDependencies from a workspace member's package.json", async () => {
+    // Only the install root's `patchedDependencies` is honored (matching
+    // `overrides`, `workspaces`, and `catalogs` behavior). Previously the
+    // member's patch paths were written to the root lockfile and resolved
+    // relative to the root directory, failing with "Couldn't find patch file".
+    const patchFilename = filepathEscape("is-even@1.0.0.patch");
+    const filedir = tempDirWithFiles("patch-workspace-member", {
+      "package.json": JSON.stringify({
+        name: "workspace-root",
+        workspaces: ["packages/*"],
+      }),
+      packages: {
+        lib: {
+          "package.json": JSON.stringify({
+            name: "lib",
+            dependencies: {
+              "is-even": "1.0.0",
+            },
+            // This only applies when `lib` itself is the install root.
+            patchedDependencies: {
+              "is-even@1.0.0": `patches/${patchFilename}`,
+            },
+          }),
+          patches: {
+            [patchFilename]: is_even_patch,
+          },
+        },
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: filedir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Couldn't find patch file");
+    expect(stderr).not.toContain("patches/");
+    expect({ stdout, exitCode }).toMatchObject({ exitCode: 0 });
+
+    // The member's patchedDependencies did not leak into the root lockfile.
+    const lockfile = await Bun.file(join(filedir, "bun.lock")).text();
+    expect(lockfile).not.toContain("patchedDependencies");
+    expect(lockfile).toContain("is-even");
+  });
+
   describe("bun patch with --linker=isolated", () => {
     const patchEnv = bunEnv;
 


### PR DESCRIPTION
## What does this PR do?

Fixes #13531

When a package depends on another package via a local path (folder dependency, e.g. `"pkg-a": "../pkgA"`) or as a workspace member, and that package's `package.json` contains `patchedDependencies`, `bun install` would fail with:

```
error: Couldn't find patch file: 'patches/foo@1.0.0.patch'
```

because the patch entries from the dependency were merged into the root lockfile's `patched_dependencies` map, and patch file paths are resolved relative to the installing project's root (not the dependency's directory).

## Root cause

`Features.patched_dependencies` is defined in `src/install_types/resolver_hooks.rs` (only `true` for `Features::MAIN`) but was never checked in `parse_with_json_impl` in `src/install/lockfile/Package.rs`. Both `patchedDependencies` parse blocks ran unconditionally for every `package.json`, including folder/link/workspace dependencies.

## Fix

Gate both `patchedDependencies` parse blocks on `FEATURES.patched_dependencies`, matching how `trustedDependencies` is already gated on `FEATURES.trusted_dependencies`.

This means `patchedDependencies` is only read from the root `package.json`, consistent with:
- `bun patch --commit` writing to the root `package.json`
- the text lockfile serializing `patchedDependencies` as a single top-level key
- pnpm migration moving `pnpm.patchedDependencies` to the root

## How did you verify your code works?

Added two regression tests in `test/cli/install/bun-install-patch.test.ts`:
1. Folder dependency: `pkgB` depends on `"../pkgA"` where `pkgA` has `patchedDependencies`
2. Workspace member: a workspace member declares `patchedDependencies`

Both fail on main with `Couldn't find patch file` and pass with this fix. Also verified that installing in `pkgA` directly still applies its patch correctly.

### Rebase note

While this PR was open, main refactored both `patchedDependencies` loop bodies in `Package.rs` onto a new `JsonObjectStringRows` helper. The rebase keeps upstream's new body verbatim and only adds the `if FEATURES.patched_dependencies` guard around each block, so the real diff is still just the two gates. Fail-before and pass-after were re-verified on the new merge base.

Supersedes #27895 (same fix, originally targeting #27894 which was closed as a duplicate of #13531).
