### PR TITLE
install: fix isolated installer hang on tarball integrity failure

### DIFF
--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -665,6 +665,16 @@ pub fn runTasks(
                 if (task.status == .fail) {
                     const err = task.err orelse error.TarballFailedToExtract;
 
+                    // Extract-task failure (integrity check, libarchive error, etc.)
+                    // is symmetric with the HTTP 4xx/5xx branch above: drop the
+                    // dedupe state so a later `enqueuePackageForDownload` for this
+                    // `task_id` schedules a fresh network task instead of waiting
+                    // on this failed one forever. Runs before the callback branch
+                    // so `Store.Installer` (which `continue`s from the callback)
+                    // is covered too. `network_dedupe_map.remove` is a no-op for
+                    // `local_tarball` tasks (they never populate the map).
+                    _ = manager.network_dedupe_map.remove(task.id);
+
                     if (@TypeOf(callbacks.onPackageDownloadError) != void) {
                         const fail_url = switch (task.tag) {
                             .extract => task.request.extract.network.url_buf,
@@ -690,18 +700,28 @@ pub fn runTasks(
                                 fail_url,
                             );
                         }
-                    } else {
-                        manager.log.addErrorFmt(
-                            null,
-                            logger.Loc.Empty,
-                            manager.allocator,
-                            "{s} extracting tarball from <b>{s}<r>",
-                            .{
-                                @errorName(err),
-                                alias,
-                            },
-                        ) catch |e| bun.handleOom(e);
+                        continue;
                     }
+
+                    manager.log.addErrorFmt(
+                        null,
+                        logger.Loc.Empty,
+                        manager.allocator,
+                        "{s} extracting tarball from <b>{s}<r>",
+                        .{
+                            @errorName(err),
+                            alias,
+                        },
+                    ) catch |e| bun.handleOom(e);
+
+                    // Void-callback fallback (resolve phase): drain the
+                    // `task_queue` entry too so a later install-phase
+                    // `enqueuePackageForDownload` doesn't wedge on `found_existing`.
+                    if (manager.task_queue.fetchRemove(task.id)) |removed| {
+                        var list = removed.value;
+                        list.deinit(manager.allocator);
+                    }
+
                     continue;
                 }
 

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -1,10 +1,10 @@
 import { file, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
-import { createHash } from "node:crypto";
 import { rm, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
-import { join } from "path";
+import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
+import { join } from "path";
 import {
   createTestContext,
   destroyTestContext,
@@ -590,11 +590,7 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
       stderr: "pipe",
       timeout: 15_000,
     });
-    const [stderr, stdout, exitCode] = await Promise.all([
-      proc.stderr.text(),
-      proc.stdout.text(),
-      proc.exited,
-    ]);
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
     // Must surface the integrity failure and must not claim success.
     expect(stderr + stdout).toContain("Integrity check failed");

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -504,7 +504,7 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
   // means the failure happens in the resolve phase, where the runTasks
   // callback is the void `onPackageDownloadError = {}` — i.e. the branch the
   // fix in runTasks.zig now cleans up.
-  it("should fail (not hang) when tarball bytes don't match manifest SHA-512", async () => {
+  it("should fail (not hang) when tarball bytes don't match manifest SHA-512", { timeout: 60_000 }, async () => {
     function octal(n: number, width: number) {
       return n.toString(8).padStart(width - 1, "0") + "\0";
     }
@@ -592,7 +592,15 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mi
     });
     const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
 
-    // Must surface the integrity failure and must not claim success.
+    // The hang path in #29646 also prints "Integrity check failed" (it comes
+    // from the streaming extractor — the hang happens *after*), exits with a
+    // SIGTERM-induced non-zero code when the spawn timeout fires, and never
+    // produces "1 package installed". So the presence of the message, the
+    // absence of success output, and a non-zero exit are all consistent with
+    // either outcome. The load-bearing assertion is `signalCode === null`:
+    // with the fix, bun exits cleanly on its own; on hang, Bun.spawn's
+    // timeout kills the child with SIGTERM.
+    expect(proc.signalCode).toBeNull();
     expect(stderr + stdout).toContain("Integrity check failed");
     expect(stdout).not.toContain("1 package installed");
     expect(exitCode).not.toBe(0);

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -1,8 +1,10 @@
 import { file, spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
+import { createHash } from "node:crypto";
 import { rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted } from "harness";
+import { bunExe, bunEnv as env, readdirSorted, tempDir } from "harness";
 import { join } from "path";
+import { gzipSync } from "node:zlib";
 import {
   createTestContext,
   destroyTestContext,
@@ -487,6 +489,117 @@ describe.concurrent("tarball integrity", () => {
       expect(await proc.exited).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
     });
+  });
+});
+
+describe.concurrent.each(["hoisted", "isolated"] as const)("tarball integrity mismatch (%s)", linker => {
+  // Regression test for #29646 — with the isolated linker, a SHA-512 mismatch
+  // during the resolve-phase tarball extract left `task_queue` /
+  // `network_dedupe_map` populated, so the install phase's later
+  // `enqueuePackageForDownload` returned early on `found_existing` and the
+  // installer waited forever for a callback that was never dispatched.
+  //
+  // We trigger the mismatch by advertising one tarball's SHA-512 in the
+  // manifest while serving a different tarball's bytes. No existing lockfile
+  // means the failure happens in the resolve phase, where the runTasks
+  // callback is the void `onPackageDownloadError = {}` — i.e. the branch the
+  // fix in runTasks.zig now cleans up.
+  it("should fail (not hang) when tarball bytes don't match manifest SHA-512", async () => {
+    function octal(n: number, width: number) {
+      return n.toString(8).padStart(width - 1, "0") + "\0";
+    }
+    function tarHeader(name: string, size: number) {
+      const buf = Buffer.alloc(512, 0);
+      buf.write(name, 0, 100, "utf8");
+      buf.write(octal(0o644, 8), 100);
+      buf.write(octal(0, 8), 108);
+      buf.write(octal(0, 8), 116);
+      buf.write(octal(size, 12), 124);
+      buf.write(octal(0, 12), 136);
+      buf.fill(" ", 148, 156);
+      buf.write("0", 156);
+      buf.write("ustar\0", 257);
+      buf.write("00", 263);
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += buf[i];
+      buf.write(octal(sum, 8), 148);
+      return buf;
+    }
+    function pad512(len: number) {
+      return Buffer.alloc((512 - (len % 512)) % 512, 0);
+    }
+    function buildTarball(body: Buffer) {
+      const tar = Buffer.concat([
+        tarHeader("package/package.json", body.length),
+        body,
+        pad512(body.length),
+        Buffer.alloc(1024, 0),
+      ]);
+      const tgz = gzipSync(tar);
+      return { tgz, integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64") };
+    }
+
+    const real = buildTarball(Buffer.from('{"name":"pkg","version":"1.0.0"}\n'));
+    const lie = buildTarball(Buffer.from('{"name":"other","version":"9.9.9"}\n'));
+
+    // Custom server instead of the dummy registry — we need to advertise an
+    // integrity hash that deliberately does not match the served bytes, which
+    // the dummy registry doesn't support.
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname.endsWith("/pkg")) {
+          return Response.json({
+            name: "pkg",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "pkg",
+                version: "1.0.0",
+                dist: {
+                  integrity: lie.integrity,
+                  tarball: `http://127.0.0.1:${server.port}/pkg/-/pkg-1.0.0.tgz`,
+                },
+              },
+            },
+          });
+        }
+        if (url.pathname.endsWith("/pkg-1.0.0.tgz")) {
+          return new Response(real.tgz, { headers: { "content-length": String(real.tgz.length) } });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+
+    using dir = tempDir("integrity-mismatch-" + linker, {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { pkg: "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${server.port}/"\nlinker = "${linker}"\n`,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([
+      proc.stderr.text(),
+      proc.stdout.text(),
+      proc.exited,
+    ]);
+
+    // Must surface the integrity failure and must not claim success.
+    expect(stderr + stdout).toContain("Integrity check failed");
+    expect(stdout).not.toContain("1 package installed");
+    expect(exitCode).not.toBe(0);
   });
 });
 


### PR DESCRIPTION
Closes #29646.

## Repro

Advertise one tarball's SHA-512 in the registry manifest while serving a different tarball's bytes. The isolated-linker install hangs indefinitely (no output past "Created store"); hoisted errors out.

```
error: Integrity check failed for tarball: pkg
Resolved, downloaded and extracted [4]
error: IntegrityCheckFailed extracting tarball from pkg
Clean lockfile: 2 packages - 2 packages in 281.7us
Resolved peers [842.2us]
Created store [85.1us]
<hang>
```

## Cause

Partially fixed by #29611 for HTTP 4xx/5xx responses. The extract-task failure branch in `src/install/PackageManager/runTasks.zig` was missed.

When the streaming extractor sets `task.err = error.IntegrityCheckFailed` and `task.status = .fail`, the resolve-phase `runTasks` (which passes `onPackageDownloadError = {}`) fell into the void-callback `else` that only logged the error and continued — never removing the entry from `network_dedupe_map` or draining its `task_queue` list.

Install-phase `Store.Installer` then called `enqueuePackageForDownload` for the failed package, hit `task_queue.found_existing == true` at `PackageManagerEnqueue.zig:258`, returned early without scheduling a new network task, and the isolated installer waited forever on `pendingTaskCount() == 0`.

## Fix

Mirror the 4xx/5xx cleanup symmetrically for extract failures in `runTasks.zig`:

- Drop the `network_dedupe_map` entry up front, before the callback branch, so the `Store.Installer` path (which `continue`s from the callback) is also covered. `Store.Installer.onPackageDownloadError` drains `task_queue` itself but doesn't touch the dedupe map.
- In the void-callback fallback, also drain the `task_queue` entry, matching the existing HTTP-error branch.

`network_dedupe_map.remove` is a no-op for `local_tarball` tasks (they never populate the map).

## Verification

Extended `test/cli/install/bun-install-tarball-integrity.test.ts` with a new `describe.each(["hoisted", "isolated"])` block that builds a tarball whose advertised SHA-512 doesn't match the served bytes. Without the fix, `isolated` times out at 5s; with the fix, both linkers surface `Integrity check failed` and exit non-zero.