### PR TITLE
build: restore Windows dep defines lost in DirectBuild conversion

### DIFF
--- a/scripts/build/deps/zlib.ts
+++ b/scripts/build/deps/zlib.ts
@@ -191,7 +191,12 @@ export const zlib: Dependency = {
       defines.ARM_CRC32_INTRIN = true;
       defines.HAVE_ARM_ACLE_H = true;
       defines.WITH_ALL_FALLBACKS = true;
-      if (cfg.windows) defines.__ARM_NEON__ = true;
+      if (cfg.windows) {
+        defines.__ARM_NEON__ = true;
+        // Upstream sets this on MSVC ARM; gates the Windows SDK's ARM
+        // intrinsic headers via <winapifamily.h>.
+        defines._ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE = true;
+      }
       if (cfg.linux) {
         defines.ARM_AUXV_HAS_NEON = true;
         defines.HAVE_LINUX_AUXVEC_H = true;

--- a/scripts/build/deps/zstd.ts
+++ b/scripts/build/deps/zstd.ts
@@ -50,6 +50,15 @@ export const zstd: Dependency = {
       ZSTD_LEGACY_SUPPORT: 5,
     };
 
+    // Upstream's if(MSVC) block sets these for the static target.
+    // ZSTD_HEAPMODE=0 makes the one-shot ZSTD_decompress() (used by
+    // src/deps/zstd.zig) stack-allocate its DCtx instead of malloc/free
+    // per call; the source default is 1.
+    if (cfg.windows) {
+      defines.ZSTD_HEAPMODE = 0;
+      defines._CRT_SECURE_NO_WARNINGS = true;
+    }
+
     // huf_decompress_amd64.S is GNU-as syntax. clang assembles it on
     // posix x64; clang-cl can't, so Windows takes the C path.
     if (cfg.x64 && !cfg.windows) {

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -682,7 +682,6 @@ export const linkerFlags: Flag[] = [
       "/delayload:ole32.dll",
       "/delayload:WINMM.dll",
       "/delayload:dbghelp.dll",
-      "/delayload:VCRUNTIME140_1.dll",
       "/delayload:WS2_32.dll",
       "/delayload:WSOCK32.dll",
       "/delayload:ADVAPI32.dll",


### PR DESCRIPTION
## Summary

Audit follow-up to #29584 / #29653. Three Windows-specific build-config corrections found by comparing each DirectBuild dep's `cfg.windows` config against what the upstream `CMakeLists.txt` sets in its `if(MSVC)` branch.

### `zstd`: define `ZSTD_HEAPMODE=0` and `_CRT_SECURE_NO_WARNINGS` on Windows

Upstream's `if(MSVC)` block (`vendor/zstd/build/cmake/lib/CMakeLists.txt:191`) sets both for the static target. Under nested-cmake we got them; after #29584 we don't. `ZSTD_HEAPMODE` controls whether the one-shot `ZSTD_decompress()` — which Bun calls (`src/deps/zstd.zig:31`) — mallocs a ~160 KB DCtx per call (default `1`) or stack-allocates it (`0`). This restores the malloc-free path on Windows.

### `zlib`: define `_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE` on win-arm64

Upstream sets it on MSVC ARM (`vendor/zlib/CMakeLists.txt:238`); it gates the Windows SDK's ARM intrinsic headers via `<winapifamily.h>`. Only affects win-arm64 builds.

### `flags.ts`: drop `/delayload:VCRUNTIME140_1.dll`

We link `/MT` (static CRT); the release binary's import table has no VCRUNTIME entry (verified with `llvm-readobj --coff-imports`). lld-link silently ignores delay-load directives for DLLs not actually imported, so this was a no-op — stale from before static-runtime linking.

### Not changed

`mimalloc` `MI_WIN_NOREDIRECT` was flagged during the audit but turns out to only matter under `MI_SHARED_LIB` (`vendor/mimalloc/src/prim/windows/prim.c:1074`), which we don't set — false positive.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `ninja -C build/debug zstd` — all 35 sources compile cleanly with `-DZSTD_HEAPMODE=0`
- [x] `bun bd test test/js/bun/util/zstd.test.ts` — 74/74 pass
- [x] `bun bd test test/js/node/zlib/zlib.test.js -t zstd` — 12/12 pass
- [ ] win-arm64 CI green (zlib define)
- [ ] Windows x64 CI green
