### PR TITLE
Preserve Handlers.active_connections across socket/listener reload()

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1383,8 +1383,15 @@ pub fn NewSocket(comptime ssl: bool) type {
 
             const this_handlers = this.getHandlers();
             const handlers = try Handlers.fromJS(globalObject, socket_obj, this_handlers.mode == .server);
+            // Preserve the live connection count. `Handlers.fromJS` returns a fresh struct with
+            // `active_connections = 0`, but this socket (and any in-flight callback scope) still
+            // holds references that were counted against the old value. Losing them causes the
+            // next `markInactive` to either free the heap-allocated client `Handlers` while the
+            // socket still points at it, or underflow the counter on the server path.
+            const active_connections = this_handlers.active_connections;
             this_handlers.deinit();
             this_handlers.* = handlers;
+            this_handlers.active_connections = active_connections;
 
             return .js_undefined;
         }

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1382,15 +1382,19 @@ pub fn NewSocket(comptime ssl: bool) type {
             };
 
             const this_handlers = this.getHandlers();
-            const handlers = try Handlers.fromJS(globalObject, socket_obj, this_handlers.mode == .server);
-            // Preserve the live connection count. `Handlers.fromJS` returns a fresh struct with
-            // `active_connections = 0`, but this socket (and any in-flight callback scope) still
-            // holds references that were counted against the old value. Losing them causes the
-            // next `markInactive` to either free the heap-allocated client `Handlers` while the
-            // socket still points at it, or underflow the counter on the server path.
+            const prev_mode = this_handlers.mode;
+            const handlers = try Handlers.fromJS(globalObject, socket_obj, prev_mode == .server);
+            // Preserve runtime state across the struct assignment. `Handlers.fromJS` returns a
+            // fresh struct with `active_connections = 0` and `mode` limited to `.server`/`.client`,
+            // but this socket (and any in-flight callback scope) still holds references that were
+            // counted against the old value, and a duplex-upgraded server socket must keep
+            // `.duplex_server`. Losing the counter causes the next `markInactive` to either free
+            // the heap-allocated client `Handlers` while the socket still points at it, or
+            // underflow on the server path.
             const active_connections = this_handlers.active_connections;
             this_handlers.deinit();
             this_handlers.* = handlers;
+            this_handlers.mode = prev_mode;
             this_handlers.active_connections = active_connections;
 
             return .js_undefined;

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -92,8 +92,14 @@ pub fn reload(this: *Listener, globalObject: *jsc.JSGlobalObject, callframe: *js
     };
 
     const handlers = try Handlers.fromJS(globalObject, socket_obj, this.handlers.mode == .server);
+    // Preserve the live connection count across the struct assignment. `Handlers.fromJS`
+    // returns `active_connections = 0`, but existing accepted sockets each hold a +1 via
+    // `markActive`. Without this, closing any of them after reload would underflow the
+    // counter (panic in safe builds, wrap in release).
+    const active_connections = this.handlers.active_connections;
     this.handlers.deinit();
     this.handlers = handlers;
+    this.handlers.active_connections = active_connections;
 
     return .js_undefined;
 }

--- a/test/js/bun/net/socket-reload-fixture.ts
+++ b/test/js/bun/net/socket-reload-fixture.ts
@@ -1,0 +1,190 @@
+// Regression fixture: socket.reload() / listener.reload() must preserve
+// Handlers.active_connections.
+//
+// Previously reload() overwrote the live counter with 0 via struct assignment.
+//  - Calling reload() inside a data handler meant the enclosing callback
+//    scope's exit() hit `0 - 1` on a u32 → panic in safe builds.
+//  - Calling reload() outside any handler dropped the count to 0; the next
+//    callback's enter/exit cycle then freed the heap-allocated client
+//    Handlers while the socket still pointed at it → heap-use-after-free
+//    on the following callback under ASAN.
+//  - Listener.reload() with live accepted sockets zeroed the count so
+//    closing any of them underflowed.
+//
+// This fixture drives all three sequences and exits 0 with "OK" on stdout.
+
+import type { Socket } from "bun";
+
+// ---------------------------------------------------------------------------
+// 1) socket.reload() from inside a data handler
+{
+  let serverSocket!: Socket;
+  const opened = Promise.withResolvers<void>();
+  const gotData = Promise.withResolvers<string>();
+  const closed = Promise.withResolvers<void>();
+
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(s) {
+        serverSocket = s;
+        opened.resolve();
+      },
+      data() {},
+    },
+  });
+
+  await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      data(socket, buf) {
+        // reload while a Handlers.Scope is live on the stack
+        socket.reload({
+          socket: {
+            data() {},
+            drain() {},
+            close() {
+              closed.resolve();
+            },
+          },
+        });
+        gotData.resolve(buf.toString());
+      },
+      drain() {},
+      close() {
+        closed.resolve();
+      },
+    },
+  });
+
+  await opened.promise;
+  serverSocket.write("hello");
+  serverSocket.flush();
+  const got = await gotData.promise;
+  if (!got.startsWith("hello")) throw new Error("bad data: " + got);
+  serverSocket.end();
+  await closed.promise;
+}
+
+// ---------------------------------------------------------------------------
+// 2) socket.reload() from outside a handler, then two separate onData events
+{
+  let serverSocket!: Socket;
+  const opened = Promise.withResolvers<void>();
+  const first = Promise.withResolvers<void>();
+  const second = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+  let chunks = "";
+
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(s) {
+        serverSocket = s;
+        opened.resolve();
+      },
+      data() {},
+    },
+  });
+
+  const client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      data() {},
+      drain() {},
+    },
+  });
+
+  await opened.promise;
+
+  // reload with no callback scope on the stack
+  client.reload({
+    socket: {
+      data(_s, buf) {
+        chunks += buf.toString();
+        if (chunks.length >= 3 && chunks.length < 6) first.resolve();
+        if (chunks.length >= 6) second.resolve();
+      },
+      drain() {},
+      close() {
+        closed.resolve();
+      },
+    },
+  });
+
+  // First onData: before the fix, enter/exit here frees the client Handlers.
+  serverSocket.write("one");
+  serverSocket.flush();
+  await first.promise;
+
+  // Second onData: before the fix, this dereferences the freed Handlers.
+  serverSocket.write("two");
+  serverSocket.flush();
+  await second.promise;
+
+  if (chunks !== "onetwo") throw new Error("bad data: " + chunks);
+  serverSocket.end();
+  await closed.promise;
+}
+
+// ---------------------------------------------------------------------------
+// 3) Listener.reload() with a live accepted socket, then close it
+{
+  let serverSocket!: Socket;
+  const opened = Promise.withResolvers<void>();
+  const serverClosed = Promise.withResolvers<void>();
+  const clientClosed = Promise.withResolvers<void>();
+
+  const server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(s) {
+        serverSocket = s;
+        opened.resolve();
+      },
+      data() {},
+      close() {
+        serverClosed.resolve();
+      },
+    },
+  });
+
+  const client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    socket: {
+      data() {},
+      drain() {},
+      close() {
+        clientClosed.resolve();
+      },
+    },
+  });
+
+  await opened.promise;
+
+  // reload the listener while 1 accepted socket is still active
+  server.reload({
+    socket: {
+      open() {},
+      data() {},
+      close() {
+        serverClosed.resolve();
+      },
+    },
+  });
+
+  // Close the accepted socket: drives handlers.markInactive() on the
+  // listener's handlers. Underflows without the fix.
+  client.end();
+  await clientClosed.promise;
+  await serverClosed.promise;
+  server.stop(true);
+}
+
+console.log("OK");

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -343,6 +343,18 @@ describe.concurrent("socket", () => {
     expect([fileURLToPath(new URL("./kqueue-filter-coalesce-fixture.ts", import.meta.url))]).toRun();
   });
 
+  it("reload() should preserve active_connections (no UAF / counter underflow)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fileURLToPath(new URL("./socket-reload-fixture.ts", import.meta.url))],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "OK\n", exitCode: 0 });
+    void stderr;
+  }, 30_000);
+
   it("it should not crash when getting a ReferenceError on client socket open", async () => {
     using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## Problem

`socket.reload()` (on `TCPSocket`/`TLSSocket`) and `listener.reload()` replace the `Handlers` struct wholesale with the value returned by `Handlers.fromJS()`, which always initialises `active_connections = 0`. But the socket's own `markActive()` contribution — and, when called from inside a callback, the live `Handlers.Scope` — are still counted against the old value.

### Consequences

- **reload() inside a data handler** → counter overwritten to 0; the enclosing `scope.exit()` then hits `0 - 1` on a `u32` → integer-overflow panic in safe builds.
- **reload() outside any handler** (client socket) → counter drops to 0; the next callback's `enter()/exit()` cycle takes it 0→1→0, and the client-mode branch of `markInactive` frees the heap `Handlers` allocation while `socket.handlers` still points at it → heap-use-after-free on the following callback (segfault in release).
- **Listener.reload()** with live accepted sockets → counter zeroed; closing any of them underflows.

### Repro

```js
using server = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { open(s){ s.write("x"); }, data(){} } });
const c = await Bun.connect({
  hostname: "127.0.0.1", port: server.port,
  socket: { data(s){ s.reload({ socket: { data(){}, drain(){} } }); }, drain(){} },
});
// debug build:  panic: integer overflow in Handlers.markInactive
// release build: SIGSEGV on the second data event
```

## Fix

Save `active_connections` before the `deinit()` + struct assignment and restore it afterwards in both `NewSocket.reload` (`src/bun.js/api/bun/socket.zig`) and `Listener.reload` (`src/bun.js/api/bun/socket/Listener.zig`).

## Verification

New subprocess fixture `test/js/bun/net/socket-reload-fixture.ts` drives all three sequences (inside-callback reload, outside-callback reload with two separate `onData` events, listener reload with a live accepted socket then close). Wired into `socket.test.ts`.

| build | result |
| --- | --- |
| `bun bd` **without** fix | `panic(main thread): integer overflow` at `Handlers.zig:82` → test fails |
| system bun (release) **without** fix | exit 139 (SIGSEGV) → test fails |
| `bun bd` **with** fix | `OK`, exit 0 → test passes |