### PR TITLE
http2: fix UAF in Stream.flushQueue after write callback rehashes streams map

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -933,21 +933,30 @@ pub const H2FrameParser = struct {
                                 var _frame = this.dataFrameQueue.dequeue().?;
                                 client.outboundQueueSize -= 1;
 
+                                // The JS callbacks below (dispatchWriteCallback / dispatch /
+                                // dispatchWithExtra) can synchronously call request() or
+                                // getNextStream(), which may grow the streams HashMap and
+                                // invalidate `this` (a pointer into the map's backing storage).
+                                // Capture everything we need from `this` and apply state
+                                // mutations now, while the pointer is still valid, then never
+                                // dereference `this` again in this block.
+                                const signal_end = _frame.end_stream and this.dataFrameQueue.isEmpty();
+                                const wait_for_trailers = this.waitForTrailers;
+                                const identifier = this.getIdentifier();
+                                identifier.ensureStillAlive();
+                                var end_state = this.state;
+                                if (signal_end and !wait_for_trailers) {
+                                    end_state = if (this.state == .HALF_CLOSED_REMOTE) .CLOSED else .HALF_CLOSED_LOCAL;
+                                    this.state = end_state;
+                                }
+
+                                // `this` must not be dereferenced past this point.
                                 if (_frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
-                                if (this.dataFrameQueue.isEmpty()) {
-                                    if (_frame.end_stream) {
-                                        if (this.waitForTrailers) {
-                                            client.dispatch(.onWantTrailers, this.getIdentifier());
-                                        } else {
-                                            const identifier = this.getIdentifier();
-                                            identifier.ensureStillAlive();
-                                            if (this.state == .HALF_CLOSED_REMOTE) {
-                                                this.state = .CLOSED;
-                                            } else {
-                                                this.state = .HALF_CLOSED_LOCAL;
-                                            }
-                                            client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(this.state)));
-                                        }
+                                if (signal_end) {
+                                    if (wait_for_trailers) {
+                                        client.dispatch(.onWantTrailers, identifier);
+                                    } else {
+                                        client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(end_state)));
                                     }
                                 }
                                 _frame.deinit(client.allocator);

--- a/test/js/node/http2/node-http2-flush-rehash-fixture.js
+++ b/test/js/node/http2/node-http2-flush-rehash-fixture.js
@@ -1,0 +1,97 @@
+"use strict";
+// Reproduces a use-after-free in H2FrameParser.Stream.flushQueue: the defer
+// block dispatched the write callback (user JS) and then continued to
+// dereference the *Stream pointer, which points into the streams HashMap's
+// backing storage. If the callback creates new streams (session.request()),
+// the HashMap can grow/rehash and invalidate that pointer.
+//
+// Under ASAN this manifests as heap-use-after-free when flushQueue reads
+// stream state after the callback returns.
+
+const http2 = require("node:http2");
+
+const server = http2.createServer();
+server.on("stream", (stream, headers) => {
+  stream.respond({ ":status": 200 });
+  // Drain the request body so the server sends WINDOW_UPDATE frames, which
+  // trigger the client's flushStreamQueue path.
+  stream.on("data", () => {});
+  stream.on("end", () => {
+    stream.end("ok");
+  });
+  stream.on("error", () => {});
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  client.on("error", err => {
+    console.error("client error", err);
+    process.exit(1);
+  });
+
+  const extras = [];
+  let rehashed = false;
+  let writeCallbackFired = false;
+
+  client.on("connect", () => {
+    const req = client.request({ ":method": "POST", ":path": "/" }, { endStream: false });
+    req.on("error", () => {});
+    req.on("response", () => {});
+    req.on("data", () => {});
+    req.on("close", () => {
+      finish();
+    });
+
+    // Write a payload larger than the default initial window size (65535)
+    // so the tail of it is queued by the native frame parser and later
+    // flushed from flushStreamQueue -> Stream.flushQueue.
+    const payload = Buffer.alloc(128 * 1024, "a");
+    req.write(payload, () => {
+      writeCallbackFired = true;
+      if (rehashed) return;
+      rehashed = true;
+      // Create many new streams synchronously from inside the write
+      // callback. Each request() calls native getNextStream()/request(),
+      // which inserts into the streams HashMap and can trigger a rehash,
+      // invalidating the *Stream pointer that flushQueue is still holding
+      // in its defer block.
+      for (let i = 0; i < 100; i++) {
+        try {
+          const r = client.request({ ":method": "GET", ":path": "/extra" });
+          r.on("error", () => {});
+          r.on("response", () => {});
+          r.on("data", () => {});
+          r.on("end", () => {});
+          extras.push(r);
+        } catch {}
+      }
+    });
+    req.end();
+  });
+
+  let finished = false;
+  function finish() {
+    if (finished) return;
+    finished = true;
+    if (!writeCallbackFired) {
+      console.error("write callback never fired");
+      process.exit(1);
+    }
+    try {
+      client.close();
+    } catch {}
+    try {
+      client.destroy();
+    } catch {}
+    server.close(() => {
+      console.log("ok");
+      process.exit(0);
+    });
+    // Force exit in case close() hangs waiting on the extra streams.
+    setTimeout(() => {
+      console.log("ok");
+      process.exit(0);
+    }, 500).unref();
+  }
+});

--- a/test/js/node/http2/node-http2-flush-rehash-fixture.js
+++ b/test/js/node/http2/node-http2-flush-rehash-fixture.js
@@ -39,9 +39,7 @@ server.listen(0, "127.0.0.1", () => {
     req.on("error", () => {});
     req.on("response", () => {});
     req.on("data", () => {});
-    req.on("close", () => {
-      finish();
-    });
+    req.on("close", () => finish());
 
     // Write a payload larger than the default initial window size (65535)
     // so the tail of it is queued by the native frame parser and later
@@ -66,6 +64,11 @@ server.listen(0, "127.0.0.1", () => {
           extras.push(r);
         } catch {}
       }
+      // The UAF (if present) fires in native code immediately after this
+      // callback returns — flushQueue's defer resumes and touches the stale
+      // *Stream. We don't need to wait for the request to complete; finish
+      // on the next turn so the defer has run.
+      setImmediate(finish);
     });
     req.end();
   });
@@ -78,20 +81,16 @@ server.listen(0, "127.0.0.1", () => {
       console.error("write callback never fired");
       process.exit(1);
     }
-    try {
-      client.close();
-    } catch {}
+    // The UAF (if present) would have already tripped ASAN inside the write
+    // callback's caller by now; no need to wait for the extra streams or a
+    // graceful shutdown.
     try {
       client.destroy();
     } catch {}
-    server.close(() => {
-      console.log("ok");
-      process.exit(0);
-    });
-    // Force exit in case close() hangs waiting on the extra streams.
-    setTimeout(() => {
-      console.log("ok");
-      process.exit(0);
-    }, 500).unref();
+    try {
+      server.close();
+    } catch {}
+    console.log("ok");
+    process.exit(0);
   }
 });

--- a/test/js/node/http2/node-http2-flush-rehash.test.ts
+++ b/test/js/node/http2/node-http2-flush-rehash.test.ts
@@ -19,4 +19,4 @@ test("http2 client write callback that opens new streams during flushQueue does 
 
   // Print stderr on failure so ASAN reports are visible in CI output.
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-}, 30_000);
+});

--- a/test/js/node/http2/node-http2-flush-rehash.test.ts
+++ b/test/js/node/http2/node-http2-flush-rehash.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// Regression test: Stream.flushQueue in h2_frame_parser.zig held a *Stream
+// pointer (into the streams HashMap) across a JS callback. If that callback
+// created new streams, the HashMap could rehash and free the backing storage,
+// leaving flushQueue to read/write freed memory when it resumed. Under ASAN
+// this aborts with heap-use-after-free; in release builds it corrupts state.
+test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rehash-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Print stderr on failure so ASAN reports are visible in CI output.
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
+}, 30_000);


### PR DESCRIPTION
## Problem

`Stream.flushQueue` in `h2_frame_parser.zig` held a `*Stream` pointer — which points into the `streams: bun.U32HashMap(Stream)` backing storage — across a synchronous JS dispatch. If the write-completion callback creates new streams (e.g. `session.request()`), `handleReceivedStreamID` → `streams.getOrPut()` can grow/rehash the map, freeing the old backing array and invalidating every `*Stream` that was derived from it.

After `dispatchWriteCallback` returned, the defer block went on to read `this.dataFrameQueue.isEmpty()`, `this.waitForTrailers`, `this.getIdentifier()`, `this.state` and write `this.state` — all against freed memory.

## Repro

1. Client POSTs > 65535 bytes so the tail of the payload is queued by the native parser (initial window exhausted).
2. Server drains the body and sends `WINDOW_UPDATE`.
3. Client handles the window update → `flush()` → `flushStreamQueue()` → `Stream.flushQueue()` dequeues a frame and fires the write callback.
4. The write callback synchronously opens 100 new requests, forcing the `streams` HashMap to rehash.
5. The defer block resumes and dereferences the stale `*Stream`.

ASAN trace without the fix:

```
==3414==ERROR: AddressSanitizer: use-after-poison on address 0x6fad45720d00
READ of size 8 at 0x6fad45720d00 thread T0
    #0 ... H2FrameParser.Stream.PendingQueue.isEmpty  h2_frame_parser.zig:880
    #1 ... H2FrameParser.Stream.flushQueue            h2_frame_parser.zig:937
    #2 ... H2FrameParser.flushStreamQueue             h2_frame_parser.zig:1670
    #3 ... H2FrameParser.flush                        h2_frame_parser.zig:1718
    #4 ... H2FrameParser.handleWindowUpdateFrame      h2_frame_parser.zig:1877
```

## Fix

In the `flushQueue` defer block, capture everything needed from `*Stream` (`dataFrameQueue.isEmpty()`, `waitForTrailers`, `getIdentifier()`, `state`) and apply the `HALF_CLOSED_*` / `CLOSED` state transition **before** running any JS. After that point the block only touches stack locals, `client`, and the dequeued `_frame` value — never `this`.

`StreamResumableIterator` already revalidates between `next()` calls, so once `flushQueue` itself stops touching `this` after the dispatch, the outer loop is safe.

## Verification

- `bun bd test test/js/node/http2/node-http2-flush-rehash.test.ts` → **fails** on `main` with the ASAN trace above, **passes** with this change (3/3 stable runs).
- Existing `test/js/node/http2/*` tests: no new failures.