### PR TITLE
fix(inspect): don't iterate WeakMap/WeakSet when formatting

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2759,14 +2759,19 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2866,14 +2871,19 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1309,14 +1309,19 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1337,6 +1342,14 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    if (is_weak) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1345,8 +1358,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,15 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+it("WeakMap/WeakSet with a user-defined size property", () => {
+  const wm = new WeakMap();
+  wm.size = 5;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  expect(() => expect(wm).toEqual({})).toThrow();
+
+  const ws = new WeakSet();
+  ws.size = 5;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  expect(() => expect(ws).toEqual({})).toThrow();
+});


### PR DESCRIPTION
## What does this PR do?

`WeakMap` and `WeakSet` are not iterable and don't have a real `.size` property. The formatters in `ConsoleObject.zig` and `pretty_format.zig` relied on `.size` returning `undefined` (coerced to `0`) to short-circuit to the empty-collection path and print `WeakMap {}` / `WeakSet {}`.

If a user assigns a `.size` property to a `WeakMap`/`WeakSet`, the formatter would see a non-zero length and attempt to `forEach` over it, which throws a `TypeError` since weak collections are not iterable.

```js
const wm = new WeakMap();
wm.size = 5;
Bun.inspect(wm); // TypeError: Type error
expect(wm).toEqual({}); // assertion failure in debug builds
```

- In `Bun.inspect` / `console.log` this surfaced as an unexpected `TypeError`.
- In `expect().toEqual()` diff printing, the exception was swallowed by `catch {}` without clearing the VM exception, tripping `assertNoExceptionExceptTermination` in debug builds.

### Fix

- Short-circuit `WeakMap`/`WeakSet` immediately in both formatters since their contents are never enumerable anyway — always print `WeakMap {}` / `WeakSet {}`.
- Clear any pending VM exception in `DiffFormatter` when `JestPrettyFormat.format` throws, so a formatting error doesn't leave a dangling exception for the next JSC call.

## How did you verify your code works?

Added a test in `test/js/bun/util/inspect.test.js`.

Found by Fuzzilli.