### PR TITLE
expect: propagate exceptions from custom asymmetricMatch

### DIFF
--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1734,6 +1734,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = execute(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -404,3 +404,26 @@ describe("MatcherContext", () => {
     });
   });
 });
+
+describe("asymmetricMatch exception propagation", () => {
+  it("propagates exceptions thrown by the matcher function", () => {
+    expect.extend({
+      _alwaysThrows() {
+        throw new Error("boom from matcher");
+      },
+    });
+
+    const matcher = expect._alwaysThrows();
+    expect(() => matcher.asymmetricMatch(1)).toThrow("boom from matcher");
+  });
+
+  it("propagates exceptions when the matcher function is a native host function that throws", () => {
+    // expect.extend itself throws when called with a non-object first argument.
+    // Registering it as a matcher means asymmetricMatch will invoke it with the
+    // received value as the first arg.
+    expect.extend({ _callsExtend: expect.extend });
+
+    const matcher = expect._callsExtend();
+    expect(() => matcher.asymmetricMatch(1)).toThrow();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug-build assertion failure (`releaseAssertNoException`) when a custom asymmetric matcher's implementation function throws.

`ExpectCustomAsymmetricMatcher.execute()` is `callconv(.c) bool` and swallows `error.JSError` via `catch false` / `catch {}`, which leaves the thrown exception pending in the VM while returning `false`. `asymmetricMatch()` then returned `jsBoolean(matched)` — a non-empty JSValue — without checking for the pending exception. The generated host-function wrapper (`toJSHostCall`) then hit `assertExceptionPresenceMatches(false)` → `releaseAssertNoException()`.

Minimal repro (crashes on debug builds before this change):

```js
const { expect } = Bun.jest(import.meta.path);
expect.extend({ foo: expect.extend });
expect.foo().asymmetricMatch(1);
```

Now the pending exception is propagated to JS instead of returning a boolean with an exception on the stack.

## How did you verify your code works?

- Added regression tests in `test/js/bun/test/expect-extend.test.js` covering both a JS matcher that throws and a native host function (`expect.extend` itself) registered as a matcher.
- Verified the new tests crash with the assertion on the previous binary and pass with the fix.
- `bun bd test test/js/bun/test/expect-extend.test.js` — 30/30 pass.

Found by Fuzzilli (fingerprint `69a0af3aa71977d5`).