### PR TITLE
Expose `Symbol.metadata` as a well-known symbol

### DIFF
--- a/src/jsc/bindings/BunGlobalScope.cpp
+++ b/src/jsc/bindings/BunGlobalScope.cpp
@@ -2,21 +2,78 @@
 #include "root.h"
 #include "ZigGlobalObject.h"
 #include "BunGlobalScope.h"
+#include "JavaScriptCore/FunctionPrototype.h"
+#include "JavaScriptCore/JSCJSValueInlines.h"
+#include "JavaScriptCore/Symbol.h"
+#include "JavaScriptCore/TopExceptionScope.h"
 #include "JavaScriptCore/VM.h"
 #include "JavaScriptCore/VMTraps.h"
 #include "JavaScriptCore/VMTrapsInlines.h"
 #include "JavaScriptCore/LazyClassStructure.h"
 #include "JavaScriptCore/LazyClassStructureInlines.h"
 #include "BunClientData.h"
+#include <wtf/text/SymbolImpl.h>
 
 namespace Bun {
 
 using namespace JSC;
 
+// TC39 Decorator Metadata well-known symbol. Process-wide StaticSymbolImpl so
+// that every realm in the same VM (main global, ShadowRealm, bun test
+// --isolate, node:vm contexts) sees the same `Symbol.metadata` value via JSC's
+// per-VM symbolImplToSymbolMap cache — ECMA-262 §6.1.5.1 requires well-known
+// symbols to be shared by all realms. When Bun's WebKit fork gains `metadata`
+// in JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL, the hasOwnProperty
+// guard below will skip the install and JSC's native symbol wins.
+// https://github.com/oven-sh/bun/issues/29724
+static WTF::SymbolImpl::StaticSymbolImpl metadataSymbolImpl { "Symbol.metadata" };
+
+static void installSymbolMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    // Matches addBuiltinGlobals: this runs during finishCreation and has no way
+    // to propagate an exception. Top exception scope swallows unexpected
+    // exceptions instead of tripping debug asserts downstream.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSC::JSObject* symbolConstructor = globalObject->get(globalObject, vm.propertyNames->Symbol).getObject();
+    scope.assertNoExceptionExceptTermination();
+    if (!symbolConstructor)
+        return;
+
+    JSC::Identifier metadataIdentifier = JSC::Identifier::fromString(vm, "metadata"_s);
+    if (symbolConstructor->hasOwnProperty(globalObject, metadataIdentifier)) {
+        scope.assertNoExceptionExceptTermination();
+        return;
+    }
+    scope.assertNoExceptionExceptTermination();
+
+    // Symbol::create(vm, impl) is cached per-VM in vm.symbolImplToSymbolMap, so
+    // every realm in this VM gets the same Symbol cell for this SymbolImpl —
+    // the spec requires well-known symbols to be shared across realms
+    // (ECMA-262 §6.1.5.1).
+    JSC::Symbol* metadataSymbol = JSC::Symbol::create(vm, static_cast<SymbolImpl&>(metadataSymbolImpl));
+    // Symbol.metadata on the Symbol constructor is non-configurable, matching
+    // every other well-known symbol (ECMA-262 §20.4.2).
+    symbolConstructor->putDirectWithoutTransition(vm, metadataIdentifier, metadataSymbol,
+        PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+
+    // Per the Decorator Metadata proposal, Function.prototype[@@metadata] is
+    // null so undecorated classes resolve `Foo[Symbol.metadata]` to null
+    // (rather than undefined) via the prototype chain. The proposal and
+    // test262 specify `{ writable: false, enumerable: false, configurable:
+    // true }` — deliberately looser than well-known-symbol attributes so
+    // userland polyfills can redefine the property.
+    JSC::JSObject* functionPrototype = globalObject->functionPrototype();
+    JSC::Identifier metadataSymbolIdentifier = JSC::Identifier::fromUid(vm, &static_cast<SymbolImpl&>(metadataSymbolImpl));
+    functionPrototype->putDirectWithoutTransition(vm, metadataSymbolIdentifier, JSC::jsNull(),
+        PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
+}
+
 void GlobalScope::finishCreation(JSC::VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
+
+    installSymbolMetadata(vm, this);
 
     m_encodeIntoObjectStructure.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -312,35 +312,104 @@ describe("ES Decorators", () => {
   });
 
   describe("metadata", () => {
+    test("Symbol.metadata is exposed as a well-known symbol", async () => {
+      // https://github.com/oven-sh/bun/issues/29724 — Symbol.metadata must be
+      // exposed globally so `class[Symbol.metadata]` works per TC39 spec.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        console.log(typeof Symbol.metadata);
+        console.log(Symbol.metadata.toString());
+        const d = Object.getOwnPropertyDescriptor(Symbol, "metadata");
+        console.log(d.writable, d.enumerable, d.configurable);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("symbol\nSymbol(Symbol.metadata)\nfalse false false\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("Symbol.metadata is set on decorated class", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
-        // Symbol.metadata may not exist natively, use the same fallback as the runtime
-        const metadataKey = Symbol.metadata || Symbol.for("Symbol.metadata");
         function dec(cls, ctx) { return cls; }
         @dec class Foo {}
-        console.log(typeof Foo[metadataKey]);
-        console.log(Foo[metadataKey] !== null);
+        console.log(typeof Foo[Symbol.metadata]);
+        console.log(Foo[Symbol.metadata] !== null);
       `);
       expect(stderr).toBe("");
       expect(stdout).toBe("object\ntrue\n");
       expect(exitCode).toBe(0);
     });
 
+    test("class field decorator writes and reads metadata via Symbol.metadata", async () => {
+      // https://github.com/oven-sh/bun/issues/29724
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, context) {
+          context.metadata["test"] = "works";
+        }
+        class Foo {
+          @dec name;
+        }
+        console.log(Foo[Symbol.metadata].test);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("works\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("metadata inherits from parent class", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`
-        const metadataKey = Symbol.metadata || Symbol.for("Symbol.metadata");
         function dec(cls, ctx) {
           ctx.metadata.decorated = true;
           return cls;
         }
         @dec class Base {}
         @dec class Child extends Base {}
-        console.log(Base[metadataKey].decorated);
-        console.log(Child[metadataKey].decorated);
-        console.log(Object.getPrototypeOf(Child[metadataKey]) === Base[metadataKey]);
+        console.log(Base[Symbol.metadata].decorated);
+        console.log(Child[Symbol.metadata].decorated);
+        console.log(Object.getPrototypeOf(Child[Symbol.metadata]) === Base[Symbol.metadata]);
       `);
       expect(stderr).toBe("");
       expect(stdout).toBe("true\ntrue\ntrue\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Symbol.metadata is shared across realms (ShadowRealm)", async () => {
+      // ECMA-262 §6.1.5.1 — well-known symbols are shared by all realms in the VM.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const r = new ShadowRealm();
+        const cross = r.evaluate("() => Symbol.metadata")();
+        console.log(cross === Symbol.metadata);
+        console.log(cross === Symbol.iterator);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true\nfalse\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Symbol.metadata is exposed inside node:vm contexts", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const { runInNewContext } = require("node:vm");
+        console.log(runInNewContext("typeof Symbol.metadata"));
+        console.log(runInNewContext("Symbol.metadata.toString()"));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("symbol\nSymbol(Symbol.metadata)\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("Function.prototype[Symbol.metadata] is null for undecorated classes", async () => {
+      // Per the Decorator Metadata proposal, undecorated classes resolve
+      // Foo[Symbol.metadata] to null via Function.prototype, not undefined.
+      // The proposal specifies `{ writable: false, enumerable: false,
+      // configurable: true }` — configurable is deliberately true so
+      // polyfills can redefine it.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class Plain {}
+        console.log(Plain[Symbol.metadata]);
+        console.log(Function.prototype[Symbol.metadata]);
+        const d = Object.getOwnPropertyDescriptor(Function.prototype, Symbol.metadata);
+        console.log(d.value, d.writable, d.enumerable, d.configurable);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("null\nnull\nnull false false true\n");
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
Fixes #29724.

## Repro

With `experimentalDecorators: false` (standard TC39 decorators):

```ts
function dec(_v, ctx) { ctx.metadata.test = 'works'; }
class Foo { @dec name; }

console.log(Symbol.metadata);          // was: undefined
console.log(Foo[Symbol.metadata]);     // was: undefined
```

## Cause

PR #26436 added `__decoratorMetadata`, which writes to `__knownSymbol("metadata")`:

```js
var __knownSymbol = (name, symbol) =>
  ((symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name));
```

`Symbol.metadata` was undefined, so every call fell back to `Symbol.for("Symbol.metadata")` — metadata landed on a registry symbol instead of the well-known symbol the TC39 spec (and `class[Symbol.metadata]`) expects.

JSC doesn't ship `metadata` in its `JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL` list.

## Fix

Install `Symbol.metadata` on the `Symbol` constructor in `GlobalObject::addBuiltinGlobals` with the same attributes JSC uses for other well-known symbols (`DontEnum | DontDelete | ReadOnly`). A `hasOwnProperty` guard makes it a no-op if a future JSC gains `Symbol.metadata` natively.

`__knownSymbol("metadata")` now returns the real well-known symbol, so decorated classes store and read metadata via the spec-compliant key.

## Verification

New tests in `test/bundler/transpiler/es-decorators.test.ts` cover:
- `Symbol.metadata` is a symbol with correct descriptor (`symbol`, `Symbol(Symbol.metadata)`, `false false false`)
- class field decorator writes metadata and `class[Symbol.metadata]` reads it back
- metadata inheritance across a parent class chain

Existing tests that used `Symbol.metadata || Symbol.for("Symbol.metadata")` as a workaround now use `Symbol.metadata` directly.

All 181 decorator tests across `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, and `decorator-metadata.test.ts` pass.