### PR TITLE
Fix null deref in Bun.inspect when Proxy prototype getter throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5299,10 +5299,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5374,7 +5375,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -100,6 +100,34 @@ it("when prototype defines the same property, don't print the same property twic
   expect(Bun.inspect(obj).trim()).toBe('{\n  foo: "456",\n}'.trim());
 });
 
+it("Proxy prototype with throwing getter does not crash", () => {
+  const obj = {};
+  const proto = {
+    get foo() {
+      throw new Error("getter threw");
+    },
+    bar: 1,
+  };
+  Object.setPrototypeOf(obj, new Proxy(proto, {}));
+  expect(Bun.inspect(obj)).toContain("bar: 1");
+});
+
+it("Proxy prototype with throwing getPrototypeOf trap does not crash", () => {
+  const obj = {};
+  Object.setPrototypeOf(
+    obj,
+    new Proxy(
+      { foo: 1 },
+      {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf threw");
+        },
+      },
+    ),
+  );
+  expect(Bun.inspect(obj)).toContain("foo: 1");
+});
+
 it("Blob inspect", () => {
   expect(Bun.inspect(new Blob(["123"]))).toBe(`Blob (3 bytes)`);
   expect(Bun.inspect(new Blob(["123".repeat(900)]))).toBe(`Blob (2.70 KB)`);
@@ -451,6 +479,32 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = {};
+    const proto = {
+      get foo() {
+        throw new Error("getter threw");
+      },
+      bar: 1,
+    };
+    Object.setPrototypeOf(obj, new Proxy(proto, {}));
+    return obj;
+  },
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { foo: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf threw");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, and `expect()` error formatting) when walking a prototype chain that contains a `Proxy`.

### Root cause

When an object's prototype is a `Proxy`, `getPropertySlot()` invokes the Proxy `get` trap, which may end up calling a getter that throws. In that case `getPropertySlot()` returns `false` with a pending exception, but the existing code only cleared the exception when it returned `true`:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;  // <- exception still pending
CLEAR_IF_EXCEPTION(scope);
```

With the exception still pending, the subsequent `iterating->getPrototype(globalObject)` returns an empty `JSValue`, and `.getObject()` on an empty `JSValue` dereferences a null cell pointer.

The same line would also crash if the `Proxy` had a throwing `getPrototypeOf` trap, since there was no exception check after `getPrototype()`.

### Fix

- Clear the exception from `getPropertySlot()` regardless of whether the slot was found.
- Check for an empty result (and clear the exception) after `getPrototype()` in the slow-path prototype walk, matching the handling already present in the fast path.

### Repro

```js
const obj = {};
const proto = {
  get foo() { throw new Error("getter threw"); },
  bar: 1,
};
Object.setPrototypeOf(obj, new Proxy(proto, {}));
Bun.inspect(obj); // segfault before, prints { bar: 1 } after
```

Found by Fuzzilli.