### PR TITLE
console: guard JSX/Proxy recursion in Bun.inspect (stack overflow SIGSEGV)

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1954,6 +1954,7 @@ pub mod formatter {
                     | Tag::Error
                     | Tag::Class
                     | Tag::Event
+                    | Tag::JSX
             )
         }
     }
@@ -3289,16 +3290,15 @@ pub mod formatter {
             if self.global_this.has_exception() {
                 return Err(jsc::JsError::Thrown);
             }
-            if !can_circ {
-                return Ok(true);
-            }
-
             if !self.stack_check.is_safe_to_recurse() {
                 self.failed = true;
                 if self.can_throw_stack_overflow {
                     return Err(self.global_this.throw_stack_overflow());
                 }
                 return Ok(false);
+            }
+            if !can_circ {
+                return Ok(true);
             }
 
             if self.map_node.is_none() {
@@ -3554,18 +3554,20 @@ pub mod formatter {
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
         ) -> JsResult<()> {
-            let target = value.get_proxy_internal_field(jsc::ProxyField::Target);
+            let mut target = value.get_proxy_internal_field(jsc::ProxyField::Target);
             // Proxy does not allow non-objects here.
             debug_assert!(target.is_cell());
             // TODO: if (options.showProxy), print like
             // `Proxy { target: ..., handlers: ... }` — this is default off so
             // it is not used.
-            self.format::<C>(
-                Tag::get(target, self.global_this)?,
-                writer_,
-                target,
-                self.global_this,
-            )
+            loop {
+                let tag = Tag::get(target, self.global_this)?;
+                if !matches!(tag.tag.tag(), Tag::Proxy) {
+                    return self.format::<C>(tag, writer_, target, self.global_this);
+                }
+                target = target.get_proxy_internal_field(jsc::ProxyField::Target);
+                debug_assert!(target.is_cell());
+            }
         }
 
         #[inline(never)]

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -419,7 +419,10 @@ impl Tag {
 
     #[inline]
     pub(crate) const fn can_have_circular_references(self) -> bool {
-        matches!(self, Tag::Array | Tag::Object | Tag::Map | Tag::Set)
+        matches!(
+            self,
+            Tag::Array | Tag::Object | Tag::Map | Tag::Set | Tag::JSX | Tag::Event
+        )
     }
 }
 
@@ -1870,6 +1873,7 @@ impl<'a> Formatter<'a> {
                     {
                         evt @ (EventType::MessageEvent | EventType::ErrorEvent) => evt,
                         _ => {
+                            let _ = self.map.remove(&value);
                             return self.print_as::<W, { Tag::Object }, ENABLE_ANSI_COLORS>(
                                 writer.ctx, value, JSType::Event,
                             );

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -314,6 +314,171 @@ it("jsx with fragment", () => {
   const output = `<>foo bar</>`;
 
   expect(input).toBe(output);
+});
+
+it("jsx with circular references does not crash", () => {
+  // Run in a subprocess: without the fix this overflows the native stack and segfaults,
+  // which would otherwise kill the test runner before it can record a failure.
+  const { exitCode, stdout } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const a = { $$typeof: Symbol.for("react.element"), type: "div", props: null, key: null };
+        a.props = a;
+        console.log(Bun.inspect(a));
+
+        const b = { $$typeof: Symbol.for("react.element"), type: "div", key: null };
+        b.props = { children: b };
+        console.log(Bun.inspect(b));
+
+        const c = { $$typeof: Symbol.for("react.element"), type: "span", key: null };
+        c.props = { children: [c, c] };
+        console.log(Bun.inspect(c));
+
+        const d = { $$typeof: Symbol.for("react.element"), type: "div", props: {} };
+        d.key = d;
+        console.log(Bun.inspect(d));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = stdout.toString();
+  expect(out).toContain("[Circular]");
+  expect(out).toContain("<div>\n  [Circular]\n</div>");
+  expect(out).toContain("<span>\n  [Circular]\n  [Circular]\n</span>");
+  expect(out).toContain("<div key=[Circular] />");
+  expect(exitCode).toBe(0);
+});
+
+it("jsx with non-object props does not crash", () => {
+  const { exitCode, stdout } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const el = { $$typeof: Symbol.for("react.element"), type: "div", props: 42, key: null };
+        console.log(Bun.inspect(el));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stdout.toString().trim()).toBe("<div />");
+  expect(exitCode).toBe(0);
+});
+
+it("jsx with circular props in test diff formatter", () => {
+  using dir = tempDir("jsx-circular-diff", {
+    "diff.test.js": `
+      import { test, expect } from "bun:test";
+      test("circular", () => {
+        const el = { $$typeof: Symbol.for("react.element"), type: "div", props: null, key: null };
+        el.props = el;
+        expect(() => expect(el).toEqual({})).toThrow();
+      });
+      test("non-object props", () => {
+        const el = { $$typeof: Symbol.for("react.element"), type: "div", props: 42, key: null };
+        expect(() => expect(el).toEqual({})).toThrow();
+      });
+    `,
+  });
+  const { exitCode, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), "test", "diff.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stderr.toString()).toContain("2 pass");
+  expect(exitCode).toBe(0);
+});
+
+it("Event in test diff formatter is not spuriously [Circular]", () => {
+  using dir = tempDir("event-diff", {
+    "diff.test.js": `
+      import { test, expect } from "bun:test";
+      test("close event", () => {
+        expect(() => expect(new CloseEvent("close", { code: 1000 })).toEqual({})).toThrow(/CloseEvent/);
+      });
+      test("custom event", () => {
+        expect(() => expect(new CustomEvent("foo")).toEqual({})).toThrow(/CustomEvent/);
+      });
+      test("circular message event still detected", () => {
+        const ev = new MessageEvent("message");
+        Object.defineProperty(ev, "data", { value: ev, configurable: true });
+        expect(() => expect(ev).toEqual({})).toThrow(/\\[Circular\\]/);
+      });
+    `,
+  });
+  const { exitCode, stderr } = Bun.spawnSync({
+    cmd: [bunExe(), "test", "diff.test.js"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stderr.toString()).toContain("3 pass");
+  expect(exitCode).toBe(0);
+});
+
+it("deeply nested Proxy chain does not crash", () => {
+  // Without the fix, print_proxy recurses on the target without a stack-safety
+  // check and segfaults; run in a subprocess so a regression fails the suite
+  // instead of killing the runner.
+  const { exitCode, stdout, signalCode } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let p = { ok: 1 };
+        for (let i = 0; i < 100000; i++) p = new Proxy(p, {});
+        console.log(Bun.inspect(p));
+        console.log(p);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`
+    "{
+      ok: 1,
+    }
+    {
+      ok: 1,
+    }"
+  `);
+  expect(signalCode).toBeFalsy();
+  expect(exitCode).toBe(0);
+});
+
+it("deeply nested non-cyclic jsx does not segfault", () => {
+  // Stack size and release-build frame size vary by platform, so a fixed depth
+  // may or may not overflow: accept either a clean RangeError or successful
+  // completion. The regression was SIGSEGV.
+  const { exitCode, stdout, signalCode } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let el = { $$typeof: Symbol.for("react.element"), type: "div", props: {}, key: null };
+        for (let i = 0; i < 20000; i++)
+          el = { $$typeof: Symbol.for("react.element"), type: "div", props: { children: el }, key: null };
+        try { Bun.inspect(el); console.log("ok"); }
+        catch (e) { console.log(e.constructor.name); }
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(["RangeError", "ok"]).toContain(stdout.toString().trim());
+  expect(signalCode).toBeFalsy();
+  expect(exitCode).toBe(0);
 });
 
 it("inspect", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,10 +316,10 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
-it("jsx with circular references does not crash", () => {
+it.concurrent("jsx with circular references does not crash", async () => {
   // Run in a subprocess: without the fix this overflows the native stack and segfaults,
   // which would otherwise kill the test runner before it can record a failure.
-  const { exitCode, stdout } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
@@ -345,16 +345,16 @@ it("jsx with circular references does not crash", () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const out = stdout.toString();
-  expect(out).toContain("[Circular]");
-  expect(out).toContain("<div>\n  [Circular]\n</div>");
-  expect(out).toContain("<span>\n  [Circular]\n  [Circular]\n</span>");
-  expect(out).toContain("<div key=[Circular] />");
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toContain("[Circular]");
+  expect(stdout).toContain("<div>\n  [Circular]\n</div>");
+  expect(stdout).toContain("<span>\n  [Circular]\n  [Circular]\n</span>");
+  expect(stdout).toContain("<div key=[Circular] />");
   expect(exitCode).toBe(0);
 });
 
-it("jsx with non-object props does not crash", () => {
-  const { exitCode, stdout } = Bun.spawnSync({
+it.concurrent("jsx with non-object props does not crash", async () => {
+  await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
@@ -367,11 +367,12 @@ it("jsx with non-object props does not crash", () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(stdout.toString().trim()).toBe("<div />");
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("<div />");
   expect(exitCode).toBe(0);
 });
 
-it("jsx with circular props in test diff formatter", () => {
+it.concurrent("jsx with circular props in test diff formatter", async () => {
   using dir = tempDir("jsx-circular-diff", {
     "diff.test.js": `
       import { test, expect } from "bun:test";
@@ -386,18 +387,19 @@ it("jsx with circular props in test diff formatter", () => {
       });
     `,
   });
-  const { exitCode, stderr } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "diff.test.js"],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(stderr.toString()).toContain("2 pass");
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("2 pass");
   expect(exitCode).toBe(0);
 });
 
-it("Event in test diff formatter is not spuriously [Circular]", () => {
+it.concurrent("Event in test diff formatter is not spuriously [Circular]", async () => {
   using dir = tempDir("event-diff", {
     "diff.test.js": `
       import { test, expect } from "bun:test";
@@ -414,22 +416,23 @@ it("Event in test diff formatter is not spuriously [Circular]", () => {
       });
     `,
   });
-  const { exitCode, stderr } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "diff.test.js"],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(stderr.toString()).toContain("3 pass");
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("3 pass");
   expect(exitCode).toBe(0);
 });
 
-it("deeply nested Proxy chain does not crash", () => {
+it.concurrent("deeply nested Proxy chain does not crash", async () => {
   // Without the fix, print_proxy recurses on the target without a stack-safety
   // check and segfaults; run in a subprocess so a regression fails the suite
   // instead of killing the runner.
-  const { exitCode, stdout, signalCode } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
@@ -444,7 +447,8 @@ it("deeply nested Proxy chain does not crash", () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(normalizeBunSnapshot(stdout.toString())).toMatchInlineSnapshot(`
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
     "{
       ok: 1,
     }
@@ -452,15 +456,15 @@ it("deeply nested Proxy chain does not crash", () => {
       ok: 1,
     }"
   `);
-  expect(signalCode).toBeFalsy();
+  expect(proc.signalCode).toBeFalsy();
   expect(exitCode).toBe(0);
 });
 
-it("deeply nested non-cyclic jsx does not segfault", () => {
+it.concurrent("deeply nested non-cyclic jsx does not segfault", async () => {
   // Stack size and release-build frame size vary by platform, so a fixed depth
   // may or may not overflow: accept either a clean RangeError or successful
   // completion. The regression was SIGSEGV.
-  const { exitCode, stdout, signalCode } = Bun.spawnSync({
+  await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
@@ -476,8 +480,9 @@ it("deeply nested non-cyclic jsx does not segfault", () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(["RangeError", "ok"]).toContain(stdout.toString().trim());
-  expect(signalCode).toBeFalsy();
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(["RangeError", "ok"]).toContain(stdout.trim());
+  expect(proc.signalCode).toBeFalsy();
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -345,7 +345,7 @@ it.concurrent("jsx with circular references does not crash", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toContain("[Circular]");
   expect(stdout).toContain("<div>\n  [Circular]\n</div>");
   expect(stdout).toContain("<span>\n  [Circular]\n  [Circular]\n</span>");
@@ -367,7 +367,7 @@ it.concurrent("jsx with non-object props does not crash", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout.trim()).toBe("<div />");
   expect(exitCode).toBe(0);
 });
@@ -394,7 +394,7 @@ it.concurrent("jsx with circular props in test diff formatter", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toContain("2 pass");
   expect(exitCode).toBe(0);
 });
@@ -423,7 +423,7 @@ it.concurrent("Event in test diff formatter is not spuriously [Circular]", async
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toContain("3 pass");
   expect(exitCode).toBe(0);
 });
@@ -447,7 +447,7 @@ it.concurrent("deeply nested Proxy chain does not crash", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
     "{
       ok: 1,
@@ -480,7 +480,7 @@ it.concurrent("deeply nested non-cyclic jsx does not segfault", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(["RangeError", "ok"]).toContain(stdout.trim());
   expect(proc.signalCode).toBeFalsy();
   expect(exitCode).toBe(0);


### PR DESCRIPTION
`console.log` / `Bun.inspect` segfaults (native stack overflow, exit 139, no crash report) on:

```js
const e = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
e.props.children = e;
console.log(e);            // SIGSEGV
```

```js
let p = {};
for (let i = 0; i < 1e5; i++) p = new Proxy(p, {});
console.log(p);            // SIGSEGV
```

A ~20k-deep non-cyclic JSX `children` chain crashes the same way. Node prints all three.

### Cause

`print_as_prelude` only ran `stack_check.is_safe_to_recurse()` and the visited-map insert for tags in `can_have_circular_references()`. `Tag::JSX` was not in that set, so the JSX printer recursed into `props` / `children` with neither guard. `Tag::Proxy` was also not in the set, and `print_proxy` recursed through `format()` on the target, so a deep Proxy chain blew the native stack before ever reaching a guarded tag. There is no JS frame on this path, so JSC's recursion limiter never fires.

### Fix

- Add `Tag::JSX` to `can_have_circular_references()` (in both `ConsoleObject.rs` and the test-runner `pretty_format.rs`) so cyclic JSX prints `[Circular]`.
- Move the `stack_check.is_safe_to_recurse()` check ahead of the `can_circ` early return in `print_as_prelude`, so every recursive `print_as` call is guarded regardless of tag. Deep non-cyclic JSX now throws a catchable `RangeError` instead of segfaulting.
- Make `print_proxy` peel nested Proxy targets in a loop instead of recursing, so a 100k-deep Proxy chain prints the innermost target without consuming stack.

### Verification

```
$ bun-debug -e 'const e={$$typeof:Symbol.for("react.element"),type:"div",key:null,ref:null,props:{}};e.props.children=e;console.log(e)'
<div>
  [Circular]
</div>

$ bun-debug -e 'let p={ok:1};for(let i=0;i<1e5;i++)p=new Proxy(p,{});console.log(p)'
{
  ok: 1,
}
```

New tests in `test/js/bun/util/inspect.test.js` run the crashing inputs in subprocesses so a regression fails the suite rather than killing the runner.

Related: #10886. That issue's scenario (a happy-dom element printed by a jest-dom matcher) is a different bug: the element is a plain object, so it already goes through the circular set and depth limit and prints as a bounded but very long object dump. It is not fixed here; #35712 (DOM nodes printed as markup) is the fix for it. This PR is the SIGSEGV class only, so it does not close #10886.

Supersedes #29170 and #34889 (closed; it bundled the `Tag::JSX` entry and the stack-check reordering from here with four unrelated fixes that each have their own PR). This PR is where the JSX and Proxy pieces land. The Proxy peeling loop, `Tag::Event` in `pretty_format`'s circular set, and the Event re-dispatch `map.remove` fix (with their tests) exist only here.

The `print_as_prelude` reordering is the same three-line move as in #34884, which seats a live `StackCheck` in `Formatter::new()` and in `pretty_format` for the callers that do not go through `format2` (the uncaught exception printer, the `expect` diff formatter). The two PRs are otherwise independent: this one needs no change from #34884 for its tests, and whichever lands second drops that one hunk on rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 19 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->

