### PR TITLE
ci: bump linux link box to 2xlarge (64 GiB) for full-LTO

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -347,7 +347,8 @@ function getLinkBunAgent(platform, options) {
   }
 
   return getEc2Agent(platform, options, {
-    instanceType: arch === "aarch64" ? "r8g.xlarge" : "r7i.xlarge",
+    // Full LTO with bun-zig.o as bitcode peaks >31 GiB on aarch64; xlarge OOMs.
+    instanceType: arch === "aarch64" ? "r8g.2xlarge" : "r7i.2xlarge",
   });
 }
 


### PR DESCRIPTION
Since 02fbd62de (#29618, enable LTO for bun-zig.o), `linux aarch64 - build-bun` OOMs on `r8g.xlarge`: lld's full-LTO link now ingests ~1.39 GB of bitcode (794 MB JSC + 347 MB libbun-profile + 247 MB bun-zig.o), peak memory crosses the 31.5 GiB available (no swap) about 18 min in, and the kernel OOM-kills lld — sometimes taking the BuildKite agent with it (`exit:-1`).

This was already failing on the PR's own CI (build 47390) before merge.

| target | instance | bitcode in | result |
|---|---|---|---|
| linux x64-glibc | r7i.xlarge (4c/32G) | 1392 MB | pass, 18.98 min |
| linux aarch64-musl | r8g.xlarge (4c/32G) | 1310 MB | pass, 18.15 min |
| **linux aarch64-glibc** | r8g.xlarge (4c/32G) | 1388 MB | **Killed, 18.75 min** |

x64 has slightly *more* bitcode and survives, so the tipping factor is LLVM's AArch64 backend holding more state during codegen than X86 — not a clang bug, just expected full-LTO scaling. x64 is one bitcode-adding commit away from the same fate.

Bump both linux link boxes to `2xlarge` (8 vCPU / 64 GiB). The extra cores also help lld's parallel LTO codegen phase (the single-threaded merge/opt half won't benefit, so expect ~14–15 min rather than half of 19).