### PR TITLE
NativeReadableStreamSource#onClose: deref controller before clearing

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2009,10 +2009,9 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
 
     #onClose() {
       this.#closed = true;
+      var controller = this.#controller?.deref?.();
       this.#controller = undefined;
       this.$data = undefined;
-
-      var controller = this.#controller?.deref?.();
 
       $putByIdDirectPrivate(this, "stream", undefined);
       if (controller) {


### PR DESCRIPTION
## Summary
- `#onClose` cleared `this.#controller = undefined` and *then* dereferenced it, so `controller` was always `undefined` and the `$enqueueJob(callClose, controller)` block was dead code.
- Reordered to deref first.
- No observable behavior change: the next `#pull` already recovers via the `!handle || this.#closed` guard at the top, so the only effect is saving one redundant pull cycle on the close path. Found while tracing the native stdin close path for #29610 (now closed).

## Test plan
- [x] `bun bd test test/js/node/process/process-stdio.test.ts test/js/web/streams/streams.test.js` — 76 pass, 1 todo
- [ ] CI green
- No new test: could not construct a case where the extra pull cycle is observable (auto-pull after `read()` always hits the `#closed` guard immediately). Draft for that reason.