### PR TITLE
fix(url): out-of-bounds write in Bun.pathToFileURL with long relative paths

### DIFF
--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -2048,9 +2048,16 @@ export fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     const str = in.toUTF8WithoutRef(bun.default_allocator);
     defer str.deinit();
 
+    const cwd = globalObject.bunVM().transpiler.fs.top_level_dir;
+
+    var sfa = std.heap.stackFallback(4096, bun.default_allocator);
+    const alloc = sfa.get();
+    const buf = bun.handleOom(alloc.alloc(u8, cwd.len + str.slice().len + 8));
+    defer alloc.free(buf);
+
     const out_slice = joinAbsStringBuf(
-        globalObject.bunVM().transpiler.fs.top_level_dir,
-        &join_buf,
+        cwd,
+        buf,
         &.{str.slice()},
         .auto,
     );

--- a/test/js/bun/util/pathToFileURL-invalid.test.ts
+++ b/test/js/bun/util/pathToFileURL-invalid.test.ts
@@ -54,3 +54,18 @@ describe("Bun.pathToFileURL with inputs that fail URL construction", () => {
     }
   });
 });
+
+// Relative paths are resolved against cwd via a fixed 4096-byte threadlocal
+// buffer. Inputs longer than that must not panic with an out-of-bounds write.
+test("Bun.pathToFileURL with relative path longer than PATH_MAX does not crash", () => {
+  const seg = Buffer.alloc(5000, "a").toString();
+  const url = pathToFileURL(seg);
+  expect(url).toBeInstanceOf(URL);
+  expect(url.protocol).toBe("file:");
+  expect(url.pathname.endsWith("/" + seg)).toBe(true);
+
+  // `..` segments that collapse to a short path should also work even when
+  // the unnormalized input is long.
+  const collapsing = Buffer.alloc(6000, "../").toString() + "x";
+  expect(pathToFileURL(collapsing).href).toStartWith("file:///");
+});


### PR DESCRIPTION
## What does this PR do?

Fixes an out-of-bounds panic (debug) / buffer overflow (release) in `Bun.pathToFileURL()` when given a relative path longer than ~4KB.

`ResolvePath__joinAbsStringBufCurrentPlatformBunString` normalized `cwd + input` into a fixed 4096-byte threadlocal buffer. The scratch buffer used for concatenation was already dynamically sized, but the output buffer for normalization was not — so `normalizeStringGenericTZ` would `@memcpy` past the end of `join_buf`.

```
panic(main thread): index out of bounds: index 5014, len 4095
resolver.resolve_path.normalizeStringGenericTZ
/workspace/bun/src/resolver/resolve_path.zig:915:29
```

Repro:
```js
Bun.pathToFileURL("a".repeat(5000));
```

Node.js accepts arbitrarily long paths here, so the fix sizes the output buffer to `cwd.len + input.len + 8` via a stack-fallback allocator — normal-length paths stay zero-alloc, oversized inputs heap-allocate. The result is immediately cloned into a `bun.String` so the buffer lifetime is scoped to the call.

## How did you verify your code works?

- Added a regression test in `test/js/bun/util/pathToFileURL-invalid.test.ts` covering both a 5000-byte segment and a long `../../..` chain that collapses back down.
- Test panics on the pre-fix debug build and passes on the fixed build.
- `bun run zig:check-all` passes on all targets.

Found by Fuzzilli (fingerprint `3ce6d2168dbaed42`).