### PR TITLE
Fix crash and dropped properties in Bun.inspect when a property lookup or getPrototypeOf throws during the property walk

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5618,16 +5618,9 @@ restart:
 
     {
 
-        JSValue iteratingValue = prototypeObject;
+        JSObject* iterating = prototypeObject.getObject();
 
-        while (JSObject* iterating = iteratingValue.getObject()) {
-            if (iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject))
-                break;
-            if (prototypeCount++ >= 5)
-                break;
-
-            JSC::EnsureStillAliveScope ensureIteratingStillAlive(iteratingValue);
-
+        while (iterating && !(iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
             if constexpr (nonIndexedOnly) {
                 iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
             } else {
@@ -5651,7 +5644,8 @@ restart:
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
                 bool hasProperty = object->getPropertySlot(globalObject, property, slot);
-                // Ignore exceptions from "Get" proxy traps.
+                // Ignore exceptions from "Get" proxy traps and throwing lazy property
+                // initializers; both report the property as not found.
                 CLEAR_IF_EXCEPTION(scope);
                 if (!hasProperty)
                     continue;
@@ -5726,11 +5720,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iteratingValue = iterating->getPrototype(globalObject);
+            JSValue prototype = iterating->getPrototype(globalObject);
             // Ignore exceptions from Proxy "getPrototypeOf" trap.
             CLEAR_IF_EXCEPTION(scope);
-            if (!iteratingValue)
+            if (!prototype)
                 break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue iteratingProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!iteratingProto)
+                break;
+            iterating = iteratingProto.getObject();
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5618,9 +5618,16 @@ restart:
 
     {
 
-        JSObject* iterating = prototypeObject.getObject();
+        JSValue iteratingValue = prototypeObject;
 
-        while (iterating && !(iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+        while (JSObject* iterating = iteratingValue.getObject()) {
+            if (iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject))
+                break;
+            if (prototypeCount++ >= 5)
+                break;
+
+            JSC::EnsureStillAliveScope ensureIteratingStillAlive(iteratingValue);
+
             if constexpr (nonIndexedOnly) {
                 iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
             } else {
@@ -5719,12 +5726,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            JSValue iteratingProto = iterating->getPrototype(globalObject);
+            iteratingValue = iterating->getPrototype(globalObject);
             // Ignore exceptions from Proxy "getPrototypeOf" trap.
             CLEAR_IF_EXCEPTION(scope);
-            if (!iteratingProto)
+            if (!iteratingValue)
                 break;
-            iterating = iteratingProto.getObject();
         }
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5644,8 +5644,7 @@ restart:
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
                 bool hasProperty = object->getPropertySlot(globalObject, property, slot);
-                // Ignore exceptions from "Get" proxy traps and throwing lazy property
-                // initializers; both report the property as not found.
+                // Ignore exceptions from "Get" proxy traps and lazy initializers; they also report the property as not found.
                 CLEAR_IF_EXCEPTION(scope);
                 if (!hasProperty)
                     continue;

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2088,6 +2088,7 @@ extern "C" napi_status napi_get_all_property_names(
                 }
             } else {
                 owner->getOwnPropertyDescriptor(globalObject, propKey, desc);
+                NAPI_RETURN_IF_EXCEPTION(env);
             }
 
             // V8 never applies ONLY_WRITABLE/ONLY_CONFIGURABLE to Proxy keys

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,7 +2077,10 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
-                    JSObject* proto = owner->getPrototype(globalObject).getObject();
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSValue protoValue = owner->getPrototype(globalObject);
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSObject* proto = protoValue ? protoValue.getObject() : nullptr;
                     if (!proto) {
                         break;
                     }

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -1,6 +1,7 @@
 import { env } from "bun";
 import { hasNonReifiedStatic } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 test("hasNonReifiedStatic", () => {
   expect(hasNonReifiedStatic(Bun), "do not eagerly initialize the Bun object. This will make Bun much slower.").toBe(
     true,
@@ -32,4 +33,40 @@ test("await import('bun')", async () => {
     expect(BunESM[property]).toBe(Bun[property]);
   }
   expect(BunESM.default).toBe(Bun);
+});
+
+test("a lazy property whose builtin fails to load throws from the read", async () => {
+  // The shell builtin ($) and the sql module body (sql, SQL, postgres) call Symbol(), so
+  // breaking it makes each builder throw. The read must throw that error (debug builds used to
+  // report the still-pending exception from inside the sql builders and abort) and the slot
+  // must stay unreified so a later read runs the builder again.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `globalThis.Symbol = NaN;
+       const results = {};
+       for (const name of ["$", "sql", "SQL", "postgres"]) {
+         results[name] = [];
+         for (let i = 0; i < 2; i++) {
+           try { Bun[name]; results[name].push("no throw"); } catch (e) { results[name].push(e.constructor.name); }
+         }
+       }
+       console.log(JSON.stringify(results));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      $: ["TypeError", "TypeError"],
+      sql: ["TypeError", "TypeError"],
+      SQL: ["TypeError", "TypeError"],
+      postgres: ["TypeError", "TypeError"],
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -40,11 +40,16 @@ test("a lazy property whose builtin fails to load throws from the read", async (
   // breaking it makes each builder throw. The read must throw that error (debug builds used to
   // report the still-pending exception from inside the sql builders and abort) and the slot
   // must stay unreified so a later read runs the builder again.
+  //
+  // process.env is read first because the shell builtin reads it before calling Symbol(), and
+  // building it on Windows reifies another property of the Bun object; doing that in the middle
+  // of the throwing read trips a separate structure assertion in debug builds.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `globalThis.Symbol = NaN;
+      `process.env;
+       globalThis.Symbol = NaN;
        const results = {};
        for (const name of ["$", "sql", "SQL", "postgres"]) {
          results[name] = [];

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -100,6 +100,30 @@ it("when prototype defines the same property, don't print the same property twic
   expect(Bun.inspect(obj).trim()).toBe('{\n  foo: "456",\n}'.trim());
 });
 
+it("Proxy prototype with a getter that throws does not crash", () => {
+  const proto = {
+    get foo() {
+      throw new Error("nope");
+    },
+  };
+  const obj = Object.create(new Proxy(proto, {}));
+  expect(Bun.inspect(obj)).toBe("{}");
+});
+
+it("Proxy prototype with a getPrototypeOf trap that throws does not crash", () => {
+  const obj = Object.create(
+    new Proxy(
+      { foo: 1 },
+      {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      },
+    ),
+  );
+  expect(Bun.inspect(obj)).toBe("{\n  foo: 1,\n}");
+});
+
 it("Blob inspect", () => {
   expect(Bun.inspect(new Blob(["123"]))).toBe(`Blob (3 bytes)`);
   expect(Bun.inspect(new Blob(["123".repeat(900)]))).toBe(`Blob (2.70 KB)`);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -100,30 +100,6 @@ it("when prototype defines the same property, don't print the same property twic
   expect(Bun.inspect(obj).trim()).toBe('{\n  foo: "456",\n}'.trim());
 });
 
-it("Proxy prototype with a getter that throws does not crash", () => {
-  const proto = {
-    get foo() {
-      throw new Error("nope");
-    },
-  };
-  const obj = Object.create(new Proxy(proto, {}));
-  expect(Bun.inspect(obj)).toBe("{}");
-});
-
-it("Proxy prototype with a getPrototypeOf trap that throws does not crash", () => {
-  const obj = Object.create(
-    new Proxy(
-      { foo: 1 },
-      {
-        getPrototypeOf() {
-          throw new Error("nope");
-        },
-      },
-    ),
-  );
-  expect(Bun.inspect(obj)).toBe("{\n  foo: 1,\n}");
-});
-
 it("Blob inspect", () => {
   expect(Bun.inspect(new Blob(["123"]))).toBe(`Blob (3 bytes)`);
   expect(Bun.inspect(new Blob(["123".repeat(900)]))).toBe(`Blob (2.70 KB)`);
@@ -600,6 +576,76 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
       "[\n  1, 2, 3, 4294967291 x empty items\n]\n",
     stderr: "",
     exitCode: 0,
+  });
+});
+
+// A property lookup that throws while an object is being formatted (a Proxy trap in the
+// prototype chain, or a lazily initialized property whose initializer throws) used to leave
+// the exception pending: the lookups of the following properties failed and were dropped from
+// the output, debug builds asserted, and moving on to the next prototype dereferenced the empty
+// value returned by the throwing getPrototype. Each case runs in a child so a regression fails
+// the test instead of taking down the runner.
+describe.concurrent("Bun.inspect when a property lookup throws", () => {
+  async function inspectInChild(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("skips a prototype property whose Proxy get trap throws and keeps the rest", async () => {
+    const result = await inspectInChild(`
+      const proto = new Proxy({ a: 1, b: 2, c: 3 }, {
+        get(target, key, receiver) {
+          if (key === "b") throw new Error("get trap");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      const obj = Object.create(proto);
+      obj.own = 0;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(result).toEqual({ stdout: "{\n  own: 0,\n  a: 1,\n  c: 3,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("skips a prototype getter that throws behind a Proxy and keeps the rest", async () => {
+    const result = await inspectInChild(`
+      const proto = new Proxy({ a: 1, get b() { throw new Error("getter"); }, c: 3 }, {});
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(result).toEqual({ stdout: "{\n  a: 1,\n  c: 3,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("stops walking the prototype chain at a Proxy whose getPrototypeOf trap throws", async () => {
+    const result = await inspectInChild(`
+      const proto = new Proxy({ a: 1 }, {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf trap");
+        },
+      });
+      const obj = Object.create(proto);
+      obj.own = 0;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(result).toEqual({ stdout: "{\n  own: 0,\n  a: 1,\n}\n", stderr: "", exitCode: 0 });
+  });
+
+  it("skips a lazily initialized Bun property whose initializer throws and keeps the rest", async () => {
+    // Bun.$ is the first property of the Bun object and is built by a builtin that calls
+    // Symbol(), as are Bun.sql and Bun.SQL further down, so breaking Symbol makes those
+    // initializers throw while Bun is formatted. Custom inspect functions (Bun.env has one on
+    // Windows) load node:util the first time one runs, which also needs Symbol, so load it first.
+    const result = await inspectInChild(`
+      Bun.inspect({ [Bun.inspect.custom]() { return ""; } });
+      globalThis.Symbol = 0;
+      const out = Bun.inspect(Bun);
+      console.log(JSON.stringify(["$", "Archive", "version"].map(key => out.includes("\\n  " + key + ": "))));
+    `);
+    expect(result).toEqual({ stdout: "[false,true,true]\n", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -580,22 +580,25 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
 });
 
 // A property lookup that throws while an object is being formatted (a Proxy trap in the
-// prototype chain, or a lazily initialized property whose initializer throws) used to leave
-// the exception pending: the lookups of the following properties failed and were dropped from
-// the output, debug builds asserted, and moving on to the next prototype dereferenced the empty
-// value returned by the throwing getPrototype. Each case runs in a child so a regression fails
-// the test instead of taking down the runner.
+// prototype chain, a lazily initialized property whose initializer throws, a module namespace
+// export that is still in its temporal dead zone) used to leave the exception pending: the
+// lookups of the following properties failed and were dropped from the output or the formatter
+// rethrew the exception from the next property, debug builds asserted, and moving on to the
+// next prototype dereferenced the empty value returned by the throwing getPrototype. Each case
+// runs in a child so a regression fails the test instead of taking down the runner.
 describe.concurrent("Bun.inspect when a property lookup throws", () => {
-  async function inspectInChild(code) {
+  async function runChild(args, cwd) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", code],
+      cmd: [bunExe(), ...args],
       env: bunEnv,
+      cwd,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode };
   }
+  const inspectInChild = code => runChild(["-e", code]);
 
   it("skips a prototype property whose Proxy get trap throws and keeps the rest", async () => {
     const result = await inspectInChild(`
@@ -646,6 +649,25 @@ describe.concurrent("Bun.inspect when a property lookup throws", () => {
       console.log(JSON.stringify(["$", "Archive", "version"].map(key => out.includes("\\n  " + key + ": "))));
     `);
     expect(result).toEqual({ stdout: "[false,true,true]\n", stderr: "", exitCode: 0 });
+  });
+
+  it("skips a module namespace export that is in its temporal dead zone and keeps the rest", async () => {
+    // b.mjs runs while a.mjs is still evaluating, so reading `later` off the namespace throws a
+    // ReferenceError. console.log used to rethrow it; util.inspect prints such an export as
+    // `<uninitialized>`, this formatter leaves it out.
+    using dir = tempDir("inspect-tdz-namespace", {
+      "a.mjs": `
+        import "./b.mjs";
+        export const later = 1;
+        export function hoisted() {}
+      `,
+      "b.mjs": `
+        import * as a from "./a.mjs";
+        console.log(a);
+      `,
+    });
+    const result = await runChild(["a.mjs"], String(dir));
+    expect(result).toEqual({ stdout: "Module {\n  hoisted: [Function: hoisted],\n}\n", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -376,7 +376,8 @@ static napi_value create_latin1_string(const Napi::CallbackInfo &info) {
 }
 
 // get_all_property_names(object, key_mode, key_filter, key_conversion)
-// returns { status, keys }
+// returns { status, keys, exception }; a pending exception is cleared and
+// returned as `exception` so callers can observe `status` alongside it.
 static napi_value get_all_property_names(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   napi_value object = info[0];
@@ -391,6 +392,15 @@ static napi_value get_all_property_names(const Napi::CallbackInfo &info) {
       static_cast<napi_key_filter>(key_filter),
       static_cast<napi_key_conversion>(key_conversion), &keys);
 
+  bool is_pending = false;
+  NODE_API_CALL(env, napi_is_exception_pending(env, &is_pending));
+  napi_value exception;
+  if (is_pending) {
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exception));
+  } else {
+    NODE_API_CALL(env, napi_get_undefined(env, &exception));
+  }
+
   napi_value result;
   NODE_API_CALL(env, napi_create_object(env, &result));
   napi_value status_val;
@@ -400,6 +410,8 @@ static napi_value get_all_property_names(const Napi::CallbackInfo &info) {
     NODE_API_CALL(env, napi_get_undefined(env, &keys));
   }
   NODE_API_CALL(env, napi_set_named_property(env, result, "keys", keys));
+  NODE_API_CALL(env,
+                napi_set_named_property(env, result, "exception", exception));
   return result;
 }
 

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -321,6 +321,64 @@ nativeTests.test_get_all_property_names_proxy_and_string_wrapper = () => {
   show("frozen writable:", apn(Object.freeze({ a: 1, b: 2 }), napi_key_writable));
 };
 
+nativeTests.test_get_all_property_names_throwing_proxy_traps = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_own_only = 1;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  const show = (label, { status, keys, exception }) =>
+    console.log(label, `status=${status}`, `keys=${JSON.stringify(keys)}`, `exception=${exception?.message}`);
+
+  // ownKeys succeeds so key collection completes; the per-key descriptor walk
+  // required by napi_key_enumerable is what invokes the throwing trap.
+  const throwingDescriptor = new Proxy(
+    {},
+    {
+      ownKeys: () => ["a"],
+      getOwnPropertyDescriptor() {
+        throw new Error("gopd trap");
+      },
+    },
+  );
+  show(
+    "own_only gopd throws:",
+    nativeTests.get_all_property_names(
+      throwingDescriptor,
+      napi_key_own_only,
+      napi_key_enumerable,
+      napi_key_keep_numbers,
+    ),
+  );
+  show(
+    "include_prototypes gopd throws on prototype:",
+    nativeTests.get_all_property_names(
+      Object.create(throwingDescriptor),
+      napi_key_include_prototypes,
+      napi_key_enumerable,
+      napi_key_keep_numbers,
+    ),
+  );
+
+  const throwingPrototype = new Proxy(
+    { a: 1 },
+    {
+      getPrototypeOf() {
+        throw new Error("getPrototypeOf trap");
+      },
+    },
+  );
+  show(
+    "include_prototypes getPrototypeOf throws:",
+    nativeTests.get_all_property_names(
+      Object.create(throwingPrototype),
+      napi_key_include_prototypes,
+      napi_key_enumerable,
+      napi_key_keep_numbers,
+    ),
+  );
+};
+
 nativeTests.test_set_property = () => {
   const objects = [
     {},

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -360,23 +360,34 @@ nativeTests.test_get_all_property_names_throwing_proxy_traps = () => {
     ),
   );
 
-  const throwingPrototype = new Proxy(
-    { a: 1 },
+};
+
+nativeTests.test_get_all_property_names_get_prototype_throws_in_descriptor_walk = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  // Key collection asks the proxy for its prototype once and must succeed so
+  // the descriptor walk is reached; the walk asks again (the target does not
+  // own "a") and that second call throws.
+  let calls = 0;
+  const proxy = new Proxy(
+    {},
     {
+      ownKeys: () => ["a"],
       getPrototypeOf() {
-        throw new Error("getPrototypeOf trap");
+        if (calls++ > 0) throw new Error("getPrototypeOf trap");
+        return null;
       },
     },
   );
-  show(
-    "include_prototypes getPrototypeOf throws:",
-    nativeTests.get_all_property_names(
-      Object.create(throwingPrototype),
-      napi_key_include_prototypes,
-      napi_key_enumerable,
-      napi_key_keep_numbers,
-    ),
+  const { status, keys, exception } = nativeTests.get_all_property_names(
+    Object.create(proxy),
+    napi_key_include_prototypes,
+    napi_key_enumerable,
+    napi_key_keep_numbers,
   );
+  console.log(`status=${status} keys=${JSON.stringify(keys)} exception=${exception?.message} calls=${calls}`);
 };
 
 nativeTests.test_set_property = () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -873,9 +873,15 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain(
         "include_prototypes gopd throws on prototype: status=10 keys=undefined exception=gopd trap",
       );
-      expect(output).toContain(
-        "include_prototypes getPrototypeOf throws: status=10 keys=undefined exception=getPrototypeOf trap",
-      );
+    });
+    it("returns napi_pending_exception when getPrototypeOf throws during the descriptor walk", async () => {
+      // Not checkSameOutput: V8 filters proxy keys while collecting them and
+      // only calls getPrototypeOf once, so a trap that throws on the second
+      // call never throws under Node.
+      const output = (await runOn(bunExe(), "test_get_all_property_names_get_prototype_throws_in_descriptor_walk", []))
+        .replaceAll(/^\[\w+\].+$/gm, "")
+        .trim();
+      expect(output).toBe("status=10 keys=undefined exception=getPrototypeOf trap calls=2");
     });
     it("matches Node for Proxy and String wrapper with napi_key_writable/napi_key_configurable", async () => {
       const output = await checkSameOutput("test_get_all_property_names_proxy_and_string_wrapper", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -867,6 +867,16 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     it("handles accessor properties when filtering by napi_key_writable", async () => {
       await checkSameOutput("test_get_all_property_names_accessor", []);
     });
+    it("returns napi_pending_exception when a Proxy trap throws during the descriptor walk", async () => {
+      const output = await checkSameOutput("test_get_all_property_names_throwing_proxy_traps", []);
+      expect(output).toContain("own_only gopd throws: status=10 keys=undefined exception=gopd trap");
+      expect(output).toContain(
+        "include_prototypes gopd throws on prototype: status=10 keys=undefined exception=gopd trap",
+      );
+      expect(output).toContain(
+        "include_prototypes getPrototypeOf throws: status=10 keys=undefined exception=getPrototypeOf trap",
+      );
+    });
     it("matches Node for Proxy and String wrapper with napi_key_writable/napi_key_configurable", async () => {
       const output = await checkSameOutput("test_get_all_property_names_proxy_and_string_wrapper", []);
       expect(output).toContain(`proxy own_only writable: status=0 keys=["x","y"]`);


### PR DESCRIPTION
### Problem

- `Bun.inspect()`, `console.log()` and `expect()` failure output crash with `Segmentation fault at address 0x5` (debug builds: UBSan "member call on null pointer of type 'JSC::JSCell'" in `JSCJSValueCell.h`) when a property lookup throws while an object is being formatted. Release repro:
  ```js
  const proto = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("boom"); } });
  console.log(Object.create(proto));
  ```
  and likewise with a Proxy whose `get` trap (or a getter reached through a Proxy) throws for one property.
- The same happens with a lazily initialized property of the `Bun` object whose initializer throws (fuzzer sample: `globalThis.Symbol` replaced, then `Bun.inspect(Bun)`; the builtin behind `Bun.$` calls `Symbol("cwd")`). Release builds print `Bun` with most of its properties missing (72 of 115 on the shipped build); debug builds abort with `ASSERTION FAILED: Unexpected exception observed` / `Symbol is not a function. (In 'Symbol("cwd")' ...)` when the next lazy property is built.
- Plain-JavaScript variant of the same leak: `console.log` of a module namespace during an import cycle, when one export is still in its temporal dead zone, throws `ReferenceError: Cannot access 'x' before initialization` out of `console.log` (the stale exception is picked up while the next export is formatted). `util.inspect` prints such an export as `<uninitialized>`.
- Cause, in the slow path of `JSC__JSValue__forEachPropertyImpl` (`src/jsc/bindings/bindings.cpp`):
  - `object->getPropertySlot()` reports a throwing Proxy trap, a throwing lazy initializer or a TDZ namespace export as "not found" with the exception still pending, and the loop `continue`d before the `CLEAR_IF_EXCEPTION` below it. The following lookups and formatting callbacks then run with that exception pending (the dropped properties, the rethrown `ReferenceError`, the debug assertion).
  - When the walk moves to the next prototype, `iterating->getPrototype(globalObject).getObject()` runs `getObject()` on the empty `JSValue` that `getPrototype` returns when it threw (either because of the stale exception above or because the `getPrototypeOf` trap itself throws). The empty value passes `isCell()`, so this reads the type byte of a null cell: the fault at address 5.
- `napi_get_all_property_names` (`src/jsc/bindings/napi.cpp`, descriptor filter loop) has the same `getPrototype().getObject()` chain after an unchecked `getOwnPropertyDescriptor`, so a Proxy trap throwing there returned `napi_ok` with an exception pending in own-only mode and segfaulted in include-prototypes mode.
- `defaultBunSQLObject` / `constructBunSQLObject` (`src/jsc/bindings/BunObject.cpp`) had a debug-only block that handed a sql module load failure to `reportUncaughtExceptionAtEventLoop` while the exception was still pending on the VM, so `globalThis.Symbol = NaN; Bun.sql` (and the fuzzer sample above, once the walk gets past `Bun.$`) aborted debug builds with `ASSERTION FAILED: ... object->structure() == this` in `Structure::storedPrototype` instead of throwing.

### Fix

- `bindings.cpp`: clear the exception after `getPropertySlot` regardless of its result, which is what the ordered variant `JSC__JSValue__forEachPropertyOrdered` already does; read the next prototype into a `JSValue`, clear the exception and stop the walk when it is empty. (An earlier revision also held the prototype being walked under an `EnsureStillAliveScope`; dropped, since the raw pointer is used after every call into JS in the loop body and so is live across them anyway.)
- Behaviour change to note: a property whose lookup throws is now left out of the output instead of the whole `console.log` / `Bun.inspect` call throwing or crashing. For TDZ namespace exports this differs from `util.inspect`'s `<uninitialized>`; printing that marker would be a formatter feature on top of this fix and is not attempted here.
- `napi.cpp`: check for an exception after `getOwnPropertyDescriptor` and after `getPrototype` and return `napi_pending_exception`, which is what Node returns for these cases.
- `BunObject.cpp`: drop the debug-only report. The exception is propagated to the reader by the `RETURN_IF_EXCEPTION` right below it, so debug builds now behave like release builds (`Bun.sql` throws).
- Why this is the right place: the formatter deliberately swallows errors thrown by individual properties (getters, traps) and prints the rest of the object; these two sites were the only ones in the walk that acted on a "not found" result or a prototype value before clearing the exception that produced it. Skipping just the property (or stopping at just the prototype) whose lookup threw is the existing behaviour for every other throw site in this function.
- Verification:
  - `test/js/bun/util/inspect.test.js`, "Bun.inspect when a property lookup throws" (5 spawned cases): a Proxy `get` trap, a getter behind a Proxy, a `getPrototypeOf` trap, a throwing lazy `Bun` property, and a two-file import cycle with a TDZ export. Without the fix (shipped release build and an unfixed debug build) all five fail: the Proxy children segfault / fail UBSan, the `Bun` child prints `[false,false,...]` on release and aborts on debug, the cycle child exits 1 with the `ReferenceError`; with it each prints everything except the one property whose lookup threw.
  - `test/js/bun/util/BunObject.test.ts`, "a lazy property whose builtin fails to load throws from the read": `Bun.$` / `sql` / `SQL` / `postgres` with `Symbol` broken throw a `TypeError` on two consecutive reads. Aborts on an unfixed debug build (the `BunObject.cpp` hunk); passes on release either way, as the removed block is debug-only. The fixture builds `process.env` before breaking `Symbol` because the `$` builder reads it, and building it on Windows reifies another `Bun` property mid-lookup, which on a Windows debug build would hit the separate `storedPrototype` assertion that #37001 fixes (verified on Linux only).
  - `test/napi/napi.test.ts`: `getOwnPropertyDescriptor` trap throwing in own-only and include-prototypes mode (compared against Node), and a `getPrototypeOf` trap that throws on the second call so the check after `getPrototype` is the one that fires.
  - Repros above and the tests also run clean under `BUN_JSC_validateExceptionChecks=1`.

### Background

- `forEachPropertyImpl` is the property walk behind Bun's native formatter. It collects the property names of the object and of up to five prototypes, looks each one up through the original object with `getPropertySlot`, and hands the value to a callback that formats it. Errors thrown by individual properties are swallowed on purpose so that one bad getter does not make `console.log` throw.
- A JSC exception is "pending" state on the VM, not C++ unwinding. A function that throws returns a failure value (`false`, or the empty `JSValue`) and leaves the exception on the VM; until something clears or rethrows it, most JSC entry points return early as soon as they are called, and debug builds assert when a function that did not throw is observed returning with an exception pending. `CLEAR_IF_EXCEPTION` drops the pending exception.
- The empty `JSValue` (`JSValue()`) is encoded as 0. `isCell()` is true for it, so `getObject()` on it dereferences a null cell pointer rather than returning null; callers have to test the value itself first.
- Lazy properties of the `Bun` object are entries in a static property table whose value is produced by a builder the first time the property is read (`PropertyCallback`). Some builders evaluate built-in JavaScript modules (the shell for `Bun.$`, the sql module for `Bun.sql`), so they can throw when that module fails to evaluate, and JSC reports that to the reader as "property not found" plus a pending exception.

### Consolidated duplicates

Found repeatedly by the fuzzer (fingerprint `d678cafe50a2ad6e`). Earlier round, folded in here in April: #29071 #28991 #28919 #28918 #28882 #28854 #28530 #28325. This round, closed in favour of this PR: #30099 #30245 #37160 #37175 #37213 #37256 #37428 #38700 #38921 #39363 #39365 #39380 #39412 #39413 (and #39411, closed earlier). The `BunObject.cpp` hunk and the `BunObject.test.ts` test come from #30245 / #37428; the same hunk is also part of #37001, which fixes the underlying `storedPrototype` assertion in JSC.

Related fixes that are not part of this bug and stay open on their own: #39382 (a custom inspect function when `node:util` fails to load), #37202 (`util.isError` with a throwing `getPrototypeOf` trap), #37331 (`forEachPropertyOrdered` when the callback throws), #37001 (stale structure in `JSObject::getPropertySlot`), #32263 (additional checks in the same napi loop).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js test/napi/napi.test.ts

<!-- robobun:evidence:end -->