### PR TITLE
feat(build): add --static-all flag for fully static Linux binaries

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -435,7 +435,7 @@ Options:
                           Fields: asan, lto, assertions, logs, baseline,
                                   canary, valgrind, webkit (prebuilt|local),
                                   buildDir, mode (full|cpp-only|link-only),
-                                  unifiedSources, timeTrace
+                                  unifiedSources, timeTrace, staticAll
   --target=<name>         Build a specific ninja target (repeatable)
   --configure-only        Emit build.ninja, don't run it
   -j<N>, -v, -k<N>        Passed through to ninja
@@ -448,6 +448,7 @@ Any bare positional and everything after is passed to the built binary:
 Examples:
   bun scripts/build.ts --profile=debug
   bun scripts/build.ts --profile=release --lto=off
+  bun scripts/build.ts --profile=release --static-all=on --asan=off
   bun scripts/build.ts test foo.test.ts
   bun scripts/build.ts --profile=debug-local run script.ts
   bun scripts/build.ts --target=bun-zig

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -293,6 +293,7 @@ function parseArgs(argv: string[]): CliArgs {
     "baseline",
     "canary",
     "staticSqlite",
+    "staticAll",
     "staticLibatomic",
     "tinycc",
     "valgrind",

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -402,8 +402,11 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // ─── Features ───
   // Each is resolved exactly once here.
 
+  const staticAll = partial.staticAll ?? false;
+
   // ASAN: default on for debug builds on arm64 macOS or linux
-  const asanDefault = debug && ((darwin && arm64) || linux);
+  // Static builds are incompatible with ASAN (Clang ASAN does not support -static)
+  const asanDefault = !staticAll && debug && ((darwin && arm64) || linux);
   const asan = partial.asan ?? asanDefault;
 
   // Zig ASAN follows ASAN unless explicitly overridden
@@ -446,8 +449,6 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // failure is loud ("cannot find -l:libatomic.a") and the fix is obvious.
   const staticLibatomic = partial.staticLibatomic ?? true;
 
-  const staticAll = partial.staticAll ?? false;
-
   // TinyCC: off on Windows ARM64 (not supported), on elsewhere
   const tinycc = partial.tinycc ?? !(windows && arm64);
 
@@ -484,6 +485,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   assert(!baseline || x64, "baseline=true requires arch=x64 (baseline disables AVX which is x64-only)");
   assert(!valgrind || linux, "valgrind=true requires os=linux");
   assert(!(asan && valgrind), "Cannot enable both asan and valgrind simultaneously");
+  assert(!staticAll || linux, "staticAll=true requires os=linux");
+  assert(!staticAll || !asan, "staticAll=true is incompatible with ASAN; pass --asan=off");
   assert(os !== "linux" || abi !== undefined, "Linux builds require an abi (gnu or musl)");
 
   // ─── Versioning ───
@@ -819,6 +822,7 @@ export function formatConfig(cfg: Config, exe: string): string {
   if (cfg.baseline) features.push("baseline");
   if (cfg.valgrind) features.push("valgrind");
   if (cfg.fuzzilli) features.push("fuzzilli");
+  if (cfg.staticAll) features.push("static-all");
   if (!cfg.canary) features.push("canary:off");
   // Non-default modes — show so you notice when a build is unusual.
   if (cfg.webkit !== "prebuilt") features.push(`webkit:${cfg.webkit}`);

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -116,6 +116,8 @@ export interface Config {
   /** MinSizeRel → optimize for size. */
   smol: boolean;
   staticSqlite: boolean;
+  /** Fully static binary: pass -static to the linker. Works on glibc (Ubuntu/Debian) and musl. */
+  staticAll: boolean;
   staticLibatomic: boolean;
   tinycc: boolean;
   valgrind: boolean;
@@ -235,6 +237,7 @@ export interface PartialConfig {
   baseline?: boolean;
   canary?: boolean;
   staticSqlite?: boolean;
+  staticAll?: boolean;
   staticLibatomic?: boolean;
   tinycc?: boolean;
   valgrind?: boolean;
@@ -443,6 +446,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // failure is loud ("cannot find -l:libatomic.a") and the fix is obvious.
   const staticLibatomic = partial.staticLibatomic ?? true;
 
+  const staticAll = partial.staticAll ?? false;
+
   // TinyCC: off on Windows ARM64 (not supported), on elsewhere
   const tinycc = partial.tinycc ?? !(windows && arm64);
 
@@ -535,6 +540,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     canary,
     smol,
     staticSqlite,
+    staticAll,
     staticLibatomic,
     tinycc,
     valgrind,

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -604,6 +604,11 @@ export const defines: Flag[] = [
     when: c => !c.staticSqlite,
     desc: "SQLite loaded at runtime",
   },
+  {
+    flag: "BUN_STATIC_BUILD=1",
+    when: c => c.linux && c.staticAll,
+    desc: "Disable glibc .symver directives in workaround-missing-symbols.cpp",
+  },
 ];
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -736,7 +741,7 @@ export const linkerFlags: Flag[] = [
       "-Wl,--wrap=powf",
       "-Wl,--wrap=quick_exit",
     ],
-    when: c => c.linux && c.abi !== "musl",
+    when: c => c.linux && c.abi !== "musl" && !c.staticAll,
     desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
   },
   {
@@ -785,8 +790,34 @@ export const linkerFlags: Flag[] = [
       "-Wl,--hash-style=both",
       "-Wl,--build-id=sha1",
     ],
-    when: c => c.linux,
+    when: c => c.linux && !c.staticAll,
     desc: "Linux linker tuning: lazy binding, large stack, compressed debug, fast gdb loading",
+  },
+  {
+    // Static build: equivalent tuning without lazy/relro/dynamic-specific flags.
+    flag: [
+      "-Wl,-z,stack-size=12800000",
+      "-Wl,--compress-debug-sections=zlib",
+      "-Wl,-O2",
+      "-Wl,--gdb-index",
+      "-Wl,--sort-section=name",
+      "-Wl,--build-id=sha1",
+    ],
+    when: c => c.linux && c.staticAll,
+    desc: "Linux linker tuning for static builds (no lazy/relro)",
+  },
+  {
+    flag: "-static",
+    when: c => c.linux && c.staticAll,
+    desc: "Fully static binary — no dynamic linker dependency",
+  },
+  {
+    // mimalloc overrides malloc/free; libc.a also defines them. Tell lld to
+    // accept multiple definitions and keep the first (mimalloc wins because
+    // it appears before -lc in link order).
+    flag: "-Wl,--allow-multiple-definition",
+    when: c => c.linux && c.staticAll,
+    desc: "Allow mimalloc to override libc malloc in static builds",
   },
   {
     flag: "-Wl,--gc-sections",
@@ -819,7 +850,7 @@ export const linkerFlags: Flag[] = [
       `-Wl,--dynamic-list=${c.cwd}/src/symbols.dyn`,
       `-Wl,--version-script=${c.cwd}/src/linker.lds`,
     ],
-    when: c => c.linux,
+    when: c => c.linux && !c.staticAll,
     desc: "Dynamic symbol list + version script",
   },
 ];

--- a/src/bun.js/bindings/workaround-missing-symbols.cpp
+++ b/src/bun.js/bindings/workaround-missing-symbols.cpp
@@ -84,6 +84,7 @@ extern "C" int kill(int pid, int sig)
 #endif
 #endif
 
+#if !defined(BUN_STATIC_BUILD)
 #if defined(__x86_64__)
 __asm__(".symver exp,exp@GLIBC_2.2.5");
 __asm__(".symver exp2,exp2@GLIBC_2.2.5");
@@ -105,8 +106,9 @@ __asm__(".symver logf,logf@GLIBC_2.17");
 __asm__(".symver pow,pow@GLIBC_2.17");
 __asm__(".symver powf,powf@GLIBC_2.17");
 #endif
+#endif // !BUN_STATIC_BUILD
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#if !defined(BUN_STATIC_BUILD) && (defined(__x86_64__) || defined(__aarch64__))
 #define BUN_WRAP_GLIBC_SYMBOL(symbol) __wrap_##symbol
 #else
 #define BUN_WRAP_GLIBC_SYMBOL(symbol) symbol


### PR DESCRIPTION
- add `staticAll` config field and CLI arg to build system
- pass `-static` linker flag and disable dynamic-only flags (symver, lazy binding, version script)
- guard glibc .symver directives behind `BUN_STATIC_BUILD` macro
- add `--allow-multiple-definition` so mimalloc can override libc malloc

### What does this PR do?

This is a demo / proof of concept to compile static linked bun linux binary

### How did you verify your code works?

I've verified that it produces a statically linked binary, but haven't done thorough runtime testing. The binary compiles and links — that's about as far as I've taken it. Would appreciate help with proper testing and validation.