### PR TITLE
fix(fs): mkdir recursive idempotency for relative paths with '..' on Windows

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -3513,6 +3513,48 @@ pub const ExistsAtType = enum {
 };
 pub fn existsAtType(fd: bun.FD, subpath: anytype) Maybe(ExistsAtType) {
     if (comptime Environment.isWindows) {
+        // Path-only queries (no directory FD) use Win32 GetFileAttributesW
+        // rather than NtQueryAttributesFile. Win32 resolves relative paths
+        // — including ones with `..` — against the current directory via
+        // `RtlDosPathNameToNtPathName_U` before going to the kernel; the
+        // NT-namespace API used in the FD branch below cannot, and rejects
+        // names containing `..` with STATUS_OBJECT_NAME_INVALID. Symmetric
+        // with `mkdirOSPath` (CreateDirectoryW) and matches the stat-by-path
+        // implementations in libuv (fs__access), .NET (GetFileAttributesEx),
+        // Go (GetFileAttributesEx), and Rust (CreateFileW + handle query).
+        if (fd == bun.invalid_fd) {
+            const T = std.meta.Child(@TypeOf(subpath));
+            const attrs = getFileAttributes(subpath) orelse {
+                const errno = bun.windows.getLastErrno();
+                syslog("GetFileAttributesW({f}) = {s}", .{ bun.fmt.fmtPath(T, subpath, .{}), @tagName(errno) });
+                return .{ .err = .{
+                    .errno = @intFromEnum(errno),
+                    .syscall = .access,
+                } };
+            };
+
+            // libuv: Windows directories should never carry FILE_ATTRIBUTE_READONLY;
+            // an entry with both DIRECTORY+READONLY set is treated as not-a-directory
+            // (typically a reparse point).
+            // https://github.com/libuv/libuv/blob/eb5af8e3c0ea19a6b0196d5db3212dae1785739b/src/win/fs.c#L2144-L2146
+            if (attrs.is_directory and !attrs.is_readonly) {
+                syslog("GetFileAttributesW({f}) = directory", .{bun.fmt.fmtPath(T, subpath, .{})});
+                return .{ .result = .directory };
+            }
+            if (!attrs.is_directory) {
+                syslog("GetFileAttributesW({f}) = file", .{bun.fmt.fmtPath(T, subpath, .{})});
+                return .{ .result = .file };
+            }
+            syslog("GetFileAttributesW({f}) = read-only directory (treated as error)", .{bun.fmt.fmtPath(T, subpath, .{})});
+            return .{ .err = Error.fromCode(.UNKNOWN, .access) };
+        }
+
+        // FD-relative case: must use NT API. Win32 has no fstatat equivalent —
+        // there is no way to express "stat path P relative to directory handle H"
+        // through `kernel32`. This path inherits the NT-namespace limitation:
+        // relative `subpath`s that contain `..` are rejected with
+        // STATUS_OBJECT_NAME_INVALID. No current FD-relative caller passes such
+        // paths.
         const wbuf = bun.w_path_buffer_pool.get();
         defer bun.w_path_buffer_pool.put(wbuf);
         var path = if (std.meta.Child(@TypeOf(subpath)) == u16)
@@ -3536,8 +3578,6 @@ pub fn existsAtType(fd: bun.FD, subpath: anytype) Maybe(ExistsAtType) {
             .Length = @sizeOf(w.OBJECT_ATTRIBUTES),
             .RootDirectory = if (std.fs.path.isAbsoluteWindowsWTF16(path))
                 null
-            else if (fd == bun.invalid_fd)
-                std.fs.cwd().fd
             else
                 fd.cast(),
             .Attributes = 0, // Note we do not use OBJ_CASE_INSENSITIVE here.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3557,6 +3557,93 @@ it("fs.mkdirSync recursive: false should error when the directory already exists
   expect(() => mkdirSync(import.meta.path, { recursive: false })).toThrowError();
 });
 
+// `mkdir(path, { recursive: true })` must be idempotent — calling it a second
+// time on a directory that was just created by the first call must succeed.
+// Other runtimes (Node, Go, Rust, .NET) all satisfy this on Windows; Bun on
+// Windows does not when `path` is relative and contains `..`, because the
+// EEXIST recovery path's `directoryExistsAt` calls `NtQueryAttributesFile`,
+// an NT-namespace API that rejects relative names containing `..` with
+// `OBJECT_NAME_INVALID`. The original EEXIST then leaks instead of being
+// recognised as "the directory already exists, so the recursive mkdir is a
+// no-op". On POSIX, mkdir resolves `..` against the cwd before any existence
+// check, so these cases pass trivially — making this a Windows-only bug
+// worth pinning down with cross-platform regression tests anyway.
+//
+// This is the bug behind downstream `safeMkdir` workarounds (e.g. Metaplay's
+// llm-docs payload generator) where `distDir` defaults to `../server/payload`
+// and every per-file `mkdir(dirname(outputPath))` after the first one
+// surfaces EEXIST.
+describe("fs.mkdir({ recursive: true }) idempotency on '..' paths", () => {
+  // Shared helper: spawn a fresh bun process whose cwd is a subdirectory of a
+  // temp dir, so `..` references the temp dir itself. The body must produce
+  // no stdout, no stderr, and exit 0.
+  async function expectClean(body: string) {
+    using dir = tempDir("mkdir-dotdot", { sub: {} });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", body],
+      env: bunEnv,
+      cwd: join(String(dir), "sub"),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }
+
+  // Case C — canonical regression: two back-to-back recursive mkdirs of the
+  // same `..`-prefixed path. The second call must be a no-op.
+  it("Case C (promises): mkdir('../foo') twice", () =>
+    expectClean(`
+      const { mkdir } = require("node:fs/promises");
+      await mkdir("../foo", { recursive: true });
+      await mkdir("../foo", { recursive: true });
+    `));
+
+  it("Case C (sync): mkdirSync('../foo') twice", () =>
+    expectClean(`
+      const { mkdirSync } = require("node:fs");
+      mkdirSync("../foo", { recursive: true });
+      mkdirSync("../foo", { recursive: true });
+    `));
+
+  // Case I — guards against an over-eager fix that bans all `..` segments.
+  // 'inner/..' cancels back to cwd; 'inner/../foo' is just 'foo' once
+  // resolved. Both calls must still succeed.
+  it("Case I: mkdir('inner/../foo') twice (cancelling '..')", () =>
+    expectClean(`
+      const { mkdir } = require("node:fs/promises");
+      await mkdir("inner/../foo", { recursive: true });
+      await mkdir("inner/../foo", { recursive: true });
+    `));
+
+  // Case F — diagnostic: pinpoints the bug to the exists-check side, not the
+  // create side. The first mkdir uses the absolute path (which works fine);
+  // the second uses the relative `..` form against an already-existing
+  // directory, which is exactly the path that exercises the broken
+  // `directoryExistsAt` lookup.
+  it("Case F: create absolute, second mkdir uses relative '..'", () =>
+    expectClean(`
+      const { mkdir } = require("node:fs/promises");
+      const path = require("node:path");
+      await mkdir(path.resolve("../foo"), { recursive: true });
+      await mkdir("../foo", { recursive: true });
+    `));
+
+  // Case H — Windows-style backslash separator. Ensures the fix isn't keyed
+  // on the forward-slash form of '../'. POSIX-only behaviour ('..\\foo' is a
+  // single literal filename containing a backslash there) doesn't exercise
+  // the bug, so this case is Windows-gated.
+  it.if(isWindows)("Case H: mkdir('..\\\\foo') twice (backslash separator)", () =>
+    expectClean(String.raw`
+      const { mkdir } = require("node:fs/promises");
+      await mkdir("..\\foo", { recursive: true });
+      await mkdir("..\\foo", { recursive: true });
+    `),
+  );
+});
+
 it("fs.statfsSync should work", () => {
   const stats = statfsSync(import.meta.path);
   ["type", "bsize", "blocks", "bfree", "bavail", "files", "ffree"].forEach(k => {


### PR DESCRIPTION
### What does this PR do?

Fixes a Windows-specific bug where `mkdir(p, { recursive: true })` surfaces `EEXIST` on the second call when `p` is a relative path containing `..`:

```js
import { mkdir } from 'node:fs/promises'
await mkdir('../foo', { recursive: true })
await mkdir('../foo', { recursive: true })   // throws EEXIST on Bun 1.3.7
```

Other runtimes (Node, Go, Rust, .NET) all satisfy this trivially. Three-line deterministic repro; no concurrency, `rm`, or environmental noise required.

### Root cause

`mkdirRecursiveOSPathImpl`'s `EEXIST` recovery calls `bun.sys.directoryExistsAt` → `existsAtType`. On Windows that function used `NtQueryAttributesFile`, an NT-namespace API. NT object names are not filesystem paths and cannot represent `..` — the call returns `STATUS_OBJECT_NAME_INVALID` for any name containing `..`. The recovery treated that as "doesn't exist as a directory", and the original `EEXIST` leaked.

Win32 APIs like `GetFileAttributesW` and `CreateDirectoryW` resolve `..` against the cwd via `RtlDosPathNameToNtPathName_U` before reaching the kernel, which is why mkdir's *create* call worked but the recovery's *exists* call did not. The relevant comparison across runtimes:

| Runtime | Path-based stat API | Handles `..` natively? |
|---|---|---|
| libuv (Node.js) | `GetFileAttributesW` / `GetFileInformationByName` / `CreateFileW`+handle | Yes (Win32) |
| .NET | `GetFileAttributesExW` | Yes (Win32) |
| Go | `GetFileAttributesEx` / `FindFirstFile` / `CreateFile` | Yes (Win32) |
| Rust | `CreateFileW`+`GetFileInformationByHandle` / `FindFirstFileExW` | Yes (Win32) |
| **Bun (before this PR)** | `NtQueryAttributesFile` | No — NT names are flat, no `..` |

No mainstream runtime uses NT-namespace APIs for path-based stat. Bun was the outlier.

This bug was the cause of downstream `safeMkdir`-style workarounds in the wild (e.g. Metaplay's `llm-docs` payload generator, where `distDir` defaults to `../server/payload` so every per-file `mkdir(dirname(outputPath))` after the first one tripped `EEXIST`).

### Fix

Switch `existsAtType`'s no-FD branch to `GetFileAttributesW` via the existing `getFileAttributes` wrapper. The FD-relative branch is unchanged: Win32 has no `fstatat` equivalent, so directory-handle-relative stat must continue to use `NtQueryAttributesFile`. No current FD-relative caller passes paths containing `..`.

### Performance

Benchmarked on a Windows release build, 5 rounds × 50,000 ops per case, across nine path shapes covering `existsSync`, `statSync`, and `mkdirSync({recursive:true})` on existing paths. Median ns/op:

| op | path shape | main (NtQuery) | this PR (Win32) | Δ |
|---|---|---:|---:|---:|
| existsSync | abs-dir-exists | 10008 | 10165 | +1.6% |
| existsSync | abs-dir-deep | 10381 | 10382 | 0% |
| existsSync | abs-dir-missing | 5605 | 5632 | +0.5% |
| existsSync | abs-file-exists | 11242 | 11411 | +1.5% |
| existsSync | abs-file-miss | 5859 | 5753 | -1.8% |
| existsSync | rel-dir-exists | 11140 | 11002 | -1.2% |
| existsSync | rel-dir-missing | 6582 | 6467 | -1.7% |
| existsSync | abs-deep-miss | 7270 | 7460 | +2.6% |
| existsSync | abs-with-dotdot | 10617 | 10216 | -3.8% |
| statSync | abs-dir-exists | 3920 | 4098 | +4.5% |
| statSync | abs-dir-deep | 4329 | 3805 | -12% |
| statSync | abs-file-exists | 4016 | 3884 | -3.3% |
| statSync | rel-dir-exists | 3960 | 3917 | -1.1% |
| statSync | abs-with-dotdot | 3864 | 3790 | -1.9% |
| mkdir-recursive | abs-dir-exists | 57419 | 56533 | -1.5% |
| mkdir-recursive | abs-dir-deep | 53025 | 52096 | -1.8% |
| mkdir-recursive | rel-dir-exists | **threw EEXIST** | 57370 | bug fixed |
| mkdir-recursive | abs-with-dotdot | (didn't reach — preceding case crashed the bench) | 51845 | bug fixed |

All deltas are within ±5% noise on the cases that work on both branches. The slight wins on `..`-containing paths (e.g. `existsSync` `abs-with-dotdot` -3.8%, `statSync` `abs-dir-deep` -12%) come from skipping the manual `\??\` NT-prefix step that the old `toNTPath` had to emit. **Net runtime cost: zero.**

The mkdir-recursive bench independently reproduced the bug: the `main` binary threw `EEXIST` on `mkdirSync(rel-dir-exists, {recursive:true})` (where the relative path resolves through `..` segments), confirming that the deterministic repro and the regression suite are testing the same code path the workaround in the wild was hitting.

### How did you verify your code works?

Five-case regression suite added in `test/js/node/fs/fs.test.ts`, covering distinct equivalence classes:

- **Case C (promises)** — `mkdir('../foo')` × 2: canonical regression.
- **Case C (sync)** — `mkdirSync('../foo')` × 2: paired variant since the sync and async paths can diverge in the implementation.
- **Case I** — `mkdir('inner/../foo')` × 2 (cancelling `..`): guards against an over-eager fix that bans all `..` segments outright.
- **Case F** — create with absolute path, then second `mkdir` with the relative `..` form: pinpoints the bug to the exists-check side, not the create side.
- **Case H** — `..\foo` (Windows-gated): backslash separator variant, ensures the fix isn't keyed on the forward-slash form.

POSIX trivially satisfies all cases (POSIX `mkdir` resolves `..` before any FS call), so the tests run cross-platform except Case H. All 5 fail on `bun 1.3.7` and pass on the debug build with this fix.