### PR TITLE
napi: clear wrapped-object back-pointer in napi_delete_reference

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -1239,6 +1239,37 @@ extern "C" napi_status napi_delete_reference(napi_env env, napi_ref ref)
     NAPI_CHECK_ENV_NOT_IN_GC(env);
     NAPI_CHECK_ARG(env, ref);
     NapiRef* napiRef = toJS(ref);
+
+    // If this NapiRef is the one backing a napi_wrap on a still-live JS
+    // object, clear that back-pointer before freeing it. napi_wrap stores the
+    // raw NapiRef* in NapiPrototype::napiRef (or in a NapiExternal hung off a
+    // private property for plain objects) and hands the same pointer back to
+    // the caller; deleting it here without detaching would leave the JS
+    // object holding a dangling NapiRef* that a later napi_unwrap /
+    // napi_remove_wrap / napi_wrap would dereference. The referenced value
+    // may already have been collected (napi_delete_reference is commonly
+    // called from a posted finalizer after GC), so guard the empty case.
+    JSValue wrapped = napiRef->value();
+    if (wrapped && wrapped.isObject()) {
+        JSObject* jsc_object = wrapped.getObject();
+        auto* globalObject = toJS(env);
+        auto& vm = JSC::getVM(globalObject);
+        if (auto* napi_instance = dynamicDowncast<NapiPrototype>(jsc_object)) {
+            if (napi_instance->napiRef == napiRef) {
+                napi_instance->napiRef = nullptr;
+            }
+        } else {
+            JSValue contents = jsc_object->getDirect(vm, WebCore::builtinNames(vm).napiWrappedContentsPrivateName());
+            if (!contents.isEmpty()) {
+                if (auto* external = dynamicDowncast<Bun::NapiExternal>(contents)) {
+                    if (static_cast<NapiRef*>(external->value()) == napiRef) {
+                        external->m_value = nullptr;
+                    }
+                }
+            }
+        }
+    }
+
     delete napiRef;
     NAPI_RETURN_SUCCESS(env);
 }

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -540,6 +540,17 @@ nativeTests.test_napi_wrap_prototype = () => {
   console.log("unwrap instance:", nativeTests.try_unwrap(new Foo()));
 };
 
+nativeTests.test_napi_wrap_delete_ref_then_unwrap = () => {
+  // Deleting the reference returned by napi_wrap while the JS object is
+  // still alive is discouraged by the N-API docs, but it must not leave the
+  // JS object holding a dangling NapiRef* that a later napi_unwrap would
+  // dereference. Exercise both the plain-object (private NapiExternal) path
+  // and the NapiPrototype fast-path.
+  nativeTests.test_wrap_delete_ref_then_access({});
+  nativeTests.test_wrap_delete_ref_then_access(new (nativeTests.get_class_with_constructor())());
+  console.log("pass");
+};
+
 nativeTests.test_napi_remove_wrap = () => {
   const targets = [{}, new (nativeTests.get_class_with_constructor())()];
   for (const t of targets) {

--- a/test/napi/napi-app/wrap_tests.cpp
+++ b/test/napi/napi-app/wrap_tests.cpp
@@ -217,6 +217,57 @@ static napi_value try_remove_wrap(const Napi::CallbackInfo &info) {
   return result;
 }
 
+static void noop_wrap_finalizer(napi_env, void *, void *) {}
+
+// Wraps the given object, deletes the returned reference while the JS object
+// is still live (addon misuse per the N-API docs, but must not cause
+// use-after-free), and verifies that subsequent napi_unwrap / napi_remove_wrap
+// / napi_wrap calls treat the object as unwrapped instead of reading through
+// the freed NapiRef.
+static napi_value
+test_wrap_delete_ref_then_access(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value js_object = info[0];
+
+  static int first_data = 42;
+  napi_ref ref = nullptr;
+  NODE_API_CALL(env, napi_wrap(env, js_object, &first_data, noop_wrap_finalizer,
+                               nullptr, &ref));
+  NODE_API_ASSERT(env, ref != nullptr);
+
+  NODE_API_CALL(env, napi_delete_reference(env, ref));
+
+  void *out = nullptr;
+  napi_status unwrap_status = napi_unwrap(env, js_object, &out);
+  printf("after delete_reference: unwrap_status=%d\n", (int)unwrap_status);
+  NODE_API_ASSERT(env, unwrap_status == napi_invalid_arg);
+  NODE_API_ASSERT(env, out == nullptr);
+
+  out = nullptr;
+  napi_status remove_status = napi_remove_wrap(env, js_object, &out);
+  printf("after delete_reference: remove_wrap_status=%d\n",
+         (int)remove_status);
+  NODE_API_ASSERT(env, remove_status == napi_invalid_arg);
+  NODE_API_ASSERT(env, out == nullptr);
+
+  static int second_data = 99;
+  napi_status rewrap_status =
+      napi_wrap(env, js_object, &second_data, nullptr, nullptr, nullptr);
+  printf("after delete_reference: rewrap_status=%d\n", (int)rewrap_status);
+  NODE_API_ASSERT(env, rewrap_status == napi_ok);
+
+  int *unwrapped = nullptr;
+  NODE_API_CALL(env, napi_unwrap(env, js_object,
+                                 reinterpret_cast<void **>(&unwrapped)));
+  NODE_API_ASSERT(env, unwrapped == &second_data);
+
+  void *removed = nullptr;
+  NODE_API_CALL(env, napi_remove_wrap(env, js_object, &removed));
+  NODE_API_ASSERT(env, removed == &second_data);
+
+  return ok(env);
+}
+
 void register_wrap_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_wrap);
   REGISTER_FUNCTION(env, exports, get_wrap_data);
@@ -228,6 +279,7 @@ void register_wrap_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, try_wrap);
   REGISTER_FUNCTION(env, exports, try_unwrap);
   REGISTER_FUNCTION(env, exports, try_remove_wrap);
+  REGISTER_FUNCTION(env, exports, test_wrap_delete_ref_then_access);
 }
 
 } // namespace napitests

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -456,6 +456,45 @@ describe.concurrent("napi", () => {
       await checkSameOutput("test_napi_remove_wrap", []);
     });
 
+    it("does not use-after-free when napi_delete_reference is called on the wrap ref", async () => {
+      // Deleting the reference returned by napi_wrap while the wrapped JS
+      // object is still alive is discouraged by the N-API docs, and Node.js
+      // itself segfaults on this sequence, so we only verify that Bun clears
+      // the dangling NapiRef* instead of dereferencing freed memory on a
+      // subsequent napi_unwrap / napi_remove_wrap / napi_wrap.
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "--expose-gc",
+          join(__dirname, "napi-app/main.js"),
+          "test_napi_wrap_delete_ref_then_unwrap",
+          "[]",
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "inherit",
+      });
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(line => line.startsWith("after delete_reference:") || line === "pass")
+        .join("\n");
+      expect(lines).toBe(
+        [
+          "after delete_reference: unwrap_status=1",
+          "after delete_reference: remove_wrap_status=1",
+          "after delete_reference: rewrap_status=0",
+          "after delete_reference: unwrap_status=1",
+          "after delete_reference: remove_wrap_status=1",
+          "after delete_reference: rewrap_status=0",
+          "pass",
+        ].join("\n"),
+      );
+      expect(exitCode).toBe(0);
+    });
+
     it("has the right lifetime", async () => {
       await checkSameOutput("test_wrap_lifetime_without_ref", []);
       await checkSameOutput("test_wrap_lifetime_with_weak_ref", []);


### PR DESCRIPTION
## What

`napi_wrap` stores a raw `NapiRef*` both in the wrapped JS object (either `NapiPrototype::napiRef` or a `NapiExternal` hung off the `napiWrappedContents` private property for plain objects) and hands the same pointer back to the caller as the optional `napi_ref` result. `napi_delete_reference` just did `delete napiRef` without clearing that back-pointer, so a still-live JS object was left holding a dangling `NapiRef*`.

A subsequent `napi_unwrap` / `napi_remove_wrap` / `napi_wrap` on that object calls `getWrapContentsIfExists`, which returns the freed pointer, and then dereferences `ref->nativeObject` on freed memory. Because `NapiRef` is TZone-allocated the slot is quickly reused by another `NapiRef`, so an addon can receive (and write through) a different addon's native pointer.

## Repro

```c
napi_wrap(env, obj, native, finalizer, hint, &ref);
napi_delete_reference(env, ref);   // addon misuse, but must not UAF
napi_unwrap(env, obj, &out);        // reads ref->nativeObject from freed NapiRef
```

Node.js v24 segfaults on the same sequence (same architectural pattern — private External holding a `Reference*`), so this is not a Bun-vs-Node behavioral difference; the N-API docs do caution against deleting a wrap ref outside its finalizer. But it still should not corrupt memory.

## Fix

Before freeing the `NapiRef`, `napi_delete_reference` now looks up the referenced JS object and, if that object's wrap slot points back to the `NapiRef` being deleted, clears it (`NapiPrototype::napiRef = nullptr` or `NapiExternal::m_value = nullptr`). After deletion the object behaves as if the wrap was removed: `napi_unwrap` / `napi_remove_wrap` return `napi_invalid_arg` and the object can be re-wrapped.

The referenced value may already have been collected (the common case where `napi_delete_reference` is called from a posted finalizer after GC), which yields a `JSValue` wrapping a null cell pointer; that case is guarded so the lookup is skipped. Non-wrap references (from `napi_create_reference`) are also unaffected since their back-pointer check never matches.

## Verification

- New `napi > napi_wrap > does not use-after-free when napi_delete_reference is called on the wrap ref` test exercises both the `NapiPrototype` fast-path (via an `napi_define_class` instance) and the plain-object `NapiExternal` path. It fails without the src/ change (`napi_unwrap` returns `napi_ok` through the freed ref) and passes with it.
- Existing `napi_wrap` lifetime tests and the node-api `test_reference`, `test_reference_double_free`, `6_object_wrap`, `7_factory_wrap`, `8_passing_wrapped` suites still pass.