### PR TITLE
[blocked on WebKit#193] Fix async stack traces inside AsyncLocalStorage.run()

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-193-c0d24b89";
+export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
+export const WEBKIT_VERSION = "autobuild-preview-pr-193-c0d24b89";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/regression/issue/24003.test.ts
+++ b/test/regression/issue/24003.test.ts
@@ -1,0 +1,96 @@
+// https://github.com/oven-sh/bun/issues/24003
+// Async stack traces were truncated to a single frame inside
+// AsyncLocalStorage.run() because the JSPromiseReaction context is wrapped in
+// an InternalFieldTuple when an async context is active, and
+// Interpreter::getAsyncStackTrace didn't unwrap it before casting to
+// JSGenerator*.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const fixture = /* ts */ `
+import { AsyncLocalStorage } from "node:async_hooks";
+const als = new AsyncLocalStorage();
+
+async function fn1() {
+  await Bun.sleep(1);
+  await fn2();
+}
+async function fn2() {
+  await Bun.sleep(1);
+  await fn3();
+}
+async function fn3() {
+  await Bun.sleep(1);
+  throw new Error("boom");
+}
+
+async function outer() {
+  await als.run({}, async function inner() {
+    await fn1();
+  });
+}
+
+try {
+  await outer();
+} catch (e) {
+  console.log((e as Error).stack);
+}
+`;
+
+test("async stack frames are preserved inside AsyncLocalStorage.run()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  // Before the fix only `fn3` appeared; the parent async frames were dropped.
+  expect(stdout).toContain("at fn3 ");
+  expect(stdout).toContain("at async fn2 ");
+  expect(stdout).toContain("at async fn1 ");
+  expect(stdout).toContain("at async inner ");
+  expect(stdout).toContain("at async outer ");
+  expect(exitCode).toBe(0);
+});
+
+test("async stack frames are preserved through Promise.all inside AsyncLocalStorage.run()", async () => {
+  const combinatorFixture = /* ts */ `
+import { AsyncLocalStorage } from "node:async_hooks";
+const als = new AsyncLocalStorage();
+
+async function leaf() {
+  await Bun.sleep(1);
+  throw new Error("boom");
+}
+async function mid() {
+  await Bun.sleep(1);
+  await leaf();
+}
+async function top() {
+  await Promise.all([mid()]);
+}
+
+try {
+  await als.run({}, async function wrap() {
+    await top();
+  });
+} catch (e) {
+  console.log((e as Error).stack);
+}
+`;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", combinatorFixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toContain("at leaf ");
+  expect(stdout).toContain("at async mid ");
+  expect(stdout).toContain("at async top ");
+  expect(stdout).toContain("at async wrap ");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #24003.

> [!IMPORTANT]
> **Blocked on oven-sh/WebKit#193.** The actual fix is in JavaScriptCore (`Interpreter::getAsyncStackTrace`); this PR only adds the regression test. The test will fail until `WEBKIT_VERSION` is bumped to a build that includes that change.
>
> The Preview Build workflow on oven-sh/WebKit#193 currently needs maintainer approval (`action_required`, fork PR). Once it runs and publishes `autobuild-preview-pr-193-c0d24b89`, bump `scripts/build/deps/webkit.ts` here and the test will pass.

## Problem

When an `AsyncLocalStorage` store is active, `error.stack` for errors thrown deep in an `await` chain only shows the innermost frame — the `async fn2`, `async fn1` etc. frames are dropped:

```ts
import { AsyncLocalStorage } from "node:async_hooks";
const als = new AsyncLocalStorage();

async function fn1() { await Bun.sleep(10); await fn2(); }
async function fn2() { await Bun.sleep(10); await fn3(); }
async function fn3() { await Bun.sleep(10); throw new Error("boom"); }

try { await als.run({}, () => fn1()); } catch (e) { console.log(e.stack); }
// Error: boom
//     at fn3 (...)        ← fn2, fn1, and callers are missing
```

## Root cause

Under `USE(BUN_JSC_ADDITIONS)`, `JSPromise::resolveWithInternalMicrotaskForAsyncAwait` wraps the awaiting generator in an `InternalFieldTuple` `[generator, asyncContext]` whenever an async context is active, and stores that tuple as the `JSPromiseReaction` context so the async context can be restored when the microtask runs.

`Interpreter::getAsyncStackTrace` walks the await chain by reading `reaction->context()` and casting it with `jsDynamicCast<JSGenerator*>`. When the context is an `InternalFieldTuple`, the cast returns `nullptr` and the chain walk stops after the first hop.

The execution path (`JSMicrotask.cpp` `AsyncFunctionResume`) and Bun's own `collectAsyncStackFramesFromPromise` in `bindings.cpp` already unwrap this tuple; only `getAsyncStackTrace` was missing it.

## Fix

**oven-sh/WebKit#193** — unwrap `InternalFieldTuple` (field 0 is the original context) in `getContextValueFromPromise`. This covers the direct-await path as well as the `Promise.all`/`Promise.race`/`Promise.any` combinator paths that all flow through that helper.

This PR adds the regression test for the basic case and the `Promise.all` combinator case.

## Verification

Validated with a local WebKit build (`bun scripts/build.ts --profile=debug --webkit=local`):

```
Caught error inside of async context Error: Some error occurred in fn3
    at fn3 (/tmp/repro.ts:19:13)
    at async fn2 (/tmp/repro.ts:13:9)
    at async fn1 (/tmp/repro.ts:7:9)
    at async <anonymous> (/tmp/repro.ts:31:13)
    at async main (/tmp/repro.ts:30:29)
```

- `test/regression/issue/24003.test.ts` — passes with the fix, fails on current release.
- `test/js/bun/test/stack.test.ts` "Async functions frame should be included in stack trace" — still passes (no regression in the non-ALS path).
- `test/js/node/async_hooks/AsyncLocalStorage.test.ts` — all 26 tests pass.
