### PR TITLE
test(bake/stress): skip 'crash #18910' on Windows and under ASAN/debug

### DIFF
--- a/test/bake/dev/stress.test.ts
+++ b/test/bake/dev/stress.test.ts
@@ -6,29 +6,45 @@
 //
 // Without this flag, each test is a "smoke test", running the iteration once.
 import { expect } from "bun:test";
+import { isASAN, isDebug } from "harness";
 import { devTest } from "../bake-harness";
 
-// https://github.com/oven-sh/bun/issues/18910
-devTest("crash #18910", {
-  files: {
-    "index.html": `<script src="./b.js"></script>`,
-    "b.js": ``,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", { allowUnlimitedReloads: true });
+// Under ASAN / debug builds the HMR client is slow enough that the fan-in of
+// reload script tags occasionally arrives for a module whose `sourceMapId`
+// hasn't been registered yet, tripping `DEBUG.ASSERT(sourceMapId)` in
+// `replaceModules`. The test is a regression guard for the Zig-side watcher
+// crash in #18910; release builds (which is how this bug shipped) still
+// exercise the guard.
+if (!isASAN && !isDebug)
+  // https://github.com/oven-sh/bun/issues/18910
+  devTest("crash #18910", {
+    // Flaky on Windows 2019 CI agents: the rapid HMR reload loop intermittently
+    // trips "Reload failed" and exits the browser client before `Subprocess.send`
+    // is called, surfacing as "Subprocess.send() cannot be used after the process
+    // has exited". The test is primarily protecting against the Zig-side watcher
+    // crash from issue #18910; the Windows-specific reload path isn't exercised
+    // by that regression, so skipping on win32 keeps the regression guard
+    // meaningful without gating CI on the chronic agent flake.
+    skip: ["win32"],
+    files: {
+      "index.html": `<script src="./b.js"></script>`,
+      "b.js": ``,
+    },
+    async test(dev) {
+      await using c = await dev.client("/", { allowUnlimitedReloads: true });
 
-    const absPath = dev.join("b.js");
+      const absPath = dev.join("b.js");
 
-    await dev.stressTest(async () => {
-      for (let i = 0; i < 10; i++) {
-        await Bun.write(absPath, "let a = 0;");
-        await Bun.sleep(10);
-        await Bun.write(absPath, "// let a = 0;");
-        await Bun.sleep(10);
-      }
-    });
+      await dev.stressTest(async () => {
+        for (let i = 0; i < 10; i++) {
+          await Bun.write(absPath, "let a = 0;");
+          await Bun.sleep(10);
+          await Bun.write(absPath, "// let a = 0;");
+          await Bun.sleep(10);
+        }
+      });
 
-    await dev.write("b.js", "globalThis.a = 1;");
-    expect(await c.js<number>`a`).toBe(1);
-  },
-});
+      await dev.write("b.js", "globalThis.a = 1;");
+      expect(await c.js<number>`a`).toBe(1);
+    },
+  });


### PR DESCRIPTION
The `crash #18910` devserver stress test is chronically flaky on two axes:

## Windows 2019 CI agents
The rapid HMR reload loop (writing `b.js` every 10ms) trips "Reload failed" and exits the browser client before the test's `Subprocess.send` call:
```
error: Subprocess.send() cannot be used after the process has exited.
error: Client exited: "Reload failed"
```

## ASAN / debug builds
Reproduces locally on Linux `bun bd`. The slower HMR client sometimes processes a reload script tag before its `sourceMapId` is registered, tripping `DEBUG.ASSERT(sourceMapId)` in `replaceModules`:
```
at Object.ASSERT (index.js:1979)
at replaceModules (index.js:2484)
error: Client exited: "Assertion failed"
```

## Scope
The test is a regression guard for the Zig-side watcher crash in https://github.com/oven-sh/bun/issues/18910. The Windows reload-client path and the ASAN-slowdown script-tag race are both unrelated to that regression, so skipping on win32 + ASAN/debug keeps the guard meaningful on the platforms the original bug shipped on (Linux/macOS release) without holding unrelated PRs hostage.
