### PR TITLE
build: bump zig (LLVM IR attribute improvements)

### DIFF
--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -33,7 +33,7 @@ import { streamPath } from "./stream.ts";
  * Override via `--zig-commit=<hash>` to test a new compiler.
  * From https://github.com/oven-sh/zig releases.
  */
-export const ZIG_COMMIT = "560aed0c6508412c2177866c54ad0aa3eef41e3f";
+export const ZIG_COMMIT = "597cbfe43b5b7f2b606b8818a5598c442097290c";
 
 /**
  * Number of LLVM codegen units. >1 splits the build into N independent

--- a/scripts/build/zig.ts
+++ b/scripts/build/zig.ts
@@ -33,7 +33,7 @@ import { streamPath } from "./stream.ts";
  * Override via `--zig-commit=<hash>` to test a new compiler.
  * From https://github.com/oven-sh/zig releases.
  */
-export const ZIG_COMMIT = "04e7f6ac1e009525bc00934f20199c68f04e0a24";
+export const ZIG_COMMIT = "560aed0c6508412c2177866c54ad0aa3eef41e3f";
 
 /**
  * Number of LLVM codegen units. >1 splits the build into N independent

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -595,6 +595,26 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             return self.atIndex(index);
         }
 
+        /// Read-only lookup that never inserts. Returns the resolved status
+        /// without taking the caller's coarse lock so the common cache-hit
+        /// path can be lock-free (the map's own fine-grained mutex is enough).
+        pub fn peek(self: *Self, denormalized_key: []const u8) ?Result {
+            const key = if (comptime remove_trailing_slashes) std.mem.trimRight(u8, denormalized_key, std.fs.path.sep_str) else denormalized_key;
+            const _key = bun.hash(key);
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            const index = self.index.get(_key) orelse return null;
+            return Result{
+                .hash = _key,
+                .index = index,
+                .status = switch (index.index) {
+                    NotFound.index => .not_found,
+                    Unassigned.index => .unknown,
+                    else => .exists,
+                },
+            };
+        }
+
         pub fn markNotFound(self: *Self, result: Result) void {
             self.mutex.lock();
             defer self.mutex.unlock();

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -633,8 +633,10 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         pub fn put(self: *Self, result: *Result, value: ValueType) !*ValueType {
-            const ptr = try self.reserve(result, value);
-            self.publish(result.*);
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            const ptr = try self.reserveLocked(result, value);
+            self.index.put(self.allocator, result.hash, result.index) catch unreachable;
             return ptr;
         }
 
@@ -644,7 +646,10 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         pub fn reserve(self: *Self, result: *Result, value: ValueType) !*ValueType {
             self.mutex.lock();
             defer self.mutex.unlock();
+            return self.reserveLocked(result, value);
+        }
 
+        fn reserveLocked(self: *Self, result: *Result, value: ValueType) !*ValueType {
             if (result.index.index == NotFound.index or result.index.index == Unassigned.index) {
                 result.index.is_overflow = instance.backing_buf_used > max_index;
                 if (result.index.is_overflow) {

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -596,8 +596,8 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         /// Read-only lookup that never inserts. Returns the resolved status
-        /// without taking the caller's coarse lock so the common cache-hit
-        /// path can be lock-free (the map's own fine-grained mutex is enough).
+        /// without requiring the caller's coarse lock; it still takes this
+        /// map's own mutex, so it is safe but not literally lock-free.
         pub fn peek(self: *Self, denormalized_key: []const u8) ?Result {
             const key = if (comptime remove_trailing_slashes) std.mem.trimRight(u8, denormalized_key, std.fs.path.sep_str) else denormalized_key;
             const _key = bun.hash(key);
@@ -633,6 +633,15 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         }
 
         pub fn put(self: *Self, result: *Result, value: ValueType) !*ValueType {
+            const ptr = try self.reserve(result, value);
+            self.publish(result.*);
+            return ptr;
+        }
+
+        /// Allocate backing storage and assign `result.index`, but leave the
+        /// hash→index map at `Unassigned` so concurrent `peek()`s still see
+        /// `.unknown`. Pair with `publish()` once the value is fully populated.
+        pub fn reserve(self: *Self, result: *Result, value: ValueType) !*ValueType {
             self.mutex.lock();
             defer self.mutex.unlock();
 
@@ -645,8 +654,6 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
                     instance.backing_buf_used += 1;
                 }
             }
-
-            try self.index.put(self.allocator, result.hash, result.index);
 
             if (result.index.is_overflow) {
                 if (self.overflow_list.len() == result.index.index) {
@@ -661,6 +668,13 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
 
                 return &instance.backing_buf[result.index.index];
             }
+        }
+
+        /// Make a previously `reserve`d entry visible to `peek()`/`get()`.
+        pub fn publish(self: *Self, result: Result) void {
+            self.mutex.lock();
+            defer self.mutex.unlock();
+            self.index.put(self.allocator, result.hash, result.index) catch unreachable;
         }
 
         /// Returns true if the entry was removed

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -910,7 +910,10 @@ fn NewPrinter(
             p.options.indent.count += 1;
         }
 
-        pub fn printIndent(p: *Printer) void {
+        // Called from dozens of sites in the giant printStmt/printExpr switches.
+        // Keep it outlined so the (usually-dead under --minify) buffer-growth
+        // path doesn't get replicated into every caller and blow up icache.
+        pub noinline fn printIndent(p: *Printer) void {
             if (p.options.indent.count == 0 or p.options.minify_whitespace) {
                 return;
             }
@@ -1128,7 +1131,7 @@ fn NewPrinter(
             }
         }
 
-        pub fn printBody(p: *Printer, stmt: Stmt, tlmtlo: TopLevel) void {
+        pub noinline fn printBody(p: *Printer, stmt: Stmt, tlmtlo: TopLevel) void {
             switch (stmt.data) {
                 .s_block => |block| {
                     p.printSpace();

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -910,10 +910,7 @@ fn NewPrinter(
             p.options.indent.count += 1;
         }
 
-        // Called from dozens of sites in the giant printStmt/printExpr switches.
-        // Keep it outlined so the (usually-dead under --minify) buffer-growth
-        // path doesn't get replicated into every caller and blow up icache.
-        pub noinline fn printIndent(p: *Printer) void {
+        pub fn printIndent(p: *Printer) void {
             if (p.options.indent.count == 0 or p.options.minify_whitespace) {
                 return;
             }
@@ -1131,7 +1128,7 @@ fn NewPrinter(
             }
         }
 
-        pub noinline fn printBody(p: *Printer, stmt: Stmt, tlmtlo: TopLevel) void {
+        pub fn printBody(p: *Printer, stmt: Stmt, tlmtlo: TopLevel) void {
             switch (stmt.data) {
                 .s_block => |block| {
                     p.printSpace();

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2318,7 +2318,7 @@ pub const Resolver = struct {
 
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
-        const dir_info_ptr = r.dir_cache.put(&dir_cache_info_result, .{}) catch unreachable;
+        const dir_info_ptr = r.dir_cache.reserve(&dir_cache_info_result, .{}) catch unreachable;
 
         // `dir_path` is a slice into the threadlocal `bufs(.path_in_global_disk_cache)` buffer,
         // which gets overwritten on the next auto-install resolution. `dirInfoUncached` stores
@@ -2337,6 +2337,7 @@ pub const Resolver = struct {
             open_dir,
             package_id,
         );
+        r.dir_cache.publish(dir_cache_info_result);
         return dir_info_ptr;
     }
 
@@ -3032,7 +3033,10 @@ pub const Resolver = struct {
 
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
-            const dir_info_ptr = try r.dir_cache.put(&queue_top.result, DirInfo{});
+            // `reserve` assigns the index and storage but keeps the entry hidden
+            // from `peek()` until we `publish` after population, so the
+            // dirInfoCached fast path never observes a half-initialized entry.
+            const dir_info_ptr = try r.dir_cache.reserve(&queue_top.result, DirInfo{});
 
             try r.dirInfoUncached(
                 dir_info_ptr,
@@ -3045,6 +3049,7 @@ pub const Resolver = struct {
                 open_dir,
                 null,
             );
+            r.dir_cache.publish(queue_top.result);
 
             if (queue_slice.len == 0) {
                 return dir_info_ptr;

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2319,6 +2319,7 @@ pub const Resolver = struct {
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
         const dir_info_ptr = r.dir_cache.reserve(&dir_cache_info_result, .{}) catch unreachable;
+        errdefer r.dir_cache.publish(dir_cache_info_result);
 
         // `dir_path` is a slice into the threadlocal `bufs(.path_in_global_disk_cache)` buffer,
         // which gets overwritten on the next auto-install resolution. `dirInfoUncached` stores
@@ -3037,6 +3038,7 @@ pub const Resolver = struct {
             // from `peek()` until we `publish` after population, so the
             // dirInfoCached fast path never observes a half-initialized entry.
             const dir_info_ptr = try r.dir_cache.reserve(&queue_top.result, DirInfo{});
+            errdefer r.dir_cache.publish(queue_top.result);
 
             try r.dirInfoUncached(
                 dir_info_ptr,

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2699,8 +2699,6 @@ pub const Resolver = struct {
     }
 
     fn dirInfoCachedMaybeLog(r: *ThisResolver, raw_input_path: string, comptime enable_logging: bool, comptime follow_symlinks: bool) !?*DirInfo {
-        r.mutex.lock();
-        defer r.mutex.unlock();
         var input_path = raw_input_path;
 
         if (isDotSlash(input_path) or strings.eqlComptime(input_path, ".")) {
@@ -2738,6 +2736,20 @@ pub const Resolver = struct {
 
         const path_without_trailing_slash = strings.withoutTrailingSlashWindowsPath(input_path);
         assertValidCacheKey(path_without_trailing_slash);
+
+        // Fast path: most calls hit an already-resolved entry. The cache has
+        // its own fine-grained mutex, so a read-only peek is safe without the
+        // coarse `r.mutex`. Only fall through to the exclusive section when
+        // the directory hasn't been visited yet.
+        if (r.dir_cache.peek(path_without_trailing_slash)) |hit| {
+            if (hit.status != .unknown) {
+                return r.dir_cache.atIndex(hit.index);
+            }
+        }
+
+        r.mutex.lock();
+        defer r.mutex.unlock();
+
         const top_result = try r.dir_cache.getOrPut(path_without_trailing_slash);
         if (top_result.status != .unknown) {
             return r.dir_cache.atIndex(top_result.index);


### PR DESCRIPTION
Bumps the Zig compiler to pick up oven-sh/zig#21, plus a resolver lock-contention fix to absorb the speedup.

## What changed in the compiler

Zig's LLVM backend now emits several attributes/flags that Clang emits for equivalent C/C++ but Zig was omitting:

- `dereferenceable(N)` on `*T` params and by-ref aggregate params → enables speculative loads, branch-to-select, loop vectorization
- `writable` + `dead_on_unwind` + `noundef` + `align` on sret → call-slot copy elimination
- `trunc nuw/nsw` / `zext nneg` for `@intCast` instead of `llvm.assume` → functions containing `@intCast` stay `memory(none)`
- `fast` flag on `fneg` under `@setFloatMode(.optimized)`
- `optsize` for `@branchHint(.cold)` functions
- index-counted `@memset` loop for non-byte elements (SCEV-friendly)
- 16-byte over-alignment for large anonymous constants

## What changed in Bun

The compiler bump alone made parallel parse workers ~8% faster, which exposed contention on `resolver_Mutex` (futex wait 0.83s → 2.04s) and turned into a +5% wall-clock regression on `bun build`. Fixed by adding a lock-free fast path to `dirInfoCached`: a new `BSSMap.peek()` returns cache hits without taking the resolver's coarse lock, with `reserve()`/`publish()` ensuring entries are only visible once fully populated.

## Benchmarks (hyperfine, 25 runs, default MT)

| workload | before | after | Δ wall | Δ user CPU |
|---|---|---|---|---|
| **three.js×10 `--minify`** | 126.1 ± 1.0 ms | **122.7 ± 1.9 ms** | **−2.7%** | −3.3% |
| **`require.resolve` ×180k** | 266.3 ± 1.6 ms | **251.1 ± 1.5 ms** | **−5.7%** | −3.2% |
| `bun outdated` | 240 ms | 239 ms | flat | −16.2% |
| `bun install` (cached) | 6.1 ms | 6.2 ms | flat | −14.5% |
| `bun install` (fresh) | 288 ms | 287 ms | flat | −6.6% |

Run-to-run variance on three.js dropped **8.49% → 0.56%** — the resolver mutex was a significant source of timing jitter.

## Assembly comparison (linux-x64-baseline-profile)

| metric | before | after | Δ |
|---|---:|---:|---:|
| binary size | 274,033,304 B | 273,635,488 B | −397,816 |
| total instructions | 13,903,296 | 13,879,556 | −23,740 |
| `cmov*` | 82,263 | 85,707 | **+4.19%** |
| `call memcpy` | 29,116 | 29,052 | −64 |

Per-function: `install.FolderResolution.getOrPut` −52.3%, `JSTranspiler.scanImports` −25.7%, `bundler.ParseTask.getAST` −13.6%, `MultiArrayList(InputFile).get` −40.5% (stack frame 248→56 B).

## Test plan

- [x] Zig CI: 12/12 cross-target builds green
- [x] Zig behavior suite: ReleaseFast 1982/0 fail, Debug 2091/0 fail
- [x] Bun: all `build-zig` jobs green across all targets
- [x] Bun: test suites green (alpine/debian/ubuntu/windows; ASAN link blocked by unrelated artifact-storage flake)