### PR TITLE
Expose socket fd for Bun.serve and node:http server sockets

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1121,6 +1121,9 @@ declare module "bun" {
      * if the underlying TCP connection is kept alive for a subsequent request.
      * Call this from inside the `fetch` handler to get a usable fd.
      *
+     * Always returns `null` for HTTP/3 requests: HTTP/3 multiplexes streams over
+     * a single shared UDP socket, so there is no meaningful per-request fd.
+     *
      * Useful for per-connection low-level socket operations via FFI, such as
      * `getsockopt(TCP_INFO)`, `setsockopt(TCP_CORK)`, `SO_RCVBUF`, etc.
      *

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1115,6 +1115,27 @@ declare module "bun" {
     requestIP(request: Request): SocketAddress | null;
 
     /**
+     * Returns the OS file descriptor (or Windows SOCKET handle) for the underlying
+     * socket of the given Request, or `null` if the socket was already closed.
+     *
+     * Useful for per-connection low-level socket operations via FFI, such as
+     * `getsockopt(TCP_INFO)`, `setsockopt(TCP_CORK)`, `SO_RCVBUF`, etc.
+     *
+     * On Windows, this returns the SOCKET handle value as a JavaScript number.
+     *
+     * @example
+     * ```js
+     * export default {
+     *  async fetch(request, server) {
+     *    const fd = server.requestFD(request);
+     *    return new Response(`fd=${fd}`);
+     *  }
+     * }
+     * ```
+     */
+    requestFD(request: Request): number | null;
+
+    /**
      * Reset the idle timeout of the given Request to the given number of seconds. `0` means no timeout.
      *
      * @example

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -1116,7 +1116,10 @@ declare module "bun" {
 
     /**
      * Returns the OS file descriptor (or Windows SOCKET handle) for the underlying
-     * socket of the given Request, or `null` if the socket was already closed.
+     * socket of the given Request. Returns `null` once the request has completed
+     * (the response has been fully sent and the request context released), even
+     * if the underlying TCP connection is kept alive for a subsequent request.
+     * Call this from inside the `fetch` handler to get a usable fd.
      *
      * Useful for per-connection low-level socket operations via FFI, such as
      * `getsockopt(TCP_INFO)`, `setsockopt(TCP_CORK)`, `SO_RCVBUF`, etc.

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1729,6 +1729,12 @@ function getNodeHTTPServerSocket() {
       return this.writableLength;
     }
 
+    get fd() {
+      const handle = this[kHandle];
+      if (!handle) return -1;
+      return handle.fd ?? -1;
+    }
+
     connect(_port, _host, _connectListener) {
       return this;
     }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -545,8 +545,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterResponse, (JSC::JSGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName))
 {
-    // No DOMAttribute on this CustomAccessor, so JSC may pass an arbitrary
-    // receiver: dynamicDowncast, not uncheckedDowncast, and -1 for foreign receivers.
     auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
         return JSValue::encode(JSC::jsNumber(-1));
@@ -556,7 +554,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * 
         return JSValue::encode(JSC::jsNumber(-1));
     }
 #if OS(WINDOWS)
-    // SOCKET is UINT_PTR; widen via double so FFI callers get the full value.
     return JSValue::encode(JSC::jsNumber(static_cast<double>(us_socket_get_fd(socket))));
 #else
     return JSValue::encode(JSC::jsNumber(us_socket_get_fd(socket)));

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -541,7 +541,14 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterResponse, (JSC::JSGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName))
 {
-    auto* thisObject = uncheckedDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
+    // `fd` is a CustomAccessor without DOMAttribute, so JSC calls this getter
+    // with an arbitrary receiver. Validate before dereferencing instead of
+    // uncheckedDowncast so e.g. `Object.getOwnPropertyDescriptor(proto, 'fd').get.call({})`
+    // returns -1 rather than asserting through `thisObject->socket`.
+    auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(JSC::jsNumber(-1));
+    }
     us_socket_t* socket = thisObject->socket;
     if (!socket || thisObject->isClosed()) {
         return JSValue::encode(JSC::jsNumber(-1));

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -13,8 +13,12 @@ extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" void us_socket_resume(us_socket_t*);
 extern "C" void us_socket_pause(us_socket_t*);
-// us_socket_get_fd is declared in <libusockets.h>, transitively included via
-// JSNodeHTTPServerSocket.h / the uSockets headers.
+// LIBUS_SOCKET_DESCRIPTOR is SOCKET (uintptr_t) on Windows, int elsewhere.
+#if OS(WINDOWS)
+extern "C" uintptr_t us_socket_get_fd(struct us_socket_t* s);
+#else
+extern "C" int us_socket_get_fd(struct us_socket_t* s);
+#endif
 
 namespace Bun {
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -545,10 +545,8 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterResponse, (JSC::JSGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName))
 {
-    // `fd` is a CustomAccessor without DOMAttribute, so JSC calls this getter
-    // with an arbitrary receiver. Validate before dereferencing instead of
-    // uncheckedDowncast so e.g. `Object.getOwnPropertyDescriptor(proto, 'fd').get.call({})`
-    // returns -1 rather than asserting through `thisObject->socket`.
+    // No DOMAttribute on this CustomAccessor, so JSC may pass an arbitrary
+    // receiver: dynamicDowncast, not uncheckedDowncast, and -1 for foreign receivers.
     auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
     if (!thisObject) [[unlikely]] {
         return JSValue::encode(JSC::jsNumber(-1));
@@ -558,8 +556,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * 
         return JSValue::encode(JSC::jsNumber(-1));
     }
 #if OS(WINDOWS)
-    // On Windows, us_socket_get_fd returns a SOCKET (UINT_PTR). Surface it as
-    // an unsigned integer so setsockopt/getsockopt via FFI receive the full value.
+    // SOCKET is UINT_PTR; widen via double so FFI callers get the full value.
     return JSValue::encode(JSC::jsNumber(static_cast<double>(us_socket_get_fd(socket))));
 #else
     return JSValue::encode(JSC::jsNumber(us_socket_get_fd(socket)));

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -13,11 +13,8 @@ extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" void us_socket_resume(us_socket_t*);
 extern "C" void us_socket_pause(us_socket_t*);
-#if OS(WINDOWS)
-extern "C" uintptr_t us_socket_get_fd(void* socket);
-#else
-extern "C" int us_socket_get_fd(void* socket);
-#endif
+// us_socket_get_fd is declared in <libusockets.h>, transitively included via
+// JSNodeHTTPServerSocket.h / the uSockets headers.
 
 namespace Bun {
 
@@ -544,7 +541,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterResponse, (JSC::JSGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName))
 {
-    auto* thisObject = jsCast<JSNodeHTTPServerSocket*>(JSC::JSValue::decode(thisValue));
+    auto* thisObject = uncheckedDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
     us_socket_t* socket = thisObject->socket;
     if (!socket || thisObject->isClosed()) {
         return JSValue::encode(JSC::jsNumber(-1));

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -13,6 +13,11 @@ extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" void us_socket_resume(us_socket_t*);
 extern "C" void us_socket_pause(us_socket_t*);
+#if OS(WINDOWS)
+extern "C" uintptr_t us_socket_get_fd(void* socket);
+#else
+extern "C" int us_socket_get_fd(void* socket);
+#endif
 
 namespace Bun {
 
@@ -45,6 +50,7 @@ JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterIsSecureEstablished);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterServername);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterAuthorizationError);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterPeerCertVerified);
+JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd);
 
 JSC_DEFINE_CUSTOM_SETTER(noOpSetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
@@ -76,6 +82,7 @@ static const JSC::HashTableValue JSNodeHTTPServerSocketPrototypeTableValues[] = 
     { "servername"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterServername, noOpSetter } },
     { "authorizationError"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterAuthorizationError, noOpSetter } },
     { "peerCertVerified"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterPeerCertVerified, noOpSetter } },
+    { "fd"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterFd, noOpSetter } },
 };
 
 void JSNodeHTTPServerSocketPrototype::finishCreation(JSC::VM& vm)
@@ -533,6 +540,22 @@ JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterResponse, (JSC::JSGlobalObj
     }
 
     return JSValue::encode(thisObject->currentResponseObject.get());
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterFd, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName))
+{
+    auto* thisObject = jsCast<JSNodeHTTPServerSocket*>(JSC::JSValue::decode(thisValue));
+    us_socket_t* socket = thisObject->socket;
+    if (!socket || thisObject->isClosed()) {
+        return JSValue::encode(JSC::jsNumber(-1));
+    }
+#if OS(WINDOWS)
+    // On Windows, us_socket_get_fd returns a SOCKET (UINT_PTR). Surface it as
+    // an unsigned integer so setsockopt/getsockopt via FFI receive the full value.
+    return JSValue::encode(JSC::jsNumber(static_cast<double>(us_socket_get_fd(socket))));
+#else
+    return JSValue::encode(JSC::jsNumber(us_socket_get_fd(socket)));
+#endif
 }
 
 } // namespace Bun

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -180,7 +180,7 @@ impl AnyRequestContext {
         dispatch!(self, None, |_T, ctx| ctx.get_remote_socket_info())
     }
 
-    pub fn get_fd(self) -> Option<bun_core::Fd> {
+    pub(crate) fn get_fd(self) -> Option<bun_core::Fd> {
         dispatch!(self, None, |T, ctx| {
             // HTTP/3 multiplexes streams over one UDP socket — no per-request fd.
             if T::IS_H3 {

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -180,6 +180,16 @@ impl AnyRequestContext {
         dispatch!(self, None, |_T, ctx| ctx.get_remote_socket_info())
     }
 
+    pub fn get_fd(self) -> Option<bun_core::Fd> {
+        dispatch!(self, None, |T, ctx| {
+            // HTTP/3 multiplexes streams over one UDP socket — no per-request fd.
+            if T::IS_H3 {
+                return None;
+            }
+            ctx.get_fd()
+        })
+    }
+
     pub(crate) fn detach_request(self) {
         dispatch!(self, (), |_T, ctx| {
             ctx.req.set(None);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4384,6 +4384,12 @@ where
         })
     }
 
+    pub fn get_fd(&self) -> Option<bun_core::Fd> {
+        let resp = self.resp.get()?;
+        let fd = resp.get_fd();
+        if fd.is_valid() { Some(fd) } else { None }
+    }
+
     pub(crate) fn set_timeout(&self, seconds: c_uint) -> bool {
         if let Some(resp) = self.live_resp() {
             // SAFETY: FFI handle

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4384,7 +4384,7 @@ where
         })
     }
 
-    pub fn get_fd(&self) -> Option<bun_core::Fd> {
+    pub(crate) fn get_fd(&self) -> Option<bun_core::Fd> {
         let resp = self.resp.get()?;
         let fd = resp.get_fd();
         if fd.is_valid() { Some(fd) } else { None }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4385,7 +4385,7 @@ where
     }
 
     pub(crate) fn get_fd(&self) -> Option<bun_core::Fd> {
-        let resp = self.resp.get()?;
+        let resp = self.live_resp()?;
         let fd = resp.get_fd();
         if fd.is_valid() { Some(fd) } else { None }
     }

--- a/src/runtime/server/server.classes.ts
+++ b/src/runtime/server/server.classes.ts
@@ -44,6 +44,10 @@ function generate(name) {
         fn: "doRequestIP",
         length: 1,
       },
+      requestFD: {
+        fn: "doRequestFD",
+        length: 1,
+      },
       timeout: {
         fn: "doTimeout",
         length: 2,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1573,7 +1573,7 @@ where
 
     /// `pub const doRequestFD = host_fn.wrapInstanceMethod(ThisServer, "requestFD", false)`
     #[bun_jsc::host_fn(method)]
-    pub fn do_request_fd(
+    pub(crate) fn do_request_fd(
         &mut self,
         global: &JSGlobalObject,
         callframe: &CallFrame,
@@ -1633,7 +1633,7 @@ where
         )
     }
 
-    pub fn request_fd(&self, request: &Request) -> JsResult<JSValue> {
+    pub(crate) fn request_fd(&self, request: &Request) -> JsResult<JSValue> {
         use bun_sys_jsc::FdJsc as _;
         let Some(fd) = request.request_context.get_fd() else {
             return Ok(JSValue::NULL);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1578,8 +1578,7 @@ where
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let args = callframe.arguments_old::<2>();
-        let mut iter = jsc::ArgumentsSlice::init(global.bun_vm_ref(), args.slice());
+        let mut iter = jsc::ArgumentsSlice::init(global.bun_vm_ref(), callframe.arguments());
         let arg = iter.next_eat().ok_or_else(|| {
             global.throw_invalid_arguments(format_args!("Missing Request object"))
         })?;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1571,6 +1571,24 @@ where
         self.request_ip(request)
     }
 
+    /// `pub const doRequestFD = host_fn.wrapInstanceMethod(ThisServer, "requestFD", false)`
+    #[bun_jsc::host_fn(method)]
+    pub fn do_request_fd(
+        &mut self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = callframe.arguments_old::<2>();
+        let mut iter = jsc::ArgumentsSlice::init(global.bun_vm_ref(), args.slice());
+        let arg = iter.next_eat().ok_or_else(|| {
+            global.throw_invalid_arguments(format_args!("Missing Request object"))
+        })?;
+        let request = arg.as_class_ref::<Request>().ok_or_else(|| {
+            global.throw_invalid_arguments(format_args!("Expected Request object"))
+        })?;
+        self.request_fd(request)
+    }
+
     /// `pub const doReload = onReload`
     #[inline]
     pub(crate) fn do_reload(
@@ -1614,6 +1632,14 @@ where
             u16::try_from(info.port).expect("int cast"),
             info.is_ipv6,
         )
+    }
+
+    pub fn request_fd(&self, request: &Request) -> JsResult<JSValue> {
+        use bun_sys_jsc::FdJsc as _;
+        let Some(fd) = request.request_context.get_fd() else {
+            return Ok(JSValue::NULL);
+        };
+        Ok(fd.to_js_without_making_lib_uv_owned())
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -358,9 +358,8 @@ impl<const SSL: bool> Response<SSL> {
     /// goes straight to `us_socket_get_fd` so the value is a real descriptor
     /// suitable for `getsockopt`/`setsockopt`.
     pub fn get_fd(&mut self) -> Fd {
-        // SAFETY: `downcast_socket` reinterprets the response handle as
-        // `*mut us_socket_t`; uWS lays these out as the same opaque handle.
-        unsafe { (*self.downcast_socket()).get_fd() }
+        // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
+        us_socket_t::opaque_mut(self.downcast_socket()).get_fd()
     }
 
     pub fn get_remote_socket_info(&mut self) -> Option<SocketAddress> {

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -352,8 +352,7 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    /// Real OS fd (Windows: SOCKET) via `us_socket_get_fd`, unlike
-    /// `get_native_handle`, which returns the `SSL*` pointer for TLS.
+    /// Real OS fd via `us_socket_get_fd`, unlike `get_native_handle` (SSL* for TLS).
     pub fn get_fd(&mut self) -> Fd {
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
         us_socket_t::opaque_mut(self.downcast_socket()).get_fd()

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -352,6 +352,17 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
+    /// Returns the underlying OS file descriptor (or Windows SOCKET) for this
+    /// response's socket, regardless of SSL. Unlike `get_native_handle`, which
+    /// returns the OpenSSL `SSL*` pointer for TLS connections, this always
+    /// goes straight to `us_socket_get_fd` so the value is a real descriptor
+    /// suitable for `getsockopt`/`setsockopt`.
+    pub fn get_fd(&mut self) -> Fd {
+        // SAFETY: `downcast_socket` reinterprets the response handle as
+        // `*mut us_socket_t`; uWS lays these out as the same opaque handle.
+        unsafe { (*self.downcast_socket()).get_fd() }
+    }
+
     pub fn get_remote_socket_info(&mut self) -> Option<SocketAddress> {
         let mut ip_ptr: *const u8 = core::ptr::null();
         let mut port: i32 = 0;
@@ -875,6 +886,17 @@ impl AnyResponse {
             AnyResponse::H3(_) => bun_core::Fd::INVALID,
             AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).get_native_handle(),
             AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).get_native_handle(),
+        }
+    }
+
+    /// Returns the underlying OS file descriptor for this response's socket,
+    /// bypassing SSL so the result is a real `us_socket_get_fd` value.
+    /// HTTP/3 multiplexes streams over one UDP socket — no per-response fd.
+    pub fn get_fd(self) -> Fd {
+        match self {
+            AnyResponse::H3(_) => bun_core::Fd::INVALID,
+            AnyResponse::SSL(ptr) => TLSResponse::as_handle(ptr).get_fd(),
+            AnyResponse::TCP(ptr) => TCPResponse::as_handle(ptr).get_fd(),
         }
     }
 

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -352,11 +352,8 @@ impl<const SSL: bool> Response<SSL> {
         }
     }
 
-    /// Returns the underlying OS file descriptor (or Windows SOCKET) for this
-    /// response's socket, regardless of SSL. Unlike `get_native_handle`, which
-    /// returns the OpenSSL `SSL*` pointer for TLS connections, this always
-    /// goes straight to `us_socket_get_fd` so the value is a real descriptor
-    /// suitable for `getsockopt`/`setsockopt`.
+    /// Real OS fd (Windows: SOCKET) via `us_socket_get_fd`, unlike
+    /// `get_native_handle`, which returns the `SSL*` pointer for TLS.
     pub fn get_fd(&mut self) -> Fd {
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
         us_socket_t::opaque_mut(self.downcast_socket()).get_fd()
@@ -888,9 +885,7 @@ impl AnyResponse {
         }
     }
 
-    /// Returns the underlying OS file descriptor for this response's socket,
-    /// bypassing SSL so the result is a real `us_socket_get_fd` value.
-    /// HTTP/3 multiplexes streams over one UDP socket — no per-response fd.
+    /// Real OS fd, bypassing SSL. H3 has no per-response fd (one UDP socket).
     pub fn get_fd(self) -> Fd {
         match self {
             AnyResponse::H3(_) => bun_core::Fd::INVALID,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3713,4 +3713,56 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
     }
     expect(savedSocket.fd).toBe(-1);
   });
+
+  // Regression: the `fd` prototype getter is a CustomAccessor without
+  // DOMAttribute, so JSC hands the getter an arbitrary receiver. Reaching
+  // the getter via `Object.getOwnPropertyDescriptor` and calling with a
+  // plain object used to hit `uncheckedDowncast`'s security assertion in
+  // debug builds (and type-confused reads in release). It must return -1.
+  test("socket.fd getter rejects unrelated receivers instead of asserting", async () => {
+    const src = /* js */ `
+      const http = require("http");
+      const server = http.createServer((req, res) => {
+        const socket = req.socket;
+        const handleSym = Object.getOwnPropertySymbols(socket)
+          .find(s => s.description === "handle");
+        const nativeHandle = socket[handleSym];
+        const proto = Object.getPrototypeOf(nativeHandle);
+        const desc = Object.getOwnPropertyDescriptor(proto, "fd");
+        if (typeof desc?.get !== "function") {
+          console.error("fd getter missing");
+          process.exit(1);
+        }
+        const got = desc.get.call({});
+        if (got !== -1) {
+          console.error("expected -1, got", got);
+          process.exit(1);
+        }
+        res.end("ok");
+      });
+      server.listen(0, async () => {
+        const { port } = server.address();
+        const r = await fetch("http://127.0.0.1:" + port + "/");
+        await r.text();
+        server.close();
+        console.log("OK");
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout: stdout.trim(), signalCode: proc.signalCode ?? null, exitCode }).toMatchObject({
+      stdout: "OK",
+      signalCode: null,
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3675,8 +3675,6 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
     expect(observedFromConnection).toBe(observedFromFetch);
   });
 
-  // Gate on linux/macOS only: `isPosix` also includes FreeBSD, but
-  // `libcPathForDlopen()` only handles linux/darwin today.
   test.if(isLinux || isMacOS)("socket.fd works with getsockname() via FFI", async () => {
     const libc = dlopen(libcPathForDlopen(), {
       getsockname: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3644,86 +3644,71 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
   }, 30_000);
 });
 describe.concurrent("node:http socket.fd (Bun extension)", () => {
-  test("request.socket.fd is a non-negative integer", async () => {
-    let observedFromFetch: number | undefined;
-    let observedFromConnection: number | undefined;
-    const server = http.createServer((req, res) => {
-      observedFromFetch = (req.socket as any).fd;
-      res.end("ok");
-    });
-    server.on("connection", socket => {
-      observedFromConnection = (socket as any).fd;
-    });
+  // Start `server` on an ephemeral port, hit it once with fetch, then close —
+  // used by all three tests below. `onConnection` runs before the request.
+  async function runFetchOnce(server: http.Server, onConnection?: (s: any) => void) {
+    if (onConnection) server.on("connection", onConnection);
     server.listen(0);
     await once(server, "listening");
     try {
-      const address = server.address() as { port: number };
-      const res = await fetch(`http://127.0.0.1:${address.port}/`);
-      await res.text();
-      expect(typeof observedFromFetch).toBe("number");
-      expect(observedFromFetch).toBeGreaterThanOrEqual(0);
-      expect(typeof observedFromConnection).toBe("number");
-      expect(observedFromConnection).toBeGreaterThanOrEqual(0);
-      expect(observedFromFetch).toBe(observedFromConnection);
+      const { port } = server.address() as { port: number };
+      await (await fetch(`http://127.0.0.1:${port}/`)).text();
     } finally {
       server.close();
     }
+  }
+
+  test("request.socket.fd is a non-negative integer", async () => {
+    let observedFromFetch: number | undefined;
+    let observedFromConnection: number | undefined;
+    await runFetchOnce(
+      http.createServer((req, res) => {
+        observedFromFetch = (req.socket as any).fd;
+        res.end("ok");
+      }),
+      socket => {
+        observedFromConnection = socket.fd;
+      },
+    );
+    expect(typeof observedFromFetch).toBe("number");
+    expect(observedFromFetch).toBeGreaterThanOrEqual(0);
+    expect(observedFromConnection).toBe(observedFromFetch);
   });
 
   test.if(isPosix)("socket.fd works with getsockname() via FFI", async () => {
     const libc = dlopen(libcPathForDlopen(), {
-      getsockname: {
-        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
-        returns: FFIType.i32,
-      },
+      getsockname: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
     });
-
     let result: { rc: number; addrLen: number } | undefined;
-    const server = http.createServer((req, res) => {
-      const fd = (req.socket as any).fd;
-      const addr = new ArrayBuffer(128);
-      const addrLen = new Uint32Array(1);
-      addrLen[0] = 128;
-      const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
-      result = { rc, addrLen: addrLen[0] };
-      res.end("ok");
-    });
-    server.listen(0);
-    await once(server, "listening");
-    try {
-      const address = server.address() as { port: number };
-      const res = await fetch(`http://127.0.0.1:${address.port}/`);
-      await res.text();
-      expect(result).toEqual({ rc: 0, addrLen: expect.any(Number) });
-      expect(result!.addrLen).toBeGreaterThan(0);
-    } finally {
-      server.close();
-    }
+    await runFetchOnce(
+      http.createServer((req, res) => {
+        const fd = (req.socket as any).fd;
+        const addr = new ArrayBuffer(128);
+        const addrLen = new Uint32Array([128]);
+        const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
+        result = { rc, addrLen: addrLen[0] };
+        res.end("ok");
+      }),
+    );
+    expect(result).toEqual({ rc: 0, addrLen: expect.any(Number) });
+    expect(result!.addrLen).toBeGreaterThan(0);
   });
 
   test("socket.fd becomes -1 after the socket is destroyed", async () => {
     let savedSocket: any;
-    const server = http.createServer((req, res) => {
-      savedSocket = req.socket;
-      res.end("ok");
-    });
-    server.listen(0);
-    await once(server, "listening");
-    try {
-      const address = server.address() as { port: number };
-      const res = await fetch(`http://127.0.0.1:${address.port}/`);
-      await res.text();
-      // Destroy the socket and wait for the close event so kHandle is cleared.
-      // Guard the destroy + `once` against the socket already being torn down,
-      // which can race under heavy load.
-      if (!savedSocket.destroyed) {
-        const closed = once(savedSocket, "close");
-        savedSocket.destroy();
-        await closed;
-      }
-      expect(savedSocket.fd).toBe(-1);
-    } finally {
-      server.close();
+    await runFetchOnce(
+      http.createServer((req, res) => {
+        savedSocket = req.socket;
+        res.end("ok");
+      }),
+    );
+    // Destroy the socket and wait for `close` so `kHandle` is cleared. Guard
+    // against the socket already being torn down, which can race under load.
+    if (!savedSocket.destroyed) {
+      const closed = once(savedSocket, "close");
+      savedSocket.destroy();
+      await closed;
     }
+    expect(savedSocket.fd).toBe(-1);
   });
 });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,5 +1,5 @@
 import type { Server, ServerWebSocket, Socket } from "bun";
-import { dlopen, FFIType, ptr, suffix } from "bun:ffi";
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import {
   bunEnv,
@@ -3644,7 +3644,7 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
   }, 30_000);
 });
 describe.concurrent("node:http socket.fd (Bun extension)", () => {
-  test("request.socket.fd is a positive integer", async () => {
+  test("request.socket.fd is a non-negative integer", async () => {
     let observedFromFetch: number | undefined;
     let observedFromConnection: number | undefined;
     const server = http.createServer((req, res) => {
@@ -3661,9 +3661,9 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
       const res = await fetch(`http://127.0.0.1:${address.port}/`);
       await res.text();
       expect(typeof observedFromFetch).toBe("number");
-      expect(observedFromFetch).toBeGreaterThan(0);
+      expect(observedFromFetch).toBeGreaterThanOrEqual(0);
       expect(typeof observedFromConnection).toBe("number");
-      expect(observedFromConnection).toBeGreaterThan(0);
+      expect(observedFromConnection).toBeGreaterThanOrEqual(0);
       expect(observedFromFetch).toBe(observedFromConnection);
     } finally {
       server.close();
@@ -3671,8 +3671,7 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
   });
 
   test.if(isPosix)("socket.fd works with getsockname() via FFI", async () => {
-    const libName = process.platform === "darwin" ? `libc.${suffix}` : `libc.${suffix}.6`;
-    const libc = dlopen(libName, {
+    const libc = dlopen(libcPathForDlopen(), {
       getsockname: {
         args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
         returns: FFIType.i32,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3712,11 +3712,16 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
     await once(server, "listening");
     try {
       const address = server.address() as { port: number };
-      const res = await fetch(`http://127.0.0.1:${address.port}/`, { headers: { Connection: "close" } });
+      const res = await fetch(`http://127.0.0.1:${address.port}/`);
       await res.text();
-      // Explicitly destroy the socket and wait for the close event so kHandle is cleared.
-      savedSocket.destroy();
-      await once(savedSocket, "close");
+      // Destroy the socket and wait for the close event so kHandle is cleared.
+      // Guard the destroy + `once` against the socket already being torn down,
+      // which can race under heavy load.
+      if (!savedSocket.destroyed) {
+        const closed = once(savedSocket, "close");
+        savedSocket.destroy();
+        await closed;
+      }
       expect(savedSocket.fd).toBe(-1);
     } finally {
       server.close();

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3675,7 +3675,9 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
     expect(observedFromConnection).toBe(observedFromFetch);
   });
 
-  test.if(isPosix)("socket.fd works with getsockname() via FFI", async () => {
+  // Gate on linux/macOS only: `isPosix` also includes FreeBSD, but
+  // `libcPathForDlopen()` only handles linux/darwin today.
+  test.if(isLinux || isMacOS)("socket.fd works with getsockname() via FFI", async () => {
     const libc = dlopen(libcPathForDlopen(), {
       getsockname: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
     });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,16 +1,22 @@
 import type { Server, ServerWebSocket, Socket } from "bun";
+import { dlopen, FFIType, ptr, suffix } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
 import {
   bunEnv,
   bunExe,
   bunRun,
+  isLinux,
+  isMacOS,
   isWindows,
+  libcPathForDlopen,
   normalizeBunSnapshot,
   rejectUnauthorizedScope,
   tempDir,
   tempDirWithFiles,
   tls,
 } from "harness";
+import http from "http";
+import { once } from "node:events";
 import path from "path";
 
 describe.concurrent("Server", () => {
@@ -3636,4 +3642,84 @@ describe("handler GC tracing (heapStats wrapper-count)", () => {
       exitCode: 0,
     });
   }, 30_000);
+});
+describe.concurrent("node:http socket.fd (Bun extension)", () => {
+  test("request.socket.fd is a positive integer", async () => {
+    let observedFromFetch: number | undefined;
+    let observedFromConnection: number | undefined;
+    const server = http.createServer((req, res) => {
+      observedFromFetch = (req.socket as any).fd;
+      res.end("ok");
+    });
+    server.on("connection", socket => {
+      observedFromConnection = (socket as any).fd;
+    });
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      const address = server.address() as { port: number };
+      const res = await fetch(`http://127.0.0.1:${address.port}/`);
+      await res.text();
+      expect(typeof observedFromFetch).toBe("number");
+      expect(observedFromFetch).toBeGreaterThan(0);
+      expect(typeof observedFromConnection).toBe("number");
+      expect(observedFromConnection).toBeGreaterThan(0);
+      expect(observedFromFetch).toBe(observedFromConnection);
+    } finally {
+      server.close();
+    }
+  });
+
+  test.if(isPosix)("socket.fd works with getsockname() via FFI", async () => {
+    const libName = process.platform === "darwin" ? `libc.${suffix}` : `libc.${suffix}.6`;
+    const libc = dlopen(libName, {
+      getsockname: {
+        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
+        returns: FFIType.i32,
+      },
+    });
+
+    let result: { rc: number; addrLen: number } | undefined;
+    const server = http.createServer((req, res) => {
+      const fd = (req.socket as any).fd;
+      const addr = new ArrayBuffer(128);
+      const addrLen = new Uint32Array(1);
+      addrLen[0] = 128;
+      const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
+      result = { rc, addrLen: addrLen[0] };
+      res.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      const address = server.address() as { port: number };
+      const res = await fetch(`http://127.0.0.1:${address.port}/`);
+      await res.text();
+      expect(result).toEqual({ rc: 0, addrLen: expect.any(Number) });
+      expect(result!.addrLen).toBeGreaterThan(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("socket.fd becomes -1 after the socket is destroyed", async () => {
+    let savedSocket: any;
+    const server = http.createServer((req, res) => {
+      savedSocket = req.socket;
+      res.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      const address = server.address() as { port: number };
+      const res = await fetch(`http://127.0.0.1:${address.port}/`, { headers: { Connection: "close" } });
+      await res.text();
+      // Explicitly destroy the socket and wait for the close event so kHandle is cleared.
+      savedSocket.destroy();
+      await once(savedSocket, "close");
+      expect(savedSocket.fd).toBe(-1);
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3755,7 +3755,10 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), signalCode: proc.signalCode ?? null, exitCode }).toMatchObject({
+    // stderr is diagnostic-only here: toMatchObject ignores keys absent from the
+    // expected object, so a future assertion-abort backtrace surfaces in the diff
+    // without asserting on (noisy) stderr content.
+    expect({ stdout: stdout.trim(), stderr, signalCode: proc.signalCode ?? null, exitCode }).toMatchObject({
       stdout: "OK",
       signalCode: null,
       exitCode: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -3754,11 +3754,7 @@ describe.concurrent("node:http socket.fd (Bun extension)", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), signalCode: proc.signalCode ?? null, exitCode }).toMatchObject({
       stdout: "OK",
       signalCode: null,

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -157,6 +157,11 @@ const server = serve({
     if (url.pathname === "/remote") {
       return Response.json(server.requestIP(req));
     }
+    if (url.pathname === "/fd") {
+      // H3 multiplexes streams over one UDP socket, so there is no per-request
+      // OS fd. This must return null rather than panicking.
+      return Response.json({ fd: server.requestFD(req) });
+    }
     return new Response("not found: " + url.pathname, { status: 404 });
   },
 });
@@ -773,6 +778,15 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       expect(["127.0.0.1", "::1"]).toContain(ip.address);
       expect(["IPv4", "IPv6"]).toContain(ip.family);
       expect(typeof ip.port).toBe("number");
+    });
+  });
+
+  // bughunt: server.requestFD(req) must return null for H3 (no per-request fd)
+  // instead of panicking through AnyRequestContext.getFd's else branch.
+  test("server.requestFD(req) returns null for HTTP/3 requests", async () => {
+    await withServer(async port => {
+      const res = (await fetchH3(port, "/fd").then(r => r.json())) as { fd: number | null };
+      expect(res.fd).toBeNull();
     });
   });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2646,9 +2646,6 @@ describe("server.requestFD", () => {
     return Response.json({ fd, rc, addrLen: addrLen[0] });
   };
 
-  // Gate FFI tests on linux/macOS only: `isPosix` also includes FreeBSD, but
-  // `libcPathForDlopen()` only handles linux/darwin today and would throw on
-  // any other POSIX platform.
   it.if(isLinux || isMacOS)("returns an fd usable with getsockname() via FFI", async () => {
     using server = Bun.serve({ port: 0, fetch: getsocknameHandler });
     const response = await fetch(server.url.origin).then(x => x.json());

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1,5 +1,5 @@
 import { file, gc, Serve, serve, Server } from "bun";
-import { dlopen, FFIType, ptr, suffix } from "bun:ffi";
+import { dlopen, FFIType, ptr } from "bun:ffi";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import {
@@ -14,6 +14,7 @@ import {
   isIPv4,
   isIPv6,
   isPosix,
+  libcPathForDlopen,
   runFixtureMaxRSS,
   tempDir,
   tls,
@@ -2594,8 +2595,8 @@ describe("server.requestIP", () => {
 });
 
 describe("server.requestFD", () => {
-  it("returns a positive integer fd for an active TCP request", async () => {
-    let observedFd: number | null = -1;
+  it("returns a non-negative integer fd for an active TCP request", async () => {
+    let observedFd: number | null = null;
     using server = Bun.serve({
       port: 0,
       fetch(req, server) {
@@ -2606,7 +2607,7 @@ describe("server.requestFD", () => {
 
     const response = await fetch(server.url.origin).then(x => x.json());
     expect(typeof response.fd).toBe("number");
-    expect(response.fd).toBeGreaterThan(0);
+    expect(response.fd).toBeGreaterThanOrEqual(0);
     expect(observedFd).toBe(response.fd);
   });
 
@@ -2631,7 +2632,7 @@ describe("server.requestFD", () => {
   });
 
   it.if(isPosix)("returns an fd usable with getsockname() via FFI", async () => {
-    const libc = dlopen(`libc.${suffix}${process.platform === "darwin" ? "" : ".6"}`, {
+    const libc = dlopen(libcPathForDlopen(), {
       getsockname: {
         args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
         returns: FFIType.i32,
@@ -2641,26 +2642,23 @@ describe("server.requestFD", () => {
     using server = Bun.serve({
       port: 0,
       fetch(req, server) {
-        const fd = server.requestFD(req);
-        if (typeof fd !== "number" || fd < 0) {
-          return Response.json({ ok: false, reason: "no fd", fd });
-        }
+        const fd = server.requestFD(req) as number;
         const addr = new ArrayBuffer(128);
         const addrLen = new Uint32Array(1);
         addrLen[0] = 128;
         const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
-        return Response.json({ ok: true, fd, rc, addrLen: addrLen[0] });
+        return Response.json({ fd, rc, addrLen: addrLen[0] });
       },
     });
 
     const response = await fetch(server.url.origin).then(x => x.json());
-    expect(response.ok).toBe(true);
+    expect(response.fd).toBeGreaterThanOrEqual(0);
     expect(response.rc).toBe(0);
     expect(response.addrLen).toBeGreaterThan(0);
   });
 
   it.if(isPosix)("returns an OS fd for an HTTPS (TLS) request, not the SSL pointer", async () => {
-    const libc = dlopen(`libc.${suffix}${process.platform === "darwin" ? "" : ".6"}`, {
+    const libc = dlopen(libcPathForDlopen(), {
       getsockname: {
         args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
         returns: FFIType.i32,
@@ -2671,23 +2669,20 @@ describe("server.requestFD", () => {
       port: 0,
       tls,
       fetch(req, server) {
-        const fd = server.requestFD(req);
-        if (typeof fd !== "number" || fd < 0) {
-          return Response.json({ ok: false, fd });
-        }
+        const fd = server.requestFD(req) as number;
         const addr = new ArrayBuffer(128);
         const addrLen = new Uint32Array(1);
         addrLen[0] = 128;
         const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
-        return Response.json({ ok: true, fd, rc, addrLen: addrLen[0] });
+        return Response.json({ fd, rc, addrLen: addrLen[0] });
       },
     });
 
     const response = await fetch(server.url.origin, { tls: { rejectUnauthorized: false } }).then(x => x.json());
-    expect(response.ok).toBe(true);
     // If requestFD had returned the SSL* heap pointer (the regression this test
     // guards against), getsockname would fail with EBADF / rc !== 0.
     expect(response.rc).toBe(0);
+    expect(response.fd).toBeGreaterThanOrEqual(0);
     expect(response.addrLen).toBeGreaterThan(0);
     // A real fd is a small non-negative integer; an SSL* cast would be huge.
     expect(response.fd).toBeLessThan(1 << 20);
@@ -2722,7 +2717,7 @@ describe("server.requestFD", () => {
     const body = Buffer.concat(received).toString().split("\r\n\r\n")[1];
     const parsed = JSON.parse(body);
     expect(typeof parsed.fd).toBe("number");
-    expect(parsed.fd).toBeGreaterThan(0);
+    expect(parsed.fd).toBeGreaterThanOrEqual(0);
   });
 });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -13,6 +13,8 @@ import {
   isIntelMacOS,
   isIPv4,
   isIPv6,
+  isLinux,
+  isMacOS,
   isPosix,
   libcPathForDlopen,
   runFixtureMaxRSS,
@@ -2644,7 +2646,10 @@ describe("server.requestFD", () => {
     return Response.json({ fd, rc, addrLen: addrLen[0] });
   };
 
-  it.if(isPosix)("returns an fd usable with getsockname() via FFI", async () => {
+  // Gate FFI tests on linux/macOS only: `isPosix` also includes FreeBSD, but
+  // `libcPathForDlopen()` only handles linux/darwin today and would throw on
+  // any other POSIX platform.
+  it.if(isLinux || isMacOS)("returns an fd usable with getsockname() via FFI", async () => {
     using server = Bun.serve({ port: 0, fetch: getsocknameHandler });
     const response = await fetch(server.url.origin).then(x => x.json());
     expect(response.fd).toBeGreaterThanOrEqual(0);
@@ -2652,7 +2657,7 @@ describe("server.requestFD", () => {
     expect(response.addrLen).toBeGreaterThan(0);
   });
 
-  it.if(isPosix)("returns an OS fd for an HTTPS (TLS) request, not the SSL pointer", async () => {
+  it.if(isLinux || isMacOS)("returns an OS fd for an HTTPS (TLS) request, not the SSL pointer", async () => {
     using server = Bun.serve({ port: 0, tls, fetch: getsocknameHandler });
     const response = await fetch(server.url.origin, { tls: { rejectUnauthorized: false } }).then(x => x.json());
     // If requestFD had returned the SSL* heap pointer (the regression this test

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2621,9 +2621,12 @@ describe("server.requestFD", () => {
     });
 
     await fetch(server.url.origin).then(x => x.text());
-    // Wait a tick so the request context can fully detach its response.
-    await Bun.sleep(50);
     expect(savedRequest).toBeDefined();
+    // Poll the observable condition instead of sleeping a fixed time:
+    // the request context detaches asynchronously once the response is fully sent.
+    for (let i = 0; i < 200 && server.requestFD(savedRequest!) !== null; i++) {
+      await Bun.sleep(0);
+    }
     expect(server.requestFD(savedRequest!)).toBeNull();
   });
 
@@ -2656,34 +2659,70 @@ describe("server.requestFD", () => {
     expect(response.addrLen).toBeGreaterThan(0);
   });
 
+  it.if(isPosix)("returns an OS fd for an HTTPS (TLS) request, not the SSL pointer", async () => {
+    const libc = dlopen(`libc.${suffix}${process.platform === "darwin" ? "" : ".6"}`, {
+      getsockname: {
+        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
+        returns: FFIType.i32,
+      },
+    });
+
+    using server = Bun.serve({
+      port: 0,
+      tls,
+      fetch(req, server) {
+        const fd = server.requestFD(req);
+        if (typeof fd !== "number" || fd < 0) {
+          return Response.json({ ok: false, fd });
+        }
+        const addr = new ArrayBuffer(128);
+        const addrLen = new Uint32Array(1);
+        addrLen[0] = 128;
+        const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
+        return Response.json({ ok: true, fd, rc, addrLen: addrLen[0] });
+      },
+    });
+
+    const response = await fetch(server.url.origin, { tls: { rejectUnauthorized: false } }).then(x => x.json());
+    expect(response.ok).toBe(true);
+    // If requestFD had returned the SSL* heap pointer (the regression this test
+    // guards against), getsockname would fail with EBADF / rc !== 0.
+    expect(response.rc).toBe(0);
+    expect(response.addrLen).toBeGreaterThan(0);
+    // A real fd is a small non-negative integer; an SSL* cast would be huge.
+    expect(response.fd).toBeLessThan(1 << 20);
+  });
+
   it.if(isPosix)("returns an fd for a unix socket request", async () => {
-    const unix = join(tmpdirSync(), "serve-fd.sock");
+    using dir = tempDir("serve-request-fd-unix", {});
+    const unix = join(String(dir), "serve-fd.sock");
     using server = Bun.serve({
       unix,
       fetch(req, server) {
         return Response.json({ fd: server.requestFD(req) });
       },
     });
-    const requestText = `GET / HTTP/1.1\r\nHost: localhost\r\n\r\n`;
+    const requestText = `GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`;
     const received: Buffer[] = [];
-    const { resolve, promise } = Promise.withResolvers<void>();
+    const { resolve: resolveClose, promise: closed } = Promise.withResolvers<void>();
     const connection = await Bun.connect({
       unix,
       socket: {
         data(_socket, data) {
           received.push(data);
-          resolve();
+        },
+        close() {
+          resolveClose();
         },
       },
     });
     connection.write(requestText);
     connection.flush();
-    await promise;
+    await closed;
     const body = Buffer.concat(received).toString().split("\r\n\r\n")[1];
     const parsed = JSON.parse(body);
     expect(typeof parsed.fd).toBe("number");
     expect(parsed.fd).toBeGreaterThan(0);
-    connection.end();
   });
 });
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1,4 +1,5 @@
 import { file, gc, Serve, serve, Server } from "bun";
+import { dlopen, FFIType, ptr, suffix } from "bun:ffi";
 import { afterAll, afterEach, describe, expect, it, mock } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
 import {
@@ -2588,6 +2589,100 @@ describe("server.requestIP", () => {
     connection.flush();
     await promise;
     expect(Buffer.concat(received).toString()).toEndWith("\r\n\r\nnull");
+    connection.end();
+  });
+});
+
+describe("server.requestFD", () => {
+  it("returns a positive integer fd for an active TCP request", async () => {
+    let observedFd: number | null = -1;
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        observedFd = server.requestFD(req);
+        return Response.json({ fd: observedFd });
+      },
+    });
+
+    const response = await fetch(server.url.origin).then(x => x.json());
+    expect(typeof response.fd).toBe("number");
+    expect(response.fd).toBeGreaterThan(0);
+    expect(observedFd).toBe(response.fd);
+  });
+
+  it("returns null after the request context has been released", async () => {
+    let savedRequest: Request | undefined;
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        savedRequest = req;
+        return new Response("ok");
+      },
+    });
+
+    await fetch(server.url.origin).then(x => x.text());
+    // Wait a tick so the request context can fully detach its response.
+    await Bun.sleep(50);
+    expect(savedRequest).toBeDefined();
+    expect(server.requestFD(savedRequest!)).toBeNull();
+  });
+
+  it.if(isPosix)("returns an fd usable with getsockname() via FFI", async () => {
+    const libc = dlopen(`libc.${suffix}${process.platform === "darwin" ? "" : ".6"}`, {
+      getsockname: {
+        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
+        returns: FFIType.i32,
+      },
+    });
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        const fd = server.requestFD(req);
+        if (typeof fd !== "number" || fd < 0) {
+          return Response.json({ ok: false, reason: "no fd", fd });
+        }
+        const addr = new ArrayBuffer(128);
+        const addrLen = new Uint32Array(1);
+        addrLen[0] = 128;
+        const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
+        return Response.json({ ok: true, fd, rc, addrLen: addrLen[0] });
+      },
+    });
+
+    const response = await fetch(server.url.origin).then(x => x.json());
+    expect(response.ok).toBe(true);
+    expect(response.rc).toBe(0);
+    expect(response.addrLen).toBeGreaterThan(0);
+  });
+
+  it.if(isPosix)("returns an fd for a unix socket request", async () => {
+    const unix = join(tmpdirSync(), "serve-fd.sock");
+    using server = Bun.serve({
+      unix,
+      fetch(req, server) {
+        return Response.json({ fd: server.requestFD(req) });
+      },
+    });
+    const requestText = `GET / HTTP/1.1\r\nHost: localhost\r\n\r\n`;
+    const received: Buffer[] = [];
+    const { resolve, promise } = Promise.withResolvers<void>();
+    const connection = await Bun.connect({
+      unix,
+      socket: {
+        data(_socket, data) {
+          received.push(data);
+          resolve();
+        },
+      },
+    });
+    connection.write(requestText);
+    connection.flush();
+    await promise;
+    const body = Buffer.concat(received).toString().split("\r\n\r\n")[1];
+    const parsed = JSON.parse(body);
+    expect(typeof parsed.fd).toBe("number");
+    expect(parsed.fd).toBeGreaterThan(0);
     connection.end();
   });
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2631,26 +2631,21 @@ describe("server.requestFD", () => {
     expect(server.requestFD(savedRequest!)).toBeNull();
   });
 
-  it.if(isPosix)("returns an fd usable with getsockname() via FFI", async () => {
+  // Handler shared by the two getsockname() FFI tests below; calls
+  // getsockname(fd) on whatever `requestFD` returns and echoes rc/addrLen.
+  const getsocknameHandler = (req: Request, server: Server) => {
     const libc = dlopen(libcPathForDlopen(), {
-      getsockname: {
-        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
-        returns: FFIType.i32,
-      },
+      getsockname: { args: [FFIType.i32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
     });
+    const fd = server.requestFD(req) as number;
+    const addr = new ArrayBuffer(128);
+    const addrLen = new Uint32Array([128]);
+    const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
+    return Response.json({ fd, rc, addrLen: addrLen[0] });
+  };
 
-    using server = Bun.serve({
-      port: 0,
-      fetch(req, server) {
-        const fd = server.requestFD(req) as number;
-        const addr = new ArrayBuffer(128);
-        const addrLen = new Uint32Array(1);
-        addrLen[0] = 128;
-        const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
-        return Response.json({ fd, rc, addrLen: addrLen[0] });
-      },
-    });
-
+  it.if(isPosix)("returns an fd usable with getsockname() via FFI", async () => {
+    using server = Bun.serve({ port: 0, fetch: getsocknameHandler });
     const response = await fetch(server.url.origin).then(x => x.json());
     expect(response.fd).toBeGreaterThanOrEqual(0);
     expect(response.rc).toBe(0);
@@ -2658,26 +2653,7 @@ describe("server.requestFD", () => {
   });
 
   it.if(isPosix)("returns an OS fd for an HTTPS (TLS) request, not the SSL pointer", async () => {
-    const libc = dlopen(libcPathForDlopen(), {
-      getsockname: {
-        args: [FFIType.i32, FFIType.ptr, FFIType.ptr],
-        returns: FFIType.i32,
-      },
-    });
-
-    using server = Bun.serve({
-      port: 0,
-      tls,
-      fetch(req, server) {
-        const fd = server.requestFD(req) as number;
-        const addr = new ArrayBuffer(128);
-        const addrLen = new Uint32Array(1);
-        addrLen[0] = 128;
-        const rc = libc.symbols.getsockname(fd, ptr(addr), ptr(addrLen));
-        return Response.json({ fd, rc, addrLen: addrLen[0] });
-      },
-    });
-
+    using server = Bun.serve({ port: 0, tls, fetch: getsocknameHandler });
     const response = await fetch(server.url.origin, { tls: { rejectUnauthorized: false } }).then(x => x.json());
     // If requestFD had returned the SSL* heap pointer (the regression this test
     // guards against), getsockname would fail with EBADF / rc !== 0.
@@ -2691,33 +2667,15 @@ describe("server.requestFD", () => {
   it.if(isPosix)("returns an fd for a unix socket request", async () => {
     using dir = tempDir("serve-request-fd-unix", {});
     const unix = join(String(dir), "serve-fd.sock");
-    using server = Bun.serve({
+    using _server = Bun.serve({
       unix,
       fetch(req, server) {
         return Response.json({ fd: server.requestFD(req) });
       },
     });
-    const requestText = `GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`;
-    const received: Buffer[] = [];
-    const { resolve: resolveClose, promise: closed } = Promise.withResolvers<void>();
-    const connection = await Bun.connect({
-      unix,
-      socket: {
-        data(_socket, data) {
-          received.push(data);
-        },
-        close() {
-          resolveClose();
-        },
-      },
-    });
-    connection.write(requestText);
-    connection.flush();
-    await closed;
-    const body = Buffer.concat(received).toString().split("\r\n\r\n")[1];
-    const parsed = JSON.parse(body);
-    expect(typeof parsed.fd).toBe("number");
-    expect(parsed.fd).toBeGreaterThanOrEqual(0);
+    const response = await fetch("http://localhost/", { unix }).then(r => r.json());
+    expect(typeof response.fd).toBe("number");
+    expect(response.fd).toBeGreaterThanOrEqual(0);
   });
 });
 


### PR DESCRIPTION
Closes #29597

## Background

From the issue: an HTTP proxy needs to call `getsockopt(TCP_INFO)` on each connection to get kernel-reported byte and segment counts. `socket.bytesRead`/`bytesWritten` are insufficient because they don't include TCP/IP overhead. The syscall needs a real OS file descriptor.

## What this adds

Three complementary APIs, chosen to parallel patterns that already exist:

### 1. `server.requestFD(request)` — new on Bun.serve

Mirrors `server.requestIP(request)` — same lookup (`request.request_context` → response → native socket handle), returns the fd as a number or `null` if the request context has been torn down.

```js
Bun.serve({
  fetch(req, server) {
    const fd = server.requestFD(req); // e.g. 17
    // ... getsockopt(fd, TCP_INFO, ...) via FFI ...
    return new Response('ok');
  },
});
```

Unlike `requestIP`, this works for unix-socket servers too (the fd exists regardless of address family).

### 2. `socket.fd` on `NodeHTTPServerSocket` (C++ prototype)

The native wrapper that Bun's `node:http` server uses for each connection now exposes a `.fd` custom getter pointing at `us_socket_get_fd`, the same underlying call `TCPSocket` (`Bun.listen`) already uses for its `.fd`. Returns `-1` when the socket is closed.

### 3. `socket.fd` on Bun's `node:http` Duplex socket

The `NodeHTTPServerSocket` Duplex wrapper exposed to user code (via `http.createServer((req, res) => …)` and the `connection` event) gets a matching `.fd` getter that forwards to the underlying C++ handle. Returns `-1` after the socket has been destroyed.

```js
http.createServer((req, res) => {
  const fd = req.socket.fd;            // usable with getsockopt/setsockopt
  res.end('ok');
}).listen(0);
```

## Verification

The tests include an end-to-end FFI check that calls `getsockname(fd, ...)` on the returned fd and asserts `rc === 0`, proving the fd is a real OS descriptor — not just a synthetic number. This covers both `server.requestFD` and `node:http` `socket.fd`.

## Platforms

On Windows, `us_socket_get_fd` returns a `SOCKET` (UINT_PTR). The C++ getter and Rust path both widen that to a JS number so winsock APIs receive the full value, matching how `TCPSocket.getFD` already does this via `to_js_without_making_lib_uv_owned`.

## Files touched

- `src/runtime/server/server.classes.ts` — declares `requestFD` on `Server`.
- `src/runtime/server/server_body.rs` — implements `do_request_fd` / `request_fd`.
- `src/runtime/server/RequestContext.rs`, `AnyRequestContext.rs` — add the `get_fd` helper, with an HTTP/3 short-circuit that returns `null` (H3 multiplexes streams over one UDP socket, so there is no per-request fd).
- `src/uws_sys/Response.rs` — adds `get_fd`, which goes straight to `us_socket_get_fd` so TLS connections return a real fd rather than the `SSL*` pointer.
- `src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp` — adds the `.fd` getter (uses `dynamicDowncast`, so an arbitrary receiver returns `-1` instead of asserting).
- `src/js/node/_http_server.ts` — adds `.fd` to the Duplex wrapper.
- `packages/bun-types/serve.d.ts` — types for `requestFD`.
- `test/js/bun/http/serve.test.ts` — 5 tests for `server.requestFD` (TCP, released context, FFI `getsockname`, HTTPS/TLS fd vs SSL pointer, unix socket).
- `test/js/bun/http/bun-server.test.ts` — 4 tests for `node:http` `socket.fd` (incl. FFI `getsockname` and arbitrary-receiver hardening).
- `test/js/bun/http/serve-http3.test.ts` — 1 test asserting HTTP/3 returns `null`.

## Rebase note

The server implementation migrated from Zig to Rust on `main` while this PR was open. Rebasing onto `main` produced modify/delete conflicts on the reference `.zig` files (`server.zig`, `RequestContext.zig`, `AnyRequestContext.zig`, `uws_sys/Response.zig`), which no longer exist there. Those edits were dropped; the shipping logic lives in the `.rs` files listed above, which rebased cleanly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 28 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts, test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->