### PR TITLE
install: fix broken dep symlinks in workspace members under a symlinked directory

### DIFF
--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -949,6 +949,43 @@ pub const Installer = struct {
                     const string_buf = lockfile.buffers.string_bytes.items;
                     const dependencies = lockfile.buffers.dependencies.items;
 
+                    // For a workspace entry whose declared `<workspace_path>`
+                    // traverses a symlink, the string-built staging node_modules
+                    // path resolves *physically* to a different directory than
+                    // the stored string suggests. Resolve that directory's real
+                    // path once so every dep symlink's relative target is
+                    // anchored at the location where the symlink is actually
+                    // written, not at the symlinked string path. If the path
+                    // is already canonical, leave this null so the existing
+                    // hot path runs with no extra syscalls.
+                    var canonical_entry_node_modules: ?bun.AbsPath(.{ .sep = .auto }) = null;
+                    defer if (canonical_entry_node_modules) |*p| p.deinit();
+                    if (pkg_res.tag == .workspace) resolve_canonical: {
+                        var workspace_abs: bun.AbsPath(.{ .sep = .auto }) = .initTopLevelDir();
+                        defer workspace_abs.deinit();
+                        workspace_abs.append(pkg_res.value.workspace.slice(string_buf));
+
+                        const dir_fd = switch (bun.sys.open(workspace_abs.sliceZ(), bun.O.DIRECTORY | bun.O.RDONLY, 0)) {
+                            .result => |fd| fd,
+                            .err => break :resolve_canonical,
+                        };
+                        defer dir_fd.close();
+
+                        var real_buf: bun.PathBuffer = undefined;
+                        const real = switch (bun.sys.getFdPath(dir_fd, &real_buf)) {
+                            .result => |r| r,
+                            .err => break :resolve_canonical,
+                        };
+
+                        if (strings.eqlLong(real, workspace_abs.slice(), true)) {
+                            break :resolve_canonical;
+                        }
+
+                        var canonical: bun.AbsPath(.{ .sep = .auto }) = .from(real);
+                        canonical.append("node_modules");
+                        canonical_entry_node_modules = canonical;
+                    }
+
                     for (entry_dependencies[this.entry_id.get()].slice()) |dep| {
                         const dep_name = dependencies[dep.dep_id].name.slice(string_buf);
 
@@ -996,6 +1033,20 @@ pub const Installer = struct {
                         }
 
                         const target = target: {
+                            if (canonical_entry_node_modules) |*canonical| {
+                                // Symlinked workspace directory: compute the
+                                // link string relative to the physical dest
+                                // parent so the stored target resolves from
+                                // where the symlink lives on disk (not the
+                                // symlinked string path, which is shallower in
+                                // the tree). `entryStoreNodeModulesPackageName`
+                                // returns null for `.workspace`, so the nested
+                                // node_modules collision case above never
+                                // triggers here and the canonical parent needs
+                                // no extra segments.
+                                break :target canonical.relative(&dep_store_path);
+                            }
+
                             var dest_save = dest.save();
                             defer dest_save.restore();
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1037,13 +1037,26 @@ pub const Installer = struct {
                                 // Symlinked workspace directory: compute the
                                 // link string relative to the physical dest
                                 // parent so the stored target resolves from
-                                // where the symlink lives on disk (not the
-                                // symlinked string path, which is shallower in
-                                // the tree). `entryStoreNodeModulesPackageName`
-                                // returns null for `.workspace`, so the nested
-                                // node_modules collision case above never
-                                // triggers here and the canonical parent needs
-                                // no extra segments.
+                                // where the symlink lives on disk, not from
+                                // the symlinked logical path (which is
+                                // shallower in the tree). Append the same
+                                // trailing segments as `dest` and then
+                                // `undo(1)` so the from-base matches the
+                                // symlink's real parent directory — critical
+                                // for scoped names like `@scope/pkg`, whose
+                                // parent is `<real_ws>/node_modules/@scope/`,
+                                // one level deeper than `<real_ws>/node_modules`.
+                                var save = canonical.save();
+                                defer save.restore();
+
+                                canonical.append(dep_name);
+                                if (installer.entryStoreNodeModulesPackageName(dep_id, pkg_id, &pkg_res, pkg_names)) |entry_node_modules_name| {
+                                    if (strings.eqlLong(dep_name, entry_node_modules_name, true)) {
+                                        canonical.append("node_modules");
+                                        canonical.append(dep_name);
+                                    }
+                                }
+                                canonical.undo(1);
                                 break :target canonical.relative(&dep_store_path);
                             }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -955,12 +955,6 @@ pub const Installer = struct {
                     // which would walk past the project root. Null when the
                     // path is already canonical so the hot path stays
                     // syscall-free.
-                    //
-                    // Open/realpath failing means we can't tell whether we'd
-                    // be writing a dangling link, so surface the sys error
-                    // instead of silently falling back to the logical-path
-                    // computation (which is exactly what produced the broken
-                    // link this branch exists to fix).
                     var canonical_entry_node_modules: ?bun.AbsPath(.{ .sep = .auto }) = null;
                     defer if (canonical_entry_node_modules) |*p| p.deinit();
                     if (pkg_res.tag == .workspace) {
@@ -1035,12 +1029,10 @@ pub const Installer = struct {
 
                         const target = target: {
                             if (canonical_entry_node_modules) |*canonical| {
-                                // Mirror `dest`'s trailing `dep_name` + `undo(1)`
-                                // so the from-base is the symlink's real parent
-                                // — one level deeper for scoped names like
-                                // `@scope/pkg`. `entryStoreNodeModulesPackageName`
-                                // is null for `.workspace`, so the collision
-                                // case above can't fire here.
+                                // Append `dep_name` then `undo(1)` so the
+                                // from-base is the symlink's real parent —
+                                // for scoped names like `@scope/pkg` that's
+                                // one level deeper than `node_modules`.
                                 var save = canonical.save();
                                 defer save.restore();
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -949,41 +949,42 @@ pub const Installer = struct {
                     const string_buf = lockfile.buffers.string_bytes.items;
                     const dependencies = lockfile.buffers.dependencies.items;
 
-                    // For a workspace entry whose declared `<workspace_path>`
-                    // traverses a symlink, the string-built staging node_modules
-                    // path resolves *physically* to a different directory than
-                    // the stored string suggests. Resolve that directory's real
-                    // path once so every dep symlink's relative target is
-                    // anchored at the location where the symlink is actually
-                    // written, not at the symlinked string path. If the path
-                    // is already canonical, leave this null so the existing
-                    // hot path runs with no extra syscalls.
+                    // If the workspace path traverses a symlink, dep symlinks
+                    // live under the realpath, so their relative targets must
+                    // be computed from there — not from the logical string,
+                    // which would walk past the project root. Null when the
+                    // path is already canonical so the hot path stays
+                    // syscall-free.
+                    //
+                    // Open/realpath failing means we can't tell whether we'd
+                    // be writing a dangling link, so surface the sys error
+                    // instead of silently falling back to the logical-path
+                    // computation (which is exactly what produced the broken
+                    // link this branch exists to fix).
                     var canonical_entry_node_modules: ?bun.AbsPath(.{ .sep = .auto }) = null;
                     defer if (canonical_entry_node_modules) |*p| p.deinit();
-                    if (pkg_res.tag == .workspace) resolve_canonical: {
+                    if (pkg_res.tag == .workspace) {
                         var workspace_abs: bun.AbsPath(.{ .sep = .auto }) = .initTopLevelDir();
                         defer workspace_abs.deinit();
                         workspace_abs.append(pkg_res.value.workspace.slice(string_buf));
 
                         const dir_fd = switch (bun.sys.open(workspace_abs.sliceZ(), bun.O.DIRECTORY | bun.O.RDONLY, 0)) {
                             .result => |fd| fd,
-                            .err => break :resolve_canonical,
+                            .err => |err| return .failure(.{ .symlink_dependencies = err }),
                         };
                         defer dir_fd.close();
 
                         var real_buf: bun.PathBuffer = undefined;
                         const real = switch (bun.sys.getFdPath(dir_fd, &real_buf)) {
                             .result => |r| r,
-                            .err => break :resolve_canonical,
+                            .err => |err| return .failure(.{ .symlink_dependencies = err }),
                         };
 
-                        if (strings.eqlLong(real, workspace_abs.slice(), true)) {
-                            break :resolve_canonical;
+                        if (!strings.eqlLong(real, workspace_abs.slice(), true)) {
+                            var canonical: bun.AbsPath(.{ .sep = .auto }) = .from(real);
+                            canonical.append("node_modules");
+                            canonical_entry_node_modules = canonical;
                         }
-
-                        var canonical: bun.AbsPath(.{ .sep = .auto }) = .from(real);
-                        canonical.append("node_modules");
-                        canonical_entry_node_modules = canonical;
                     }
 
                     for (entry_dependencies[this.entry_id.get()].slice()) |dep| {
@@ -1034,28 +1035,16 @@ pub const Installer = struct {
 
                         const target = target: {
                             if (canonical_entry_node_modules) |*canonical| {
-                                // Symlinked workspace directory: compute the
-                                // link string relative to the physical dest
-                                // parent so the stored target resolves from
-                                // where the symlink lives on disk, not from
-                                // the symlinked logical path (which is
-                                // shallower in the tree). Append the same
-                                // trailing segments as `dest` and then
-                                // `undo(1)` so the from-base matches the
-                                // symlink's real parent directory — critical
-                                // for scoped names like `@scope/pkg`, whose
-                                // parent is `<real_ws>/node_modules/@scope/`,
-                                // one level deeper than `<real_ws>/node_modules`.
+                                // Mirror `dest`'s trailing `dep_name` + `undo(1)`
+                                // so the from-base is the symlink's real parent
+                                // — one level deeper for scoped names like
+                                // `@scope/pkg`. `entryStoreNodeModulesPackageName`
+                                // is null for `.workspace`, so the collision
+                                // case above can't fire here.
                                 var save = canonical.save();
                                 defer save.restore();
 
                                 canonical.append(dep_name);
-                                if (installer.entryStoreNodeModulesPackageName(dep_id, pkg_id, &pkg_res, pkg_names)) |entry_node_modules_name| {
-                                    if (strings.eqlLong(dep_name, entry_node_modules_name, true)) {
-                                        canonical.append("node_modules");
-                                        canonical.append(dep_name);
-                                    }
-                                }
                                 canonical.undo(1);
                                 break :target canonical.relative(&dep_store_path);
                             }

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -488,6 +488,93 @@ describe("isolated workspaces", () => {
       { name: "pkg3", dependencies: { "different-name": "workspace:." } },
     ]);
   });
+
+  // https://github.com/oven-sh/bun/issues/29598
+  //
+  // When a workspace member is listed through a path that traverses a
+  // symlink, the member's `<workspace>/node_modules/<dep>` links are
+  // physically created at the resolved target directory — but their
+  // content (the relative `..`-prefix) used to be computed against the
+  // logical path, so they walked past the project root and pointed at
+  // nothing. Resolve the workspace dir's real path before computing the
+  // link target so require() works from inside the symlinked member.
+  test("symlinked workspace members get runnable dependency links", async () => {
+    using dir = tempDir("isolated-workspace-symlink-", {
+      "bunfig.toml": `[install]\nlinker = "isolated"\ncache = ".bun-cache"\n`,
+      "package.json": JSON.stringify({
+        name: "root",
+        private: true,
+        workspaces: ["app", "repos/ext/shared-lib"],
+      }),
+      "app/package.json": JSON.stringify({
+        name: "app",
+        private: true,
+        dependencies: { "shared-lib": "workspace:*" },
+      }),
+      "app/index.js": `import { check } from "shared-lib"; console.log(check("ok"));`,
+      // Published-style dep the symlinked workspace consumes via `file:`,
+      // so the link goes into `<project>/node_modules/.bun/<entry>/...`
+      // just like an npm dep — that's the shape the bug lived in.
+      // Placed next to the *real* workspace so the `file:` path resolves
+      // the same whether bun walks the logical or canonical workspace
+      // directory.
+      "real-workspaces/vendor/shared-dep/package.json": JSON.stringify({
+        name: "shared-dep",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+      "real-workspaces/vendor/shared-dep/index.js": `module.exports = { id: "shared-dep" };`,
+      "real-workspaces/shared-lib/package.json": JSON.stringify({
+        name: "shared-lib",
+        private: true,
+        type: "module",
+        exports: { ".": "./index.js" },
+        dependencies: { "shared-dep": "file:../vendor/shared-dep" },
+      }),
+      "real-workspaces/shared-lib/index.js": `import pkg from "shared-dep"; export const check = v => pkg.id + ":" + v;`,
+    });
+    const root = String(dir);
+
+    // The workspace is listed as `repos/ext/shared-lib`, but `repos/ext`
+    // is a symlink to `../real-workspaces`, so the member's real path
+    // is `<project>/real-workspaces/shared-lib`.
+    await mkdir(join(root, "repos"), { recursive: true });
+    await symlink(join("..", "real-workspaces"), join(root, "repos", "ext"));
+
+    await using install = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: bunEnv,
+      cwd: root,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [installStderr, installExit] = await Promise.all([install.stderr.text(), install.exited]);
+    expect(installStderr).not.toContain("error:");
+    expect(installExit).toBe(0);
+
+    // The package-local dep link lives at the real member path. Its
+    // target must resolve up through `<project>/node_modules/.bun/...`.
+    const depLinkPath = join(root, "real-workspaces", "shared-lib", "node_modules", "shared-dep");
+    const depLinkTarget = await readlink(depLinkPath);
+    expect(depLinkTarget).toContain(".bun");
+    expect(existsSync(join(depLinkPath, "package.json"))).toBeTrue();
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "app/index.js"],
+      env: bunEnv,
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // ASAN may write a warning to stderr in debug builds — the important
+    // signal is that the module resolved and the value printed.
+    expect(stderr).not.toContain("ENOENT");
+    expect(stderr).not.toContain("Cannot find");
+    expect(stdout).toBe("shared-dep:ok\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe("optional peers", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -572,8 +572,8 @@ describe("isolated workspaces", () => {
     // `<project>/node_modules/.bun/...`.
     const sharedDepLink = join(root, "real-workspaces", "shared-lib", "node_modules", "shared-dep");
     const scopedDepLink = join(root, "real-workspaces", "shared-lib", "node_modules", "@myscope", "helper");
-    expect((await readlink(sharedDepLink))).toContain(".bun");
-    expect((await readlink(scopedDepLink))).toContain(".bun");
+    expect(await readlink(sharedDepLink)).toContain(".bun");
+    expect(await readlink(scopedDepLink)).toContain(".bun");
     expect(existsSync(join(sharedDepLink, "package.json"))).toBeTrue();
     expect(existsSync(join(scopedDepLink, "package.json"))).toBeTrue();
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -512,14 +512,10 @@ describe("isolated workspaces", () => {
         dependencies: { "shared-lib": "workspace:*" },
       }),
       "app/index.js": `import { check } from "shared-lib"; console.log(check("ok"));`,
-      // Published-style deps the symlinked workspace consumes via
-      // `file:`, so the links go into `<project>/node_modules/.bun/<entry>/...`
-      // just like npm deps — that's the shape the bug lived in. Placed
-      // next to the *real* workspace so the `file:` path resolves the
-      // same whether bun walks the logical or canonical workspace dir.
-      // Covers both an unscoped dep (link parent is `node_modules`) and a
-      // scoped one (link parent is `node_modules/@scope`, one level deeper
-      // — the relative target has to account for it).
+      // Vendor deps live next to the *real* workspace so `file:` resolves
+      // the same through logical or canonical paths. Unscoped + scoped
+      // both covered — the scoped link parent is one level deeper, which
+      // the relative target has to account for.
       "real-workspaces/vendor/shared-dep/package.json": JSON.stringify({
         name: "shared-dep",
         version: "1.0.0",
@@ -555,17 +551,7 @@ describe("isolated workspaces", () => {
     await mkdir(join(root, "repos"), { recursive: true });
     await symlink(join("..", "real-workspaces"), join(root, "repos", "ext"));
 
-    await using install = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      env: bunEnv,
-      cwd: root,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [installStderr, installExit] = await Promise.all([install.stderr.text(), install.exited]);
-    expect(installStderr).not.toContain("error:");
-    expect(installExit).toBe(0);
+    await runBunInstall(bunEnv, root);
 
     // Package-local dep links live at the real member path. Both the
     // unscoped and the scoped target must resolve up through
@@ -584,11 +570,7 @@ describe("isolated workspaces", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // ASAN may write a warning to stderr in debug builds — the important
-    // signal is that the module resolved and the value printed.
-    expect(stderr).not.toContain("ENOENT");
-    expect(stderr).not.toContain("Cannot find");
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(stdout).toBe("shared-dep+@myscope/helper:ok\n");
     expect(exitCode).toBe(0);
   });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -512,26 +512,40 @@ describe("isolated workspaces", () => {
         dependencies: { "shared-lib": "workspace:*" },
       }),
       "app/index.js": `import { check } from "shared-lib"; console.log(check("ok"));`,
-      // Published-style dep the symlinked workspace consumes via `file:`,
-      // so the link goes into `<project>/node_modules/.bun/<entry>/...`
-      // just like an npm dep — that's the shape the bug lived in.
-      // Placed next to the *real* workspace so the `file:` path resolves
-      // the same whether bun walks the logical or canonical workspace
-      // directory.
+      // Published-style deps the symlinked workspace consumes via
+      // `file:`, so the links go into `<project>/node_modules/.bun/<entry>/...`
+      // just like npm deps — that's the shape the bug lived in. Placed
+      // next to the *real* workspace so the `file:` path resolves the
+      // same whether bun walks the logical or canonical workspace dir.
+      // Covers both an unscoped dep (link parent is `node_modules`) and a
+      // scoped one (link parent is `node_modules/@scope`, one level deeper
+      // — the relative target has to account for it).
       "real-workspaces/vendor/shared-dep/package.json": JSON.stringify({
         name: "shared-dep",
         version: "1.0.0",
         main: "index.js",
       }),
       "real-workspaces/vendor/shared-dep/index.js": `module.exports = { id: "shared-dep" };`,
+      "real-workspaces/vendor/@myscope/helper/package.json": JSON.stringify({
+        name: "@myscope/helper",
+        version: "1.0.0",
+        main: "index.js",
+      }),
+      "real-workspaces/vendor/@myscope/helper/index.js": `module.exports = { id: "@myscope/helper" };`,
       "real-workspaces/shared-lib/package.json": JSON.stringify({
         name: "shared-lib",
         private: true,
         type: "module",
         exports: { ".": "./index.js" },
-        dependencies: { "shared-dep": "file:../vendor/shared-dep" },
+        dependencies: {
+          "shared-dep": "file:../vendor/shared-dep",
+          "@myscope/helper": "file:../vendor/@myscope/helper",
+        },
       }),
-      "real-workspaces/shared-lib/index.js": `import pkg from "shared-dep"; export const check = v => pkg.id + ":" + v;`,
+      "real-workspaces/shared-lib/index.js":
+        `import pkg from "shared-dep";` +
+        `import scoped from "@myscope/helper";` +
+        `export const check = v => pkg.id + "+" + scoped.id + ":" + v;`,
     });
     const root = String(dir);
 
@@ -553,12 +567,15 @@ describe("isolated workspaces", () => {
     expect(installStderr).not.toContain("error:");
     expect(installExit).toBe(0);
 
-    // The package-local dep link lives at the real member path. Its
-    // target must resolve up through `<project>/node_modules/.bun/...`.
-    const depLinkPath = join(root, "real-workspaces", "shared-lib", "node_modules", "shared-dep");
-    const depLinkTarget = await readlink(depLinkPath);
-    expect(depLinkTarget).toContain(".bun");
-    expect(existsSync(join(depLinkPath, "package.json"))).toBeTrue();
+    // Package-local dep links live at the real member path. Both the
+    // unscoped and the scoped target must resolve up through
+    // `<project>/node_modules/.bun/...`.
+    const sharedDepLink = join(root, "real-workspaces", "shared-lib", "node_modules", "shared-dep");
+    const scopedDepLink = join(root, "real-workspaces", "shared-lib", "node_modules", "@myscope", "helper");
+    expect((await readlink(sharedDepLink))).toContain(".bun");
+    expect((await readlink(scopedDepLink))).toContain(".bun");
+    expect(existsSync(join(sharedDepLink, "package.json"))).toBeTrue();
+    expect(existsSync(join(scopedDepLink, "package.json"))).toBeTrue();
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "app/index.js"],
@@ -572,7 +589,7 @@ describe("isolated workspaces", () => {
     // signal is that the module resolved and the value printed.
     expect(stderr).not.toContain("ENOENT");
     expect(stderr).not.toContain("Cannot find");
-    expect(stdout).toBe("shared-dep:ok\n");
+    expect(stdout).toBe("shared-dep+@myscope/helper:ok\n");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #29598.

## Repro

```sh
mkdir -p root/app external/shared-lib root/repos
ln -s ../../external root/repos/ext

cat > external/shared-lib/package.json <<'EOF'
{ "name": "shared-lib", "private": true, "type": "module",
  "exports": { ".": "./index.js" },
  "dependencies": { "is-number": "7.0.0" } }
EOF
cat > external/shared-lib/index.js <<'EOF'
import isNumber from 'is-number'
export const check = (value) => isNumber(value)
EOF
cat > root/package.json <<'EOF'
{ "name": "root", "private": true,
  "workspaces": ["app", "repos/ext/shared-lib"] }
EOF
cat > root/app/package.json <<'EOF'
{ "name": "app", "private": true, "type": "module",
  "dependencies": { "shared-lib": "workspace:*" } }
EOF
cat > root/app/index.js <<'EOF'
import { check } from 'shared-lib'
console.log(check(1))
EOF

cd root && bun install && bun app/index.js
```

`bun install` succeeds. `bun app/index.js` then fails with:

```
error: ENOENT reading "/tmp/.../external/shared-lib/node_modules/is-number"
```

The written link:

```
external/shared-lib/node_modules/is-number -> ../../../../node_modules/.bun/is-number@7.0.0/node_modules/is-number
```

Four `..`s from `external/shared-lib/node_modules` walks past the project root.

## Cause

`src/install/isolated_install/Installer.zig`, the `.symlink_dependencies` task step: `dest` is built by string-joining `top_level_dir` + the lockfile's `workspace_path` + `"node_modules"` + `dep_name`. For a workspace member listed through a path that traverses a symlink (`repos/ext/shared-lib` here), that string path resolves *physically* to a different directory than the joined string suggests — in the repro, the staging `node_modules` really lives at `external/shared-lib/node_modules` (three levels under `/tmp/bug-repro`), not `root/repos/ext/shared-lib/node_modules` (four levels). `dest.relative(&dep_store_path)` is pure string arithmetic, so it counted the deeper logical depth and emitted one extra `..`.

The link landed at its real location, but with a content string anchored to a path that doesn't exist from there.

## Fix

When the entry is a workspace, resolve the workspace directory's real path once (`open` + `getFdPath`) before the dep loop. Use that as the `from` for `Path.relative` so the stored target string is relative to where the symlink is physically created, not to the symlinked logical path. The `dest` passed to `sys.symlink` stays logical so the kernel follows the same chain it always did. When the workspace path is already canonical, the extra `open` is skipped — the existing hot path runs unchanged.

## Verification

- Debug build on the repro above: `is-number -> ../../../root/node_modules/.bun/...` (3 `..`s), `bun app/index.js` prints `true`.
- `readlink -f` resolves the link to the `.bun/` store entry.
- Direct-directory control (same workspace layout without the symlink) still writes the existing 4-`..` link and runs — no regression.
- Test covering the symlinked-workspace shape added to `test/cli/install/isolated-install.test.ts`.