### PR TITLE
net: route throws from socket lifecycle listeners to uncaughtException

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -46,6 +46,9 @@ const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
 const ArrayPrototypePush = Array.prototype.push;
 const MathMax = Math.max;
+// Captured at module load so the uncaughtException routing below can't be
+// defeated by user code clobbering globalThis.reportError after net loads.
+const reportError = globalThis.reportError;
 
 const { UV_ECANCELED, UV_ETIMEDOUT } = process.binding("uv");
 const isWindows = process.platform === "win32";
@@ -175,6 +178,25 @@ function destroyNT(self, err) {
 function destroyWhenAborted(err) {
   if (!this.destroyed) {
     this.destroy(err.target.reason);
+  }
+}
+// Runs `fn` and routes any synchronous throw to `uncaughtException` via
+// `reportError`, instead of letting it unwind back through the native socket
+// callback — which would catch it and funnel it into the socket's onError
+// handler (its 'error' event) or, on the `onOpen` path, tear the connection
+// down. Node surfaces a throw from these lifecycle listeners as
+// `uncaughtException` and leaves the socket alone.
+//
+// Use this around a *group* of consecutive `self.emit(...)` calls rather
+// than one-per-emit: Node's synchronous `emit('a'); emit('b')` short-circuits
+// — a throw from the 'a' listener prevents 'b' from firing at all. Wrapping
+// each emit individually would reorder that into "'a' threw, reported, 'b'
+// still fires", which is not what Node does.
+function safelyInvokeListeners(fn) {
+  try {
+    fn();
+  } catch (e) {
+    reportError(e);
   }
 }
 // in node's code this callback is called 'onReadableStreamEnd' but that seemed confusing when `ReadableStream`s now exist
@@ -370,8 +392,10 @@ const SocketHandlers: SocketHandler = {
       self[kBytesWritten] = socket.bytesWritten;
       // this is not actually emitted on nodejs when socket used on the connection
       // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
-      self.emit("connect", self);
-      self.emit("ready");
+      safelyInvokeListeners(() => {
+        self.emit("connect", self);
+        self.emit("ready");
+      });
     }
 
     SocketHandlers.drain(socket);
@@ -979,11 +1003,13 @@ function onconnection(err, clientHandle) {
     });
   }
 
-  self.emit("connection", _socket);
-  // the duplex implementation start paused, so we resume when pauseOnConnect is falsy
-  if (!pauseOnConnect && !isTLS) {
-    _socket.resume();
-  }
+  safelyInvokeListeners(() => {
+    self.emit("connection", _socket);
+    // the duplex implementation start paused, so we resume when pauseOnConnect is falsy
+    if (!pauseOnConnect && !isTLS) {
+      _socket.resume();
+    }
+  });
 }
 
 // TODO: SocketHandlers2 is a bad name but its temporary. reworking the Server in a followup PR
@@ -1465,7 +1491,10 @@ function Socket(options?) {
         try {
           onread.callback(buffer.length, buffer);
         } catch (e) {
-          self.emit("error", e);
+          // Node surfaces a throw from onread.callback as 'uncaughtException'
+          // (it's invoked from onStreamRead with no try/catch). Route it via
+          // reportError instead of emitting on the socket's 'error' event.
+          reportError(e);
         }
       },
     };
@@ -2992,8 +3021,10 @@ function afterConnect(status, handle, req, readable, writable) {
       self._handle.setKeepAlive(true, self[kSetKeepAliveInitialDelay]);
     }
 
-    self.emit("connect");
-    self.emit("ready");
+    safelyInvokeListeners(() => {
+      self.emit("connect");
+      self.emit("ready");
+    });
 
     if (self[kPerfHooksNetConnectContext] && hasObserver("net")) {
       stopPerf(self, kPerfHooksNetConnectContext);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1062,3 +1062,219 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/29761
+describe.concurrent("uncaughtException in socket listener", () => {
+  it("surfaces a throw from onread.callback as uncaughtException", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          const server = net.createServer((socket) => {
+            socket.write("hello via onread");
+          });
+          server.listen(0, () => {
+            const port = server.address().port;
+            const client = net.createConnection({
+              port,
+              onread: {
+                buffer: Buffer.alloc(64),
+                callback(nread, buffer) {
+                  console.log("ONREAD:" + buffer.toString("utf8", 0, nread));
+                  throw new Error("ONREAD-BOOM");
+                },
+              },
+            });
+            client.on("error", (err) => console.log("SOCKET_ERROR:" + err.message));
+          });
+          process.on("uncaughtException", (err) => {
+            console.log("UNCAUGHT:" + err.message);
+            process.exit(0);
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("ONREAD:hello via onread");
+    expect(stdout).toContain("UNCAUGHT:ONREAD-BOOM");
+    expect(stdout).not.toContain("SOCKET_ERROR:");
+    expect(exitCode, stderr).toBe(0);
+  });
+
+  it("surfaces a throw from a client 'connect' listener as uncaughtException and leaves the socket alive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          let client;
+          const server = net.createServer((socket) => {
+            socket.on("data", (d) => {
+              console.log("SERVER_RECV:" + d);
+              socket.end();
+            });
+            socket.on("end", () => server.close(() => process.exit(0)));
+          });
+          server.listen(0, () => {
+            const port = server.address().port;
+            client = net.createConnection({ port });
+            client.on("error", (err) => console.log("SOCKET_ERROR:" + err.message));
+            client.on("connect", () => {
+              console.log("CONNECT-FIRED");
+              throw new Error("CONNECT-BOOM");
+            });
+          });
+          // Drive the post-throw write from the uncaughtException handler
+          // so the assertion is event-driven, not time-based.
+          process.on("uncaughtException", (err) => {
+            console.log("UNCAUGHT:" + err.message);
+            console.log("WRITABLE:" + client.writable);
+            client.write("hi-after-throw");
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("CONNECT-FIRED");
+    expect(stdout).toContain("UNCAUGHT:CONNECT-BOOM");
+    expect(stdout).toContain("WRITABLE:true");
+    expect(stdout).toContain("SERVER_RECV:hi-after-throw");
+    expect(stdout).not.toContain("SOCKET_ERROR:");
+    expect(exitCode, stderr).toBe(0);
+  });
+
+  it("surfaces a throw from a client 'ready' listener as uncaughtException", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          const server = net.createServer((socket) => {});
+          server.listen(0, () => {
+            const port = server.address().port;
+            const client = net.createConnection({ port });
+            client.on("error", (err) => console.log("SOCKET_ERROR:" + err.message));
+            client.on("ready", () => {
+              console.log("READY-FIRED");
+              throw new Error("READY-BOOM");
+            });
+          });
+          process.on("uncaughtException", (err) => {
+            console.log("UNCAUGHT:" + err.message);
+            process.exit(0);
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("READY-FIRED");
+    expect(stdout).toContain("UNCAUGHT:READY-BOOM");
+    expect(stdout).not.toContain("SOCKET_ERROR:");
+    expect(exitCode, stderr).toBe(0);
+  });
+
+  it("surfaces a throw from a server 'connection' listener as uncaughtException", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          const server = net.createServer((socket) => {
+            console.log("CONNECTION-FIRED");
+            throw new Error("CONNECTION-BOOM");
+          });
+          server.on("error", (err) => console.log("SERVER_ERROR:" + err.message));
+          server.listen(0, () => {
+            const port = server.address().port;
+            const client = net.createConnection({ port });
+            client.on("error", () => {});
+          });
+          process.on("uncaughtException", (err) => {
+            console.log("UNCAUGHT:" + err.message);
+            process.exit(0);
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("CONNECTION-FIRED");
+    expect(stdout).toContain("UNCAUGHT:CONNECTION-BOOM");
+    expect(stdout).not.toContain("SERVER_ERROR:");
+    expect(exitCode, stderr).toBe(0);
+  });
+
+  // Node's `self.emit('connect'); self.emit('ready')` runs synchronously:
+  // if the 'connect' listener throws, execution unwinds and 'ready' never
+  // fires. Matching those short-circuit semantics means wrapping consecutive
+  // emit groups in a single try/catch rather than catching each emit
+  // individually.
+  it("short-circuits subsequent emits when a listener throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          let client;
+          const server = net.createServer((socket) => {
+            socket.on("data", (d) => {
+              console.log("DATA:" + d);
+              socket.end();
+            });
+            socket.on("end", () => server.close(() => process.exit(0)));
+          });
+          server.listen(0, () => {
+            const port = server.address().port;
+            client = net.createConnection({ port });
+            client.on("error", () => {});
+            client.on("connect", () => {
+              console.log("CONNECT");
+              throw new Error("CONNECT-BOOM");
+            });
+            // 'ready' fires synchronously right after 'connect' in the same
+            // emit frame. If the fix wraps each emit individually, READY
+            // prints before UNCAUGHT; with a single try/catch around the pair
+            // the throw short-circuits and READY never fires.
+            client.on("ready", () => console.log("READY"));
+          });
+          // Drive the post-throw write from uncaughtException so the server
+          // round-trip forces us to wait past the emit sequence before the
+          // test can exit — gives 'ready' a full tick to fire if the fix is
+          // wrong.
+          process.on("uncaughtException", (err) => {
+            console.log("UNCAUGHT:" + err.message);
+            client.write("done");
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("CONNECT");
+    expect(stdout).toContain("UNCAUGHT:CONNECT-BOOM");
+    expect(stdout).toContain("DATA:done");
+    // 'ready' must NOT fire — a throw from the preceding 'connect' listener
+    // aborts the synchronous emit sequence (Node semantics).
+    expect(stdout).not.toContain("READY");
+    expect(exitCode, stderr).toBe(0);
+  });
+});


### PR DESCRIPTION
Part of #29761.

When a user listener attached to a `net.Socket` / `net.Server` lifecycle event throws synchronously, the throw unwinds back into the native socket callback, which catches it and funnels it into the socket's onError handler (the `'error'` event) or, on the open path, tears the connection down. Node instead re-raises the throw as `'uncaughtException'` and leaves the socket alive.

### Fix

Add a `safelyInvokeListeners(fn)` helper that wraps a group of consecutive `self.emit(...)` calls and forwards a caught throw through `reportError` (which surfaces as `'uncaughtException'`). Wrapping a whole emit group (not each emit) preserves Node's short-circuit semantics: a throw from the `'connect'` listener aborts the synchronous sequence so `'ready'` never fires. `reportError` is captured at module load so the routing can't be defeated by user code clobbering `globalThis.reportError`.

Applied to the non-TLS lifecycle paths a user listener reaches synchronously from a native socket callback:

- **open:** `SocketHandlers.open` `'connect'`/`'ready'`; `afterConnect` `'connect'`/`'ready'`
- **server accept:** `onconnection` `'connection'`
- **onread.callback:** `reportError` instead of `self.emit('error')`

### Scope: the `'data'` listener case is deferred

The original report is about a throwing `'data'` listener. An earlier revision fixed that by wrapping `self.push(buffer)` in the `data` handlers (`pushDataToSocket`), but CI showed it breaks `node:http`:

- `test-http-abort-client`, `test-http-client-aborted-event`, `test-http-server-capture-rejections`: a `Parse Error: Invalid character in chunk size` surfaced as `uncaughtException` instead of the client `res` `'error'` (ECONNRESET).
- `test-http-catch-uncaughtexception`: hang/timeout.

All four pass on main and failed with the `data`-path wrapping. Root cause: http's client `socketOnData` is itself a `socket.on('data')` listener, and Bun's native HTTP parser **throws** parse errors where Node **returns** them; http relies on the native layer catching that throw and routing it to the socket `'error'` event. Wrapping `self.push` at the JS layer intercepts that routing, and catching mid-`Readable.push()` also corrupts stream state (the hang). There is no way to distinguish a user `'data'` listener throw from an internal consumer (the http parser) throw at the `net` push layer.

A correct `'data'`-path fix needs a coordinated change in the native socket `onData` path (routing a genuine data-callback throw to `uncaughtException` after the `Readable` unwinds, matching Node's C++ boundary) plus http's parser returning parse errors inline, and it also affects the `Bun.connect` API surface. That is an architectural decision left for a follow-up; this PR ships the safe, same-bug-class lifecycle fixes.

### Verification

New `describe.concurrent("uncaughtException in socket listener")` block in `test/js/node/net/node-net.test.ts`:

- client `'connect'` throw → `uncaughtException`; socket stays writable (Node leaves it alive).
- client `'ready'` throw → `uncaughtException`.
- server `'connection'` throw → `uncaughtException`.
- `onread.callback` throw → `uncaughtException`.
- connect→ready short-circuit: a throw from `'connect'` aborts the emit group so `'ready'` never fires.

Each test fails with `net.ts` reverted to main and passes with the fix. A 40-test `node:http` parallel sweep stays clean (only the pre-existing `agent-keepalive` flake, which also fails on main).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 14 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->