### PR TITLE
Fix crash formatting WeakMap/WeakSet with user-assigned .size property

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2764,9 +2764,10 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
 
-                if (length == 0) {
+                if (length == 0 or is_weak) {
                     return writer.print("{s} {{}}", .{map_name});
                 }
 
@@ -2871,9 +2872,10 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
 
-                if (length == 0) {
+                if (length == 0 or is_weak) {
                     return writer.print("{s} {{}}", .{set_name});
                 }
 

--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,6 +2757,10 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                if (value.jsType() == .WeakMap) {
+                    return writer.writeAll("WeakMap {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2764,10 +2768,9 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const is_weak = value.jsType() == .WeakMap;
-                const map_name = if (is_weak) "WeakMap" else "Map";
+                const map_name = "Map";
 
-                if (length == 0 or is_weak) {
+                if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
                 }
 
@@ -2865,6 +2868,10 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                if (value.jsType() == .WeakSet) {
+                    return writer.writeAll("WeakSet {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2872,10 +2879,9 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const is_weak = value.jsType() == .WeakSet;
-                const set_name = if (is_weak) "WeakSet" else "Set";
+                const set_name = "Set";
 
-                if (length == 0 or is_weak) {
+                if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});
                 }
 

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -44,7 +44,7 @@ pub const DiffFormatter = struct {
                 &received_buf.writer,
                 fmt_options,
             ) catch {
-                this.globalThis.clearException();
+                _ = this.globalThis.clearExceptionExceptTermination();
             };
 
             JestPrettyFormat.format(
@@ -55,7 +55,7 @@ pub const DiffFormatter = struct {
                 &expected_buf.writer,
                 fmt_options,
             ) catch {
-                this.globalThis.clearException();
+                _ = this.globalThis.clearExceptionExceptTermination();
             };
         }
 

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1314,9 +1314,10 @@ pub const JestPrettyFormat = struct {
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
 
-                    if (length == 0) {
+                    if (length == 0 or is_weak) {
                         return writer.print("{s} {{}}", .{map_name});
                     }
 
@@ -1344,9 +1345,10 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
 
-                    if (length == 0) {
+                    if (length == 0 or is_weak) {
                         return writer.print("{s} {{}}", .{set_name});
                     }
 

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,6 +1307,10 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    if (value.jsType() == .WeakMap) {
+                        return writer.writeAll("WeakMap {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1314,10 +1318,9 @@ pub const JestPrettyFormat = struct {
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const is_weak = value.jsType() == .WeakMap;
-                    const map_name = if (is_weak) "WeakMap" else "Map";
+                    const map_name = "Map";
 
-                    if (length == 0 or is_weak) {
+                    if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
                     }
 
@@ -1336,6 +1339,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    if (value.jsType() == .WeakSet) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.writeAll("WeakSet {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1345,10 +1353,9 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const is_weak = value.jsType() == .WeakSet;
-                    const set_name = if (is_weak) "WeakSet" else "Set";
+                    const set_name = "Set";
 
-                    if (length == 0 or is_weak) {
+                    if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});
                     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -803,4 +803,36 @@ describe("WeakMap/WeakSet with user-assigned .size property", () => {
     wm.size = 1000;
     expect(() => expect(wm).toMatchObject([])).toThrow();
   });
+
+  it("expect().toMatchObject() diff formatting does not crash on WeakSet with .size", () => {
+    const ws = new WeakSet();
+    ws.size = 1000;
+    expect(() => expect(ws).toMatchObject([])).toThrow();
+  });
+
+  it("Bun.inspect does not invoke .size getter on WeakMap", () => {
+    const wm = new WeakMap();
+    let called = false;
+    Object.defineProperty(wm, "size", {
+      get() {
+        called = true;
+        throw new Error("should not be called");
+      },
+    });
+    expect(Bun.inspect(wm)).toBe("WeakMap {}");
+    expect(called).toBe(false);
+  });
+
+  it("Bun.inspect does not invoke .size getter on WeakSet", () => {
+    const ws = new WeakSet();
+    let called = false;
+    Object.defineProperty(ws, "size", {
+      get() {
+        called = true;
+        throw new Error("should not be called");
+      },
+    });
+    expect(Bun.inspect(ws)).toBe("WeakSet {}");
+    expect(called).toBe(false);
+  });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,35 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("WeakMap/WeakSet with user-assigned .size property", () => {
+  it("Bun.inspect does not attempt to iterate WeakMap", () => {
+    const wm = new WeakMap();
+    wm.size = 1000;
+    expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  });
+
+  it("Bun.inspect does not attempt to iterate WeakSet", () => {
+    const ws = new WeakSet();
+    ws.size = 1000;
+    expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  });
+
+  it("expect().toEqual() diff formatting does not crash on WeakMap with .size", () => {
+    const wm = new WeakMap();
+    wm.size = 1;
+    expect(() => expect(wm).toEqual(new Map())).toThrow();
+  });
+
+  it("expect().toEqual() diff formatting does not crash on WeakSet with .size", () => {
+    const ws = new WeakSet();
+    ws.size = 1;
+    expect(() => expect(ws).toEqual(new Set())).toThrow();
+  });
+
+  it("expect().toMatchObject() diff formatting does not crash on WeakMap with .size", () => {
+    const wm = new WeakMap();
+    wm.size = 1000;
+    expect(() => expect(wm).toMatchObject([])).toThrow();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`assertNoExceptionExceptTermination`) found by Fuzzilli (fingerprint `01f48445a286814c`).

### Root cause

`WeakMap` and `WeakSet` are not iterable and have no `.size` getter. When formatting them, both `ConsoleObject.zig` and `pretty_format.zig` read `.size` as a user-observable property lookup and, if non-zero, call `forEach` (which wraps `JSC::forEachInIterable`). If a user assigns a non-zero `.size` to a `WeakMap`/`WeakSet`, the iteration attempt throws a `TypeError`.

In the `expect()` diff path (`DiffFormatter.format`), that `JSError` was swallowed by `catch {}` without clearing the pending VM exception, so the next call into JSC hit the `assertNoExceptionExceptTermination` assertion.

### Fix

- Never attempt to iterate `WeakMap`/`WeakSet` in the formatters — always render them as `WeakMap {}` / `WeakSet {}` regardless of a user-set `.size`.
- Clear any pending exception in `DiffFormatter` when formatting fails, so other throwing cases (getters, proxies, etc.) can't leave a stale exception behind.

### Repro

```js
const wm = new WeakMap();
wm.size = 1;
expect(wm).toEqual(new Map()); // used to hit an assertion in debug builds
```

## How did you verify your code works?

Added regression tests in `test/js/bun/util/inspect.test.js` covering `Bun.inspect`, `expect().toEqual()`, and `expect().toMatchObject()` for both `WeakMap` and `WeakSet` with a user-assigned `.size`.