### PR TITLE
Fix null deref in forEachProperty when Proxy prototype throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5299,10 +5299,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5374,7 +5375,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,31 @@ const fixture = [
         },
       },
     ),
+  () => {
+    class Foo {
+      get bar() {
+        throw new Error("getter throws");
+      }
+    }
+    const v = new Foo();
+    Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
+    return v;
+  },
+  () => {
+    const v = {};
+    Object.setPrototypeOf(
+      v,
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf throws");
+          },
+        },
+      ),
+    );
+    return v;
+  },
 ];
 
 describe("crash testing", () => {
@@ -469,6 +494,46 @@ describe("crash testing", () => {
 
 it("possibly formatted emojis log", () => {
   expect(Bun.inspect("✔")).toBe('"✔"');
+});
+
+describe("object with Proxy prototype", () => {
+  it("throwing getter through Proxy prototype", () => {
+    class Foo {
+      get bar() {
+        throw new Error("getter throws");
+      }
+    }
+    const v = new Foo();
+    Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
+    expect(() => Bun.inspect(v)).not.toThrow();
+  });
+
+  it("throwing getPrototypeOf trap", () => {
+    const v = {};
+    Object.setPrototypeOf(
+      v,
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf throws");
+          },
+        },
+      ),
+    );
+    expect(() => Bun.inspect(v)).not.toThrow();
+  });
+
+  it("non-throwing getter through Proxy prototype still works", () => {
+    class Foo {
+      get bar() {
+        return 42;
+      }
+    }
+    const v = new Foo();
+    Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
+    expect(Bun.inspect(v)).toContain("42");
+  });
 });
 
 it("new Date(..)", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, expect error formatting, etc.) when inspecting an object whose prototype chain contains a Proxy.

### Root cause

When an object's prototype chain contains a Proxy, `forEachProperty` takes the slow path. Two cases were mishandled:

1. `getPropertySlot()` with `InternalMethodType::Get` on a Proxy invokes `performProxyGet`, which calls the getter immediately (via `performDefaultGet` → `slot.getValue()`). If the getter throws, `getPropertySlot` returns `false`. The early `continue` then skipped over `CLEAR_IF_EXCEPTION(scope)`, leaving a pending exception for the remainder of the loop.

2. `iterating->getPrototype(globalObject)` on a Proxy can throw (either from a `getPrototypeOf` trap, or because of the pending exception from (1) hitting an internal `RETURN_IF_EXCEPTION`). When it throws it returns an empty `JSValue`, and calling `.getObject()` on that is `asCell()->getObject()` with `asCell() == nullptr`.

### Fix

- Clear the exception from `getPropertySlot()` before the `continue`.
- Check the result of `getPrototype()` for an empty value and clear the exception before dereferencing, matching how the fast path already handles this.

### Repro

```js
class Foo {
  get bar() { throw new Error("getter throws"); }
}
const v = new Foo();
Object.setPrototypeOf(v, new Proxy(Object.getPrototypeOf(v), {}));
Bun.inspect(v); // previously: UBSAN null member call / crash
```

```js
const v = {};
Object.setPrototypeOf(v, new Proxy({}, {
  getPrototypeOf() { throw new Error("nope"); }
}));
Bun.inspect(v); // previously: UBSAN null member call / crash
```

## How did you verify your code works?

- Original fuzzer repro no longer crashes (throws proper `expect().toBe()` error instead).
- Added regression tests in `test/js/bun/util/inspect.test.js`.
- Full `inspect.test.js` passes (77 tests).