### PR TITLE
http2: fix UAF in H2FrameParser.forEachStream on hashmap rehash

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -3941,7 +3941,11 @@ pub const H2FrameParser = struct {
         const callback = args[0];
         const thisValue: JSValue = if (args.len > 1) args[1] else .js_undefined;
         var count: u32 = 0;
-        var it = this.streams.valueIterator();
+        // The callback runs arbitrary JS and may call request()/getNextStream(),
+        // which reaches handleReceivedStreamID() -> streams.getOrPut() and can
+        // rehash the hashmap, invalidating a raw valueIterator(). Use the
+        // resumable iterator like emitAbortToAllStreams/emitErrorToAllStreams do.
+        var it = StreamResumableIterator.init(this);
         while (it.next()) |stream| {
             const value = stream.jsContext.get() orelse continue;
             this.handlers.vm.eventLoop().runCallback(callback, globalObject, thisValue, &[_]jsc.JSValue{value});

--- a/test/js/node/http2/node-http2-foreach-rehash-fixture.js
+++ b/test/js/node/http2/node-http2-foreach-rehash-fixture.js
@@ -1,0 +1,57 @@
+// Reproduces a use-after-free in H2FrameParser.forEachStream(): the raw
+// HashMap valueIterator() was held across a JS callback. When the session
+// socket times out, #onTimeout() calls parser.forEachStream(emitTimeout),
+// which emits 'timeout' on every open stream. If a 'timeout' listener calls
+// session.request(), that reaches handleReceivedStreamID() -> streams.getOrPut(),
+// which can grow/rehash the hashmap and free the backing storage the iterator
+// is still pointing at. Under ASAN this is a heap-use-after-free.
+"use strict";
+
+const http2 = require("node:http2");
+const { once } = require("node:events");
+
+const server = http2.createServer();
+// Never respond so streams stay open and the socket goes idle.
+server.on("stream", () => {});
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  client.on("error", () => {});
+  await once(client, "connect");
+
+  // Create enough streams to put the parser's stream hashmap near/over its
+  // grow threshold, so that adding more from inside the iteration forces a
+  // rehash while the raw iterator is still live.
+  const INITIAL_STREAMS = 24;
+  const streams = [];
+  for (let i = 0; i < INITIAL_STREAMS; i++) {
+    const req = client.request({ ":path": "/", ":method": "POST" });
+    req.on("error", () => {});
+    // Inside forEachStream's callback: add more streams to force a rehash.
+    req.on("timeout", () => {
+      for (let j = 0; j < 4; j++) {
+        try {
+          const extra = client.request({ ":path": "/", ":method": "POST" });
+          extra.on("error", () => {});
+        } catch {}
+      }
+    });
+    streams.push(req);
+  }
+
+  // Arm the socket inactivity timeout; when it fires, #onTimeout() runs
+  // parser.forEachStream(emitTimeout) over all open streams.
+  const fired = once(client, "timeout");
+  client.setTimeout(50);
+  await fired;
+
+  // Give any additional iterator steps a chance to run before shutting down.
+  await new Promise(resolve => setImmediate(resolve));
+
+  client.destroy();
+  server.close(() => {
+    console.log("OK");
+    process.exit(0);
+  });
+});

--- a/test/js/node/http2/node-http2-foreach-rehash.test.ts
+++ b/test/js/node/http2/node-http2-foreach-rehash.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// H2FrameParser.forEachStream() held a raw HashMap valueIterator() across a
+// user-supplied JS callback. On session socket timeout, #onTimeout() calls
+// parser.forEachStream(emitTimeout), which emits 'timeout' on every open
+// stream. A 'timeout' listener that calls session.request() reaches
+// handleReceivedStreamID() -> streams.getOrPut(), which can grow/rehash the
+// hashmap and free the backing storage the iterator is still walking. Under
+// ASAN this is a heap-use-after-free in hash_map.FieldIterator.next.
+it("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const filteredStderr = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1979,3 +1979,23 @@ it("http2 request.destroy() with error", async () => {
     });
   });
 });
+
+it("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
+  // H2FrameParser.forEachStream() held a raw HashMap valueIterator() across a JS
+  // callback. Calling session.request() from that callback can rehash the streams
+  // hashmap and free the iterator's backing storage (heap-use-after-free under ASAN).
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const filteredStderr = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1979,23 +1979,3 @@ it("http2 request.destroy() with error", async () => {
     });
   });
 });
-
-it("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
-  // H2FrameParser.forEachStream() held a raw HashMap valueIterator() across a JS
-  // callback. Calling session.request() from that callback can rehash the streams
-  // hashmap and free the iterator's backing storage (heap-use-after-free under ASAN).
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash-fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const filteredStderr = stderr
-    .split("\n")
-    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-  expect(filteredStderr).toBe("");
-  expect(stdout).toBe("OK\n");
-  expect(exitCode).toBe(0);
-}, 30_000);


### PR DESCRIPTION
## Repro

`H2FrameParser.forEachStream()` held a raw `this.streams.valueIterator()` across a user-supplied JS callback.

1. Open an HTTP/2 client session and create enough requests to bring the internal `streams` hashmap near its grow threshold.
2. Arm `session.setTimeout(...)`. When the socket goes idle, `#onTimeout()` calls `parser.forEachStream(emitTimeout)`, which emits `'timeout'` on every open stream.
3. From a stream `'timeout'` listener, call `session.request()`. That reaches `getNextStream()` → `handleReceivedStreamID()` → `this.streams.getOrPut()`, which grows/rehashes the hashmap and frees its old backing arrays.
4. Back in `forEachStream`, `it.next()` reads from the freed backing storage.

Under ASAN (`bun bd`) this aborts with:

```
AddressSanitizer: use-after-poison ... in hash_map.HashMapUnmanaged(...).FieldIterator(...).next
  at bun.js.api.bun.h2_frame_parser.H2FrameParser.forEachStream (h2_frame_parser.zig:3945)
```

## Cause

`forEachStream` used the raw `valueIterator()` while the sibling functions `emitAbortToAllStreams` and `emitErrorToAllStreams` already switched to `StreamResumableIterator` — which re-derives its position from the live hashmap on each step and is safe across a rehash. `forEachStream` was never updated.

## Fix

Switch `forEachStream` to `StreamResumableIterator.init(this)`, matching the other two call sites that run JS while iterating.

## Verification

New fixture `test/js/node/http2/node-http2-foreach-rehash-fixture.js` + test in `node-http2.test.js`:

- Without the fix, `bun bd test` fails with the ASAN `use-after-poison` report above.
- With the fix, `bun bd test` passes.