### PR TITLE
install: honor process umask when creating directories

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1057,7 +1057,7 @@ impl<'a> PackageInstall<'a> {
             while let Some(entry) = walker.next()? {
                 match entry.kind {
                     EntryKind::Directory => {
-                        let _ = sys::mkdirat(destination_dir_, entry.path, 0o755);
+                        let _ = sys::mkdirat(destination_dir_, entry.path, sys::UMASK_MKDIR_MODE);
                     }
                     EntryKind::File => {
                         let path_len = entry.path.len();
@@ -1125,7 +1125,7 @@ impl<'a> PackageInstall<'a> {
                 self.destination_dir_subpath_buf[slash] = 0;
                 // SAFETY: NUL written above.
                 let subdir = ZStr::from_buf(self.destination_dir_subpath_buf, slash);
-                let _ = sys::mkdirat(destination_dir, subdir, 0o755);
+                let _ = sys::mkdirat(destination_dir, subdir, sys::UMASK_MKDIR_MODE);
                 self.destination_dir_subpath_buf[slash] = SEP;
             }
         }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1333,6 +1333,16 @@ impl<'a> Linker<'a> {
     fn chmod_on_ok(err: Option<Error>, abs_target: &ZStr) {
         // hoisted from `defer` block in create_symlink
         if err.is_none() {
+            // `UMASK` is populated by `ensure_umask()`, which the hoisted
+            // installer, isolated installer, and `bun link` / `bun unlink`
+            // all call on the main thread before scheduling bin-link work.
+            // If a future caller forgets to prime, `UMASK` stays at `0` and
+            // `0o777 & !0` silently widens bin perms to `0o777`. Assert in
+            // debug builds so a miss is loud.
+            debug_assert!(
+                HAS_SET_UMASK.load(Ordering::Acquire),
+                "Bin::Linker::ensure_umask() not primed before bin chmod — would widen to 0o777",
+            );
             let mode = 0o777 & !(UMASK.load(Ordering::Acquire) as Mode);
             let _ = sys::lchmod(abs_target, mode);
         }

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -191,8 +191,10 @@ pub(crate) fn install_hoisted_packages(
 
         new_node_modules = true;
 
-        // Attempt to create a new node_modules folder
-        if let Err(err) = sys::mkdir(bun_core::zstr!("node_modules"), 0o755) {
+        // Attempt to create a new node_modules folder. Pass 0o777 so the
+        // kernel's umask application decides the final permission
+        // (matches Node/npm/pnpm; issue #29723).
+        if let Err(err) = sys::mkdir(bun_core::zstr!("node_modules"), sys::UMASK_MKDIR_MODE) {
             if err.errno != sys::E::EEXIST as _ {
                 Output::err(
                     err,

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -40,6 +40,8 @@ use bun_sys::{self as sys, Fd};
 use bun_wyhash::{Wyhash, Wyhash11};
 
 use crate::analytics;
+#[cfg(unix)]
+use crate::bin_real as bin;
 use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
@@ -222,6 +224,15 @@ pub(crate) fn install_isolated_packages(
     packages_to_install: Option<&[PackageID]>,
 ) -> Result<crate::package_install::Summary, AllocError> {
     analytics::features::isolated_bun_install.fetch_add(1, Ordering::Relaxed);
+
+    // Prime `Bin::Linker::UMASK` on the main thread before any bin-linking
+    // tasks are scheduled. `ensure_umask()` uses a compare-exchange gate
+    // plus umask(0)/umask(prev) probe on the process-global umask — calling
+    // it later from worker threads would add a window where umask is
+    // temporarily 0 while concurrent mkdirat calls run (issue #29723).
+    // Hoisted install primes it the same way from its main-thread entry.
+    #[cfg(unix)]
+    bin::Linker::ensure_umask();
 
     // Take a raw pointer so column borrows below don't tie up `&mut manager`
     // (which owns the lockfile).
@@ -1675,12 +1686,12 @@ pub(crate) fn install_isolated_packages(
         // matches `Installer::NODE_MODULES_BUN`.
         let bun_modules_path = paths::path_literal!("node_modules/.bun");
 
-        match sys::mkdirat(Fd::cwd(), node_modules_path, 0o755) {
+        match sys::mkdirat(Fd::cwd(), node_modules_path, sys::UMASK_MKDIR_MODE) {
             Ok(()) => {
                 // fallthrough to creating bun_modules below
             }
             Err(_) => {
-                match sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {
+                match sys::mkdirat(Fd::cwd(), bun_modules_path, sys::UMASK_MKDIR_MODE) {
                     Err(_) => break 'is_new_bun_modules false,
                     Ok(()) => {}
                 }
@@ -1707,7 +1718,9 @@ pub(crate) fn install_isolated_packages(
                         .assume_ok();
 
                     // 1
-                    if sys::mkdirat(Fd::cwd(), rename_path.slice_z(), 0o755).is_err() {
+                    if sys::mkdirat(Fd::cwd(), rename_path.slice_z(), sys::UMASK_MKDIR_MODE)
+                        .is_err()
+                    {
                         break 'is_new_bun_modules true;
                     }
 
@@ -1817,12 +1830,16 @@ pub(crate) fn install_isolated_packages(
                     }
 
                     // 2
-                    if let Err(err) = sys::mkdirat(Fd::cwd(), node_modules_path, 0o755) {
+                    if let Err(err) =
+                        sys::mkdirat(Fd::cwd(), node_modules_path, sys::UMASK_MKDIR_MODE)
+                    {
                         Output::err(err, "failed to create './node_modules'", format_args!(""));
                         Global::exit(1);
                     }
 
-                    if let Err(err) = sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {
+                    if let Err(err) =
+                        sys::mkdirat(Fd::cwd(), bun_modules_path, sys::UMASK_MKDIR_MODE)
+                    {
                         Output::err(
                             err,
                             "failed to create './node_modules/.bun'",
@@ -1904,7 +1921,7 @@ pub(crate) fn install_isolated_packages(
             }
         }
 
-        if let Err(err) = sys::mkdirat(Fd::cwd(), bun_modules_path, 0o755) {
+        if let Err(err) = sys::mkdirat(Fd::cwd(), bun_modules_path, sys::UMASK_MKDIR_MODE) {
             Output::err(
                 err,
                 "failed to create './node_modules/.bun'",

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1220,6 +1220,12 @@ impl BunxCommand {
             Global::exit(1);
         }
 
+        // The bunx cache root lives in the shared temp directory, and
+        // `is_trusted_cache_root` refuses group/other-writable roots. Request
+        // 0o755 explicitly instead of the umask-honoring default (0o777) so a
+        // permissive umask like 0o002 cannot widen the root into a state bunx
+        // itself rejects; the kernel can only subtract bits from 0o755.
+        bun_sys::mkdir_recursive_at_mode(Fd::cwd(), bunx_cache_dir, 0o755)?;
         let bunx_install_dir = Fd::cwd().make_open_path(bunx_cache_dir)?;
 
         'create_package_json: {

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -320,9 +320,13 @@ pub struct CreateFlags {
 }
 
 impl Dir {
-    /// Single-level `mkdirat` (mode 0o755) relative to
+    /// Single-level `mkdirat` relative to
     /// this dir. Unlike `make_path`, does NOT create intermediate directories
     /// and surfaces `EEXIST` for callers to branch on.
+    ///
+    /// Passes `UMASK_MKDIR_MODE` (0o777) so the kernel applies the process
+    /// umask — default umask `0o022` still yields `0o755`, `umask 0o002`
+    /// yields `0o775` (issue #29723).
     pub fn make_dir(&self, sub_path: &[u8]) -> core::result::Result<(), bun_errno::SystemErrno> {
         let mut buf = bun_paths::PathBuffer::default();
         let len = sub_path.len().min(buf.0.len() - 1);
@@ -330,7 +334,7 @@ impl Dir {
         buf.0[len] = 0;
         // SAFETY: NUL-terminated above.
         let z = ZStr::from_buf(&buf.0[..], len);
-        match mkdirat(self.fd, z, 0o755) {
+        match mkdirat(self.fd, z, UMASK_MKDIR_MODE) {
             Ok(()) => Ok(()),
             Err(e) if e.get_errno() == E::EEXIST => Err(bun_errno::SystemErrno::EEXIST),
             Err(e) => Err(e.into()),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -968,6 +968,15 @@ impl AsFd for &Dir {
     }
 }
 
+/// Mode passed to `mkdirat(2)` when creating directories.
+///
+/// POSIX applies the process umask on top of this, so the final permission
+/// is `0o777 & ~umask`. With the default umask of `0o022` this yields
+/// `0o755` (same as before), but `umask 0o002` yields `0o775` — letting
+/// multi-user setups work like they do with Node, npm, pnpm, and `mkdir(1)`
+/// (issue #29723).
+pub const UMASK_MKDIR_MODE: Mode = 0o777;
+
 // Raw Linux syscalls via rustix (linux_raw backend). Hot-path I/O on Linux
 // routes through here instead of glibc — see module doc. Android: same kernel,
 // same syscall ABI; `linux_syscall.rs` carries its own
@@ -2448,10 +2457,16 @@ mod posix_impl {
         Ok(())
     }
     /// `bun.makePath` — `mkdirat` walking up parents on ENOENT, like `mkdir -p`.
+    ///
+    /// Passes `UMASK_MKDIR_MODE` (0o777) so the kernel applies the process
+    /// umask to the final permissions, matching `mkdir(1)`, Node, npm, and
+    /// pnpm. Default umask `0o022` still yields `0o755`; `umask 0o002`
+    /// yields `0o775` — letting multi-user repos work with bun install
+    /// (issue #29723).
     #[inline]
     pub fn mkdir_recursive_at(dir: impl AsFd, sub_path: &[u8]) -> Maybe<()> {
         let dir = dir.as_fd();
-        mkdir_recursive_at_mode(dir, sub_path, 0o755)
+        mkdir_recursive_at_mode(dir, sub_path, UMASK_MKDIR_MODE)
     }
     /// `mkdir_recursive_at` with an explicit `mode` for created directories
     /// (matches `bun.api.node.fs.NodeFS.mkdirRecursive`'s `mode` arg).

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -8878,6 +8878,83 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // Regression for https://github.com/oven-sh/bun/issues/29723:
+  // `bun install` hard-coded 0o755 when creating directories, which meant the
+  // caller's umask could never loosen the perms beyond 0o755. With
+  // `umask 0o002` a user would still get 0o755 cache/node_modules dirs —
+  // blocking shared multi-user repos.
+  //
+  // POSIX-only. Windows has no umask, and directory creation goes through a
+  // different code path there.
+  //
+  // Parametrized over the two linkers because they share almost no directory-
+  // creation code — isolated goes through `isolated_install.rs` /
+  // `isolated_install/Installer.rs`, hoisted through `hoisted_install.rs`
+  // and `PackageInstall::install_with_hardlink`. Bin linking in particular
+  // relied on `Bin::Linker::ensure_umask()` being primed by the hoisted
+  // entry point; the isolated path never called it, so bin targets would
+  // chmod to 0o777 regardless of umask.
+  for (const linker of ["hoisted", "isolated"] as const) {
+    it.skipIf(isWindows)(
+      `${linker} install respects process umask for directories and bin targets (#29723)`,
+      async () => {
+        // Local tarball that ships an executable bin — exercises both the
+        // package-dir mkdir path and `Bin.Linker.createSymlink`'s chmod.
+        const tarSrc = tempDirWithFiles(`bun-install-umask-29723-tar-${linker}`, {
+          "package/package.json": JSON.stringify({
+            name: "multi-tool-pkg",
+            version: "1.0.0",
+            bin: { "multi-tool": "bin/multi-tool.js" },
+          }),
+          "package/bin/multi-tool.js": `#!/usr/bin/env node\nconsole.log("EXECUTED: multi-tool (main binary)");\n`,
+        });
+        const pkgDir = tempDirWithFiles(`bun-install-umask-29723-${linker}`, {
+          "package.json": JSON.stringify({
+            name: "foo",
+            version: "0.0.1",
+            dependencies: {
+              "multi-tool-pkg": "file:multi-tool-pkg-1.0.0.tgz",
+            },
+          }),
+          "bunfig.toml": `[install]\nlinker = "${linker}"\n`,
+        });
+        await Bun.$`chmod +x ${tarSrc}/package/bin/multi-tool.js`;
+        await Bun.$`tar -czf ${join(pkgDir, "multi-tool-pkg-1.0.0.tgz")} -C ${tarSrc} package`;
+        const cacheDir = join(pkgDir, ".umask-cache");
+
+        // Drive umask through a shell wrapper — calling process.umask() in
+        // the test runner would leak into unrelated concurrent tests.
+        //
+        // BUN_INSTALL_CACHE_DIR wins over bunfig's `cache = "..."`, and the
+        // CI runner sets it to a per-test tmpdir. Point it at our own dir
+        // so the assertion below checks the cache we actually created.
+        await using proc = Bun.spawn({
+          cmd: ["sh", "-c", `umask 0002 && exec "$@"`, "sh", bunExe(), "install"],
+          cwd: pkgDir,
+          env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+          stderr: "pipe",
+          stdout: "ignore",
+          stdin: "ignore",
+        });
+        const [errText, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(errText).not.toContain("error:");
+        expect(exitCode).toBe(0);
+
+        const statMode = (p: string) => stat(p).then(s => s.mode & 0o777);
+
+        // Directories we create: final mode = 0o777 & ~0o002 = 0o775.
+        expect(await statMode(join(pkgDir, "node_modules"))).toBe(0o775);
+        expect(await statMode(cacheDir)).toBe(0o775);
+
+        // Bin target — `stat` follows the symlink so this is the mode of
+        // the executable file that `Bin.Linker.createSymlink` chmod'd.
+        // Pre-fix isolated installs left this at 0o777.
+        const binLink = join(pkgDir, "node_modules", ".bin", "multi-tool");
+        expect((await stat(binLink)).mode & 0o777).toBe(0o775);
+      },
+    );
+  }
+
   it("should handle @scoped name that contains tilde, issue#7045", async () => {
     await withContext(defaultOpts, async ctx => {
       await writeFile(

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -837,6 +837,94 @@ console.log("EXECUTED: multi-tool-alt (alternate binary)");
       expect(out).not.toContain("EXECUTED: multi-tool (main binary)");
       expect(exited).toBe(0);
     });
+
+    // bunx creates its cache root in the shared temp dir, and
+    // `is_trusted_cache_root` refuses roots that are group/other-writable. A
+    // permissive umask must not widen the root bunx creates for itself, or
+    // the second invocation refuses the cache the first one made (#29723).
+    it.skipIf(isWindows)("reuses its own cache when created under a permissive umask", async () => {
+      const urls: string[] = [];
+
+      const tempDir = tmpdirSync();
+      const packageDir = join(tempDir, "package");
+      await Bun.$`mkdir -p ${packageDir}/bin`;
+      await writeFile(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "multi-tool-pkg",
+          version: "1.0.0",
+          bin: {
+            "multi-tool": "bin/multi-tool.js",
+          },
+        }),
+      );
+      await writeFile(
+        join(packageDir, "bin", "multi-tool.js"),
+        `#!/usr/bin/env node
+console.log("EXECUTED: multi-tool (main binary)");
+`,
+      );
+      await Bun.$`chmod +x ${packageDir}/bin/multi-tool.js`;
+      const tgzDir = tmpdirSync();
+      await Bun.$`cd ${tempDir} && tar -czf ${join(tgzDir, "multi-tool-pkg-1.0.0.tgz")} package`;
+
+      setHandler(
+        dummyRegistry(
+          urls,
+          {
+            "1.0.0": {
+              bin: {
+                "multi-tool": "bin/multi-tool.js",
+              },
+              as: "1.0.0",
+            },
+          },
+          0,
+          tgzDir,
+        ),
+      );
+
+      const run = () => {
+        const subprocess = spawn({
+          cmd: [
+            "sh",
+            "-c",
+            `umask 0002 && exec "$@"`,
+            "sh",
+            bunExe(),
+            "x",
+            "--package",
+            "multi-tool-pkg",
+            "multi-tool",
+          ],
+          cwd: x_dir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: {
+            ...env,
+            npm_config_registry: `http://localhost:${port}/`,
+          },
+        });
+        return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+      };
+
+      // First run creates the cache root under umask 0o002 and installs into it.
+      {
+        const [err, out, exited] = await run();
+        expect(err).not.toContain("refusing to use bunx cache directory");
+        expect(out).toContain("EXECUTED: multi-tool (main binary)");
+        expect(exited).toBe(0);
+      }
+
+      // Second run must accept the cache root the first run just created.
+      {
+        const [err, out, exited] = await run();
+        expect(err).not.toContain("refusing to use bunx cache directory");
+        expect(out).toContain("EXECUTED: multi-tool (main binary)");
+        expect(exited).toBe(0);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
> **Rebase note (latest):** rebased onto main after the Zig→Rust install port. The live code is now in the `.rs` files (`src/sys/lib.rs`, `src/install/*.rs`); the `.zig` siblings are kept as reference. One conflict in `src/install/bin.rs`: main's hardening PR #31339 switched the bin chmod from `sys::chmod` to `sys::lchmod` (chmod the symlink itself rather than follow it), and PR #30722 had already landed the `ensure_umask()` infrastructure + `0o777 & ~umask` bin chmod (taken from an earlier revision of this branch). Resolved by keeping main's `lchmod` + `mode` and re-adding only my `debug_assert!(HAS_SET_UMASK…)` guard ahead of it. The directory-mode fix (`UMASK_MKDIR_MODE`, the actual subject of #29723 — directories coming out `0o755` regardless of umask) is **not** on main and remains the core of this PR. Both umask regression tests (hoisted + isolated) pass on the rebased branch.

---

Fixes #29723.

### Repro (Linux)

```console
$ umask 002
$ cat > package.json <<'EOF'
{"dependencies":{"is-number":"7.0.0"}}
EOF
$ BUN_INSTALL_CACHE_DIR=./.testcache bun install
$ stat -c '%a %n' .testcache node_modules node_modules/is-number
755 .testcache
755 node_modules
755 node_modules/is-number          # reporter expected 775
```

### Cause

Two things conspired to ignore the caller's umask:

1. The install path hard-codes `0o755` on every `mkdirat` — e.g. `bun.sys.mkdir("node_modules", 0o755)`, `sys.mkdirat(..., node_modules_path, 0o755)`, `bun.sys.mkdirat(..., entry.path, 0o755)`. `std.fs.Dir.makeDir` / `makeOpenPath` (used via `MakePath.makeOpenPath` etc.) hard-code the same `default_mode = 0o755`. Kernel umask is subtractive, so `0o755 & ~0o002 == 0o755` — umask can never loosen perms beyond 0o755.
2. `Bin.Linker.ensureUmask()` calls `bun.sys.umask(0)` before the install loop. Even if mkdirat received `0o777`, the kernel would stop masking, so dirs would come out `0o777` instead of `0o775`.

### Fix

- `bun.makePath`, `bun.makePathW`, `bun.MakePath.makePath`, and `bun.MakePath.makeOpenPath` now pass `0o777` to `mkdirat` on POSIX (new `bun.umask_mkdir_mode` constant). Windows paths are untouched.
- Direct `sys.mkdirat(..., 0o755)` calls in `hoisted_install.zig`, `isolated_install.zig`, `PackageInstall.zig` switch to `bun.umask_mkdir_mode`.
- Install call sites that went through `std.fs.Dir.makeOpenPath` (`PackageManagerOptions`, `PackageManagerDirectories`, `PackageManager.zig`, `PackageInstaller.zig`, `PackageInstall.zig`) now call `bun.MakePath.makeOpenPath`, so they pick up the umask-friendly path.
- `Bin.Linker.ensureUmask` no longer zeros the process umask — it reads and restores. The code that needed an exact mode already `fchmod`s afterwards (`tryNormalizeShebang`, the bin symlink chmod), so dropping the `umask(0)` is a no-op for them.
- Bin symlink chmod was `umask | 0o777` which is always `0o777`; changed to `0o777 & ~umask` so bin files respect umask too (`0o755` at default, `0o775` at `umask 0o002`).

### Verification

| umask  | cache dir | node_modules | pkg dir | bin target |
| ------ | --------- | ------------ | ------- | ---------- |
| 0o022  | 0o755     | 0o755        | 0o755   | 0o755      |
| 0o002  | 0o775     | 0o775        | 0o775   | 0o775      |
| 0o077  | 0o700     | 0o700        | 0o700   | 0o700      |

Default behavior (0o022) is unchanged — matches Node/npm/pnpm.

Test added in `test/cli/install/bun-install.test.ts` (skips on Windows). Fails on main, passes here.

### bunx interaction

`is_trusted_cache_root` (added on main by #31339) refuses a bunx cache root in the shared temp dir that is group/other-writable. With umask-honoring mkdir, a permissive umask like `0o002` made bunx create its own cache root `0o775`, so the second invocation refused the cache the first one created (caught by CI on every platform). bunx now requests `0o755` explicitly for its cache root: the kernel can only subtract bits from it, so the root can never become group/other-writable while stricter umasks still tighten it. Covered by a second regression test in `test/cli/install/bunx.test.ts` that runs bunx twice under `umask 0002` against the mock registry; it fails without the bunx change and passes with it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 21 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->