### PR TITLE
build(linux-musl): statically link libstdc++/libgcc

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -833,14 +833,17 @@ export const linkerFlags: Flag[] = [
     desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
   },
   {
+    // Alpine's `build-base` ships libstdc++.a / libgcc.a / libgcc_eh.a via the
+    // g++ / gcc packages — same as glibc distros — so static linking works on
+    // both ABIs. Previously the musl branch linked these dynamically, which
+    // forced users on clean Alpine images to `apk add libstdc++ libgcc` before
+    // bun would launch (#29681). Bun still links musl libc dynamically (via
+    // /lib/ld-musl-*.so.1), so dynamic TLS keeps working for mimalloc etc.
+    // Android has its own link recipe below (compiler-rt + libc++); this rule
+    // covers gnu and musl only.
     flag: ["-static-libstdc++", "-static-libgcc"],
-    when: c => c.linux && c.abi === "gnu",
-    desc: "Static C++ runtime (don't depend on host libstdc++)",
-  },
-  {
-    flag: ["-lstdc++", "-lgcc"],
-    when: c => c.linux && c.abi === "musl",
-    desc: "Dynamic C++ runtime on musl (static unavailable)",
+    when: c => c.linux && (c.abi === "gnu" || c.abi === "musl"),
+    desc: "Static C++ runtime (don't depend on host libstdc++/libgcc_s)",
   },
   {
     flag: c => [

--- a/scripts/verify-baseline-static/allowlist-aarch64.txt
+++ b/scripts/verify-baseline-static/allowlist-aarch64.txt
@@ -128,6 +128,19 @@ uw_update_context_1  [SVE]
 
 
 # ----------------------------------------------------------------------------
+# libgcc ARM SME TPIDR2 thread-pointer save. AAPCS helper that's only reached
+# when a caller is invoked in SME streaming mode or has live ZA state —
+# neither exists on armv8-a+crc baseline CPUs, so the SVE insns inside are
+# unreachable. Started appearing on musl-aarch64 when #29683 switched it to
+# -static-libgcc (Alpine's libgcc is newer and ships this helper; the Ubuntu
+# libgcc used for the glibc build doesn't have it yet, hence no match there).
+# Gate: AAPCS SME save/restore prologues, only emitted by SME-aware code.
+# (1 symbols)
+# ----------------------------------------------------------------------------
+__arm_tpidr2_save    [SVE]
+
+
+# ----------------------------------------------------------------------------
 # libdeflate Adler-32 NEON DotProd. Gate: HWCAP_ASIMDDP.
 # (1 symbols)
 # ----------------------------------------------------------------------------

--- a/test/regression/issue/29681.test.ts
+++ b/test/regression/issue/29681.test.ts
@@ -5,44 +5,36 @@
  * launch. PR #15186 introduced the dynamic linking; earlier Bun releases
  * linked these statically (as glibc builds still do).
  *
- * The fix (scripts/build/flags.ts) collapses the separate musl branch and
- * always emits `-static-libstdc++ -static-libgcc` on Linux. This test
- * evaluates the linker-flag table directly so a future regression that
- * reintroduces `-lstdc++ -lgcc` for musl — or drops the static flags —
- * fails here instead of at distro-install time.
+ * The fix (scripts/build/flags.ts) drops the musl-only `-lstdc++ -lgcc`
+ * branch and always emits `-static-libstdc++ -static-libgcc` on Linux.
+ *
+ * This test evaluates the linker-flag table by reading `flags.ts` as
+ * source and running the `linkerFlags` array literal through a minimal
+ * fake config for each {gnu, musl} × {x64, aarch64} combination. The
+ * array is parsed + transpiled rather than `import`ed directly because
+ * the debug build's module loader mis-handles the transitive `config.ts`
+ * import graph (unrelated to this fix).
+ *
+ * If a future edit re-introduces `-lstdc++` / `-lgcc` for musl, or drops
+ * the `-static-*` flags, this test fails here instead of at Alpine
+ * install time.
  */
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { linkerFlags } from "../../../scripts/build/flags.ts";
 
-// Minimal Config shape covering every field referenced by linkerFlags
-// predicates. We don't import resolveConfig — it would require a real
-// toolchain/cwd — and we don't need the unrelated fields.
-interface FakeConfig {
-  linux: boolean;
-  darwin: boolean;
-  windows: boolean;
-  unix: boolean;
-  x64: boolean;
-  arm64: boolean;
-  debug: boolean;
-  release: boolean;
-  abi: "gnu" | "musl" | undefined;
-  lto: boolean;
-  asan: boolean;
-  smol: boolean;
-  assertions: boolean;
-  valgrind: boolean;
-  fuzzilli: boolean;
-  ci: boolean;
-  pgoGenerate: string | undefined;
-  pgoUse: string | undefined;
-  osxDeploymentTarget: string | undefined;
-  osxSysroot: string | undefined;
-  cwd: string;
-  buildDir: string;
-  ld: string;
+// Only the fields the linkerFlags predicates read. Extra booleans default
+// to `false`/`undefined` so unrelated predicates (windows, macOS, etc.)
+// simply don't fire.
+type FakeConfig = Record<string, unknown>;
+
+interface FlagEntry {
+  flag: string | string[] | ((cfg: FakeConfig) => string | string[]);
+  when?: (cfg: FakeConfig) => boolean;
+  desc: string;
 }
+
+const FLAGS_TS = join(import.meta.dir, "..", "..", "..", "scripts", "build", "flags.ts");
 
 function makeLinuxConfig(abi: "gnu" | "musl", arch: "x64" | "aarch64"): FakeConfig {
   const cwd = join(import.meta.dir, "..", "..", "..");
@@ -73,13 +65,70 @@ function makeLinuxConfig(abi: "gnu" | "musl", arch: "x64" | "aarch64"): FakeConf
   };
 }
 
-function resolveLinkerFlags(cfg: FakeConfig): string[] {
+/**
+ * Parse out the `linkerFlags` array literal from flags.ts and evaluate it
+ * as JS. Returns the Flag[] table. See the file-level comment for why
+ * we avoid a plain `import`.
+ */
+function loadLinkerFlags(): FlagEntry[] {
+  const src = readFileSync(FLAGS_TS, "utf8");
+
+  // Find the declaration. The type annotation `Flag[]` contains a `[`
+  // too, so start the array search from after the `=`.
+  const declIdx = src.indexOf("export const linkerFlags");
+  if (declIdx < 0) throw new Error("linkerFlags declaration not found");
+  const eqIdx = src.indexOf("=", declIdx);
+  const arrStart = src.indexOf("[", eqIdx);
+  if (arrStart < 0) throw new Error("linkerFlags array not found");
+
+  // Walk to the matching close bracket, respecting string literals and
+  // line comments. The array has no nested `/* */` blocks, no template
+  // literals with `${}` nesting, and no regex literals, so this is safe.
+  let depth = 0;
+  let inStr: string | null = null;
+  let end = arrStart;
+  for (; end < src.length; end++) {
+    const c = src[end]!;
+    if (inStr !== null) {
+      if (c === "\\") end++;
+      else if (c === inStr) inStr = null;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") inStr = c;
+    else if (c === "/" && src[end + 1] === "/") {
+      while (end < src.length && src[end] !== "\n") end++;
+    } else if (c === "[") depth++;
+    else if (c === "]" && --depth === 0) break;
+  }
+  if (depth !== 0) throw new Error("linkerFlags array did not close");
+
+  const arrayLiteral = src.slice(arrStart, end + 1);
+
+  // Transpile TS → JS (strips `as Foo` casts, arrow param type annots).
+  const js = new Bun.Transpiler({ loader: "ts" }).transformSync(`globalThis.__t__ = ${arrayLiteral};`);
+
+  // Stub the helpers referenced inside the array (imported at the top
+  // of flags.ts). None of them matter for the musl-libstdc++ check;
+  // they just need to resolve so eval doesn't throw.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function("bunExeName", "slash", "join", js)(
+    () => "bun",
+    (p: string) => p,
+    (...parts: string[]) => parts.join("/"),
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+  const arr = g.__t__ as FlagEntry[];
+  delete g.__t__;
+  return arr;
+}
+
+function resolveLinkerFlags(cfg: FakeConfig, table: FlagEntry[]): string[] {
   const out: string[] = [];
-  for (const f of linkerFlags) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (f.when && !f.when(cfg as any)) continue;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const v = typeof f.flag === "function" ? f.flag(cfg as any) : f.flag;
+  for (const f of table) {
+    if (f.when && !f.when(cfg)) continue;
+    const v = typeof f.flag === "function" ? f.flag(cfg) : f.flag;
     out.push(...(Array.isArray(v) ? v : [v]));
   }
   return out;
@@ -91,9 +140,9 @@ test.each([
   ["gnu", "x64"],
   ["gnu", "aarch64"],
 ] as const)("linux-%s-%s links libstdc++/libgcc statically", (abi, arch) => {
-  const flags = resolveLinkerFlags(makeLinuxConfig(abi, arch));
+  const flags = resolveLinkerFlags(makeLinuxConfig(abi, arch), loadLinkerFlags());
 
-  // Must opt into static C++ runtime.
+  // Must opt into the static C++ runtime.
   expect(flags).toContain("-static-libstdc++");
   expect(flags).toContain("-static-libgcc");
 

--- a/test/regression/issue/29681.test.ts
+++ b/test/regression/issue/29681.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for #29681 — the prebuilt `bun-linux-*-musl` binaries
+ * linked `libstdc++.so.6` and `libgcc_s.so.1` dynamically, forcing users
+ * on clean Alpine images to `apk add libstdc++ libgcc` before bun would
+ * launch. PR #15186 introduced the dynamic linking; earlier Bun releases
+ * linked these statically (as glibc builds still do).
+ *
+ * The fix (scripts/build/flags.ts) collapses the separate musl branch and
+ * always emits `-static-libstdc++ -static-libgcc` on Linux. This test
+ * evaluates the linker-flag table directly so a future regression that
+ * reintroduces `-lstdc++ -lgcc` for musl — or drops the static flags —
+ * fails here instead of at distro-install time.
+ */
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+import { linkerFlags } from "../../../scripts/build/flags.ts";
+
+// Minimal Config shape covering every field referenced by linkerFlags
+// predicates. We don't import resolveConfig — it would require a real
+// toolchain/cwd — and we don't need the unrelated fields.
+interface FakeConfig {
+  linux: boolean;
+  darwin: boolean;
+  windows: boolean;
+  unix: boolean;
+  x64: boolean;
+  arm64: boolean;
+  debug: boolean;
+  release: boolean;
+  abi: "gnu" | "musl" | undefined;
+  lto: boolean;
+  asan: boolean;
+  smol: boolean;
+  assertions: boolean;
+  valgrind: boolean;
+  fuzzilli: boolean;
+  ci: boolean;
+  pgoGenerate: string | undefined;
+  pgoUse: string | undefined;
+  osxDeploymentTarget: string | undefined;
+  osxSysroot: string | undefined;
+  cwd: string;
+  buildDir: string;
+  ld: string;
+}
+
+function makeLinuxConfig(abi: "gnu" | "musl", arch: "x64" | "aarch64"): FakeConfig {
+  const cwd = join(import.meta.dir, "..", "..", "..");
+  return {
+    linux: true,
+    darwin: false,
+    windows: false,
+    unix: true,
+    x64: arch === "x64",
+    arm64: arch === "aarch64",
+    debug: false,
+    release: true,
+    abi,
+    lto: false,
+    asan: false,
+    smol: false,
+    assertions: false,
+    valgrind: false,
+    fuzzilli: false,
+    ci: false,
+    pgoGenerate: undefined,
+    pgoUse: undefined,
+    osxDeploymentTarget: undefined,
+    osxSysroot: undefined,
+    cwd,
+    buildDir: join(cwd, "build", "release"),
+    ld: "/usr/bin/ld.lld",
+  };
+}
+
+function resolveLinkerFlags(cfg: FakeConfig): string[] {
+  const out: string[] = [];
+  for (const f of linkerFlags) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (f.when && !f.when(cfg as any)) continue;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = typeof f.flag === "function" ? f.flag(cfg as any) : f.flag;
+    out.push(...(Array.isArray(v) ? v : [v]));
+  }
+  return out;
+}
+
+test.each([
+  ["musl", "x64"],
+  ["musl", "aarch64"],
+  ["gnu", "x64"],
+  ["gnu", "aarch64"],
+] as const)("linux-%s-%s links libstdc++/libgcc statically", (abi, arch) => {
+  const flags = resolveLinkerFlags(makeLinuxConfig(abi, arch));
+
+  // Must opt into static C++ runtime.
+  expect(flags).toContain("-static-libstdc++");
+  expect(flags).toContain("-static-libgcc");
+
+  // Must NOT fall back to dynamic `-lstdc++` / `-lgcc` — that is what
+  // caused #29681 ("symbol not found" on clean Alpine until
+  // `apk add libstdc++ libgcc`).
+  expect(flags).not.toContain("-lstdc++");
+  expect(flags).not.toContain("-lgcc");
+});


### PR DESCRIPTION
Fixes #29681.

## Repro

```console
$ docker run -it --rm alpine:3.22 /bin/sh
/ # apk add curl bash
/ # curl -fsSL https://bun.com/install | bash
/ # ~/.bun/bin/bun
Error loading shared library libstdc++.so.6: No such file or directory
Error loading shared library libgcc_s.so.1: No such file or directory
Error relocating /root/.bun/bin/bun: __once_proxy: symbol not found
...
```

## Cause

`scripts/build/flags.ts` explicitly opts the musl build out of `-static-libstdc++ -static-libgcc`:

```ts
{ flag: ["-static-libstdc++", "-static-libgcc"], when: c => c.linux && c.abi !== "musl", ... },
{ flag: ["-lstdc++", "-lgcc"],                    when: c => c.linux && c.abi === "musl",  desc: "Dynamic C++ runtime on musl (static unavailable)" },
```

The `static unavailable` comment is wrong. PR #15186 (Nov 2024) introduced this branch; earlier Bun releases linked these statically. Alpine's `build-base` ships `libstdc++.a` / `libgcc.a` / `libgcc_eh.a` via `g++` / `gcc`, so static linking works on musl just like it does on glibc — and it's what the `oven/bun:alpine` image has papered over with `apk add libgcc libstdc++` ever since.

## Fix

Collapse the two rules into one `-static-libstdc++ -static-libgcc` rule for all Linux targets. Bun still links musl libc dynamically (via `/lib/ld-musl-*.so.1`), so dynamic TLS keeps working for mimalloc etc. Scope matches the reported bug — this narrows `libstdc++.so.6`/`libgcc_s.so.1` dependencies only, no attempt at a fully-static `-static` build (#27375 is a separate, larger concern).

## Verification

`test/regression/issue/29681.test.ts` evaluates `linkerFlags` for musl/gnu × x64/aarch64 configurations and asserts `-static-libstdc++` / `-static-libgcc` are present and `-lstdc++` / `-lgcc` are not. Passes with the fix; reintroducing the musl dynamic branch fails the two musl cases.

End-to-end confirmation once CI ships the next musl artifacts: `ldd bun` on `bun-linux-x64-musl` should show only `/lib/ld-musl-x86_64.so.1` + `libc.musl-*.so.1`, with `libstdc++.so.6` / `libgcc_s.so.1` gone.