### PR TITLE
ci(runner): share install cache across spawn=N workers on test runners

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,11 +10,14 @@ preload = "./test/preload.ts"
 
 [install]
 linker = "isolated"
-# The CI test runner points BUN_INSTALL_CACHE_DIR at a per-call tmpdir and
-# deletes it between the root and test/ installs. With the global store
-# enabled, `node_modules/.bun/<pkg>` is an absolute symlink into that
-# now-deleted cache, so `test/`'s `file:../node_modules/react` dep dangles.
-# The feature is exercised by test/cli/install/isolated-install.test.ts.
+# globalStore symlinks node_modules/.bun/<pkg> into BUN_INSTALL_CACHE_DIR.
+# The CI runner now uses a persistent shared cache for the setup install
+# (see scripts/runner.node.mjs spawnBunInstall), so the original "cache is
+# deleted between root and test/ installs" concern no longer applies — but
+# per-test spawns still get a throwaway cache, and test/bunfig.toml keeps
+# this off for verdaccio's phantom deps. Leaving it disabled here until
+# someone verifies enabling it is safe end-to-end; the feature itself is
+# exercised by test/cli/install/isolated-install.test.ts.
 globalStore = false
 minimumReleaseAge = 259200 # three days
 minimumReleaseAgeExcludes = ["typescript"]

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1543,16 +1543,38 @@ function parseTestStdout(stdout, testPath) {
   };
 }
 
+// Persistent macOS test runners run several buildkite-agent workers per box
+// (spawn=N). spawnBun() points BUN_INSTALL_CACHE_DIR at a fresh mkdtemp that
+// it deletes after the call, so every worker's setup `bun install` is a cold
+// download + extract of the full test/ dependency tree. With N concurrent
+// installs each spawning ncpu extraction threads, the box spends minutes in
+// openat/mkdirat contention and the 3-minute timeout fires.
+//
+// For the setup install only, override the cache to a fixed per-box path so
+// all workers share warm tarballs/extracts. The path lives under tmpdir(),
+// which the daily com.buildkite.cleanup wipe clears, so it doesn't grow
+// unbounded. Per-test spawns still get isolated tmpdir caches via spawnBun().
+const sharedInstallCache = join(tmpdir(), "bun-ci-shared-install-cache");
+
 /**
  * @param {string} execPath
  * @param {SpawnOptions} options
  * @returns {Promise<TestResult>}
  */
 async function spawnBunInstall(execPath, options) {
+  mkdirSync(sharedInstallCache, { recursive: true });
   let { ok, error, stdout, duration, crashes } = await spawnBun(execPath, {
     args: ["install"],
     timeout: testTimeout,
     ...options,
+    env: {
+      ...options.env,
+      BUN_INSTALL_CACHE_DIR: sharedInstallCache,
+      // Bound bun's worker pool so N concurrent installs don't multiply to
+      // N*ncpu extraction threads on the first cold run after the daily wipe.
+      // bun.getThreadCount() honors GOMAXPROCS.
+      GOMAXPROCS: "8",
+    },
   });
   if (crashes) stdout += crashes;
   const relativePath = relative(cwd, options.cwd);


### PR DESCRIPTION
## Problem

The macOS test runners now run multiple buildkite-agent workers per box (`spawn=N`). Every worker's setup `bun install` was getting a fresh `mkdtemp` for `BUN_INSTALL_CACHE_DIR` (deleted after the call), so N concurrent cold installs of `test/`'s ~2900 packages each spawned `ncpu` extraction threads. On the 24-core M2 Ultra at spawn=6 that's ~144 threads in `openat`/`mkdirat`/`close`, and the install step started timing out at 3 minutes (showing up as `test/package.json - timeout` flakes that pass on retry).

`sample` of a stuck process confirmed: not a hang — main thread in `installIsolatedPackages` event loop, all 26 pool threads blocked in extraction syscalls.

## Change

In `spawnBunInstall` only:
- Override `BUN_INSTALL_CACHE_DIR` to a fixed per-box path under `tmpdir()` so all workers share warm tarballs/extracts. The daily `com.buildkite.cleanup` wipe clears `/tmp/*`, so it doesn't grow unbounded.
- Set `GOMAXPROCS=8` so the first cold install after the wipe doesn't multiply to N×ncpu threads.

Per-test spawns are untouched — they still get isolated throwaway caches via `spawnBun()`. Only affects `test-bun` steps; build steps don't run `runner.node.mjs`.

## Result

Local cold:warm ratio (release bun, M4 Max): **7.48 s → 2.32 s** (~3.2×). CI runs `bun-profile` with `BUN_GARBAGE_COLLECTOR_LEVEL=1` / `BUN_JSC_randomIntegrityAuditRate=1.0`, so its absolute baseline is ~55 s, not 8 s — projecting the same ratio: **~55 s cold → ~17 s warm**, and at spawn=6 only the first worker after the daily wipe pays cold; the other five hit warm cache and skip extraction entirely, so the 200 s+ syscall pileup goes away.

Also updates the `bunfig.toml` comment that described the old runner behaviour.