### PR TITLE
compile: fail gracefully instead of SIGBUS on truncated standalone binary

### DIFF
--- a/src/StandaloneModuleGraph.zig
+++ b/src/StandaloneModuleGraph.zig
@@ -156,6 +156,9 @@ pub const StandaloneModuleGraph = struct {
 
     const ELF = struct {
         pub extern "C" fn Bun__getStandaloneModuleGraphELFVaddr() ?*align(1) u64;
+        extern "c" fn getauxval(auxv_type: c_ulong) c_ulong;
+        const AT_PHDR = 3;
+        const AT_PHNUM = 5;
 
         pub fn getData() ?[]const u8 {
             const vaddr = (Bun__getStandaloneModuleGraphELFVaddr() orelse return null).*;
@@ -163,10 +166,75 @@ pub const StandaloneModuleGraph = struct {
             // BUN_COMPILED.size holds the virtual address of the appended data.
             // The kernel mapped it via PT_LOAD, so we can dereference directly.
             // Format at target: [u64 payload_len][payload bytes]
+            //
+            // The kernel does not validate p_offset + p_filesz <= st_size at
+            // execve time; a truncated executable maps fine and only SIGBUSes
+            // on first access to a page past EOF. The pre-#26923 read() path
+            // surfaced a short file as an I/O error — restore that gracefulness
+            // by checking the on-disk size against the segment header before
+            // touching the mapping.
+            const seg = findLoadSegment(vaddr) orelse {
+                // No auxv (static? unusual loader). Fall back to the unchecked
+                // path rather than fail closed.
+                return getDataUnchecked(vaddr);
+            };
+            const required = seg.p_offset + seg.p_filesz;
+            switch (bun.sys.stat("/proc/self/exe")) {
+                .result => |st| {
+                    const have: u64 = @intCast(@max(st.size, 0));
+                    if (have < required) reportTruncated(have, required);
+                },
+                // /proc unavailable (rare: minimal chroot). Best-effort skip.
+                .err => {},
+            }
+
+            const target: [*]const u8 = @ptrFromInt(vaddr);
+            const payload_len = std.mem.readInt(u64, target[0..8], .little);
+            if (payload_len < 8) return null;
+
+            // Clamp to the segment so a corrupted length header cannot walk
+            // off the end of the mapping into adjacent (or absent) pages.
+            const seg_avail = seg.p_memsz -| (vaddr - seg.p_vaddr) -| 8;
+            if (payload_len > seg_avail) {
+                Output.debugWarn("bun standalone payload_len {d} exceeds segment {d}", .{ payload_len, seg_avail });
+                return null;
+            }
+            return target[8..][0..payload_len];
+        }
+
+        fn getDataUnchecked(vaddr: u64) ?[]const u8 {
             const target: [*]const u8 = @ptrFromInt(vaddr);
             const payload_len = std.mem.readInt(u64, target[0..8], .little);
             if (payload_len < 8) return null;
             return target[8..][0..payload_len];
+        }
+
+        /// Locate the PT_LOAD covering `vaddr` in the kernel-supplied program
+        /// header table (AT_PHDR/AT_PHNUM). Returns null only if auxv itself
+        /// is missing — vaddr-not-in-any-segment is treated as truncation.
+        fn findLoadSegment(vaddr: u64) ?std.elf.Elf64_Phdr {
+            const phdr_addr = getauxval(AT_PHDR);
+            const phnum = getauxval(AT_PHNUM);
+            if (phdr_addr == 0 or phnum == 0) return null;
+            const phdrs: [*]align(1) const std.elf.Elf64_Phdr = @ptrFromInt(phdr_addr);
+            for (0..phnum) |i| {
+                const ph = phdrs[i];
+                if (ph.p_type != std.elf.PT_LOAD) continue;
+                if (vaddr >= ph.p_vaddr and vaddr < ph.p_vaddr +| ph.p_memsz) return ph;
+            }
+            // vaddr is set but lies outside every PT_LOAD: the segment was
+            // dropped (e.g. by an aggressive ELF rewriter) while BUN_COMPILED
+            // kept its stale pointer. Treat as truncation.
+            reportTruncated(0, vaddr);
+        }
+
+        fn reportTruncated(have: u64, required: u64) noreturn {
+            Output.errGeneric(
+                "this single-file executable is incomplete — its embedded module data is not fully present on disk (have {d} bytes, need at least {d}).\n" ++
+                    "  This usually means the binary was only partially downloaded or copied. Re-download or reinstall and try again.",
+                .{ have, required },
+            );
+            bun.Global.exit(1);
         }
     };
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isArm64, isLinux, isMacOS, isMusl, isWindows, tempDir } from "harness";
-import { chmodSync } from "node:fs";
+import { chmodSync, truncateSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -280,6 +280,44 @@ if (isLinux) {
 
       expect(stdout).toContain("large-exec-only-20000");
       expect(exitCode).toBe(0);
+    });
+
+    test("truncated compiled binary fails gracefully instead of SIGBUS", async () => {
+      // The kernel maps PT_LOAD without checking p_offset+p_filesz <= st_size,
+      // so a binary cut short past the .bun segment header used to SIGBUS on
+      // first access to the trailer (e.g. after an incomplete download/copy).
+      const largeString = Buffer.alloc(64 * 1024, "z").toString();
+      using dir = tempDir("build-compile-truncated", {
+        "app.js": `const data = "${largeString}"; console.log("never-runs-" + data.length);`,
+      });
+
+      const outfile = join(dir + "", "app-truncated");
+      const result = await Bun.build({
+        entrypoints: [join(dir + "", "app.js")],
+        compile: { outfile },
+      });
+      expect(result.success).toBe(true);
+      const exe = result.outputs[0].path;
+
+      // Chop off 16KB — enough that the page containing the trailer lies
+      // entirely past EOF (whole-page-past-EOF is what delivers SIGBUS;
+      // a partial last page is silently zero-filled). The first page of
+      // the segment, holding the length header, stays intact.
+      const size = (await Bun.file(exe).stat()).size;
+      truncateSync(exe, size - 16 * 1024);
+
+      await using proc = Bun.spawn({
+        cmd: [exe],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("single-file executable is incomplete");
+      expect(stderr).toContain("Re-download or reinstall");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
     });
 
     test("compiled binary has .bun ELF section", async () => {


### PR DESCRIPTION
## What

Since #26923, Linux `bun build --compile` output reads its embedded module graph from a `PT_LOAD` segment the kernel maps at `execve`. The kernel does **not** check `p_offset + p_filesz <= st_size`, so if the binary on disk is shorter than the program header claims (incomplete download, partial copy, etc.), the mapping succeeds and the process **SIGBUSes** on first access to a page past EOF — in `StandaloneModuleGraph.fromExecutable`, while reading the trailer:

```
panic(main thread): Bus error at address 0x...
```

Before #26923 this surfaced as a `read()` error. This PR restores the graceful failure: before touching the mapping, walk `getauxval(AT_PHDR/AT_PHNUM)` to find the segment, `stat("/proc/self/exe")`, and if the file is shorter than the segment requires, print:

```
error: this single-file executable is incomplete — its embedded module data is not fully present on disk (have N bytes, need at least M).
  This usually means the binary was only partially downloaded or copied. Re-download or reinstall and try again.
```

and exit 1. Also bound-checks the embedded length header against the segment extent so a corrupted header can't walk off the end of the mapping.

`stat()` needs no read permission, so the `chmod 111` case that motivated #26923 is unaffected. If `/proc` or auxv is unavailable the check is best-effort skipped.

## Test plan

- [x] `bun bd test test/bundler/bun-build-compile.test.ts` — new `truncated compiled binary fails gracefully instead of SIGBUS` test
- [x] `USE_SYSTEM_BUN=1 bun test ...` reproduces the SIGBUS panic on the same test
- [x] existing `chmod 111` tests still pass
- [x] `bun run zig:check-all`