### PR TITLE
jsc: enable useEagerCodeBlockJettisonTiming

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -295,7 +295,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::useConcurrentJIT() = true;
             // JSC::Options::useSigillCrashAnalyzer() = true;
             JSC::Options::useSourceProviderCache() = true;
-            // JSC::Options::useUnlinkedCodeBlockJettisoning() = false;
+            JSC::Options::useUnlinkedCodeBlockJettisoning() = true;
             JSC::Options::useEagerCodeBlockJettisonTiming() = true;
             JSC::Options::exposeInternalModuleLoader() = true;
             JSC::Options::useSharedArrayBuffer() = true;

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -296,6 +296,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             // JSC::Options::useSigillCrashAnalyzer() = true;
             JSC::Options::useSourceProviderCache() = true;
             // JSC::Options::useUnlinkedCodeBlockJettisoning() = false;
+            JSC::Options::useEagerCodeBlockJettisonTiming() = true;
             JSC::Options::exposeInternalModuleLoader() = true;
             JSC::Options::useSharedArrayBuffer() = true;
             JSC::Options::useJITCage() = false;


### PR DESCRIPTION
## Summary
- Set `JSC::Options::useEagerCodeBlockJettisonTiming() = true` in `JSCInitialize`
- This shrinks the time slices for jettisoning a CodeBlock due to old age, allowing JSC to reclaim memory from cold compiled code more aggressively

## Test plan
- [x] `bun bd` builds
- [x] `BUN_JSC_dumpOptions=2 ./build/debug/bun-debug -e '0' 2>&1 | grep useEagerCodeBlockJettisonTiming` → `true`
- [ ] CI green