### PR TITLE
fetch: protect stream error JSValue stored in ByteStream pending result

### DIFF
--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -175,9 +175,7 @@ pub fn onData(
 
             if (to_copy.len == 0) {
                 if (stream == .err) {
-                    this.pending.result = .{
-                        .err = stream.err,
-                    };
+                    this.setPendingError(stream.err);
                 } else {
                     this.pending.result = .{
                         .done = {},
@@ -241,7 +239,7 @@ pub fn append(
                 this.buffer.appendSliceAssumeCapacity(chunk);
             },
             .err => {
-                this.pending.result = .{ .err = stream.err };
+                this.setPendingError(stream.err);
             },
             .done => {},
             else => unreachable,
@@ -262,7 +260,7 @@ pub fn append(
                 @panic("Expected buffer action to be null");
             }
 
-            this.pending.result = .{ .err = stream.err };
+            this.setPendingError(stream.err);
         },
         .done => {},
         // We don't support the rest of these yet
@@ -270,6 +268,22 @@ pub fn append(
     }
 
     return;
+}
+
+/// Stores an error into `pending.result`, taking care to protect any raw
+/// `JSValue` so it survives GC until it is consumed by `toBufferedValue`,
+/// `fulfillPromise`, or `Result.deinit` (all of which unprotect it).
+///
+/// Without this, the error value's only GC root may be a `Strong` held by
+/// the owning `Response` body; if the user holds onto the `ReadableStream`
+/// but drops the `Response`, that root disappears and we would hand a
+/// collected cell to JS on the next read.
+fn setPendingError(this: *@This(), err: streams.Result.StreamError) void {
+    if (err == .JSValue) {
+        err.JSValue.protect();
+    }
+    this.pending.result.deinit();
+    this.pending.result = .{ .err = err };
 }
 
 pub fn setValue(this: *@This(), view: jsc.JSValue) void {

--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -358,10 +358,12 @@ pub fn onCancel(this: *@This()) void {
     this.done = true;
     this.pending_value.deinit();
 
+    // Always release any stored error; setPendingError may have protected a
+    // JSValue that nothing else will consume once we mark ourselves done.
+    this.pending_buffer = &.{};
+    this.pending.result.deinit();
+    this.pending.result = .{ .done = {} };
     if (view != .zero) {
-        this.pending_buffer = &.{};
-        this.pending.result.deinit();
-        this.pending.result = .{ .done = {} };
         this.pending.run();
     }
 
@@ -394,6 +396,12 @@ pub fn deinit(this: *@This()) void {
         } else {
             this.pending.run();
         }
+    } else {
+        // `done` may have been set by onPull/onCancel without consuming a
+        // stored error (e.g. an error arrived after some buffered data and
+        // onPull returned the data as `into_array_and_done`). Release it.
+        this.pending.result.deinit();
+        this.pending.result = .{ .done = {} };
     }
     if (this.buffer_action) |*action| {
         action.deinit();

--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -445,6 +445,7 @@ pub fn toBufferedValue(this: *@This(), globalThis: *jsc.JSGlobalObject, action: 
     if (this.pending.result == .err) {
         const err, _ = this.pending.result.err.toJSWeak(globalThis);
         this.pending.result.deinit();
+        this.pending.result = .{ .done = {} };
         this.done = true;
         this.buffer.clearAndFree();
         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1,7 +1,7 @@
 import { Socket } from "bun";
 import { describe, expect, it } from "bun:test";
 import { createReadStream, readFileSync } from "fs";
-import { gcTick, isWindows, tempDirWithFilesAnon } from "harness";
+import { bunEnv, bunExe, gcTick, isWindows, tempDirWithFilesAnon } from "harness";
 import http from "http";
 import type { AddressInfo } from "net";
 import path, { join } from "path";
@@ -1403,4 +1403,87 @@ describe.concurrent("fetch() with streaming", () => {
     expect(new TextDecoder().decode(result.value!)).toBe("hello\n");
     server.kill("SIGTERM");
   });
+});
+
+// Runs in a subprocess so aggressive GC does not interact with concurrent tests above.
+it("stored body-stream error survives GC after Response is collected", async () => {
+  // When a fetch response body errors (e.g. connection reset after headers)
+  // while there is no pending read and no buffered consumer, ByteStream.append
+  // stores the error JSValue in `pending.result`. That value must be protected:
+  // once the Response is GC'd, the body's own Strong ref is dropped, and the
+  // stored error would otherwise become a dangling JSCell that is later handed
+  // to JS via readableStreamToText() → toBufferedValue().
+  const fixture = /* js */ `
+    let serverSocket;
+    const socketReady = Promise.withResolvers();
+    const socketClosed = Promise.withResolvers();
+
+    const server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket) {
+          socket.write("HTTP/1.1 200 OK\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
+          socket.flush();
+          serverSocket = socket;
+          socketReady.resolve();
+        },
+        open() {},
+        close() { socketClosed.resolve(); },
+        error() {},
+      },
+    });
+
+    let body;
+    {
+      let res = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+      body = res.body; // creates ByteStream, no pending read, no buffer action
+      await socketReady.promise;
+
+      // Abort the connection so the body stream receives an error while
+      // pending.state is still .none (we have not called read()).
+      serverSocket.terminate();
+      await socketClosed.promise;
+      // Let the HTTP thread's error propagate to the JS-thread ByteStream.
+      for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));
+
+      res = undefined; // drop the Response; only 'body' is kept alive
+    }
+
+    // Collect the Response; its body.value.Error Strong (the only remaining
+    // root for the stored error JSValue) goes away with it.
+    for (let i = 0; i < 10; i++) {
+      Bun.gc(true);
+      await new Promise(r => setImmediate(r));
+      // Allocate to encourage reuse of the freed JSCell.
+      for (let j = 0; j < 64; j++) globalThis.__churn = new Error("churn " + i + ":" + j);
+    }
+    Bun.gc(true);
+
+    let caught;
+    try {
+      await Bun.readableStreamToText(body);
+    } catch (e) {
+      caught = e;
+    }
+
+    server.stop(true);
+
+    if (caught instanceof Error && typeof caught.message === "string") {
+      process.stdout.write("PASS " + (caught.code ?? caught.name) + "\\n");
+    } else {
+      process.stdout.write("FAIL " + Object.prototype.toString.call(caught) + "\\n");
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toStartWith("PASS");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/fetch.stream.test.ts
+++ b/test/js/web/fetch/fetch.stream.test.ts
@@ -1482,8 +1482,16 @@ it("stored body-stream error survives GC after Response is collected", async () 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  // ASAN debug builds unconditionally print a signal-handler warning to
+  // stderr at startup; ignore that line. On regression the JSC assertion
+  // lands on stderr, so surface it in the failure output.
+  const stderrLines = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(stderrLines).toBe("");
   expect(stdout.trim()).toStartWith("PASS");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Problem

`ByteStream.append` / `onData` stored `stream.err` directly into `pending.result` when there was no pending pull and no buffer action. When the error is a `StreamError.JSValue`, that raw `JSValue` was never `protect()`'d, even though every consumer (`Result.deinit`, `fulfillPromise`, `toBufferedValue`) already treats that variant as strong and unprotects it.

The only GC root for the error in that window is the `Strong` held in the owning `Response`'s `body.value.Error`. If user code keeps the `ReadableStream` but drops the `Response`, the `Response` is collected along with that `Strong`, and `pending.result.err.JSValue` is left pointing at a freed JSCell. The next `Bun.readableStreamToText(body)` → `toBufferedValue` would reject a promise with that collected cell.

This addresses the TODO at `streams.zig:225` (`// TODO: use an explicit jsc.Strong.Optional here.`) at the storage site rather than changing the union type.

## Repro

```js
const res = await fetch(urlThatResetsAfterHeaders);
const body = res.body;            // no read(), no buffer action
/* server terminates connection → ByteStream.append stores raw .JSValue */
res = undefined; Bun.gc(true);     // Response + its Strong collected
await Bun.readableStreamToText(body); // reads freed JSCell
```

Debug build before fix:
```
ASSERTION FAILED: decontaminate()
.../JavaScriptCore/StructureID.h(94) : Structure *JSC::StructureID::decode() const
```

## Fix

Add `ByteStream.setPendingError` which `protect()`s the `.JSValue` variant before storing it in `pending.result`, and `deinit()`s the previous result first (the error is delivered twice on this path — once from `FetchTasklet.onBodyReceived` directly, once from `Body.toErrorInstance` — so the old protected value must be released). All existing consumers already unprotect on consumption, so the balance is maintained.

## Verification

New test in `test/js/web/fetch/fetch.stream.test.ts` spawns a subprocess that reproduces the exact sequence (headers → terminate → drop Response → GC → `readableStreamToText`):

- **before**: subprocess aborts with the StructureID assertion, stdout empty → test fails
- **after**: subprocess rejects cleanly with `ECONNRESET`, prints `PASS ECONNRESET` → test passes