### PR TITLE
docs(standalone-html): recommend @tailwindcss/cli for Tailwind integration

### DIFF
--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -243,6 +243,8 @@ For iterative development, use `bun run --parallel` to run the Tailwind watcher 
 
 `bun run --parallel` was added in Bun v1.3.9.
 
+If you're building via [`Bun.build()`](#javascript-api) instead of the `bun build` CLI, run `@tailwindcss/cli` as a separate prebuild step before calling `Bun.build()` — the `<link rel="stylesheet">` then resolves to the generated file during bundling.
+
 ## How it works
 
 When you pass `--compile --target=browser` with an HTML entrypoint, Bun:

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -237,7 +237,8 @@ For iterative development, use `bun run --parallel` to run the Tailwind watcher 
 ```
 
 <Info>
-  Pass `--watch=always` (not `--watch`) — without it, `@tailwindcss/cli` exits when stdin is not a TTY, which is the case under `bun run --parallel`.
+  Pass `--watch=always` (not `--watch`) — without it, `@tailwindcss/cli` exits when stdin is not a TTY, which is the
+  case under `bun run --parallel`.
 </Info>
 
 `bun run --parallel` was added in Bun v1.3.9.

--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -164,19 +164,25 @@ Bun bundles all of React, your components, and your CSS into `dist/index.html`. 
 
 ## Using with Tailwind CSS
 
-Install the plugin and reference Tailwind in your HTML or CSS:
+Use the official [`@tailwindcss/cli`](https://tailwindcss.com/docs/installation/tailwind-cli) to generate a CSS file, then let Bun inline it into the standalone HTML.
 
 ```bash terminal icon="terminal"
-bun install --dev bun-plugin-tailwind
+bun add --dev tailwindcss @tailwindcss/cli
 ```
 
+Create a Tailwind entry stylesheet and reference the generated CSS from your HTML:
+
 <CodeGroup>
+
+```css tailwind.css icon="file-code"
+@import "tailwindcss";
+```
 
 ```html index.html icon="file-code"
 <!doctype html>
 <html>
   <head>
-    <link rel="stylesheet" href="tailwindcss" />
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body class="bg-gray-100 flex items-center justify-center min-h-screen">
     <div id="root"></div>
@@ -203,23 +209,38 @@ createRoot(document.getElementById("root")!).render(<App />);
 
 </CodeGroup>
 
-Build with the plugin using the JavaScript API:
-
-```ts build.ts icon="/icons/typescript.svg"
-await Bun.build({
-  entrypoints: ["./index.html"],
-  compile: true,
-  target: "browser",
-  outdir: "./dist",
-  plugins: [require("bun-plugin-tailwind")],
-});
-```
+Run the Tailwind CLI to produce `styles.css`, then compile the HTML:
 
 ```bash terminal icon="terminal"
-bun run build.ts
+bun tailwindcss -i ./tailwind.css -o ./styles.css --minify
+bun build --compile --target=browser ./index.html --outdir=dist
 ```
 
-Bun inlines the generated Tailwind CSS directly into the HTML file as a `<style>` tag.
+Bun inlines the generated `styles.css` into `dist/index.html` as a `<style>` tag, alongside your bundled JavaScript. The final output is still a single self-contained file.
+
+### Dev workflow with watch mode
+
+For iterative development, use `bun run --parallel` to run the Tailwind watcher and your server side by side:
+
+```json package.json icon="file-json"
+{
+  "scripts": {
+    "dev": "bun run --parallel dev:css dev:server",
+    "dev:css": "bun tailwindcss -i ./tailwind.css -o ./styles.css --watch=always",
+    "dev:server": "bun ./index.html",
+
+    "build": "bun run build:css && bun run build:html",
+    "build:css": "bun tailwindcss -i ./tailwind.css -o ./styles.css --minify",
+    "build:html": "bun build --compile --target=browser ./index.html --outdir=dist"
+  }
+}
+```
+
+<Info>
+  Pass `--watch=always` (not `--watch`) — without it, `@tailwindcss/cli` exits when stdin is not a TTY, which is the case under `bun run --parallel`.
+</Info>
+
+`bun run --parallel` was added in Bun v1.3.9.
 
 ## How it works
 


### PR DESCRIPTION
Updates the Tailwind CSS section in `docs/bundler/standalone-html.mdx` to recommend the official `@tailwindcss/cli` instead of `bun-plugin-tailwind`.

Requested in #29603.

## Why

- `@tailwindcss/cli` only downloads the host-platform binary. `bun-plugin-tailwind` pulls every platform's binary.
- `bun-plugin-tailwind` is pinned to `tailwindcss` 4.1.4 via static bundling; the CLI tracks whatever Tailwind version you install.
- Works for both SSR and client-side flows — no `[serve.static]` wiring required.

The `[serve.static] plugins = ["bun-plugin-tailwind"]` flow in `html-static.mdx`, `fullstack.mdx`, and `create.mdx` is intentionally left alone — that's the documented dev-server integration and changing it would require code changes to `bun create`/`bun init` templates, which is out of scope for this request.

## What changed

- New install line: `bun add --dev tailwindcss @tailwindcss/cli`.
- Added a `tailwind.css` entry file with `@import "tailwindcss";` to clearly distinguish the Tailwind source from the generated `styles.css` the HTML references.
- Two-step build: run the CLI to produce `styles.css`, then `bun build --compile`. Bun inlines the generated CSS into the standalone HTML.
- Added a "Dev workflow with watch mode" subsection showing `bun run --parallel` for running the Tailwind watcher alongside `bun ./index.html`.
- Called out the `--watch=always` gotcha — bare `--watch` exits when stdin isn't a TTY, which is always the case under `bun run --parallel`.
- Noted the minimum Bun version for `bun run --parallel` (v1.3.9).

## Verified locally

The documented commands produce a self-contained `dist/index.html`:

```
bun add --dev tailwindcss @tailwindcss/cli
bun tailwindcss -i ./tailwind.css -o ./styles.css --minify
bun build --compile --target=browser ./index.html --outdir=dist
```

Inspecting the output: the Tailwind header, `.bg-gray-100`, `.bg-white`, etc. are inlined as a `<style>` tag; no external `<link>` elements remain. The dev-mode `bun run --parallel dev:css dev:server` also emits the prefixed Foreman-style output as described, and `--watch=always` is required to keep the watcher alive.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->