### PR TITLE
build: -fno-pch-timestamp so ccache-returned PCHs don't fail mtime validation

### DIFF
--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -109,10 +109,15 @@ export function registerCompileRules(n: Ninja, cfg: Config): void {
   // suppress JSC warnings, which makes everything it transitively includes
   // "system" for -MMD purposes. -MMD would give a near-empty depfile; -MD
   // tracks all headers so PCH invalidates when WebKit headers change.
+  // -fno-pch-timestamp: don't embed input mtimes in the PCH. ccache returns
+  // cached PCH outputs by content hash, so the embedded mtime can be stale
+  // (e.g. after deleting pch/ and reconfiguring) → every consumer fails with
+  // "mtime changed". ninja's depfile already tracks invalidation; clang's
+  // redundant mtime check just fights ccache.
   n.rule("pch", {
     command: cfg.windows
-      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags /clang:-fpch-instantiate-templates /Yc$pch_header /FI$pch_header /Fp$out /c $in /Fo$pch_stub_obj`
-      : `${ccacheLauncher}${cxx} $cxxflags -Winvalid-pch -fpch-instantiate-templates -Xclang -emit-pch -Xclang -include -Xclang $pch_header -x c++-header -MD -MT $out -MF $out.d -c $in -o $out`,
+      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags /clang:-fpch-instantiate-templates -Xclang -fno-pch-timestamp /Yc$pch_header /FI$pch_header /Fp$out /c $in /Fo$pch_stub_obj`
+      : `${ccacheLauncher}${cxx} $cxxflags -Winvalid-pch -fpch-instantiate-templates -Xclang -fno-pch-timestamp -Xclang -emit-pch -Xclang -include -Xclang $pch_header -x c++-header -MD -MT $out -MF $out.d -c $in -o $out`,
     description: "pch $out",
     ...depfileOpts,
   });


### PR DESCRIPTION
## Summary

clang embeds input-file mtimes in the PCH and validates them when a consumer loads it. ccache caches PCH outputs by content+flags hash, so a cache hit can return a PCH whose embedded mtime no longer matches the stub on disk — every consuming TU then fails with:

```
fatal error: file 'pch/root-pch.h.hxx.cxx' has been modified since the
precompiled header was built: mtime changed (was X, now Y)
```

**Repro:** build → delete `build/debug/pch/` → reconfigure (`writeIfChanged` recreates the stub with a fresh mtime since the file no longer exists) → build. ccache hits on the PCH compile (same content+flags), returns the old PCH with the old mtime baked in, and every PCH consumer fails. I hit this while switching between branches that touch `globalFlags`.

**Fix:** `-Xclang -fno-pch-timestamp` on the `pch` rule omits the timestamps so there's nothing for the consumer to validate. ninja's depfile + `implicitInputs` already track when the PCH actually needs rebuilding; clang's mtime check is redundant and just fights ccache. This is the approach [ccache's own docs recommend](https://ccache.dev/manual/latest.html#_precompiled_headers) for clang PCH.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] Reproduced the failure on main, then verified the fix: built PCH (stub mtime 1776984853) → `rm -rf build/debug/pch` → reconfigure (stub mtime now 1776988329) → `ninja pch` (ccache hit) → `ninja BunProcess.cpp.obj` succeeds instead of failing
- [ ] CI green (flag applies to both Windows and posix PCH paths)
