### PR TITLE
shell: normalize CRLF line endings in .sh files

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2804,11 +2804,9 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             self.tokens.push(Token::Newline);
                             fell_through = true;
                         }
-                        // Handle CRLF line endings from Windows-edited scripts.
-                        // A `\r` immediately before `\n` in Normal state is
-                        // discarded so the `\n` fires its usual word-break +
-                        // Newline token. Inside quotes, `\r` stays literal
-                        // (matches bash/dash).
+                        // CRLF: drop a `\r` right before `\n` in Normal state so
+                        // the `\n` arm handles the newline. Inside quotes `\r`
+                        // stays literal (matches bash/dash).
                         c if c == u32::from(b'\r') => {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'\r' as usize));
                             if self.chars.state == CharState::Single
@@ -3154,17 +3152,9 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 }
                 continue;
             }
-            // Escaped CR from `\<CR><LF>` line-continuation in a
-            // CRLF-encoded script: `read_char()` swallowed the backslash
-            // and returned the `\r` as escaped, leaving the `\n` for the
-            // next read. Consume that `\n` so the whole `\<CR><LF>` acts
-            // as a single line continuation (matches the escaped-`\n`
-            // case above). Escaped CR *not* followed by `\n` preserves
-            // both bytes verbatim: in Normal state the swallowed
-            // backslash was already the escape prefix (so only `\r`
-            // remains), but in Double state bash/POSIX treats `\<CR>`
-            // as literal `\` + CR, so re-emit the backslash that
-            // read_char() consumed.
+            // `\<CR><LF>` line-continuation (CRLF parity with escaped-`\n`).
+            // Bare escaped CR in Double state re-emits the swallowed
+            // backslash so `\<CR>` stays literal `\` + CR (bash/POSIX).
             else if char == u32::from(b'\r') {
                 debug_assert!(input.escaped);
                 if let Some(next) = self.peek() {
@@ -4067,10 +4057,8 @@ impl<'a, const ENCODING: StringEncoding> ShellCharIter<'a, ENCODING> {
                     Src::Unicode(u) => u.index_next().map(|v| v.char),
                 }?;
                 match peeked {
-                    // Backslash only applies to these characters.
-                    // `\r` is included so `\<CR><LF>` in a CRLF script
-                    // reaches the escaped-`\r` line-continuation handler
-                    // in the main lexer (parity with `\<LF>`).
+                    // Backslash only applies to these characters. `\r` lets
+                    // `\<CR><LF>` reach the escaped-`\r` handler (parity with `\<LF>`).
                     c if c == u32::from(b'$')
                         || c == u32::from(b'`')
                         || c == u32::from(b'"')

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2804,6 +2804,26 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             self.tokens.push(Token::Newline);
                             fell_through = true;
                         }
+                        // Handle CRLF line endings from Windows-edited scripts.
+                        // A `\r` immediately before `\n` in Normal state is
+                        // discarded so the `\n` fires its usual word-break +
+                        // Newline token. Inside quotes, `\r` stays literal
+                        // (matches bash/dash).
+                        c if c == u32::from(b'\r') => {
+                            const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'\r' as usize));
+                            if self.chars.state == CharState::Single
+                                || self.chars.state == CharState::Double
+                            {
+                                break 'escaped;
+                            }
+                            if let Some(next) = self.peek() {
+                                if !next.escaped && next.char == u32::from(b'\n') {
+                                    fell_through = true;
+                                    break 'escaped;
+                                }
+                            }
+                            break 'escaped;
+                        }
                         // glob asterisks
                         c if c == u32::from(b'*') => {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'*' as usize));
@@ -3133,6 +3153,32 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                     self.break_word_impl(true, true, false)?;
                 }
                 continue;
+            }
+            // Escaped CR from `\<CR><LF>` line-continuation in a
+            // CRLF-encoded script: `read_char()` swallowed the backslash
+            // and returned the `\r` as escaped, leaving the `\n` for the
+            // next read. Consume that `\n` so the whole `\<CR><LF>` acts
+            // as a single line continuation (matches the escaped-`\n`
+            // case above). Escaped CR *not* followed by `\n` preserves
+            // both bytes verbatim: in Normal state the swallowed
+            // backslash was already the escape prefix (so only `\r`
+            // remains), but in Double state bash/POSIX treats `\<CR>`
+            // as literal `\` + CR, so re-emit the backslash that
+            // read_char() consumed.
+            else if char == u32::from(b'\r') {
+                debug_assert!(input.escaped);
+                if let Some(next) = self.peek() {
+                    if !next.escaped && next.char == u32::from(b'\n') {
+                        let _ = self.eat();
+                        if self.chars.state != CharState::Double {
+                            self.break_word_impl(true, true, false)?;
+                        }
+                        continue;
+                    }
+                }
+                if self.chars.state == CharState::Double {
+                    self.append_char_to_str_pool(u32::from(b'\\'))?;
+                }
             }
 
             self.append_char_to_str_pool(char)?;
@@ -4021,12 +4067,16 @@ impl<'a, const ENCODING: StringEncoding> ShellCharIter<'a, ENCODING> {
                     Src::Unicode(u) => u.index_next().map(|v| v.char),
                 }?;
                 match peeked {
-                    // Backslash only applies to these characters
+                    // Backslash only applies to these characters.
+                    // `\r` is included so `\<CR><LF>` in a CRLF script
+                    // reaches the escaped-`\r` line-continuation handler
+                    // in the main lexer (parity with `\<LF>`).
                     c if c == u32::from(b'$')
                         || c == u32::from(b'`')
                         || c == u32::from(b'"')
                         || c == u32::from(b'\\')
                         || c == u32::from(b'\n')
+                        || c == u32::from(b'\r')
                         || c == u32::from(b'#') =>
                     {
                         char = peeked;

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -3,6 +3,17 @@ import { chmodSync, mkdirSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
+// Debug/ASAN builds print "WARNING: ASAN interferes with JSC signal handlers..."
+// to stderr when JSC initializes, which is unrelated to the .sh dispatch path
+// under test here but still shows up occasionally across platforms. Strip it
+// before asserting stderr is clean.
+function stripAsanWarning(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter(l => !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
+
 describe.concurrent("run-shell", () => {
   test("running a shell script works", async () => {
     const dir = tmpdirSync();
@@ -36,6 +47,93 @@ describe.concurrent("run-shell", () => {
     });
     const stderr = await proc.stderr.text();
     expect(stderr).toBe("error: Failed to run script.sh due to error Unexpected ')'\n");
+  });
+
+  // https://github.com/oven-sh/bun/issues/29669
+  test("CRLF line endings are normalized (no command-not-found, no \\r in args)", async () => {
+    // Each line ends in CRLF. Before the fix, `export\r` wasn't a known
+    // builtin so bun emitted "command not found: export", and `echo $X\r`
+    // passed a trailing \r through to stdout.
+    using dir = tempDir("bun-shell-crlf", {
+      "crlf.sh": 'export VITE_PARAM=value\r\necho "[$VITE_PARAM]"\r\necho done\r\n',
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "crlf.sh")],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stripAsanWarning(stderr)).toBe("");
+    expect(stdout).toBe("[value]\ndone\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/29669 — backslash line-continuation
+  // in a CRLF-encoded script (`cmd arg1 \<CR><LF>arg2`). Without the escaped-CR
+  // handler, the `\<CR>` was swallowed but `\r` got glued onto the previous
+  // word and the `<LF>` emitted a real Newline — so `arg2` ran as a separate
+  // command instead of continuing the line.
+  test("CRLF with backslash line continuation", async () => {
+    using dir = tempDir("bun-shell-crlf-cont", {
+      "cont.sh": "echo first \\\r\n  second \\\r\n  third\r\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "cont.sh")],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stripAsanWarning(stderr)).toBe("");
+    expect(stdout).toBe("first second third\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/29669 — backslash line-continuation
+  // inside a double-quoted string. CRLF and LF must behave the same: the
+  // `\<newline>` pair is consumed. Before adding `\r` to the Double-state
+  // escape list, CRLF left a literal backslash + CR + LF embedded in the
+  // string value while LF produced a single joined string.
+  test("CRLF with backslash line continuation inside double quotes", async () => {
+    using dir = tempDir("bun-shell-crlf-dq", {
+      "dq.sh": 'MSG="hello \\\r\nworld"\r\necho "$MSG"\r\n',
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "dq.sh")],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stripAsanWarning(stderr)).toBe("");
+    expect(stdout).toBe("hello world\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Bare CR (not followed by LF) preceded by a backslash inside double
+  // quotes. POSIX/bash treat `\<CR>` as literal `\` + CR because CR isn't
+  // in the small set of chars a backslash escapes inside double quotes.
+  // Making `\r` escapable (to reach the line-continuation handler) must
+  // not silently drop the backslash when the CR is standalone.
+  test("bare CR inside double quotes keeps literal backslash", async () => {
+    using dir = tempDir("bun-shell-bare-cr", {
+      "bare.sh": 'echo "a\\\rb"\n',
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "bare.sh")],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stripAsanWarning(stderr)).toBe("");
+    expect(stdout).toBe("a\\\rb\n");
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/cli/run/run-shell.test.ts
+++ b/test/cli/run/run-shell.test.ts
@@ -51,9 +51,6 @@ describe.concurrent("run-shell", () => {
 
   // https://github.com/oven-sh/bun/issues/29669
   test("CRLF line endings are normalized (no command-not-found, no \\r in args)", async () => {
-    // Each line ends in CRLF. Before the fix, `export\r` wasn't a known
-    // builtin so bun emitted "command not found: export", and `echo $X\r`
-    // passed a trailing \r through to stdout.
     using dir = tempDir("bun-shell-crlf", {
       "crlf.sh": 'export VITE_PARAM=value\r\necho "[$VITE_PARAM]"\r\necho done\r\n',
     });
@@ -70,11 +67,7 @@ describe.concurrent("run-shell", () => {
     expect(exitCode).toBe(0);
   });
 
-  // https://github.com/oven-sh/bun/issues/29669 — backslash line-continuation
-  // in a CRLF-encoded script (`cmd arg1 \<CR><LF>arg2`). Without the escaped-CR
-  // handler, the `\<CR>` was swallowed but `\r` got glued onto the previous
-  // word and the `<LF>` emitted a real Newline — so `arg2` ran as a separate
-  // command instead of continuing the line.
+  // https://github.com/oven-sh/bun/issues/29669
   test("CRLF with backslash line continuation", async () => {
     using dir = tempDir("bun-shell-crlf-cont", {
       "cont.sh": "echo first \\\r\n  second \\\r\n  third\r\n",
@@ -92,11 +85,7 @@ describe.concurrent("run-shell", () => {
     expect(exitCode).toBe(0);
   });
 
-  // https://github.com/oven-sh/bun/issues/29669 — backslash line-continuation
-  // inside a double-quoted string. CRLF and LF must behave the same: the
-  // `\<newline>` pair is consumed. Before adding `\r` to the Double-state
-  // escape list, CRLF left a literal backslash + CR + LF embedded in the
-  // string value while LF produced a single joined string.
+  // https://github.com/oven-sh/bun/issues/29669
   test("CRLF with backslash line continuation inside double quotes", async () => {
     using dir = tempDir("bun-shell-crlf-dq", {
       "dq.sh": 'MSG="hello \\\r\nworld"\r\necho "$MSG"\r\n',
@@ -114,11 +103,9 @@ describe.concurrent("run-shell", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Bare CR (not followed by LF) preceded by a backslash inside double
-  // quotes. POSIX/bash treat `\<CR>` as literal `\` + CR because CR isn't
-  // in the small set of chars a backslash escapes inside double quotes.
-  // Making `\r` escapable (to reach the line-continuation handler) must
-  // not silently drop the backslash when the CR is standalone.
+  // https://github.com/oven-sh/bun/issues/29669
+  // Guard: making `\r` escapable must not drop the backslash for a bare
+  // `\<CR>` in double quotes; POSIX/bash keep it as literal `\` + CR.
   test("bare CR inside double quotes keeps literal backslash", async () => {
     using dir = tempDir("bun-shell-bare-cr", {
       "bare.sh": 'echo "a\\\rb"\n',


### PR DESCRIPTION
Fixes #29669

## Repro

```sh
printf 'export VITE_PARAM=value\r\nbun run build\r\n' > repro.sh
echo '{}' > package.json
bun run ./repro.sh
```

Before:
```
error: Script not found "build\r"
```
(the `\r` reset the terminal cursor, so the user saw "rror: Script not found \"build\"").

Windows-edited `.sh` files all have this shape, and the investigation note confirmed it repros identically on Linux if the file has CRLF.

## Cause

`src/shell/shell.zig` lexer handled `'\n'` as a word-breaker / Newline token but had no case for `'\r'`. `Chars.isWhitespace` listed `\r` but that helper is only consulted in narrow spots (comment lookbehind, `[[`/`]]` followers). In normal word scanning, `\r` fell through to `appendCharToStrPool` and got glued onto the preceding token — so `export\r` wasn't a recognised builtin, `VITE_PARAM=value\r` became the literal value, and `bun run build\r` failed script lookup.

## Fix

Add a `'\r'` case in the lexer's main char dispatch: in Normal state, if the next char is `'\n'`, swallow the `\r` (the `\n` handler then emits its usual word-break + Newline token). Inside single/double quotes, fall through and preserve the byte literally — matches bash/dash behaviour for quoted multi-line strings. Bare `\r` not followed by `\n` is also preserved (no silent Mac-classic CR-only line ending behaviour change).

## Verification

- `test/cli/run/run-shell.test.ts` — new test runs a CRLF-terminated script containing `export`, expanded-var echo, and a plain `echo`. FAILS on main (reveals `\r` in stdout diff), PASSES with this patch.
- Existing shell lex/parse tests (`test/js/bun/shell/lex.test.ts`, `parse.test.ts`): 46/46 pass unchanged.
- `bunshell.test.ts` pass/fail split identical before and after (292 pass / 52 pre-existing fails).