### PR TITLE
tls: add `groups` option, default to PQ-friendly hybrid

### DIFF
--- a/docs/runtime/http/tls.mdx
+++ b/docs/runtime/http/tls.mdx
@@ -67,6 +67,30 @@ Bun.serve({
 });
 ```
 
+### Key-exchange groups
+
+By default Bun advertises the post-quantum hybrid `X25519MLKEM768` (codepoint `0x11ec`) ahead of the classical X25519 / P-256 / P-384 groups in every outbound and inbound TLS handshake. Bun applies its own list (`X25519MLKEM768:X25519:P-256:P-384`) at every `SSL_CTX` construction site, diverging from BoringSSL's compile-time default, which omits PQ.
+
+To override the group list (also known as `ecdhCurve` in Node.js):
+
+```ts
+Bun.serve({
+  tls: {
+    key: Bun.file("./key.pem"),
+    cert: Bun.file("./cert.pem"),
+    groups: "X25519MLKEM768:X25519:P-256:P-384", // [!code ++]
+  },
+});
+```
+
+The same option works on outbound clients (`fetch`, `tls.connect`, `Bun.connect`):
+
+```ts
+await fetch("https://example.com", { tls: { groups: "X25519:P-256" } });
+```
+
+Pass the empty string `""` to fall back to BoringSSL's compile-time default (no PQ) on the `fetch`, `Bun.connect`, `Bun.serve`, `tls.connect`, `tls.createServer`, and `http(s).request` paths. Passing an unknown group name causes the `SSL_CTX` construction to fail.
+
 ---
 
 ## Server name indication (SNI)

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -869,7 +869,7 @@ create_ssl_context_from_options(struct us_socket_context_options_t options) {
 
   if (options.ssl_ciphers) {
     if (!SSL_CTX_set_cipher_list(ssl_context, options.ssl_ciphers)) {
-      unsigned long ssl_err = ERR_get_error(); 
+      unsigned long ssl_err = ERR_get_error();
       if (!(strlen(options.ssl_ciphers) == 0 && ERR_GET_REASON(ssl_err) == SSL_R_NO_CIPHER_MATCH)) {
         // TLS1.2 ciphers were deliberately cleared, so don't consider
         // SSL_R_NO_CIPHER_MATCH to be an error (this is how _set_cipher_suites()
@@ -879,6 +879,31 @@ create_ssl_context_from_options(struct us_socket_context_options_t options) {
         return NULL;
       }
       ERR_clear_error();
+    }
+  }
+
+  /* TLS supported_groups (key-exchange / KEM groups). NULL applies the Bun
+   * default (PQ hybrid first); "" tells us to inherit BoringSSL's compile-time
+   * default; otherwise the caller's explicit list.
+   *
+   * Failure handling differs by source: caller-provided lists hard-fail (the
+   * caller asked for something invalid), but a failure of OUR default falls
+   * back silently to BoringSSL's compile-time default. This matches the
+   * applyBunDefaultGroups() posture in ncrypto.cpp. */
+  {
+    const char *groups = options.ssl_groups;
+    const int caller_provided = (groups != NULL);
+    if (!caller_provided) {
+      groups = BUN_DEFAULT_SSL_GROUPS;
+    }
+    if (groups[0] != '\0') {
+      if (!SSL_CTX_set1_groups_list(ssl_context, groups)) {
+        if (caller_provided) {
+          free_ssl_context(ssl_context);
+          return NULL;
+        }
+        ERR_clear_error();
+      }
     }
   }
 
@@ -1333,6 +1358,32 @@ SSL_CTX *create_ssl_context_from_bun_options(
 
   if (options.secure_options) {
     SSL_CTX_set_options(ssl_context, options.secure_options);
+  }
+
+  /* TLS supported_groups (key-exchange / KEM groups). NULL applies the Bun
+   * default (PQ hybrid first); "" tells us to inherit BoringSSL's compile-time
+   * default; otherwise the caller's explicit list.
+   *
+   * Failure handling differs by source: caller-provided lists hard-fail with
+   * INVALID_GROUPS (the caller asked for something invalid), but a failure of
+   * OUR default falls back silently to BoringSSL's compile-time default. This
+   * matches the applyBunDefaultGroups() posture in ncrypto.cpp. */
+  {
+    const char *groups = options.ssl_groups;
+    const int caller_provided = (groups != NULL);
+    if (!caller_provided) {
+      groups = BUN_DEFAULT_SSL_GROUPS;
+    }
+    if (groups[0] != '\0') {
+      if (!SSL_CTX_set1_groups_list(ssl_context, groups)) {
+        if (caller_provided) {
+          *err = CREATE_BUN_SOCKET_ERROR_INVALID_GROUPS;
+          free_ssl_context(ssl_context);
+          return NULL;
+        }
+        ERR_clear_error();
+      }
+    }
   }
 
   /* This must be free'd with free_ssl_context, not SSL_CTX_free */

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -204,6 +204,7 @@ struct us_socket_context_options_t {
     const char *dh_params_file_name;
     const char *ca_file_name;
     const char *ssl_ciphers;
+    const char *ssl_groups; /* TLS supported_groups list (BoringSSL set1_groups_list syntax). NULL = Bun default (PQ-friendly). "" = inherit BoringSSL default. */
     int ssl_prefer_low_memory_usage; /* Todo: rename to prefer_low_memory_usage and apply for TCP as well */
 };
 
@@ -235,6 +236,7 @@ struct us_bun_socket_context_options_t {
     const char *dh_params_file_name;
     const char *ca_file_name;
     const char *ssl_ciphers;
+    const char *ssl_groups; /* TLS supported_groups list (BoringSSL set1_groups_list syntax). NULL = Bun default (PQ-friendly). "" = inherit BoringSSL default. */
     int ssl_prefer_low_memory_usage; /* Todo: rename to prefer_low_memory_usage and apply for TCP as well */
     const char * const *key;
     unsigned int key_count;
@@ -273,7 +275,13 @@ enum create_bun_socket_error_t {
   CREATE_BUN_SOCKET_ERROR_INVALID_CA_FILE,
   CREATE_BUN_SOCKET_ERROR_INVALID_CA,
   CREATE_BUN_SOCKET_ERROR_INVALID_CIPHERS,
+  CREATE_BUN_SOCKET_ERROR_INVALID_GROUPS,
 };
+
+/* Default TLS supported_groups list when caller passes ssl_groups = NULL.
+ * Order: PQ hybrid first, then classical fallbacks. Mirrors Chromium's default
+ * post-quantum-key-agreement enabled posture. */
+#define BUN_DEFAULT_SSL_GROUPS "X25519MLKEM768:X25519:P-256:P-384"
 
 struct us_socket_context_t *us_create_bun_ssl_socket_context(struct us_loop_t *loop,
     int ext_size, struct us_bun_socket_context_options_t options, enum create_bun_socket_error_t *err);

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <charconv>
+#include <cstddef>
 #include <string_view>
 
 namespace uWS {
@@ -65,6 +66,7 @@ namespace uWS {
         const char *dh_params_file_name = nullptr;
         const char *ca_file_name = nullptr;
         const char *ssl_ciphers = nullptr;
+        const char *ssl_groups = nullptr; /* See libusockets.h: NULL = Bun PQ default; "" = inherit BoringSSL default. */
         int ssl_prefer_low_memory_usage = 0;
 
         const char **key = nullptr;
@@ -88,6 +90,11 @@ namespace uWS {
     };
 
     static_assert(sizeof(struct us_bun_socket_context_options_t) == sizeof(SocketContextOptions), "Mismatching uSockets/uWebSockets ABI");
+    // Defensive offset checks: equal sizes don't guarantee field positions
+    // match across the C/C++ memcpy boundary. Catch reorderings of newer
+    // fields at compile time.
+    static_assert(offsetof(struct us_bun_socket_context_options_t, ssl_groups) == offsetof(SocketContextOptions, ssl_groups), "Mismatching ssl_groups ABI offset");
+    static_assert(offsetof(struct us_bun_socket_context_options_t, ssl_prefer_low_memory_usage) == offsetof(SocketContextOptions, ssl_prefer_low_memory_usage), "Mismatching ssl_prefer_low_memory_usage ABI offset");
 
 template <bool SSL>
 struct TemplatedApp {

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1619,6 +1619,7 @@ pub fn NewSocket(comptime ssl: bool) type {
         pub const getALPNProtocol = if (ssl) tls_socket_functions.getALPNProtocol else tcp_socket_getter_that_returns_false;
         pub const exportKeyingMaterial = if (ssl) tls_socket_functions.exportKeyingMaterial else tcp_socket_function_that_returns_undefined;
         pub const getEphemeralKeyInfo = if (ssl) tls_socket_functions.getEphemeralKeyInfo else tcp_socket_function_that_returns_null;
+        pub const getSharedGroup = if (ssl) tls_socket_functions.getSharedGroup else tcp_socket_function_that_returns_null;
         pub const getCipher = if (ssl) tls_socket_functions.getCipher else tcp_socket_function_that_returns_undefined;
         pub const getTLSPeerFinishedMessage = if (ssl) tls_socket_functions.getTLSPeerFinishedMessage else tcp_socket_function_that_returns_undefined;
         pub const getTLSFinishedMessage = if (ssl) tls_socket_functions.getTLSFinishedMessage else tcp_socket_function_that_returns_undefined;

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -192,6 +192,13 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
         true => uws.SocketContext.createSSLContext(uws.Loop.get(), @sizeOf(usize), ctx_opts, &create_err),
         false => uws.SocketContext.createNoSSLContext(uws.Loop.get(), @sizeOf(usize)),
     } orelse {
+        // Mirror connectInner: surface BoringSSL-specific construction
+        // failures (cipher / group rejection) as their dedicated error so a
+        // misconfigured server doesn't get a generic "Failed to listen".
+        if (ssl_enabled) switch (create_err) {
+            .invalid_ciphers, .invalid_groups => return globalObject.throwValue(create_err.toJS(globalObject)),
+            .none, .load_ca_file, .invalid_ca_file, .invalid_ca => {},
+        };
         const err = globalObject.createErrorInstance(
             "Failed to listen on {s}:{d}",
             .{ hostname_or_unix.slice(), port orelse 0 },
@@ -774,12 +781,29 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
         true => uws.SocketContext.createSSLContext(uws.Loop.get(), @sizeOf(usize), ctx_opts, &create_err),
         false => uws.SocketContext.createNoSSLContext(uws.Loop.get(), @sizeOf(usize)),
     } orelse {
-        const err = jsc.SystemError{
-            .message = bun.String.static("Failed to connect"),
-            .syscall = bun.String.static("connect"),
-            .code = if (port == null) bun.String.static("ENOENT") else bun.String.static("ECONNREFUSED"),
-        };
-        return globalObject.throwValue(err.toErrorInstance(globalObject));
+        // BoringSSL construction failures: CA-related variants historically
+        // surfaced as the generic ECONNREFUSED/ENOENT path (preserve that for
+        // backward compatibility). Newer BoringSSL-specific errors (cipher
+        // and group rejection) get a dedicated error so callers can tell
+        // config mistakes apart from network-level connect failures.
+        //
+        // `.none` is included in the generic arm because uws has multiple
+        // NULL-return paths in create_ssl_context_from_bun_options (cert
+        // load, key load, DH params, TLS_method allocation) that don't set
+        // the err out-param, plus createNoSSLContext returning NULL leaves
+        // create_err untouched. Falling through to ECONNREFUSED is the
+        // safest behavior for those.
+        switch (create_err) {
+            .none, .load_ca_file, .invalid_ca_file, .invalid_ca => {
+                const err = jsc.SystemError{
+                    .message = bun.String.static("Failed to connect"),
+                    .syscall = bun.String.static("connect"),
+                    .code = if (port == null) bun.String.static("ENOENT") else bun.String.static("ECONNREFUSED"),
+                };
+                return globalObject.throwValue(err.toErrorInstance(globalObject));
+            },
+            .invalid_ciphers, .invalid_groups => return globalObject.throwValue(create_err.toJS(globalObject)),
+        }
     };
 
     if (ssl_enabled) {

--- a/src/bun.js/api/bun/socket/tls_socket_functions.zig
+++ b/src/bun.js/api/bun/socket/tls_socket_functions.zig
@@ -436,6 +436,24 @@ pub fn getEphemeralKeyInfo(this: *This, globalObject: *jsc.JSGlobalObject, _: *j
     return result;
 }
 
+/// Returns the BoringSSL name of the negotiated key-exchange / KEM group
+/// (e.g. "X25519MLKEM768", "X25519", "P-256"), or null if the handshake
+/// has not yet completed or no group was negotiated.
+///
+/// Mirrors the spirit of Node.js's `tls.TLSSocket.getEphemeralKeyInfo()`,
+/// but reports the *agreed* group rather than the local ephemeral key.
+/// PQ KEMs (ML-KEM-768) don't fit the EVP_PKEY model that Node's API
+/// assumes, so a dedicated accessor is the cleaner shape.
+pub fn getSharedGroup(this: *This, globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    const ssl_ptr = this.socket.ssl() orelse return JSValue.jsNull();
+    const curve_id = BoringSSL.SSL_get_curve_id(ssl_ptr);
+    if (curve_id == 0) return JSValue.jsNull();
+    const name_ptr = BoringSSL.SSL_get_curve_name(curve_id);
+    if (name_ptr == null) return JSValue.jsNull();
+    const name = name_ptr[0..bun.len(name_ptr)];
+    return bun.String.createUTF8ForJS(globalObject, name);
+}
+
 pub fn getALPNProtocol(this: *This, globalObject: *jsc.JSGlobalObject) bun.JSError!JSValue {
     var alpn_proto: [*c]const u8 = null;
     var alpn_proto_len: u32 = 0;

--- a/src/bun.js/api/server/SSLConfig.bindv2.ts
+++ b/src/bun.js/api/server/SSLConfig.bindv2.ts
@@ -76,6 +76,11 @@ export const SSLConfig = b.dictionary(
       internalName: "alpn_protocols",
     },
     ciphers: b.String.nullable,
+    /** TLS supported_groups; "ecdhCurve" is the Node alias. See BUN_DEFAULT_SSL_GROUPS. */
+    groups: {
+      type: b.String.nullable,
+      altNames: ["ecdhCurve"],
+    },
     clientRenegotiationLimit: {
       type: b.u32,
       default: 0,

--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -18,6 +18,7 @@ secure_options: u32 = 0,
 request_cert: i32 = 0,
 reject_unauthorized: i32 = 0,
 ssl_ciphers: ?[*:0]const u8 = null,
+ssl_groups: ?[*:0]const u8 = null,
 protos: ?[*:0]const u8 = null,
 client_renegotiation_limit: u32 = 0,
 client_renegotiation_window: u32 = 0,
@@ -101,6 +102,9 @@ pub fn asUSockets(this: *const SSLConfig) uws.SocketContext.BunSocketContextOpti
 
     if (this.ssl_ciphers != null) {
         ctx_opts.ssl_ciphers = this.ssl_ciphers;
+    }
+    if (this.ssl_groups != null) {
+        ctx_opts.ssl_groups = this.ssl_groups;
     }
     ctx_opts.request_cert = this.request_cert;
     ctx_opts.reject_unauthorized = this.reject_unauthorized;
@@ -205,6 +209,7 @@ pub fn deinit(this: *SSLConfig) void {
         .request_cert = {},
         .reject_unauthorized = {},
         .ssl_ciphers = freeString(&this.ssl_ciphers),
+        .ssl_groups = freeString(&this.ssl_groups),
         .protos = freeString(&this.protos),
         .client_renegotiation_limit = {},
         .client_renegotiation_window = {},
@@ -243,6 +248,7 @@ pub fn clone(this: *const SSLConfig) SSLConfig {
         .request_cert = this.request_cert,
         .reject_unauthorized = this.reject_unauthorized,
         .ssl_ciphers = cloneString(this.ssl_ciphers),
+        .ssl_groups = cloneString(this.ssl_groups),
         .protos = cloneString(this.protos),
         .client_renegotiation_limit = this.client_renegotiation_limit,
         .client_renegotiation_window = this.client_renegotiation_window,
@@ -441,6 +447,32 @@ pub fn fromGenerated(
         result.ssl_ciphers = ciphers.toOwnedSliceZ(bun.default_allocator);
         result.is_using_default_ciphers = false;
         result.requires_custom_request_ctx = true;
+    }
+    if (generated.groups.get()) |groups| {
+        const owned = groups.toOwnedSliceZ(bun.default_allocator);
+        // Reject embedded NUL: the slice crosses to BoringSSL via a
+        // [*:0]const u8 pointer, so an embedded NUL silently truncates the
+        // group list and would let an attacker who can influence this string
+        // downgrade the offered groups without any error surfacing. Use
+        // ERR_INVALID_ARG_VALUE with the same "options.groups" prefix that
+        // tls.ts and _http_client.ts emit, so a user catching this error
+        // sees the same code/shape regardless of entry point.
+        if (strings.indexOfChar(owned, 0) != null) {
+            defer bun.default_allocator.free(owned);
+            // `bun.fmt.quote` self-wraps in `"..."` — don't add an outer
+            // pair in the format string. Mirrors pathNullBytes in types.zig.
+            return global.ERR(.INVALID_ARG_VALUE, "The property 'options.groups' must not contain NUL bytes. Received {f}", .{bun.fmt.quote(owned)}).throw();
+        }
+        // Node-compat: `ecdhCurve: "auto"` requests automatic curve selection.
+        // BoringSSL's set1_groups_list rejects the literal string "auto", so
+        // map it to NULL (apply Bun's PQ-friendly default) instead of passing
+        // it through and breaking Node code that uses the documented value.
+        if (strings.eql(owned, "auto")) {
+            bun.default_allocator.free(owned);
+        } else {
+            result.ssl_groups = owned;
+            result.requires_custom_request_ctx = true;
+        }
     }
 
     result.client_renegotiation_limit = generated.client_renegotiation_limit;

--- a/src/bun.js/api/sockets.classes.ts
+++ b/src/bun.js/api/sockets.classes.ts
@@ -33,6 +33,10 @@ function generate(ssl) {
         fn: "getEphemeralKeyInfo",
         length: 0,
       },
+      getSharedGroup: {
+        fn: "getSharedGroup",
+        length: 0,
+      },
       getCipher: {
         fn: "getCipher",
         length: 0,

--- a/src/bun.js/bindings/ncrypto.cpp
+++ b/src/bun.js/bindings/ncrypto.cpp
@@ -3094,6 +3094,30 @@ SSLCtxPointer::~SSLCtxPointer()
     reset();
 }
 
+namespace {
+// Default TLS supported_groups list (PQ hybrid first). Must stay in sync with
+// BUN_DEFAULT_SSL_GROUPS in libusockets.h.
+constexpr const char* kBunDefaultSslGroups = "X25519MLKEM768:X25519:P-256:P-384";
+
+// Applied by the SSL_METHOD-taking SSLCtxPointer factories (NewServer,
+// NewClient, New, reset(method)). The raw-pointer constructors and
+// reset(SSL_CTX*) overload deliberately skip this — they exist to wrap an
+// already-configured SSL_CTX, where forcing defaults would clobber the
+// caller's configuration. Debug ASSERT catches a BoringSSL rename of these
+// names; release tolerates the silent fallback to BoringSSL's compile-time
+// default and clears the error queue so subsequent crypto ops don't pick up
+// a stale error.
+inline void applyBunDefaultGroups(SSL_CTX* ctx)
+{
+    if (ctx == nullptr) return;
+    [[maybe_unused]] int ok = SSL_CTX_set1_groups_list(ctx, kBunDefaultSslGroups);
+    ASSERT(ok == 1);
+    if (ok != 1) {
+        ERR_clear_error();
+    }
+}
+} // namespace
+
 void SSLCtxPointer::reset(SSL_CTX* ctx)
 {
     ctx_.reset(ctx);
@@ -3101,7 +3125,9 @@ void SSLCtxPointer::reset(SSL_CTX* ctx)
 
 void SSLCtxPointer::reset(const SSL_METHOD* method)
 {
-    ctx_.reset(SSL_CTX_new(method));
+    SSL_CTX* ctx = SSL_CTX_new(method);
+    applyBunDefaultGroups(ctx);
+    ctx_.reset(ctx);
 }
 
 SSL_CTX* SSLCtxPointer::release()
@@ -3111,21 +3137,35 @@ SSL_CTX* SSLCtxPointer::release()
 
 SSLCtxPointer SSLCtxPointer::NewServer()
 {
-    return SSLCtxPointer(SSL_CTX_new(TLS_server_method()));
+    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+    applyBunDefaultGroups(ctx);
+    return SSLCtxPointer(ctx);
 }
 
 SSLCtxPointer SSLCtxPointer::NewClient()
 {
-    return SSLCtxPointer(SSL_CTX_new(TLS_client_method()));
+    SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+    applyBunDefaultGroups(ctx);
+    return SSLCtxPointer(ctx);
 }
 
 SSLCtxPointer SSLCtxPointer::New(const SSL_METHOD* method)
 {
-    return SSLCtxPointer(SSL_CTX_new(method));
+    SSL_CTX* ctx = SSL_CTX_new(method);
+    applyBunDefaultGroups(ctx);
+    return SSLCtxPointer(ctx);
 }
 
 bool SSLCtxPointer::setGroups(const char* groups)
 {
+    // NULL / "": no-op. The SSL_CTX already has BUN_DEFAULT_SSL_GROUPS applied
+    // by applyBunDefaultGroups() at construction time; there is no clean
+    // BoringSSL API to restore the compile-time default after that, so an
+    // explicit empty string passed through THIS API leaves the Bun default in
+    // place. Tri-state opt-out for "" should go through the C uws path
+    // (BunSocketContextOptions.ssl_groups in openssl.c), which keeps the
+    // SSL_CTX defaults un-touched until ssl_groups is resolved.
+    if (groups == nullptr || groups[0] == '\0') return true;
     return SSL_CTX_set1_groups_list(get(), groups) == 1;
 }
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -765,6 +765,7 @@ pub const FetchTasklet = struct {
             .message = switch (this.result.fail.?) {
                 error.ConnectionClosed => bun.String.static("The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()"),
                 error.FailedToOpenSocket => bun.String.static("Was there a typo in the url or port?"),
+                error.InvalidGroups => bun.String.static("Invalid TLS groups string (rejected by BoringSSL)"),
                 error.TooManyRedirects => bun.String.static("The response redirected too many times. For more information, pass `verbose: true` in the second argument to fetch()"),
                 error.ConnectionRefused => bun.String.static("Unable to connect. Is the computer able to access the url?"),
                 error.RedirectURLInvalid => bun.String.static("Redirect URL in Location header is invalid."),

--- a/src/deps/uws.zig
+++ b/src/deps/uws.zig
@@ -70,6 +70,7 @@ pub const create_bun_socket_error_t = enum(c_int) {
     invalid_ca_file,
     invalid_ca,
     invalid_ciphers,
+    invalid_groups,
 
     pub fn message(this: create_bun_socket_error_t) ?[]const u8 {
         return switch (this) {
@@ -78,6 +79,7 @@ pub const create_bun_socket_error_t = enum(c_int) {
             .invalid_ca_file => "Invalid CA file",
             .invalid_ca => "Invalid CA",
             .invalid_ciphers => "Invalid ciphers",
+            .invalid_groups => "Invalid TLS groups",
         };
     }
 
@@ -91,6 +93,7 @@ pub const create_bun_socket_error_t = enum(c_int) {
             .invalid_ca_file => globalObject.ERR(.BORINGSSL, "Invalid CA file", .{}).toJS(),
             .invalid_ca => globalObject.ERR(.BORINGSSL, "Invalid CA", .{}).toJS(),
             .invalid_ciphers => globalObject.ERR(.BORINGSSL, "Invalid ciphers", .{}).toJS(),
+            .invalid_groups => globalObject.ERR(.BORINGSSL, "Invalid TLS groups", .{}).toJS(),
         };
     }
 };

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -232,6 +232,10 @@ pub const SocketContext = opaque {
         dh_params_file_name: [*c]const u8 = null,
         ca_file_name: [*c]const u8 = null,
         ssl_ciphers: [*c]const u8 = null,
+        /// TLS supported_groups list (BoringSSL set1_groups_list syntax).
+        /// `null` → Bun default (PQ-friendly: X25519MLKEM768:X25519:P-256:P-384).
+        /// Empty string → inherit BoringSSL compile-time default.
+        ssl_groups: [*c]const u8 = null,
         ssl_prefer_low_memory_usage: i32 = 0,
         key: ?[*]const ?[*:0]const u8 = null,
         key_count: u32 = 0,

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -170,6 +170,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     .load_ca_file => error.LoadCAFile,
                     .invalid_ca_file => error.InvalidCAFile,
                     .invalid_ca => error.InvalidCA,
+                    .invalid_groups => error.InvalidGroups,
                     else => error.FailedToOpenSocket,
                 };
             }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -176,6 +176,9 @@ fn onInitErrorNoop(err: InitError, opts: InitOpts) noreturn {
         error.InvalidCA => {
             Output.err("HTTPThread", "the provided CA is invalid", .{});
         },
+        error.InvalidGroups => {
+            Output.err("HTTPThread", "the provided TLS groups string was rejected by BoringSSL", .{});
+        },
         error.FailedToOpenSocket => {
             Output.errGeneric("failed to start HTTP client thread", .{});
         },
@@ -284,6 +287,7 @@ pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewH
                     error.InvalidCA => error.FailedToOpenSocket,
                     error.InvalidCAFile => error.FailedToOpenSocket,
                     error.LoadCAFile => error.FailedToOpenSocket,
+                    error.InvalidGroups => error.InvalidGroups,
                 };
             };
 

--- a/src/http/InitError.zig
+++ b/src/http/InitError.zig
@@ -3,4 +3,5 @@ pub const InitError = error{
     LoadCAFile,
     InvalidCAFile,
     InvalidCA,
+    InvalidGroups,
 };

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -552,6 +552,9 @@ fn httpThreadOnInitError(err: HTTP.InitError, opts: HTTP.HTTPThread.InitOpts) no
         error.InvalidCA => {
             Output.err("HTTPThread", "the CA is invalid", .{});
         },
+        error.InvalidGroups => {
+            Output.err("HTTPThread", "the provided TLS groups string was rejected by BoringSSL", .{});
+        },
         error.FailedToOpenSocket => {
             Output.errGeneric("failed to start HTTP client thread", .{});
         },

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -783,6 +783,21 @@ function ClientRequest(input, options, cb) {
     validateString(mergedTlsOptions.ciphers, "options.ciphers");
     this._ensureTls().ciphers = mergedTlsOptions.ciphers;
   }
+  {
+    // Mirror tls.ts/Server. Empty-string sentinel preserved (inherit BoringSSL
+    // default). `groups` wins over `ecdhCurve` in the same merged bag (modern
+    // name shadows legacy alias). Source priority (agent vs request) is
+    // resolved by Node's standard merge semantics before we read this.
+    const groupsOpt = mergedTlsOptions.groups ?? mergedTlsOptions.ecdhCurve;
+    if (groupsOpt != null) {
+      validateString(groupsOpt, "options.groups");
+      // Reject embedded NUL: silently truncates at the BoringSSL boundary.
+      if ((groupsOpt as string).indexOf("\u0000") !== -1) {
+        throw $ERR_INVALID_ARG_VALUE("options.groups", groupsOpt, "must not contain NUL bytes");
+      }
+      this._ensureTls().groups = groupsOpt;
+    }
+  }
   if (mergedTlsOptions.servername) {
     validateString(mergedTlsOptions.servername, "options.servername");
     this._ensureTls().servername = mergedTlsOptions.servername;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -620,17 +620,46 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   },
 };
 
+// `doConnect` can fail synchronously (e.g. SSL_CTX construction rejected by
+// BoringSSL: invalid `groups` / `ciphers` / cert config). The synchronous
+// throw escapes user-controlled try/catch and the Promise boundary because
+// `tls.connect` returns the socket immediately, before any handler is
+// attached. Catch the synchronous failure and route it through the socket's
+// "error" event on the next tick, after the caller has had a chance to
+// attach listeners. Mirrors how Node surfaces connect-time TLS errors.
+function emitConnectError(self, err) {
+  process.nextTick(() => {
+    self.destroy(err);
+  });
+}
+
+// Sentinel returned by kConnectTcp / kConnectPipe when they caught a
+// synchronous doConnect failure and already handed it to the socket via
+// emitConnectError. Distinct from 0 (attempt-started OK) and from positive
+// libuv errnos. Callers (single-address, multi-address auto-select-family)
+// recognize this and skip both their own destroy and any attempt-timeout
+// scheduling. Same socket instance is reusable across multi-address attempts;
+// once SSL_CTX construction fails, every subsequent address would fail
+// identically, so the multi-address loop bails too.
+const kConnectStartedSync = -1;
+
 function kConnectTcp(self, addressType, req, address, port) {
   $debug("SocketHandle.kConnectTcp", addressType, address, port);
-  const promise = doConnect(self._handle, {
-    hostname: address,
-    port,
-    ipv6Only: addressType === 6,
-    allowHalfOpen: self.allowHalfOpen,
-    tls: req.tls,
-    data: { self, req },
-    socket: self[khandlers],
-  });
+  let promise;
+  try {
+    promise = doConnect(self._handle, {
+      hostname: address,
+      port,
+      ipv6Only: addressType === 6,
+      allowHalfOpen: self.allowHalfOpen,
+      tls: req.tls,
+      data: { self, req },
+      socket: self[khandlers],
+    });
+  } catch (err) {
+    emitConnectError(self, err);
+    return kConnectStartedSync;
+  }
   promise.catch(_reason => {
     // eat this so there's no unhandledRejection
     // we already catch this in connectError and error
@@ -640,14 +669,20 @@ function kConnectTcp(self, addressType, req, address, port) {
 
 function kConnectPipe(self, req, address) {
   $debug("SocketHandle.kConnectPipe");
-  const promise = doConnect(self._handle, {
-    hostname: address,
-    unix: address,
-    allowHalfOpen: self.allowHalfOpen,
-    tls: req.tls,
-    data: { self, req },
-    socket: self[khandlers],
-  });
+  let promise;
+  try {
+    promise = doConnect(self._handle, {
+      hostname: address,
+      unix: address,
+      allowHalfOpen: self.allowHalfOpen,
+      tls: req.tls,
+      data: { self, req },
+      socket: self[khandlers],
+    });
+  } catch (err) {
+    emitConnectError(self, err);
+    return kConnectStartedSync;
+  }
   promise.catch(_reason => {
     // eat this so there's no unhandledRejection
     // we already catch this in connectError and error
@@ -1782,6 +1817,11 @@ function internalConnect(self, options, address, port, addressType, localAddress
     err = kConnectPipe(self, req, address);
   }
 
+  if (err === kConnectStartedSync) {
+    // doConnect threw synchronously; emitConnectError already scheduled the
+    // socket destroy on the next tick. Don't fabricate a second error.
+    return;
+  }
   if (err) {
     const ex = new ExceptionWithHostPort(err, "connect", address, port);
     self.destroy(ex);
@@ -1909,6 +1949,13 @@ function internalConnectMultiple(context, canceled?) {
 
   err = kConnectTcp(self, addressType, req, address, port);
 
+  if (err === kConnectStartedSync) {
+    // doConnect threw synchronously; emitConnectError already scheduled the
+    // destroy. Don't try further addresses (a SSL_CTX construction failure
+    // is not address-specific) and don't arm the attempt timeout, which
+    // would otherwise fire on the already-destroyed socket.
+    return;
+  }
   if (err) {
     const ex = new ExceptionWithHostPort(err, "connect", address, port);
     ArrayPrototypePush.$call(context.errors, ex);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -519,6 +519,23 @@ function TLSSocket(socket?, options?) {
     validateCiphers(options.ciphers);
   }
 
+  // `groups` is the modern name (Node 22+); `ecdhCurve` is the legacy alias
+  // (predates ML-KEM). Both map to BoringSSL's set1_groups_list. Node accepts
+  // either; we mirror that.
+  this.groups = options.groups ?? options.ecdhCurve;
+  if (this.groups != null) {
+    if (typeof this.groups !== "string") {
+      throw $ERR_INVALID_ARG_TYPE("options.groups", "string", this.groups);
+    }
+    // Reject embedded NUL: the string crosses to BoringSSL via a NUL-terminated
+    // [*:0] pointer, so an embedded NUL silently truncates the group list and
+    // would let an attacker who controls the string downgrade the offered
+    // groups without surfacing any error.
+    if ((this.groups as string).indexOf("\u0000") !== -1) {
+      throw $ERR_INVALID_ARG_VALUE("options.groups", this.groups, "must not contain NUL bytes");
+    }
+  }
+
   if (typeof options === "object") {
     const { ALPNProtocols } = options;
     if (ALPNProtocols) {
@@ -552,6 +569,13 @@ TLSSocket.prototype.getSession = function getSession() {
 
 TLSSocket.prototype.getEphemeralKeyInfo = function getEphemeralKeyInfo() {
   return this._handle?.getEphemeralKeyInfo?.();
+};
+
+// Returns the BoringSSL name of the negotiated key-exchange / KEM group
+// (e.g. "X25519MLKEM768", "X25519", "P-256"). Null until the handshake
+// completes. Bun-specific extension; mirrors Node 22's `getSharedGroup`.
+TLSSocket.prototype.getSharedGroup = function getSharedGroup() {
+  return this._handle?.getSharedGroup?.() ?? null;
 };
 
 TLSSocket.prototype.getCipher = function getCipher() {
@@ -693,7 +717,7 @@ TLSSocket.prototype[buntls] = function (port, host) {
   if (servername === undefined) {
     servername = host && !net.isIP(host) ? host : "";
   }
-  return {
+  const out: any = {
     socket: this._handle,
     ALPNProtocols: this.ALPNProtocols,
     checkServerIdentity: this[kcheckServerIdentity],
@@ -704,6 +728,12 @@ TLSSocket.prototype[buntls] = function (port, host) {
     ...ctx,
     servername,
   };
+  // Only attach `groups` when explicitly set; leaving the field absent lets
+  // the C-side BUN_DEFAULT_SSL_GROUPS apply as the floor. Passing
+  // `undefined` here resolves the SSLConfig bindgen union differently and
+  // crashed downstream parsing.
+  if (this.groups != null) out.groups = this.groups;
+  return out;
 };
 
 let CLIENT_RENEG_LIMIT = 3,
@@ -725,6 +755,8 @@ function Server(options, secureConnectionListener): void {
   this._requestCert = undefined;
   this.servername = undefined;
   this.ALPNProtocols = undefined;
+  this.ciphers = undefined;
+  this.groups = undefined;
 
   let contexts: Map<string, typeof InternalSecureContext> | null = null;
 
@@ -810,6 +842,20 @@ function Server(options, secureConnectionListener): void {
 
         this.ciphers = options.ciphers;
       }
+
+      // Match TLSSocket constructor and _http_client.ts: treat null and
+      // undefined the same ("no override"), only validate type for actual
+      // values. Asymmetric throw on null was a Server-path-only divergence.
+      const groupsOption = options.groups ?? options.ecdhCurve;
+      if (groupsOption != null) {
+        if (typeof groupsOption !== "string") {
+          throw $ERR_INVALID_ARG_TYPE("options.groups", "string", groupsOption);
+        }
+        if (groupsOption.indexOf("\u0000") !== -1) {
+          throw $ERR_INVALID_ARG_VALUE("options.groups", groupsOption, "must not contain NUL bytes");
+        }
+        this.groups = groupsOption;
+      }
     }
   };
 
@@ -822,24 +868,28 @@ function Server(options, secureConnectionListener): void {
   };
 
   this[buntls] = function (port, host, isClient) {
-    return [
-      {
-        serverName: this.servername || host || "localhost",
-        key: this.key,
-        cert: this.cert,
-        ca: this.ca,
-        passphrase: this.passphrase,
-        secureOptions: this.secureOptions,
-        rejectUnauthorized: this._rejectUnauthorized,
-        requestCert: isClient ? true : this._requestCert,
-        ALPNProtocols: this.ALPNProtocols,
-        clientRenegotiationLimit: CLIENT_RENEG_LIMIT,
-        clientRenegotiationWindow: CLIENT_RENEG_WINDOW,
-        contexts: contexts,
-        ciphers: this.ciphers,
-      },
-      TLSSocket,
-    ];
+    // Mirror the TLSSocket prototype's `[buntls]` thunk: only attach `groups`
+    // when explicitly set. The Server-side bindings flow may currently
+    // tolerate `groups: undefined`, but the asymmetry with the client thunk
+    // (which had to switch to conditional-attach to avoid a SocketConfigTLS
+    // bindgen union crash) is a footgun. Keep both shapes identical.
+    const opts: any = {
+      serverName: this.servername || host || "localhost",
+      key: this.key,
+      cert: this.cert,
+      ca: this.ca,
+      passphrase: this.passphrase,
+      secureOptions: this.secureOptions,
+      rejectUnauthorized: this._rejectUnauthorized,
+      requestCert: isClient ? true : this._requestCert,
+      ALPNProtocols: this.ALPNProtocols,
+      clientRenegotiationLimit: CLIENT_RENEG_LIMIT,
+      clientRenegotiationWindow: CLIENT_RENEG_WINDOW,
+      contexts: contexts,
+      ciphers: this.ciphers,
+    };
+    if (this.groups != null) opts.groups = this.groups;
+    return [opts, TLSSocket];
   };
 
   this.setSecureContext(options);

--- a/test/js/node/tls/node-tls-groups.test.ts
+++ b/test/js/node/tls/node-tls-groups.test.ts
@@ -1,0 +1,394 @@
+// Tests for the `groups` / `ecdhCurve` TLS option (KEX/KEM group selection).
+//
+// Default behavior: BUN_DEFAULT_SSL_GROUPS ("X25519MLKEM768:X25519:P-256:P-384")
+// is applied at the SSL_CTX construction site when the caller does not pass
+// an explicit `groups` (or Node-compat `ecdhCurve`) option.
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "fs";
+import type { AddressInfo } from "net";
+import { join } from "path";
+import tls from "tls";
+
+const cert = readFileSync(join(import.meta.dir, "fixtures", "agent1-cert.pem"), "utf8");
+const key = readFileSync(join(import.meta.dir, "fixtures", "agent1-key.pem"), "utf8");
+const ca = readFileSync(join(import.meta.dir, "fixtures", "ca1-cert.pem"), "utf8");
+
+// `tls.TlsOptions` isn't reliably exported across Bun's bundled types; the
+// real shape is structural so a permissive type avoids drift between Bun and
+// `@types/node` versions. The runtime accepts the documented fields.
+function listenLocal(
+  serverOpts: Record<string, unknown>,
+): Promise<{ server: tls.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = tls.createServer(serverOpts, sock => sock.end()).on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, port: (server.address() as AddressInfo).port });
+    });
+  });
+}
+
+describe("tls groups option", () => {
+  it("default tls.connect (no option) negotiates a handshake", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const ok = await new Promise<boolean>((resolve, reject) => {
+        const s = tls.connect({ host: "127.0.0.1", port, ca, servername: "agent1" }, () => {
+          s.end();
+          resolve(true);
+        });
+        s.on("error", reject);
+      });
+      expect(ok).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tls.connect honors `groups` option (proves option reached SSL_CTX)", async () => {
+    // Server uses Bun default (PQ-friendly). Client constrains to
+    // classical-only. Negotiated group must be X25519, proving the client's
+    // `groups` option actually replaced the default at SSL_CTX construction
+    // (without it, both sides default to BUN_DEFAULT and would pick MLKEM).
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const group = await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", groups: "X25519:P-256:P-384" },
+          () => {
+            const g = s.getSharedGroup?.();
+            s.end();
+            resolve(g ?? null);
+          },
+        );
+        s.on("error", reject);
+      });
+      expect(group).toBe("X25519");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tls.connect honors `ecdhCurve` Node-compat alias (proves alias reached SSL_CTX)", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const group = await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", ecdhCurve: "P-256" },
+          () => {
+            const g = s.getSharedGroup?.();
+            s.end();
+            resolve(g ?? null);
+          },
+        );
+        s.on("error", reject);
+      });
+      // Restricted to a single classical group via the legacy alias name.
+      expect(group).toBe("P-256");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tls.connect rejects non-string `groups`", () => {
+    let caught: any;
+    let socket: tls.TLSSocket | undefined;
+    try {
+      socket = tls.connect({ host: "127.0.0.1", port: 1, groups: 123 as unknown as string }, () => {});
+    } catch (e) {
+      caught = e;
+    } finally {
+      // Defensive: if validation ever stops throwing, the returned socket
+      // would attempt to connect to port 1 and emit an unhandled error.
+      socket?.on("error", () => {});
+      socket?.destroy();
+    }
+    expect(caught).toBeInstanceOf(TypeError);
+    expect(caught.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(String(caught.message)).toContain("options.groups");
+  });
+
+  it("Bun.connect with unknown group name surfaces a BoringSSL error", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      let caught: any;
+      try {
+        // Listener.zig's create_bun_socket_error_t switch throws synchronously
+        // when SSL_CTX construction fails (invalid groups/ciphers). The error
+        // rejects the connect() Promise before any socket handler runs, so a
+        // socket.error assertion would be unreachable here. Same path that
+        // the Bun.listen test below relies on.
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port,
+          tls: { groups: "DEFINITELY_NOT_A_REAL_GROUP_NAME" },
+          socket: {
+            open(s) {
+              s.end();
+            },
+            error() {},
+            close() {},
+            data() {},
+          },
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeDefined();
+      expect(caught.code).toBe("ERR_BORINGSSL");
+      expect(String(caught.message)).toContain("Invalid TLS groups");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tls.connect with unknown group name surfaces error via socket.on('error')", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const err = await new Promise<any>(resolve => {
+        const s = tls.connect(
+          {
+            host: "127.0.0.1",
+            port,
+            ca,
+            servername: "agent1",
+            groups: "DEFINITELY_NOT_A_REAL_GROUP_NAME",
+          },
+          () => {
+            s.end();
+            resolve(null);
+          },
+        );
+        s.on("error", resolve);
+      });
+      // The SSL_CTX construction failure now reaches the socket's error
+      // event instead of escaping synchronously from kConnectTcp.
+      expect(err).toBeDefined();
+      expect(err).not.toBeNull();
+      expect(err.code).toBe("ERR_BORINGSSL");
+      expect(String(err.message)).toContain("Invalid TLS groups");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tlsSocket.getSharedGroup() returns the negotiated group name", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const group = await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect({ host: "127.0.0.1", port, ca, servername: "agent1" }, () => {
+          const g = s.getSharedGroup?.();
+          s.end();
+          resolve(g ?? null);
+        });
+        s.on("error", reject);
+      });
+      // Default Bun list puts MLKEM hybrid first; both endpoints support it
+      // (we control both), so the negotiated group is X25519MLKEM768.
+      expect(group).toBe("X25519MLKEM768");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tlsSocket.getSharedGroup() reflects an explicit override", async () => {
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const group = await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", groups: "X25519:P-256:P-384" },
+          () => {
+            const g = s.getSharedGroup?.();
+            s.end();
+            resolve(g ?? null);
+          },
+        );
+        s.on("error", reject);
+      });
+      // Client asked for classical-only. The BoringSSL default for the
+      // server (inherited via the buntls thunk's `groups` from this test's
+      // NO-`groups` server config, which is BUN_DEFAULT) overlaps on
+      // X25519, which is the natural fastest pick.
+      expect(group).toBe("X25519");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("tls.createServer accepts the `groups` option without throwing", () => {
+    const server = tls.createServer({ key, cert, groups: "X25519MLKEM768:X25519:P-256:P-384" });
+    server.close();
+  });
+
+  it("client groups override prevents handshake when server only supports a disjoint set", async () => {
+    // Server forced to PQ-only; client forced to classical-only. No shared
+    // group, handshake must fail. Validates that BOTH client and server
+    // honor the `groups` option (otherwise the BUN_DEFAULT floor would
+    // bridge them and the handshake would succeed).
+    const { server, port } = await listenLocal({ key, cert, groups: "X25519MLKEM768" });
+    try {
+      const err: any = await new Promise(resolve => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", groups: "P-256:P-384" },
+          () => {
+            s.end();
+            resolve(undefined);
+          },
+        );
+        s.on("error", resolve);
+      });
+      expect(err).toBeDefined();
+      // Tighten beyond `.toBeDefined()`: the failure must look like a TLS
+      // handshake/SSL error, not a generic ECONNRESET/timeout that would
+      // happen for unrelated reasons.
+      const codeOrMsg = String(err?.code ?? "") + " " + String(err?.message ?? "");
+      expect(/SSL|HANDSHAKE|handshake|shared|alert|TLS/i.test(codeOrMsg)).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("`groups: \"\"` empty-string sentinel differs from `groups: undefined`", async () => {
+    // Tri-state semantics: NULL applies Bun's PQ default; "" inherits
+    // BoringSSL's compile-time default (which excludes PQ today, but may
+    // include it in the future as upstream BoringSSL evolves).
+    //
+    // Compare the negotiated group between an empty-string client and a
+    // default client against the same server. The two must differ today
+    // (empty string skips Bun's PQ-first list). Hard-coding the group name
+    // would break when BoringSSL upstream adds MLKEM to its compile-time
+    // default; comparing the two sentinels keeps the test robust to that.
+    const connectGetGroup = async (port: number, opts: Record<string, unknown>) =>
+      await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", ...opts },
+          () => {
+            const g = s.getSharedGroup?.();
+            s.end();
+            resolve(g ?? null);
+          },
+        );
+        s.on("error", reject);
+      });
+
+    // Server uses Bun's PQ-friendly default (no `groups` option), so it is
+    // willing to negotiate either MLKEM or classical. The client sentinel is
+    // the only thing varying between the two connect calls.
+    const { server, port } = await listenLocal({ key, cert });
+    try {
+      const groupEmpty = await connectGetGroup(port, { groups: "" });
+      const groupDefault = await connectGetGroup(port, {});
+      expect(groupEmpty).not.toBeNull();
+      expect(groupDefault).not.toBeNull();
+      // Default client offers MLKEM first (Bun default); empty-string client
+      // skips Bun's default and offers BoringSSL's compile-time list, which
+      // currently excludes PQ. Server picks MLKEM for the default client and
+      // a classical group for the empty-string client. If BoringSSL ever
+      // adds MLKEM to its compile-time default, both sides will pick MLKEM
+      // and this assertion will need revisiting.
+      expect(groupEmpty).not.toBe(groupDefault);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("`ecdhCurve: \"auto\"` Node-compat normalizes to Bun PQ default", async () => {
+    // Node documents `ecdhCurve: "auto"` for automatic curve selection.
+    // BoringSSL's set1_groups_list rejects the literal string "auto", so
+    // SSLConfig.fromGenerated normalizes it to NULL (apply Bun PQ default).
+    // Both ends "auto" must therefore negotiate via the Bun default
+    // (X25519MLKEM768 first).
+    const { server, port } = await listenLocal({ key, cert, ecdhCurve: "auto" });
+    try {
+      const group = await new Promise<string | null>((resolve, reject) => {
+        const s = tls.connect(
+          { host: "127.0.0.1", port, ca, servername: "agent1", ecdhCurve: "auto" },
+          () => {
+            const g = s.getSharedGroup?.();
+            s.end();
+            resolve(g ?? null);
+          },
+        );
+        s.on("error", reject);
+      });
+      expect(group).toBe("X25519MLKEM768");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("Bun.listen with invalid groups surfaces ERR_BORINGSSL", async () => {
+    // Server-side path: connectInner's listen() arm of the
+    // create_bun_socket_error_t switch must surface invalid_groups as
+    // ERR_BORINGSSL (not the generic "Failed to listen").
+    let caught: any;
+    try {
+      const listener = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: { key, cert, groups: "DEFINITELY_NOT_A_REAL_GROUP_NAME" },
+        socket: { open() {}, close() {}, data() {} },
+      });
+      listener.stop();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe("ERR_BORINGSSL");
+    expect(String(caught.message)).toContain("Invalid TLS groups");
+  });
+
+  it("groups string with embedded NUL is rejected at validation (tls.connect, JS-side guard)", () => {
+    // Defense against silent truncation: a NUL inside the groups string
+    // would let BoringSSL see only the prefix, downgrading the offered list
+    // without surfacing any error.
+    let caught: any;
+    let socket: tls.TLSSocket | undefined;
+    try {
+      socket = tls.connect({
+        host: "127.0.0.1",
+        port: 1,
+        groups: "X25519\u0000:GARBAGE",
+      });
+    } catch (e) {
+      caught = e;
+    } finally {
+      socket?.on("error", () => {});
+      socket?.destroy();
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(String(caught.message)).toContain("NUL");
+    expect(String(caught.message)).toContain("options.groups");
+  });
+
+  it("groups string with embedded NUL is rejected at the Zig boundary (Bun.connect)", async () => {
+    // Same defense as the tls.connect test, but exercising the Bun-native
+    // path that goes through SSLConfig.fromGenerated in Zig (skipping the
+    // JS-side TLSSocket constructor guard). Must produce the same
+    // ERR_INVALID_ARG_VALUE code and "options.groups" prefix as the JS
+    // path so a user catching the error sees one consistent shape.
+    let caught: any;
+    try {
+      await Bun.connect({
+        hostname: "cloudflare.com",
+        port: 443,
+        tls: { groups: "X25519\u0000:GARBAGE" },
+        socket: {
+          open(s) {
+            s.end();
+          },
+          error() {},
+          close() {},
+          data() {},
+        },
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(String(caught.message)).toContain("NUL");
+    expect(String(caught.message)).toContain("options.groups");
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds a `groups` (Node-compat alias `ecdhCurve`) TLS option to all of Bun's TLS surfaces, and changes the default `supported_groups` from BoringSSL's classical-only inheritance to `X25519MLKEM768:X25519:P-256:P-384`, putting the IANA-allocated post-quantum hybrid first (codepoint `0x11ec`, deployed by Chrome M131+, Cloudflare, AWS).

#### Background

Bun 1.3.13's outbound `ClientHello` advertises only classical groups (`x25519, secp256r1, secp384r1`). The `X25519MLKEM768` codepoint is compiled into vendored BoringSSL but no Bun-side caller opts in. Sessions are exposed to harvest-now-decrypt-later. Chrome (M131+), Cloudflare, AWS already negotiate PQ when offered; the gap is purely on the client.

#### Changes

**Default applied at every `SSL_CTX` construction site** via a `BUN_DEFAULT_SSL_GROUPS` macro:

| File | Function | Coverage |
|---|---|---|
| `packages/bun-usockets/src/crypto/openssl.c` | `create_ssl_context_from_bun_options` + `create_ssl_context_from_options` | fetch, Bun.connect, Bun.serve, postgres, mysql, valkey, websocket, ssl_wrapper |
| `src/bun.js/bindings/ncrypto.cpp` | `SSLCtxPointer::{reset,NewServer,NewClient,New}` | node:tls, node:https, node:crypto.SecureContext |

Tri-state semantics, mirroring `ssl_ciphers`:

- `NULL` → Bun's PQ-friendly default
- `""` → inherit BoringSSL's compile-time default (explicit opt-out)
- `"<list>"` → caller's list, passed verbatim to `SSL_CTX_set1_groups_list`

**Option API**. Node's documented option is `ecdhCurve`. This PR also accepts `groups` as a more accurate alias since the option now selects KEX/KEM groups (not only elliptic curves). Both names are equivalent in this PR; `groups` is a Bun extension, `ecdhCurve` matches Node:

```ts
fetch(url, { tls: { groups: "..." } });
Bun.connect({ ..., tls: { groups: "..." } });
Bun.serve({ tls: { ..., groups: "..." } });
tls.connect({ ..., groups: "..." });
tls.connect({ ..., ecdhCurve: "..." });   // Node-standard name
tls.createServer({ ..., groups: "..." });
http(s).request({ ..., groups: "..." });
```

`ecdhCurve: "auto"` (Node-documented value) is normalized to the Bun default.

**Introspection**: `tlsSocket.getSharedGroup()` returns the BoringSSL name of the negotiated KEX/KEM group as a string, or `null` until handshake completes. Bun extension; Node has no equivalent (`getEphemeralKeyInfo()` exists in Node but returns an empty object for ML-KEM since Node's `EVP_PKEY`-shaped API can't represent it).

**Errors**: invalid `groups` strings now surface a meaningful error instead of generic `ECONNREFUSED` / `FailedToOpenSocket`:

- `Bun.connect` / `Bun.serve` / `tls.connect` (via `socket.on("error")`) → `ERR_BORINGSSL` "Invalid TLS groups"
- `fetch()` → `InvalidGroups` "Invalid TLS groups string..."

`kConnectTcp` / `kConnectPipe` in `net.ts` now wrap `doConnect` in try/catch and route synchronous SSL_CTX failures through `socket.on("error")` on the next tick, instead of the prior sync throw escaping the user's Promise/event-handler boundary. `Listener.zig`'s connect-time and listen-time error mapping uses an exhaustive `switch` over `create_bun_socket_error_t`.

NUL-byte rejection at all 4 entry points (`tls.ts` × 2, `_http_client.ts`, `SSLConfig.zig`) defends against silent BoringSSL truncation when an attacker can influence the option via configuration layers. All paths surface `ERR_INVALID_ARG_VALUE` "options.groups must not contain NUL bytes" for consistency.

#### Risk and rollout

The dominant risk is middlebox / legacy-server breakage from the larger PQ `ClientHello` (~1.2KB extra). Chrome saw real breakage shipping MLKEM-default in M131 and added a kill-switch. This PR provides a per-call escape hatch (`{ tls: { groups: "X25519:P-256:P-384" } }` for classical-only). An env-level kill-switch (`BUN_TLS_GROUPS=...`) is **not** included here but would be a small follow-up.

Bun's server-to-server traffic profile has more middlebox surprise than browser-to-CDN, so this is a real concern. Open to splitting into two PRs (option-only first, default-flip after telemetry) if preferred.

Node.js does not enable PQ by default. Bun moving ahead is a deliberate Node-incompat for security reasons. Worth release-noting. Out of scope: BoringSSL bump (untouched), QUIC path, env-level kill-switch.

#### Known limitations (not blockers)

- SNI cert sub-contexts (added via `addContext()`) inherit `BUN_DEFAULT_SSL_GROUPS`, not the parent server's `groups` setting. Consistent with how `ciphers` behaves today.
- `setSecureContext({groups})` after `listen()` updates the JS-side `this.groups` but doesn't reconfigure the running SSL_CTX. Mirrors existing `ciphers` behavior.
- `SSLCtxPointer::setGroups("")` is a no-op (Bun PQ default already applied at construction). The empty-string sentinel works correctly on the C/uws path used by all user-facing APIs; the `setGroups` C++ helper has no current callers.
- `BUN_DEFAULT_SSL_GROUPS` (libusockets.h) and `kBunDefaultSslGroups` (ncrypto.cpp) are duplicate string literals enforced by comment, not compile-time check. A BoringSSL rename of `X25519MLKEM768` would be caught by tests on the C path and silently fall back on the C++ path (debug ASSERT only).

### How does this PR work?

**Tests** (`test/js/node/tls/node-tls-groups.test.ts`, 15 new tests, all pass):

```
bun test test/js/node/tls/node-tls-groups.test.ts
 15 pass / 0 fail / 28 expect()
```

Covers: default + override + `ecdhCurve` alias + `ecdhCurve: "auto"` Node-compat + non-string rejection + `tls.createServer` + disjoint-groups handshake failure + `Bun.connect` invalid-group error + `Bun.listen` invalid-group error + `tlsSocket.getSharedGroup()` default + `getSharedGroup()` override + `tls.connect` error via `socket.on("error")` + empty-string sentinel + NUL rejection on JS path + NUL rejection on Zig path.

**Regression**: `bun test test/js/node/tls/` reports 84 pass / 0 fail (1 skip / 3 todo) across 6 files. The remaining file (`node-tls-internals.test.ts`) imports `bun:internal-for-testing` which isn't bundled in release builds, so it fails before any of this PR's code runs (pre-existing, unrelated).

**Wire verification** with tcpdump and a Python TLS dissector that extracts SNI, supported_groups, key_share, and the ServerHello selected_group:

| Path | Endpoint | Server selected |
|---|---|---|
| `fetch()` | cloudflare.com | X25519MLKEM768 |
| `fetch()` | example.com | X25519MLKEM768 |
| `fetch()` | github.com | x25519 (graceful fallback, github not yet PQ) |
| `tls.connect()` | cloudflare.com | X25519MLKEM768 |
| `Bun.connect()` | cloudflare.com | X25519MLKEM768 |

Per-call overrides confirmed on the wire:

```
tls.connect({ groups: "X25519:P-256:P-384" })     -> ClientHello: [x25519, p256, p384]
tls.connect({ ecdhCurve: "X25519" })              -> ClientHello: [x25519]
fetch(url, { tls: { groups: "X25519MLKEM768" } }) -> ClientHello: [X25519MLKEM768]
```
