### PR TITLE
test: avoid TLA self-cycle in bun-main dynamic-import test

### DIFF
--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -21,14 +21,25 @@ test.concurrent("dynamic import('bun:main') returns the wrapper module", async (
     // package.json disables auto-install so a regression in the bun:main alias
     // cannot silently fall through to fetching the npm `main` package.
     "package.json": "{}",
+    // bun:main statically imports entry.mjs, so awaiting import("bun:main")
+    // at the top level of entry.mjs is a TLA self-cycle that never resolves.
+    // Defer the import to a .then() so entry.mjs (and therefore bun:main)
+    // can finish evaluating first.
     "entry.mjs": `
-      const m = await import("bun:main");
-      if (m[Symbol.toStringTag] !== "Module") throw new Error("expected module namespace, got " + Object.prototype.toString.call(m));
-      // The wrapper has no named exports. The npm \`main\` package (what this
-      // resolved to before the alias fix) exports {default,length,name,prototype}.
-      const keys = Object.keys(m);
-      if (keys.length !== 0) throw new Error("expected empty wrapper namespace, got keys: " + keys.join(","));
-      console.log("OK");
+      import("bun:main").then(
+        m => {
+          if (m[Symbol.toStringTag] !== "Module") throw new Error("expected module namespace, got " + Object.prototype.toString.call(m));
+          // The wrapper has no named exports. The npm \`main\` package (what this
+          // resolved to before the alias fix) exports {default,length,name,prototype}.
+          const keys = Object.keys(m);
+          if (keys.length !== 0) throw new Error("expected empty wrapper namespace, got keys: " + keys.join(","));
+          console.log("OK");
+        },
+        e => {
+          console.error(String(e));
+          process.exit(1);
+        },
+      );
     `,
   });
   await using proc = Bun.spawn({

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -26,20 +26,17 @@ test.concurrent("dynamic import('bun:main') returns the wrapper module", async (
     // Defer the import to a .then() so entry.mjs (and therefore bun:main)
     // can finish evaluating first.
     "entry.mjs": `
-      import("bun:main").then(
-        m => {
-          if (m[Symbol.toStringTag] !== "Module") throw new Error("expected module namespace, got " + Object.prototype.toString.call(m));
-          // The wrapper has no named exports. The npm \`main\` package (what this
-          // resolved to before the alias fix) exports {default,length,name,prototype}.
-          const keys = Object.keys(m);
-          if (keys.length !== 0) throw new Error("expected empty wrapper namespace, got keys: " + keys.join(","));
-          console.log("OK");
-        },
-        e => {
-          console.error(String(e));
-          process.exit(1);
-        },
-      );
+      import("bun:main").then(m => {
+        if (m[Symbol.toStringTag] !== "Module") throw new Error("expected module namespace, got " + Object.prototype.toString.call(m));
+        // The wrapper has no named exports. The npm \`main\` package (what this
+        // resolved to before the alias fix) exports {default,length,name,prototype}.
+        const keys = Object.keys(m);
+        if (keys.length !== 0) throw new Error("expected empty wrapper namespace, got keys: " + keys.join(","));
+        console.log("OK");
+      }).catch(e => {
+        console.error(String(e));
+        process.exit(1);
+      });
     `,
   });
   await using proc = Bun.spawn({


### PR DESCRIPTION
Follow-up to #29719.

`bun:main` statically imports the entry file, so `await import("bun:main")` at the entry's top level is a TLA self-cycle: `bun:main` waits for `entry.mjs` (async dep), and `entry.mjs` waits for `bun:main`'s evaluation promise. Per spec that promise never settles.

The old JSC module loader broke these cycles early, which is why #29719 passed locally (tested against `892042c2`, pre-#29393). After #29393 (WebKit module-loader rewrite) the loader correctly leaves the promise unsettled, so the test now hangs and times out at 90s — see build 48023 (debian-asan, win x64, win x64-baseline).

Fix: drop the top-level `await` and use `import("bun:main").then(...)` so `entry.mjs` finishes synchronously, `bun:main` finishes, and the import resolves on the next microtask. The preload and `--hot` tests are unaffected (preload isn't in `bun:main`'s dep graph).

Note: this also surfaced that Bun now hangs forever on any unsettled-TLA cycle instead of exiting 13 like Node — separate PR coming for that.

## How did you verify your code works?

- `bun bd test test/js/bun/resolve/bun-main-entry-point.test.ts` — 3 pass, 20 consecutive runs on Windows
- `USE_SYSTEM_BUN=1 bun test ...` — 2 fail (still catches the alias bug on unfixed bun)