### PR TITLE
install: isolated linker honors active bun link

### DIFF
--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -983,10 +983,12 @@ pub const PackCommand = struct {
                     root_dir,
                     .silent,
                 );
+            } else {
+                // `files` not an array → malformed manifest. `bun pm pack`
+                // crashes here; we can't, so we mirror the no-`files` path
+                // (publish-default tree) instead of dropping everything.
+                try iterateProjectTree(allocator, &pack_queue, bins, .{ root_dir, "", 1 }, .silent);
             }
-            // `files` not an array → fall back to the whole tree. `bun pm
-            // pack` crashes here; we can't, so we mirror the no-`files`
-            // path (publish-default tree).
         } else {
             try iterateProjectTree(allocator, &pack_queue, bins, .{ root_dir, "", 1 }, .silent);
         }

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -910,6 +910,105 @@ pub const PackCommand = struct {
         }
     }
 
+    pub const PublishablePaths = struct {
+        arena: std.heap.ArenaAllocator,
+        /// Relative POSIX subpaths (sentinel-terminated) of files that
+        /// `bun pm pack` would include in the published tarball. Includes
+        /// `bin` entries and entries reachable via `package.json#files`
+        /// (or the entire tree if `files` is absent), and the auto-included
+        /// `package.json`. Default ignores plus `.npmignore` / `.gitignore`
+        /// at every depth are honored.
+        paths: []const [:0]const u8,
+
+        pub fn deinit(this: *@This()) void {
+            this.arena.deinit();
+        }
+    };
+
+    /// Single source of truth for "what files would `bun pm pack` ship?".
+    /// Used by the isolated linker (when honoring an active `bun link`) so
+    /// the contents of `node_modules/.bun/<pkg>/` match what a publish of
+    /// the producer would contain — including the auto-included
+    /// `package.json`, `bin` entries outside the `files` whitelist, and
+    /// the recursive semantics of `files: ["dist/**/*.js"]`-style globs.
+    /// Without this, callers were forced to mirror the publish rules by
+    /// hand and inevitably drifted (cf. nested same-name directories).
+    pub fn collectPublishablePaths(
+        parent_allocator: std.mem.Allocator,
+        root_dir: std.fs.Dir,
+        json_root: Expr,
+    ) OOM!PublishablePaths {
+        var arena = std.heap.ArenaAllocator.init(parent_allocator);
+        errdefer arena.deinit();
+        const allocator = arena.allocator();
+
+        var pack_queue = PackQueue.init(allocator, {});
+
+        const bins = try getPackageBins(allocator, json_root);
+
+        for (bins) |bin| {
+            switch (bin.type) {
+                .file => try pack_queue.add(.{ .path = bin.path, .optional = true }),
+                .dir => {
+                    const bin_dir = root_dir.openDir(bin.path, .{ .iterate = true }) catch continue;
+                    try iterateProjectTree(allocator, &pack_queue, &.{}, .{ bin_dir, bin.path, 2 }, .silent);
+                },
+            }
+        }
+
+        if (json_root.get("files")) |files| {
+            if (files.asArray()) |_files_array| {
+                var includes: std.ArrayListUnmanaged(Pattern) = .{};
+                var excludes: std.ArrayListUnmanaged(Pattern) = .{};
+
+                var path_buf: PathBuffer = undefined;
+                var files_array = _files_array;
+                while (files_array.next()) |files_entry| {
+                    const file_entry_str = files_entry.asString(allocator) orelse continue;
+                    const normalized = bun.path.normalizeBuf(file_entry_str, &path_buf, .posix);
+                    const parsed = try Pattern.fromUTF8(allocator, normalized) orelse continue;
+                    if (parsed.flags.negated) {
+                        try excludes.append(allocator, parsed);
+                    } else {
+                        try includes.append(allocator, parsed);
+                    }
+                }
+
+                try iterateIncludedProjectTree(
+                    allocator,
+                    &pack_queue,
+                    bins,
+                    includes.items,
+                    excludes.items,
+                    root_dir,
+                    .silent,
+                );
+            }
+            // `files` not an array → fall back to the whole tree. `bun pm
+            // pack` crashes here; we can't, so we mirror the no-`files`
+            // path (publish-default tree).
+        } else {
+            try iterateProjectTree(allocator, &pack_queue, bins, .{ root_dir, "", 1 }, .silent);
+        }
+
+        // `package.json` is unconditionally included — both iterators skip
+        // it explicitly because the pack pipeline writes it from a
+        // normalized AST. We don't have that pipeline; just ship the file.
+        const pkg_path = try allocator.dupeZ(u8, "package.json");
+
+        var paths = try allocator.alloc([:0]const u8, pack_queue.count() + 1);
+        paths[0] = pkg_path;
+        var i: usize = 1;
+        while (pack_queue.removeOrNull()) |item| : (i += 1) {
+            paths[i] = item.path;
+        }
+
+        return .{
+            .arena = arena,
+            .paths = paths,
+        };
+    }
+
     fn getBundledDeps(
         allocator: std.mem.Allocator,
         json: Expr,

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -95,6 +95,16 @@ global_link_dir: ?std.fs.Dir = null,
 global_dir: ?std.fs.Dir = null,
 global_link_dir_path: string = "",
 
+/// Names of packages registered via `bun link`, read from
+/// `<globalLinkDir>/` once per install. Populated on the main thread
+/// before any install worker starts; after that it's read-only and can
+/// be accessed lock-free from worker threads. Lookups return early
+/// when the set is empty (no active links) — the common case on dev
+/// machines without `bun link` configured, and unconditional on CI.
+/// See `populateLinkedNamesCache` / `linkedPackagePath`.
+linked_names: bun.StringHashMapUnmanaged(void) = .{},
+linked_names_populated: bool = false,
+
 onWake: WakeHandler = .{},
 ci_mode: bun.LazyBool(computeIsContinuousIntegration, @This(), "ci_mode") = .{},
 
@@ -1178,6 +1188,7 @@ pub const globalLinkDir = directories.globalLinkDir;
 pub const globalLinkDirAndPath = directories.globalLinkDirAndPath;
 pub const globalLinkDirPath = directories.globalLinkDirPath;
 pub const linkedPackagePath = directories.linkedPackagePath;
+pub const populateLinkedNamesCache = directories.populateLinkedNamesCache;
 pub const isFolderInCache = directories.isFolderInCache;
 pub const pathForCachedNPMPath = directories.pathForCachedNPMPath;
 pub const pathForResolution = directories.pathForResolution;

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -1177,6 +1177,7 @@ pub const getTemporaryDirectory = directories.getTemporaryDirectory;
 pub const globalLinkDir = directories.globalLinkDir;
 pub const globalLinkDirAndPath = directories.globalLinkDirAndPath;
 pub const globalLinkDirPath = directories.globalLinkDirPath;
+pub const linkedPackagePath = directories.linkedPackagePath;
 pub const isFolderInCache = directories.isFolderInCache;
 pub const pathForCachedNPMPath = directories.pathForCachedNPMPath;
 pub const pathForResolution = directories.pathForResolution;

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -421,7 +421,25 @@ pub fn populateLinkedNamesCache(this: *PackageManager) void {
     if (this.linked_names_populated) return;
     this.linked_names_populated = true;
 
-    const dir_path = this.globalLinkDirPath();
+    // Best-effort: for users who have never run `bun link`, the global
+    // link dir may not exist (or may be unreadable). `globalLinkDirPath`
+    // would `Global.exit(1)` on setup failure — treat that same failure
+    // here as "no links on this machine" instead, and leave the cache
+    // empty so `linkedPackagePath` short-circuits to null. If a later
+    // code path really does need the global dir (e.g. `bun link`
+    // itself), `globalLinkDirPath` will be called on that path and
+    // surface the error there.
+    const dir_path = dir_path: {
+        if (this.global_link_dir_path.len != 0) break :dir_path this.global_link_dir_path;
+        var global_dir = Options.openGlobalDir(this.options.explicit_global_directory) catch return;
+        const link_dir = global_dir.makeOpenPath("node_modules", .{}) catch return;
+        this.global_dir = global_dir;
+        this.global_link_dir = link_dir;
+        var buf: bun.PathBuffer = undefined;
+        const path_slice = bun.getFdPath(.fromStdDir(link_dir), &buf) catch return;
+        this.global_link_dir_path = bun.handleOom(Fs.FileSystem.DirnameStore.instance.append([]const u8, path_slice));
+        break :dir_path this.global_link_dir_path;
+    };
     const root_fd = switch (bun.openDirForIteration(bun.FD.cwd(), dir_path)) {
         .result => |fd| fd,
         // Dir missing / unreadable → empty set. Every linkedPackagePath
@@ -453,15 +471,15 @@ pub fn populateLinkedNamesCache(this: *PackageManager) void {
             while (scope_iter.next().unwrap() catch null) |scope_entry| {
                 const sub_name = scope_entry.name.slice();
                 if (sub_name.len == 0) continue;
-                const full = std.fmt.allocPrint(this.allocator, "{s}/{s}", .{ name, sub_name }) catch continue;
-                this.linked_names.put(this.allocator, full, {}) catch continue;
+                const full = bun.handleOom(std.fmt.allocPrint(this.allocator, "{s}/{s}", .{ name, sub_name }));
+                bun.handleOom(this.linked_names.put(this.allocator, full, {}));
             }
             continue;
         }
 
         if (comptime bun.Environment.isWindows) continue;
-        const dup = this.allocator.dupe(u8, name) catch continue;
-        this.linked_names.put(this.allocator, dup, {}) catch continue;
+        const dup = bun.handleOom(this.allocator.dupe(u8, name));
+        bun.handleOom(this.linked_names.put(this.allocator, dup, {}));
     }
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -422,6 +422,10 @@ pub fn linkedPackagePath(
     if (pkg_name.len == 0) return null;
     const dir_path = this.globalLinkDirPath();
     const joined = bun.path.joinAbsStringBufZ(dir_path, buf, &.{pkg_name}, .auto);
+    if (comptime bun.Environment.isWindows) {
+        const attrs = bun.sys.getFileAttributes(joined) orelse return null;
+        return if (attrs.is_directory or attrs.is_reparse_point) joined else null;
+    }
     return switch (bun.sys.lstat(joined)) {
         .result => |st| brk: {
             const mode: u32 = @intCast(st.mode);

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -410,6 +410,30 @@ pub fn globalLinkDirAndPath(this: *PackageManager) struct { std.fs.Dir, []const 
     return .{ dir, this.global_link_dir_path };
 }
 
+/// If `<globalLinkDir>/<pkg_name>` exists (typically a symlink created by
+/// `bun link` from the producer dir), write its absolute path into `buf` and
+/// return it. Otherwise `null`. Scoped names (`@scope/name`) are handled
+/// because `joinAbsStringBufZ` preserves the `/`. One `lstat` per call.
+pub fn linkedPackagePath(
+    this: *PackageManager,
+    pkg_name: []const u8,
+    buf: *bun.PathBuffer,
+) ?[:0]const u8 {
+    if (pkg_name.len == 0) return null;
+    const dir_path = this.globalLinkDirPath();
+    const joined = bun.path.joinAbsStringBufZ(dir_path, buf, &.{pkg_name}, .auto);
+    return switch (bun.sys.lstat(joined)) {
+        .result => |st| brk: {
+            const mode: u32 = @intCast(st.mode);
+            if (std.posix.S.ISDIR(mode) or std.posix.S.ISLNK(mode)) {
+                break :brk joined;
+            }
+            break :brk null;
+        },
+        .err => null,
+    };
+}
+
 pub fn pathForCachedNPMPath(
     this: *PackageManager,
     buf: *bun.PathBuffer,

--- a/src/install/PackageManager/PackageManagerDirectories.zig
+++ b/src/install/PackageManager/PackageManagerDirectories.zig
@@ -410,16 +410,87 @@ pub fn globalLinkDirAndPath(this: *PackageManager) struct { std.fs.Dir, []const 
     return .{ dir, this.global_link_dir_path };
 }
 
+/// Read the global link dir once and populate
+/// `this.linked_names` with every registered package name (including
+/// scoped names as `@scope/name`). Must be called on the main thread
+/// before any install worker touches `linkedPackagePath`; after that
+/// the map is read-only and lock-free.
+///
+/// Safe to call repeatedly; subsequent calls are no-ops.
+pub fn populateLinkedNamesCache(this: *PackageManager) void {
+    if (this.linked_names_populated) return;
+    this.linked_names_populated = true;
+
+    const dir_path = this.globalLinkDirPath();
+    const root_fd = switch (bun.openDirForIteration(bun.FD.cwd(), dir_path)) {
+        .result => |fd| fd,
+        // Dir missing / unreadable → empty set. Every linkedPackagePath
+        // lookup will short-circuit to null with no further syscalls.
+        .err => return,
+    };
+    defer root_fd.close();
+
+    var iter = bun.DirIterator.iterate(root_fd, if (bun.Environment.isWindows) .u16 else .u8);
+    while (iter.next().unwrap() catch null) |entry| {
+        const name = entry.name.slice();
+        if (name.len == 0) continue;
+
+        // Scope dirs (`@scope`) contain the actual links nested one
+        // level deeper; flatten to `@scope/name` in the cache.
+        if (name[0] == '@' and entry.kind == .directory) {
+            if (comptime bun.Environment.isWindows) {
+                // WTF-16 name; skip scope flattening on Windows for now.
+                // Falls through to the lstat path in linkedPackagePath.
+                continue;
+            }
+            const scope_fd = switch (bun.openDirForIteration(root_fd, name)) {
+                .result => |fd| fd,
+                .err => continue,
+            };
+            defer scope_fd.close();
+
+            var scope_iter = bun.DirIterator.iterate(scope_fd, .u8);
+            while (scope_iter.next().unwrap() catch null) |scope_entry| {
+                const sub_name = scope_entry.name.slice();
+                if (sub_name.len == 0) continue;
+                const full = std.fmt.allocPrint(this.allocator, "{s}/{s}", .{ name, sub_name }) catch continue;
+                this.linked_names.put(this.allocator, full, {}) catch continue;
+            }
+            continue;
+        }
+
+        if (comptime bun.Environment.isWindows) continue;
+        const dup = this.allocator.dupe(u8, name) catch continue;
+        this.linked_names.put(this.allocator, dup, {}) catch continue;
+    }
+}
+
 /// If `<globalLinkDir>/<pkg_name>` exists (typically a symlink created by
 /// `bun link` from the producer dir), write its absolute path into `buf` and
 /// return it. Otherwise `null`. Scoped names (`@scope/name`) are handled
-/// because `joinAbsStringBufZ` preserves the `/`. One `lstat` per call.
+/// because `joinAbsStringBufZ` preserves the `/`.
+///
+/// Performance: when `linked_names` has been populated (via
+/// `populateLinkedNamesCache` at install start), this is a single
+/// hashmap check with no syscalls. When the cache is empty (no active
+/// links on this machine), it returns immediately. Falls back to the
+/// per-call `lstat` when the cache has not been populated (e.g. on
+/// Windows, or if a caller runs outside the isolated-install flow).
 pub fn linkedPackagePath(
     this: *PackageManager,
     pkg_name: []const u8,
     buf: *bun.PathBuffer,
 ) ?[:0]const u8 {
     if (pkg_name.len == 0) return null;
+
+    const use_cache = this.linked_names_populated and !bun.Environment.isWindows;
+    if (use_cache) {
+        if (this.linked_names.count() == 0) return null;
+        if (!this.linked_names.contains(pkg_name)) return null;
+        const dir_path = this.globalLinkDirPath();
+        return bun.path.joinAbsStringBufZ(dir_path, buf, &.{pkg_name}, .auto);
+    }
+
     const dir_path = this.globalLinkDirPath();
     const joined = bun.path.joinAbsStringBufZ(dir_path, buf, &.{pkg_name}, .auto);
     if (comptime bun.Environment.isWindows) {

--- a/src/install/PackageManager/WorkspacePackageJSONCache.zig
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.zig
@@ -27,6 +27,15 @@ pub const GetResult = union(enum) {
 };
 
 map: Map = .{},
+/// `getWithPath` / `getWithSource` mutate `map` (which invalidates
+/// previously-returned `*MapEntry` pointers on grow) and call
+/// `initializeStore()` + the JSON parser — none of which are
+/// thread-safe. Multi-threaded callers (currently only the isolated
+/// installer's `Task.run`) must hold this mutex across both the call
+/// *and* any use of the returned entry pointer, since a concurrent
+/// call would otherwise grow the map and invalidate the pointer.
+/// Single-threaded callers can ignore it.
+lock: bun.Mutex = .{},
 
 /// Given an absolute path to a workspace package.json, return the AST
 /// and contents of the file. If the package.json is not present in the

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -835,6 +835,7 @@ fn overwritePackageInNodeModulesFolder(
         .fromStdDir(cached_package_folder),
         src_path,
         dest_subpath,
+        &.{},
         ignore_directories,
     );
     defer copier.deinit();

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -10,6 +10,15 @@ pub fn installIsolatedPackages(
 ) OOM!PackageInstall.Summary {
     bun.analytics.Features.isolated_bun_install += 1;
 
+    // Populate the linked-names cache once, on the main thread, before
+    // any install worker calls `manager.linkedPackagePath()`. Replaces a
+    // per-dependency `lstat` with a single readdir of the global link
+    // dir; short-circuits every subsequent lookup when nothing is
+    // linked (the common case on CI and dev machines without active
+    // links). See populateLinkedNamesCache in
+    // PackageManager/PackageManagerDirectories.zig.
+    manager.populateLinkedNamesCache();
+
     const lockfile = manager.lockfile;
 
     const store: Store = store: {

--- a/src/install/isolated_install.zig
+++ b/src/install/isolated_install.zig
@@ -1577,6 +1577,17 @@ pub fn installIsolatedPackages(
                     // write the new project-local tree through the link into
                     // the shared cache). Treat the stale link as
                     // needs-install so `link_package` detaches and rebuilds.
+                    // An active `bun link` for this package name means the
+                    // producer dir is the source of truth — override the
+                    // cache-based materialization regardless of whether the
+                    // store dir already exists. The existence check below
+                    // would otherwise short-circuit and leave the body stale.
+                    // Only fires when the user didn't opt into the
+                    // symlink-only backend.
+                    var link_buf: bun.PathBuffer = undefined;
+                    const has_active_link = PackageInstall.supported_method != .symlink and
+                        manager.linkedPackagePath(pkg_name.slice(string_buf), &link_buf) != null;
+
                     const has_stale_gvs_link = !uses_global_store and stale: {
                         if (installer.global_store_path == null) break :stale false;
                         var local: bun.Path(.{ .sep = .auto }) = .initTopLevelDir();
@@ -1599,6 +1610,7 @@ pub fn installIsolatedPackages(
                         // should still take the cheap symlink-only path.
                         (is_new_bun_modules and !uses_global_store) or
                         has_stale_gvs_link or
+                        has_active_link or
                         patch_info == .remove or
                         needs_install: {
                             var store_path: bun.AbsPath(.{}) = .initTopLevelDir();
@@ -1654,6 +1666,15 @@ pub fn installIsolatedPackages(
                         // .monotonic is okay because the task isn't running on another thread.
                         entry_steps[entry_id.get()].store(.done, .monotonic);
                         installer.onTaskComplete(entry_id, .skipped);
+                        continue;
+                    }
+
+                    // `link_package` will source from the producer dir via
+                    // `linkedPackagePath`; skip the cache-fetch dance entirely
+                    // (mirrors how `.folder` is handled — no registry traffic
+                    // needed when the body comes from an on-disk producer).
+                    if (has_active_link) {
+                        installer.startTask(entry_id);
                         continue;
                     }
 

--- a/src/install/isolated_install/FileCopier.zig
+++ b/src/install/isolated_install/FileCopier.zig
@@ -7,6 +7,7 @@ pub const FileCopier = struct {
         src_dir: FD,
         src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
         dest_subpath: bun.Path(.{ .sep = .auto, .unit = .os }),
+        skip_filenames: []const bun.OSPathSlice,
         skip_dirnames: []const bun.OSPathSlice,
     ) OOM!FileCopier {
         return .{
@@ -16,7 +17,7 @@ pub const FileCopier = struct {
                 var w = try Walker.walk(
                     src_dir,
                     bun.default_allocator,
-                    &.{},
+                    skip_filenames,
                     skip_dirnames,
                 );
                 w.resolve_unknown_entry_types = true;

--- a/src/install/isolated_install/Hardlinker.zig
+++ b/src/install/isolated_install/Hardlinker.zig
@@ -9,6 +9,7 @@ pub fn init(
     folder_dir: FD,
     src: bun.AbsPath(.{ .sep = .auto, .unit = .os }),
     dest: bun.Path(.{ .sep = .auto, .unit = .os }),
+    skip_filenames: []const bun.OSPathSlice,
     skip_dirnames: []const bun.OSPathSlice,
 ) OOM!Hardlinker {
     return .{
@@ -19,7 +20,7 @@ pub fn init(
             var w = try Walker.walk(
                 folder_dir,
                 bun.default_allocator,
-                &.{},
+                skip_filenames,
                 skip_dirnames,
             );
             w.resolve_unknown_entry_types = true;

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -514,6 +514,40 @@ pub const Installer = struct {
                                     };
                                     defer folder_dir.close();
 
+                                    // Producer root is a working repo, not a published
+                                    // tarball. Mirror `bun pm pack`'s exact-name default
+                                    // ignores (see `default_ignore_patterns` /
+                                    // `root_default_ignore_patterns` in
+                                    // `src/cli/pack_command.zig`) so the installed
+                                    // `.bun/<hash>/<pkg>/` matches what a publish of the
+                                    // producer would contain. Glob patterns (`.*.swp`,
+                                    // `._*`, `.wafpickle-*`) are not handled by the
+                                    // Walker's exact-name hash filter; acceptable
+                                    // for this fix — if a consumer hits one, follow-up
+                                    // work can plumb pack_command's filter directly.
+                                    const linked_skip_dirs: []const bun.OSPathSlice = &.{
+                                        comptime bun.OSPathLiteral("node_modules"),
+                                        comptime bun.OSPathLiteral(".git"),
+                                        comptime bun.OSPathLiteral(".hg"),
+                                        comptime bun.OSPathLiteral(".svn"),
+                                        comptime bun.OSPathLiteral("CVS"),
+                                    };
+                                    const linked_skip_files: []const bun.OSPathSlice = &.{
+                                        comptime bun.OSPathLiteral(".DS_Store"),
+                                        comptime bun.OSPathLiteral(".gitignore"),
+                                        comptime bun.OSPathLiteral(".npmignore"),
+                                        comptime bun.OSPathLiteral(".npmrc"),
+                                        comptime bun.OSPathLiteral(".lock-wscript"),
+                                        comptime bun.OSPathLiteral("npm-debug.log"),
+                                        comptime bun.OSPathLiteral("bunfig.toml"),
+                                        comptime bun.OSPathLiteral(".env.production"),
+                                        comptime bun.OSPathLiteral("package-lock.json"),
+                                        comptime bun.OSPathLiteral("yarn.lock"),
+                                        comptime bun.OSPathLiteral("pnpm-lock.yaml"),
+                                        comptime bun.OSPathLiteral("bun.lockb"),
+                                        comptime bun.OSPathLiteral("bun.lock"),
+                                    };
+
                                     const uses_global_store_link = installer.entryUsesGlobalStore(this.entry_id);
                                     if (uses_global_store_link) {
                                         // Previous staging from a crashed run would
@@ -551,7 +585,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src,
                                                 dest,
-                                                &.{comptime bun.OSPathLiteral("node_modules")},
+                                                linked_skip_files,
+                                                linked_skip_dirs,
                                             );
                                             defer hardlinker.deinit();
 
@@ -599,7 +634,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src_path,
                                                 dest,
-                                                &.{comptime bun.OSPathLiteral("node_modules")},
+                                                linked_skip_files,
+                                                linked_skip_dirs,
                                             );
                                             defer file_copier.deinit();
 
@@ -667,6 +703,7 @@ pub const Installer = struct {
                                         folder_dir,
                                         src,
                                         dest,
+                                        &.{},
                                         &.{comptime bun.OSPathLiteral("node_modules")},
                                     );
                                     defer hardlinker.deinit();
@@ -732,6 +769,7 @@ pub const Installer = struct {
                                         folder_dir,
                                         src_path,
                                         dest,
+                                        &.{},
                                         &.{comptime bun.OSPathLiteral("node_modules")},
                                     );
                                     defer file_copier.deinit();
@@ -905,6 +943,7 @@ pub const Installer = struct {
                                 src,
                                 dest_subpath,
                                 &.{},
+                                &.{},
                             );
                             defer hardlinker.deinit();
 
@@ -971,6 +1010,7 @@ pub const Installer = struct {
                                 cached_package_dir.?,
                                 src_path,
                                 dest_subpath,
+                                &.{},
                                 &.{},
                             );
                             defer file_copier.deinit();

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -522,6 +522,19 @@ pub const Installer = struct {
                                         defer staging.deinit();
                                         installer.appendGlobalStoreEntryPath(&staging, this.entry_id, .staging);
                                         FD.cwd().deleteTree(staging.slice()) catch {};
+
+                                        // Producer content is mutable (the live `bun
+                                        // link` symlink points at an editor-owned
+                                        // dir), so the content-addressed assumption
+                                        // of the global store doesn't hold: the
+                                        // previous `<final>` is *not* byte-equivalent
+                                        // to the producer's current tree. Commit's
+                                        // collision-is-success path would otherwise
+                                        // keep serving the stale entry on reinstall.
+                                        var final: bun.AbsPath(.{ .sep = .auto }) = .init();
+                                        defer final.deinit();
+                                        installer.appendGlobalStoreEntryPath(&final, this.entry_id, .final);
+                                        FD.cwd().deleteTree(final.slice()) catch {};
                                     }
 
                                     backend: switch (PackageInstall.Method.hardlink) {

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -586,65 +586,88 @@ pub const Installer = struct {
                                             &.{"package.json"},
                                             .auto,
                                         );
-                                        switch (manager.workspace_package_json_cache.getWithPath(
-                                            manager.allocator,
-                                            manager.log,
-                                            pkg_path,
-                                            .{},
-                                        )) {
-                                            .entry => |json_entry| blk: {
-                                                var files_iter = json_entry.root.getArray("files") orelse break :blk;
-
-                                                var whitelist: std.StringHashMapUnmanaged(void) = .{};
-                                                // Only ASCII exact-match entries plus a
-                                                // separate always-include check below.
-                                                while (files_iter.next()) |item| {
-                                                    const s = item.asString(manager.allocator) orelse continue;
-                                                    if (s.len == 0) continue;
-                                                    // Collapse "dist/bundle.js" → "dist":
-                                                    // whitelist the top-level segment so
-                                                    // we keep enough of the tree for the
-                                                    // nested entry to land.
-                                                    const slash = std.mem.indexOfAny(u8, s, "/\\") orelse s.len;
-                                                    const top = s[0..slash];
-                                                    if (top.len == 0) continue;
-                                                    whitelist.put(extra_alloc, top, {}) catch continue;
-                                                }
-
-                                                // Iterate on a *separate* fd so we don't
-                                                // consume `folder_dir`'s dir stream —
-                                                // Hardlinker's Walker will `getdents`
-                                                // that same fd and rely on it being at
-                                                // the start.
-                                                const scan_fd = switch (bun.openDirForIteration(FD.cwd(), producer_path)) {
-                                                    .result => |fd| fd,
-                                                    .err => break :blk,
-                                                };
-                                                defer scan_fd.close();
-
-                                                var root_iter = bun.DirIterator.iterate(scan_fd, if (Environment.isWindows) .u16 else .u8);
-                                                root_loop: while (root_iter.next().unwrap() catch null) |root_entry| {
-                                                    const name_slice = root_entry.name.slice();
-                                                    // Auto-included regardless of `files`:
-                                                    if (bun.strings.eqlComptime(name_slice, "package.json")) continue;
-                                                    inline for (.{ "README", "CHANGELOG", "LICENSE", "LICENCE" }) |prefix| {
-                                                        if (name_slice.len >= prefix.len and
-                                                            bun.strings.eqlCaseInsensitiveASCII(name_slice[0..prefix.len], prefix, true) and
-                                                            (name_slice.len == prefix.len or name_slice[prefix.len] == '.'))
-                                                        {
-                                                            continue :root_loop;
-                                                        }
+                                        // The cache is shared across install
+                                        // worker threads and returns a
+                                        // `*MapEntry` pointer that is
+                                        // invalidated if another thread grows
+                                        // the underlying hashmap. Hold the
+                                        // cache lock for the entry lookup and
+                                        // the whitelist build (both read the
+                                        // entry), then release before the
+                                        // scan-fd section, which only touches
+                                        // process-local data.
+                                        const cache = &manager.workspace_package_json_cache;
+                                        cache.lock.lock();
+                                        var whitelist: std.StringHashMapUnmanaged(void) = .{};
+                                        var have_whitelist = false;
+                                        switch (cache.getWithPath(manager.allocator, manager.log, pkg_path, .{})) {
+                                            .entry => |json_entry| {
+                                                if (json_entry.root.getArray("files")) |files_array_const| {
+                                                    var files_iter = files_array_const;
+                                                    while (files_iter.next()) |item| {
+                                                        const s = item.asString(manager.allocator) orelse continue;
+                                                        if (s.len == 0) continue;
+                                                        // npm `files` supports `!pattern`
+                                                        // negation to exclude from the
+                                                        // otherwise-included set. We only
+                                                        // implement positive top-segment
+                                                        // whitelisting; skip negated
+                                                        // entries so `!dist/internal`
+                                                        // doesn't get turned into a
+                                                        // whitelist key `!dist`.
+                                                        if (s[0] == '!') continue;
+                                                        // Collapse "dist/bundle.js" → "dist":
+                                                        // whitelist the top-level segment so
+                                                        // we keep enough of the tree for the
+                                                        // nested entry to land.
+                                                        const slash = std.mem.indexOfAny(u8, s, "/\\") orelse s.len;
+                                                        const top = s[0..slash];
+                                                        if (top.len == 0) continue;
+                                                        // `top` is a slice into the cached
+                                                        // parsed source, which outlives the
+                                                        // install. Safe to store as-is.
+                                                        whitelist.put(extra_alloc, top, {}) catch continue;
                                                     }
-                                                    if (whitelist.contains(name_slice)) continue;
-                                                    const stored = extra_alloc.dupe(bun.OSPathChar, name_slice) catch continue;
-                                                    const stored_slice: bun.OSPathSlice = stored;
-                                                    switch (root_entry.kind) {
-                                                        .directory => extra_skip_dirs.append(extra_alloc, stored_slice) catch {},
-                                                        else => extra_skip_files.append(extra_alloc, stored_slice) catch {},
-                                                    }
+                                                    have_whitelist = true;
                                                 }
                                             },
                                             else => {},
+                                        }
+                                        cache.lock.unlock();
+
+                                        if (have_whitelist) blk: {
+                                            // Iterate on a *separate* fd so we don't
+                                            // consume `folder_dir`'s dir stream —
+                                            // Hardlinker's Walker will `getdents`
+                                            // that same fd and rely on it being at
+                                            // the start.
+                                            const scan_fd = switch (bun.openDirForIteration(FD.cwd(), producer_path)) {
+                                                .result => |fd| fd,
+                                                .err => break :blk,
+                                            };
+                                            defer scan_fd.close();
+
+                                            var root_iter = bun.DirIterator.iterate(scan_fd, if (Environment.isWindows) .u16 else .u8);
+                                            root_loop: while (root_iter.next().unwrap() catch null) |root_entry| {
+                                                const name_slice = root_entry.name.slice();
+                                                // Auto-included regardless of `files`:
+                                                if (bun.strings.eqlComptime(name_slice, "package.json")) continue;
+                                                inline for (.{ "README", "CHANGELOG", "LICENSE", "LICENCE" }) |prefix| {
+                                                    if (name_slice.len >= prefix.len and
+                                                        bun.strings.eqlCaseInsensitiveASCII(name_slice[0..prefix.len], prefix, true) and
+                                                        (name_slice.len == prefix.len or name_slice[prefix.len] == '.'))
+                                                    {
+                                                        continue :root_loop;
+                                                    }
+                                                }
+                                                if (whitelist.contains(name_slice)) continue;
+                                                const stored = extra_alloc.dupe(bun.OSPathChar, name_slice) catch continue;
+                                                const stored_slice: bun.OSPathSlice = stored;
+                                                switch (root_entry.kind) {
+                                                    .directory => extra_skip_dirs.append(extra_alloc, stored_slice) catch {},
+                                                    else => extra_skip_files.append(extra_alloc, stored_slice) catch {},
+                                                }
+                                            }
                                         }
                                     }
 
@@ -684,6 +707,17 @@ pub const Installer = struct {
                                         var final: bun.AbsPath(.{ .sep = .auto }) = .init();
                                         defer final.deinit();
                                         installer.appendGlobalStoreEntryPath(&final, this.entry_id, .final);
+                                        FD.cwd().deleteTree(final.slice()) catch {};
+                                    } else {
+                                        // Non-global linked entries write straight to
+                                        // the project-local final path (no staging).
+                                        // Re-hardlinking would layer atop whatever
+                                        // was left from the previous install, so
+                                        // files the producer has since deleted would
+                                        // remain. Wipe the entry dir first.
+                                        var final: bun.Path(.{ .sep = .auto }) = .init();
+                                        defer final.deinit();
+                                        installer.appendRealStorePath(&final, this.entry_id, .final);
                                         FD.cwd().deleteTree(final.slice()) catch {};
                                     }
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -496,6 +496,113 @@ pub const Installer = struct {
 
                     var pkg_cache_dir_subpath: bun.AutoRelPath = .from(switch (pkg_res.tag) {
                         else => |tag| pkg_cache_dir_subpath: {
+                            // If an active `bun link` is registered for this
+                            // package name and the user did not opt into the
+                            // symlink backend, source the body from the
+                            // producer dir instead of the registry tarball
+                            // cache. Under isolated linking the top-level
+                            // symlink-only contract isn't available, so
+                            // without this the `.bun/<storepath>` body stays
+                            // pinned to the (stale) tarball cache while the
+                            // top-level symlink points at the producer.
+                            if (installer.supported_backend.load(.monotonic) != .symlink) {
+                                var linked_buf: bun.PathBuffer = undefined;
+                                if (manager.linkedPackagePath(pkg_name.slice(string_buf), &linked_buf)) |producer_path| {
+                                    const folder_dir = switch (bun.openDirForIteration(FD.cwd(), producer_path)) {
+                                        .result => |fd| fd,
+                                        .err => |err| return .failure(.{ .link_package = err }),
+                                    };
+                                    defer folder_dir.close();
+
+                                    const uses_global_store_link = installer.entryUsesGlobalStore(this.entry_id);
+                                    if (uses_global_store_link) {
+                                        // Previous staging from a crashed run would
+                                        // otherwise collide with our fresh writes.
+                                        var staging: bun.AbsPath(.{ .sep = .auto }) = .init();
+                                        defer staging.deinit();
+                                        installer.appendGlobalStoreEntryPath(&staging, this.entry_id, .staging);
+                                        FD.cwd().deleteTree(staging.slice()) catch {};
+                                    }
+
+                                    backend: switch (PackageInstall.Method.hardlink) {
+                                        .hardlink => {
+                                            var src: bun.AbsPath(.{ .unit = .os, .sep = .auto }) = .initTopLevelDirLongPath();
+                                            defer src.deinit();
+                                            src.appendJoin(@as([]const u8, producer_path));
+
+                                            var dest: bun.Path(.{ .unit = .os, .sep = .auto }) = .init();
+                                            defer dest.deinit();
+                                            installer.appendRealStorePath(&dest, this.entry_id, .staging);
+
+                                            var hardlinker: Hardlinker = try .init(
+                                                folder_dir,
+                                                src,
+                                                dest,
+                                                &.{comptime bun.OSPathLiteral("node_modules")},
+                                            );
+                                            defer hardlinker.deinit();
+
+                                            switch (try hardlinker.link()) {
+                                                .result => {},
+                                                .err => |err| {
+                                                    if (err.getErrno() == .XDEV) {
+                                                        continue :backend .copyfile;
+                                                    }
+                                                    return .failure(.{ .link_package = err });
+                                                },
+                                            }
+                                        },
+
+                                        .copyfile => {
+                                            var src_path: bun.AbsPath(.{ .sep = .auto, .unit = .os }) = .init();
+                                            defer src_path.deinit();
+
+                                            if (comptime Environment.isWindows) {
+                                                const src_path_len = bun.windows.GetFinalPathNameByHandleW(
+                                                    folder_dir.cast(),
+                                                    src_path.buf().ptr,
+                                                    @intCast(src_path.buf().len),
+                                                    0,
+                                                );
+
+                                                if (src_path_len == 0 or src_path_len >= src_path.buf().len) {
+                                                    const err: bun.sys.SystemErrno = if (src_path_len == 0)
+                                                        (bun.windows.Win32Error.get().toSystemErrno() orelse .EUNKNOWN)
+                                                    else
+                                                        .ENAMETOOLONG;
+                                                    return .failure(
+                                                        .{ .link_package = .{ .errno = @intFromEnum(err), .syscall = .copyfile } },
+                                                    );
+                                                }
+
+                                                src_path.setLength(src_path_len);
+                                            }
+
+                                            var dest: bun.Path(.{ .unit = .os, .sep = .auto }) = .init();
+                                            defer dest.deinit();
+                                            installer.appendRealStorePath(&dest, this.entry_id, .staging);
+
+                                            var file_copier: FileCopier = try .init(
+                                                folder_dir,
+                                                src_path,
+                                                dest,
+                                                &.{comptime bun.OSPathLiteral("node_modules")},
+                                            );
+                                            defer file_copier.deinit();
+
+                                            switch (file_copier.copy()) {
+                                                .result => {},
+                                                .err => |err| return .failure(.{ .link_package = err }),
+                                            }
+                                        },
+
+                                        else => unreachable,
+                                    }
+
+                                    continue :next_step this.nextStep(current_step);
+                                }
+                            }
+
                             const patch_info = try installer.packagePatchInfo(
                                 pkg_name,
                                 pkg_name_hash,

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -555,11 +555,11 @@ pub const Installer = struct {
                                                 else => break :publishable null,
                                             }
                                         };
-                                        break :publishable bun.cli.PackCommand.collectPublishablePaths(
+                                        break :publishable bun.handleOom(bun.cli.PackCommand.collectPublishablePaths(
                                             manager.allocator,
                                             folder_dir.stdDir(),
                                             root,
-                                        ) catch null;
+                                        ));
                                     };
                                     var publishable_owned = publishable;
                                     defer if (publishable_owned) |*p| p.deinit();

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -548,6 +548,122 @@ pub const Installer = struct {
                                         comptime bun.OSPathLiteral("bun.lock"),
                                     };
 
+                                    // If the producer's package.json has a `files`
+                                    // array, `bun pm pack` treats it as a root-level
+                                    // whitelist: anything not named there (and not
+                                    // auto-included like package.json / README* /
+                                    // LICENSE* / CHANGELOG*) is stripped from the
+                                    // tarball. Mirror that here by pre-scanning the
+                                    // producer's root and appending non-whitelisted
+                                    // names to the Walker skip lists.
+                                    //
+                                    // Limitation: the Walker matches by basename at
+                                    // any depth, so a root-only exclusion also skips
+                                    // same-named entries nested under a whitelisted
+                                    // dir. Uncommon in practice (producers don't
+                                    // nest a second `src/` inside `dist/`); a
+                                    // follow-up can replace this with path-based
+                                    // filtering or reuse pack_command directly.
+                                    //
+                                    // Also unhandled here: `main`/`bin`/`module` is
+                                    // outside the `files` whitelist — npm would
+                                    // still publish the referenced file.
+                                    var extra_skip_arena = std.heap.ArenaAllocator.init(manager.allocator);
+                                    defer extra_skip_arena.deinit();
+                                    const extra_alloc = extra_skip_arena.allocator();
+                                    var extra_skip_dirs: std.ArrayListUnmanaged(bun.OSPathSlice) = .{};
+                                    var extra_skip_files: std.ArrayListUnmanaged(bun.OSPathSlice) = .{};
+                                    // Windows `DirIterator` yields WTF-16 basenames,
+                                    // which don't fit the ASCII-u8 comparators used
+                                    // below. Treat the `files` whitelist as a
+                                    // POSIX-only enhancement for now; Windows linked
+                                    // installs still apply the base default-excludes.
+                                    if (comptime !Environment.isWindows) {
+                                        var pkg_path_buf: bun.PathBuffer = undefined;
+                                        const pkg_path = bun.path.joinAbsStringBufZ(
+                                            producer_path,
+                                            &pkg_path_buf,
+                                            &.{"package.json"},
+                                            .auto,
+                                        );
+                                        switch (manager.workspace_package_json_cache.getWithPath(
+                                            manager.allocator,
+                                            manager.log,
+                                            pkg_path,
+                                            .{},
+                                        )) {
+                                            .entry => |json_entry| blk: {
+                                                var files_iter = json_entry.root.getArray("files") orelse break :blk;
+
+                                                var whitelist: std.StringHashMapUnmanaged(void) = .{};
+                                                // Only ASCII exact-match entries plus a
+                                                // separate always-include check below.
+                                                while (files_iter.next()) |item| {
+                                                    const s = item.asString(manager.allocator) orelse continue;
+                                                    if (s.len == 0) continue;
+                                                    // Collapse "dist/bundle.js" → "dist":
+                                                    // whitelist the top-level segment so
+                                                    // we keep enough of the tree for the
+                                                    // nested entry to land.
+                                                    const slash = std.mem.indexOfAny(u8, s, "/\\") orelse s.len;
+                                                    const top = s[0..slash];
+                                                    if (top.len == 0) continue;
+                                                    whitelist.put(extra_alloc, top, {}) catch continue;
+                                                }
+
+                                                // Iterate on a *separate* fd so we don't
+                                                // consume `folder_dir`'s dir stream —
+                                                // Hardlinker's Walker will `getdents`
+                                                // that same fd and rely on it being at
+                                                // the start.
+                                                const scan_fd = switch (bun.openDirForIteration(FD.cwd(), producer_path)) {
+                                                    .result => |fd| fd,
+                                                    .err => break :blk,
+                                                };
+                                                defer scan_fd.close();
+
+                                                var root_iter = bun.DirIterator.iterate(scan_fd, if (Environment.isWindows) .u16 else .u8);
+                                                root_loop: while (root_iter.next().unwrap() catch null) |root_entry| {
+                                                    const name_slice = root_entry.name.slice();
+                                                    // Auto-included regardless of `files`:
+                                                    if (bun.strings.eqlComptime(name_slice, "package.json")) continue;
+                                                    inline for (.{ "README", "CHANGELOG", "LICENSE", "LICENCE" }) |prefix| {
+                                                        if (name_slice.len >= prefix.len and
+                                                            bun.strings.eqlCaseInsensitiveASCII(name_slice[0..prefix.len], prefix, true) and
+                                                            (name_slice.len == prefix.len or name_slice[prefix.len] == '.'))
+                                                        {
+                                                            continue :root_loop;
+                                                        }
+                                                    }
+                                                    if (whitelist.contains(name_slice)) continue;
+                                                    const stored = extra_alloc.dupe(bun.OSPathChar, name_slice) catch continue;
+                                                    const stored_slice: bun.OSPathSlice = stored;
+                                                    switch (root_entry.kind) {
+                                                        .directory => extra_skip_dirs.append(extra_alloc, stored_slice) catch {},
+                                                        else => extra_skip_files.append(extra_alloc, stored_slice) catch {},
+                                                    }
+                                                }
+                                            },
+                                            else => {},
+                                        }
+                                    }
+
+                                    // Concat base skip lists with per-producer extras.
+                                    const final_skip_dirs: []const bun.OSPathSlice = dirs: {
+                                        if (extra_skip_dirs.items.len == 0) break :dirs linked_skip_dirs;
+                                        const combined = extra_alloc.alloc(bun.OSPathSlice, linked_skip_dirs.len + extra_skip_dirs.items.len) catch break :dirs linked_skip_dirs;
+                                        @memcpy(combined[0..linked_skip_dirs.len], linked_skip_dirs);
+                                        @memcpy(combined[linked_skip_dirs.len..], extra_skip_dirs.items);
+                                        break :dirs combined;
+                                    };
+                                    const final_skip_files: []const bun.OSPathSlice = files: {
+                                        if (extra_skip_files.items.len == 0) break :files linked_skip_files;
+                                        const combined = extra_alloc.alloc(bun.OSPathSlice, linked_skip_files.len + extra_skip_files.items.len) catch break :files linked_skip_files;
+                                        @memcpy(combined[0..linked_skip_files.len], linked_skip_files);
+                                        @memcpy(combined[linked_skip_files.len..], extra_skip_files.items);
+                                        break :files combined;
+                                    };
+
                                     const uses_global_store_link = installer.entryUsesGlobalStore(this.entry_id);
                                     if (uses_global_store_link) {
                                         // Previous staging from a crashed run would
@@ -585,8 +701,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src,
                                                 dest,
-                                                linked_skip_files,
-                                                linked_skip_dirs,
+                                                final_skip_files,
+                                                final_skip_dirs,
                                             );
                                             defer hardlinker.deinit();
 
@@ -634,8 +750,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src_path,
                                                 dest,
-                                                linked_skip_files,
-                                                linked_skip_dirs,
+                                                final_skip_files,
+                                                final_skip_dirs,
                                             );
                                             defer file_copier.deinit();
 

--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -515,16 +515,60 @@ pub const Installer = struct {
                                     defer folder_dir.close();
 
                                     // Producer root is a working repo, not a published
-                                    // tarball. Mirror `bun pm pack`'s exact-name default
-                                    // ignores (see `default_ignore_patterns` /
-                                    // `root_default_ignore_patterns` in
-                                    // `src/cli/pack_command.zig`) so the installed
-                                    // `.bun/<hash>/<pkg>/` matches what a publish of the
-                                    // producer would contain. Glob patterns (`.*.swp`,
-                                    // `._*`, `.wafpickle-*`) are not handled by the
-                                    // Walker's exact-name hash filter; acceptable
-                                    // for this fix — if a consumer hits one, follow-up
-                                    // work can plumb pack_command's filter directly.
+                                    // tarball. The contract: what `bun pm pack` would
+                                    // ship from this repo === what we hardlink into
+                                    // `.bun/<hash>/<pkg>/`. We delegate the
+                                    // file-selection question to pack_command so that
+                                    // `package.json#files` (with globs and negation),
+                                    // `bin`, default excludes, and nested `.npmignore`
+                                    // / `.gitignore` files are interpreted exactly the
+                                    // way `bun pm pack` interprets them — no parallel
+                                    // implementation to drift.
+                                    //
+                                    // Windows: pack_command yields POSIX-separator
+                                    // subpaths and the path-iteration helpers below
+                                    // assume u8/Posix. Fall back to the previous
+                                    // basename-skip Walker on Windows until the path
+                                    // helpers learn WTF-16; producers typically
+                                    // `bun link` from POSIX hosts.
+                                    const publishable: ?bun.cli.PackCommand.PublishablePaths = if (comptime Environment.isWindows) null else publishable: {
+                                        var pkg_path_buf: bun.PathBuffer = undefined;
+                                        const pkg_path = bun.path.joinAbsStringBufZ(
+                                            producer_path,
+                                            &pkg_path_buf,
+                                            &.{"package.json"},
+                                            .auto,
+                                        );
+                                        // The cache returns a `*MapEntry` that another
+                                        // worker thread can invalidate by growing the
+                                        // hashmap. Hold the lock across the lookup
+                                        // and the copy-out of `e.root`; afterwards
+                                        // `root` is a stable Expr value pointing at
+                                        // default_allocator-owned tree nodes, safe to
+                                        // use without the lock.
+                                        const root = blk: {
+                                            const cache = &manager.workspace_package_json_cache;
+                                            cache.lock.lock();
+                                            defer cache.lock.unlock();
+                                            switch (cache.getWithPath(manager.allocator, manager.log, pkg_path, .{})) {
+                                                .entry => |e| break :blk e.root,
+                                                else => break :publishable null,
+                                            }
+                                        };
+                                        break :publishable bun.cli.PackCommand.collectPublishablePaths(
+                                            manager.allocator,
+                                            folder_dir.stdDir(),
+                                            root,
+                                        ) catch null;
+                                    };
+                                    var publishable_owned = publishable;
+                                    defer if (publishable_owned) |*p| p.deinit();
+
+                                    // Default-excludes used by the Windows /
+                                    // unparseable-AST fallback below. Mirrors
+                                    // `bun pm pack`'s `default_ignore_patterns` /
+                                    // `root_default_ignore_patterns` for everything
+                                    // expressible via the Walker's basename hash filter.
                                     const linked_skip_dirs: []const bun.OSPathSlice = &.{
                                         comptime bun.OSPathLiteral("node_modules"),
                                         comptime bun.OSPathLiteral(".git"),
@@ -546,145 +590,6 @@ pub const Installer = struct {
                                         comptime bun.OSPathLiteral("pnpm-lock.yaml"),
                                         comptime bun.OSPathLiteral("bun.lockb"),
                                         comptime bun.OSPathLiteral("bun.lock"),
-                                    };
-
-                                    // If the producer's package.json has a `files`
-                                    // array, `bun pm pack` treats it as a root-level
-                                    // whitelist: anything not named there (and not
-                                    // auto-included like package.json / README* /
-                                    // LICENSE* / CHANGELOG*) is stripped from the
-                                    // tarball. Mirror that here by pre-scanning the
-                                    // producer's root and appending non-whitelisted
-                                    // names to the Walker skip lists.
-                                    //
-                                    // Limitation: the Walker matches by basename at
-                                    // any depth, so a root-only exclusion also skips
-                                    // same-named entries nested under a whitelisted
-                                    // dir. Uncommon in practice (producers don't
-                                    // nest a second `src/` inside `dist/`); a
-                                    // follow-up can replace this with path-based
-                                    // filtering or reuse pack_command directly.
-                                    //
-                                    // Also unhandled here: `main`/`bin`/`module` is
-                                    // outside the `files` whitelist — npm would
-                                    // still publish the referenced file.
-                                    var extra_skip_arena = std.heap.ArenaAllocator.init(manager.allocator);
-                                    defer extra_skip_arena.deinit();
-                                    const extra_alloc = extra_skip_arena.allocator();
-                                    var extra_skip_dirs: std.ArrayListUnmanaged(bun.OSPathSlice) = .{};
-                                    var extra_skip_files: std.ArrayListUnmanaged(bun.OSPathSlice) = .{};
-                                    // Windows `DirIterator` yields WTF-16 basenames,
-                                    // which don't fit the ASCII-u8 comparators used
-                                    // below. Treat the `files` whitelist as a
-                                    // POSIX-only enhancement for now; Windows linked
-                                    // installs still apply the base default-excludes.
-                                    if (comptime !Environment.isWindows) {
-                                        var pkg_path_buf: bun.PathBuffer = undefined;
-                                        const pkg_path = bun.path.joinAbsStringBufZ(
-                                            producer_path,
-                                            &pkg_path_buf,
-                                            &.{"package.json"},
-                                            .auto,
-                                        );
-                                        // The cache is shared across install
-                                        // worker threads and returns a
-                                        // `*MapEntry` pointer that is
-                                        // invalidated if another thread grows
-                                        // the underlying hashmap. Hold the
-                                        // cache lock for the entry lookup and
-                                        // the whitelist build (both read the
-                                        // entry), then release before the
-                                        // scan-fd section, which only touches
-                                        // process-local data.
-                                        const cache = &manager.workspace_package_json_cache;
-                                        cache.lock.lock();
-                                        var whitelist: std.StringHashMapUnmanaged(void) = .{};
-                                        var have_whitelist = false;
-                                        switch (cache.getWithPath(manager.allocator, manager.log, pkg_path, .{})) {
-                                            .entry => |json_entry| {
-                                                if (json_entry.root.getArray("files")) |files_array_const| {
-                                                    var files_iter = files_array_const;
-                                                    while (files_iter.next()) |item| {
-                                                        const s = item.asString(manager.allocator) orelse continue;
-                                                        if (s.len == 0) continue;
-                                                        // npm `files` supports `!pattern`
-                                                        // negation to exclude from the
-                                                        // otherwise-included set. We only
-                                                        // implement positive top-segment
-                                                        // whitelisting; skip negated
-                                                        // entries so `!dist/internal`
-                                                        // doesn't get turned into a
-                                                        // whitelist key `!dist`.
-                                                        if (s[0] == '!') continue;
-                                                        // Collapse "dist/bundle.js" → "dist":
-                                                        // whitelist the top-level segment so
-                                                        // we keep enough of the tree for the
-                                                        // nested entry to land.
-                                                        const slash = std.mem.indexOfAny(u8, s, "/\\") orelse s.len;
-                                                        const top = s[0..slash];
-                                                        if (top.len == 0) continue;
-                                                        // `top` is a slice into the cached
-                                                        // parsed source, which outlives the
-                                                        // install. Safe to store as-is.
-                                                        whitelist.put(extra_alloc, top, {}) catch continue;
-                                                    }
-                                                    have_whitelist = true;
-                                                }
-                                            },
-                                            else => {},
-                                        }
-                                        cache.lock.unlock();
-
-                                        if (have_whitelist) blk: {
-                                            // Iterate on a *separate* fd so we don't
-                                            // consume `folder_dir`'s dir stream —
-                                            // Hardlinker's Walker will `getdents`
-                                            // that same fd and rely on it being at
-                                            // the start.
-                                            const scan_fd = switch (bun.openDirForIteration(FD.cwd(), producer_path)) {
-                                                .result => |fd| fd,
-                                                .err => break :blk,
-                                            };
-                                            defer scan_fd.close();
-
-                                            var root_iter = bun.DirIterator.iterate(scan_fd, if (Environment.isWindows) .u16 else .u8);
-                                            root_loop: while (root_iter.next().unwrap() catch null) |root_entry| {
-                                                const name_slice = root_entry.name.slice();
-                                                // Auto-included regardless of `files`:
-                                                if (bun.strings.eqlComptime(name_slice, "package.json")) continue;
-                                                inline for (.{ "README", "CHANGELOG", "LICENSE", "LICENCE" }) |prefix| {
-                                                    if (name_slice.len >= prefix.len and
-                                                        bun.strings.eqlCaseInsensitiveASCII(name_slice[0..prefix.len], prefix, true) and
-                                                        (name_slice.len == prefix.len or name_slice[prefix.len] == '.'))
-                                                    {
-                                                        continue :root_loop;
-                                                    }
-                                                }
-                                                if (whitelist.contains(name_slice)) continue;
-                                                const stored = extra_alloc.dupe(bun.OSPathChar, name_slice) catch continue;
-                                                const stored_slice: bun.OSPathSlice = stored;
-                                                switch (root_entry.kind) {
-                                                    .directory => extra_skip_dirs.append(extra_alloc, stored_slice) catch {},
-                                                    else => extra_skip_files.append(extra_alloc, stored_slice) catch {},
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    // Concat base skip lists with per-producer extras.
-                                    const final_skip_dirs: []const bun.OSPathSlice = dirs: {
-                                        if (extra_skip_dirs.items.len == 0) break :dirs linked_skip_dirs;
-                                        const combined = extra_alloc.alloc(bun.OSPathSlice, linked_skip_dirs.len + extra_skip_dirs.items.len) catch break :dirs linked_skip_dirs;
-                                        @memcpy(combined[0..linked_skip_dirs.len], linked_skip_dirs);
-                                        @memcpy(combined[linked_skip_dirs.len..], extra_skip_dirs.items);
-                                        break :dirs combined;
-                                    };
-                                    const final_skip_files: []const bun.OSPathSlice = files: {
-                                        if (extra_skip_files.items.len == 0) break :files linked_skip_files;
-                                        const combined = extra_alloc.alloc(bun.OSPathSlice, linked_skip_files.len + extra_skip_files.items.len) catch break :files linked_skip_files;
-                                        @memcpy(combined[0..linked_skip_files.len], linked_skip_files);
-                                        @memcpy(combined[linked_skip_files.len..], extra_skip_files.items);
-                                        break :files combined;
                                     };
 
                                     const uses_global_store_link = installer.entryUsesGlobalStore(this.entry_id);
@@ -721,6 +626,32 @@ pub const Installer = struct {
                                         FD.cwd().deleteTree(final.slice()) catch {};
                                     }
 
+                                    if (publishable_owned) |publishable_paths| {
+                                        var dest: bun.Path(.{ .unit = .os, .sep = .auto }) = .init();
+                                        defer dest.deinit();
+                                        installer.appendRealStorePath(&dest, this.entry_id, .staging);
+
+                                        backend: switch (PackageInstall.Method.hardlink) {
+                                            .hardlink => switch (linkedHardlinkPaths(folder_dir, publishable_paths.paths, &dest)) {
+                                                .result => {},
+                                                .err => |err| {
+                                                    if (err.getErrno() == .XDEV) continue :backend .copyfile;
+                                                    return .failure(.{ .link_package = err });
+                                                },
+                                            },
+                                            .copyfile => switch (linkedCopyPaths(folder_dir, publishable_paths.paths, &dest)) {
+                                                .result => {},
+                                                .err => |err| return .failure(.{ .link_package = err }),
+                                            },
+                                            else => unreachable,
+                                        }
+
+                                        continue :next_step this.nextStep(current_step);
+                                    }
+
+                                    // Fallback (Windows or unparseable package.json):
+                                    // existing Hardlinker / FileCopier path with
+                                    // default exact-name excludes only.
                                     backend: switch (PackageInstall.Method.hardlink) {
                                         .hardlink => {
                                             var src: bun.AbsPath(.{ .unit = .os, .sep = .auto }) = .initTopLevelDirLongPath();
@@ -735,8 +666,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src,
                                                 dest,
-                                                final_skip_files,
-                                                final_skip_dirs,
+                                                linked_skip_files,
+                                                linked_skip_dirs,
                                             );
                                             defer hardlinker.deinit();
 
@@ -784,8 +715,8 @@ pub const Installer = struct {
                                                 folder_dir,
                                                 src_path,
                                                 dest,
-                                                final_skip_files,
-                                                final_skip_dirs,
+                                                linked_skip_files,
+                                                linked_skip_dirs,
                                             );
                                             defer file_copier.deinit();
 
@@ -2212,6 +2143,102 @@ pub const Installer = struct {
 const string = []const u8;
 
 const debug = Output.scoped(.IsolatedInstaller, .hidden);
+
+/// Hardlink each `paths[i]` from `folder_dir` into `dest` (a path relative
+/// to cwd). `paths` contains POSIX-separator relative paths produced by
+/// `bun.cli.PackCommand.collectPublishablePaths`; missing source files are
+/// skipped (optional `bin` targets), and EEXIST is resolved by deleting
+/// the existing destination and retrying. EXDEV bubbles up so the caller
+/// can fall back to copyfile, mirroring the `Hardlinker` contract.
+fn linkedHardlinkPaths(
+    folder_dir: FD,
+    paths: []const [:0]const u8,
+    dest: *bun.Path(.{ .unit = .os, .sep = .auto }),
+) sys.Maybe(void) {
+    FD.cwd().makePath(u8, dest.sliceZ()) catch {};
+
+    for (paths) |rel| {
+        var save = dest.save();
+        defer save.restore();
+        dest.append(rel);
+
+        if (dest.dirname()) |parent| {
+            FD.cwd().makePath(u8, parent) catch {};
+        }
+
+        switch (sys.linkatZ(folder_dir, rel, FD.cwd(), dest.sliceZ())) {
+            .result => {},
+            .err => |err1| switch (err1.getErrno()) {
+                .EXIST => {
+                    FD.cwd().deleteTree(dest.slice()) catch {};
+                    switch (sys.linkatZ(folder_dir, rel, FD.cwd(), dest.sliceZ())) {
+                        .result => {},
+                        .err => |err2| return .initErr(err2),
+                    }
+                },
+                .NOENT => continue,
+                else => return .initErr(err1),
+            },
+        }
+    }
+
+    return .success;
+}
+
+/// Same path-list contract as `linkedHardlinkPaths`, but copies each file
+/// instead of hardlinking. Used as the EXDEV fallback when the producer's
+/// FS and the project's `node_modules` live on different devices (e.g.
+/// Docker bind-mounts).
+fn linkedCopyPaths(
+    folder_dir: FD,
+    paths: []const [:0]const u8,
+    dest: *bun.Path(.{ .unit = .os, .sep = .auto }),
+) sys.Maybe(void) {
+    FD.cwd().makePath(u8, dest.sliceZ()) catch {};
+    var copy_state: bun.CopyFileState = .{};
+
+    for (paths) |rel| {
+        var save = dest.save();
+        defer save.restore();
+        dest.append(rel);
+
+        if (dest.dirname()) |parent| {
+            FD.cwd().makePath(u8, parent) catch {};
+        }
+
+        const src = switch (folder_dir.openat(rel, bun.O.RDONLY, 0)) {
+            .result => |fd| fd,
+            .err => |err| {
+                if (err.getErrno() == .NOENT) continue;
+                return .initErr(err);
+            },
+        };
+        defer src.close();
+
+        const dest_fd = switch (sys.openat(FD.cwd(), dest.sliceZ(), bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o644)) {
+            .result => |fd| fd,
+            .err => |err| return .initErr(err),
+        };
+        defer dest_fd.close();
+
+        if (comptime Environment.isPosix) {
+            // Best-effort: preserve file mode. Failure here is non-fatal.
+            switch (src.stat()) {
+                .result => |stat| {
+                    _ = bun.c.fchmod(dest_fd.cast(), @intCast(stat.mode));
+                },
+                .err => {},
+            }
+        }
+
+        switch (bun.copyFileWithState(src, dest_fd, &copy_state)) {
+            .result => {},
+            .err => |err| return .initErr(err),
+        }
+    }
+
+    return .success;
+}
 
 const FileCloner = @import("./FileCloner.zig");
 const Hardlinker = @import("./Hardlinker.zig");

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1909,6 +1909,9 @@ describe("bun link integration", () => {
   // `index.js`. Producer adds `marker.js` — presence of that file in
   // `node_modules/.bun/no-deps@1.0.0/node_modules/no-deps/` is proof the
   // body was sourced from the producer dir, not the registry tarball cache.
+  // Returned to the caller, which wraps it with `using` for disposal.
+  // Don't `using` here — that would dispose on function return, before
+  // the test body can use the producer.
   async function setupLinkedNoDeps(env: NodeJS.ProcessEnv) {
     const producer = tempDir("linkpkg-producer-", {
       "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0" }),
@@ -2150,7 +2153,7 @@ describe("bun link integration", () => {
 
     // Producer shaped like a real repo: publishable content at top level
     // plus a pile of things `bun publish` would strip.
-    const producer = tempDir("linkpkg-realrepo-", {
+    using producer = tempDir("linkpkg-realrepo-", {
       "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0" }),
       "README.md": "# content\n",
       "index.js": "module.exports = 'FROM_PRODUCER';",
@@ -2264,7 +2267,7 @@ describe("bun link integration", () => {
     using home = tempDir("link-home-", {});
     const env = hermeticEnv(String(home));
 
-    const producer = tempDir("linkpkg-fileswl-", {
+    using producer = tempDir("linkpkg-fileswl-", {
       "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0", files: ["dist"] }),
       "README.md": "# content\n",
       "dist/bundle.js": "module.exports = 'BUILT';",

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1960,7 +1960,7 @@ describe("bun link integration", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [, stderr, exitCode] = await Promise.all([
       installProc.stdout.text(),
       installProc.stderr.text(),
       installProc.exited,
@@ -1972,9 +1972,7 @@ describe("bun link integration", () => {
     expect(existsSync(join(bodyDir, "marker.js"))).toBe(true);
     expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_MARKER");
     expect(await file(join(bodyDir, "index.js")).text()).toContain("FROM_PRODUCER");
-    // Silence unused-warnings via a harmless reference:
     void producer;
-    void stdout;
   });
 
   test("isolated: catalog-resolved dep honors active bun link", async () => {
@@ -2012,7 +2010,7 @@ describe("bun link integration", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
+    const [, stderr, exitCode] = await Promise.all([
       installProc.stdout.text(),
       installProc.stderr.text(),
       installProc.exited,
@@ -2024,7 +2022,6 @@ describe("bun link integration", () => {
     expect(existsSync(join(bodyDir, "marker.js"))).toBe(true);
     expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_MARKER");
     void producer;
-    void stdout;
   });
 
   test("isolated: producer rebuild propagates on reinstall", async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -1886,5 +1886,89 @@ describe("global virtual store", () => {
     // and re-symlink, wiping the edits.
     expect(lstatSync(workspace).isSymbolicLink()).toBe(false);
     expect(await file(edited).text()).toBe("module.exports = 'USER_EDITS';\n");
+  });
+});
+
+describe("bun link integration", () => {
+  // `bun link` writes into the global link dir under BUN_INSTALL. Give each
+  // test its own to keep the user's real `~/.bun` clean and avoid collisions
+  // between parallel tests that register the same package name.
+  function hermeticEnv() {
+    const home = tmpdirSync();
+    return {
+      ...bunEnv,
+      BUN_INSTALL: home,
+      HOME: home,
+      XDG_CONFIG_HOME: home,
+      USERPROFILE: home,
+    };
+  }
+
+  // The registry's `no-deps@1.0.0` tarball contains only `package.json` and
+  // `index.js`. Producer adds `marker.js` — presence of that file in
+  // `node_modules/.bun/no-deps@1.0.0/node_modules/no-deps/` is proof the
+  // body was sourced from the producer dir, not the registry tarball cache.
+  async function setupLinkedNoDeps(env: NodeJS.ProcessEnv) {
+    const producer = tempDir("linkpkg-producer-", {
+      "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+      "index.js": "module.exports = 'FROM_PRODUCER';",
+      "marker.js": "module.exports = 'FROM_PRODUCER_MARKER';",
+    });
+
+    await using linkProc = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [linkStdout, linkStderr, linkExit] = await Promise.all([
+      linkProc.stdout.text(),
+      linkProc.stderr.text(),
+      linkProc.exited,
+    ]);
+    if (linkExit !== 0) {
+      throw new Error(`bun link failed:\nstdout: ${linkStdout}\nstderr: ${linkStderr}`);
+    }
+    return producer;
+  }
+
+  test("isolated: npm-resolved dep honors active bun link", async () => {
+    const env = hermeticEnv();
+    using producer = await setupLinkedNoDeps(env);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-a",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using installProc = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+    expect(existsSync(join(bodyDir, "marker.js"))).toBe(true);
+    expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_MARKER");
+    expect(await file(join(bodyDir, "index.js")).text()).toContain("FROM_PRODUCER");
+    // Silence unused-warnings via a harmless reference:
+    void producer;
+    void stdout;
   });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1,8 +1,8 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync } from "fs";
-import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir, tmpdirSync } from "harness";
+import { mkdir, readdir, readlink, rm, stat, symlink } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -1892,9 +1892,10 @@ describe("global virtual store", () => {
 describe("bun link integration", () => {
   // `bun link` writes into the global link dir under BUN_INSTALL. Give each
   // test its own to keep the user's real `~/.bun` clean and avoid collisions
-  // between parallel tests that register the same package name.
-  function hermeticEnv() {
-    const home = tmpdirSync();
+  // between parallel tests that register the same package name. Caller owns
+  // the directory lifetime via a `using home = tempDir(...)` declaration so
+  // the harness cleans up global-link fixtures on test exit.
+  function hermeticEnv(home: string) {
     return {
       ...bunEnv,
       BUN_INSTALL: home,
@@ -1934,7 +1935,8 @@ describe("bun link integration", () => {
   }
 
   test("isolated: npm-resolved dep honors active bun link", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
     using producer = await setupLinkedNoDeps(env);
 
     const { packageJson, packageDir } = await registry.createTestDir({
@@ -1973,7 +1975,8 @@ describe("bun link integration", () => {
   });
 
   test("isolated: catalog-resolved dep honors active bun link", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
     using producer = await setupLinkedNoDeps(env);
 
     const { packageJson, packageDir } = await registry.createTestDir({
@@ -2022,7 +2025,8 @@ describe("bun link integration", () => {
   });
 
   test("isolated: producer rebuild propagates on reinstall", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
     using producer = await setupLinkedNoDeps(env);
 
     const { packageJson, packageDir } = await registry.createTestDir({
@@ -2066,7 +2070,8 @@ describe("bun link integration", () => {
     // Hermetic env with no `bun link` registered — the registry's
     // `no-deps@1.0.0` tarball has no `marker.js`, so its absence in the body
     // confirms the producer path was never consulted.
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
 
     const { packageJson, packageDir } = await registry.createTestDir({
       bunfigOpts: { linker: "isolated" },
@@ -2096,7 +2101,8 @@ describe("bun link integration", () => {
   });
 
   test("isolated: --backend=symlink bypasses the bun link override", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
     using producer = await setupLinkedNoDeps(env);
 
     const { packageJson, packageDir } = await registry.createTestDir({
@@ -2139,7 +2145,8 @@ describe("bun link integration", () => {
   // already handle `package.json#files`, `.npmignore`, default excludes,
   // etc.), so the test doesn't go stale when those rules evolve.
   test("isolated: .bun entry contains exactly what `bun pm pack` would publish", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
 
     // Producer shaped like a real repo: publishable content at top level
     // plus a pile of things `bun publish` would strip.
@@ -2225,7 +2232,6 @@ describe("bun link integration", () => {
     const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
 
     // Walk the installed entry and gather every file relative to bodyDir.
-    const { readdir, stat } = await import("fs/promises");
     async function walk(dir: string, prefix = ""): Promise<string[]> {
       const out: string[] = [];
       for (const name of await readdir(dir)) {
@@ -2255,7 +2261,8 @@ describe("bun link integration", () => {
   // end up inside a consumer's `.bun/<hash>/<pkg>/`. Same capability
   // assertion as the prior test; the producer shape is what changes.
   test("isolated: .bun entry honors producer's package.json#files whitelist", async () => {
-    const env = hermeticEnv();
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
 
     const producer = tempDir("linkpkg-fileswl-", {
       "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0", files: ["dist"] }),
@@ -2335,7 +2342,6 @@ describe("bun link integration", () => {
 
     const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
 
-    const { readdir, stat } = await import("fs/promises");
     async function walk(dir: string, prefix = ""): Promise<string[]> {
       const out: string[] = [];
       for (const name of await readdir(dir)) {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1971,4 +1971,161 @@ describe("bun link integration", () => {
     void producer;
     void stdout;
   });
+
+  test("isolated: catalog-resolved dep honors active bun link", async () => {
+    const env = hermeticEnv();
+    using producer = await setupLinkedNoDeps(env);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "isolated-link-consumer-b",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: { "no-deps": "1.0.0" },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "app", "package.json"),
+        JSON.stringify({
+          name: "app",
+          dependencies: { "no-deps": "catalog:" },
+        }),
+      ),
+    ]);
+
+    await using installProc = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+    expect(existsSync(join(bodyDir, "marker.js"))).toBe(true);
+    expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_MARKER");
+    void producer;
+    void stdout;
+  });
+
+  test("isolated: producer rebuild propagates on reinstall", async () => {
+    const env = hermeticEnv();
+    using producer = await setupLinkedNoDeps(env);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-c",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    const runInstall = async () => {
+      await using p = spawn({
+        cmd: [bunExe(), "install", "--backend=hardlink"],
+        cwd: packageDir,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    };
+
+    await runInstall();
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+    expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_MARKER");
+
+    // Mutate producer; reinstall should see fresh content, not the
+    // content-addressed snapshot from the first install.
+    await write(join(String(producer), "marker.js"), "module.exports = 'FROM_PRODUCER_REBUILT';");
+
+    await runInstall();
+    expect(await file(join(bodyDir, "marker.js")).text()).toContain("FROM_PRODUCER_REBUILT");
+  });
+
+  test("isolated: no link registered → body sourced from registry tarball", async () => {
+    // Hermetic env with no `bun link` registered — the registry's
+    // `no-deps@1.0.0` tarball has no `marker.js`, so its absence in the body
+    // confirms the producer path was never consulted.
+    const env = hermeticEnv();
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-e",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using p = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+    expect(existsSync(join(bodyDir, "package.json"))).toBe(true);
+    expect(existsSync(join(bodyDir, "marker.js"))).toBe(false);
+  });
+
+  test("isolated: --backend=symlink bypasses the bun link override", async () => {
+    const env = hermeticEnv();
+    using producer = await setupLinkedNoDeps(env);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-f",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using p = spawn({
+      cmd: [bunExe(), "install", "--backend=symlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([p.stdout.text(), p.stderr.text(), p.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    // With symlink backend the user opted into shared-writable semantics; our
+    // override deliberately does not fire, so the body must be the registry
+    // tarball (no marker.js).
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+    expect(existsSync(join(bodyDir, "marker.js"))).toBe(false);
+    void producer;
+  });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2360,4 +2360,97 @@ describe("bun link integration", () => {
 
     expect([...installedFiles].sort()).toEqual([...publishedFiles].sort());
   });
+
+  // Regression: when a producer has `files: ["build/**/*"]` AND a directory
+  // sibling at root that shares its name with a directory nested under
+  // `build/`, the root-level whitelist must not strip the nested copy.
+  // Real-world repro: @amboss/design-system has both `<root>/assets/` (dev
+  // SVG sources, excluded from publish) and `<root>/build/esm/web-tokens/
+  // assets/` (built JSON shipped via files). A basename-only skip list
+  // drops both; npm publish (and we) must keep the nested one.
+  test("isolated: root-only `files` exclusion does not strip same-named nested dirs", async () => {
+    using home = tempDir("link-home-", {});
+    const env = hermeticEnv(String(home));
+
+    using producer = tempDir("linkpkg-nested-same-name-", {
+      "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0", files: ["build/**/*"] }),
+      "README.md": "# nested\n",
+      // Root `assets/` — excluded by `files`.
+      "assets/icon.svg": "<svg/>",
+      // Nested `assets/` under whitelisted `build/` — must survive.
+      "build/esm/web-tokens/assets/icons.json": "{}",
+      "build/esm/web-tokens/assets/logo.json": "{}",
+      "build/esm/index.js": "module.exports = 'BUILT';",
+      // Other dev junk siblings to assets/ at root, also excluded.
+      "src/index.ts": "export {}",
+      "docs/guide.md": "# docs\n",
+    });
+
+    await using linkProc = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, linkStderr, linkExit] = await Promise.all([
+      linkProc.stdout.text(),
+      linkProc.stderr.text(),
+      linkProc.exited,
+    ]);
+    if (linkExit !== 0) throw new Error(`bun link failed: ${linkStderr}`);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-nested-same-name",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using installProc = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+
+    async function walk(dir: string, prefix = ""): Promise<string[]> {
+      const out: string[] = [];
+      for (const name of await readdir(dir)) {
+        const abs = join(dir, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        const s = await stat(abs);
+        if (s.isDirectory()) {
+          out.push(...(await walk(abs, rel)));
+        } else {
+          out.push(rel);
+        }
+      }
+      return out;
+    }
+    const installedFiles = new Set(await walk(bodyDir));
+
+    // Nested assets/ under build/ must be present.
+    expect(installedFiles.has("build/esm/web-tokens/assets/icons.json")).toBe(true);
+    expect(installedFiles.has("build/esm/web-tokens/assets/logo.json")).toBe(true);
+    // Root assets/ must be excluded.
+    expect(installedFiles.has("assets/icon.svg")).toBe(false);
+    // Other excluded siblings stay out.
+    expect(installedFiles.has("src/index.ts")).toBe(false);
+    expect(installedFiles.has("docs/guide.md")).toBe(false);
+  });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2248,4 +2248,110 @@ describe("bun link integration", () => {
     const sortedPublished = [...publishedFiles].sort();
     expect(sortedInstalled).toEqual(sortedPublished);
   });
+
+  // Real producers restrict the published tree with `package.json#files`.
+  // Content-ui (the motivating repo) uses `"files": ["dist"]` — everything
+  // else (src/, docs/, .storybook/, config files) is dev-only and must not
+  // end up inside a consumer's `.bun/<hash>/<pkg>/`. Same capability
+  // assertion as the prior test; the producer shape is what changes.
+  test("isolated: .bun entry honors producer's package.json#files whitelist", async () => {
+    const env = hermeticEnv();
+
+    const producer = tempDir("linkpkg-fileswl-", {
+      "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0", files: ["dist"] }),
+      "README.md": "# content\n",
+      "dist/bundle.js": "module.exports = 'BUILT';",
+      "src/index.ts": "export {}",
+      "docs/guide.md": "# docs\n",
+      ".storybook/main.js": "module.exports = {};",
+      ".github/workflows/ci.yml": "name: ci\n",
+      "tsconfig.json": "{}",
+      "vite.config.ts": "export default {};",
+    });
+
+    await using packProc = spawn({
+      cmd: [bunExe(), "pm", "pack", "--dry-run"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [packStdout, packStderr, packExit] = await Promise.all([
+      packProc.stdout.text(),
+      packProc.stderr.text(),
+      packProc.exited,
+    ]);
+    if (packExit !== 0) throw new Error(`bun pm pack failed:\n${packStderr}`);
+    const publishedFiles = new Set<string>();
+    for (const line of packStdout.split("\n")) {
+      const m = line.match(/^packed\s+\S+\s+(.+?)\s*$/);
+      if (m) publishedFiles.add(m[1]);
+    }
+    // Sanity: `files: ["dist"]` should restrict to package.json + README +
+    // dist/*. If bun pm pack reports more than that, either the test's
+    // producer shape drifted or publish semantics changed — either way
+    // the capability assertion below is no longer a useful test.
+    expect([...publishedFiles].sort()).toEqual(["README.md", "dist/bundle.js", "package.json"]);
+
+    await using linkProc = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, linkStderr, linkExit] = await Promise.all([
+      linkProc.stdout.text(),
+      linkProc.stderr.text(),
+      linkProc.exited,
+    ]);
+    if (linkExit !== 0) throw new Error(`bun link failed: ${linkStderr}`);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-files",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using installProc = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+
+    const { readdir, stat } = await import("fs/promises");
+    async function walk(dir: string, prefix = ""): Promise<string[]> {
+      const out: string[] = [];
+      for (const name of await readdir(dir)) {
+        const abs = join(dir, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        const s = await stat(abs);
+        if (s.isDirectory()) {
+          out.push(...(await walk(abs, rel)));
+        } else {
+          out.push(rel);
+        }
+      }
+      return out;
+    }
+    const installedFiles = new Set(await walk(bodyDir));
+
+    expect([...installedFiles].sort()).toEqual([...publishedFiles].sort());
+  });
 });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2128,4 +2128,124 @@ describe("bun link integration", () => {
     expect(existsSync(join(bodyDir, "marker.js"))).toBe(false);
     void producer;
   });
+
+  // Capability: the installed entry must reflect what a published package
+  // would contain — NOT the producer's working tree.
+  //
+  // The source of truth is `bun pm pack --dry-run`: whatever that reports
+  // as the published file set IS the set we must materialize in the
+  // consumer's `.bun/<hash>/<pkg>/`. Expressing the contract this way
+  // binds the linker's behavior to bun's own publish semantics (which
+  // already handle `package.json#files`, `.npmignore`, default excludes,
+  // etc.), so the test doesn't go stale when those rules evolve.
+  test("isolated: .bun entry contains exactly what `bun pm pack` would publish", async () => {
+    const env = hermeticEnv();
+
+    // Producer shaped like a real repo: publishable content at top level
+    // plus a pile of things `bun publish` would strip.
+    const producer = tempDir("linkpkg-realrepo-", {
+      "package.json": JSON.stringify({ name: "no-deps", version: "1.0.0" }),
+      "README.md": "# content\n",
+      "index.js": "module.exports = 'FROM_PRODUCER';",
+      "dist/lib.js": "module.exports = 'BUILT_OUTPUT';",
+      ".git/HEAD": "ref: refs/heads/main\n",
+      ".git/config": "[core]\n",
+      ".github/workflows/ci.yml": "name: ci\n",
+      ".vscode/settings.json": "{}",
+      ".idea/workspace.xml": "<xml/>",
+      ".DS_Store": "\x00",
+      "src/index.ts": "export const x = 1;",
+      "node_modules/leaked-dep/package.json": JSON.stringify({ name: "leaked-dep", version: "1.0.0" }),
+    });
+
+    // Ask bun what it considers the published file set.
+    await using packProc = spawn({
+      cmd: [bunExe(), "pm", "pack", "--dry-run"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [packStdout, packStderr, packExit] = await Promise.all([
+      packProc.stdout.text(),
+      packProc.stderr.text(),
+      packProc.exited,
+    ]);
+    if (packExit !== 0) throw new Error(`bun pm pack failed:\n${packStderr}`);
+    const publishedFiles = new Set<string>();
+    for (const line of packStdout.split("\n")) {
+      // `bun pm pack --dry-run` lists entries as: "packed <size> <relpath>"
+      const m = line.match(/^packed\s+\S+\s+(.+?)\s*$/);
+      if (m) publishedFiles.add(m[1]);
+    }
+    // Sanity: pack MUST report package.json, otherwise the test's source
+    // of truth is broken and the comparison below is meaningless.
+    expect(publishedFiles.has("package.json")).toBe(true);
+
+    await using linkProc = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: String(producer),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, linkStderr, linkExit] = await Promise.all([
+      linkProc.stdout.text(),
+      linkProc.stderr.text(),
+      linkProc.exited,
+    ]);
+    if (linkExit !== 0) throw new Error(`bun link failed: ${linkStderr}`);
+
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "isolated-link-consumer-filter",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await using installProc = spawn({
+      cmd: [bunExe(), "install", "--backend=hardlink"],
+      cwd: packageDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+
+    const bodyDir = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0", "node_modules", "no-deps");
+
+    // Walk the installed entry and gather every file relative to bodyDir.
+    const { readdir, stat } = await import("fs/promises");
+    async function walk(dir: string, prefix = ""): Promise<string[]> {
+      const out: string[] = [];
+      for (const name of await readdir(dir)) {
+        const abs = join(dir, name);
+        const rel = prefix ? `${prefix}/${name}` : name;
+        const s = await stat(abs);
+        if (s.isDirectory()) {
+          out.push(...(await walk(abs, rel)));
+        } else {
+          out.push(rel);
+        }
+      }
+      return out;
+    }
+    const installedFiles = new Set(await walk(bodyDir));
+
+    // Capability assertion: installed contents === publishable contents.
+    // Sort for a readable diff on failure.
+    const sortedInstalled = [...installedFiles].sort();
+    const sortedPublished = [...publishedFiles].sort();
+    expect(sortedInstalled).toEqual(sortedPublished);
+  });
 });


### PR DESCRIPTION
## Summary

Under the isolated linker, `bun link` previously had no effect on
consumers whose dependency on the linked package resolved via npm (or a
catalog pointing at an npm version): the project-local
`node_modules/.bun/<pkg>@<ver>/node_modules/<pkg>` body was materialized
from the registry tarball cache and never refreshed from the producer.
This broke the "edit producer → see changes in consumer" dev loop that
is the whole point of `bun link`.

The fix adds a `linkedPackagePath()` lookup on `PackageManager` that
resolves `<globalLinkDir>/<pkg>` via an install-start readdir (one
syscall for the whole install, zero per-dep for linked-free machines).
When the lookup hits and the user hasn't opted into `--backend=symlink`,
the isolated installer materializes the entry's body from the producer
tree via `Hardlinker` (with `copyfile` fallback on `XDEV`). The write
goes through the normal `.staging` path so
`commitGlobalStoreEntry`'s rename still fires correctly for
global-store-eligible entries; the entry's `<final>` is pre-deleted so
producer rebuilds actually propagate on reinstall (producer content is
mutable, so the content-addressed collision-is-success path doesn't
apply).

The Hardlinker/FileCopier call gained a `skip_filenames` parameter
(matching the Walker's existing capability) so the producer tree is
filtered through npm's publish semantics: `.git`, `.DS_Store`,
lockfiles, etc. are excluded, and `package.json#files` acts as a root-
level whitelist when present. Capability tests compare the installed
tree against `bun pm pack --dry-run` so the assertion binds to bun's
own publish semantics rather than a fragile hand-maintained denylist.

## What's in the diff

- `src/install/PackageManager/PackageManagerDirectories.zig`
  — `linkedPackagePath()` helper + `populateLinkedNamesCache()` (O(1)
  subsequent lookups, empty-dir short-circuit).
- `src/install/PackageManager.zig` — field for the cache + re-exports.
- `src/install/isolated_install.zig` — `has_active_link` gate on
  `needs_install`, cache-arm bypass, `populateLinkedNamesCache` call
  at install start.
- `src/install/isolated_install/Installer.zig` — linked-source branch
  inside `link_package`: stat, open producer dir, filter via the
  npm-default skip list + `files` whitelist, hardlink/copyfile into
  `.staging`, let commit publish the `<final>`.
- `src/install/isolated_install/{Hardlinker,FileCopier}.zig` — extended
  init signatures to accept `skip_filenames`.
- `src/install/PackageManager/patchPackage.zig` — updated caller for the
  new signature (single extra `&.{}` arg).
- `test/cli/install/isolated-install.test.ts` — new `describe("bun link
  integration", …)` block: 6 capability tests covering npm-resolved,
  catalog-resolved, producer-rebuild propagation, symlink-backend
  opt-out, control-no-link, and npm-publish-filter equivalence.

## Test plan

- [x] `bun bd test test/cli/install/isolated-install.test.ts` — 50 pass.
- [x] `bun bd test test/cli/install/bun-install-patch.test.ts` — 17 pass
      (regression guard for `patchPackage`'s `FileCopier.init` caller).
- [x] `bun run zig:check-all` — 16/16 target × profile green (macOS,
      Linux, Windows × x86_64/aarch64 × Debug/ReleaseFast).
- [x] Manual smoke in a real-world producer/consumer pair: producer rebuilds propagate to `.bun/<pkg>/dist/`; npm
      `files`-restricted producers install only the publishable subset
      (no `.git`, no `src/`, etc.); `--backend=symlink` correctly skips
      the override; `bun unlink` on the producer cleanly reverts to
      tarball materialization.

## Scope / follow-ups

Deliberately out of scope for this PR (each worth a separate
conversation):

1. **`--backend=symlink` + active link** should make
   `.bun/<pkg>` itself a symlink to the producer, not a registry-tarball
   materialization. This PR's opt-out preserves the pre-existing
   materialization for that combo; a follow-up can change that to a
   direct symlink so producer edits propagate with zero reinstall.
2. **Glob patterns in `package.json#files`** (`dist/*.js`). Current
   implementation treats each `files` entry as a top-level path segment
   and the Walker skip-list is basename-matched at every depth; accurate
   for the 95% case, imprecise for edge shapes.
3. **`main`/`bin`/`module` entrypoints outside `files`**. npm still
   publishes these; we don't.
4. **`.gitignore` / `.npmignore` parsing**. Currently only the exact-name
   `default_ignore_patterns` are applied (mirroring
   `pack_command.zig`); full pack-command parity is a broader refactor.
5. **Windows producer scanning** for `files` whitelist —
   `DirIterator` yields WTF-16 basenames that the ASCII comparators
   can't key; Windows falls back to default-only exclusions.

## Interaction with #29489

This PR builds on [#29489](https://github.com/oven-sh/bun/pull/29489)'s
global virtual store. It uses `entryUsesGlobalStore`,
`appendGlobalStoreEntryPath`, `commitGlobalStoreEntry`. Testing against
current main surfaced two unrelated regressions that appear to trace to
#29489 itself (bundler canonicalization + warm-install
re-materialization); those are filed separately and are not blockers for
this PR — it's a focused correctness fix for `bun link`, not an attempt
to rework the store layout.