### PR TITLE
fix(dns): preserve OS order in internal DNS cache

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2611,7 +2611,13 @@ pub mod internal {
         pub addr: SockaddrStorage,
     }
 
-    // re-order result to interleave ipv4 and ipv6 (also pack into a single allocation)
+    // Pack the linked list returned by getaddrinfo() into a single allocation.
+    // The order the OS gave us is preserved — the system's RFC 6724 destination
+    // selection / `gai.conf` / `AI_ADDRCONFIG` filter already decided which
+    // family should be preferred, and Node.js likewise reports `verbatim` order
+    // by default. See https://github.com/oven-sh/bun/issues/29695 — reordering
+    // to always put IPv6 first here breaks fetch/Bun.serve outbound on hosts
+    // where IPv6 is configured but unreachable.
     fn process_results(info: *mut AddrInfo) -> Box<[ResultEntry]> {
         let mut count: usize = 0;
         let mut info_: *mut AddrInfo = info;
@@ -2654,27 +2660,8 @@ pub mod internal {
         // SAFETY: every slot 0..count was written above
         let mut results: Box<[ResultEntry]> = unsafe { results.assume_init() };
 
-        // sort (interleave ipv4 and ipv6)
-        let mut want = netc::AF_INET6 as usize;
-        'outer: for idx in 0..count {
-            if results[idx].info.ai_family as usize == want {
-                continue;
-            }
-            for j in (idx + 1)..count {
-                if results[j].info.ai_family as usize == want {
-                    results.swap(idx, j);
-                    want = if want == netc::AF_INET6 as usize {
-                        netc::AF_INET as usize
-                    } else {
-                        netc::AF_INET6 as usize
-                    };
-                }
-            }
-            // the rest of the list is all one address family
-            break 'outer;
-        }
-
-        // set up pointers
+        // re-link the copied entries and re-home the `addr` pointer at the
+        // packed storage so the list outlives the original freeaddrinfo
         for idx in 0..count {
             let (left, right) = results.split_at_mut(idx + 1);
             let entry = &mut left[idx];

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -7,94 +7,138 @@
 // ECONNRESET — and it also disagreed with `dns.lookup()` and with the OS's own
 // RFC 6724 destination selection.
 //
-// This test drives the bug via a custom `/etc/gai.conf` that asks glibc to
-// prefer IPv4 and then checks that the uws connect path honors that order.
-// It only runs on glibc Linux as root (the only environment that can rewrite
-// gai.conf and has getaddrinfo() read it) — macOS uses libinfo and has no
-// gai.conf, musl has no gai.conf, and containers without root can't make
-// the syscall observe a different order.
-import { afterAll, beforeAll, expect, test } from "bun:test";
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { bunEnv, bunExe, isGlibc, isLinux } from "harness";
+// To drive the bug without touching the machine-wide `/etc/gai.conf` (which
+// would leak into every test running in the same shard) the test compiles a
+// tiny `LD_PRELOAD` shim that intercepts only one hostname: `mock29695`
+// resolves to `[127.0.0.1, ::1]` in that exact order, everything else falls
+// through to glibc. The shim lives in tempDir() and is scoped to the single
+// Bun.spawn subprocess that runs the actual fetch. Only runs on glibc Linux
+// with `cc` available and an IPv6 loopback — macOS uses libinfo so
+// LD_PRELOAD doesn't reach the same code path, musl's loader ignores
+// LD_PRELOAD for setuid binaries and has its own getaddrinfo, and we need
+// ::1 for the dual-stack listener to actually bind.
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { bunEnv, bunExe, isGlibc, isLinux, tempDirWithFiles } from "harness";
+import { join } from "node:path";
+import { which } from "bun";
 
-const GAI_CONF_PATH = "/etc/gai.conf";
-const GAI_CONF_BACKUP = "/etc/gai.conf.bun-29695.bak";
-
-// Prefer IPv4 over IPv6 at the destination-selection step. This flips the
-// order glibc returns from getaddrinfo("localhost") so the list is
-// [127.0.0.1, ::1] instead of the usual [::1, 127.0.0.1] — giving us a
-// deterministic signal that the uws DNS path respected OS order rather
-// than forcing AAAA first.
-const GAI_CONF_PREFER_IPV4 = `# Temporary override written by test/regression/issue/29695.test.ts.
-label  ::1/128       0
-label  ::/0          1
-label  2002::/16     2
-label  ::/96         3
-label  ::ffff:0:0/96 4
-label  fec0::/10     5
-label  fc00::/7      6
-label  2001:0::/32   7
-
-precedence  ::1/128       50
-precedence  ::/0          40
-precedence  2002::/16     30
-precedence  ::/96         20
-precedence  ::ffff:0:0/96 100
-`;
+const CC = which("cc") ?? which("gcc");
 
 const canRun =
   isLinux &&
   isGlibc &&
-  process.getuid?.() === 0 &&
-  // Need ::1 loopback so we have an AAAA record to race against 127.0.0.1.
+  CC !== null &&
+  // Need ::1 loopback so the dual-stack server's AAAA listener actually comes up.
   existsSync("/proc/net/if_inet6") &&
-  readFileSync("/proc/net/if_inet6", "utf8").split("\n").some(line => line.startsWith("00000000000000000000000000000001"));
+  readFileSync("/proc/net/if_inet6", "utf8")
+    .split("\n")
+    .some(line => line.startsWith("00000000000000000000000000000001"));
 
-let savedBackup = false;
+// A libc `getaddrinfo`/`freeaddrinfo` shim: for the host `mock29695` it
+// returns a two-element linked list [127.0.0.1, ::1] in that exact order,
+// packed into a single allocation so `freeaddrinfo` can be a single free().
+// Everything else is forwarded to the real implementations via dlsym.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
 
-function restoreGaiConf() {
-  try {
-    unlinkSync(GAI_CONF_PATH);
-  } catch {}
-  if (savedBackup) {
-    try {
-      renameSync(GAI_CONF_BACKUP, GAI_CONF_PATH);
-    } catch {}
-    savedBackup = false;
-  }
+#define MOCK_HOST "mock29695"
+#define MOCK_MAGIC 0xBEEFCAFE12345678ULL
+
+struct mock_bundle {
+    unsigned long long magic;
+    struct addrinfo a4;
+    struct addrinfo a6;
+    struct sockaddr_in sa4;
+    struct sockaddr_in6 sa6;
+};
+
+int getaddrinfo(const char *node, const char *service,
+                const struct addrinfo *hints, struct addrinfo **res) {
+    if (node && strcmp(node, MOCK_HOST) == 0) {
+        unsigned short port = service ? (unsigned short)atoi(service) : 0;
+        struct mock_bundle *b = calloc(1, sizeof(*b));
+        if (!b) return EAI_MEMORY;
+        b->magic = MOCK_MAGIC;
+
+        b->sa4.sin_family = AF_INET;
+        b->sa4.sin_port = htons(port);
+        b->sa4.sin_addr.s_addr = htonl(0x7F000001); /* 127.0.0.1 */
+
+        b->sa6.sin6_family = AF_INET6;
+        b->sa6.sin6_port = htons(port);
+        b->sa6.sin6_addr.s6_addr[15] = 1; /* ::1 */
+
+        int socktype = (hints && hints->ai_socktype) ? hints->ai_socktype : SOCK_STREAM;
+
+        b->a4.ai_family = AF_INET;
+        b->a4.ai_socktype = socktype;
+        b->a4.ai_addrlen = sizeof(b->sa4);
+        b->a4.ai_addr = (struct sockaddr *)&b->sa4;
+        b->a4.ai_next = &b->a6;
+
+        b->a6.ai_family = AF_INET6;
+        b->a6.ai_socktype = socktype;
+        b->a6.ai_addrlen = sizeof(b->sa6);
+        b->a6.ai_addr = (struct sockaddr *)&b->sa6;
+
+        *res = &b->a4;
+        return 0;
+    }
+
+    int (*real)(const char*, const char*, const struct addrinfo*, struct addrinfo**) =
+        dlsym(RTLD_NEXT, "getaddrinfo");
+    return real(node, service, hints, res);
 }
 
-beforeAll(() => {
-  if (!canRun) return;
-
-  if (existsSync(GAI_CONF_PATH)) {
-    renameSync(GAI_CONF_PATH, GAI_CONF_BACKUP);
-    savedBackup = true;
-  }
-  writeFileSync(GAI_CONF_PATH, GAI_CONF_PREFER_IPV4);
-
-  // Belt-and-suspenders: even if the test runner crashes between
-  // beforeAll and afterAll, don't leave a modified /etc/gai.conf that
-  // bleeds into unrelated tests.
-  process.once("exit", restoreGaiConf);
-});
-
-afterAll(() => {
-  if (!canRun) return;
-  restoreGaiConf();
-});
+void freeaddrinfo(struct addrinfo *res) {
+    if (res) {
+        /* Recover the bundle head: .a4 lives at offsetof(mock_bundle, a4)
+         * inside the bundle, so subtracting that from res gets us back to
+         * the magic word. */
+        char *p = (char *)res - offsetof(struct mock_bundle, a4);
+        struct mock_bundle *b = (struct mock_bundle *)p;
+        if (b->magic == MOCK_MAGIC) {
+            free(b);
+            return;
+        }
+    }
+    void (*real)(struct addrinfo *) = dlsym(RTLD_NEXT, "freeaddrinfo");
+    real(res);
+}
+`;
 
 test.skipIf(!canRun)(
   "fetch() respects OS getaddrinfo() ordering instead of forcing IPv6 first",
   async () => {
-    // Run the fetch in a fresh subprocess: the DISABLE_ADDRCONFIG feature
-    // flag is sampled and cached on first use by the env_var layer, so it
-    // has to be set before any DNS lookup happens.
-    //
-    // `Bun.serve({ hostname: "::" })` listens on a dual-stack socket, so an
-    // incoming IPv4 connection shows up as the IPv4-mapped address
-    // `::ffff:127.0.0.1` and a native IPv6 connection shows up as `::1`.
-    // That gives us a one-bit signal for "which family did fetch pick?".
+    // Compile the shim into the test's tempDir so the .so is torn down with
+    // the directory and never pollutes a shared location.
+    const dir = tempDirWithFiles("issue-29695", { "shim.c": SHIM_C });
+    const shimSo = join(dir, "shim.so");
+    await using cc = Bun.spawn({
+      cmd: [CC!, "-shared", "-fPIC", "-ldl", "-o", shimSo, join(dir, "shim.c")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [ccStdout, ccStderr, ccExit] = await Promise.all([cc.stdout.text(), cc.stderr.text(), cc.exited]);
+    // If the compile failed the exitCode assertion below will surface the
+    // full diagnostic through the ccStderr value. The printed object keeps
+    // that message in scope for the failure message.
+    expect({ ccStdout, ccStderr, ccExit }).toMatchObject({ ccExit: 0 });
+
+    // Run the fetch in a fresh subprocess so LD_PRELOAD / the feature flag
+    // are isolated. `Bun.serve({ hostname: "::" })` listens on a dual-stack
+    // socket, so an IPv4 connection shows up as `::ffff:127.0.0.1` and a
+    // native IPv6 connection shows up as `::1` — a one-bit signal for which
+    // family the internal DNS cache picked.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -107,32 +151,35 @@ test.skipIf(!canRun)(
               return Response.json(srv.requestIP(req));
             },
           });
-          const body = await fetch(\`http://localhost:\${server.port}/\`, { keepalive: false }).then(r => r.json());
+          const body = await fetch(\`http://mock29695:\${server.port}/\`, { keepalive: false }).then(r => r.json());
           console.log(JSON.stringify(body));
         `,
       ],
       env: {
         ...bunEnv,
+        LD_PRELOAD: shimSo,
+        // DISABLE_ADDRCONFIG bypasses AI_ADDRCONFIG in the uws DNS path so the
+        // shim's AAAA record isn't filtered out on containers whose only IPv6
+        // route is loopback.
         BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG: "1",
-        // The farm proxy otherwise refuses to forward arbitrary hostnames;
-        // make sure localhost stays direct in both upper- and lowercase.
-        NO_PROXY: "localhost,127.0.0.1,::1",
-        no_proxy: "localhost,127.0.0.1,::1",
+        // Egress proxy in some CI sandboxes refuses to forward arbitrary
+        // hostnames; keep the mock hostname local.
+        NO_PROXY: "mock29695,localhost,127.0.0.1,::1",
+        no_proxy: "mock29695,localhost,127.0.0.1,::1",
       },
       stdout: "pipe",
       stderr: "pipe",
     });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
-
-    // Parse the only JSON object the child printed.
+    // Parse the one JSON line the child printed.
     const body = JSON.parse(stdout.trim().split("\n").at(-1)!);
 
-    // With the gai.conf override, OS order is [127.0.0.1, ::1]. After the
-    // fix, the internal DNS cache preserves that order and the dual-stack
-    // server sees the IPv4-mapped address. Before the fix, the cache
-    // forced AAAA to the front and the server saw pure ::1.
+    // With the shim, getaddrinfo() returns [127.0.0.1, ::1] in that order.
+    // After the fix, the internal DNS cache preserves that order and the
+    // dual-stack server sees the IPv4-mapped address. Before the fix, the
+    // cache forced AAAA to the front and the server saw pure ::1.
     expect(body).toMatchObject({ address: "::ffff:127.0.0.1", family: "IPv6" });
+    expect(exitCode).toBe(0);
   },
 );

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -17,11 +17,11 @@
 // LD_PRELOAD doesn't reach the same code path, musl's loader ignores
 // LD_PRELOAD for setuid binaries and has its own getaddrinfo, and we need
 // ::1 for the dual-stack listener to actually bind.
-import { expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
-import { bunEnv, bunExe, isGlibc, isLinux, tempDir } from "harness";
-import { join } from "node:path";
 import { which } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isGlibc, isLinux, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 const CC = which("cc") ?? which("gcc");
 
@@ -115,35 +115,33 @@ void freeaddrinfo(struct addrinfo *res) {
 }
 `;
 
-test.skipIf(!canRun)(
-  "fetch() respects OS getaddrinfo() ordering instead of forcing IPv6 first",
-  async () => {
-    // Compile the shim into the test's tempDir so the .so is torn down with
-    // the directory and never pollutes a shared location.
-    using dir = tempDir("issue-29695", { "shim.c": SHIM_C });
-    const shimSo = join(String(dir), "shim.so");
-    await using cc = Bun.spawn({
-      cmd: [CC!, "-shared", "-fPIC", "-ldl", "-o", shimSo, join(String(dir), "shim.c")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [ccStdout, ccStderr, ccExit] = await Promise.all([cc.stdout.text(), cc.stderr.text(), cc.exited]);
-    // If the compile failed the exitCode assertion below will surface the
-    // full diagnostic through the ccStderr value. The printed object keeps
-    // that message in scope for the failure message.
-    expect({ ccStdout, ccStderr, ccExit }).toMatchObject({ ccExit: 0 });
+test.skipIf(!canRun)("fetch() respects OS getaddrinfo() ordering instead of forcing IPv6 first", async () => {
+  // Compile the shim into the test's tempDir so the .so is torn down with
+  // the directory and never pollutes a shared location.
+  using dir = tempDir("issue-29695", { "shim.c": SHIM_C });
+  const shimSo = join(String(dir), "shim.so");
+  await using cc = Bun.spawn({
+    cmd: [CC!, "-shared", "-fPIC", "-ldl", "-o", shimSo, join(String(dir), "shim.c")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccStdout, ccStderr, ccExit] = await Promise.all([cc.stdout.text(), cc.stderr.text(), cc.exited]);
+  // If the compile failed the exitCode assertion below will surface the
+  // full diagnostic through the ccStderr value. The printed object keeps
+  // that message in scope for the failure message.
+  expect({ ccStdout, ccStderr, ccExit }).toMatchObject({ ccExit: 0 });
 
-    // Run the fetch in a fresh subprocess so LD_PRELOAD / the feature flag
-    // are isolated. `Bun.serve({ hostname: "::" })` listens on a dual-stack
-    // socket, so an IPv4 connection shows up as `::ffff:127.0.0.1` and a
-    // native IPv6 connection shows up as `::1` — a one-bit signal for which
-    // family the internal DNS cache picked.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        /* ts */ `
+  // Run the fetch in a fresh subprocess so LD_PRELOAD / the feature flag
+  // are isolated. `Bun.serve({ hostname: "::" })` listens on a dual-stack
+  // socket, so an IPv4 connection shows up as `::ffff:127.0.0.1` and a
+  // native IPv6 connection shows up as `::1` — a one-bit signal for which
+  // family the internal DNS cache picked.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      /* ts */ `
           using server = Bun.serve({
             hostname: "::",
             port: 0,
@@ -154,32 +152,31 @@ test.skipIf(!canRun)(
           const body = await fetch(\`http://mock29695:\${server.port}/\`, { keepalive: false }).then(r => r.json());
           console.log(JSON.stringify(body));
         `,
-      ],
-      env: {
-        ...bunEnv,
-        LD_PRELOAD: shimSo,
-        // DISABLE_ADDRCONFIG bypasses AI_ADDRCONFIG in the uws DNS path so the
-        // shim's AAAA record isn't filtered out on containers whose only IPv6
-        // route is loopback.
-        BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG: "1",
-        // Egress proxy in some CI sandboxes refuses to forward arbitrary
-        // hostnames; keep the mock hostname local.
-        NO_PROXY: "mock29695,localhost,127.0.0.1,::1",
-        no_proxy: "mock29695,localhost,127.0.0.1,::1",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    ],
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: shimSo,
+      // DISABLE_ADDRCONFIG bypasses AI_ADDRCONFIG in the uws DNS path so the
+      // shim's AAAA record isn't filtered out on containers whose only IPv6
+      // route is loopback.
+      BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG: "1",
+      // Egress proxy in some CI sandboxes refuses to forward arbitrary
+      // hostnames; keep the mock hostname local.
+      NO_PROXY: "mock29695,localhost,127.0.0.1,::1",
+      no_proxy: "mock29695,localhost,127.0.0.1,::1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Parse the one JSON line the child printed.
-    const body = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  // Parse the one JSON line the child printed.
+  const body = JSON.parse(stdout.trim().split("\n").at(-1)!);
 
-    // With the shim, getaddrinfo() returns [127.0.0.1, ::1] in that order.
-    // After the fix, the internal DNS cache preserves that order and the
-    // dual-stack server sees the IPv4-mapped address. Before the fix, the
-    // cache forced AAAA to the front and the server saw pure ::1.
-    expect(body).toMatchObject({ address: "::ffff:127.0.0.1", family: "IPv6" });
-    expect(exitCode).toBe(0);
-  },
-);
+  // With the shim, getaddrinfo() returns [127.0.0.1, ::1] in that order.
+  // After the fix, the internal DNS cache preserves that order and the
+  // dual-stack server sees the IPv4-mapped address. Before the fix, the
+  // cache forced AAAA to the front and the server saw pure ::1.
+  expect(body).toMatchObject({ address: "::ffff:127.0.0.1", family: "IPv6" });
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -37,28 +37,65 @@ const canRun =
 
 // A libc `getaddrinfo`/`freeaddrinfo` shim: for the host `mock29695` it
 // returns a two-element linked list [127.0.0.1, ::1] in that exact order,
-// packed into a single allocation so `freeaddrinfo` can be a single free().
-// Everything else is forwarded to the real implementations via dlsym.
+// packed into a single allocation. Everything else is forwarded to the
+// real implementations via dlsym.
+//
+// Identifying "our" bundles in freeaddrinfo is done through a small
+// registry of live bundle head pointers rather than by reading memory
+// behind the caller-supplied addrinfo — the real glibc getaddrinfo()
+// (called for Bun.serve({hostname: "::"})) hands back allocations we do
+// not own, and reading bytes outside those would be undefined behavior.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <stddef.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 
 #define MOCK_HOST "mock29695"
-#define MOCK_MAGIC 0xBEEFCAFE12345678ULL
+#define MOCK_REGISTRY_SIZE 32
 
 struct mock_bundle {
-    unsigned long long magic;
     struct addrinfo a4;
     struct addrinfo a6;
     struct sockaddr_in sa4;
     struct sockaddr_in6 sa6;
 };
+
+/* Live bundles we handed out. The registry is tiny and protected by a
+ * mutex — the test only makes a handful of DNS calls, so walking this
+ * is fine. Slots that match freeaddrinfo()'s res are cleared and freed;
+ * anything else falls through to the real freeaddrinfo. */
+static struct mock_bundle *g_registry[MOCK_REGISTRY_SIZE];
+static pthread_mutex_t g_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static void registry_add(struct mock_bundle *b) {
+    pthread_mutex_lock(&g_registry_mutex);
+    for (int i = 0; i < MOCK_REGISTRY_SIZE; i++) {
+        if (g_registry[i] == NULL) {
+            g_registry[i] = b;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_registry_mutex);
+}
+
+static struct mock_bundle *registry_take(const struct addrinfo *res) {
+    struct mock_bundle *found = NULL;
+    pthread_mutex_lock(&g_registry_mutex);
+    for (int i = 0; i < MOCK_REGISTRY_SIZE; i++) {
+        if (g_registry[i] != NULL && res == &g_registry[i]->a4) {
+            found = g_registry[i];
+            g_registry[i] = NULL;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&g_registry_mutex);
+    return found;
+}
 
 int getaddrinfo(const char *node, const char *service,
                 const struct addrinfo *hints, struct addrinfo **res) {
@@ -66,7 +103,6 @@ int getaddrinfo(const char *node, const char *service,
         unsigned short port = service ? (unsigned short)atoi(service) : 0;
         struct mock_bundle *b = calloc(1, sizeof(*b));
         if (!b) return EAI_MEMORY;
-        b->magic = MOCK_MAGIC;
 
         b->sa4.sin_family = AF_INET;
         b->sa4.sin_port = htons(port);
@@ -89,6 +125,7 @@ int getaddrinfo(const char *node, const char *service,
         b->a6.ai_addrlen = sizeof(b->sa6);
         b->a6.ai_addr = (struct sockaddr *)&b->sa6;
 
+        registry_add(b);
         *res = &b->a4;
         return 0;
     }
@@ -99,16 +136,10 @@ int getaddrinfo(const char *node, const char *service,
 }
 
 void freeaddrinfo(struct addrinfo *res) {
-    if (res) {
-        /* Recover the bundle head: .a4 lives at offsetof(mock_bundle, a4)
-         * inside the bundle, so subtracting that from res gets us back to
-         * the magic word. */
-        char *p = (char *)res - offsetof(struct mock_bundle, a4);
-        struct mock_bundle *b = (struct mock_bundle *)p;
-        if (b->magic == MOCK_MAGIC) {
-            free(b);
-            return;
-        }
+    struct mock_bundle *b = registry_take(res);
+    if (b) {
+        free(b);
+        return;
     }
     void (*real)(struct addrinfo *) = dlsym(RTLD_NEXT, "freeaddrinfo");
     real(res);
@@ -135,8 +166,18 @@ test.skipIf(!canRun)("fetch() respects OS getaddrinfo() ordering instead of forc
   // Run the fetch in a fresh subprocess so LD_PRELOAD / the feature flag
   // are isolated. `Bun.serve({ hostname: "::" })` listens on a dual-stack
   // socket, so an IPv4 connection shows up as `::ffff:127.0.0.1` and a
-  // native IPv6 connection shows up as `::1` — a one-bit signal for which
-  // family the internal DNS cache picked.
+  // native IPv6 connection shows up as `::1`.
+  //
+  // uws' start_connections() opens up to CONCURRENT_CONNECTIONS=4 sockets
+  // in the same tick (packages/bun-usockets/src/context.c:596), so strictly
+  // this test observes *which loopback connect won the happy-eyeballs
+  // race* — not which entry `processResults()` placed first. On glibc
+  // Linux loopback the first connect syscall wins deterministically in
+  // practice: the fix makes it pass 10/10 and the buggy IPv6-first
+  // interleave fails 10/10 on the same host. If this ever flakes in CI,
+  // the right fix is a stronger probe (eBPF socket trace, or reducing
+  // CONCURRENT_CONNECTIONS via an env flag) rather than loosening the
+  // assertion.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -168,7 +209,13 @@ test.skipIf(!canRun)("fetch() respects OS getaddrinfo() ordering instead of forc
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Surface the subprocess's stderr before we try to parse stdout — if the
+  // child failed (LD_PRELOAD rejected, `::` bind failed, fetch threw) the
+  // real error lives in stderr and JSON.parse("") would otherwise mask it
+  // with a useless "Unexpected end of JSON input".
+  expect({ exitCode, stderr }).toMatchObject({ exitCode: 0 });
 
   // Parse the one JSON line the child printed.
   const body = JSON.parse(stdout.trim().split("\n").at(-1)!);
@@ -178,5 +225,4 @@ test.skipIf(!canRun)("fetch() respects OS getaddrinfo() ordering instead of forc
   // dual-stack server sees the IPv4-mapped address. Before the fix, the
   // cache forced AAAA to the front and the server saw pure ::1.
   expect(body).toMatchObject({ address: "::ffff:127.0.0.1", family: "IPv6" });
-  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -1,0 +1,138 @@
+// Regression for https://github.com/oven-sh/bun/issues/29695
+//
+// The internal DNS cache that fetch/Bun.serve outbound/uws uses was always
+// reordering getaddrinfo() results so the first entry was IPv6. On hosts where
+// IPv6 is configured but a specific destination is unreachable (python.org via
+// a VPN, etc.) this made fetch pick a dead AAAA before a reachable A, producing
+// ECONNRESET — and it also disagreed with `dns.lookup()` and with the OS's own
+// RFC 6724 destination selection.
+//
+// This test drives the bug via a custom `/etc/gai.conf` that asks glibc to
+// prefer IPv4 and then checks that the uws connect path honors that order.
+// It only runs on glibc Linux as root (the only environment that can rewrite
+// gai.conf and has getaddrinfo() read it) — macOS uses libinfo and has no
+// gai.conf, musl has no gai.conf, and containers without root can't make
+// the syscall observe a different order.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, isGlibc, isLinux } from "harness";
+
+const GAI_CONF_PATH = "/etc/gai.conf";
+const GAI_CONF_BACKUP = "/etc/gai.conf.bun-29695.bak";
+
+// Prefer IPv4 over IPv6 at the destination-selection step. This flips the
+// order glibc returns from getaddrinfo("localhost") so the list is
+// [127.0.0.1, ::1] instead of the usual [::1, 127.0.0.1] — giving us a
+// deterministic signal that the uws DNS path respected OS order rather
+// than forcing AAAA first.
+const GAI_CONF_PREFER_IPV4 = `# Temporary override written by test/regression/issue/29695.test.ts.
+label  ::1/128       0
+label  ::/0          1
+label  2002::/16     2
+label  ::/96         3
+label  ::ffff:0:0/96 4
+label  fec0::/10     5
+label  fc00::/7      6
+label  2001:0::/32   7
+
+precedence  ::1/128       50
+precedence  ::/0          40
+precedence  2002::/16     30
+precedence  ::/96         20
+precedence  ::ffff:0:0/96 100
+`;
+
+const canRun =
+  isLinux &&
+  isGlibc &&
+  process.getuid?.() === 0 &&
+  // Need ::1 loopback so we have an AAAA record to race against 127.0.0.1.
+  existsSync("/proc/net/if_inet6") &&
+  readFileSync("/proc/net/if_inet6", "utf8").split("\n").some(line => line.startsWith("00000000000000000000000000000001"));
+
+let savedBackup = false;
+
+function restoreGaiConf() {
+  try {
+    unlinkSync(GAI_CONF_PATH);
+  } catch {}
+  if (savedBackup) {
+    try {
+      renameSync(GAI_CONF_BACKUP, GAI_CONF_PATH);
+    } catch {}
+    savedBackup = false;
+  }
+}
+
+beforeAll(() => {
+  if (!canRun) return;
+
+  if (existsSync(GAI_CONF_PATH)) {
+    renameSync(GAI_CONF_PATH, GAI_CONF_BACKUP);
+    savedBackup = true;
+  }
+  writeFileSync(GAI_CONF_PATH, GAI_CONF_PREFER_IPV4);
+
+  // Belt-and-suspenders: even if the test runner crashes between
+  // beforeAll and afterAll, don't leave a modified /etc/gai.conf that
+  // bleeds into unrelated tests.
+  process.once("exit", restoreGaiConf);
+});
+
+afterAll(() => {
+  if (!canRun) return;
+  restoreGaiConf();
+});
+
+test.skipIf(!canRun)(
+  "fetch() respects OS getaddrinfo() ordering instead of forcing IPv6 first",
+  async () => {
+    // Run the fetch in a fresh subprocess: the DISABLE_ADDRCONFIG feature
+    // flag is sampled and cached on first use by the env_var layer, so it
+    // has to be set before any DNS lookup happens.
+    //
+    // `Bun.serve({ hostname: "::" })` listens on a dual-stack socket, so an
+    // incoming IPv4 connection shows up as the IPv4-mapped address
+    // `::ffff:127.0.0.1` and a native IPv6 connection shows up as `::1`.
+    // That gives us a one-bit signal for "which family did fetch pick?".
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* ts */ `
+          using server = Bun.serve({
+            hostname: "::",
+            port: 0,
+            fetch(req, srv) {
+              return Response.json(srv.requestIP(req));
+            },
+          });
+          const body = await fetch(\`http://localhost:\${server.port}/\`, { keepalive: false }).then(r => r.json());
+          console.log(JSON.stringify(body));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_FEATURE_FLAG_DISABLE_ADDRCONFIG: "1",
+        // The farm proxy otherwise refuses to forward arbitrary hostnames;
+        // make sure localhost stays direct in both upper- and lowercase.
+        NO_PROXY: "localhost,127.0.0.1,::1",
+        no_proxy: "localhost,127.0.0.1,::1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: expect.any(String), exitCode: 0 });
+
+    // Parse the only JSON object the child printed.
+    const body = JSON.parse(stdout.trim().split("\n").at(-1)!);
+
+    // With the gai.conf override, OS order is [127.0.0.1, ::1]. After the
+    // fix, the internal DNS cache preserves that order and the dual-stack
+    // server sees the IPv4-mapped address. Before the fix, the cache
+    // forced AAAA to the front and the server saw pure ::1.
+    expect(body).toMatchObject({ address: "::ffff:127.0.0.1", family: "IPv6" });
+  },
+);

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -65,18 +65,24 @@ struct mock_bundle {
     struct sockaddr_in6 sa6;
 };
 
-/* Live bundles we handed out. The registry is tiny and protected by a
+/* Live bundles we handed out, paired with the addrinfo head pointer the
+ * caller actually received. The registry is tiny and protected by a
  * mutex — the test only makes a handful of DNS calls, so walking this
  * is fine. Slots that match freeaddrinfo()'s res are cleared and freed;
  * anything else falls through to the real freeaddrinfo. */
-static struct mock_bundle *g_registry[MOCK_REGISTRY_SIZE];
+struct mock_slot {
+    struct mock_bundle *bundle;
+    struct addrinfo *head;
+};
+static struct mock_slot g_registry[MOCK_REGISTRY_SIZE];
 static pthread_mutex_t g_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-static void registry_add(struct mock_bundle *b) {
+static void registry_add(struct mock_bundle *b, struct addrinfo *head) {
     pthread_mutex_lock(&g_registry_mutex);
     for (int i = 0; i < MOCK_REGISTRY_SIZE; i++) {
-        if (g_registry[i] == NULL) {
-            g_registry[i] = b;
+        if (g_registry[i].bundle == NULL) {
+            g_registry[i].bundle = b;
+            g_registry[i].head = head;
             break;
         }
     }
@@ -87,9 +93,10 @@ static struct mock_bundle *registry_take(const struct addrinfo *res) {
     struct mock_bundle *found = NULL;
     pthread_mutex_lock(&g_registry_mutex);
     for (int i = 0; i < MOCK_REGISTRY_SIZE; i++) {
-        if (g_registry[i] != NULL && res == &g_registry[i]->a4) {
-            found = g_registry[i];
-            g_registry[i] = NULL;
+        if (g_registry[i].bundle != NULL && g_registry[i].head == res) {
+            found = g_registry[i].bundle;
+            g_registry[i].bundle = NULL;
+            g_registry[i].head = NULL;
             break;
         }
     }
@@ -100,6 +107,11 @@ static struct mock_bundle *registry_take(const struct addrinfo *res) {
 int getaddrinfo(const char *node, const char *service,
                 const struct addrinfo *hints, struct addrinfo **res) {
     if (node && strcmp(node, MOCK_HOST) == 0) {
+        int family = hints ? hints->ai_family : AF_UNSPEC;
+        if (family != AF_UNSPEC && family != AF_INET && family != AF_INET6) {
+            return EAI_FAMILY;
+        }
+
         unsigned short port = service ? (unsigned short)atoi(service) : 0;
         struct mock_bundle *b = calloc(1, sizeof(*b));
         if (!b) return EAI_MEMORY;
@@ -118,15 +130,28 @@ int getaddrinfo(const char *node, const char *service,
         b->a4.ai_socktype = socktype;
         b->a4.ai_addrlen = sizeof(b->sa4);
         b->a4.ai_addr = (struct sockaddr *)&b->sa4;
-        b->a4.ai_next = &b->a6;
 
         b->a6.ai_family = AF_INET6;
         b->a6.ai_socktype = socktype;
         b->a6.ai_addrlen = sizeof(b->sa6);
         b->a6.ai_addr = (struct sockaddr *)&b->sa6;
 
-        registry_add(b);
-        *res = &b->a4;
+        /* Honor hints->ai_family so this shim doesn't violate the libc
+         * contract if the caller ever restricts the family. AF_UNSPEC
+         * keeps both entries in the IPv4-first order this regression
+         * guard depends on. */
+        struct addrinfo *head;
+        if (family == AF_INET) {
+            head = &b->a4;
+        } else if (family == AF_INET6) {
+            head = &b->a6;
+        } else {
+            b->a4.ai_next = &b->a6;
+            head = &b->a4;
+        }
+
+        registry_add(b, head);
+        *res = head;
         return 0;
     }
 

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -19,7 +19,7 @@
 // ::1 for the dual-stack listener to actually bind.
 import { expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
-import { bunEnv, bunExe, isGlibc, isLinux, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isGlibc, isLinux, tempDir } from "harness";
 import { join } from "node:path";
 import { which } from "bun";
 
@@ -120,10 +120,10 @@ test.skipIf(!canRun)(
   async () => {
     // Compile the shim into the test's tempDir so the .so is torn down with
     // the directory and never pollutes a shared location.
-    const dir = tempDirWithFiles("issue-29695", { "shim.c": SHIM_C });
-    const shimSo = join(dir, "shim.so");
+    using dir = tempDir("issue-29695", { "shim.c": SHIM_C });
+    const shimSo = join(String(dir), "shim.so");
     await using cc = Bun.spawn({
-      cmd: [CC!, "-shared", "-fPIC", "-ldl", "-o", shimSo, join(dir, "shim.c")],
+      cmd: [CC!, "-shared", "-fPIC", "-ldl", "-o", shimSo, join(String(dir), "shim.c")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/regression/issue/29695.test.ts
+++ b/test/regression/issue/29695.test.ts
@@ -194,9 +194,9 @@ test.skipIf(!canRun)("fetch() respects OS getaddrinfo() ordering instead of forc
   // native IPv6 connection shows up as `::1`.
   //
   // uws' start_connections() opens up to CONCURRENT_CONNECTIONS=4 sockets
-  // in the same tick (packages/bun-usockets/src/context.c:596), so strictly
+  // in the same tick (packages/bun-usockets/src/context.c), so strictly
   // this test observes *which loopback connect won the happy-eyeballs
-  // race* — not which entry `processResults()` placed first. On glibc
+  // race* — not which entry `process_results()` placed first. On glibc
   // Linux loopback the first connect syscall wins deterministically in
   // practice: the fix makes it pass 10/10 and the buggy IPv6-first
   // interleave fails 10/10 on the same host. If this ever flakes in CI,


### PR DESCRIPTION
## What

`process_results()` in `src/runtime/dns_jsc/dns.rs` — the internal DNS cache that feeds `fetch`, `Bun.serve` outbound, `Bun.connect` and every other uws connect — was always reordering `getaddrinfo()` results so the first entry was IPv6:

```rust
// sort (interleave ipv4 and ipv6)
let mut want = netc::AF_INET6 as usize;
'outer: for idx in 0..count {
    if results[idx].info.ai_family as usize == want {
        continue;
    }
    for j in (idx + 1)..count {
        if results[j].info.ai_family as usize == want {
            results.swap(idx, j);
            want = if want == netc::AF_INET6 as usize {
                netc::AF_INET as usize
            } else {
                netc::AF_INET6 as usize
            };
        }
    }
    break 'outer;
}
```

On hosts where IPv6 is configured but a specific destination is unreachable (the VPN case in #29695 against `www.python.org`), this picks a dead AAAA before a reachable A and returns `ECONNRESET`. It also disagrees with `dns.lookup()` (which reports `verbatim` by default) and with what the OS already decided via RFC 6724 destination selection and `/etc/gai.conf`.

(This originally modified the Zig `processResults()` in `src/bun.js/api/bun/dns.zig`; the DNS module was ported Zig→Rust on main, so the fix was re-applied to the Rust `process_results()`.)

## Fix

Drop the IPv6-first interleave. The packing into a single allocation stays (the linked list still needs to outlive `freeaddrinfo`); the sort goes. `AI_ADDRCONFIG`, `gai.conf`, and libinfo on mac have already told glibc which family should come first for this destination — we should just honor that.

## Verification

`test/regression/issue/29695.test.ts` compiles a small `LD_PRELOAD` shim that makes `getaddrinfo("mock29695")` return `[127.0.0.1, ::1]` in that exact order, then spawns a Bun subprocess with the shim preloaded running `Bun.serve({ hostname: "::" })` and `fetch("http://mock29695:PORT/")`. The dual-stack listener reports `::ffff:127.0.0.1` when the connection came in over IPv4 and `::1` when it was native IPv6, giving a one-bit signal for which family the internal DNS cache picked.

- **Before:** subprocess hits the server as `::1` (the cache forced AAAA to the front).
- **After:** subprocess hits the server as `::ffff:127.0.0.1` (OS order preserved).

Guarded to glibc Linux with `cc` available and an IPv6 loopback — macOS uses libinfo so LD_PRELOAD doesn't intercept the same code path, musl ignores LD_PRELOAD for setuid binaries and has its own getaddrinfo, and we need `::1` for the dual-stack listener to bind. The shim lives in a disposable `tempDir()` scoped to the one `Bun.spawn` that needs it, so nothing host-global is touched.

Fixes #29695