### PR TITLE
fix(s3): double free of path when S3Client operation throws

### DIFF
--- a/src/runtime/webcore/S3Client.zig
+++ b/src/runtime/webcore/S3Client.zig
@@ -135,7 +135,6 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path", .{});
         };
-        errdefer path.deinit();
         const options = args.nextEat();
         var blob = Blob.new(try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer));
         return blob.toJS(globalThis);
@@ -151,8 +150,6 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to presign", .{});
         };
-        errdefer path.deinit();
-
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -169,7 +166,6 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check if it exists", .{});
         };
-        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -186,7 +182,6 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the size of", .{});
         };
-        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -203,7 +198,6 @@ pub const S3Client = struct {
             }
             return globalThis.throwInvalidArguments("Expected a path to check the stat of", .{});
         };
-        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();
@@ -217,8 +211,8 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to write to", .{}).throw();
         };
-        errdefer path.deinit();
         const data = args.nextEat() orelse {
+            path.deinit();
             return globalThis.ERR(.MISSING_ARGS, "Expected a Blob-y thing to write", .{}).throw();
         };
 
@@ -251,7 +245,6 @@ pub const S3Client = struct {
         const path: jsc.Node.PathLike = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse {
             return globalThis.ERR(.MISSING_ARGS, "Expected a path to unlink", .{}).throw();
         };
-        errdefer path.deinit();
         const options = args.nextEat();
         var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, options, ptr.credentials, ptr.options, ptr.acl, ptr.storage_class, ptr.request_payer);
         defer blob.detach();

--- a/src/runtime/webcore/S3File.zig
+++ b/src/runtime/webcore/S3File.zig
@@ -83,6 +83,7 @@ pub fn presign(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
                 return globalThis.throwInvalidArguments("Expected a S3 or path to presign", .{});
             }
             const options = args.nextEat();
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
             return try getPresignUrlFrom(&blob, globalThis, options);
@@ -113,6 +114,7 @@ pub fn unlink(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
                 return globalThis.throwInvalidArguments("Expected a S3 or path to delete", .{});
             }
             const options = args.nextEat();
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
             return try blob.store.?.data.s3.unlink(blob.store.?, globalThis, options);
@@ -150,6 +152,7 @@ pub fn write(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSE
             if (path == .fd) {
                 return globalThis.throwInvalidArguments("Expected a S3 or path to upload", .{});
             }
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
 
@@ -189,6 +192,7 @@ pub fn size(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
             if (path == .fd) {
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
 
@@ -222,6 +226,7 @@ pub fn exists(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             if (path == .fd) {
                 return globalThis.throwInvalidArguments("Expected a S3 or path to check if it exists", .{});
             }
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
 
@@ -243,6 +248,7 @@ fn constructS3FileInternalStore(
     return constructS3FileWithS3Credentials(globalObject, path, options, existing_credentials);
 }
 /// if the credentials have changed, we need to clone it, if not we can just ref/deref it
+/// Always takes ownership of `path`; freed on error, stored in the returned blob on success.
 pub fn constructS3FileWithS3CredentialsAndOptions(
     globalObject: *jsc.JSGlobalObject,
     path: jsc.Node.PathLike,
@@ -253,7 +259,10 @@ pub fn constructS3FileWithS3CredentialsAndOptions(
     default_storage_class: ?bun.S3.StorageClass,
     default_request_payer: bool,
 ) bun.JSError!Blob {
-    var aws_options = try S3.S3Credentials.getCredentialsWithOptions(default_credentials.*, default_options, options, default_acl, default_storage_class, default_request_payer, globalObject);
+    var aws_options = S3.S3Credentials.getCredentialsWithOptions(default_credentials.*, default_options, options, default_acl, default_storage_class, default_request_payer, globalObject) catch |err| {
+        path.deinit();
+        return err;
+    };
     defer aws_options.deinit();
 
     const store = brk: {
@@ -298,13 +307,17 @@ pub fn constructS3FileWithS3CredentialsAndOptions(
     return blob;
 }
 
+/// Always takes ownership of `path`; freed on error, stored in the returned blob on success.
 pub fn constructS3FileWithS3Credentials(
     globalObject: *jsc.JSGlobalObject,
     path: jsc.Node.PathLike,
     options: ?jsc.JSValue,
     existing_credentials: S3.S3Credentials,
 ) bun.JSError!Blob {
-    var aws_options = try S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalObject);
+    var aws_options = S3.S3Credentials.getCredentialsWithOptions(existing_credentials, .{}, options, null, null, false, globalObject) catch |err| {
+        path.deinit();
+        return err;
+    };
     defer aws_options.deinit();
     const store = bun.handleOom(Blob.Store.initS3(path, null, aws_options.credentials, bun.default_allocator));
     errdefer store.deinit();
@@ -573,6 +586,7 @@ pub fn stat(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSEr
             if (path == .fd) {
                 return globalThis.throwInvalidArguments("Expected a S3 or path to get size", .{});
             }
+            path_or_blob = .{ .path = .{ .path = .{ .string = bun.PathString.empty } } };
             var blob = try constructS3FileInternalStore(globalThis, path.path, options);
             defer blob.deinit();
 

--- a/test/js/bun/s3/s3-path-double-free.test.ts
+++ b/test/js/bun/s3/s3-path-double-free.test.ts
@@ -46,6 +46,20 @@ describe("S3Client error paths do not double-free the path", () => {
     expect(() => client.write(nonAsciiPath)).toThrow();
   });
 
+  test.each(["exists", "size", "stat", "unlink"] as const)(
+    "instance %s() throwing before blob creation",
+    method => {
+      const client = new Bun.S3Client();
+      expect(() =>
+        client[method](nonAsciiPath, {
+          get type() {
+            throw new Error("boom");
+          },
+        }),
+      ).toThrow("boom");
+    },
+  );
+
   test("static presign() throwing after blob creation", () => {
     expect(() =>
       Bun.S3Client.presign(nonAsciiPath, {
@@ -86,4 +100,17 @@ describe("S3Client error paths do not double-free the path", () => {
       }),
     ).toThrow("boom");
   });
+
+  test.each(["exists", "size", "stat", "unlink"] as const)(
+    "static %s() throwing before blob creation",
+    method => {
+      expect(() =>
+        Bun.S3Client[method](nonAsciiPath, {
+          get type() {
+            throw new Error("boom");
+          },
+        }),
+      ).toThrow("boom");
+    },
+  );
 });

--- a/test/js/bun/s3/s3-path-double-free.test.ts
+++ b/test/js/bun/s3/s3-path-double-free.test.ts
@@ -46,19 +46,16 @@ describe("S3Client error paths do not double-free the path", () => {
     expect(() => client.write(nonAsciiPath)).toThrow();
   });
 
-  test.each(["exists", "size", "stat", "unlink"] as const)(
-    "instance %s() throwing before blob creation",
-    method => {
-      const client = new Bun.S3Client();
-      expect(() =>
-        client[method](nonAsciiPath, {
-          get type() {
-            throw new Error("boom");
-          },
-        }),
-      ).toThrow("boom");
-    },
-  );
+  test.each(["exists", "size", "stat", "unlink"] as const)("instance %s() throwing before blob creation", method => {
+    const client = new Bun.S3Client();
+    expect(() =>
+      client[method](nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
 
   test("static presign() throwing after blob creation", () => {
     expect(() =>
@@ -101,16 +98,13 @@ describe("S3Client error paths do not double-free the path", () => {
     ).toThrow("boom");
   });
 
-  test.each(["exists", "size", "stat", "unlink"] as const)(
-    "static %s() throwing before blob creation",
-    method => {
-      expect(() =>
-        Bun.S3Client[method](nonAsciiPath, {
-          get type() {
-            throw new Error("boom");
-          },
-        }),
-      ).toThrow("boom");
-    },
-  );
+  test.each(["exists", "size", "stat", "unlink"] as const)("static %s() throwing before blob creation", method => {
+    expect(() =>
+      Bun.S3Client[method](nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
 });

--- a/test/js/bun/s3/s3-path-double-free.test.ts
+++ b/test/js/bun/s3/s3-path-double-free.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+// A non-ASCII character forces the PathLike to be an allocated encoded_slice.
+// When the operation fails after the path has been placed in the blob store,
+// it must be freed exactly once; previously both the blob store and the
+// caller's errdefer would free it, causing an ASAN use-after-poison.
+const nonAsciiPath = "bucket/key-ü.txt";
+
+describe("S3Client error paths do not double-free the path", () => {
+  test("instance presign() throwing after blob creation", () => {
+    const client = new Bun.S3Client({ accessKeyId: "x", secretAccessKey: "y", endpoint: "http://example.com" });
+    expect(() => client.presign(nonAsciiPath, { expiresIn: -1 })).toThrow();
+    expect(() =>
+      client.presign(nonAsciiPath, {
+        get method() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+
+  test("instance presign() throwing before blob creation", () => {
+    const client = new Bun.S3Client();
+    expect(() =>
+      client.presign(nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+
+  test("instance file() throwing before blob creation", () => {
+    const client = new Bun.S3Client();
+    expect(() =>
+      client.file(nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+
+  test("instance write() with non-ASCII path and missing data", () => {
+    const client = new Bun.S3Client();
+    expect(() => client.write(nonAsciiPath)).toThrow();
+  });
+
+  test("static presign() throwing after blob creation", () => {
+    expect(() =>
+      Bun.S3Client.presign(nonAsciiPath, {
+        accessKeyId: "x",
+        secretAccessKey: "y",
+        endpoint: "http://example.com",
+        expiresIn: -1,
+      }),
+    ).toThrow();
+    expect(() =>
+      Bun.S3Client.presign(nonAsciiPath, {
+        accessKeyId: "x",
+        secretAccessKey: "y",
+        endpoint: "http://example.com",
+        get method() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+
+  test("static presign() throwing before blob creation", () => {
+    expect(() =>
+      Bun.S3Client.presign(nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+
+  test("static file() throwing before blob creation", () => {
+    expect(() =>
+      Bun.S3Client.file(nonAsciiPath, {
+        get type() {
+          throw new Error("boom");
+        },
+      }),
+    ).toThrow("boom");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an ASAN use-after-poison (double free) in `S3Client` methods when an operation throws after the internal blob has been constructed.

### Root cause

In methods like `S3Client.prototype.presign`:

```zig
const path = try jsc.Node.PathLike.fromJS(globalThis, &args) orelse { ... };
errdefer path.deinit();
var blob = try S3File.constructS3FileWithS3CredentialsAndOptions(globalThis, path, ...);
defer blob.detach();
return S3File.getPresignUrlFrom(&blob, globalThis, options);
```

`constructS3FileWithS3CredentialsAndOptions` stores `path` directly in the blob's store (no copy). If `getPresignUrlFrom` then throws (missing credentials, `expiresIn: -1`, a throwing option getter, etc.), `defer blob.detach()` frees the path via the store **and** `errdefer path.deinit()` frees it again.

This only manifests visibly when the `PathLike` is an allocated `.encoded_slice`, which happens for paths containing non-ASCII characters (UTF-16 → UTF-8 conversion allocates).

The same pattern existed across `file`/`presign`/`exists`/`size`/`stat`/`write`/`unlink` on both the instance and the static `S3Client` / `S3File` code paths.

### Fix

- `constructS3FileWithS3Credentials` and `constructS3FileWithS3CredentialsAndOptions` now **always** take ownership of `path`: freed on error, stored in the returned blob on success.
- All `S3Client` instance methods drop the `errdefer path.deinit()` since ownership is unconditionally transferred. `write` explicitly frees `path` in the missing-data case before the constructor is reached.
- The `S3File` static methods clear `path_or_blob` before handing the path to the constructor so their `errdefer` becomes a no-op once ownership is gone.

### Repro

```js
new Bun.S3Client().presign("bucket/key-ü.txt", { expiresIn: -1 });
```

Before: `AddressSanitizer: use-after-poison` in `PathLike.deinit`.
After: throws `expiresIn must be greather than 0` cleanly.

## How did you verify your code works?

- Reproduced the ASAN crash with both instance and static `presign` using a non-ASCII path.
- Added `test/js/bun/s3/s3-path-double-free.test.ts` covering both the before-blob and after-blob error paths for instance and static methods.
- `bun bd test test/js/bun/s3/s3-path-double-free.test.ts` passes; the same test crashes under the previous ASAN build.
- Original fuzzer crash script runs to completion with exit 0.