### PR TITLE
ci: drop redundant darwin release=13 test platforms

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -138,10 +138,14 @@ const buildPlatforms = [
  * @type {Platform[]}
  */
 const testPlatforms = [
+  // Darwin test agents are targeted by queue + arch only (see getTestAgent),
+  // not by `release` — so a second release entry per arch just runs the suite
+  // twice on whatever agent is free, it doesn't pin a specific macOS version.
+  // We used to list "13" here as `tier: previous`; dropping it halves the
+  // per-PR darwin job count with no coverage loss. New macOS 26 runners pick
+  // up these jobs without needing a separate entry.
   { os: "darwin", arch: "aarch64", release: "14", tier: "latest" },
-  { os: "darwin", arch: "aarch64", release: "13", tier: "previous" },
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
-  { os: "darwin", arch: "x64", release: "13", tier: "previous" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", baseline: true, distro: "debian", release: "13", tier: "latest" },


### PR DESCRIPTION
## Summary

`getTestAgent()` for darwin targets jobs by `queue` + `os` + `arch` only — **not** `release`. So the `release: "13"` entries weren't actually testing on macOS 13; they just ran the suite a second time on whatever agent picked them up. (There are no `release=13` arm64 agents in the fleet anyway.)

Dropping them halves per-PR darwin test jobs (**8 → 4**) with zero coverage loss. The fixed-capacity macOS runner fleet has been the throughput bottleneck (~1.8 PR/hr arm64); this doubles effective throughput before any new hardware.

New macOS 26 runners pick up the remaining jobs without needing a separate `release: "26"` entry, since release isn't part of the agent query rules.

## Test plan
- [x] `node --check .buildkite/ci.mjs`
- [ ] Verify a PR build generates 4 darwin test jobs instead of 8