### PR TITLE
install: hoist `catalog:` peer dependencies like their resolved npm range

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -764,8 +764,19 @@ pub(crate) fn install_isolated_packages(
 
                             let res = &pkg_resolutions[ids.pkg_id as usize];
 
-                            if peer_dep.version.tag != VersionTag::Npm
-                                || res.tag != ResolutionTag::Npm
+                            // `catalog:` peer dependencies only carry the catalog
+                            // name; resolve to the underlying version so the
+                            // satisfies check below behaves the same as if the
+                            // npm range had been written directly.
+                            let catalog_resolved;
+                            let peer_version = if peer_dep.version.tag == VersionTag::Catalog {
+                                catalog_resolved = lockfile.resolve_catalog_dependency(peer_dep);
+                                catalog_resolved.as_ref().unwrap_or(&peer_dep.version)
+                            } else {
+                                &peer_dep.version
+                            };
+
+                            if peer_version.tag != VersionTag::Npm || res.tag != ResolutionTag::Npm
                             {
                                 // TODO: print warning for this? we don't have a version
                                 // to compare to say if this satisfies or not.
@@ -773,8 +784,8 @@ pub(crate) fn install_isolated_packages(
                             }
 
                             // SAFETY: tag was checked == .Npm directly above for both
-                            // `peer_dep.version` and `res`.
-                            let peer_dep_version = &peer_dep.version.npm().version;
+                            // `peer_version` and `res`.
+                            let peer_dep_version = &peer_version.npm().version;
                             let res_version = &res.npm().version;
 
                             if !peer_dep_version.satisfies(*res_version, string_buf, string_buf) {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -764,10 +764,7 @@ pub(crate) fn install_isolated_packages(
 
                             let res = &pkg_resolutions[ids.pkg_id as usize];
 
-                            // `catalog:` peer dependencies only carry the catalog
-                            // name; resolve to the underlying version so the
-                            // satisfies check below behaves the same as if the
-                            // npm range had been written directly.
+                            // A `catalog:` peer is compared by the range the catalog resolves to.
                             let catalog_resolved;
                             let peer_version = if peer_dep.version.tag == VersionTag::Catalog {
                                 catalog_resolved = lockfile.resolve_catalog_dependency(peer_dep);

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1065,10 +1065,23 @@ impl Tree {
                     }
                 };
 
-                if dependency.version.tag == crate::dependency::VersionTag::Npm {
+                // `catalog:` peer dependencies only carry the catalog name, not the
+                // resolved npm version range. Look it up so a catalog peer hoists
+                // the same way the equivalent npm range would.
+                let catalog_resolved;
+                let peer_version = if dependency.version.tag
+                    == crate::dependency::VersionTag::Catalog
+                {
+                    catalog_resolved = builder.lockfile().resolve_catalog_dependency(dependency);
+                    catalog_resolved.as_ref().unwrap_or(&dependency.version)
+                } else {
+                    &dependency.version
+                };
+
+                if peer_version.tag == crate::dependency::VersionTag::Npm {
                     let resolution: Resolution =
                         builder.lockfile().packages.items_resolution()[res_id as usize];
-                    let version = &dependency.version.npm().version;
+                    let version = &peer_version.npm().version;
                     if resolution.tag == crate::resolution::Tag::Npm
                         && version.satisfies(resolution.npm().version, builder.buf(), builder.buf())
                     {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1065,9 +1065,7 @@ impl Tree {
                     }
                 };
 
-                // `catalog:` peer dependencies only carry the catalog name, not the
-                // resolved npm version range. Look it up so a catalog peer hoists
-                // the same way the equivalent npm range would.
+                // A `catalog:` peer is compared by the range the catalog resolves to.
                 let catalog_resolved;
                 let peer_version = if dependency.version.tag
                     == crate::dependency::VersionTag::Catalog

--- a/test/regression/issue/23615.test.ts
+++ b/test/regression/issue/23615.test.ts
@@ -1,0 +1,174 @@
+// https://github.com/oven-sh/bun/issues/23615
+
+import { file, spawn } from "bun";
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { readlinkSync } from "fs";
+import { rm } from "fs/promises";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted } from "harness";
+import { join } from "path";
+
+const registry = new VerdaccioRegistry();
+
+beforeAll(async () => {
+  await registry.start();
+});
+
+afterAll(() => {
+  registry.stop();
+});
+
+async function install(packageDir: string) {
+  const { stderr, stdout, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  return { out, err, code };
+}
+
+test("catalog: peer dependency hoists like the equivalent npm range (isolated)", async () => {
+  // Two versions of `no-deps` will exist in the lockfile:
+  //   - 1.0.0 (direct dependency of workspace `app`)
+  //   - 2.0.0 (transitive via root's `one-fixed-dep@2.0.0`)
+  //
+  // Workspace `lib` declares `peerDependencies: { no-deps: "catalog:" }`
+  // where the catalog entry is the range `>=1.0.0`. The peer resolver will
+  // pick 2.0.0 (highest satisfying), but when building the lockfile tree
+  // under `app` — which already provides `no-deps@1.0.0` and whose range
+  // `>=1.0.0` is satisfied by 1.0.0 — the peer should hoist and reuse
+  // app's copy. Previously the `.catalog` tag skipped that check and lib
+  // got its own nested `no-deps@2.0.0`.
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "root",
+        workspaces: {
+          packages: ["packages/*"],
+          catalog: {
+            "no-deps": ">=1.0.0",
+          },
+        },
+        dependencies: {
+          "one-fixed-dep": "2.0.0",
+        },
+      }),
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "lib": "workspace:*",
+        },
+      }),
+      "packages/lib/package.json": JSON.stringify({
+        name: "lib",
+        peerDependencies: {
+          "no-deps": "catalog:",
+        },
+      }),
+    },
+  });
+
+  // fresh install (no lockfile, no node_modules)
+  {
+    const { err, code } = await install(packageDir);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+  }
+
+  // The lockfile tree should have hoisted lib's catalog peer the same way
+  // it would an npm range: no nested `lib/no-deps` entry.
+  const lockfile = await file(join(packageDir, "bun.lock")).text();
+  expect(lockfile).not.toContain('"lib/no-deps"');
+
+  async function checkLinks() {
+    // Both app (direct dep) and lib (catalog peer) link to the same
+    // `no-deps@1.0.0` store entry — no duplicate install.
+    const libNoDeps = readlinkSync(join(packageDir, "packages/lib/node_modules/no-deps"));
+    const appNoDeps = readlinkSync(join(packageDir, "packages/app/node_modules/no-deps"));
+    expect(libNoDeps).toContain(join("no-deps@1.0.0", "node_modules", "no-deps"));
+    expect(appNoDeps).toContain(join("no-deps@1.0.0", "node_modules", "no-deps"));
+
+    const store = await readdirSorted(join(packageDir, "node_modules/.bun"));
+    expect(store).toEqual(["no-deps@1.0.0", "no-deps@2.0.0", "node_modules", "one-fixed-dep@2.0.0"]);
+  }
+
+  // reinstall from lockfile (no node_modules) — this is what runs on
+  // every other machine/CI after the lockfile is committed, and where the
+  // nested entry caused lib to link `no-deps@2.0.0` instead of the copy
+  // its consumer `app` provides.
+  {
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    const { err, code } = await install(packageDir);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+    await checkLinks();
+  }
+
+  // reinstall with both lockfile and node_modules present
+  {
+    const { err, code } = await install(packageDir);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+    await checkLinks();
+  }
+});
+
+test("catalog: peer dependency produces same lockfile as equivalent npm range", async () => {
+  // Sanity check: the lockfile produced with `catalog:` should be
+  // byte-identical (modulo the workspace dep literal and the catalog
+  // section itself) to the lockfile produced with the underlying npm
+  // range written out directly.
+  async function lockfileFor(peerVersion: string, withCatalog: boolean) {
+    const { packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+      files: {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: {
+            packages: ["packages/*"],
+            ...(withCatalog ? { catalog: { "no-deps": ">=1.0.0" } } : {}),
+          },
+          dependencies: {
+            "one-fixed-dep": "2.0.0",
+          },
+        }),
+        "packages/app/package.json": JSON.stringify({
+          name: "app",
+          dependencies: {
+            "no-deps": "1.0.0",
+            "lib": "workspace:*",
+          },
+        }),
+        "packages/lib/package.json": JSON.stringify({
+          name: "lib",
+          peerDependencies: {
+            "no-deps": peerVersion,
+          },
+        }),
+      },
+    });
+
+    const { err, code } = await install(packageDir);
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+
+    const text = await file(join(packageDir, "bun.lock")).text();
+    // bun.lock uses trailing commas (not strict JSON); just extract the
+    // top-level keys from the "packages" section.
+    const idx = text.indexOf('"packages": {');
+    expect(idx).toBeGreaterThan(-1);
+    const section = text.slice(idx);
+    const keys = [...section.matchAll(/^\s{4}"([^"]+)": \[/gm)].map(m => m[1]).sort();
+    expect(keys.length).toBeGreaterThan(0);
+    return keys;
+  }
+
+  const catalogKeys = await lockfileFor("catalog:", true);
+  const npmKeys = await lockfileFor(">=1.0.0", false);
+
+  expect(catalogKeys).toEqual(npmKeys);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the catalog deduplication half of #23615.

When a workspace package declares a peer dependency via `catalog:`, the in-memory dependency record carries `tag = Catalog` (just the catalog group name), not the underlying npm version range. Two places that compare peer versions only handled `Npm`:

- `Tree::hoist_dependency` (builds the lockfile tree / `bun.lock` `"packages"` keys)
- the isolated-install peer resolver

so a `catalog:` peer that should have hoisted to an ancestor's existing install was instead placed at a nested tree level.

### Observable effect

```jsonc
// root package.json
{
  "workspaces": { "packages": ["packages/*"], "catalog": { "no-deps": ">=1.0.0" } },
  "dependencies": { "one-fixed-dep": "2.0.0" }       // pulls no-deps@2.0.0 transitively
}
// packages/app/package.json
{ "dependencies": { "no-deps": "1.0.0", "lib": "workspace:*" } }
// packages/lib/package.json
{ "peerDependencies": { "no-deps": "catalog:" } }
```

**Before** — `bun.lock` gains a spurious nested key and, after installing from that lockfile, `lib` links to a *different* copy of the peer than its consumer `app` provides:

```
"packages": {
  "no-deps": ["no-deps@1.0.0", ...],
  "lib/no-deps": ["no-deps@2.0.0", ...],      // ← only present with catalog:
  "one-fixed-dep/no-deps": ["no-deps@2.0.0", ...],
}

packages/app/node_modules/no-deps -> .bun/no-deps@1.0.0/...
packages/lib/node_modules/no-deps -> .bun/no-deps@2.0.0/...   // ← dedup broken
```

With the equivalent npm range `"no-deps": ">=1.0.0"` written directly (no catalog), the nested `lib/no-deps` entry is absent and both `app` and `lib` link `no-deps@1.0.0`.

**After** — `catalog:` produces the exact same lockfile and install layout as the equivalent npm range:

```
packages/app/node_modules/no-deps -> .bun/no-deps@1.0.0/...
packages/lib/node_modules/no-deps -> .bun/no-deps@1.0.0/...   // ← same copy
```

This is the "two copies of the same module" symptom from the issue thread: TypeScript `Type 'X' is not assignable to type 'X'` between two store paths of the same package/version, `instanceof` mismatches, etc.

### Fix

Resolve the catalog entry to its underlying `DependencyVersion` (via `Lockfile::resolve_catalog_dependency`) before running the `satisfies()` comparison in `Tree::hoist_dependency` and the isolated-install peer resolver, so `catalog:` peers behave identically to the npm range they reference. If the catalog lookup fails or resolves to a non-npm version, falls back to the original `dependency.version` (preserving prior behavior).

Rebased onto main after the Zig→Rust migration; the original Zig const-receiver relaxations (`CatalogMap::get`, `resolve_catalog_dependency`) are no longer needed since the Rust versions already take `&self`.

### Not in this PR

Stale `node_modules/.bun` store entries after a catalog version change (the other half of #23615). Those entries are orphaned (no symlink references them after the change) but aren't GC'd; that needs a `modulesCacheMaxAge`-style cleanup and is better handled separately.

## How did you verify your code works?

New regression test `test/regression/issue/23615.test.ts`:

- asserts `bun.lock` has no nested `"lib/no-deps"` key with a `catalog:` peer
- asserts that after installing from the lockfile, `app` and `lib` link the same `no-deps@1.0.0` store entry
- asserts the `"packages"` keys in `bun.lock` are identical between `"no-deps": "catalog:"` and `"no-deps": ">=1.0.0"`

Both tests fail on `main` and pass with this change. `test/cli/install/catalogs.test.ts` and `test/cli/install/isolated-install.test.ts` continue to pass; `bun run rust:check-all` succeeds on all targets.

---

Fixes #23800

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 12 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/23615.test.ts"
bun test v1.4.0 (a16c273e0)

test/regression/issue/23615.test.ts:
80 |   }
81 | 
82 |   // The lockfile tree should have hoisted lib's catalog peer the same way
83 |   // it would an npm range: no nested `lib/no-deps` entry.
84 |   const lockfile = await file(join(packageDir, "bun.lock")).text();
85 |   expect(lockfile).not.toContain('"lib/no-deps"');
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "\"lib/no-deps\""
Received: "{\n  \"lockfileVersion\": 2,\n  \"configVersion\": 1,\n  \"workspaces\": {\n    \"\": {\n      \"name\": \"root\",\n      \"dependencies\": {\n        \"one-fixed-dep\": \"2.0.0\",\n      },\n    },\n    \"packages/app\": {\n      \"name\": \"app\",\n      \"dependencies\": {\n        \"lib\": \"workspace:*\",\n        \"no-deps\": \"1.0.0\",\n      },\n    },\n    \"packages/lib\": {\n      \"name\": \"lib\",\n      \"peerDependencies\": {\n        \"no-deps\": \"catalog:\",\n      },\n    },\n  },\n  \"catalog\": {\n  
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/regression/issue/23615.test.ts:
80 |   }
81 | 
82 |   // The lockfile tree should have hoisted lib's catalog peer the same way
83 |   // it would an npm range: no nested `lib/no-deps` entry.
84 |   const lockfile = await file(join(packageDir, "bun.lock")).text();
85 |   expect(lockfile).not.toContain('"lib/no-deps"');
                            ^
error: expect(received).not.toContain(expected)

Expected to not contain: "\"lib/no-deps\""
Received: "{\n  \"lockfileVersion\": 2,\n  \"configVersion\": 1,\n  \"workspaces\": {\n    \"\": {\n      \"name\": \"root\",\n      \"dependencies\": {\n        \"one-fixed-dep\": \"2.0.0\",\n      },\n    },\n    \"packages/app\": {\n      \"name\": \"app\",\n      \"dependencies\": {\n        \"lib\": \"workspace:*\",\n        \"no-deps\": \"1.0.0\",\n      },\n    },\n    \"packages/lib\": {\n      \"name\": \"lib\",\n      \"peerDependencies\": {\n        \"no-deps\": \"catalog:\",\n      },\n    },\n  },\n  \"catalog\": {\n    \"no-deps\": \">=1.0.0\",\n  },\n  \"packages\": {\n    \"app\": [\"app@workspace:packages/app\"],\n\n    \"lib\": [\"lib@workspace:packages/lib\"],\n\n    \"no
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/23615.test.ts"
bun test v1.4.0 (a16c273e0)

test/regression/issue/23615.test.ts:
(pass) catalog: peer dependency hoists like the equivalent npm range (isolated) [623.02ms]
(pass) catalog: peer dependency produces same lockfile as equivalent npm range [501.70ms]

 2 pass
 0 fail
 22 expect() calls
Ran 2 tests across 1 file. [4.53s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a16c273e0d
  features     baseline

22 deps, 123 codegen, 1176 objects in 795ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [50.00ms]
[5/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [1.00ms]
[6/1238] fetch zlib
[zlib] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] subs
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/isolated_install.rs     |  16 +++-
 src/install/lockfile/Tree.rs        |  15 +++-
 test/regression/issue/23615.test.ts | 174 ++++++++++++++++++++++++++++++++++++
 3 files changed, 199 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/install/isolated_install.rs          3      3     34
src/install/lockfile/Tree.rs             4      3     34
test/regression/issue/23615.test.ts      7     11     34
```

</details>

<!-- robobun:evidence:end -->