### PR TITLE
spawn: close stdin pipe fd on child exit when .stdin is never read

### DIFF
--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -744,7 +744,19 @@ pub fn spawnMaybeSync(
         spawned.stdin,
         &promise_for_stream,
     ) catch {
+        // The aggregate above already ran: ref_count = 2 and stdout/stderr/
+        // stdio_pipes are live, but neither the JS wrapper nor the process
+        // exit handler have been wired up to own those refs yet. Tear down
+        // what `finalize()` would have and release both refs.
+        _ = subprocess.tryKill(subprocess.killSignal);
+        subprocess.finalizeStreams();
+        subprocess.process.detach();
+        subprocess.process.deref();
+        MaxBuf.removeFromSubprocess(&subprocess.stdout_maxbuf);
+        MaxBuf.removeFromSubprocess(&subprocess.stderr_maxbuf);
         subprocess.deref();
+        subprocess.deref();
+        if (globalThis.hasException()) return error.JSError;
         return globalThis.throwOutOfMemory();
     };
 

--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -692,31 +692,19 @@ pub fn spawnMaybeSync(
         .globalThis = globalThis,
         .process = process,
         .pid_rusage = null,
-        // Assigned immediately after this literal. `Writable.init()` writes
-        // to `subprocess.weak_file_sink_stdin_ptr`, `subprocess.flags`, and
-        // calls `subprocess.ref()` for `.pipe`/`.readable_stream` stdin; if
-        // called from inside this aggregate initializer those writes are
-        // clobbered by `.ref_count = .initExactRefs(2)`, `.flags = .{...}`,
-        // and the default `weak_file_sink_stdin_ptr = null` below.
+        // stdin/stdout/stderr are assigned immediately after this literal.
+        // `Writable.init()` writes to `subprocess.weak_file_sink_stdin_ptr`,
+        // `subprocess.flags`, and calls `subprocess.ref()` for `.pipe` /
+        // `.readable_stream` stdin; if called from inside this aggregate
+        // initializer those writes are clobbered by `.ref_count =
+        // .initExactRefs(2)`, `.flags = .{...}`, and the default
+        // `weak_file_sink_stdin_ptr = null` below. stdout/stderr are deferred
+        // so that if `Writable.init()` fails the catch block doesn't have to
+        // tear down unstarted `PipeReader`s (whose `deinit()` asserts
+        // `isDone()`).
         .stdin = .{ .ignore = {} },
-        .stdout = Readable.init(
-            stdio[1],
-            event_loop,
-            subprocess,
-            spawned.stdout,
-            jsc_vm.allocator,
-            subprocess.stdout_maxbuf,
-            is_sync,
-        ),
-        .stderr = Readable.init(
-            stdio[2],
-            event_loop,
-            subprocess,
-            spawned.stderr,
-            jsc_vm.allocator,
-            subprocess.stderr_maxbuf,
-            is_sync,
-        ),
+        .stdout = .{ .ignore = {} },
+        .stderr = .{ .ignore = {} },
         // 1. JavaScript.
         // 2. Process.
         .ref_count = .initExactRefs(2),
@@ -743,12 +731,17 @@ pub fn spawnMaybeSync(
         subprocess,
         spawned.stdin,
         &promise_for_stream,
-    ) catch {
-        // The aggregate above already ran: ref_count = 2 and stdout/stderr/
-        // stdio_pipes are live, but neither the JS wrapper nor the process
-        // exit handler have been wired up to own those refs yet. Tear down
-        // what `finalize()` would have and release both refs.
-        _ = subprocess.tryKill(subprocess.killSignal);
+    ) catch |err| {
+        // ref_count = 2 from the aggregate above, but neither the JS
+        // wrapper nor the process exit handler are wired up yet, so
+        // release both. stdout/stderr are still `.ignore` — close the raw
+        // spawned pipe fds directly since `Readable.init()` will not run.
+        // `finalizeStreams()` here only closes `stdio_pipes` and the pidfd;
+        // stdin/stdout/stderr are `.ignore` so their `closeIO` is a no-op.
+        if (Environment.isPosix) {
+            if (spawned.stdout) |fd| fd.close();
+            if (spawned.stderr) |fd| fd.close();
+        }
         subprocess.finalizeStreams();
         subprocess.process.detach();
         subprocess.process.deref();
@@ -756,9 +749,28 @@ pub fn spawnMaybeSync(
         MaxBuf.removeFromSubprocess(&subprocess.stderr_maxbuf);
         subprocess.deref();
         subprocess.deref();
-        if (globalThis.hasException()) return error.JSError;
+        if (err == error.JSError) return error.JSError;
         return globalThis.throwOutOfMemory();
     };
+
+    subprocess.stdout = Readable.init(
+        stdio[1],
+        event_loop,
+        subprocess,
+        spawned.stdout,
+        jsc_vm.allocator,
+        subprocess.stdout_maxbuf,
+        is_sync,
+    );
+    subprocess.stderr = Readable.init(
+        stdio[2],
+        event_loop,
+        subprocess,
+        spawned.stderr,
+        jsc_vm.allocator,
+        subprocess.stderr_maxbuf,
+        is_sync,
+    );
 
     // For inline terminal options: close parent's slave_fd so EOF is received when child exits
     // For existing terminal: keep slave_fd open so terminal can be reused for more spawns

--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -735,12 +735,19 @@ pub fn spawnMaybeSync(
         // ref_count = 2 from the aggregate above, but neither the JS
         // wrapper nor the process exit handler are wired up yet, so
         // release both. stdout/stderr are still `.ignore` — close the raw
-        // spawned pipe fds directly since `Readable.init()` will not run.
-        // `finalizeStreams()` here only closes `stdio_pipes` and the pidfd;
-        // stdin/stdout/stderr are `.ignore` so their `closeIO` is a no-op.
+        // spawned pipe handles directly since `Readable.init()` will not
+        // run. `finalizeStreams()` here only closes `stdio_pipes` and the
+        // pidfd; stdin/stdout/stderr are `.ignore` so their `closeIO` is a
+        // no-op.
         if (Environment.isPosix) {
             if (spawned.stdout) |fd| fd.close();
             if (spawned.stderr) |fd| fd.close();
+        } else {
+            inline for (.{ spawned.stdout, spawned.stderr }) |r| switch (r) {
+                .buffer => |pipe| pipe.close(Subprocess.onPipeClose),
+                .buffer_fd => |fd| fd.close(),
+                .unavailable => {},
+            };
         }
         subprocess.finalizeStreams();
         subprocess.process.detach();

--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -692,16 +692,13 @@ pub fn spawnMaybeSync(
         .globalThis = globalThis,
         .process = process,
         .pid_rusage = null,
-        .stdin = Writable.init(
-            &stdio[0],
-            event_loop,
-            subprocess,
-            spawned.stdin,
-            &promise_for_stream,
-        ) catch {
-            subprocess.deref();
-            return globalThis.throwOutOfMemory();
-        },
+        // Assigned immediately after this literal. `Writable.init()` writes
+        // to `subprocess.weak_file_sink_stdin_ptr`, `subprocess.flags`, and
+        // calls `subprocess.ref()` for `.pipe`/`.readable_stream` stdin; if
+        // called from inside this aggregate initializer those writes are
+        // clobbered by `.ref_count = .initExactRefs(2)`, `.flags = .{...}`,
+        // and the default `weak_file_sink_stdin_ptr = null` below.
+        .stdin = .{ .ignore = {} },
         .stdout = Readable.init(
             stdio[1],
             event_loop,
@@ -738,6 +735,17 @@ pub fn spawnMaybeSync(
         .stderr_maxbuf = subprocess.stderr_maxbuf,
         .stdout_maxbuf = subprocess.stdout_maxbuf,
         .terminal = existing_terminal orelse if (terminal_info) |info| info.terminal else null,
+    };
+
+    subprocess.stdin = Writable.init(
+        &stdio[0],
+        event_loop,
+        subprocess,
+        spawned.stdin,
+        &promise_for_stream,
+    ) catch {
+        subprocess.deref();
+        return globalThis.throwOutOfMemory();
     };
 
     // For inline terminal options: close parent's slave_fd so EOF is received when child exits

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -751,7 +751,7 @@ fn closeIO(this: *Subprocess, comptime io: @Type(.enum_literal)) void {
     }
 }
 
-fn onPipeClose(this: *uv.Pipe) callconv(.c) void {
+pub fn onPipeClose(this: *uv.Pipe) callconv(.c) void {
     // safely free the pipes
     bun.default_allocator.destroy(this);
 }

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -651,7 +651,22 @@ pub fn onProcessExit(this: *Subprocess, process: *Process, status: bun.spawn.Sta
         this.weak_file_sink_stdin_ptr = null;
         this.flags.has_stdin_destructor_called = true;
 
-        // It is okay if it does call deref() here, as in that case it was truly ref'd.
+        // `onAttachedProcessExit()` → `writer.close()` → `FileSink.onClose`
+        // fires `pipe.signal` synchronously on POSIX. When the signal still
+        // targets `&this.stdin` (the user never read `.stdin`, or did and
+        // `Writable.toJS` left it wired), that would re-enter
+        // `Writable.onClose` → `pipe.deref()` while `onAttachedProcessExit`
+        // is still running on `pipe`. Detach the signal first and drive the
+        // `onStdinDestroyed()` deref ourselves instead; this also leaves
+        // `this.stdin` as `.pipe` so reading `.stdin` after exit still
+        // returns the sink.
+        if (@intFromPtr(pipe.signal.ptr) == @intFromPtr(&this.stdin)) {
+            pipe.signal.clear();
+        }
+        const must_deref = this.flags.deref_on_stdin_destroyed;
+        this.flags.deref_on_stdin_destroyed = false;
+        defer if (must_deref) this.deref();
+
         pipe.onAttachedProcessExit(&status);
     }
 

--- a/src/bun.js/api/bun/subprocess/Writable.zig
+++ b/src/bun.js/api/bun/subprocess/Writable.zig
@@ -239,23 +239,26 @@ pub const Writable = union(enum) {
             .pipe => |pipe| {
                 this.* = .{ .ignore = {} };
                 if (subprocess.process.hasExited() and !subprocess.flags.has_stdin_destructor_called) {
-                    // onAttachedProcessExit() can call deref on the
-                    // subprocess. Since we never called ref(), it would be
-                    // unbalanced to do so, leading to a use-after-free.
-                    // So, let's not do that.
-                    // https://github.com/oven-sh/bun/pull/14092
-                    bun.debugAssert(!subprocess.flags.deref_on_stdin_destroyed);
-                    const debug_ref_count = if (Environment.isDebug) subprocess.ref_count else 0;
+                    // `Writable.init()` already called `subprocess.ref()` and
+                    // set `deref_on_stdin_destroyed`. `onAttachedProcessExit()`
+                    // → `writer.close()` → `pipe.signal` → `Writable.onClose`
+                    // → `onStdinDestroyed()` balances that ref, so a ref-count
+                    // drop across this call is expected (previously these
+                    // writes were clobbered by the struct-literal reassignment
+                    // in spawnMaybeSync and this path asserted no ref change;
+                    // see https://github.com/oven-sh/bun/pull/14092).
                     pipe.onAttachedProcessExit(&subprocess.process.status);
-                    if (Environment.isDebug) {
-                        bun.debugAssert(subprocess.ref_count.get() == debug_ref_count.get());
-                    }
                     return pipe.toJS(globalThis);
                 } else {
                     subprocess.flags.has_stdin_destructor_called = false;
                     subprocess.weak_file_sink_stdin_ptr = pipe;
-                    subprocess.ref();
-                    subprocess.flags.deref_on_stdin_destroyed = true;
+                    if (!subprocess.flags.deref_on_stdin_destroyed) {
+                        // `Writable.init()` already did this for fresh pipes;
+                        // only take a new ref if `onStdinDestroyed()` has since
+                        // consumed it.
+                        subprocess.ref();
+                        subprocess.flags.deref_on_stdin_destroyed = true;
+                    }
                     if (@intFromPtr(pipe.signal.ptr) == @intFromPtr(subprocess)) {
                         pipe.signal.clear();
                     }

--- a/src/bun.js/api/bun/subprocess/Writable.zig
+++ b/src/bun.js/api/bun/subprocess/Writable.zig
@@ -114,6 +114,8 @@ pub const Writable = union(enum) {
                         if (stdio.* == .readable_stream) {
                             const assign_result = pipe.assignToStream(&stdio.readable_stream, event_loop.global);
                             if (assign_result.toError()) |err| {
+                                subprocess.weak_file_sink_stdin_ptr = null;
+                                subprocess.flags.deref_on_stdin_destroyed = false;
                                 pipe.deref();
                                 subprocess.deref();
                                 return event_loop.global.throwValue(err);
@@ -190,6 +192,8 @@ pub const Writable = union(enum) {
                 if (stdio.* == .readable_stream) {
                     const assign_result = pipe.assignToStream(&stdio.readable_stream, event_loop.global);
                     if (assign_result.toError()) |err| {
+                        subprocess.weak_file_sink_stdin_ptr = null;
+                        subprocess.flags.deref_on_stdin_destroyed = false;
                         pipe.deref();
                         subprocess.deref();
                         return event_loop.global.throwValue(err);

--- a/test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts
@@ -1,0 +1,69 @@
+// When `stdin: "pipe"` is passed to Bun.spawn and the `.stdin` getter is
+// never read, the stdin pipe fd should still be closed when the child
+// exits — not deferred to GC.
+//
+// Root cause: `Writable.init()` wrote `subprocess.weak_file_sink_stdin_ptr`,
+// `subprocess.ref()`, and `subprocess.flags.*` while being called as a field
+// initializer inside the `subprocess.* = Subprocess{ ... }` aggregate, so
+// those writes were immediately clobbered by the rest of the literal
+// (including `weak_file_sink_stdin_ptr`'s default of `null`). `onProcessExit`
+// then found no pipe to close and the fd lived until Subprocess finalization.
+
+import { expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { isPosix } from "harness";
+
+function countOpenFds(): number {
+  // Linux and macOS both expose per-process fd tables here.
+  try {
+    return readdirSync("/proc/self/fd").length;
+  } catch {
+    return readdirSync("/dev/fd").length;
+  }
+}
+
+// Windows has no /proc/self/fd equivalent; the observable leak is
+// POSIX-specific anyway (libuv pipe close on Windows is async regardless).
+test.skipIf(!isPosix)("stdin: 'pipe' fd is closed on child exit without reading .stdin", async () => {
+  const N = 100;
+
+  // Warm up: spawn once so any lazily-opened runtime fds (signalfd, etc.)
+  // are already present in the baseline.
+  {
+    const p = Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+    await p.exited;
+  }
+
+  const baseline = countOpenFds();
+
+  const children: Bun.Subprocess[] = [];
+  for (let i = 0; i < N; i++) {
+    children.push(Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" }));
+  }
+  await Promise.all(children.map(p => p.exited));
+
+  // fd closes go through bun.Async.Closer on POSIX; give the close thread
+  // a moment — but do NOT invoke GC, since the bug was that cleanup only
+  // happened via Subprocess finalization.
+  for (let i = 0; i < 20 && countOpenFds() - baseline > N / 4; i++) await Bun.sleep(20);
+
+  const afterExit = countOpenFds() - baseline;
+
+  // Keep `children` alive across the measurement so GC finalization cannot
+  // be what closed the fds.
+  expect(children.length).toBe(N);
+
+  // Without the fix every stdin pipe (one per child) is still open here,
+  // so `afterExit` ≈ N. Allow slack for a few async closes still in flight.
+  expect(afterExit).toBeLessThan(N / 4);
+});
+
+// Reading `.stdin` after the child has already exited should still return
+// the FileSink (not `undefined`) — the fix must not regress this.
+test.skipIf(!isPosix)("reading .stdin after child exit still returns a FileSink", async () => {
+  const p = Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" });
+  await p.exited;
+  const stdin = p.stdin;
+  expect(stdin).toBeDefined();
+  expect(typeof (stdin as any).write).toBe("function");
+});

--- a/test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts
@@ -10,8 +10,8 @@
 // then found no pipe to close and the fd lived until Subprocess finalization.
 
 import { expect, test } from "bun:test";
-import { readdirSync } from "node:fs";
 import { isPosix } from "harness";
+import { readdirSync } from "node:fs";
 
 function countOpenFds(): number {
   // Linux and macOS both expose per-process fd tables here.


### PR DESCRIPTION
## What

When `stdin: "pipe"` is passed to `Bun.spawn` and the `.stdin` getter is never read, the stdin pipe fd now closes when the child exits instead of waiting for GC to finalize the `Subprocess`.

## Repro

```js
import { readdirSync } from "fs";
const fds = () => readdirSync("/proc/self/fd").length;

const before = fds();
const ps = [];
for (let i = 0; i < 200; i++)
  ps.push(Bun.spawn({ cmd: ["true"], stdin: "pipe", stdout: "ignore", stderr: "ignore" }));
await Promise.all(ps.map(p => p.exited));
console.log("leaked:", fds() - before); // before: 200, after: 0
```

## Root cause

`spawnMaybeSync` constructs the `Subprocess` with

```zig
subprocess.* = Subprocess{
    .stdin = Writable.init(&stdio[0], event_loop, subprocess, ...),
    ...
    .ref_count = .initExactRefs(2),
    .flags = .{ .is_sync = is_sync },
};
```

`Writable.init()` (for `.pipe` / `.readable_stream`) writes `subprocess.weak_file_sink_stdin_ptr = pipe`, calls `subprocess.ref()`, and sets `subprocess.flags.deref_on_stdin_destroyed` / `has_stdin_destructor_called` — but it runs as a field initializer inside that aggregate, so those writes are immediately clobbered by `.ref_count = .initExactRefs(2)`, `.flags = .{...}`, and `weak_file_sink_stdin_ptr`'s default of `null`. The four lines in `Writable.init()` were effectively dead code.

With `weak_file_sink_stdin_ptr` left `null`, `onProcessExit` resolved `stdin = null`, skipped the `pipe.onAttachedProcessExit()` cleanup, and the stdin write fd stayed open until `Subprocess` finalization.

(The lost `subprocess.ref()` happened to be cancelled out by the lost `deref_on_stdin_destroyed`, so there was no ref-count leak — only an fd leak.)

## Fix

- `js_bun_spawn_bindings.zig`: call `Writable.init()` *after* the `Subprocess{...}` aggregate so its writes to `subprocess.*` are not overwritten.
- `Writable.toJS()`: guard the `subprocess.ref()` in the live-process branch on `!deref_on_stdin_destroyed` so it doesn't double-ref now that `init()` has already taken one; drop the stale `debugAssert(!deref_on_stdin_destroyed)` / ref-count-unchanged asserts in the exited branch (they codified the old clobbering).
- `onProcessExit`: when the pipe's signal still targets `&this.stdin`, clear it before `onAttachedProcessExit()` and drive the matching `subprocess.deref()` inline. Otherwise the now-reachable synchronous chain `onAttachedProcessExit` → `writer.close()` → `FileSink.onClose` → `signal.close` → `Writable.onClose` → `pipe.deref()` could free the `FileSink` while `onAttachedProcessExit` is still running on it. This also leaves `this.stdin == .pipe` so reading `.stdin` after exit still returns the sink.

## Verification

New `test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts` spawns 100 children with `stdin: "pipe"` without touching `.stdin`, awaits all exits, and asserts the open-fd delta is ≈0 without invoking GC (fails on main with ~100 leaked). A second test checks `.stdin` read after exit still returns a `FileSink`.

`zig:check-all` passes; existing `spawn-*` / `child_process` test results unchanged vs main.