### PR TITLE
timers: clear pending exception when timeout warning emission throws

### DIFF
--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -369,7 +369,13 @@ pub const All = struct {
             warning_type_js,
             .js_undefined,
             .js_undefined,
-        ) catch {};
+        ) catch {
+            // Emitting a warning should never interrupt execution, but the emit path calls
+            // into user-observable JS (process.nextTick, getters, etc.) which can throw.
+            // Swallowing error.JSError alone leaves the exception pending on the VM and
+            // trips assertExceptionPresenceMatches in the host-call wrapper, so clear it.
+            _ = globalThis.clearExceptionExceptTermination();
+        };
     }
 
     const CountdownOverflowBehavior = enum(u8) {

--- a/src/bun.js/api/Timer.zig
+++ b/src/bun.js/api/Timer.zig
@@ -361,19 +361,24 @@ pub const All = struct {
             },
         };
         var warning_type_string = bun.String.createAtomIfPossible(@tagName(warning_type));
-        // Ignore errors from transferToJS since this is just a warning and shouldn't interrupt execution
-        const warning_js = warning_string.transferToJS(globalThis) catch return;
-        const warning_type_js = warning_type_string.transferToJS(globalThis) catch return;
+        // Emitting a warning should never interrupt execution, but the emit path calls
+        // into user-observable JS (process.nextTick, getters, etc.) which can throw.
+        // Swallowing error.JSError alone leaves the exception pending on the VM and
+        // trips assertExceptionPresenceMatches in the host-call wrapper, so clear it.
+        const warning_js = warning_string.transferToJS(globalThis) catch {
+            _ = globalThis.clearExceptionExceptTermination();
+            return;
+        };
+        const warning_type_js = warning_type_string.transferToJS(globalThis) catch {
+            _ = globalThis.clearExceptionExceptTermination();
+            return;
+        };
         globalThis.emitWarning(
             warning_js,
             warning_type_js,
             .js_undefined,
             .js_undefined,
         ) catch {
-            // Emitting a warning should never interrupt execution, but the emit path calls
-            // into user-observable JS (process.nextTick, getters, etc.) which can throw.
-            // Swallowing error.JSError alone leaves the exception pending on the VM and
-            // trips assertExceptionPresenceMatches in the host-call wrapper, so clear it.
             _ = globalThis.clearExceptionExceptTermination();
         };
     }

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -366,3 +366,33 @@ it("Returning a Promise in setTimeout (unref'd) doesnt keep the event loop alive
 it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () => {
   expect([path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"]).toRun();
 });
+
+it("setTimeout does not leak a pending exception when emitting a timeout warning throws", async () => {
+  // The out-of-range timeout warning queues a process.nextTick, which reads process._exiting.
+  // If that read throws, the exception must not be left pending on the VM when setTimeout
+  // returns — otherwise debug builds hit releaseAssertNoException().
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        process.nextTick(() => {});
+        Object.defineProperty(process, "_exiting", {
+          get() { throw new TypeError("boom"); },
+          configurable: true,
+        });
+        const t = setTimeout(() => {}, 1e100);
+        clearTimeout(t);
+        console.log("survived");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("survived");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -391,8 +391,9 @@ it("setTimeout does not leak a pending exception when emitting a timeout warning
     stderr: "pipe",
   });
 
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect(stderr).not.toContain("boom");
   expect(stdout.trim()).toBe("survived");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What does this PR do?

`warnInvalidCountdown` in `Timer.zig` swallows `error.JSError` from `emitWarning` with `catch {}`, but that leaves the JSC exception pending on the VM. The host-call wrapper for `setTimeout` then returns a non-zero value while an exception is set, which:

- trips `assertExceptionPresenceMatches` → `releaseAssertNoException()` in debug/CI builds
- surfaces the exception as if `setTimeout` itself threw in release builds

The emit-warning path runs user-observable JS (`process.emitWarning` → `queueNextTick` → the JS `nextTick` function, which reads `process._exiting`), so it can throw for reasons unrelated to the timer being scheduled.

## How did you verify your code works?

Minimal repro that crashed before this change and now returns the timer normally:

```js
process.nextTick(() => {});
Object.defineProperty(process, "_exiting", {
  get() { throw new TypeError("boom"); },
  configurable: true,
});
setTimeout(() => {}, 1e100); // triggers TimeoutOverflowWarning → queueNextTick → reads _exiting
```

Added a regression test in `test/js/web/timers/setTimeout.test.js` that spawns this in a subprocess and checks it exits cleanly.

Fuzzer fingerprint: `342817fec707f1b9`