### PR TITLE
Bun.spawn: don't close user-provided extra stdio fds

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1509,8 +1509,12 @@ pub fn spawnProcessPosix(
             },
             .pipe => |fd| {
                 try actions.dup2(fd, fileno);
-
-                try extra_fds.append(fd);
+                // This file descriptor was passed in by the user (e.g. a
+                // number in the stdio array). It is not owned by Bun.spawn,
+                // so we must not close it in finalizeStreams. Store
+                // invalid_fd to keep the positional slot for
+                // subprocess.stdio without taking ownership.
+                try extra_fds.append(bun.invalid_fd);
             },
         }
     }

--- a/test/js/bun/spawn/spawn-extra-fd-ownership.test.ts
+++ b/test/js/bun/spawn/spawn-extra-fd-ownership.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+
+// When a raw file descriptor number is passed in the stdio array at an
+// index > 2, Bun.spawn does not own that fd and must not close it when the
+// Subprocess is finalized.
+test.skipIf(!isPosix)(
+  "Bun.spawn does not close user-provided extra stdio fds",
+  async () => {
+    using dir = tempDir("spawn-extra-fd", {
+      "run.js": `
+      const { openSync, fstatSync, readFileSync } = require("node:fs");
+      const path = require("node:path");
+
+      const file = path.join(process.argv[2], "out.txt");
+      const fd = openSync(file, "w");
+
+      async function once() {
+        const proc = Bun.spawn({
+          cmd: ["/bin/sh", "-c", "echo hi >&3"],
+          stdio: ["ignore", "ignore", "ignore", fd],
+        });
+        await proc.exited;
+      }
+
+      for (let i = 0; i < 4; i++) {
+        await once();
+        Bun.gc(true);
+        await Bun.sleep(1);
+        Bun.gc(true);
+      }
+
+      // If Bun had closed fd during finalization of one of the subprocesses
+      // above, the next fstat would fail with EBADF (or worse, the fd slot
+      // could have been reused by an unrelated file).
+      fstatSync(fd);
+
+      // Also make sure the child was actually able to write through fd 3 so
+      // we know the fd was wired up.
+      const contents = readFileSync(file, "utf8");
+      if (!contents.includes("hi")) {
+        throw new Error("child did not write to fd 3: " + JSON.stringify(contents));
+      }
+
+      console.log("ok");
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.js", String(dir)],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const stderrLines = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderrLines).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  },
+  20000,
+);


### PR DESCRIPTION
## What

When a raw file descriptor number is passed in the `stdio` array at an index > 2 (e.g. `stdio: ['ignore', 'ignore', 'ignore', fd]`), that fd is owned by the caller, not by `Bun.spawn`. Previously the fd was appended to the subprocess's `extra_pipes` list and closed in `finalizeStreams()` when the `Subprocess` was garbage-collected.

## Repro

```js
const fd = openSync('out.txt', 'w');
for (let i = 0; i < 4; i++) {
  const proc = Bun.spawn({
    cmd: ['/bin/sh', '-c', 'echo hi >&3'],
    stdio: ['ignore', 'ignore', 'ignore', fd],
  });
  await proc.exited;
  Bun.gc(true);
}
// second iteration throws: EBADF: bad file descriptor, posix_spawn
```

## Cause

`spawnProcessPosix` stored the user's fd directly in `extra_fds` → `stdio_pipes`, and `Subprocess.finalizeStreams()` closes every valid fd in that list. For stdio[0..2] a raw fd is handled via `Readable`/`Writable` which explicitly do *not* close the `.fd` variant; the extra-fd path was inconsistent with that.

## Fix

Store `bun.invalid_fd` in the slot instead, so the positional entry is preserved for `subprocess.stdio` but `finalizeStreams()` skips the close. This matches:
- the existing behaviour for raw fds at stdio[0..2]
- the Windows path, which already reports these slots as `.unavailable`

## Verification

- New test `test/js/bun/spawn/spawn-extra-fd-ownership.test.ts` fails on main with `EBADF: bad file descriptor, posix_spawn` and passes with this change.
- `bun bd test test/js/bun/spawn/spawn.ipc.test.ts` passes (IPC uses the same `extra_fds` array via socketpair — those fds are still owned and closed correctly).
- `bun run zig:check-all` passes on all targets.