### PR TITLE
[DO NOT MERGE] one-shot recovery for darwin-test-x64-1

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1284,6 +1284,29 @@ async function getPipelineOptions() {
 async function getPipeline(options = {}) {
   const priority = getPriority();
 
+  // One-shot recovery branch: emit only a fix-up step that runs on every
+  // macOS-13 x64 test box (idempotent). Used to restore darwin-test-x64-1's
+  // tailscale binary + add release-tier=oldest via its still-working
+  // buildkite-agent. Delete this block (and the branch) once it's run.
+  if (getEnv("BUILDKITE_BRANCH", false) === "claude/fix-darwin-test-x64-1") {
+    return {
+      priority,
+      steps: [
+        {
+          key: "recover-darwin-x64",
+          label: ":hammer_and_wrench: recover darwin-test-x64",
+          // Run on each macOS-13 x64 test box; the script is a no-op on the
+          // two that are already healthy.
+          parallelism: 3,
+          agents: { queue: "test-darwin", os: "darwin", arch: "x64", release: "13" },
+          command: "bash .buildkite/recover-darwin-x64.sh",
+          timeout_in_minutes: 5,
+        },
+      ],
+    };
+  }
+
+
   if (isBuildManual() && !Object.keys(options).length) {
     return {
       priority,

--- a/.buildkite/recover-darwin-x64.sh
+++ b/.buildkite/recover-darwin-x64.sh
@@ -40,78 +40,41 @@ fi
 # we're back in via tailscale-ssh as root, we'll reinstall the system daemon
 # properly and remove this LaunchAgent.
 #
-# Diagnostics — figure out why the system daemon isn't reachable even
-# though the plist exists.
-echo "--- tailscale diagnostics"
-ls -l /Library/LaunchDaemons/com.tailscale.tailscaled.plist /usr/local/bin/tailscaled 2>&1
-launchctl print system/com.tailscale.tailscaled 2>&1 | grep -E "state|pid|last exit" || true
-pgrep -fl tailscaled || echo "(no tailscaled process)"
-/usr/local/bin/tailscale status 2>&1 | head -5 || true
-ls -la /Library/Tailscale/ 2>&1 || true
-
 # Only act on the broken box (public IP match). Siblings are fine.
 PUBIP="$(curl -s --max-time 3 ifconfig.me || true)"
 if [ "$PUBIP" = "207.254.60.44" ]; then
 
-  echo "--- this is x64-1; bootstrapping userspace daemon"
+  echo "--- this is x64-1; re-authenticating system tailscaled"
 
+  # Clean up the abandoned userspace LaunchAgent attempt from the previous
+  # revision (it failed to bootstrap from a non-GUI session anyway).
+  rm -f "$HOME/Library/LaunchAgents/com.tailscale.userspace.plist"
+  rm -rf "$HOME/.tailscale-userspace"
+
+  # The system daemon IS running (see diagnostics) but the node was removed
+  # server-side, so it's connected-to-nothing with stale local state. Re-auth
+  # it with a fresh key. `tailscale up` talks to the running tailscaled over
+  # its local socket; the operator is the install user, so administrator can
+  # do this without sudo.
   KEY="$(buildkite-agent secret get TAILSCALE_AUTH_KEY_TMP 2>/dev/null || true)"
   if [ -z "$KEY" ]; then
-    echo "WARN: TAILSCALE_AUTH_KEY_TMP secret not set — skipping tailscale bring-up"
+    echo "WARN: TAILSCALE_AUTH_KEY_TMP secret not set — skipping re-auth"
   else
-    TS_HOME="$HOME/.tailscale-userspace"
-    SOCK="$TS_HOME/tailscaled.sock"
-    mkdir -p "$TS_HOME" "$HOME/Library/LaunchAgents"
-
-    # User LaunchAgent so it survives the daily reboot until we replace it
-    # with the real system daemon. RunAtLoad+KeepAlive = start at login and
-    # restart on crash.
-    cat > "$HOME/Library/LaunchAgents/com.tailscale.userspace.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.tailscale.userspace</string>
-  <key>ProgramArguments</key><array>
-    <string>/usr/local/bin/tailscaled</string>
-    <string>--tun=userspace-networking</string>
-    <string>--statedir=$TS_HOME</string>
-    <string>--socket=$SOCK</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>$TS_HOME/tailscaled.log</string>
-  <key>StandardErrorPath</key><string>$TS_HOME/tailscaled.log</string>
-</dict></plist>
-PLIST
-
-    # Start now. bootstrap is idempotent-ish; ignore "already loaded" noise.
-    launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.tailscale.userspace.plist" 2>&1 || true
-    launchctl kickstart -k "gui/$(id -u)/com.tailscale.userspace" 2>&1 || true
-
-    # Give tailscaled a moment to open its socket.
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-      [ -S "$SOCK" ] && break
-      sleep 1
-    done
-
-    if [ -S "$SOCK" ]; then
-      # Register as a fresh node; we'll merge/clean up in the admin console.
-      # Hostname suffix makes it obvious this is the temporary userspace node.
-      /usr/local/bin/tailscale --socket="$SOCK" up \
-        --auth-key="$KEY" \
-        --ssh \
-        --hostname="darwin-test-x64-1-userspace" \
-        --advertise-tags=tag:server \
-        --accept-risk=all 2>&1
-      echo "--- tailscale userspace status:"
-      /usr/local/bin/tailscale --socket="$SOCK" status 2>&1 | head -3
-    else
-      echo "ERROR: tailscaled socket never appeared"
-      tail -n 40 "$TS_HOME/tailscaled.log" 2>/dev/null || true
-    fi
+    /usr/local/bin/tailscale up \
+      --auth-key="$KEY" \
+      --force-reauth \
+      --ssh \
+      --hostname="darwin-test-x64-1" \
+      --advertise-tags=tag:server \
+      --accept-risk=all 2>&1
+    rc=$?
+    echo "tailscale up exit=$rc"
+    # Don't print `tailscale status` — it leaks tailnet device names/IPs to
+    # the public build log. Self-IP only is enough to confirm.
+    /usr/local/bin/tailscale ip -4 2>&1 || true
   fi
 else
-  echo "not x64-1 ($PUBIP) — skipping userspace bring-up"
+  echo "not x64-1 ($PUBIP) — skipping re-auth"
 fi
 
 echo "--- done; agent will pick up cfg on next restart"

--- a/.buildkite/recover-darwin-x64.sh
+++ b/.buildkite/recover-darwin-x64.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# One-shot recovery for darwin-test-x64-1 (and harmless on its siblings).
+# - Restores /usr/local/bin/tailscale{,d} from the go-installed copies so
+#   tailscale-ssh works again after the next reboot.
+# - Adds release-tier=oldest to the buildkite-agent cfg if missing.
+# Idempotent: safe to run on any macOS-13 x64 test box.
+set -euo pipefail
+
+echo "--- host: $(hostname) / $(curl -s --max-time 3 ifconfig.me || true)"
+
+# 1. Restore tailscale binaries if they were removed.
+for b in tailscale tailscaled; do
+  if [ ! -e "/usr/local/bin/$b" ] || [ -L "/usr/local/bin/$b" ] && [ ! -e "$(readlink -f "/usr/local/bin/$b" 2>/dev/null)" ]; then
+    if [ -x "$HOME/go/bin/$b" ]; then
+      sudo cp "$HOME/go/bin/$b" "/usr/local/bin/$b"
+      sudo chmod 755 "/usr/local/bin/$b"
+      echo "restored /usr/local/bin/$b"
+    fi
+  else
+    echo "/usr/local/bin/$b already present"
+  fi
+done
+
+# 2. Add release-tier=oldest to the agent cfg if missing.
+CFG=/usr/local/etc/buildkite-agent/buildkite-agent.cfg
+if [ -f "$CFG" ] && ! grep -q "release-tier=" "$CFG"; then
+  sudo cp "$CFG" "$CFG.bak-tier"
+  sudo sed -i '' 's/^tags="\(.*\)"$/tags="\1,release-tier=oldest"/' "$CFG"
+  echo "added release-tier=oldest to $CFG"
+  grep '^tags=' "$CFG"
+else
+  echo "cfg already has release-tier or not found"
+fi
+
+echo "--- done; agent will pick up cfg on next restart (daily reboot or manual)"

--- a/.buildkite/recover-darwin-x64.sh
+++ b/.buildkite/recover-darwin-x64.sh
@@ -40,12 +40,20 @@ fi
 # we're back in via tailscale-ssh as root, we'll reinstall the system daemon
 # properly and remove this LaunchAgent.
 #
-# Only act on the box that's actually missing the system daemon — siblings
-# have a working /Library/LaunchDaemons plist and a live `tailscale status`.
-if [ ! -f /Library/LaunchDaemons/com.tailscale.tailscaled.plist ] \
-   && ! /usr/local/bin/tailscale status >/dev/null 2>&1; then
+# Diagnostics — figure out why the system daemon isn't reachable even
+# though the plist exists.
+echo "--- tailscale diagnostics"
+ls -l /Library/LaunchDaemons/com.tailscale.tailscaled.plist /usr/local/bin/tailscaled 2>&1
+launchctl print system/com.tailscale.tailscaled 2>&1 | grep -E "state|pid|last exit" || true
+pgrep -fl tailscaled || echo "(no tailscaled process)"
+/usr/local/bin/tailscale status 2>&1 | head -5 || true
+ls -la /Library/Tailscale/ 2>&1 || true
 
-  echo "--- system tailscaled missing; bootstrapping userspace daemon"
+# Only act on the broken box (public IP match). Siblings are fine.
+PUBIP="$(curl -s --max-time 3 ifconfig.me || true)"
+if [ "$PUBIP" = "207.254.60.44" ]; then
+
+  echo "--- this is x64-1; bootstrapping userspace daemon"
 
   KEY="$(buildkite-agent secret get TAILSCALE_AUTH_KEY_TMP 2>/dev/null || true)"
   if [ -z "$KEY" ]; then
@@ -103,7 +111,7 @@ PLIST
     fi
   fi
 else
-  echo "system tailscaled present or already up — skipping userspace bring-up"
+  echo "not x64-1 ($PUBIP) — skipping userspace bring-up"
 fi
 
 echo "--- done; agent will pick up cfg on next restart"

--- a/.buildkite/recover-darwin-x64.sh
+++ b/.buildkite/recover-darwin-x64.sh
@@ -32,5 +32,79 @@ else
   echo "cfg already has release-tier (or cfg not at $CFG)"
 fi
 
+# 3. Bring tailscale back via a *userspace* tailscaled — no root needed.
+# The system-daemon plist was removed during the failed brew migration and
+# /Library/LaunchDaemons is root-only, so we run tailscaled with
+# --tun=userspace-networking from a user LaunchAgent instead. That's enough
+# for tailscale-ssh (it's tailscaled's own SSH server, not OS sshd). Once
+# we're back in via tailscale-ssh as root, we'll reinstall the system daemon
+# properly and remove this LaunchAgent.
+#
+# Only act on the box that's actually missing the system daemon — siblings
+# have a working /Library/LaunchDaemons plist and a live `tailscale status`.
+if [ ! -f /Library/LaunchDaemons/com.tailscale.tailscaled.plist ] \
+   && ! /usr/local/bin/tailscale status >/dev/null 2>&1; then
+
+  echo "--- system tailscaled missing; bootstrapping userspace daemon"
+
+  KEY="$(buildkite-agent secret get TAILSCALE_AUTH_KEY_TMP 2>/dev/null || true)"
+  if [ -z "$KEY" ]; then
+    echo "WARN: TAILSCALE_AUTH_KEY_TMP secret not set — skipping tailscale bring-up"
+  else
+    TS_HOME="$HOME/.tailscale-userspace"
+    SOCK="$TS_HOME/tailscaled.sock"
+    mkdir -p "$TS_HOME" "$HOME/Library/LaunchAgents"
+
+    # User LaunchAgent so it survives the daily reboot until we replace it
+    # with the real system daemon. RunAtLoad+KeepAlive = start at login and
+    # restart on crash.
+    cat > "$HOME/Library/LaunchAgents/com.tailscale.userspace.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.tailscale.userspace</string>
+  <key>ProgramArguments</key><array>
+    <string>/usr/local/bin/tailscaled</string>
+    <string>--tun=userspace-networking</string>
+    <string>--statedir=$TS_HOME</string>
+    <string>--socket=$SOCK</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$TS_HOME/tailscaled.log</string>
+  <key>StandardErrorPath</key><string>$TS_HOME/tailscaled.log</string>
+</dict></plist>
+PLIST
+
+    # Start now. bootstrap is idempotent-ish; ignore "already loaded" noise.
+    launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/com.tailscale.userspace.plist" 2>&1 || true
+    launchctl kickstart -k "gui/$(id -u)/com.tailscale.userspace" 2>&1 || true
+
+    # Give tailscaled a moment to open its socket.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      [ -S "$SOCK" ] && break
+      sleep 1
+    done
+
+    if [ -S "$SOCK" ]; then
+      # Register as a fresh node; we'll merge/clean up in the admin console.
+      # Hostname suffix makes it obvious this is the temporary userspace node.
+      /usr/local/bin/tailscale --socket="$SOCK" up \
+        --auth-key="$KEY" \
+        --ssh \
+        --hostname="darwin-test-x64-1-userspace" \
+        --advertise-tags=tag:server \
+        --accept-risk=all 2>&1
+      echo "--- tailscale userspace status:"
+      /usr/local/bin/tailscale --socket="$SOCK" status 2>&1 | head -3
+    else
+      echo "ERROR: tailscaled socket never appeared"
+      tail -n 40 "$TS_HOME/tailscaled.log" 2>/dev/null || true
+    fi
+  fi
+else
+  echo "system tailscaled present or already up — skipping userspace bring-up"
+fi
+
 echo "--- done; agent will pick up cfg on next restart"
 exit 0

--- a/.buildkite/recover-darwin-x64.sh
+++ b/.buildkite/recover-darwin-x64.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 # One-shot recovery for darwin-test-x64-1 (and harmless on its siblings).
-# - Restores /usr/local/bin/tailscale{,d} from the go-installed copies so
-#   tailscale-ssh works again after the next reboot.
-# - Adds release-tier=oldest to the buildkite-agent cfg if missing.
-# Idempotent: safe to run on any macOS-13 x64 test box.
-set -euo pipefail
+# Runs as the buildkite-agent's user (administrator) — no sudo, since the
+# cfg and /usr/local/bin are administrator:admin on the Homebrew x64 boxes.
+set -uo pipefail
 
 echo "--- host: $(hostname) / $(curl -s --max-time 3 ifconfig.me || true)"
 
 # 1. Restore tailscale binaries if they were removed.
 for b in tailscale tailscaled; do
-  if [ ! -e "/usr/local/bin/$b" ] || [ -L "/usr/local/bin/$b" ] && [ ! -e "$(readlink -f "/usr/local/bin/$b" 2>/dev/null)" ]; then
+  if [ ! -e "/usr/local/bin/$b" ]; then
     if [ -x "$HOME/go/bin/$b" ]; then
-      sudo cp "$HOME/go/bin/$b" "/usr/local/bin/$b"
-      sudo chmod 755 "/usr/local/bin/$b"
-      echo "restored /usr/local/bin/$b"
+      if cp "$HOME/go/bin/$b" "/usr/local/bin/$b" 2>/dev/null && chmod 755 "/usr/local/bin/$b"; then
+        echo "restored /usr/local/bin/$b"
+      else
+        echo "WARN: cannot write /usr/local/bin/$b (need root) — skipping"
+      fi
     fi
   else
     echo "/usr/local/bin/$b already present"
@@ -24,12 +24,13 @@ done
 # 2. Add release-tier=oldest to the agent cfg if missing.
 CFG=/usr/local/etc/buildkite-agent/buildkite-agent.cfg
 if [ -f "$CFG" ] && ! grep -q "release-tier=" "$CFG"; then
-  sudo cp "$CFG" "$CFG.bak-tier"
-  sudo sed -i '' 's/^tags="\(.*\)"$/tags="\1,release-tier=oldest"/' "$CFG"
-  echo "added release-tier=oldest to $CFG"
+  cp "$CFG" "$CFG.bak-tier"
+  sed -i '' 's/^tags="\(.*\)"$/tags="\1,release-tier=oldest"/' "$CFG"
+  echo "added release-tier=oldest:"
   grep '^tags=' "$CFG"
 else
-  echo "cfg already has release-tier or not found"
+  echo "cfg already has release-tier (or cfg not at $CFG)"
 fi
 
-echo "--- done; agent will pick up cfg on next restart (daily reboot or manual)"
+echo "--- done; agent will pick up cfg on next restart"
+exit 0


### PR DESCRIPTION
Triggers a single BuildKite step on the macOS-13 x64 boxes to restore tailscaled and add release-tier=oldest. Close after the build runs.