### PR TITLE
test: deflake cpu-prof.test.ts on Windows (time-bound all workloads to 100ms)

### DIFF
--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -151,12 +151,20 @@ describe.concurrent("--cpu-prof", () => {
   });
 
   test("profile captures function names", async () => {
+    // Time-bounded (not iteration-bounded) so myFunction occupies the CPU for
+    // a contiguous 100ms and is guaranteed to span multiple sampler ticks even
+    // on Windows, where JSC's SamplingProfiler effectively ticks at the
+    // ~15.6ms default timer quantum. An iteration-bounded loop JITs to <1ms,
+    // and since the entry module evaluates via an async fetch/link/evaluate
+    // chain the first tick can land in loader internals as "(program)" with
+    // user code finishing before the second tick.
     using dir = tempDir("cpu-prof-functions", {
       "test.js": `
         function myFunction() {
           let sum = 0;
-          for (let i = 0; i < 1000000; i++) {
-            sum += i;
+          const end = performance.now() + 100;
+          while (performance.now() < end) {
+            for (let i = 0; i < 1000; i++) sum += i;
           }
           return sum;
         }

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -3,6 +3,11 @@ import { readdirSync, readFileSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
+// Every workload below is time-bounded for 100ms. On Windows JSC's
+// SamplingProfiler effectively ticks at the ~15.6ms default timer quantum, and
+// the entry module evaluates via an async fetch/link/evaluate chain — so
+// shorter windows (the previous 32/50ms) can elapse before a single sample is
+// taken, leaving "No samples collected." in --cpu-prof-md output.
 describe.concurrent("--cpu-prof", () => {
   test("generates CPU profile with default name", async () => {
     using dir = tempDir("cpu-prof", {
@@ -14,7 +19,7 @@ describe.concurrent("--cpu-prof", () => {
         }
 
         const now = performance.now();
-        while (now + 50 > performance.now()) {
+        while (now + 100 > performance.now()) {
             Bun.inspect(fibonacci(20));
         }
       `,
@@ -96,7 +101,7 @@ describe.concurrent("--cpu-prof", () => {
     using dir = tempDir("cpu-prof-name", {
       "test.js": `
         function loop() {
-          const end = Date.now() + 32;
+          const end = Date.now() + 100;
           while (Date.now() < end) {}
         }
         loop();
@@ -124,7 +129,7 @@ describe.concurrent("--cpu-prof", () => {
     using dir = tempDir("cpu-prof-dir", {
       "test.js": `
         function loop() {
-          const end = Date.now() + 32;
+          const end = Date.now() + 100;
           while (Date.now() < end) {}
         }
         loop();
@@ -151,13 +156,6 @@ describe.concurrent("--cpu-prof", () => {
   });
 
   test("profile captures function names", async () => {
-    // Time-bounded (not iteration-bounded) so myFunction occupies the CPU for
-    // a contiguous 100ms and is guaranteed to span multiple sampler ticks even
-    // on Windows, where JSC's SamplingProfiler effectively ticks at the
-    // ~15.6ms default timer quantum. An iteration-bounded loop JITs to <1ms,
-    // and since the entry module evaluates via an async fetch/link/evaluate
-    // chain the first tick can land in loader internals as "(program)" with
-    // user code finishing before the second tick.
     using dir = tempDir("cpu-prof-functions", {
       "test.js": `
         function myFunction() {
@@ -207,7 +205,7 @@ describe.concurrent("--cpu-prof", () => {
 
         function main() {
           const now = performance.now();
-          while (now + 50 > performance.now()) {
+          while (now + 100 > performance.now()) {
             Bun.inspect(fibonacci(20));
           }
         }
@@ -256,7 +254,7 @@ describe.concurrent("--cpu-prof", () => {
     using dir = tempDir("cpu-prof-md-name", {
       "test.js": `
         function loop() {
-          const end = Date.now() + 32;
+          const end = Date.now() + 100;
           while (Date.now() < end) {}
         }
         loop();
@@ -300,7 +298,7 @@ describe.concurrent("--cpu-prof", () => {
         }
         function main() {
           const now = performance.now();
-          while (now + 50 > performance.now()) {
+          while (now + 100 > performance.now()) {
             workA();
             workB();
           }
@@ -341,7 +339,7 @@ describe.concurrent("--cpu-prof", () => {
     using dir = tempDir("cpu-prof-md-standalone", {
       "test.js": `
         function loop() {
-          const end = Date.now() + 32;
+          const end = Date.now() + 100;
           while (Date.now() < end) {}
         }
         loop();
@@ -375,7 +373,7 @@ describe.concurrent("--cpu-prof", () => {
     using dir = tempDir("cpu-prof-both-formats", {
       "test.js": `
         function loop() {
-          const end = Date.now() + 32;
+          const end = Date.now() + 100;
           while (Date.now() < end) {}
         }
         loop();


### PR DESCRIPTION
## What does this PR do?

Deflakes `test/cli/run/cpu-prof.test.ts` on Windows, which flaked in 9 of the last 200 builds — e.g. [build 48023](https://buildkite.com/bun/bun/builds/48023) on Windows 2019 x64-baseline at line 187:

```
expect(functionNames.some((name: string) => name !== "(root)" && name !== "(program)")).toBe(true);
Expected: true  Received: false
```

and again on this PR's first push ([build 48042](https://buildkite.com/bun/bun/builds/48042)) at lines 241/285 with `Received: "No samples collected.\n"`.

**Root cause:** On Windows, JSC's SamplingProfiler effectively ticks at the ~15.6ms default timer quantum (WTF::sleep is bounded by it without `timeBeginPeriod`). After #29393 (WebKit module-loader rewrite), entry-module evaluation is async — `loadAndEvaluateModule` returns a pending promise and user code runs after fetch→link→evaluate microtask checkpoints — so the first sampler tick can land in loader internals before user code starts. The previous workloads were either iteration-bounded (`for (i < 1000000)`, JITs to <1ms) or time-bounded for only 32/50ms, which is no longer enough margin to guarantee even one sample lands in user code.

7 of the 9 historical flakes are post-#29393; the other 2 predate it. The test was always borderline, the rewrite made it ~7× flakier. Jarred's earlier deflake (8058d78b6a) bumped 16→32ms and time-bounded the first test, but that's no longer sufficient.

**Fix:** Time-bound every workload in the file for 100ms (~6 sampler ticks on Windows), including the previously iteration-bounded `myFunction()`. Under `describe.concurrent` the wall-clock cost is the max not the sum, so the suite stays at ~1.9s.

## How did you verify your code works?

- `bun bd test test/cli/run/cpu-prof.test.ts` — 30/30 consecutive passes on Windows after each commit
- BuildKite history scan of last 200 builds correlating flake commits with WebKit upgrade ancestry
