### PR TITLE
http2: heap-allocate Stream so *Stream survives map rehash during re-entrant JS

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -683,7 +683,7 @@ pub const H2FrameParser = struct {
     // TODO: this will be removed when I re-add header and data priorization
     outboundQueueSize: usize = 0,
 
-    streams: bun.U32HashMap(Stream),
+    streams: bun.U32HashMap(*Stream),
 
     hpack: ?*lshpack.HPACK = null,
 
@@ -740,7 +740,7 @@ pub const H2FrameParser = struct {
             it.index = this.index;
             while (it.next()) |item| {
                 this.index = it.index;
-                return item.value_ptr;
+                return item.value_ptr.*;
             }
             this.index = it.index;
             return null;
@@ -787,6 +787,12 @@ pub const H2FrameParser = struct {
 
         // when we have backpressure we queue the data e round robin the Streams
         dataFrameQueue: PendingQueue,
+
+        // Stream is heap-allocated and stored by pointer in the streams map so that
+        // *Stream stays valid across re-entrant JS callbacks that may insert into
+        // (and rehash) the map. Lifetime == H2FrameParser lifetime; freed in deinit().
+        pub const new = bun.TrivialNew(Stream);
+
         const SignalRef = struct {
             signal: *jsc.WebCore.AbortSignal,
             parser: *H2FrameParser,
@@ -801,10 +807,9 @@ pub const H2FrameParser = struct {
             pub fn abortListener(this: *SignalRef, reason: JSValue) void {
                 log("abortListener", .{});
                 reason.ensureStillAlive();
-                const stream = this.parser.streams.getEntry(this.stream_id) orelse return;
-                const value = stream.value_ptr;
-                if (value.state != .CLOSED) {
-                    this.parser.abortStream(value, Bun__wrapAbortError(this.parser.globalThis, reason));
+                const stream = this.parser.streams.get(this.stream_id) orelse return;
+                if (stream.state != .CLOSED) {
+                    this.parser.abortStream(stream, Bun__wrapAbortError(this.parser.globalThis, reason));
                 }
             }
 
@@ -1252,7 +1257,8 @@ pub const H2FrameParser = struct {
 
     fn incrementWindowSizeIfNeeded(this: *H2FrameParser) void {
         var it = this.streams.valueIterator();
-        while (it.next()) |stream| {
+        while (it.next()) |item| {
+            const stream = item.*;
             log("incrementWindowSizeIfNeeded stream {} {} {} {}", .{ stream.id, stream.usedWindowSize, stream.windowSize, this.isServer });
             if (stream.usedWindowSize >= stream.windowSize / 2 and stream.usedWindowSize > 0) {
                 const consumed = stream.usedWindowSize;
@@ -1915,8 +1921,7 @@ pub const H2FrameParser = struct {
             if (this.isServer and strings.eqlComptime(header.name, ":status")) {
                 this.sendGoAway(stream_id, ErrorCode.PROTOCOL_ERROR, "Server received :status header", this.lastStreamID, true);
 
-                if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
-                return null;
+                return this.streams.get(stream_id);
             }
 
             // RFC 7540 Section 6.5.2: Calculate header list size
@@ -1931,8 +1936,7 @@ pub const H2FrameParser = struct {
                 } else {
                     this.endStream(stream, ErrorCode.ENHANCE_YOUR_CALM);
                 }
-                if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
-                return null;
+                return this.streams.get(stream_id);
             }
 
             count += 1;
@@ -1943,8 +1947,7 @@ pub const H2FrameParser = struct {
                 } else {
                     this.endStream(stream, ErrorCode.ENHANCE_YOUR_CALM);
                 }
-                if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
-                return null;
+                return this.streams.get(stream_id);
             }
 
             if (getHTTP2CommonString(globalObject, header.well_know)) |js_header_name| {
@@ -1982,9 +1985,7 @@ pub const H2FrameParser = struct {
         }
 
         this.dispatchWith3Extra(.onStreamHeaders, stream.getIdentifier(), headers, sensitiveHeaders, jsc.JSValue.jsNumber(flags));
-        // callbacks can change the Stream ptr in this case we always return the new one
-        if (this.streams.getEntry(stream_id)) |entry| return entry.value_ptr;
-        return null;
+        return this.streams.get(stream_id);
     }
 
     pub fn handleDataFrame(this: *H2FrameParser, frame: FrameHeader, data: []const u8, stream_: ?*Stream) usize {
@@ -2061,9 +2062,7 @@ pub const H2FrameParser = struct {
             this.currentFrame = null;
             stream.padding = null;
             if (emitted) {
-                // we need to revalidate the stream ptr after emitting onStreamData
-                const entry = this.streams.getEntry(frame.streamIdentifier) orelse return end;
-                stream = entry.value_ptr;
+                stream = this.streams.get(frame.streamIdentifier) orelse return end;
             }
             if (frame.flags & @intFromEnum(DataFrameFlags.END_STREAM) != 0) {
                 const identifier = stream.getIdentifier();
@@ -2446,7 +2445,8 @@ pub const H2FrameParser = struct {
                         const new_size: i64 = this.localSettings.initialWindowSize;
                         const delta = new_size - old_size;
                         var it = this.streams.valueIterator();
-                        while (it.next()) |stream| {
+                        while (it.next()) |item| {
+                            const stream = item.*;
                             // Adjust the stream's local window size by the delta
                             if (delta >= 0) {
                                 stream.windowSize +|= @intCast(@as(u64, @intCast(delta)));
@@ -2472,7 +2472,8 @@ pub const H2FrameParser = struct {
 
                     if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
                         var it = this.streams.valueIterator();
-                        while (it.next()) |stream| {
+                        while (it.next()) |item| {
+                            const stream = item.*;
                             if (remoteSettings.initialWindowSize >= stream.remoteWindowSize) {
                                 stream.remoteWindowSize = remoteSettings.initialWindowSize;
                             }
@@ -2503,7 +2504,8 @@ pub const H2FrameParser = struct {
             log("remoteSettings.initialWindowSize: {} {} {}", .{ remoteSettings.initialWindowSize, this.remoteUsedWindowSize, this.remoteWindowSize });
             if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
                 var it = this.streams.valueIterator();
-                while (it.next()) |stream| {
+                while (it.next()) |item| {
+                    const stream = item.*;
                     if (remoteSettings.initialWindowSize >= stream.remoteWindowSize) {
                         stream.remoteWindowSize = remoteSettings.initialWindowSize;
                     }
@@ -2524,8 +2526,8 @@ pub const H2FrameParser = struct {
         }
 
         // already exists
-        if (this.streams.getEntry(streamIdentifier)) |entry| {
-            return entry.value_ptr;
+        if (this.streams.get(streamIdentifier)) |stream| {
+            return stream;
         }
 
         if (streamIdentifier > this.lastStreamID) {
@@ -2533,8 +2535,6 @@ pub const H2FrameParser = struct {
         }
 
         // new stream open
-        const entry = bun.handleOom(this.streams.getOrPut(streamIdentifier));
-
         // Per RFC 7540 Section 6.5.1: The sender of SETTINGS can only rely on the
         // setting being applied AFTER receiving SETTINGS_ACK. Until then, the peer
         // hasn't seen our settings and uses the default window size.
@@ -2543,21 +2543,22 @@ pub const H2FrameParser = struct {
             DEFAULT_WINDOW_SIZE
         else
             this.localSettings.initialWindowSize;
-        entry.value_ptr.* = Stream.init(
+        const stream = Stream.new(Stream.init(
             streamIdentifier,
             local_window_size,
             if (this.remoteSettings) |s| s.initialWindowSize else DEFAULT_WINDOW_SIZE,
             this.paddingStrategy,
-        );
-        const this_value = this.strong_this.tryGet() orelse return entry.value_ptr;
-        const ctx_value = js.gc.context.get(this_value) orelse return entry.value_ptr;
-        const callback = js.gc.onStreamStart.get(this_value) orelse return entry.value_ptr;
+        ));
+        bun.handleOom(this.streams.put(streamIdentifier, stream));
 
-        // we assume that onStreamStart will never mutate the stream hash map
+        const this_value = this.strong_this.tryGet() orelse return stream;
+        const ctx_value = js.gc.context.get(this_value) orelse return stream;
+        const callback = js.gc.onStreamStart.get(this_value) orelse return stream;
+
         _ = callback.call(this.handlers.globalObject, ctx_value, &[_]jsc.JSValue{ ctx_value, jsc.JSValue.jsNumber(streamIdentifier) }) catch |err| {
             this.handlers.globalObject.reportActiveExceptionAsUnhandled(err);
         };
-        return entry.value_ptr;
+        return stream;
     }
 
     fn readBytes(this: *H2FrameParser, bytes: []const u8) bun.JSError!usize {
@@ -2879,7 +2880,8 @@ pub const H2FrameParser = struct {
             this.sendWindowUpdate(0, UInt31WithReserved.init(increment, false));
         }
         var it = this.streams.valueIterator();
-        while (it.next()) |stream| {
+        while (it.next()) |item| {
+            const stream = item.*;
             if (stream.usedWindowSize > windowSizeValue) {
                 continue;
             }
@@ -3103,7 +3105,7 @@ pub const H2FrameParser = struct {
         }
         if (stream_id > 0) {
             // dont error but dont send frame to invalid stream id
-            _ = this.streams.getPtr(stream_id) orelse {
+            _ = this.streams.get(stream_id) orelse {
                 return .js_undefined;
             };
         }
@@ -3128,7 +3130,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        const stream = this.streams.getPtr(stream_id) orelse {
+        const stream = this.streams.get(stream_id) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3152,7 +3154,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        const stream = this.streams.getPtr(stream_id) orelse {
+        const stream = this.streams.get(stream_id) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3180,7 +3182,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        var stream = this.streams.getPtr(stream_id) orelse {
+        var stream = this.streams.get(stream_id) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
         var state = jsc.JSValue.createEmptyObject(globalObject, 6);
@@ -3214,7 +3216,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        var stream = this.streams.getPtr(stream_id) orelse {
+        var stream = this.streams.get(stream_id) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3312,7 +3314,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        const stream = this.streams.getPtr(stream_id) orelse {
+        const stream = this.streams.get(stream_id) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
         if (!error_arg.isNumber()) {
@@ -3467,7 +3469,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        var stream = this.streams.getPtr(@intCast(stream_id)) orelse {
+        var stream = this.streams.get(@intCast(stream_id)) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3545,7 +3547,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Invalid stream id", .{});
         }
 
-        var stream = this.streams.getPtr(@intCast(stream_id)) orelse {
+        var stream = this.streams.get(@intCast(stream_id)) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3789,7 +3791,7 @@ pub const H2FrameParser = struct {
         }
         const close = close_arg.toBoolean();
 
-        var stream = this.streams.getPtr(@intCast(stream_id)) orelse {
+        var stream = this.streams.get(@intCast(stream_id)) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
         if (!stream.canSendData()) {
@@ -3902,7 +3904,7 @@ pub const H2FrameParser = struct {
             return globalObject.throw("Expected stream_id to be a number", .{});
         }
 
-        var stream = this.streams.getPtr(stream_id_arg.to(u32)) orelse {
+        var stream = this.streams.get(stream_id_arg.to(u32)) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
 
@@ -3920,7 +3922,7 @@ pub const H2FrameParser = struct {
         if (!stream_id_arg.isNumber()) {
             return globalObject.throw("Expected stream_id to be a number", .{});
         }
-        var stream = this.streams.getPtr(stream_id_arg.to(u32)) orelse {
+        var stream = this.streams.get(stream_id_arg.to(u32)) orelse {
             return globalObject.throw("Invalid stream id", .{});
         };
         const context_arg = args_list.ptr[1];
@@ -3941,7 +3943,7 @@ pub const H2FrameParser = struct {
         const callback = args[0];
         const thisValue: JSValue = if (args.len > 1) args[1] else .js_undefined;
         var count: u32 = 0;
-        var it = this.streams.valueIterator();
+        var it = StreamResumableIterator.init(this);
         while (it.next()) |stream| {
             const value = stream.jsContext.get() orelse continue;
             this.handlers.vm.eventLoop().runCallback(callback, globalObject, thisValue, &[_]jsc.JSValue{value});
@@ -4638,7 +4640,7 @@ pub const H2FrameParser = struct {
                             .capacity = 0,
                         },
                     },
-                    .streams = bun.U32HashMap(Stream).init(bun.default_allocator),
+                    .streams = bun.U32HashMap(*Stream).init(bun.default_allocator),
                 };
                 break :brk self;
             } else {
@@ -4654,7 +4656,7 @@ pub const H2FrameParser = struct {
                             .capacity = 0,
                         },
                     },
-                    .streams = bun.U32HashMap(Stream).init(bun.default_allocator),
+                    .streams = bun.U32HashMap(*Stream).init(bun.default_allocator),
                 });
             }
         };
@@ -4759,7 +4761,7 @@ pub const H2FrameParser = struct {
 
     pub fn detachFromJS(this: *H2FrameParser, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
         jsc.markBinding(@src());
-        var it = this.streams.valueIterator();
+        var it = StreamResumableIterator.init(this);
         while (it.next()) |stream| {
             stream.freeResources(this, false);
         }
@@ -4801,12 +4803,14 @@ pub const H2FrameParser = struct {
         this.detach();
         this.strong_this.deinit();
         var it = this.streams.valueIterator();
-        while (it.next()) |stream| {
+        while (it.next()) |item| {
+            const stream = item.*;
             stream.freeResources(this, true);
+            bun.destroy(stream);
         }
         var streams = this.streams;
         defer streams.deinit();
-        this.streams = bun.U32HashMap(Stream).init(bun.default_allocator);
+        this.streams = bun.U32HashMap(*Stream).init(bun.default_allocator);
     }
 
     pub fn finalize(this: *H2FrameParser) void {

--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -2518,7 +2518,7 @@ pub const H2FrameParser = struct {
         return data.len;
     }
 
-    /// We need to be very carefull because this is not a stable ptr
+    /// Returned *Stream is heap-allocated and stable for the lifetime of this H2FrameParser.
     fn handleReceivedStreamID(this: *H2FrameParser, streamIdentifier: u32) ?*Stream {
         // connection stream
         if (streamIdentifier == 0) {

--- a/test/js/node/http2/node-http2-flush-rehash.fixture.js
+++ b/test/js/node/http2/node-http2-flush-rehash.fixture.js
@@ -1,0 +1,96 @@
+"use strict";
+// Reproduces a use-after-free in H2FrameParser.Stream.flushQueue: the defer
+// block dispatched the write callback (user JS) and then continued to
+// dereference the *Stream pointer, which points into the streams HashMap's
+// backing storage. If the callback creates new streams (session.request()),
+// the HashMap can grow/rehash and invalidate that pointer.
+//
+// Under ASAN this manifests as heap-use-after-free when flushQueue reads
+// stream state after the callback returns.
+
+const http2 = require("node:http2");
+
+const server = http2.createServer();
+server.on("stream", (stream, headers) => {
+  stream.respond({ ":status": 200 });
+  // Drain the request body so the server sends WINDOW_UPDATE frames, which
+  // trigger the client's flushStreamQueue path.
+  stream.on("data", () => {});
+  stream.on("end", () => {
+    stream.end("ok");
+  });
+  stream.on("error", () => {});
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  client.on("error", err => {
+    console.error("client error", err);
+    process.exit(1);
+  });
+
+  const extras = [];
+  let rehashed = false;
+  let writeCallbackFired = false;
+
+  client.on("connect", () => {
+    const req = client.request({ ":method": "POST", ":path": "/" }, { endStream: false });
+    req.on("error", () => {});
+    req.on("response", () => {});
+    req.on("data", () => {});
+    req.on("close", () => finish());
+
+    // Write a payload larger than the default initial window size (65535)
+    // so the tail of it is queued by the native frame parser and later
+    // flushed from flushStreamQueue -> Stream.flushQueue.
+    const payload = Buffer.alloc(128 * 1024, "a");
+    req.write(payload, () => {
+      writeCallbackFired = true;
+      if (rehashed) return;
+      rehashed = true;
+      // Create many new streams synchronously from inside the write
+      // callback. Each request() calls native getNextStream()/request(),
+      // which inserts into the streams HashMap and can trigger a rehash,
+      // invalidating the *Stream pointer that flushQueue is still holding
+      // in its defer block.
+      for (let i = 0; i < 100; i++) {
+        try {
+          const r = client.request({ ":method": "GET", ":path": "/extra" });
+          r.on("error", () => {});
+          r.on("response", () => {});
+          r.on("data", () => {});
+          r.on("end", () => {});
+          extras.push(r);
+        } catch {}
+      }
+      // The UAF (if present) fires in native code immediately after this
+      // callback returns — flushQueue's defer resumes and touches the stale
+      // *Stream. We don't need to wait for the request to complete; finish
+      // on the next turn so the defer has run.
+      setImmediate(finish);
+    });
+    req.end();
+  });
+
+  let finished = false;
+  function finish() {
+    if (finished) return;
+    finished = true;
+    if (!writeCallbackFired) {
+      console.error("write callback never fired");
+      process.exit(1);
+    }
+    // The UAF (if present) would have already tripped ASAN inside the write
+    // callback's caller by now; no need to wait for the extra streams or a
+    // graceful shutdown.
+    try {
+      client.destroy();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+    console.log("ok");
+    process.exit(0);
+  }
+});

--- a/test/js/node/http2/node-http2-foreach-rehash.fixture.js
+++ b/test/js/node/http2/node-http2-foreach-rehash.fixture.js
@@ -1,0 +1,57 @@
+// Reproduces a use-after-free in H2FrameParser.forEachStream(): the raw
+// HashMap valueIterator() was held across a JS callback. When the session
+// socket times out, #onTimeout() calls parser.forEachStream(emitTimeout),
+// which emits 'timeout' on every open stream. If a 'timeout' listener calls
+// session.request(), that reaches handleReceivedStreamID() -> streams.put(),
+// which can grow/rehash the hashmap and free the backing storage the iterator
+// is still pointing at. Under ASAN this is a heap-use-after-free.
+"use strict";
+
+const http2 = require("node:http2");
+const { once } = require("node:events");
+
+const server = http2.createServer();
+// Never respond so streams stay open and the socket goes idle.
+server.on("stream", () => {});
+
+server.listen(0, async () => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+  client.on("error", () => {});
+  await once(client, "connect");
+
+  // Create enough streams to put the parser's stream hashmap near/over its
+  // grow threshold, so that adding more from inside the iteration forces a
+  // rehash while the raw iterator is still live.
+  const INITIAL_STREAMS = 24;
+  const streams = [];
+  for (let i = 0; i < INITIAL_STREAMS; i++) {
+    const req = client.request({ ":path": "/", ":method": "POST" });
+    req.on("error", () => {});
+    // Inside forEachStream's callback: add more streams to force a rehash.
+    req.on("timeout", () => {
+      for (let j = 0; j < 4; j++) {
+        try {
+          const extra = client.request({ ":path": "/", ":method": "POST" });
+          extra.on("error", () => {});
+        } catch {}
+      }
+    });
+    streams.push(req);
+  }
+
+  // Arm the socket inactivity timeout; when it fires, #onTimeout() runs
+  // parser.forEachStream(emitTimeout) over all open streams.
+  const fired = once(client, "timeout");
+  client.setTimeout(50);
+  await fired;
+
+  // Give any additional iterator steps a chance to run before shutting down.
+  await new Promise(resolve => setImmediate(resolve));
+
+  client.destroy();
+  server.close(() => {
+    console.log("OK");
+    process.exit(0);
+  });
+});

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -18,7 +18,7 @@ test("session.request() from a stream 'timeout' listener during forEachStream do
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
-}, 30_000);
+});
 
 test("http2 client request() does not hold *Stream across user-controlled options getters", async () => {
   const script = /* js */ `
@@ -94,7 +94,7 @@ test("http2 client request() does not hold *Stream across user-controlled option
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "done", exitCode: 0 });
-}, 30_000);
+});
 
 test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
   await using proc = Bun.spawn({
@@ -105,4 +105,4 @@ test("http2 client write callback that opens new streams during flushQueue does 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-}, 30_000);
+});

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// H2FrameParser stored Stream by value in a HashMap. Any *Stream obtained
+// from getPtr/value_ptr/valueIterator pointed into the map's backing storage
+// and dangled if a re-entrant JS callback inserted a new stream and triggered
+// a rehash. Streams are now heap-allocated and stored by pointer, so *Stream
+// is stable for the lifetime of the H2FrameParser regardless of map growth.
+// These three tests cover the call sites where this was observed under ASAN.
+
+test("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash.fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
+}, 30_000);
+
+test("http2 client request() does not hold *Stream across user-controlled options getters", async () => {
+  const script = /* js */ `
+    const http2 = require("node:http2");
+
+    const server = http2.createServer();
+    server.on("stream", (stream) => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    server.on("error", () => {});
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      const client = http2.connect("http://127.0.0.1:" + port);
+      client.on("error", () => {});
+
+      client.on("connect", () => {
+        let triggered = false;
+
+        // Use a POST so the options object is passed through to the native
+        // parser without being shallow-copied.
+        const options = {
+          get paddingStrategy() {
+            if (!triggered) {
+              triggered = true;
+              // Insert enough new streams to force the HashMap to rehash,
+              // invalidating any *Stream pointer held by the outer request().
+              for (let i = 0; i < 128; i++) {
+                const r = client.request({ ":path": "/", ":method": "GET" });
+                r.on("error", () => {});
+                r.on("response", () => {});
+                r.resume();
+              }
+            }
+            return 0;
+          },
+          // Ensure the outer request writes through the (previously dangling)
+          // stream pointer after the getter returns.
+          exclusive: true,
+          parent: 1,
+          weight: 16,
+          waitForTrailers: false,
+          endStream: true,
+        };
+
+        const req = client.request({ ":path": "/", ":method": "POST" }, options);
+        req.on("error", () => {});
+        req.on("response", () => {});
+        req.resume();
+        req.on("close", () => {
+          client.close(() => {
+            server.close(() => {
+              if (!triggered) {
+                console.error("getter was never invoked");
+                process.exit(1);
+              }
+              console.log("done");
+              process.exit(0);
+            });
+          });
+        });
+        req.end();
+      });
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "done", exitCode: 0 });
+}, 30_000);
+
+test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rehash.fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
+}, 30_000);


### PR DESCRIPTION
### What does this PR do?

`H2FrameParser.streams` stored `Stream` **by value** in a `bun.U32HashMap`. Any `*Stream` obtained from `getPtr` / `getEntry().value_ptr` / `valueIterator()` pointed into the map's backing storage and dangled whenever a re-entrant JS callback (an options getter, a write callback, a `forEachStream` callback, `onStreamStart`) called `session.request()` and triggered a rehash. Under ASAN this surfaces as heap-use-after-free at several distinct call sites.

This changes the map to `bun.U32HashMap(*Stream)` with `Stream` heap-allocated via `bun.TrivialNew` in `handleReceivedStreamID` and freed in `H2FrameParser.deinit`. `*Stream` is now stable for the lifetime of the parser regardless of map growth, which fixes every current and future call site that holds a `*Stream` across a JS dispatch.

Streams are never individually removed from the map today (`freeResources()` clears resources in place but the entry remains until parser deinit), so no ref-counting is required — the parser is already ref-counted and owns the streams for its full lifetime. Reclaiming closed-stream entries is a pre-existing concern unchanged by this PR and will be addressed separately.

`forEachStream` and `detachFromJS` additionally switch from `valueIterator()` to `StreamResumableIterator` since they call into JS while walking buckets; the bucket walk itself can still be invalidated by rehash even though the values it yields are now stable.

### How did you verify your code works?

`test/js/node/http2/node-http2-streams-rehash.test.ts` covers the three known repros (forEachStream timeout listener, request() options getter, flushQueue write callback). All three trip ASAN heap-use-after-free on a debug build of `main` and pass with this change. The existing 245-test `node-http2.test.js` suite continues to pass.

Closes #29754
Closes #29756
Closes #29759