### PR TITLE
FormData: match WebKit's multipart boundary exactly

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -585,7 +585,7 @@ pub fn fromDOMFormData(
     var hex_buf: [70]u8 = undefined;
     const boundary = brk: {
         var random = globalThis.bunVM().rareData().nextUUID().bytes;
-        break :brk std.fmt.bufPrint(&hex_buf, "-WebkitFormBoundary{x}", .{&random}) catch unreachable;
+        break :brk std.fmt.bufPrint(&hex_buf, "----WebKitFormBoundary{x}", .{&random}) catch unreachable;
     };
 
     var context = FormDataContext{

--- a/test/js/bun/http/form-data-set-append.test.js
+++ b/test/js/bun/http/form-data-set-append.test.js
@@ -1,7 +1,46 @@
 import { expect, test } from "bun:test";
 
-// https://github.com/oven-sh/bun/issues/12325
+// https://github.com/oven-sh/bun/issues/29630
+// FormData must produce a boundary matching WebKit exactly:
+//   declared: "----WebKitFormBoundary{hex}" (4 leading dashes, capital K)
+//   body markers: "------WebKitFormBoundary{hex}" (6 dashes)
+// Previously Bun emitted "-WebkitFormBoundary{hex}" (1 dash, lowercase k),
+// which produced 3-dash body markers — a format no other mainstream client
+// uses and which trips buggy downstream multipart parsers.
+test("FormData request body uses WebKit-compatible boundary (#29630)", async () => {
+  const fd = new FormData();
+  fd.append("file", new Blob([new Uint8Array([1, 2, 3])], { type: "application/octet-stream" }), "page-17.pdf");
+  fd.append("purpose", "user_data");
 
+  const req = new Request("http://localhost/", { method: "POST", body: fd });
+
+  const contentType = req.headers.get("content-type");
+  // Must match WebKit exactly: 4 leading dashes, capital K, followed by 32 hex chars
+  expect(contentType).toMatch(/^multipart\/form-data; boundary=----WebKitFormBoundary[0-9a-f]{32}$/);
+
+  const boundary = contentType.slice("multipart/form-data; boundary=".length);
+
+  const body = await req.text();
+  // Body markers are "--" + boundary, so 6 dashes before WebKitFormBoundary.
+  expect(body.startsWith(`--${boundary}\r\n`)).toBe(true);
+  expect(body.startsWith("------WebKitFormBoundary")).toBe(true);
+  // Terminator is "--" + boundary + "--\r\n".
+  expect(body.endsWith(`\r\n--${boundary}--\r\n`)).toBe(true);
+});
+
+test("FormData via Response uses WebKit-compatible boundary (#29630)", async () => {
+  const fd = new FormData();
+  fd.append("field", "value");
+
+  const res = new Response(fd);
+  const contentType = res.headers.get("content-type");
+  expect(contentType).toMatch(/^multipart\/form-data; boundary=----WebKitFormBoundary[0-9a-f]{32}$/);
+
+  const body = await res.text();
+  expect(body.startsWith("------WebKitFormBoundary")).toBe(true);
+});
+
+// https://github.com/oven-sh/bun/issues/12325
 test("formdata set with File works as expected", async () => {
   const expected = ["617580375", "text-notes1.txt"];
 


### PR DESCRIPTION
Fixes #29630.

## Bug

Bun's `FormData` generated a multipart boundary that doesn't match any
other mainstream client:

| Client            | Declared boundary                          | Body marker                                |
| ----------------- | ------------------------------------------ | ------------------------------------------ |
| WebKit browsers   | `----WebKitFormBoundary{hex}` (4 dashes)   | `------WebKitFormBoundary{hex}` (6 dashes) |
| undici            | `----formdata-undici-0{N}` (4 dashes)      | `------formdata-undici-0{N}` (6 dashes)    |
| **Bun (before)**  | `-WebkitFormBoundary{hex}` (**1 dash**)    | `---WebkitFormBoundary{hex}` (**3 dashes**) |

Note also the lowercase `k` — WebKit browsers use capital `K`.

This unique format triggers bugs in some downstream multipart parsers
(the reporter hit a deterministic 400 from OpenAI's `files.create`
endpoint on specific binary payloads that uploads fine from Node/undici).

## Cause

Single site, `src/bun.js/webcore/Blob.zig:588`:

```zig
break :brk std.fmt.bufPrint(&hex_buf, "-WebkitFormBoundary{x}", .{&random}) catch unreachable;
```

## Fix

Change the format string to match WebKit exactly
(`vendor/WebKit/Source/WebCore/platform/network/FormDataBuilder.cpp:142`
uses `"----WebKitFormBoundary"`):

```zig
break :brk std.fmt.bufPrint(&hex_buf, "----WebKitFormBoundary{x}", .{&random}) catch unreachable;
```

The 22-byte prefix + 32 hex chars (54 bytes) still fits in the existing
`[70]u8` buffer. The usage sites at lines 603–605 already emit
`"--" + boundary + "--\r\n"`, so they automatically produce the correct
6-dash body markers without changes.

## Verification

Before:
```
content-type: multipart/form-data; boundary=-WebkitFormBoundary22a1c702...
body: ---WebkitFormBoundary22a1c702...\r\n...
```

After:
```
content-type: multipart/form-data; boundary=----WebKitFormBoundary5ec838da...
body: ------WebKitFormBoundary5ec838da...\r\n...
```

## Tests

Added two tests to `test/js/bun/http/form-data-set-append.test.js`
that assert:
- `content-type` matches `^multipart/form-data; boundary=----WebKitFormBoundary[0-9a-f]+$`
- body starts with `------WebKitFormBoundary...\r\n`
- body ends with `\r\n--<boundary>--\r\n`

Gate check:
- Stashed src changes → both new tests **fail** (declared boundary has 1 dash, lowercase k).
- Restored src changes → all 4 tests in the file **pass**.
