### PR TITLE
Fix null JSCell deref in Bun lazy property callbacks and forEachProperty

### DIFF
--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -94,7 +94,8 @@ FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 
 // definition of the C++ wrapper to call the Zig function
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
-    return JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    JSC::JSValue result = JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    return result ? result : JSC::jsUndefined(); \
 } \
 
 FOR_EACH_GETTER(DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER);

--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -95,7 +95,12 @@ FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 // definition of the C++ wrapper to call the Zig function
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
     JSC::JSValue result = JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
-    return result ? result : JSC::jsUndefined(); \
+    if (!result) { \
+        auto scope = DECLARE_THROW_SCOPE(vm); \
+        CLEAR_IF_EXCEPTION(scope); \
+        return JSC::jsUndefined(); \
+    } \
+    return result; \
 } \
 
 FOR_EACH_GETTER(DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -316,11 +316,14 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    JSObject* sqlObject = sqlValue.getObject();
+    if (!sqlObject) [[unlikely]] {
+        return jsUndefined();
+    }
+    JSValue result = sqlObject->get(globalObject, vm.propertyNames->defaultKeyword);
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    return result;
 }
 
 static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
@@ -328,12 +331,15 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    JSObject* sqlObject = sqlValue.getObject();
+    if (!sqlObject) [[unlikely]] {
+        return jsUndefined();
+    }
     auto clientData = WebCore::clientData(vm);
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
+    JSValue result = sqlObject->get(globalObject, clientData->builtinNames().SQLPublicName());
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    return result;
 }
 
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
@@ -366,20 +372,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -316,13 +316,19 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return jsUndefined();
+    }
     JSObject* sqlObject = sqlValue.getObject();
     if (!sqlObject) [[unlikely]] {
         return jsUndefined();
     }
     JSValue result = sqlObject->get(globalObject, vm.propertyNames->defaultKeyword);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return jsUndefined();
+    }
     return result;
 }
 
@@ -331,14 +337,20 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return jsUndefined();
+    }
     JSObject* sqlObject = sqlValue.getObject();
     if (!sqlObject) [[unlikely]] {
         return jsUndefined();
     }
     auto clientData = WebCore::clientData(vm);
     JSValue result = sqlObject->get(globalObject, clientData->builtinNames().SQLPublicName());
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return jsUndefined();
+    }
     return result;
 }
 
@@ -372,19 +384,16 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
-
-    if (!shell.isObject()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
+    if (scope.exception() || !shell.isObject()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
         return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
-    if (!ShellError.isObject()) [[unlikely]] {
-        throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
+    if (scope.exception() || !ShellError.isObject()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
         return jsUndefined();
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5444,7 +5444,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // getPrototype may throw (e.g. Proxy getPrototypeOf trap).
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+// Lazily-initialized properties on the Bun object (PropertyCallback in the
+// static hash table) run arbitrary code on first access. If that code throws
+// (e.g. RangeError from stack exhaustion), the callback must still return a
+// valid JSValue so that reifyStaticProperty does not pass an empty value to
+// putDirect.
+test.each(["sql", "SQL", "$", "Glob"])(
+  "accessing Bun.%s near stack overflow does not crash",
+  async prop => {
+    const src = `
+      function F() {
+        try { new this.constructor(); } catch {}
+        Bun[${JSON.stringify(prop)}];
+      }
+      try { new F(); } catch {}
+      process.exitCode = 0;
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const exitCode = await proc.exited;
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -25,3 +25,26 @@ test.concurrent.each(["sql", "SQL", "$", "Glob"])("accessing Bun.%s near stack o
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });
+
+// forEachPropertyImpl walks the prototype chain via getPrototype(), which may
+// throw via a Proxy getPrototypeOf trap. The returned empty JSValue must not
+// be passed to getObject().
+test.concurrent("Bun.inspect with throwing Proxy getPrototypeOf trap does not crash", async () => {
+  const src = `
+      const obj = { a: 1 };
+      Object.setPrototypeOf(obj, new Proxy({}, {
+        getPrototypeOf() { throw new Error("trap"); }
+      }));
+      Bun.inspect(obj);
+      process.exitCode = 0;
+    `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const exitCode = await proc.exited;
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -1,15 +1,13 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Lazily-initialized properties on the Bun object (PropertyCallback in the
 // static hash table) run arbitrary code on first access. If that code throws
 // (e.g. RangeError from stack exhaustion), the callback must still return a
 // valid JSValue so that reifyStaticProperty does not pass an empty value to
 // putDirect.
-test.each(["sql", "SQL", "$", "Glob"])(
-  "accessing Bun.%s near stack overflow does not crash",
-  async prop => {
-    const src = `
+test.each(["sql", "SQL", "$", "Glob"])("accessing Bun.%s near stack overflow does not crash", async prop => {
+  const src = `
       function F() {
         try { new this.constructor(); } catch {}
         Bun[${JSON.stringify(prop)}];
@@ -17,14 +15,13 @@ test.each(["sql", "SQL", "$", "Glob"])(
       try { new F(); } catch {}
       process.exitCode = 0;
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", src],
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    const exitCode = await proc.exited;
-    expect(proc.signalCode).toBeNull();
-    expect(exitCode).toBe(0);
-  },
-);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const exitCode = await proc.exited;
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -6,7 +6,7 @@ import { bunEnv, bunExe } from "harness";
 // (e.g. RangeError from stack exhaustion), the callback must still return a
 // valid JSValue so that reifyStaticProperty does not pass an empty value to
 // putDirect.
-test.each(["sql", "SQL", "$", "Glob"])("accessing Bun.%s near stack overflow does not crash", async prop => {
+test.concurrent.each(["sql", "SQL", "$", "Glob"])("accessing Bun.%s near stack overflow does not crash", async prop => {
   const src = `
       function F() {
         try { new this.constructor(); } catch {}

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,18 +451,6 @@ const fixture = [
         },
       },
     ),
-  () =>
-    Object.setPrototypeOf(
-      { a: 1 },
-      new Proxy(
-        {},
-        {
-          getPrototypeOf() {
-            throw new Error("trap");
-          },
-        },
-      ),
-    ),
 ];
 
 describe("crash testing", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,18 @@ const fixture = [
         },
       },
     ),
+  () =>
+    Object.setPrototypeOf(
+      { a: 1 },
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      ),
+    ),
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What

Fuzzilli found two crashes with the same fingerprint (`JSCJSValueCellInlines.h: member call on null pointer of type 'JSC::JSCell'`) from calling `.getObject()` on an empty `JSValue`.

### 1. Bun object lazy property callbacks near stack overflow

```
  in JSC::JSValue::getObject()
  in Bun::defaultBunSQLObject (BunObject.cpp)
  in JSC::reifyStaticProperty (Lookup.h)
```

Repro:
```js
function F() {
    try { new this.constructor(); } catch (e) {}
    Bun.sql;
}
new F();
```

### 2. `forEachPropertyImpl` with throwing Proxy `getPrototypeOf`

```
  in JSC::JSValue::getObject()
  in JSC__JSValue__forEachPropertyImpl (bindings.cpp)
```

Repro:
```js
Bun.inspect(Object.setPrototypeOf({ a: 1 }, new Proxy({}, {
  getPrototypeOf() { throw new Error(); }
})));
```

## Why

**Lazy properties:** `Bun.sql`, `Bun.$`, `Bun.SQL`, `Bun.Glob`, etc. are registered as `PropertyCallback` entries in the Bun object's static hash table. JSC's `reifyStaticProperty` calls the callback and unconditionally passes the result to `putDirect`. If the callback returns an empty `JSValue` (as ours did via `RETURN_IF_EXCEPTION(scope, {})` when `requireId` or `JSC::call` threw), `putDirect` dereferences a null `JSCell`. The debug-only `reportUncaughtExceptionAtEventLoop` call in the SQL callbacks additionally cleared the pending exception, so `sqlValue.getObject()` was invoked on an empty value directly.

**forEachProperty:** When walking the prototype chain for console formatting, `iterating->getPrototype(globalObject)` can throw via a Proxy `getPrototypeOf` trap. The empty return value was passed directly to `.getObject()`.

## How

- `defaultBunSQLObject` / `constructBunSQLObject`: drop the debug-only uncaught-exception reporting, guard `getObject()`, and return `jsUndefined()` on exception.
- `constructBunShell`: return `jsUndefined()` instead of `{}` on exception.
- `DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER`: return `jsUndefined()` when the Zig getter returns `.zero`.
- `forEachPropertyImpl`: clear the exception after `getPrototype()` (matching the fast path above) and null-check before advancing.