### PR TITLE
build(linux): strip .eh_frame_hdr alongside .eh_frame in release binary

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -871,7 +871,11 @@ export const stripFlags: Flag[] = [
     // musl: no eh_frame handling differences, but CMake gates on NOT musl so we do too.
     // Strip only runs on plain release (shouldStrip gates debug/asan/valgrind/assertions)
     // which in CI always has LTO on — in practice paired with --no-eh-frame-hdr.
-    flag: ["-R", ".eh_frame", "-R", ".gcc_except_table"],
+    //
+    // GNU strip does not rewrite the program header table — so any
+    // PT_GNU_EH_FRAME phdr entry also survives as an orphan. See the
+    // --no-eh-frame-hdr rationale in linkFlags above.
+    flag: ["-R", ".eh_frame", "-R", ".eh_frame_hdr", "-R", ".gcc_except_table"],
     when: c => c.linux && c.abi !== "musl",
     desc: "Remove unwind sections (GNU strip required — llvm-strip leaves [LOAD #2 [R]])",
   },


### PR DESCRIPTION
### What does this PR do?

Adds `.eh_frame_hdr` to the list of sections removed by GNU strip when producing the stripped Linux release binary.

### Why?

The strip step currently removes `.eh_frame` and `.gcc_except_table`, but leaves `.eh_frame_hdr` in place. GNU strip does not rewrite the program header table, so the `PT_GNU_EH_FRAME` phdr entry survives as an orphan pointing at a vaddr whose backing section data is gone. On any unwind attempt (e.g. `pthread_exit` during Worker teardown), libgcc's `_Unwind_IteratePhdrCallback` dereferences that vaddr → SEGV.

Stripping `.eh_frame_hdr` alongside `.eh_frame` removes the stale reference.

### Scope

Only affects the stripped release binary on Linux glibc. The strip step is already gated by `shouldStrip` (`!debug && !asan && !valgrind && !assertions`), so debug/ASAN/assertions builds are untouched. macOS, Windows, and musl are unaffected.
