### PR TITLE
Read ESM registry from moduleLoader() instead of globalThis.Loader

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2228,26 +2228,10 @@ void GlobalObject::finishCreation(VM& vm)
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSMap>::Initializer& init) {
             auto* global = init.owner;
             auto& vm = init.vm;
-            auto scope = DECLARE_THROW_SCOPE(vm);
-
-            // if we get the termination exception, we'd still like to set a non-null Map so that
-            // we don't segfault
-            auto setEmpty = [&]() {
-                ASSERT(scope.exception());
-                init.set(JSC::JSMap::create(init.vm, init.owner->mapStructure()));
-            };
 
             JSMap* registry = nullptr;
-            auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            scope.assertNoExceptionExceptTermination();
-            RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                scope.assertNoExceptionExceptTermination();
-                RETURN_IF_EXCEPTION(scope, setEmpty());
-                if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
-                }
+            if (auto* loader = global->moduleLoader()) {
+                registry = jsDynamicCast<JSC::JSMap*>(loader->getDirect(vm, JSC::Identifier::fromString(vm, "registry"_s)));
             }
 
             if (!registry) {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -560,3 +560,34 @@ it("recursion throws stack overflow at entry point", () => {
 
   expect(result.stderr.toString()).toContain("RangeError: Maximum call stack size exceeded.");
 });
+
+describe.each([
+  ["a primitive", `globalThis.Loader = 8;`],
+  ["an object with a non-Map registry", `globalThis.Loader = { registry: 42 };`],
+  ["a throwing getter", `Object.defineProperty(globalThis, "Loader", { get() { throw new Error("boom"); } });`],
+])("build.module when globalThis.Loader is overwritten with %s", (_, setup) => {
+  it.concurrent("does not crash", async () => {
+    const code = `
+      ${setup}
+      Bun.plugin({
+        name: "x",
+        setup(build) {
+          build.module("m", () => ({ exports: {}, loader: "object" }));
+        },
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "",
+      stderr: expect.not.stringMatching(/runtime error|ASSERTION FAILED|panic/),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -575,19 +575,16 @@ describe.each([
           build.module("m", () => ({ exports: {}, loader: "object" }));
         },
       });
+      console.log("ok");
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", code],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "inherit",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "",
-      stderr: expect.not.stringMatching(/runtime error|ASSERTION FAILED|panic/),
-      exitCode: 0,
-      signalCode: null,
-    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

The lazy initializer for `m_esmRegistryMap` looked up the `Loader` property on the global object. Since user code can overwrite `globalThis.Loader`, this could crash in three ways:

- `globalThis.Loader = 8` → `loaderValue.getObject()` returns `nullptr`, then we call a member on it (null deref / segfault)
- `globalThis.Loader = { registry: 42 }` → `jsCast<JSMap*>(registryValue)` asserts
- `Object.defineProperty(globalThis, "Loader", { get() { throw ... } })` → `assertNoExceptionExceptTermination()` fires

Now the initializer reads the registry directly from `JSGlobalObject::moduleLoader()` via `getDirect` + `jsDynamicCast`, the same way `Zig__GlobalObject__getModuleRegistryMap` and `Zig__GlobalObject__resetModuleRegistryMap` already do it a few hundred lines up. This can't throw and isn't affected by user code touching the global.

Found by Fuzzilli.

## How did you verify your code works?

Added regression tests for all three variants in `test/js/bun/plugin/plugins.test.ts` that segfault on main and pass with this change.