### PR TITLE
fix(server): add kJSTypeBigInt to JSC C API JSType enum

### DIFF
--- a/src/bun.js/javascript_core_c_api.zig
+++ b/src/bun.js/javascript_core_c_api.zig
@@ -32,6 +32,7 @@ pub const JSType = enum(c_uint) {
     kJSTypeString,
     kJSTypeObject,
     kJSTypeSymbol,
+    kJSTypeBigInt,
 };
 pub const kJSTypeUndefined = @intFromEnum(JSType.kJSTypeUndefined);
 pub const kJSTypeNull = @intFromEnum(JSType.kJSTypeNull);
@@ -40,6 +41,7 @@ pub const kJSTypeNumber = @intFromEnum(JSType.kJSTypeNumber);
 pub const kJSTypeString = @intFromEnum(JSType.kJSTypeString);
 pub const kJSTypeObject = @intFromEnum(JSType.kJSTypeObject);
 pub const kJSTypeSymbol = @intFromEnum(JSType.kJSTypeSymbol);
+pub const kJSTypeBigInt = @intFromEnum(JSType.kJSTypeBigInt);
 /// From JSValueRef.h:81
 pub const JSTypedArrayType = enum(c_uint) {
     kJSTypedArrayTypeInt8Array,

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -12,6 +12,7 @@ pub const fetch_type_error_names: JSTypeErrorEnum = brk: {
     errors.set(JSType.kJSTypeString, "String");
     errors.set(JSType.kJSTypeObject, "Object");
     errors.set(JSType.kJSTypeSymbol, "Symbol");
+    errors.set(JSType.kJSTypeBigInt, "BigInt");
     break :brk errors;
 };
 
@@ -23,6 +24,7 @@ pub const fetch_type_error_string_values = .{
     std.fmt.comptimePrint("fetch() expects a string, but received {s}", .{fetch_type_error_names.get(JSType.kJSTypeString)}),
     std.fmt.comptimePrint("fetch() expects a string, but received {s}", .{fetch_type_error_names.get(JSType.kJSTypeObject)}),
     std.fmt.comptimePrint("fetch() expects a string, but received {s}", .{fetch_type_error_names.get(JSType.kJSTypeSymbol)}),
+    std.fmt.comptimePrint("fetch() expects a string, but received {s}", .{fetch_type_error_names.get(JSType.kJSTypeBigInt)}),
 };
 
 pub const fetch_type_error_strings: JSTypeErrorEnum = brk: {
@@ -54,6 +56,10 @@ pub const fetch_type_error_strings: JSTypeErrorEnum = brk: {
     errors.set(
         JSType.kJSTypeSymbol,
         bun.asByteSlice(fetch_type_error_string_values[6]),
+    );
+    errors.set(
+        JSType.kJSTypeBigInt,
+        bun.asByteSlice(fetch_type_error_string_values[7]),
     );
     break :brk errors;
 };

--- a/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
+++ b/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("server.fetch should reject invalid argument types without crashing", async () => {
   using server = Bun.serve({

--- a/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
+++ b/test/js/bun/http/bun-serve-fetch-invalid-args.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+
+test("server.fetch should reject invalid argument types without crashing", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response("Hello World!");
+    },
+  });
+  // @ts-expect-error
+  await expect(server.fetch(1n)).rejects.toThrow("fetch() expects a string, but received BigInt");
+  // @ts-expect-error
+  await expect(server.fetch(Symbol("x"))).rejects.toThrow("fetch() expects a string, but received Symbol");
+  // @ts-expect-error
+  await expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
+  // @ts-expect-error
+  await expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
+});

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -326,6 +326,23 @@ describe.concurrent("Server", () => {
     }
   });
 
+  test("server.fetch should reject invalid argument types without crashing", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response("Hello World!");
+      },
+    });
+    // @ts-expect-error
+    expect(server.fetch(1n)).rejects.toThrow("fetch() expects a string, but received BigInt");
+    // @ts-expect-error
+    expect(server.fetch(Symbol("x"))).rejects.toThrow("fetch() expects a string, but received Symbol");
+    // @ts-expect-error
+    expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
+    // @ts-expect-error
+    expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
+  });
+
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -326,23 +326,6 @@ describe.concurrent("Server", () => {
     }
   });
 
-  test("server.fetch should reject invalid argument types without crashing", async () => {
-    using server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        return new Response("Hello World!");
-      },
-    });
-    // @ts-expect-error
-    await expect(server.fetch(1n)).rejects.toThrow("fetch() expects a string, but received BigInt");
-    // @ts-expect-error
-    await expect(server.fetch(Symbol("x"))).rejects.toThrow("fetch() expects a string, but received Symbol");
-    // @ts-expect-error
-    await expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
-    // @ts-expect-error
-    await expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
-  });
-
   test("server should return a body for a OPTIONS Request", async () => {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -334,13 +334,13 @@ describe.concurrent("Server", () => {
       },
     });
     // @ts-expect-error
-    expect(server.fetch(1n)).rejects.toThrow("fetch() expects a string, but received BigInt");
+    await expect(server.fetch(1n)).rejects.toThrow("fetch() expects a string, but received BigInt");
     // @ts-expect-error
-    expect(server.fetch(Symbol("x"))).rejects.toThrow("fetch() expects a string, but received Symbol");
+    await expect(server.fetch(Symbol("x"))).rejects.toThrow("fetch() expects a string, but received Symbol");
     // @ts-expect-error
-    expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
+    await expect(server.fetch(true)).rejects.toThrow("fetch() expects a string, but received Boolean");
     // @ts-expect-error
-    expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
+    await expect(server.fetch(1)).rejects.toThrow("fetch() expects a string, but received Number");
   });
 
   test("server should return a body for a OPTIONS Request", async () => {


### PR DESCRIPTION
## What does this PR do?

`server.fetch()` panicked with `index out of bounds: index 7, len 7` (debug) or segfaulted (release) when passed a `BigInt` argument.

The Zig binding for the JavaScriptCore C API `JSType` enum was missing the `kJSTypeBigInt` variant. `JSValueGetType` can return this value, and the result is used as an index into an `EnumArray` of error messages in `onFetch`. When a BigInt was passed, the index (7) was out of bounds for the 7-element array.

### Repro

```js
const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
server.fetch(1n);
```

### Fix

- Add `kJSTypeBigInt` to the `JSType` enum in `javascript_core_c_api.zig` to match `JSValueRef.h`
- Add the corresponding entries to `fetch_type_error_names` / `fetch_type_error_string_values` / `fetch_type_error_strings`

Now rejects with `TypeError: fetch() expects a string, but received BigInt` instead of crashing.

## How did you verify your code works?

Added a regression test in `test/js/bun/http/bun-server.test.ts` covering BigInt, Symbol, Boolean, and Number arguments. Verified it crashes on main and passes with this fix.