### PR TITLE
test(fs.glob): regression coverage for symlink cycles (#29699)

### DIFF
--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -288,9 +288,9 @@ describe.skipIf(isWindows)("fs.glob symlink semantics (matches Node)", () => {
       matches.push(file);
       if (matches.length > 3) break; // guard: the bug emitted an unbounded stream
     }
-    expect(matches).toEqual([path.join("src", "foo.test.ts")]);
+    expect(matches).toStrictEqual([path.join("src", "foo.test.ts")]);
     // globSync takes the same path.
-    expect(fs.globSync("**/*.test.ts", { cwd: path.join(root, "a") })).toEqual([path.join("src", "foo.test.ts")]);
+    expect(fs.globSync("**/*.test.ts", { cwd: path.join(root, "a") })).toStrictEqual([path.join("src", "foo.test.ts")]);
   });
 
   it("a wildcard segment does not descend into a directory symlink", () => {
@@ -300,7 +300,7 @@ describe.skipIf(isWindows)("fs.glob symlink semantics (matches Node)", () => {
     fs.symlinkSync("dir", path.join(root, "link"), "dir");
     // `*` matches both `dir` and `link`, but the walk only descends the
     // real directory — the symlink is not crossed.
-    expect(fs.globSync("*/*.txt", { cwd: root })).toEqual([path.join("dir", "inside.txt")]);
+    expect(fs.globSync("*/*.txt", { cwd: root })).toStrictEqual([path.join("dir", "inside.txt")]);
   });
 
   it("a literal path segment still traverses a directory symlink", () => {
@@ -310,7 +310,7 @@ describe.skipIf(isWindows)("fs.glob symlink semantics (matches Node)", () => {
       "dir/inside.txt": "x",
     });
     fs.symlinkSync("dir", path.join(root, "link"), "dir");
-    expect(fs.globSync("link/*.txt", { cwd: root })).toEqual([path.join("link", "inside.txt")]);
+    expect(fs.globSync("link/*.txt", { cwd: root })).toStrictEqual([path.join("link", "inside.txt")]);
   });
 
   it("matches a symlink that points at a file", () => {
@@ -318,6 +318,6 @@ describe.skipIf(isWindows)("fs.glob symlink semantics (matches Node)", () => {
       "target.txt": "t",
     });
     fs.symlinkSync("target.txt", path.join(root, "alias.txt"), "file");
-    expect(fs.globSync("*.txt", { cwd: root }).sort()).toEqual(["alias.txt", "target.txt"]);
+    expect(fs.globSync("*.txt", { cwd: root }).sort()).toStrictEqual(["alias.txt", "target.txt"]);
   });
 });

--- a/test/js/node/fs/glob.test.ts
+++ b/test/js/node/fs/glob.test.ts
@@ -5,6 +5,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { isWindows, tempDirWithFiles } from "harness";
 import fs from "node:fs";
+import path from "node:path";
 
 let tmp: string;
 beforeAll(() => {
@@ -259,5 +260,64 @@ describe("fs.globSync exclude with withFileTypes", () => {
     const inners = results.filter(d => d.name === "inner.txt");
     expect(inners).toHaveLength(1);
     expect(String(inners[0].parentPath).replaceAll("\\", "/")).toEndWith("keep");
+  });
+});
+
+// Regression coverage for https://github.com/oven-sh/bun/issues/29699:
+// fs.glob must not follow directory symlinks (Node's default), or a
+// pnpm-style symlink cycle loops until ENAMETOOLONG. These are
+// skipped on Windows because the fixtures need real directory symlinks.
+describe.skipIf(isWindows)("fs.glob symlink semantics (matches Node)", () => {
+  it("does not loop on a pnpm-style symlink cycle", async () => {
+    // a/node_modules/b -> b, b/node_modules/c -> c, c/node_modules/a -> a.
+    // Following the cycle would emit bar.test.ts and deeper duplicates
+    // forever; Node finds exactly the one test file under the cwd.
+    const root = tempDirWithFiles("glob-pnpm-cycle", {
+      "a/src/foo.test.ts": "export {}",
+      "b/src/bar.test.ts": "export {}",
+      "a/node_modules/.keep": "",
+      "b/node_modules/.keep": "",
+      "c/node_modules/.keep": "",
+    });
+    fs.symlinkSync("../../b", path.join(root, "a/node_modules/b"), "dir");
+    fs.symlinkSync("../../c", path.join(root, "b/node_modules/c"), "dir");
+    fs.symlinkSync("../../a", path.join(root, "c/node_modules/a"), "dir");
+
+    const matches: string[] = [];
+    for await (const file of fs.promises.glob("**/*.test.ts", { cwd: path.join(root, "a") })) {
+      matches.push(file);
+      if (matches.length > 3) break; // guard: the bug emitted an unbounded stream
+    }
+    expect(matches).toEqual([path.join("src", "foo.test.ts")]);
+    // globSync takes the same path.
+    expect(fs.globSync("**/*.test.ts", { cwd: path.join(root, "a") })).toEqual([path.join("src", "foo.test.ts")]);
+  });
+
+  it("a wildcard segment does not descend into a directory symlink", () => {
+    const root = tempDirWithFiles("glob-wild-symlink", {
+      "dir/inside.txt": "x",
+    });
+    fs.symlinkSync("dir", path.join(root, "link"), "dir");
+    // `*` matches both `dir` and `link`, but the walk only descends the
+    // real directory — the symlink is not crossed.
+    expect(fs.globSync("*/*.txt", { cwd: root })).toEqual([path.join("dir", "inside.txt")]);
+  });
+
+  it("a literal path segment still traverses a directory symlink", () => {
+    // Node's nuance: wildcard segments stop at symlinks, literal ones
+    // cross them. `link/*.txt` names the symlink literally, so it descends.
+    const root = tempDirWithFiles("glob-literal-symlink", {
+      "dir/inside.txt": "x",
+    });
+    fs.symlinkSync("dir", path.join(root, "link"), "dir");
+    expect(fs.globSync("link/*.txt", { cwd: root })).toEqual([path.join("link", "inside.txt")]);
+  });
+
+  it("matches a symlink that points at a file", () => {
+    const root = tempDirWithFiles("glob-symlink-file", {
+      "target.txt": "t",
+    });
+    fs.symlinkSync("target.txt", path.join(root, "alias.txt"), "file");
+    expect(fs.globSync("*.txt", { cwd: root }).sort()).toEqual(["alias.txt", "target.txt"]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Adds regression coverage for #29699 (`fs.glob` followed directory symlinks and looped on pnpm-style cycles).

This PR originally fixed the bug in the Zig `GlobWalker` + the thin JS wrapper over `Bun.Glob`. While it was in review, `main` landed a from-scratch rewrite of `fs.glob` as a pure-JS port of Node v26.3.0 (commit dae2e8722b, "fs: port Node.js v26.3.0 fs tests ... glob port", #31830), which replaced that implementation entirely and independently fixed #29699. The original fix is therefore dead code, so this PR is rebased onto `main` and reduced to the regression tests the rewrite did not include.

The rewrite added no symlink or cycle tests, so the reported bug had no guard. This adds four `fs.glob` tests in `test/js/node/fs/glob.test.ts`, skipped on Windows (they need real directory symlinks):

- pnpm-style `a -> b -> c -> a` cycle yields exactly one match (the bug emitted an unbounded stream of duplicates until `ENAMETOOLONG`)
- wildcard segments do not descend directory symlinks
- literal segments still traverse directory symlinks (Node's nuance)
- symlinks pointing at files still match

### How did you verify your code works?

- Ran the four new tests on a debug build of `main`: all pass.
- Ran the issue's exact reproduction on the same build:

  ```
  runtime: bun 1.4.0-debug
  found: ["src/foo.test.ts"]      # matches Node v26.3.0 exactly
  ```

- Diffed `main` against Node v26.3.0 across 15 symlink edge cases (wildcard-vs-literal descent, trailing-slash-on-symlink, dangling symlinks, absolute patterns). `main` matches Node on all of them, confirming there is no behavioral gap left to fix.

Because the bug is already fixed on `main`, these are regression guards rather than a fail-before/pass-after fix — there is no unfixed `main` state to demonstrate against. A maintainer may prefer to merge the coverage or close this PR in favor of #31830.