### PR TITLE
fix(s3): double deref of path string on error in S3Client static methods

### DIFF
--- a/src/bun.js/webcore/S3File.zig
+++ b/src/bun.js/webcore/S3File.zig
@@ -84,6 +84,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
         },
@@ -114,6 +115,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             }
             const options = args.nextEat();
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
         },
@@ -151,6 +153,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
 
             var blob_internal: PathOrBlob = .{ .blob = blob };
@@ -190,6 +193,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
 
             return S3BlobStatTask.size(globalThis, &blob);
@@ -223,6 +227,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
 
             return S3BlobStatTask.exists(globalThis, &blob);
@@ -574,6 +579,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
+            path_or_blob = .{ .path = .{ .fd = bun.invalid_fd } };
             defer blob.deinit();
 
             return S3BlobStatTask.stat(globalThis, &blob);

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1564,6 +1564,10 @@ describe.concurrent("s3 missing credentials", () => {
       await Bun.s3.presign("test");
     });
   });
+  it("S3Client.presign static", () => {
+    expect(() => S3Client.presign("some/bucket/key")).toThrow("Missing S3 credentials");
+    expect(() => S3Client.presign("some/bucket/key", {})).toThrow("Missing S3 credentials");
+  });
   it("file", async () => {
     assertMissingCredentials(async () => {
       await Bun.s3.file("test").text();


### PR DESCRIPTION
## What does this PR do?

Fixes a crash (`reached unreachable code` from the `hasAtLeastOneRef()` assertion in `WTFStringImplStruct.deref`) when a static `Bun.S3Client` method that accepts a path — `presign`, `unlink`, `write`, `size`, `exists`, `stat` — throws after successfully constructing the internal S3 blob.

For example, calling `Bun.S3Client.presign("some/bucket/key")` with no credentials configured would crash instead of throwing `ERR_S3_MISSING_CREDENTIALS`.

### Root cause

```zig
var path_or_blob = try PathOrBlob.fromJSNoCopy(globalThis, &args);
errdefer {
    if (path_or_blob == .path) {
        path_or_blob.path.deinit();
    }
}
...
var blob = try constructS3FileInternalStore(globalThis, path.path, options);
defer blob.deinit();
return try getPresignUrlFrom(&blob, globalThis, options);
```

`constructS3FileInternalStore` stores the path in the blob's `S3` store (transferring ownership). If the subsequent operation throws, `defer blob.deinit()` derefs the path via the store, then the outer `errdefer` derefs it again.

### Fix

After the blob is created, overwrite `path_or_blob` with a harmless `.fd` value so the `errdefer`'s `deinit()` becomes a no-op once ownership has transferred.

## How did you verify your code works?

- Added a regression test in `test/js/bun/s3/s3.test.ts` that crashes on `main` and passes with this fix.
- Verified the original fuzzer repro no longer crashes.
- Verified the happy path (`S3Client.presign` with valid credentials) still produces a URL.

Found by Fuzzilli. Fingerprint: `a7f2578a4715b60c`