### PR TITLE
Use wtf/MathExtras.h for double→int conversions; fjcvtzs/fcvtzs on arm64

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -48,6 +48,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
+#include <wtf/MathExtras.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
@@ -1923,7 +1924,7 @@ bool inline parseArrayIndex(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalO
         return true;
     }
 
-    int64_t index = static_cast<int64_t>(value.toIntegerWithTruncation(globalObject));
+    int64_t index = truncateDoubleToInt64(value.toNumber(globalObject));
     RETURN_IF_EXCEPTION(scope, false);
 
     if (index < 0) {
@@ -2070,7 +2071,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
     if (fstart > byteLength) {
         return JSC::JSValue::encode(JSC::jsEmptyString(vm));
     }
-    start = static_cast<uint32_t>(fstart);
+    start = truncateDoubleToUint32(fstart);
 lstart:
 
     if (!arg3.isUndefined()) {
@@ -2215,7 +2216,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeEncodingBody(JSC::VM& 
             return Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, lexicalGlobalObject, "length");
         }
         // Convert NaN length to 0, negative to 0 (for NaN offset case)
-        int64_t intLength = (std::isnan(length) || length < 0) ? 0 : static_cast<int64_t>(length);
+        int64_t intLength = (std::isnan(length) || length < 0) ? 0 : truncateDoubleToInt64(length);
         // Clamp to available buffer space
         maxLength = std::min(byteLength - safeOffset, static_cast<size_t>(intLength));
     }
@@ -2471,7 +2472,7 @@ static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, J
         return 0;
     }
 
-    offset = static_cast<size_t>(offsetD);
+    offset = truncateDoubleToUint64(offsetD);
 
     if (offset > maxOffset) [[unlikely]] {
         Bun::ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "offset"_s, 0, maxOffset, offsetVal);
@@ -3068,7 +3069,7 @@ EncodedJSValue constructBufferFromArrayBuffer(JSC::ThrowScope& throwScope, JSGlo
         double offsetD = offsetValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (std::isnan(offsetD)) offsetD = 0;
-        offset = offsetD;
+        offset = truncateDoubleToUint64(offsetD);
         if (offset > byteLength) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "offset"_s);
         length -= offset;
     }
@@ -3077,7 +3078,7 @@ EncodedJSValue constructBufferFromArrayBuffer(JSC::ThrowScope& throwScope, JSGlo
         double lengthD = lengthValue.toNumber(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(throwScope, {});
         if (std::isnan(lengthD)) lengthD = 0;
-        length = lengthD;
+        length = truncateDoubleToUint64(lengthD);
         if (length > byteLength - offset) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(throwScope, lexicalGlobalObject, "length"_s);
     }
 

--- a/src/bun.js/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
+++ b/src/bun.js/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
@@ -8,6 +8,7 @@
 #include "BunString.h"
 #include "wtf/text/ASCIILiteral.h"
 #include "wtf/Vector.h"
+#include <wtf/MathExtras.h>
 
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
@@ -41,7 +42,7 @@ static JSNodePerformanceHooksHistogram* createHistogramInternal(JSGlobalObject* 
     if (lowestVal.isNumber()) {
         double dbl = lowestVal.asNumber();
         if (!std::isnan(dbl)) {
-            lowest = static_cast<int64_t>(dbl);
+            lowest = truncateDoubleToInt64(dbl);
         }
     } else if (lowestVal.isBigInt()) {
         auto* bigInt = jsCast<JSBigInt*>(lowestVal);
@@ -51,7 +52,7 @@ static JSNodePerformanceHooksHistogram* createHistogramInternal(JSGlobalObject* 
     if (highestVal.isNumber()) {
         double dbl = highestVal.asNumber();
         if (!std::isnan(dbl)) {
-            highest = static_cast<int64_t>(dbl);
+            highest = truncateDoubleToInt64(dbl);
         }
     } else if (highestVal.isBigInt()) {
         auto* bigInt = jsCast<JSBigInt*>(highestVal);
@@ -61,7 +62,7 @@ static JSNodePerformanceHooksHistogram* createHistogramInternal(JSGlobalObject* 
     if (figuresVal.isNumber()) {
         double dbl = figuresVal.asNumber();
         if (!std::isnan(dbl)) {
-            figures = static_cast<int>(dbl);
+            figures = truncateDoubleToInt32(dbl);
         }
     }
 

--- a/src/bun.js/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/bun.js/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -6,6 +6,7 @@
 #include "JSNodePerformanceHooksHistogramPrototype.h"
 #include "JSNodePerformanceHooksHistogram.h"
 #include "wtf/text/ASCIILiteral.h"
+#include <wtf/MathExtras.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
@@ -66,7 +67,7 @@ JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramProtoFuncRecord, (JSGlob
     JSValue arg = callFrame->uncheckedArgument(0);
     int64_t value;
     if (arg.isNumber()) {
-        value = static_cast<int64_t>(arg.asNumber());
+        value = truncateDoubleToInt64(arg.asNumber());
     } else if (arg.isBigInt()) {
         auto* bigInt = jsCast<JSBigInt*>(arg);
         value = JSBigInt::toBigInt64(bigInt);
@@ -388,7 +389,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
     if (callFrame->argumentCount() >= 1) {
         JSValue lowestArg = callFrame->uncheckedArgument(0);
         if (lowestArg.isNumber()) {
-            lowest = static_cast<int64_t>(lowestArg.asNumber());
+            lowest = truncateDoubleToInt64(lowestArg.asNumber());
         } else if (lowestArg.isBigInt()) {
             auto* bigInt = jsCast<JSBigInt*>(lowestArg);
             lowest = JSBigInt::toBigInt64(bigInt);
@@ -398,7 +399,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
     if (callFrame->argumentCount() >= 2) {
         JSValue highestArg = callFrame->uncheckedArgument(1);
         if (highestArg.isNumber()) {
-            highest = static_cast<int64_t>(highestArg.asNumber());
+            highest = truncateDoubleToInt64(highestArg.asNumber());
         } else if (highestArg.isBigInt()) {
             auto* bigInt = jsCast<JSBigInt*>(highestArg);
             highest = JSBigInt::toBigInt64(bigInt);
@@ -408,7 +409,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
     if (callFrame->argumentCount() >= 3) {
         JSValue figuresArg = callFrame->uncheckedArgument(2);
         if (figuresArg.isNumber()) {
-            figures = static_cast<int>(figuresArg.asNumber());
+            figures = truncateDoubleToInt32(figuresArg.asNumber());
         }
     }
 

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -610,8 +610,8 @@ pub const JSValue = enum(i64) {
             JSValue => number,
             u0 => jsNumberFromInt32(0),
             f32, f64 => {
-                if (canBeStrictInt32(number)) {
-                    return jsNumberFromInt32(@intFromFloat(number));
+                if (tryConvertToStrictInt32(number)) |int| {
+                    return jsNumberFromInt32(int);
                 }
                 return jsDoubleNumber(number);
             },
@@ -820,23 +820,65 @@ pub const JSValue = enum(i64) {
         return jsDoubleNumber(@floatFromInt(i));
     }
 
-    // https://github.com/oven-sh/WebKit/blob/df8aa4c4d01a1c2fe22ac599adfe0a582fce2b20/Source/JavaScriptCore/runtime/MathCommon.h#L243-L249
-    pub fn canBeStrictInt32(value: f64) bool {
-        if (std.math.isInf(value) or std.math.isNan(value)) {
-            return false;
+    // Mirrors WTF::tryConvertToStrictInt32 (wtf/MathExtras.h). Returns the int32
+    // when `value` is exactly representable as i32 (rejects -0.0, NaN, ±Inf,
+    // non-integers, out-of-range).
+    pub fn tryConvertToStrictInt32(value: f64) ?i32 {
+        if (comptime has_fjcvtzs) {
+            // ARMv8.3 FJCVTZS performs JS ToInt32 and sets Z=1 iff no rounding,
+            // wrap, sign-flip or NaN/Inf occurred — i.e. iff the input was an
+            // exact int32 (including +0.0 → 0; -0.0 clears Z).
+            var result: i32 = undefined;
+            var exact: u32 = undefined;
+            asm (
+                \\fjcvtzs %[out:w], %[in:d]
+                \\cset %[z:w], eq
+                : [out] "=r" (result),
+                  [z] "=r" (exact),
+                : [in] "w" (value),
+                : .{ .nzcv = true });
+            return if (exact != 0) result else null;
         }
-        const int: i32 = int: {
-            @setRuntimeSafety(false);
-            break :int @intFromFloat(value);
-        };
-        return !(@as(f64, @floatFromInt(int)) != value or (int == 0 and std.math.signbit(value))); // true for -0.0
+
+        // Range gate also rejects NaN/±Inf via unordered compare.
+        if (!(value >= -2147483648.0 and value < 2147483648.0)) {
+            return null;
+        }
+        const int: i32 = @intFromFloat(value);
+        if (@as(f64, @floatFromInt(int)) != value or (int == 0 and std.math.signbit(value))) {
+            return null;
+        }
+        return int;
     }
+
+    pub fn canBeStrictInt32(value: f64) bool {
+        return tryConvertToStrictInt32(value) != null;
+    }
+
+    const has_fjcvtzs = bun.Environment.isAarch64 and
+        std.Target.aarch64.featureSetHas(@import("builtin").cpu.features, .jsconv);
 
     fn coerceJSValueDoubleTruncatingT(comptime T: type, num: f64) T {
         return coerceJSValueDoubleTruncatingTT(T, T, num);
     }
 
     fn coerceJSValueDoubleTruncatingTT(comptime T: type, comptime Out: type, num: f64) Out {
+        if (comptime bun.Environment.isAarch64 and T == Out and (T == i32 or T == i64)) {
+            // fcvtzs saturates exactly as below: NaN→0, overflow→min/max.
+            // Inline asm prevents LLVM from applying fptosi poison reasoning.
+            return switch (T) {
+                i32 => asm ("fcvtzs %[out:w], %[in:d]"
+                    : [out] "=r" (-> i32),
+                    : [in] "w" (num),
+                ),
+                i64 => asm ("fcvtzs %[out:x], %[in:d]"
+                    : [out] "=r" (-> i64),
+                    : [in] "w" (num),
+                ),
+                else => unreachable,
+            };
+        }
+
         if (std.math.isNan(num)) {
             return 0;
         }

--- a/src/bun.js/bindings/node/http/JSHTTPParserPrototype.cpp
+++ b/src/bun.js/bindings/node/http/JSHTTPParserPrototype.cpp
@@ -3,6 +3,7 @@
 #include "JSConnectionsList.h"
 #include "ZigGlobalObject.h"
 #include "JSDOMExceptionHandling.h"
+#include <wtf/MathExtras.h>
 
 namespace Bun {
 
@@ -183,7 +184,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPParser_initialize, (JSGlobalObject * globalObject
 
     if (callFrame->argumentCount() > 2) {
         if (maxHttpHeaderSizeValue.isNumber()) {
-            maxHttpHeaderSize = static_cast<uint64_t>(maxHttpHeaderSizeValue.asNumber());
+            maxHttpHeaderSize = truncateDoubleToUint64(maxHttpHeaderSizeValue.asNumber());
         }
     }
 
@@ -206,7 +207,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPParser_initialize, (JSGlobalObject * globalObject
         }
     }
 
-    llhttp_type_t type = static_cast<llhttp_type_t>(typeValue.toNumber(globalObject));
+    llhttp_type_t type = static_cast<llhttp_type_t>(typeValue.toInt32(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
     JSHTTPParser* parser = jsDynamicCast<JSHTTPParser*>(thisValue);

--- a/src/bun.js/bindings/wrapAnsi.cpp
+++ b/src/bun.js/bindings/wrapAnsi.cpp
@@ -5,6 +5,7 @@
 #include <wtf/text/WTFString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/Vector.h>
+#include <wtf/MathExtras.h>
 #include <cmath>
 
 // Zig exports for visible width calculation
@@ -705,7 +706,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionBunWrapAnsi, (JSC::JSGlobalObject * globalObj
         RETURN_IF_EXCEPTION(scope, {});
         // Only set columns if positive and finite (negative values would wrap to huge size_t)
         if (colsDouble > 0 && std::isfinite(colsDouble))
-            columns = static_cast<size_t>(colsDouble);
+            columns = truncateDoubleToUint64(colsDouble);
     }
 
     // Parse options


### PR DESCRIPTION
## What does this PR do?

**C++ (correctness):** replace `static_cast<intN_t>(double)` with `truncateDoubleTo{Int32,Int64,Uint32,Uint64}` from `wtf/MathExtras.h` at argument-parsing sites where the input can be NaN/±Inf/out-of-range — `JSBuffer.cpp` (parseArrayIndex, toString start, write length, BigInt offset, `Buffer.from(ArrayBuffer, offset, length)`), perf_hooks Histogram constructor/prototype, `JSHTTPParserPrototype.cpp`, `wrapAnsi.cpp`. Same hardware instruction is emitted; this removes UB — `static_cast` of an out-of-range double is undefined, which lets the optimizer assume the input was in range and potentially elide the bounds check that follows. The MathExtras helpers go through intrinsics/inline asm so no such assumption is possible.

**Zig (perf, arm64):**
- `JSValue.tryConvertToStrictInt32(f64) ?i32` mirrors `WTF::tryConvertToStrictInt32`. On targets with `.jsconv` (apple_m1 → v8.4a → v8.3a) it lowers to `fjcvtzs + cset` instead of isnan/isinf/convert/round-trip/signbit, and `jsNumberWithType(f64)` reuses the returned int instead of converting again. On x86_64 / Linux arm64 it falls through to a range-gated `@intFromFloat` (which also fixes a pre-existing out-of-range `fptosi` in the old `canBeStrictInt32`).
- `coerceJSValueDoubleTruncatingTT` for `i32`/`i64` on aarch64 is now a single `fcvtzs` via inline asm — its NaN→0 / overflow→min/max saturation is bit-identical to the branchy fallback. The `i52` case keeps the branches.

## How did you verify your code works?

- `bun bd test test/js/node/buffer.test.js` — 457 pass
- `bun bd test test/js/bun/perf_hooks/histogram.test.ts` — 38 pass
- `bun bd test test/js/node/http/node-http-parser` — 9 pass
- `bun run zig:check-all` — 61/61
- `objdump -d build/debug/bun-debug | grep fjcvtzs` confirms the new sites
- `Bun.color(NaN | ±Infinity | 1e300 | 2147483647.9, "ansi-256")` matches system bun (probes Zig `toInt64` saturation)
- `Buffer.readDoubleLE` round-trip of `-0.0`, `NaN`, `±Infinity`, `INT32_MIN/MAX±1` unchanged