### PR TITLE
fix(expect): propagate exceptions from custom asymmetric matchers

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -561,6 +561,7 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
         flags = flags & ~FLAG_NOT;
 
         bool passed = ExpectCustomAsymmetricMatcher__execute(customMatcher->wrapped(), JSValue::encode(matcherProp), globalObject, JSValue::encode(otherProp));
+        RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
         return passed ? AsymmetricMatcherResult::PASS : AsymmetricMatcherResult::FAIL;
     }
 

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -1051,6 +1051,7 @@ pub const Expect = struct {
             promise.setHandled(vm);
 
             globalThis.bunVM().waitForPromise(promise);
+            if (globalThis.hasException()) return error.JSError;
 
             result = promise.result(vm);
             result.ensureStillAlive();
@@ -1732,6 +1733,7 @@ pub const ExpectCustomAsymmetricMatcher = struct {
         const arguments = callframe.arguments_old(1).slice();
         const received_value = if (arguments.len < 1) .js_undefined else arguments[0];
         const matched = try executeImpl(this, callframe.this(), globalThis, received_value);
+        if (globalThis.hasException()) return error.JSError;
         return JSValue.jsBoolean(matched);
     }
 

--- a/test/js/bun/test/expect-extend-asymmetric-match-throw.test.ts
+++ b/test/js/bun/test/expect-extend-asymmetric-match-throw.test.ts
@@ -10,3 +10,39 @@ test("asymmetricMatch propagates exceptions thrown by the matcher", () => {
   const matcher = expect._toThrowOnMatch();
   expect(() => matcher.asymmetricMatch({})).toThrow("boom from matcher");
 });
+
+test("asymmetricMatch propagates InvalidMatcherError when matcher returns a non-result object", () => {
+  expect.extend({
+    _toReturnInvalid(received) {
+      // Returning another asymmetric matcher instead of { pass, message } triggers
+      // the "Unexpected return from matcher function" error path.
+      return expect.any(received);
+    },
+  });
+  // @ts-expect-error: _toReturnInvalid is registered dynamically via expect.extend
+  const matcher = expect._toReturnInvalid();
+  expect(() => matcher.asymmetricMatch(expect)).toThrow(/Unexpected return from matcher function/);
+});
+
+test("custom asymmetric matcher that throws inside toEqual propagates the exception", () => {
+  expect.extend({
+    _toThrowInDeepEquals() {
+      throw new Error("boom from deep-equals matcher");
+    },
+  });
+  // @ts-expect-error: _toThrowInDeepEquals is registered dynamically via expect.extend
+  const matcher = expect._toThrowInDeepEquals();
+  // Using the matcher inside toEqual exercises the C++ matchAsymmetricMatcher path.
+  expect(() => expect({ a: 1 }).toEqual({ a: matcher })).toThrow("boom from deep-equals matcher");
+});
+
+test("custom asymmetric matcher returning an invalid result inside toEqual propagates the exception", () => {
+  expect.extend({
+    _toReturnInvalidInDeepEquals(received) {
+      return expect.any(received);
+    },
+  });
+  // @ts-expect-error: _toReturnInvalidInDeepEquals is registered dynamically via expect.extend
+  const matcher = expect._toReturnInvalidInDeepEquals();
+  expect(() => expect({ a: Date }).toEqual({ a: matcher })).toThrow(/Unexpected return from matcher function/);
+});


### PR DESCRIPTION
## What does this PR do?

Fuzzilli found a flaky debug assertion crash (fingerprint `472ba50e07be71e4`):

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Unexpected return from matcher function `any`.
Matcher functions should return an object in the following format:
  {message?: string | function, pass: boolean}
'Any<Expect>' was returned

!exception()
JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

### Root cause

The crash requires state from a previous REPRL iteration where `expect.extend({ any: ... })` overrode the built-in `expect.any` with a custom matcher. In the crashing sample, `expect.any(Date)` then produced an `ExpectCustomAsymmetricMatcher` whose `.asymmetricMatch(expect)` call ends up in `executeCustomMatcher`, which throws `throwInvalidMatcherError` (the matcher returned an `ExpectAny` instance instead of `{ pass, message }`).

There were three places where a pending exception from this path could survive without being surfaced as `error.JSError`, ultimately tripping the host-function wrapper's `assertExceptionPresenceMatches` / `releaseAssertNoException`:

- `matchAsymmetricMatcherAndGetFlags` (C++) called `ExpectCustomAsymmetricMatcher__execute` — whose Zig side does `catch false` and leaves the JSC exception pending — without a following `RETURN_IF_EXCEPTION`.
- `executeCustomMatcher` drained the event loop via `waitForPromise` for async matcher results and then continued without checking for a pending exception.
- `asymmetricMatch` returned `jsBoolean(matched)` after `executeImpl` without guarding against a pending exception that may have been set during execution.

### Fix

Add the missing exception checks at each of those points. All three are one-liners.

### Repro

The exact fuzzer crash depends on state carried over between REPRL iterations and is not deterministically reproducible standalone, but the scenarios it relies on are now covered by regression tests (direct `.asymmetricMatch()` call and the `toEqual` / deep-equals path) for both throwing matchers and matchers that return an invalid result.

## How did you verify your code works?

- `bun bd test test/js/bun/test/expect-extend-asymmetric-match-throw.test.ts` — 4/4 pass.
- `bun bd test test/js/bun/test/expect-extend.test.js` — 28/28 pass.
- Original fuzzer sample and a forced `expect.extend({ any: expect.any })` variant run cleanly under the rebuilt `debug-fuzz` binary.