### PR TITLE
build: fix misconfigured Windows compile flags (/EHsc, libarchive, hdrhistogram)

### DIFF
--- a/patches/hdrhistogram/bitscan-type.patch
+++ b/patches/hdrhistogram/bitscan-type.patch
@@ -1,0 +1,11 @@
+--- a/src/hdr_histogram.c
++++ b/src/hdr_histogram.c
+@@ -144,7 +144,7 @@ static int64_t counts_get_normalised(const struct hdr_histogram* h, int32_t inde
+ static int32_t count_leading_zeros_64(int64_t value)
+ {
+ #if defined(_MSC_VER) && !(defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64)))
+-    uint32_t leading_zero = 0;
++    unsigned long leading_zero = 0;
+ #if defined(_WIN64)
+     _BitScanReverse64(&leading_zero, value);
+ #else

--- a/scripts/build/deps/hdrhistogram.ts
+++ b/scripts/build/deps/hdrhistogram.ts
@@ -2,9 +2,10 @@
  * HdrHistogram_c — high-dynamic-range latency histogram. Used by bun test's
  * per-test timing output and benchmark reporting.
  *
- * DirectBuild: 7 .c files, no config.h. The log writer (which would pull in
- * zlib) is replaced by hdr_histogram_log_no_op.c — we only need the in-memory
- * histogram API.
+ * DirectBuild: 3 .c files, no config.h. Only the in-memory histogram API is
+ * used (JSNodePerformanceHooksHistogram.cpp), so the interval-recorder/
+ * thread/time/phaser modules are omitted; the log writer (which would pull
+ * in zlib) is replaced by hdr_histogram_log_no_op.c.
  */
 
 import type { Dependency } from "../source.ts";
@@ -20,17 +21,11 @@ export const hdrhistogram: Dependency = {
     commit: HDRHISTOGRAM_COMMIT,
   }),
 
+  patches: ["patches/hdrhistogram/bitscan-type.patch"],
+
   build: cfg => ({
     kind: "direct",
-    sources: [
-      "src/hdr_encoding.c",
-      "src/hdr_histogram.c",
-      "src/hdr_histogram_log_no_op.c",
-      "src/hdr_interval_recorder.c",
-      "src/hdr_thread.c",
-      "src/hdr_time.c",
-      "src/hdr_writer_reader_phaser.c",
-    ],
+    sources: ["src/hdr_encoding.c", "src/hdr_histogram.c", "src/hdr_histogram_log_no_op.c"],
     includes: ["include"],
     defines: cfg.windows ? { _CRT_SECURE_NO_WARNINGS: true } : { _GNU_SOURCE: true },
   }),

--- a/scripts/build/deps/highway.ts
+++ b/scripts/build/deps/highway.ts
@@ -44,10 +44,9 @@ export const highway: Dependency = {
       includes: ["."],
       defines: { HWY_STATIC_DEFINE: true },
       // -fno-exceptions / -fmath-errno aren't CLOptions (clang-cl warns
-      // "unknown argument ignored"). Match upstream's MSVC branch instead:
-      // /EHs-c- overrides globalFlags' /EHsc (later flag wins) so highway
-      // is built without exceptions like it was under nested-cmake.
-      cflags: cfg.windows ? ["/EHs-c-", "-D_HAS_EXCEPTIONS=0"] : ["-fno-exceptions", "-fmath-errno"],
+      // "unknown argument ignored"). globalFlags supplies /EHs-c- and /GR-
+      // on Windows; upstream's MSVC branch additionally sets the STL macro.
+      cflags: cfg.windows ? ["-D_HAS_EXCEPTIONS=0"] : ["-fno-exceptions", "-fmath-errno"],
     };
 
     // clang-cl on arm64-windows doesn't define __ARM_NEON even though NEON

--- a/scripts/build/deps/libarchive.ts
+++ b/scripts/build/deps/libarchive.ts
@@ -127,6 +127,9 @@ export const libarchive: Dependency = {
       LIBARCHIVE_STATIC: 1,
       // ELF-only; clang-cl doesn't support __attribute__((visibility)).
       ...(!cfg.windows && { __LIBARCHIVE_ENABLE_VISIBILITY: true }),
+      // Upstream's CMakeLists sets this on MSVC; the DirectBuild conversion
+      // missed it (97× -Wdeprecated-declarations on localtime/strncpy/etc).
+      ...(cfg.windows && { _CRT_SECURE_NO_DEPRECATE: true }),
     },
     cflags: [
       ...(cfg.windows ? [] : ["-fvisibility=hidden"]),

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -186,7 +186,7 @@ export const globalFlags: Flag[] = [
     desc: "Disable C++ exceptions",
   },
   {
-    flag: "/EHsc",
+    flag: "/EHs-c-",
     when: c => c.windows,
     desc: "Disable C++ exceptions (MSVC: s- disables C++, c- disables C)",
   },
@@ -954,6 +954,12 @@ export const fileOverrides: FileOverride[] = [
     when: c => c.linux && c.lto && c.abi !== "musl",
     desc: "Disable LTO: LLD 21 emits glibc versioned symbols (exp@GLIBC_2.17) into .lto_discard which fails to parse '@'",
   },
+  {
+    file: "src/bun.js/bindings/windows/rescle.cpp",
+    extraFlags: "/EHsc",
+    when: c => c.windows,
+    desc: "Vendored electron/rcedit; VersionInfo ctor throws std::system_error caught in OnEnumResourceLanguage. Self-contained throw/catch — already excluded from PCH",
+  },
 ];
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1061,8 +1067,9 @@ export function computeCpuTargetFlags(cfg: Config): string[] {
  * specific source. Returns extra flags to append (may be empty).
  */
 export function extraFlagsFor(cfg: Config, srcRelPath: string): string[] {
+  const key = srcRelPath.replaceAll("\\", "/");
   for (const o of fileOverrides) {
-    if (o.file !== srcRelPath) continue;
+    if (o.file !== key) continue;
     if (o.when && !o.when(cfg)) continue;
     return resolveFlagValue(o.extraFlags, cfg);
   }


### PR DESCRIPTION
## Summary

Follow-up to #29584 / #29645. Four Windows build-flag corrections — all places where the configured flag didn't match the intent (vs. just suppressing warnings). Clean rebuild goes from **104 warnings → 3**.

### `/EHsc` → `/EHs-c-` in `globalFlags`

The desc has always said "Disable C++ exceptions (s- disables C++, c- disables C)", `bunDefines` sets `_HAS_EXCEPTIONS=0`, unix gets `-fno-exceptions`, and link strips unwind sections — but the flag was `/EHsc` which **enables** synchronous exceptions. This dates back to the original Windows CMake (bun 1.0.9, `4403c4075`); the TS migration faithfully copied it.

`rescle.cpp` is the one TU that actually uses `throw`/`catch` (vendored electron/rcedit; `VersionInfo` ctor throws `std::system_error`, caught in `OnEnumResourceLanguage`). It now gets a `fileOverrides` entry restoring `/EHsc` — it's already in `noPchSources` so there's no PCH-flag mismatch. `extraFlagsFor()` now normalizes `\` → `/` so the override table matches on Windows (the only prior entry was Linux-only).

### `highway`: drop redundant `/EHs-c-`

Now that `globalFlags` supplies it. Keep `-D_HAS_EXCEPTIONS=0` (upstream's MSVC branch sets it; `bunDefines` doesn't flow to deps).

### `libarchive`: define `_CRT_SECURE_NO_DEPRECATE` on Windows

Upstream's `CMakeLists.txt:2234` sets this on MSVC; the DirectBuild conversion missed carrying it over. Restores parity with the nested-cmake build. (97× `-Wdeprecated-declarations` on `localtime`/`gmtime`/`strncpy`/etc.)

### `hdrhistogram`: trim to the 3 sources Bun uses + fix `_BitScanReverse64` arg type

`JSNodePerformanceHooksHistogram.cpp` only uses the in-memory histogram API from `hdr_histogram.h`; the interval-recorder/thread/time/phaser modules are never referenced (verified no cross-includes). Dropping them removes 3× `-Wincompatible-pointer-types` from `hdr_interval_recorder.c` (the `T**` → `void**` warning).

The 4th warning, in `hdr_histogram.c:149`, is upstream passing `uint32_t*` to `_BitScanReverse64`'s `unsigned long*` param — same width on LLP64 but distinct types. Upstream HEAD (we're already on it) still has this; fixed via a one-line patch changing the local to `unsigned long`.

## Not in this PR

The 3 remaining warnings are pre-existing and not flag misconfigurations:
- 2× `-Wunused-value` in `rescle.cpp` from the Windows SDK's `UnlockResource` no-op macro `((hResData), 0)`
- 1× `-Wmicrosoft-cast` in `JSBundlerPlugin.cpp:383` (`GetProcAddress` → `void*`)

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] Full clean rebuild on Windows: 104 → 3 warnings, link + smoke test pass
- [x] `bun bd test test/js/bun/perf_hooks/histogram.test.ts` — 38/38 pass (hdrhistogram trim + patch)
- [x] `bun bd test test/cli/install/bun-pack.test.ts` — 70/70 pass (libarchive)
- [ ] Windows CI green
- [ ] Linux/Darwin CI green (libarchive/hdrhistogram changes are Windows-only conditioned, but verifying)
