### PR TITLE
build: disable exceptions for highway on Windows (clang-cl)

### DIFF
--- a/scripts/build/deps/highway.ts
+++ b/scripts/build/deps/highway.ts
@@ -43,9 +43,10 @@ export const highway: Dependency = {
       ],
       includes: ["."],
       defines: { HWY_STATIC_DEFINE: true },
-      // -fmath-errno isn't a CLOption (clang-cl warns); highway's own
-      // cmake skips it in the MSVC branch.
-      cflags: cfg.windows ? ["-fno-exceptions"] : ["-fno-exceptions", "-fmath-errno"],
+      // Neither -fno-exceptions nor -fmath-errno are CLOptions (clang-cl
+      // warns "unknown argument ignored"). globalFlags supplies /EH* and
+      // /GR- on Windows; highway's own cmake skips both in its MSVC branch.
+      cflags: cfg.windows ? [] : ["-fno-exceptions", "-fmath-errno"],
     };
 
     // clang-cl on arm64-windows doesn't define __ARM_NEON even though NEON

--- a/scripts/build/deps/highway.ts
+++ b/scripts/build/deps/highway.ts
@@ -47,9 +47,7 @@ export const highway: Dependency = {
       // "unknown argument ignored"). Match upstream's MSVC branch instead:
       // /EHs-c- overrides globalFlags' /EHsc (later flag wins) so highway
       // is built without exceptions like it was under nested-cmake.
-      cflags: cfg.windows
-        ? ["/EHs-c-", "-D_HAS_EXCEPTIONS=0"]
-        : ["-fno-exceptions", "-fmath-errno"],
+      cflags: cfg.windows ? ["/EHs-c-", "-D_HAS_EXCEPTIONS=0"] : ["-fno-exceptions", "-fmath-errno"],
     };
 
     // clang-cl on arm64-windows doesn't define __ARM_NEON even though NEON

--- a/scripts/build/deps/highway.ts
+++ b/scripts/build/deps/highway.ts
@@ -43,10 +43,13 @@ export const highway: Dependency = {
       ],
       includes: ["."],
       defines: { HWY_STATIC_DEFINE: true },
-      // Neither -fno-exceptions nor -fmath-errno are CLOptions (clang-cl
-      // warns "unknown argument ignored"). globalFlags supplies /EH* and
-      // /GR- on Windows; highway's own cmake skips both in its MSVC branch.
-      cflags: cfg.windows ? [] : ["-fno-exceptions", "-fmath-errno"],
+      // -fno-exceptions / -fmath-errno aren't CLOptions (clang-cl warns
+      // "unknown argument ignored"). Match upstream's MSVC branch instead:
+      // /EHs-c- overrides globalFlags' /EHsc (later flag wins) so highway
+      // is built without exceptions like it was under nested-cmake.
+      cflags: cfg.windows
+        ? ["/EHs-c-", "-D_HAS_EXCEPTIONS=0"]
+        : ["-fno-exceptions", "-fmath-errno"],
     };
 
     // clang-cl on arm64-windows doesn't define __ARM_NEON even though NEON


### PR DESCRIPTION
## Summary

Fixes 9× `clang-cl: warning: unknown argument ignored in clang-cl: '-fno-exceptions' [-Wunknown-argument]` when building highway on Windows, and restores highway's no-exceptions build that was lost in the DirectBuild conversion.

#29584 converted highway from nested-cmake to DirectBuild and passed `-fno-exceptions` in the Windows `cflags` branch. clang-cl doesn't recognize the gcc spelling and was ignoring it, so highway was actually being compiled **with** exceptions enabled via `globalFlags`' `/EHsc` — a behavior change from nested-cmake, where highway's own `CMakeLists.txt` set `/EHs-c-` + `-D_HAS_EXCEPTIONS=0` in its MSVC branch (`vendor/highway/CMakeLists.txt:367-370`).

This swaps the unrecognized `-fno-exceptions` for `/EHs-c- -D_HAS_EXCEPTIONS=0`, which clang-cl understands. The dep-specific `cflags` are appended after `globalFlags` in `source.ts:1433`, so `/EHs-c-` overrides `/EHsc` (later flag wins).

Separately: `globalFlags` itself has `/EHsc` with desc "Disable C++ exceptions" (`flags.ts:189-191`) — the flag enables exceptions but the desc describes `/EHs-c-`. That's been there since the original Windows CMake (bun 1.0.9) and affects every Windows TU; left for a follow-up.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `ninja -C build/debug highway` — all 9 objects compile with no warnings
- [x] Verified `/EHs-c- -D_HAS_EXCEPTIONS=0` appear after `/EHsc` in generated `build.ninja`
- [ ] Windows CI green
