### PR TITLE
JSRef: make downgrade() a no-op when already finalized

### DIFF
--- a/src/bun.js/bindings/JSRef.zig
+++ b/src/bun.js/bindings/JSRef.zig
@@ -159,9 +159,7 @@ pub const JSRef = union(enum) {
                 strong.deinit();
                 this.* = .{ .weak = value };
             },
-            .finalized => {
-                bun.debugAssert(false);
-            },
+            .finalized => {},
         }
     }
 

--- a/test/js/web/timers/clearImmediate-gc.test.ts
+++ b/test/js/web/timers/clearImmediate-gc.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+it("clearImmediate then GC does not crash when the queued immediate is skipped", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        clearImmediate(setImmediate(() => {}));
+        Bun.gc(true);
+        setTimeout(() => {}, 1);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const stderrLines = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderrLines).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/timers/setImmediate.test.js
+++ b/test/js/web/timers/setImmediate.test.js
@@ -55,6 +55,28 @@ it("clearImmediate", async () => {
   await promise;
 });
 
+it("clearImmediate then GC does not crash when the queued immediate is skipped", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        clearImmediate(setImmediate(() => {}));
+        Bun.gc(true);
+        setTimeout(() => {}, 1);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("setImmediate should not keep the process alive forever", async () => {
   let process = null;
   const success = async () => {

--- a/test/js/web/timers/setImmediate.test.js
+++ b/test/js/web/timers/setImmediate.test.js
@@ -55,33 +55,6 @@ it("clearImmediate", async () => {
   await promise;
 });
 
-it("clearImmediate then GC does not crash when the queued immediate is skipped", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-        clearImmediate(setImmediate(() => {}));
-        Bun.gc(true);
-        setTimeout(() => {}, 1);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  const stderrLines = stderr
-    .split("\n")
-    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-  expect(stderrLines).toBe("");
-  expect(stdout).toBe("");
-  expect(exitCode).toBe(0);
-});
-
 it("setImmediate should not keep the process alive forever", async () => {
   let process = null;
   const success = async () => {

--- a/test/js/web/timers/setImmediate.test.js
+++ b/test/js/web/timers/setImmediate.test.js
@@ -71,8 +71,13 @@ it("clearImmediate then GC does not crash when the queued immediate is skipped",
     stderr: "pipe",
   });
 
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  const stderrLines = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderrLines).toBe("");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fuzzilli found a crash (fingerprint `234ef371515ec743`) which minimizes to:

```js
clearImmediate(setImmediate(() => {}));
Bun.gc(true);
setTimeout(() => {}, 1);
```

```
panic(main thread): reached unreachable code
  bun.js.bindings.JSRef.JSRef.downgrade
  bun.js.api.Timer.TimerObjectInternals.runImmediateTask
  bun.js.api.Timer.ImmediateObject.runImmediateTask
  bun.js.event_loop.tickImmediateTasks
```

### What happens

1. `setImmediate()` enqueues the immediate and holds a **strong** `JSRef` to the JS wrapper.
2. `clearImmediate()` → `cancel()` sets `has_cleared_timer = true` and **downgrades** the `JSRef` to weak so GC can collect the wrapper. The native `ImmediateObject` stays in the queue.
3. `Bun.gc(true)` collects the JS wrapper → its finalizer sets the `JSRef` to `.finalized`.
4. The event loop ticks immediates. `runImmediateTask()` sees `has_cleared_timer` and calls `this_value.downgrade()` as part of cleanup — but the ref is now `.finalized`, which hit `bun.debugAssert(false)`.

The same pattern shows up in `ReadableStreamInternals.ts` (`setImmediate`/`clearImmediate` around async-iterator body pulls), which is how the fuzzer arrived here via `new Request(url, { body: asyncGeneratorFn }).clone()`.

### Fix

Make `JSRef.downgrade()` a no-op on `.finalized`. Downgrading means "release the strong ref so GC can collect the object"; if the object has already been collected there is nothing to release. This matches how `setWeak()` and `deinit()` already treat `.finalized`, and it also covers other `downgrade()` callers in `TimerObjectInternals.fire()` that can reach the same state.