### PR TITLE
ResolveMessage: own the referrer slice

### DIFF
--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -173,7 +173,7 @@ pub const ResolveMessage = struct {
         resolve_error.* = ResolveMessage{
             .msg = try msg.clone(allocator),
             .allocator = allocator,
-            .referrer = Fs.Path.init(referrer),
+            .referrer = Fs.Path.init(try allocator.dupe(u8, referrer)),
         };
         return resolve_error.toJS(globalThis);
     }
@@ -226,6 +226,9 @@ pub const ResolveMessage = struct {
 
     pub fn finalize(this: *ResolveMessage) callconv(.c) void {
         this.msg.deinit(bun.default_allocator);
+        if (this.referrer) |referrer| {
+            this.allocator.free(referrer.text);
+        }
     }
 };
 

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1961,13 +1961,15 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
 
         1 => {
             const msg = log.msgs.items[0];
+            const referrer_utf8 = referrer.toUTF8(bun.default_allocator);
+            defer referrer_utf8.deinit();
             ret.* = ErrorableResolvedSource.err(err, switch (msg.metadata) {
                 .build => (bun.api.BuildMessage.create(globalThis, globalThis.allocator(), msg) catch |e| globalThis.takeException(e)),
                 .resolve => (bun.api.ResolveMessage.create(
                     globalThis,
                     globalThis.allocator(),
                     msg,
-                    referrer.toUTF8(bun.default_allocator).slice(),
+                    referrer_utf8.slice(),
                 ) catch |e| globalThis.takeException(e)),
             });
             return;
@@ -1979,6 +1981,9 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
             const errors = errors_stack[0..len];
             const logs = log.msgs.items[0..len];
 
+            const referrer_utf8 = referrer.toUTF8(bun.default_allocator);
+            defer referrer_utf8.deinit();
+
             for (logs, errors) |msg, *current| {
                 current.* = switch (msg.metadata) {
                     .build => bun.api.BuildMessage.create(globalThis, globalThis.allocator(), msg) catch |e| globalThis.takeException(e),
@@ -1986,7 +1991,7 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
                         globalThis,
                         globalThis.allocator(),
                         msg,
-                        referrer.toUTF8(bun.default_allocator).slice(),
+                        referrer_utf8.slice(),
                     ) catch |e| globalThis.takeException(e),
                 };
             }

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -60,6 +60,22 @@ describe("ResolveMessage", () => {
       await import(":://filesystem");
     }).toThrow("Cannot find module");
   });
+
+  it("referrer is not freed before it is read", () => {
+    // Non-ASCII in the source path forces resolveMaybeNeedsTrailingSlash to
+    // allocate a new UTF-8 buffer which is freed on return. ResolveMessage
+    // used to borrow that buffer for .referrer, causing a use-after-free
+    // when the property was read later.
+    let err: any;
+    try {
+      Bun.resolveSync("./does-not-exist", "/tmp/caf\u00e9-tr\u00e8s-long-\u{1F389}/file.js");
+    } catch (e) {
+      err = e;
+    }
+    Bun.gc(true);
+    expect(err.referrer).toStartWith("/tmp/caf");
+    expect(err.referrer).toEndWith("/file.js");
+  });
 });
 
 // These tests reproduce panics where the module resolver wrote past fixed-size


### PR DESCRIPTION
`ResolveMessage.create` stored the `referrer` path via `Fs.Path.init` without cloning. Every caller passes a temporary buffer — the `toUTF8()` of a `bun.String` that is `deinit()`'d on return — so reading `.referrer` after the creating frame unwound was a use-after-free.

Found by Fuzzilli as a flaky `use-after-poison` via `vi.mock()` → `Bun__resolveSyncWithSource` → `resolveMaybeNeedsTrailingSlash`, but it reproduces deterministically under ASAN with any non-ASCII source path:

```js
let err;
try {
  Bun.resolveSync("./does-not-exist", "/tmp/café-🎉/file.js");
} catch (e) { err = e; }
Bun.gc(true);
err.referrer; // use-after-poison
```

```
==3080==ERROR: AddressSanitizer: use-after-poison on address 0x77cca9db0000 ...
READ of size 44 at 0x77cca9db0000 thread T0
    #0 in __asan_memcpy
    #1 in Zig::toStringCopy(ZigString) helpers.h:217
    #2 in ZigString__toValueGC bindings.cpp:3402
    #3 in ZigString.toJS ZigString.zig:57
    #4 in ResolveMessage.getReferrer ResolveMessage.zig:221
```

In release builds the first 8 bytes of the returned referrer are overwritten by mimalloc's free-list pointer instead of crashing.

Clone the referrer in `create()` and free it in `finalize()`. Also `deinit()` the `toUTF8()` temporaries in `processFetchLog` now that `create()` copies.