### PR TITLE
fix(Bun.serve): emit single Content-Length header on default fallback response

### DIFF
--- a/src/runtime/server/RequestContext.zig
+++ b/src/runtime/server/RequestContext.zig
@@ -405,6 +405,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     resp.writeHeader("content-type", MimeType.html.value);
                     resp.writeHeader("content-encoding", "gzip");
                     resp.writeHeaderInt("content-length", welcome_page_html_gz.len);
+                    // Tell uws we've written the Content-Length header so it
+                    // doesn't emit a second one in end(). See #29714.
+                    resp.markWroteContentLengthHeader();
                     ctx.end(welcome_page_html_gz, ctx.shouldCloseConnection());
                     return;
                 }
@@ -412,6 +415,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 resp.writeStatus("200 OK");
                 resp.writeHeader("content-type", MimeType.text.value);
                 resp.writeHeaderInt("content-length", missing_content.len);
+                // Tell uws we've written the Content-Length header so it
+                // doesn't emit a second one in end(). See #29714.
+                resp.markWroteContentLengthHeader();
                 ctx.flags.has_written_status = true;
                 ctx.end(missing_content, ctx.shouldCloseConnection());
             }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -358,6 +358,66 @@ it("should display a welcome message when the response value type is incorrect",
   );
 });
 
+// https://github.com/oven-sh/bun/issues/29714
+it("default fallback response has a single Content-Length header", async () => {
+  await runTest(
+    {
+      // @ts-ignore — intentionally return undefined to trigger the default
+      // "Welcome to Bun!" fallback response.
+      fetch() {},
+    },
+    async server => {
+      const wireBytes = await new Promise<string>((resolve, reject) => {
+        const sock = net.connect(Number(server.port), "127.0.0.1", () => {
+          sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        });
+        let buf = "";
+        sock.on("data", d => (buf += d.toString("latin1")));
+        sock.on("end", () => resolve(buf));
+        sock.on("error", reject);
+      });
+
+      // The raw wire bytes must contain exactly one Content-Length header
+      // (case-insensitive) — RFC 7230 §3.3.2.
+      const headerSection = wireBytes.split("\r\n\r\n", 1)[0];
+      const contentLengthCount = headerSection
+        .split("\r\n")
+        .filter(line => /^content-length\s*:/i.test(line)).length;
+      expect(contentLengthCount).toBe(1);
+    },
+  );
+});
+
+// https://github.com/oven-sh/bun/issues/29714
+it("default browser fallback response has a single Content-Length header", async () => {
+  await runTest(
+    {
+      // @ts-ignore — intentionally return undefined to trigger the default
+      // browser-navigation fallback (gzip HTML welcome page).
+      fetch() {},
+    },
+    async server => {
+      const wireBytes = await new Promise<string>((resolve, reject) => {
+        const sock = net.connect(Number(server.port), "127.0.0.1", () => {
+          sock.write(
+            "GET / HTTP/1.1\r\nHost: localhost\r\nSec-Fetch-Dest: document\r\nConnection: close\r\n\r\n",
+          );
+        });
+        let buf = "";
+        sock.on("data", d => (buf += d.toString("latin1")));
+        sock.on("end", () => resolve(buf));
+        sock.on("error", reject);
+      });
+
+      const headerSection = wireBytes.split("\r\n\r\n", 1)[0];
+      const contentLengthCount = headerSection
+        .split("\r\n")
+        .filter(line => /^content-length\s*:/i.test(line)).length;
+      expect(contentLengthCount).toBe(1);
+    },
+  );
+});
+
 it("request.signal works in trivial case", async () => {
   var aborty = new AbortController();
   var signaler = Promise.withResolvers();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -380,9 +380,7 @@ it("default fallback response has a single Content-Length header", async () => {
       // The raw wire bytes must contain exactly one Content-Length header
       // (case-insensitive) — RFC 7230 §3.3.2.
       const headerSection = wireBytes.split("\r\n\r\n", 1)[0];
-      const contentLengthCount = headerSection
-        .split("\r\n")
-        .filter(line => /^content-length\s*:/i.test(line)).length;
+      const contentLengthCount = headerSection.split("\r\n").filter(line => /^content-length\s*:/i.test(line)).length;
       expect(contentLengthCount).toBe(1);
     },
   );
@@ -399,9 +397,7 @@ it("default browser fallback response has a single Content-Length header", async
     async server => {
       const wireBytes = await new Promise<string>((resolve, reject) => {
         const sock = net.connect(Number(server.port), "127.0.0.1", () => {
-          sock.write(
-            "GET / HTTP/1.1\r\nHost: localhost\r\nSec-Fetch-Dest: document\r\nConnection: close\r\n\r\n",
-          );
+          sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nSec-Fetch-Dest: document\r\nConnection: close\r\n\r\n");
         });
         let buf = "";
         sock.on("data", d => (buf += d.toString("latin1")));
@@ -410,9 +406,7 @@ it("default browser fallback response has a single Content-Length header", async
       });
 
       const headerSection = wireBytes.split("\r\n\r\n", 1)[0];
-      const contentLengthCount = headerSection
-        .split("\r\n")
-        .filter(line => /^content-length\s*:/i.test(line)).length;
+      const contentLengthCount = headerSection.split("\r\n").filter(line => /^content-length\s*:/i.test(line)).length;
       expect(contentLengthCount).toBe(1);
     },
   );


### PR DESCRIPTION
## What

When `fetch()` returns a non-`Response` value (`undefined`, `Symbol`, etc.), `Bun.serve` falls back to the default "Welcome to Bun!" landing-page response. That response was emitting **two** `Content-Length` headers on the wire — an RFC 7230 §3.3.2 violation.

## Repro (from #29714)

```js
const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch() {} });
const net = await import("node:net");
const wire = await new Promise((r, j) => {
  const s = net.connect(server.port, "127.0.0.1", () => s.write(
    "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"));
  let b = ""; s.on("data", d => b += d); s.on("end", () => r(b));
});
console.log(wire);
server.stop();
```

Before:
```
HTTP/1.1 200 OK
content-type: text/plain;charset=utf-8
content-length: 57        ← first
Date: ...
Content-Length: 57        ← second (duplicate)

Welcome to Bun! ...
```

After:
```
HTTP/1.1 200 OK
content-type: text/plain;charset=utf-8
content-length: 57
Date: ...

Welcome to Bun! ...
```

## Cause

`renderMissingCorked` in `src/bun.js/api/server/RequestContext.zig` writes `content-length` via `resp.writeHeaderInt` (raw byte emission), then calls `ctx.end(body, ...)`. `end()` in uWebSockets passes `allowContentLength = !(state & HTTP_WROTE_CONTENT_LENGTH_HEADER)` to `internalEnd`. The raw write does **not** set that state bit, so uws re-emits `Content-Length` itself.

The same bug lived on the browser-navigation branch (`sec-fetch-dest: document`) which serves the gzipped HTML welcome page.

## Fix

Call `resp.markWroteContentLengthHeader()` after the manual `writeHeaderInt`. This is the same pattern already used in `onResolveSendfile` (`RequestContext.zig:2190`) and `FileRoute.zig:131`.

## Verification

Both new tests in `test/js/bun/http/serve.test.ts` fail on main and pass with this change:

- `default fallback response has a single Content-Length header` (plain text path)
- `default browser fallback response has a single Content-Length header` (gzip HTML path, triggered via `Sec-Fetch-Dest: document`)

Tests inspect the raw wire bytes and count `^content-length:`-matching header lines (case-insensitive).

Fixes #29714