### PR TITLE
fetch: don't run FetchTasklet.deinit on HTTP thread during shutdown

### DIFF
--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -74,12 +74,33 @@ pub const FetchTasklet = struct {
     }
 
     pub fn derefFromThread(this: *FetchTasklet) void {
+        // Testing hook (ci_assert builds only): sleep before decrementing the ref count so
+        // the JS thread has time to process onProgressUpdate, drop its ref, drain the event
+        // loop, and set `is_shutting_down`. Without this the JS-deref-then-shutdown vs
+        // HTTP-deref race is too narrow to exercise deterministically. The stderr marker
+        // lets the test assert the hook is actually compiled in. Used by
+        // test/regression/issue/26225/shutdown-race.test.ts.
+        if (comptime bun.Environment.ci_assert) {
+            if (bun.getenvZ("BUN_DEBUG_FETCH_TASKLET_DEREF_SLEEP_MS")) |str| {
+                if (std.fmt.parseInt(u64, str, 10) catch null) |ms| {
+                    std.debug.print("[FetchTasklet.derefFromThread sleep {d}ms]\n", .{ms});
+                    std.Thread.sleep(ms * std.time.ns_per_ms);
+                }
+            }
+        }
+
         const count = this.ref_count.fetchSub(1, .monotonic);
         bun.debugAssert(count > 0);
 
         if (count == 1) {
             if (this.javascript_vm.isShuttingDown()) {
-                this.deinit() catch |err| switch (err) {};
+                // Process is exiting. `deinit()` (via `clearData()`) would touch
+                // JS-thread-only state from the HTTP thread: `ResumableSink`'s
+                // single-threaded `RefCount` (ThreadLock bound to the JS thread in
+                // `startRequestStream`), plus several `jsc.Strong`/`jsc.Weak` refs and
+                // `Response`. The JS event loop won't drain at this point either, so
+                // dispatching there is futile. Just leak — every resource here is
+                // in-process memory the OS is about to reclaim.
                 return;
             }
             // this is really unlikely to happen, but can happen

--- a/test/regression/issue/26225/shutdown-race.test.ts
+++ b/test/regression/issue/26225/shutdown-race.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 // Regression test for the "ThreadLock is locked by thread X, not thread Y" panic
 // seen on process exit after a fetch() with a streaming request body (originally
@@ -62,11 +62,7 @@ test.skipIf(!isDebug && !isASAN)(
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Precondition: the sleep hook must be compiled in for this test to be
     // meaningful. Without it the race is effectively unreachable and this test

--- a/test/regression/issue/26225/shutdown-race.test.ts
+++ b/test/regression/issue/26225/shutdown-race.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isASAN } from "harness";
+
+// Regression test for the "ThreadLock is locked by thread X, not thread Y" panic
+// seen on process exit after a fetch() with a streaming request body (originally
+// flaked in test/regression/issue/26225.test.ts on x64-asan).
+//
+// Root cause: FetchTasklet.derefFromThread() runs on the HTTP thread. If the JS
+// thread has already dropped its ref and set `is_shutting_down`, the old code
+// called `this.deinit()` directly from the HTTP thread. `deinit()` → `clearData()`
+// → `clearSink()` then derefs the ResumableSink, whose single-threaded RefCount
+// was ThreadLock-bound to the JS thread in `startRequestStream()` — triggering
+// the assertion.
+//
+// The race window (between the HTTP thread's `mutex.unlock()` and
+// `derefFromThread()`) is too narrow to hit without help, so this test uses a
+// ci_assert-gated sleep hook (`BUN_DEBUG_FETCH_TASKLET_DEREF_SLEEP_MS`) to widen
+// it, plus `BUN_DESTRUCT_VM_ON_EXIT=1` so the JS thread's VM teardown keeps the
+// process alive long enough for the HTTP thread to wake and observe
+// `isShuttingDown() == true`.
+//
+// The ThreadLock assertion and the sleep hook only exist in ci_assert builds.
+test.skipIf(!isDebug && !isASAN)(
+  "fetch with streaming body: HTTP thread does not run FetchTasklet.deinit on shutdown",
+  async () => {
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const bytes = await req.arrayBuffer();
+        return Response.json({ ok: true, bytesReceived: bytes.byteLength });
+      },
+    });
+
+    const client = /* js */ `
+      const { Readable } = require("node:stream");
+      async function* gen() {
+        yield Buffer.alloc(1024 * 50, 0x42);
+        yield Buffer.alloc(1024 * 50, 0x42);
+      }
+      fetch("http://127.0.0.1:${server.port}", {
+        method: "POST",
+        body: Readable.from(gen()),
+        headers: { "content-type": "application/octet-stream" },
+      })
+        .then(r => r.json())
+        .then(r => { console.log(JSON.stringify(r)); })
+        .catch(e => { console.error(e); process.exit(1); });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", client],
+      env: {
+        ...bunEnv,
+        // Widen the HTTP-thread race window so the JS thread reliably reaches
+        // `is_shutting_down = true` first.
+        BUN_DEBUG_FETCH_TASKLET_DEREF_SLEEP_MS: "50",
+        // Keep the process alive past `is_shutting_down` long enough for the
+        // HTTP thread to wake from its sleep and hit the shutdown branch.
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // Precondition: the sleep hook must be compiled in for this test to be
+    // meaningful. Without it the race is effectively unreachable and this test
+    // would pass for the wrong reason.
+    expect(stderr).toContain("[FetchTasklet.derefFromThread sleep 50ms]");
+
+    // The actual regression check: the subprocess must complete cleanly. Before
+    // the fix, `deinit()` ran on the HTTP thread here and touched JS-thread-only
+    // state (ResumableSink ThreadLock, jsc.Strong/Weak) while the main thread was
+    // concurrently tearing down the JSC VM — crashing with a ThreadLock
+    // assertion or a WTF::AtomStringImpl assertion depending on which landed first.
+    expect(stdout.trim()).toBe(JSON.stringify({ ok: true, bytesReceived: 1024 * 100 }));
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky `ThreadLock` assertion failure on process exit after a `fetch()` with a streaming request body, seen in `test/regression/issue/26225.test.ts` on `x64-asan`:

```
panic: Internal assertion failure: `ThreadLock` is locked by thread 35273, not thread 35278
```

### Root cause

`FetchTasklet.derefFromThread()` runs on the HTTP thread. When it drops the last ref while `vm.isShuttingDown()`, it previously called `this.deinit()` directly. `deinit()` → `clearData()` touches JS-thread-only state from the HTTP thread:

- `clearSink()` → `ResumableSink.deref()` — single-threaded `bun.ptr.RefCount` whose `ThreadLock` was bound to the JS thread in `startRequestStream()`
- `jsc.Weak`/`jsc.Strong` refs (`response`, `readable_stream_ref`, `abort_reason`, `check_server_identity`, `request_body.ReadableStream`) — JSC heap access from the wrong thread
- `Response.unref()`

The shutdown short-circuit that runs `deinit()` on the HTTP thread was added in e735bffaa9 (#27385).

### The race

```zig
// callback() on the HTTP thread:
defer if (is_done) task.derefFromThread();   // runs LAST
task.mutex.lock();
defer task.mutex.unlock();                    // runs before derefFromThread
// ...
task.javascript_vm.eventLoop().enqueueTaskConcurrent(...);  // wakes JS thread
```

Between `mutex.unlock()` and `derefFromThread()` on the HTTP thread, the JS thread can acquire the mutex, run `onProgressUpdate` (which drops the JS-side ref), drain the event loop, and reach `vm.onExit()` → `is_shutting_down = true`. Then the HTTP thread's `derefFromThread()` drops the last ref, sees `isShuttingDown()`, and runs `deinit()` on the HTTP thread → crash.

The window is effectively one instruction wide — it only surfaces under ASAN on a loaded CI machine where the `futex_wake` in `mutex.unlock()` preempts the HTTP thread.

### Fix

Don't run `deinit()` on the HTTP thread during shutdown. The JS event loop won't drain at that point anyway, and everything `FetchTasklet` holds is in-process memory the OS is about to reclaim.

## How did you verify your code works?

The race is too narrow to hit unaided (0/100 locally under heavy parallel load), so this adds a `ci_assert`-gated sleep hook `BUN_DEBUG_FETCH_TASKLET_DEREF_SLEEP_MS` to widen the window deterministically. Combined with `BUN_DESTRUCT_VM_ON_EXIT=1` (keeps the process alive past `is_shutting_down` while the JSC VM tears down), the new test `test/regression/issue/26225/shutdown-race.test.ts` reproduces the crash 100% before the fix and passes 100% after.

**Before** (hook present, fix reverted):
```
panic: Internal assertion failure: `ThreadLock` is locked by thread 5571, not thread 5580
...
ptr.ref_count.RefCount(...ResumableSink...).deref
bun.js.webcore.fetch.FetchTasklet.FetchTasklet.clearSink
```

**After**: 5/5 pass.

The hook is compiled out in release builds (gated on `bun.Environment.ci_assert`, same as `ThreadLock` itself). The test skips on non-debug/non-ASAN builds.