### PR TITLE
test(hot): use atomic rename for 2MB rewrites in sourcemap-generation test

### DIFF
--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -494,6 +494,23 @@ it(
 
 const comment_line = "//" + Buffer.alloc(2000, "B").toString() + "\n";
 const comment_spam = Buffer.alloc(comment_line.length * 1000, comment_line).toString();
+
+// The source files in the sourcemap tests are ~2MB, so writeFileSync is a
+// truncate followed by several write() calls. Each emits its own inotify
+// IN_MODIFY event, and --hot's reload loop can read the file mid-write. When
+// that happens the per-path SavedSourceMap entry is overwritten with a map for
+// the truncated content, and the still-pending error from the previous full
+// transpile is printed with un-remapped transpiled coords (line 1). Write to a
+// sibling temp file and rename(2) it into place so the watched path only ever
+// flips between complete versions; the existing
+// "should hot reload when a file is renamed() into place" test covers that the
+// rename event itself triggers a reload.
+function writeHotFileAtomicSync(path: string, content: string) {
+  const tmp = path + ".next";
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
+
 it(
   "should work with sourcemap generation",
   async () => {
@@ -514,7 +531,7 @@ throw new Error('0');`,
     const reloadCounter = await driveErrorReloadCycle(runner, {
       targetCount: 50,
       onReload: counter => {
-        writeFileSync(
+        writeHotFileAtomicSync(
           hotRunnerRoot,
           `// source content
 ${comment_spam}


### PR DESCRIPTION
## What

Adds a small `writeHotFileAtomicSync` helper (write to `.next` + `renameSync`) and uses it for the per-iteration rewrite in the "should work with sourcemap generation" test instead of a bare `writeFileSync`.

## Why

This test was flaking on aarch64 with `invalid string: at .../hot-runner-root.js:1:12` (builds 47979/47982/47988/47989/47990/47992).

The file written on each reload is ~2MB, so `writeFileSync` is a truncate followed by several `write()` calls. Each emits its own inotify `IN_MODIFY`, and `--hot`'s reload loop (`hot_reloader.zig:246` `while (pending_count.swap(0) > 0) reload()`) can re-read the file mid-write. The `SavedSourceMap` entry for the path is overwritten in place on every transpile (`SavedSourceMap.zig:150`), so a partial-read transpile clobbers the map that the still-pending error from the previous full transpile needs. When that error is finally remapped (`VirtualMachine.zig:2877`), the lookup misses and the **transpiled** coords are printed verbatim — comments are stripped so the throw is on output line 1, hence `:1:12`.

Writing to a sibling temp file and `rename(2)`-ing it into place means the watched path only ever flips between complete versions. The existing "should hot reload when a file is renamed() into place" test already validates that the rename event triggers a reload.

The underlying path-keyed-sourcemap-overwrite is a real `--hot` race that can also affect users whose editors save non-atomically; that's worth a separate runtime fix, but is out of scope for this deflake.

## Test plan

- [x] `bun bd test test/cli/hot/hot.test.ts -t "should work with sourcemap generation"` — 1 pass, 101 expect() calls (50 iterations)
- [x] 80 parallel runs under load with debug build: 80/80 pass
- [x] Full `hot.test.ts` run: only pre-existing unrelated failure ("should not hot reload when a random file is written" fails on `main` too with the local debug build)