### PR TITLE
Fix stack overflow when inspecting JSX elements with circular references

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,24 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference in key", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.key = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular reference in props", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props.foo = el;
+  expect(Bun.inspect(el)).toBe("<div foo=[Circular] />");
+});
+
+it("jsx with circular reference in children", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props.children = [el];
+  expect(Bun.inspect(el)).toBe("<div>\n  [Circular]\n</div>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

`Bun.inspect()` / `console.log()` would crash with a stack overflow when formatting a React element that contained a circular reference to itself via `key`, `props`, or `children`.

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
el.key = el;
Bun.inspect(el); // segfault (stack overflow)
```

The JSX formatter recurses into `key`, `props`, and `children`, but `.JSX` was not included in `canHaveCircularReferences()`, so the visited-map tracking and stack-overflow guard were never applied. This PR adds `.JSX` to that set so circular JSX elements print `[Circular]` instead of recursing forever.

## How did you verify your code works?

Added regression tests for circular references via `key`, `props`, and `children`. All existing `inspect.test.js` tests continue to pass.

Found by Fuzzilli (fingerprint `bb8715595a137556`).