### PR TITLE
Fix stack overflow in Bun.inspect for JSX elements with circular references

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,24 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference does not crash", () => {
+  const a = { $$typeof: Symbol.for("react.element"), type: "div" };
+  a.key = a;
+  expect(Bun.inspect(a)).toBe("<div key=[Circular] />");
+
+  const b = { $$typeof: Symbol.for("react.element"), type: "span", props: {} };
+  b.props.children = b;
+  expect(Bun.inspect(b)).toBe("<span>\n  [Circular]\n</span>");
+
+  const c = { $$typeof: Symbol.for("react.element"), type: "p", props: {} };
+  c.props.self = c;
+  expect(Bun.inspect(c)).toBe("<p self=[Circular] />");
+
+  const d = { $$typeof: Symbol.for("react.element"), type: "ul", props: {} };
+  d.props.children = [d];
+  expect(Bun.inspect(d)).toBe("<ul>\n  [Circular]\n</ul>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What

`Bun.inspect()` (and `console.log`) crashed with a stack overflow when given a React element that referenced itself via `key`, `props`, or `children`.

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div" };
el.key = el;
Bun.inspect(el); // SIGSEGV
```

## Why

`Tag.canHaveCircularReferences()` did not include `.JSX`, so the visited-map cycle detection in `printAs` was skipped entirely for JSX elements. Any cycle through a React element recursed until the stack was exhausted.

## Fix

Add `.JSX` to `canHaveCircularReferences()` in both `ConsoleObject.zig` and `test/pretty_format.zig`. Circular JSX references now render as `[Circular]` like other objects:

```
<div key=[Circular] />
```

Found by Fuzzilli (fingerprint `6e718886f45af13a`).