### PR TITLE
build: fix -Bsymbolics-functions typo (Linux link flags)

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -814,7 +814,7 @@ export const linkerFlags: Flag[] = [
   },
   {
     flag: c => [
-      "-Bsymbolics-functions",
+      "-Wl,-Bsymbolic-functions",
       "-rdynamic",
       `-Wl,--dynamic-list=${c.cwd}/src/symbols.dyn`,
       `-Wl,--version-script=${c.cwd}/src/linker.lds`,


### PR DESCRIPTION
## Summary

The flag is `-Bsymbolic-functions` (no `s` after `symbolic`). As written, clang's driver parses `-Bsymbolics-functions` as `-B<path>` and adds a tool-search directory named `symbolics-functions` — silently doing nothing. The typo was in the original CMake (`BuildBun.cmake:1230`) and was carried over to the TypeScript build (`a8ee0d38db`).

Also passes via `-Wl,` since it's an ld flag, not a clang driver flag. With `-rdynamic` the executable exports symbols for napi/dlopen modules; `-Bsymbolic-functions` binds the executable's own internal function calls directly instead of routing through the dynamic symbol table.

Found during a Windows build-flag audit; flagged as a bonus since it's Linux-only.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [ ] Linux CI green (this is a no-op on Windows/Darwin)
- [ ] napi tests pass on Linux (verifies `-rdynamic` exports still work with the corrected flag)
