### PR TITLE
inspect: handle throwing Proxy traps when walking prototype chain

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5299,10 +5299,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5374,7 +5375,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,31 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf trap");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
+  () => {
+    class Foo {
+      get bar() {
+        throw new Error("getter");
+      }
+    }
+    const obj = new Foo();
+    Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Found by Fuzzilli (fingerprint `218ad011667156dc`).

## What

`Bun.inspect` / `console.log` crashes with a null pointer dereference when formatting an object whose prototype chain includes a Proxy that throws from a trap.

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, {
  getPrototypeOf() { throw new Error("trap"); }
}));
Bun.inspect(obj); // segfault
```

```js
class Foo {
  get bar() { throw new Error("getter"); }
}
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
Bun.inspect(obj); // segfault
```

## Why

In the slow path of `JSC__JSValue__forEachPropertyImpl`:

1. `getPropertySlot()` going through a Proxy `[[Get]]` can throw and return `false`. The `continue` was taken before `CLEAR_IF_EXCEPTION`, leaving the exception pending.
2. `iterating->getPrototype(globalObject)` on a Proxy can throw (throwing `getPrototypeOf` trap) or short-circuit on a pending exception, returning an empty `JSValue`. Calling `.getObject()` on an empty value is `asCell() == nullptr` → null deref.

## How

Clear the exception before the `continue`, and guard the empty return from `getPrototype()` — same pattern the fast path already uses a few lines above.