### PR TITLE
Fix Bun.pathToFileURL crash with relative paths longer than PATH_MAX

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2048,9 +2048,19 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     const str = in.toUTF8WithoutRef(bun.default_allocator);
     defer str.deinit();
 
+    const cwd = globalObject.bunVM().transpiler.fs.top_level_dir;
+
+    // The input is user-controlled and may be arbitrarily long. The
+    // threadlocal `join_buf` is only 4096 bytes, so use a stack-fallback
+    // allocator that heap-allocates for oversized inputs.
+    var sfa = std.heap.stackFallback(bun.MAX_PATH_BYTES * 2, bun.default_allocator);
+    const alloc = sfa.get();
+    const buf = bun.handleOom(alloc.alloc(u8, cwd.len + str.slice().len + 2));
+    defer alloc.free(buf);
+
     const out_slice = joinAbsStringBuf(
-        globalObject.bunVM().transpiler.fs.top_level_dir,
-        &join_buf,
+        cwd,
+        buf,
         &.{str.slice()},
         .auto,
     );

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2053,7 +2053,7 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     // The input is user-controlled and may be arbitrarily long. The
     // threadlocal `join_buf` is only 4096 bytes, so use a stack-fallback
     // allocator that heap-allocates for oversized inputs.
-    var sfa = std.heap.stackFallback(bun.MAX_PATH_BYTES * 2, bun.default_allocator);
+    var sfa = std.heap.stackFallback(4096, bun.default_allocator);
     const alloc = sfa.get();
     const buf = bun.handleOom(alloc.alloc(u8, cwd.len + str.slice().len + 2));
     defer alloc.free(buf);

--- a/test/js/bun/util/fileUrl.test.js
+++ b/test/js/bun/util/fileUrl.test.js
@@ -6,6 +6,18 @@ describe("pathToFileURL", () => {
   it("should convert a path to a file url", () => {
     expect(pathToFileURL("/path/to/file.js").href).toBe("file:///path/to/file.js");
   });
+
+  it("should handle relative paths longer than PATH_MAX", () => {
+    const long = Buffer.alloc(6000, "a").toString();
+    const url = pathToFileURL(long);
+    expect(url.href.endsWith("/" + long)).toBe(true);
+  });
+
+  it("should normalize long relative paths with .. segments", () => {
+    const input = Buffer.alloc(14000, "abcdef/").toString() + Buffer.alloc(6000, "../").toString() + "final";
+    const url = pathToFileURL(input);
+    expect(url.href).toBe(`${pathToFileURL(process.cwd())}/final`);
+  });
 });
 
 describe("fileURLToPath", () => {


### PR DESCRIPTION
## What does this PR do?

`Bun.pathToFileURL()` crashed with an index-out-of-bounds panic when given a relative path that, when joined with cwd, exceeded 4096 bytes.

`ResolvePath__joinAbsStringBufCurrentPlatformBunString` passed the fixed 4096-byte threadlocal `join_buf` as the output buffer to `joinAbsStringBuf`. The inner normalizer writes the result into that buffer and does not bound-check against it, so long inputs overflowed:

```
panic(main thread): index out of bounds: index 5738, len 4095
resolver.resolve_path.normalizeStringGenericTZ
  src/resolver/resolve_path.zig:915
...
Bun::functionPathToFileURL
  src/bun.js/bindings/BunObject.cpp:793
```

The fix uses a stack-fallback allocator sized to `cwd.len + input.len + 2` for the output buffer, so short paths stay zero-alloc and long paths heap-allocate. This matches Node.js, which happily returns a file URL for arbitrarily long paths.

## How did you verify your code works?

```js
Bun.pathToFileURL("a".repeat(6000)).href.length
// before: panic
// after:  6022 (same as Node.js)
```

Added tests in `test/js/bun/util/fileUrl.test.js` covering both a long flat segment and a long path that normalizes down via `..` segments. Verified the new tests crash the unfixed debug build and pass with the fix. `zig:check-all` passes on all targets.

Found via Fuzzilli (fingerprint `d8774a764480e01d`).