### PR TITLE
Cap the startup `RLIMIT_NOFILE` raise at `1 << 20`

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -798,8 +798,8 @@ pub const FileSystem = struct {
                 file_limit = limit.max;
                 Limit.handles = file_limit;
                 // Cap at 1<<20 to match Node.js. On macOS the hard limit defaults to
-                // RLIM_INFINITY; raising soft anywhere near INT_MAX breaks some child
-                // processes
+                // RLIM_INFINITY; raising soft anywhere near INT_MAX breaks child
+                // processes that read the limit into an int.
                 // https://github.com/nodejs/node/blob/v25.9.0/src/node.cc#L621-L627
                 // https://github.com/postgres/postgres/blob/fee2b3ea2ecd0da0c88832b37ac0d9f6b3bfb9a9/src/backend/storage/file/fd.c#L1072
                 // https://discord.com/channels/876711213126520882/1316342194176790609/1318175562367242271

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -797,19 +797,23 @@ pub const FileSystem = struct {
                 Limit.handles_before = limit;
                 file_limit = limit.max;
                 Limit.handles = file_limit;
-                const max_to_use: @TypeOf(limit.max) = if (Environment.isMusl)
-                    // musl has extremely low defaults here, so we really want
-                    // to enable this on musl or tests will start failing.
-                    @max(limit.max, 163840)
-                else
-                    // apparently, requesting too high of a number can cause other processes to not start.
-                    // https://discord.com/channels/876711213126520882/1316342194176790609/1318175562367242271
-                    // https://github.com/postgres/postgres/blob/fee2b3ea2ecd0da0c88832b37ac0d9f6b3bfb9a9/src/backend/storage/file/fd.c#L1072
-                    limit.max;
+                // Cap at 1<<20 to match Node.js. On macOS the hard limit defaults to
+                // RLIM_INFINITY; raising soft anywhere near INT_MAX breaks some child
+                // processes
+                // https://github.com/nodejs/node/blob/v25.9.0/src/node.cc#L621-L627
+                // https://github.com/postgres/postgres/blob/fee2b3ea2ecd0da0c88832b37ac0d9f6b3bfb9a9/src/backend/storage/file/fd.c#L1072
+                // https://discord.com/channels/876711213126520882/1316342194176790609/1318175562367242271
+                const max_to_use: @TypeOf(limit.max) = @min(
+                    // musl has extremely low defaults, so ensure at least 163840 there.
+                    if (Environment.isMusl) @max(limit.max, 163840) else limit.max,
+                    1 << 20,
+                );
                 if (limit.cur < max_to_use) {
                     var new_limit = std.mem.zeroes(std.posix.rlimit);
                     new_limit.cur = max_to_use;
-                    new_limit.max = max_to_use;
+                    // Don't lower the hard limit (Node only touches rlim_cur). The @max
+                    // is for the musl branch above, which may raise past the current hard.
+                    new_limit.max = @max(limit.max, max_to_use);
 
                     std.posix.setrlimit(resource, new_limit) catch break :blk;
                     file_limit = new_limit.max;

--- a/src/fs.zig
+++ b/src/fs.zig
@@ -790,37 +790,32 @@ pub const FileSystem = struct {
                 return std.math.maxInt(usize);
             }
 
-            var file_limit: usize = 0;
-            blk: {
-                const resource = std.posix.rlimit_resource.NOFILE;
-                const limit = try std.posix.getrlimit(resource);
-                Limit.handles_before = limit;
-                file_limit = limit.max;
-                Limit.handles = file_limit;
-                // Cap at 1<<20 to match Node.js. On macOS the hard limit defaults to
-                // RLIM_INFINITY; raising soft anywhere near INT_MAX breaks child
-                // processes that read the limit into an int.
-                // https://github.com/nodejs/node/blob/v25.9.0/src/node.cc#L621-L627
-                // https://github.com/postgres/postgres/blob/fee2b3ea2ecd0da0c88832b37ac0d9f6b3bfb9a9/src/backend/storage/file/fd.c#L1072
-                // https://discord.com/channels/876711213126520882/1316342194176790609/1318175562367242271
-                const max_to_use: @TypeOf(limit.max) = @min(
-                    // musl has extremely low defaults, so ensure at least 163840 there.
-                    if (Environment.isMusl) @max(limit.max, 163840) else limit.max,
-                    1 << 20,
-                );
-                if (limit.cur < max_to_use) {
-                    var new_limit = std.mem.zeroes(std.posix.rlimit);
-                    new_limit.cur = max_to_use;
-                    // Don't lower the hard limit (Node only touches rlim_cur). The @max
-                    // is for the musl branch above, which may raise past the current hard.
-                    new_limit.max = @max(limit.max, max_to_use);
+            const resource = std.posix.rlimit_resource.NOFILE;
+            var lim = try std.posix.getrlimit(resource);
+            Limit.handles_before = lim;
 
-                    std.posix.setrlimit(resource, new_limit) catch break :blk;
-                    file_limit = new_limit.max;
-                    Limit.handles = file_limit;
-                }
+            // Cap at 1<<20 to match Node.js. On macOS the hard limit defaults to
+            // RLIM_INFINITY; raising soft anywhere near INT_MAX breaks child processes
+            // that read the limit into an int.
+            // https://github.com/nodejs/node/blob/v25.9.0/src/node.cc#L621-L627
+            // https://github.com/postgres/postgres/blob/fee2b3ea2ecd0da0c88832b37ac0d9f6b3bfb9a9/src/backend/storage/file/fd.c#L1072
+            // https://discord.com/channels/876711213126520882/1316342194176790609/1318175562367242271
+            const target: @TypeOf(lim.max) = @min(
+                // musl has extremely low defaults, so ensure at least 163840 there.
+                if (Environment.isMusl) @max(lim.max, 163840) else lim.max,
+                1 << 20,
+            );
+            if (lim.cur < target) {
+                var raised = lim;
+                raised.cur = target;
+                // Don't lower the hard limit (Node only touches rlim_cur). The @max
+                // is for the musl branch above, which may raise past the current hard.
+                raised.max = @max(lim.max, target);
+                if (std.posix.setrlimit(resource, raised)) |_| lim.cur = raised.cur else |_| {}
             }
-            return file_limit;
+
+            Limit.handles = @intCast(lim.cur);
+            return @intCast(lim.cur);
         }
 
         var _entries_option_map: *EntriesOption.Map = undefined;

--- a/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
+++ b/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
@@ -3,8 +3,7 @@
  *
  * On macOS the hard RLIMIT_NOFILE defaults to RLIM_INFINITY. Both Bun and Node
  * raise the soft limit on startup; Node caps the raise at 1<<20. Raising it
- * anywhere near INT_MAX breaks some child processes that read the limit into
- * an int — e.g., FlexLM lmutil fails with "Cannot read data (-16,287)".
+ * anywhere near INT_MAX breaks child processes that read the limit into an int.
  *
  * The test lowers the soft limit to 256 before exec'ing the runtime so its
  * startup raise actually runs (neither Bun nor Node lowers an already-high

--- a/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
+++ b/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
@@ -9,9 +9,9 @@
  * startup raise actually runs (neither Bun nor Node lowers an already-high
  * limit), then checks what a grandchild shell sees.
  */
-import { test } from "node:test";
 import assert from "node:assert";
 import { execFile } from "node:child_process";
+import { test } from "node:test";
 import { promisify } from "node:util";
 
 const execFileP = promisify(execFile);

--- a/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
+++ b/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * This test runs under both `node --test` and `bun test`.
+ *
+ * On macOS the hard RLIMIT_NOFILE defaults to RLIM_INFINITY. Both Bun and Node
+ * raise the soft limit on startup; Node caps the raise at 1<<20. Raising it
+ * anywhere near INT_MAX breaks some child processes that read the limit into
+ * an int — e.g., FlexLM lmutil fails with "Cannot read data (-16,287)".
+ *
+ * The test lowers the soft limit to 256 before exec'ing the runtime so its
+ * startup raise actually runs (neither Bun nor Node lowers an already-high
+ * limit), then checks what a grandchild shell sees.
+ */
+import { test } from "node:test";
+import assert from "node:assert";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileP = promisify(execFile);
+
+test(
+  "child process inherits a sane RLIMIT_NOFILE (capped at 1<<20)",
+  { skip: process.platform === "win32" },
+  async () => {
+    const inner = `console.log(require("child_process").execFileSync("/bin/sh", ["-c", "ulimit -Sn"]).toString().trim())`;
+    const { stdout } = await execFileP(
+      "/bin/sh",
+      ["-c", `ulimit -Sn 256; exec "$1" -e "$2"`, "sh", process.execPath, inner],
+      { env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" } },
+    );
+
+    const soft = stdout.trim();
+    assert.notStrictEqual(soft, "unlimited", `soft NOFILE limit should be capped, got "unlimited"`);
+    const n = Number(soft);
+    assert.ok(Number.isFinite(n), `expected numeric limit, got ${JSON.stringify(soft)}`);
+    assert.ok(n > 256, `runtime should raise the soft limit above 256, got ${n}`);
+    assert.ok(n <= 1 << 20, `runtime should cap the soft limit at 1<<20, got ${n}`);
+  },
+);

--- a/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
+++ b/test/js/node/child_process/child-process-rlimit-nofile.test.mjs
@@ -23,7 +23,7 @@ test(
     const inner = `console.log(require("child_process").execFileSync("/bin/sh", ["-c", "ulimit -Sn"]).toString().trim())`;
     const { stdout } = await execFileP(
       "/bin/sh",
-      ["-c", `ulimit -Sn 256; exec "$1" -e "$2"`, "sh", process.execPath, inner],
+      ["-c", `ulimit -Sn 256 && exec "$1" -e "$2"`, "sh", process.execPath, inner],
       { env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1" } },
     );
 

--- a/test/js/node/child_process/child-process-rlimit-nofile.test.ts
+++ b/test/js/node/child_process/child-process-rlimit-nofile.test.ts
@@ -1,5 +1,6 @@
 /**
- * This test runs under both `node --test` and `bun test`.
+ * This test runs under `bun test` and (via node:test/node:assert) under
+ * `node --experimental-strip-types --test`.
  *
  * On macOS the hard RLIMIT_NOFILE defaults to RLIM_INFINITY. Both Bun and Node
  * raise the soft limit on startup; Node caps the raise at 1<<20. Raising it


### PR DESCRIPTION
## What

Cap the startup `RLIMIT_NOFILE` raise at `1 << 20`, matching Node.js, and stop lowering the hard limit as a side effect.

## Why

On macOS the hard `NOFILE` limit defaults to `RLIM_INFINITY`. `adjustUlimit()` raises soft → hard on startup, so child processes spawned by Bun inherit a soft limit of 2⁶³−1. Programs that read the limit into an `int` then misbehave — observed as a spawned binary failing its own socket reads once the soft limit exceeds ~`INT_MAX`, while the same binary works when spawned by Node.

Node.js caps this raise at `1 << 20` ([src/node.cc#L621-L627](https://github.com/nodejs/node/blob/v25.9.0/src/node.cc#L621-L627)). 903d8bfa4 intended to be conservative here but used `limit.max` as the ceiling, which on macOS is still infinity.

## How

- `max_to_use = @min(..., 1 << 20)` — caps the soft limit. The musl floor of 163840 is preserved.
- `new_limit.max = @max(limit.max, max_to_use)` — previously we set `max = max_to_use`, which would now *lower* the hard limit. Node only touches `rlim_cur`; do the same so children that genuinely need >1M fds can still raise themselves.

Not adding Node's binary-search fallback (for when `setrlimit(1<<20)` fails despite hard=infinity) — Bun has never done that and it's orthogonal to this bug.

## Test

`test/js/node/child_process/child-process-rlimit-nofile.test.mjs` uses `node:test` + `node:assert` so the same file runs under Node and Bun:

| Runner | Result |
|---|---|
| `node --test` | pass (1048575) |
| `bun test` (before) | fail (`unlimited`) |
| `bun bd test` (after) | pass (1048576) |
