### PR TITLE
usockets: fix NULL deref when socket is closed inside TLS renegotiation handshake callback

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -583,6 +583,12 @@ restart:
     } else if (s->handshake_state == HANDSHAKE_RENEGOTIATION_PENDING) {
       // renegotiation ended successfully call on_handshake
       us_internal_trigger_handshake_callback(s, 1);
+      // the on_handshake callback runs user code which may close this socket
+      // (us_internal_ssl_socket_close -> ssl_on_close frees s->ssl). if that
+      // happened, bail out instead of looping back to SSL_read(NULL, ...).
+      if (us_internal_ssl_socket_is_closed(s)) {
+        return NULL;
+      }
     }
 
     read += just_read;

--- a/test/js/node/tls/renegotiation.test.ts
+++ b/test/js/node/tls/renegotiation.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
-import { bunEnv, tls } from "harness";
+import { bunEnv, bunExe, tls } from "harness";
 import type { IncomingMessage } from "http";
 import { join } from "path";
 let url: URL;
@@ -130,6 +130,75 @@ it("allow renegotiation in tls module", async () => {
   const body = await promise;
   expect(body).toBe("Hello World");
 });
+
+it("should not crash when socket is closed inside the renegotiation handshake callback", async () => {
+  // When a TLS 1.2 server initiates renegotiation and then sends application data, the
+  // client-side SSL_read loop fires the on_handshake callback once the renegotiated
+  // handshake completes. If user code closes the socket inside that callback, the SSL*
+  // is freed (s->ssl = NULL) and the loop must not continue into SSL_read(NULL, ...).
+  // Run in a subprocess so a NULL-deref SIGSEGV shows up as a non-zero exit instead of
+  // taking down the test runner.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", renegotiationCloseInHandshakeFixture],
+    env: {
+      ...bunEnv,
+      SERVER_HOST: url.hostname,
+      SERVER_PORT: url.port,
+      // If the subprocess segfaults in an ASAN build, symbolizing a ~1 GB
+      // binary can take longer than the test timeout. We only need the exit
+      // code / signal to assert that it did not crash.
+      ASAN_OPTIONS: ((bunEnv.ASAN_OPTIONS ?? "") + ":symbolize=0").replace(/^:/, ""),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+    stdout: "ok",
+    exitCode: 0,
+    signalCode: null,
+    stderr: expect.any(String),
+  });
+});
+
+const renegotiationCloseInHandshakeFixture = /* js */ `
+const { promise: done, resolve } = Promise.withResolvers();
+let handshakes = 0;
+const socket = await Bun.connect({
+  hostname: process.env.SERVER_HOST,
+  port: Number(process.env.SERVER_PORT),
+  tls: { rejectUnauthorized: false },
+  socket: {
+    open() {},
+    data() {},
+    error() {
+      resolve();
+    },
+    close() {
+      resolve();
+    },
+    handshake(socket) {
+      handshakes++;
+      if (handshakes === 1) {
+        // Trigger the server's request handler so it initiates renegotiation
+        // and writes application data once the renegotiated handshake completes.
+        socket.write("GET / HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n");
+      } else {
+        // Second handshake = renegotiation completed. Closing here used to NULL
+        // s->ssl while ssl_on_data's SSL_read loop was still running.
+        socket.terminate();
+        resolve();
+      }
+    },
+  },
+});
+await done;
+if (handshakes < 2) {
+  throw new Error("expected renegotiation handshake callback to fire, got " + handshakes + " handshake(s)");
+}
+console.log("ok");
+`;
 
 it("should fail if renegotiation fails using tls module", async () => {
   const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
## What does this PR do?

Fixes a NULL-deref crash in `ssl_on_data` (`packages/bun-usockets/src/crypto/openssl.c`).

### Repro

TLS 1.2 client (`Bun.connect`) → server sends `HelloRequest` → `SSL_read` returns `SSL_ERROR_WANT_RENEGOTIATE` → `us_internal_ssl_renegotiate` sets `handshake_state = HANDSHAKE_RENEGOTIATION_PENDING`. The next `SSL_read` that returns application data (`just_read > 0`) fires `us_internal_trigger_handshake_callback(s, 1)`, which runs the user's `handshake` handler. If that handler closes the socket (e.g. `socket.terminate()`), `ssl_on_close` runs and does `SSL_free(s->ssl); s->ssl = NULL;`. Control returns to `ssl_on_data`, falls through to `read += just_read`, and the `while (1)` loop calls `SSL_read(s->ssl, ...)` with `s->ssl == NULL`:

```
AddressSanitizer: SEGV on unknown address 0x000000000098
    #0 ... in SSL_is_quic vendor/boringssl/ssl/ssl_lib.cc:2895
```

### Root cause

Every other re-entrant callback site in `ssl_on_data` (`on_data` at lines 535, 577, 600 and `on_writable` at 623) is followed by `if (!s || us_internal_ssl_socket_is_closed(s)) return NULL;`. The renegotiation handshake callback at line 585 was missing this guard.

### Fix

Add the same `us_internal_ssl_socket_is_closed(s)` check after `us_internal_trigger_handshake_callback` in the renegotiation branch, returning `NULL` to stop the loop if the user closed the socket. `s` itself is not freed until `us_internal_free_closed_sockets` at end-of-iteration, so dereferencing `s->s` for the closed check is safe.

### Verification

Added a test to `test/js/node/tls/renegotiation.test.ts` that connects via `Bun.connect` to the existing Node.js TLS 1.2 renegotiation server, calls `socket.terminate()` inside the second (renegotiation) `handshake` callback, and asserts the subprocess exits 0 with no signal.

- Without the fix (debug/ASAN): subprocess exits 1 with `AddressSanitizer: SEGV ... in SSL_is_quic`.
- Without the fix (release): subprocess is killed by `SIGSEGV` / `panic: Segmentation fault at address 0x98`.
- With the fix: subprocess exits 0 across 5 consecutive runs.
- All 7 pre-existing tests in `renegotiation.test.ts` continue to pass.