### PR TITLE
hot: defer reload while a rejected module is unreported

### DIFF
--- a/src/bun.js/SavedSourceMap.zig
+++ b/src/bun.js/SavedSourceMap.zig
@@ -142,6 +142,21 @@ pub fn deinit(this: *SavedSourceMap) void {
 }
 
 pub fn putMappings(this: *SavedSourceMap, source: *const logger.Source, mappings: MutableString) !void {
+    // --hot can re-read a file mid-rewrite (truncate + write) and transpile
+    // a comment-only prefix into a 0-mapping map. Overwriting a real map
+    // with that would make any still-unreported error from the previous
+    // transpile remap against nothing and leak transpiled coords. A map
+    // with no mappings can never answer a lookup, so dropping it is never
+    // worse than installing it.
+    if (mappings.list.items.len >= InternalSourceMap.header_size) {
+        const incoming: InternalSourceMap = .{ .data = mappings.list.items.ptr };
+        if (incoming.mappingCount() == 0) {
+            this.lock();
+            defer this.unlock();
+            if (this.map.contains(bun.hash(source.path.text))) return;
+        }
+    }
+
     const blob = try bun.default_allocator.dupe(u8, mappings.list.items);
     errdefer bun.default_allocator.free(blob);
     try this.putValue(source.path.text, Value.init(bun.cast(*InternalSourceMap, blob.ptr)));

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -773,10 +773,23 @@ pub fn reload(this: *VirtualMachine, _: ?*HotReloader.Task) void {
     // race through one registry. Defer instead; the main loop reschedules
     // via reportExceptionInHotReloadedModuleIfNeeded once the in-flight
     // promise resolves or rejects.
+    //
+    // Also defer when the previous promise has rejected but its error
+    // hasn't been printed yet: reloadEntryPoint() re-transpiles and
+    // overwrites source_mappings[path] in place, so a watcher event that
+    // slips in between the rejection microtask and the report would remap
+    // that error against the wrong sourcemap.
     if (this.pending_internal_promise) |p| {
-        if (p.status() == .pending) {
-            this.hot_reload_deferred = true;
-            return;
+        switch (p.status()) {
+            .pending => {
+                this.hot_reload_deferred = true;
+                return;
+            },
+            .rejected => if (this.pending_internal_promise_reported_at != this.hot_reload_counter) {
+                this.hot_reload_deferred = true;
+                return;
+            },
+            .fulfilled => {},
         }
     }
     this.hot_reload_deferred = false;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -536,6 +536,53 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
 );
 
 it(
+  "should not remap against a stale sourcemap after a partial-file reload",
+  async () => {
+    // Regression: the watcher can deliver a second reload Task between the
+    // moment a module's eval rejects and the moment that rejection is
+    // printed. The second reload re-transpiles and overwrites
+    // source_mappings[path] in place, so the still-unreported error gets
+    // remapped against the wrong map and transpiled coordinates leak
+    // through — or, since the new pending promise replaces the old one,
+    // the error is dropped entirely.
+    //
+    // To make the window deterministic the hot file truncates itself to a
+    // comment-only stub immediately before throwing, guaranteeing a fresh
+    // watcher event lands between reject and report.
+    const writeFull = (counter: number) =>
+      writeFileSync(
+        hotRunnerRoot,
+        `// source content
+${comment_spam}require("fs").writeFileSync(__filename, "// stub ${counter}\\n");
+${Buffer.alloc(counter * 2, " ").toString()}throw new Error('${counter}');`,
+      );
+    writeFull(0);
+    await using runner = spawn({
+      cmd: [bunExe(), "--smol", "--hot", "run", hotRunnerRoot],
+      env: bunEnv,
+      cwd,
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const reloadCounter = await driveErrorReloadCycle(runner, {
+      targetCount: 20,
+      onReload: writeFull,
+      verifyLine: (errorLine, nextLine, counter) => {
+        if (!nextLine) throw new Error(errorLine);
+        const match = nextLine.match(/\s*at.*?:(\d+):(\d+)\)?$/);
+        if (!match) throw new Error("no :line:col in: " + JSON.stringify(nextLine));
+        if (match[1] !== "1003") throw new Error("expected :1003: but got: " + JSON.stringify(nextLine));
+        expect(Number(match[2])).toBe(1 + "throw new ".length + counter * 2);
+      },
+    });
+    await runner.exited;
+    expect(reloadCounter).toBe(20);
+  },
+  longTimeout,
+);
+
+it(
   "should work with sourcemap loading",
   async () => {
     let bundleIn = join(cwd, "bundle_in.ts");


### PR DESCRIPTION
## What

Runtime fix for the `--hot` sourcemap race that #29735 works around at the test level. Two changes:

- **`VirtualMachine.reload()`** now also defers when `pending_internal_promise` is `.rejected` but its error hasn't been printed yet (`pending_internal_promise_reported_at != hot_reload_counter`), not just when `.pending`. The deferred reload runs from `reportExceptionInHotReloadedModuleIfNeeded()` *after* the error is remapped and printed against its own sourcemap.
- **`SavedSourceMap.putMappings()`** keeps the existing table entry when the incoming `InternalSourceMap` has zero mappings. A 0-mapping map can never answer a lookup, so dropping it is never worse than installing it; this defends against any other path that re-transpiles a comment-only partial read.

## Why

`vm.source_mappings` is a path-hash → blob table overwritten in place on every transpile. The event-loop tick drains microtasks between tasks, so a watcher event that arrives after a module's eval rejects but before `reportExceptionInHotReloadedModuleIfNeeded()` prints it can run another `reload()` — which re-reads the file (possibly mid-rewrite, since a 2MB `writeFileSync` is truncate + several `write()`s) and overwrites the table entry. The still-unreported error is then either remapped against the wrong map (transpiled coords leak through, e.g. `:1:12` when the source is line 1003) or dropped entirely when the new `pending_internal_promise` replaces the old one.

This was flaking on aarch64 in `should work with sourcemap generation` (see #29735) and can also affect users whose editors save non-atomically.

## Test

The new test in `test/cli/hot/hot.test.ts` makes the window deterministic: the hot file truncates itself to a comment-only stub immediately before throwing, guaranteeing a fresh watcher event lands between reject and report.

- [x] `bun bd test test/cli/hot/hot.test.ts -t "should not remap against a stale sourcemap"` — 1 pass, 41 expect() calls (20 iterations)
- [x] `USE_SYSTEM_BUN=1 bun test test/cli/hot/hot.test.ts -t "should not remap against a stale sourcemap"` — fails (the error is dropped and the test times out waiting for it)
- [x] `bun bd test test/cli/hot/hot.test.ts -t sourcemap` — all 4 sourcemap tests pass
- [x] `bun run zig:check-all` — clean

**Note:** the self-rewriting hot file in the new test occasionally exposes a separate, pre-existing edge case where an entry that rewrites itself mid-eval and then throws can lose the error (reproduces on released bun too). I observed this as a rare hang on debug builds when running under heavy parallel load; it did not reproduce in serial `bun bd test` runs. If it surfaces in CI it's worth a follow-up — the root cause is independent of this change.