### PR TITLE
runtime: exit 13 on unsettled top-level await instead of hanging

### DIFF
--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -545,15 +545,23 @@ pub const Run = struct {
                     to_print.print(vm.global, .Log, .Log);
                 }
 
-                // Node.js exit code 13: the entry module's evaluation promise
-                // is still pending after the event loop fully drained (TLA
-                // cycle, or `await` on a promise nothing will ever settle).
-                if (vm.pending_internal_promise) |p| {
-                    if (p.status() == .pending and vm.exit_handler.exit_code == 0) {
+                // The entry's evaluation may have settled after the early
+                // post-loadEntryPoint check (which ran while it was still
+                // .pending). Handle late rejection so it isn't swallowed, and
+                // map a still-pending promise to Node's exit code 13.
+                if (vm.pending_internal_promise) |p| switch (p.status()) {
+                    .rejected => if (vm.pending_internal_promise_reported_at != vm.hot_reload_counter) {
+                        _ = vm.uncaughtException(vm.global, p.result(vm.global.vm()), true);
+                        p.setHandled();
+                        vm.pending_internal_promise_reported_at = vm.hot_reload_counter;
+                        if (vm.exit_handler.exit_code == 0) vm.exit_handler.exit_code = 1;
+                    },
+                    .pending => if (vm.exit_handler.exit_code == 0) {
                         vm.reportUnsettledTopLevelAwait();
                         vm.exit_handler.exit_code = 13;
-                    }
-                }
+                    },
+                    .fulfilled => {},
+                };
             }
 
             if (vm.log.msgs.items.len > 0) {

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -550,11 +550,7 @@ pub const Run = struct {
                 // cycle, or `await` on a promise nothing will ever settle).
                 if (vm.pending_internal_promise) |p| {
                     if (p.status() == .pending and vm.exit_handler.exit_code == 0) {
-                        Output.prettyErrorln(
-                            "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await in <b>{s}<r>",
-                            .{vm.main},
-                        );
-                        Output.flush();
+                        vm.reportUnsettledTopLevelAwait();
                         vm.exit_handler.exit_code = 13;
                     }
                 }

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -495,9 +495,26 @@ pub const Run = struct {
                     vm.eventLoop().tickPossiblyForever();
                 }
             } else {
-                while (vm.isEventLoopAlive()) {
-                    vm.tick();
-                    vm.eventLoop().autoTickActive();
+                while (true) {
+                    while (vm.isEventLoopAlive()) {
+                        vm.tick();
+                        vm.eventLoop().autoTickActive();
+                    }
+
+                    vm.onBeforeExit();
+
+                    // The entry's evaluation promise may still be pending if
+                    // loadEntryPoint bailed on an idle loop. beforeExit may
+                    // have just settled it (Node parity), but the resulting
+                    // microtask isn't counted by isEventLoopAlive(); drain
+                    // once and re-enter only if that produced more work.
+                    if (vm.pending_internal_promise) |p| {
+                        if (p.status() == .pending) {
+                            vm.tick();
+                            if (vm.isEventLoopAlive()) continue;
+                        }
+                    }
+                    break;
                 }
 
                 if (this.ctx.runtime_options.eval.eval_and_print) {
@@ -528,7 +545,19 @@ pub const Run = struct {
                     to_print.print(vm.global, .Log, .Log);
                 }
 
-                vm.onBeforeExit();
+                // Node.js exit code 13: the entry module's evaluation promise
+                // is still pending after the event loop fully drained (TLA
+                // cycle, or `await` on a promise nothing will ever settle).
+                if (vm.pending_internal_promise) |p| {
+                    if (p.status() == .pending and vm.exit_handler.exit_code == 0) {
+                        Output.prettyErrorln(
+                            "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await in <b>{s}<r>",
+                            .{vm.main},
+                        );
+                        Output.flush();
+                        vm.exit_handler.exit_code = 13;
+                    }
+                }
             }
 
             if (vm.log.msgs.items.len > 0) {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2477,7 +2477,18 @@ pub fn loadEntryPoint(this: *VirtualMachine, entry_path: string) anyerror!*JSInt
         }
 
         this.eventLoop().performGC();
-        this.waitForPromise(.{ .internal = promise });
+        // Can't use `waitForPromise` here: with the spec-aligned module loader
+        // a TLA cycle (or any never-settling top-level await) leaves this
+        // promise pending forever, and `waitForPromise` would busy-spin on
+        // tickWithoutIdle. Tick while there is work that could resolve it; if
+        // the loop drains and the promise is still pending the caller reports
+        // unsettled TLA and exits 13.
+        while (promise.status() == .pending) {
+            this.eventLoop().tick();
+            if (promise.status() != .pending) break;
+            if (!this.isEventLoopAlive()) break;
+            this.eventLoop().autoTick();
+        }
     }
 
     return this.pending_internal_promise.?;

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -862,6 +862,23 @@ pub fn enterUWSLoop(this: *VirtualMachine) void {
     loop.run();
 }
 
+extern fn Bun__findStalledTopLevelAwait(*JSGlobalObject) bun.String;
+
+/// Print a warning naming the module(s) whose body is suspended on its own
+/// top-level await. Falls back to the entry path if the registry walk finds
+/// nothing (e.g. eval mode).
+pub fn reportUnsettledTopLevelAwait(this: *VirtualMachine) void {
+    var stalled = Bun__findStalledTopLevelAwait(this.global);
+    defer stalled.deref();
+    const stalled_utf8 = stalled.toUTF8(bun.default_allocator);
+    defer stalled_utf8.deinit();
+    Output.prettyErrorln(
+        "<r><yellow>warn<r><d>:<r> Detected unsettled top-level await at <b>{s}<r>",
+        .{if (stalled_utf8.len > 0) stalled_utf8.slice() else this.main},
+    );
+    Output.flush();
+}
+
 pub fn onBeforeExit(this: *VirtualMachine) void {
     this.exit_handler.dispatchOnBeforeExit();
     var dispatch = false;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -686,6 +686,35 @@ static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
+// Find module specifiers whose body is suspended on its own top-level await
+// (status EvaluatingAsync, syntactically has TLA, and isn't waiting on any
+// async dependency). Used to point the unsettled-TLA warning at the actual
+// stalled module rather than the entry path.
+extern "C" BunString Bun__findStalledTopLevelAwait(JSC::JSGlobalObject* globalObject)
+{
+    StringBuilder builder;
+    for (auto& [key, entry] : globalObject->moduleLoader()->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        auto* record = entry->record();
+        if (!record || !record->hasTLA())
+            continue;
+        auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
+        if (!cyclic || cyclic->status() != JSC::CyclicModuleRecord::Status::EvaluatingAsync)
+            continue;
+        // Skip modules that are EvaluatingAsync only because they're waiting
+        // on a dependency — the dependency is the actual culprit.
+        if (auto pending = record->pendingAsyncDependencies(); pending && *pending > 0)
+            continue;
+        if (!builder.isEmpty())
+            builder.append('\n');
+        builder.append(String { key.first });
+    }
+    if (builder.isEmpty())
+        return BunStringEmpty;
+    return Bun::toStringRef(builder.toString());
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -91,6 +91,37 @@ describe("unsettled top-level await", () => {
     });
   });
 
+  test.concurrent("warning names the stalled module, not the entry", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `import "./mid.mjs";\n`,
+        "mid.mjs": `import "./leaf.mjs";\n`,
+        "leaf.mjs": `await new Promise(() => {});\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.stderr).toContain("leaf.mjs");
+    expect(r.stderr).not.toContain("entry.mjs");
+    expect(r.stderr).not.toContain("mid.mjs");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test.concurrent("warning lists every stalled sibling", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `import "./sib1.mjs"; import "./sib2.mjs";\n`,
+        "sib1.mjs": `await new Promise(() => {});\n`,
+        "sib2.mjs": `await new Promise(() => {});\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("sib1.mjs");
+    expect(r.stderr).toContain("sib2.mjs");
+    expect(r.stderr).not.toContain("entry.mjs");
+    expect(r.exitCode).toBe(13);
+  });
+
   test.concurrent("explicit process.exitCode is respected over 13", async () => {
     const r = await run(
       {

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -174,6 +174,23 @@ describe("unsettled top-level await", () => {
     expect(r.exitCode).toBe(13);
   });
 
+  test.concurrent("beforeExit can reject the TLA and the error is reported", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `
+          let reject;
+          process.on("beforeExit", () => reject(new Error("Xyz")));
+          await new Promise((_, r) => { reject = r; });
+          console.log("DONE");
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("Xyz");
+    expect(r.exitCode).toBe(1);
+  });
+
   test.concurrent("beforeExit settles TLA which then schedules more async work", async () => {
     const r = await run(
       {

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -91,6 +91,58 @@ describe("unsettled top-level await", () => {
     });
   });
 
+  test.concurrent("explicit process.exitCode is respected over 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `
+          process.on("exit", code => console.log("exit", code, process.exitCode));
+          process.exitCode = 42;
+          await new Promise(() => {});
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toEqual({
+      stdout: "exit 42 42\n",
+      stderr: "",
+      exitCode: 42,
+    });
+  });
+
+  test.concurrent("process exit listener sees code 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `
+          process.on("exit", code => console.log("exit", code, process.exitCode));
+          await new Promise(() => {});
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("exit 13 13\n");
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test.concurrent("worker process.exit() does not settle main thread's TLA", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `
+          import { Worker, isMainThread } from "worker_threads";
+          if (isMainThread) {
+            new Worker(new URL(import.meta.url));
+            await new Promise(() => {});
+          } else {
+            process.exit();
+          }
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
   test.concurrent("beforeExit settles TLA which then schedules more async work", async () => {
     const r = await run(
       {

--- a/test/js/node/process/unsettled-top-level-await.test.ts
+++ b/test/js/node/process/unsettled-top-level-await.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Node.js exit code 13: when the event loop drains while the entry module's
+// top-level await is still pending, the process exits 13 with a warning
+// instead of hanging forever. Regressed by the JSC module-loader rewrite,
+// which (correctly) stopped resolving TLA self-cycles.
+
+async function run(files: Record<string, string>, entry: string) {
+  using dir = tempDir("unsettled-tla", { "package.json": "{}", ...files });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+describe("unsettled top-level await", () => {
+  test.concurrent("await on a never-resolving promise exits 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `console.log("BEFORE");\nawait new Promise(() => {});\nconsole.log("AFTER");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stdout).toBe("BEFORE\n");
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test.concurrent("dynamic-import TLA cycle exits 13", async () => {
+    const r = await run(
+      {
+        "a.mjs": `import "./b.mjs";\n`,
+        "b.mjs": `console.log("B_BEFORE");\nawait import("./a.mjs");\nconsole.log("B_AFTER");\n`,
+      },
+      "./a.mjs",
+    );
+    expect(r.stdout).toBe("B_BEFORE\n");
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test.concurrent("await on an unref'd timer exits 13", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `await new Promise(r => setTimeout(r, 100000).unref());\n`,
+      },
+      "./entry.mjs",
+    );
+    expect(r.stderr).toContain("unsettled top-level await");
+    expect(r.exitCode).toBe(13);
+  });
+
+  test.concurrent("ref'd timer keeps the loop alive and TLA settles", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `await new Promise(r => setTimeout(r, 50));\nconsole.log("DONE");\n`,
+      },
+      "./entry.mjs",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toEqual({
+      stdout: "DONE\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("beforeExit can settle the TLA", async () => {
+    // Node parity: a beforeExit handler that resolves the awaited promise
+    // lets the entry resume instead of triggering exit 13.
+    const r = await run(
+      {
+        "entry.mjs": `
+          let resolve;
+          process.on("beforeExit", () => { console.log("beforeExit"); resolve(); });
+          await new Promise(r => { resolve = r; });
+          console.log("DONE");
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toEqual({
+      stdout: "beforeExit\nDONE\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("beforeExit settles TLA which then schedules more async work", async () => {
+    const r = await run(
+      {
+        "entry.mjs": `
+          let resolve;
+          process.on("beforeExit", () => { console.log("beforeExit"); resolve(); });
+          await new Promise(r => { resolve = r; });
+          console.log("RESUMED");
+          await new Promise(r => setTimeout(r, 20));
+          console.log("DONE");
+        `,
+      },
+      "./entry.mjs",
+    );
+    expect({ stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }).toEqual({
+      stdout: "beforeExit\nRESUMED\nDONE\nbeforeExit\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #14951

## What

When the entry module's top-level `await` never settles (TLA self-cycle, `await new Promise(() => {})`, awaiting an `unref()`'d timer), warn and exit with code 13 instead of busy-spinning forever.

## Why

`loadEntryPoint` waited on the entry's evaluation promise via `waitForPromise`, which loops `tick(); autoTick();` until the promise settles. After #29393 (spec-aligned JSC module loader) a TLA self-cycle correctly leaves that promise pending forever, so `waitForPromise` busy-spun on `tickWithoutIdle` and the process hung. The plain `await new Promise(() => {})` case hung before #29393 too — the cycle case used to (non-spec-correctly) resolve under the old loader, which masked it.

| Case | Node | Bun before | Bun after |
|---|---|---|---|
| `await new Promise(() => {})` | warn + exit 13 | **hang at 100% CPU** | warn + exit 13 |
| TLA dynamic-import cycle | warn + exit 13 | resolve (pre-#29393) → **hang** (post) | warn + exit 13 |
| `await` on `unref()`'d timer | warn + exit 13 | **hang** | warn + exit 13 |
| `await new Promise(r => setTimeout(r, 50))` | exit 0 | exit 0 | exit 0 |
| beforeExit handler resolves the awaited promise | resumes, exit 0 | **hang** | resumes, exit 0 |
| `process.exitCode = 42; await new Promise(() => {})` | exit 42, no warn | hang | exit 42, no warn |

## How

- `VirtualMachine.loadEntryPoint`: replace `waitForPromise` with a loop that breaks once `isEventLoopAlive()` is false, so an idle loop returns to the caller instead of spinning.
- `bun.js.zig` main run loop: fold `onBeforeExit()` into the loop so a beforeExit handler that settles the TLA can resume the entry (Node parity); after the loop fully drains, if the entry promise is still `.pending` and no other error set the exit code, print a warning and set `exit_code = 13`.

JSC has no equivalent of V8's `GetStalledTopLevelAwaitMessages`, so the warning names the entry path rather than the exact `await` line.

## Related but not changed here

- #14708 — that repro still prints `"It works!"` because JSC resolves the static back-edge synchronously (Safari does the same; V8/Node deadlock); not affected by this PR.
- #23102 / `loadEntryPointForWebWorker` and `loadEntryPointForTestRunner` use the same `waitForPromise` pattern and can still spin; left for a follow-up since their error-reporting surfaces differ.

## How did you verify your code works?

- `bun bd test test/js/node/process/unsettled-top-level-await.test.ts` — 9 pass on Windows
- `USE_SYSTEM_BUN=1 bun test ...` — 5 fail (timeouts/mismatch on unfixed bun)
- Ran all 10 scenarios from Node's `test/es-module/test-esm-tla-unfinished.mjs` against the build — all match Node's exit codes and listener behavior
- `bun bd test test/js/node/process/process.test.js -t onBeforeExit` — 3 pass
- `bun bd test test/js/bun/resolve/require-esm-transitive-tla.test.ts` — 2 pass
- `bun bd test test/cli/run/transpiler-cache.test.ts test/cli/run/run-eval.test.ts test/cli/run/preload-test.test.js` — 46 pass
- `bun run zig:check-all` — pass