### PR TITLE
os.cpus: handle non-contiguous CPU IDs on Linux

### DIFF
--- a/src/bun_core/env_var.zig
+++ b/src/bun_core/env_var.zig
@@ -42,6 +42,13 @@ pub const BUN_DEBUG = New(kind.string, "BUN_DEBUG", .{});
 pub const BUN_DEBUG_ALL = New(kind.boolean, "BUN_DEBUG_ALL", .{});
 pub const BUN_DEBUG_CSS_ORDER = New(kind.boolean, "BUN_DEBUG_CSS_ORDER", .{ .default = false });
 pub const BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE = New(kind.boolean, "BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE", .{ .default = false });
+/// Testing hook for `os.cpus()` on Linux: if set, `cpusImplLinux` reads from
+/// `<root>/proc/stat`, `<root>/proc/cpuinfo`, and
+/// `<root>/sys/devices/system/cpu/...` instead of the real kernel paths. Used
+/// by `test/js/node/os/os.test.js` to cover systems with non-contiguous CPU
+/// numbering (e.g. dual-socket EPYC where the `processor:` field jumps from
+/// 63 to 128) without needing that hardware. See #29689.
+pub const BUN_DEBUG_CPUS_PROCFS_ROOT = New(kind.string, "BUN_DEBUG_CPUS_PROCFS_ROOT", .{});
 /// Testing hook for `bun build --compile`: force `hostUsesNixStoreInterpreter()`
 /// to return true without mutating `/etc/NIXOS` on the shared rootfs. Used by
 /// `test/regression/issue/29290.test.ts` to exercise the Nix-host branch.

--- a/src/runtime/node/node_os.zig
+++ b/src/runtime/node/node_os.zig
@@ -116,7 +116,7 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
             // CPU lines are formatted as `cpu0 user nice sys idle iowait irq softirq`
             var toks = std.mem.tokenizeAny(u8, line, " \t");
             const cpu_name = toks.next() orelse break;
-            if (!std.mem.startsWith(u8, cpu_name, "cpu")) break; // done with CPUs
+            if (!strings.hasPrefixComptime(cpu_name, "cpu")) break; // done with CPUs
 
             // Parse the real CPU ID from the `cpuN` prefix, not the array slot.
             // On non-contiguous systems these are sparse (`cpu0..cpu63, cpu128..`).

--- a/src/runtime/node/node_os.zig
+++ b/src/runtime/node/node_os.zig
@@ -57,15 +57,34 @@ pub fn cpus(global: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
 fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
     // Create the return array
     const values = try jsc.JSValue.createEmptyArray(globalThis, 0);
+
+    // The JS array is a packed `[0, num_cpus)` but the kernel's CPU IDs can be
+    // sparse — on multi-socket systems (e.g. dual-socket EPYC) `/proc/stat`
+    // and `/proc/cpuinfo` expose IDs like `0..63, 128..191`. Parse the real
+    // ID from each `cpuN` line and keep `cpu_id -> array_index` in a map so
+    // passes 2 and 3 can translate IDs back to slots. See #29689.
+    var cpu_id_to_index = std.AutoHashMap(u32, u32).init(bun.default_allocator);
+    defer cpu_id_to_index.deinit();
     var num_cpus: u32 = 0;
 
     var stack_fallback = std.heap.stackFallback(1024 * 8, bun.default_allocator);
     var file_buf = std.array_list.Managed(u8).init(stack_fallback.get());
     defer file_buf.deinit();
 
+    // Optional test-only override: when set, procfs/sysfs paths are read from
+    // `<root>/proc/...` and `<root>/sys/...` instead of the real kernel
+    // pseudo-filesystem, so regression tests can cover non-contiguous CPU
+    // numbering without needing such hardware.
+    const procfs_root: []const u8 = bun.env_var.BUN_DEBUG_CPUS_PROCFS_ROOT.get() orelse "";
+    var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+
     // Read /proc/stat to get number of CPUs and times
     {
-        const file = std.fs.cwd().openFile("/proc/stat", .{}) catch {
+        const stat_path = if (procfs_root.len == 0)
+            "/proc/stat"
+        else
+            try std.fmt.bufPrint(&path_buf, "{s}/proc/stat", .{procfs_root});
+        const file = std.fs.cwd().openFile(stat_path, .{}) catch {
             // hidepid mounts (common on Android) deny /proc/stat. lazyCpus in os.ts
             // pre-creates hostCpuCount lazy proxies, so return that many stub
             // entries (zeroed times / unknown model / speed 0) — matches Node.
@@ -96,10 +115,16 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
         while (line_iter.next()) |line| {
             // CPU lines are formatted as `cpu0 user nice sys idle iowait irq softirq`
             var toks = std.mem.tokenizeAny(u8, line, " \t");
-            const cpu_name = toks.next();
-            if (cpu_name == null or !std.mem.startsWith(u8, cpu_name.?, "cpu")) break; // done with CPUs
+            const cpu_name = toks.next() orelse break;
+            if (!std.mem.startsWith(u8, cpu_name, "cpu")) break; // done with CPUs
 
-            //NOTE: libuv assumes this is fixed on Linux, not sure that's actually the case
+            // Parse the real CPU ID from the `cpuN` prefix, not the array slot.
+            // On non-contiguous systems these are sparse (`cpu0..cpu63, cpu128..`).
+            // The aggregate `cpu` line was skipped above; parseInt on an empty
+            // slice fails with `InvalidCharacter`, so we'd stop there too if
+            // the kernel ever emitted two aggregate lines.
+            const cpu_id = std.fmt.parseInt(u32, cpu_name[3..], 10) catch break;
+
             const scale = 10;
 
             var times = CPUTimes{};
@@ -110,17 +135,26 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
             _ = try (toks.next() orelse error.eol); // skip iowait
             times.irq = scale * try std.fmt.parseInt(u64, toks.next() orelse return error.eol, 10);
 
-            // Actually create the JS object representing the CPU
-            const cpu = jsc.JSValue.createEmptyObject(globalThis, 1);
+            // Actually create the JS object representing the CPU.
+            // `model` is seeded to "unknown" so CPUs whose IDs don't appear in
+            // /proc/cpuinfo — or where /proc/cpuinfo is unreadable — still end
+            // up with a valid string, and the cpuinfo pass can overwrite it.
+            const cpu = jsc.JSValue.createEmptyObject(globalThis, 2);
             cpu.put(globalThis, jsc.ZigString.static("times"), times.toValue(globalThis));
+            cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.static("unknown").withEncoding().toJS(globalThis));
             try values.putIndex(globalThis, num_cpus, cpu);
 
+            try cpu_id_to_index.put(cpu_id, num_cpus);
             num_cpus += 1;
         }
     }
 
     // Read /proc/cpuinfo to get model information (optional)
-    if (std.fs.cwd().openFile("/proc/cpuinfo", .{})) |file| {
+    const cpuinfo_path = if (procfs_root.len == 0)
+        "/proc/cpuinfo"
+    else
+        try std.fmt.bufPrint(&path_buf, "{s}/proc/cpuinfo", .{procfs_root});
+    if (std.fs.cwd().openFile(cpuinfo_path, .{})) |file| {
         defer file.close();
 
         const read = try bun.sys.File.from(file).readToEndWithArrayList(&file_buf, .probably_small).unwrap();
@@ -132,45 +166,40 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
         const key_processor = "processor\t: ";
         const key_model_name = "model name\t: ";
 
-        var cpu_index: u32 = 0;
-        var has_model_name = true;
+        // `array_index` is the slot in `values` that the current `processor:`
+        // block refers to, translated through `cpu_id_to_index`. `null` means
+        // we saw a `processor:` line whose ID wasn't in `/proc/stat` — skip
+        // any model-name line for it rather than writing to the wrong slot.
+        var array_index: ?u32 = null;
         while (line_iter.next()) |line| {
             if (strings.hasPrefixComptime(line, key_processor)) {
-                if (!has_model_name) {
-                    const cpu = try values.getIndex(globalThis, cpu_index);
-                    cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.static("unknown").withEncoding().toJS(globalThis));
-                }
-                // If this line starts a new processor, parse the index from the line
                 const digits = std.mem.trim(u8, line[key_processor.len..], " \t\n");
-                cpu_index = try std.fmt.parseInt(u32, digits, 10);
-                if (cpu_index >= num_cpus) return error.too_may_cpus;
-                has_model_name = false;
+                const cpu_id = try std.fmt.parseInt(u32, digits, 10);
+                array_index = cpu_id_to_index.get(cpu_id);
             } else if (strings.hasPrefixComptime(line, key_model_name)) {
-                // If this is the model name, extract it and store on the current cpu
+                // If this is the model name, extract it and store on the current cpu.
                 const model_name = line[key_model_name.len..];
-                const cpu = try values.getIndex(globalThis, cpu_index);
-                cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.init(model_name).withEncoding().toJS(globalThis));
-                has_model_name = true;
+                if (array_index) |idx| {
+                    const cpu = try values.getIndex(globalThis, idx);
+                    cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.init(model_name).withEncoding().toJS(globalThis));
+                }
             }
         }
-        if (!has_model_name) {
-            const cpu = try values.getIndex(globalThis, cpu_index);
-            cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.static("unknown").withEncoding().toJS(globalThis));
-        }
-    } else |_| {
-        // Initialize model name to "unknown"
-        var it = try values.arrayIterator(globalThis);
-        while (try it.next()) |cpu| {
-            cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.static("unknown").withEncoding().toJS(globalThis));
-        }
-    }
+    } else |_| {}
 
-    // Read /sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq to get current frequency (optional)
-    for (0..num_cpus) |cpu_index| {
-        const cpu = try values.getIndex(globalThis, @truncate(cpu_index));
+    // Read /sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq for each
+    // real CPU ID (not for each sequential index — the sysfs paths use the
+    // kernel's sparse numbering on non-contiguous systems).
+    var it = cpu_id_to_index.iterator();
+    while (it.next()) |entry| {
+        const cpu_id = entry.key_ptr.*;
+        const array_index = entry.value_ptr.*;
+        const cpu = try values.getIndex(globalThis, array_index);
 
-        var path_buf: [128]u8 = undefined;
-        const path = try std.fmt.bufPrint(&path_buf, "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq", .{cpu_index});
+        const path = if (procfs_root.len == 0)
+            try std.fmt.bufPrint(&path_buf, "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq", .{cpu_id})
+        else
+            try std.fmt.bufPrint(&path_buf, "{s}/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq", .{ procfs_root, cpu_id });
         if (std.fs.cwd().openFile(path, .{})) |file| {
             defer file.close();
 

--- a/src/runtime/node/node_os.zig
+++ b/src/runtime/node/node_os.zig
@@ -76,7 +76,7 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
     // pseudo-filesystem, so regression tests can cover non-contiguous CPU
     // numbering without needing such hardware.
     const procfs_root: []const u8 = bun.env_var.BUN_DEBUG_CPUS_PROCFS_ROOT.get() orelse "";
-    var path_buf: [bun.MAX_PATH_BYTES]u8 = undefined;
+    var path_buf: bun.PathBuffer = undefined;
 
     // Read /proc/stat to get number of CPUs and times
     {
@@ -135,11 +135,13 @@ fn cpusImplLinux(globalThis: *jsc.JSGlobalObject) !jsc.JSValue {
             _ = try (toks.next() orelse error.eol); // skip iowait
             times.irq = scale * try std.fmt.parseInt(u64, toks.next() orelse return error.eol, 10);
 
-            // Actually create the JS object representing the CPU.
-            // `model` is seeded to "unknown" so CPUs whose IDs don't appear in
-            // /proc/cpuinfo — or where /proc/cpuinfo is unreadable — still end
-            // up with a valid string, and the cpuinfo pass can overwrite it.
-            const cpu = jsc.JSValue.createEmptyObject(globalThis, 2);
+            // Actually create the JS object representing the CPU. Capacity 3
+            // matches the final shape (`times`, `model`, `speed`) and the
+            // Darwin/Windows implementations. `model` is seeded to "unknown"
+            // so CPUs whose IDs don't appear in /proc/cpuinfo — or where
+            // /proc/cpuinfo is unreadable — still end up with a valid string,
+            // and the cpuinfo pass can overwrite it.
+            const cpu = jsc.JSValue.createEmptyObject(globalThis, 3);
             cpu.put(globalThis, jsc.ZigString.static("times"), times.toValue(globalThis));
             cpu.put(globalThis, jsc.ZigString.static("model"), jsc.ZigString.static("unknown").withEncoding().toJS(globalThis));
             try values.putIndex(globalThis, num_cpus, cpu);

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -158,16 +158,25 @@ it("cpus", () => {
 it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () => {
   // Simulated 8-CPU EPYC-style layout: IDs 0..3 then 8..11. The crash
   // reproduces with any ID >= total CPU count; 8 with count 8 is enough.
+  //
+  // Per-id-distinct values in every stage (`times.user` in /proc/stat,
+  // model suffix in /proc/cpuinfo, kHz in scaling_cur_freq) let the test
+  // prove each JS slot is populated from the right CPU ID — if any of
+  // the three passes mis-mapped `cpu_id → array_index` and silently wrote
+  // to the wrong slot, the per-slot toEqual below would catch it.
   const cpuIds = [0, 1, 2, 3, 8, 9, 10, 11];
 
+  // /proc/stat user ticks encode the id: `id + 1` × 10 (after the ×10
+  // scale applied by cpusImplLinux this lands at 10, 20, …, 120).
   const statBody =
     "cpu  100 0 100 1000 0 0 0 0 0 0\n" +
-    cpuIds.map(id => `cpu${id} 10 0 10 100 0 0 0 0 0 0`).join("\n") +
+    cpuIds.map(id => `cpu${id} ${id + 1} 0 10 100 0 0 0 0 0 0`).join("\n") +
     "\nintr 0\nctxt 0\n";
 
+  // /proc/cpuinfo model encodes the id.
   const cpuinfoBody =
     cpuIds
-      .map(id => `processor\t: ${id}\n` + `model name\t: AMD EPYC 7713 64-Core Processor\n` + `cpu MHz\t\t: 2000.000\n`)
+      .map(id => `processor\t: ${id}\n` + `model name\t: AMD EPYC 7713 (core ${id})\n` + `cpu MHz\t\t: 2000.000\n`)
       .join("\n") + "\n";
 
   using dir = tempDir("cpus-noncontiguous", {
@@ -175,13 +184,12 @@ it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () =
     "proc/cpuinfo": cpuinfoBody,
   });
 
-  // Stage a scaling_cur_freq for every real CPU ID under the fake sysfs
-  // tree so the frequency pass has something to read at the sparse paths.
+  // scaling_cur_freq encodes the id as (id + 1) × 1000 kHz, which the
+  // /1000 conversion in cpusImplLinux turns into (id + 1) MHz.
   for (const id of cpuIds) {
     const freqDir = join(String(dir), "sys/devices/system/cpu", `cpu${id}`, "cpufreq");
     mkdirSync(freqDir, { recursive: true });
-    // 2,000,000 kHz -> 2000 MHz after /1000
-    writeFileSync(join(freqDir, "scaling_cur_freq"), "2000000\n");
+    writeFileSync(join(freqDir, "scaling_cur_freq"), `${(id + 1) * 1000}\n`);
   }
 
   // os.cpus() returns a lazy-populated array sized to the *real* host's
@@ -201,27 +209,28 @@ it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () =
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // Released bun (USE_SYSTEM_BUN=1) without the fix dies here with
-  // `Failed to get CPU information` (ERR_SYSTEM_ERROR) on stderr and a
-  // non-zero exit. Check exitCode + parsed stdout; ignore ASAN-build
-  // noise on stderr.
-  expect(exitCode, `stderr: ${stderr}`).toBe(0);
-
+  // Pass 1 packs array slots in /proc/stat order, so slot i corresponds
+  // to cpuIds[i]. Assert the full per-slot shape so a mis-mapping in any
+  // of the three passes would fail a specific entry, not just length.
   const cpus = JSON.parse(stdout);
-  expect(cpus).toHaveLength(cpuIds.length);
-  for (const cpu of cpus) {
-    expect(cpu).toEqual({
-      model: "AMD EPYC 7713 64-Core Processor",
-      speed: 2000,
+  expect(cpus).toEqual(
+    cpuIds.map(id => ({
+      model: `AMD EPYC 7713 (core ${id})`,
+      speed: id + 1,
       times: {
-        user: 100, // 10 ticks * scale 10
+        user: (id + 1) * 10, // raw ticks × scale 10
         nice: 0,
         sys: 100,
         idle: 1000,
         irq: 0,
       },
-    });
-  }
+    })),
+  );
+
+  // Released bun (USE_SYSTEM_BUN=1) without the fix dies here with
+  // `Failed to get CPU information` (ERR_SYSTEM_ERROR) on stderr and a
+  // non-zero exit. Ignore ASAN-build noise on stderr.
+  expect(exitCode, `stderr: ${stderr}`).toBe(0);
 });
 
 it("networkInterfaces", () => {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { mkdirSync, realpathSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { join } from "path";
 import * as os from "node:os";
 
 it("arch", () => {
@@ -139,6 +140,96 @@ it("cpus", () => {
     expect(typeof cpu.times.nice === "number").toBe(true);
     expect(typeof cpu.times.sys === "number").toBe(true);
     expect(typeof cpu.times.user === "number").toBe(true);
+  }
+});
+
+// https://github.com/oven-sh/bun/issues/29689
+//
+// On Linux, cpusImplLinux used the `processor:` field from /proc/cpuinfo
+// directly as an array index, and iterated 0..num_cpus for sysfs. Dual-
+// socket EPYCs expose /proc/stat and /proc/cpuinfo with sparse IDs —
+// e.g. cpu0..cpu63, cpu128..cpu191 — so `processor: 128` tripped the
+// `cpu_index >= num_cpus` guard and os.cpus() threw ERR_SYSTEM_ERROR.
+//
+// Fix: parse the real CPU ID from each `cpuN` line, keep a
+// cpu_id->array_index map, and use that map in the /proc/cpuinfo and
+// sysfs passes. Exercise via BUN_DEBUG_CPUS_PROCFS_ROOT which redirects
+// procfs/sysfs reads to a staged tempdir.
+it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () => {
+  // Simulated 8-CPU EPYC-style layout: IDs 0..3 then 8..11. The crash
+  // reproduces with any ID >= total CPU count; 8 with count 8 is enough.
+  const cpuIds = [0, 1, 2, 3, 8, 9, 10, 11];
+
+  const statBody =
+    "cpu  100 0 100 1000 0 0 0 0 0 0\n" +
+    cpuIds.map(id => `cpu${id} 10 0 10 100 0 0 0 0 0 0`).join("\n") +
+    "\nintr 0\nctxt 0\n";
+
+  const cpuinfoBody =
+    cpuIds
+      .map(
+        id =>
+          `processor\t: ${id}\n` +
+          `model name\t: AMD EPYC 7713 64-Core Processor\n` +
+          `cpu MHz\t\t: 2000.000\n`,
+      )
+      .join("\n") + "\n";
+
+  using dir = tempDir("cpus-noncontiguous", {
+    "proc/stat": statBody,
+    "proc/cpuinfo": cpuinfoBody,
+  });
+
+  // Stage a scaling_cur_freq for every real CPU ID under the fake sysfs
+  // tree so the frequency pass has something to read at the sparse paths.
+  for (const id of cpuIds) {
+    const freqDir = join(String(dir), "sys/devices/system/cpu", `cpu${id}`, "cpufreq");
+    mkdirSync(freqDir, { recursive: true });
+    // 2,000,000 kHz -> 2000 MHz after /1000
+    writeFileSync(join(freqDir, "scaling_cur_freq"), "2000000\n");
+  }
+
+  // os.cpus() returns a lazy-populated array sized to the *real* host's
+  // CPU count (hostCpuCount) whose per-slot getters trigger a single
+  // populate() from the binding. Read a field to force populate, then
+  // slice to the populated length so the outer shape reflects the fake
+  // procfs — not the CI host's real CPU count.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      "const cpus = require('os').cpus(); void cpus[0]?.model; console.log(JSON.stringify(cpus.slice(0, cpus.length)));",
+    ],
+    env: { ...bunEnv, BUN_DEBUG_CPUS_PROCFS_ROOT: String(dir) },
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Released bun (USE_SYSTEM_BUN=1) without the fix dies here with
+  // `Failed to get CPU information` (ERR_SYSTEM_ERROR) on stderr and a
+  // non-zero exit. Check exitCode + parsed stdout; ignore ASAN-build
+  // noise on stderr.
+  expect(exitCode, `stderr: ${stderr}`).toBe(0);
+
+  const cpus = JSON.parse(stdout);
+  expect(cpus).toHaveLength(cpuIds.length);
+  for (const cpu of cpus) {
+    expect(cpu).toEqual({
+      model: "AMD EPYC 7713 64-Core Processor",
+      speed: 2000,
+      times: {
+        user: 100, // 10 ticks * scale 10
+        nice: 0,
+        sys: 100,
+        idle: 1000,
+        irq: 0,
+      },
+    });
   }
 });
 

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { mkdirSync, realpathSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
-import { join } from "path";
 import * as os from "node:os";
+import { join } from "path";
 
 it("arch", () => {
   expect(["x64", "x86", "arm64"].some(arch => os.arch() === arch)).toBe(true);
@@ -167,12 +167,7 @@ it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () =
 
   const cpuinfoBody =
     cpuIds
-      .map(
-        id =>
-          `processor\t: ${id}\n` +
-          `model name\t: AMD EPYC 7713 64-Core Processor\n` +
-          `cpu MHz\t\t: 2000.000\n`,
-      )
+      .map(id => `processor\t: ${id}\n` + `model name\t: AMD EPYC 7713 64-Core Processor\n` + `cpu MHz\t\t: 2000.000\n`)
       .join("\n") + "\n";
 
   using dir = tempDir("cpus-noncontiguous", {
@@ -204,11 +199,7 @@ it.skipIf(!isLinux)("cpus() handles non-contiguous CPU IDs (#29689)", async () =
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Released bun (USE_SYSTEM_BUN=1) without the fix dies here with
   // `Failed to get CPU information` (ERR_SYSTEM_ERROR) on stderr and a


### PR DESCRIPTION
Fixes #29689.

### Reproduction

`os.cpus()` on Linux threw `ERR_SYSTEM_ERROR: Failed to get CPU information` on systems with non-contiguous CPU numbering — most commonly dual-socket AMD EPYCs, where `/proc/stat` and `/proc/cpuinfo` expose IDs like `cpu0..cpu63, cpu128..cpu191` with a total count of 128.

### Root cause

`cpusImplLinux` in `src/bun.js/node/node_os.zig` conflated two different things:

1. **Pass 1** reads `/proc/stat` and packs one JS object per `cpuN` line into sequential slots `[0, num_cpus)`, correctly.
2. **Pass 2** reads `/proc/cpuinfo` and uses the `processor:` field as a direct array index. On EPYC, `processor: 128` hits the guard `if (cpu_index >= num_cpus) return error.too_may_cpus;` (128 ≥ 128), and the outer wrapper rethrows as `ERR_SYSTEM_ERROR`.
3. **Pass 3** iterates `0..num_cpus` and reads `/sys/devices/system/cpu/cpuN/cpufreq/scaling_cur_freq`. Even if Pass 2 had succeeded, this path doesn't exist for IDs 64..127 and silently reports `speed: 0` for every CPU in the second half.

The code was aware it might be wrong — an existing `NOTE: libuv assumes this is fixed on Linux, not sure that's actually the case` has been in the file since the initial 2023 implementation. Libuv (and therefore Node) gets this right: array index = sequential appearance in `/proc/stat`, and `/sys/.../cpuN/...` lookups use the real CPU ID parsed from the `cpuN` prefix.

### Fix

- Parse the real CPU id from each `cpuN` line in `/proc/stat`, keep a `cpu_id -> array_index` map, and use it in `/proc/cpuinfo` and the cpufreq sysfs pass.
- Seed `model` to `"unknown"` per slot during Pass 1 so a slot whose ID is missing from `/proc/cpuinfo` still ends up with a string (matches libuv's initialization order).
- Added a test-only env var `BUN_DEBUG_CPUS_PROCFS_ROOT` that redirects procfs/sysfs reads to a staged tempdir, so the regression test can cover non-contiguous numbering without requiring that hardware in CI. Patterned after the existing `BUN_DEBUG_FORCE_NIX_HOST` hook.

### Verification

- `bun bd test test/js/node/os/os.test.js` — both the existing `cpus` test and the new `cpus() handles non-contiguous CPU IDs (#29689)` pass.
- `USE_SYSTEM_BUN=1 bun test test/js/node/os/os.test.js -t non-contiguous` — fails against released bun (expected length 8, got 128), confirming the test exercises the fix.
- `bun run zig:check-all` — clean on linux-gnu, linux-musl, macos, for both x86_64 and aarch64.