### PR TITLE
http2: fix write-after-free in request() when options getter re-enters

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -11,7 +11,6 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, symlink
 import { homedir, arch as hostArch, platform as hostPlatform } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { NODEJS_ABI_VERSION, NODEJS_VERSION } from "./deps/nodejs-headers.ts";
-import { WEBKIT_VERSION } from "./deps/webkit.ts";
 import { assert, BuildError } from "./error.ts";
 import { clangTargetArch } from "./tools.ts";
 import { cyan, dim, green } from "./tty.ts";
@@ -45,8 +44,19 @@ export interface Host {
 }
 
 /**
+ * WebKit commit — determines prebuilt download URL + what to checkout
+ * for local mode. Override via `--webkit-version=<hash>` to test a branch.
+ * From https://github.com/oven-sh/WebKit releases.
+ *
+ * Kept here (and re-exported from deps/webkit.ts) to break the
+ * config → deps/webkit → flags → config import cycle that the post-#29393
+ * module loader surfaces as a TDZ error when scripts/build.ts is loaded.
+ */
+export const WEBKIT_VERSION = "bdf6aab38a9c6f99df3fd1486406ab6b74180fbb";
+
+/**
  * Pinned version defaults. Each lives at the top of its own file
- * (deps/webkit.ts, zig.ts, deps/nodejs-headers.ts) — look there to bump.
+ * (zig.ts, deps/nodejs-headers.ts) — look there to bump.
  * Overridable via PartialConfig for testing (e.g. trying a WebKit branch).
  */
 const versionDefaults = {

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -1,9 +1,9 @@
 /**
- * WebKit commit — determines prebuilt download URL + what to checkout
- * for local mode. Override via `--webkit-version=<hash>` to test a branch.
- * From https://github.com/oven-sh/WebKit releases.
+ * WebKit commit — re-exported from config.ts to avoid a
+ * deps/webkit → flags → config → deps/webkit cycle that trips a TDZ in
+ * the post-#29393 module loader. See `WEBKIT_VERSION` in config.ts.
  */
-export const WEBKIT_VERSION = "bdf6aab38a9c6f99df3fd1486406ab6b74180fbb";
+export { WEBKIT_VERSION } from "../config.ts";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4210,6 +4210,10 @@ pub const H2FrameParser = struct {
         var wait_for_trailers_opt: ?bool = null;
         var stream_dependency_opt: ?u32 = null;
         var weight_opt: ?u16 = null;
+        // Keep the JS AbortSignal wrapper on the stack (conservative GC root)
+        // until after handleReceivedStreamID/setContext so the underlying
+        // RefCounted<AbortSignal> cannot be collected before it is attached.
+        var signal_value: JSValue = .js_undefined;
         var signal_opt: ?*jsc.WebCore.AbortSignal = null;
         var options_error: enum { none, not_object, parent_range, weight_range } = .none;
 
@@ -4300,6 +4304,7 @@ pub const H2FrameParser = struct {
 
             if (try options.get(globalObject, "signal")) |signal_arg| {
                 if (signal_arg.as(jsc.WebCore.AbortSignal)) |signal_| {
+                    signal_value = signal_arg;
                     signal_opt = signal_;
                 } else {
                     return globalObject.throwInvalidArgumentTypeValue("options.signal", "AbortSignal", signal_arg);
@@ -4307,9 +4312,15 @@ pub const H2FrameParser = struct {
             }
         }
 
-        // All user-controlled getters have run. It is now safe to obtain a pointer
-        // into this.streams and write through it without risk of rehash from user JS.
-        const stream = this.handleReceivedStreamID(stream_id) orelse {
+        // All user-controlled getters have run. handleReceivedStreamID() may
+        // dispatch onStreamStart (internal JS) when creating a new entry; the
+        // stream normally already exists here (created by getNextStream() in
+        // JS), but re-acquire the pointer by id afterwards so any future
+        // change to that callback cannot leave us holding a stale value_ptr.
+        if (this.handleReceivedStreamID(stream_id) == null) {
+            return jsc.JSValue.jsNumber(-1);
+        }
+        const stream = this.streams.getPtr(stream_id) orelse {
             return jsc.JSValue.jsNumber(-1);
         };
         if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
@@ -4342,6 +4353,7 @@ pub const H2FrameParser = struct {
             stream.weight = w;
         }
         if (signal_opt) |signal_| {
+            signal_value.ensureStillAlive();
             if (signal_.aborted()) {
                 stream.state = .IDLE;
                 this.abortStream(stream, Bun__wrapAbortError(globalObject, signal_.abortReason()));

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -4193,12 +4193,11 @@ pub const H2FrameParser = struct {
         const encoded_data = encoded_headers.items;
         const encoded_size = encoded_data.len;
 
-        const stream = this.handleReceivedStreamID(stream_id) orelse {
-            return jsc.JSValue.jsNumber(-1);
-        };
-        if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
-            stream.setContext(stream_ctx_arg, globalObject);
-        }
+        // Read all user-supplied option properties into locals BEFORE acquiring a
+        // *Stream pointer into this.streams. options.get() performs a full JS
+        // [[Get]] and may invoke accessor getters / Proxy traps that call back into
+        // request()/getNextStream(), which can insert into this.streams and trigger
+        // a rehash, invalidating any previously held *Stream (entry.value_ptr).
         var flags: u8 = @intFromEnum(HeadersFrameFlags.END_HEADERS);
         var exclusive: bool = false;
         var has_priority: bool = false;
@@ -4207,18 +4206,23 @@ pub const H2FrameParser = struct {
         var silent: bool = false;
         var waitForTrailers: bool = false;
         var end_stream: bool = false;
-        if (args_list.len > 4 and !args_list.ptr[4].isEmptyOrUndefinedOrNull()) {
+        var padding_strategy_opt: ?PaddingStrategy = null;
+        var wait_for_trailers_opt: ?bool = null;
+        var stream_dependency_opt: ?u32 = null;
+        var weight_opt: ?u16 = null;
+        var signal_opt: ?*jsc.WebCore.AbortSignal = null;
+        var options_error: enum { none, not_object, parent_range, weight_range } = .none;
+
+        if (args_list.len > 4 and !args_list.ptr[4].isEmptyOrUndefinedOrNull()) read_options: {
             const options = args_list.ptr[4];
             if (!options.isObject()) {
-                stream.state = .CLOSED;
-                stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
-                this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                return jsc.JSValue.jsNumber(stream_id);
+                options_error = .not_object;
+                break :read_options;
             }
 
             if (try options.get(globalObject, "paddingStrategy")) |padding_js| {
                 if (padding_js.isNumber()) {
-                    stream.paddingStrategy = switch (padding_js.to(u32)) {
+                    padding_strategy_opt = switch (padding_js.to(u32)) {
                         1 => .aligned,
                         2 => .max,
                         else => .none,
@@ -4229,7 +4233,7 @@ pub const H2FrameParser = struct {
             if (try options.get(globalObject, "waitForTrailers")) |trailes_js| {
                 if (trailes_js.isBoolean()) {
                     waitForTrailers = trailes_js.asBoolean();
-                    stream.waitForTrailers = waitForTrailers;
+                    wait_for_trailers_opt = waitForTrailers;
                 }
             }
 
@@ -4259,7 +4263,6 @@ pub const H2FrameParser = struct {
                 if (exclusive_js.isBoolean()) {
                     if (exclusive_js.asBoolean()) {
                         exclusive = true;
-                        stream.exclusive = true;
                         has_priority = true;
                     }
                 } else {
@@ -4272,12 +4275,10 @@ pub const H2FrameParser = struct {
                     has_priority = true;
                     parent = parent_js.toInt32();
                     if (parent <= 0 or parent > MAX_STREAM_ID) {
-                        stream.state = .CLOSED;
-                        stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
-                        this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        return jsc.JSValue.jsNumber(stream.id);
+                        options_error = .parent_range;
+                        break :read_options;
                     }
-                    stream.streamDependency = @intCast(parent);
+                    stream_dependency_opt = @intCast(parent);
                 } else {
                     return globalObject.throwInvalidArgumentTypeValue("options.parent", "number", parent_js);
                 }
@@ -4288,38 +4289,65 @@ pub const H2FrameParser = struct {
                     has_priority = true;
                     weight = weight_js.toInt32();
                     if (weight < 1 or weight > std.math.maxInt(u8)) {
-                        stream.state = .CLOSED;
-                        stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
-                        this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                        return jsc.JSValue.jsNumber(stream_id);
+                        options_error = .weight_range;
+                        break :read_options;
                     }
-                    stream.weight = @intCast(weight);
+                    weight_opt = @intCast(weight);
                 } else {
                     return globalObject.throwInvalidArgumentTypeValue("options.weight", "number", weight_js);
                 }
-
-                if (weight < 1 or weight > std.math.maxInt(u8)) {
-                    stream.state = .CLOSED;
-                    stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
-                    this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
-                    return jsc.JSValue.jsNumber(stream_id);
-                }
-
-                stream.weight = @intCast(weight);
             }
 
             if (try options.get(globalObject, "signal")) |signal_arg| {
                 if (signal_arg.as(jsc.WebCore.AbortSignal)) |signal_| {
-                    if (signal_.aborted()) {
-                        stream.state = .IDLE;
-                        this.abortStream(stream, Bun__wrapAbortError(globalObject, signal_.abortReason()));
-                        return jsc.JSValue.jsNumber(stream_id);
-                    }
-                    stream.attachSignal(this, signal_);
+                    signal_opt = signal_;
                 } else {
                     return globalObject.throwInvalidArgumentTypeValue("options.signal", "AbortSignal", signal_arg);
                 }
             }
+        }
+
+        // All user-controlled getters have run. It is now safe to obtain a pointer
+        // into this.streams and write through it without risk of rehash from user JS.
+        const stream = this.handleReceivedStreamID(stream_id) orelse {
+            return jsc.JSValue.jsNumber(-1);
+        };
+        if (!stream_ctx_arg.isEmptyOrUndefinedOrNull() and stream_ctx_arg.isObject()) {
+            stream.setContext(stream_ctx_arg, globalObject);
+        }
+
+        switch (options_error) {
+            .none => {},
+            .not_object, .parent_range, .weight_range => {
+                stream.state = .CLOSED;
+                stream.rstCode = @intFromEnum(ErrorCode.INTERNAL_ERROR);
+                this.dispatchWithExtra(.onStreamError, stream.getIdentifier(), jsc.JSValue.jsNumber(stream.rstCode));
+                return jsc.JSValue.jsNumber(stream_id);
+            },
+        }
+
+        if (padding_strategy_opt) |ps| {
+            stream.paddingStrategy = ps;
+        }
+        if (wait_for_trailers_opt) |v| {
+            stream.waitForTrailers = v;
+        }
+        if (exclusive) {
+            stream.exclusive = true;
+        }
+        if (stream_dependency_opt) |dep| {
+            stream.streamDependency = dep;
+        }
+        if (weight_opt) |w| {
+            stream.weight = w;
+        }
+        if (signal_opt) |signal_| {
+            if (signal_.aborted()) {
+                stream.state = .IDLE;
+                this.abortStream(stream, Bun__wrapAbortError(globalObject, signal_.abortReason()));
+                return jsc.JSValue.jsNumber(stream_id);
+            }
+            stream.attachSignal(this, signal_);
         }
 
         // too much memory being use

--- a/test/js/node/http2/node-http2-request-options-uaf.test.ts
+++ b/test/js/node/http2/node-http2-request-options-uaf.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 // H2FrameParser.request() previously obtained a *Stream pointer into the

--- a/test/js/node/http2/node-http2-request-options-uaf.test.ts
+++ b/test/js/node/http2/node-http2-request-options-uaf.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+
+// H2FrameParser.request() previously obtained a *Stream pointer into the
+// streams HashMap and then called options.get(...) (which performs a full
+// JS [[Get]] including accessor getters / Proxy traps) while holding that
+// pointer. A getter that re-entered session.request() could insert new
+// streams, rehash the map, and leave the outer call writing through a
+// dangling pointer (heap-use-after-free under ASAN).
+//
+// The fix reads all option properties into locals before acquiring the
+// *Stream, so no user JS runs while the HashMap pointer is held.
+//
+// This test only runs under sanitizer builds (debug/asan) where the UAF is
+// deterministically caught; on release builds without ASAN the corruption
+// is silent and the test would not reliably exercise the bug.
+test.skipIf(!isDebug && !isASAN)(
+  "http2 client request() does not hold *Stream across user-controlled options getters",
+  async () => {
+    const script = /* js */ `
+    const http2 = require("node:http2");
+
+    const server = http2.createServer();
+    server.on("stream", (stream) => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    server.on("error", () => {});
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      const client = http2.connect("http://127.0.0.1:" + port);
+      client.on("error", () => {});
+
+      client.on("connect", () => {
+        let triggered = false;
+
+        // Use a POST so the options object is passed through to the native
+        // parser without being shallow-copied.
+        const options = {
+          get paddingStrategy() {
+            if (!triggered) {
+              triggered = true;
+              // Insert enough new streams to force the HashMap to rehash,
+              // invalidating any *Stream pointer held by the outer request().
+              for (let i = 0; i < 128; i++) {
+                const r = client.request({ ":path": "/", ":method": "GET" });
+                r.on("error", () => {});
+                r.on("response", () => {});
+                r.resume();
+              }
+            }
+            return 0;
+          },
+          // Ensure the outer request writes through the (previously dangling)
+          // stream pointer after the getter returns.
+          exclusive: true,
+          parent: 1,
+          weight: 16,
+          waitForTrailers: false,
+          endStream: true,
+        };
+
+        const req = client.request({ ":path": "/", ":method": "POST" }, options);
+        req.on("error", () => {});
+        req.on("response", () => {});
+        req.resume();
+        req.on("close", () => {
+          client.close(() => {
+            server.close(() => {
+              if (!triggered) {
+                console.error("getter was never invoked");
+                process.exit(1);
+              }
+              console.log("done");
+              process.exit(0);
+            });
+          });
+        });
+        req.end();
+      });
+    });
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // On failure the subprocess aborts with an AddressSanitizer report in
+    // stderr and never prints "done". stderr is not asserted directly because
+    // sanitizer builds emit a benign startup warning even on success.
+    if (exitCode !== 0) console.error(stderr);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "done", exitCode: 0 });
+  },
+  30_000,
+);

--- a/test/js/node/http2/node-http2-request-options-uaf.test.ts
+++ b/test/js/node/http2/node-http2-request-options-uaf.test.ts
@@ -97,5 +97,4 @@ test.skipIf(!isDebug && !isASAN)(
     if (exitCode !== 0) console.error(stderr);
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "done", exitCode: 0 });
   },
-  30_000,
 );

--- a/test/js/node/http2/node-http2-request-options-uaf.test.ts
+++ b/test/js/node/http2/node-http2-request-options-uaf.test.ts
@@ -95,6 +95,7 @@ test.skipIf(!isDebug && !isASAN)(
     // stderr and never prints "done". stderr is not asserted directly because
     // sanitizer builds emit a benign startup warning even on success.
     if (exitCode !== 0) console.error(stderr);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "done", exitCode: 0 });
+    expect(stdout.trim()).toBe("done");
+    expect(exitCode).toBe(0);
   },
 );


### PR DESCRIPTION
## Problem

`H2FrameParser.request()` obtained a `*Stream` via `handleReceivedStreamID()` — which returns `entry.value_ptr` pointing directly into the `streams: bun.U32HashMap(Stream)` backing array — and then called `options.get(globalObject, "paddingStrategy" / "waitForTrailers" / "silent" / "endStream" / "exclusive" / "parent" / "weight" / "signal")` on the user-supplied `options` object while holding that pointer.

`JSValue.get` performs a full JS `[[Get]]` and invokes accessor getters / Proxy traps. A getter that calls `session.request()` again reaches `getNextStream()` → `handleReceivedStreamID()` → `streams.getOrPut()`, which can rehash the map and free the array the outer `*Stream` points into. The subsequent writes (`stream.paddingStrategy`, `stream.waitForTrailers`, `stream.exclusive`, `stream.streamDependency`, `stream.weight`, `stream.attachSignal(...)`, `stream.state`) are then writes through a dangling pointer — attacker-controlled heap corruption.

For non-`NoPayloadMethods` (e.g. `POST`/`PUT`), `ClientHttp2Session.prototype.request` passes the user's `options` object straight through to the native parser without a shallow copy, so accessor descriptors reach native code unchanged.

## Repro

```js
const client = http2.connect(url);
client.on("connect", () => {
  let triggered = false;
  client.request({ ":method": "POST", ":path": "/" }, {
    get paddingStrategy() {
      if (!triggered) {
        triggered = true;
        for (let i = 0; i < 128; i++) client.request({ ":path": "/" }); // rehash
      }
      return 0;
    },
    exclusive: true, parent: 1, weight: 16, endStream: true,
  });
});
```

Under ASAN this aborts with:
```
AddressSanitizer: use-after-poison ... WRITE of size 1 ...
  in H2FrameParser.request  h2_frame_parser.zig:4221:54
```

## Fix

Read every option property into a local **before** calling `handleReceivedStreamID()`, so all user-controlled getters run while no `*Stream` is held. Then acquire the pointer and apply the collected values with no intervening user JS. Range/type errors that previously closed the stream inline are deferred via an `options_error` enum and reported against the freshly looked-up stream.

## Verification

- `bun bd` + stash fix → test fails with ASAN use-after-poison at `h2_frame_parser.zig:4221`
- `bun bd` with fix → test passes
- `test/js/node/http2/node-http2.test.js` passes (pre-existing flakes unrelated)
- `test/js/node/http2/node-http2-continuation.test.ts`, `node-http2-upgrade.test.mts` pass