### PR TITLE
Fix WeakRef [[KeptAlive]] not cleared at JSC-internal microtask checkpoints

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -344,8 +344,27 @@ extern "C" JSC::EncodedJSValue BunObject__createBunStdin(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStderr(JSC::JSGlobalObject*);
 extern "C" JSC::EncodedJSValue BunObject__createBunStdout(JSC::JSGlobalObject*);
 
+// ECMA-262 sec-clear-kept-objects requires [[KeptAlive]] to be cleared between
+// microtask jobs so WeakRef.deref() does not strongly hold targets across
+// `await` boundaries. JSC implements this as VM::finalizeSynchronousJSExecution
+// (just bumps the weak-ref version counter — essentially free). We hook it
+// onto the per-microtask tick because Bun's outer microtask drain in
+// drainMicrotasksWithGlobal() only fires when control returns to Bun's event
+// loop, while async-function continuations on already-fulfilled promises
+// resume inside JSC's own microtask checkpoint without surfacing to Bun.
+//
+// V8's MicrotaskQueue::PerformCheckpoint clears [[KeptAlive]] once at the end
+// of the checkpoint; per-microtask is more aggressive but spec-compliant
+// (see the note on sec-clear-kept-objects: "ClearKeptObjects can be called at
+// the end of every Job").
+static ALWAYS_INLINE void releaseWeakRefsOnMicrotaskTick(JSC::VM& vm)
+{
+    vm.finalizeSynchronousJSExecution();
+}
+
 static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
 {
+    releaseWeakRefsOnMicrotaskTick(vm);
     auto* globalObject = defaultGlobalObject();
     if (auto queue = globalObject->m_nextTickQueue.get()) {
         globalObject->resetOnEachMicrotaskTick();
@@ -353,8 +372,14 @@ static void checkIfNextTickWasCalledDuringMicrotask(JSC::VM& vm)
     }
 }
 
+static void releaseWeakRefsOnMicrotask(JSC::VM& vm)
+{
+    releaseWeakRefsOnMicrotaskTick(vm);
+}
+
 static void cleanupAsyncHooksData(JSC::VM& vm)
 {
+    releaseWeakRefsOnMicrotaskTick(vm);
     auto* globalObject = defaultGlobalObject();
     globalObject->m_asyncContextData.get()->putInternalField(vm, 0, jsUndefined());
     globalObject->asyncHooksNeedsCleanup = false;
@@ -362,7 +387,7 @@ static void cleanupAsyncHooksData(JSC::VM& vm)
         vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
         checkIfNextTickWasCalledDuringMicrotask(vm);
     } else {
-        vm.setOnEachMicrotaskTick(nullptr);
+        vm.setOnEachMicrotaskTick(&releaseWeakRefsOnMicrotask);
     }
 }
 
@@ -408,7 +433,12 @@ void Zig::GlobalObject::resetOnEachMicrotaskTick()
         vm.setOnEachMicrotaskTick(&cleanupAsyncHooksData);
     } else {
         if (this->m_nextTickQueue) {
-            vm.setOnEachMicrotaskTick(nullptr);
+            // Was nullptr; install a hook that bumps the WeakRef version every
+            // microtask tick so ECMA-262 ClearKeptObjects fires at every
+            // microtask job, including JSC-internal checkpoints (e.g.
+            // async-function resumes on already-fulfilled promises) that never
+            // surface to Bun's outer drainMicrotasksWithGlobal().
+            vm.setOnEachMicrotaskTick(&releaseWeakRefsOnMicrotask);
         } else {
             vm.setOnEachMicrotaskTick(&checkIfNextTickWasCalledDuringMicrotask);
         }
@@ -515,6 +545,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     vm.setOnComputeErrorInfoJSValue(computeErrorInfoWrapperToJSValue);
     vm.setComputeLineColumnWithSourcemap(computeLineColumnWithSourcemap);
     vm.setOnEachMicrotaskTick([](JSC::VM& vm) -> void {
+        releaseWeakRefsOnMicrotaskTick(vm);
         // if you process.nextTick on a microtask we need this
         auto* globalObject = defaultGlobalObject();
         if (auto queue = globalObject->m_nextTickQueue.get()) {

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -101,19 +101,18 @@ describe("bun:jsc", () => {
   // own state (extra retained values, async hook state) cannot keep the
   // target alive incidentally.
   it("WeakRef target collects after `await Promise.resolve()` (per-microtask ClearKeptObjects)", async () => {
-    using dir = tempDir("weakref-await", {
-      "test.mjs":
-        `import { fullGC } from "bun:jsc";\n` +
-        `function makeRef() { return new WeakRef({ value: 1 }); }\n` +
-        `const ref = makeRef();\n` +
-        `await Promise.resolve();\n` +
-        `fullGC();\n` +
-        `console.log(ref.deref() === undefined ? "PASS" : "FAIL");\n`,
-    });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test.mjs"],
+      cmd: [
+        bunExe(),
+        "-e",
+        `import { fullGC } from "bun:jsc";
+        function makeRef() { return new WeakRef({ value: 1 }); }
+        const ref = makeRef();
+        await Promise.resolve();
+        fullGC();
+        console.log(ref.deref() === undefined ? "PASS" : "FAIL");`,
+      ],
       env: bunEnv,
-      cwd: String(dir),
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect(stdout.trim()).toBe("PASS");

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -94,6 +94,30 @@ describe("bun:jsc", () => {
   });
   it("releaseWeakRefs", () => {
     expect(releaseWeakRefs()).toBeUndefined();
+  });
+  // ECMA-262 sec-clear-kept-objects: [[KeptAlive]] is emptied at every
+  // microtask checkpoint, including async-function continuations on
+  // already-fulfilled promises. Run in a subprocess so the test runner's
+  // own state (extra retained values, async hook state) cannot keep the
+  // target alive incidentally.
+  it("WeakRef target collects after `await Promise.resolve()` (per-microtask ClearKeptObjects)", async () => {
+    using dir = tempDir("weakref-await", {
+      "test.mjs":
+        `import { fullGC } from "bun:jsc";\n` +
+        `function makeRef() { return new WeakRef({ value: 1 }); }\n` +
+        `const ref = makeRef();\n` +
+        `await Promise.resolve();\n` +
+        `fullGC();\n` +
+        `console.log(ref.deref() === undefined ? "PASS" : "FAIL");\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("PASS");
+    expect(exitCode).toBe(0);
   });
   it("totalCompileTime", () => {
     expect(totalCompileTime(count)).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
## Summary

Bun called `VM::finalizeSynchronousJSExecution` (the JSC entry point that bumps `m_currentWeakRefVersion` — i.e. ECMA-262 `ClearKeptObjects`) only from the Zig drain in `event_loop.zig drainMicrotasksWithGlobal`, which fires when control returns to Bun's event loop. JSC drains its own microtask queue **inline** for async-function resumes on already-fulfilled promises (e.g. `await Promise.resolve()`), so user code that mixed `WeakRef.deref()` with such awaits retained targets across the boundary — diverging from V8/Node and the spec.

This hooks the call onto JSC's per-microtask tick callback (`vm.setOnEachMicrotaskTick`) in `ZigGlobalObject`, which already existed for `process.nextTick` plumbing. Per-Job clearing (vs V8's per-checkpoint) is explicitly permitted by [the note on `sec-clear-kept-objects`](https://tc39.es/ecma262/#sec-clear-kept-objects) ("ClearKeptObjects can be called at the end of every Job"), and the cost is two stores per microtask. The pre-drain release in `event_loop.zig` is unchanged — it still covers turn-boundary residue.

Reducer (fails on main, passes with the fix):

```js
import { fullGC } from "bun:jsc";
const ref = new WeakRef({ value: 1 });
await Promise.resolve();
fullGC();
console.log(ref.deref()); // main: { value: 1 }; with fix: undefined
```

Refs #24285 — the `WeakRef` workaround Jarred suggested in [this comment](https://github.com/oven-sh/bun/issues/24285#issuecomment-3476134061) now works as the reporter expected, without `bun:jsc.releaseWeakRefs()`. The other concerns in that thread (the `bun.repeatedlyGcAndRunFinalizers()` request and the N-API `napi_wrap` finalizer comment from `@robert-johansson`) are separate and not addressed here.

## Test plan

- [x] New regression test in `test/js/bun/jsc/bun-jsc.test.ts`. Confirmed:
  - `USE_SYSTEM_BUN=1 bun test ... -t "WeakRef target collects"` → **fail** (`Received: "FAIL"`)
  - `bun bd test test/js/bun/jsc/bun-jsc.test.ts` → **29 pass / 0 fail**
- [x] No regressions in nearby suites:
  - `test/js/node/test/parallel/test-weakref.js` — exit 0
  - `test/js/node/test/parallel/test-finalization-registry-shutdown.js` — exit 0
  - `test/js/node/util/test-aborted.test.ts` — 5/5
  - `test/js/bun/websocket/websocket-upgrade-signal-gc.test.ts` — 1/1
  - `test/js/web/timers/setTimeout.test.js` + setImmediate + `test/js/web/process/process-nextTick.test.ts` — 26 pass / 1 todo / 0 fail
  - `test/js/node/async_hooks/` — only failure was unrelated (`verdaccio/bin/verdaccio` resolution, missing dev dep)
  - `test/js/bun/jsc/domjit.test.ts` timeouts on debug+ASAN are pre-existing (verified by stashing the patch)
- [x] User's original reducer from the issue thread now reports `cleared after 1 GC(s)`.

## Notes

`Bun.gc(true)` already calls `finalizeSynchronousJSExecution` on either side of the GC (`bindings.cpp` `JSC__VM__runGC`), which is why some user-facing reducers using `Bun.gc(true)` did not surface this bug — the GC entrypoint masked it. The bug only manifests when KeptAlive is read **between** an `await` and an unrelated GC, e.g. via `bun:jsc.fullGC()` (which doesn't itself bump the WeakRef version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)