### PR TITLE
build(windows): use -Xclang -include instead of /FI in pch rule

### DIFF
--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -114,9 +114,15 @@ export function registerCompileRules(n: Ninja, cfg: Config): void {
   // (e.g. after deleting pch/ and reconfiguring) → every consumer fails with
   // "mtime changed". ninja's depfile already tracks invalidation; clang's
   // redundant mtime check just fights ccache.
+  // Windows: -Xclang -include, NOT /FI. clang-cl's /FI auto-promotes to
+  // -include-pch when a .pch already exists at the /Fp path — even for the
+  // /Yc -emit-pch cc1 job — so a stale PCH (e.g. after a cxxflags change)
+  // gets validated instead of overwritten and the build fails with
+  // "<langopt> was enabled in precompiled file but is currently disabled".
+  // -Xclang goes straight to cc1, bypassing the driver's auto-detection.
   n.rule("pch", {
     command: cfg.windows
-      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags /clang:-fpch-instantiate-templates -Xclang -fno-pch-timestamp /Yc$pch_header /FI$pch_header /Fp$out /c $in /Fo$pch_stub_obj`
+      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags /clang:-fpch-instantiate-templates -Xclang -fno-pch-timestamp /Yc$pch_header -Xclang -include -Xclang $pch_header /Fp$out /c $in /Fo$pch_stub_obj`
       : `${ccacheLauncher}${cxx} $cxxflags -Winvalid-pch -fpch-instantiate-templates -Xclang -fno-pch-timestamp -Xclang -emit-pch -Xclang -include -Xclang $pch_header -x c++-header -MD -MT $out -MF $out.d -c $in -o $out`,
     description: "pch $out",
     ...depfileOpts,


### PR DESCRIPTION
## Summary

clang-cl's `/FI<header>` auto-promotes itself to `-include-pch <pch>` when a `.pch` already exists at the `/Fp` path — and it does this for **both** internal cc1 jobs of `/Yc`, including the `-emit-pch` job that's supposed to overwrite the PCH. So when cxxflags change and ninja re-runs the `pch` rule, the create-PCH step ends up validating the stale PCH instead of overwriting it.

I hit this after pulling #29653 (`/EHsc` → `/EHs-c-`) into a build dir that had a pre-existing PCH:

```
[499/864] pch pch\root-pch.h.hxx.pch
FAILED: pch/root-pch.h.hxx.pch pch/root-pch.h.hxx.cxx.obj
error: exception handling was enabled in precompiled file 'pch\root-pch.h.hxx.pch' but is currently disabled
```

Minimal repro (no ccache, no Bun headers — clang 21.1.8):

```sh
printf '#include <vector>\n' > h.hxx; printf '/* stub */\n' > stub.cxx
clang-cl /EHsc  /Ych.hxx /FIh.hxx /Fph.hxx.pch /c stub.cxx /Fostub.obj   # ok
clang-cl /EHs-c- /Ych.hxx /FIh.hxx /Fph.hxx.pch /c stub.cxx /Fostub.obj  # FAILS
```

`clang-cl -v` on the second line shows the `-emit-pch` cc1 invocation receiving `-include-pch h.hxx.pch` instead of `-include h.hxx` — `-###` with the `.pch` deleted shows `-include`, so it's filesystem-dependent driver behavior.

**Fix:** swap `/FI$pch_header` for `-Xclang -include -Xclang $pch_header`. The cc1-level `-include` bypasses the driver's PCH auto-detection, so `-emit-pch` always reads the header source. The Unix `pch` rule and the Windows `cxx_pch` consumer rule already use this form, so this also makes the two platforms' force-include spelling consistent.

## Test plan

- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] Minimal repro: `/Yc` + `-Xclang -include` + stale-flag PCH on disk → exit 0, PCH overwritten (size changes)
- [x] `-###` confirms `-emit-pch` job gets `-include` (not `-include-pch`) with PCH on disk
- [x] `ninja pch\root-pch.h.hxx.pch` builds 156MB PCH; a `cxx_pch` consumer compiles against it
- [ ] Windows CI green