### PR TITLE
fail instead of hanging when tarball download returns 4xx/5xx

### DIFF
--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -387,15 +387,26 @@ pub fn runTasks(
                     const err = task.response.fail orelse error.TarballFailedToDownload;
 
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
-                        const package_id = manager.lockfile.buffers.resolutions.items[extract.dependency_id];
-                        callbacks.onPackageDownloadError(
-                            extract_ctx,
-                            package_id,
-                            extract.name.slice(),
-                            &extract.resolution,
-                            err,
-                            task.url_buf,
-                        );
+                        if (Ctx == *Store.Installer) {
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                task.task_id,
+                                extract.name.slice(),
+                                &extract.resolution,
+                                err,
+                                task.url_buf,
+                            );
+                        } else {
+                            const package_id = manager.lockfile.buffers.resolutions.items[extract.dependency_id];
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                package_id,
+                                extract.name.slice(),
+                                &extract.resolution,
+                                err,
+                                task.url_buf,
+                            );
+                        }
                         continue;
                     }
 
@@ -436,6 +447,12 @@ pub fn runTasks(
                         }
                     }
 
+                    if (manager.task_queue.fetchRemove(task.task_id)) |removed| {
+                        var list = removed.value;
+                        list.deinit(manager.allocator);
+                    }
+                    _ = manager.network_dedupe_map.remove(task.task_id);
+
                     continue;
                 };
 
@@ -452,16 +469,27 @@ pub fn runTasks(
                             405...499 => error.TarballHTTP4xx,
                             else => error.TarballHTTP5xx,
                         };
-                        const package_id = manager.lockfile.buffers.resolutions.items[extract.dependency_id];
 
-                        callbacks.onPackageDownloadError(
-                            extract_ctx,
-                            package_id,
-                            extract.name.slice(),
-                            &extract.resolution,
-                            err,
-                            task.url_buf,
-                        );
+                        if (Ctx == *Store.Installer) {
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                task.task_id,
+                                extract.name.slice(),
+                                &extract.resolution,
+                                err,
+                                task.url_buf,
+                            );
+                        } else {
+                            const package_id = manager.lockfile.buffers.resolutions.items[extract.dependency_id];
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                package_id,
+                                extract.name.slice(),
+                                &extract.resolution,
+                                err,
+                                task.url_buf,
+                            );
+                        }
                         continue;
                     }
 
@@ -498,6 +526,17 @@ pub fn runTasks(
                             }
                         }
                     }
+
+                    // The download will not be retried for this task_id, so
+                    // drop the dedupe state. Otherwise the install phase's
+                    // `enqueuePackageForDownload` sees `found_existing`, never
+                    // schedules a network task, and waits forever for a
+                    // callback that will not arrive.
+                    if (manager.task_queue.fetchRemove(task.task_id)) |removed| {
+                        var list = removed.value;
+                        list.deinit(manager.allocator);
+                    }
+                    _ = manager.network_dedupe_map.remove(task.task_id);
 
                     continue;
                 }
@@ -609,18 +648,30 @@ pub fn runTasks(
                     const err = task.err orelse error.TarballFailedToExtract;
 
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
-                        callbacks.onPackageDownloadError(
-                            extract_ctx,
-                            package_id,
-                            alias,
-                            resolution,
-                            err,
-                            switch (task.tag) {
-                                .extract => task.request.extract.network.url_buf,
-                                .local_tarball => task.request.local_tarball.tarball.url.slice(),
-                                else => unreachable,
-                            },
-                        );
+                        const fail_url = switch (task.tag) {
+                            .extract => task.request.extract.network.url_buf,
+                            .local_tarball => task.request.local_tarball.tarball.url.slice(),
+                            else => unreachable,
+                        };
+                        if (Ctx == *Store.Installer) {
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                task.id,
+                                alias,
+                                resolution,
+                                err,
+                                fail_url,
+                            );
+                        } else {
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                package_id,
+                                alias,
+                                resolution,
+                                err,
+                                fail_url,
+                            );
+                        }
                     } else {
                         manager.log.addErrorFmt(
                             null,
@@ -816,16 +867,27 @@ pub fn runTasks(
                 if (task.status == .fail) {
                     const err = task.err orelse error.Failed;
 
-                    manager.log.addErrorFmt(
-                        null,
-                        logger.Loc.Empty,
-                        manager.allocator,
-                        "{s} checking out repository for <b>{s}<r>",
-                        .{
-                            @errorName(err),
+                    if (@TypeOf(callbacks.onPackageDownloadError) != void and Ctx == *Store.Installer) {
+                        callbacks.onPackageDownloadError(
+                            extract_ctx,
+                            task.id,
                             alias.slice(),
-                        },
-                    ) catch |e| bun.handleOom(e);
+                            resolution,
+                            err,
+                            manager.lockfile.str(&resolution.value.git.repo),
+                        );
+                    } else {
+                        manager.log.addErrorFmt(
+                            null,
+                            logger.Loc.Empty,
+                            manager.allocator,
+                            "{s} checking out repository for <b>{s}<r>",
+                            .{
+                                @errorName(err),
+                                alias.slice(),
+                            },
+                        ) catch |e| bun.handleOom(e);
+                    }
 
                     continue;
                 }

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -394,7 +394,11 @@ pub fn runTasks(
                     // will not arrive. `Store.Installer.onPackageDownloadError`
                     // drains `task_queue` itself but does not touch
                     // `network_dedupe_map`, so this must run on the callback
-                    // path too.
+                    // path too. Capture `is_required` first —
+                    // `isNetworkTaskRequired` reads the map and returns `true`
+                    // when the entry is gone, which would upgrade optional-dep
+                    // warnings to errors on the void-callback fallback below.
+                    const is_required = manager.isNetworkTaskRequired(task.task_id);
                     _ = manager.network_dedupe_map.remove(task.task_id);
 
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
@@ -422,7 +426,7 @@ pub fn runTasks(
                     }
 
                     const fmt = "{s} downloading tarball <b>{s}@{f}<r>";
-                    if (manager.isNetworkTaskRequired(task.task_id)) {
+                    if (is_required) {
                         manager.log.addErrorFmt(
                             null,
                             logger.Loc.Empty,
@@ -473,7 +477,10 @@ pub fn runTasks(
                     // enqueue for this task_id schedules a fresh network task
                     // instead of waiting on this failed one. Runs before the
                     // callback branch so `Store.Installer` (which `continue`s
-                    // from the callback) is covered too.
+                    // from the callback) is covered too. Capture
+                    // `is_required` first — `isNetworkTaskRequired` reads the
+                    // map and returns `true` when the entry is gone.
+                    const is_required = manager.isNetworkTaskRequired(task.task_id);
                     _ = manager.network_dedupe_map.remove(task.task_id);
 
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
@@ -510,7 +517,7 @@ pub fn runTasks(
                         continue;
                     }
 
-                    if (manager.isNetworkTaskRequired(task.task_id)) {
+                    if (is_required) {
                         manager.log.addErrorFmt(
                             null,
                             logger.Loc.Empty,

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -386,6 +386,17 @@ pub fn runTasks(
                 const metadata = task.response.metadata orelse {
                     const err = task.response.fail orelse error.TarballFailedToDownload;
 
+                    // The download will not be retried for this task_id, so
+                    // drop the dedupe state before dispatching the error.
+                    // Otherwise a later `enqueuePackageForDownload` for the
+                    // same package sees `found_existing`, never schedules a
+                    // network task, and waits forever for a callback that
+                    // will not arrive. `Store.Installer.onPackageDownloadError`
+                    // drains `task_queue` itself but does not touch
+                    // `network_dedupe_map`, so this must run on the callback
+                    // path too.
+                    _ = manager.network_dedupe_map.remove(task.task_id);
+
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
                         if (Ctx == *Store.Installer) {
                             callbacks.onPackageDownloadError(
@@ -451,7 +462,6 @@ pub fn runTasks(
                         var list = removed.value;
                         list.deinit(manager.allocator);
                     }
-                    _ = manager.network_dedupe_map.remove(task.task_id);
 
                     continue;
                 };
@@ -459,6 +469,13 @@ pub fn runTasks(
                 const response = metadata.response;
 
                 if (response.status_code > 399) {
+                    // Non-retryable HTTP error: drop dedupe state so a later
+                    // enqueue for this task_id schedules a fresh network task
+                    // instead of waiting on this failed one. Runs before the
+                    // callback branch so `Store.Installer` (which `continue`s
+                    // from the callback) is covered too.
+                    _ = manager.network_dedupe_map.remove(task.task_id);
+
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
                         const err = switch (response.status_code) {
                             400 => error.TarballHTTP400,
@@ -527,16 +544,10 @@ pub fn runTasks(
                         }
                     }
 
-                    // The download will not be retried for this task_id, so
-                    // drop the dedupe state. Otherwise the install phase's
-                    // `enqueuePackageForDownload` sees `found_existing`, never
-                    // schedules a network task, and waits forever for a
-                    // callback that will not arrive.
                     if (manager.task_queue.fetchRemove(task.task_id)) |removed| {
                         var list = removed.value;
                         list.deinit(manager.allocator);
                     }
-                    _ = manager.network_dedupe_map.remove(task.task_id);
 
                     continue;
                 }
@@ -792,6 +803,59 @@ pub fn runTasks(
                             err,
                             url,
                         );
+                    } else if (@TypeOf(callbacks.onPackageDownloadError) != void and Ctx == *Store.Installer) {
+                        // The isolated installer queued its entry contexts
+                        // under `checkout_id`, not `clone_id`. A failed clone
+                        // never reaches checkout, so drain every waiting
+                        // checkout for this repo or the install loop blocks
+                        // forever on the entry's pending-task slot.
+                        var drained_any = false;
+                        if (manager.task_queue.fetchRemove(task.id)) |removed| {
+                            var waiters = removed.value;
+                            defer waiters.deinit(manager.allocator);
+                            const pkg_resolutions = manager.lockfile.packages.items(.resolution);
+                            for (waiters.items) |waiter| {
+                                const dep_id = switch (waiter) {
+                                    .dependency => |id| id,
+                                    else => continue,
+                                };
+                                const pkg_id = manager.lockfile.buffers.resolutions.items[dep_id];
+                                if (pkg_id == invalid_package_id) continue;
+                                const res = &pkg_resolutions[pkg_id];
+                                if (res.tag != .git) continue;
+                                const checkout_id = Task.Id.forGitCheckout(
+                                    manager.lockfile.str(&res.value.git.repo),
+                                    manager.lockfile.str(&res.value.git.resolved),
+                                );
+                                drained_any = true;
+                                callbacks.onPackageDownloadError(
+                                    extract_ctx,
+                                    checkout_id,
+                                    name,
+                                    res,
+                                    err,
+                                    url,
+                                );
+                            }
+                        }
+                        if (!drained_any) {
+                            // No clone waiters recorded (or all were skipped
+                            // above) — fall back to the clone task's own
+                            // resolution so the originating entry is still
+                            // released.
+                            const checkout_id = Task.Id.forGitCheckout(
+                                url,
+                                manager.lockfile.str(&clone.res.value.git.resolved),
+                            );
+                            callbacks.onPackageDownloadError(
+                                extract_ctx,
+                                checkout_id,
+                                name,
+                                &clone.res,
+                                err,
+                                url,
+                            );
+                        }
                     } else if (log_level != .silent) {
                         manager.log.addErrorFmt(
                             null,

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1837,7 +1837,7 @@ pub fn installIsolatedPackages(
                         .onExtract = Store.Installer.onPackageExtracted,
                         .onResolve = {},
                         .onPackageManifestError = {},
-                        .onPackageDownloadError = {},
+                        .onPackageDownloadError = Store.Installer.onPackageDownloadError,
                     },
                     true,
                     pkg_manager.options.log_level,

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -100,6 +100,59 @@ pub const Installer = struct {
         }
     }
 
+    /// Called from main thread when a tarball download or extraction fails.
+    /// Without this, the upfront pending-task slot for each waiting entry is
+    /// never released and the install loop blocks forever on
+    /// `pendingTaskCount() == 0`.
+    pub fn onPackageDownloadError(
+        this: *Installer,
+        task_id: install.Task.Id,
+        name: []const u8,
+        resolution: *const Resolution,
+        err: anyerror,
+        url: []const u8,
+    ) void {
+        if (this.manager.task_queue.fetchRemove(task_id)) |removed| {
+            var callbacks = removed.value;
+            defer callbacks.deinit(this.manager.allocator);
+
+            const entry_steps = this.store.entries.items(.step);
+            for (callbacks.items) |install_ctx| {
+                const entry_id = install_ctx.isolated_package_install_context;
+                entry_steps[entry_id.get()].store(.done, .monotonic);
+                this.onTaskFail(entry_id, .{ .download = .{
+                    .err = err,
+                    .url = url,
+                } });
+            }
+        } else {
+            // No waiting entry — still surface the error so it isn't lost.
+            const string_buf = this.lockfile.buffers.string_bytes.items;
+            Output.errGeneric("failed to download <b>{s}@{f}<r>: {s}\n  <d>{s}<r>", .{
+                name,
+                resolution.fmt(string_buf, .auto),
+                downloadErrorReason(err),
+                url,
+            });
+            Output.flush();
+        }
+    }
+
+    fn downloadErrorReason(e: anyerror) []const u8 {
+        return switch (e) {
+            error.TarballHTTP400 => "400 Bad Request",
+            error.TarballHTTP401 => "401 Unauthorized",
+            error.TarballHTTP402 => "402 Payment Required",
+            error.TarballHTTP403 => "403 Forbidden",
+            error.TarballHTTP404 => "404 Not Found",
+            error.TarballHTTP4xx => "HTTP 4xx",
+            error.TarballHTTP5xx => "HTTP 5xx",
+            error.TarballFailedToExtract => "failed to extract",
+            error.TarballFailedToDownload => "download failed",
+            else => @errorName(e),
+        };
+    }
+
     pub fn applyPackagePatch(this: *Installer, entry_id: Store.Entry.Id, patch: PatchInfo.Patch, log: *bun.logger.Log) void {
         const store = this.store;
         const entry_node_ids = store.entries.items(.node_id);
@@ -164,6 +217,14 @@ pub const Installer = struct {
                 Output.err(bin_err, "failed to link binaries for package: {s}@{f}", .{
                     pkg_name.slice(string_buf),
                     pkg_res.fmt(string_buf, .auto),
+                });
+            },
+            .download => |dl| {
+                Output.errGeneric("failed to download <b>{s}@{f}<r>: {s}\n  <d>{s}<r>", .{
+                    pkg_name.slice(string_buf),
+                    pkg_res.fmt(string_buf, .auto),
+                    downloadErrorReason(dl.err),
+                    dl.url,
                 });
             },
             else => {},
@@ -384,6 +445,7 @@ pub const Installer = struct {
             run_scripts: anyerror,
             binaries: anyerror,
             patching: bun.logger.Log,
+            download: struct { err: anyerror, url: []const u8 },
 
             pub fn clone(this: *const Error, allocator: std.mem.Allocator) Error {
                 return switch (this.*) {
@@ -392,6 +454,7 @@ pub const Installer = struct {
                     .binaries => |err| .{ .binaries = err },
                     .run_scripts => |err| .{ .run_scripts = err },
                     .patching => |log| .{ .patching = log },
+                    .download => |dl| .{ .download = dl },
                 };
             }
         };

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -489,3 +489,96 @@ describe.concurrent("tarball integrity", () => {
     });
   });
 });
+
+describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download failure (%s)", linker => {
+  it("should fail (not hang) when registry returns 404 for tarball", async () => {
+    await withContext({ linker }, async ctx => {
+      const urls: string[] = [];
+      let tarballStatus = 200;
+      setContextHandler(ctx, async request => {
+        const url = request.url.replaceAll("%2f", "/");
+        urls.push(url);
+        if (url.endsWith(".tgz")) {
+          if (tarballStatus !== 200) {
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  controller.enqueue(
+                    new TextEncoder().encode(
+                      JSON.stringify({ errors: [{ status: 404, message: "Could not find resource" }] }),
+                    ),
+                  );
+                  controller.close();
+                },
+              }),
+              { status: tarballStatus, headers: { "content-type": "application/json" } },
+            );
+          }
+          return new Response(file(join(import.meta.dir, "baz-0.0.3.tgz")));
+        }
+        return Response.json({
+          name: "baz",
+          versions: {
+            "0.0.3": {
+              name: "baz",
+              version: "0.0.3",
+              dist: { tarball: `${ctx.registry_url}baz-0.0.3.tgz` },
+            },
+          },
+          "dist-tags": { latest: "0.0.3" },
+        });
+      });
+
+      // Project-local .npmrc takes precedence over any user-level ~/.npmrc.
+      await writeFile(join(ctx.package_dir, ".npmrc"), `registry=${ctx.registry_url}\n`);
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { baz: "0.0.3" },
+        }),
+      );
+
+      // First install: succeeds, writes lockfile + node_modules.
+      {
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("404");
+        expect(exitCode).toBe(0);
+      }
+
+      // Second install with node_modules removed and tarball now 404: should
+      // fail with a clear error, not hang. The lockfile is kept so the resolve
+      // phase is a no-op and the tarball download happens in the install phase.
+      await rm(join(ctx.package_dir, "node_modules"), { recursive: true, force: true });
+      tarballStatus = 404;
+      urls.length = 0;
+
+      {
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+
+        // Previously, the isolated installer would hang indefinitely here
+        // because the store entry's pending-task slot was never released.
+        expect(urls.some(u => u.endsWith(".tgz"))).toBe(true);
+        expect(stderr).toContain("baz");
+        expect(stderr).toMatch(/404/);
+        expect(stdout).not.toContain("1 package installed");
+        expect(exitCode).not.toBe(0);
+      }
+    });
+  });
+});

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -575,7 +575,9 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download fai
         // because the store entry's pending-task slot was never released.
         expect(urls.some(u => u.endsWith(".tgz"))).toBe(true);
         expect(stderr).toContain("baz");
-        expect(stderr).toMatch(/404/);
+        // The isolated installer maps the status to a human-readable
+        // reason phrase; the hoisted installer prints `GET <url> - 404`.
+        expect(stderr).toContain(linker === "isolated" ? "404 Not Found" : "404");
         expect(stdout).not.toContain("1 package installed");
         expect(exitCode).not.toBe(0);
       }


### PR DESCRIPTION
### What does this PR do?

Fixes `bun install` hanging indefinitely when a tarball download returns a 4xx/5xx HTTP error during the install phase (i.e. resolving from an existing lockfile with an empty cache/`node_modules`).

**Isolated linker hang.** `Store.Installer` registered `onPackageDownloadError = {}`, so when a tarball download or extraction failed, `runTasks` would `continue` without ever releasing the store entry's pending-task slot. The install loop then blocked forever on `pendingTaskCount() == 0`. This PR wires up `Store.Installer.onPackageDownloadError`, which drains the waiting entries from `task_queue`, marks them `.done` with a new `.download` failure variant, and prints a human-readable reason (`404 Not Found`, etc.). Git checkout failures now go through the same path so they also unblock the loop.

**Stale dedupe state.** Separately, on a non-retryable download failure (both the `response.fail` and HTTP 4xx/5xx branches in `runTasks`), the `task_queue` / `network_dedupe_map` entries for that `task_id` were never removed. A later `enqueuePackageForDownload` for the same package would see `found_existing`, skip scheduling a network task, and wait forever for a callback that will never arrive. We now clear both maps after giving up on a download.

The isolated installer's callback is keyed by `task_id` rather than `package_id` because that's what the queued `isolated_package_install_context` entries are indexed on; `runTasks` branches on `Ctx == *Store.Installer` to pass the right key.

### How did you verify your code works?

New test in `test/cli/install/bun-install-tarball-integrity.test.ts`, parameterised over both `hoisted` and `isolated` linkers:

1. Install once successfully against a fake registry (writes lockfile + populates cache).
2. `rm -rf node_modules`, flip the registry to return `404` for the tarball, install again.
3. Assert the process **exits non-zero** with `baz` and `404` in stderr, and does not report "1 package installed".

Before this change the isolated case hangs at step 2 and times out; after, both linkers fail fast with:

```
error: failed to download baz@0.0.3: 404 Not Found
  http://localhost:.../baz-0.0.3.tgz
```
