### PR TITLE
spawn: return caller-supplied fds from Subprocess.stdio[N]

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7162,8 +7162,9 @@ declare module "bun" {
     /**
      * Access extra file descriptors passed to the `stdio` option in the options object.
      *
-     * Entries beyond index 2 are `number` for `"pipe"` slots and `null` otherwise
-     * (including when a raw file descriptor was supplied — that fd remains owned by the caller).
+     * Entries beyond index 2 are `number` for `"pipe"` slots and for slots where a raw
+     * file descriptor was supplied (the same fd is returned; it remains owned by the
+     * caller and is never closed by the subprocess). Other slots are `null`.
      */
     readonly stdio: [null, null, null, ...(number | null)[]];
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7162,9 +7162,10 @@ declare module "bun" {
     /**
      * Access extra file descriptors passed to the `stdio` option in the options object.
      *
-     * Entries beyond index 2 are `number` for `"pipe"` slots and for slots where a raw
-     * file descriptor was supplied (the same fd is returned; it remains owned by the
-     * caller and is never closed by the subprocess). Other slots are `null`.
+     * Entries beyond index 2 are `number` for `"pipe"` slots and, on POSIX, for slots
+     * where a raw file descriptor was supplied (the same fd is returned; it remains
+     * owned by the caller and is never closed by the subprocess). Other slots —
+     * including raw fds on Windows — are `null`.
      */
     readonly stdio: [null, null, null, ...(number | null)[]];
 

--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -678,7 +678,7 @@ pub fn spawnMaybeSync(
     });
 
     const posix_ipc_fd = if (Environment.isPosix and !is_sync and maybe_ipc_mode != null)
-        spawned.extra_pipes.items[@intCast(ipc_channel)]
+        spawned.extra_pipes.items[@intCast(ipc_channel)].fd()
     else
         bun.invalid_fd;
 
@@ -795,7 +795,7 @@ pub fn spawnMaybeSync(
                 subprocess.ipc_data.?.socket = .{ .open = posix_ipc_info };
             }
             // uws owns the fd now (owns_fd=1); neutralize the slot so finalizeStreams doesn't double-close.
-            subprocess.stdio_pipes.items[@intCast(ipc_channel)] = bun.invalid_fd;
+            subprocess.stdio_pipes.items[@intCast(ipc_channel)] = .unavailable;
         } else {
             if (ipc_data.windowsConfigureServer(
                 subprocess.stdio_pipes.items[@intCast(ipc_channel)].buffer,

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1183,7 +1183,7 @@ pub const PosixSpawnResult = struct {
         }
     };
 
-    pub fn close(this: *WindowsSpawnResult) void {
+    pub fn close(this: *PosixSpawnResult) void {
         for (this.extra_pipes.items) |item| {
             switch (item) {
                 .owned_fd => |f| f.close(),

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1156,16 +1156,39 @@ pub const PosixSpawnResult = struct {
     stdout: ?bun.FD = null,
     stderr: ?bun.FD = null,
     ipc: ?bun.FD = null,
-    extra_pipes: std.array_list.Managed(bun.FD) = std.array_list.Managed(bun.FD).init(bun.default_allocator),
+    extra_pipes: std.array_list.Managed(ExtraPipe) = std.array_list.Managed(ExtraPipe).init(bun.default_allocator),
 
     memfds: [3]bool = .{ false, false, false },
 
     // ESRCH can happen when requesting the pidfd
     has_exited: bool = false,
 
+    /// Entry in `extra_pipes` for a stdio slot at index >= 3.
+    pub const ExtraPipe = union(enum) {
+        /// We created this fd (e.g. socketpair for `"pipe"`); expose it via
+        /// `Subprocess.stdio[N]` and close it in `finalizeStreams`.
+        owned_fd: bun.FD,
+        /// The caller supplied this fd in the stdio array; expose it via
+        /// `Subprocess.stdio[N]` but never close it — the caller retains ownership.
+        unowned_fd: bun.FD,
+        /// Nothing to expose for this slot (`"ignore"`, `"inherit"`, a path, or
+        /// the IPC channel after ownership has been transferred to uSockets).
+        unavailable: void,
+
+        pub fn fd(this: ExtraPipe) bun.FD {
+            return switch (this) {
+                .owned_fd, .unowned_fd => |f| f,
+                .unavailable => bun.invalid_fd,
+            };
+        }
+    };
+
     pub fn close(this: *WindowsSpawnResult) void {
-        for (this.extra_pipes.items) |fd| {
-            fd.close();
+        for (this.extra_pipes.items) |item| {
+            switch (item) {
+                .owned_fd => |f| f.close(),
+                .unowned_fd, .unavailable => {},
+            }
         }
 
         this.extra_pipes.clearAndFree();
@@ -1324,7 +1347,7 @@ pub fn spawnProcessPosix(
         try actions.chdir(options.cwd);
     }
     var spawned = PosixSpawnResult{};
-    var extra_fds = std.array_list.Managed(bun.FD).init(bun.default_allocator);
+    var extra_fds = std.array_list.Managed(PosixSpawnResult.ExtraPipe).init(bun.default_allocator);
     errdefer extra_fds.deinit();
     var stack_fallback = std.heap.stackFallback(2048, bun.default_allocator);
     const allocator = stack_fallback.get();
@@ -1480,16 +1503,16 @@ pub fn spawnProcessPosix(
             .dup2 => @panic("TODO dup2 extra fd"),
             .inherit => {
                 try actions.inherit(fileno);
-                try extra_fds.append(bun.invalid_fd);
+                try extra_fds.append(.unavailable);
             },
             .ignore => {
                 try actions.openZ(fileno, "/dev/null", bun.O.RDWR, 0o664);
-                try extra_fds.append(bun.invalid_fd);
+                try extra_fds.append(.unavailable);
             },
 
             .path => |path| {
                 try actions.open(fileno, path, bun.O.RDWR | bun.O.CREAT, 0o664);
-                try extra_fds.append(bun.invalid_fd);
+                try extra_fds.append(.unavailable);
             },
             .ipc, .buffer => {
                 const fds: [2]bun.FD = try bun.sys.socketpair(
@@ -1508,14 +1531,14 @@ pub fn spawnProcessPosix(
                 try actions.dup2(fds[1], fileno);
                 if (fds[1] != fileno)
                     try actions.close(fds[1]);
-                try extra_fds.append(fds[0]);
+                try extra_fds.append(.{ .owned_fd = fds[0] });
             },
             .pipe => |fd| {
                 try actions.dup2(fd, fileno);
                 // The fd was supplied by the caller (a number in the stdio array) and is
-                // not owned by us. Record an invalid sentinel so finalizeStreams skips it
-                // instead of closing the caller's descriptor out from under them.
-                try extra_fds.append(bun.invalid_fd);
+                // not owned by us. Record it so `stdio[N]` returns the caller's fd, but
+                // mark it unowned so finalizeStreams leaves it open.
+                try extra_fds.append(.{ .unowned_fd = fd });
             },
         }
     }
@@ -1546,7 +1569,7 @@ pub fn spawnProcessPosix(
         .result => |pid| {
             spawned.pid = pid;
             spawned.extra_pipes = extra_fds;
-            extra_fds = std.array_list.Managed(bun.FD).init(bun.default_allocator);
+            extra_fds = std.array_list.Managed(PosixSpawnResult.ExtraPipe).init(bun.default_allocator);
 
             if (comptime Environment.isLinux) {
                 // If it's spawnSync and we want to block the entire thread

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -17,7 +17,7 @@ process: *Process,
 stdin: Writable,
 stdout: Readable,
 stderr: Readable,
-stdio_pipes: if (Environment.isWindows) std.ArrayListUnmanaged(StdioResult) else std.ArrayListUnmanaged(bun.FD) = .{},
+stdio_pipes: if (Environment.isWindows) std.ArrayListUnmanaged(StdioResult) else std.ArrayListUnmanaged(bun.spawn.PosixSpawnResult.ExtraPipe) = .{},
 pid_rusage: ?Rusage = null,
 
 /// Terminal attached to this subprocess (if spawned with terminal option)
@@ -485,10 +485,9 @@ pub fn getStdio(this: *Subprocess, global: *JSGlobalObject) bun.JSError!JSValue 
             } else {
                 try array.push(global, .null);
             }
-        } else if (item.isValid()) {
-            try array.push(global, JSValue.jsNumber(item.cast()));
-        } else {
-            try array.push(global, .null);
+        } else switch (item) {
+            .owned_fd, .unowned_fd => |fd| try array.push(global, JSValue.jsNumber(fd.cast())),
+            .unavailable => try array.push(global, .null),
         }
     }
     return array;
@@ -749,8 +748,9 @@ pub fn finalizeStreams(this: *Subprocess) void {
             if (item == .buffer) {
                 item.buffer.close(onPipeClose);
             }
-        } else if (item.isValid()) {
-            item.close();
+        } else switch (item) {
+            .owned_fd => |fd| fd.close(),
+            .unowned_fd, .unavailable => {},
         }
     }
     this.stdio_pipes.clearAndFree(bun.default_allocator);

--- a/src/cli/test/parallel/Worker.zig
+++ b/src/cli/test/parallel/Worker.zig
@@ -90,7 +90,7 @@ pub fn start(this: *Worker) !void {
         if (spawned.stdout) |fd| try this.out.reader.start(fd, true).unwrap();
         if (spawned.stderr) |fd| try this.err.reader.start(fd, true).unwrap();
         if (spawned.extra_pipes.items.len > 0) {
-            if (!this.ipc.adopt(coord.vm, spawned.extra_pipes.items[0])) return error.ChannelAdoptFailed;
+            if (!this.ipc.adopt(coord.vm, spawned.extra_pipes.items[0].fd())) return error.ChannelAdoptFailed;
         } else {
             this.ipc.done = true;
         }

--- a/src/install/PackageManager/security_scanner.zig
+++ b/src/install/PackageManager/security_scanner.zig
@@ -795,7 +795,7 @@ pub const SecurityScanSubprocess = struct {
         this.ipc_reader.flags.nonblocking = true;
         this.ipc_reader.flags.socket = false;
 
-        try this.finishSpawn(&spawned, ipc_output_fds[0], spawned.extra_pipes.items[1]);
+        try this.finishSpawn(&spawned, ipc_output_fds[0], spawned.extra_pipes.items[1].fd());
     }
 
     /// Windows fd 4: .buffer stdio for extra_fds sets UV_OVERLAPPED_PIPE on the

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -857,9 +857,9 @@ describe("close handling", () => {
       await using proc = spawn({
         cmd: [bunExe(), "-e", ""],
         env: bunEnv,
-        stdio: ["ignore", "ignore", "ignore", "ignore", fd, "inherit"],
+        stdio: ["ignore", "ignore", "ignore", "ignore", fd],
       });
-      expect(proc.stdio).toEqual([null, null, null, null, fd, null]);
+      expect(proc.stdio).toEqual([null, null, null, null, fd]);
       await proc.exited;
     } finally {
       try {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -826,7 +826,9 @@ describe("close handling", () => {
             stdio: ["ignore", "ignore", "ignore", fd],
           }),
         );
-        expect(procs[0].stdio[3]).toBe(null);
+        // The caller-supplied fd should be exposed on stdio[N] (not null) while
+        // still not being closed by the subprocess.
+        expect(procs[0].stdio).toEqual([null, null, null, fd]);
         await Promise.all(procs.map(p => p.exited));
       })();
 
@@ -842,6 +844,23 @@ describe("close handling", () => {
         stdio: ["ignore", "ignore", "inherit", fd],
       });
       expect(await exited).toBe(0);
+    } finally {
+      try {
+        closeSync(fd);
+      } catch {}
+    }
+  });
+
+  it.skipIf(isWindows)("stdio[N] for non-fd extra slots is null", async () => {
+    const fd = openSync(import.meta.path, "r");
+    try {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", ""],
+        env: bunEnv,
+        stdio: ["ignore", "ignore", "ignore", "ignore", fd, "inherit"],
+      });
+      expect(proc.stdio).toEqual([null, null, null, null, fd, null]);
+      await proc.exited;
     } finally {
       try {
         closeSync(fd);


### PR DESCRIPTION
## What does this PR do?

Follow-up to #29606. That change kept `Bun.spawn` from closing caller-owned fds passed as extra stdio (`stdio[N]`, N≥3) by storing `bun.invalid_fd` in the `extra_pipes` slot. Correct for lifetime, but it meant `Subprocess.stdio[N]` now returned `null` for those entries — the caller could no longer read back the fd they passed in.

This PR tracks ownership instead of erasing the fd. `PosixSpawnResult.extra_pipes` / `Subprocess.stdio_pipes` now hold:

```zig
union(enum) {
    owned_fd: bun.FD,    // socketpair for "pipe" — expose and close
    unowned_fd: bun.FD,  // caller-supplied fd — expose, never close
    unavailable: void,   // "ignore"/"inherit"/path/IPC-after-adoption — null
}
```

- `getStdio` returns the fd number for both `owned_fd` and `unowned_fd`, `null` for `unavailable`
- `finalizeStreams` only closes `owned_fd`

So after this change, for `stdio: [..., ..., ..., myFd]`:
- `proc.stdio[3] === myFd` (was `null` after #29606)
- `myFd` is still never closed by the subprocess

Internal slots (`"ignore"`, `"inherit"`, file paths, and the IPC channel once uSockets takes ownership) continue to report `null`.

## How did you verify your code works?

- Updated `test/js/bun/spawn/spawn.test.ts`: the existing "does not close caller-owned fds" test now asserts `proc.stdio[3]` equals the supplied fd (and still checks the fd survives GC).
- New test verifies `null` for `"ignore"`/`"inherit"` slots alongside the user fd at the correct index.
- `bun bd test test/js/bun/spawn/spawn.test.ts -t "close handling"` — 66 pass
- `bun bd test test/js/bun/spawn/spawn.ipc.test.ts` — 6 pass
- `bun run zig:check-all` — passes on all targets