### PR TITLE
crash_handler: capture fault PC and registers from ucontext

### DIFF
--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -206,7 +206,7 @@ pub fn crashHandler(
     if (bun.Environment.isDebug)
         bun.Output.disableScopedDebugWriter();
 
-    var trace_str_buf = bun.BoundedArray(u8, 1024){};
+    var trace_str_buf = bun.BoundedArray(u8, 4096){};
 
     nosuspend switch (panic_stage) {
         0 => {
@@ -364,6 +364,17 @@ pub fn crashHandler(
                             trace_buf.index = trace_buf_libc.index;
                         }
                     }
+
+                    // Prepend the faulting instruction as frame 0. The unwinder
+                    // above walks from inside the signal handler, so without
+                    // this the trace begins at the libc trampoline and the
+                    // actual crash site is missing from the report.
+                    if (fault_registers) |fr| if (fr.pc != 0) {
+                        const n = @min(trace_buf.index, addr_buf.len - 1);
+                        std.mem.copyBackwards(usize, addr_buf[1 .. n + 1], addr_buf[0..n]);
+                        addr_buf[0] = fr.pc;
+                        trace_buf.index = n + 1;
+                    };
                     break :blk &trace_buf;
                 };
 
@@ -372,10 +383,15 @@ pub fn crashHandler(
 
                     dumpStackTrace(trace.*, .{});
 
+                    if (fault_registers) |fr| {
+                        writer.print("{f}", .{fr}) catch std.posix.abort();
+                    }
+
                     trace_str_buf.writer().print("{f}", .{TraceString{
                         .trace = trace,
                         .reason = reason,
                         .action = .view_trace,
+                        .fault_regs = fault_registers,
                     }}) catch std.posix.abort();
                 } else {
                     if (!has_printed_message) {
@@ -441,6 +457,7 @@ pub fn crashHandler(
                         .trace = trace,
                         .reason = reason,
                         .action = .open_issue,
+                        .fault_regs = fault_registers,
                     }}) catch std.posix.abort();
 
                     writer.writeAll(trace_str_buf.slice()) catch std.posix.abort();
@@ -852,6 +869,143 @@ const arch_display_string = if (bun.Environment.isAarch64)
 else
     "x64";
 
+/// CPU register state captured at the moment a fatal signal/exception was
+/// raised. The kernel passes this to the signal handler via `ucontext_t` (or
+/// `EXCEPTION_POINTERS.ContextRecord` on Windows), but historically Bun
+/// discarded it. Recording it gives us:
+///
+/// - The exact faulting instruction (`pc`). Without this, frame 0 of the
+///   captured stack trace is the libc signal trampoline (`_sigtramp` /
+///   `__restore_rt`), so the remapped trace points one or more frames above
+///   the real crash site.
+/// - General-purpose register values, which often hold `this`, iterators,
+///   and the dereferenced pointer at the moment of a null/stale-pointer
+///   crash.
+///
+/// `pc` is prepended to the captured stack trace as frame 0; the full
+/// register set is appended to the encoded trace string for the bun.report
+/// remapper to display.
+pub const FaultRegisters = struct {
+    pc: usize,
+    gp: [gp_count]usize,
+
+    pub const gp_count = gp_names.len;
+
+    pub const gp_names: []const [:0]const u8 = if (bun.Environment.isAarch64)
+        // x0-x30 (x29=fp, x30=lr) then sp.
+        &.{
+            "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",
+            "x8",  "x9",  "x10", "x11", "x12", "x13", "x14", "x15",
+            "x16", "x17", "x18", "x19", "x20", "x21", "x22", "x23",
+            "x24", "x25", "x26", "x27", "x28", "fp",  "lr",  "sp",
+        }
+    else
+        // x86_64: 16 GPRs then rip is stored separately as `pc`.
+        &.{
+            "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp",
+            "r8",  "r9",  "r10", "r11", "r12", "r13", "r14", "r15",
+        };
+
+    /// Extract from the third argument of a `SA_SIGINFO` POSIX signal handler.
+    /// Returns null if the kernel passed a null context (defensive — should
+    /// not happen in practice when `SA_SIGINFO` is set).
+    pub fn fromPosixContext(ctx_ptr: ?*const anyopaque) ?FaultRegisters {
+        if (comptime !std.debug.have_ucontext) return null;
+        const raw = ctx_ptr orelse return null;
+
+        // Some kernels don't align `ctx_ptr` properly; load via align(1).
+        const unaligned: *align(1) const std.posix.ucontext_t = @ptrCast(raw);
+        var ctx: std.posix.ucontext_t = unaligned.*;
+        if (comptime bun.Environment.isMac and bun.Environment.isAarch64) {
+            // Darwin/arm64 kernel bug: `__mcontext_data` is written immediately
+            // after `mcontext` instead of after the 8 bytes of padding the C
+            // struct layout expects. Re-read it from the unpadded layout so
+            // that `relocateContext` (which sets `mcontext = &__mcontext_data`)
+            // points at valid data. See std.debug.dumpSegfaultInfoPosix.
+            ctx.__mcontext_data = @as(*align(1) const extern struct {
+                onstack: c_int,
+                sigmask: std.c.sigset_t,
+                stack: std.c.stack_t,
+                link: ?*std.c.ucontext_t,
+                mcsize: u64,
+                mcontext: *std.c.mcontext_t,
+                __mcontext_data: std.c.mcontext_t align(@sizeOf(usize)),
+            }, @ptrCast(raw)).__mcontext_data;
+        }
+        std.debug.relocateContext(&ctx);
+
+        var self: FaultRegisters = undefined;
+        switch (comptime bun.Environment.os) {
+            .mac => {
+                const ss = ctx.mcontext.ss;
+                if (comptime bun.Environment.isAarch64) {
+                    self.pc = ss.pc;
+                    inline for (0..29) |i| self.gp[i] = ss.regs[i];
+                    self.gp[29] = ss.fp;
+                    self.gp[30] = ss.lr;
+                    self.gp[31] = ss.sp;
+                } else {
+                    self.pc = ss.rip;
+                    self.gp = .{
+                        ss.rax, ss.rbx, ss.rcx, ss.rdx, ss.rdi, ss.rsi, ss.rbp, ss.rsp,
+                        ss.r8,  ss.r9,  ss.r10, ss.r11, ss.r12, ss.r13, ss.r14, ss.r15,
+                    };
+                }
+            },
+            .linux => {
+                const mc = ctx.mcontext;
+                if (comptime bun.Environment.isAarch64) {
+                    self.pc = mc.pc;
+                    inline for (0..31) |i| self.gp[i] = mc.regs[i];
+                    self.gp[31] = mc.sp;
+                } else {
+                    const REG = std.os.linux.REG;
+                    const r = mc.gregs;
+                    self.pc = r[REG.RIP];
+                    self.gp = .{
+                        r[REG.RAX], r[REG.RBX], r[REG.RCX], r[REG.RDX],
+                        r[REG.RDI], r[REG.RSI], r[REG.RBP], r[REG.RSP],
+                        r[REG.R8],  r[REG.R9],  r[REG.R10], r[REG.R11],
+                        r[REG.R12], r[REG.R13], r[REG.R14], r[REG.R15],
+                    };
+                }
+            },
+            .windows, .wasm => comptime unreachable,
+        }
+        return self;
+    }
+
+    pub fn fromWindowsContext(ctx: *const windows.CONTEXT) FaultRegisters {
+        var self: FaultRegisters = undefined;
+        if (comptime bun.Environment.isAarch64) {
+            self.pc = ctx.Pc;
+            inline for (0..31) |i| self.gp[i] = ctx.DUMMYUNIONNAME.X[i];
+            self.gp[31] = ctx.Sp;
+        } else {
+            self.pc = ctx.Rip;
+            self.gp = .{
+                ctx.Rax, ctx.Rbx, ctx.Rcx, ctx.Rdx, ctx.Rdi, ctx.Rsi, ctx.Rbp, ctx.Rsp,
+                ctx.R8,  ctx.R9,  ctx.R10, ctx.R11, ctx.R12, ctx.R13, ctx.R14, ctx.R15,
+            };
+        }
+        return self;
+    }
+
+    pub fn format(self: FaultRegisters, writer: *std.Io.Writer) !void {
+        const cols = if (bun.Environment.isAarch64) 3 else 2;
+        try writer.print("Registers (pc={x:0>16}):\n", .{self.pc});
+        inline for (gp_names, 0..) |name, i| {
+            try writer.print("  {s: >3}={x:0>16}", .{ name, self.gp[i] });
+            if (i % cols == cols - 1 or i == gp_names.len - 1) try writer.writeByte('\n');
+        }
+    }
+};
+
+/// Set by `handleSegfaultPosix` / `handleSegfaultWindows` immediately before
+/// calling `crashHandler`, then consumed there. Threadlocal so a crash on one
+/// thread doesn't see another thread's registers.
+threadlocal var fault_registers: ?FaultRegisters = null;
+
 const metadata_version_line = std.fmt.comptimePrint(
     "Bun {s}v{s} {s} {s}{s}\n",
     .{
@@ -863,12 +1017,14 @@ const metadata_version_line = std.fmt.comptimePrint(
     },
 );
 
-fn handleSegfaultPosix(sig: i32, info: *const std.posix.siginfo_t, _: ?*const anyopaque) callconv(.c) noreturn {
+fn handleSegfaultPosix(sig: i32, info: *const std.posix.siginfo_t, ctx: ?*const anyopaque) callconv(.c) noreturn {
     const addr = switch (bun.Environment.os) {
         .linux => @intFromPtr(info.fields.sigfault.addr),
         .mac, .freebsd => @intFromPtr(info.addr),
         .windows, .wasm => @compileError("unreachable"),
     };
+
+    fault_registers = FaultRegisters.fromPosixContext(ctx);
 
     crashHandler(
         switch (sig) {
@@ -958,24 +1114,23 @@ pub fn resetSegfaultHandler() void {
 }
 
 pub fn handleSegfaultWindows(info: *windows.EXCEPTION_POINTERS) callconv(.winapi) c_long {
-    crashHandler(
-        switch (info.ExceptionRecord.ExceptionCode) {
-            windows.EXCEPTION_DATATYPE_MISALIGNMENT => .{ .datatype_misalignment = {} },
-            windows.EXCEPTION_ACCESS_VIOLATION => .{ .segmentation_fault = info.ExceptionRecord.ExceptionInformation[1] },
-            windows.EXCEPTION_ILLEGAL_INSTRUCTION => .{ .illegal_instruction = info.ContextRecord.getRegs().ip },
-            windows.EXCEPTION_STACK_OVERFLOW => .{ .stack_overflow = {} },
+    const reason: CrashReason = switch (info.ExceptionRecord.ExceptionCode) {
+        windows.EXCEPTION_DATATYPE_MISALIGNMENT => .{ .datatype_misalignment = {} },
+        windows.EXCEPTION_ACCESS_VIOLATION => .{ .segmentation_fault = info.ExceptionRecord.ExceptionInformation[1] },
+        windows.EXCEPTION_ILLEGAL_INSTRUCTION => .{ .illegal_instruction = info.ContextRecord.getRegs().ip },
+        windows.EXCEPTION_STACK_OVERFLOW => .{ .stack_overflow = {} },
 
-            // exception used for thread naming
-            // https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2017/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2017#set-a-thread-name-by-throwing-an-exception
-            // related commit
-            // https://github.com/go-delve/delve/pull/1384
-            bun.windows.MS_VC_EXCEPTION => return bun.windows.EXCEPTION_CONTINUE_EXECUTION,
+        // exception used for thread naming
+        // https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2017/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2017#set-a-thread-name-by-throwing-an-exception
+        // related commit
+        // https://github.com/go-delve/delve/pull/1384
+        bun.windows.MS_VC_EXCEPTION => return bun.windows.EXCEPTION_CONTINUE_EXECUTION,
 
-            else => return windows.EXCEPTION_CONTINUE_SEARCH,
-        },
-        null,
-        @intFromPtr(info.ExceptionRecord.ExceptionAddress),
-    );
+        else => return windows.EXCEPTION_CONTINUE_SEARCH,
+    };
+
+    fault_registers = FaultRegisters.fromWindowsContext(info.ContextRecord);
+    crashHandler(reason, null, @intFromPtr(info.ExceptionRecord.ExceptionAddress));
 }
 
 extern "c" fn gnu_get_libc_version() ?[*:0]const u8;
@@ -1160,10 +1315,15 @@ const Platform = enum(u8) {
 ///
 /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
 /// '2' - same as '1' but this build is known to be a canary build
+/// '3' - same as '1' but for fault reasons (segfault/SIGILL/SIGBUS/SIGFPE)
+///       a register block follows the fault address: one VLQ count `n`, then
+///       `n` u64 values each as two VLQs, in `FaultRegisters.gp_names` order
+///       followed by pc.
+/// '4' - same as '3' but this build is known to be a canary build
 const version_char = if (bun.Environment.is_canary)
-    "2"
+    "4"
 else
-    "1";
+    "3";
 
 const git_sha = if (bun.Environment.git_sha.len > 0) bun.Environment.git_sha[0..7] else "unknown";
 
@@ -1342,6 +1502,7 @@ const TraceString = struct {
     trace: *const std.builtin.StackTrace,
     reason: CrashReason,
     action: TraceString.Action,
+    fault_regs: ?FaultRegisters = null,
 
     const Action = enum {
         /// Open a pre-filled GitHub issue with the expanded trace
@@ -1411,21 +1572,26 @@ fn encodeTraceString(opts: TraceString, writer: anytype) !void {
 
         .@"unreachable" => try writer.writeByte('1'),
 
-        .segmentation_fault => |addr| {
-            try writer.writeByte('2');
+        inline .segmentation_fault,
+        .illegal_instruction,
+        .bus_error,
+        .floating_point_error,
+        => |addr, tag| {
+            try writer.writeByte(switch (tag) {
+                .segmentation_fault => '2',
+                .illegal_instruction => '3',
+                .bus_error => '4',
+                .floating_point_error => '5',
+                else => comptime unreachable,
+            });
             try writeU64AsTwoVLQs(writer, addr);
-        },
-        .illegal_instruction => |addr| {
-            try writer.writeByte('3');
-            try writeU64AsTwoVLQs(writer, addr);
-        },
-        .bus_error => |addr| {
-            try writer.writeByte('4');
-            try writeU64AsTwoVLQs(writer, addr);
-        },
-        .floating_point_error => |addr| {
-            try writer.writeByte('5');
-            try writeU64AsTwoVLQs(writer, addr);
+            if (opts.fault_regs) |fr| {
+                try VLQ.encode(@intCast(FaultRegisters.gp_count + 1)).writeTo(writer);
+                for (fr.gp) |reg| try writeU64AsTwoVLQs(writer, reg);
+                try writeU64AsTwoVLQs(writer, fr.pc);
+            } else {
+                try writer.writeAll(VLQ.zero.slice());
+            }
         },
 
         .datatype_misalignment => try writer.writeByte('6'),

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -889,6 +889,20 @@ pub const FaultRegisters = struct {
     pc: usize,
     gp: [gp_count]usize,
 
+    /// Register capture is restricted to the (os, arch) pairs we can actually
+    /// test. On anything else (FreeBSD, Android, future ports) the extractors
+    /// return null and the trace string encodes a zero-length register block,
+    /// so the format is still v3/v4 but carries no register data. This keeps
+    /// the wire format uniform without risking a bad `ucontext_t` layout
+    /// assumption on a platform we haven't verified.
+    pub const supported = (bun.Environment.isX64 or bun.Environment.isAarch64) and switch (bun.Environment.os) {
+        .mac, .windows => true,
+        // Android shares the Linux kernel ucontext ABI but we have no test
+        // coverage for it; opt out until proven.
+        .linux => !bun.Environment.isAndroid,
+        else => false,
+    };
+
     pub const gp_count = gp_names.len;
 
     pub const gp_names: []const [:0]const u8 = if (bun.Environment.isAarch64)
@@ -907,75 +921,76 @@ pub const FaultRegisters = struct {
         };
 
     /// Extract from the third argument of a `SA_SIGINFO` POSIX signal handler.
-    /// Returns null if the kernel passed a null context (defensive — should
-    /// not happen in practice when `SA_SIGINFO` is set).
+    /// Returns null on platforms where capture isn't `supported`, or if the
+    /// kernel passed a null context.
     pub fn fromPosixContext(ctx_ptr: ?*const anyopaque) ?FaultRegisters {
-        if (comptime !std.debug.have_ucontext) return null;
         const raw = ctx_ptr orelse return null;
-
-        // Some kernels don't align `ctx_ptr` properly; load via align(1).
-        const unaligned: *align(1) const std.posix.ucontext_t = @ptrCast(raw);
-        var ctx: std.posix.ucontext_t = unaligned.*;
-        if (comptime bun.Environment.isMac and bun.Environment.isAarch64) {
-            // Darwin/arm64 kernel bug: `__mcontext_data` is written immediately
-            // after `mcontext` instead of after the 8 bytes of padding the C
-            // struct layout expects. Re-read it from the unpadded layout so
-            // that `relocateContext` (which sets `mcontext = &__mcontext_data`)
-            // points at valid data. See std.debug.dumpSegfaultInfoPosix.
-            ctx.__mcontext_data = @as(*align(1) const extern struct {
-                onstack: c_int,
-                sigmask: std.c.sigset_t,
-                stack: std.c.stack_t,
-                link: ?*std.c.ucontext_t,
-                mcsize: u64,
-                mcontext: *std.c.mcontext_t,
-                __mcontext_data: std.c.mcontext_t align(@sizeOf(usize)),
-            }, @ptrCast(raw)).__mcontext_data;
-        }
-        std.debug.relocateContext(&ctx);
-
-        var self: FaultRegisters = undefined;
         switch (comptime bun.Environment.os) {
-            .mac => {
-                const ss = ctx.mcontext.ss;
-                if (comptime bun.Environment.isAarch64) {
-                    self.pc = ss.pc;
-                    inline for (0..29) |i| self.gp[i] = ss.regs[i];
-                    self.gp[29] = ss.fp;
-                    self.gp[30] = ss.lr;
-                    self.gp[31] = ss.sp;
-                } else {
-                    self.pc = ss.rip;
-                    self.gp = .{
-                        ss.rax, ss.rbx, ss.rcx, ss.rdx, ss.rdi, ss.rsi, ss.rbp, ss.rsp,
-                        ss.r8,  ss.r9,  ss.r10, ss.r11, ss.r12, ss.r13, ss.r14, ss.r15,
-                    };
+            inline .mac, .linux => |os| if (comptime supported and std.debug.have_ucontext) {
+                // Some kernels don't align `ctx_ptr` properly; load via align(1).
+                const unaligned: *align(1) const std.posix.ucontext_t = @ptrCast(raw);
+                var ctx: std.posix.ucontext_t = unaligned.*;
+                if (comptime os == .mac and bun.Environment.isAarch64) {
+                    // Darwin/arm64 kernel bug: `__mcontext_data` is written immediately
+                    // after `mcontext` instead of after the 8 bytes of padding the C
+                    // struct layout expects. Re-read it from the unpadded layout so
+                    // that `relocateContext` (which sets `mcontext = &__mcontext_data`)
+                    // points at valid data. See std.debug.dumpSegfaultInfoPosix.
+                    ctx.__mcontext_data = @as(*align(1) const extern struct {
+                        onstack: c_int,
+                        sigmask: std.c.sigset_t,
+                        stack: std.c.stack_t,
+                        link: ?*std.c.ucontext_t,
+                        mcsize: u64,
+                        mcontext: *std.c.mcontext_t,
+                        __mcontext_data: std.c.mcontext_t align(@sizeOf(usize)),
+                    }, @ptrCast(raw)).__mcontext_data;
                 }
-            },
-            .linux => {
-                const mc = ctx.mcontext;
-                if (comptime bun.Environment.isAarch64) {
-                    self.pc = mc.pc;
-                    inline for (0..31) |i| self.gp[i] = mc.regs[i];
-                    self.gp[31] = mc.sp;
+                std.debug.relocateContext(&ctx);
+
+                var self: FaultRegisters = undefined;
+                if (comptime os == .mac) {
+                    const ss = ctx.mcontext.ss;
+                    if (comptime bun.Environment.isAarch64) {
+                        self.pc = ss.pc;
+                        inline for (0..29) |i| self.gp[i] = ss.regs[i];
+                        self.gp[29] = ss.fp;
+                        self.gp[30] = ss.lr;
+                        self.gp[31] = ss.sp;
+                    } else {
+                        self.pc = ss.rip;
+                        self.gp = .{
+                            ss.rax, ss.rbx, ss.rcx, ss.rdx, ss.rdi, ss.rsi, ss.rbp, ss.rsp,
+                            ss.r8,  ss.r9,  ss.r10, ss.r11, ss.r12, ss.r13, ss.r14, ss.r15,
+                        };
+                    }
                 } else {
-                    const REG = std.os.linux.REG;
-                    const r = mc.gregs;
-                    self.pc = r[REG.RIP];
-                    self.gp = .{
-                        r[REG.RAX], r[REG.RBX], r[REG.RCX], r[REG.RDX],
-                        r[REG.RDI], r[REG.RSI], r[REG.RBP], r[REG.RSP],
-                        r[REG.R8],  r[REG.R9],  r[REG.R10], r[REG.R11],
-                        r[REG.R12], r[REG.R13], r[REG.R14], r[REG.R15],
-                    };
+                    const mc = ctx.mcontext;
+                    if (comptime bun.Environment.isAarch64) {
+                        self.pc = mc.pc;
+                        inline for (0..31) |i| self.gp[i] = mc.regs[i];
+                        self.gp[31] = mc.sp;
+                    } else {
+                        const REG = std.os.linux.REG;
+                        const r = mc.gregs;
+                        self.pc = r[REG.RIP];
+                        self.gp = .{
+                            r[REG.RAX], r[REG.RBX], r[REG.RCX], r[REG.RDX],
+                            r[REG.RDI], r[REG.RSI], r[REG.RBP], r[REG.RSP],
+                            r[REG.R8],  r[REG.R9],  r[REG.R10], r[REG.R11],
+                            r[REG.R12], r[REG.R13], r[REG.R14], r[REG.R15],
+                        };
+                    }
                 }
+                return self;
             },
-            .windows, .wasm => comptime unreachable,
+            else => {},
         }
-        return self;
+        return null;
     }
 
-    pub fn fromWindowsContext(ctx: *const windows.CONTEXT) FaultRegisters {
+    pub fn fromWindowsContext(ctx: *const windows.CONTEXT) ?FaultRegisters {
+        if (comptime !supported) return null;
         var self: FaultRegisters = undefined;
         if (comptime bun.Environment.isAarch64) {
             self.pc = ctx.Pc;

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -365,11 +365,16 @@ pub fn crashHandler(
                         }
                     }
 
-                    // Prepend the faulting instruction as frame 0. The unwinder
-                    // above walks from inside the signal handler, so without
-                    // this the trace begins at the libc trampoline and the
-                    // actual crash site is missing from the report.
-                    if (fault_registers) |fr| if (fr.pc != 0) {
+                    // Prepend the faulting instruction as frame 0. On POSIX the
+                    // unwinder above walks from inside the signal handler, so
+                    // without this the trace begins at the libc trampoline and
+                    // the actual crash site is missing from the report. On
+                    // Windows `captureStackTrace(ExceptionAddress, …)` may
+                    // already yield it as frame 0 (or an empty trace), so skip
+                    // the prepend if it's already there.
+                    if (fault_registers) |fr| if (fr.pc != 0 and
+                        (trace_buf.index == 0 or addr_buf[0] != fr.pc))
+                    {
                         const n = @min(trace_buf.index, addr_buf.len - 1);
                         std.mem.copyBackwards(usize, addr_buf[1 .. n + 1], addr_buf[0..n]);
                         addr_buf[0] = fr.pc;

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -894,14 +894,16 @@ pub const FaultRegisters = struct {
     pc: usize,
     gp: [gp_count]usize,
 
-    /// Register capture is restricted to the (os, arch) pairs we can actually
-    /// test. On anything else (FreeBSD, Android, future ports) the extractors
-    /// return null and the trace string encodes a zero-length register block,
-    /// so the format is still v3/v4 but carries no register data. This keeps
-    /// the wire format uniform without risking a bad `ucontext_t` layout
-    /// assumption on a platform we haven't verified.
+    /// Register capture is restricted to the (os, arch) pairs we have actually
+    /// verified at runtime. On anything else the extractors return null and the
+    /// trace string stays on the legacy '1'/'2' format — byte-identical to a
+    /// build without this feature — so an unverified `ucontext_t`/CONTEXT
+    /// layout assumption can't corrupt reports.
+    ///
+    /// Windows is opted out until we can test it on real hardware; the
+    /// `fromWindowsContext` path compiles but is unexercised.
     pub const supported = (bun.Environment.isX64 or bun.Environment.isAarch64) and switch (bun.Environment.os) {
-        .mac, .windows => true,
+        .mac => true,
         // Android shares the Linux kernel ucontext ABI but we have no test
         // coverage for it; opt out until proven.
         .linux => !bun.Environment.isAndroid,
@@ -929,9 +931,11 @@ pub const FaultRegisters = struct {
     /// Returns null on platforms where capture isn't `supported`, or if the
     /// kernel passed a null context.
     pub fn fromPosixContext(ctx_ptr: ?*const anyopaque) ?FaultRegisters {
-        const raw = ctx_ptr orelse return null;
-        switch (comptime bun.Environment.os) {
-            inline .mac, .linux => |os| if (comptime supported and std.debug.have_ucontext) {
+        // `supported` implies os ∈ {.mac, .linux}; the body is dead on every
+        // other target so Zig never analyzes the platform-specific fields.
+        if (comptime supported and std.debug.have_ucontext) switch (comptime bun.Environment.os) {
+            inline .mac, .linux => |os| {
+                const raw = ctx_ptr orelse return null;
                 // Some kernels don't align `ctx_ptr` properly; load via align(1).
                 const unaligned: *align(1) const std.posix.ucontext_t = @ptrCast(raw);
                 var ctx: std.posix.ucontext_t = unaligned.*;
@@ -989,8 +993,8 @@ pub const FaultRegisters = struct {
                 }
                 return self;
             },
-            else => {},
-        }
+            else => comptime unreachable,
+        };
         return null;
     }
 
@@ -1341,7 +1345,15 @@ const Platform = enum(u8) {
 ///       `n` u64 values each as two VLQs, in `FaultRegisters.gp_names` order
 ///       followed by pc. The canary bit moves into `TraceFlags` so each
 ///       future format change costs one version slot, not two.
-const version_char = "3";
+///
+/// Builds where `FaultRegisters.supported` is false stay on '1'/'2' so the
+/// emitted trace string is byte-identical to a build without this feature.
+const version_char = if (FaultRegisters.supported)
+    "3"
+else if (bun.Environment.is_canary)
+    "2"
+else
+    "1";
 
 /// Single VLQ of build-shape flags emitted right after the sha in v3+
 /// trace strings. Append-only; bun.report ignores unknown high bits.
@@ -1559,7 +1571,9 @@ fn encodeTraceString(opts: TraceString, writer: anytype) !void {
     try writer.writeByte(if (bun.cli.Cli.cmd) |cmd| cmd.char() else '_');
 
     try writer.writeAll(version_char ++ git_sha);
-    try VLQ.encode(@bitCast(TraceFlags.current)).writeTo(writer);
+    if (comptime FaultRegisters.supported) {
+        try VLQ.encode(@bitCast(TraceFlags.current)).writeTo(writer);
+    }
 
     const packed_features = bun.analytics.packedFeatures();
     try writeU64AsTwoVLQs(writer, @bitCast(packed_features));
@@ -1618,12 +1632,14 @@ fn encodeTraceString(opts: TraceString, writer: anytype) !void {
                 else => comptime unreachable,
             });
             try writeU64AsTwoVLQs(writer, addr);
-            if (opts.fault_regs) |fr| {
-                try VLQ.encode(@intCast(FaultRegisters.gp_count + 1)).writeTo(writer);
-                for (fr.gp) |reg| try writeU64AsTwoVLQs(writer, reg);
-                try writeU64AsTwoVLQs(writer, fr.pc);
-            } else {
-                try writer.writeAll(VLQ.zero.slice());
+            if (comptime FaultRegisters.supported) {
+                if (opts.fault_regs) |fr| {
+                    try VLQ.encode(@intCast(FaultRegisters.gp_count + 1)).writeTo(writer);
+                    for (fr.gp) |reg| try writeU64AsTwoVLQs(writer, reg);
+                    try writeU64AsTwoVLQs(writer, fr.pc);
+                } else {
+                    try writer.writeAll(VLQ.zero.slice());
+                }
             }
         },
 

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -1330,15 +1330,27 @@ const Platform = enum(u8) {
 ///
 /// '1' - original. uses 7 char hash with VLQ encoded stack-frames
 /// '2' - same as '1' but this build is known to be a canary build
-/// '3' - same as '1' but for fault reasons (segfault/SIGILL/SIGBUS/SIGFPE)
-///       a register block follows the fault address: one VLQ count `n`, then
+/// '3' - after the 7-char sha: one meta-flags VLQ (`TraceFlags`), then the
+///       v1 body. For fault reasons (segfault/SIGILL/SIGBUS/SIGFPE) a
+///       register block follows the fault address: one VLQ count `n`, then
 ///       `n` u64 values each as two VLQs, in `FaultRegisters.gp_names` order
-///       followed by pc.
-/// '4' - same as '3' but this build is known to be a canary build
-const version_char = if (bun.Environment.is_canary)
-    "4"
-else
-    "3";
+///       followed by pc. The canary bit moves into `TraceFlags` so each
+///       future format change costs one version slot, not two.
+const version_char = "3";
+
+/// Single VLQ of build-shape flags emitted right after the sha in v3+
+/// trace strings. Append-only; bun.report ignores unknown high bits.
+const TraceFlags = packed struct(u32) {
+    /// This build was produced by the canary pipeline. A given commit can
+    /// produce both a canary and a release binary (different comptime
+    /// `is_canary` branches), so the sha alone can't recover this.
+    is_canary: bool,
+    _reserved: u31 = 0,
+
+    const current: TraceFlags = .{
+        .is_canary = bun.Environment.is_canary,
+    };
+};
 
 const git_sha = if (bun.Environment.git_sha.len > 0) bun.Environment.git_sha[0..7] else "unknown";
 
@@ -1542,6 +1554,7 @@ fn encodeTraceString(opts: TraceString, writer: anytype) !void {
     try writer.writeByte(if (bun.cli.Cli.cmd) |cmd| cmd.char() else '_');
 
     try writer.writeAll(version_char ++ git_sha);
+    try VLQ.encode(@bitCast(TraceFlags.current)).writeTo(writer);
 
     const packed_features = bun.analytics.packedFeatures();
     try writeU64AsTwoVLQs(writer, @bitCast(packed_features));

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -125,7 +125,9 @@ describe.skipIf(isASAN)("ucontext-aware fault handler", () => {
     await reported.promise;
 
     // Trace URL path: /<bun-version>/<platform><cmd><version_char><7-char-sha><body>/ack
-    const m = reportedPath!.match(/^\/[\w.+-]+\/[a-zA-Z][a-zA-Z_](?<ver>[0-9])(?:[0-9a-f]{7}|unknown)(?<body>.*)\/ack$/);
+    const m = reportedPath!.match(
+      /^\/[\w.+-]+\/[a-zA-Z][a-zA-Z_](?<ver>[0-9])(?:[0-9a-f]{7}|unknown)(?<body>.*)\/ack$/,
+    );
     expect(stderr).toContain(reportedPath!.replace(/\/ack$/, ""));
     expect(m, `unexpected trace URL: ${reportedPath}`).not.toBeNull();
     return { ver: m!.groups!.ver, body: m!.groups!.body };

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isASAN, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -90,4 +90,59 @@ describe("automatic crash reporter", () => {
       expect(sent).toBe(true);
     });
   }
+});
+
+// ASAN builds don't install Bun's segfault handler.
+describe.skipIf(isASAN)("ucontext-aware fault handler", () => {
+  async function crash(approach: "panic" | "segfault") {
+    let reportedPath: string | undefined;
+    const reported = Promise.withResolvers<void>();
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        reportedPath = new URL(request.url).pathname;
+        reported.resolve();
+        return new Response("OK");
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: server.url.toString(),
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const [, stderr] = await Promise.all([proc.exited, proc.stderr.text()]);
+    await reported.promise;
+
+    // Trace URL path: /<bun-version>/<platform><cmd><version_char><7-char-sha><body>/ack
+    const m = reportedPath!.match(/^\/[\w.+-]+\/[a-zA-Z][a-zA-Z_](?<ver>[0-9])(?:[0-9a-f]{7}|unknown)(?<body>.*)\/ack$/);
+    expect(stderr).toContain(reportedPath!.replace(/\/ack$/, ""));
+    expect(m, `unexpected trace URL: ${reportedPath}`).not.toBeNull();
+    return { ver: m!.groups!.ver, body: m!.groups!.body };
+  }
+
+  test("trace string uses v3/v4 format with register block", async () => {
+    const segv = await crash("segfault");
+    // Older builds emit '1'/'2' here; '3'/'4' means the encoder appends the
+    // GP register set after the fault address.
+    expect(segv.ver).toMatch(/^[34]$/);
+  });
+
+  test("segfault trace string is longer than panic (encodes registers)", async () => {
+    const [segv, panic] = await Promise.all([crash("segfault"), crash("panic")]);
+    // Both share the same frames+features prefix length to within a few bytes;
+    // the segfault body additionally carries 16-32 GP registers as two VLQs
+    // each, which is at least ~80 chars even when most regs are zero.
+    expect(segv.body.length - panic.body.length).toBeGreaterThan(50);
+  });
 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -92,8 +92,9 @@ describe("automatic crash reporter", () => {
   }
 });
 
-// ASAN builds don't install Bun's segfault handler.
-describe.skipIf(isASAN)("ucontext-aware fault handler", () => {
+// ASAN builds don't install Bun's segfault handler. Windows is opted out of
+// FaultRegisters.supported until verified, so it still emits v1/v2.
+describe.skipIf(isASAN || isWindows)("ucontext-aware fault handler", () => {
   async function crash(approach: "panic" | "segfault") {
     let reportedPath: string | undefined;
     const reported = Promise.withResolvers<void>();

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -133,11 +133,11 @@ describe.skipIf(isASAN)("ucontext-aware fault handler", () => {
     return { ver: m!.groups!.ver, body: m!.groups!.body };
   }
 
-  test("trace string uses v3/v4 format with register block", async () => {
+  test("trace string uses v3 format with register block", async () => {
     const segv = await crash("segfault");
-    // Older builds emit '1'/'2' here; '3'/'4' means the encoder appends the
-    // GP register set after the fault address.
-    expect(segv.ver).toMatch(/^[34]$/);
+    // Older builds emit '1'/'2' here; '3' means a TraceFlags VLQ follows the
+    // sha and the encoder appends the GP register set after the fault address.
+    expect(segv.ver).toBe("3");
   });
 
   test("segfault trace string is longer than panic (encodes registers)", async () => {


### PR DESCRIPTION
## What does this PR do?

The POSIX segfault handler was discarding its `ucontext_t*` argument. That throws away two things we really want when triaging a native crash:

- **The exact faulting PC.** Without it, frame 0 of every remapped trace is `_sigtramp` / `__restore_rt`, so the report points one or more frames above the real crash site and the top line is "unknown / js code".
- **GP register state at the fault.** For null/stale-pointer crashes this usually contains `this`, the iterator, and the dereferenced pointer — enough to distinguish "entry is null" from "buffer is out of bounds" without a debugger.

This PR reads the context, prepends the fault PC as frame 0 of the captured trace, prints a register table in debug-trace builds, and appends the full GP register set to the encoded trace string (version char bumped to `'3'`/`'4'`). Windows gets the same treatment via `EXCEPTION_POINTERS.ContextRecord`.

Example debug output after a `*(u64*)0xDEADBEEF = ...`:

```
panic(main thread): Segmentation fault at address 0xDEADBEEF
... 0x88B2769 0xB4D8FE6 ...        <- frame 0 is now the str/mov, not the trampoline
Registers (pc=00000000088b276a):
  rax=00000000deadbeef  rbx=fffe000000000001
  rcx=00007fa3e9700000  rdx=00007ffdfd8d3c70
  ...
```

### bun.report follow-up

The remapper needs a small decoder change: treat `'3'` like `'1'` and `'4'` like `'2'`, then for reason bytes `2`–`5` read one VLQ count `n` followed by `n` u64 values (two VLQs each) in `FaultRegisters.gp_names` order plus PC. Frame 0 already decodes correctly with no changes since it's just another instruction address.

## How did you verify your code works?

- `bun run zig:check-all` — all 16 OS/arch × debug/release combinations compile.
- `bun run build --asan=off test test/cli/run/run-crash-handler.test.ts` — 6 pass, 0 fail.
- New tests fail under `USE_SYSTEM_BUN=1` (version char `'1'`, segfault body shorter than panic) and pass on this build.
- Manually inspected the debug-trace register dump and the encoded trace URL on Linux x64.