### PR TITLE
Fix abort in structuredClone with ArrayBuffer >= 2GiB

### DIFF
--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
@@ -1774,8 +1774,12 @@ private:
                 }
 
                 if (arrayBuffer->isResizableOrGrowableShared()) {
-                    write(ResizableArrayBufferTag);
                     uint64_t byteLength = arrayBuffer->byteLength();
+                    if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) * 2 + byteLength)) [[unlikely]] {
+                        code = SerializationReturnCode::DataCloneError;
+                        return true;
+                    }
+                    write(ResizableArrayBufferTag);
                     write(byteLength);
                     uint64_t maxByteLength = arrayBuffer->maxByteLength().value_or(0);
                     write(maxByteLength);
@@ -1783,8 +1787,12 @@ private:
                     return true;
                 }
 
-                write(ArrayBufferTag);
                 uint64_t byteLength = arrayBuffer->byteLength();
+                if (!m_buffer.tryReserveCapacity(static_cast<uint64_t>(m_buffer.size()) + sizeof(uint8_t) + sizeof(uint64_t) + byteLength)) [[unlikely]] {
+                    code = SerializationReturnCode::DataCloneError;
+                    return true;
+                }
+                write(ArrayBufferTag);
                 write(byteLength);
                 write(static_cast<const uint8_t*>(arrayBuffer->data()), byteLength);
                 return true;

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -330,7 +330,7 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
     ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
     ["Uint8Array", "new Uint8Array(2 ** 31)"],
   ] as const) {
-    test.concurrent(label, async () => {
+    test(label, async () => {
       const script = `
         let buf;
         try {
@@ -350,7 +350,7 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
         cmd: [bunExe(), "-e", script],
         env: bunEnv,
         stdout: "pipe",
-        stderr: "pipe",
+        stderr: "inherit",
       });
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(["DataCloneError", "SKIP"]).toContain(stdout.trim());

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -318,3 +318,43 @@ function createBlob(arr: number[]): Blob {
 
   return new Blob([view]);
 }
+
+describe("structuredClone with ArrayBuffer larger than serialization buffer capacity", () => {
+  // The serialization buffer is a WTF::Vector<uint8_t> capped at 2GiB. Cloning an
+  // ArrayBuffer at or above that size must throw DataCloneError instead of aborting.
+  // Run in a subprocess so the ~2GiB allocation does not bloat the test runner.
+  for (const [label, expr] of [
+    ["ArrayBuffer", "new ArrayBuffer(2 ** 31)"],
+    ["resizable ArrayBuffer", "new ArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
+    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)"],
+    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })"],
+    ["Uint8Array", "new Uint8Array(2 ** 31)"],
+  ] as const) {
+    test.concurrent(label, async () => {
+      const script = `
+        let buf;
+        try {
+          buf = ${expr};
+        } catch {
+          console.log("SKIP");
+          process.exit(0);
+        }
+        try {
+          structuredClone(buf);
+          console.log("UNEXPECTED_SUCCESS");
+        } catch (e) {
+          console.log(e.name);
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(["DataCloneError", "SKIP"]).toContain(stdout.trim());
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## What

`structuredClone()` (and `bun:jsc` `serialize()`) aborted the process when serializing an `ArrayBuffer`, `SharedArrayBuffer`, resizable/growable variant, or typed array view whose backing buffer was ~2GiB or larger.

```js
structuredClone(new ArrayBuffer(2 ** 31)); // SIGABRT
```

## Why

The structured-clone serialization buffer is a `WTF::Vector<uint8_t>`, whose capacity is capped at `UINT32_MAX >> 1` (2GiB - 1). Writing the raw bytes of a large `ArrayBuffer` into it via `Vector::append` pushes the total size past that cap, and `append` uses `FailureAction::Crash`, so `allocateBuffer` hits `CRASH()`.

## Fix

Before writing `ArrayBuffer` contents in the `ArrayBufferTag` / `ResizableArrayBufferTag` paths, call `m_buffer.tryReserveCapacity(...)` for the tag + length header(s) + payload. If the reservation fails (capacity limit or OOM), fail serialization with `DataCloneError` instead of crashing. Because reservation happens before the tag is written, the serialized stream is not left in a partially-written state, and because the reservation only succeeds for sizes that fit the vector, the subsequent `write(const uint8_t*, unsigned)` call (which takes a 32-bit length) cannot receive a truncated length either.

Found by Fuzzilli. Fingerprint `5a52c34b9bc49de3`.

## Also in this PR

`scripts/build/deps/index.ts` (and its 4 callers) changes `allDeps` from a module-level `const` array to a cached `function allDeps()`. This is unrelated to the crash fix but was required to land it: `deps/webkit.ts` → `flags.ts`/`source.ts` → `config.ts` → `deps/webkit.ts` forms an import cycle, and depending on which module the graph is entered through, the `webkit` binding can still be in TDZ when `deps/index.ts` eagerly constructs the `allDeps` array. Rebuilding with a bun built from current `main` trips this and `bun bd` / `bun run build:release` fail with `Cannot access 'webkit' before initialization`. Deferring the array construction to first call sidesteps the ordering dependency without changing the list contents or link order.