### PR TITLE
Bun.spawn: downgrade JSRef after async stdout/stderr drain

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -228,6 +228,13 @@ pub fn onCloseIO(this: *Subprocess, kind: StdioKind) void {
             }
         },
     }
+
+    // When the process exits before its stdout/stderr pipes have finished
+    // draining, onProcessExit's deferred updateHasPendingActivity() observes
+    // the pipe as still pending and keeps `this_value` Strong. When the pipe
+    // later completes and reaches here, we must re-evaluate so the JSRef can
+    // be downgraded and the JSSubprocess + buffered output become collectable.
+    this.updateHasPendingActivity();
 }
 
 pub fn jsRef(this: *Subprocess) void {

--- a/test/js/bun/spawn/spawn-unread-stdout-gc.test.ts
+++ b/test/js/bun/spawn/spawn-unread-stdout-gc.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// When a child process exits while its stdout/stderr pipe still has pending
+// activity, onProcessExit keeps the Subprocess JSRef Strong. The pipe later
+// drains and PipeReader.onReaderDone → Subprocess.onCloseIO converts the
+// Readable from `.pipe` to `.buffer`, but previously did not call
+// updateHasPendingActivity(), so the JSRef stayed Strong forever and the
+// JSSubprocess (plus its buffered output) leaked.
+//
+// To reproduce deterministically we need the stdout drain to complete
+// asynchronously, *after* onProcessExit returns. On POSIX the read() issued
+// from onProcessExit normally drains the pipe to EOF synchronously, so we
+// force EAGAIN by having a grandchild inherit stdout and keep the write end
+// open past the direct child's exit. The exit notification then arrives
+// while the pipe is still pending, and onCloseIO runs later from the event
+// loop — the path that leaked.
+//
+// Windows uses a different pipe/process model; the scenario is POSIX-shaped.
+test.skipIf(isWindows)(
+  "Subprocess is collectable when stdout pipe drains asynchronously after process exit",
+  async () => {
+    const script = /* js */ `
+      let collected = 0;
+      const registry = new FinalizationRegistry(() => {
+        collected++;
+      });
+
+      const ITERS = 10;
+
+      // The child spawns a detached grandchild that inherits stdout and writes
+      // after a short delay, then the child exits immediately. The grandchild
+      // keeps the write end of the pipe open past the child's exit, so
+      // onProcessExit's read() hits EAGAIN and the drain completes later.
+      const childScript =
+        "const { spawn } = require('child_process');" +
+        "spawn(process.execPath, ['-e', 'setTimeout(() => process.stdout.write(Buffer.alloc(1024, 88)), 30)']," +
+        "  { stdio: ['ignore', 'inherit', 'ignore'], detached: true }).unref();";
+
+      async function once() {
+        const proc = Bun.spawn({
+          cmd: [process.execPath, "-e", childScript],
+          env: process.env,
+          stdout: "pipe",
+          stderr: "ignore",
+          stdin: "ignore",
+        });
+        await proc.exited;
+        // Intentionally never touch proc.stdout — onCloseIO will convert the
+        // pipe to a buffered Readable that nobody references.
+        registry.register(proc, undefined);
+      }
+
+      for (let i = 0; i < ITERS; i++) {
+        await once();
+      }
+
+      // Give grandchildren time to write, exit, and for the pipes to reach
+      // EOF and fire onReaderDone → onCloseIO on the event loop. Then GC.
+      for (let i = 0; i < 60 && collected < ITERS; i++) {
+        await Bun.sleep(25);
+        Bun.gc(true);
+      }
+
+      console.log(JSON.stringify({ collected, iters: ITERS }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const stderrLines = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderrLines).toBe("");
+    const { collected, iters } = JSON.parse(stdout.trim());
+    // Without the fix, zero Subprocess wrappers are collected because their
+    // JSRef is never downgraded. With the fix they are all collectable.
+    expect(collected).toBe(iters);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## What

`Subprocess.onCloseIO` now calls `updateHasPendingActivity()` after it converts a stdout/stderr `.pipe` to `.buffer`/`.ignore` (or clears stdin).

## Why

If the child process exits while a stdout/stderr `PipeReader` is still pending — e.g. a grandchild still holds the write end of the pipe, or the exit notification races ahead of pipe EOF — `onProcessExit`'s deferred `updateHasPendingActivity()` observes `hasPendingActivityStdio() == true` and keeps `this_value` as a **Strong** JSRef.

Later, the pipe drains asynchronously on the event loop and `PipeReader.onReaderDone` → `Subprocess.onCloseIO` flips the Readable to `.buffer`/`.ignore`. Previously nothing re-evaluated pending activity at that point, so the JSRef stayed Strong forever and the `JSSubprocess` object plus its buffered output leaked for the lifetime of the parent process.

## Repro

The new `test/js/bun/spawn/spawn-unread-stdout-gc.test.ts` spawns a child that immediately spawns a detached grandchild inheriting stdout, then exits. The grandchild writes after a short delay, so `onProcessExit` in the parent hits EAGAIN on the stdout read and the drain completes asynchronously via `onCloseIO`. A `FinalizationRegistry` then checks that the `Subprocess` wrappers are collectable.

## Verification

- Without the fix: **0/10** Subprocess objects collected (consistently).
- With the fix: **10/10** collected (consistently across multiple runs).
- `git stash -- src/` → test fails; `git stash pop` → test passes.
- Existing spawn tests unaffected (spawn-noread-leak, exit-code, spawn-signal, spawn-stdin-destroy, spawn-many-teardown all pass).