### PR TITLE
test(resolve): cover getModuleNamespace fast-path edge cases

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-200-28f2acb7";
+export const WEBKIT_VERSION = "bdf6aab38a9c6f99df3fd1486406ab6b74180fbb";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f5f6c3f654bd19baf14a849160c704b12d198f87";
+export const WEBKIT_VERSION = "autobuild-preview-pr-200-143fb225";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-200-143fb225";
+export const WEBKIT_VERSION = "autobuild-preview-pr-200-28f2acb7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/star-export-namespace.test.ts
+++ b/test/js/bun/resolve/star-export-namespace.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// GetModuleNamespace over a deep `export * from` chain used to walk the whole
+// star graph once per exported name (O(names × edges)). The single-BFS fast
+// path resolves every uniquely-bound name in one pass; ambiguity / shadowing /
+// indirect exports must still fall back to the spec walk. These cover the
+// shapes the fast path has to get right.
+test("namespace over export-star chain has every transitive binding", async () => {
+  const files: Record<string, string> = { "leaf.mjs": `export const THE_END = true;\n` };
+  for (let i = 0; i < 30; i++) {
+    const reexports = Array.from({ length: Math.trunc(i * 0.25) }, (_, j) => `export * from "./m${j}.mjs";`).join("\n");
+    files[`m${i}.mjs`] = `${reexports}\nexport * from "./${i === 29 ? "leaf" : `m${i + 1}`}.mjs";\nexport const v${i} = ${i};\n`;
+  }
+  files["entry.mjs"] = `
+    const ns = await import("./m0.mjs");
+    const keys = Object.keys(ns).sort();
+    if (keys.length !== 31) throw new Error("expected 31 keys, got " + keys.length);
+    if (!ns.THE_END) throw new Error("THE_END missing");
+    for (let i = 0; i < 30; i++) if (ns["v" + i] !== i) throw new Error("v" + i + " = " + ns["v" + i]);
+    console.log("ok " + keys.length);
+  `;
+  using dir = tempDir("star-export-chain", files);
+  await using proc = Bun.spawn({ cmd: [bunExe(), "entry.mjs"], cwd: String(dir), env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toBe("ok 31");
+  expect(exitCode).toBe(0);
+});
+
+test("star-export ambiguity is excluded from namespace, shadowing wins for named import", async () => {
+  using dir = tempDir("star-export-ambig", {
+    "a.mjs": `export const dup = "a"; export const onlyA = 1;`,
+    "b.mjs": `export const dup = "b"; export const onlyB = 2;`,
+    // root: dup is ambiguous (two siblings). onlyA/onlyB unique.
+    "root.mjs": `export * from "./a.mjs"; export * from "./b.mjs";`,
+    // shadow: local dup shadows the star, so dup is *not* ambiguous here.
+    "shadow.mjs": `export * from "./a.mjs"; export * from "./b.mjs"; export const dup = "shadow";`,
+    "entry.mjs": `
+      const ns = await import("./root.mjs");
+      if ("dup" in ns) throw new Error("ambiguous dup leaked into namespace");
+      if (ns.onlyA !== 1 || ns.onlyB !== 2) throw new Error("unique bindings missing");
+      const sh = await import("./shadow.mjs");
+      if (sh.dup !== "shadow") throw new Error("local should shadow star, got " + sh.dup);
+      // Named import of an ambiguous binding is a link-time SyntaxError.
+      let threw = false;
+      try { await import("./named.mjs"); } catch (e) { threw = /ambiguous|multiple/i.test(String(e)); }
+      if (!threw) throw new Error("ambiguous named import did not throw");
+      console.log("ok");
+    `,
+    "named.mjs": `import { dup } from "./root.mjs"; export { dup };`,
+  });
+  await using proc = Bun.spawn({ cmd: [bunExe(), "entry.mjs"], cwd: String(dir), env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+test("indirect re-export through star chain still resolves (slow path)", async () => {
+  using dir = tempDir("star-export-indirect", {
+    "src.mjs": `export const inner = 42;`,
+    "mid.mjs": `export { inner as renamed } from "./src.mjs";`,
+    "root.mjs": `export * from "./mid.mjs";`,
+    "entry.mjs": `
+      const ns = await import("./root.mjs");
+      if (ns.renamed !== 42) throw new Error("indirect export lost: " + ns.renamed);
+      console.log("ok");
+    `,
+  });
+  await using proc = Bun.spawn({ cmd: [bunExe(), "entry.mjs"], cwd: String(dir), env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toBe("ok");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/star-export-namespace.test.ts
+++ b/test/js/bun/resolve/star-export-namespace.test.ts
@@ -10,7 +10,8 @@ test("namespace over export-star chain has every transitive binding", async () =
   const files: Record<string, string> = { "leaf.mjs": `export const THE_END = true;\n` };
   for (let i = 0; i < 30; i++) {
     const reexports = Array.from({ length: Math.trunc(i * 0.25) }, (_, j) => `export * from "./m${j}.mjs";`).join("\n");
-    files[`m${i}.mjs`] = `${reexports}\nexport * from "./${i === 29 ? "leaf" : `m${i + 1}`}.mjs";\nexport const v${i} = ${i};\n`;
+    files[`m${i}.mjs`] =
+      `${reexports}\nexport * from "./${i === 29 ? "leaf" : `m${i + 1}`}.mjs";\nexport const v${i} = ${i};\n`;
   }
   files["entry.mjs"] = `
     const ns = await import("./m0.mjs");


### PR DESCRIPTION
Companion to oven-sh/WebKit#200.

Adds correctness coverage for the new JSC `GetModuleNamespace` single-BFS fast path:
- deep `export * from` chain — every transitive binding is present
- two siblings with the same local — name is excluded (ambiguous), but a local in the importing module shadows correctly
- indirect re-export through a star chain — still resolves via the slow path

These pass on both the current and patched JSC (the optimization preserves observable behavior).

Bench impact from the WebKit change (500 modules, 30k star edges, local release without LTO):
- before: ~694ms
- after: ~320ms
- node 24: ~525ms, deno 2.7: ~157ms

Separately found while auditing: a fresh `import()` that reaches a module whose previous load failed resolves on Bun (all versions back to 1.3.11) but rejects on Node/Deno — pre-existing, not touched by this PR.