### PR TITLE
Blob: render empty blobs as zero-byte, not "detached"

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -677,15 +677,21 @@ pub fn writeFormat(this: *Blob, comptime Formatter: type, formatter: *Formatter,
     const Writer = @TypeOf(writer);
 
     if (this.isDetached()) {
-        if (this.is_jsdom_file) {
-            try writer.writeAll(comptime Output.prettyFmt("<d>[<r>File<r> detached<d>]<r>", enable_ansi_colors));
-        } else {
-            try writer.writeAll(comptime Output.prettyFmt("<d>[<r>Blob<r> detached<d>]<r>", enable_ansi_colors));
+        // A blob with no store and size > 0 was genuinely detached (e.g. after
+        // transferring its contents). An empty `new Blob([])` or `new File([])`
+        // also has no store but is a valid zero-byte blob — render it like a
+        // normal zero-sized blob instead of calling it "detached".
+        if (this.size > 0) {
+            if (this.is_jsdom_file) {
+                try writer.writeAll(comptime Output.prettyFmt("<d>[<r>File<r> detached<d>]<r>", enable_ansi_colors));
+            } else {
+                try writer.writeAll(comptime Output.prettyFmt("<d>[<r>Blob<r> detached<d>]<r>", enable_ansi_colors));
+            }
+            return;
         }
-        return;
-    }
 
-    {
+        try writeFormatForSize(this.is_jsdom_file, 0, writer, enable_ansi_colors);
+    } else {
         const store = this.store.?;
         switch (store.data) {
             .s3 => |*s3| {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -118,7 +118,7 @@ it("Blob inspect", () => {
   headers: Headers {},
   redirected: false,
   bodyUsed: false,
-  [Blob detached]
+  Blob (0 KB)
 }`);
   expect(Bun.inspect(new Response("Hello"))).toBe(`Response (5 bytes) {
   ok: true,
@@ -606,6 +606,38 @@ it("console.log on a Blob shows name", () => {
   expect(Bun.inspect(file)).toBe(
     `File (3 bytes) {\n  name: "",\n  type: "text/plain;charset=utf-8",\n  lastModified: ${file.lastModified}\n}`,
   );
+});
+
+// https://github.com/oven-sh/bun/issues/29637
+// An empty `new Blob([])` or `new File([])` has `store == null` internally,
+// but that's identical to the state after the blob was transferred away. The
+// inspect output used to call both "detached" — the empty case should render
+// as a normal zero-byte blob/file instead.
+it("empty Blob and File inspect as zero-byte, not detached", () => {
+  expect(Bun.inspect(new Blob([]))).toBe("Blob (0 KB)");
+  expect(Bun.inspect(new Blob())).toBe("Blob (0 KB)");
+
+  const emptyFile = new File([], "empty.txt");
+  expect(Bun.inspect(emptyFile)).toBe(
+    `File (0 KB) {\n  name: "empty.txt",\n  lastModified: ${emptyFile.lastModified}\n}`,
+  );
+
+  // structuredClone round-trips through serialization that leaves the store
+  // null when contents are empty — make sure the cloned form also renders
+  // cleanly.
+  const clonedBlob = structuredClone(new Blob([]));
+  expect(Bun.inspect(clonedBlob)).toBe("Blob (0 KB)");
+
+  const cloned = structuredClone({
+    file: new File([], "example.txt"),
+    blob: new Blob([]),
+  });
+  expect(Bun.inspect(cloned.blob)).toBe("Blob (0 KB)");
+  expect(cloned.file).toBeInstanceOf(File);
+  expect(cloned.file.name).toBe("example.txt");
+  expect(cloned.file.size).toBe(0);
+  // Make sure nothing in the combined output is flagged as detached.
+  expect(Bun.inspect(cloned)).not.toContain("detached");
 });
 
 it("console.log on a arguments shows list", () => {


### PR DESCRIPTION
## Repro

```js
const clone = structuredClone({
  file: new File([], 'example.txt'),
  blob: new Blob([]),
});
console.log(clone);
```

Before:

```
{
  file: [File detached],
  blob: [Blob detached],
}
```

After (matches Node's semantics: a valid zero-byte blob):

```
{
  file: File (0 KB) {
    name: "example.txt",
    lastModified: 1776939172157
  },
  blob: Blob (0 KB),
}
```

Also reproduces with `console.log(new Blob([]))` — no clone needed.

## Cause

A `Blob` with zero content has `store == null, size == 0`. That's
indistinguishable from `initEmpty` and from a blob after the transfer
path nulls out `store`. `isDetached()` returns `store == null` and the
inspect path printed `[Blob detached]` / `[File detached]` for all
three cases, even though nothing in the first two is actually detached.

`structuredClone` made this more visible: its deserialization path calls
`Blob.init` which only creates a store when `bytes.len > 0`, so every
cloned empty blob lost its store and fell into the detached branch.

## Fix

Distinguish the two by checking `size` — a genuinely detached blob has
a nonzero `size` with no store (since `detach()` leaves `size`
unchanged), while an empty blob has both set to zero. The fix in
`writeFormat`:

```zig
if (this.isDetached()) {
    if (this.size > 0) {
        // still "detached"
        try writer.writeAll("[Blob detached]");
        return;
    }
    try writeFormatForSize(this.is_jsdom_file, 0, writer, enable_ansi_colors);
} else {
    // ...existing store-backed path
}
```

Zero-size blobs without a store now render like any other zero-byte
blob: `Blob (0 KB)` / `File (0 KB) { name, lastModified }`.

## Verification

- `test/js/bun/util/inspect.test.js` — new case ("empty Blob and File
  inspect as zero-byte, not detached") covering `new Blob([])`,
  `new File([], name)`, and a `structuredClone`-round-tripped empty
  blob/file.
- Gate: test fails on the pre-fix build (`Expected: "Blob (0 KB)"  Received: "[Blob detached]"`), passes after.
- Existing `Blob inspect` test updated: `new Response(new Blob())` now
  prints `Blob (0 KB)` inside, not `[Blob detached]`.
- `test/js/web/fetch/` blob test suite and
  `test/js/web/structured-clone-blob-file.test.ts` all pass.

Fixes #29637