### PR TITLE
deps: bump mimalloc to dbbb9a08 (upstream v3.3.1 + fork-safety fixes)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "57029fb1f193e633462e76af745599e1dbfd4b58";
+const MIMALLOC_COMMIT = "dbbb9a0819d00d521f9f58ad4d0a336efa4ce53a";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "57029fb1f193e633462e76af745599e1dbfd4b58",
+    mimalloc: "dbbb9a0819d00d521f9f58ad4d0a336efa4ce53a",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
Bumps [oven-sh/mimalloc](https://github.com/oven-sh/mimalloc) `bun-dev3-v2` from `57029fb1` → `dbbb9a08`, pulling in 96 commits from upstream `microsoft/mimalloc@dev3` (through `2b1376ad`, mimalloc v3.3.1) plus new fork-safety hardening on our side.

## Upstream changes (microsoft/mimalloc dev3 a3fb9498..2b1376ad)

Mostly hardening from upstream's audit pass (microsoft/mimalloc#1271). Highlights:

**Correctness / safety**
- Overflow checks added throughout: `mi_wcsdup`, `strdup`/`strndup`, `_mi_os_alloc_aligned_at_offset`, guarded-alloc paths, TLS index bounds
- NULL checks: `subproc_delete`, subproc stat getters, guarded aligned allocation, guarded pointer setup
- Fix off-by-one in `_mi_arenas_free` slice-index bounds check
- Fix `mi_os_alloc_aligned_at_offset` to allow decommitting exactly one page
- Metadata-corruption detection when collecting `thread_free` list
- Clear committed bits on commit failure
- Don't bypass arena `commit_fun`

**Thread-locals (pertinent to `mi_heap_new()` heaps)**
- Version field widened to 48 bits, `MI_TLS_VERSION_MAX` wraparound (was `SIZE_MAX/2`)
- `mi_thread_local_create_expand` now zalloc+memcpy instead of realloc (ensures zeroed chunkmap on growth — supersedes our `rezalloc_aligned` patch)
- Always reset thread-local theap to NULL on init failure
- Avoid pthread keys equal to 0

**Atomics / init**
- New `mi_atomic_do_once { … }` primitive replaces ad-hoc `mi_atomic_once_t`/`mi_atomic_once()` patterns; `mi_process_init` and macOS zone registration now use it
- `mi_atomic_yield` removed → `_mi_prim_thread_yield()`
- `auto_thread_done` and `deferred_free` now use proper atomic init/variables
- Acquire (vs relaxed) load for `heap->arena_pages[i]` pointer
- Relaxed an `arena_pages->pages` is-clear assertion that doesn't hold concurrently

**Stats** (overlapped our patches — upstream's versions adopted)
- `mi_subproc_stats_get` restores `size`/`version` header after memzero
- `mi_subproc_stats_get_json` returns full aggregated stats

**Platform**
- macOS: improved zone interpose (checks zone argument), `zone_from_ptr` uses `mi_any_heap_contains`
- macOS: only use fixed TLS slots on arm64/x64, fall back to pthreads elsewhere (PowerPC)
- Linux: `unix_madvise` always returns an error code
- Emscripten: `sched_yield` instead of `emscripten_sleep`, `getentropy` include
- Random: propagate `weak` field on context split, fix chacha weak-field clearing
- Consistent `tseq`/`n` parameter ordering across `mi_bbitmap_try_find_and_clearN*`

**Removed** (superseded by upstream equivalents)
- Our `MI_TLS_IDX_MASK` version-wrap fix → upstream `MI_TLS_VERSION_MAX`
- Our `mi_rezalloc_aligned` chunkmap fix → upstream zalloc+memcpy expansion
- Our stats header-restore fix → upstream's identical fix

## New on the Bun fork (this bump)

**Fork-safety hardening for `mi_heap_delete` after multithreaded `fork()`**

Fixes a ~45% flake in `test-fork-user-heap` (now 0/100). Two changes in `arena.c`:

1. **Publish ordering**: `arena_pages->pages` bit is now set *after* `_mi_page_map_register` (was before), and cleared *before* `_mi_page_map_unregister` on free. The bit is what `mi_heap_visit_page_at` walks, so this guarantees a fully-initialized page-map entry for any page a visitor finds — except across `fork()`.

2. **Torn-snapshot tolerance**: `fork()` from a multithreaded process can capture a torn cross-page snapshot — another thread's atomic `arena_pages` bit-set propagated to memory while its earlier *plain* page-map / `xthread_free` stores did not, and that thread no longer exists in the child to make progress. `mi_heap_visit_page_at` (in `claim_pages` mode, i.e. during delete/destroy) now detects the forked-child case via a new `_mi_process_is_forked_child` flag, re-derives the missing page-map entry from the arena, and force-claims ownership instead of spinning forever waiting for a dead thread.

This makes `mi_heap_delete()` in a forked child robust against the inherent raciness of `fork()` vs lock-free fast-path allocation — relevant for `Bun.spawn()` and any user code that forks while worker threads are allocating from custom heaps.

## Kept from previous bump (unchanged Bun-side patches)
- macOS fixed TLS slots 96/97 (vs upstream 108/109 — those collide with dyld's `__thread` storage destructors)
- macOS out-of-process zone enumerator via `memory_reader_t` (Instruments support)
- `MI_NO_PROCESS_DETACH` opt-out of exit-time destructor
- `mi_heap_dump_json` / `mi_heap_get_seq` introspection APIs
- Fork-safe lock acquisition/reinit (`_mi_process_fork_prepare/parent/child`)
- `mi_theap_merge_stats` guard against concurrent `_mi_theap_free`
- `arena_pages` bit / page-map cleanup on alloc-fresh failure paths
- Debug fault-injection hooks + repro tests (`test-heap-mt`, `test-fork-user-heap`, `test-heap-delete-race`, `test-commit-fail`)

Diff: https://github.com/oven-sh/mimalloc/compare/57029fb1...dbbb9a08