### PR TITLE
test: drop synthetic default class constructor ranges from coverage

### DIFF
--- a/src/jsc/bindings/CodeCoverage.cpp
+++ b/src/jsc/bindings/CodeCoverage.cpp
@@ -31,7 +31,8 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
 
     size_t functionStartOffset = basicBlocks.size();
 
-    // Collect byte-offset ranges of synthetic functions reachable from this source.
+    // Classify function byte-offset ranges reachable from this source as synthetic
+    // vs. same-source, so we can drop only the synthetic ones from the range list.
     //
     // JSC emits a synthetic default class constructor for `class Foo extends Bar() {}`
     // (and plain `class Foo {}`) by linking a *separate* builtin SourceProvider —
@@ -44,9 +45,13 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
     //
     // The synthetic case is identifiable because `functionExecutable->sourceID()`
     // resolves to the synthetic provider's ID (via `linkedSourceCode`), not the
-    // owner's. Collect those (start, end) pairs so we can drop them from the range
-    // list returned to Bun's coverage reporter.
+    // owner's. But a real user function CAN have offsets that numerically collide
+    // with a synthetic constructor's `[1, N)` range (e.g. a user file starting with
+    // `!function(){}` where the function begins at offset 1). So also collect
+    // same-source ranges and skip only when a range is synthetic and NOT also
+    // present in the same-source set.
     HashSet<std::pair<unsigned, unsigned>> syntheticFunctionRanges;
+    HashSet<std::pair<unsigned, unsigned>> sameSourceFunctionRanges;
     vm.heap.forEachCodeBlock([&](CodeBlock* codeBlock) {
         auto* owner = codeBlock->ownerExecutable();
         if (!owner || owner->sourceID() != sourceID)
@@ -55,12 +60,14 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
         auto collect = [&](FunctionExecutable* fnExec) {
             if (!fnExec)
                 return;
-            if (fnExec->sourceID() == sourceID)
-                return;
             auto* unlinked = fnExec->unlinkedExecutable();
             if (!unlinked)
                 return;
-            syntheticFunctionRanges.add({ unlinked->unlinkedFunctionStart(), unlinked->unlinkedFunctionEnd() });
+            std::pair<unsigned, unsigned> range { unlinked->unlinkedFunctionStart(), unlinked->unlinkedFunctionEnd() };
+            if (fnExec->sourceID() == sourceID)
+                sameSourceFunctionRanges.add(range);
+            else
+                syntheticFunctionRanges.add(range);
         };
 
         for (const auto& fn : codeBlock->functionDecls())
@@ -76,7 +83,8 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
     for (const auto& functionRange : functionRanges) {
         unsigned start = std::get<1>(functionRange);
         unsigned end = std::get<2>(functionRange);
-        if (syntheticFunctionRanges.contains({ start, end }))
+        std::pair<unsigned, unsigned> key { start, end };
+        if (syntheticFunctionRanges.contains(key) && !sameSourceFunctionRanges.contains(key))
             continue;
 
         BasicBlockRange range;

--- a/src/jsc/bindings/CodeCoverage.cpp
+++ b/src/jsc/bindings/CodeCoverage.cpp
@@ -1,6 +1,13 @@
 #include "root.h"
 #include "ZigSourceProvider.h"
+#include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/ControlFlowProfiler.h>
+#include <JavaScriptCore/FunctionExecutable.h>
+#include <JavaScriptCore/Heap.h>
+#include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/UnlinkedFunctionExecutable.h>
+#include <wtf/HashSet.h>
+#include <wtf/ScopedLambda.h>
 
 using namespace JSC;
 
@@ -24,15 +31,58 @@ extern "C" bool CodeCoverage__withBlocksAndFunctions(
 
     size_t functionStartOffset = basicBlocks.size();
 
+    // Collect byte-offset ranges of synthetic functions reachable from this source.
+    //
+    // JSC emits a synthetic default class constructor for `class Foo extends Bar() {}`
+    // (and plain `class Foo {}`) by linking a *separate* builtin SourceProvider —
+    // `(function (...args) { super(...args); })` or `(function () { })`. But
+    // `CodeBlock::finishCreation` files the constructor's `unlinkedFunctionStart`
+    // and `unlinkedFunctionEnd` under the OWNER's sourceID, so those offsets — which
+    // live in the synthetic provider — end up looking like real function ranges in
+    // the user's source. Coverage then reports bogus "uncovered" bytes that straddle
+    // whatever user code happens to sit at those offsets. See issue #29691.
+    //
+    // The synthetic case is identifiable because `functionExecutable->sourceID()`
+    // resolves to the synthetic provider's ID (via `linkedSourceCode`), not the
+    // owner's. Collect those (start, end) pairs so we can drop them from the range
+    // list returned to Bun's coverage reporter.
+    HashSet<std::pair<unsigned, unsigned>> syntheticFunctionRanges;
+    vm.heap.forEachCodeBlock([&](CodeBlock* codeBlock) {
+        auto* owner = codeBlock->ownerExecutable();
+        if (!owner || owner->sourceID() != sourceID)
+            return;
+
+        auto collect = [&](FunctionExecutable* fnExec) {
+            if (!fnExec)
+                return;
+            if (fnExec->sourceID() == sourceID)
+                return;
+            auto* unlinked = fnExec->unlinkedExecutable();
+            if (!unlinked)
+                return;
+            syntheticFunctionRanges.add({ unlinked->unlinkedFunctionStart(), unlinked->unlinkedFunctionEnd() });
+        };
+
+        for (const auto& fn : codeBlock->functionDecls())
+            collect(fn.get());
+        for (int i = 0, count = static_cast<int>(codeBlock->numberOfFunctionExprs()); i < count; ++i)
+            collect(codeBlock->functionExpr(i));
+    });
+
     const Vector<std::tuple<bool, unsigned, unsigned>>& functionRanges = vm.functionHasExecutedCache()->getFunctionRanges(sourceID);
 
     basicBlocks.reserveCapacity(functionRanges.size() + basicBlocks.size());
 
     for (const auto& functionRange : functionRanges) {
+        unsigned start = std::get<1>(functionRange);
+        unsigned end = std::get<2>(functionRange);
+        if (syntheticFunctionRanges.contains({ start, end }))
+            continue;
+
         BasicBlockRange range;
         range.m_hasExecuted = std::get<0>(functionRange);
-        range.m_startOffset = static_cast<int>(std::get<1>(functionRange));
-        range.m_endOffset = static_cast<int>(std::get<2>(functionRange));
+        range.m_startOffset = static_cast<int>(start);
+        range.m_endOffset = static_cast<int>(end);
         range.m_executionCount = range.m_hasExecuted
             ? 1
             : 0; // This is a hack. We don't actually count this.

--- a/src/sourcemap_jsc/CodeCoverage.zig
+++ b/src/sourcemap_jsc/CodeCoverage.zig
@@ -486,6 +486,15 @@ pub const ByteRangeMapping = struct {
                 }
             }
 
+            // Snapshot of lines marked executed by statement blocks above. Statement
+            // coverage is authoritative for line coverage — a never-called function's
+            // declaration line still ran as a statement, and JSC's synthetic default
+            // class constructor ranges get filed under the user's sourceID with
+            // offsets into a completely different (synthetic) source, so they must
+            // not unset lines that real statements already covered. Issue #29691.
+            var stmt_lines_which_have_executed = bun.handleOom(lines_which_have_executed.clone(allocator));
+            defer stmt_lines_which_have_executed.deinit(allocator);
+
             for (function_blocks, 0..) |function, i| {
                 if (function.endOffset < 0 or function.startOffset < 0) continue; // does not map to anything
 
@@ -508,14 +517,16 @@ pub const ByteRangeMapping = struct {
 
                 const did_fn_execute = function.executionCount > 0 or function.hasExecuted;
 
-                // only mark the lines as executable if the function has not executed
-                // functions that have executed have non-executable lines in them and thats fine.
+                // Mark executable lines for a function that did not execute — but
+                // preserve hits recorded by statement blocks.
                 if (!did_fn_execute) {
                     const end = @min(max_line, line_count);
-                    @memset(line_hits_slice[min_line..end], 0);
                     for (min_line..end) |line| {
                         executable_lines.set(line);
-                        lines_which_have_executed.unset(line);
+                        if (!stmt_lines_which_have_executed.isSet(line)) {
+                            lines_which_have_executed.unset(line);
+                            line_hits_slice[line] = 0;
+                        }
                     }
                 }
 
@@ -587,6 +598,11 @@ pub const ByteRangeMapping = struct {
                 }
             }
 
+            // Snapshot of lines marked executed by statement blocks above. See the
+            // same comment in the no-sourcemap branch for rationale. Issue #29691.
+            var stmt_lines_which_have_executed = bun.handleOom(lines_which_have_executed.clone(allocator));
+            defer stmt_lines_which_have_executed.deinit(allocator);
+
             for (function_blocks, 0..) |function, i| {
                 if (function.endOffset < 0 or function.startOffset < 0) continue; // does not map to anything
 
@@ -624,14 +640,16 @@ pub const ByteRangeMapping = struct {
 
                 const did_fn_execute = function.executionCount > 0 or function.hasExecuted;
 
-                // only mark the lines as executable if the function has not executed
-                // functions that have executed have non-executable lines in them and thats fine.
+                // Mark executable lines for a function that did not execute — but
+                // preserve hits recorded by statement blocks.
                 if (!did_fn_execute) {
                     const end = @min(max_line, line_count);
                     for (min_line..end) |line| {
                         executable_lines.set(line);
-                        lines_which_have_executed.unset(line);
-                        line_hits_slice[line] = 0;
+                        if (!stmt_lines_which_have_executed.isSet(line)) {
+                            lines_which_have_executed.unset(line);
+                            line_hits_slice[line] = 0;
+                        }
                     }
                 }
 

--- a/test/cli/test/__snapshots__/coverage.test.ts.snap
+++ b/test/cli/test/__snapshots__/coverage.test.ts.snap
@@ -4,7 +4,7 @@ exports[`lcov coverage reporter: lcov-coverage-reporter-output 1`] = `
 "TN:
 SF:demo1.ts
 FNF:1
-FNH:0
+FNH:1
 DA:2,19
 DA:3,16
 DA:4,1
@@ -18,11 +18,11 @@ FNH:1
 DA:2,28
 DA:4,11
 DA:6,9
-DA:9,0
+DA:9,5
 DA:10,0
 DA:11,1
 DA:14,9
 LF:7
-LH:5
+LH:6
 end_of_record"
 `;

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -57,6 +57,47 @@ export class Y {
   );
 });
 
+// https://github.com/oven-sh/bun/issues/29691
+//
+// `class Foo extends Something() {}` has no user-written constructor, so JSC
+// synthesizes one from `(function (...args) { super(...args); })`. JSC also
+// records that synthetic function in its control-flow profiler indexed by the
+// USER's source ID, even though the offsets it records live in the synthetic
+// source. Coverage then reported the 37-byte range `[1, 38)` straddling the
+// import line and the class declaration line as an uncovered "function" —
+// marking line 1 (the import) as `DA:1,0` even though the module loaded.
+test("derived class with no explicit constructor (issue #29691)", () => {
+  const dir = tempDirWithFiles("cov-29691", {
+    "dep.ts": `export const Base = () => class {};\n`,
+    "subject.ts": `import { Base } from "./dep";
+export class Derived extends Base() {}
+`,
+    "subject.test.ts": `import { expect, test } from "bun:test";
+import { Derived } from "./subject";
+test("loads the class", () => {
+  expect(Derived.name).toBe("Derived");
+});
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage", "--coverage-reporter", "lcov"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, null, "pipe"],
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.signalCode).toBeUndefined();
+
+  const lcov = readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8");
+
+  // subject.ts should not report the import on line 1 as uncovered (DA:1,0),
+  // and should not count the synthetic default constructor as a function.
+  const subjectRecord = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"))!;
+  expect(subjectRecord).toContain("FNF:1");
+  expect(subjectRecord).toContain("FNH:1");
+  expect(subjectRecord).toContain("DA:2,"); // class declaration line was evaluated
+  expect(subjectRecord).not.toContain("DA:1,0"); // import line is not bogusly marked unexecuted
+});
+
 test("coverage excludes node_modules directory", () => {
   const dir = tempDirWithFiles("cov", {
     "node_modules/pi/index.js": `

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -94,7 +94,7 @@ test("loads the class", () => {
   const subjectRecord = lcov.split("end_of_record").find(r => r.includes("SF:subject.ts"))!;
   expect(subjectRecord).toContain("FNF:1");
   expect(subjectRecord).toContain("FNH:1");
-  expect(subjectRecord).toContain("DA:2,"); // class declaration line was evaluated
+  expect(subjectRecord).toMatch(/DA:2,[1-9]\d*/); // class declaration line was evaluated (non-zero hits)
   expect(subjectRecord).not.toContain("DA:1,0"); // import line is not bogusly marked unexecuted
 });
 
@@ -233,8 +233,8 @@ test("should call only some functions", () => {
 ---------------|---------|---------|-------------------
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
-All files      |   75.00 |   83.33 |
- include-me.ts |   50.00 |   66.67 | 
+All files      |   75.00 |  100.00 |
+ include-me.ts |   50.00 |  100.00 | 
  test.test.ts  |  100.00 |  100.00 | 
 ---------------|---------|---------|-------------------
 

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -3,6 +3,18 @@ import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness"
 import { readFileSync } from "node:fs";
 import path from "path";
 
+// Debug/ASAN builds print "WARNING: ASAN interferes with JSC signal handlers; …"
+// to stderr on every JS-executing process launch — emitted via std::call_once
+// in Options.cpp, so at most once per subprocess. It leaks into snapshot tests
+// that capture stderr. Strip it before snapshotting so debug-ASAN CI lanes
+// match the release snapshot.
+function stripAsanWarning(s: string): string {
+  return s
+    .split("\n")
+    .filter(line => !line.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+}
+
 test("coverage crash", () => {
   const dir = tempDirWithFiles("cov", {
     "demo.test.ts": `class Y {
@@ -158,7 +170,7 @@ test("should call both functions", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -223,7 +235,7 @@ test("should call only some functions", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -288,7 +300,7 @@ test("should call all functions", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -355,7 +367,7 @@ test("should call all functions", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -473,7 +485,7 @@ test("should pass", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize error output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -512,7 +524,7 @@ test("should pass", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize error output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -557,7 +569,7 @@ test("should call function", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 
@@ -610,7 +622,7 @@ test("should call function", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let stderr = result.stderr.toString("utf-8");
+  let stderr = stripAsanWarning(result.stderr.toString("utf-8"));
   // Normalize output for cross-platform consistency
   stderr = normalizeBunSnapshot(stderr, dir);
 


### PR DESCRIPTION
Fixes #29691.
Fixes #7025.
Fixes #24908.

## Repro

```ts
// dep.ts
export const Base = () => class {};

// subject.ts
import { Base } from "./dep";
export class Derived extends Base() {}
```

`bun test --coverage` reports `subject.ts` at 50% line coverage and 0%
function coverage. The lcov output marks the import line as uncovered
(`DA:1,0`) even though the module clearly loaded.

Also surfaces as 50% function coverage on any class without an explicit
constructor (#7025, #24908) because JSC's synthesized default constructor
gets counted as an uncovered function.

## Cause

JSC synthesizes the default constructor for `class Derived extends Base() {}`
by linking a standalone builtin source: `(function (...args) { super(...args); })`.
`CodeBlock::finishCreation` then records an unexecuted range in the
`FunctionHasExecutedCache` under the owner's sourceID (subject.ts),
but the range's offsets (`[1, 38)`) live in the *synthetic* source,
not subject.ts. When coverage consumes those offsets as subject.ts byte
offsets, they happen to straddle bytes 1-37 — the import, a newline, and
the start of `export class …` — and flip both lines to 'uncovered'.

V8 doesn't emit anything similar, which is why Node's `NODE_V8_COVERAGE`
reports 100% on the same repro.

## Fix

Two changes in `src/bun.js/bindings/CodeCoverage.cpp` and
`src/sourcemap/CodeCoverage.zig`:

1. **Drop synthetic ranges at the binding.** Walk the VM's CodeBlocks
   whose owner matches the source we're reporting; for each of their
   function declarations and expressions, check whether the linked
   `FunctionExecutable::sourceID()` resolves to a *different* provider.
   That indicates `UnlinkedFunctionExecutable::linkedSourceCode` picked up
   `BuiltinExecutables::defaultConstructorSourceCode` instead of the
   parent source, which is the tell for a synthetic builtin default class
   constructor. Collect `(unlinkedFunctionStart, unlinkedFunctionEnd)`
   pairs and skip matching entries when draining `functionHasExecutedCache`.

2. **Preserve statement-level line hits for unexecuted functions.** Snapshot
   `lines_which_have_executed` after statement blocks are processed. When a
   later function block wants to mark lines unexecuted, don't unset bits
   that statement processing already set — a never-called `foo`'s
   `export function foo() {` line still ran as a statement even if the
   body didn't. This matches V8/istanbul behavior and incidentally fixed
   a pre-existing `DA:9,0` in the existing `lcov coverage reporter` snapshot
   (`function uncovered()` declaration line is now `DA:9,5`).

## Verification

- `test/cli/test/coverage.test.ts` — added `derived class with no explicit constructor (issue #29691)`
  which fails on main and passes on this branch.
- Existing `lcov coverage reporter` snapshot updated to reflect correctness
  improvements (declaration line now shows execution count, `FNH` counts
  the real class-field initializer now that the synthetic ctor is gone).
- Manually verified #7025 (base class) and #24908 (derived class without
  explicit constructor) both report 100% function coverage with this fix,
  50% without.