### PR TITLE
build: split zig compiler pin into STABLE/FAST

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -402,10 +402,8 @@ function getZigAgent(platform, options) {
   }
 
   // Everything else cross-compiles from Linux aarch64. ASAN gets a wider
-  // box (8 vCPU) to match cg=CI_ASAN_CODEGEN_THREADS=8; non-ASAN gets
-  // 2 vCPU to match cg=CI_CODEGEN_THREADS=2 (or cg=1 under LTO/Windows).
-  // cg must equal vCPU count — the fork spawns cg OS threads + cg LLVM
-  // contexts (zig_llvm.cpp StdThreadPool), so oversubscribing OOMs.
+  // box: it builds with cg=CI_ASAN_CODEGEN_THREADS (8) so it can use the
+  // parallel backend; non-ASAN stays at cg=1 so 2 vCPU suffice.
   return getEc2Agent(getZigPlatform(), options, {
     instanceType: platform.profile === "asan" ? "r8g.2xlarge" : "r8g.large",
   });

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -402,8 +402,10 @@ function getZigAgent(platform, options) {
   }
 
   // Everything else cross-compiles from Linux aarch64. ASAN gets a wider
-  // box: it builds with cg=CI_ASAN_CODEGEN_THREADS (8) so it can use the
-  // parallel backend; release stays at cg=1 (full IPO) so 2 vCPU suffice.
+  // box (8 vCPU) to match cg=CI_ASAN_CODEGEN_THREADS=8; non-ASAN gets
+  // 2 vCPU to match cg=CI_CODEGEN_THREADS=2 (or cg=1 under LTO/Windows).
+  // cg must equal vCPU count — the fork spawns cg OS threads + cg LLVM
+  // contexts (zig_llvm.cpp StdThreadPool), so oversubscribing OOMs.
   return getEc2Agent(getZigPlatform(), options, {
     instanceType: platform.profile === "asan" ? "r8g.2xlarge" : "r8g.large",
   });

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -516,6 +516,9 @@ function getBuildArgs(target, options, mode) {
   }
   if (baseline) args.push("--baseline=on");
   if (profile === "asan") args.push("--asan=on");
+  // PR builds use the FAST zig compiler (sharded codegen, no zig-side LTO);
+  // main-branch builds (canary + production) use STABLE with full LTO.
+  if (!isMainBranch()) args.push("--pr=on");
 
   // canary: options.canary can be number (revision count) or undefined
   // (default on). Old system used CANARY_REVISION as a counter; build.ts

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -514,8 +514,8 @@ function getBuildArgs(target, options, mode) {
   }
   if (baseline) args.push("--baseline=on");
   if (profile === "asan") args.push("--asan=on");
-  // PR builds use the FAST zig compiler (sharded codegen, no zig-side LTO);
-  // main-branch builds (canary + production) use STABLE with full LTO.
+  // PR builds use the FAST zig compiler; main-branch builds (canary +
+  // production) use STABLE. See zigFastCompiler() in scripts/build/zig.ts.
   if (!isMainBranch()) args.push("--pr=on");
 
   // canary: options.canary can be number (revision count) or undefined

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -355,6 +355,7 @@ function parseArgs(argv: string[]): CliArgs {
     "timeTrace",
     "ci",
     "buildkite",
+    "pr",
   ]);
   // PartialConfig fields that are STRINGS.
   const stringFields = new Set([

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -588,8 +588,8 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
   const archive = resolve(cfg.buildDir, `${cfg.libPrefix}${exeName}${cfg.libSuffix}`);
 
   // bun-zig*.o from zig-only: same paths emitZig writes to. Shared
-  // helper so both sides of the CI split agree (single file at cg<=1;
-  // N shards at cg=CI_CODEGEN_THREADS / CI_ASAN_CODEGEN_THREADS).
+  // helper so both sides of the CI split agree (single file at cg<=1,
+  // N shards for asan at cg=CI_ASAN_CODEGEN_THREADS).
   const zigObjects = zigObjectPaths(cfg);
 
   // Only need ldflags + stripflags (no cflags/cxxflags — no compile).

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -588,8 +588,8 @@ function emitLinkOnly(n: Ninja, cfg: Config): BunOutput {
   const archive = resolve(cfg.buildDir, `${cfg.libPrefix}${exeName}${cfg.libSuffix}`);
 
   // bun-zig*.o from zig-only: same paths emitZig writes to. Shared
-  // helper so both sides of the CI split agree (single file at cg<=1,
-  // N shards for asan at cg=CI_ASAN_CODEGEN_THREADS).
+  // helper so both sides of the CI split agree (single file at cg<=1;
+  // N shards at cg=CI_CODEGEN_THREADS / CI_ASAN_CODEGEN_THREADS).
   const zigObjects = zigObjectPaths(cfg);
 
   // Only need ldflags + stripflags (no cflags/cxxflags — no compile).

--- a/scripts/build/clean.ts
+++ b/scripts/build/clean.ts
@@ -85,6 +85,7 @@ const presets: Record<string, () => string[]> = {
   deep: () => [
     resolve(cwd, "build"),
     resolve(cwd, "vendor", "zig"),
+    resolve(cwd, "vendor", "zig-stable"),
     resolve(cwd, ".zig-cache"),
     resolve(cwd, "zig-out"),
     ...allDeps.filter(d => !userManagedDeps.has(d.name)).map(d => resolve(cwd, "vendor", d.name)),

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -242,6 +242,14 @@ export interface Config {
    * codegenThreads() in zig.ts.
    */
   zigFast: boolean;
+  /**
+   * Whether the zig step emits LTO bitcode (`-Dlto=true`) instead of machine
+   * code. Distinct from `lto` (the C++/link side): on FAST builds zig emits
+   * sharded machine code so codegenThreads()>1 can fire, while C++ still
+   * compiles with -flto and lld LTOs the C++ bitcode (mixed-input link).
+   * Only STABLE (production) gets full cross-language LTO including zig.
+   */
+  zigLto: boolean;
   /** WebKit commit. Default in versions.ts; override to test a WebKit branch. */
   webkitVersion: string;
 }
@@ -757,6 +765,11 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const zigFastDefault = zigFastCompiler({ ci, canary });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
   const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
+  // FAST builds (PR/canary CI, local) skip LTO on the zig side so
+  // codegenThreads()>1 can shard the LLVM emit; the C++/link side keeps
+  // `lto` and lld handles the mixed bitcode + machine-code link. STABLE
+  // (production) keeps full cross-language LTO.
+  const zigLto = lto && !zigFast;
 
   // ─── macOS SDK ───
   // Must be passed to nested cmake builds or they'll pick the wrong SDK.
@@ -852,6 +865,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     canaryRevision,
     zigCommit,
     zigFast,
+    zigLto,
     webkitVersion,
   };
 }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -15,7 +15,7 @@ import { WEBKIT_VERSION } from "./deps/webkit.ts";
 import { assert, BuildError } from "./error.ts";
 import { clangTargetArch } from "./tools.ts";
 import { cyan, dim, green } from "./tty.ts";
-import { ZIG_COMMIT } from "./zig.ts";
+import { ZIG_COMMIT_FAST, ZIG_COMMIT_STABLE, zigFastCompiler } from "./zig.ts";
 
 export type OS = "linux" | "darwin" | "windows" | "freebsd";
 export type Arch = "x64" | "aarch64";
@@ -48,11 +48,14 @@ export interface Host {
  * Pinned version defaults. Each lives at the top of its own file
  * (deps/webkit.ts, zig.ts, deps/nodejs-headers.ts) — look there to bump.
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
+ *
+ * Zig is NOT here: there are two pins (STABLE/FAST) and which one applies
+ * depends on resolved build options (ci/asan/windows/lto), so the default
+ * is computed inside resolveConfig via zigFastCompiler().
  */
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
   nodejsAbiVersion: NODEJS_ABI_VERSION,
-  zigCommit: ZIG_COMMIT,
   webkitVersion: WEBKIT_VERSION,
 };
 
@@ -229,8 +232,15 @@ export interface Config {
   /** Node.js compat version. Default in versions.ts; override to test a bump. */
   nodejsVersion: string;
   nodejsAbiVersion: string;
-  /** Zig compiler commit. Default in versions.ts; override to test a new compiler. */
+  /** Zig compiler commit. Defaults to STABLE or FAST per zigFast; override to test a new compiler. */
   zigCommit: string;
+  /**
+   * Which zig compiler line this build uses — true = `upgrade-0.15.2-fast`
+   * (parallel sema + sharded codegen), false = `upgrade-0.15.2` (stable).
+   * Derived from {windows, lto, ci, asan} via zigFastCompiler(); also gates
+   * ZIG_PARALLEL_SEMA and codegenThreads() in zig.ts.
+   */
+  zigFast: boolean;
   /** WebKit commit. Default in versions.ts; override to test a WebKit branch. */
   webkitVersion: string;
 }
@@ -736,8 +746,11 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // to test a branch before bumping the pinned default.
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
-  const zigCommit = partial.zigCommit ?? versionDefaults.zigCommit;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
+  // Zig: STABLE for shipped builds (non-ASAN CI, Windows, LTO), FAST
+  // (parallel sema + sharded codegen) for local dev and ASAN CI.
+  const zigFast = zigFastCompiler({ windows, lto, ci, asan });
+  const zigCommit = partial.zigCommit ?? (zigFast ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
 
   // ─── macOS SDK ───
   // Must be passed to nested cmake builds or they'll pick the wrong SDK.
@@ -832,6 +845,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     nodejsAbiVersion,
     canaryRevision,
     zigCommit,
+    zigFast,
     webkitVersion,
   };
 }
@@ -1074,7 +1088,9 @@ export function formatConfig(cfg: Config, exe: string): string {
   // revert my WebKit test branch" before the build goes weird.
   if (cfg.webkitVersion !== versionDefaults.webkitVersion)
     features.push(`webkit-version:${cfg.webkitVersion.slice(0, 10)}`);
-  if (cfg.zigCommit !== versionDefaults.zigCommit) features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
+  if (cfg.zigFast) features.push("zig:fast");
+  if (cfg.zigCommit !== ZIG_COMMIT_STABLE && cfg.zigCommit !== ZIG_COMMIT_FAST)
+    features.push(`zig-commit:${cfg.zigCommit.slice(0, 10)}`);
   if (cfg.nodejsVersion !== versionDefaults.nodejsVersion) features.push(`nodejs:${cfg.nodejsVersion}`);
   lines.push(`  ${label("features")} ${features.length > 0 ? c.cyan(features.join(", ")) : c.dim("(none)")}`);
   return lines.join("\n");

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -50,8 +50,8 @@ export interface Host {
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
  *
  * Zig is NOT here: there are two pins (STABLE/FAST) and which one applies
- * depends on resolved build options (ci/asan/windows/lto), so the default
- * is computed inside resolveConfig via zigFastCompiler().
+ * depends on resolved build options (ci/canary), so the default is
+ * computed inside resolveConfig via zigFastCompiler().
  */
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
@@ -237,8 +237,9 @@ export interface Config {
   /**
    * Which zig compiler line this build uses — true = `upgrade-0.15.2-fast`
    * (parallel sema + sharded codegen), false = `upgrade-0.15.2` (stable).
-   * Derived from {windows, lto, ci, asan} via zigFastCompiler(); also gates
-   * ZIG_PARALLEL_SEMA and codegenThreads() in zig.ts.
+   * Derived from {ci, canary} via zigFastCompiler(), or from an explicit
+   * `--zig-commit` matching a known pin. Gates ZIG_PARALLEL_SEMA and
+   * codegenThreads() in zig.ts.
    */
   zigFast: boolean;
   /** WebKit commit. Default in versions.ts; override to test a WebKit branch. */
@@ -749,9 +750,14 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
   // Zig: STABLE only for tagged production releases (ci + --canary=off);
   // local dev, PR CI, and canary CI all use FAST (parallel sema + sharded
-  // codegen on the upgrade-0.15.2-fast fork).
-  const zigFast = zigFastCompiler({ ci, canary });
-  const zigCommit = partial.zigCommit ?? (zigFast ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
+  // codegen on the upgrade-0.15.2-fast fork). An explicit --zig-commit
+  // matching a known pin overrides the {ci,canary} default so e.g.
+  // `--zig-commit=$STABLE` doesn't leave zigFast=true (which would make
+  // ninja declare bun-zig.{0..N-1}.o that the stable compiler can't emit).
+  const zigFastDefault = zigFastCompiler({ ci, canary });
+  const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
+  const zigFast =
+    zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
 
   // ─── macOS SDK ───
   // Must be passed to nested cmake builds or they'll pick the wrong SDK.

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -50,7 +50,7 @@ export interface Host {
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
  *
  * Zig is NOT here: there are two pins (STABLE/FAST) and which one applies
- * depends on resolved build options (windows/ci/pr), so the default is
+ * depends on resolved build options (host.os/ci/pr), so the default is
  * computed inside resolveConfig via zigFastCompiler().
  */
 const versionDefaults = {
@@ -244,7 +244,7 @@ export interface Config {
   /**
    * Which zig compiler line this build uses — true = `upgrade-0.15.2-fast`
    * (parallel sema + sharded codegen), false = `upgrade-0.15.2` (stable).
-   * Derived from {windows, ci, pr} via zigFastCompiler(), or from an
+   * Derived from {host.os, ci, pr} via zigFastCompiler(), or from an
    * explicit `--zig-commit` matching a known pin. Gates ZIG_PARALLEL_SEMA
    * and codegenThreads() in zig.ts.
    */
@@ -757,13 +757,13 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
-  // Zig: FAST (parallel sema + sharded codegen) for non-Windows local dev
-  // and PR CI; STABLE for Windows (oven-sh/zig#20 not landed) and
-  // main-branch CI (canary + production). An explicit --zig-commit
+  // Zig: FAST (parallel sema + sharded codegen) for non-Windows-host local
+  // dev and PR CI; STABLE for Windows hosts (oven-sh/zig#20 not landed)
+  // and main-branch CI (canary + production). An explicit --zig-commit
   // matching a known pin overrides the default so e.g.
   // `--zig-commit=$STABLE` doesn't leave zigFast=true (which would make
   // ninja declare bun-zig.{0..N-1}.o that the stable compiler can't emit).
-  const zigFastDefault = zigFastCompiler({ windows, ci, pr });
+  const zigFastDefault = zigFastCompiler({ hostWindows: host.os === "windows", ci, pr });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
   const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
 

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -249,14 +249,6 @@ export interface Config {
    * codegenThreads() in zig.ts.
    */
   zigFast: boolean;
-  /**
-   * Whether the zig step emits LTO bitcode (`-Dlto=true`) instead of machine
-   * code. Distinct from `lto` (the C++/link side): on FAST builds zig emits
-   * sharded machine code so codegenThreads()>1 can fire, while C++ still
-   * compiles with -flto and lld LTOs the C++ bitcode (mixed-input link).
-   * Only STABLE (production) gets full cross-language LTO including zig.
-   */
-  zigLto: boolean;
   /** WebKit commit. Default in versions.ts; override to test a WebKit branch. */
   webkitVersion: string;
 }
@@ -774,11 +766,6 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const zigFastDefault = zigFastCompiler({ ci, pr });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
   const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
-  // FAST builds skip LTO on the zig side so codegenThreads()>1 can shard
-  // the LLVM emit; the C++/link side keeps `lto` and lld handles the mixed
-  // bitcode + machine-code link. STABLE (canary + production) keeps full
-  // cross-language LTO including the zig object.
-  const zigLto = lto && !zigFast;
 
   // ─── macOS SDK ───
   // Must be passed to nested cmake builds or they'll pick the wrong SDK.
@@ -875,7 +862,6 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     canaryRevision,
     zigCommit,
     zigFast,
-    zigLto,
     webkitVersion,
   };
 }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -756,8 +756,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // ninja declare bun-zig.{0..N-1}.o that the stable compiler can't emit).
   const zigFastDefault = zigFastCompiler({ ci, canary });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
-  const zigFast =
-    zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
+  const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
 
   // ─── macOS SDK ───
   // Must be passed to nested cmake builds or they'll pick the wrong SDK.

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -50,8 +50,8 @@ export interface Host {
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
  *
  * Zig is NOT here: there are two pins (STABLE/FAST) and which one applies
- * depends on resolved build options (ci/canary), so the default is
- * computed inside resolveConfig via zigFastCompiler().
+ * depends on resolved build options (ci/pr), so the default is computed
+ * inside resolveConfig via zigFastCompiler().
  */
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
@@ -142,6 +142,13 @@ export interface Config {
   // ─── Environment ───
   ci: boolean;
   buildkite: boolean;
+  /**
+   * True for pull-request CI builds (`!isMainBranch()` in ci.mjs). Distinct
+   * from `canary`: canary nightly builds run on main with `pr=false`. Gates
+   * the FAST zig compiler — only PR CI uses it; canary/production stay on
+   * STABLE with full cross-language LTO.
+   */
+  pr: boolean;
 
   // ─── Dependency modes ───
   webkit: WebKitMode;
@@ -237,7 +244,7 @@ export interface Config {
   /**
    * Which zig compiler line this build uses — true = `upgrade-0.15.2-fast`
    * (parallel sema + sharded codegen), false = `upgrade-0.15.2` (stable).
-   * Derived from {ci, canary} via zigFastCompiler(), or from an explicit
+   * Derived from {ci, pr} via zigFastCompiler(), or from an explicit
    * `--zig-commit` matching a known pin. Gates ZIG_PARALLEL_SEMA and
    * codegenThreads() in zig.ts.
    */
@@ -283,6 +290,7 @@ export interface PartialConfig {
   timeTrace?: boolean;
   ci?: boolean;
   buildkite?: boolean;
+  pr?: boolean;
   webkit?: WebKitMode;
   buildDir?: string;
   cacheDir?: string;
@@ -581,6 +589,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // detection in ci.ts instead, so running a non-CI profile on a CI machine
   // still gets collapsible logs but not CI build flags.
   const ci = partial.ci ?? false;
+  const pr = partial.pr ?? false;
   const buildkite = partial.buildkite ?? false;
 
   // ─── Features ───
@@ -756,19 +765,19 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
-  // Zig: STABLE only for tagged production releases (ci + --canary=off);
-  // local dev, PR CI, and canary CI all use FAST (parallel sema + sharded
-  // codegen on the upgrade-0.15.2-fast fork). An explicit --zig-commit
-  // matching a known pin overrides the {ci,canary} default so e.g.
-  // `--zig-commit=$STABLE` doesn't leave zigFast=true (which would make
-  // ninja declare bun-zig.{0..N-1}.o that the stable compiler can't emit).
-  const zigFastDefault = zigFastCompiler({ ci, canary });
+  // Zig: FAST (parallel sema + sharded codegen) for local dev and PR CI;
+  // STABLE for main-branch CI (canary nightly + tagged production). An
+  // explicit --zig-commit matching a known pin overrides the {ci,pr}
+  // default so e.g. `--zig-commit=$STABLE` doesn't leave zigFast=true
+  // (which would make ninja declare bun-zig.{0..N-1}.o that the stable
+  // compiler can't emit).
+  const zigFastDefault = zigFastCompiler({ ci, pr });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
   const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
-  // FAST builds (PR/canary CI, local) skip LTO on the zig side so
-  // codegenThreads()>1 can shard the LLVM emit; the C++/link side keeps
-  // `lto` and lld handles the mixed bitcode + machine-code link. STABLE
-  // (production) keeps full cross-language LTO.
+  // FAST builds skip LTO on the zig side so codegenThreads()>1 can shard
+  // the LLVM emit; the C++/link side keeps `lto` and lld handles the mixed
+  // bitcode + machine-code link. STABLE (canary + production) keeps full
+  // cross-language LTO including the zig object.
   const zigLto = lto && !zigFast;
 
   // ─── macOS SDK ───
@@ -823,6 +832,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     timeTrace: partial.timeTrace ?? false,
     ci,
     buildkite,
+    pr,
     webkit: partial.webkit ?? "prebuilt",
     cwd,
     buildDir,

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -50,8 +50,8 @@ export interface Host {
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
  *
  * Zig is NOT here: there are two pins (STABLE/FAST) and which one applies
- * depends on resolved build options (ci/pr), so the default is computed
- * inside resolveConfig via zigFastCompiler().
+ * depends on resolved build options (windows/ci/pr), so the default is
+ * computed inside resolveConfig via zigFastCompiler().
  */
 const versionDefaults = {
   nodejsVersion: NODEJS_VERSION,
@@ -244,9 +244,9 @@ export interface Config {
   /**
    * Which zig compiler line this build uses — true = `upgrade-0.15.2-fast`
    * (parallel sema + sharded codegen), false = `upgrade-0.15.2` (stable).
-   * Derived from {ci, pr} via zigFastCompiler(), or from an explicit
-   * `--zig-commit` matching a known pin. Gates ZIG_PARALLEL_SEMA and
-   * codegenThreads() in zig.ts.
+   * Derived from {windows, ci, pr} via zigFastCompiler(), or from an
+   * explicit `--zig-commit` matching a known pin. Gates ZIG_PARALLEL_SEMA
+   * and codegenThreads() in zig.ts.
    */
   zigFast: boolean;
   /** WebKit commit. Default in versions.ts; override to test a WebKit branch. */
@@ -757,13 +757,13 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
-  // Zig: FAST (parallel sema + sharded codegen) for local dev and PR CI;
-  // STABLE for main-branch CI (canary nightly + tagged production). An
-  // explicit --zig-commit matching a known pin overrides the {ci,pr}
-  // default so e.g. `--zig-commit=$STABLE` doesn't leave zigFast=true
-  // (which would make ninja declare bun-zig.{0..N-1}.o that the stable
-  // compiler can't emit).
-  const zigFastDefault = zigFastCompiler({ ci, pr });
+  // Zig: FAST (parallel sema + sharded codegen) for non-Windows local dev
+  // and PR CI; STABLE for Windows (oven-sh/zig#20 not landed) and
+  // main-branch CI (canary + production). An explicit --zig-commit
+  // matching a known pin overrides the default so e.g.
+  // `--zig-commit=$STABLE` doesn't leave zigFast=true (which would make
+  // ninja declare bun-zig.{0..N-1}.o that the stable compiler can't emit).
+  const zigFastDefault = zigFastCompiler({ windows, ci, pr });
   const zigCommit = partial.zigCommit ?? (zigFastDefault ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
   const zigFast = zigCommit === ZIG_COMMIT_STABLE ? false : zigCommit === ZIG_COMMIT_FAST ? true : zigFastDefault;
 

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -747,9 +747,10 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const nodejsVersion = partial.nodejsVersion ?? versionDefaults.nodejsVersion;
   const nodejsAbiVersion = partial.nodejsAbiVersion ?? versionDefaults.nodejsAbiVersion;
   const webkitVersion = partial.webkitVersion ?? versionDefaults.webkitVersion;
-  // Zig: STABLE for shipped builds (non-ASAN CI, Windows, LTO), FAST
-  // (parallel sema + sharded codegen) for local dev and ASAN CI.
-  const zigFast = zigFastCompiler({ windows, lto, ci, asan });
+  // Zig: STABLE only for tagged production releases (ci + --canary=off);
+  // local dev, PR CI, and canary CI all use FAST (parallel sema + sharded
+  // codegen on the upgrade-0.15.2-fast fork).
+  const zigFast = zigFastCompiler({ ci, canary });
   const zigCommit = partial.zigCommit ?? (zigFast ? ZIG_COMMIT_FAST : ZIG_COMMIT_STABLE);
 
   // ─── macOS SDK ───

--- a/scripts/build/tsconfig.json
+++ b/scripts/build/tsconfig.json
@@ -16,6 +16,6 @@
     "types": ["bun"],
     "verbatimModuleSyntax": true
   },
-  "include": ["./**/*.ts", "../build.ts", "../glob-sources.ts"],
+  "include": ["./**/*.ts", "../build.ts", "../glob-sources.ts", "../prefetch-deps.ts"],
   "exclude": ["node_modules"]
 }

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -71,27 +71,24 @@ export function zigFastCompiler(opts: { ci: boolean; pr: boolean }): boolean {
  * the parallel-sema speedup) and still emit a single object. Forced to 1:
  *   - STABLE compiler: no shard support in upgrade-0.15.2.
  *   - Windows targets: COFF shard emission is unimplemented in the fork.
- *   - zigLto: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit
- *     one .o instead of N and the no_merge_shards path would expect missing
- *     files. (Distinct from cfg.lto — FAST builds keep C++ LTO but skip
- *     zig-side LTO so this gate doesn't fire.)
+ *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
+ *     .o instead of N and the no_merge_shards path would expect missing files.
+ *   - Non-ASAN CI: getZigAgent only provisions the wide box (r8g.2xlarge)
+ *     for ASAN; everything else gets 2 vCPU. Sharding there would thrash.
  *
- * CI shards at a FIXED count so zig-only and link-only — which run on
- * different machines — agree on artifact names. The count matches
- * getZigAgent's provisioned vCPU: 8 for ASAN (r8g.2xlarge), 2 for
- * everything else (r8g.large). Local dev shards at availableParallelism().
+ * ASAN CI shards at a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only
+ * and link-only — which run on different machines — agree on artifact
+ * names. Local dev shards at availableParallelism().
  */
 function codegenThreads(cfg: Config): number {
   if (!cfg.zigFast) return 1;
   if (cfg.windows) return 1;
-  if (cfg.zigLto) return 1;
-  if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : CI_CODEGEN_THREADS;
+  if (cfg.lto) return 1;
+  if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : 1;
   return availableParallelism();
 }
 
-/** Fixed shard count for non-ASAN CI builds. Matches getZigAgent's r8g.large (2 vCPU). */
-export const CI_CODEGEN_THREADS = 2;
-/** Fixed shard count for ASAN CI builds. Matches getZigAgent's r8g.2xlarge (8 vCPU). */
+/** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
 export const CI_ASAN_CODEGEN_THREADS = 8;
 
 /**
@@ -548,10 +545,7 @@ function zigBuildArgs(cfg: Config): string[] {
     `-Denable_fuzzilli=${bool(cfg.fuzzilli)}`,
     `-Denable_valgrind=${bool(cfg.valgrind)}`,
     `-Denable_tinycc=${bool(cfg.tinycc)}`,
-    // zigLto, not lto: FAST builds emit machine code (so codegenThreads()
-    // can shard) while the C++/link side keeps full LTO. lld handles the
-    // mixed bitcode + machine-code link.
-    `-Dlto=${bool(cfg.zigLto)}`,
+    `-Dlto=${bool(cfg.lto)}`,
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -54,16 +54,19 @@ export const ZIG_COMMIT_FAST = "af6e006bec4494b5f716b1508e7113fc2210ed67";
  * (before the full Config exists, hence the narrow input shape).
  *
  * STABLE is used for:
- *   - Windows targets (local + CI): the FAST fork's Windows-side
- *     allocator/condvar fixes (oven-sh/zig#20) haven't landed yet.
+ *   - Windows HOSTS (local + CI): the FAST fork's Windows allocator/
+ *     condvar fixes (oven-sh/zig#20) haven't landed; psema is a host-side
+ *     concern (where the compiler runs), so the gate is host.os not the
+ *     target. In CI Windows targets build natively on Windows hosts
+ *     (getZigAgent), so host===target there anyway.
  *   - Main-branch CI (canary nightly + tagged production): anything that
  *     ships to users gets the proven compiler with full cross-language LTO.
  *
- * FAST for everything else: non-Windows local dev and non-Windows PR CI
+ * FAST for everything else: non-Windows-host local dev and PR CI
  * (`pr` set by ci.mjs when `!isMainBranch()`).
  */
-export function zigFastCompiler(opts: { windows: boolean; ci: boolean; pr: boolean }): boolean {
-  if (opts.windows) return false;
+export function zigFastCompiler(opts: { hostWindows: boolean; ci: boolean; pr: boolean }): boolean {
+  if (opts.hostWindows) return false;
   return !opts.ci || opts.pr;
 }
 
@@ -258,8 +261,8 @@ export function codegenEmbed(cfg: Config): boolean {
  * Where zig lives. Defaults to vendor/zig (FAST — the local-dev default,
  * also hardcoded in package.json/.vscode/.claude/docs so don't rename) or
  * vendor/zig-stable (STABLE). Per-variant so flipping between a
- * `zigFast=true` config and a `--canary=off` / `--zig-commit=$STABLE`
- * config doesn't wipe and re-download the other compiler (fetchZig nukes
+ * `zigFast=true` config and e.g. `--zig-commit=$STABLE` or a `ci-*`
+ * profile doesn't wipe and re-download the other compiler (fetchZig nukes
  * the dest on commit mismatch). Both dirs are gitignored.
  *
  * Override via $BUN_ZIG_PATH to point at an existing zig install (e.g.

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -53,12 +53,17 @@ export const ZIG_COMMIT_FAST = "af6e006bec4494b5f716b1508e7113fc2210ed67";
  * true → FAST, false → STABLE. Called from config.ts during resolution
  * (before the full Config exists, hence the narrow input shape).
  *
- * FAST for local dev (`!ci`) and PR CI (`pr`, set by ci.mjs when
- * `!isMainBranch()`). STABLE for main-branch CI — both canary nightly and
- * tagged production — so anything that ships to users gets the proven
- * compiler with full cross-language LTO.
+ * STABLE is used for:
+ *   - Windows targets (local + CI): the FAST fork's Windows-side
+ *     allocator/condvar fixes (oven-sh/zig#20) haven't landed yet.
+ *   - Main-branch CI (canary nightly + tagged production): anything that
+ *     ships to users gets the proven compiler with full cross-language LTO.
+ *
+ * FAST for everything else: non-Windows local dev and non-Windows PR CI
+ * (`pr` set by ci.mjs when `!isMainBranch()`).
  */
-export function zigFastCompiler(opts: { ci: boolean; pr: boolean }): boolean {
+export function zigFastCompiler(opts: { windows: boolean; ci: boolean; pr: boolean }): boolean {
+  if (opts.windows) return false;
   return !opts.ci || opts.pr;
 }
 

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,8 +39,8 @@ import { streamPath } from "./stream.ts";
  *   FAST    oven-sh/zig branch `upgrade-0.15.2-fast`. STABLE + the
  *           parallel-sema/shard-codegen patchset. ~8× faster on a
  *           16-core box but the parallelisation is not yet proven
- *           bit-identical across runs, so tagged production releases
- *           stay on STABLE; everything else uses this.
+ *           bit-identical across runs, so main-branch CI (canary +
+ *           production) stays on STABLE; local dev and PR CI use this.
  *
  * `cfg.zigFast` (resolved in config.ts via zigFastCompiler) picks which.
  * Override via `--zig-commit=<hash>` to test something else.
@@ -53,14 +53,13 @@ export const ZIG_COMMIT_FAST = "af6e006bec4494b5f716b1508e7113fc2210ed67";
  * true → FAST, false → STABLE. Called from config.ts during resolution
  * (before the full Config exists, hence the narrow input shape).
  *
- * STABLE is reserved for tagged production releases: CI with `--canary=off`
- * (buildkite only passes that for the publish pipeline). Local dev, PR CI,
- * and canary CI all use FAST. Windows/LTO are NOT gated here — they use
- * the FAST binary too (for the parallel-sema speedup); only the shard
- * count is forced to 1 there, see codegenThreads().
+ * FAST for local dev (`!ci`) and PR CI (`pr`, set by ci.mjs when
+ * `!isMainBranch()`). STABLE for main-branch CI — both canary nightly and
+ * tagged production — so anything that ships to users gets the proven
+ * compiler with full cross-language LTO.
  */
-export function zigFastCompiler(opts: { ci: boolean; canary: boolean }): boolean {
-  return !(opts.ci && !opts.canary);
+export function zigFastCompiler(opts: { ci: boolean; pr: boolean }): boolean {
+  return !opts.ci || opts.pr;
 }
 
 /**

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -29,40 +29,55 @@ import { quote, quoteArgs } from "./shell.ts";
 import { streamPath } from "./stream.ts";
 
 /**
- * Zig compiler commit — determines compiler download + bundled stdlib.
- * Override via `--zig-commit=<hash>` to test a new compiler.
- * From https://github.com/oven-sh/zig releases.
+ * Zig compiler commits — determine compiler download + bundled stdlib.
+ * Two pins from https://github.com/oven-sh/zig releases:
+ *
+ *   STABLE  oven-sh/zig branch `upgrade-0.15.2`. Upstream 0.15.2 + our
+ *           required correctness patches. Serial sema/codegen — same
+ *           pipeline as upstream. Used for shipped builds.
+ *
+ *   FAST    oven-sh/zig branch `upgrade-0.15.2-fast`. STABLE + the
+ *           parallel-sema/shard-codegen patchset. ~8× faster on a
+ *           16-core box but the parallelisation is not yet proven
+ *           bit-identical across runs, so it's dev/ASAN-CI only.
+ *
+ * `cfg.zigFast` (resolved in config.ts via zigFastCompiler) picks which.
+ * Override via `--zig-commit=<hash>` to test something else.
  */
-export const ZIG_COMMIT = "04e7f6ac1e009525bc00934f20199c68f04e0a24";
+export const ZIG_COMMIT_STABLE = "24475de8100b01a135c79d1629fa2e5341572fd1";
+export const ZIG_COMMIT_FAST = "af6e006bec4494b5f716b1508e7113fc2210ed67";
 
 /**
- * Number of LLVM codegen units. >1 splits the build into N independent
- * LLVM modules — parallelises emit, but cross-unit calls become
- * `linkonce_odr` externs so LLVM can't inline or IPO across them.
+ * Decides which compiler pin a given build configuration uses. Returns
+ * true → FAST, false → STABLE. Called from config.ts during resolution
+ * (before the full Config exists, hence the narrow input shape).
  *
- * Sharding is gated off for:
- *   - Non-ASAN CI: shipped releases want full IPO; cg=1 keeps that and
- *     keeps the upload/download contract a single file.
- *   - Windows targets: COFF shard emission is unimplemented in oven-sh/zig.
- *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
- *     .o instead of N and the no_merge_shards path would expect missing files.
+ * STABLE is forced for:
+ *   - Non-ASAN CI: shipped releases must use the proven compiler.
+ *   - Windows targets: COFF shard emission is unimplemented in the fork.
+ *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so sharding can't
+ *     fire anyway, and stable already has the LTO module-summary fix.
  *
- * ASAN CI uses a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only and
- * link-only — which run on different machines — agree on the artifact
- * names. Local builds shard at availableParallelism(); benchmark against
- * a non-ASAN CI artifact if cross-unit inlining matters.
+ * Everything else (local dev, ASAN CI) gets FAST.
+ */
+export function zigFastCompiler(opts: { windows: boolean; lto: boolean; ci: boolean; asan: boolean }): boolean {
+  if (opts.windows) return false;
+  if (opts.lto) return false;
+  if (opts.ci) return opts.asan;
+  return true;
+}
+
+/**
+ * Number of LLVM codegen units. Only meaningful on the FAST compiler;
+ * STABLE has no shard support so it's always 1 there. On FAST, ASAN CI
+ * uses a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only and link-only
+ * — which run on different machines — agree on artifact names; local dev
+ * shards at availableParallelism(). Benchmark against a non-ASAN CI
+ * artifact if cross-unit inlining matters.
  */
 function codegenThreads(cfg: Config): number {
-  if (cfg.windows) return 1;
-  if (cfg.lto) return 1;
-  if (cfg.ci) {
-    // ASAN is a test-only build (not shipped), so cross-shard IPO loss is
-    // fine and the speedup is worth it. The count is FIXED so zig-only and
-    // link-only — which run on different machines — agree on the artifact
-    // names. Non-asan CI stays at 1: shipped releases want full IPO.
-    return cfg.asan ? CI_ASAN_CODEGEN_THREADS : 1;
-  }
-  return availableParallelism();
+  if (!cfg.zigFast) return 1;
+  return cfg.ci ? CI_ASAN_CODEGEN_THREADS : availableParallelism();
 }
 
 /** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
@@ -327,7 +342,9 @@ export function registerZigRules(n: Ninja, cfg: Config): void {
   // our fork (upstream added Feb 2026, not backported).
   const interleave = false;
   const consoleMode = !interleave || hostWin;
-  const parallelSema = " --env=ZIG_PARALLEL_SEMA=1";
+  // ZIG_PARALLEL_SEMA is only recognised by the FAST compiler; harmless
+  // on STABLE but pointless to set there.
+  const parallelSema = cfg.zigFast ? " --env=ZIG_PARALLEL_SEMA=1" : "";
   n.rule("zig_build", {
     command: `${stream} ${consoleMode ? "--console" : "--zig-progress"} --env=ZIG_LOCAL_CACHE_DIR=$zig_local_cache --env=ZIG_GLOBAL_CACHE_DIR=$zig_global_cache${parallelSema} $zig build $step $args`,
     // $out can be 16 shard paths; the build edge sets a compact $label.
@@ -510,9 +527,9 @@ function zigBuildArgs(cfg: Config): string[] {
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,
-    // Sharded LLVM codegen — one shard per host core on the parallel
-    // compiler. Zig has no "auto" value (0 = single-threaded). MUST be 0
-    // on the stable compiler — see codegenThreads().
+    // Sharded LLVM codegen. 1 on STABLE (build.zig @hasField-gates the
+    // Compile field so this is a no-op there); availableParallelism() or
+    // CI_ASAN_CODEGEN_THREADS on FAST.
     `-Dllvm_codegen_threads=${codegenThreads(cfg)}`,
 
     // Versioning

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -72,8 +72,10 @@ export function zigFastCompiler(opts: { ci: boolean; canary: boolean }): boolean
  * the parallel-sema speedup) and still emit a single object. Forced to 1:
  *   - STABLE compiler: no shard support in upgrade-0.15.2.
  *   - Windows targets: COFF shard emission is unimplemented in the fork.
- *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
- *     .o instead of N and the no_merge_shards path would expect missing files.
+ *   - zigLto: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit
+ *     one .o instead of N and the no_merge_shards path would expect missing
+ *     files. (Distinct from cfg.lto — FAST builds keep C++ LTO but skip
+ *     zig-side LTO so this gate doesn't fire.)
  *
  * CI shards at a FIXED count so zig-only and link-only — which run on
  * different machines — agree on artifact names. The count matches
@@ -83,7 +85,7 @@ export function zigFastCompiler(opts: { ci: boolean; canary: boolean }): boolean
 function codegenThreads(cfg: Config): number {
   if (!cfg.zigFast) return 1;
   if (cfg.windows) return 1;
-  if (cfg.lto) return 1;
+  if (cfg.zigLto) return 1;
   if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : CI_CODEGEN_THREADS;
   return availableParallelism();
 }
@@ -547,7 +549,10 @@ function zigBuildArgs(cfg: Config): string[] {
     `-Denable_fuzzilli=${bool(cfg.fuzzilli)}`,
     `-Denable_valgrind=${bool(cfg.valgrind)}`,
     `-Denable_tinycc=${bool(cfg.tinycc)}`,
-    `-Dlto=${bool(cfg.lto)}`,
+    // zigLto, not lto: FAST builds emit machine code (so codegenThreads()
+    // can shard) while the C++/link side keeps full LTO. lld handles the
+    // mixed bitcode + machine-code link.
+    `-Dlto=${bool(cfg.zigLto)}`,
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -39,7 +39,8 @@ import { streamPath } from "./stream.ts";
  *   FAST    oven-sh/zig branch `upgrade-0.15.2-fast`. STABLE + the
  *           parallel-sema/shard-codegen patchset. ~8× faster on a
  *           16-core box but the parallelisation is not yet proven
- *           bit-identical across runs, so it's dev/ASAN-CI only.
+ *           bit-identical across runs, so tagged production releases
+ *           stay on STABLE; everything else uses this.
  *
  * `cfg.zigFast` (resolved in config.ts via zigFastCompiler) picks which.
  * Override via `--zig-commit=<hash>` to test something else.
@@ -52,32 +53,40 @@ export const ZIG_COMMIT_FAST = "af6e006bec4494b5f716b1508e7113fc2210ed67";
  * true → FAST, false → STABLE. Called from config.ts during resolution
  * (before the full Config exists, hence the narrow input shape).
  *
- * STABLE is forced for:
- *   - Non-ASAN CI: shipped releases must use the proven compiler.
- *   - Windows targets: COFF shard emission is unimplemented in the fork.
- *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so sharding can't
- *     fire anyway, and stable already has the LTO module-summary fix.
- *
- * Everything else (local dev, ASAN CI) gets FAST.
+ * STABLE is reserved for tagged production releases: CI with `--canary=off`
+ * (buildkite only passes that for the publish pipeline). Local dev, PR CI,
+ * and canary CI all use FAST. Windows/LTO are NOT gated here — they use
+ * the FAST binary too (for the parallel-sema speedup); only the shard
+ * count is forced to 1 there, see codegenThreads().
  */
-export function zigFastCompiler(opts: { windows: boolean; lto: boolean; ci: boolean; asan: boolean }): boolean {
-  if (opts.windows) return false;
-  if (opts.lto) return false;
-  if (opts.ci) return opts.asan;
-  return true;
+export function zigFastCompiler(opts: { ci: boolean; canary: boolean }): boolean {
+  return !(opts.ci && !opts.canary);
 }
 
 /**
- * Number of LLVM codegen units. Only meaningful on the FAST compiler;
- * STABLE has no shard support so it's always 1 there. On FAST, ASAN CI
- * uses a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only and link-only
- * — which run on different machines — agree on artifact names; local dev
- * shards at availableParallelism(). Benchmark against a non-ASAN CI
- * artifact if cross-unit inlining matters.
+ * Number of LLVM codegen units. >1 splits the build into N independent
+ * LLVM modules — parallelises emit, but cross-unit calls become
+ * `linkonce_odr` externs so LLVM can't inline or IPO across them.
+ *
+ * This is independent of zigFast: a build can use the FAST compiler (for
+ * the parallel-sema speedup) and still emit a single object. Forced to 1:
+ *   - STABLE compiler: no shard support in upgrade-0.15.2.
+ *   - Windows targets: COFF shard emission is unimplemented in the fork.
+ *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
+ *     .o instead of N and the no_merge_shards path would expect missing files.
+ *   - Non-ASAN CI: getZigAgent only provisions the wide box (r8g.2xlarge)
+ *     for ASAN; everything else gets 2 vCPU. Sharding there would thrash.
+ *
+ * ASAN CI shards at a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only
+ * and link-only — which run on different machines — agree on artifact
+ * names. Local dev shards at availableParallelism().
  */
 function codegenThreads(cfg: Config): number {
   if (!cfg.zigFast) return 1;
-  return cfg.ci ? CI_ASAN_CODEGEN_THREADS : availableParallelism();
+  if (cfg.windows) return 1;
+  if (cfg.lto) return 1;
+  if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : 1;
+  return availableParallelism();
 }
 
 /** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
@@ -527,9 +536,8 @@ function zigBuildArgs(cfg: Config): string[] {
     // Always ON — bun uses mimalloc as its default allocator. The flag
     // exists for experimentation; in practice it's never OFF.
     `-Duse_mimalloc=true`,
-    // Sharded LLVM codegen. 1 on STABLE (build.zig @hasField-gates the
-    // Compile field so this is a no-op there); availableParallelism() or
-    // CI_ASAN_CODEGEN_THREADS on FAST.
+    // Sharded LLVM codegen. build.zig @hasField-gates the Compile field,
+    // so passing 1 to STABLE is a no-op.
     `-Dllvm_codegen_threads=${codegenThreads(cfg)}`,
 
     // Versioning

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -74,22 +74,23 @@ export function zigFastCompiler(opts: { ci: boolean; canary: boolean }): boolean
  *   - Windows targets: COFF shard emission is unimplemented in the fork.
  *   - LTO: zig_llvm.cpp gates SplitModule on !lto, so cg>1 would emit one
  *     .o instead of N and the no_merge_shards path would expect missing files.
- *   - Non-ASAN CI: getZigAgent only provisions the wide box (r8g.2xlarge)
- *     for ASAN; everything else gets 2 vCPU. Sharding there would thrash.
  *
- * ASAN CI shards at a FIXED count (CI_ASAN_CODEGEN_THREADS) so zig-only
- * and link-only — which run on different machines — agree on artifact
- * names. Local dev shards at availableParallelism().
+ * CI shards at a FIXED count so zig-only and link-only — which run on
+ * different machines — agree on artifact names. The count matches
+ * getZigAgent's provisioned vCPU: 8 for ASAN (r8g.2xlarge), 2 for
+ * everything else (r8g.large). Local dev shards at availableParallelism().
  */
 function codegenThreads(cfg: Config): number {
   if (!cfg.zigFast) return 1;
   if (cfg.windows) return 1;
   if (cfg.lto) return 1;
-  if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : 1;
+  if (cfg.ci) return cfg.asan ? CI_ASAN_CODEGEN_THREADS : CI_CODEGEN_THREADS;
   return availableParallelism();
 }
 
-/** Fixed shard count for CI ASAN builds. Matches getZigAgent's instance size. */
+/** Fixed shard count for non-ASAN CI builds. Matches getZigAgent's r8g.large (2 vCPU). */
+export const CI_CODEGEN_THREADS = 2;
+/** Fixed shard count for ASAN CI builds. Matches getZigAgent's r8g.2xlarge (8 vCPU). */
 export const CI_ASAN_CODEGEN_THREADS = 8;
 
 /**

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -251,11 +251,12 @@ export function codegenEmbed(cfg: Config): boolean {
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Where zig lives. Defaults to vendor/zig (STABLE) or vendor/zig-fast
- * (FAST), per-variant so flipping between a `zigFast=true` config and a
- * `--canary=off` / `--zig-commit=$STABLE` config doesn't wipe and
- * re-download the other compiler (fetchZig nukes the dest on commit
- * mismatch). Both dirs are gitignored.
+ * Where zig lives. Defaults to vendor/zig (FAST — the local-dev default,
+ * also hardcoded in package.json/.vscode/.claude/docs so don't rename) or
+ * vendor/zig-stable (STABLE). Per-variant so flipping between a
+ * `zigFast=true` config and a `--canary=off` / `--zig-commit=$STABLE`
+ * config doesn't wipe and re-download the other compiler (fetchZig nukes
+ * the dest on commit mismatch). Both dirs are gitignored.
  *
  * Override via $BUN_ZIG_PATH to point at an existing zig install (e.g.
  * share one compiler across worktrees, test a zig fork build, or pre-fetch
@@ -273,9 +274,14 @@ function zigPath(cfg: Config): string {
   return resolve(cfg.cwd, env);
 }
 
-/** vendor/ subdirectory name — `zig` (STABLE) or `zig-fast` (FAST). Exported for prefetch-deps.ts. */
+/**
+ * vendor/ subdirectory name — `zig` (FAST) or `zig-stable` (STABLE).
+ * FAST keeps the plain `zig` name because it's the local-dev default and
+ * package.json/.vscode/.claude hardcode `vendor/zig/`. Exported for
+ * prefetch-deps.ts.
+ */
 export function zigVendorBasename(cfg: Config): string {
-  return cfg.zigFast ? "zig-fast" : "zig";
+  return cfg.zigFast ? "zig" : "zig-stable";
 }
 
 function zigExecutable(cfg: Config): string {

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -251,8 +251,11 @@ export function codegenEmbed(cfg: Config): boolean {
 // ───────────────────────────────────────────────────────────────────────────
 
 /**
- * Where zig lives. Defaults to vendor/zig (gitignored), shared across
- * profiles — the commit pin is global and changing it affects everything.
+ * Where zig lives. Defaults to vendor/zig (STABLE) or vendor/zig-fast
+ * (FAST), per-variant so flipping between a `zigFast=true` config and a
+ * `--canary=off` / `--zig-commit=$STABLE` config doesn't wipe and
+ * re-download the other compiler (fetchZig nukes the dest on commit
+ * mismatch). Both dirs are gitignored.
  *
  * Override via $BUN_ZIG_PATH to point at an existing zig install (e.g.
  * share one compiler across worktrees, test a zig fork build, or pre-fetch
@@ -262,12 +265,17 @@ export function codegenEmbed(cfg: Config): boolean {
  */
 function zigPath(cfg: Config): string {
   const env = process.env.BUN_ZIG_PATH;
-  if (!env) return resolve(cfg.vendorDir, "zig");
+  if (!env) return resolve(cfg.vendorDir, zigVendorBasename(cfg));
   // Shells don't expand ~ inside quotes; handle it here so a quoted export works.
   if (env === "~" || env.startsWith("~/") || env.startsWith("~\\")) return join(homedir(), env.slice(1));
   // Anchor relative paths to the repo root so ninja's regen rule (which runs
   // from buildDir) resolves the same path as the initial configure.
   return resolve(cfg.cwd, env);
+}
+
+/** vendor/ subdirectory name — `zig` (STABLE) or `zig-fast` (FAST). Exported for prefetch-deps.ts. */
+export function zigVendorBasename(cfg: Config): string {
+  return cfg.zigFast ? "zig-fast" : "zig";
 }
 
 function zigExecutable(cfg: Config): string {

--- a/scripts/prefetch-deps.ts
+++ b/scripts/prefetch-deps.ts
@@ -18,7 +18,7 @@
  *   bun scripts/prefetch-deps.ts <prefetchDir>
  *
  * Enumerates variants on the dimensions that affect download URLs (asan, lto,
- * baseline, musl, canary) for the current host os/arch. Variants without a
+ * baseline, musl, pr) for the current host os/arch. Variants without a
  * published artifact are skipped — better to over-enumerate and 404 than to
  * miss one.
  */
@@ -45,7 +45,7 @@ const extractedDir = resolve(dest, "extracted");
 //
 // github-archive sources are config-independent, so one base config covers
 // them. WebKit prebuilt URL varies by (musl, baseline, debug|lto, asan); zig
-// by host + safe + canary (canary picks STABLE vs FAST commit). Iterate the
+// by host + safe + pr (pr picks STABLE vs FAST commit). Iterate the
 // cross-product, dedupe URLs.
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -58,8 +58,8 @@ for (const asan of [false, true]) {
   for (const lto of [false, true]) {
     for (const baseline of baseCfg.x64 ? [false, true] : [false]) {
       for (const abi of baseCfg.linux ? (["gnu", "musl"] as const) : [undefined]) {
-        for (const canary of [false, true]) {
-          variants.push({ ...base, asan, lto, baseline, canary, ...(abi !== undefined && { abi }) });
+        for (const pr of [false, true]) {
+          variants.push({ ...base, asan, lto, baseline, pr, ...(abi !== undefined && { abi }) });
         }
       }
     }
@@ -128,7 +128,7 @@ for (const partial of variants) {
   // so only one safe-variant can match an extracted tree); both safe URLs go
   // into by-url/ so a safe-flag flip still avoids the network. The extract
   // name follows zigVendorBasename so extracted/zig/ and extracted/zig-stable/
-  // both populate (canary loop covers both commits).
+  // both populate (pr loop covers both commits).
   const ciSafe = zigCompilerSafe(cfg);
   const zigName = zigVendorBasename(cfg);
   for (const safe of [false, true]) {

--- a/scripts/prefetch-deps.ts
+++ b/scripts/prefetch-deps.ts
@@ -18,8 +18,9 @@
  *   bun scripts/prefetch-deps.ts <prefetchDir>
  *
  * Enumerates variants on the dimensions that affect download URLs (asan, lto,
- * baseline, musl) for the current host os/arch. Variants without a published
- * artifact are skipped — better to over-enumerate and 404 than to miss one.
+ * baseline, musl, canary) for the current host os/arch. Variants without a
+ * published artifact are skipped — better to over-enumerate and 404 than to
+ * miss one.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -29,7 +30,7 @@ import { resolveConfig, type Config, type PartialConfig } from "./build/config.t
 import { resolveToolchain } from "./build/configure.ts";
 import { allDeps } from "./build/deps/index.ts";
 import { downloadWithRetry, extractTarGz, extractZip, prefetchPathForUrl } from "./build/download.ts";
-import { zigCompilerSafe, zigDownloadUrl } from "./build/zig.ts";
+import { zigCompilerSafe, zigDownloadUrl, zigVendorBasename } from "./build/zig.ts";
 
 const dest = process.argv[2];
 if (dest === undefined) {
@@ -44,7 +45,8 @@ const extractedDir = resolve(dest, "extracted");
 //
 // github-archive sources are config-independent, so one base config covers
 // them. WebKit prebuilt URL varies by (musl, baseline, debug|lto, asan); zig
-// by host + safe. Iterate the cross-product, dedupe URLs.
+// by host + safe + canary (canary picks STABLE vs FAST commit). Iterate the
+// cross-product, dedupe URLs.
 // ───────────────────────────────────────────────────────────────────────────
 
 const toolchain = resolveToolchain();
@@ -56,7 +58,9 @@ for (const asan of [false, true]) {
   for (const lto of [false, true]) {
     for (const baseline of baseCfg.x64 ? [false, true] : [false]) {
       for (const abi of baseCfg.linux ? (["gnu", "musl"] as const) : [undefined]) {
-        variants.push({ ...base, asan, lto, baseline, ...(abi !== undefined && { abi }) });
+        for (const canary of [false, true]) {
+          variants.push({ ...base, asan, lto, baseline, canary, ...(abi !== undefined && { abi }) });
+        }
       }
     }
   }
@@ -113,23 +117,28 @@ for (const partial of variants) {
           stamp: ".identity",
           value: src.identity,
           kind: "tar.gz",
-          rm: src.rmAfterExtract,
+          ...(src.rmAfterExtract !== undefined && { rm: src.rmAfterExtract }),
         },
       });
     }
   }
 
-  // Zig — host-only download. Only the variant CI actually uses on this host
-  // gets pre-EXTRACTED to extracted/zig/ (the build's dest is always
-  // vendor/zig regardless of safe, so only one extracted tree can match);
-  // both URLs go into by-url/ so a safe-flag flip still avoids the network.
+  // Zig — host-only download. Pre-extract only the safe-variant CI actually
+  // uses on this host (the build's dest is per-{stable,fast} but not per-safe,
+  // so only one safe-variant can match an extracted tree); both safe URLs go
+  // into by-url/ so a safe-flag flip still avoids the network. The extract
+  // name follows zigVendorBasename so extracted/zig/ and extracted/zig-fast/
+  // both populate (canary loop covers both commits).
   const ciSafe = zigCompilerSafe(cfg);
+  const zigName = zigVendorBasename(cfg);
   for (const safe of [false, true]) {
     const url = zigDownloadUrl(cfg, safe);
     const stampValue = `${cfg.zigCommit}${safe ? "-safe" : ""}`;
     add({
       url,
-      extract: safe === ciSafe ? { name: "zig", stamp: ".zig-commit", value: stampValue, kind: "zip" } : undefined,
+      ...(safe === ciSafe && {
+        extract: { name: zigName, stamp: ".zig-commit", value: stampValue, kind: "zip" as const },
+      }),
     });
   }
 }

--- a/scripts/prefetch-deps.ts
+++ b/scripts/prefetch-deps.ts
@@ -127,7 +127,7 @@ for (const partial of variants) {
   // uses on this host (the build's dest is per-{stable,fast} but not per-safe,
   // so only one safe-variant can match an extracted tree); both safe URLs go
   // into by-url/ so a safe-flag flip still avoids the network. The extract
-  // name follows zigVendorBasename so extracted/zig/ and extracted/zig-fast/
+  // name follows zigVendorBasename so extracted/zig/ and extracted/zig-stable/
   // both populate (canary loop covers both commits).
   const ciSafe = zigCompilerSafe(cfg);
   const zigName = zigVendorBasename(cfg);


### PR DESCRIPTION
Splits the single `ZIG_COMMIT` into two pins so anything that ships to users (and anything running on a Windows host) is built with the proven serial compiler, while non-Windows local dev and PR CI use the parallel-sema fork.

| build | compiler | cg | LTO |
|---|---|---:|---|
| local dev (macOS/Linux host) | **FAST** ([`upgrade-0.15.2-fast`](https://github.com/oven-sh/zig/tree/upgrade-0.15.2-fast)) | N | unchanged |
| local dev (Windows host) | STABLE | 1 | unchanged |
| PR CI (Linux/macOS-host jobs) | **FAST** | 1 (8 for asan) | unchanged |
| PR CI (Windows-host jobs) | STABLE | 1 | unchanged |
| canary CI (main) | STABLE ([`upgrade-0.15.2`](https://github.com/oven-sh/zig/tree/upgrade-0.15.2)) | 1 | unchanged |
| production CI | STABLE | 1 | unchanged |

LTO and shard counts are **unchanged from main** — this PR only picks which compiler binary to download. Windows hosts stay on STABLE because the FAST fork's Windows allocator/condvar fixes (oven-sh/zig#20) haven't landed.

### oven-sh/zig side (already pushed)
- `upgrade-0.15.2` reset to `365343af4f` + the two non-parallel commits (f16 Darwin ABI, LTO module summary) + workflow trigger/name → `24475de810`
- `upgrade-0.15.2-fast` = above + the 11 psema/shard/mimalloc commits → `af6e006bec` (tree-identical to old `04e7f6ac1e` mod workflow)
- `backup/upgrade-0.15.2-pre-split` = old tip `04e7f6ac1e`

### Here
- `zig.ts`: `ZIG_COMMIT` → `ZIG_COMMIT_STABLE`/`ZIG_COMMIT_FAST`; `zigFastCompiler({hostWindows, ci, pr})` predicate; `ZIG_PARALLEL_SEMA` and `codegenThreads()` gate on `cfg.zigFast`; `vendor/zig` (FAST) vs `vendor/zig-stable` (STABLE)
- `config.ts`: add `cfg.pr` and `cfg.zigFast`; resolve `zigCommit` from them (explicit `--zig-commit` matching a known pin overrides); surface `zig:fast` in the configure banner
- `ci.mjs`: pass `--pr=on` when `!isMainBranch()`
- `prefetch-deps.ts`: enumerate `pr` so both compiler SHAs are baked into CI images; now in tsconfig
- `clean.ts`: deep preset also removes `vendor/zig-stable/`
- `build.ts`: accept `--pr=on/off`

Both releases exist: [`upgrade-0.15.2 @ 24475de810`](https://github.com/oven-sh/zig/releases/tag/autobuild-24475de8100b01a135c79d1629fa2e5341572fd1), [`upgrade-0.15.2-fast @ af6e006bec`](https://github.com/oven-sh/zig/releases/tag/autobuild-af6e006bec4494b5f716b1508e7113fc2210ed67).