### PR TITLE
process.stdin: don't push zero-length chunks (microtask spin)

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -219,9 +219,14 @@ export function getStdinStream(
     $debug("internalRead();");
     try {
       $assert(reader);
-      const { value } = await reader.read();
+      const { value, done } = await reader.read();
 
-      if (value) {
+      // Guard byteLength: an empty Uint8Array is truthy, so `if (value)` would
+      // push a zero-length chunk → Readable calls _read again → reader.read()
+      // resolves with another empty chunk → microtask spin in
+      // JSC::MicrotaskQueue::drainImpl. Observed when stdin is a half-closed
+      // unix-domain socket after the parent crashes.
+      if (!done && value?.byteLength) {
         stream.push(value);
 
         if (shouldDisown) disown();


### PR DESCRIPTION
## Summary
- `internalRead()` in `getStdinStream` checked `if (value)` on the result of `reader.read()`. An empty `Uint8Array` is truthy, so a zero-length chunk gets pushed into the `Readable`, which triggers another `_read`, which resolves with another empty chunk — busy-looping `JSC::MicrotaskQueue::drainImpl`.
- Reproduces when stdin is a half-closed unix-domain socket after the parent process crashes.
- Fix: destructure `done` and gate on `!done && value?.byteLength` so empty reads fall through to the end/destroy path.

## Test plan
- [x] `bun bd` builds
- [x] `bun bd test test/js/node/process/process-stdio.test.ts test/regression/issue/stdin-pause-resume.test.ts` — 11 pass
- [ ] CI green