### PR TITLE
Fix crash in esmRegistryMap init when globalThis.Loader is tampered with

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2230,8 +2230,8 @@ void GlobalObject::finishCreation(VM& vm)
             auto& vm = init.vm;
             auto scope = DECLARE_THROW_SCOPE(vm);
 
-            // if we get the termination exception, we'd still like to set a non-null Map so that
-            // we don't segfault
+            // if we get an exception (termination, or from a Proxy trap on the global's
+            // prototype chain), we'd still like to set a non-null Map so that we don't segfault
             auto setEmpty = [&]() {
                 ASSERT(scope.exception());
                 init.set(JSC::JSMap::create(init.vm, init.owner->mapStructure()));
@@ -2239,14 +2239,12 @@ void GlobalObject::finishCreation(VM& vm)
 
             JSMap* registry = nullptr;
             auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            scope.assertNoExceptionExceptTermination();
             RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (loaderValue) {
-                auto registryValue = loaderValue.getObject()->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                scope.assertNoExceptionExceptTermination();
+            if (auto* loaderObject = loaderValue ? loaderValue.getObject() : nullptr) {
+                auto registryValue = loaderObject->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
                 RETURN_IF_EXCEPTION(scope, setEmpty());
                 if (registryValue) {
-                    registry = jsCast<JSC::JSMap*>(registryValue);
+                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
                 }
             }
 

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -2228,28 +2228,16 @@ void GlobalObject::finishCreation(VM& vm)
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSMap>::Initializer& init) {
             auto* global = init.owner;
             auto& vm = init.vm;
-            auto scope = DECLARE_THROW_SCOPE(vm);
 
-            // if we get an exception (termination, or from a Proxy trap on the global's
-            // prototype chain), we'd still like to set a non-null Map so that we don't segfault
-            auto setEmpty = [&]() {
-                ASSERT(scope.exception());
-                init.set(JSC::JSMap::create(init.vm, init.owner->mapStructure()));
-            };
-
+            // Read the registry via the C++ moduleLoader() accessor and getDirect() so
+            // user tampering with globalThis.Loader or the global prototype can't affect us.
             JSMap* registry = nullptr;
-            auto loaderValue = global->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "Loader"_s));
-            RETURN_IF_EXCEPTION(scope, setEmpty());
-            if (auto* loaderObject = loaderValue ? loaderValue.getObject() : nullptr) {
-                auto registryValue = loaderObject->getIfPropertyExists(global, JSC::Identifier::fromString(vm, "registry"_s));
-                RETURN_IF_EXCEPTION(scope, setEmpty());
-                if (registryValue) {
-                    registry = jsDynamicCast<JSC::JSMap*>(registryValue);
-                }
+            if (auto* loader = global->moduleLoader()) {
+                registry = jsDynamicCast<JSC::JSMap*>(loader->getDirect(vm, JSC::Identifier::fromString(vm, "registry"_s)));
             }
 
             if (!registry) {
-                registry = JSC::JSMap::create(init.vm, init.owner->mapStructure());
+                registry = JSC::JSMap::create(vm, global->mapStructure());
             }
 
             init.set(registry);

--- a/test/js/bun/util/exotic-global-mutable-prototype.test.ts
+++ b/test/js/bun/util/exotic-global-mutable-prototype.test.ts
@@ -61,7 +61,6 @@ test.concurrent.each([
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  expect(stdout).toBe("ok\n");
-  expect(exitCode).toBe(0);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: expect.any(String), exitCode: 0 });
 });

--- a/test/js/bun/util/exotic-global-mutable-prototype.test.ts
+++ b/test/js/bun/util/exotic-global-mutable-prototype.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // StructureFlag: ~IsImmutablePrototypeExoticObject
 //
@@ -31,4 +32,36 @@ test("Object.setPrototypeOf works on globalThis", () => {
     // @ts-expect-error
     globalThis.a,
   ).toBeUndefined();
+});
+
+// The ESM registry map is initialized lazily by reading globalThis.Loader.registry. If
+// the global's prototype chain has a Proxy with a throwing `has` trap, or Loader has been
+// replaced with a non-object, or Loader.registry is not a Map, Bun should not crash.
+test.concurrent.each([
+  [
+    "Proxy has trap throws",
+    `delete globalThis.Loader;
+     Object.setPrototypeOf(globalThis, new Proxy(Object.getPrototypeOf(globalThis), {
+       has() { throw new TypeError("boom"); },
+     }));`,
+  ],
+  ["Loader is not an object", `globalThis.Loader = 42;`],
+  ["Loader.registry is not a Map", `globalThis.Loader = { registry: {} };`],
+])("require() does not crash when globalThis.Loader is tampered with (%s)", async (_, setup) => {
+  using dir = tempDir("loader-tamper", {
+    "mod.js": "module.exports = 1;",
+    "entry.js": `${setup}
+       try { require("./mod.js"); } catch {}
+       console.log("ok");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
The lazy initializer for `m_esmRegistryMap` reads `globalThis.Loader.registry` to find JSC's module registry map. This lookup goes through the global's prototype chain, which user code can replace with a Proxy or override entirely.

Three failure modes fixed in the same initializer:

- `getIfPropertyExists()` uses `InternalMethodType::HasProperty`, so a Proxy `has` trap in the prototype chain can throw any exception, not just a termination exception. Removed the `assertNoExceptionExceptTermination()` calls — the `RETURN_IF_EXCEPTION` immediately after already handles this.
- If `globalThis.Loader` is replaced with a primitive, `loaderValue.getObject()` returns null and we called a method on it (segfault in release). Guard with a null check.
- If `Loader.registry` is not a `JSMap`, `jsCast<JSMap*>` asserts in debug. Use `jsDynamicCast` so we fall through to creating a fresh map instead.

In all three cases we now fall back to an empty registry map (or propagate the exception to the caller, which already checks for it) instead of crashing.

Found by Fuzzilli (fingerprint `c6482694ec03cf30`): the fuzzer's Probe instrumentation installs a Proxy on the prototype of probed values, and across REPRL iterations that Proxy ended up on `globalThis`'s prototype with a broken `has` trap, which the next iteration's `require()` then tripped over.

Repro for the release-visible segfault:
```js
globalThis.Loader = 42;
require("./some-local-file.js");
// panic(main thread): Segmentation fault at address 0x6
```