### PR TITLE
build: enable LTO for bun-zig.o

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,6 +51,7 @@ const BunBuildOptions = struct {
     /// `./build/codegen` or equivalent
     codegen_path: []const u8,
     no_llvm: bool,
+    lto: bool,
     override_no_export_cpp_apis: bool,
 
     cached_options_module: ?*Module = null,
@@ -201,6 +202,7 @@ pub fn build(b: *Build) !void {
     const obj_format = b.option(ObjectFormat, "obj_format", "Output file for object files") orelse .obj;
 
     const no_llvm = b.option(bool, "no_llvm", "Experiment with Zig self hosted backends. No stability guaranteed") orelse false;
+    const lto = b.option(bool, "lto", "Emit LLVM bitcode for full LTO instead of a native object") orelse false;
     const override_no_export_cpp_apis = b.option(bool, "override-no-export-cpp-apis", "Override the default export_cpp_apis logic to disable exports") orelse false;
 
     var build_options = BunBuildOptions{
@@ -211,6 +213,7 @@ pub fn build(b: *Build) !void {
         .codegen_path = codegen_path,
         .codegen_embed = codegen_embed,
         .no_llvm = no_llvm,
+        .lto = lto,
         .override_no_export_cpp_apis = override_no_export_cpp_apis,
         .version = try Version.parse(bun_version),
         .canary_revision = canary: {
@@ -640,6 +643,7 @@ fn addMultiCheck(
                 .reported_nodejs_version = root_build_options.reported_nodejs_version,
                 .codegen_path = root_build_options.codegen_path,
                 .no_llvm = root_build_options.no_llvm,
+                .lto = false,
                 .enable_asan = root_build_options.enable_asan,
                 .enable_valgrind = root_build_options.enable_valgrind,
                 .enable_tinycc = root_build_options.enable_tinycc,
@@ -751,6 +755,10 @@ fn configureObj(b: *Build, opts: *BunBuildOptions, obj: *Compile) void {
     // Object options
     obj.use_llvm = !opts.no_llvm;
     obj.use_lld = if (opts.os == .mac or opts.os == .linux) false else !opts.no_llvm;
+    if (opts.lto) {
+        obj.lto = .full;
+        obj.use_lld = true;
+    }
 
     if (@hasField(std.meta.Child(@TypeOf(obj)), "llvm_codegen_threads"))
         obj.llvm_codegen_threads = opts.llvm_codegen_threads orelse 0;

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -15,7 +15,7 @@ import { WEBKIT_VERSION } from "./deps/webkit.ts";
 import { BuildError, assert } from "./error.ts";
 import { clangTargetArch } from "./tools.ts";
 import { cyan, dim, green } from "./tty.ts";
-import { defaultZigCommit } from "./zig.ts";
+import { ZIG_COMMIT } from "./zig.ts";
 
 export type OS = "linux" | "darwin" | "windows";
 export type Arch = "x64" | "aarch64";
@@ -51,7 +51,7 @@ export interface Host {
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
   nodejsAbiVersion: NODEJS_ABI_VERSION,
-  // zigCommit's default varies by host OS — see defaultZigCommit() in zig.ts.
+  zigCommit: ZIG_COMMIT,
   webkitVersion: WEBKIT_VERSION,
 };
 
@@ -475,7 +475,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // to test a branch before bumping the pinned default.
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
-  const zigCommit = partial.zigCommit ?? defaultZigCommit(host.os);
+  const zigCommit = partial.zigCommit ?? versionDefaults.zigCommit;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
 
   // ─── macOS SDK ───
@@ -803,7 +803,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== defaultZigCommit(cfg.host.os)) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigCommit !== versionDefaults.zigCommit) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -19,7 +19,7 @@ import { existsSync, readFileSync, symlinkSync } from "node:fs";
 import { mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { availableParallelism, homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { Config, OS } from "./config.ts";
+import type { Config } from "./config.ts";
 import { downloadWithRetry, extractZip } from "./download.ts";
 import { assert } from "./error.ts";
 import { fetchCliPath } from "./fetch-cli.ts";
@@ -31,38 +31,8 @@ import { streamPath } from "./stream.ts";
  * Zig compiler commit — determines compiler download + bundled stdlib.
  * Override via `--zig-commit=<hash>` to test a new compiler.
  * From https://github.com/oven-sh/zig releases.
- *
- * TEMPORARY SPLIT: ZIG_COMMIT is the pre-parallel-sema compiler, kept
- * for Windows hosts only (COFF shard emission isn't implemented and
- * the build path needs a single object). Everything else — local and
- * CI, all targets — uses ZIG_COMMIT_PARALLEL (parallel sema is
- * deterministic; codegen-unit count is decided separately by
- * codegenThreads()). Once Windows is supported, collapse both back to
- * one constant.
  */
-export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "04e7f6ac1e009525bc00934f20199c68f04e0a24";
-
-/**
- * The one place that picks which compiler to use. The parallel compiler
- * is used everywhere except Windows (its sharded-codegen object emission
- * for COFF is unimplemented). Parallel SEMA is deterministic and changes
- * no output, so CI gets it too — only the codegen-unit count differs by
- * config (see codegenThreads()).
- */
-export function defaultZigCommit(hostOs: OS): string {
-  if (hostOs === "windows") return ZIG_COMMIT;
-  return ZIG_COMMIT_PARALLEL;
-}
-
-/**
- * True iff `cfg` is using the parallel-sema compiler. Gates
- * ZIG_PARALLEL_SEMA and the `llvm_no_merge_shards` build.zig path —
- * the stable compiler doesn't understand either.
- */
-function usingParallelCompiler(cfg: Config): boolean {
-  return cfg.zigCommit !== ZIG_COMMIT;
-}
+export const ZIG_COMMIT = "04e7f6ac1e009525bc00934f20199c68f04e0a24";
 
 /**
  * Number of LLVM codegen units. >1 splits the build into N independent
@@ -73,6 +43,8 @@ function usingParallelCompiler(cfg: Config): boolean {
  *   - Non-ASAN CI: shipped releases want full IPO; cg=1 keeps that and
  *     keeps the upload/download contract a single file.
  *   - Windows targets: COFF shard emission is unimplemented in oven-sh/zig.
+ *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
+ *     .o instead of N and the no_merge_shards path would expect missing files.
  *
  * ASAN CI uses a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only and
  * link-only — which run on different machines — agree on the artifact
@@ -80,12 +52,8 @@ function usingParallelCompiler(cfg: Config): boolean {
  * a non-ASAN CI artifact if cross-unit inlining matters.
  */
 function codegenThreads(cfg: Config): number {
-  if (!usingParallelCompiler(cfg)) return 0;
   if (cfg.windows) return 1;
-  // LTO emits a single bitcode file (zig_llvm.cpp gates SplitModule on
-  // !lto), so sharding would emit one .o instead of N — keep cg=1 here so
-  // the no_merge_shards path doesn't expect files that won't exist.
-  if (zigLto(cfg)) return 1;
+  if (cfg.lto) return 1;
   if (cfg.ci) {
     // ASAN is a test-only build (not shipped), so cross-shard IPO loss is
     // fine and the speedup is worth it. The count is FIXED so zig-only and
@@ -98,17 +66,6 @@ function codegenThreads(cfg: Config): number {
 
 /** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
 export const CI_ASAN_CODEGEN_THREADS = 8;
-
-/**
- * Whether bun-zig.o should be emitted as LLVM bitcode for LTO instead of a
- * native object. Tracks the project-wide LTO flag, but only on the parallel
- * compiler — the older ZIG_COMMIT predates the EnableSplitLTOUnit/summary
- * fix in zig_llvm.cpp, so its bitcode would be rejected by lld's
- * `-fwhole-program-vtables` consistency check.
- */
-function zigLto(cfg: Config): boolean {
-  return cfg.lto && usingParallelCompiler(cfg);
-}
 
 /**
  * Output object file names for the zig step, matching what build.zig emits.
@@ -306,7 +263,7 @@ export function registerZigRules(n: Ninja, cfg: Config): void {
   // our fork (upstream added Feb 2026, not backported).
   const interleave = false;
   const consoleMode = !interleave || hostWin;
-  const parallelSema = usingParallelCompiler(cfg) ? " --env=ZIG_PARALLEL_SEMA=1" : "";
+  const parallelSema = " --env=ZIG_PARALLEL_SEMA=1";
   n.rule("zig_build", {
     command: `${stream} ${consoleMode ? "--console" : "--zig-progress"} --env=ZIG_LOCAL_CACHE_DIR=$zig_local_cache --env=ZIG_GLOBAL_CACHE_DIR=$zig_global_cache${parallelSema} $zig build $step $args`,
     description: "zig $step → $out",
@@ -482,7 +439,7 @@ function zigBuildArgs(cfg: Config): string[] {
     `-Denable_fuzzilli=${bool(cfg.fuzzilli)}`,
     `-Denable_valgrind=${bool(cfg.valgrind)}`,
     `-Denable_tinycc=${bool(cfg.tinycc)}`,
-    `-Dlto=${bool(zigLto(cfg))}`,
+    `-Dlto=${bool(cfg.lto)}`,
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -41,7 +41,7 @@ import { streamPath } from "./stream.ts";
  * one constant.
  */
 export const ZIG_COMMIT = "365343af4fc5a1a632e6b54aadd0b87be30edd81";
-export const ZIG_COMMIT_PARALLEL = "0bcf4c3d998133e724d27e9fd783172ffed4c943";
+export const ZIG_COMMIT_PARALLEL = "04e7f6ac1e009525bc00934f20199c68f04e0a24";
 
 /**
  * The one place that picks which compiler to use. The parallel compiler
@@ -82,6 +82,10 @@ function usingParallelCompiler(cfg: Config): boolean {
 function codegenThreads(cfg: Config): number {
   if (!usingParallelCompiler(cfg)) return 0;
   if (cfg.windows) return 1;
+  // LTO emits a single bitcode file (zig_llvm.cpp gates SplitModule on
+  // !lto), so sharding would emit one .o instead of N — keep cg=1 here so
+  // the no_merge_shards path doesn't expect files that won't exist.
+  if (zigLto(cfg)) return 1;
   if (cfg.ci) {
     // ASAN is a test-only build (not shipped), so cross-shard IPO loss is
     // fine and the speedup is worth it. The count is FIXED so zig-only and
@@ -94,6 +98,17 @@ function codegenThreads(cfg: Config): number {
 
 /** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
 export const CI_ASAN_CODEGEN_THREADS = 8;
+
+/**
+ * Whether bun-zig.o should be emitted as LLVM bitcode for LTO instead of a
+ * native object. Tracks the project-wide LTO flag, but only on the parallel
+ * compiler — the older ZIG_COMMIT predates the EnableSplitLTOUnit/summary
+ * fix in zig_llvm.cpp, so its bitcode would be rejected by lld's
+ * `-fwhole-program-vtables` consistency check.
+ */
+function zigLto(cfg: Config): boolean {
+  return cfg.lto && usingParallelCompiler(cfg);
+}
 
 /**
  * Output object file names for the zig step, matching what build.zig emits.
@@ -467,6 +482,7 @@ function zigBuildArgs(cfg: Config): string[] {
     `-Denable_fuzzilli=${bool(cfg.fuzzilli)}`,
     `-Denable_valgrind=${bool(cfg.valgrind)}`,
     `-Denable_tinycc=${bool(cfg.tinycc)}`,
+    `-Dlto=${bool(zigLto(cfg))}`,
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,


### PR DESCRIPTION
Emit `bun-zig.o` as LLVM bitcode (`obj.lto = .full`) so it participates in the same LTO link as the C/C++ side, instead of being a native ELF object that lld can only link, not optimize across.

## Why this didn't work before

The only documented Zig→bitcode path was `-Dobj_format=bc`, which routes through `getEmittedLlvmBc()` → `-femit-llvm-bc`. That writes Zig's **self-hosted** unoptimized bitcode (Producer `"zig 0.15.2"`) before libLLVM ever touches it, and the self-hosted writer has encoding bugs for large modules → `Invalid record` in lld. The proper `-flto` path was blocked by `use_lld = false` on Linux causing `LtoRequiresLld` or silent fallback.

This PR uses `obj.lto = .full` + `obj.use_lld = true`, which routes through libLLVM's `WriteBitcodeToFile` after the LTO pre-link O3 pipeline. The output (Producer `"LLVM20.1.2"`) is forward-compatible with lld 21/22.

Bumps `ZIG_COMMIT_PARALLEL` to pick up oven-sh/zig@04e7f6ac1e, which adds `EnableSplitLTOUnit=1` + a module summary to Zig's LTO bitcode — required for `-fwhole-program-vtables` to accept the link (otherwise: `inconsistent LTO Unit splitting`).

## What gets inlined

| Boundary | Declared | Eliminated | % |
|---|---|---|---|
| Zig `export fn` → C++ | 336 | 142 | 42% |
| C `us_*` (usockets) ← Zig | 115 | 79 | 69% |
| C++ `uws_*` (uWebSockets wrappers) ← Zig | 108 | 76 | 70% |
| `mi_free` | — | all | 100% (0 call insns) |

Verified by disassembly: e.g. `Bun__readOriginTimer` body (optional check, `clock_gettime`, ns math) appears directly inside C++ `Process_functionHRTime`; symbol is gone.

## Measured impact (linux-x64, vs latest canary)

| | LTO | no Zig LTO | Δ |
|---|---|---|---|
| `Bun.escapeHTML` | 171.3 ns | 183.2 ns | **6.5%** |
| `TextDecoder.decode` | 104.0 ns | 106.8 ns | **2.6%** |
| `oha -n 1M -c 50` | ~200,600 req/s | ~193,800 req/s | **3.5%** |

Caveat: canary is a slightly different revision; same-revision A/B would be cleaner.

## Notes

- `zigLto(cfg)` gates on `usingParallelCompiler` — the older Windows `ZIG_COMMIT` predates the summary fix.
- `codegenThreads()` returns 1 when LTO is on (zig_llvm.cpp gates SplitModule on `!lto`).