### PR TITLE
spawn: don't close caller-owned fds passed as extra stdio

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7161,8 +7161,11 @@ declare module "bun" {
 
     /**
      * Access extra file descriptors passed to the `stdio` option in the options object.
+     *
+     * Entries beyond index 2 are `number` for `"pipe"` slots and `null` otherwise
+     * (including when a raw file descriptor was supplied — that fd remains owned by the caller).
      */
-    readonly stdio: [null, null, null, ...number[]];
+    readonly stdio: [null, null, null, ...(number | null)[]];
 
     /**
      * This returns the same value as {@link Subprocess.stdout}

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1480,13 +1480,16 @@ pub fn spawnProcessPosix(
             .dup2 => @panic("TODO dup2 extra fd"),
             .inherit => {
                 try actions.inherit(fileno);
+                try extra_fds.append(bun.invalid_fd);
             },
             .ignore => {
                 try actions.openZ(fileno, "/dev/null", bun.O.RDWR, 0o664);
+                try extra_fds.append(bun.invalid_fd);
             },
 
             .path => |path| {
                 try actions.open(fileno, path, bun.O.RDWR | bun.O.CREAT, 0o664);
+                try extra_fds.append(bun.invalid_fd);
             },
             .ipc, .buffer => {
                 const fds: [2]bun.FD = try bun.sys.socketpair(

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1509,8 +1509,10 @@ pub fn spawnProcessPosix(
             },
             .pipe => |fd| {
                 try actions.dup2(fd, fileno);
-
-                try extra_fds.append(fd);
+                // The fd was supplied by the caller (a number in the stdio array) and is
+                // not owned by us. Record an invalid sentinel so finalizeStreams skips it
+                // instead of closing the caller's descriptor out from under them.
+                try extra_fds.append(bun.invalid_fd);
             },
         }
     }

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -71,7 +71,7 @@ function depromise<T>(_promise: Promise<T>): T {
   tsd.expectType(proc.stdio[0]).is<null>();
   tsd.expectType(proc.stdio[1]).is<null>();
   tsd.expectType(proc.stdio[2]).is<null>();
-  tsd.expectType(proc.stdio[3]).is<number | undefined>();
+  tsd.expectType(proc.stdio[3]).is<number | null | undefined>();
 
   tsd.expectType(proc.stdin).is<FileSink>();
   tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -40,7 +40,7 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
 
   it("ipc works when preceded by a non-pipe extra stdio slot", async () => {
     const { promise, resolve, reject } = Promise.withResolvers<string>();
-    const child = spawn([bunExe(), path.join(__dirname, "bun-ipc-child.js")], {
+    await using child = spawn([bunExe(), path.join(__dirname, "bun-ipc-child.js")], {
       env: bunEnv,
       stdio: ["inherit", "inherit", "inherit", "ignore"],
       serialization: mode,
@@ -48,6 +48,5 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
     });
     child.exited.then(code => reject(new Error(`exited ${code} before message`)));
     expect(await promise).toBe("hello");
-    child.kill();
   });
 });

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunExe, gcTick } from "harness";
+import { bunEnv, bunExe, gcTick } from "harness";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -36,5 +36,18 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
 
     childProc.send(parentMessage);
     gcTick();
+  });
+
+  it("ipc works when preceded by a non-pipe extra stdio slot", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const child = spawn([bunExe(), path.join(__dirname, "bun-ipc-child.js")], {
+      env: bunEnv,
+      stdio: ["inherit", "inherit", "inherit", "ignore"],
+      serialization: mode,
+      ipc: message => resolve(message),
+    });
+    child.exited.then(code => reject(new Error(`exited ${code} before message`)));
+    expect(await promise).toBe("hello");
+    child.kill();
   });
 });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -826,6 +826,7 @@ describe("close handling", () => {
             stdio: ["ignore", "ignore", "ignore", fd],
           }),
         );
+        expect(procs[0].stdio[3]).toBe(null);
         await Promise.all(procs.map(p => p.exited));
       })();
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -814,6 +814,39 @@ describe("close handling", () => {
       }
     }
   }
+
+  it.skipIf(isWindows)("does not close caller-owned fds passed as extra stdio", async () => {
+    const fd = openSync(import.meta.path, "r");
+    try {
+      await (async function () {
+        const procs = Array.from({ length: 8 }, () =>
+          spawn({
+            cmd: [bunExe(), "-e", ""],
+            env: bunEnv,
+            stdio: ["ignore", "ignore", "ignore", fd],
+          }),
+        );
+        await Promise.all(procs.map(p => p.exited));
+      })();
+
+      Bun.gc(true);
+      await Bun.sleep(0);
+      Bun.gc(true);
+
+      expect(() => fstatSync(fd)).not.toThrow();
+
+      const { exited } = spawn({
+        cmd: [bunExe(), "-e", `require("fs").fstatSync(3)`],
+        env: bunEnv,
+        stdio: ["ignore", "ignore", "inherit", fd],
+      });
+      expect(await exited).toBe(0);
+    } finally {
+      try {
+        closeSync(fd);
+      } catch {}
+    }
+  });
 });
 
 it("dispose keyword works", async () => {


### PR DESCRIPTION
## What does this PR do?

When a raw fd number is passed as `stdio[N]` (N≥3), that descriptor is owned by the caller, not by `Bun.spawn`. #29416 made `finalizeStreams` unconditionally close every entry in `stdio_pipes`, which on POSIX includes the caller's fd — so after the `Subprocess` is GC'd, the parent's fd is closed and the number gets recycled. Callers that cache an fd and reuse it across many spawns (e.g. a self-exec handle passed as `stdio[3]`) start seeing `EACCES`/`EBADF` once the first batch of subprocesses is collected.

Fix: store `bun.invalid_fd` in the `extra_pipes` slot for the `.pipe` case instead of the caller's fd. `finalizeStreams` and `getStdio` already skip invalid entries (added in #29416 for the IPC slot), and this keeps index alignment for the IPC channel lookup. Windows already records `.unavailable` here and was unaffected.

## How did you verify your code works?

- [ ] New test in `test/js/bun/spawn/spawn.test.ts` — opens an fd, passes it as `stdio[3]` across 8 spawns, GCs, then asserts `fstatSync(fd)` still succeeds and the fd is still usable as `stdio[3]` in a fresh spawn
- [ ] `bun bd test test/js/bun/spawn/spawn.test.ts`