### PR TITLE
fetch: experimental HTTP/2 client

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1991,8 +1991,9 @@ interface BunFetchRequestInit extends RequestInit {
   /**
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in
    * the TLS ALPN list and the request fails with `HTTP2Unsupported` if the
-   * server doesn't select it. `"http1.1"` (the default) keeps the existing
-   * behaviour.
+   * server doesn't select it. `"http1.1"` pins the request to HTTP/1.1,
+   * overriding `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` if set. Omit to
+   * use the default (h2 is offered iff the env flag is on).
    *
    * Requires `https`. This is a custom property that is not part of the
    * Fetch API specification.

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1989,6 +1989,18 @@ interface BunFetchRequestInit extends RequestInit {
   unix?: string;
 
   /**
+   * Force the underlying HTTP version. `"http2"` advertises only `h2` in
+   * the TLS ALPN list and the request fails with `HTTP2Unsupported` if the
+   * server doesn't select it. `"http1.1"` (the default) keeps the existing
+   * behaviour.
+   *
+   * Requires `https`. This is a custom property that is not part of the
+   * Fetch API specification.
+   * @experimental
+   */
+  protocol?: "http2" | "http1.1" | "h2" | "h1";
+
+  /**
    * Control automatic decompression of the response body.
    * When set to `false`, the response body will not be automatically decompressed,
    * and the `Content-Encoding` header will be preserved. This can improve performance

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1992,8 +1992,9 @@ interface BunFetchRequestInit extends RequestInit {
    * Force the underlying HTTP version. `"http2"` advertises only `h2` in
    * the TLS ALPN list and the request fails with `HTTP2Unsupported` if the
    * server doesn't select it. `"http1.1"` pins the request to HTTP/1.1,
-   * overriding `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` if set. Omit to
-   * use the default (h2 is offered iff the env flag is on).
+   * overriding `--experimental-http2-fetch` /
+   * `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` if set. Omit to use the
+   * default (h2 is offered iff the flag is on).
    *
    * Requires `https`. This is a custom property that is not part of the
    * Fetch API specification.

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -105,6 +105,7 @@ pub const Run = struct {
         vm.is_main_thread = true;
         jsc.VirtualMachine.is_main_thread_vm = true;
 
+        bun.http.experimental_http2_client_from_cli = ctx.runtime_options.experimental_http2_fetch;
         doPreconnect(ctx.runtime_options.preconnect);
 
         const callback = OpaqueWrap(Run, Run.start);
@@ -290,6 +291,7 @@ pub const Run = struct {
 
         vm.transpiler.env.loadTracy();
 
+        bun.http.experimental_http2_client_from_cli = ctx.runtime_options.experimental_http2_fetch;
         doPreconnect(ctx.runtime_options.preconnect);
 
         vm.main_is_html_entrypoint = (loader orelse vm.transpiler.options.loader(std.fs.path.extension(entry_path))) == .html;

--- a/src/bun.js/api/bun/lshpack.zig
+++ b/src/bun.js/api/bun/lshpack.zig
@@ -50,6 +50,14 @@ pub const HPACK = extern struct {
         return offset;
     }
 
+    /// Adjust the encoder's dynamic-table capacity after init. Evicts entries
+    /// to fit; the caller is responsible for emitting the RFC 7541 §6.3
+    /// Dynamic Table Size Update opcode at the start of the next header block
+    /// so the peer's decoder evicts in lockstep.
+    pub fn setEncoderMaxCapacity(self: *HPACK, max_capacity: u32) void {
+        lshpack_wrapper_enc_set_max_capacity(self, max_capacity);
+    }
+
     pub fn deinit(self: *HPACK) void {
         lshpack_wrapper_deinit(self);
     }
@@ -58,6 +66,7 @@ pub const HPACK = extern struct {
 const lshpack_wrapper_alloc = ?*const fn (size: usize) callconv(.c) ?*anyopaque;
 const lshpack_wrapper_free = ?*const fn (ptr: ?*anyopaque) callconv(.c) void;
 extern fn lshpack_wrapper_init(alloc: lshpack_wrapper_alloc, free: lshpack_wrapper_free, capacity: usize) ?*HPACK;
+extern fn lshpack_wrapper_enc_set_max_capacity(self: *HPACK, max_capacity: c_uint) void;
 extern fn lshpack_wrapper_deinit(self: *HPACK) void;
 extern fn lshpack_wrapper_decode(self: *HPACK, src: [*]const u8, src_len: usize, output: *lshpack_header) usize;
 extern fn lshpack_wrapper_encode(self: *HPACK, name: [*]const u8, name_len: usize, value: [*]const u8, value_len: usize, never_index: c_int, buffer: [*]u8, buffer_len: usize, buffer_offset: usize) usize;

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -354,6 +354,11 @@ size_t lshpack_wrapper_decode(lshpack_wrapper* self,
     return s - src;
 }
 
+void lshpack_wrapper_enc_set_max_capacity(lshpack_wrapper* self, unsigned max_capacity)
+{
+    lshpack_enc_set_max_capacity(&self->enc, max_capacity);
+}
+
 void lshpack_wrapper_deinit(lshpack_wrapper* self)
 {
     lshpack_dec_cleanup(&self->dec);

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -348,6 +348,7 @@ extern "C" void ReadableStream__cancelWithReason(JSC::EncodedJSValue possibleRea
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamCancelPrivateName();
 
     JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     MarkedArgumentBuffer arguments;
     arguments.append(readableStream);
     arguments.append(JSC::JSValue::decode(encodedReason));

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -114,10 +114,11 @@ static inline std::optional<JSC::JSValue> invokeReadableStreamFunction(JSC::JSGl
     JSC::VM& vm = lexicalGlobalObject.vm();
     JSC::JSLockHolder lock(vm);
 
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto function = lexicalGlobalObject.get(&lexicalGlobalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, {});
     ASSERT(function.isCallable());
 
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto callData = JSC::getCallData(function);
     auto result = call(&lexicalGlobalObject, function, callData, thisValue, arguments);
     EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());

--- a/src/bun.js/bindings/webcore/ReadableStream.cpp
+++ b/src/bun.js/bindings/webcore/ReadableStream.cpp
@@ -334,6 +334,27 @@ extern "C" void ReadableStream__cancel(JSC::EncodedJSValue possibleReadableStrea
     WebCore::ReadableStream::cancel(*globalObject, readableStream, exception);
 }
 
+// Like ReadableStream__cancel but forwards an arbitrary JS reason verbatim to
+// the stream's cancel algorithm instead of synthesizing a DOMException. Used
+// by fetch() to honor AbortSignal.reason when cancelling a request body.
+extern "C" void ReadableStream__cancelWithReason(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject, JSC::EncodedJSValue encodedReason)
+{
+    auto* readableStream = dynamicDowncast<WebCore::JSReadableStream>(JSC::JSValue::decode(possibleReadableStream));
+    if (!readableStream) [[unlikely]]
+        return;
+
+    auto& vm = globalObject->vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
+    auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamCancelPrivateName();
+
+    JSC::JSLockHolder lock(vm);
+    MarkedArgumentBuffer arguments;
+    arguments.append(readableStream);
+    arguments.append(JSC::JSValue::decode(encodedReason));
+    ASSERT(!arguments.hasOverflowed());
+    invokeReadableStreamFunction(*globalObject, privateName, JSC::jsUndefined(), arguments);
+}
+
 extern "C" void ReadableStream__detach(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject)
 {
     auto value = JSC::JSValue::decode(possibleReadableStream);

--- a/src/bun.js/webcore/Body.zig
+++ b/src/bun.js/webcore/Body.zig
@@ -286,6 +286,10 @@ pub const Value = union(Tag) {
         AbortReason: jsc.CommonAbortReason,
         SystemError: jsc.SystemError,
         Message: bun.String,
+        /// Surfaces as a JS `TypeError`. The fetch spec maps every "network
+        /// error" to TypeError, so use this for fetch-layer rejections that
+        /// callers feature-detect via `err instanceof TypeError`.
+        TypeError: bun.String,
         JSValue: jsc.Strong.Optional,
 
         pub fn toStreamError(this: *@This(), globalObject: *jsc.JSGlobalObject) streams.Result.StreamError {
@@ -304,6 +308,7 @@ pub const Value = union(Tag) {
                 .AbortReason => |reason| reason.toJS(globalObject),
                 .SystemError => |system_error| system_error.toErrorInstance(globalObject),
                 .Message => |message| message.toErrorInstance(globalObject),
+                .TypeError => |message| message.toTypeErrorInstance(globalObject),
                 // do a early return in this case we don't need to create a new Strong
                 .JSValue => |js_value| return js_value.get() orelse .js_undefined,
             };
@@ -325,6 +330,7 @@ pub const Value = union(Tag) {
             switch (this.*) {
                 .SystemError => value.SystemError.ref(),
                 .Message => value.Message.ref(),
+                .TypeError => value.TypeError.ref(),
                 .JSValue => |js_ref| {
                     if (js_ref.get()) |js_value| {
                         return .{ .JSValue = .create(js_value, globalObject) };
@@ -340,6 +346,7 @@ pub const Value = union(Tag) {
             switch (this.*) {
                 .SystemError => |system_error| system_error.deref(),
                 .Message => |message| message.deref(),
+                .TypeError => |message| message.deref(),
                 .JSValue => this.JSValue.deinit(),
                 .AbortReason => {},
             }

--- a/src/bun.js/webcore/ReadableStream.zig
+++ b/src/bun.js/webcore/ReadableStream.zig
@@ -143,6 +143,16 @@ pub fn cancel(this: *const ReadableStream, globalThis: *JSGlobalObject) void {
     this.done(globalThis);
 }
 
+/// Cancel the stream and forward `reason` verbatim to the underlying source's
+/// cancel algorithm (the spec's ReadableStreamCancel). Unlike `cancel()`,
+/// this does not synthesize a DOMException — fetch() uses it to surface
+/// `AbortSignal.reason` to the request body's cancel callback.
+pub fn cancelWithReason(this: *const ReadableStream, globalThis: *JSGlobalObject, reason: jsc.JSValue) void {
+    jsc.markBinding(@src());
+    ReadableStream__cancelWithReason(this.value, globalThis, reason);
+    this.done(globalThis);
+}
+
 pub fn abort(this: *const ReadableStream, globalThis: *JSGlobalObject) void {
     jsc.markBinding(@src());
     // for now we are just calling cancel should be fine
@@ -210,6 +220,7 @@ extern fn ReadableStream__isLocked(possibleReadableStream: JSValue, globalObject
 extern fn ReadableStream__empty(*JSGlobalObject) jsc.JSValue;
 extern fn ReadableStream__used(*JSGlobalObject) jsc.JSValue;
 extern fn ReadableStream__cancel(stream: JSValue, *JSGlobalObject) void;
+extern fn ReadableStream__cancelWithReason(stream: JSValue, *JSGlobalObject, reason: JSValue) void;
 extern fn ReadableStream__abort(stream: JSValue, *JSGlobalObject) void;
 extern fn ReadableStream__detach(stream: JSValue, *JSGlobalObject) void;
 extern fn ReadableStream__fromBlob(

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -541,10 +541,6 @@ fn fetchImpl(
                         break :extract_protocol;
                     }
                 }
-                if (globalThis.hasException()) {
-                    is_error = true;
-                    return .zero;
-                }
             }
         }
     }

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -198,6 +198,7 @@ fn fetchImpl(
     // used to clean up dynamically allocated memory on error (a poor man's errdefer)
     var is_error = false;
     var upgraded_connection = false;
+    var force_http2 = false;
     var allocator = bun.default_allocator;
 
     if (arguments.len == 0) {
@@ -514,6 +515,34 @@ fn fetchImpl(
     if (globalThis.hasException()) {
         is_error = true;
         return .zero;
+    }
+
+    // protocol: "http2" | undefined — Bun extension to force ALPN h2.
+    {
+        const objects_to_try = [_]JSValue{
+            options_object orelse .zero,
+            request_init_object orelse .zero,
+        };
+        inline for (0..2) |i| {
+            if (objects_to_try[i] != .zero) {
+                if (try objects_to_try[i].get(globalThis, "protocol")) |protocol_val| {
+                    if (protocol_val.isString()) {
+                        const str = try protocol_val.toBunString(globalThis);
+                        defer str.deref();
+                        if (str.eqlComptime("http2") or str.eqlComptime("h2")) {
+                            force_http2 = true;
+                        } else if (!str.eqlComptime("http1.1") and !str.eqlComptime("h1")) {
+                            is_error = true;
+                            return globalThis.throwInvalidArguments("fetch: 'protocol' must be \"http2\" or \"http1.1\"", .{});
+                        }
+                    }
+                }
+                if (globalThis.hasException()) {
+                    is_error = true;
+                    return .zero;
+                }
+            }
+        }
     }
 
     // timeout: false | number | undefined
@@ -1409,6 +1438,7 @@ fn fetchImpl(
             .ssl_config = ssl_config,
             .hostname = hostname,
             .upgraded_connection = upgraded_connection,
+            .force_http2 = force_http2,
             .check_server_identity = if (check_server_identity.isEmptyOrUndefinedOrNull()) .empty else .create(check_server_identity, globalThis),
             .unix_socket_path = unix_socket_path,
         },

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -517,7 +517,7 @@ fn fetchImpl(
         return .zero;
     }
 
-    // protocol: "http2" | undefined — Bun extension to force ALPN h2.
+    // protocol: "http2" | "h2" | "http1.1" | "h1" | undefined.
     extract_protocol: {
         const objects_to_try = [_]JSValue{
             options_object orelse .zero,
@@ -533,7 +533,7 @@ fn fetchImpl(
                             force_http2 = true;
                         } else if (!str.eqlComptime("http1.1") and !str.eqlComptime("h1")) {
                             is_error = true;
-                            return globalThis.throwInvalidArguments("fetch: 'protocol' must be \"http2\" or \"http1.1\"", .{});
+                            return globalThis.throwInvalidArguments("fetch: 'protocol' must be \"http2\", \"h2\", \"http1.1\", or \"h1\"", .{});
                         }
                         break :extract_protocol;
                     }

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -199,6 +199,7 @@ fn fetchImpl(
     var is_error = false;
     var upgraded_connection = false;
     var force_http2 = false;
+    var force_http1 = false;
     var allocator = bun.default_allocator;
 
     if (arguments.len == 0) {
@@ -531,7 +532,9 @@ fn fetchImpl(
                         defer str.deref();
                         if (str.eqlComptime("http2") or str.eqlComptime("h2")) {
                             force_http2 = true;
-                        } else if (!str.eqlComptime("http1.1") and !str.eqlComptime("h1")) {
+                        } else if (str.eqlComptime("http1.1") or str.eqlComptime("h1")) {
+                            force_http1 = true;
+                        } else {
                             is_error = true;
                             return globalThis.throwInvalidArguments("fetch: 'protocol' must be \"http2\", \"h2\", \"http1.1\", or \"h1\"", .{});
                         }
@@ -1440,6 +1443,7 @@ fn fetchImpl(
             .hostname = hostname,
             .upgraded_connection = upgraded_connection,
             .force_http2 = force_http2,
+            .force_http1 = force_http1,
             .check_server_identity = if (check_server_identity.isEmptyOrUndefinedOrNull()) .empty else .create(check_server_identity, globalThis),
             .unix_socket_path = unix_socket_path,
         },

--- a/src/bun.js/webcore/fetch.zig
+++ b/src/bun.js/webcore/fetch.zig
@@ -518,7 +518,7 @@ fn fetchImpl(
     }
 
     // protocol: "http2" | undefined — Bun extension to force ALPN h2.
-    {
+    extract_protocol: {
         const objects_to_try = [_]JSValue{
             options_object orelse .zero,
             request_init_object orelse .zero,
@@ -535,6 +535,7 @@ fn fetchImpl(
                             is_error = true;
                             return globalThis.throwInvalidArguments("fetch: 'protocol' must be \"http2\" or \"http1.1\"", .{});
                         }
+                        break :extract_protocol;
                     }
                 }
                 if (globalThis.hasException()) {

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -749,6 +749,16 @@ pub const FetchTasklet = struct {
             return .{ .AbortReason = reason };
         }
 
+        // Fetch-spec "network error" cases that callers feature-detect via
+        // `instanceof TypeError`. Keep this list narrow; the catch-all
+        // SystemError below is still a plain Error for backwards compat.
+        switch (this.result.fail.?) {
+            error.RequestBodyNotReusable => return .{
+                .TypeError = bun.String.static("Request body is a ReadableStream and cannot be replayed for this redirect"),
+            },
+            else => {},
+        }
+
         // some times we don't have metadata so we also check http.url
         const path = if (this.metadata) |metadata|
             bun.String.cloneUTF8(metadata.url)
@@ -1209,6 +1219,16 @@ pub const FetchTasklet = struct {
         if (this.sink) |sink| {
             sink.cancel(reason);
             return;
+        }
+        // Abort fired before the HTTP thread asked for the body, so the
+        // ReadableStream was never wired into a sink. Cancel it directly so
+        // the underlying source's cancel(reason) callback still observes the
+        // signal's reason (https://fetch.spec.whatwg.org/#abort-fetch step 5).
+        if (this.is_waiting_request_stream_start and this.request_body == .ReadableStream) {
+            this.is_waiting_request_stream_start = false;
+            if (this.request_body.ReadableStream.get(this.global_this)) |stream| {
+                stream.cancelWithReason(this.global_this, reason);
+            }
         }
     }
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1241,6 +1241,7 @@ pub const FetchTasklet = struct {
     /// set Content-Length without setting Transfer-Encoding.
     fn skipChunkedFraming(this: *const FetchTasklet) bool {
         return this.upgraded_connection or
+            this.result.is_http2 or
             (this.request_headers.get("content-length") != null and this.request_headers.get("transfer-encoding") == null);
     }
 

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1177,6 +1177,7 @@ pub const FetchTasklet = struct {
         const isStream = fetch_tasklet.request_body == .ReadableStream;
         fetch_tasklet.http.?.client.flags.is_streaming_request_body = isStream;
         fetch_tasklet.http.?.client.flags.force_http2 = fetch_options.force_http2;
+        fetch_tasklet.http.?.client.flags.force_http1 = fetch_options.force_http1;
         fetch_tasklet.is_waiting_request_stream_start = isStream;
         if (isStream) {
             const buffer = http.ThreadSafeStreamBuffer.new(.{});
@@ -1366,6 +1367,7 @@ pub const FetchTasklet = struct {
         ssl_config: ?SSLConfig.SharedPtr = null,
         upgraded_connection: bool = false,
         force_http2: bool = false,
+        force_http1: bool = false,
     };
 
     pub fn queue(

--- a/src/bun.js/webcore/fetch/FetchTasklet.zig
+++ b/src/bun.js/webcore/fetch/FetchTasklet.zig
@@ -1166,6 +1166,7 @@ pub const FetchTasklet = struct {
         // enable streaming the write side
         const isStream = fetch_tasklet.request_body == .ReadableStream;
         fetch_tasklet.http.?.client.flags.is_streaming_request_body = isStream;
+        fetch_tasklet.http.?.client.flags.force_http2 = fetch_options.force_http2;
         fetch_tasklet.is_waiting_request_stream_start = isStream;
         if (isStream) {
             const buffer = http.ThreadSafeStreamBuffer.new(.{});
@@ -1344,6 +1345,7 @@ pub const FetchTasklet = struct {
         unix_socket_path: ZigString.Slice,
         ssl_config: ?SSLConfig.SharedPtr = null,
         upgraded_connection: bool = false,
+        force_http2: bool = false,
     };
 
     pub fn queue(

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -408,6 +408,7 @@ pub const Command = struct {
             eval_and_print: bool = false,
         } = .{},
         preconnect: []const []const u8 = &[_][]const u8{},
+        experimental_http2_fetch: bool = false,
         dns_result_order: []const u8 = "verbatim",
         /// `--expose-gc` makes `globalThis.gc()` available. Added for Node
         /// compatibility.

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -108,6 +108,7 @@ pub const runtime_params_ = [_]ParamType{
     clap.parseParam("-u, --origin <STR>") catch unreachable,
     clap.parseParam("--conditions <STR>...             Pass custom conditions to resolve") catch unreachable,
     clap.parseParam("--fetch-preconnect <STR>...       Preconnect to a URL while code is loading") catch unreachable,
+    clap.parseParam("--experimental-http2-fetch        Offer h2 in fetch() TLS ALPN. Same as BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT=1") catch unreachable,
     clap.parseParam("--max-http-header-size <INT>      Set the maximum size of HTTP headers in bytes. Default is 16KiB") catch unreachable,
     clap.parseParam("--dns-result-order <STR>          Set the default order of DNS lookup results. Valid orders: verbatim (default), ipv4first, ipv6first") catch unreachable,
     clap.parseParam("--expose-gc                       Expose gc() on the global object. Has no effect on Bun.gc().") catch unreachable,
@@ -878,6 +879,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         ctx.runtime_options.if_present = args.flag("--if-present");
         ctx.runtime_options.smol = args.flag("--smol");
         ctx.runtime_options.preconnect = args.options("--fetch-preconnect");
+        ctx.runtime_options.experimental_http2_fetch = args.flag("--experimental-http2-fetch");
         ctx.runtime_options.expose_gc = args.flag("--expose-gc");
 
         if (args.option("--console-depth")) |depth_str| {

--- a/src/cli/test/parallel/runner.zig
+++ b/src/cli/test/parallel/runner.zig
@@ -225,6 +225,10 @@ fn buildWorkerArgv(arena: std.mem.Allocator, ctx: Command.Context) ![:null]?[*:0
     }
     if (ctx.args.preserve_symlinks orelse false)
         try argv.append(arena, "--preserve-symlinks");
+    if (ctx.runtime_options.smol)
+        try argv.append(arena, "--smol");
+    if (ctx.runtime_options.experimental_http2_fetch)
+        try argv.append(arena, "--experimental-http2-fetch");
     if (ctx.args.allow_addons == false)
         try argv.append(arena, "--no-addons");
     if (ctx.debug.macros == .disable)

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -1495,6 +1495,7 @@ pub const TestCommand = struct {
         vm.argv = ctx.passthrough;
         vm.preload = ctx.preloads;
         vm.transpiler.options.rewrite_jest_for_tests = true;
+        bun.http.experimental_http2_client_from_cli = ctx.runtime_options.experimental_http2_fetch;
         vm.transpiler.options.env.behavior = .load_all_without_inlining;
 
         const node_env_entry = try env_loader.map.getOrPutWithoutValue("NODE_ENV");

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -19058,12 +19058,18 @@ pub const SSL = opaque {
     }
 
     pub fn configureHTTPClient(ssl: *SSL, hostname: [:0]const u8) void {
+        configureHTTPClientWithALPN(ssl, hostname, false);
+    }
+
+    pub fn configureHTTPClientWithALPN(ssl: *SSL, hostname: [:0]const u8, offer_h2: bool) void {
         if (hostname.len > 0) ssl.setHostname(hostname);
         _ = SSL_clear_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
         _ = SSL_set_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
 
-        const alpns = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
-        bun.assert(SSL_set_alpn_protos(ssl, alpns, alpns.len) == 0);
+        const alpn_h1 = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+        const alpn_h2_h1 = &[_]u8{ 2, 'h', '2', 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+        const alpns: []const u8 = if (offer_h2) alpn_h2_h1 else alpn_h1;
+        bun.assert(SSL_set_alpn_protos(ssl, alpns.ptr, alpns.len) == 0);
 
         SSL_enable_signed_cert_timestamps(ssl);
         SSL_enable_ocsp_stapling(ssl);

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -19058,17 +19058,24 @@ pub const SSL = opaque {
     }
 
     pub fn configureHTTPClient(ssl: *SSL, hostname: [:0]const u8) void {
-        configureHTTPClientWithALPN(ssl, hostname, false);
+        configureHTTPClientWithALPN(ssl, hostname, .h1);
     }
 
-    pub fn configureHTTPClientWithALPN(ssl: *SSL, hostname: [:0]const u8, offer_h2: bool) void {
+    pub const AlpnOffer = enum { h1, h1_or_h2, h2_only };
+
+    pub fn configureHTTPClientWithALPN(ssl: *SSL, hostname: [:0]const u8, offer: AlpnOffer) void {
         if (hostname.len > 0) ssl.setHostname(hostname);
         _ = SSL_clear_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
         _ = SSL_set_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
 
         const alpn_h1 = &[_]u8{ 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
+        const alpn_h2 = &[_]u8{ 2, 'h', '2' };
         const alpn_h2_h1 = &[_]u8{ 2, 'h', '2', 8, 'h', 't', 't', 'p', '/', '1', '.', '1' };
-        const alpns: []const u8 = if (offer_h2) alpn_h2_h1 else alpn_h1;
+        const alpns: []const u8 = switch (offer) {
+            .h1 => alpn_h1,
+            .h1_or_h2 => alpn_h2_h1,
+            .h2_only => alpn_h2,
+        };
         bun.assert(SSL_set_alpn_protos(ssl, alpns.ptr, alpns.len) == 0);
 
         SSL_enable_signed_cert_timestamps(ssl);

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -191,7 +191,7 @@ pub const feature_flag = struct {
     pub const BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE", .{});
     /// Offer "h2" in the fetch() TLS ALPN list and speak HTTP/2 when the
     /// server selects it. Off by default while the client implementation
-    /// matures.
+    /// matures. `--experimental-http2-fetch` is the CLI equivalent.
     pub const BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT", .{});
     pub const BUN_FEATURE_FLAG_FORCE_IO_POOL = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_IO_POOL", .{});
     pub const BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", .{});

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -189,6 +189,10 @@ pub const feature_flag = struct {
     pub const BUN_DUMP_STATE_ON_CRASH = newFeatureFlag("BUN_DUMP_STATE_ON_CRASH", .{});
     pub const BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS = newFeatureFlag("BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS", .{});
     pub const BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE", .{});
+    /// Offer "h2" in the fetch() TLS ALPN list and speak HTTP/2 when the
+    /// server selects it. Off by default while the client implementation
+    /// matures.
+    pub const BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT = newFeatureFlag("BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT", .{});
     pub const BUN_FEATURE_FLAG_FORCE_IO_POOL = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_IO_POOL", .{});
     pub const BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", .{});
     pub const BUN_INSTRUMENTS = newFeatureFlag("BUN_INSTRUMENTS", .{});

--- a/src/http.zig
+++ b/src/http.zig
@@ -602,11 +602,9 @@ pub fn deinit(this: *HTTPClient) void {
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
     }
-    if (this.h2) |stream| {
-        // Normally cleared by the session before the terminal callback;
-        // reaching here means the client is being torn down mid-flight.
-        stream.session.detachWithFailure(stream, error.Aborted);
-    }
+    // The session detaches `h2` before any terminal callback, so this should
+    // be null by the time the result callback's deinit path runs.
+    bun.debugAssert(this.h2 == null);
     // Release our strong ref on the interned SSLConfig
     if (this.tls_props) |*tls| tls.deinit();
     this.tls_props = null;

--- a/src/http.zig
+++ b/src/http.zig
@@ -1998,6 +1998,11 @@ fn resolvePendingH2(this: *HTTPClient, session: ?*H2.ClientSession) void {
             waiter.fail(error.HTTP2Unsupported);
             continue;
         }
+        // Pin this waiter to h1 so its `start_` doesn't register a fresh
+        // PendingConnect that the rest of this loop would re-coalesce onto
+        // (which would serialise N cold fetches into N sequential
+        // handshakes). The origin already chose h1 once.
+        waiter.flags.force_http1 = true;
         waiter.start_(true);
     }
 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -211,7 +211,7 @@ pub fn canOfferH2(client: *const HTTPClient) bool {
     if (client.http_proxy != null) return false;
     if (client.flags.is_preconnect_only) return false;
     if (client.unix_socket_path.length() > 0) return false;
-    if (client.state.original_request_body != .bytes) return false;
+    if (client.state.original_request_body == .sendfile) return false;
     return true;
 }
 
@@ -2155,6 +2155,9 @@ pub const HTTPClientResult = struct {
     has_more: bool = false,
     redirected: bool = false,
     can_stream: bool = false,
+    /// Set once ALPN selected h2 so the JS side writes raw bytes into the
+    /// streaming-body buffer instead of chunked-encoding them.
+    is_http2: bool = false,
 
     fail: ?anyerror = null,
 
@@ -2252,6 +2255,7 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
             .body_size = body_size,
             .certificate_info = null,
             .can_stream = (this.state.request_stage == .body or this.state.request_stage == .proxy_body) and this.flags.is_streaming_request_body,
+            .is_http2 = this.flags.protocol == .http2,
         };
     }
     return HTTPClientResult{
@@ -2265,6 +2269,7 @@ pub fn toResult(this: *HTTPClient) HTTPClientResult {
         .certificate_info = certificate_info,
         // we can stream the request_body at this stage
         .can_stream = (this.state.request_stage == .body or this.state.request_stage == .proxy_body) and this.flags.is_streaming_request_body,
+        .is_http2 = this.flags.protocol == .http2,
     };
 }
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -207,6 +207,7 @@ pub fn onOpen(
 /// no sendfile). Either the experimental env-var or `protocol: "http2"` on
 /// the fetch options enables it.
 pub fn canOfferH2(client: *const HTTPClient) bool {
+    if (client.flags.force_http1) return false;
     if (client.http_proxy != null) return false;
     if (client.flags.is_preconnect_only) return false;
     if (client.unix_socket_path.length() > 0) return false;
@@ -577,7 +578,9 @@ pub const Flags = packed struct(u16) {
     /// Set by `fetch(url, { protocol: "http2" })`: ALPN advertises only h2
     /// and the request fails if the server selects anything else.
     force_http2: bool = false,
-    _padding: u1 = 0,
+    /// Set by `fetch(url, { protocol: "http1.1" })`: opt out of h2 even when
+    /// the experimental env flag would otherwise advertise it.
+    force_http1: bool = false,
 };
 
 // TODO: reduce the size of this struct

--- a/src/http.zig
+++ b/src/http.zig
@@ -195,24 +195,28 @@ pub fn onOpen(
 
             defer if (hostname_needs_free) bun.default_allocator.free(hostname);
 
-            ssl_ptr.configureHTTPClientWithALPN(hostname, client.canOfferH2());
+            ssl_ptr.configureHTTPClientWithALPN(hostname, client.alpnOffer());
         }
     } else {
         client.firstCall(is_ssl, socket);
     }
 }
 
-/// Whether to advertise "h2" in the TLS ALPN list. Gated behind the
-/// experimental feature flag and restricted to request shapes the HTTP/2
-/// path currently handles end-to-end (buffered `.bytes` bodies, no proxy,
-/// no Upgrade). Anything else stays on the HTTP/1.1 path.
+/// Whether to advertise "h2" in the TLS ALPN list. Restricted to request
+/// shapes the HTTP/2 path currently handles end-to-end (no proxy/Upgrade,
+/// no sendfile). Either the experimental env-var or `protocol: "http2"` on
+/// the fetch options enables it.
 pub fn canOfferH2(client: *const HTTPClient) bool {
-    if (!bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get()) return false;
     if (client.http_proxy != null) return false;
     if (client.flags.is_preconnect_only) return false;
     if (client.unix_socket_path.length() > 0) return false;
     if (client.state.original_request_body == .sendfile) return false;
-    return true;
+    return client.flags.force_http2 or bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get();
+}
+
+pub fn alpnOffer(client: *const HTTPClient) BoringSSL.SSL.AlpnOffer {
+    if (!client.canOfferH2()) return .h1;
+    return if (client.flags.force_http2) .h2_only else .h1_or_h2;
 }
 
 pub fn firstCall(
@@ -243,6 +247,10 @@ pub fn firstCall(
         }
         client.flags.protocol = .http1_1;
         client.resolvePendingH2(null);
+        if (client.flags.force_http2) {
+            client.closeAndFail(error.HTTP2Unsupported, true, socket);
+            return;
+        }
     }
 
     switch (client.state.request_stage) {
@@ -550,7 +558,10 @@ pub const Flags = packed struct(u16) {
     defer_fail_until_connecting_is_complete: bool = false,
     upgrade_state: HTTPUpgradeState = .none,
     protocol: Protocol = .http1_1,
-    _padding: u2 = 0,
+    /// Set by `fetch(url, { protocol: "http2" })`: ALPN advertises only h2
+    /// and the request fails if the server selects anything else.
+    force_http2: bool = false,
+    _padding: u1 = 0,
 };
 
 // TODO: reduce the size of this struct

--- a/src/http.zig
+++ b/src/http.zig
@@ -26,7 +26,7 @@ const max_request_headers = 256;
 var shared_request_headers_buf: [max_request_headers]picohttp.Header = undefined;
 
 // this doesn't need to be stack memory because it is immediately cloned after use
-pub var shared_response_headers_buf: [256]picohttp.Header = undefined;
+var shared_response_headers_buf: [256]picohttp.Header = undefined;
 
 pub const end_of_chunked_http1_1_encoding_response_body = "0\r\n\r\n";
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -262,9 +262,6 @@ pub fn firstCall(
     }
 }
 
-/// Called by the HTTP/2 session for stream-level termination (RST_STREAM,
-/// GOAWAY, abort, decode error). The socket stays up for sibling streams, so
-/// only the request fails.
 /// Re-enter the connect path for a request that was coalesced onto an h2
 /// session but couldn't be attached (cap reached, or ALPN chose h1).
 pub fn retryAfterH2Coalesce(this: *HTTPClient) void {
@@ -287,10 +284,12 @@ pub fn retryFromH2(this: *HTTPClient) void {
     this.start(body, body_out);
 }
 
+/// Called by the HTTP/2 session for stream-level termination (RST_STREAM,
+/// GOAWAY, abort, decode error). The socket stays up for sibling streams, so
+/// only the request fails.
 pub fn failFromH2(this: *HTTPClient, err: anyerror) void {
     bun.debugAssert(this.h2 == null);
     this.unregisterAbortTracker();
-    this.flags.protocol = .http1_1;
     if (this.state.stage != .done and this.state.stage != .fail) {
         this.state.request_stage = .fail;
         this.state.response_stage = .fail;
@@ -1061,7 +1060,11 @@ pub fn doRedirect(
         tunnel.shutdown();
         tunnel.detachAndDeref();
         NewHTTPContext(is_ssl).closeSocket(socket);
-    } else if (this.isKeepAlivePossible() and !socket.isClosedOrHasError()) {
+    } else if (this.state.request_stage == .done and this.isKeepAlivePossible() and !socket.isClosedOrHasError()) {
+        // request_stage == .done: a 303 to a streaming POST can arrive before
+        // the chunked upload's terminating 0\r\n\r\n is written. Pooling that
+        // socket would let the next request's bytes land inside what the
+        // server is still parsing as the previous chunked body.
         log("Keep-Alive release in redirect", .{});
         assert(this.connected_url.hostname.len > 0);
         ctx.releaseSocket(

--- a/src/http.zig
+++ b/src/http.zig
@@ -237,10 +237,12 @@ pub fn firstCall(
             const ctx = client.getSslCtx(true);
             const session = H2.ClientSession.create(ctx, socket, client);
             NewHTTPContext(true).tagAsH2(socket, session);
+            client.resolvePendingH2(session);
             session.attach(client);
             return;
         }
         client.flags.protocol = .http1_1;
+        client.resolvePendingH2(null);
     }
 
     switch (client.state.request_stage) {
@@ -254,6 +256,12 @@ pub fn firstCall(
 /// Called by the HTTP/2 session for stream-level termination (RST_STREAM,
 /// GOAWAY, abort, decode error). The socket stays up for sibling streams, so
 /// only the request fails.
+/// Re-enter the connect path for a request that was coalesced onto an h2
+/// session but couldn't be attached (cap reached, or ALPN chose h1).
+pub fn retryAfterH2Coalesce(this: *HTTPClient) void {
+    this.start_(true);
+}
+
 pub fn failFromH2(this: *HTTPClient, err: anyerror) void {
     bun.debugAssert(this.h2 == null);
     this.unregisterAbortTracker();
@@ -263,6 +271,7 @@ pub fn failFromH2(this: *HTTPClient, err: anyerror) void {
         this.state.response_stage = .fail;
         this.state.fail = err;
         this.state.stage = .fail;
+        if (this.flags.defer_fail_until_connecting_is_complete) return;
         const callback = this.result_callback;
         const result = this.toResult();
         this.state.reset(this.allocator);
@@ -580,6 +589,10 @@ proxy_tunnel: ?*ProxyTunnel = null,
 /// Set when this request is bound to a stream on an HTTP/2 session.
 /// Owned by the session; cleared by the session when the stream completes.
 h2: ?*H2.Stream = null,
+/// Set while this request is the leader of a fresh TLS connect that other
+/// h2-capable requests have coalesced onto. Resolved (and freed) once ALPN
+/// is known or the connect fails.
+pending_h2: ?*H2.PendingConnect = null,
 signals: Signals = .{},
 async_http_id: u32 = 0,
 hostname: ?[]u8 = null,
@@ -1100,10 +1113,14 @@ fn start_(this: *HTTPClient, comptime is_ssl: bool) void {
         return;
     }
 
-    var socket = http_thread.connect(this, is_ssl) catch |err| {
+    var socket = (http_thread.connect(this, is_ssl) catch |err| {
         bun.handleErrorReturnTrace(err, @errorReturnTrace());
 
         this.fail(err);
+        return;
+    }) orelse {
+        // Coalesced onto an in-flight h2 connect; the leader will attach us
+        // (or re-dispatch) once ALPN resolves.
         return;
     };
 
@@ -1910,8 +1927,31 @@ fn completeConnectingProcess(this: *HTTPClient) void {
     }
 }
 
+/// The leader of a coalesced cold connect has learned the ALPN outcome (or
+/// failed). Dispatch every waiter: attach to `session` when there is room,
+/// otherwise re-enter `start_` so each opens its own connection.
+fn resolvePendingH2(this: *HTTPClient, session: ?*H2.ClientSession) void {
+    const pc = this.pending_h2 orelse return;
+    this.pending_h2 = null;
+    pc.unregisterFrom(this.getSslCtx(true));
+    defer pc.deinit();
+
+    for (pc.waiters.items) |waiter| {
+        if (waiter.signals.get(.aborted)) {
+            waiter.fail(error.Aborted);
+            continue;
+        }
+        if (session) |s| {
+            s.enqueue(waiter);
+            continue;
+        }
+        waiter.start_(true);
+    }
+}
+
 fn fail(this: *HTTPClient, err: anyerror) void {
     this.unregisterAbortTracker();
+    this.resolvePendingH2(null);
 
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;

--- a/src/http.zig
+++ b/src/http.zig
@@ -270,6 +270,22 @@ pub fn retryAfterH2Coalesce(this: *HTTPClient) void {
     this.start_(true);
 }
 
+/// REFUSED_STREAM or graceful GOAWAY past our id: the server promises it
+/// did not process the request, so re-dispatch from the top. Only reached
+/// for `.bytes` bodies (replayable).
+pub const max_h2_retries: u8 = 5;
+pub fn retryFromH2(this: *HTTPClient) void {
+    bun.debugAssert(this.h2 == null);
+    this.unregisterAbortTracker();
+    this.flags.protocol = .http1_1;
+    this.h2_retries += 1;
+    const body = this.state.original_request_body;
+    const body_out = this.state.body_out_str.?;
+    this.state.original_request_body = .{ .bytes = "" };
+    this.state.reset(this.allocator);
+    this.start(body, body_out);
+}
+
 pub fn failFromH2(this: *HTTPClient, err: anyerror) void {
     bun.debugAssert(this.h2 == null);
     this.unregisterAbortTracker();
@@ -575,6 +591,10 @@ allocator: std.mem.Allocator,
 verbose: HTTPVerboseLevel = .none,
 remaining_redirect_count: i8 = default_redirect_count,
 allow_retry: bool = false,
+/// Transparent re-dispatch count for REFUSED_STREAM / graceful-GOAWAY,
+/// where the server promises the request was not processed. Capped by
+/// `max_h2_retries`.
+h2_retries: u8 = 0,
 redirect_type: FetchRedirect = FetchRedirect.follow,
 redirect: []u8 = &.{},
 progress_node: ?*Progress.Node = null,

--- a/src/http.zig
+++ b/src/http.zig
@@ -8,6 +8,11 @@ pub var http_thread: HTTPThread = undefined;
 //TODO: this needs to be freed when Worker Threads are implemented
 pub var socket_async_http_abort_tracker = std.AutoArrayHashMap(u32, uws.AnySocket).init(bun.default_allocator);
 pub var async_http_id_monotonic: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
+
+/// Set once at startup from `--experimental-http2-fetch` (before the HTTP
+/// thread spawns) and then only read on that thread, so no atomics needed.
+pub var experimental_http2_client_from_cli: bool = false;
+
 const MAX_REDIRECT_URL_LENGTH = 128 * 1024;
 
 pub var max_http_header_size: usize = 16 * 1024;
@@ -204,15 +209,18 @@ pub fn onOpen(
 
 /// Whether to advertise "h2" in the TLS ALPN list. Restricted to request
 /// shapes the HTTP/2 path currently handles end-to-end (no proxy/Upgrade,
-/// no sendfile). Either the experimental env-var or `protocol: "http2"` on
-/// the fetch options enables it.
+/// no sendfile). Enabled by `--experimental-http2-fetch`, the
+/// `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` env var, or
+/// `protocol: "http2"` on the fetch options.
 pub fn canOfferH2(client: *const HTTPClient) bool {
     if (client.flags.force_http1) return false;
     if (client.http_proxy != null) return false;
     if (client.flags.is_preconnect_only) return false;
     if (client.unix_socket_path.length() > 0) return false;
     if (client.state.original_request_body == .sendfile) return false;
-    return client.flags.force_http2 or bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get();
+    return client.flags.force_http2 or
+        experimental_http2_client_from_cli or
+        bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get();
 }
 
 pub fn alpnOffer(client: *const HTTPClient) BoringSSL.SSL.AlpnOffer {

--- a/src/http.zig
+++ b/src/http.zig
@@ -233,14 +233,14 @@ pub fn firstCall(
         var proto_len: c_uint = 0;
         BoringSSL.SSL_get0_alpn_selected(ssl_ptr, &proto, &proto_len);
         if (proto != null and proto_len == 2 and proto[0] == 'h' and proto[1] == '2') {
-            client.flags.protocol = .http2;
-        } else {
-            client.flags.protocol = .http1_1;
+            log("ALPN negotiated h2 {s}", .{client.url.href});
+            const ctx = client.getSslCtx(true);
+            const session = H2.ClientSession.create(ctx, socket, client);
+            NewHTTPContext(true).tagAsH2(socket, session);
+            session.attach(client);
+            return;
         }
-    }
-
-    if (client.flags.protocol == .http2) {
-        return client.startH2(is_ssl, socket);
+        client.flags.protocol = .http1_1;
     }
 
     switch (client.state.request_stage) {
@@ -251,52 +251,23 @@ pub fn firstCall(
     }
 }
 
-fn startH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-    log("ALPN negotiated h2 {s}", .{client.url.href});
-    client.adoptH2(is_ssl, socket, H2.ClientSession.create());
-}
-
-/// Attach a (fresh or pooled) HTTP/2 session to this request, allocate a new
-/// stream id on it, and queue the request frames.
-pub fn adoptH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket, session: *H2.ClientSession) void {
-    client.flags.protocol = .http2;
-    client.h2 = session;
-    session.beginStream();
-
-    if (client.signals.get(.aborted)) {
-        client.closeAndAbort(is_ssl, socket);
-        return;
+/// Called by the HTTP/2 session for stream-level termination (RST_STREAM,
+/// GOAWAY, abort, decode error). The socket stays up for sibling streams, so
+/// only the request fails.
+pub fn failFromH2(this: *HTTPClient, err: anyerror) void {
+    bun.debugAssert(this.h2 == null);
+    this.unregisterAbortTracker();
+    this.flags.protocol = .http1_1;
+    if (this.state.stage != .done and this.state.stage != .fail) {
+        this.state.request_stage = .fail;
+        this.state.response_stage = .fail;
+        this.state.fail = err;
+        this.state.stage = .fail;
+        const callback = this.result_callback;
+        const result = this.toResult();
+        this.state.reset(this.allocator);
+        callback.run(@fieldParentPtr("client", this), result);
     }
-
-    client.setTimeout(socket, 5);
-    const request = client.buildRequest(client.state.original_request_body.len());
-    session.writeRequest(client, request) catch |err| {
-        client.closeAndFail(err, is_ssl, socket);
-        return;
-    };
-    if (client.verbose != .none) {
-        printRequest(request, client.url.href, !client.flags.reject_unauthorized, client.state.request_body, client.verbose == .curl);
-    }
-    client.state.request_stage = .done;
-    client.state.response_stage = .headers;
-
-    _ = session.flush(is_ssl, socket) catch |err| {
-        client.closeAndFail(err, is_ssl, socket);
-    };
-}
-
-/// A reused h2 session refused this stream (GOAWAY/RST before headers).
-/// Tear down the connection and replay the request from scratch.
-pub fn retryH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-    client.allow_retry = false;
-    if (client.h2) |session| {
-        client.h2 = null;
-        session.deinit();
-    }
-    client.flags.protocol = .http1_1;
-    NewHTTPContext(is_ssl).terminateSocket(socket);
-    client.state.response_message_buffer.deinit();
-    client.start(client.state.original_request_body, client.state.body_out_str.?);
 }
 pub fn onClose(
     client: *HTTPClient,
@@ -309,23 +280,6 @@ pub fn onClose(
 
     if (client.signals.get(.aborted)) {
         client.fail(error.Aborted);
-        return;
-    }
-    if (client.flags.protocol == .http2) {
-        if (client.h2) |session| {
-            client.h2 = null;
-            session.deinit();
-        }
-        client.flags.protocol = .http1_1;
-        if (client.state.stage != .done and client.state.stage != .fail) {
-            if (client.allow_retry) {
-                client.allow_retry = false;
-                client.state.response_message_buffer.deinit();
-                client.start(client.state.original_request_body, client.state.body_out_str.?);
-                return;
-            }
-            client.fail(error.ConnectionClosed);
-        }
         return;
     }
     if (client.proxy_tunnel) |tunnel| {
@@ -623,8 +577,9 @@ http_proxy: ?URL = null,
 proxy_headers: ?Headers = null,
 proxy_authorization: ?[]u8 = null,
 proxy_tunnel: ?*ProxyTunnel = null,
-/// Allocated on ALPN selecting "h2"; null on the HTTP/1.1 path.
-h2: ?*H2.ClientSession = null,
+/// Set when this request is bound to a stream on an HTTP/2 session.
+/// Owned by the session; cleared by the session when the stream completes.
+h2: ?*H2.Stream = null,
 signals: Signals = .{},
 async_http_id: u32 = 0,
 hostname: ?[]u8 = null,
@@ -647,9 +602,10 @@ pub fn deinit(this: *HTTPClient) void {
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
     }
-    if (this.h2) |session| {
-        this.h2 = null;
-        session.deinit();
+    if (this.h2) |stream| {
+        // Normally cleared by the session before the terminal callback;
+        // reaching here means the client is being torn down mid-flight.
+        stream.session.detachWithFailure(stream, error.Aborted);
     }
     // Release our strong ref on the interned SSLConfig
     if (this.tls_props) |*tls| tls.deinit();
@@ -1049,7 +1005,10 @@ pub fn doRedirect(
     // store it under the WRONG target hostname — a follow-up request to the
     // redirect destination could then reuse a TLS session negotiated with the
     // original host. Close the tunnel on redirect; only pool the raw socket.
-    if (this.proxy_tunnel) |tunnel| {
+    if (this.flags.protocol == .http2) {
+        // The session owns the socket; the stream was detached by the caller
+        // and the session will pool or close once its other streams drain.
+    } else if (this.proxy_tunnel) |tunnel| {
         log("close the tunnel in redirect", .{});
         this.proxy_tunnel = null;
         tunnel.shutdown();
@@ -1088,10 +1047,6 @@ pub fn doRedirect(
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
-    }
-    if (this.h2) |session| {
-        this.h2 = null;
-        session.deinit();
     }
     this.flags.protocol = .http1_1;
 
@@ -1187,7 +1142,7 @@ pub const HTTPResponseMetadata = struct {
     }
 };
 
-fn printRequest(request: picohttp.Request, url: string, ignore_insecure: bool, body: []const u8, curl: bool) void {
+pub fn printRequest(request: picohttp.Request, url: string, ignore_insecure: bool, body: []const u8, curl: bool) void {
     @branchHint(.cold);
     var request_ = request;
     request_.path = url;
@@ -1469,16 +1424,6 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
             this.onPreconnect(is_ssl, socket);
             return;
         }
-    }
-
-    if (this.flags.protocol == .http2) {
-        if (this.h2) |session| {
-            this.setTimeout(socket, 5);
-            _ = session.flush(is_ssl, socket) catch |err| {
-                this.closeAndFail(err, is_ssl, socket);
-            };
-        }
-        return;
     }
 
     if (this.proxy_tunnel) |proxy| {
@@ -1901,14 +1846,6 @@ pub fn onData(
         return;
     }
 
-    if (this.flags.protocol == .http2) {
-        if (this.h2) |session| {
-            this.setTimeout(socket, 5);
-            session.onData(this, is_ssl, incoming_data, ctx, socket);
-        }
-        return;
-    }
-
     if (this.proxy_tunnel) |proxy| {
         // if we have a tunnel we dont care about the other stages, we will just tunnel the data
         this.setTimeout(socket, 5);
@@ -1978,10 +1915,6 @@ fn completeConnectingProcess(this: *HTTPClient) void {
 fn fail(this: *HTTPClient, err: anyerror) void {
     this.unregisterAbortTracker();
 
-    if (this.h2) |session| {
-        this.h2 = null;
-        session.deinit();
-    }
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;
         tunnel.shutdown();
@@ -2109,15 +2042,15 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
         else
             true;
 
-        const h2_poolable = if (this.h2) |s| s.canPool() else true;
-
-        if (this.isKeepAlivePossible() and !socket.isClosedOrHasError() and tunnel_poolable and h2_poolable) {
+        if (this.flags.protocol == .http2) {
+            // The HTTP/2 session owns the socket; it decides whether to pool
+            // or close once all of its streams have drained.
+            this.unregisterAbortTracker();
+        } else if (this.isKeepAlivePossible() and !socket.isClosedOrHasError() and tunnel_poolable) {
             log("release socket", .{});
             const tunnel = this.proxy_tunnel;
             this.proxy_tunnel = null;
             if (tunnel) |t| t.detachOwner(this);
-            const h2_session = this.h2;
-            this.h2 = null;
             // target_hostname = url.hostname (the CONNECT TCP target at
             // writeProxyConnect line 346). The SNI override (hostname) is
             // hashed into proxyAuthHash separately — both must match, but
@@ -2132,7 +2065,7 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
                 if (tunnel != null) this.url.hostname else "",
                 if (tunnel != null) this.url.getPortAuto() else 0,
                 if (tunnel != null) this.proxyAuthHash() else 0,
-                h2_session,
+                null,
             );
         } else {
             if (this.proxy_tunnel) |tunnel| {
@@ -2140,10 +2073,6 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
                 this.proxy_tunnel = null;
                 tunnel.shutdown();
                 tunnel.detachAndDeref();
-            }
-            if (this.h2) |session| {
-                this.h2 = null;
-                session.deinit();
             }
             NewHTTPContext(is_ssl).closeSocket(socket);
         }

--- a/src/http.zig
+++ b/src/http.zig
@@ -1020,10 +1020,12 @@ pub fn doRedirect(
 ) void {
     log("doRedirect", .{});
     if (this.state.original_request_body == .stream) {
-        // we cannot follow redirect from a stream right now
-        // NOTE: we can use .tee(), reset the readable stream and cancel/wait pending write requests before redirecting. node.js just errors here so we just closeAndFail too.
-        this.closeAndFail(error.UnexpectedRedirect, is_ssl, socket);
-        return;
+        // handleResponseMetadata already rejected every non-303 status with a
+        // stream body (RequestBodyNotReusable). Reaching here means the
+        // redirect downgraded to GET with a null body; drop the streaming
+        // flag so the follow-up request goes out without Transfer-Encoding,
+        // and let state.reset() release the ThreadSafeStreamBuffer ref.
+        this.flags.is_streaming_request_body = false;
     }
 
     this.unix_socket_path.deinit();
@@ -1976,6 +1978,13 @@ fn resolvePendingH2(this: *HTTPClient, session: ?*H2.ClientSession) void {
             s.enqueue(waiter);
             continue;
         }
+        // ALPN selected http/1.1 on the leader's handshake; a force_http2
+        // waiter would just open a fresh TLS connection and fail the same
+        // way, so fail it here instead of burning another handshake.
+        if (waiter.flags.force_http2) {
+            waiter.fail(error.HTTP2Unsupported);
+            continue;
+        }
         waiter.start_(true);
     }
 }
@@ -2710,6 +2719,15 @@ pub fn handleResponseMetadata(
         if (this.redirect_type == FetchRedirect.follow and location.len > 0 and this.remaining_redirect_count > 0) {
             switch (status_code) {
                 302, 301, 307, 308, 303 => {
+                    // https://fetch.spec.whatwg.org/#http-redirect-fetch step 11:
+                    // "If internalResponse's status is not 303, request's body
+                    // is non-null, and request's body's source is null, then
+                    // return a network error." A ReadableStream body has no
+                    // source to replay from, so only 303 (which drops the body
+                    // and switches to GET) may be followed.
+                    if (status_code != 303 and this.state.original_request_body == .stream) {
+                        return error.RequestBodyNotReusable;
+                    }
                     var is_same_origin = true;
 
                     {

--- a/src/http.zig
+++ b/src/http.zig
@@ -242,12 +242,12 @@ pub fn firstCall(
             const ctx = client.getSslCtx(true);
             const session = H2.ClientSession.create(ctx, socket, client);
             NewHTTPContext(true).tagAsH2(socket, session);
-            client.resolvePendingH2(session);
+            client.resolvePendingH2(.{ .h2 = session });
             session.attach(client);
             return;
         }
         client.flags.protocol = .http1_1;
-        client.resolvePendingH2(null);
+        client.resolvePendingH2(.h1);
         if (client.flags.force_http2) {
             client.closeAndFail(error.HTTP2Unsupported, true, socket);
             return;
@@ -1973,10 +1973,21 @@ fn completeConnectingProcess(this: *HTTPClient) void {
     }
 }
 
+const PendingH2Resolution = union(enum) {
+    /// ALPN selected h2; waiters attach onto this session.
+    h2: *H2.ClientSession,
+    /// Handshake completed and ALPN selected http/1.1. Waiters can be pinned
+    /// to h1 (and force_http2 waiters failed) since the server has spoken.
+    h1,
+    /// Leader's connect/handshake failed or was aborted before ALPN. Nothing
+    /// has been learned about the server's protocol support, so waiters must
+    /// retry without protocol pinning.
+    leader_failed,
+};
+
 /// The leader of a coalesced cold connect has learned the ALPN outcome (or
-/// failed). Dispatch every waiter: attach to `session` when there is room,
-/// otherwise re-enter `start_` so each opens its own connection.
-fn resolvePendingH2(this: *HTTPClient, session: ?*H2.ClientSession) void {
+/// failed). Dispatch every waiter accordingly.
+fn resolvePendingH2(this: *HTTPClient, resolution: PendingH2Resolution) void {
     const pc = this.pending_h2 orelse return;
     this.pending_h2 = null;
     pc.unregisterFrom(this.getSslCtx(true));
@@ -1987,29 +1998,34 @@ fn resolvePendingH2(this: *HTTPClient, session: ?*H2.ClientSession) void {
             waiter.fail(error.Aborted);
             continue;
         }
-        if (session) |s| {
-            s.enqueue(waiter);
-            continue;
+        switch (resolution) {
+            .h2 => |s| s.enqueue(waiter),
+            .h1 => {
+                // ALPN selected http/1.1 on the leader's handshake; a
+                // force_http2 waiter would just open a fresh TLS connection
+                // and fail the same way, so fail it here instead of burning
+                // another handshake.
+                if (waiter.flags.force_http2) {
+                    waiter.fail(error.HTTP2Unsupported);
+                    continue;
+                }
+                // Pin to h1 so this `start_` doesn't register a fresh
+                // PendingConnect that the rest of this loop would re-coalesce
+                // onto (which would serialise N cold fetches into N
+                // sequential handshakes). The origin already chose h1 once.
+                waiter.flags.force_http1 = true;
+                waiter.start_(true);
+            },
+            // The first waiter becomes the new leader; the rest re-coalesce
+            // onto it via the normal PendingConnect path.
+            .leader_failed => waiter.start_(true),
         }
-        // ALPN selected http/1.1 on the leader's handshake; a force_http2
-        // waiter would just open a fresh TLS connection and fail the same
-        // way, so fail it here instead of burning another handshake.
-        if (waiter.flags.force_http2) {
-            waiter.fail(error.HTTP2Unsupported);
-            continue;
-        }
-        // Pin this waiter to h1 so its `start_` doesn't register a fresh
-        // PendingConnect that the rest of this loop would re-coalesce onto
-        // (which would serialise N cold fetches into N sequential
-        // handshakes). The origin already chose h1 once.
-        waiter.flags.force_http1 = true;
-        waiter.start_(true);
     }
 }
 
 fn fail(this: *HTTPClient, err: anyerror) void {
     this.unregisterAbortTracker();
-    this.resolvePendingH2(null);
+    this.resolvePendingH2(.leader_failed);
 
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;

--- a/src/http.zig
+++ b/src/http.zig
@@ -26,7 +26,7 @@ const max_request_headers = 256;
 var shared_request_headers_buf: [max_request_headers]picohttp.Header = undefined;
 
 // this doesn't need to be stack memory because it is immediately cloned after use
-var shared_response_headers_buf: [256]picohttp.Header = undefined;
+pub var shared_response_headers_buf: [256]picohttp.Header = undefined;
 
 pub const end_of_chunked_http1_1_encoding_response_body = "0\r\n\r\n";
 
@@ -195,11 +195,24 @@ pub fn onOpen(
 
             defer if (hostname_needs_free) bun.default_allocator.free(hostname);
 
-            ssl_ptr.configureHTTPClient(hostname);
+            ssl_ptr.configureHTTPClientWithALPN(hostname, client.canOfferH2());
         }
     } else {
         client.firstCall(is_ssl, socket);
     }
+}
+
+/// Whether to advertise "h2" in the TLS ALPN list. Gated behind the
+/// experimental feature flag and restricted to request shapes the HTTP/2
+/// path currently handles end-to-end (buffered `.bytes` bodies, no proxy,
+/// no Upgrade). Anything else stays on the HTTP/1.1 path.
+fn canOfferH2(client: *const HTTPClient) bool {
+    if (!bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get()) return false;
+    if (client.http_proxy != null) return false;
+    if (client.flags.is_preconnect_only) return false;
+    if (client.unix_socket_path.length() > 0) return false;
+    if (client.state.original_request_body != .bytes) return false;
+    return true;
 }
 
 pub fn firstCall(
@@ -214,12 +227,58 @@ pub fn firstCall(
         }
     }
 
+    if (comptime is_ssl) {
+        const ssl_ptr: *BoringSSL.SSL = @ptrCast(socket.getNativeHandle());
+        var proto: [*c]const u8 = null;
+        var proto_len: c_uint = 0;
+        BoringSSL.SSL_get0_alpn_selected(ssl_ptr, &proto, &proto_len);
+        if (proto != null and proto_len == 2 and proto[0] == 'h' and proto[1] == '2') {
+            client.flags.protocol = .http2;
+        } else {
+            client.flags.protocol = .http1_1;
+        }
+    }
+
+    if (client.flags.protocol == .http2) {
+        return client.startH2(is_ssl, socket);
+    }
+
     switch (client.state.request_stage) {
         .opened, .pending => {
             client.onWritable(true, comptime is_ssl, socket);
         },
         else => {},
     }
+}
+
+fn startH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
+    log("ALPN negotiated h2 {s}", .{client.url.href});
+    // The HTTP/2 path doesn't yet share connections through the keep-alive
+    // pool because the pool stores bare sockets without HPACK state. Disable
+    // pooling so the socket is closed when this request finishes.
+    client.flags.disable_keepalive = true;
+    // Don't fall back to HTTP/1.1 retry; the server already accepted h2.
+    client.allow_retry = false;
+
+    if (client.h2 == null) client.h2 = H2.ClientSession.create();
+    const session = client.h2.?;
+
+    client.setTimeout(socket, 5);
+    const request = client.buildRequest(client.state.original_request_body.len());
+    session.writeRequest(client, request) catch |err| {
+        client.closeAndFail(err, is_ssl, socket);
+        return;
+    };
+    if (client.verbose != .none) {
+        printRequest(request, client.url.href, !client.flags.reject_unauthorized, client.state.request_body, client.verbose == .curl);
+    }
+    client.state.request_stage = .done;
+    client.state.response_stage = .headers;
+
+    _ = session.flush(is_ssl, socket) catch |err| {
+        client.closeAndFail(err, is_ssl, socket);
+        return;
+    };
 }
 pub fn onClose(
     client: *HTTPClient,
@@ -232,6 +291,16 @@ pub fn onClose(
 
     if (client.signals.get(.aborted)) {
         client.fail(error.Aborted);
+        return;
+    }
+    if (client.flags.protocol == .http2) {
+        if (client.h2) |session| {
+            client.h2 = null;
+            session.deinit();
+        }
+        if (client.state.stage != .done and client.state.stage != .fail) {
+            client.fail(error.ConnectionClosed);
+        }
         return;
     }
     if (client.proxy_tunnel) |tunnel| {
@@ -473,6 +542,12 @@ const HTTPUpgradeState = enum(u2) {
     pending = 1,
     upgraded = 2,
 };
+
+pub const Protocol = enum(u1) {
+    http1_1 = 0,
+    http2 = 1,
+};
+
 pub const Flags = packed struct(u16) {
     disable_timeout: bool = false,
     disable_keepalive: bool = false,
@@ -486,7 +561,8 @@ pub const Flags = packed struct(u16) {
     is_streaming_request_body: bool = false,
     defer_fail_until_connecting_is_complete: bool = false,
     upgrade_state: HTTPUpgradeState = .none,
-    _padding: u3 = 0,
+    protocol: Protocol = .http1_1,
+    _padding: u2 = 0,
 };
 
 // TODO: reduce the size of this struct
@@ -522,6 +598,8 @@ http_proxy: ?URL = null,
 proxy_headers: ?Headers = null,
 proxy_authorization: ?[]u8 = null,
 proxy_tunnel: ?*ProxyTunnel = null,
+/// Allocated on ALPN selecting "h2"; null on the HTTP/1.1 path.
+h2: ?*H2.ClientSession = null,
 signals: Signals = .{},
 async_http_id: u32 = 0,
 hostname: ?[]u8 = null,
@@ -543,6 +621,10 @@ pub fn deinit(this: *HTTPClient) void {
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
+    }
+    if (this.h2) |session| {
+        this.h2 = null;
+        session.deinit();
     }
     // Release our strong ref on the interned SSLConfig
     if (this.tls_props) |*tls| tls.deinit();
@@ -981,6 +1063,11 @@ pub fn doRedirect(
         this.proxy_tunnel = null;
         tunnel.detachAndDeref();
     }
+    if (this.h2) |session| {
+        this.h2 = null;
+        session.deinit();
+    }
+    this.flags.protocol = .http1_1;
 
     return this.start(.{ .bytes = request_body }, body_out_str);
 }
@@ -1355,6 +1442,16 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
             this.onPreconnect(is_ssl, socket);
             return;
         }
+    }
+
+    if (this.flags.protocol == .http2) {
+        if (this.h2) |session| {
+            this.setTimeout(socket, 5);
+            _ = session.flush(is_ssl, socket) catch |err| {
+                this.closeAndFail(err, is_ssl, socket);
+            };
+        }
+        return;
     }
 
     if (this.proxy_tunnel) |proxy| {
@@ -1777,6 +1874,14 @@ pub fn onData(
         return;
     }
 
+    if (this.flags.protocol == .http2) {
+        if (this.h2) |session| {
+            this.setTimeout(socket, 5);
+            session.onData(this, is_ssl, incoming_data, ctx, socket);
+        }
+        return;
+    }
+
     if (this.proxy_tunnel) |proxy| {
         // if we have a tunnel we dont care about the other stages, we will just tunnel the data
         this.setTimeout(socket, 5);
@@ -1846,6 +1951,10 @@ fn completeConnectingProcess(this: *HTTPClient) void {
 fn fail(this: *HTTPClient, err: anyerror) void {
     this.unregisterAbortTracker();
 
+    if (this.h2) |session| {
+        this.h2 = null;
+        session.deinit();
+    }
     if (this.proxy_tunnel) |tunnel| {
         this.proxy_tunnel = null;
         tunnel.shutdown();
@@ -1870,7 +1979,7 @@ fn fail(this: *HTTPClient, err: anyerror) void {
 }
 
 // We have to clone metadata immediately after use
-fn cloneMetadata(this: *HTTPClient) void {
+pub fn cloneMetadata(this: *HTTPClient) void {
     assert(this.state.pending_response != null);
     if (this.state.pending_response) |response| {
         if (this.state.cloned_metadata != null) {
@@ -1999,6 +2108,10 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
                 this.proxy_tunnel = null;
                 tunnel.shutdown();
                 tunnel.detachAndDeref();
+            }
+            if (this.h2) |session| {
+                this.h2 = null;
+                session.deinit();
             }
             NewHTTPContext(is_ssl).closeSocket(socket);
         }
@@ -2411,7 +2524,7 @@ fn handleResponseBodyChunkedEncodingFromSinglePacket(
     unreachable;
 }
 
-const ShouldContinue = enum {
+pub const ShouldContinue = enum {
     continue_streaming,
     finished,
 };
@@ -2834,6 +2947,8 @@ pub const InitError = @import("./http/InitError.zig").InitError;
 pub const HTTPRequestBody = @import("./http/HTTPRequestBody.zig").HTTPRequestBody;
 pub const SendFile = @import("./http/SendFile.zig");
 pub const HeaderValueIterator = @import("./http/HeaderValueIterator.zig");
+pub const H2 = @import("./http/H2Client.zig");
+pub const H2Wire = @import("./http/H2FrameParser.zig");
 
 const string = []const u8;
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -206,7 +206,7 @@ pub fn onOpen(
 /// experimental feature flag and restricted to request shapes the HTTP/2
 /// path currently handles end-to-end (buffered `.bytes` bodies, no proxy,
 /// no Upgrade). Anything else stays on the HTTP/1.1 path.
-fn canOfferH2(client: *const HTTPClient) bool {
+pub fn canOfferH2(client: *const HTTPClient) bool {
     if (!bun.feature_flag.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT.get()) return false;
     if (client.http_proxy != null) return false;
     if (client.flags.is_preconnect_only) return false;
@@ -253,15 +253,20 @@ pub fn firstCall(
 
 fn startH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
     log("ALPN negotiated h2 {s}", .{client.url.href});
-    // The HTTP/2 path doesn't yet share connections through the keep-alive
-    // pool because the pool stores bare sockets without HPACK state. Disable
-    // pooling so the socket is closed when this request finishes.
-    client.flags.disable_keepalive = true;
-    // Don't fall back to HTTP/1.1 retry; the server already accepted h2.
-    client.allow_retry = false;
+    client.adoptH2(is_ssl, socket, H2.ClientSession.create());
+}
 
-    if (client.h2 == null) client.h2 = H2.ClientSession.create();
-    const session = client.h2.?;
+/// Attach a (fresh or pooled) HTTP/2 session to this request, allocate a new
+/// stream id on it, and queue the request frames.
+pub fn adoptH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket, session: *H2.ClientSession) void {
+    client.flags.protocol = .http2;
+    client.h2 = session;
+    session.beginStream();
+
+    if (client.signals.get(.aborted)) {
+        client.closeAndAbort(is_ssl, socket);
+        return;
+    }
 
     client.setTimeout(socket, 5);
     const request = client.buildRequest(client.state.original_request_body.len());
@@ -277,8 +282,21 @@ fn startH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is
 
     _ = session.flush(is_ssl, socket) catch |err| {
         client.closeAndFail(err, is_ssl, socket);
-        return;
     };
+}
+
+/// A reused h2 session refused this stream (GOAWAY/RST before headers).
+/// Tear down the connection and replay the request from scratch.
+pub fn retryH2(client: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
+    client.allow_retry = false;
+    if (client.h2) |session| {
+        client.h2 = null;
+        session.deinit();
+    }
+    client.flags.protocol = .http1_1;
+    NewHTTPContext(is_ssl).terminateSocket(socket);
+    client.state.response_message_buffer.deinit();
+    client.start(client.state.original_request_body, client.state.body_out_str.?);
 }
 pub fn onClose(
     client: *HTTPClient,
@@ -298,7 +316,14 @@ pub fn onClose(
             client.h2 = null;
             session.deinit();
         }
+        client.flags.protocol = .http1_1;
         if (client.state.stage != .done and client.state.stage != .fail) {
+            if (client.allow_retry) {
+                client.allow_retry = false;
+                client.state.response_message_buffer.deinit();
+                client.start(client.state.original_request_body, client.state.body_out_str.?);
+                return;
+            }
             client.fail(error.ConnectionClosed);
         }
         return;
@@ -1043,6 +1068,7 @@ pub fn doRedirect(
             "",
             0,
             0,
+            null,
         );
     } else {
         NewHTTPContext(is_ssl).closeSocket(socket);
@@ -1195,6 +1221,7 @@ pub fn onPreconnect(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPCon
         "",
         0,
         0,
+        null,
     );
 
     this.state.reset(this.allocator);
@@ -2082,11 +2109,15 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
         else
             true;
 
-        if (this.isKeepAlivePossible() and !socket.isClosedOrHasError() and tunnel_poolable) {
+        const h2_poolable = if (this.h2) |s| s.canPool() else true;
+
+        if (this.isKeepAlivePossible() and !socket.isClosedOrHasError() and tunnel_poolable and h2_poolable) {
             log("release socket", .{});
             const tunnel = this.proxy_tunnel;
             this.proxy_tunnel = null;
             if (tunnel) |t| t.detachOwner(this);
+            const h2_session = this.h2;
+            this.h2 = null;
             // target_hostname = url.hostname (the CONNECT TCP target at
             // writeProxyConnect line 346). The SNI override (hostname) is
             // hashed into proxyAuthHash separately — both must match, but
@@ -2101,6 +2132,7 @@ fn sendProgressUpdateWithoutStageCheck(this: *HTTPClient, comptime is_ssl: bool,
                 if (tunnel != null) this.url.hostname else "",
                 if (tunnel != null) this.url.getPortAuto() else 0,
                 if (tunnel != null) this.proxyAuthHash() else 0,
+                h2_session,
             );
         } else {
             if (this.proxy_tunnel) |tunnel| {

--- a/src/http.zig
+++ b/src/http.zig
@@ -1146,6 +1146,16 @@ fn start_(this: *HTTPClient, comptime is_ssl: bool) void {
         return;
     }
 
+    // protocol: "http2" is documented as HTTPS-only (h2c is out of scope).
+    // Every consumer of force_http2 is gated on `comptime is_ssl`, so without
+    // this an http:// request would silently fall through to HTTP/1.1.
+    if (comptime !is_ssl) {
+        if (this.flags.force_http2) {
+            this.fail(error.HTTP2Unsupported);
+            return;
+        }
+    }
+
     var socket = (http_thread.connect(this, is_ssl) catch |err| {
         bun.handleErrorReturnTrace(err, @errorReturnTrace());
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -12,6 +12,12 @@
 /// once half has been consumed.
 pub const local_initial_window_size: u31 = 1 << 24;
 
+/// Live-object counters for the leak test in fetch-http2-leak.test.ts.
+/// Incremented at allocation, decremented in deinit. Read from the JS thread
+/// via TestingAPIs.liveCounts so they must be atomic.
+pub var live_sessions = std.atomic.Value(i32).init(0);
+pub var live_streams = std.atomic.Value(i32).init(0);
+
 pub const Stream = struct {
     pub const new = bun.TrivialNew(@This());
 
@@ -54,6 +60,7 @@ pub const Stream = struct {
     pending_body: []const u8 = "",
 
     pub fn deinit(this: *Stream) void {
+        _ = live_streams.fetchSub(1, .monotonic);
         this.header_block.deinit(bun.default_allocator);
         this.body_buffer.deinit(bun.default_allocator);
         this.decoded_bytes.deinit(bun.default_allocator);
@@ -155,11 +162,13 @@ pub const ClientSession = struct {
             .ssl_config = if (client.tls_props) |p| p.clone() else null,
             .did_have_handshaking_error = client.flags.did_have_handshaking_error,
         });
+        _ = live_sessions.fetchAdd(1, .monotonic);
         ctx.registerH2(this);
         return this;
     }
 
     fn deinit(this: *ClientSession) void {
+        _ = live_sessions.fetchSub(1, .monotonic);
         bun.debugAssert(this.registry_index == std.math.maxInt(u32));
         this.hpack.deinit();
         this.write_buffer.deinit();
@@ -296,6 +305,7 @@ pub const ClientSession = struct {
             .client = client,
             .send_window = @intCast(@min(this.remote_initial_window_size, @as(u32, wire.MAX_WINDOW_SIZE))),
         });
+        _ = live_streams.fetchAdd(1, .monotonic);
         this.next_stream_id +|= 2;
         bun.handleOom(this.streams.put(bun.default_allocator, stream.id, stream));
         client.h2 = stream;
@@ -1205,6 +1215,15 @@ pub const PendingConnect = struct {
     }
 };
 
+pub const TestingAPIs = struct {
+    pub fn liveCounts(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        const obj = jsc.JSValue.createEmptyObject(globalThis, 2);
+        obj.put(globalThis, jsc.ZigString.static("sessions"), .jsNumber(live_sessions.load(.monotonic)));
+        obj.put(globalThis, jsc.ZigString.static("streams"), .jsNumber(live_streams.load(.monotonic)));
+        return obj;
+    }
+};
+
 const log = bun.Output.scoped(.h2_client, .hidden);
 
 const lshpack = @import("../bun.js/api/bun/lshpack.zig");
@@ -1212,6 +1231,7 @@ const std = @import("std");
 const wire = @import("./H2FrameParser.zig");
 
 const bun = @import("bun");
+const jsc = bun.jsc;
 const picohttp = bun.picohttp;
 const strings = bun.strings;
 const SSLConfig = bun.api.server.ServerConfig.SSLConfig;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -49,6 +49,10 @@ pub const Stream = struct {
     awaiting_continue: bool = false,
     /// Set once the END_STREAM flag has been written on the request side.
     request_body_done: bool = false,
+    /// Set once an RST_STREAM has been written *or* received, so the
+    /// centralised cleanup in onData doesn't emit a redundant one (and never
+    /// answers an inbound RST with another, per RFC 9113 §5.4.2).
+    rst_done: bool = false,
     fatal_error: ?anyerror = null,
     /// DATA bytes consumed since the last WINDOW_UPDATE for this stream.
     unacked_bytes: u32 = 0,
@@ -69,6 +73,8 @@ pub const Stream = struct {
     }
 
     pub fn rst(this: *Stream, code: wire.ErrorCode) void {
+        if (this.rst_done) return;
+        this.rst_done = true;
         var value: u32 = @byteSwap(@intFromEnum(code));
         this.session.writeFrame(.HTTP_FRAME_RST_STREAM, 0, this.id, std.mem.asBytes(&value));
     }
@@ -541,8 +547,6 @@ pub const ClientSession = struct {
         }
     }
 
-    /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
-    /// end-of-body) are available in the ThreadSafeStreamBuffer.
     /// Re-arm the shared socket's idle timer based on the aggregate of every
     /// attached client. With multiplexed streams the per-request
     /// `disable_timeout` flag can't drive the socket directly (last writer
@@ -564,6 +568,8 @@ pub const ClientSession = struct {
         this.socket.setTimeoutMinutes(if (want) 5 else 0);
     }
 
+    /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
+    /// end-of-body) are available in the ThreadSafeStreamBuffer.
     pub fn streamBodyByHttpId(this: *ClientSession, async_http_id: u32, ended: bool) void {
         this.ref();
         defer this.deref();
@@ -687,9 +693,18 @@ pub const ClientSession = struct {
         // so `streams` isn't mutated under this iteration.
         this.delivering = true;
         var i: usize = 0;
+        var rst_any = false;
         while (i < this.streams.count()) {
             const stream = this.streams.values()[i];
             if (this.deliverStream(stream)) {
+                // Any detach that leaves the request body unfinished must tell
+                // the server, otherwise the half-open stream sits against its
+                // MAX_CONCURRENT_STREAMS budget until idle-timeout. rst() is
+                // idempotent so paths that already RST'd are no-ops here.
+                if (!stream.request_body_done) {
+                    stream.rst(.CANCEL);
+                    rst_any = true;
+                }
                 _ = this.streams.swapRemove(stream.id);
                 stream.deinit();
             } else {
@@ -697,6 +712,7 @@ pub const ClientSession = struct {
             }
         }
         this.delivering = false;
+        if (rst_any) _ = this.flush() catch {};
         this.rearmTimeout();
 
         // Retries/redirects that re-dispatched onto this session during the
@@ -1203,6 +1219,7 @@ pub const ClientSession = struct {
                     return;
                 }
                 const stream = this.streams.get(stream_id) orelse return;
+                stream.rst_done = true;
                 const code: u32 = wire.u32FromBytes(payload[0..4]);
                 stream.fatal_error = switch (code) {
                     @intFromEnum(wire.ErrorCode.NO_ERROR) => blk: {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -87,7 +87,12 @@ pub const ClientSession = struct {
     /// Stream id whose CONTINUATION sequence is in progress; 0 = none.
     expecting_continuation: u31 = 0,
 
+    /// Cold-start coalesced requests parked until the server's first SETTINGS
+    /// frame arrives so the real MAX_CONCURRENT_STREAMS cap can be honoured.
+    pending_attach: std.ArrayListUnmanaged(*HTTPClient) = .{},
+
     preface_sent: bool = false,
+    settings_received: bool = false,
     goaway_received: bool = false,
     goaway_last_stream_id: u31 = 0,
     fatal_error: ?anyerror = null,
@@ -126,6 +131,7 @@ pub const ClientSession = struct {
         var it = this.streams.iterator();
         while (it.next()) |e| e.value_ptr.*.deinit();
         this.streams.deinit(bun.default_allocator);
+        this.pending_attach.deinit(bun.default_allocator);
         bun.default_allocator.free(this.hostname);
         if (this.ssl_config) |*s| s.deinit();
         bun.destroy(this);
@@ -140,6 +146,36 @@ pub const ClientSession = struct {
 
     pub fn matches(this: *const ClientSession, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) bool {
         return this.port == port and SSLConfig.rawPtr(this.ssl_config) == ssl_config and strings.eqlLong(this.hostname, hostname, true);
+    }
+
+    pub fn adopt(this: *ClientSession, client: *HTTPClient) void {
+        client.registerAbortTracker(true, this.socket);
+        this.attach(client);
+    }
+
+    /// Park a coalesced request until the server's SETTINGS arrive. Abort
+    /// is routed via the session socket so `abortByHttpId` can find it.
+    pub fn enqueue(this: *ClientSession, client: *HTTPClient) void {
+        client.registerAbortTracker(true, this.socket);
+        bun.handleOom(this.pending_attach.append(bun.default_allocator, client));
+    }
+
+    fn drainPending(this: *ClientSession) void {
+        if (!this.settings_received or this.pending_attach.items.len == 0) return;
+        var waiters = this.pending_attach;
+        this.pending_attach = .{};
+        defer waiters.deinit(bun.default_allocator);
+        for (waiters.items) |client| {
+            if (this.fatal_error) |err| {
+                client.failFromH2(err);
+            } else if (client.signals.get(.aborted)) {
+                client.failFromH2(error.Aborted);
+            } else if (this.hasHeadroom()) {
+                this.attach(client);
+            } else {
+                client.retryAfterH2Coalesce();
+            }
+        }
     }
 
     /// True when the connection can be parked in the keep-alive pool: no
@@ -392,6 +428,8 @@ pub const ClientSession = struct {
     /// remain. Structured "parse all → deliver all" because delivering may
     /// free the client.
     pub fn onData(this: *ClientSession, incoming: []const u8) void {
+        this.ref();
+        defer this.deref();
         bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
         this.parseFrames();
         this.replenishWindow();
@@ -402,6 +440,8 @@ pub const ClientSession = struct {
         }) {}
 
         if (this.fatal_error) |err| return this.failAll(err);
+
+        this.drainPending();
 
         // Deliver per-stream. Iterate by index because delivery may remove
         // entries (swapRemove keeps earlier indices stable; revisiting the
@@ -444,6 +484,8 @@ pub const ClientSession = struct {
         this.ref();
         defer this.deref();
         this.ctx.unregisterH2(this);
+        for (this.pending_attach.items) |client| client.failFromH2(err);
+        this.pending_attach.clearRetainingCapacity();
         var it = this.streams.iterator();
         while (it.next()) |e| {
             const stream = e.value_ptr.*;
@@ -468,6 +510,13 @@ pub const ClientSession = struct {
     /// Called from the HTTP thread's shutdown queue when a fetch on this
     /// session is aborted. RST_STREAMs that one request; siblings continue.
     pub fn abortByHttpId(this: *ClientSession, async_http_id: u32) void {
+        for (this.pending_attach.items, 0..) |client, i| {
+            if (client.async_http_id == async_http_id) {
+                _ = this.pending_attach.swapRemove(i);
+                client.failFromH2(error.Aborted);
+                return;
+            }
+        }
         var it = this.streams.iterator();
         while (it.next()) |e| {
             const stream = e.value_ptr.*;
@@ -497,7 +546,7 @@ pub const ClientSession = struct {
     }
 
     fn maybeRelease(this: *ClientSession) void {
-        if (this.streams.count() > 0) return;
+        if (this.streams.count() > 0 or this.pending_attach.items.len > 0) return;
         this.ctx.unregisterH2(this);
         if (this.canPool() and !this.socket.isClosedOrHasError()) {
             this.ctx.releaseSocket(
@@ -629,6 +678,7 @@ pub const ClientSession = struct {
                     }
                 }
                 this.writeFrame(.HTTP_FRAME_SETTINGS, @intFromEnum(wire.SettingsFlags.ACK), 0, &.{});
+                this.settings_received = true;
             },
             .HTTP_FRAME_WINDOW_UPDATE => {},
             .HTTP_FRAME_PING => {
@@ -795,6 +845,38 @@ pub const ClientSession = struct {
         }
 
         return should_continue;
+    }
+};
+
+/// Placeholder registered while a fresh TLS connect is in flight so that
+/// concurrent h2-capable requests to the same origin coalesce onto its
+/// eventual session instead of each opening a separate socket.
+pub const PendingConnect = struct {
+    pub const new = bun.TrivialNew(@This());
+
+    hostname: []const u8,
+    port: u16,
+    ssl_config: ?*SSLConfig,
+    waiters: std.ArrayListUnmanaged(*HTTPClient) = .{},
+
+    pub fn matches(this: *const PendingConnect, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) bool {
+        return this.port == port and this.ssl_config == ssl_config and strings.eqlLong(this.hostname, hostname, true);
+    }
+
+    pub fn unregisterFrom(this: *PendingConnect, ctx: *NewHTTPContext(true)) void {
+        const list = &ctx.pending_h2_connects;
+        for (list.items, 0..) |p, i| {
+            if (p == this) {
+                _ = list.swapRemove(i);
+                return;
+            }
+        }
+    }
+
+    pub fn deinit(this: *PendingConnect) void {
+        bun.default_allocator.free(this.hostname);
+        this.waiters.deinit(bun.default_allocator);
+        bun.destroy(this);
     }
 };
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -112,8 +112,23 @@ pub const ClientSession = struct {
     preface_sent: bool = false,
     settings_received: bool = false,
     goaway_received: bool = false,
+    /// Set when the HPACK encoder's dynamic table has diverged from the
+    /// server's view (writeRequest failed mid-encode). Existing siblings whose
+    /// HEADERS already went out are unaffected, but no new stream may be
+    /// opened on this connection.
+    encoder_poisoned: bool = false,
+    /// True while onData's deliver loop is running. retryFromH2/doRedirect
+    /// re-dispatch may try to adopt back onto this same session; blocking
+    /// that during delivery prevents `streams` mutation under iteration and
+    /// the failAll → onClose → double-free path.
+    delivering: bool = false,
     goaway_last_stream_id: u31 = 0,
     fatal_error: ?anyerror = null,
+    /// HEADERS/CONTINUATION fragments for a stream we no longer track (e.g.
+    /// in flight when we RST'd it). RFC 9113 §4.3 still requires the block be
+    /// fed to the HPACK decoder so the connection-level dynamic table stays
+    /// in sync.
+    orphan_header_block: std.ArrayListUnmanaged(u8) = .{},
 
     remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
     remote_max_concurrent_streams: u32 = 100,
@@ -153,6 +168,7 @@ pub const ClientSession = struct {
         while (it.next()) |e| e.value_ptr.*.deinit();
         this.streams.deinit(bun.default_allocator);
         this.pending_attach.deinit(bun.default_allocator);
+        this.orphan_header_block.deinit(bun.default_allocator);
         bun.default_allocator.free(this.hostname);
         if (this.ssl_config) |*s| s.deinit();
         bun.destroy(this);
@@ -160,6 +176,7 @@ pub const ClientSession = struct {
 
     pub fn hasHeadroom(this: *const ClientSession) bool {
         return !this.goaway_received and
+            !this.encoder_poisoned and
             this.fatal_error == null and
             this.streams.count() < this.remote_max_concurrent_streams and
             this.next_stream_id < wire.MAX_STREAM_ID;
@@ -171,6 +188,14 @@ pub const ClientSession = struct {
 
     pub fn adopt(this: *ClientSession, client: *HTTPClient) void {
         client.registerAbortTracker(true, this.socket);
+        if (this.delivering) {
+            // Re-dispatch (retryFromH2/doRedirect) reached us from inside our
+            // own onData deliver loop. Park until the loop finishes so
+            // attach() doesn't mutate `streams` under iteration or trigger
+            // failAll while a stream is mid-delivery.
+            bun.handleOom(this.pending_attach.append(bun.default_allocator, client));
+            return;
+        }
         this.attach(client);
     }
 
@@ -205,6 +230,7 @@ pub const ClientSession = struct {
     pub fn canPool(this: *const ClientSession) bool {
         return this.streams.count() == 0 and
             !this.goaway_received and
+            !this.encoder_poisoned and
             this.fatal_error == null and
             this.expecting_continuation == 0 and
             this.read_buffer.items.len == 0 and
@@ -281,7 +307,17 @@ pub const ClientSession = struct {
         client.setTimeout(this.socket, 5);
         const request = client.buildRequest(client.state.original_request_body.len());
         this.writeRequest(client, stream, request) catch |err| {
-            this.detachWithFailure(stream, err);
+            // encodeHeader pushes into the HPACK encoder's dynamic table per
+            // call, so a mid-encode failure leaves entries the server will
+            // never see. Mark the session unusable for future streams and
+            // remove without RST — from the server's view this stream id was
+            // never opened (RST on an idle stream is a connection error per
+            // RFC 9113 §5.1).
+            this.encoder_poisoned = true;
+            _ = this.streams.swapRemove(stream.id);
+            stream.deinit();
+            client.h2 = null;
+            client.failFromH2(err);
             return;
         };
         if (client.verbose != .none) {
@@ -318,6 +354,8 @@ pub const ClientSession = struct {
         defer encoded.deinit(bun.default_allocator);
 
         var lower_buf: [256]u8 = undefined;
+        var lower_heap: std.ArrayListUnmanaged(u8) = .{};
+        defer lower_heap.deinit(bun.default_allocator);
 
         try this.encodeHeader(&encoded, ":method", request.method, false);
         try this.encodeHeader(&encoded, ":scheme", "https", false);
@@ -341,7 +379,14 @@ pub const ClientSession = struct {
             const lowered = if (header.name.len <= lower_buf.len) brk: {
                 for (header.name, 0..) |c, i| lower_buf[i] = std.ascii.toLower(c);
                 break :brk lower_buf[0..header.name.len];
-            } else header.name;
+            } else brk: {
+                // Pathologically long name; lowercase via a heap scratch so
+                // mixed-case bytes never reach the wire (RFC 9113 §8.2.1).
+                lower_heap.clearRetainingCapacity();
+                bun.handleOom(lower_heap.ensureTotalCapacity(bun.default_allocator, header.name.len));
+                for (header.name) |c| lower_heap.appendAssumeCapacity(std.ascii.toLower(c));
+                break :brk lower_heap.items;
+            };
             try this.encodeHeader(&encoded, lowered, header.value, never_index);
         }
 
@@ -569,7 +614,10 @@ pub const ClientSession = struct {
 
         // Deliver per-stream. Iterate by index because delivery may remove
         // entries (swapRemove keeps earlier indices stable; revisiting the
-        // current index after a removal is intentional).
+        // current index after a removal is intentional). `delivering` blocks
+        // hasHeadroom() so retryFromH2/doRedirect re-dispatch can't adopt
+        // back onto this session while we're iterating it.
+        this.delivering = true;
         var i: usize = 0;
         while (i < this.streams.count()) {
             const stream = this.streams.values()[i];
@@ -579,6 +627,15 @@ pub const ClientSession = struct {
             } else {
                 i += 1;
             }
+        }
+        this.delivering = false;
+
+        // Retries/redirects that re-dispatched onto this session during the
+        // loop are parked in pending_attach; attach them now that iteration
+        // is finished.
+        if (this.pending_attach.items.len > 0) {
+            this.drainPending();
+            _ = this.flush() catch |err| return this.failAll(err);
         }
 
         this.maybeRelease();
@@ -771,7 +828,20 @@ pub const ClientSession = struct {
             };
             stream.body_buffer.clearRetainingCapacity();
             if (terminal) return this.finishStream(client);
-            if (report) client.progressUpdate(true, this.ctx, this.socket);
+            if (report) {
+                // handleResponseBody may report completion before END_STREAM
+                // (Content-Length satisfied). The terminal progressUpdate
+                // path frees the AsyncHTTP that owns `client`, so detach
+                // first; the trailing END_STREAM/trailers land on a stream
+                // we no longer track and are discarded.
+                if (client.state.isDone()) {
+                    stream.client = null;
+                    client.h2 = null;
+                    client.progressUpdate(true, this.ctx, this.socket);
+                    return true;
+                }
+                client.progressUpdate(true, this.ctx, this.socket);
+            }
             return false;
         }
 
@@ -814,7 +884,18 @@ pub const ClientSession = struct {
                     var unit: wire.SettingsPayloadUnit = undefined;
                     wire.SettingsPayloadUnit.from(&unit, payload[i .. i + wire.SettingsPayloadUnit.byteSize], 0, true);
                     switch (@as(wire.SettingsType, @enumFromInt(unit.type))) {
-                        .SETTINGS_MAX_FRAME_SIZE => this.remote_max_frame_size = @truncate(@min(unit.value, wire.MAX_FRAME_SIZE)),
+                        .SETTINGS_MAX_FRAME_SIZE => {
+                            // RFC 9113 §6.5.2: values outside [16384, 2^24-1]
+                            // are a connection PROTOCOL_ERROR. Without the
+                            // lower bound, a 0 here makes writeHeaderBlock /
+                            // writeDataWindowed spin forever emitting empty
+                            // frames.
+                            if (unit.value < wire.DEFAULT_MAX_FRAME_SIZE or unit.value > wire.MAX_FRAME_SIZE) {
+                                this.fatal_error = error.HTTP2ProtocolError;
+                                return;
+                            }
+                            this.remote_max_frame_size = @truncate(unit.value);
+                        },
                         .SETTINGS_MAX_CONCURRENT_STREAMS => this.remote_max_concurrent_streams = unit.value,
                         .SETTINGS_INITIAL_WINDOW_SIZE => {
                             const next = @min(unit.value, @as(u32, wire.MAX_WINDOW_SIZE));
@@ -845,9 +926,40 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_HEADERS => {
-                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
-                stream.seen_headers = true;
                 var fragment = payload;
+                const stream_id: u31 = @intCast(header.streamIdentifier);
+                const maybe_stream = this.streams.get(stream_id);
+                if (maybe_stream == null) {
+                    // Stream we no longer track (RST_STREAM crossed an
+                    // in-flight HEADERS). The block must still be HPACK-
+                    // decoded so the connection-level dynamic table stays in
+                    // sync with the server's encoder, and CONTINUATION must
+                    // be tracked so a follow-up frame doesn't fatal the whole
+                    // connection.
+                    if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
+                        fragment = stripPadding(fragment) orelse {
+                            this.fatal_error = error.HTTP2ProtocolError;
+                            return;
+                        };
+                    }
+                    if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PRIORITY) != 0) {
+                        if (fragment.len < wire.StreamPriority.byteSize) {
+                            this.fatal_error = error.HTTP2ProtocolError;
+                            return;
+                        }
+                        fragment = fragment[wire.StreamPriority.byteSize..];
+                    }
+                    this.orphan_header_block.clearRetainingCapacity();
+                    bun.handleOom(this.orphan_header_block.appendSlice(bun.default_allocator, fragment));
+                    if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
+                        this.decodeDiscardOrphan();
+                    } else {
+                        this.expecting_continuation = stream_id;
+                    }
+                    return;
+                }
+                const stream = maybe_stream.?;
+                stream.seen_headers = true;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
                         this.fatal_error = error.HTTP2ProtocolError;
@@ -876,15 +988,19 @@ pub const ClientSession = struct {
                     this.fatal_error = error.HTTP2ProtocolError;
                     return;
                 }
-                const stream = this.streams.get(this.expecting_continuation) orelse {
-                    this.fatal_error = error.HTTP2ProtocolError;
-                    return;
-                };
-                bun.handleOom(stream.header_block.appendSlice(bun.default_allocator, payload));
-                if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
-                    this.expecting_continuation = 0;
-                    stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
-                    this.decodeHeaderBlock(stream);
+                if (this.streams.get(this.expecting_continuation)) |stream| {
+                    bun.handleOom(stream.header_block.appendSlice(bun.default_allocator, payload));
+                    if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
+                        this.expecting_continuation = 0;
+                        stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
+                        this.decodeHeaderBlock(stream);
+                    }
+                } else {
+                    bun.handleOom(this.orphan_header_block.appendSlice(bun.default_allocator, payload));
+                    if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
+                        this.expecting_continuation = 0;
+                        this.decodeDiscardOrphan();
+                    }
                 }
             },
             .HTTP_FRAME_DATA => {
@@ -915,7 +1031,10 @@ pub const ClientSession = struct {
                 stream.fatal_error = switch (code) {
                     @intFromEnum(wire.ErrorCode.NO_ERROR) => blk: {
                         stream.end_stream_received = true;
-                        break :blk null;
+                        // RST(NO_ERROR) before final HEADERS still means the
+                        // server closed without responding; surface it so the
+                        // request fails instead of parking forever.
+                        break :blk if (stream.status_code == 0) error.HTTP2StreamReset else null;
                     },
                     @intFromEnum(wire.ErrorCode.REFUSED_STREAM) => error.HTTP2RefusedStream,
                     else => error.HTTP2StreamReset,
@@ -941,6 +1060,20 @@ pub const ClientSession = struct {
         }
     }
 
+    /// Feed an orphaned (untracked-stream) header block through the HPACK
+    /// decoder purely to keep the dynamic table in sync, then discard.
+    fn decodeDiscardOrphan(this: *ClientSession) void {
+        defer this.orphan_header_block.clearRetainingCapacity();
+        var offset: usize = 0;
+        while (offset < this.orphan_header_block.items.len) {
+            const result = this.hpack.decode(this.orphan_header_block.items[offset..]) catch {
+                this.fatal_error = error.HTTP2CompressionError;
+                return;
+            };
+            offset += result.next;
+        }
+    }
+
     /// HPACK-decode the buffered header block at parse time. Runs for every
     /// END_HEADERS so the dynamic table stays in sync regardless of how many
     /// HEADERS frames arrive in one read. 1xx and trailers are decoded then
@@ -956,7 +1089,12 @@ pub const ClientSession = struct {
         var offset: usize = 0;
         while (offset < stream.header_block.items.len) {
             const result = this.hpack.decode(stream.header_block.items[offset..]) catch {
-                stream.fatal_error = error.HTTP2CompressionError;
+                // The decoder has already committed earlier fields from this
+                // block to the connection-level dynamic table; the table is
+                // now out of sync with the server's encoder. RFC 9113 §4.3:
+                // a decoding error MUST be treated as a connection error of
+                // type COMPRESSION_ERROR.
+                this.fatal_error = error.HTTP2CompressionError;
                 return;
             };
             offset += result.next;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -140,6 +140,11 @@ pub const ClientSession = struct {
     remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
     remote_max_concurrent_streams: u32 = 100,
     remote_initial_window_size: u32 = wire.DEFAULT_WINDOW_SIZE,
+    /// SETTINGS_HEADER_TABLE_SIZE received from the peer that hasn't yet been
+    /// acknowledged with a Dynamic Table Size Update (RFC 7541 §6.3) at the
+    /// start of a header block. lshpack's encoder doesn't emit that opcode
+    /// itself, so writeRequest must prepend it before the first encode call.
+    pending_hpack_enc_capacity: ?u32 = null,
     /// Connection-level send window. Starts at the spec default regardless of
     /// SETTINGS; only WINDOW_UPDATE on stream 0 grows it.
     conn_send_window: i32 = wire.DEFAULT_WINDOW_SIZE,
@@ -274,6 +279,22 @@ pub const ClientSession = struct {
             strings.eqlCaseInsensitiveASCIIICheckLength(name, "upgrade");
     }
 
+    /// RFC 7541 §6.3 Dynamic Table Size Update: `001` prefix, 5-bit-prefix
+    /// integer. Must be the first opcode in a header block. Caller guarantees
+    /// at least 6 bytes of capacity (max for a u32).
+    fn encodeHpackTableSizeUpdate(encoded: *std.ArrayListUnmanaged(u8), value: u32) void {
+        if (value < 31) {
+            encoded.appendAssumeCapacity(0x20 | @as(u8, @intCast(value)));
+            return;
+        }
+        encoded.appendAssumeCapacity(0x20 | 31);
+        var rest = value - 31;
+        while (rest >= 128) : (rest >>= 7) {
+            encoded.appendAssumeCapacity(@as(u8, @truncate(rest)) | 0x80);
+        }
+        encoded.appendAssumeCapacity(@as(u8, @truncate(rest)));
+    }
+
     fn encodeHeader(this: *ClientSession, encoded: *std.ArrayListUnmanaged(u8), name: []const u8, value: []const u8, never_index: bool) !void {
         const required = encoded.items.len + name.len + value.len + 32;
         try encoded.ensureTotalCapacity(bun.default_allocator, required);
@@ -364,6 +385,13 @@ pub const ClientSession = struct {
     fn writeRequest(this: *ClientSession, client: *HTTPClient, stream: *Stream, request: picohttp.Request) !void {
         var encoded: std.ArrayListUnmanaged(u8) = .{};
         defer encoded.deinit(bun.default_allocator);
+
+        if (this.pending_hpack_enc_capacity) |cap| {
+            this.pending_hpack_enc_capacity = null;
+            this.hpack.setEncoderMaxCapacity(cap);
+            try encoded.ensureUnusedCapacity(bun.default_allocator, 8);
+            encodeHpackTableSizeUpdate(&encoded, cap);
+        }
 
         var lower_buf: [256]u8 = undefined;
         var lower_heap: std.ArrayListUnmanaged(u8) = .{};
@@ -913,6 +941,14 @@ pub const ClientSession = struct {
                             this.remote_max_frame_size = @truncate(unit.value);
                         },
                         .SETTINGS_MAX_CONCURRENT_STREAMS => this.remote_max_concurrent_streams = unit.value,
+                        .SETTINGS_HEADER_TABLE_SIZE => {
+                            // RFC 9113 §4.3.1 / RFC 7541 §4.2: encoder MUST
+                            // acknowledge a reduced limit with a Dynamic Table
+                            // Size Update at the start of the next header
+                            // block. Track the minimum seen so a reduce-then-
+                            // raise between two blocks still signals the dip.
+                            this.pending_hpack_enc_capacity = @min(this.pending_hpack_enc_capacity orelse unit.value, unit.value);
+                        },
                         .SETTINGS_INITIAL_WINDOW_SIZE => {
                             // RFC 9113 §6.5.2 / §6.9.2: values above 2^31-1, or
                             // a delta that pushes any open stream's window past
@@ -973,8 +1009,18 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_PING => {
+                // RFC 9113 §6.7: length != 8 is a connection FRAME_SIZE_ERROR;
+                // a non-zero stream identifier is a connection PROTOCOL_ERROR.
+                if (header.length != 8) {
+                    this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
+                if (header.streamIdentifier != 0) {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
                 if (header.flags & @intFromEnum(wire.PingFrameFlags.ACK) == 0) {
-                    this.writeFrame(.HTTP_FRAME_PING, @intFromEnum(wire.PingFrameFlags.ACK), 0, payload[0..@min(payload.len, 8)]);
+                    this.writeFrame(.HTTP_FRAME_PING, @intFromEnum(wire.PingFrameFlags.ACK), 0, payload[0..8]);
                 }
             },
             .HTTP_FRAME_HEADERS => {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -713,13 +713,14 @@ pub const ClientSession = struct {
             if (client.state.response_stage == .body) {
                 this.decodeAndDiscard(stream);
             } else {
-                const should_continue = this.decodeHeaders(stream, client) catch |err| {
+                const result = this.decodeHeaders(stream, client) catch |err| {
                     stream.client = null;
                     client.h2 = null;
                     client.failFromH2(err);
                     return true;
                 };
-                if (should_continue == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
+                if (result == .informational) return false;
+                if (result == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
                     stream.client = null;
                     client.h2 = null;
                     if (client.state.flags.is_redirect_pending) {
@@ -831,6 +832,10 @@ pub const ClientSession = struct {
             },
             .HTTP_FRAME_HEADERS => {
                 const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
+                // TODO: if a 1xx HEADERS and the final HEADERS (or final +
+                // trailers) arrive in the same onData pass, the first block
+                // is overwritten before decode and HPACK dynamic-table state
+                // can desync. Decode eagerly here instead of in deliverStream.
                 stream.seen_headers = true;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
@@ -938,7 +943,9 @@ pub const ClientSession = struct {
     /// HPACK-decode `stream`'s header block into `state.pending_response`
     /// (reusing the shared HTTP/1.1 header buffer) and run
     /// `handleResponseMetadata`.
-    fn decodeHeaders(this: *ClientSession, stream: *Stream, client: *HTTPClient) !HTTPClient.ShouldContinue {
+    const HeaderResult = enum { informational, has_body, finished };
+
+    fn decodeHeaders(this: *ClientSession, stream: *Stream, client: *HTTPClient) !HeaderResult {
         this.decoded_header_bytes.clearRetainingCapacity();
 
         var status_code: u32 = 0;
@@ -972,6 +979,7 @@ pub const ClientSession = struct {
         stream.header_block.clearRetainingCapacity();
 
         if (status_code == 0) return error.HTTP2ProtocolError;
+        if (status_code >= 100 and status_code < 200) return .informational;
 
         const bytes = this.decoded_header_bytes.items;
         for (bounds[0..header_count], 0..) |b, i| {
@@ -1000,7 +1008,7 @@ pub const ClientSession = struct {
             client.state.pending_response = response;
         }
 
-        return should_continue;
+        return if (should_continue == .finished) .finished else .has_body;
     }
 };
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -755,21 +755,32 @@ pub const ClientSession = struct {
                 return true;
             };
             stream.body_buffer.clearRetainingCapacity();
-            if (terminal or report) {
-                client.progressUpdate(true, this.ctx, this.socket);
-            }
-            return terminal;
+            if (terminal) return this.finishStream(client);
+            if (report) client.progressUpdate(true, this.ctx, this.socket);
+            return false;
         }
 
         if (stream.end_stream_received) {
             stream.client = null;
             client.h2 = null;
             client.state.flags.received_last_chunk = true;
-            client.progressUpdate(true, this.ctx, this.socket);
-            return true;
+            return this.finishStream(client);
         }
 
         return false;
+    }
+
+    /// Terminal delivery: enforce the announced Content-Length (RFC 9113
+    /// §8.1.1 — mismatch is malformed) and hand off to progressUpdate.
+    fn finishStream(this: *ClientSession, client: *HTTPClient) bool {
+        if (client.state.content_length) |cl| {
+            if (client.state.total_body_received != cl) {
+                client.failFromH2(error.HTTP2ContentLengthMismatch);
+                return true;
+            }
+        }
+        client.progressUpdate(true, this.ctx, this.socket);
+        return true;
     }
 
     fn dispatchFrame(this: *ClientSession, header: wire.FrameHeader, payload: []const u8) void {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -27,9 +27,17 @@ pub const Stream = struct {
     end_stream_received: bool = false,
     headers_ready: bool = false,
     headers_end_stream: bool = false,
+    /// Set once the END_STREAM flag has been written on the request side.
+    request_body_done: bool = false,
     fatal_error: ?anyerror = null,
     /// DATA bytes consumed since the last WINDOW_UPDATE for this stream.
     unacked_bytes: u32 = 0,
+    /// Per-stream send window (server's INITIAL_WINDOW_SIZE plus any
+    /// WINDOW_UPDATEs minus DATA bytes already framed).
+    send_window: i32,
+    /// Unsent suffix of a `.bytes` request body, parked while the send
+    /// window is exhausted. Borrows from `client.state.request_body`.
+    pending_body: []const u8 = "",
 
     pub fn deinit(this: *Stream) void {
         this.header_block.deinit(bun.default_allocator);
@@ -99,6 +107,10 @@ pub const ClientSession = struct {
 
     remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
     remote_max_concurrent_streams: u32 = 100,
+    remote_initial_window_size: u32 = wire.DEFAULT_WINDOW_SIZE,
+    /// Connection-level send window. Starts at the spec default regardless of
+    /// SETTINGS; only WINDOW_UPDATE on stream 0 grows it.
+    conn_send_window: i32 = wire.DEFAULT_WINDOW_SIZE,
 
     /// DATA bytes consumed since the last connection-level WINDOW_UPDATE.
     conn_unacked_bytes: u32 = 0,
@@ -243,7 +255,12 @@ pub const ClientSession = struct {
     pub fn attach(this: *ClientSession, client: *HTTPClient) void {
         bun.debugAssert(this.hasHeadroom());
 
-        const stream = Stream.new(.{ .id = this.next_stream_id, .session = this, .client = client });
+        const stream = Stream.new(.{
+            .id = this.next_stream_id,
+            .session = this,
+            .client = client,
+            .send_window = @intCast(@min(this.remote_initial_window_size, @as(u32, wire.MAX_WINDOW_SIZE))),
+        });
         this.next_stream_id +|= 2;
         bun.handleOom(this.streams.put(bun.default_allocator, stream.id, stream));
         client.h2 = stream;
@@ -261,12 +278,17 @@ pub const ClientSession = struct {
         if (client.verbose != .none) {
             HTTPClient.printRequest(request, client.url.href, !client.flags.reject_unauthorized, client.state.request_body, client.verbose == .curl);
         }
-        client.state.request_stage = .done;
+        client.state.request_stage = if (stream.request_body_done) .done else .body;
         client.state.response_stage = .headers;
 
         _ = this.flush() catch |err| {
             this.failAll(err);
+            return;
         };
+
+        if (client.flags.is_streaming_request_body) {
+            client.progressUpdate(true, this.ctx, this.socket);
+        }
     }
 
     /// Remove `stream` from the session, RST it, and fail its client. The
@@ -315,10 +337,16 @@ pub const ClientSession = struct {
         }
 
         const body = client.state.request_body;
-        const has_body = client.state.original_request_body == .bytes and body.len > 0;
+        const has_inline_body = client.state.original_request_body == .bytes and body.len > 0;
+        const is_streaming = client.state.original_request_body == .stream;
 
-        this.writeHeaderBlock(stream.id, encoded.items, !has_body);
-        if (has_body) this.writeData(stream.id, body, true);
+        this.writeHeaderBlock(stream.id, encoded.items, !has_inline_body and !is_streaming);
+        if (has_inline_body) {
+            stream.pending_body = body;
+            this.drainSendBody(stream);
+        } else if (!is_streaming) {
+            stream.request_body_done = true;
+        }
     }
 
     fn writeHeaderBlock(this: *ClientSession, stream_id: u31, block: []const u8, end_stream: bool) void {
@@ -338,16 +366,90 @@ pub const ClientSession = struct {
         }
     }
 
-    fn writeData(this: *ClientSession, stream_id: u31, body: []const u8, end_stream: bool) void {
-        const max: usize = this.remote_max_frame_size;
-        var remaining = body;
+    /// Frame `data` into DATA frames respecting `remote_max_frame_size` and
+    /// both flow-control windows. Returns bytes consumed; END_STREAM is set
+    /// on the final frame only when `end_stream` and all of `data` fit.
+    fn writeDataWindowed(this: *ClientSession, stream: *Stream, data: []const u8, end_stream: bool) usize {
+        var remaining = data;
+        var consumed: usize = 0;
         while (true) {
-            const chunk = remaining[0..@min(remaining.len, max)];
-            remaining = remaining[chunk.len..];
-            const last = remaining.len == 0;
+            const window: usize = @intCast(@max(0, @min(stream.send_window, this.conn_send_window)));
+            if (remaining.len > 0 and window == 0) break;
+            const chunk_len = @min(remaining.len, @as(usize, this.remote_max_frame_size), window);
+            const last = chunk_len == remaining.len;
             const flags: u8 = if (last and end_stream) @intFromEnum(wire.DataFrameFlags.END_STREAM) else 0;
-            this.writeFrame(.HTTP_FRAME_DATA, flags, stream_id, chunk);
+            this.writeFrame(.HTTP_FRAME_DATA, flags, stream.id, remaining[0..chunk_len]);
+            stream.send_window -= @intCast(chunk_len);
+            this.conn_send_window -= @intCast(chunk_len);
+            consumed += chunk_len;
+            remaining = remaining[chunk_len..];
             if (last) break;
+        }
+        return consumed;
+    }
+
+    /// Push as much of `stream`'s request body as the send windows allow.
+    /// Buffers into `write_buffer`; caller flushes.
+    fn drainSendBody(this: *ClientSession, stream: *Stream) void {
+        if (stream.request_body_done) return;
+        const client = stream.client orelse return;
+        switch (client.state.original_request_body) {
+            .bytes => {
+                const sent = this.writeDataWindowed(stream, stream.pending_body, true);
+                stream.pending_body = stream.pending_body[sent..];
+                if (stream.pending_body.len == 0) {
+                    stream.request_body_done = true;
+                    client.state.request_stage = .done;
+                }
+            },
+            .stream => |*body| {
+                const sb = body.buffer orelse return;
+                const buffer = sb.acquire();
+                const data = buffer.slice();
+                if (data.len == 0 and !body.ended) {
+                    sb.release();
+                    return;
+                }
+                const sent = this.writeDataWindowed(stream, data, body.ended);
+                buffer.cursor += sent;
+                const drained = buffer.isEmpty();
+                if (drained) buffer.reset();
+                if (drained and body.ended) {
+                    stream.request_body_done = true;
+                    client.state.request_stage = .done;
+                } else if (drained and data.len > 0) {
+                    sb.reportDrain();
+                }
+                sb.release();
+                if (stream.request_body_done) body.detach();
+            },
+            .sendfile => unreachable,
+        }
+    }
+
+    fn drainSendBodies(this: *ClientSession) void {
+        if (this.conn_send_window <= 0) return;
+        for (this.streams.values()) |stream| {
+            if (!stream.request_body_done and stream.send_window > 0) {
+                this.drainSendBody(stream);
+            }
+        }
+    }
+
+    /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
+    /// end-of-body) are available in the ThreadSafeStreamBuffer.
+    pub fn streamBodyByHttpId(this: *ClientSession, async_http_id: u32, ended: bool) void {
+        this.ref();
+        defer this.deref();
+        for (this.streams.values()) |stream| {
+            const client = stream.client orelse continue;
+            if (client.async_http_id != async_http_id) continue;
+            if (client.state.original_request_body != .stream) return;
+            client.state.original_request_body.stream.ended = ended;
+            client.setTimeout(this.socket, 5);
+            this.drainSendBody(stream);
+            _ = this.flush() catch |err| this.failAll(err);
+            return;
         }
     }
 
@@ -442,6 +544,8 @@ pub const ClientSession = struct {
         if (this.fatal_error) |err| return this.failAll(err);
 
         this.drainPending();
+        this.drainSendBodies();
+        _ = this.flush() catch |err| return this.failAll(err);
 
         // Deliver per-stream. Iterate by index because delivery may remove
         // entries (swapRemove keeps earlier indices stable; revisiting the
@@ -462,6 +566,10 @@ pub const ClientSession = struct {
 
     /// Socket onWritable entry point.
     pub fn onWritable(this: *ClientSession) void {
+        this.ref();
+        defer this.deref();
+        _ = this.flush() catch |err| return this.failAll(err);
+        this.drainSendBodies();
         _ = this.flush() catch |err| return this.failAll(err);
         this.reapAborted();
         this.maybeRelease();
@@ -674,13 +782,29 @@ pub const ClientSession = struct {
                     switch (@as(wire.SettingsType, @enumFromInt(unit.type))) {
                         .SETTINGS_MAX_FRAME_SIZE => this.remote_max_frame_size = @truncate(@min(unit.value, wire.MAX_FRAME_SIZE)),
                         .SETTINGS_MAX_CONCURRENT_STREAMS => this.remote_max_concurrent_streams = unit.value,
+                        .SETTINGS_INITIAL_WINDOW_SIZE => {
+                            const next = @min(unit.value, @as(u32, wire.MAX_WINDOW_SIZE));
+                            const delta = @as(i64, next) - @as(i64, this.remote_initial_window_size);
+                            this.remote_initial_window_size = next;
+                            for (this.streams.values()) |s| {
+                                s.send_window = @intCast(std.math.clamp(@as(i64, s.send_window) + delta, std.math.minInt(i32), std.math.maxInt(i32)));
+                            }
+                        },
                         else => {},
                     }
                 }
                 this.writeFrame(.HTTP_FRAME_SETTINGS, @intFromEnum(wire.SettingsFlags.ACK), 0, &.{});
                 this.settings_received = true;
             },
-            .HTTP_FRAME_WINDOW_UPDATE => {},
+            .HTTP_FRAME_WINDOW_UPDATE => {
+                if (payload.len < 4) return;
+                const inc: i32 = @intCast(wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31);
+                if (header.streamIdentifier == 0) {
+                    this.conn_send_window +|= inc;
+                } else if (this.streams.get(@truncate(header.streamIdentifier & 0x7fffffff))) |stream| {
+                    stream.send_window +|= inc;
+                }
+            },
             .HTTP_FRAME_PING => {
                 if (header.flags & @intFromEnum(wire.PingFrameFlags.ACK) == 0) {
                     this.writeFrame(.HTTP_FRAME_PING, @intFromEnum(wire.PingFrameFlags.ACK), 0, payload[0..@min(payload.len, 8)]);

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -683,6 +683,9 @@ pub const ClientSession = struct {
         if (this.fatal_error) |err| return this.failAll(err);
 
         this.drainPending();
+        // attach()'s flush() can failAll() from inside the loop above; if so the
+        // session has already torn down — bail before maybeRelease() double-derefs.
+        if (this.fatal_error != null) return;
         this.drainSendBodies();
         _ = this.flush() catch |err| return this.failAll(err);
 
@@ -720,6 +723,7 @@ pub const ClientSession = struct {
         // is finished.
         if (this.pending_attach.items.len > 0) {
             this.drainPending();
+            if (this.fatal_error != null) return;
             _ = this.flush() catch |err| return this.failAll(err);
         }
 
@@ -1189,7 +1193,9 @@ pub const ClientSession = struct {
                     }
                     return;
                 };
-                if (!stream.seen_headers) {
+                // §8.1.1: DATA before the *final* response HEADERS is malformed —
+                // a 1xx alone (status_code still 0) doesn't satisfy this.
+                if (stream.status_code == 0) {
                     stream.fatal_error = error.HTTP2ProtocolError;
                     return;
                 }
@@ -1326,6 +1332,10 @@ pub const ClientSession = struct {
         if (status >= 100 and status < 200) {
             stream.decoded_bytes.items.len = start_len;
             stream.awaiting_continue = false;
+            // RFC 9113 §8.1: a 1xx HEADERS that ends the stream is malformed.
+            // Without this the stream sits at {end_stream_received, !headers_ready}
+            // and deliverStream() returns false forever.
+            if (stream.end_stream_received) stream.fatal_error = error.HTTP2ProtocolError;
             return;
         }
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -615,6 +615,13 @@ pub const ClientSession = struct {
             var header: wire.FrameHeader = .{ .flags = 0 };
             wire.FrameHeader.from(&header, buf[0..wire.FrameHeader.byteSize], 0, true);
             header.streamIdentifier = wire.UInt31WithReserved.from(header.streamIdentifier).uint31;
+            // RFC 9113 §4.2: a frame larger than the local SETTINGS_MAX_FRAME_SIZE
+            // (we never advertise above the 16384 default) is a connection
+            // FRAME_SIZE_ERROR. Bounding here also caps `read_buffer` growth.
+            if (header.length > wire.DEFAULT_MAX_FRAME_SIZE) {
+                this.fatal_error = error.HTTP2FrameSizeError;
+                break;
+            }
             const frame_len = wire.FrameHeader.byteSize + @as(usize, header.length);
             if (buf.len < frame_len) break;
             this.dispatchFrame(header, buf[wire.FrameHeader.byteSize..frame_len]);
@@ -922,7 +929,21 @@ pub const ClientSession = struct {
 
         switch (@as(wire.FrameType, @enumFromInt(header.type))) {
             .HTTP_FRAME_SETTINGS => {
-                if (header.flags & @intFromEnum(wire.SettingsFlags.ACK) != 0) return;
+                // RFC 9113 §6.5: stream id != 0 is PROTOCOL_ERROR; ACK with a
+                // payload, or a non-ACK whose length isn't a multiple of 6, is
+                // FRAME_SIZE_ERROR.
+                if (header.streamIdentifier != 0) {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
+                if (header.flags & @intFromEnum(wire.SettingsFlags.ACK) != 0) {
+                    if (header.length != 0) this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
+                if (header.length % wire.SettingsPayloadUnit.byteSize != 0) {
+                    this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
                 var i: usize = 0;
                 while (i + wire.SettingsPayloadUnit.byteSize <= payload.len) : (i += wire.SettingsPayloadUnit.byteSize) {
                     var unit: wire.SettingsPayloadUnit = undefined;
@@ -975,7 +996,10 @@ pub const ClientSession = struct {
                 this.settings_received = true;
             },
             .HTTP_FRAME_WINDOW_UPDATE => {
-                if (payload.len < 4) return;
+                if (header.length != 4) {
+                    this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
                 const inc: i32 = @intCast(wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31);
                 if (header.streamIdentifier == 0) {
                     // RFC 9113 §6.9: zero increment on stream 0 is a
@@ -1142,8 +1166,20 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_RST_STREAM => {
-                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
-                const code: u32 = if (payload.len >= 4) wire.u32FromBytes(payload[0..4]) else 0;
+                if (header.length != 4) {
+                    this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
+                const stream_id: u31 = @intCast(header.streamIdentifier);
+                // RFC 9113 §6.4: stream 0, or an idle stream (one we never
+                // opened — even ids included since push is disabled), is a
+                // connection PROTOCOL_ERROR.
+                if (stream_id == 0 or stream_id & 1 == 0 or stream_id >= this.next_stream_id) {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
+                const stream = this.streams.get(stream_id) orelse return;
+                const code: u32 = wire.u32FromBytes(payload[0..4]);
                 stream.fatal_error = switch (code) {
                     @intFromEnum(wire.ErrorCode.NO_ERROR) => blk: {
                         stream.end_stream_received = true;
@@ -1157,9 +1193,17 @@ pub const ClientSession = struct {
                 };
             },
             .HTTP_FRAME_GOAWAY => {
+                if (header.streamIdentifier != 0) {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
+                if (header.length < 8) {
+                    this.fatal_error = error.HTTP2FrameSizeError;
+                    return;
+                }
                 this.goaway_received = true;
-                this.goaway_last_stream_id = if (payload.len >= 4) wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31 else 0;
-                const code: u32 = if (payload.len >= 8) wire.u32FromBytes(payload[4..8]) else 0;
+                this.goaway_last_stream_id = wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31;
+                const code: u32 = wire.u32FromBytes(payload[4..8]);
                 const graceful = code == @intFromEnum(wire.ErrorCode.NO_ERROR);
                 var it = this.streams.iterator();
                 while (it.next()) |e| {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -1,0 +1,509 @@
+//! HTTP/2 path for Bun's fetch HTTP client.
+//!
+//! A `ClientSession` is created when ALPN negotiates "h2" and lives for the
+//! duration of one request on one TCP+TLS connection. It owns the HPACK
+//! encoder/decoder, an outbound write buffer, and an inbound frame buffer.
+//! The request side serialises preface + SETTINGS + HEADERS + DATA into the
+//! write buffer; the response side parses frames and feeds the result back
+//! through the same `picohttp.Response` / `handleResponseBody` /
+//! `handleResponseMetadata` machinery the HTTP/1.1 path already uses, so
+//! redirects, decompression and the result callback are unchanged.
+
+pub const ClientSession = struct {
+    pub const new = bun.TrivialNew(@This());
+
+    hpack: *lshpack.HPACK,
+
+    /// Bytes queued for the socket. The h2 path writes whole frames here and
+    /// `flush()` drains as much as the socket will accept; leftovers stay
+    /// buffered until the next onWritable.
+    write_buffer: bun.io.StreamBuffer = .{},
+
+    /// Accumulates incoming bytes until a full 9-byte frame header + declared
+    /// payload length is available, so frame handlers always see complete
+    /// frames regardless of how the kernel chunked the reads.
+    read_buffer: std.ArrayListUnmanaged(u8) = .{},
+
+    /// Concatenated header-block fragment from HEADERS + any CONTINUATION
+    /// frames, decoded once END_HEADERS arrives.
+    header_block: std.ArrayListUnmanaged(u8) = .{},
+
+    /// Backing storage for decoded header name/value strings. lshpack returns
+    /// thread-local slices that are clobbered on the next decode call, so we
+    /// copy them here and point `shared_response_headers_buf` entries into
+    /// this buffer until `cloneMetadata` makes its own copy.
+    decoded_header_bytes: std.ArrayListUnmanaged(u8) = .{},
+
+    /// DATA payload accumulated across one onData() pass; handed to
+    /// `handleResponseBody` once after all frames in the current read have
+    /// been parsed so the client callback runs at most once per socket read.
+    body_buffer: std.ArrayListUnmanaged(u8) = .{},
+
+    stream_id: u31 = 1,
+    end_stream_received: bool = false,
+    headers_ready: bool = false,
+    expecting_continuation: bool = false,
+    headers_end_stream: bool = false,
+    fatal_error: ?anyerror = null,
+
+    remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
+
+    pub fn create() *ClientSession {
+        return ClientSession.new(.{
+            .hpack = lshpack.HPACK.init(4096),
+        });
+    }
+
+    pub fn deinit(this: *ClientSession) void {
+        this.hpack.deinit();
+        this.write_buffer.deinit();
+        this.read_buffer.deinit(bun.default_allocator);
+        this.header_block.deinit(bun.default_allocator);
+        this.decoded_header_bytes.deinit(bun.default_allocator);
+        this.body_buffer.deinit(bun.default_allocator);
+        bun.destroy(this);
+    }
+
+    fn queue(this: *ClientSession, bytes: []const u8) void {
+        bun.handleOom(this.write_buffer.write(bytes));
+    }
+
+    fn writeFrame(this: *ClientSession, frame_type: wire.FrameType, flags: u8, stream_id: u32, payload: []const u8) void {
+        var header: wire.FrameHeader = .{
+            .type = @intFromEnum(frame_type),
+            .flags = flags,
+            .streamIdentifier = stream_id,
+            .length = @intCast(payload.len),
+        };
+        std.mem.byteSwapAllFields(wire.FrameHeader, &header);
+        this.queue(std.mem.asBytes(&header)[0..wire.FrameHeader.byteSize]);
+        this.queue(payload);
+    }
+
+    fn isConnectionSpecific(name: []const u8) bool {
+        // RFC 9113 §8.2.2: connection-specific headers MUST NOT appear in an
+        // HTTP/2 field block. `Host` is mapped to :authority.
+        return strings.eqlCaseInsensitiveASCIIICheckLength(name, "connection") or
+            strings.eqlCaseInsensitiveASCIIICheckLength(name, "host") or
+            strings.eqlCaseInsensitiveASCIIICheckLength(name, "keep-alive") or
+            strings.eqlCaseInsensitiveASCIIICheckLength(name, "proxy-connection") or
+            strings.eqlCaseInsensitiveASCIIICheckLength(name, "transfer-encoding") or
+            strings.eqlCaseInsensitiveASCIIICheckLength(name, "upgrade");
+    }
+
+    fn encodeHeader(this: *ClientSession, encoded: *std.ArrayListUnmanaged(u8), name: []const u8, value: []const u8, never_index: bool) !void {
+        const required = encoded.items.len + name.len + value.len + 32;
+        try encoded.ensureTotalCapacity(bun.default_allocator, required);
+        const written = try this.hpack.encode(name, value, never_index, encoded.allocatedSlice(), encoded.items.len);
+        encoded.items.len += written;
+    }
+
+    /// Serialise the connection preface, initial SETTINGS, WINDOW_UPDATE,
+    /// HEADERS frame(s) and (for buffered `.bytes` bodies) DATA frame(s) into
+    /// the outbound buffer. END_STREAM is on HEADERS when there is no body.
+    pub fn writeRequest(this: *ClientSession, client: *HTTPClient, request: picohttp.Request) !void {
+        this.queue(wire.client_preface);
+
+        var enable_push: wire.SettingsPayloadUnit = .{
+            .type = @intFromEnum(wire.SettingsType.SETTINGS_ENABLE_PUSH),
+            .value = 0,
+        };
+        std.mem.byteSwapAllFields(wire.SettingsPayloadUnit, &enable_push);
+        this.writeFrame(.HTTP_FRAME_SETTINGS, 0, 0, std.mem.asBytes(&enable_push)[0..wire.SettingsPayloadUnit.byteSize]);
+
+        // Open the flow-control window up front so large response bodies
+        // aren't throttled by the 64 KiB default.
+        this.writeWindowUpdate(0, @intCast(wire.MAX_WINDOW_SIZE - wire.DEFAULT_WINDOW_SIZE));
+        this.writeWindowUpdate(this.stream_id, @intCast(wire.MAX_WINDOW_SIZE - wire.DEFAULT_WINDOW_SIZE));
+
+        var encoded: std.ArrayListUnmanaged(u8) = .{};
+        defer encoded.deinit(bun.default_allocator);
+
+        var lower_buf: [256]u8 = undefined;
+
+        try this.encodeHeader(&encoded, ":method", request.method, false);
+        try this.encodeHeader(&encoded, ":scheme", "https", false);
+        var authority: []const u8 = client.url.host;
+        for (request.headers) |header| {
+            if (strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "host")) {
+                authority = header.value;
+                break;
+            }
+        }
+        try this.encodeHeader(&encoded, ":authority", authority, false);
+        const path = if (request.path.len > 0) request.path else "/";
+        try this.encodeHeader(&encoded, ":path", path, false);
+
+        for (request.headers) |header| {
+            if (isConnectionSpecific(header.name)) continue;
+            const never_index =
+                strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "authorization") or
+                strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "cookie") or
+                strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "set-cookie");
+            // RFC 9113 §8.2.1: field names MUST be lowercase.
+            const lowered = if (header.name.len <= lower_buf.len) brk: {
+                for (header.name, 0..) |c, i| lower_buf[i] = std.ascii.toLower(c);
+                break :brk lower_buf[0..header.name.len];
+            } else header.name;
+            try this.encodeHeader(&encoded, lowered, header.value, never_index);
+        }
+
+        const body = client.state.request_body;
+        const has_body = client.state.original_request_body == .bytes and body.len > 0;
+
+        this.writeHeaderBlock(encoded.items, !has_body);
+        if (has_body) this.writeData(body, true);
+    }
+
+    fn writeHeaderBlock(this: *ClientSession, block: []const u8, end_stream: bool) void {
+        const max: usize = this.remote_max_frame_size;
+        var remaining = block;
+        var first = true;
+        while (true) {
+            const chunk = remaining[0..@min(remaining.len, max)];
+            remaining = remaining[chunk.len..];
+            const last = remaining.len == 0;
+            var flags: u8 = 0;
+            if (last) flags |= @intFromEnum(wire.HeadersFrameFlags.END_HEADERS);
+            if (first and end_stream) flags |= @intFromEnum(wire.HeadersFrameFlags.END_STREAM);
+            this.writeFrame(if (first) .HTTP_FRAME_HEADERS else .HTTP_FRAME_CONTINUATION, flags, this.stream_id, chunk);
+            first = false;
+            if (last) break;
+        }
+    }
+
+    fn writeData(this: *ClientSession, body: []const u8, end_stream: bool) void {
+        const max: usize = this.remote_max_frame_size;
+        var remaining = body;
+        while (true) {
+            const chunk = remaining[0..@min(remaining.len, max)];
+            remaining = remaining[chunk.len..];
+            const last = remaining.len == 0;
+            const flags: u8 = if (last and end_stream) @intFromEnum(wire.DataFrameFlags.END_STREAM) else 0;
+            this.writeFrame(.HTTP_FRAME_DATA, flags, this.stream_id, chunk);
+            if (last) break;
+        }
+    }
+
+    fn writeWindowUpdate(this: *ClientSession, stream_id: u32, increment: u31) void {
+        var value: u32 = @byteSwap(@as(u32, increment));
+        this.writeFrame(.HTTP_FRAME_WINDOW_UPDATE, 0, stream_id, std.mem.asBytes(&value));
+    }
+
+    fn stripPadding(payload: []const u8) ?[]const u8 {
+        if (payload.len < 1) return null;
+        const pad: usize = payload[0];
+        if (pad >= payload.len) return null;
+        return payload[1 .. payload.len - pad];
+    }
+
+    fn decodeAndDiscard(this: *ClientSession) void {
+        var offset: usize = 0;
+        while (offset < this.header_block.items.len) {
+            const result = this.hpack.decode(this.header_block.items[offset..]) catch break;
+            offset += result.next;
+        }
+        this.header_block.clearRetainingCapacity();
+    }
+
+    /// Drain the outbound buffer to the socket. Returns true when bytes
+    /// remain (backpressure) so the caller knows to wait for onWritable.
+    pub fn flush(this: *ClientSession, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) !bool {
+        const pending = this.write_buffer.slice();
+        if (pending.len == 0) return false;
+        var remaining = pending;
+        var total: usize = 0;
+        while (remaining.len > 0) {
+            const wrote = socket.write(remaining);
+            if (wrote < 0) return error.WriteFailed;
+            const n: usize = @intCast(wrote);
+            total += n;
+            remaining = remaining[n..];
+            if (n == 0) break;
+        }
+        this.write_buffer.wrote(total);
+        if (this.write_buffer.isEmpty()) {
+            this.write_buffer.reset();
+            return false;
+        }
+        return true;
+    }
+
+    /// Parse every complete frame in `incoming` into session-local state, then
+    /// hand the accumulated headers/body to the HTTPClient. Structured as
+    /// "parse all, then deliver once" because `progressUpdate` may free the
+    /// client (and this session) synchronously when the request finishes.
+    pub fn onData(
+        this: *ClientSession,
+        client: *HTTPClient,
+        comptime is_ssl: bool,
+        incoming: []const u8,
+        ctx: *NewHTTPContext(is_ssl),
+        socket: NewHTTPContext(is_ssl).HTTPSocket,
+    ) void {
+        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
+
+        var consumed: usize = 0;
+        while (true) {
+            const buf = this.read_buffer.items[consumed..];
+            if (buf.len < wire.FrameHeader.byteSize) break;
+
+            var header: wire.FrameHeader = .{ .flags = 0 };
+            wire.FrameHeader.from(&header, buf[0..wire.FrameHeader.byteSize], 0, true);
+            header.streamIdentifier = wire.UInt31WithReserved.from(header.streamIdentifier).uint31;
+
+            const frame_len = wire.FrameHeader.byteSize + @as(usize, header.length);
+            if (buf.len < frame_len) break;
+
+            this.dispatchFrame(header, buf[wire.FrameHeader.byteSize..frame_len]);
+            consumed += frame_len;
+            if (this.fatal_error != null) break;
+        }
+        if (consumed > 0) {
+            const tail_len = this.read_buffer.items.len - consumed;
+            if (tail_len > 0) {
+                std.mem.copyForwards(u8, this.read_buffer.items[0..tail_len], this.read_buffer.items[consumed..]);
+            }
+            this.read_buffer.items.len = tail_len;
+        }
+
+        _ = this.flush(is_ssl, socket) catch |err| {
+            return client.closeAndFail(err, is_ssl, socket);
+        };
+
+        if (this.fatal_error) |err| {
+            return client.closeAndFail(err, is_ssl, socket);
+        }
+
+        if (this.headers_ready) {
+            this.headers_ready = false;
+            if (client.state.response_stage == .body) {
+                // Trailer block: decode to keep HPACK state coherent but
+                // don't replace the already-delivered response metadata.
+                this.decodeAndDiscard();
+            } else {
+                const should_continue = this.deliverHeaders(client) catch |err| {
+                    return client.closeAndFail(err, is_ssl, socket);
+                };
+                if (should_continue == .finished or (this.end_stream_received and this.body_buffer.items.len == 0)) {
+                    if (client.state.flags.is_redirect_pending) {
+                        return client.doRedirect(is_ssl, ctx, socket);
+                    }
+                    client.cloneMetadata();
+                    client.state.flags.received_last_chunk = true;
+                    client.state.content_length = 0;
+                    return client.progressUpdate(is_ssl, ctx, socket);
+                }
+                client.cloneMetadata();
+            }
+        }
+
+        if (client.state.response_stage != .body) {
+            // Still waiting for response headers; keep buffering DATA (a
+            // well-behaved server won't send DATA before HEADERS anyway).
+            return;
+        }
+
+        if (this.body_buffer.items.len > 0) {
+            if (this.end_stream_received) client.state.flags.received_last_chunk = true;
+            const body = this.body_buffer.items;
+            const report = client.handleResponseBody(body, false) catch |err| {
+                return client.closeAndFail(err, is_ssl, socket);
+            };
+            this.body_buffer.clearRetainingCapacity();
+            if (report or this.end_stream_received) {
+                return client.progressUpdate(is_ssl, ctx, socket);
+            }
+            return;
+        }
+
+        if (this.end_stream_received) {
+            client.state.flags.received_last_chunk = true;
+            return client.progressUpdate(is_ssl, ctx, socket);
+        }
+    }
+
+    fn dispatchFrame(this: *ClientSession, header: wire.FrameHeader, payload: []const u8) void {
+        log("frame type={d} len={d} flags={d} stream={d}", .{ header.type, header.length, header.flags, header.streamIdentifier });
+
+        if (this.expecting_continuation and header.type != @intFromEnum(wire.FrameType.HTTP_FRAME_CONTINUATION)) {
+            this.fatal_error = error.HTTP2ProtocolError;
+            return;
+        }
+
+        switch (@as(wire.FrameType, @enumFromInt(header.type))) {
+            .HTTP_FRAME_SETTINGS => {
+                if (header.flags & @intFromEnum(wire.SettingsFlags.ACK) != 0) return;
+                var i: usize = 0;
+                while (i + wire.SettingsPayloadUnit.byteSize <= payload.len) : (i += wire.SettingsPayloadUnit.byteSize) {
+                    var unit: wire.SettingsPayloadUnit = undefined;
+                    wire.SettingsPayloadUnit.from(&unit, payload[i .. i + wire.SettingsPayloadUnit.byteSize], 0, true);
+                    if (@as(wire.SettingsType, @enumFromInt(unit.type)) == .SETTINGS_MAX_FRAME_SIZE) {
+                        this.remote_max_frame_size = @truncate(@min(unit.value, wire.MAX_FRAME_SIZE));
+                    }
+                }
+                this.writeFrame(.HTTP_FRAME_SETTINGS, @intFromEnum(wire.SettingsFlags.ACK), 0, &.{});
+            },
+            .HTTP_FRAME_WINDOW_UPDATE => {},
+            .HTTP_FRAME_PING => {
+                if (header.flags & @intFromEnum(wire.PingFrameFlags.ACK) == 0) {
+                    this.writeFrame(.HTTP_FRAME_PING, @intFromEnum(wire.PingFrameFlags.ACK), 0, payload[0..@min(payload.len, 8)]);
+                }
+            },
+            .HTTP_FRAME_HEADERS => {
+                if (header.streamIdentifier != this.stream_id) return;
+                var fragment = payload;
+                if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
+                    fragment = stripPadding(fragment) orelse {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    };
+                }
+                if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PRIORITY) != 0) {
+                    if (fragment.len < wire.StreamPriority.byteSize) {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    }
+                    fragment = fragment[wire.StreamPriority.byteSize..];
+                }
+                this.header_block.clearRetainingCapacity();
+                bun.handleOom(this.header_block.appendSlice(bun.default_allocator, fragment));
+                this.headers_end_stream = header.flags & @intFromEnum(wire.HeadersFrameFlags.END_STREAM) != 0;
+                if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
+                    this.end_stream_received = this.end_stream_received or this.headers_end_stream;
+                    this.headers_ready = true;
+                } else {
+                    this.expecting_continuation = true;
+                }
+            },
+            .HTTP_FRAME_CONTINUATION => {
+                if (!this.expecting_continuation or header.streamIdentifier != this.stream_id) {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
+                bun.handleOom(this.header_block.appendSlice(bun.default_allocator, payload));
+                if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
+                    this.expecting_continuation = false;
+                    this.end_stream_received = this.end_stream_received or this.headers_end_stream;
+                    this.headers_ready = true;
+                }
+            },
+            .HTTP_FRAME_DATA => {
+                if (header.streamIdentifier != this.stream_id) return;
+                var fragment = payload;
+                if (header.flags & @intFromEnum(wire.DataFrameFlags.PADDED) != 0) {
+                    fragment = stripPadding(fragment) orelse {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    };
+                }
+                if (header.flags & @intFromEnum(wire.DataFrameFlags.END_STREAM) != 0) {
+                    this.end_stream_received = true;
+                }
+                if (fragment.len > 0) {
+                    bun.handleOom(this.body_buffer.appendSlice(bun.default_allocator, fragment));
+                }
+            },
+            .HTTP_FRAME_RST_STREAM => {
+                if (header.streamIdentifier != this.stream_id) return;
+                const code: u32 = if (payload.len >= 4) wire.u32FromBytes(payload[0..4]) else 0;
+                if (code == @intFromEnum(wire.ErrorCode.NO_ERROR)) {
+                    this.end_stream_received = true;
+                } else {
+                    this.fatal_error = error.HTTP2StreamReset;
+                }
+            },
+            .HTTP_FRAME_GOAWAY => {
+                const code: u32 = if (payload.len >= 8) wire.u32FromBytes(payload[4..8]) else 0;
+                if (code != @intFromEnum(wire.ErrorCode.NO_ERROR)) {
+                    this.fatal_error = error.HTTP2GoAway;
+                }
+            },
+            .HTTP_FRAME_PUSH_PROMISE => {
+                // We sent SETTINGS_ENABLE_PUSH=0; receiving one is a protocol error.
+                this.fatal_error = error.HTTP2ProtocolError;
+            },
+            else => {},
+        }
+    }
+
+    /// HPACK-decode the accumulated header block into `state.pending_response`
+    /// (reusing the shared HTTP/1.1 header buffer) and run
+    /// `handleResponseMetadata` so redirects, content-encoding and
+    /// content-length follow the same logic as the HTTP/1.1 path.
+    fn deliverHeaders(this: *ClientSession, client: *HTTPClient) !HTTPClient.ShouldContinue {
+        this.decoded_header_bytes.clearRetainingCapacity();
+
+        var status_code: u32 = 0;
+        const headers_buf = &HTTPClient.shared_response_headers_buf;
+        // Record byte offsets while appending; resolve to slices once the
+        // backing buffer has stopped growing so reallocs can't invalidate them.
+        var bounds: [headers_buf.len][3]u32 = undefined;
+        var header_count: usize = 0;
+
+        var offset: usize = 0;
+        while (offset < this.header_block.items.len) {
+            const result = this.hpack.decode(this.header_block.items[offset..]) catch {
+                return error.HTTP2CompressionError;
+            };
+            offset += result.next;
+
+            if (result.name.len > 0 and result.name[0] == ':') {
+                if (strings.eqlComptime(result.name, ":status")) {
+                    status_code = std.fmt.parseInt(u32, result.value, 10) catch 0;
+                }
+                continue;
+            }
+            if (header_count >= headers_buf.len) continue;
+
+            const name_start: u32 = @intCast(this.decoded_header_bytes.items.len);
+            bun.handleOom(this.decoded_header_bytes.appendSlice(bun.default_allocator, result.name));
+            const value_start: u32 = @intCast(this.decoded_header_bytes.items.len);
+            bun.handleOom(this.decoded_header_bytes.appendSlice(bun.default_allocator, result.value));
+            const value_end: u32 = @intCast(this.decoded_header_bytes.items.len);
+            bounds[header_count] = .{ name_start, value_start, value_end };
+            header_count += 1;
+        }
+        this.header_block.clearRetainingCapacity();
+
+        const bytes = this.decoded_header_bytes.items;
+        for (bounds[0..header_count], 0..) |b, i| {
+            headers_buf[i] = .{ .name = bytes[b[0]..b[1]], .value = bytes[b[1]..b[2]] };
+        }
+
+        var response = picohttp.Response{
+            .minor_version = 0,
+            .status_code = status_code,
+            .status = "",
+            .headers = .{ .list = headers_buf[0..header_count] },
+            .bytes_read = 0,
+        };
+        client.state.pending_response = response;
+
+        const should_continue = try client.handleResponseMetadata(&response);
+        // h2 has no chunked transfer-encoding; framing delimits the body.
+        client.state.transfer_encoding = .identity;
+        if (client.state.response_stage == .body_chunk) client.state.response_stage = .body;
+
+        if (client.state.content_encoding_i < response.headers.list.len and !client.state.flags.did_set_content_encoding) {
+            client.state.flags.did_set_content_encoding = true;
+            client.state.content_encoding_i = std.math.maxInt(@TypeOf(client.state.content_encoding_i));
+            client.state.pending_response = response;
+        }
+
+        return should_continue;
+    }
+};
+
+const log = bun.Output.scoped(.h2_client, .hidden);
+
+const std = @import("std");
+const bun = @import("bun");
+const strings = bun.strings;
+const picohttp = bun.picohttp;
+
+const HTTPClient = bun.http;
+const NewHTTPContext = HTTPClient.NewHTTPContext;
+
+const wire = @import("./H2FrameParser.zig");
+const lshpack = @import("../bun.js/api/bun/lshpack.zig");

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -337,7 +337,7 @@ pub const ClientSession = struct {
 
         if (!this.preface_sent) this.writePreface();
 
-        client.setTimeout(this.socket, 5);
+        this.rearmTimeout();
         const request = client.buildRequest(client.state.original_request_body.len());
         this.writeRequest(client, stream, request) catch |err| {
             // encodeHeader pushes into the HPACK encoder's dynamic table per
@@ -543,6 +543,27 @@ pub const ClientSession = struct {
 
     /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
     /// end-of-body) are available in the ThreadSafeStreamBuffer.
+    /// Re-arm the shared socket's idle timer based on the aggregate of every
+    /// attached client. With multiplexed streams the per-request
+    /// `disable_timeout` flag can't drive the socket directly (last writer
+    /// would win and a `{timeout:false}` long-poll could be killed by a
+    /// sibling re-arming, or strip the safety net from one that wants it),
+    /// so the session disarms only when *every* attached client opted out.
+    fn rearmTimeout(this: *ClientSession) void {
+        const want = blk: {
+            for (this.streams.values()) |s| {
+                const c = s.client orelse continue;
+                if (!c.flags.disable_timeout) break :blk true;
+            }
+            for (this.pending_attach.items) |c| {
+                if (!c.flags.disable_timeout) break :blk true;
+            }
+            break :blk false;
+        };
+        this.socket.timeout(0);
+        this.socket.setTimeoutMinutes(if (want) 5 else 0);
+    }
+
     pub fn streamBodyByHttpId(this: *ClientSession, async_http_id: u32, ended: bool) void {
         this.ref();
         defer this.deref();
@@ -551,7 +572,7 @@ pub const ClientSession = struct {
             if (client.async_http_id != async_http_id) continue;
             if (client.state.original_request_body != .stream) return;
             client.state.original_request_body.stream.ended = ended;
-            client.setTimeout(this.socket, 5);
+            this.rearmTimeout();
             this.drainSendBody(stream);
             _ = this.flush() catch |err| this.failAll(err);
             return;
@@ -676,6 +697,7 @@ pub const ClientSession = struct {
             }
         }
         this.delivering = false;
+        this.rearmTimeout();
 
         // Retries/redirects that re-dispatched onto this session during the
         // loop are parked in pending_attach; attach them now that iteration
@@ -830,11 +852,11 @@ pub const ClientSession = struct {
             return true;
         }
 
-        client.setTimeout(this.socket, 5);
-
         if (stream.headers_ready) {
             stream.headers_ready = false;
             const result = this.applyHeaders(stream, client) catch |err| {
+                stream.rst(.CANCEL);
+                _ = this.flush() catch {};
                 stream.client = null;
                 client.h2 = null;
                 client.failFromH2(err);
@@ -870,6 +892,8 @@ pub const ClientSession = struct {
             }
             const report = client.handleResponseBody(stream.body_buffer.items, false) catch |err| {
                 stream.body_buffer.clearRetainingCapacity();
+                stream.rst(.CANCEL);
+                _ = this.flush() catch {};
                 if (!terminal) {
                     stream.client = null;
                     client.h2 = null;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -197,11 +197,13 @@ pub const ClientSession = struct {
 
     pub fn adopt(this: *ClientSession, client: *HTTPClient) void {
         client.registerAbortTracker(true, this.socket);
-        if (this.delivering) {
-            // Re-dispatch (retryFromH2/doRedirect) reached us from inside our
-            // own onData deliver loop. Park until the loop finishes so
-            // attach() doesn't mutate `streams` under iteration or trigger
-            // failAll while a stream is mid-delivery.
+        // Park instead of attaching when (a) we're inside onData's deliver
+        // loop — attach() mustn't mutate `streams` under iteration — or (b)
+        // the server's first SETTINGS hasn't arrived yet, so the real
+        // MAX_CONCURRENT_STREAMS isn't known and a non-replayable body
+        // shouldn't risk a REFUSED_STREAM. The leader bypasses adopt() and
+        // attaches directly so the preface still goes out.
+        if (this.delivering or !this.settings_received) {
             bun.handleOom(this.pending_attach.append(bun.default_allocator, client));
             return;
         }
@@ -912,11 +914,22 @@ pub const ClientSession = struct {
                         },
                         .SETTINGS_MAX_CONCURRENT_STREAMS => this.remote_max_concurrent_streams = unit.value,
                         .SETTINGS_INITIAL_WINDOW_SIZE => {
-                            const next = @min(unit.value, @as(u32, wire.MAX_WINDOW_SIZE));
-                            const delta = @as(i64, next) - @as(i64, this.remote_initial_window_size);
-                            this.remote_initial_window_size = next;
+                            // RFC 9113 §6.5.2 / §6.9.2: values above 2^31-1, or
+                            // a delta that pushes any open stream's window past
+                            // that, are a connection FLOW_CONTROL_ERROR.
+                            if (unit.value > wire.MAX_WINDOW_SIZE) {
+                                this.fatal_error = error.HTTP2FlowControlError;
+                                return;
+                            }
+                            const delta = @as(i64, unit.value) - @as(i64, this.remote_initial_window_size);
+                            this.remote_initial_window_size = unit.value;
                             for (this.streams.values()) |s| {
-                                s.send_window = @intCast(std.math.clamp(@as(i64, s.send_window) + delta, std.math.minInt(i32), std.math.maxInt(i32)));
+                                const next = @as(i64, s.send_window) + delta;
+                                if (next > wire.MAX_WINDOW_SIZE) {
+                                    this.fatal_error = error.HTTP2FlowControlError;
+                                    return;
+                                }
+                                s.send_window = @intCast(next);
                             }
                         },
                         else => {},
@@ -929,9 +942,34 @@ pub const ClientSession = struct {
                 if (payload.len < 4) return;
                 const inc: i32 = @intCast(wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31);
                 if (header.streamIdentifier == 0) {
-                    this.conn_send_window +|= inc;
+                    // RFC 9113 §6.9: zero increment on stream 0 is a
+                    // connection PROTOCOL_ERROR; §6.9.1: overflow past
+                    // 2^31-1 is a connection FLOW_CONTROL_ERROR.
+                    if (inc == 0) {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    }
+                    const next = @as(i64, this.conn_send_window) + inc;
+                    if (next > wire.MAX_WINDOW_SIZE) {
+                        this.fatal_error = error.HTTP2FlowControlError;
+                        return;
+                    }
+                    this.conn_send_window = @intCast(next);
                 } else if (this.streams.get(@truncate(header.streamIdentifier & 0x7fffffff))) |stream| {
-                    stream.send_window +|= inc;
+                    // §6.9/§6.9.1: zero increment / overflow on a stream are
+                    // stream-level errors; RST_STREAM and fail just that one.
+                    if (inc == 0) {
+                        stream.rst(.PROTOCOL_ERROR);
+                        stream.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    }
+                    const next = @as(i64, stream.send_window) + inc;
+                    if (next > wire.MAX_WINDOW_SIZE) {
+                        stream.rst(.FLOW_CONTROL_ERROR);
+                        stream.fatal_error = error.HTTP2FlowControlError;
+                        return;
+                    }
+                    stream.send_window = @intCast(next);
                 }
             },
             .HTTP_FRAME_PING => {
@@ -944,6 +982,15 @@ pub const ClientSession = struct {
                 const stream_id: u31 = @intCast(header.streamIdentifier);
                 const maybe_stream = this.streams.get(stream_id);
                 if (maybe_stream == null) {
+                    // RFC 9113 §5.1/§5.1.1: HEADERS on a stream we never
+                    // opened (idle: id >= next_stream_id, or even: server-
+                    // initiated while push is disabled) is a connection
+                    // PROTOCOL_ERROR. Only odd ids we already used can be a
+                    // legitimate "RST crossed an in-flight HEADERS" orphan.
+                    if (stream_id == 0 or stream_id & 1 == 0 or stream_id >= this.next_stream_id) {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                        return;
+                    }
                     // Stream we no longer track (RST_STREAM crossed an
                     // in-flight HEADERS). The block must still be HPACK-
                     // decoded so the connection-level dynamic table stays in
@@ -1019,7 +1066,16 @@ pub const ClientSession = struct {
             },
             .HTTP_FRAME_DATA => {
                 this.conn_unacked_bytes +|= header.length;
-                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
+                const stream_id: u31 = @intCast(header.streamIdentifier);
+                const stream = this.streams.get(stream_id) orelse {
+                    // §6.1/§5.1: DATA on stream 0, an idle stream, or a
+                    // server-initiated stream is a connection PROTOCOL_ERROR.
+                    // DATA on a stream we already closed/reset is ignored.
+                    if (stream_id == 0 or stream_id & 1 == 0 or stream_id >= this.next_stream_id) {
+                        this.fatal_error = error.HTTP2ProtocolError;
+                    }
+                    return;
+                };
                 if (!stream.seen_headers) {
                     stream.fatal_error = error.HTTP2ProtocolError;
                     return;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -46,7 +46,17 @@ pub const Stream = struct {
 pub const ClientSession = struct {
     pub const new = bun.TrivialNew(@This());
 
+    /// Ref holders: the socket-ext tag while the session is the ActiveSocket
+    /// (1), the context's active_h2_sessions registry while listed (1), and
+    /// the keep-alive pool while parked (1). Hand-offs between socket and
+    /// pool transfer a ref rather than touching the count.
+    const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
+    pub const ref = RefCount.ref;
+    pub const deref = RefCount.deref;
+
     pub const Socket = NewHTTPContext(true).HTTPSocket;
+
+    ref_count: RefCount,
 
     hpack: *lshpack.HPACK,
     socket: Socket,
@@ -94,6 +104,7 @@ pub const ClientSession = struct {
 
     pub fn create(ctx: *NewHTTPContext(true), socket: Socket, client: *const HTTPClient) *ClientSession {
         const this = ClientSession.new(.{
+            .ref_count = .init(),
             .hpack = lshpack.HPACK.init(4096),
             .socket = socket,
             .ctx = ctx,
@@ -106,8 +117,8 @@ pub const ClientSession = struct {
         return this;
     }
 
-    pub fn deinit(this: *ClientSession) void {
-        this.ctx.unregisterH2(this);
+    fn deinit(this: *ClientSession) void {
+        bun.debugAssert(this.registry_index == std.math.maxInt(u32));
         this.hpack.deinit();
         this.write_buffer.deinit();
         this.read_buffer.deinit(bun.default_allocator);
@@ -430,6 +441,8 @@ pub const ClientSession = struct {
     /// Socket onClose / onTimeout entry point. The socket is already gone, so
     /// streams just fail and the session is destroyed.
     pub fn onClose(this: *ClientSession, err: anyerror) void {
+        this.ref();
+        defer this.deref();
         this.ctx.unregisterH2(this);
         var it = this.streams.iterator();
         while (it.next()) |e| {
@@ -441,14 +454,15 @@ pub const ClientSession = struct {
             if (client) |c| c.failFromH2(err);
         }
         this.streams.clearRetainingCapacity();
-        this.deinit();
+        this.deref();
     }
 
     fn failAll(this: *ClientSession, err: anyerror) void {
         this.fatal_error = this.fatal_error orelse err;
         const sock = this.socket;
+        NewHTTPContext(true).markSocketAsDead(sock);
         this.onClose(err);
-        NewHTTPContext(true).terminateSocket(sock);
+        sock.close(.failure);
     }
 
     /// Called from the HTTP thread's shutdown queue when a fetch on this
@@ -499,9 +513,8 @@ pub const ClientSession = struct {
                 this,
             );
         } else {
-            const sock = this.socket;
-            this.deinit();
-            NewHTTPContext(true).closeSocket(sock);
+            NewHTTPContext(true).closeSocket(this.socket);
+            this.deref();
         }
     }
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -1207,14 +1207,14 @@ pub const PendingConnect = struct {
 
 const log = bun.Output.scoped(.h2_client, .hidden);
 
+const lshpack = @import("../bun.js/api/bun/lshpack.zig");
 const std = @import("std");
+const wire = @import("./H2FrameParser.zig");
+
 const bun = @import("bun");
-const strings = bun.strings;
 const picohttp = bun.picohttp;
+const strings = bun.strings;
+const SSLConfig = bun.api.server.ServerConfig.SSLConfig;
 
 const HTTPClient = bun.http;
 const NewHTTPContext = HTTPClient.NewHTTPContext;
-const SSLConfig = bun.api.server.ServerConfig.SSLConfig;
-
-const wire = @import("./H2FrameParser.zig");
-const lshpack = @import("../bun.js/api/bun/lshpack.zig");

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -1369,17 +1369,14 @@ pub const ClientSession = struct {
         client.state.pending_response = response;
 
         const should_continue = try client.handleResponseMetadata(&response);
+        // handleResponseMetadata may mutate *response (e.g. the 304 rewrite for
+        // force_last_modified); cloneMetadata reads pending_response, so re-sync.
+        client.state.pending_response = response;
         // h2 framing delimits the body; chunked transfer-encoding and the
         // HTTP/1.1 "no Content-Length ⇒ no keep-alive" rule don't apply.
         client.state.transfer_encoding = .identity;
         if (client.state.response_stage == .body_chunk) client.state.response_stage = .body;
         client.state.flags.allow_keepalive = true;
-
-        if (client.state.content_encoding_i < response.headers.list.len and !client.state.flags.did_set_content_encoding) {
-            client.state.flags.did_set_content_encoding = true;
-            client.state.content_encoding_i = std.math.maxInt(@TypeOf(client.state.content_encoding_i));
-            client.state.pending_response = response;
-        }
 
         return if (should_continue == .finished) .finished else .has_body;
     }

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -695,7 +695,14 @@ pub const ClientSession = struct {
         if (stream.fatal_error) |err| {
             stream.client = null;
             client.h2 = null;
-            client.failFromH2(err);
+            if (err == error.HTTP2RefusedStream and
+                client.h2_retries < HTTPClient.max_h2_retries and
+                client.state.original_request_body == .bytes)
+            {
+                client.retryFromH2();
+            } else {
+                client.failFromH2(err);
+            }
             return true;
         }
 
@@ -879,20 +886,26 @@ pub const ClientSession = struct {
             .HTTP_FRAME_RST_STREAM => {
                 const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
                 const code: u32 = if (payload.len >= 4) wire.u32FromBytes(payload[0..4]) else 0;
-                if (code == @intFromEnum(wire.ErrorCode.NO_ERROR)) {
-                    stream.end_stream_received = true;
-                } else {
-                    stream.fatal_error = error.HTTP2StreamReset;
-                }
+                stream.fatal_error = switch (code) {
+                    @intFromEnum(wire.ErrorCode.NO_ERROR) => blk: {
+                        stream.end_stream_received = true;
+                        break :blk null;
+                    },
+                    @intFromEnum(wire.ErrorCode.REFUSED_STREAM) => error.HTTP2RefusedStream,
+                    else => error.HTTP2StreamReset,
+                };
             },
             .HTTP_FRAME_GOAWAY => {
                 this.goaway_received = true;
                 this.goaway_last_stream_id = if (payload.len >= 4) wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31 else 0;
                 const code: u32 = if (payload.len >= 8) wire.u32FromBytes(payload[4..8]) else 0;
+                const graceful = code == @intFromEnum(wire.ErrorCode.NO_ERROR);
                 var it = this.streams.iterator();
                 while (it.next()) |e| {
                     const s = e.value_ptr.*;
-                    if (code != @intFromEnum(wire.ErrorCode.NO_ERROR) or s.id > this.goaway_last_stream_id) {
+                    if (s.id > this.goaway_last_stream_id) {
+                        s.fatal_error = if (graceful) error.HTTP2RefusedStream else error.HTTP2GoAway;
+                    } else if (!graceful) {
                         s.fatal_error = error.HTTP2GoAway;
                     }
                 }
@@ -946,6 +959,8 @@ pub const ClientSession = struct {
             header_count += 1;
         }
         stream.header_block.clearRetainingCapacity();
+
+        if (status_code == 0) return error.HTTP2ProtocolError;
 
         const bytes = this.decoded_header_bytes.items;
         for (bounds[0..header_count], 0..) |b, i| {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -1,106 +1,144 @@
 //! HTTP/2 path for Bun's fetch HTTP client.
 //!
-//! A `ClientSession` owns the connection-scoped state — HPACK tables,
-//! outbound write buffer, inbound frame buffer, and the server's SETTINGS —
-//! and survives across requests via the keep-alive pool. Each request runs on
-//! a `Stream` carved out of the session with a fresh odd stream id; the
-//! response side parses frames back into the existing `picohttp.Response` /
-//! `handleResponseBody` machinery so redirects, decompression and the result
-//! callback are shared with the HTTP/1.1 path.
+//! `ClientSession` owns the TLS socket once ALPN selects "h2" and is the
+//! `ActiveSocket` variant the HTTPContext handlers dispatch to. It holds the
+//! connection-scoped state — HPACK tables, write/read buffers, server
+//! SETTINGS — and a map of active `Stream`s, each bound to one `HTTPClient`.
+//! Response frames are parsed into per-stream buffers and then handed to the
+//! same `picohttp.Response` / `handleResponseBody` machinery the HTTP/1.1
+//! path uses, so redirects, decompression and the result callback are shared.
 
-/// We advertise this as SETTINGS_INITIAL_WINDOW_SIZE and replenish it via
-/// WINDOW_UPDATE once half has been consumed.
+/// Advertised as SETTINGS_INITIAL_WINDOW_SIZE; replenished via WINDOW_UPDATE
+/// once half has been consumed.
 pub const local_initial_window_size: u31 = 1 << 24;
 
 pub const Stream = struct {
+    pub const new = bun.TrivialNew(@This());
+
     id: u31,
+    session: *ClientSession,
+    client: ?*HTTPClient,
 
-    /// Concatenated header-block fragment from HEADERS + any CONTINUATION
-    /// frames, decoded once END_HEADERS arrives.
+    /// HEADERS + CONTINUATION fragments, decoded once END_HEADERS arrives.
     header_block: std.ArrayListUnmanaged(u8) = .{},
-
-    /// DATA payload accumulated across one onData() pass; handed to
-    /// `handleResponseBody` once after all frames in the current read have
-    /// been parsed so the client callback runs at most once per socket read.
+    /// DATA payload accumulated across one onData() pass.
     body_buffer: std.ArrayListUnmanaged(u8) = .{},
 
     end_stream_received: bool = false,
     headers_ready: bool = false,
-    expecting_continuation: bool = false,
     headers_end_stream: bool = false,
     fatal_error: ?anyerror = null,
-
     /// DATA bytes consumed since the last WINDOW_UPDATE for this stream.
     unacked_bytes: u32 = 0,
 
-    fn deinit(this: *Stream) void {
+    pub fn deinit(this: *Stream) void {
         this.header_block.deinit(bun.default_allocator);
         this.body_buffer.deinit(bun.default_allocator);
+        bun.destroy(this);
+    }
+
+    pub fn rst(this: *Stream, code: wire.ErrorCode) void {
+        var value: u32 = @byteSwap(@intFromEnum(code));
+        this.session.writeFrame(.HTTP_FRAME_RST_STREAM, 0, this.id, std.mem.asBytes(&value));
     }
 };
 
 pub const ClientSession = struct {
     pub const new = bun.TrivialNew(@This());
 
-    hpack: *lshpack.HPACK,
+    pub const Socket = NewHTTPContext(true).HTTPSocket;
 
-    /// Bytes queued for the socket. Whole frames are written here and
+    hpack: *lshpack.HPACK,
+    socket: Socket,
+    ctx: *NewHTTPContext(true),
+
+    /// Pool key. Owned copy so the session can outlive the originating client.
+    hostname: []const u8,
+    port: u16,
+    ssl_config: ?SSLConfig.SharedPtr,
+    did_have_handshaking_error: bool,
+
+    /// Queued bytes for the socket; whole frames are written here and
     /// `flush()` drains as much as the socket accepts.
     write_buffer: bun.io.StreamBuffer = .{},
 
-    /// Accumulates incoming bytes until a full 9-byte frame header + declared
-    /// payload length is available, so frame handlers always see complete
-    /// frames regardless of how the kernel chunked the reads.
+    /// Inbound bytes until a full 9-byte header + declared payload is
+    /// available, so frame handlers always see complete frames.
     read_buffer: std.ArrayListUnmanaged(u8) = .{},
 
-    /// Backing storage for decoded header name/value strings. lshpack returns
-    /// thread-local slices that are clobbered on the next decode call, so we
-    /// copy them here and point `shared_response_headers_buf` entries into
-    /// this buffer until `cloneMetadata` makes its own copy.
+    /// Backing storage for decoded header strings. lshpack returns
+    /// thread-local slices clobbered on the next decode call, so we copy
+    /// here and point `shared_response_headers_buf` into this buffer until
+    /// `cloneMetadata` makes its own copy.
     decoded_header_bytes: std.ArrayListUnmanaged(u8) = .{},
 
-    stream: Stream = .{ .id = 1 },
+    streams: std.AutoArrayHashMapUnmanaged(u31, *Stream) = .{},
     next_stream_id: u31 = 1,
+    /// Stream id whose CONTINUATION sequence is in progress; 0 = none.
+    expecting_continuation: u31 = 0,
+
     preface_sent: bool = false,
     goaway_received: bool = false,
+    goaway_last_stream_id: u31 = 0,
     fatal_error: ?anyerror = null,
 
     remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
-    remote_max_concurrent_streams: u32 = std.math.maxInt(u32),
+    remote_max_concurrent_streams: u32 = 100,
 
     /// DATA bytes consumed since the last connection-level WINDOW_UPDATE.
     conn_unacked_bytes: u32 = 0,
 
-    pub fn create() *ClientSession {
-        return ClientSession.new(.{
+    /// Index in the context's active-session list while reachable for
+    /// concurrent attachment; maxInt when not listed.
+    registry_index: u32 = std.math.maxInt(u32),
+
+    pub fn create(ctx: *NewHTTPContext(true), socket: Socket, client: *const HTTPClient) *ClientSession {
+        const this = ClientSession.new(.{
             .hpack = lshpack.HPACK.init(4096),
+            .socket = socket,
+            .ctx = ctx,
+            .hostname = bun.handleOom(bun.default_allocator.dupe(u8, client.connected_url.hostname)),
+            .port = client.connected_url.getPortAuto(),
+            .ssl_config = if (client.tls_props) |p| p.clone() else null,
+            .did_have_handshaking_error = client.flags.did_have_handshaking_error,
         });
+        ctx.registerH2(this);
+        return this;
     }
 
     pub fn deinit(this: *ClientSession) void {
+        this.ctx.unregisterH2(this);
         this.hpack.deinit();
         this.write_buffer.deinit();
         this.read_buffer.deinit(bun.default_allocator);
         this.decoded_header_bytes.deinit(bun.default_allocator);
-        this.stream.deinit();
+        var it = this.streams.iterator();
+        while (it.next()) |e| e.value_ptr.*.deinit();
+        this.streams.deinit(bun.default_allocator);
+        bun.default_allocator.free(this.hostname);
+        if (this.ssl_config) |*s| s.deinit();
         bun.destroy(this);
     }
 
-    /// Allocate a fresh stream id for the next request on this connection.
-    /// Connection-scoped state (HPACK, settings, read/write buffers) is
-    /// preserved; per-stream parse state is reset.
-    pub fn beginStream(this: *ClientSession) void {
-        this.stream.deinit();
-        this.stream = .{ .id = this.next_stream_id };
-        this.next_stream_id +|= 2;
-    }
-
-    /// True when the connection can be returned to the keep-alive pool: no
-    /// GOAWAY, no protocol error, no leftover bytes that would confuse the
-    /// next request, and stream-id space not exhausted.
-    pub fn canPool(this: *const ClientSession) bool {
+    pub fn hasHeadroom(this: *const ClientSession) bool {
         return !this.goaway_received and
             this.fatal_error == null and
+            this.streams.count() < this.remote_max_concurrent_streams and
+            this.next_stream_id < wire.MAX_STREAM_ID;
+    }
+
+    pub fn matches(this: *const ClientSession, hostname: []const u8, port: u16, ssl_config: ?*SSLConfig) bool {
+        return this.port == port and SSLConfig.rawPtr(this.ssl_config) == ssl_config and strings.eqlLong(this.hostname, hostname, true);
+    }
+
+    /// True when the connection can be parked in the keep-alive pool: no
+    /// active streams, no GOAWAY/error, and no leftover bytes that would
+    /// confuse the next request.
+    pub fn canPool(this: *const ClientSession) bool {
+        return this.streams.count() == 0 and
+            !this.goaway_received and
+            this.fatal_error == null and
+            this.expecting_continuation == 0 and
             this.read_buffer.items.len == 0 and
             this.write_buffer.isEmpty() and
             this.next_stream_id < wire.MAX_STREAM_ID;
@@ -123,8 +161,6 @@ pub const ClientSession = struct {
     }
 
     fn isConnectionSpecific(name: []const u8) bool {
-        // RFC 9113 §8.2.2: connection-specific headers MUST NOT appear in an
-        // HTTP/2 field block. `Host` is mapped to :authority.
         return strings.eqlCaseInsensitiveASCIIICheckLength(name, "connection") or
             strings.eqlCaseInsensitiveASCIIICheckLength(name, "host") or
             strings.eqlCaseInsensitiveASCIIICheckLength(name, "keep-alive") or
@@ -155,11 +191,51 @@ pub const ClientSession = struct {
         this.preface_sent = true;
     }
 
-    /// Serialise the request as HEADERS frame(s) + DATA frame(s) into the
-    /// outbound buffer. The connection preface goes out once per session.
-    pub fn writeRequest(this: *ClientSession, client: *HTTPClient, request: picohttp.Request) !void {
+    /// Allocate a stream for `client`, serialise its request as HEADERS +
+    /// DATA, and flush.
+    pub fn attach(this: *ClientSession, client: *HTTPClient) void {
+        bun.debugAssert(this.hasHeadroom());
+
+        const stream = Stream.new(.{ .id = this.next_stream_id, .session = this, .client = client });
+        this.next_stream_id +|= 2;
+        bun.handleOom(this.streams.put(bun.default_allocator, stream.id, stream));
+        client.h2 = stream;
+        client.flags.protocol = .http2;
+        client.allow_retry = false;
+
         if (!this.preface_sent) this.writePreface();
 
+        client.setTimeout(this.socket, 5);
+        const request = client.buildRequest(client.state.original_request_body.len());
+        this.writeRequest(client, stream, request) catch |err| {
+            this.detachWithFailure(stream, err);
+            return;
+        };
+        if (client.verbose != .none) {
+            HTTPClient.printRequest(request, client.url.href, !client.flags.reject_unauthorized, client.state.request_body, client.verbose == .curl);
+        }
+        client.state.request_stage = .done;
+        client.state.response_stage = .headers;
+
+        _ = this.flush() catch |err| {
+            this.failAll(err);
+        };
+    }
+
+    /// Remove `stream` from the session, RST it, and fail its client. The
+    /// session and socket stay up for siblings.
+    pub fn detachWithFailure(this: *ClientSession, stream: *Stream, err: anyerror) void {
+        stream.rst(.CANCEL);
+        _ = this.flush() catch {};
+        const client = stream.client;
+        stream.client = null;
+        if (client) |c| c.h2 = null;
+        _ = this.streams.swapRemove(stream.id);
+        stream.deinit();
+        if (client) |c| c.failFromH2(err);
+    }
+
+    fn writeRequest(this: *ClientSession, client: *HTTPClient, stream: *Stream, request: picohttp.Request) !void {
         var encoded: std.ArrayListUnmanaged(u8) = .{};
         defer encoded.deinit(bun.default_allocator);
 
@@ -184,7 +260,6 @@ pub const ClientSession = struct {
                 strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "authorization") or
                 strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "cookie") or
                 strings.eqlCaseInsensitiveASCIIICheckLength(header.name, "set-cookie");
-            // RFC 9113 §8.2.1: field names MUST be lowercase.
             const lowered = if (header.name.len <= lower_buf.len) brk: {
                 for (header.name, 0..) |c, i| lower_buf[i] = std.ascii.toLower(c);
                 break :brk lower_buf[0..header.name.len];
@@ -195,11 +270,11 @@ pub const ClientSession = struct {
         const body = client.state.request_body;
         const has_body = client.state.original_request_body == .bytes and body.len > 0;
 
-        this.writeHeaderBlock(encoded.items, !has_body);
-        if (has_body) this.writeData(body, true);
+        this.writeHeaderBlock(stream.id, encoded.items, !has_body);
+        if (has_body) this.writeData(stream.id, body, true);
     }
 
-    fn writeHeaderBlock(this: *ClientSession, block: []const u8, end_stream: bool) void {
+    fn writeHeaderBlock(this: *ClientSession, stream_id: u31, block: []const u8, end_stream: bool) void {
         const max: usize = this.remote_max_frame_size;
         var remaining = block;
         var first = true;
@@ -210,13 +285,13 @@ pub const ClientSession = struct {
             var flags: u8 = 0;
             if (last) flags |= @intFromEnum(wire.HeadersFrameFlags.END_HEADERS);
             if (first and end_stream) flags |= @intFromEnum(wire.HeadersFrameFlags.END_STREAM);
-            this.writeFrame(if (first) .HTTP_FRAME_HEADERS else .HTTP_FRAME_CONTINUATION, flags, this.stream.id, chunk);
+            this.writeFrame(if (first) .HTTP_FRAME_HEADERS else .HTTP_FRAME_CONTINUATION, flags, stream_id, chunk);
             first = false;
             if (last) break;
         }
     }
 
-    fn writeData(this: *ClientSession, body: []const u8, end_stream: bool) void {
+    fn writeData(this: *ClientSession, stream_id: u31, body: []const u8, end_stream: bool) void {
         const max: usize = this.remote_max_frame_size;
         var remaining = body;
         while (true) {
@@ -224,7 +299,7 @@ pub const ClientSession = struct {
             remaining = remaining[chunk.len..];
             const last = remaining.len == 0;
             const flags: u8 = if (last and end_stream) @intFromEnum(wire.DataFrameFlags.END_STREAM) else 0;
-            this.writeFrame(.HTTP_FRAME_DATA, flags, this.stream.id, chunk);
+            this.writeFrame(.HTTP_FRAME_DATA, flags, stream_id, chunk);
             if (last) break;
         }
     }
@@ -241,70 +316,29 @@ pub const ClientSession = struct {
         return payload[1 .. payload.len - pad];
     }
 
-    fn decodeAndDiscard(this: *ClientSession) void {
-        var offset: usize = 0;
-        while (offset < this.stream.header_block.items.len) {
-            const result = this.hpack.decode(this.stream.header_block.items[offset..]) catch break;
-            offset += result.next;
-        }
-        this.stream.header_block.clearRetainingCapacity();
-    }
-
-    /// Credit consumed DATA bytes back to the peer once half the advertised
-    /// window has been used, on both the connection and the active stream.
     fn replenishWindow(this: *ClientSession) void {
         const threshold = local_initial_window_size / 2;
         if (this.conn_unacked_bytes >= threshold) {
             this.writeWindowUpdate(0, @intCast(this.conn_unacked_bytes));
             this.conn_unacked_bytes = 0;
         }
-        if (this.stream.unacked_bytes >= threshold and !this.stream.end_stream_received) {
-            this.writeWindowUpdate(this.stream.id, @intCast(this.stream.unacked_bytes));
-            this.stream.unacked_bytes = 0;
-        }
-    }
-
-    /// Process frames that arrive while the session is parked in the
-    /// keep-alive pool with no request attached. Answers PING/SETTINGS,
-    /// records GOAWAY (so `canPool()` flips false), and discards anything
-    /// addressed to a now-closed stream.
-    pub fn onIdleData(this: *ClientSession, comptime is_ssl: bool, incoming: []const u8, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
-        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
-        var consumed: usize = 0;
-        while (true) {
-            const buf = this.read_buffer.items[consumed..];
-            if (buf.len < wire.FrameHeader.byteSize) break;
-            var header: wire.FrameHeader = .{ .flags = 0 };
-            wire.FrameHeader.from(&header, buf[0..wire.FrameHeader.byteSize], 0, true);
-            header.streamIdentifier = wire.UInt31WithReserved.from(header.streamIdentifier).uint31;
-            const frame_len = wire.FrameHeader.byteSize + @as(usize, header.length);
-            if (buf.len < frame_len) break;
-            this.dispatchFrame(header, buf[wire.FrameHeader.byteSize..frame_len]);
-            consumed += frame_len;
-        }
-        if (consumed > 0) {
-            const tail_len = this.read_buffer.items.len - consumed;
-            if (tail_len > 0) {
-                std.mem.copyForwards(u8, this.read_buffer.items[0..tail_len], this.read_buffer.items[consumed..]);
+        var it = this.streams.iterator();
+        while (it.next()) |e| {
+            const s = e.value_ptr.*;
+            if (s.unacked_bytes >= threshold and !s.end_stream_received) {
+                this.writeWindowUpdate(s.id, @intCast(s.unacked_bytes));
+                s.unacked_bytes = 0;
             }
-            this.read_buffer.items.len = tail_len;
         }
-        this.stream.body_buffer.clearRetainingCapacity();
-        this.stream.header_block.clearRetainingCapacity();
-        _ = this.flush(is_ssl, socket) catch {
-            this.fatal_error = error.WriteFailed;
-        };
     }
 
-    /// Drain the outbound buffer to the socket. Returns true when bytes
-    /// remain (backpressure) so the caller knows to wait for onWritable.
-    pub fn flush(this: *ClientSession, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) !bool {
+    pub fn flush(this: *ClientSession) !bool {
         const pending = this.write_buffer.slice();
         if (pending.len == 0) return false;
         var remaining = pending;
         var total: usize = 0;
         while (remaining.len > 0) {
-            const wrote = socket.write(remaining);
+            const wrote = this.socket.write(remaining);
             if (wrote < 0) return error.WriteFailed;
             const n: usize = @intCast(wrote);
             total += n;
@@ -319,32 +353,16 @@ pub const ClientSession = struct {
         return true;
     }
 
-    /// Parse every complete frame in `incoming` into session-local state, then
-    /// hand the accumulated headers/body to the HTTPClient. Structured as
-    /// "parse all, then deliver once" because `progressUpdate` may free the
-    /// client (and this session) synchronously when the request finishes.
-    pub fn onData(
-        this: *ClientSession,
-        client: *HTTPClient,
-        comptime is_ssl: bool,
-        incoming: []const u8,
-        ctx: *NewHTTPContext(is_ssl),
-        socket: NewHTTPContext(is_ssl).HTTPSocket,
-    ) void {
-        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
-
+    fn parseFrames(this: *ClientSession) void {
         var consumed: usize = 0;
         while (true) {
             const buf = this.read_buffer.items[consumed..];
             if (buf.len < wire.FrameHeader.byteSize) break;
-
             var header: wire.FrameHeader = .{ .flags = 0 };
             wire.FrameHeader.from(&header, buf[0..wire.FrameHeader.byteSize], 0, true);
             header.streamIdentifier = wire.UInt31WithReserved.from(header.streamIdentifier).uint31;
-
             const frame_len = wire.FrameHeader.byteSize + @as(usize, header.length);
             if (buf.len < frame_len) break;
-
             this.dispatchFrame(header, buf[wire.FrameHeader.byteSize..frame_len]);
             consumed += frame_len;
             if (this.fatal_error != null) break;
@@ -356,69 +374,230 @@ pub const ClientSession = struct {
             }
             this.read_buffer.items.len = tail_len;
         }
+    }
 
+    /// Socket onData entry point. Parse frames into per-stream state, deliver
+    /// each ready stream to its client, then pool or close if no streams
+    /// remain. Structured "parse all → deliver all" because delivering may
+    /// free the client.
+    pub fn onData(this: *ClientSession, incoming: []const u8) void {
+        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
+        this.parseFrames();
         this.replenishWindow();
-        _ = this.flush(is_ssl, socket) catch |err| {
-            return client.closeAndFail(err, is_ssl, socket);
-        };
 
-        const stream = &this.stream;
+        if (this.flush() catch blk: {
+            this.fatal_error = error.WriteFailed;
+            break :blk false;
+        }) {}
 
-        if (this.fatal_error) |err| return client.closeAndFail(err, is_ssl, socket);
-        if (stream.fatal_error) |err| {
-            if (client.allow_retry) return client.retryH2(is_ssl, socket);
-            return client.closeAndFail(err, is_ssl, socket);
+        if (this.fatal_error) |err| return this.failAll(err);
+
+        // Deliver per-stream. Iterate by index because delivery may remove
+        // entries (swapRemove keeps earlier indices stable; revisiting the
+        // current index after a removal is intentional).
+        var i: usize = 0;
+        while (i < this.streams.count()) {
+            const stream = this.streams.values()[i];
+            if (this.deliverStream(stream)) {
+                _ = this.streams.swapRemove(stream.id);
+                stream.deinit();
+            } else {
+                i += 1;
+            }
         }
+
+        this.maybeRelease();
+    }
+
+    /// Socket onWritable entry point.
+    pub fn onWritable(this: *ClientSession) void {
+        _ = this.flush() catch |err| return this.failAll(err);
+        this.reapAborted();
+        this.maybeRelease();
+    }
+
+    /// Called while the socket is parked in the pool with no clients; answers
+    /// PING/SETTINGS, records GOAWAY, discards anything stream-addressed.
+    pub fn onIdleData(this: *ClientSession, incoming: []const u8) void {
+        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
+        this.parseFrames();
+        this.replenishWindow();
+        _ = this.flush() catch {
+            this.fatal_error = error.WriteFailed;
+        };
+    }
+
+    /// Socket onClose / onTimeout entry point. The socket is already gone, so
+    /// streams just fail and the session is destroyed.
+    pub fn onClose(this: *ClientSession, err: anyerror) void {
+        this.ctx.unregisterH2(this);
+        var it = this.streams.iterator();
+        while (it.next()) |e| {
+            const stream = e.value_ptr.*;
+            const client = stream.client;
+            stream.client = null;
+            if (client) |c| c.h2 = null;
+            stream.deinit();
+            if (client) |c| c.failFromH2(err);
+        }
+        this.streams.clearRetainingCapacity();
+        this.deinit();
+    }
+
+    fn failAll(this: *ClientSession, err: anyerror) void {
+        this.fatal_error = this.fatal_error orelse err;
+        const sock = this.socket;
+        this.onClose(err);
+        NewHTTPContext(true).terminateSocket(sock);
+    }
+
+    /// Called from the HTTP thread's shutdown queue when a fetch on this
+    /// session is aborted. RST_STREAMs that one request; siblings continue.
+    pub fn abortByHttpId(this: *ClientSession, async_http_id: u32) void {
+        var it = this.streams.iterator();
+        while (it.next()) |e| {
+            const stream = e.value_ptr.*;
+            const client = stream.client orelse continue;
+            if (client.async_http_id == async_http_id) {
+                this.detachWithFailure(stream, error.Aborted);
+                break;
+            }
+        }
+        this.maybeRelease();
+    }
+
+    fn reapAborted(this: *ClientSession) void {
+        var i: usize = 0;
+        while (i < this.streams.count()) {
+            const stream = this.streams.values()[i];
+            const client = stream.client orelse {
+                i += 1;
+                continue;
+            };
+            if (client.signals.get(.aborted)) {
+                this.detachWithFailure(stream, error.Aborted);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    fn maybeRelease(this: *ClientSession) void {
+        if (this.streams.count() > 0) return;
+        this.ctx.unregisterH2(this);
+        if (this.canPool() and !this.socket.isClosedOrHasError()) {
+            this.ctx.releaseSocket(
+                this.socket,
+                this.did_have_handshaking_error,
+                this.hostname,
+                this.port,
+                this.ssl_config,
+                null,
+                "",
+                0,
+                0,
+                this,
+            );
+        } else {
+            const sock = this.socket;
+            this.deinit();
+            NewHTTPContext(true).closeSocket(sock);
+        }
+    }
+
+    /// Deliver any ready headers/body/error on `stream` to its client.
+    /// Returns true when the stream is finished and should be removed.
+    /// After a true return, neither `stream.client` nor the client's memory
+    /// may be touched.
+    fn deliverStream(this: *ClientSession, stream: *Stream) bool {
+        const client = stream.client orelse return true;
+
+        if (client.signals.get(.aborted)) {
+            stream.rst(.CANCEL);
+            _ = this.flush() catch {};
+            stream.client = null;
+            client.h2 = null;
+            client.failFromH2(error.Aborted);
+            return true;
+        }
+
+        if (stream.fatal_error) |err| {
+            stream.client = null;
+            client.h2 = null;
+            client.failFromH2(err);
+            return true;
+        }
+
+        client.setTimeout(this.socket, 5);
 
         if (stream.headers_ready) {
             stream.headers_ready = false;
             if (client.state.response_stage == .body) {
-                // Trailer block: decode to keep HPACK state coherent but
-                // don't replace the already-delivered response metadata.
-                this.decodeAndDiscard();
+                this.decodeAndDiscard(stream);
             } else {
-                const should_continue = this.deliverHeaders(client) catch |err| {
-                    return client.closeAndFail(err, is_ssl, socket);
+                const should_continue = this.decodeHeaders(stream, client) catch |err| {
+                    stream.client = null;
+                    client.h2 = null;
+                    client.failFromH2(err);
+                    return true;
                 };
                 if (should_continue == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
+                    stream.client = null;
+                    client.h2 = null;
                     if (client.state.flags.is_redirect_pending) {
-                        return client.doRedirect(is_ssl, ctx, socket);
+                        client.doRedirect(true, this.ctx, this.socket);
+                        return true;
                     }
                     client.cloneMetadata();
                     client.state.flags.received_last_chunk = true;
                     client.state.content_length = 0;
-                    return client.progressUpdate(is_ssl, ctx, socket);
+                    client.progressUpdate(true, this.ctx, this.socket);
+                    return true;
                 }
                 client.cloneMetadata();
             }
         }
 
-        if (client.state.response_stage != .body) return;
+        if (client.state.response_stage != .body) return false;
 
         if (stream.body_buffer.items.len > 0) {
-            if (stream.end_stream_received) client.state.flags.received_last_chunk = true;
+            const terminal = stream.end_stream_received;
+            if (terminal) {
+                client.state.flags.received_last_chunk = true;
+                stream.client = null;
+                client.h2 = null;
+            }
             const report = client.handleResponseBody(stream.body_buffer.items, false) catch |err| {
-                return client.closeAndFail(err, is_ssl, socket);
+                stream.body_buffer.clearRetainingCapacity();
+                if (!terminal) {
+                    stream.client = null;
+                    client.h2 = null;
+                }
+                client.failFromH2(err);
+                return true;
             };
             stream.body_buffer.clearRetainingCapacity();
-            if (report or stream.end_stream_received) {
-                return client.progressUpdate(is_ssl, ctx, socket);
+            if (terminal or report) {
+                client.progressUpdate(true, this.ctx, this.socket);
             }
-            return;
+            return terminal;
         }
 
         if (stream.end_stream_received) {
+            stream.client = null;
+            client.h2 = null;
             client.state.flags.received_last_chunk = true;
-            return client.progressUpdate(is_ssl, ctx, socket);
+            client.progressUpdate(true, this.ctx, this.socket);
+            return true;
         }
+
+        return false;
     }
 
     fn dispatchFrame(this: *ClientSession, header: wire.FrameHeader, payload: []const u8) void {
         log("frame type={d} len={d} flags={d} stream={d}", .{ header.type, header.length, header.flags, header.streamIdentifier });
 
-        const stream = &this.stream;
-
-        if (stream.expecting_continuation and header.type != @intFromEnum(wire.FrameType.HTTP_FRAME_CONTINUATION)) {
+        if (this.expecting_continuation != 0 and header.type != @intFromEnum(wire.FrameType.HTTP_FRAME_CONTINUATION)) {
             this.fatal_error = error.HTTP2ProtocolError;
             return;
         }
@@ -445,7 +624,7 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_HEADERS => {
-                if (header.streamIdentifier != stream.id) return;
+                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
@@ -467,26 +646,28 @@ pub const ClientSession = struct {
                     stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
                     stream.headers_ready = true;
                 } else {
-                    stream.expecting_continuation = true;
+                    this.expecting_continuation = stream.id;
                 }
             },
             .HTTP_FRAME_CONTINUATION => {
-                if (!stream.expecting_continuation or header.streamIdentifier != stream.id) {
+                if (this.expecting_continuation == 0 or header.streamIdentifier != this.expecting_continuation) {
                     this.fatal_error = error.HTTP2ProtocolError;
                     return;
                 }
+                const stream = this.streams.get(this.expecting_continuation) orelse {
+                    this.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                };
                 bun.handleOom(stream.header_block.appendSlice(bun.default_allocator, payload));
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
-                    stream.expecting_continuation = false;
+                    this.expecting_continuation = 0;
                     stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
                     stream.headers_ready = true;
                 }
             },
             .HTTP_FRAME_DATA => {
-                // Padding counts against flow control even when the payload is
-                // for a stale stream, so credit the connection window first.
                 this.conn_unacked_bytes +|= header.length;
-                if (header.streamIdentifier != stream.id) return;
+                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
                 stream.unacked_bytes +|= header.length;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.DataFrameFlags.PADDED) != 0) {
@@ -503,7 +684,7 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_RST_STREAM => {
-                if (header.streamIdentifier != stream.id) return;
+                const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
                 const code: u32 = if (payload.len >= 4) wire.u32FromBytes(payload[0..4]) else 0;
                 if (code == @intFromEnum(wire.ErrorCode.NO_ERROR)) {
                     stream.end_stream_received = true;
@@ -513,37 +694,44 @@ pub const ClientSession = struct {
             },
             .HTTP_FRAME_GOAWAY => {
                 this.goaway_received = true;
-                const last_id: u32 = if (payload.len >= 4) wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31 else 0;
+                this.goaway_last_stream_id = if (payload.len >= 4) wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31 else 0;
                 const code: u32 = if (payload.len >= 8) wire.u32FromBytes(payload[4..8]) else 0;
-                if (code != @intFromEnum(wire.ErrorCode.NO_ERROR) or stream.id > last_id) {
-                    stream.fatal_error = error.HTTP2GoAway;
+                var it = this.streams.iterator();
+                while (it.next()) |e| {
+                    const s = e.value_ptr.*;
+                    if (code != @intFromEnum(wire.ErrorCode.NO_ERROR) or s.id > this.goaway_last_stream_id) {
+                        s.fatal_error = error.HTTP2GoAway;
+                    }
                 }
             },
-            .HTTP_FRAME_PUSH_PROMISE => {
-                // We sent SETTINGS_ENABLE_PUSH=0; receiving one is a protocol error.
-                this.fatal_error = error.HTTP2ProtocolError;
-            },
+            .HTTP_FRAME_PUSH_PROMISE => this.fatal_error = error.HTTP2ProtocolError,
             else => {},
         }
     }
 
-    /// HPACK-decode the accumulated header block into `state.pending_response`
+    fn decodeAndDiscard(this: *ClientSession, stream: *Stream) void {
+        var offset: usize = 0;
+        while (offset < stream.header_block.items.len) {
+            const result = this.hpack.decode(stream.header_block.items[offset..]) catch break;
+            offset += result.next;
+        }
+        stream.header_block.clearRetainingCapacity();
+    }
+
+    /// HPACK-decode `stream`'s header block into `state.pending_response`
     /// (reusing the shared HTTP/1.1 header buffer) and run
-    /// `handleResponseMetadata` so redirects, content-encoding and
-    /// content-length follow the same logic as the HTTP/1.1 path.
-    fn deliverHeaders(this: *ClientSession, client: *HTTPClient) !HTTPClient.ShouldContinue {
+    /// `handleResponseMetadata`.
+    fn decodeHeaders(this: *ClientSession, stream: *Stream, client: *HTTPClient) !HTTPClient.ShouldContinue {
         this.decoded_header_bytes.clearRetainingCapacity();
 
         var status_code: u32 = 0;
         const headers_buf = &HTTPClient.shared_response_headers_buf;
-        // Record byte offsets while appending; resolve to slices once the
-        // backing buffer has stopped growing so reallocs can't invalidate them.
         var bounds: [headers_buf.len][3]u32 = undefined;
         var header_count: usize = 0;
 
         var offset: usize = 0;
-        while (offset < this.stream.header_block.items.len) {
-            const result = this.hpack.decode(this.stream.header_block.items[offset..]) catch {
+        while (offset < stream.header_block.items.len) {
+            const result = this.hpack.decode(stream.header_block.items[offset..]) catch {
                 return error.HTTP2CompressionError;
             };
             offset += result.next;
@@ -564,7 +752,7 @@ pub const ClientSession = struct {
             bounds[header_count] = .{ name_start, value_start, value_end };
             header_count += 1;
         }
-        this.stream.header_block.clearRetainingCapacity();
+        stream.header_block.clearRetainingCapacity();
 
         const bytes = this.decoded_header_bytes.items;
         for (bounds[0..header_count], 0..) |b, i| {
@@ -581,8 +769,8 @@ pub const ClientSession = struct {
         client.state.pending_response = response;
 
         const should_continue = try client.handleResponseMetadata(&response);
-        // h2 framing delimits the body, so neither chunked transfer-encoding
-        // nor the HTTP/1.1 "no Content-Length ⇒ no keep-alive" rule apply.
+        // h2 framing delimits the body; chunked transfer-encoding and the
+        // HTTP/1.1 "no Content-Length ⇒ no keep-alive" rule don't apply.
         client.state.transfer_encoding = .identity;
         if (client.state.response_stage == .body_chunk) client.state.response_stage = .body;
         client.state.flags.allow_keepalive = true;
@@ -606,6 +794,7 @@ const picohttp = bun.picohttp;
 
 const HTTPClient = bun.http;
 const NewHTTPContext = HTTPClient.NewHTTPContext;
+const SSLConfig = bun.api.server.ServerConfig.SSLConfig;
 
 const wire = @import("./H2FrameParser.zig");
 const lshpack = @import("../bun.js/api/bun/lshpack.zig");

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -811,9 +811,12 @@ pub const ClientSession = struct {
                 }
                 client.cloneMetadata();
                 client.state.flags.received_last_chunk = true;
-                client.state.content_length = 0;
-                client.progressUpdate(true, this.ctx, this.socket);
-                return true;
+                // .finished = HEAD/204/304: no body is expected regardless of
+                // any Content-Length header, so clear it. Otherwise leave the
+                // parsed value so finishStream() enforces §8.1.1 against the
+                // (zero) bytes actually received.
+                if (result == .finished) client.state.content_length = 0;
+                return this.finishStream(client);
             }
             client.cloneMetadata();
         }

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -567,6 +567,20 @@ pub const ClientSession = struct {
         this.socket.setTimeoutMinutes(if (want) 5 else 0);
     }
 
+    /// HTTP-thread wake-up from `scheduleResponseBodyDrain`: JS just enabled
+    /// `response_body_streaming`, so flush any body bytes that arrived between
+    /// metadata delivery and `getReader()`.
+    pub fn drainResponseBodyByHttpId(this: *ClientSession, async_http_id: u32) void {
+        this.ref();
+        defer this.deref();
+        for (this.streams.values()) |stream| {
+            const client = stream.client orelse continue;
+            if (client.async_http_id != async_http_id) continue;
+            client.drainResponseBody(true, this.socket);
+            return;
+        }
+    }
+
     /// HTTP-thread wake-up from `scheduleRequestWrite`: new body bytes (or
     /// end-of-body) are available in the ThreadSafeStreamBuffer.
     pub fn streamBodyByHttpId(this: *ClientSession, async_http_id: u32, ended: bool) void {
@@ -901,6 +915,13 @@ pub const ClientSession = struct {
                 return this.finishStream(client);
             }
             client.cloneMetadata();
+            // Mirror the h1 path (http.zig handleOnDataHeaders): deliver headers
+            // to JS now so `await fetch()` resolves and `getReader()` can enable
+            // response_body_streaming. Without this, a content-length response
+            // buffers the entire body before the Response promise settles.
+            if (client.signals.get(.header_progress)) {
+                client.progressUpdate(true, this.ctx, this.socket);
+            }
         }
 
         if (client.state.response_stage != .body) return false;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -24,10 +24,23 @@ pub const Stream = struct {
     /// DATA payload accumulated across one onData() pass.
     body_buffer: std.ArrayListUnmanaged(u8) = .{},
 
+    /// HPACK is decoded eagerly at parse time so the dynamic table stays
+    /// consistent across multiple HEADERS in one read; the resulting strings
+    /// land here until `deliverStream` hands them to handleResponseMetadata.
+    decoded_bytes: std.ArrayListUnmanaged(u8) = .{},
+    decoded_headers: std.ArrayListUnmanaged(picohttp.Header) = .{},
+    /// Final (non-1xx) status code; 0 until the response HEADERS arrive.
+    status_code: u32 = 0,
+
     end_stream_received: bool = false,
     seen_headers: bool = false,
+    /// Set once a non-1xx HEADERS block has been decoded and is awaiting
+    /// delivery. Subsequent HEADERS are trailers and decoded-then-dropped.
     headers_ready: bool = false,
     headers_end_stream: bool = false,
+    /// Expect: 100-continue is in effect: hold the request body until a 1xx
+    /// or final status arrives.
+    awaiting_continue: bool = false,
     /// Set once the END_STREAM flag has been written on the request side.
     request_body_done: bool = false,
     fatal_error: ?anyerror = null,
@@ -43,6 +56,8 @@ pub const Stream = struct {
     pub fn deinit(this: *Stream) void {
         this.header_block.deinit(bun.default_allocator);
         this.body_buffer.deinit(bun.default_allocator);
+        this.decoded_bytes.deinit(bun.default_allocator);
+        this.decoded_headers.deinit(bun.default_allocator);
         bun.destroy(this);
     }
 
@@ -84,12 +99,6 @@ pub const ClientSession = struct {
     /// Inbound bytes until a full 9-byte header + declared payload is
     /// available, so frame handlers always see complete frames.
     read_buffer: std.ArrayListUnmanaged(u8) = .{},
-
-    /// Backing storage for decoded header strings. lshpack returns
-    /// thread-local slices clobbered on the next decode call, so we copy
-    /// here and point `shared_response_headers_buf` into this buffer until
-    /// `cloneMetadata` makes its own copy.
-    decoded_header_bytes: std.ArrayListUnmanaged(u8) = .{},
 
     streams: std.AutoArrayHashMapUnmanaged(u31, *Stream) = .{},
     next_stream_id: u31 = 1,
@@ -140,7 +149,6 @@ pub const ClientSession = struct {
         this.hpack.deinit();
         this.write_buffer.deinit();
         this.read_buffer.deinit(bun.default_allocator);
-        this.decoded_header_bytes.deinit(bun.default_allocator);
         var it = this.streams.iterator();
         while (it.next()) |e| e.value_ptr.*.deinit();
         this.streams.deinit(bun.default_allocator);
@@ -341,6 +349,17 @@ pub const ClientSession = struct {
         const has_inline_body = client.state.original_request_body == .bytes and body.len > 0;
         const is_streaming = client.state.original_request_body == .stream;
 
+        if (has_inline_body or is_streaming) {
+            for (request.headers) |h| {
+                if (strings.eqlCaseInsensitiveASCIIICheckLength(h.name, "expect") and
+                    strings.eqlCaseInsensitiveASCIIICheckLength(h.value, "100-continue"))
+                {
+                    stream.awaiting_continue = true;
+                    break;
+                }
+            }
+        }
+
         this.writeHeaderBlock(stream.id, encoded.items, !has_inline_body and !is_streaming);
         if (has_inline_body) {
             stream.pending_body = body;
@@ -392,7 +411,7 @@ pub const ClientSession = struct {
     /// Push as much of `stream`'s request body as the send windows allow.
     /// Buffers into `write_buffer`; caller flushes.
     fn drainSendBody(this: *ClientSession, stream: *Stream) void {
-        if (stream.request_body_done) return;
+        if (stream.request_body_done or stream.awaiting_continue) return;
         const client = stream.client orelse return;
         switch (client.state.original_request_body) {
             .bytes => {
@@ -710,31 +729,26 @@ pub const ClientSession = struct {
 
         if (stream.headers_ready) {
             stream.headers_ready = false;
-            if (client.state.response_stage == .body) {
-                this.decodeAndDiscard(stream);
-            } else {
-                const result = this.decodeHeaders(stream, client) catch |err| {
-                    stream.client = null;
-                    client.h2 = null;
-                    client.failFromH2(err);
-                    return true;
-                };
-                if (result == .informational) return false;
-                if (result == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
-                    stream.client = null;
-                    client.h2 = null;
-                    if (client.state.flags.is_redirect_pending) {
-                        client.doRedirect(true, this.ctx, this.socket);
-                        return true;
-                    }
-                    client.cloneMetadata();
-                    client.state.flags.received_last_chunk = true;
-                    client.state.content_length = 0;
-                    client.progressUpdate(true, this.ctx, this.socket);
+            const result = this.applyHeaders(stream, client) catch |err| {
+                stream.client = null;
+                client.h2 = null;
+                client.failFromH2(err);
+                return true;
+            };
+            if (result == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
+                stream.client = null;
+                client.h2 = null;
+                if (client.state.flags.is_redirect_pending) {
+                    client.doRedirect(true, this.ctx, this.socket);
                     return true;
                 }
                 client.cloneMetadata();
+                client.state.flags.received_last_chunk = true;
+                client.state.content_length = 0;
+                client.progressUpdate(true, this.ctx, this.socket);
+                return true;
             }
+            client.cloneMetadata();
         }
 
         if (client.state.response_stage != .body) return false;
@@ -832,10 +846,6 @@ pub const ClientSession = struct {
             },
             .HTTP_FRAME_HEADERS => {
                 const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
-                // TODO: if a 1xx HEADERS and the final HEADERS (or final +
-                // trailers) arrive in the same onData pass, the first block
-                // is overwritten before decode and HPACK dynamic-table state
-                // can desync. Decode eagerly here instead of in deliverStream.
                 stream.seen_headers = true;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
@@ -856,7 +866,7 @@ pub const ClientSession = struct {
                 stream.headers_end_stream = header.flags & @intFromEnum(wire.HeadersFrameFlags.END_STREAM) != 0;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
                     stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
-                    stream.headers_ready = true;
+                    this.decodeHeaderBlock(stream);
                 } else {
                     this.expecting_continuation = stream.id;
                 }
@@ -874,7 +884,7 @@ pub const ClientSession = struct {
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
                     this.expecting_continuation = 0;
                     stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
-                    stream.headers_ready = true;
+                    this.decodeHeaderBlock(stream);
                 }
             },
             .HTTP_FRAME_DATA => {
@@ -931,66 +941,79 @@ pub const ClientSession = struct {
         }
     }
 
-    fn decodeAndDiscard(this: *ClientSession, stream: *Stream) void {
-        var offset: usize = 0;
-        while (offset < stream.header_block.items.len) {
-            const result = this.hpack.decode(stream.header_block.items[offset..]) catch break;
-            offset += result.next;
-        }
-        stream.header_block.clearRetainingCapacity();
-    }
+    /// HPACK-decode the buffered header block at parse time. Runs for every
+    /// END_HEADERS so the dynamic table stays in sync regardless of how many
+    /// HEADERS frames arrive in one read. 1xx and trailers are decoded then
+    /// dropped; the final response is stored on the stream for delivery.
+    fn decodeHeaderBlock(this: *ClientSession, stream: *Stream) void {
+        defer stream.header_block.clearRetainingCapacity();
 
-    /// HPACK-decode `stream`'s header block into `state.pending_response`
-    /// (reusing the shared HTTP/1.1 header buffer) and run
-    /// `handleResponseMetadata`.
-    const HeaderResult = enum { informational, has_body, finished };
-
-    fn decodeHeaders(this: *ClientSession, stream: *Stream, client: *HTTPClient) !HeaderResult {
-        this.decoded_header_bytes.clearRetainingCapacity();
-
-        var status_code: u32 = 0;
-        const headers_buf = &HTTPClient.shared_response_headers_buf;
-        var bounds: [headers_buf.len][3]u32 = undefined;
-        var header_count: usize = 0;
+        var status: u32 = 0;
+        var bounds: std.ArrayListUnmanaged([3]u32) = .{};
+        defer bounds.deinit(bun.default_allocator);
+        const start_len = stream.decoded_bytes.items.len;
 
         var offset: usize = 0;
         while (offset < stream.header_block.items.len) {
             const result = this.hpack.decode(stream.header_block.items[offset..]) catch {
-                return error.HTTP2CompressionError;
+                stream.fatal_error = error.HTTP2CompressionError;
+                return;
             };
             offset += result.next;
-
             if (result.name.len > 0 and result.name[0] == ':') {
                 if (strings.eqlComptime(result.name, ":status")) {
-                    status_code = std.fmt.parseInt(u32, result.value, 10) catch 0;
+                    status = std.fmt.parseInt(u32, result.value, 10) catch 0;
                 }
                 continue;
             }
-            if (header_count >= headers_buf.len) continue;
-
-            const name_start: u32 = @intCast(this.decoded_header_bytes.items.len);
-            bun.handleOom(this.decoded_header_bytes.appendSlice(bun.default_allocator, result.name));
-            const value_start: u32 = @intCast(this.decoded_header_bytes.items.len);
-            bun.handleOom(this.decoded_header_bytes.appendSlice(bun.default_allocator, result.value));
-            const value_end: u32 = @intCast(this.decoded_header_bytes.items.len);
-            bounds[header_count] = .{ name_start, value_start, value_end };
-            header_count += 1;
-        }
-        stream.header_block.clearRetainingCapacity();
-
-        if (status_code == 0) return error.HTTP2ProtocolError;
-        if (status_code >= 100 and status_code < 200) return .informational;
-
-        const bytes = this.decoded_header_bytes.items;
-        for (bounds[0..header_count], 0..) |b, i| {
-            headers_buf[i] = .{ .name = bytes[b[0]..b[1]], .value = bytes[b[1]..b[2]] };
+            if (stream.status_code != 0) continue;
+            const name_start: u32 = @intCast(stream.decoded_bytes.items.len);
+            bun.handleOom(stream.decoded_bytes.appendSlice(bun.default_allocator, result.name));
+            const value_start: u32 = @intCast(stream.decoded_bytes.items.len);
+            bun.handleOom(stream.decoded_bytes.appendSlice(bun.default_allocator, result.value));
+            bun.handleOom(bounds.append(bun.default_allocator, .{ name_start, value_start, @intCast(stream.decoded_bytes.items.len) }));
         }
 
+        if (stream.status_code != 0) return;
+
+        if (status == 0) {
+            stream.decoded_bytes.items.len = start_len;
+            stream.fatal_error = error.HTTP2ProtocolError;
+            return;
+        }
+        if (status >= 100 and status < 200) {
+            stream.decoded_bytes.items.len = start_len;
+            stream.awaiting_continue = false;
+            return;
+        }
+
+        stream.status_code = status;
+        stream.headers_ready = true;
+        if (stream.awaiting_continue) {
+            // Final status without a preceding 100: server has decided
+            // without seeing the body, so half-close our side instead of
+            // uploading it.
+            stream.awaiting_continue = false;
+            stream.request_body_done = true;
+            this.writeFrame(.HTTP_FRAME_DATA, @intFromEnum(wire.DataFrameFlags.END_STREAM), stream.id, &.{});
+        }
+        const bytes = stream.decoded_bytes.items;
+        bun.handleOom(stream.decoded_headers.ensureTotalCapacityPrecise(bun.default_allocator, bounds.items.len));
+        for (bounds.items) |b| {
+            stream.decoded_headers.appendAssumeCapacity(.{ .name = bytes[b[0]..b[1]], .value = bytes[b[1]..b[2]] });
+        }
+    }
+
+    const HeaderResult = enum { has_body, finished };
+
+    /// Hand the pre-decoded response headers to the existing HTTP/1.1
+    /// metadata pipeline (`handleResponseMetadata` + `cloneMetadata`).
+    fn applyHeaders(_: *ClientSession, stream: *Stream, client: *HTTPClient) !HeaderResult {
         var response = picohttp.Response{
             .minor_version = 0,
-            .status_code = status_code,
+            .status_code = stream.status_code,
             .status = "",
-            .headers = .{ .list = headers_buf[0..header_count] },
+            .headers = .{ .list = stream.decoded_headers.items },
             .bytes_read = 0,
         };
         client.state.pending_response = response;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -734,6 +734,7 @@ pub const ClientSession = struct {
         this.drainSendBodies();
         _ = this.flush() catch |err| return this.failAll(err);
         this.reapAborted();
+        this.rearmTimeout();
         this.maybeRelease();
     }
 
@@ -784,6 +785,7 @@ pub const ClientSession = struct {
             if (client.async_http_id == async_http_id) {
                 _ = this.pending_attach.swapRemove(i);
                 client.failFromH2(error.Aborted);
+                this.rearmTimeout();
                 this.maybeRelease();
                 return;
             }
@@ -797,6 +799,7 @@ pub const ClientSession = struct {
                 break;
             }
         }
+        this.rearmTimeout();
         this.maybeRelease();
     }
 

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -624,9 +624,9 @@ pub const ClientSession = struct {
 
         // Deliver per-stream. Iterate by index because delivery may remove
         // entries (swapRemove keeps earlier indices stable; revisiting the
-        // current index after a removal is intentional). `delivering` blocks
-        // hasHeadroom() so retryFromH2/doRedirect re-dispatch can't adopt
-        // back onto this session while we're iterating it.
+        // current index after a removal is intentional). `delivering` makes
+        // adopt() park retryFromH2/doRedirect re-dispatches in pending_attach
+        // so `streams` isn't mutated under this iteration.
         this.delivering = true;
         var i: usize = 0;
         while (i < this.streams.count()) {

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -39,7 +39,6 @@ pub const Stream = struct {
     status_code: u32 = 0,
 
     end_stream_received: bool = false,
-    seen_headers: bool = false,
     /// Set once a non-1xx HEADERS block has been decoded and is awaiting
     /// delivery. Subsequent HEADERS are trailers and decoded-then-dropped.
     headers_ready: bool = false,
@@ -1137,7 +1136,6 @@ pub const ClientSession = struct {
                     return;
                 }
                 const stream = maybe_stream.?;
-                stream.seen_headers = true;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
                         this.fatal_error = error.HTTP2ProtocolError;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -1,22 +1,51 @@
 //! HTTP/2 path for Bun's fetch HTTP client.
 //!
-//! A `ClientSession` is created when ALPN negotiates "h2" and lives for the
-//! duration of one request on one TCP+TLS connection. It owns the HPACK
-//! encoder/decoder, an outbound write buffer, and an inbound frame buffer.
-//! The request side serialises preface + SETTINGS + HEADERS + DATA into the
-//! write buffer; the response side parses frames and feeds the result back
-//! through the same `picohttp.Response` / `handleResponseBody` /
-//! `handleResponseMetadata` machinery the HTTP/1.1 path already uses, so
-//! redirects, decompression and the result callback are unchanged.
+//! A `ClientSession` owns the connection-scoped state — HPACK tables,
+//! outbound write buffer, inbound frame buffer, and the server's SETTINGS —
+//! and survives across requests via the keep-alive pool. Each request runs on
+//! a `Stream` carved out of the session with a fresh odd stream id; the
+//! response side parses frames back into the existing `picohttp.Response` /
+//! `handleResponseBody` machinery so redirects, decompression and the result
+//! callback are shared with the HTTP/1.1 path.
+
+/// We advertise this as SETTINGS_INITIAL_WINDOW_SIZE and replenish it via
+/// WINDOW_UPDATE once half has been consumed.
+pub const local_initial_window_size: u31 = 1 << 24;
+
+pub const Stream = struct {
+    id: u31,
+
+    /// Concatenated header-block fragment from HEADERS + any CONTINUATION
+    /// frames, decoded once END_HEADERS arrives.
+    header_block: std.ArrayListUnmanaged(u8) = .{},
+
+    /// DATA payload accumulated across one onData() pass; handed to
+    /// `handleResponseBody` once after all frames in the current read have
+    /// been parsed so the client callback runs at most once per socket read.
+    body_buffer: std.ArrayListUnmanaged(u8) = .{},
+
+    end_stream_received: bool = false,
+    headers_ready: bool = false,
+    expecting_continuation: bool = false,
+    headers_end_stream: bool = false,
+    fatal_error: ?anyerror = null,
+
+    /// DATA bytes consumed since the last WINDOW_UPDATE for this stream.
+    unacked_bytes: u32 = 0,
+
+    fn deinit(this: *Stream) void {
+        this.header_block.deinit(bun.default_allocator);
+        this.body_buffer.deinit(bun.default_allocator);
+    }
+};
 
 pub const ClientSession = struct {
     pub const new = bun.TrivialNew(@This());
 
     hpack: *lshpack.HPACK,
 
-    /// Bytes queued for the socket. The h2 path writes whole frames here and
-    /// `flush()` drains as much as the socket will accept; leftovers stay
-    /// buffered until the next onWritable.
+    /// Bytes queued for the socket. Whole frames are written here and
+    /// `flush()` drains as much as the socket accepts.
     write_buffer: bun.io.StreamBuffer = .{},
 
     /// Accumulates incoming bytes until a full 9-byte frame header + declared
@@ -24,29 +53,23 @@ pub const ClientSession = struct {
     /// frames regardless of how the kernel chunked the reads.
     read_buffer: std.ArrayListUnmanaged(u8) = .{},
 
-    /// Concatenated header-block fragment from HEADERS + any CONTINUATION
-    /// frames, decoded once END_HEADERS arrives.
-    header_block: std.ArrayListUnmanaged(u8) = .{},
-
     /// Backing storage for decoded header name/value strings. lshpack returns
     /// thread-local slices that are clobbered on the next decode call, so we
     /// copy them here and point `shared_response_headers_buf` entries into
     /// this buffer until `cloneMetadata` makes its own copy.
     decoded_header_bytes: std.ArrayListUnmanaged(u8) = .{},
 
-    /// DATA payload accumulated across one onData() pass; handed to
-    /// `handleResponseBody` once after all frames in the current read have
-    /// been parsed so the client callback runs at most once per socket read.
-    body_buffer: std.ArrayListUnmanaged(u8) = .{},
-
-    stream_id: u31 = 1,
-    end_stream_received: bool = false,
-    headers_ready: bool = false,
-    expecting_continuation: bool = false,
-    headers_end_stream: bool = false,
+    stream: Stream = .{ .id = 1 },
+    next_stream_id: u31 = 1,
+    preface_sent: bool = false,
+    goaway_received: bool = false,
     fatal_error: ?anyerror = null,
 
     remote_max_frame_size: u24 = wire.DEFAULT_MAX_FRAME_SIZE,
+    remote_max_concurrent_streams: u32 = std.math.maxInt(u32),
+
+    /// DATA bytes consumed since the last connection-level WINDOW_UPDATE.
+    conn_unacked_bytes: u32 = 0,
 
     pub fn create() *ClientSession {
         return ClientSession.new(.{
@@ -58,10 +81,29 @@ pub const ClientSession = struct {
         this.hpack.deinit();
         this.write_buffer.deinit();
         this.read_buffer.deinit(bun.default_allocator);
-        this.header_block.deinit(bun.default_allocator);
         this.decoded_header_bytes.deinit(bun.default_allocator);
-        this.body_buffer.deinit(bun.default_allocator);
+        this.stream.deinit();
         bun.destroy(this);
+    }
+
+    /// Allocate a fresh stream id for the next request on this connection.
+    /// Connection-scoped state (HPACK, settings, read/write buffers) is
+    /// preserved; per-stream parse state is reset.
+    pub fn beginStream(this: *ClientSession) void {
+        this.stream.deinit();
+        this.stream = .{ .id = this.next_stream_id };
+        this.next_stream_id +|= 2;
+    }
+
+    /// True when the connection can be returned to the keep-alive pool: no
+    /// GOAWAY, no protocol error, no leftover bytes that would confuse the
+    /// next request, and stream-id space not exhausted.
+    pub fn canPool(this: *const ClientSession) bool {
+        return !this.goaway_received and
+            this.fatal_error == null and
+            this.read_buffer.items.len == 0 and
+            this.write_buffer.isEmpty() and
+            this.next_stream_id < wire.MAX_STREAM_ID;
     }
 
     fn queue(this: *ClientSession, bytes: []const u8) void {
@@ -98,23 +140,25 @@ pub const ClientSession = struct {
         encoded.items.len += written;
     }
 
-    /// Serialise the connection preface, initial SETTINGS, WINDOW_UPDATE,
-    /// HEADERS frame(s) and (for buffered `.bytes` bodies) DATA frame(s) into
-    /// the outbound buffer. END_STREAM is on HEADERS when there is no body.
-    pub fn writeRequest(this: *ClientSession, client: *HTTPClient, request: picohttp.Request) !void {
+    fn writePreface(this: *ClientSession) void {
         this.queue(wire.client_preface);
 
-        var enable_push: wire.SettingsPayloadUnit = .{
-            .type = @intFromEnum(wire.SettingsType.SETTINGS_ENABLE_PUSH),
-            .value = 0,
-        };
-        std.mem.byteSwapAllFields(wire.SettingsPayloadUnit, &enable_push);
-        this.writeFrame(.HTTP_FRAME_SETTINGS, 0, 0, std.mem.asBytes(&enable_push)[0..wire.SettingsPayloadUnit.byteSize]);
+        var settings: [2 * wire.SettingsPayloadUnit.byteSize]u8 = undefined;
+        wire.SettingsPayloadUnit.encode(settings[0..6], .SETTINGS_ENABLE_PUSH, 0);
+        wire.SettingsPayloadUnit.encode(settings[6..12], .SETTINGS_INITIAL_WINDOW_SIZE, local_initial_window_size);
+        this.writeFrame(.HTTP_FRAME_SETTINGS, 0, 0, &settings);
 
-        // Open the flow-control window up front so large response bodies
-        // aren't throttled by the 64 KiB default.
-        this.writeWindowUpdate(0, @intCast(wire.MAX_WINDOW_SIZE - wire.DEFAULT_WINDOW_SIZE));
-        this.writeWindowUpdate(this.stream_id, @intCast(wire.MAX_WINDOW_SIZE - wire.DEFAULT_WINDOW_SIZE));
+        // Connection-level window starts at 64 KiB regardless of SETTINGS;
+        // open it to match the per-stream window so the first response isn't
+        // throttled before our first WINDOW_UPDATE.
+        this.writeWindowUpdate(0, local_initial_window_size - wire.DEFAULT_WINDOW_SIZE);
+        this.preface_sent = true;
+    }
+
+    /// Serialise the request as HEADERS frame(s) + DATA frame(s) into the
+    /// outbound buffer. The connection preface goes out once per session.
+    pub fn writeRequest(this: *ClientSession, client: *HTTPClient, request: picohttp.Request) !void {
+        if (!this.preface_sent) this.writePreface();
 
         var encoded: std.ArrayListUnmanaged(u8) = .{};
         defer encoded.deinit(bun.default_allocator);
@@ -166,7 +210,7 @@ pub const ClientSession = struct {
             var flags: u8 = 0;
             if (last) flags |= @intFromEnum(wire.HeadersFrameFlags.END_HEADERS);
             if (first and end_stream) flags |= @intFromEnum(wire.HeadersFrameFlags.END_STREAM);
-            this.writeFrame(if (first) .HTTP_FRAME_HEADERS else .HTTP_FRAME_CONTINUATION, flags, this.stream_id, chunk);
+            this.writeFrame(if (first) .HTTP_FRAME_HEADERS else .HTTP_FRAME_CONTINUATION, flags, this.stream.id, chunk);
             first = false;
             if (last) break;
         }
@@ -180,7 +224,7 @@ pub const ClientSession = struct {
             remaining = remaining[chunk.len..];
             const last = remaining.len == 0;
             const flags: u8 = if (last and end_stream) @intFromEnum(wire.DataFrameFlags.END_STREAM) else 0;
-            this.writeFrame(.HTTP_FRAME_DATA, flags, this.stream_id, chunk);
+            this.writeFrame(.HTTP_FRAME_DATA, flags, this.stream.id, chunk);
             if (last) break;
         }
     }
@@ -199,11 +243,57 @@ pub const ClientSession = struct {
 
     fn decodeAndDiscard(this: *ClientSession) void {
         var offset: usize = 0;
-        while (offset < this.header_block.items.len) {
-            const result = this.hpack.decode(this.header_block.items[offset..]) catch break;
+        while (offset < this.stream.header_block.items.len) {
+            const result = this.hpack.decode(this.stream.header_block.items[offset..]) catch break;
             offset += result.next;
         }
-        this.header_block.clearRetainingCapacity();
+        this.stream.header_block.clearRetainingCapacity();
+    }
+
+    /// Credit consumed DATA bytes back to the peer once half the advertised
+    /// window has been used, on both the connection and the active stream.
+    fn replenishWindow(this: *ClientSession) void {
+        const threshold = local_initial_window_size / 2;
+        if (this.conn_unacked_bytes >= threshold) {
+            this.writeWindowUpdate(0, @intCast(this.conn_unacked_bytes));
+            this.conn_unacked_bytes = 0;
+        }
+        if (this.stream.unacked_bytes >= threshold and !this.stream.end_stream_received) {
+            this.writeWindowUpdate(this.stream.id, @intCast(this.stream.unacked_bytes));
+            this.stream.unacked_bytes = 0;
+        }
+    }
+
+    /// Process frames that arrive while the session is parked in the
+    /// keep-alive pool with no request attached. Answers PING/SETTINGS,
+    /// records GOAWAY (so `canPool()` flips false), and discards anything
+    /// addressed to a now-closed stream.
+    pub fn onIdleData(this: *ClientSession, comptime is_ssl: bool, incoming: []const u8, socket: NewHTTPContext(is_ssl).HTTPSocket) void {
+        bun.handleOom(this.read_buffer.appendSlice(bun.default_allocator, incoming));
+        var consumed: usize = 0;
+        while (true) {
+            const buf = this.read_buffer.items[consumed..];
+            if (buf.len < wire.FrameHeader.byteSize) break;
+            var header: wire.FrameHeader = .{ .flags = 0 };
+            wire.FrameHeader.from(&header, buf[0..wire.FrameHeader.byteSize], 0, true);
+            header.streamIdentifier = wire.UInt31WithReserved.from(header.streamIdentifier).uint31;
+            const frame_len = wire.FrameHeader.byteSize + @as(usize, header.length);
+            if (buf.len < frame_len) break;
+            this.dispatchFrame(header, buf[wire.FrameHeader.byteSize..frame_len]);
+            consumed += frame_len;
+        }
+        if (consumed > 0) {
+            const tail_len = this.read_buffer.items.len - consumed;
+            if (tail_len > 0) {
+                std.mem.copyForwards(u8, this.read_buffer.items[0..tail_len], this.read_buffer.items[consumed..]);
+            }
+            this.read_buffer.items.len = tail_len;
+        }
+        this.stream.body_buffer.clearRetainingCapacity();
+        this.stream.header_block.clearRetainingCapacity();
+        _ = this.flush(is_ssl, socket) catch {
+            this.fatal_error = error.WriteFailed;
+        };
     }
 
     /// Drain the outbound buffer to the socket. Returns true when bytes
@@ -267,16 +357,21 @@ pub const ClientSession = struct {
             this.read_buffer.items.len = tail_len;
         }
 
+        this.replenishWindow();
         _ = this.flush(is_ssl, socket) catch |err| {
             return client.closeAndFail(err, is_ssl, socket);
         };
 
-        if (this.fatal_error) |err| {
+        const stream = &this.stream;
+
+        if (this.fatal_error) |err| return client.closeAndFail(err, is_ssl, socket);
+        if (stream.fatal_error) |err| {
+            if (client.allow_retry) return client.retryH2(is_ssl, socket);
             return client.closeAndFail(err, is_ssl, socket);
         }
 
-        if (this.headers_ready) {
-            this.headers_ready = false;
+        if (stream.headers_ready) {
+            stream.headers_ready = false;
             if (client.state.response_stage == .body) {
                 // Trailer block: decode to keep HPACK state coherent but
                 // don't replace the already-delivered response metadata.
@@ -285,7 +380,7 @@ pub const ClientSession = struct {
                 const should_continue = this.deliverHeaders(client) catch |err| {
                     return client.closeAndFail(err, is_ssl, socket);
                 };
-                if (should_continue == .finished or (this.end_stream_received and this.body_buffer.items.len == 0)) {
+                if (should_continue == .finished or (stream.end_stream_received and stream.body_buffer.items.len == 0)) {
                     if (client.state.flags.is_redirect_pending) {
                         return client.doRedirect(is_ssl, ctx, socket);
                     }
@@ -298,26 +393,21 @@ pub const ClientSession = struct {
             }
         }
 
-        if (client.state.response_stage != .body) {
-            // Still waiting for response headers; keep buffering DATA (a
-            // well-behaved server won't send DATA before HEADERS anyway).
-            return;
-        }
+        if (client.state.response_stage != .body) return;
 
-        if (this.body_buffer.items.len > 0) {
-            if (this.end_stream_received) client.state.flags.received_last_chunk = true;
-            const body = this.body_buffer.items;
-            const report = client.handleResponseBody(body, false) catch |err| {
+        if (stream.body_buffer.items.len > 0) {
+            if (stream.end_stream_received) client.state.flags.received_last_chunk = true;
+            const report = client.handleResponseBody(stream.body_buffer.items, false) catch |err| {
                 return client.closeAndFail(err, is_ssl, socket);
             };
-            this.body_buffer.clearRetainingCapacity();
-            if (report or this.end_stream_received) {
+            stream.body_buffer.clearRetainingCapacity();
+            if (report or stream.end_stream_received) {
                 return client.progressUpdate(is_ssl, ctx, socket);
             }
             return;
         }
 
-        if (this.end_stream_received) {
+        if (stream.end_stream_received) {
             client.state.flags.received_last_chunk = true;
             return client.progressUpdate(is_ssl, ctx, socket);
         }
@@ -326,7 +416,9 @@ pub const ClientSession = struct {
     fn dispatchFrame(this: *ClientSession, header: wire.FrameHeader, payload: []const u8) void {
         log("frame type={d} len={d} flags={d} stream={d}", .{ header.type, header.length, header.flags, header.streamIdentifier });
 
-        if (this.expecting_continuation and header.type != @intFromEnum(wire.FrameType.HTTP_FRAME_CONTINUATION)) {
+        const stream = &this.stream;
+
+        if (stream.expecting_continuation and header.type != @intFromEnum(wire.FrameType.HTTP_FRAME_CONTINUATION)) {
             this.fatal_error = error.HTTP2ProtocolError;
             return;
         }
@@ -338,8 +430,10 @@ pub const ClientSession = struct {
                 while (i + wire.SettingsPayloadUnit.byteSize <= payload.len) : (i += wire.SettingsPayloadUnit.byteSize) {
                     var unit: wire.SettingsPayloadUnit = undefined;
                     wire.SettingsPayloadUnit.from(&unit, payload[i .. i + wire.SettingsPayloadUnit.byteSize], 0, true);
-                    if (@as(wire.SettingsType, @enumFromInt(unit.type)) == .SETTINGS_MAX_FRAME_SIZE) {
-                        this.remote_max_frame_size = @truncate(@min(unit.value, wire.MAX_FRAME_SIZE));
+                    switch (@as(wire.SettingsType, @enumFromInt(unit.type))) {
+                        .SETTINGS_MAX_FRAME_SIZE => this.remote_max_frame_size = @truncate(@min(unit.value, wire.MAX_FRAME_SIZE)),
+                        .SETTINGS_MAX_CONCURRENT_STREAMS => this.remote_max_concurrent_streams = unit.value,
+                        else => {},
                     }
                 }
                 this.writeFrame(.HTTP_FRAME_SETTINGS, @intFromEnum(wire.SettingsFlags.ACK), 0, &.{});
@@ -351,7 +445,7 @@ pub const ClientSession = struct {
                 }
             },
             .HTTP_FRAME_HEADERS => {
-                if (header.streamIdentifier != this.stream_id) return;
+                if (header.streamIdentifier != stream.id) return;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
@@ -366,30 +460,34 @@ pub const ClientSession = struct {
                     }
                     fragment = fragment[wire.StreamPriority.byteSize..];
                 }
-                this.header_block.clearRetainingCapacity();
-                bun.handleOom(this.header_block.appendSlice(bun.default_allocator, fragment));
-                this.headers_end_stream = header.flags & @intFromEnum(wire.HeadersFrameFlags.END_STREAM) != 0;
+                stream.header_block.clearRetainingCapacity();
+                bun.handleOom(stream.header_block.appendSlice(bun.default_allocator, fragment));
+                stream.headers_end_stream = header.flags & @intFromEnum(wire.HeadersFrameFlags.END_STREAM) != 0;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
-                    this.end_stream_received = this.end_stream_received or this.headers_end_stream;
-                    this.headers_ready = true;
+                    stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
+                    stream.headers_ready = true;
                 } else {
-                    this.expecting_continuation = true;
+                    stream.expecting_continuation = true;
                 }
             },
             .HTTP_FRAME_CONTINUATION => {
-                if (!this.expecting_continuation or header.streamIdentifier != this.stream_id) {
+                if (!stream.expecting_continuation or header.streamIdentifier != stream.id) {
                     this.fatal_error = error.HTTP2ProtocolError;
                     return;
                 }
-                bun.handleOom(this.header_block.appendSlice(bun.default_allocator, payload));
+                bun.handleOom(stream.header_block.appendSlice(bun.default_allocator, payload));
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.END_HEADERS) != 0) {
-                    this.expecting_continuation = false;
-                    this.end_stream_received = this.end_stream_received or this.headers_end_stream;
-                    this.headers_ready = true;
+                    stream.expecting_continuation = false;
+                    stream.end_stream_received = stream.end_stream_received or stream.headers_end_stream;
+                    stream.headers_ready = true;
                 }
             },
             .HTTP_FRAME_DATA => {
-                if (header.streamIdentifier != this.stream_id) return;
+                // Padding counts against flow control even when the payload is
+                // for a stale stream, so credit the connection window first.
+                this.conn_unacked_bytes +|= header.length;
+                if (header.streamIdentifier != stream.id) return;
+                stream.unacked_bytes +|= header.length;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.DataFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
@@ -398,25 +496,27 @@ pub const ClientSession = struct {
                     };
                 }
                 if (header.flags & @intFromEnum(wire.DataFrameFlags.END_STREAM) != 0) {
-                    this.end_stream_received = true;
+                    stream.end_stream_received = true;
                 }
                 if (fragment.len > 0) {
-                    bun.handleOom(this.body_buffer.appendSlice(bun.default_allocator, fragment));
+                    bun.handleOom(stream.body_buffer.appendSlice(bun.default_allocator, fragment));
                 }
             },
             .HTTP_FRAME_RST_STREAM => {
-                if (header.streamIdentifier != this.stream_id) return;
+                if (header.streamIdentifier != stream.id) return;
                 const code: u32 = if (payload.len >= 4) wire.u32FromBytes(payload[0..4]) else 0;
                 if (code == @intFromEnum(wire.ErrorCode.NO_ERROR)) {
-                    this.end_stream_received = true;
+                    stream.end_stream_received = true;
                 } else {
-                    this.fatal_error = error.HTTP2StreamReset;
+                    stream.fatal_error = error.HTTP2StreamReset;
                 }
             },
             .HTTP_FRAME_GOAWAY => {
+                this.goaway_received = true;
+                const last_id: u32 = if (payload.len >= 4) wire.UInt31WithReserved.fromBytes(payload[0..4]).uint31 else 0;
                 const code: u32 = if (payload.len >= 8) wire.u32FromBytes(payload[4..8]) else 0;
-                if (code != @intFromEnum(wire.ErrorCode.NO_ERROR)) {
-                    this.fatal_error = error.HTTP2GoAway;
+                if (code != @intFromEnum(wire.ErrorCode.NO_ERROR) or stream.id > last_id) {
+                    stream.fatal_error = error.HTTP2GoAway;
                 }
             },
             .HTTP_FRAME_PUSH_PROMISE => {
@@ -442,8 +542,8 @@ pub const ClientSession = struct {
         var header_count: usize = 0;
 
         var offset: usize = 0;
-        while (offset < this.header_block.items.len) {
-            const result = this.hpack.decode(this.header_block.items[offset..]) catch {
+        while (offset < this.stream.header_block.items.len) {
+            const result = this.hpack.decode(this.stream.header_block.items[offset..]) catch {
                 return error.HTTP2CompressionError;
             };
             offset += result.next;
@@ -464,7 +564,7 @@ pub const ClientSession = struct {
             bounds[header_count] = .{ name_start, value_start, value_end };
             header_count += 1;
         }
-        this.header_block.clearRetainingCapacity();
+        this.stream.header_block.clearRetainingCapacity();
 
         const bytes = this.decoded_header_bytes.items;
         for (bounds[0..header_count], 0..) |b, i| {
@@ -481,9 +581,11 @@ pub const ClientSession = struct {
         client.state.pending_response = response;
 
         const should_continue = try client.handleResponseMetadata(&response);
-        // h2 has no chunked transfer-encoding; framing delimits the body.
+        // h2 framing delimits the body, so neither chunked transfer-encoding
+        // nor the HTTP/1.1 "no Content-Length ⇒ no keep-alive" rule apply.
         client.state.transfer_encoding = .identity;
         if (client.state.response_stage == .body_chunk) client.state.response_stage = .body;
+        client.state.flags.allow_keepalive = true;
 
         if (client.state.content_encoding_i < response.headers.list.len and !client.state.flags.did_set_content_encoding) {
             client.state.flags.did_set_content_encoding = true;

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -709,6 +709,7 @@ pub const ClientSession = struct {
             if (client.async_http_id == async_http_id) {
                 _ = this.pending_attach.swapRemove(i);
                 client.failFromH2(error.Aborted);
+                this.maybeRelease();
                 return;
             }
         }

--- a/src/http/H2Client.zig
+++ b/src/http/H2Client.zig
@@ -25,6 +25,7 @@ pub const Stream = struct {
     body_buffer: std.ArrayListUnmanaged(u8) = .{},
 
     end_stream_received: bool = false,
+    seen_headers: bool = false,
     headers_ready: bool = false,
     headers_end_stream: bool = false,
     /// Set once the END_STREAM flag has been written on the request side.
@@ -812,6 +813,7 @@ pub const ClientSession = struct {
             },
             .HTTP_FRAME_HEADERS => {
                 const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
+                stream.seen_headers = true;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.HeadersFrameFlags.PADDED) != 0) {
                     fragment = stripPadding(fragment) orelse {
@@ -855,6 +857,10 @@ pub const ClientSession = struct {
             .HTTP_FRAME_DATA => {
                 this.conn_unacked_bytes +|= header.length;
                 const stream = this.streams.get(@intCast(header.streamIdentifier)) orelse return;
+                if (!stream.seen_headers) {
+                    stream.fatal_error = error.HTTP2ProtocolError;
+                    return;
+                }
                 stream.unacked_bytes +|= header.length;
                 var fragment = payload;
                 if (header.flags & @intFromEnum(wire.DataFrameFlags.PADDED) != 0) {

--- a/src/http/H2FrameParser.zig
+++ b/src/http/H2FrameParser.zig
@@ -173,5 +173,5 @@ pub const SettingsPayloadUnit = packed struct(u48) {
     }
 };
 
-const std = @import("std");
 const bun = @import("bun");
+const std = @import("std");

--- a/src/http/H2FrameParser.zig
+++ b/src/http/H2FrameParser.zig
@@ -1,0 +1,173 @@
+//! HTTP/2 wire-format types shared by the fetch HTTP client and the
+//! node:http2 JS bindings. These are pure packed structs with no JSC or
+//! socket dependencies so both call sites can use the same encode/decode
+//! logic.
+
+pub const client_preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+pub const MAX_WINDOW_SIZE = std.math.maxInt(i32);
+pub const MAX_HEADER_TABLE_SIZE = std.math.maxInt(u32);
+pub const MAX_STREAM_ID = std.math.maxInt(i32);
+pub const MAX_FRAME_SIZE = std.math.maxInt(u24);
+pub const DEFAULT_WINDOW_SIZE = std.math.maxInt(u16);
+pub const DEFAULT_MAX_FRAME_SIZE: u24 = 16384;
+
+pub const FrameType = enum(u8) {
+    HTTP_FRAME_DATA = 0x00,
+    HTTP_FRAME_HEADERS = 0x01,
+    HTTP_FRAME_PRIORITY = 0x02,
+    HTTP_FRAME_RST_STREAM = 0x03,
+    HTTP_FRAME_SETTINGS = 0x04,
+    HTTP_FRAME_PUSH_PROMISE = 0x05,
+    HTTP_FRAME_PING = 0x06,
+    HTTP_FRAME_GOAWAY = 0x07,
+    HTTP_FRAME_WINDOW_UPDATE = 0x08,
+    HTTP_FRAME_CONTINUATION = 0x09,
+    HTTP_FRAME_ALTSVC = 0x0A,
+    HTTP_FRAME_ORIGIN = 0x0C,
+    _,
+};
+
+pub const PingFrameFlags = enum(u8) {
+    ACK = 0x1,
+};
+
+pub const DataFrameFlags = enum(u8) {
+    END_STREAM = 0x1,
+    PADDED = 0x8,
+};
+
+pub const HeadersFrameFlags = enum(u8) {
+    END_STREAM = 0x1,
+    END_HEADERS = 0x4,
+    PADDED = 0x8,
+    PRIORITY = 0x20,
+};
+
+pub const SettingsFlags = enum(u8) {
+    ACK = 0x1,
+};
+
+pub const ErrorCode = enum(u32) {
+    NO_ERROR = 0x0,
+    PROTOCOL_ERROR = 0x1,
+    INTERNAL_ERROR = 0x2,
+    FLOW_CONTROL_ERROR = 0x3,
+    SETTINGS_TIMEOUT = 0x4,
+    STREAM_CLOSED = 0x5,
+    FRAME_SIZE_ERROR = 0x6,
+    REFUSED_STREAM = 0x7,
+    CANCEL = 0x8,
+    COMPRESSION_ERROR = 0x9,
+    CONNECT_ERROR = 0xa,
+    ENHANCE_YOUR_CALM = 0xb,
+    INADEQUATE_SECURITY = 0xc,
+    HTTP_1_1_REQUIRED = 0xd,
+    MAX_PENDING_SETTINGS_ACK = 0xe,
+    _,
+};
+
+pub const SettingsType = enum(u16) {
+    SETTINGS_HEADER_TABLE_SIZE = 0x1,
+    SETTINGS_ENABLE_PUSH = 0x2,
+    SETTINGS_MAX_CONCURRENT_STREAMS = 0x3,
+    SETTINGS_INITIAL_WINDOW_SIZE = 0x4,
+    SETTINGS_MAX_FRAME_SIZE = 0x5,
+    SETTINGS_MAX_HEADER_LIST_SIZE = 0x6,
+    SETTINGS_ENABLE_CONNECT_PROTOCOL = 0x8,
+    SETTINGS_NO_RFC7540_PRIORITIES = 0x9,
+    _,
+};
+
+pub inline fn u32FromBytes(src: []const u8) u32 {
+    bun.debugAssert(src.len == 4);
+    return std.mem.readInt(u32, src[0..4], .big);
+}
+
+pub const UInt31WithReserved = packed struct(u32) {
+    reserved: bool = false,
+    uint31: u31 = 0,
+
+    pub inline fn from(value: u32) UInt31WithReserved {
+        return .{ .uint31 = @truncate(value & 0x7fffffff), .reserved = value & 0x80000000 != 0 };
+    }
+
+    pub inline fn init(value: u31, reserved: bool) UInt31WithReserved {
+        return .{ .uint31 = value, .reserved = reserved };
+    }
+
+    pub inline fn toUInt32(value: UInt31WithReserved) u32 {
+        return @bitCast(value);
+    }
+
+    pub inline fn fromBytes(src: []const u8) UInt31WithReserved {
+        const value: u32 = u32FromBytes(src);
+        return .{ .uint31 = @truncate(value & 0x7fffffff), .reserved = value & 0x80000000 != 0 };
+    }
+
+    pub inline fn write(this: UInt31WithReserved, comptime Writer: type, writer: Writer) bool {
+        var value: u32 = this.uint31;
+        if (this.reserved) {
+            value |= 0x80000000;
+        }
+
+        value = @byteSwap(value);
+
+        return (writer.write(std.mem.asBytes(&value)) catch 0) != 0;
+    }
+};
+
+pub const StreamPriority = packed struct(u40) {
+    streamIdentifier: u32 = 0,
+    weight: u8 = 0,
+
+    pub const byteSize: usize = 5;
+    pub inline fn write(this: *StreamPriority, comptime Writer: type, writer: Writer) bool {
+        var swap = this.*;
+        std.mem.byteSwapAllFields(StreamPriority, &swap);
+
+        return (writer.write(std.mem.asBytes(&swap)[0..StreamPriority.byteSize]) catch 0) != 0;
+    }
+
+    pub inline fn from(dst: *StreamPriority, src: []const u8) void {
+        @memcpy(@as(*[StreamPriority.byteSize]u8, @ptrCast(dst)), src);
+        std.mem.byteSwapAllFields(StreamPriority, dst);
+    }
+};
+
+pub const FrameHeader = packed struct(u72) {
+    length: u24 = 0,
+    type: u8 = @intFromEnum(FrameType.HTTP_FRAME_SETTINGS),
+    flags: u8 = 0,
+    streamIdentifier: u32 = 0,
+
+    pub const byteSize: usize = 9;
+    pub inline fn write(this: *FrameHeader, comptime Writer: type, writer: Writer) bool {
+        var swap = this.*;
+        std.mem.byteSwapAllFields(FrameHeader, &swap);
+
+        return (writer.write(std.mem.asBytes(&swap)[0..FrameHeader.byteSize]) catch 0) != 0;
+    }
+
+    pub inline fn from(dst: *FrameHeader, src: []const u8, offset: usize, comptime end: bool) void {
+        @memcpy(@as(*[FrameHeader.byteSize]u8, @ptrCast(dst))[offset .. src.len + offset], src);
+        if (comptime end) {
+            std.mem.byteSwapAllFields(FrameHeader, dst);
+        }
+    }
+};
+
+pub const SettingsPayloadUnit = packed struct(u48) {
+    type: u16,
+    value: u32,
+    pub const byteSize: usize = 6;
+    pub inline fn from(dst: *SettingsPayloadUnit, src: []const u8, offset: usize, comptime end: bool) void {
+        @memcpy(@as(*[SettingsPayloadUnit.byteSize]u8, @ptrCast(dst))[offset .. src.len + offset], src);
+        if (comptime end) {
+            std.mem.byteSwapAllFields(SettingsPayloadUnit, dst);
+        }
+    }
+};
+
+const std = @import("std");
+const bun = @import("bun");

--- a/src/http/H2FrameParser.zig
+++ b/src/http/H2FrameParser.zig
@@ -1,7 +1,7 @@
-//! HTTP/2 wire-format types shared by the fetch HTTP client and the
-//! node:http2 JS bindings. These are pure packed structs with no JSC or
-//! socket dependencies so both call sites can use the same encode/decode
-//! logic.
+//! HTTP/2 wire-format types for the fetch() HTTP/2 client. Kept free of JSC
+//! and socket dependencies so the node:http2 JS bindings (which currently
+//! carry their own copies in src/bun.js/api/bun/h2_frame_parser.zig) can later
+//! share them.
 
 pub const client_preface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
@@ -104,17 +104,6 @@ pub const UInt31WithReserved = packed struct(u32) {
         const value: u32 = u32FromBytes(src);
         return .{ .uint31 = @truncate(value & 0x7fffffff), .reserved = value & 0x80000000 != 0 };
     }
-
-    pub inline fn write(this: UInt31WithReserved, comptime Writer: type, writer: Writer) bool {
-        var value: u32 = this.uint31;
-        if (this.reserved) {
-            value |= 0x80000000;
-        }
-
-        value = @byteSwap(value);
-
-        return (writer.write(std.mem.asBytes(&value)) catch 0) != 0;
-    }
 };
 
 pub const StreamPriority = packed struct(u40) {
@@ -122,12 +111,6 @@ pub const StreamPriority = packed struct(u40) {
     weight: u8 = 0,
 
     pub const byteSize: usize = 5;
-    pub inline fn write(this: *StreamPriority, comptime Writer: type, writer: Writer) bool {
-        var swap = this.*;
-        std.mem.byteSwapAllFields(StreamPriority, &swap);
-
-        return (writer.write(std.mem.asBytes(&swap)[0..StreamPriority.byteSize]) catch 0) != 0;
-    }
 
     pub inline fn from(dst: *StreamPriority, src: []const u8) void {
         @memcpy(@as(*[StreamPriority.byteSize]u8, @ptrCast(dst)), src);
@@ -142,12 +125,6 @@ pub const FrameHeader = packed struct(u72) {
     streamIdentifier: u32 = 0,
 
     pub const byteSize: usize = 9;
-    pub inline fn write(this: *FrameHeader, comptime Writer: type, writer: Writer) bool {
-        var swap = this.*;
-        std.mem.byteSwapAllFields(FrameHeader, &swap);
-
-        return (writer.write(std.mem.asBytes(&swap)[0..FrameHeader.byteSize]) catch 0) != 0;
-    }
 
     pub inline fn from(dst: *FrameHeader, src: []const u8, offset: usize, comptime end: bool) void {
         @memcpy(@as(*[FrameHeader.byteSize]u8, @ptrCast(dst))[offset .. src.len + offset], src);

--- a/src/http/H2FrameParser.zig
+++ b/src/http/H2FrameParser.zig
@@ -167,6 +167,10 @@ pub const SettingsPayloadUnit = packed struct(u48) {
             std.mem.byteSwapAllFields(SettingsPayloadUnit, dst);
         }
     }
+    pub inline fn encode(dst: *[byteSize]u8, setting: SettingsType, value: u32) void {
+        std.mem.writeInt(u16, dst[0..2], @intFromEnum(setting), .big);
+        std.mem.writeInt(u32, dst[2..6], value, .big);
+    }
 };
 
 const std = @import("std");

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -109,6 +109,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         pub fn registerH2(this: *@This(), session: *H2.ClientSession) void {
             if (comptime !ssl) return;
             if (session.registry_index != std.math.maxInt(u32)) return;
+            session.ref();
             session.registry_index = @intCast(this.active_h2_sessions.items.len);
             bun.handleOom(this.active_h2_sessions.append(bun.default_allocator, session));
         }
@@ -122,6 +123,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             bun.debugAssert(idx < list.items.len and list.items[idx] == session);
             _ = list.swapRemove(idx);
             if (idx < list.items.len) list.items[idx].registry_index = idx;
+            session.deref();
         }
 
         pub fn tagAsH2(socket: HTTPSocket, session: *H2.ClientSession) void {
@@ -171,7 +173,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         bun.default_allocator.free(pooled.target_hostname);
                         pooled.target_hostname = "";
                     }
-                    if (pooled.h2_session) |s| s.deinit();
+                    if (pooled.h2_session) |s| s.deref();
                     pooled.h2_session = null;
                     pooled.http_socket.close(.failure);
                 }
@@ -338,7 +340,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 t.shutdown();
                 t.detachAndDeref();
             }
-            if (h2_session) |s| s.deinit();
+            if (h2_session) |s| s.deref();
             closeSocket(socket);
         }
 
@@ -456,7 +458,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     bun.default_allocator.free(pooled.target_hostname);
                     pooled.target_hostname = "";
                 }
-                if (pooled.h2_session) |s| s.deinit();
+                if (pooled.h2_session) |s| s.deref();
                 pooled.h2_session = null;
                 assert(pooled.owner.pending_sockets.put(pooled));
             }

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -589,10 +589,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 // TCP fin must be closed, but we must keep the original tagged
                 // pointer so that their onClose callback is called.
                 //
-                // Three possible states:
+                // Four possible states:
                 // 1. HTTP Keep-Alive socket: it must be removed from the pool
                 // 2. HTTP Client socket: it might need to be retried
-                // 3. Dead socket: it is already marked as dead
+                // 3. HTTP/2 session: fail every stream on it
+                // 4. Dead socket: it is already marked as dead
                 const tagged = getTagged(ptr);
                 markTaggedSocketAsDead(socket, tagged);
                 socket.close(.failure);

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -627,7 +627,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             target_hostname: []const u8,
             target_port: u16,
             proxy_auth_hash: u64,
-            want_h2: bool,
+            want_h2: BoringSSL.SSL.AlpnOffer,
         ) ?ExistingSocket {
             if (hostname.len > MAX_KEEPALIVE_HOSTNAME)
                 return null;
@@ -649,10 +649,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     continue;
                 }
 
-                // A request that can't speak h2 must not pick an h2 socket.
-                // An h2-capable request may pick either; ALPN on the pooled
-                // socket already decided which protocol it speaks.
-                if (socket.h2_session != null and !want_h2) {
+                // ALPN on the pooled socket has already decided which protocol
+                // it speaks; only match callers compatible with that choice.
+                if (socket.h2_session != null) {
+                    if (want_h2 == .h1) continue;
+                } else if (want_h2 == .h2_only) {
                     continue;
                 }
 
@@ -770,7 +771,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     target_hostname,
                     target_port,
                     proxy_auth_hash,
-                    if (comptime ssl) client.canOfferH2() else false,
+                    if (comptime ssl) client.alpnOffer() else .h1,
                 )) |found| {
                     const sock = found.socket;
                     if (sock.ext(**anyopaque)) |ctx| {

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -84,6 +84,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         /// HTTP/2 sessions with at least one active stream, available for
         /// concurrent attachment if `hasHeadroom()`.
         active_h2_sessions: std.ArrayListUnmanaged(*H2.ClientSession) = .{},
+        /// HTTPClients whose fresh TLS connect is in flight and whose request
+        /// is h2-capable. Subsequent h2-capable requests to the same origin
+        /// coalesce onto the first one's session once ALPN resolves rather
+        /// than each opening its own socket.
+        pending_h2_connects: std.ArrayListUnmanaged(*H2.PendingConnect) = .{},
 
         const Context = @This();
         pub const HTTPSocket = uws.NewSocketHandler(ssl);
@@ -180,6 +185,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             }
 
             this.active_h2_sessions.deinit(bun.default_allocator);
+            for (this.pending_h2_connects.items) |pc| pc.deinit();
+            this.pending_h2_connects.deinit(bun.default_allocator);
 
             // Use deferred free pattern (via nextTick) to avoid freeing the uSockets
             // context while close callbacks may still reference it.
@@ -690,7 +697,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             return null;
         }
 
-        pub fn connectSocket(this: *@This(), client: *HTTPClient, socket_path: []const u8) !HTTPSocket {
+        pub fn connectSocket(this: *@This(), client: *HTTPClient, socket_path: []const u8) !?HTTPSocket {
             client.connected_url = if (client.http_proxy) |proxy| proxy else client.url;
             const socket = try HTTPSocket.connectUnixAnon(
                 socket_path,
@@ -702,7 +709,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             return socket;
         }
 
-        pub fn connect(this: *@This(), client: *HTTPClient, hostname_: []const u8, port: u16) !HTTPSocket {
+        pub fn connect(this: *@This(), client: *HTTPClient, hostname_: []const u8, port: u16) !?HTTPSocket {
             const hostname = if (FeatureFlags.hardcode_localhost_to_127_0_0_1 and strings.eqlComptime(hostname_, "localhost"))
                 "127.0.0.1"
             else
@@ -715,9 +722,14 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 if (client.canOfferH2()) {
                     for (this.active_h2_sessions.items) |session| {
                         if (session.hasHeadroom() and session.matches(hostname, port, SSLConfig.rawPtr(client.tls_props))) {
-                            client.registerAbortTracker(true, session.socket);
-                            session.attach(client);
-                            return session.socket;
+                            session.adopt(client);
+                            return null;
+                        }
+                    }
+                    for (this.pending_h2_connects.items) |pc| {
+                        if (pc.matches(hostname, port, SSLConfig.rawPtr(client.tls_props))) {
+                            bun.handleOom(pc.waiters.append(bun.default_allocator, client));
+                            return null;
                         }
                     }
                 }
@@ -752,10 +764,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                             session.socket = sock;
                             tagAsH2(sock, session);
                             this.registerH2(session);
-                            client.registerAbortTracker(true, sock);
-                            session.attach(client);
+                            session.adopt(client);
                         } else unreachable;
-                        return sock;
+                        return null;
                     }
                     if (found.tunnel) |tunnel| {
                         // Reattach the pooled tunnel BEFORE onOpen so the
@@ -784,6 +795,17 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 false,
             );
             client.allow_retry = false;
+            if (comptime ssl) {
+                if (client.canOfferH2()) {
+                    const pc = H2.PendingConnect.new(.{
+                        .hostname = bun.handleOom(bun.default_allocator.dupe(u8, hostname)),
+                        .port = port,
+                        .ssl_config = SSLConfig.rawPtr(client.tls_props),
+                    });
+                    bun.handleOom(this.pending_h2_connects.append(bun.default_allocator, pc));
+                    client.pending_h2 = pc;
+                }
+            }
             return socket;
         }
     };

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -119,6 +119,24 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             bun.handleOom(this.active_h2_sessions.append(bun.default_allocator, session));
         }
 
+        /// Called from drainQueuedShutdowns when the abort-tracker lookup
+        /// misses: a request parked in `PendingConnect.waiters` (coalesced
+        /// onto a leader's in-flight TLS connect) never registered a socket,
+        /// so it can only be found by scanning here.
+        pub fn abortPendingH2Waiter(this: *@This(), async_http_id: u32) bool {
+            if (comptime !ssl) return false;
+            for (this.pending_h2_connects.items) |pc| {
+                for (pc.waiters.items, 0..) |waiter, i| {
+                    if (waiter.async_http_id == async_http_id) {
+                        _ = pc.waiters.swapRemove(i);
+                        waiter.failFromH2(error.Aborted);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         pub fn unregisterH2(this: *@This(), session: *H2.ClientSession) void {
             if (comptime !ssl) return;
             const idx = session.registry_index;

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -26,6 +26,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             /// established with different credentials are not cross-shared.
             /// 0 = no proxy auth.
             proxy_auth_hash: u64 = 0,
+            /// HTTP/2 connection state (HPACK tables, server SETTINGS) when
+            /// this socket negotiated "h2". Owned by the pool while parked.
+            h2_session: ?*H2.ClientSession = null,
         };
 
         pub fn markTaggedSocketAsDead(socket: HTTPSocket, tagged: ActiveSocket) void {
@@ -140,6 +143,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         bun.default_allocator.free(pooled.target_hostname);
                         pooled.target_hostname = "";
                     }
+                    if (pooled.h2_session) |s| s.deinit();
+                    pooled.h2_session = null;
                     pooled.http_socket.close(.failure);
                 }
             }
@@ -244,6 +249,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             target_hostname: []const u8,
             target_port: u16,
             proxy_auth_hash: u64,
+            h2_session: ?*H2.ClientSession,
         ) void {
             // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
@@ -285,6 +291,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     else
                         "";
                     pending.target_port = target_port;
+                    pending.h2_session = h2_session;
 
                     log("Keep-Alive release {s}:{d} tunnel={} target={s}:{d}", .{
                         hostname,
@@ -301,6 +308,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 t.shutdown();
                 t.detachAndDeref();
             }
+            if (h2_session) |s| s.deinit();
             closeSocket(socket);
         }
 
@@ -415,6 +423,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     bun.default_allocator.free(pooled.target_hostname);
                     pooled.target_hostname = "";
                 }
+                if (pooled.h2_session) |s| s.deinit();
+                pooled.h2_session = null;
                 assert(pooled.owner.pending_sockets.put(pooled));
             }
 
@@ -441,6 +451,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     if (pooled.proxy_tunnel != null) {
                         log("Data on idle pooled tunnel — evicting", .{});
                         terminateSocket(socket);
+                        return;
+                    }
+
+                    if (pooled.h2_session) |session| {
+                        session.onIdleData(comptime ssl, buf, socket);
+                        if (!session.canPool()) terminateSocket(socket);
                         return;
                     }
 
@@ -525,6 +541,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             /// Non-null if the socket carries an established CONNECT tunnel.
             /// Ownership (one strong ref) is transferred to the caller.
             tunnel: ?*ProxyTunnel,
+            /// Non-null if the socket negotiated "h2"; ownership transferred.
+            h2_session: ?*H2.ClientSession,
         };
 
         fn existingSocket(
@@ -537,6 +555,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             target_hostname: []const u8,
             target_port: u16,
             proxy_auth_hash: u64,
+            want_h2: bool,
         ) ?ExistingSocket {
             if (hostname.len > MAX_KEEPALIVE_HOSTNAME)
                 return null;
@@ -555,6 +574,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 }
 
                 if (socket.did_have_handshaking_error_while_reject_unauthorized_is_false and reject_unauthorized) {
+                    continue;
+                }
+
+                // An h2 socket can only serve a request that will speak h2;
+                // an h1 socket can only serve a request that will speak h1.
+                if (want_h2 != (socket.h2_session != null)) {
                     continue;
                 }
 
@@ -606,9 +631,11 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         bun.default_allocator.free(socket.target_hostname);
                         socket.target_hostname = "";
                     }
+                    const h2_session = socket.h2_session;
+                    socket.h2_session = null;
                     assert(this.pending_sockets.put(socket));
                     log("+ Keep-Alive reuse {s}:{d}{s}", .{ hostname, port, if (tunnel != null) " (with tunnel)" else "" });
-                    return .{ .socket = http_socket, .tunnel = tunnel };
+                    return .{ .socket = http_socket, .tunnel = tunnel, .h2_session = h2_session };
                 }
             }
 
@@ -653,12 +680,18 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     target_hostname,
                     target_port,
                     proxy_auth_hash,
+                    if (comptime ssl) client.canOfferH2() else false,
                 )) |found| {
                     const sock = found.socket;
                     if (sock.ext(**anyopaque)) |ctx| {
                         ctx.* = bun.cast(**anyopaque, ActiveSocket.init(client).ptr());
                     }
                     client.allow_retry = true;
+                    if (found.h2_session) |session| {
+                        client.registerAbortTracker(comptime ssl, sock);
+                        client.adoptH2(comptime ssl, sock, session);
+                        return sock;
+                    }
                     if (found.tunnel) |tunnel| {
                         // Reattach the pooled tunnel BEFORE onOpen so the
                         // request/response stage is already .proxy_headers.
@@ -707,6 +740,7 @@ const ProxyTunnel = @import("./ProxyTunnel.zig");
 const TaggedPointerUnion = @import("../ptr.zig").TaggedPointerUnion;
 
 const bun = @import("bun");
+const H2 = bun.http.H2;
 const Environment = bun.Environment;
 const FeatureFlags = bun.FeatureFlags;
 const assert = bun.assert;

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -824,11 +824,10 @@ const log = bun.Output.scoped(.HTTPContext, .hidden);
 const HTTPCertError = @import("./HTTPCertError.zig");
 const HTTPThread = @import("./HTTPThread.zig");
 const ProxyTunnel = @import("./ProxyTunnel.zig");
+const std = @import("std");
 const TaggedPointerUnion = @import("../ptr.zig").TaggedPointerUnion;
 
-const std = @import("std");
 const bun = @import("bun");
-const H2 = bun.http.H2;
 const Environment = bun.Environment;
 const FeatureFlags = bun.FeatureFlags;
 const assert = bun.assert;
@@ -838,4 +837,5 @@ const BoringSSL = bun.BoringSSL.c;
 const SSLConfig = bun.api.server.ServerConfig.SSLConfig;
 
 const HTTPClient = bun.http;
+const H2 = bun.http.H2;
 const InitError = HTTPClient.InitError;

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -81,6 +81,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
         ref_count: RefCount,
         pending_sockets: PooledSocketHiveAllocator,
         us_socket_context: *uws.SocketContext,
+        /// HTTP/2 sessions with at least one active stream, available for
+        /// concurrent attachment if `hasHeadroom()`.
+        active_h2_sessions: std.ArrayListUnmanaged(*H2.ClientSession) = .{},
 
         const Context = @This();
         pub const HTTPSocket = uws.NewSocketHandler(ssl);
@@ -97,10 +100,35 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             DeadSocket,
             HTTPClient,
             PooledSocket,
+            H2.ClientSession,
         });
         const ssl_int = @as(c_int, @intFromBool(ssl));
 
         const MAX_KEEPALIVE_HOSTNAME = 128;
+
+        pub fn registerH2(this: *@This(), session: *H2.ClientSession) void {
+            if (comptime !ssl) return;
+            if (session.registry_index != std.math.maxInt(u32)) return;
+            session.registry_index = @intCast(this.active_h2_sessions.items.len);
+            bun.handleOom(this.active_h2_sessions.append(bun.default_allocator, session));
+        }
+
+        pub fn unregisterH2(this: *@This(), session: *H2.ClientSession) void {
+            if (comptime !ssl) return;
+            const idx = session.registry_index;
+            if (idx == std.math.maxInt(u32)) return;
+            session.registry_index = std.math.maxInt(u32);
+            const list = &this.active_h2_sessions;
+            bun.debugAssert(idx < list.items.len and list.items[idx] == session);
+            _ = list.swapRemove(idx);
+            if (idx < list.items.len) list.items[idx].registry_index = idx;
+        }
+
+        pub fn tagAsH2(socket: HTTPSocket, session: *H2.ClientSession) void {
+            if (socket.ext(**anyopaque)) |ctx| {
+                ctx.* = bun.cast(**anyopaque, ActiveSocket.init(session).ptr());
+            }
+        }
 
         pub fn sslCtx(this: *@This()) *BoringSSL.SSL_CTX {
             if (comptime !ssl) {
@@ -148,6 +176,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     pooled.http_socket.close(.failure);
                 }
             }
+
+            this.active_h2_sessions.deinit(bun.default_allocator);
 
             // Use deferred free pattern (via nextTick) to avoid freeing the uSockets
             // context while close callbacks may still reference it.
@@ -410,6 +440,9 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 if (tagged.get(HTTPClient)) |client| {
                     return client.onClose(comptime ssl, socket);
                 }
+                if (tagged.get(H2.ClientSession)) |session| {
+                    return session.onClose(error.ConnectionClosed);
+                }
             }
 
             fn addMemoryBackToPool(pooled: *PooledSocket) void {
@@ -441,6 +474,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         client.getSslCtx(ssl),
                         socket,
                     );
+                } else if (tagged.get(H2.ClientSession)) |session| {
+                    return session.onData(buf);
                 } else if (tagged.is(PooledSocket)) {
                     const pooled = tagged.as(PooledSocket);
                     // If this pooled socket carries a CONNECT tunnel, any
@@ -455,7 +490,7 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     }
 
                     if (pooled.h2_session) |session| {
-                        session.onIdleData(comptime ssl, buf, socket);
+                        session.onIdleData(buf);
                         if (!session.canPool()) terminateSocket(socket);
                         return;
                     }
@@ -483,6 +518,8 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                         comptime ssl,
                         socket,
                     );
+                } else if (tagged.get(H2.ClientSession)) |session| {
+                    return session.onWritable();
                 } else if (tagged.is(PooledSocket)) {
                     // it's a keep-alive socket
                 } else {
@@ -498,6 +535,10 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                 const tagged = getTagged(ptr);
                 if (tagged.get(HTTPClient)) |client| {
                     return client.onTimeout(comptime ssl, socket);
+                }
+                if (tagged.get(H2.ClientSession)) |session| {
+                    markSocketAsDead(socket);
+                    session.onClose(error.Timeout);
                 }
 
                 terminateSocket(socket);
@@ -531,6 +572,10 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
 
                 if (tagged.get(HTTPClient)) |client| {
                     client.onClose(comptime ssl, socket);
+                    return;
+                }
+                if (tagged.get(H2.ClientSession)) |session| {
+                    session.onClose(error.ConnectionClosed);
                     return;
                 }
             }
@@ -577,9 +622,10 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     continue;
                 }
 
-                // An h2 socket can only serve a request that will speak h2;
-                // an h1 socket can only serve a request that will speak h1.
-                if (want_h2 != (socket.h2_session != null)) {
+                // A request that can't speak h2 must not pick an h2 socket.
+                // An h2-capable request may pick either; ALPN on the pooled
+                // socket already decided which protocol it speaks.
+                if (socket.h2_session != null and !want_h2) {
                     continue;
                 }
 
@@ -663,6 +709,18 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
             client.connected_url = if (client.http_proxy) |proxy| proxy else client.url;
             client.connected_url.hostname = hostname;
 
+            if (comptime ssl) {
+                if (client.canOfferH2()) {
+                    for (this.active_h2_sessions.items) |session| {
+                        if (session.hasHeadroom() and session.matches(hostname, port, SSLConfig.rawPtr(client.tls_props))) {
+                            client.registerAbortTracker(true, session.socket);
+                            session.attach(client);
+                            return session.socket;
+                        }
+                    }
+                }
+            }
+
             if (client.isKeepAlivePossible()) {
                 const want_tunnel = client.http_proxy != null and client.url.isHTTPS();
                 // CONNECT TCP target (writeProxyConnect line 346). The SNI
@@ -688,8 +746,13 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                     }
                     client.allow_retry = true;
                     if (found.h2_session) |session| {
-                        client.registerAbortTracker(comptime ssl, sock);
-                        client.adoptH2(comptime ssl, sock, session);
+                        if (comptime ssl) {
+                            session.socket = sock;
+                            tagAsH2(sock, session);
+                            this.registerH2(session);
+                            client.registerAbortTracker(true, sock);
+                            session.attach(client);
+                        } else unreachable;
                         return sock;
                     }
                     if (found.tunnel) |tunnel| {
@@ -739,6 +802,7 @@ const HTTPThread = @import("./HTTPThread.zig");
 const ProxyTunnel = @import("./ProxyTunnel.zig");
 const TaggedPointerUnion = @import("../ptr.zig").TaggedPointerUnion;
 
+const std = @import("std");
 const bun = @import("bun");
 const H2 = bun.http.H2;
 const Environment = bun.Environment;

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -360,6 +360,14 @@ fn evictOldestSslContext() void {
     entry.config_ref.deinit();
 }
 
+fn abortPendingH2Waiter(this: *@This(), async_http_id: u32) bool {
+    if (this.https_context.abortPendingH2Waiter(async_http_id)) return true;
+    for (custom_ssl_context_map.values()) |entry| {
+        if (entry.ctx.abortPendingH2Waiter(async_http_id)) return true;
+    }
+    return false;
+}
+
 fn drainQueuedShutdowns(this: *@This()) void {
     while (true) {
         // socket.close() can potentially be slow
@@ -396,11 +404,16 @@ fn drainQueuedShutdowns(this: *@This()) void {
                     },
                 }
             } else {
-                // No socket for this id: the request either hasn't started
-                // yet (still in `queued_tasks`/`deferred_tasks`) or has
-                // already completed. Flag it so `drainEvents` knows to scan
-                // the queue for aborted-but-unstarted tasks even when
-                // `active >= max` would otherwise short-circuit.
+                // No socket for this id. It may be a request coalesced onto a
+                // leader's in-flight h2 TLS connect (parked in `pc.waiters`
+                // with no abort-tracker entry); scan those first so the abort
+                // doesn't wait for the leader's connect to resolve.
+                if (this.abortPendingH2Waiter(http.async_http_id)) continue;
+                // Otherwise the request either hasn't started yet (still in
+                // `queued_tasks`/`deferred_tasks`) or has already completed.
+                // Flag it so `drainEvents` knows to scan the queue for
+                // aborted-but-unstarted tasks even when `active >= max`
+                // would otherwise short-circuit.
                 this.has_pending_queued_abort = true;
             }
         }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -441,6 +441,9 @@ fn drainQueuedWrites(this: *@This()) void {
                                 client.flushStream(is_tls, socket);
                             }
                         }
+                        if (tagged.get(bun.http.H2.ClientSession)) |session| {
+                            session.streamBodyByHttpId(write.async_http_id, ended);
+                        }
                     },
                 }
             }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -388,6 +388,10 @@ fn drainQueuedShutdowns(this: *@This()) void {
                             client.closeAndAbort(comptime is_tls, socket);
                             continue;
                         }
+                        if (tagged.get(bun.http.H2.ClientSession)) |session| {
+                            session.abortByHttpId(http.async_http_id);
+                            continue;
+                        }
                         socket.close(.failure);
                     },
                 }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -243,7 +243,7 @@ pub fn onStart(opts: InitOpts) void {
     bun.http.http_thread.processEvents();
 }
 
-pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !NewHTTPContext(is_ssl).HTTPSocket {
+pub fn connect(this: *@This(), client: *HTTPClient, comptime is_ssl: bool) !?NewHTTPContext(is_ssl).HTTPSocket {
     if (client.unix_socket_path.length() > 0) {
         return try this.context(is_ssl).connectSocket(client, client.unix_socket_path.slice());
     }

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -491,6 +491,9 @@ fn drainQueuedHTTPResponseBodyDrains(this: *@This()) void {
                         if (tagged.get(HTTPClient)) |client| {
                             client.drainResponseBody(comptime is_tls, socket);
                         }
+                        if (tagged.get(bun.http.H2.ClientSession)) |session| {
+                            session.drainResponseBodyByHttpId(drain.async_http_id);
+                        }
                     },
                 }
             }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -853,7 +853,7 @@ export function assignStreamIntoResumableSink(stream, sink) {
       }
     }
 
-    // Native ResumableSink invokes this as (stream, reason) — see
+    // Native ResumableSink invokes this as (undefined, reason) — see
     // ResumableSink.cancel in ResumableSink.zig. The first slot is unused
     // here (we close over `stream`), but the parameter is required so the
     // abort reason lands in the right argument.

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -853,7 +853,11 @@ export function assignStreamIntoResumableSink(stream, sink) {
       }
     }
 
-    function cancelStream(reason: Error | null) {
+    // Native ResumableSink invokes this as (stream, reason) — see
+    // ResumableSink.cancel in ResumableSink.zig. The first slot is unused
+    // here (we close over `stream`), but the parameter is required so the
+    // abort reason lands in the right argument.
+    function cancelStream(_, reason: Error | null) {
       if (closed) return;
       let wasClosed = closed;
       closed = true;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -252,3 +252,10 @@ export const sysErrorNameFromLibuv: (errno: number) => string | undefined = $new
   "TestingAPIs.sysErrorNameFromLibuv",
   1,
 );
+
+export const fetchH2Internals = {
+  liveCounts: $newZigFunction("http/H2Client.zig", "TestingAPIs.liveCounts", 0) as () => {
+    sessions: number;
+    streams: number;
+  },
+};

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -776,6 +776,39 @@ test("--parallel --randomize without --seed is reproducible via the printed seed
   const second = await run([`--seed=${first.seed}`]);
   // Within-file ordering must match exactly when the printed seed is replayed.
   expect({ a: second.a, b: second.b }).toEqual({ a: first.a, b: first.b });
+});
+
+test("--parallel forwards --experimental-http2-fetch to workers", async () => {
+  // The worker's Bun.argv/execArgv are rewritten to look like `bun <file>`, so
+  // assert the *effect*: an h2-only server (allowHTTP1:false) replies 200 only
+  // when ALPN offered h2; without the flag the worker would see 403 "Missing
+  // ALPN Protocol".
+  const fixture = `import {test,expect} from "bun:test";
+    import {createSecureServer} from "node:http2";
+    import {once} from "node:events";
+    test("h2", async () => {
+      const {key, cert} = JSON.parse(process.env.H2_TLS);
+      const s = createSecureServer({key, cert, allowHTTP1:false}, (q,r)=>r.end(q.httpVersion));
+      s.listen(0); await once(s,"listening");
+      try {
+        const r = await fetch("https://localhost:"+s.address().port, {tls:{rejectUnauthorized:false}});
+        expect(r.status).toBe(200);
+        expect(await r.text()).toBe("2.0");
+      } finally { s.close(); }
+    });`;
+  using dir = tempDir("parallel-h2-flag", { "a.test.js": fixture, "b.test.js": fixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--experimental-http2-fetch"],
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", H2_TLS: JSON.stringify(tls) },
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
 });
 
 test("--parallel forwards --conditions to workers", async () => {

--- a/test/js/third_party/undici-h2/RESULTS.md
+++ b/test/js/third_party/undici-h2/RESULTS.md
@@ -9,7 +9,7 @@ rewritten; test bodies are byte-identical to upstream.
 - `Client`/`Agent`/`Pool` → no-op stubs with `.close()`/`.destroy()`
 - `pem.generate()` → returns harness `tls` cert/key
 - `closeClientAndServerAsPromise` → inline replacement for `test/utils/node-http`
-- `test` → wraps `node:test` to no-op `t.plan()` (Bun's `node:test` shim throws `ERR_NOT_IMPLEMENTED` for it; undici only uses it as an assertion-count hint, the `t.assert.*` calls do the actual work)
+- `test` → wraps `node:test` so `t.plan(n)` is enforced via an assertion-counting Proxy (Bun's `node:test` shim throws `ERR_NOT_IMPLEMENTED` for `t.plan`)
 
 ## Run
 

--- a/test/js/third_party/undici-h2/RESULTS.md
+++ b/test/js/third_party/undici-h2/RESULTS.md
@@ -1,0 +1,52 @@
+# undici fetch/http2 conformance against Bun's HTTP/2 client
+
+Vendored from `nodejs/undici@5878f54` (`test/fetch/http2.js`, the only file
+matching `test/fetch/http2*.js`). Only the `require()` block at the top is
+rewritten; test bodies are byte-identical to upstream.
+
+`undici-shim.mjs` provides:
+- `fetch` → `globalThis.fetch(url, { ...opts, protocol: "http2", tls: { rejectUnauthorized: false } })` for `https:` URLs (drops `dispatcher`)
+- `Client`/`Agent`/`Pool` → no-op stubs with `.close()`/`.destroy()`
+- `pem.generate()` → returns harness `tls` cert/key
+- `closeClientAndServerAsPromise` → inline replacement for `test/utils/node-http`
+- `test` → wraps `node:test` to no-op `t.plan()` (Bun's `node:test` shim throws `ERR_NOT_IMPLEMENTED` for it; undici only uses it as an assertion-count hint, the `t.assert.*` calls do the actual work)
+
+## Run
+
+```sh
+bun bd test test/js/third_party/undici-h2/run.test.ts
+```
+
+## Results
+
+| undici sub-test | status |
+| --- | --- |
+| `[Fetch] Issue#2311` | pass |
+| `[Fetch] Simple GET with h2` | pass |
+| `[Fetch] Should handle h2 request with body (string or buffer)` | pass |
+| `[Fetch] Should handle h2 request with body (stream)` | pass |
+| `Should handle h2 request with body (Blob)` | pass |
+| `Should handle h2 request with body (Blob:ArrayBuffer)` | pass |
+| `Issue#2415` | pass |
+| `Issue #2386` | pass |
+| `Issue #3046` (multiple `set-cookie`) | pass |
+| `[Fetch] Empty POST without h2 has Content-Length` | pass |
+| `[Fetch] Empty POST with h2 has Content-Length` | pass |
+
+**11/11 pass** on the debug build. Regression check: `USE_SYSTEM_BUN=1` → 1/11
+pass (only the plain-http test), confirming the suite exercises the h2 path.
+
+## Skipped
+
+The other `test/http2-*.js` files in undici (`http2-goaway.js`, `http2-abort.js`,
+`http2-stream.js`, etc.) test the `Client`/`Agent` dispatcher API rather than
+`fetch()`, so they are out of scope for this harness. `h2c-client.js` needs
+prior-knowledge cleartext h2 (not yet supported).
+
+## Updating
+
+```sh
+git -C ~/code/undici pull
+cp ~/code/undici/test/fetch/http2.js test/js/third_party/undici-h2/http2.js
+# re-apply the require() rewrite at the top (see git history)
+```

--- a/test/js/third_party/undici-h2/http2.js
+++ b/test/js/third_party/undici-h2/http2.js
@@ -6,7 +6,7 @@ const { createReadStream, readFileSync } = require('node:fs')
 const { once } = require('node:events')
 const { Readable } = require('node:stream')
 
-// Vendored: undici-shim provides node:test wrapper (no-op t.plan), pem
+// Vendored: undici-shim provides node:test wrapper (t.plan enforced), pem
 // (harness TLS certs), Client/fetch/Headers stubs, and the
 // closeClientAndServerAsPromise helper. Test bodies below are unmodified
 // from undici test/fetch/http2.js.

--- a/test/js/third_party/undici-h2/http2.js
+++ b/test/js/third_party/undici-h2/http2.js
@@ -1,0 +1,578 @@
+'use strict'
+
+const { createSecureServer } = require('node:http2')
+const { createServer } = require('node:http')
+const { createReadStream, readFileSync } = require('node:fs')
+const { once } = require('node:events')
+const { Readable } = require('node:stream')
+
+// Vendored: undici-shim provides node:test wrapper (no-op t.plan), pem
+// (harness TLS certs), Client/fetch/Headers stubs, and the
+// closeClientAndServerAsPromise helper. Test bodies below are unmodified
+// from undici test/fetch/http2.js.
+const { test, pem, Client, fetch, Headers, closeClientAndServerAsPromise } = require('./undici-shim.mjs')
+
+test('[Fetch] Issue#2311', async (t) => {
+  const expectedBody = 'hello from client!'
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }), async (req, res) => {
+    let body = ''
+
+    req.setEncoding('utf8')
+
+    res.writeHead(200, {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': req.headers['x-my-header']
+    })
+
+    for await (const chunk of req) {
+      body += chunk
+    }
+
+    res.end(body)
+  })
+
+  t.plan(2)
+
+  server.listen()
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'POST',
+      dispatcher: client,
+      headers: {
+        'x-my-header': 'foo',
+        'content-type': 'text-plain'
+      },
+      body: expectedBody
+    }
+  )
+
+  const responseBody = await response.text()
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  t.assert.strictEqual(responseBody, expectedBody)
+  t.assert.strictEqual(response.headers.get('x-custom-h2'), 'foo')
+})
+
+test('[Fetch] Simple GET with h2', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const expectedRequestBody = 'hello h2!'
+
+  server.on('stream', async (stream, headers) => {
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': headers['x-my-header'],
+      'x-method': headers[':method'],
+      ':status': 200
+    })
+
+    stream.end(expectedRequestBody)
+  })
+
+  t.plan(5)
+
+  server.listen()
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'GET',
+      dispatcher: client,
+      headers: {
+        'x-my-header': 'foo',
+        'content-type': 'text-plain'
+      }
+    }
+  )
+
+  const responseBody = await response.text()
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  t.assert.strictEqual(responseBody, expectedRequestBody)
+  t.assert.strictEqual(response.headers.get('x-method'), 'GET')
+  t.assert.strictEqual(response.headers.get('x-custom-h2'), 'foo')
+  // https://github.com/nodejs/undici/issues/2415
+  t.assert.throws(() => {
+    response.headers.get(':status')
+  }, TypeError)
+
+  // See https://fetch.spec.whatwg.org/#concept-response-status-message
+  t.assert.strictEqual(response.statusText, '')
+})
+
+test('[Fetch] Should handle h2 request with body (string or buffer)', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const expectedBody = 'hello from client!'
+  const expectedRequestBody = 'hello h2!'
+  const requestBody = []
+
+  server.on('stream', async (stream, headers) => {
+    stream.on('data', chunk => requestBody.push(chunk))
+
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': headers['x-my-header'],
+      ':status': 200
+    })
+
+    stream.end(expectedRequestBody)
+  })
+
+  t.plan(2)
+
+  server.listen()
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'POST',
+      dispatcher: client,
+      headers: {
+        'x-my-header': 'foo',
+        'content-type': 'text-plain'
+      },
+      body: expectedBody
+    }
+  )
+
+  const responseBody = await response.text()
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  t.assert.strictEqual(Buffer.concat(requestBody).toString('utf-8'), expectedBody)
+  t.assert.strictEqual(responseBody, expectedRequestBody)
+})
+
+// Skipping for now, there is something odd in the way the body is handled
+test(
+  '[Fetch] Should handle h2 request with body (stream)',
+  async (t) => {
+    const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+    const expectedBody = readFileSync(__filename, 'utf-8')
+    const stream = createReadStream(__filename)
+    const requestChunks = []
+
+    t.plan(8)
+
+    server.on('stream', async (stream, headers) => {
+      t.assert.strictEqual(headers[':method'], 'PUT')
+      t.assert.strictEqual(headers[':path'], '/')
+      t.assert.strictEqual(headers[':scheme'], 'https')
+
+      stream.respond({
+        'content-type': 'text/plain; charset=utf-8',
+        'x-custom-h2': headers['x-my-header'],
+        ':status': 200
+      })
+
+      for await (const chunk of stream) {
+        requestChunks.push(chunk)
+      }
+
+      stream.end('hello h2!')
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new Client(`https://localhost:${server.address().port}`, {
+      connect: {
+        rejectUnauthorized: false
+      },
+      allowH2: true
+    })
+
+    t.after(closeClientAndServerAsPromise(client, server))
+
+    const response = await fetch(
+      `https://localhost:${server.address().port}/`,
+      // Needs to be passed to disable the reject unauthorized
+      {
+        method: 'PUT',
+        dispatcher: client,
+        headers: {
+          'x-my-header': 'foo',
+          'content-type': 'text-plain'
+        },
+        body: Readable.toWeb(stream),
+        duplex: 'half'
+      }
+    )
+
+    const responseBody = await response.text()
+
+    t.assert.strictEqual(response.status, 200)
+    t.assert.strictEqual(response.headers.get('content-type'), 'text/plain; charset=utf-8')
+    t.assert.strictEqual(response.headers.get('x-custom-h2'), 'foo')
+    t.assert.strictEqual(responseBody, 'hello h2!')
+    t.assert.strictEqual(Buffer.concat(requestChunks).toString('utf-8'), expectedBody)
+  }
+)
+test('Should handle h2 request with body (Blob)', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const expectedBody = 'asd'
+  const requestChunks = []
+  const body = new Blob(['asd'], {
+    type: 'text/plain'
+  })
+
+  t.plan(8)
+
+  server.on('stream', async (stream, headers) => {
+    t.assert.strictEqual(headers[':method'], 'POST')
+    t.assert.strictEqual(headers[':path'], '/')
+    t.assert.strictEqual(headers[':scheme'], 'https')
+
+    stream.on('data', chunk => requestChunks.push(chunk))
+
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      'x-custom-h2': headers['x-my-header'],
+      ':status': 200
+    })
+
+    stream.end('hello h2!')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      body,
+      method: 'POST',
+      dispatcher: client,
+      headers: {
+        'x-my-header': 'foo',
+        'content-type': 'text-plain'
+      }
+    }
+  )
+
+  const responseBody = await response.arrayBuffer()
+
+  t.assert.strictEqual(response.status, 200)
+  t.assert.strictEqual(response.headers.get('content-type'), 'text/plain; charset=utf-8')
+  t.assert.strictEqual(response.headers.get('x-custom-h2'), 'foo')
+  t.assert.strictEqual(new TextDecoder().decode(responseBody).toString(), 'hello h2!')
+  t.assert.strictEqual(Buffer.concat(requestChunks).toString('utf-8'), expectedBody)
+})
+
+test(
+  'Should handle h2 request with body (Blob:ArrayBuffer)',
+  async (t) => {
+    const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+    const expectedBody = 'hello'
+    const requestChunks = []
+    const expectedResponseBody = { hello: 'h2' }
+    const buf = Buffer.from(expectedBody)
+    const body = new ArrayBuffer(buf.byteLength)
+
+    buf.copy(new Uint8Array(body))
+
+    t.plan(8)
+
+    server.on('stream', async (stream, headers) => {
+      t.assert.strictEqual(headers[':method'], 'PUT')
+      t.assert.strictEqual(headers[':path'], '/')
+      t.assert.strictEqual(headers[':scheme'], 'https')
+
+      stream.on('data', chunk => requestChunks.push(chunk))
+
+      stream.respond({
+        'content-type': 'application/json',
+        'x-custom-h2': headers['x-my-header'],
+        ':status': 200
+      })
+
+      stream.end(JSON.stringify(expectedResponseBody))
+    })
+
+    server.listen(0)
+    await once(server, 'listening')
+
+    const client = new Client(`https://localhost:${server.address().port}`, {
+      connect: {
+        rejectUnauthorized: false
+      },
+      allowH2: true
+    })
+
+    t.after(closeClientAndServerAsPromise(client, server))
+
+    const response = await fetch(
+      `https://localhost:${server.address().port}/`,
+      // Needs to be passed to disable the reject unauthorized
+      {
+        body,
+        method: 'PUT',
+        dispatcher: client,
+        headers: {
+          'x-my-header': 'foo',
+          'content-type': 'text-plain'
+        }
+      }
+    )
+
+    const responseBody = await response.json()
+
+    t.assert.strictEqual(response.status, 200)
+    t.assert.strictEqual(response.headers.get('content-type'), 'application/json')
+    t.assert.strictEqual(response.headers.get('x-custom-h2'), 'foo')
+    t.assert.deepStrictEqual(responseBody, expectedResponseBody)
+    t.assert.strictEqual(Buffer.concat(requestChunks).toString('utf-8'), expectedBody)
+  }
+)
+
+test('Issue#2415', async (t) => {
+  t.plan(1)
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', async (stream, headers) => {
+    stream.respond({
+      ':status': 200
+    })
+    stream.end('test')
+  })
+
+  server.listen()
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'GET',
+      dispatcher: client
+    }
+  )
+
+  await response.text()
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  t.assert.doesNotThrow(() => new Headers(response.headers))
+})
+
+test('Issue #2386', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+  const body = Buffer.from('hello')
+  const requestChunks = []
+  const expectedResponseBody = { hello: 'h2' }
+  const controller = new AbortController()
+  const signal = controller.signal
+
+  t.plan(4)
+
+  server.on('stream', async (stream, headers) => {
+    t.assert.strictEqual(headers[':method'], 'PUT')
+    t.assert.strictEqual(headers[':path'], '/')
+    t.assert.strictEqual(headers[':scheme'], 'https')
+
+    stream.on('data', chunk => requestChunks.push(chunk))
+
+    stream.respond({
+      'content-type': 'application/json',
+      'x-custom-h2': headers['x-my-header'],
+      ':status': 200
+    })
+
+    stream.end(JSON.stringify(expectedResponseBody))
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      body,
+      signal,
+      method: 'PUT',
+      dispatcher: client,
+      headers: {
+        'x-my-header': 'foo',
+        'content-type': 'text-plain'
+      }
+    }
+  )
+
+  controller.abort()
+  t.assert.ok(true)
+})
+
+test('Issue #3046', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  t.plan(6)
+
+  server.on('stream', async (stream, headers) => {
+    t.assert.strictEqual(headers[':method'], 'GET')
+    t.assert.strictEqual(headers[':path'], '/')
+    t.assert.strictEqual(headers[':scheme'], 'https')
+
+    stream.respond({
+      'set-cookie': ['hello=world', 'foo=bar'],
+      'content-type': 'text/html; charset=utf-8',
+      ':status': 200
+    })
+
+    stream.end('<h1>Hello World</h1>')
+  })
+
+  server.listen(0)
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'GET',
+      dispatcher: client
+    }
+  )
+
+  t.assert.strictEqual(response.status, 200)
+  t.assert.strictEqual(response.headers.get('content-type'), 'text/html; charset=utf-8')
+  t.assert.deepStrictEqual(response.headers.getSetCookie(), ['hello=world', 'foo=bar'])
+})
+
+// The two following tests ensure that empty POST requests have a Content-Length of 0
+// specified, both with and without HTTP/2 enabled.
+// The RFC 9110 (see https://httpwg.org/specs/rfc9110.html#field.content-length)
+// states it SHOULD have one for methods like POST that define a meaning for enclosed content.
+test('[Fetch] Empty POST without h2 has Content-Length', async (t) => {
+  const server = createServer({ joinDuplicateHeaders: true }, (req, res) => {
+    res.statusCode = 200
+    res.end(`content-length:${req.headers['content-length']}`)
+  }).listen(0)
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+
+  t.after(async () => {
+    server.close()
+    await client.close()
+  })
+
+  t.plan(1)
+
+  await once(server, 'listening')
+
+  const response = await fetch(
+    `http://localhost:${server.address().port}/`, {
+      method: 'POST',
+      dispatcher: client
+    }
+  )
+
+  const responseBody = await response.text()
+  t.assert.strictEqual(responseBody, `content-length:${0}`)
+})
+
+test('[Fetch] Empty POST with h2 has Content-Length', async (t) => {
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', async (stream, headers) => {
+    stream.respond({
+      'content-type': 'text/plain; charset=utf-8',
+      ':status': 200
+    })
+
+    stream.end(`content-length:${headers['content-length']}`)
+  })
+
+  t.plan(1)
+
+  server.listen()
+  await once(server, 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+
+  t.after(closeClientAndServerAsPromise(client, server))
+
+  const response = await fetch(
+    `https://localhost:${server.address().port}/`,
+    // Needs to be passed to disable the reject unauthorized
+    {
+      method: 'POST',
+      dispatcher: client
+    }
+  )
+
+  const responseBody = await response.text()
+
+  t.assert.strictEqual(responseBody, `content-length:${0}`)
+})

--- a/test/js/third_party/undici-h2/run.test.ts
+++ b/test/js/third_party/undici-h2/run.test.ts
@@ -1,0 +1,11 @@
+// Runs undici's vendored test/fetch/http2.js against Bun's built-in fetch()
+// over the experimental HTTP/2 client path. Each undici sub-test registers
+// itself via node:test, which Bun's runner surfaces individually.
+//
+// Update by re-copying from a fresh undici checkout and re-applying the
+// import rewrite at the top of http2.js (see undici-shim.mjs).
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+process.env.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT = "1";
+
+await import("./http2.js");

--- a/test/js/third_party/undici-h2/run.test.ts
+++ b/test/js/third_party/undici-h2/run.test.ts
@@ -5,7 +5,8 @@
 // Update by re-copying from a fresh undici checkout and re-applying the
 // import rewrite at the top of http2.js (see undici-shim.mjs).
 
+// The shim forces protocol:"http2" per request, so the env feature-flag is
+// not needed (and process.env writes don't reach the C environ anyway).
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-process.env.BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT = "1";
 
 await import("./http2.js");

--- a/test/js/third_party/undici-h2/undici-shim.mjs
+++ b/test/js/third_party/undici-h2/undici-shim.mjs
@@ -1,0 +1,74 @@
+// Shim that lets vendored undici test/fetch/http2.js run against Bun's
+// built-in fetch() with the experimental HTTP/2 client path. The undici
+// dispatcher API is stubbed out; only the fetch() surface is exercised.
+
+import { tls as harnessTls } from "harness";
+import { test as nodeTest } from "node:test";
+import * as nodeAssert from "node:assert";
+
+// Bun's node:test shim doesn't implement t.plan(); undici uses it pervasively
+// as an assertion-count hint. Wrap to make it a no-op so the actual
+// t.assert.* calls are what pass/fail each sub-test.
+export function test(name, fn) {
+  return nodeTest(name, async function (t) {
+    t.plan = () => {};
+    if (!t.assert) t.assert = nodeAssert;
+    return fn.call(this, t);
+  });
+}
+
+class StubDispatcher {
+  constructor() {}
+  close(cb) {
+    if (typeof cb === "function") cb();
+    return Promise.resolve();
+  }
+  destroy(cb) {
+    if (typeof cb === "function") cb();
+    return Promise.resolve();
+  }
+}
+
+export class Client extends StubDispatcher {}
+export class Agent extends StubDispatcher {}
+export class Pool extends StubDispatcher {}
+
+let globalDispatcher = new Agent();
+export function setGlobalDispatcher(d) {
+  globalDispatcher = d;
+}
+export function getGlobalDispatcher() {
+  return globalDispatcher;
+}
+
+export function fetch(input, init = {}) {
+  const { dispatcher, ...rest } = init;
+  void dispatcher;
+  const url = String(input?.url ?? input);
+  // Only force the h2 ALPN path for https; one vendored test exercises
+  // plain http to assert Content-Length parity with the h1 path.
+  if (url.startsWith("https:")) {
+    rest.protocol = "http2";
+    rest.tls = { rejectUnauthorized: false, ...(rest.tls || {}) };
+  }
+  return globalThis.fetch(input, rest);
+}
+
+export const Response = globalThis.Response;
+export const Request = globalThis.Request;
+export const Headers = globalThis.Headers;
+export const FormData = globalThis.FormData;
+
+// Stand-in for `@metcoder95/https-pem` so vendored tests don't need the
+// npm package; createSecureServer just needs `{ key, cert }`.
+export const pem = {
+  generate: async () => ({ key: harnessTls.key, cert: harnessTls.cert }),
+};
+
+// Stand-in for undici's test/utils/node-http.js helper.
+export function closeClientAndServerAsPromise(client, server) {
+  return async () => {
+    await client.close();
+    await new Promise(resolve => server.close(resolve));
+  };
+}

--- a/test/js/third_party/undici-h2/undici-shim.mjs
+++ b/test/js/third_party/undici-h2/undici-shim.mjs
@@ -70,11 +70,6 @@ export function getGlobalDispatcher() {
   return globalDispatcher;
 }
 
-// CI sees a deterministic 90s hang on the first test that doesn't reproduce
-// off-CI; until that's root-caused, log each fetch boundary so the BuildKite
-// log shows whether the hang is connect, headers, body, or cleanup.
-const trace = process.env.CI ? (m, ...a) => console.error(`[undici-h2 ${m}]`, ...a) : () => {};
-
 export function fetch(input, init = {}) {
   const { dispatcher, ...rest } = init;
   void dispatcher;
@@ -85,17 +80,7 @@ export function fetch(input, init = {}) {
     rest.protocol = "http2";
     rest.tls = { rejectUnauthorized: false, ...(rest.tls || {}) };
   }
-  trace("fetch start", rest.method ?? "GET", url);
-  return globalThis.fetch(input, rest).then(
-    r => {
-      trace("fetch resolved", r.status, url);
-      return r;
-    },
-    e => {
-      trace("fetch rejected", e?.code ?? e?.name, url);
-      throw e;
-    },
-  );
+  return globalThis.fetch(input, rest);
 }
 
 export const Response = globalThis.Response;
@@ -110,11 +95,15 @@ export const pem = {
 };
 
 // Stand-in for undici's test/utils/node-http.js helper.
+//
+// We don't await server.close()'s callback: the test process's own pooled h2
+// ClientSession holds the connection open, and Http2SecureServer.close() waits
+// for net.Server's _connections to drain — under ASAN that handoff is slow
+// enough to exceed the 90s test timeout. Closing the listener and moving on is
+// sufficient; the lingering loopback socket dies with the test process.
 export function closeClientAndServerAsPromise(client, server) {
   return async () => {
-    trace("server close start");
     await client.close();
-    await new Promise(resolve => server.close(resolve));
-    trace("server close done");
+    server.close();
   };
 }

--- a/test/js/third_party/undici-h2/undici-shim.mjs
+++ b/test/js/third_party/undici-h2/undici-shim.mjs
@@ -70,6 +70,11 @@ export function getGlobalDispatcher() {
   return globalDispatcher;
 }
 
+// CI sees a deterministic 90s hang on the first test that doesn't reproduce
+// off-CI; until that's root-caused, log each fetch boundary so the BuildKite
+// log shows whether the hang is connect, headers, body, or cleanup.
+const trace = process.env.CI ? (m, ...a) => console.error(`[undici-h2 ${m}]`, ...a) : () => {};
+
 export function fetch(input, init = {}) {
   const { dispatcher, ...rest } = init;
   void dispatcher;
@@ -80,7 +85,17 @@ export function fetch(input, init = {}) {
     rest.protocol = "http2";
     rest.tls = { rejectUnauthorized: false, ...(rest.tls || {}) };
   }
-  return globalThis.fetch(input, rest);
+  trace("fetch start", rest.method ?? "GET", url);
+  return globalThis.fetch(input, rest).then(
+    r => {
+      trace("fetch resolved", r.status, url);
+      return r;
+    },
+    e => {
+      trace("fetch rejected", e?.code ?? e?.name, url);
+      throw e;
+    },
+  );
 }
 
 export const Response = globalThis.Response;
@@ -97,7 +112,9 @@ export const pem = {
 // Stand-in for undici's test/utils/node-http.js helper.
 export function closeClientAndServerAsPromise(client, server) {
   return async () => {
+    trace("server close start");
     await client.close();
     await new Promise(resolve => server.close(resolve));
+    trace("server close done");
   };
 }

--- a/test/js/third_party/undici-h2/undici-shim.mjs
+++ b/test/js/third_party/undici-h2/undici-shim.mjs
@@ -1,24 +1,54 @@
 // Shim that lets vendored undici test/fetch/http2.js run against Bun's
-// built-in fetch() with the experimental HTTP/2 client path. The undici
-// dispatcher API is stubbed out; only the fetch() surface is exercised.
+// built-in fetch() with the experimental HTTP/2 client path. Test bodies are
+// byte-identical to upstream; this file supplies the handful of imports the
+// upstream require() block expects.
 
-import { tls as harnessTls } from "harness";
-import { test as nodeTest } from "node:test";
+import { test as bunTest, expect } from "bun:test";
 import * as nodeAssert from "node:assert";
+import { tls as harnessTls } from "harness";
 
-// Bun's node:test shim doesn't implement t.plan(); undici uses it pervasively
-// as an assertion-count hint. Wrap to make it a no-op so the actual
-// t.assert.* calls are what pass/fail each sub-test.
+// Map undici's node:test surface (t.plan / t.assert / t.after) onto bun:test.
+// t.plan(n) is enforced: every t.assert.* call is counted and the test fails
+// if the final tally doesn't match, so a callback that never fires can't
+// silently pass.
 export function test(name, fn) {
-  return nodeTest(name, async function (t) {
-    t.plan = () => {};
-    if (!t.assert) t.assert = nodeAssert;
-    return fn.call(this, t);
+  return bunTest(name, async () => {
+    let planned = -1;
+    let seen = 0;
+    const cleanups = [];
+    const assert = new Proxy(nodeAssert, {
+      get(target, prop) {
+        const real = target[prop];
+        if (typeof real !== "function") return real;
+        return (...args) => {
+          seen++;
+          return real(...args);
+        };
+      },
+    });
+    const t = {
+      plan: n => void (planned = n),
+      after: cb => void cleanups.push(cb),
+      assert,
+    };
+    let err;
+    try {
+      await fn(t);
+    } catch (e) {
+      err = e;
+    }
+    for (let i = cleanups.length - 1; i >= 0; i--) await cleanups[i]();
+    if (err) throw err;
+    if (planned >= 0 && seen !== planned) {
+      throw new Error(`plan mismatch: expected ${planned} assertions, saw ${seen}`);
+    }
   });
 }
 
+// undici's fetch() takes a `dispatcher` (its own connection pool); Bun's
+// fetch() manages h2 sessions internally. Stub the dispatcher classes so
+// `new Client(...)` / `client.close()` in test setup/teardown are inert.
 class StubDispatcher {
-  constructor() {}
   close(cb) {
     if (typeof cb === "function") cb();
     return Promise.resolve();
@@ -28,7 +58,6 @@ class StubDispatcher {
     return Promise.resolve();
   }
 }
-
 export class Client extends StubDispatcher {}
 export class Agent extends StubDispatcher {}
 export class Pool extends StubDispatcher {}
@@ -45,8 +74,8 @@ export function fetch(input, init = {}) {
   const { dispatcher, ...rest } = init;
   void dispatcher;
   const url = String(input?.url ?? input);
-  // Only force the h2 ALPN path for https; one vendored test exercises
-  // plain http to assert Content-Length parity with the h1 path.
+  // One vendored test exercises plain http to assert Content-Length parity
+  // with the h1 path; only force the h2 ALPN offer for https.
   if (url.startsWith("https:")) {
     rest.protocol = "http2";
     rest.tls = { rejectUnauthorized: false, ...(rest.tls || {}) };
@@ -59,8 +88,8 @@ export const Request = globalThis.Request;
 export const Headers = globalThis.Headers;
 export const FormData = globalThis.FormData;
 
-// Stand-in for `@metcoder95/https-pem` so vendored tests don't need the
-// npm package; createSecureServer just needs `{ key, cert }`.
+// Stand-in for `@metcoder95/https-pem` so the vendored file doesn't need the
+// npm package; createSecureServer just wants `{ key, cert }`.
 export const pem = {
   generate: async () => ({ key: harnessTls.key, cert: harnessTls.cert }),
 };

--- a/test/js/third_party/wpt-h2/RESULTS.md
+++ b/test/js/third_party/wpt-h2/RESULTS.md
@@ -11,7 +11,7 @@ globals, a `node:http2` server emulating the wptserve endpoints they hit, and a
 | `USE_SYSTEM_BUN=1` | 3 | 4 | 17 | 24 |
 
 The three system-Bun passes are the protocol-agnostic feature-detect cases
-(data: URLs, `Request` header inspection); the eleven that flip from fail to
+(data: URLs, `Request` header inspection); the seventeen that flip from fail to
 pass are the actual h2 path coverage.
 
 ## Passing on this branch

--- a/test/js/third_party/wpt-h2/RESULTS.md
+++ b/test/js/third_party/wpt-h2/RESULTS.md
@@ -1,0 +1,44 @@
+# WPT fetch `.h2.any.js` conformance results
+
+Vendored from `web-platform-tests/wpt @ ebf8e3069ec4ac6498826bf9066419e46b0f4ac5`.
+Three files copied byte-for-byte; the harness supplies `promise_test`/`assert_*`
+globals, a `node:http2` server emulating the wptserve endpoints they hit, and a
+`fetch()` wrapper that forces ALPN h2.
+
+| Build | pass | todo | fail | total |
+|---|---|---|---|---|
+| `bun bd` (this branch) | 14 | 10 | 0 | 24 |
+| `USE_SYSTEM_BUN=1` | 3 | 10 | 11 | 24 |
+
+The three system-Bun passes are the protocol-agnostic feature-detect cases
+(data: URLs, `Request` header inspection); the eleven that flip from fail to
+pass are the actual h2 path coverage.
+
+## Passing on this branch
+
+- statusText over H2 for status 200/210/400/404/410/500/502 should be the empty string (×7)
+- Fetch with POST with empty ReadableStream
+- Fetch with POST with ReadableStream
+- Fetch with POST with ReadableStream on 421 response should return the response and not retry.
+- Feature detect for POST with ReadableStream
+- Feature detect for POST with ReadableStream, using request object
+- Synchronous feature detect fails if feature unsupported
+- Streaming upload with body containing a number
+
+## Known failures (`test.todo`)
+
+All ten are pre-existing fetch-spec gaps in Bun that reproduce identically on
+the HTTP/1.1 path; none are HTTP/2 client regressions.
+
+| Test | Cause |
+|---|---|
+| Synchronous feature detect | `Request` constructor doesn't read `RequestInit.duplex`, so the getter never fires |
+| Streaming upload with body containing a String | Bun coerces string chunks instead of rejecting with TypeError |
+| Streaming upload with body containing null | Bun treats a `null` chunk as empty instead of rejecting with TypeError |
+| Streaming upload should fail on a 401 response | Bun returns the 401 response; spec says reject TypeError because the stream body can't be replayed for the auth challenge |
+| ReadbleStream should be closed on signal.abort | Bun doesn't propagate the abort reason into `ReadableStream.cancel(reason)` |
+| Fetch upload streaming should be accepted on 303 | Bun forces `redirect:"error"` for streaming bodies, so 303 surfaces as `UnexpectedRedirect` instead of dropping the body and following |
+| Fetch upload streaming should fail on 301 | Rejects, but with `UnexpectedRedirect` rather than the spec-required TypeError |
+| Fetch upload streaming should fail on 302 | Same |
+| Fetch upload streaming should fail on 307 | Same |
+| Fetch upload streaming should fail on 308 | Same |

--- a/test/js/third_party/wpt-h2/RESULTS.md
+++ b/test/js/third_party/wpt-h2/RESULTS.md
@@ -7,8 +7,8 @@ globals, a `node:http2` server emulating the wptserve endpoints they hit, and a
 
 | Build | pass | todo | fail | total |
 |---|---|---|---|---|
-| `bun bd` (this branch) | 14 | 10 | 0 | 24 |
-| `USE_SYSTEM_BUN=1` | 3 | 10 | 11 | 24 |
+| `bun bd` (this branch) | 20 | 4 | 0 | 24 |
+| `USE_SYSTEM_BUN=1` | 3 | 4 | 17 | 24 |
 
 The three system-Bun passes are the protocol-agnostic feature-detect cases
 (data: URLs, `Request` header inspection); the eleven that flip from fail to
@@ -24,21 +24,18 @@ pass are the actual h2 path coverage.
 - Feature detect for POST with ReadableStream, using request object
 - Synchronous feature detect fails if feature unsupported
 - Streaming upload with body containing a number
+- ReadbleStream should be closed on signal.abort
+- Fetch upload streaming should be accepted on 303
+- Fetch upload streaming should fail on 301 / 302 / 307 / 308 (×4)
 
 ## Known failures (`test.todo`)
 
-All ten are pre-existing fetch-spec gaps in Bun that reproduce identically on
-the HTTP/1.1 path; none are HTTP/2 client regressions.
+Pre-existing fetch-spec gaps that reproduce identically over HTTP/1.1; none
+are HTTP/2 client regressions.
 
 | Test | Cause |
 |---|---|
 | Synchronous feature detect | `Request` constructor doesn't read `RequestInit.duplex`, so the getter never fires |
 | Streaming upload with body containing a String | Bun coerces string chunks instead of rejecting with TypeError |
 | Streaming upload with body containing null | Bun treats a `null` chunk as empty instead of rejecting with TypeError |
-| Streaming upload should fail on a 401 response | Bun returns the 401 response; spec says reject TypeError because the stream body can't be replayed for the auth challenge |
-| ReadbleStream should be closed on signal.abort | Bun doesn't propagate the abort reason into `ReadableStream.cancel(reason)` |
-| Fetch upload streaming should be accepted on 303 | Bun forces `redirect:"error"` for streaming bodies, so 303 surfaces as `UnexpectedRedirect` instead of dropping the body and following |
-| Fetch upload streaming should fail on 301 | Rejects, but with `UnexpectedRedirect` rather than the spec-required TypeError |
-| Fetch upload streaming should fail on 302 | Same |
-| Fetch upload streaming should fail on 307 | Same |
-| Fetch upload streaming should fail on 308 | Same |
+| Streaming upload should fail on a 401 response | Spec step 14 of HTTP-network-or-cache fetch only applies when "request's window is an environment settings object" — i.e. browsers with credential prompting. Server runtimes (Node/undici, Deno, Bun) return the 401 as-is. Intentionally not changing. |

--- a/test/js/third_party/wpt-h2/redirect-upload.h2.any.js
+++ b/test/js/third_party/wpt-h2/redirect-upload.h2.any.js
@@ -1,0 +1,33 @@
+// META: global=window,worker
+// META: script=../resources/utils.js
+// META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
+
+const redirectUrl = RESOURCES_DIR + "redirect.h2.py";
+const redirectLocation = "top.txt";
+
+async function fetchStreamRedirect(statusCode) {
+  const url = RESOURCES_DIR + "redirect.h2.py" +
+   `?redirect_status=${statusCode}&location=${redirectLocation}`;
+  const requestInit = {method: "POST"};
+  requestInit["body"] = new ReadableStream({start: controller => {
+    const encoder = new TextEncoder();
+    controller.enqueue(encoder.encode("Test"));
+    controller.close();
+  }});
+  requestInit.duplex = "half";
+  return fetch(url, requestInit);
+}
+
+promise_test(async () => {
+  const resp = await fetchStreamRedirect(303);
+  assert_equals(resp.status, 200);
+  assert_true(new URL(resp.url).pathname.endsWith(redirectLocation),
+   "Response's url should be the redirected one");
+}, "Fetch upload streaming should be accepted on 303");
+
+for (const statusCode of [301, 302, 307, 308]) {
+  promise_test(t => {
+    return promise_rejects_js(t, TypeError, fetchStreamRedirect(statusCode));
+  }, `Fetch upload streaming should fail on ${statusCode}`);
+}

--- a/test/js/third_party/wpt-h2/request-upload.h2.any.js
+++ b/test/js/third_party/wpt-h2/request-upload.h2.any.js
@@ -1,0 +1,209 @@
+// META: global=window,worker
+// META: script=../resources/utils.js
+// META: script=/common/utils.js
+// META: script=/common/get-host-info.sub.js
+
+const duplex = "half";
+
+async function assertUpload(url, method, createBody, expectedBody) {
+  const requestInit = {method};
+  const body = createBody();
+  if (body) {
+    requestInit["body"] = body;
+    requestInit.duplex = "half";
+  }
+  const resp = await fetch(url, requestInit);
+  const text = await resp.text();
+  assert_equals(text, expectedBody);
+}
+
+function testUpload(desc, url, method, createBody, expectedBody) {
+  promise_test(async () => {
+    await assertUpload(url, method, createBody, expectedBody);
+  }, desc);
+}
+
+function createStream(chunks) {
+  return new ReadableStream({
+    start: (controller) => {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    }
+  });
+}
+
+const url = RESOURCES_DIR + "echo-content.h2.py"
+
+testUpload("Fetch with POST with empty ReadableStream", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      controller.close();
+    }})
+  },
+  "");
+
+testUpload("Fetch with POST with ReadableStream", url,
+  "POST",
+  () => {
+    return new ReadableStream({start: controller => {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode("Test"));
+      controller.close();
+    }})
+  },
+  "Test");
+
+promise_test(async (test) => {
+  const body = new ReadableStream({start: controller => {
+    const encoder = new TextEncoder();
+    controller.enqueue(encoder.encode("Test"));
+    controller.close();
+  }});
+  const resp = await fetch(
+    "/fetch/connection-pool/resources/network-partition-key.py?"
+    + `status=421&uuid=${token()}&partition_id=${self.origin}`
+    + `&dispatch=check_partition&addcounter=true`,
+    {method: "POST", body: body, duplex});
+  assert_equals(resp.status, 421);
+  const text = await resp.text();
+  assert_equals(text, "ok. Request was sent 1 times. 1 connections were created.");
+}, "Fetch with POST with ReadableStream on 421 response should return the response and not retry.");
+
+promise_test(async (test) => {
+  const request = new Request('', {
+    body: new ReadableStream(),
+    method: 'POST',
+    duplex,
+  });
+
+  assert_equals(request.headers.get('Content-Type'), null, `Request should not have a content-type set`);
+
+  const response = await fetch('data:a/a;charset=utf-8,test', {
+    method: 'POST',
+    body: new ReadableStream(),
+    duplex,
+  });
+
+  assert_equals(await response.text(), 'test', `Response has correct body`);
+}, "Feature detect for POST with ReadableStream");
+
+promise_test(async (test) => {
+  const request = new Request('data:a/a;charset=utf-8,test', {
+    body: new ReadableStream(),
+    method: 'POST',
+    duplex,
+ });
+
+  assert_equals(request.headers.get('Content-Type'), null, `Request should not have a content-type set`);
+  const response = await fetch(request);
+  assert_equals(await response.text(), 'test', `Response has correct body`);
+}, "Feature detect for POST with ReadableStream, using request object");
+
+test(() => {
+  let duplexAccessed = false;
+
+  const request = new Request("", {
+    body: new ReadableStream(),
+    method: "POST",
+    get duplex() {
+      duplexAccessed = true;
+      return "half";
+    },
+  });
+
+  assert_equals(
+    request.headers.get("Content-Type"),
+    null,
+    `Request should not have a content-type set`
+  );
+  assert_true(duplexAccessed, `duplex dictionary property should be accessed`);
+}, "Synchronous feature detect");
+
+// The asserts the synchronousFeatureDetect isn't broken by a partial implementation.
+// An earlier feature detect was broken by Safari implementing streaming bodies as part of Request,
+// but it failed when passed to fetch().
+// This tests ensures that UAs must not implement RequestInit.duplex and streaming request bodies without also implementing the fetch() parts.
+promise_test(async () => {
+  let duplexAccessed = false;
+
+  const request = new Request("", {
+    body: new ReadableStream(),
+    method: "POST",
+    get duplex() {
+      duplexAccessed = true;
+      return "half";
+    },
+  });
+
+  const supported =
+    request.headers.get("Content-Type") === null && duplexAccessed;
+
+  // If the feature detect fails, assume the browser is being truthful (other tests pick up broken cases here)
+  if (!supported) return false;
+
+  await assertUpload(
+    url,
+    "POST",
+    () =>
+      new ReadableStream({
+        start: (controller) => {
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode("Test"));
+          controller.close();
+        },
+      }),
+    "Test"
+  );
+}, "Synchronous feature detect fails if feature unsupported");
+
+promise_test(async (t) => {
+  const body = createStream(["hello"]);
+  const method = "POST";
+  await promise_rejects_js(t, TypeError, fetch(url, { method, body, duplex }));
+}, "Streaming upload with body containing a String");
+
+promise_test(async (t) => {
+  const body = createStream([null]);
+  const method = "POST";
+  await promise_rejects_js(t, TypeError, fetch(url, { method, body, duplex }));
+}, "Streaming upload with body containing null");
+
+promise_test(async (t) => {
+  const body = createStream([33]);
+  const method = "POST";
+  await promise_rejects_js(t, TypeError, fetch(url, { method, body, duplex }));
+}, "Streaming upload with body containing a number");
+
+promise_test(async (t) => {
+  const url = "/fetch/api/resources/authentication.py?realm=test";
+  const body = createStream([]);
+  const method = "POST";
+  await promise_rejects_js(t, TypeError, fetch(url, { method, body, duplex }));
+}, "Streaming upload should fail on a 401 response");
+
+promise_test(async (t) => {
+  const abortMessage = 'foo abort';
+  let streamCancelPromise = new Promise(async res => {
+    var stream = new ReadableStream({
+      cancel: function(reason) {
+        res(reason);
+      }
+    });
+    let abortController = new AbortController();
+    let fetchPromise = promise_rejects_exactly(t, abortMessage, fetch('', {
+                                                 method: 'POST',
+                                                 body: stream,
+                                                 duplex: 'half',
+                                                 signal: abortController.signal
+                                               }));
+    abortController.abort(abortMessage);
+    await fetchPromise;
+  });
+
+  let cancelReason = await streamCancelPromise;
+  assert_equals(
+      cancelReason, abortMessage, 'ReadableStream.cancel should be called.');
+}, 'ReadbleStream should be closed on signal.abort');

--- a/test/js/third_party/wpt-h2/run.test.ts
+++ b/test/js/third_party/wpt-h2/run.test.ts
@@ -1,0 +1,60 @@
+// Runs the vendored WPT fetch .h2.any.js tests against Bun's fetch() over
+// the experimental HTTP/2 client path. The .any.js files are byte-identical
+// to upstream; this driver supplies the testharness globals, a wptserve
+// stand-in, and a fetch() wrapper that forces ALPN h2.
+//
+// Vendored from web-platform-tests/wpt @ ebf8e3069ec4ac6498826bf9066419e46b0f4ac5
+//   fetch/api/basic/status.h2.any.js
+//   fetch/api/basic/request-upload.h2.any.js
+//   fetch/api/redirect/redirect-upload.h2.any.js
+
+import { afterAll } from "bun:test";
+import { wptTest } from "./testharness-shim";
+import { startServer } from "./server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const { origin, close } = await startServer();
+afterAll(close);
+
+const g = globalThis as any;
+g.RESOURCES_DIR = origin + "/fetch/api/resources/";
+g.self = { origin };
+
+const realFetch = globalThis.fetch;
+const realRequest = globalThis.Request;
+
+// A few tests construct `new Request("")` purely to inspect the resulting
+// headers; resolve relative inputs against the test server so that doesn't
+// throw before the assertion runs.
+g.Request = new Proxy(realRequest, {
+  construct(target, [input, init]) {
+    if (typeof input === "string" && !/^[a-z]+:/.test(input)) {
+      input = origin + (input.startsWith("/") ? input : "/" + input);
+    }
+    return Reflect.construct(target, [input, init]);
+  },
+});
+
+g.fetch = (input: any, init: any = {}) => {
+  let url: string;
+  if (typeof input === "string") {
+    if (!/^[a-z]+:/.test(input)) input = origin + (input.startsWith("/") ? input : "/" + input);
+    url = input;
+  } else {
+    url = input.url;
+  }
+  if (url.startsWith("https:")) {
+    init = { ...init, protocol: "http2", tls: { rejectUnauthorized: false, ...(init.tls || {}) } };
+  }
+  return realFetch(input, init);
+};
+
+// bun:test injects its own `test` binding into every imported module, which
+// would shadow the WPT-style test(fn, name) global. Load each vendored file
+// as text and run it inside a Function whose `test` parameter is the shim.
+// All other testharness identifiers resolve via globalThis.
+for (const file of ["status.h2.any.js", "request-upload.h2.any.js", "redirect-upload.h2.any.js"]) {
+  const src = readFileSync(join(import.meta.dir, file), "utf8");
+  new Function("test", src)(wptTest);
+}

--- a/test/js/third_party/wpt-h2/run.test.ts
+++ b/test/js/third_party/wpt-h2/run.test.ts
@@ -9,10 +9,10 @@
 //   fetch/api/redirect/redirect-upload.h2.any.js
 
 import { afterAll } from "bun:test";
-import { wptTest } from "./testharness-shim";
-import { startServer } from "./server";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { startServer } from "./server";
+import { wptTest } from "./testharness-shim";
 
 const { origin, close } = await startServer();
 afterAll(close);

--- a/test/js/third_party/wpt-h2/server.ts
+++ b/test/js/third_party/wpt-h2/server.ts
@@ -8,6 +8,11 @@ import { once } from "node:events";
 import { tls } from "harness";
 
 export async function startServer(): Promise<{ origin: string; close: () => Promise<void> }> {
+  // Per-uuid request counter for the network-partition-key.py route, so the
+  // 421 no-retry assertion observes the actual request count instead of a
+  // hardcoded "1".
+  const partitionHits = new Map<string, number>();
+
   const server = createSecureServer({ key: tls.key, cert: tls.cert }, (req, res) => {
     const url = new URL(req.url, "https://localhost");
     const path = url.pathname;
@@ -41,8 +46,11 @@ export async function startServer(): Promise<{ origin: string; close: () => Prom
 
     if (path.includes("/network-partition-key.py")) {
       const status = Number(url.searchParams.get("status") ?? 200);
+      const uuid = url.searchParams.get("uuid") ?? "";
+      const n = (partitionHits.get(uuid) ?? 0) + 1;
+      partitionHits.set(uuid, n);
       res.writeHead(status, { "content-type": "text/plain" });
-      res.end("ok. Request was sent 1 times. 1 connections were created.");
+      res.end(`ok. Request was sent ${n} times. 1 connections were created.`);
       return;
     }
 

--- a/test/js/third_party/wpt-h2/server.ts
+++ b/test/js/third_party/wpt-h2/server.ts
@@ -1,0 +1,77 @@
+// Minimal stand-in for the wptserve endpoints the vendored .h2.any.js
+// files hit. Routes by URL suffix so the WPT files' hardcoded paths
+// (../resources/foo.py, /xhr/..., /fetch/...) all resolve regardless of
+// what RESOURCES_DIR prefix we feed them.
+
+import { createSecureServer } from "node:http2";
+import { once } from "node:events";
+import { tls } from "harness";
+
+export async function startServer(): Promise<{ origin: string; close: () => Promise<void> }> {
+  const server = createSecureServer({ key: tls.key, cert: tls.cert }, (req, res) => {
+    const url = new URL(req.url, "https://localhost");
+    const path = url.pathname;
+
+    if (path.endsWith("/echo-content.h2.py")) {
+      res.writeHead(200, { "content-type": "text/plain" });
+      req.pipe(res);
+      return;
+    }
+
+    if (path.endsWith("/redirect.h2.py")) {
+      const status = Number(url.searchParams.get("redirect_status") ?? 302);
+      const location = url.searchParams.get("location") ?? "";
+      res.writeHead(status, { location });
+      res.end();
+      return;
+    }
+
+    if (path.endsWith("/top.txt")) {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("top");
+      return;
+    }
+
+    if (path.includes("/status.py")) {
+      const code = Number(url.searchParams.get("code") ?? 200);
+      res.writeHead(code);
+      res.end();
+      return;
+    }
+
+    if (path.includes("/network-partition-key.py")) {
+      const status = Number(url.searchParams.get("status") ?? 200);
+      res.writeHead(status, { "content-type": "text/plain" });
+      res.end("ok. Request was sent 1 times. 1 connections were created.");
+      return;
+    }
+
+    if (path.includes("/authentication.py")) {
+      res.writeHead(401, { "www-authenticate": 'Basic realm="test"' });
+      res.end();
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("not found: " + path);
+  });
+
+  const sessions = new Set<import("node:http2").ServerHttp2Session>();
+  server.on("session", s => {
+    sessions.add(s);
+    s.on("close", () => sessions.delete(s));
+  });
+
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("node:net").AddressInfo;
+
+  return {
+    origin: `https://localhost:${port}`,
+    close: () =>
+      new Promise(resolve => {
+        for (const s of sessions) s.destroy();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/test/js/third_party/wpt-h2/server.ts
+++ b/test/js/third_party/wpt-h2/server.ts
@@ -69,6 +69,15 @@ export async function startServer(): Promise<{ origin: string; close: () => Prom
     sessions.add(s);
     s.on("close", () => sessions.delete(s));
   });
+  // Track raw TCP sockets too: a client connection that handshook but never
+  // became an h2 session (ALPN miss / mid-handshake reset) is invisible to
+  // `sessions`, and net.Server.close() will block on it.
+  const sockets = new Set<import("node:net").Socket>();
+  server.on("connection", s => {
+    sockets.add(s);
+    s.on("close", () => sockets.delete(s));
+  });
+  server.on("clientError", () => {});
 
   server.listen(0);
   await once(server, "listening");
@@ -78,7 +87,9 @@ export async function startServer(): Promise<{ origin: string; close: () => Prom
     origin: `https://localhost:${port}`,
     close: () =>
       new Promise(resolve => {
+        if (process.env.CI) console.error(`[wpt-h2 close] sessions=${sessions.size} sockets=${sockets.size}`);
         for (const s of sessions) s.destroy();
+        for (const s of sockets) s.destroy();
         server.close(() => resolve());
       }),
   };

--- a/test/js/third_party/wpt-h2/server.ts
+++ b/test/js/third_party/wpt-h2/server.ts
@@ -87,7 +87,6 @@ export async function startServer(): Promise<{ origin: string; close: () => Prom
     origin: `https://localhost:${port}`,
     close: () =>
       new Promise(resolve => {
-        if (process.env.CI) console.error(`[wpt-h2 close] sessions=${sessions.size} sockets=${sockets.size}`);
         for (const s of sessions) s.destroy();
         for (const s of sockets) s.destroy();
         server.close(() => resolve());

--- a/test/js/third_party/wpt-h2/status.h2.any.js
+++ b/test/js/third_party/wpt-h2/status.h2.any.js
@@ -1,0 +1,17 @@
+// See also /xhr/status.h2.window.js
+
+[
+  200,
+  210,
+  400,
+  404,
+  410,
+  500,
+  502
+].forEach(status => {
+  promise_test(async t => {
+    const response = await fetch("/xhr/resources/status.py?code=" + status);
+    assert_equals(response.status, status, "status should be " + status);
+    assert_equals(response.statusText, "", "statusText should be the empty string");
+  }, "statusText over H2 for status " + status + " should be the empty string");
+});

--- a/test/js/third_party/wpt-h2/testharness-shim.ts
+++ b/test/js/third_party/wpt-h2/testharness-shim.ts
@@ -16,16 +16,6 @@ export const knownFailures = new Set<string>([
   // Spec requires TypeError on a 401 challenge with a non-replayable body;
   // Bun returns the 401 response instead.
   "Streaming upload should fail on a 401 response",
-  // Bun's fetch doesn't propagate the abort reason into ReadableStream.cancel.
-  "ReadbleStream should be closed on signal.abort",
-  // Bun forces redirect:"error" for streaming bodies, so every redirect
-  // (including 303, which the spec says should drop the body and follow)
-  // surfaces as a non-TypeError "UnexpectedRedirect". Same on the h1 path.
-  "Fetch upload streaming should be accepted on 303",
-  "Fetch upload streaming should fail on 301",
-  "Fetch upload streaming should fail on 302",
-  "Fetch upload streaming should fail on 307",
-  "Fetch upload streaming should fail on 308",
 ]);
 
 function register(name: string, body: () => unknown | Promise<unknown>) {

--- a/test/js/third_party/wpt-h2/testharness-shim.ts
+++ b/test/js/third_party/wpt-h2/testharness-shim.ts
@@ -1,0 +1,87 @@
+// Minimal WPT testharness.js shim mapped onto bun:test. Only the surface
+// the vendored .h2.any.js files touch is implemented. Tests whose names
+// appear in `knownFailures` are registered via test.todo so the suite
+// stays green while still surfacing the gap.
+
+import { test as bunTest, expect } from "bun:test";
+
+export const knownFailures = new Set<string>([
+  // Bun's Request constructor doesn't read RequestInit.duplex (general fetch
+  // spec gap, not h2-specific).
+  "Synchronous feature detect",
+  // Spec requires TypeError when a streamed chunk is not a BufferSource; Bun
+  // currently coerces strings and treats null as empty.
+  "Streaming upload with body containing a String",
+  "Streaming upload with body containing null",
+  // Spec requires TypeError on a 401 challenge with a non-replayable body;
+  // Bun returns the 401 response instead.
+  "Streaming upload should fail on a 401 response",
+  // Bun's fetch doesn't propagate the abort reason into ReadableStream.cancel.
+  "ReadbleStream should be closed on signal.abort",
+  // Bun forces redirect:"error" for streaming bodies, so every redirect
+  // (including 303, which the spec says should drop the body and follow)
+  // surfaces as a non-TypeError "UnexpectedRedirect". Same on the h1 path.
+  "Fetch upload streaming should be accepted on 303",
+  "Fetch upload streaming should fail on 301",
+  "Fetch upload streaming should fail on 302",
+  "Fetch upload streaming should fail on 307",
+  "Fetch upload streaming should fail on 308",
+]);
+
+function register(name: string, body: () => unknown | Promise<unknown>) {
+  if (knownFailures.has(name)) {
+    bunTest.todo(name);
+    return;
+  }
+  bunTest(name, async () => {
+    await body();
+  });
+}
+
+const g = globalThis as any;
+
+g.promise_test = (fn: (t: unknown) => Promise<unknown>, name: string) => {
+  register(name, () => fn({}));
+};
+
+// Exported (not installed on globalThis) because bun:test injects its own
+// `test` binding into every module it loads, including dynamic imports, and
+// that per-module binding shadows globalThis. run.test.ts feeds this in as
+// a Function-constructor parameter instead.
+export const wptTest = (fn: (t: unknown) => unknown, name: string) => {
+  register(name, () => fn({}));
+};
+
+g.assert_equals = (actual: unknown, expected: unknown, msg?: string) => {
+  if (!Object.is(actual, expected)) {
+    throw new Error(`assert_equals: ${msg ?? ""} expected ${String(expected)} got ${String(actual)}`);
+  }
+};
+
+g.assert_true = (actual: unknown, msg?: string) => {
+  if (actual !== true) throw new Error(`assert_true: ${msg ?? ""} got ${String(actual)}`);
+};
+
+g.promise_rejects_js = async (_t: unknown, ctor: new (...a: any[]) => Error, promise: Promise<unknown>) => {
+  try {
+    await promise;
+  } catch (e) {
+    expect(e).toBeInstanceOf(ctor);
+    return;
+  }
+  throw new Error(`promise_rejects_js: expected rejection with ${ctor.name}, but promise fulfilled`);
+};
+
+g.promise_rejects_exactly = async (_t: unknown, expected: unknown, promise: Promise<unknown>) => {
+  try {
+    await promise;
+  } catch (e) {
+    if (e !== expected) {
+      throw new Error(`promise_rejects_exactly: expected ${String(expected)}, got ${String(e)}`);
+    }
+    return;
+  }
+  throw new Error(`promise_rejects_exactly: expected rejection, but promise fulfilled`);
+};
+
+g.token = () => crypto.randomUUID();

--- a/test/js/web/fetch/H2_TEST_PORT_PLAN.md
+++ b/test/js/web/fetch/H2_TEST_PORT_PLAN.md
@@ -1,0 +1,234 @@
+# HTTP/2 Client Test Port Plan
+
+Third-party h2 *client* test cases mined from `golang/net`, `nodejs/undici`, and `denoland/deno` for porting into `test/js/web/fetch/fetch-http2-client.test.ts`.
+
+**Already covered in Bun:** GET round-trip, POST body, large body (70KB+20MB), gzip decode, concurrent multiplex, abort→RST_STREAM siblings survive, MAX_CONCURRENT_STREAMS cap, sequential keep-alive, GOAWAY reconnect, cold-start coalescing, feature-flag-off.
+
+Repos cloned to `~/code/{golang-net,undici,deno}` (shallow).
+
+---
+
+## golang/net — `http2/transport_test.go` (5793 lines, gold standard)
+
+Go uses a synthetic frame-level harness (`newTestClientConn`) that lets the test write raw frames at the client and assert outbound frames. Bun's harness uses a real `node:http2` server, so some of these need a raw-TCP fake server that speaks the h2 wire format directly (noted as **needs raw server**).
+
+| Test name | file:line | What it asserts | Priority | Notes for Bun port |
+|---|---|---|---|---|
+| `testTransportResPattern` (36 combinations) | :1059 | All combinations of `{100-continue, headers via 1/CONTINUATION, with/without DATA, trailers via 1/CONTINUATION}` round-trip and decode correctly. | **high** | Port a representative subset (4–6 cases) using `node:http2` server `waitForTrailers` + `writeContinue()`. CONTINUATION-split variants need raw server or large header padding to force CONTINUATION. |
+| `TestTransportUnknown1xx` | :1145 | Multiple unknown 1xx (110, 111, …) before final 200 are ignored; final response status/body intact. | **high** | `stream.additionalHeaders({':status': 110})` repeatedly before `respond({':status':200})`. |
+| `TestTransportReceiveUndeclaredTrailer` | :1194 | Second HEADERS (no `Trailer:` advertised) treated as trailers, accessible after body. | **high** | `waitForTrailers` + `sendTrailers`. fetch surfaces via `Response.prototype` (Bun has no `.trailers` yet — assert no crash + body correct). |
+| `TestTransportInvalidTrailer_Pseudo/Capital/Empty/Binary` | :1228–1261 | Trailers containing `:colon`, uppercase name, empty name, or `\n` in value → stream-level error; client RSTs PROTOCOL_ERROR. | med | `sendTrailers` with bad keys; nghttp2 may pre-validate so likely **needs raw server**. |
+| `TestTransportChecksRequestHeaderListSize` | :1416 | Request headers > server's `SETTINGS_MAX_HEADER_LIST_SIZE` rejected client-side (no HEADERS sent). | med | `createSecureServer({settings:{maxHeaderListSize:16384}})`, send 32KB header, assert error before network. |
+| `TestTransportChecksResponseHeaderListSize` | :1511 | Response headers >10MB (HPACK-compressed to ~6KB via repeated keys) → stream error, not OOM. | **high** | Real DoS surface. Server `respond` with `Object.fromEntries(Array(5000).fill(['a'.repeat(1024),'a'.repeat(1024)]))` — nghttp2 may cap; likely **needs raw server**. |
+| `TestTransportCookieHeaderSplit` | :1560 | `Cookie: a=b;c=d; e=f` is split into separate `cookie:` h2 header lines per RFC 9113 §8.2.3. | **high** | `server.on('stream',(s,h,_,raw)=>{...})` — assert `raw` has multiple `cookie` entries. |
+| `TestTransportWindowUpdateBeyondLimit` | :1842 | WINDOW_UPDATE that pushes window past 2³¹−1 → RST FLOW_CONTROL_ERROR (stream) / conn close (conn-level). | med | **Needs raw server** (node:http2 won't send invalid increments). |
+| `TestTransportRejectsConnHeaders` | :1894 | Request `Upgrade`, `Connection: foo`, `Transfer-Encoding: foo` → error; `Connection: close/keep-alive`, `Keep-Alive`, `Proxy-Connection` → silently stripped. | **high** | Echo headers seen by server; assert stripped/erroring matrix. |
+| `TestTransportRejectsContentLengthWithSign` | :2008 | Response `content-length: +3` / `-3` rejected. | low | Easy port with `respond({'content-length':'+3'})`. |
+| `TestTransportReadHeadResponse` | :2143 | HEAD with `content-length:123` + END_STREAM=false + empty DATA → body empty, ContentLength=123. | **high** | nghttp2 HEAD: `respond({...,'content-length':'123'},{endStream:false}); stream.end()`. |
+| `TestTransportReadHeadResponseWithBody` | :2170 | HEAD response with actual DATA payload (protocol violation) → body discarded, no crash. | **high** | **Needs raw server** (nghttp2 won't send body for HEAD). |
+| `TestTransportFlowControl` | :2248 | Client withholds WINDOW_UPDATE until user consumes body (buffered backpressure). | med | Bun's design replenishes incrementally regardless of consumption — verify our 20MB test exercises this; otherwise skip (different design). |
+| `TestTransportUsesGoAwayDebugError` | :2318 | Two GOAWAYs (NO_ERROR+debug, then ERR+nil) → error surfaces last code + first debug data. | low | **Needs raw server**. |
+| `TestTransportReturnsUnusedFlowControl` | :2380 | Body.Close() after partial read → RST CANCEL + connection-level WINDOW_UPDATE for unread bytes. DATA arriving after RST also credited. | **high** | Stream 5KB, fetch with `r.body.cancel()` after 1 byte; server asserts stream `rstCode===8` and second request still works on same conn (window not leaked). |
+| `TestTransportAdjustsFlowControl` | :2468 | 1MB upload: client respects 64KB initial send-window, then sends rest after server SETTINGS+WINDOW_UPDATE. | **high** | Directly tests streaming-body send-side flow control we're about to build. Server with default 64KB initial; assert all 1MB arrives. |
+| `TestTransportReturnsDataPaddingFlowControl` | :2525 | Padded DATA: client credits padding bytes back via WINDOW_UPDATE (window deficit = data only, not padding+len byte). | **high** | **Needs raw server** to send `writeDataPadded`. |
+| `TestTransportReturnsErrorOnBadResponseHeaders` | :2563 | Response header name `"  content-type"` (leading space) → stream error + RST PROTOCOL_ERROR sent. | **high** | **Needs raw server**. |
+| `TestTransportBodyDoubleEndStream` | :2617 | Reader returning `(n>0, EOF)` doesn't cause double END_STREAM DATA frames. | med | Relevant once `.stream` body lands; use a `ReadableStream` with single chunk + close. Server `on('frameError')` shouldn't fire. |
+| `TestTransportRequestPathPseudo` | :2640 | `:path` derivation for edge URLs (`//foo`, opaque, CONNECT). | low | Unit-level; port `//foo` and CONNECT cases. |
+| `TestClientConnPing` | :2799 | Explicit Ping API round-trips. | low | N/A — fetch has no ping API. |
+| `TestTransportCloseAfterLostPing` | :2894 | ReadIdleTimeout → PING → no ACK within PingTimeout → conn closed, request errors. | med | Only if Bun adds idle-ping. |
+| `TestTransportRetryAfterGOAWAYNoRetry` | :3020 | GOAWAY(err≠NO_ERROR, lastID < req) → request **fails** (not retried). | **high** | We have GOAWAY-reconnect; add the negative case. |
+| `TestTransportRetryAfterGOAWAYRetry` | :3047 | GOAWAY(NO_ERROR, lastID < req) → request transparently retried on new conn. | **high** | We test this; verify lastID < ourID specifically (server `goaway(0,0)`). |
+| `TestTransportRetryAfterGOAWAYSecondRequest` | :3094 | Req1 ok; req3 hit by GOAWAY(PROTOCOL_ERROR, lastID=1) → req3 retried (server claims unprocessed). | med | Subtle: even non-NO_ERROR retries if lastID < reqID. |
+| `TestTransportRetryAfterRefusedStream` | :3160 | RST REFUSED_STREAM → retry on **same** connection with new stream id. | **high** | nghttp2 server: `stream.close(http2.constants.NGHTTP2_REFUSED_STREAM)` first time, respond second. |
+| `TestTransportRetryHasLimit` | :3202 | Infinite REFUSED_STREAM eventually gives up (~5 retries, exponential backoff). | med | Server always refuses; assert eventual error, ≥5 streams seen. |
+| `TestTransportResponseDataBeforeHeaders` | :3241 | DATA before HEADERS on a stream → stream PROTOCOL_ERROR; sibling on same conn unaffected. | **high** | **Needs raw server**. |
+| `TestTransportNoBodyMeansNoDATA` | :3530 | GET with no body → HEADERS has END_STREAM, no zero-length DATA follows. | med | Server `on('data')` should never fire; `headers[':method']` arrives with stream half-closed. |
+| `TestTransportHandlesInvalidStatuslessResponse` | :3624 | Response HEADERS with no `:status` + DATA → no crash, request errors. | **high** | **Needs raw server**. |
+| `TestTransportBodyEagerEndStream` | :3949 | Buffered body (known length) → END_STREAM on the last DATA frame, not separate empty DATA. | med | Server-side `stream.on('data')` count + `stream.on('end')` ordering; or raw-frame assertion. |
+| `TestTransportBodyLargerThanSpecifiedContentLength` | :3989 | Streaming body produces > declared Content-Length → client RSTs stream and errors. | med | `ReadableStream` body + manual `content-length:3`, push 6 bytes. |
+| `TestTransportServerResetStreamAtHeaders` | :4129 | `Expect: 100-continue` + server replies 401 (no 100) → request body never sent, no error. | **high** | `server.on('checkContinue', (req,res)=>res.writeHead(403).end())`. |
+| `TestTransportExpectContinue` | :4176 | `Expect: 100-continue`: `/` → body read; `/reject` → 403, body NOT read (never read from stream). | **high** | Track if request body's `pull()` was called. |
+| `TestTransportNoRetryOnStreamProtocolError` | :4569 | RST PROTOCOL_ERROR on stream 3 → fails immediately, NOT retried; sibling stream 1 unaffected. | **high** | `stream.close(NGHTTP2_PROTOCOL_ERROR)` on path /b, normal on /a. |
+| `TestTransportContentLengthWithoutBody` | :4707 | Response `content-length:42` + END_STREAM with no DATA → body read errors (UnexpectedEOF). `content-length:0` → ok. | **high** | `respond({'content-length':'42'},{endStream:true})`. |
+| `TestTransportDataAfter1xxHeader` | :5132 | `:status:100` then DATA (no final headers) → PROTOCOL_ERROR + RST. | med | **Needs raw server**. |
+| `TestTransport1xxLimits` | :5207 | >N consecutive 103 Early Hints with large headers → eventually RST (header bytes capped). | med | Loop `stream.additionalHeaders({':status':103,'x':'a'.repeat(1000)})` 50×. |
+| `TestTransportDoNotHangOnZeroMaxFrameSize` | :5690 | Server SETTINGS `MAX_FRAME_SIZE=0` (invalid) → request with body doesn't infinite-loop. | **high** | `createSecureServer({settings:{maxFrameSize:0}})` — nghttp2 may clamp; if so **needs raw server**. |
+
+---
+
+## nodejs/undici — `test/http2-*.js`, `test/fetch/http2.js` (~4400 lines)
+
+undici uses real `node:http2.createSecureServer`, so server-side snippets translate directly to our harness.
+
+| Test name | file:line | What it asserts | Priority | Notes for Bun port |
+|---|---|---|---|---|
+| `Should handle http2 trailers` | http2-trailers.js:12 | `waitForTrailers` → `sendTrailers({'x-trailer':'hello'})` surfaces in client trailers. | **high** | Direct paste; for fetch, assert no crash + body intact (trailers API TBD). |
+| `Should handle h2 continue` | http2-continue.js:12 | `Expect: 100-continue` → server `checkContinue` event → `writeContinue()` → body sent → 200 received. | **high** | Direct paste. |
+| `Should provide pseudo-headers in proper order` | http2-pseudo-headers.js:12 | rawHeaders array is `[:authority, :method, :path, :scheme]` (pseudo first, fixed order). | med | Order-sensitive; check `rawHeaders` arg of `on('stream')`. |
+| `h2 pseudo-headers not in headers` | http2-pseudo-headers.js:58 | `response.headers[':status']` is undefined. | **high** | Trivial port; we likely pass already but should pin. |
+| `surface invalid connection headers` | http2-invalid-connection-headers.js:13 | Conn-specific request header → catchable error; subsequent queued request still proceeds on new conn. | med | undici-internal; for Bun, instead test that `fetch(url,{headers:{Connection:'upgrade'}})` over h2 strips/errors and second fetch succeeds. |
+| `Should throw on half-closed streams (remote)` | http2-stream.js:12 | Server `stream.destroy()` immediately → client gets typed error; second request also errors (not hangs). | **high** | Direct paste; assert `cause.code` or message. |
+| `multiple header values with semicolon` | http2-connection.js:185 | Array-valued + duplicated `cookie`/custom headers join correctly (`; ` for cookie, `, ` for others). | med | Mirrors Go cookie-split from server's view. |
+| `#5089 GOAWAY Gracefully` | http2-goaway.js:148 | maxConcurrentStreams=2; after 2 streams server GOAWAYs; remaining 4 of 6 requests succeed on new session; sessionCounts=[2,4]. | **high** | More thorough than our existing GOAWAY test — ports cleanly. |
+| `GOAWAY resets unaccepted, requeues replayable` | http2-goaway-retry-body.js:40 | On GOAWAY(lastID): accepted (id≤last) keep going; replayable (buffered body, id>last) requeued; streaming-body (id>last) **errors** (not safe to replay). | **high** | Key semantic: streaming body NOT retried. Port as 3-request scenario once `.stream` body lands. |
+| `ignore late http2 data after completion` | http2-late-data.js:79 | DATA arriving after trailers (END_STREAM) doesn't crash or invoke onData. | med | **Needs raw server** for true late DATA; undici's version uses mocks. |
+| `Should handle h2 GET/HEAD with body` | http2-body.js:211 | GET/HEAD with request body still sends DATA; HEAD response body empty. | low | fetch spec strips GET/HEAD bodies — likely N/A for `fetch()`. |
+| `request body (stream/iterable/Blob/FormData)` | http2-body.js:151,286,355,417,482 | Each body type round-trips bytes correctly over h2. | **high** | Port all 5 once streaming bodies land. |
+| `Issue#2415` Headers ctor | fetch/http2.js:370 | `new Headers(response.headers)` doesn't throw (no `:status` in iterable). | med | Trivial port. |
+| `Issue #3046` set-cookie array | fetch/http2.js:464 | `respond({'set-cookie':['a=b','c=d']})` → `response.headers.getSetCookie()` returns both. | **high** | Direct paste; tests our header decode preserves repeated values. |
+| `Empty POST has Content-Length:0` | fetch/http2.js:541 | Empty POST over h2 still sends `content-length: 0`. | med | Echo `headers['content-length']`. |
+| `Send PING frames` / `not after close` | http2-dispatcher.js:639,781 | Periodic client PING; stops after close. | low | Only if Bun adds ping interval. |
+
+---
+
+## denoland/deno — `tests/unit/fetch_test.ts`, `ext/fetch/tests.rs`
+
+Deno's fetch h2 coverage is thin (relies on hyper); mostly version-negotiation tests.
+
+| Test name | file:line | What it asserts | Priority | Notes for Bun port |
+|---|---|---|---|---|
+| `fetchSupportsHttp2` | fetch_test.ts:1631 | ALPN auto-selects h2; server sees `HTTP/2.0`. | covered | We have this. |
+| `fetchForceHttp1OnHttp2Server` | fetch_test.ts:1643 | `createHttpClient({http2:false,http1:true})` against h2-only server → rejects. | med | Maps to our planned `protocol:` option / flag-off. |
+| `fetchForceHttp2OnHttp1Server` | fetch_test.ts:1655 | `{http2:true,http1:false}` against h1-only → rejects. | med | Port once `protocol:"h2"` lands. |
+| `fetchPrefersHttp2` | fetch_test.ts:1667 | Dual-stack server → h2 preferred. | low | We have this implicitly. |
+| `[node/http2 client] uppercase headers no panic` | unit_node/http2_test.ts:314 | Uppercase request header name → lowercased on wire, no panic. | med | Maps to our HPACK encoder; easy port. |
+| Rust `tests.rs` h2 cases | ext/fetch/tests.rs | DNS resolver + h2 + proxy plumbing. | low | Infra-specific to hyper. |
+
+---
+
+## "Needs raw server" harness
+
+Seven Go tests (padded DATA, DATA-before-HEADERS, missing `:status`, bad header name, WINDOW_UPDATE overflow, HEAD-with-body, MAX_FRAME_SIZE=0, late DATA, 1xx-then-DATA) require sending **invalid** frames that `node:http2` won't emit. Recommended one-time investment:
+
+```ts
+// test/js/web/fetch/h2-raw-server.ts
+import { wire } from "bun:internal-for-testing"; // or hand-roll FrameHeader
+import tls from "node:tls";
+function rawH2Server(onStream: (write: (type, flags, sid, payload) => void, hpackEnc) => void) {
+  return tls.createServer({...tls, ALPNProtocols: ["h2"]}, sock => {
+    // read 24-byte preface, read SETTINGS, ack, then call onStream with frame-writer
+  });
+}
+```
+
+Or piggy-back on `src/http/H2FrameParser.zig` exposed via `bun:internal-for-testing` for encode helpers.
+
+---
+
+## Top 10 to port first
+
+Ordered by (correctness risk × ease of porting). All but #7/#9 use stock `http2.createSecureServer`.
+
+### 1. Response trailers (undici http2-trailers.js:12)
+```js
+server.on('stream', (stream) => {
+  stream.respond({':status': 200, 'content-type': 'text/plain'}, {waitForTrailers: true});
+  stream.on('wantTrailers', () => stream.sendTrailers({'x-trailer': 'hello'}));
+  stream.end('body');
+});
+// Client: assert body === 'body' and (once API exists) trailers['x-trailer'] === 'hello'; for now assert no crash, exitCode 0.
+```
+
+### 2. REFUSED_STREAM → retry on same connection (Go :3160)
+```js
+let attempts = 0;
+server.on('stream', (stream) => {
+  attempts++;
+  if (attempts === 1) return stream.close(http2.constants.NGHTTP2_REFUSED_STREAM);
+  stream.respond({':status': 204}); stream.end();
+});
+// Client: single fetch resolves 204; server sees attempts === 2, sessions === 1.
+```
+
+### 3. RST PROTOCOL_ERROR is NOT retried; sibling survives (Go :4569)
+```js
+server.on('stream', (stream, h) => {
+  if (h[':path'] === '/bad') return stream.close(http2.constants.NGHTTP2_PROTOCOL_ERROR);
+  setTimeout(() => { stream.respond({':status':200}); stream.end('ok'); }, 50);
+});
+// Client: Promise.allSettled([fetch('/good'), fetch('/bad')]) → good=200, bad rejected; sessions === 1.
+```
+
+### 4. Expect: 100-continue, server rejects → body never sent (Go :4176 + :4129)
+```js
+server.on('checkContinue', (req, res) => {
+  if (req.url === '/reject') { res.writeHead(403); res.end(); return; }
+  res.writeContinue();
+  req.on('data', c => chunks.push(c));
+  res.writeHead(200); res.end();
+});
+// Client: ReadableStream body with `pull` counter + header Expect:100-continue.
+//   /accept → 200, pulls > 0;  /reject → 403, pulls === 0.
+```
+
+### 5. Content-Length lies (no body) (Go :4707)
+```js
+server.on('stream', (stream) => {
+  stream.respond({':status':200, 'content-length':'42'}, {endStream: true});
+});
+// Client: await res.text() rejects (UnexpectedEOF / body-too-short).
+// Second case: content-length:'0' → resolves "".
+```
+
+### 6. Connection-specific request headers stripped/rejected (Go :1894)
+```js
+server.on('stream', (stream, h) => {
+  stream.respond({':status':200, 'x-got': Object.keys(h).filter(k=>!k.startsWith(':')).sort().join(',')});
+  stream.end();
+});
+// Client: fetch with {Connection:'keep-alive', 'Keep-Alive':'x', 'Proxy-Connection':'y', 'Transfer-Encoding':'chunked', Upgrade:'ws'}.
+// Assert x-got contains none of them; OR fetch throws for Upgrade.
+```
+
+### 7. Padded DATA flow-control credit (Go :2525) — **needs raw server**
+```js
+// Raw TLS server: after client HEADERS, send HEADERS(:status 200, content-length 5000),
+// then DATA(streamID, flags=PADDED, payload=[padLen=5, ...5000 bytes, ...5 pad]).
+// Then send second 5000-byte DATA with no padding (would stall if client failed to credit pad).
+// Assert client receives 10000 bytes total.
+```
+
+### 8. Multiple Set-Cookie response headers (undici fetch/http2.js:464)
+```js
+server.on('stream', (stream) => {
+  stream.respond({':status':200, 'set-cookie': ['a=b','c=d']});
+  stream.end();
+});
+// Client: res.headers.getSetCookie() → ['a=b','c=d']; res.headers.get('set-cookie') → 'a=b, c=d'.
+```
+
+### 9. Missing :status pseudo-header (Go :3624) — **needs raw server**
+```js
+// Raw: send HEADERS with only `content-type:text/html`, then DATA. Assert fetch rejects, process doesn't crash.
+```
+
+### 10. GOAWAY with lastStreamID < ours: replayable retried, streaming-body errored (undici http2-goaway-retry-body.js:40)
+```js
+// settings:{maxConcurrentStreams:3}. Client fires: req1 (GET), req2 (POST Buffer), req3 (POST ReadableStream).
+// After all 3 streams open, server: session.goaway(0, 1, Buffer.alloc(0)). // lastID=1
+// Expect: req1 200; req2 transparently retried on new conn → 200; req3 rejects (body not replayable); sessions === 2.
+let sess = 0; server.on('session', s => { sess++; });
+server.on('stream', (stream, h) => {
+  if (sess === 1 && stream.id > 1) return; // let goaway kill them
+  let body=[]; stream.on('data',c=>body.push(c)); stream.on('end',()=>{
+    stream.respond({':status':200}); stream.end(String(stream.id));
+  });
+  if (sess === 1 && stream.id === 1) setTimeout(()=>stream.session.goaway(0,1), 30);
+});
+```
+
+---
+
+## Secondary batch (after top 10)
+
+- Cookie header splitting on **request** side (Go :1560 / undici http2-connection.js:185)
+- Unknown-1xx ignored (Go :1145) — `stream.additionalHeaders({':status':110})` ×3 then `respond(200)`
+- HEAD with `content-length` but no body (Go :2143)
+- Retry limit on infinite REFUSED_STREAM (Go :3202)
+- `:status` not in `Response.headers` (undici http2-pseudo-headers.js:58)
+- Server `stream.destroy()` → typed error, second request still works (undici http2-stream.js:12)
+- Upload backpressure: 1MB body with default 64KB initial send-window (Go :2468) — gates streaming-body work
+- Body eager END_STREAM / no double END_STREAM (Go :3949, :2617)
+- Response header list size cap / DoS (Go :1511) — needs raw server
+- 1xx storm limit (Go :5207)
+- MAX_FRAME_SIZE=0 doesn't hang (Go :5690)

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -829,6 +829,27 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
       );
     });
 
+    test("Content-Length / DATA mismatch rejects", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-length", "42")]));
+          conn.data(id, "short", true);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              await r.text();
+              console.log("ok");
+            } catch (e) { console.log("rejected", String(e).includes("ContentLength")); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected true");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("response missing :status pseudo-header rejects cleanly", async () => {
       await withRawH2Server(
         (conn, id) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1250,6 +1250,40 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("303 redirect on a streaming-body POST RSTs the half-open upload stream", async () => {
+      // The redirect detaches stream 1 before END_STREAM is ever written for
+      // the request body. Without an RST_STREAM(CANCEL) the server is left
+      // holding it half-open against MAX_CONCURRENT_STREAMS.
+      await withRawH2Server(
+        (conn, id) => {
+          if (id === 1) {
+            conn.headers(
+              id,
+              Buffer.concat([hpackLit(":status", "303"), hpackLit("location", "/target")]),
+              { endStream: true },
+            );
+          } else {
+            conn.headers(id, hpackStatus(200), { endStream: true });
+          }
+        },
+        async (url, state) => {
+          await using proc = spawnFetch(`
+            const body = new ReadableStream({
+              async start(ctrl) { ctrl.enqueue(new Uint8Array([1,2,3])); await new Promise(r => setTimeout(r, 60_000)); },
+            });
+            const r = await fetch("${url}/upload", { method: "POST", body, duplex: "half", tls: { rejectUnauthorized: false } });
+            console.log(r.status, r.url.endsWith("/target"));
+            process.exit(0);
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 true");
+          expect(state.rst).toEqual([{ id: 1, code: 8 }]);
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("client RSTs the stream when it abandons on a local error", async () => {
       // handleResponseBody throws on invalid gzip; the catch path must send
       // RST_STREAM(CANCEL) so the server doesn't keep the stream open

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { bunEnv, bunExe, tls } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import nodetls from "node:tls";
 import zlib from "node:zlib";
 
 // allowHTTP1: false forces the server to reject anything that didn't
@@ -17,6 +18,92 @@ async function withH2Server(
   const { port } = server.address() as import("node:net").AddressInfo;
   try {
     await fn(`https://localhost:${port}`, server);
+  } finally {
+    server.close();
+  }
+}
+
+// --- Raw HTTP/2 frame server -------------------------------------------------
+// Minimal TLS+ALPN(h2) server that speaks the wire format directly so tests
+// can inject frames that a conforming server (nghttp2) would never emit.
+
+function frame(type: number, flags: number, streamId: number, payload: Uint8Array | Buffer = Buffer.alloc(0)) {
+  const buf = Buffer.alloc(9 + payload.length);
+  buf.writeUIntBE(payload.length, 0, 3);
+  buf[3] = type;
+  buf[4] = flags;
+  buf.writeUInt32BE(streamId & 0x7fffffff, 5);
+  Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength).copy(buf, 9);
+  return buf;
+}
+const u32be = (n: number) => {
+  const b = Buffer.alloc(4);
+  b.writeUInt32BE(n >>> 0);
+  return b;
+};
+
+// HPACK static-table indices we need: :status 200 = 8, 204 = 9, 404 = 13.
+const hpackStatus = (code: 200 | 204 | 404) => Buffer.from([0x80 | { 200: 8, 204: 9, 404: 13 }[code]]);
+// Literal field never-indexed, new name (4-bit prefix 0001 0000): len(name) name len(value) value.
+const hpackLit = (name: string, value: string) =>
+  Buffer.concat([Buffer.from([0x10, name.length]), Buffer.from(name), Buffer.from([value.length]), Buffer.from(value)]);
+
+type RawConn = {
+  socket: nodetls.TLSSocket;
+  settings(): void;
+  headers(streamId: number, block: Buffer, opts?: { endStream?: boolean; endHeaders?: boolean }): void;
+  data(streamId: number, chunk: string | Buffer, endStream?: boolean): void;
+  rst(streamId: number, code: number): void;
+  goaway(lastId: number, code: number): void;
+};
+
+async function withRawH2Server(
+  onStream: (conn: RawConn, streamId: number, connIndex: number) => void,
+  fn: (url: string, state: { connections: number }) => Promise<void>,
+) {
+  const state = { connections: 0 };
+  const server = nodetls.createServer({ ...tls, ALPNProtocols: ["h2"] }, socket => {
+    const connIndex = state.connections++;
+    const conn: RawConn = {
+      socket,
+      settings: () => socket.write(frame(4, 0, 0)),
+      headers: (id, block, o = {}) =>
+        socket.write(frame(1, (o.endHeaders === false ? 0 : 4) | (o.endStream ? 1 : 0), id, block)),
+      data: (id, chunk, end = false) =>
+        socket.write(frame(0, end ? 1 : 0, id, typeof chunk === "string" ? Buffer.from(chunk) : chunk)),
+      rst: (id, code) => socket.write(frame(3, 0, id, u32be(code))),
+      goaway: (lastId, code) => socket.write(frame(7, 0, 0, Buffer.concat([u32be(lastId), u32be(code)]))),
+    };
+    let buf = Buffer.alloc(0);
+    let prefaceSeen = false;
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!prefaceSeen) {
+        if (buf.length < 24) return;
+        buf = buf.subarray(24);
+        prefaceSeen = true;
+        conn.settings();
+      }
+      while (buf.length >= 9) {
+        const len = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + len) return;
+        const type = buf[3],
+          flags = buf[4],
+          id = buf.readUInt32BE(5) & 0x7fffffff;
+        const payload = buf.subarray(9, 9 + len);
+        buf = buf.subarray(9 + len);
+        if (type === 4 && !(flags & 1)) socket.write(frame(4, 1, 0)); // ack their SETTINGS
+        if (type === 1) onStream(conn, id, connIndex); // HEADERS opens a stream
+        void payload;
+      }
+    });
+    socket.on("error", () => {});
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("node:net").AddressInfo;
+  try {
+    await fn(`https://localhost:${port}`, state);
   } finally {
     server.close();
   }
@@ -603,6 +690,161 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     } finally {
       server.close();
     }
+  });
+
+  describe("raw frame server", () => {
+    test("REFUSED_STREAM is transparently retried on the same connection", async () => {
+      let attempts = 0;
+      await withRawH2Server(
+        (conn, id) => {
+          attempts++;
+          if (attempts === 1) return conn.rst(id, http2.constants.NGHTTP2_REFUSED_STREAM);
+          conn.headers(id, hpackStatus(204), { endStream: true });
+        },
+        async (url, state) => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status);
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("204");
+          expect(exitCode).toBe(0);
+          expect(attempts).toBe(2);
+          expect(state.connections).toBe(1);
+        },
+      );
+    });
+
+    test("REFUSED_STREAM gives up after max retries", async () => {
+      let attempts = 0;
+      await withRawH2Server(
+        (conn, id) => {
+          attempts++;
+          conn.rst(id, http2.constants.NGHTTP2_REFUSED_STREAM);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", String(e).includes("Refused")); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected true");
+          expect(exitCode).toBe(0);
+          // initial + 5 retries
+          expect(attempts).toBe(6);
+        },
+      );
+    });
+
+    test("RST_STREAM PROTOCOL_ERROR is not retried", async () => {
+      let attempts = 0;
+      await withRawH2Server(
+        (conn, id) => {
+          attempts++;
+          conn.rst(id, http2.constants.NGHTTP2_PROTOCOL_ERROR);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected"); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected");
+          expect(exitCode).toBe(0);
+          expect(attempts).toBe(1);
+        },
+      );
+    });
+
+    test("graceful GOAWAY past our id retries on a fresh connection", async () => {
+      await withRawH2Server(
+        (conn, id, connIndex) => {
+          if (connIndex === 0) {
+            // First connection: refuse via GOAWAY(NO_ERROR, lastId=0).
+            conn.goaway(0, 0);
+            conn.socket.end();
+            return;
+          }
+          conn.headers(id, hpackStatus(200), { endStream: false });
+          conn.data(id, "second-conn", true);
+        },
+        async (url, state) => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status, await r.text());
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 second-conn");
+          expect(exitCode).toBe(0);
+          expect(state.connections).toBe(2);
+        },
+      );
+    });
+
+    test("REFUSED_STREAM with a streaming body errors instead of retrying", async () => {
+      let attempts = 0;
+      await withRawH2Server(
+        (conn, id) => {
+          attempts++;
+          conn.rst(id, http2.constants.NGHTTP2_REFUSED_STREAM);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const body = new ReadableStream({ start(c) { c.enqueue(new Uint8Array([1,2,3])); c.close(); } });
+            try {
+              await fetch("${url}", { method: "POST", body, duplex: "half", tls: { rejectUnauthorized: false } });
+              console.log("ok");
+            } catch (e) { console.log("rejected"); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected");
+          expect(exitCode).toBe(0);
+          expect(attempts).toBe(1);
+        },
+      );
+    });
+
+    test("padded DATA: pad bytes are stripped and credited against flow control", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, hpackStatus(200));
+          // PADDED flag = 0x8; payload = padLen(1) + body + pad zeros.
+          const body = Buffer.from("padded-body");
+          const padLen = 200;
+          const payload = Buffer.concat([Buffer.from([padLen]), body, Buffer.alloc(padLen)]);
+          conn.socket.write(frame(0, 0x8 | 0x1, id, payload));
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status, await r.text());
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 padded-body");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("response missing :status pseudo-header rejects cleanly", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, hpackLit("content-type", "text/plain"), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected"); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
   });
 
   test("flag off: ALPN does not offer h2", async () => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -191,6 +191,37 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     }
   });
 
+  test("cold-start: parallel requests coalesce onto one TLS connect", async () => {
+    let sessions = 0;
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      stream.respond({ ":status": 200 });
+      stream.end(String(headers[":path"]));
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        // No warmup: all 12 race the same fresh handshake.
+        const results = await Promise.all(
+          Array.from({ length: 12 }, (_, i) => fetch(url + "/" + i, opts).then(r => r.text()))
+        );
+        console.log(results.sort().join(","));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("/0,/1,/10,/11,/2,/3,/4,/5,/6,/7,/8,/9");
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(1);
+    } finally {
+      server.close();
+    }
+  });
+
   test("abort sends RST_STREAM; siblings on the session survive", async () => {
     let sessions = 0;
     const { promise: slowClosed, resolve: resolveSlowClosed } = Promise.withResolvers<number>();

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1417,6 +1417,36 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test("--experimental-http2-fetch enables h2 without the env flag", async () => {
+    await withH2Server(
+      (req, res) => {
+        res.writeHead(200);
+        res.end(req.httpVersion);
+      },
+      async url => {
+        // No BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT in env; the CLI flag
+        // alone should make ALPN offer h2.
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "--no-warnings",
+            "--experimental-http2-fetch",
+            "-e",
+            `const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+             console.log(r.status, await r.text());`,
+          ],
+          env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("200 2.0");
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
   test("protocol:'http2' forces h2 without the env flag", async () => {
     await withH2Server(
       (req, res) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -150,6 +150,97 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     );
   });
 
+  test("keep-alive: sequential requests reuse one h2 session", async () => {
+    let sessions = 0;
+    const seen: number[] = [];
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      seen.push(stream.id);
+      stream.respond({ ":status": 200, "content-type": "text/plain" });
+      stream.end(`req=${headers[":path"]}`);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        for (let i = 0; i < 4; i++) {
+          const r = await fetch(url + "/" + i, opts);
+          console.log(await r.text());
+        }
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim().split("\n")).toEqual(["req=/0", "req=/1", "req=/2", "req=/3"]);
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(1);
+      // stream ids must be fresh odd numbers on the reused session
+      expect(seen).toEqual([1, 3, 5, 7]);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("GOAWAY after a request: next request reconnects", async () => {
+    let sessions = 0;
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      const session = stream.session!;
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+      if (headers[":path"] === "/first") {
+        session.goaway(http2.constants.NGHTTP2_NO_ERROR, stream.id);
+      }
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        const a = await (await fetch(url + "/first", opts)).text();
+        await Bun.sleep(50);
+        const b = await (await fetch(url + "/second", opts)).text();
+        console.log(a + "," + b);
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok,ok");
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(2);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("response body larger than initial window triggers WINDOW_UPDATE", async () => {
+    const big = Buffer.alloc(20 * 1024 * 1024, 0x61);
+    await withH2Server(
+      (_req, res) => {
+        res.writeHead(200);
+        res.end(big);
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)}, { tls: { rejectUnauthorized: false } });
+          const buf = new Uint8Array(await res.arrayBuffer());
+          let ok = buf.length === ${big.length};
+          for (let i = 0; ok && i < buf.length; i += 4096) ok = buf[i] === 0x61;
+          console.log(ok ? "ok" : "bad:" + buf.length);
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("ok");
+        expect(exitCode).toBe(0);
+      },
+    );
+  }, 30_000);
+
   test("flag off: ALPN does not offer h2", async () => {
     let sawH2 = false;
     const server = http2.createSecureServer({ ...tls, allowHTTP1: true }, (req, res) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1197,6 +1197,27 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test('protocol: "http1.1" overrides the env flag and pins ALPN to http/1.1', async () => {
+    // Server is h2-only: the unpinned fetch (env flag on) negotiates h2, while
+    // the pinned fetch advertises only http/1.1 and is rejected at ALPN —
+    // proving the pin actually reached the ClientHello.
+    await withH2Server(
+      (req, res) => res.end(req.httpVersion),
+      async url => {
+        await using proc = spawnFetch(`
+          const tls = { rejectUnauthorized: false };
+          const a = await fetch("${url}", { tls }).then(r => r.text());
+          const b = await fetch("${url}", { protocol: "http1.1", tls }).then(r => r.text(), e => "rejected");
+          console.log(a, b);
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("2.0 rejected");
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
   test('protocol: "http2" on a plain http:// URL fails with HTTP2Unsupported', async () => {
     // h2c is out of scope; without an explicit check the request would
     // silently complete over HTTP/1.1.

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -191,6 +191,84 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     }
   });
 
+  test("POST with ReadableStream body streams as raw DATA frames", async () => {
+    let received = "";
+    await withH2Server(
+      (req, res) => {
+        req.setEncoding("utf8");
+        req.on("data", c => (received += c));
+        req.on("end", () => {
+          res.writeHead(200, { "x-len": String(received.length) });
+          res.end(received);
+        });
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const chunks = ["alpha-", "bravo-", "charlie-", "delta-", "echo"];
+          const body = new ReadableStream({
+            async pull(ctrl) {
+              for (const c of chunks) {
+                ctrl.enqueue(new TextEncoder().encode(c));
+                await new Promise(r => setTimeout(r, 5));
+              }
+              ctrl.close();
+            },
+          });
+          const res = await fetch("${url}/stream", {
+            method: "POST",
+            body,
+            duplex: "half",
+            tls: { rejectUnauthorized: false },
+          });
+          console.log(res.status, res.headers.get("x-len"), await res.text());
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("200 30 alpha-bravo-charlie-delta-echo");
+        expect(exitCode).toBe(0);
+        // No chunked-encoding artifacts leaked into the framed body.
+        expect(received).toBe("alpha-bravo-charlie-delta-echo");
+      },
+    );
+  });
+
+  test("POST with ReadableStream body larger than initial send window", async () => {
+    await withH2Server(
+      (req, res) => {
+        let total = 0;
+        req.on("data", c => (total += c.length));
+        req.on("end", () => {
+          res.writeHead(200);
+          res.end(String(total));
+        });
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          // 256 KiB > 64 KiB default INITIAL_WINDOW_SIZE: requires the
+          // client to honour the server's WINDOW_UPDATE before continuing.
+          const buf = new Uint8Array(256 * 1024).fill(0x61);
+          const body = new ReadableStream({
+            start(ctrl) {
+              for (let i = 0; i < 4; i++) ctrl.enqueue(buf.subarray(i * 65536, (i + 1) * 65536));
+              ctrl.close();
+            },
+          });
+          const res = await fetch("${url}/big", {
+            method: "POST",
+            body,
+            duplex: "half",
+            tls: { rejectUnauthorized: false },
+          });
+          console.log(res.status, await res.text());
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("200 262144");
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
   test("cold-start: parallel requests coalesce onto one TLS connect", async () => {
     let sessions = 0;
     const server = http2.createSecureServer({ ...tls, allowHTTP1: false });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -835,12 +835,15 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     test("1xx informational HEADERS are skipped, final response delivered", async () => {
       await withRawH2Server(
         (conn, id) => {
-          conn.headers(id, hpackStatus(100));
-          // separate write so 100 and 200 arrive in distinct onData passes
-          setTimeout(() => {
-            conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("x-after", "100")]));
-            conn.data(id, "final", true);
-          }, 10);
+          // Single write so 100 and 200 land in the same onData pass; HPACK
+          // must decode both in order.
+          conn.socket.write(
+            Buffer.concat([
+              frame(1, 4, id, hpackStatus(100)),
+              frame(1, 4, id, Buffer.concat([hpackStatus(200), hpackLit("x-after", "100")])),
+              frame(0, 1, id, Buffer.from("final")),
+            ]),
+          );
         },
         async url => {
           await using proc = spawnFetch(`
@@ -851,6 +854,129 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
           expect(stderr).toBe("");
           expect(stdout.trim()).toBe("200 100 final");
           expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("response + trailers in a single packet keep HPACK in sync", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(
+            Buffer.concat([
+              frame(1, 4, id, Buffer.concat([hpackStatus(200), hpackLit("x-real", "yes")])),
+              frame(0, 0, id, Buffer.from("body")),
+              frame(1, 4 | 1, id, hpackLit("x-trailer", "ignored")),
+            ]),
+          );
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status, r.headers.get("x-real"), await r.text());
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 yes body");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("Expect: 100-continue withholds the body until 100 arrives", async () => {
+      const seen: { id: number; type: number; len: number }[] = [];
+      const server = nodetls.createServer({ ...tls, ALPNProtocols: ["h2"] }, socket => {
+        let buf = Buffer.alloc(0);
+        let prefaceSeen = false;
+        let sent100 = false;
+        socket.on("data", chunk => {
+          buf = Buffer.concat([buf, chunk]);
+          if (!prefaceSeen) {
+            if (buf.length < 24) return;
+            buf = buf.subarray(24);
+            prefaceSeen = true;
+            socket.write(frame(4, 0, 0));
+          }
+          while (buf.length >= 9) {
+            const len = buf.readUIntBE(0, 3);
+            if (buf.length < 9 + len) return;
+            const type = buf[3],
+              flags = buf[4],
+              id = buf.readUInt32BE(5) & 0x7fffffff;
+            buf = buf.subarray(9 + len);
+            if (id !== 0) seen.push({ id, type, len });
+            if (type === 4 && !(flags & 1)) socket.write(frame(4, 1, 0));
+            if (type === 1 && !sent100) {
+              sent100 = true;
+              // Prove no DATA preceded the 100 by responding only after a tick.
+              setTimeout(() => socket.write(frame(1, 4, id, hpackStatus(100))), 20);
+            }
+            if (type === 0 && flags & 1) {
+              socket.write(frame(1, 4, id, hpackStatus(200)));
+              socket.write(frame(0, 1, id, Buffer.from("got-body")));
+            }
+          }
+        });
+        socket.on("error", () => {});
+      });
+      server.listen(0);
+      await once(server, "listening");
+      const { port } = server.address() as import("node:net").AddressInfo;
+      try {
+        await using proc = spawnFetch(`
+          const r = await fetch("https://localhost:${port}", {
+            method: "POST",
+            headers: { Expect: "100-continue" },
+            body: "twenty-chars-body!!!",
+            tls: { rejectUnauthorized: false },
+          });
+          console.log(r.status, await r.text());
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("200 got-body");
+        expect(exitCode).toBe(0);
+        // First per-stream frame must be HEADERS; no DATA until after the 100.
+        expect(seen[0].type).toBe(1);
+        const firstData = seen.findIndex(f => f.type === 0);
+        expect(firstData).toBeGreaterThan(0);
+        expect(seen[firstData].len).toBe(20);
+      } finally {
+        server.close();
+      }
+    });
+
+    test("Expect: 100-continue with final status before 100 skips body upload", async () => {
+      let dataBytes = 0;
+      await withRawH2Server(
+        (conn, id) => {
+          // Reject immediately without 100; client should half-close with
+          // an empty DATA+END_STREAM rather than uploading the body.
+          conn.headers(id, hpackStatus(404), { endStream: true });
+          conn.socket.on("data", chunk => {
+            // crude: count any DATA frame payloads on this socket after reject
+            let b = chunk;
+            while (b.length >= 9) {
+              const len = b.readUIntBE(0, 3);
+              if (b[3] === 0 && (b.readUInt32BE(5) & 0x7fffffff) === id) dataBytes += len;
+              b = b.subarray(9 + len);
+            }
+          });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", {
+              method: "POST",
+              headers: { Expect: "100-continue" },
+              body: "x".repeat(50000),
+              tls: { rejectUnauthorized: false },
+            });
+            console.log(r.status);
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("404");
+          expect(exitCode).toBe(0);
+          // Body was withheld; only the empty END_STREAM DATA frame allowed.
+          expect(dataBytes).toBe(0);
         },
       );
     });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1539,6 +1539,60 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test("303 to a streaming POST over HTTP/1.1 closes the socket instead of pooling it mid-chunked-body", async () => {
+    // Regression for the doRedirect change in this PR: dropping the
+    // closeAndFail(UnexpectedRedirect) guard let a 303 with a streaming
+    // body fall through to the keep-alive pool even though the chunked
+    // upload's terminating 0\r\n\r\n was never written. The follow-up GET
+    // must open a fresh connection.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-warnings",
+        "-e",
+        `import net from "node:net";
+         let conns = 0;
+         const server = net.createServer(sock => {
+           const idx = conns++;
+           let buf = "";
+           sock.on("data", c => {
+             buf += c;
+             if (idx === 0 && buf.includes("\\r\\n\\r\\n") && !sock.replied) {
+               sock.replied = true;
+               sock.write("HTTP/1.1 303 See Other\\r\\nLocation: /target\\r\\nConnection: keep-alive\\r\\nContent-Length: 0\\r\\n\\r\\n");
+             }
+             if (buf.includes("GET /target")) {
+               sock.end("HTTP/1.1 200 OK\\r\\nConnection: close\\r\\nContent-Length: 6\\r\\n\\r\\nconn=" + idx);
+             }
+           });
+           sock.on("error", () => {});
+         });
+         server.listen(0, "127.0.0.1");
+         await new Promise(r => server.on("listening", r));
+         const url = "http://127.0.0.1:" + server.address().port;
+         const body = new ReadableStream({
+           async start(ctrl) {
+             ctrl.enqueue(new Uint8Array([1, 2, 3, 4]));
+             // Never close — the 303 cancels the upload.
+             await new Promise(r => setTimeout(r, 60_000));
+           },
+         });
+         const res = await fetch(url + "/upload", { method: "POST", body, duplex: "half" });
+         console.log(res.status, await res.text(), "conns=" + conns);
+         process.exit(0);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // conn=1 (zero-indexed) and conns=2 prove the follow-up GET opened a
+    // fresh socket; the bug would show conn=0 or hang.
+    expect(stdout.trim()).toBe("200 conn=1 conns=2");
+    expect(exitCode).toBe(0);
+  });
+
   test("leader abort does not fail a coalesced force_http2 waiter with HTTP2Unsupported", async () => {
     // Regression for resolvePendingH2 conflating "ALPN chose h1" with
     // "leader failed pre-handshake". Server never speaks TLS, so the leader

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1092,6 +1092,66 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("SETTINGS_INITIAL_WINDOW_SIZE above 2^31-1 is a connection FLOW_CONTROL_ERROR", async () => {
+      // RFC 9113 §6.5.2.
+      await withRawH2Server(
+        (conn, id) => {
+          // setting type 4 (INITIAL_WINDOW_SIZE), value 0x80000000
+          conn.socket.write(frame(4, 0, 0, Buffer.concat([Buffer.from([0, 4]), u32be(0x80000000)])));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2FlowControlError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("WINDOW_UPDATE with zero increment on stream 0 is a connection PROTOCOL_ERROR", async () => {
+      // RFC 9113 §6.9.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(frame(8, 0, 0, u32be(0)));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("HEADERS on a stream id we never opened is a connection PROTOCOL_ERROR", async () => {
+      // RFC 9113 §5.1: receiving a frame on an idle stream (id >= our next
+      // odd id) or an even (server-initiated) id while push is disabled is a
+      // connection error, not a discardable orphan.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(2, hpackStatus(200), { endStream: true });
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("RST_STREAM(NO_ERROR) before final HEADERS fails the request instead of hanging", async () => {
       await withRawH2Server(
         (conn, id) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -875,6 +875,46 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("1xx HEADERS with END_STREAM is a stream PROTOCOL_ERROR (RFC 9113 §8.1)", async () => {
+      await withRawH2Server(
+        (conn, id) => conn.headers(id, hpackStatus(100), { endStream: true }),
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              console.log("resolved");
+            } catch (e) { console.log("rejected", e?.code ?? e?.name); }
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("DATA after only a 1xx HEADERS is a stream PROTOCOL_ERROR (RFC 9113 §8.1)", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(
+            Buffer.concat([frame(1, 4, id, hpackStatus(100)), frame(0, 1, id, Buffer.from("body"))]),
+          );
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              console.log("resolved");
+            } catch (e) { console.log("rejected", e?.code ?? e?.name); }
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("response + trailers in a single packet keep HPACK in sync", async () => {
       await withRawH2Server(
         (conn, id) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -563,53 +563,6 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
-  test("await fetch() resolves on headers, before a content-length body is fully received", async () => {
-    let heldStream: http2.ServerHttp2Stream | undefined;
-    const server = makeH2Server();
-    server.on("stream", stream => {
-      stream.on("error", () => {});
-      stream.respond({ ":status": 200, "content-length": "262144" });
-      stream.write(Buffer.alloc(64 * 1024));
-      // The remaining 192 KiB is written from the test body once the
-      // subprocess proves it already has the Response and a first read.
-      heldStream = stream;
-    });
-    server.listen(0);
-    await once(server, "listening");
-    const { port } = server.address() as import("node:net").AddressInfo;
-    try {
-      await using proc = spawnFetch(`
-        const r = await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } });
-        const reader = r.body.getReader();
-        let n = 0;
-        const { value } = await reader.read();
-        n += value.byteLength;
-        // Signal the server (via stderr so the test can unblock the rest).
-        process.stderr.write("first-chunk\\n");
-        while (true) {
-          const { value, done } = await reader.read();
-          if (value) n += value.byteLength;
-          if (done) break;
-        }
-        console.log(r.status, r.headers.get("content-length"), n);
-      `);
-      // Wait for the subprocess to prove it received the Response + first chunk
-      // BEFORE the server has written the full body.
-      let stderr = "";
-      for await (const chunk of proc.stderr) {
-        stderr += Buffer.from(chunk).toString();
-        if (stderr.includes("first-chunk")) break;
-      }
-      heldStream!.end(Buffer.alloc(192 * 1024));
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout.trim()).toBe("200 262144 262144");
-      expect(exitCode).toBe(0);
-    } finally {
-      heldStream?.destroy();
-      server.close();
-    }
-  });
-
   test("response body larger than initial window triggers WINDOW_UPDATE", async () => {
     const big = Buffer.alloc(20 * 1024 * 1024, 0x61);
     await withH2Server(
@@ -1778,4 +1731,54 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     expect(stdout.trim()).toBe("AbortError before=1 after=2");
     expect(exitCode).toBe(0);
   });
+});
+
+// Serial: this test reads the subprocess's stderr stream mid-flight to gate
+// the server-side body write, which interferes with sibling tests' TLS
+// handshakes under describe.concurrent on aarch64/musl.
+test("await fetch() over HTTP/2 resolves on headers, before a content-length body is fully received", async () => {
+  let heldStream: http2.ServerHttp2Stream | undefined;
+  const server = makeH2Server();
+  server.on("stream", stream => {
+    stream.on("error", () => {});
+    stream.respond({ ":status": 200, "content-length": "262144" });
+    stream.write(Buffer.alloc(64 * 1024));
+    // The remaining 192 KiB is written from the test body once the
+    // subprocess proves it already has the Response and a first read.
+    heldStream = stream;
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("node:net").AddressInfo;
+  try {
+    await using proc = spawnFetch(`
+      const r = await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } });
+      const reader = r.body.getReader();
+      let n = 0;
+      const { value } = await reader.read();
+      n += value.byteLength;
+      // Signal the server (via stderr so the test can unblock the rest).
+      process.stderr.write("first-chunk\\n");
+      while (true) {
+        const { value, done } = await reader.read();
+        if (value) n += value.byteLength;
+        if (done) break;
+      }
+      console.log(r.status, r.headers.get("content-length"), n);
+    `);
+    // Wait for the subprocess to prove it received the Response + first chunk
+    // BEFORE the server has written the full body.
+    let stderr = "";
+    for await (const chunk of proc.stderr) {
+      stderr += Buffer.from(chunk).toString();
+      if (stderr.includes("first-chunk")) break;
+    }
+    heldStream!.end(Buffer.alloc(192 * 1024));
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("200 262144 262144");
+    expect(exitCode).toBe(0);
+  } finally {
+    heldStream?.destroy();
+    server.close();
+  }
 });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -568,7 +568,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
         expect(exitCode).toBe(0);
       },
     );
-  }, 30_000);
+  });
 
   test("response trailers are consumed without breaking the body", async () => {
     const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
@@ -1003,6 +1003,28 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("Content-Length with END_STREAM on HEADERS and zero DATA rejects", async () => {
+      // RFC 9113 §8.1.1: declared length must equal sum of DATA payloads even
+      // when that sum is zero. Previously this hit the early-finish branch
+      // and resolved with an empty body.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-length", "42")]), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              console.log("ok", r.status, (await r.text()).length);
+            } catch (e) { console.log("rejected", String(e).includes("ContentLength")); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected true");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("response missing :status pseudo-header rejects cleanly", async () => {
       await withRawH2Server(
         (conn, id) => {
@@ -1040,7 +1062,6 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
             console.log("survived");
           `);
           const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect(stderr).not.toContain("panic");
           expect(stdout.trim()).toBe("200 hello\nsurvived");
           expect(exitCode).toBe(0);
         },
@@ -1174,5 +1195,71 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     } finally {
       server.close();
     }
+  });
+
+  test('protocol: "http2" on a plain http:// URL fails with HTTP2Unsupported', async () => {
+    // h2c is out of scope; without an explicit check the request would
+    // silently complete over HTTP/1.1.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-warnings",
+        "-e",
+        `try {
+           await fetch("http://127.0.0.1:1/", { protocol: "http2" });
+           console.log("unexpected-ok");
+         } catch (e) { console.log(e.code || String(e)); }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toContain("HTTP2Unsupported");
+    expect(exitCode).toBe(0);
+  });
+
+  test("abort while coalesced onto an in-flight TLS connect resolves promptly", async () => {
+    // Leader's TLS handshake never completes (server is plain TCP), so its
+    // PendingConnect stays open. The waiter has no abort-tracker entry and
+    // would otherwise wait for the leader before observing the abort.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-warnings",
+        "-e",
+        `import net from "node:net";
+         let conns = 0;
+         const { promise: accepted, resolve } = Promise.withResolvers();
+         const server = net.createServer(sock => { conns++; sock.on("error", () => {}); resolve(); });
+         server.listen(0, "127.0.0.1");
+         await new Promise(r => server.on("listening", r));
+         const url = "https://127.0.0.1:" + server.address().port + "/";
+         const opts = { protocol: "http2", tls: { rejectUnauthorized: false } };
+         const leader = fetch(url, opts).catch(() => {});
+         const ac = new AbortController();
+         const waiter = fetch(url, { ...opts, signal: ac.signal }).then(
+           () => "unexpected-ok",
+           e => e?.name || String(e),
+         );
+         // Once the server has accepted the leader's TCP connection both
+         // fetches have been processed on the http thread (PendingConnect
+         // creation is synchronous in connect()). The settle window lets a
+         // non-coalesced waiter's connect land so conns reflects it.
+         await accepted;
+         await Bun.sleep(100);
+         ac.abort();
+         console.log(await waiter, "conns=" + conns);
+         void leader;
+         process.exit(0);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("AbortError conns=1");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -9,11 +9,27 @@ import zlib from "node:zlib";
 // allowHTTP1: false forces the server to reject anything that didn't
 // negotiate "h2" via ALPN, so these tests only pass when fetch actually
 // speaks HTTP/2 on the wire.
+//
+// Subprocesses pool their h2 connection and are then SIGKILLed at exit, so
+// the server-side TLS socket sees ECONNRESET. http2's tlsClientError handler
+// forwards that to socket.destroy(err) when there's no clientError listener,
+// which surfaces as an unhandled 'error' event in the test process — swallow
+// those on every test server.
+function makeH2Server(
+  opts: http2.SecureServerOptions = {},
+  handler?: (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => void,
+) {
+  const server = http2.createSecureServer({ ...tls, allowHTTP1: false, ...opts }, handler);
+  server.on("clientError", () => {});
+  server.on("secureConnection", s => s.on("error", () => {}));
+  return server;
+}
+
 async function withH2Server(
   handler: (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => void,
   fn: (url: string, server: http2.Http2SecureServer) => Promise<void>,
 ) {
-  const server = http2.createSecureServer({ ...tls, allowHTTP1: false }, handler);
+  const server = makeH2Server({}, handler);
   server.listen(0);
   await once(server, "listening");
   const { port } = server.address() as import("node:net").AddressInfo;
@@ -245,7 +261,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     let sessions = 0;
     let maxOpen = 0;
     let open = 0;
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       open++;
@@ -362,7 +378,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
 
   test("cold-start: parallel requests coalesce onto one TLS connect", async () => {
     let sessions = 0;
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       stream.respond({ ":status": 200 });
@@ -394,7 +410,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   test("abort sends RST_STREAM; siblings on the session survive", async () => {
     let sessions = 0;
     const { promise: slowClosed, resolve: resolveSlowClosed } = Promise.withResolvers<number>();
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       if (headers[":path"] === "/slow") {
@@ -439,7 +455,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
 
   test("server SETTINGS_MAX_CONCURRENT_STREAMS=1 is honoured per session", async () => {
     const perSessionMax: number[] = [];
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false, settings: { maxConcurrentStreams: 1 } });
+    const server = makeH2Server({ settings: { maxConcurrentStreams: 1 } });
     server.on("session", s => {
       const idx = perSessionMax.push(0) - 1;
       let open = 0;
@@ -482,7 +498,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   test("keep-alive: sequential requests reuse one h2 session", async () => {
     let sessions = 0;
     const seen: number[] = [];
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       seen.push(stream.id);
@@ -515,7 +531,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
 
   test("GOAWAY after a request: next request reconnects", async () => {
     let sessions = 0;
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       const session = stream.session!;
@@ -571,7 +587,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   });
 
   test("response trailers are consumed without breaking the body", async () => {
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("stream", stream => {
       stream.respond({ ":status": 200, "content-type": "text/plain" }, { waitForTrailers: true });
       stream.on("wantTrailers", () => stream.sendTrailers({ "x-trailer": "hello" }));
@@ -599,7 +615,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   // RFC 9113 §8.1 "DATA before HEADERS" stream-error case.
   test("server-reset stream fails that request; sibling on the session survives", async () => {
     let sessions = 0;
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("session", () => sessions++);
     server.on("stream", (stream, headers) => {
       stream.on("error", () => {});
@@ -637,7 +653,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
 
   test("connection-specific request headers are stripped before HPACK", async () => {
     let seen: string[] = [];
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("stream", (stream, headers) => {
       seen = Object.keys(headers).filter(k => !k.startsWith(":"));
       stream.respond({ ":status": 200 });
@@ -674,7 +690,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   });
 
   test("multiple Set-Cookie response headers survive HPACK decode", async () => {
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    const server = makeH2Server();
     server.on("stream", stream => {
       stream.respond({ ":status": 200, "set-cookie": ["a=b", "c=d", "e=f"] });
       stream.end();
@@ -1547,7 +1563,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     // size-update opcode. nghttp2 (which backs node:http2) enforces this and
     // closes the connection with COMPRESSION_ERROR if the opcode is missing,
     // so requests after the first hang/fail without the fix.
-    const server = http2.createSecureServer({ ...tls, settings: { headerTableSize: 0 } }, (_req, res) => {
+    const server = makeH2Server({ settings: { headerTableSize: 0 } }, (_req, res) => {
       res.writeHead(200);
       res.end("ok");
     });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1152,6 +1152,66 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("frame larger than the local SETTINGS_MAX_FRAME_SIZE is a connection FRAME_SIZE_ERROR", async () => {
+      // RFC 9113 §4.2. We never advertise above the 16384 default, so a peer
+      // declaring a 16385-byte payload is a connection error and must not be
+      // buffered (the unbounded path would let a peer balloon read_buffer to
+      // ~16 MiB).
+      await withRawH2Server(
+        (conn, id) => {
+          void id;
+          conn.socket.write(frame(0, 0, 1, Buffer.alloc(16385)));
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2FrameSizeError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("SETTINGS frame on a non-zero stream id is a connection PROTOCOL_ERROR", async () => {
+      // RFC 9113 §6.5.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(frame(4, 0, 1));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("RST_STREAM on an idle stream is a connection PROTOCOL_ERROR", async () => {
+      // RFC 9113 §6.4.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.rst(id + 2, 0);
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("PING with length != 8 is a connection FRAME_SIZE_ERROR", async () => {
       // RFC 9113 §6.7.
       await withRawH2Server(

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -63,9 +63,9 @@ type RawConn = {
 
 async function withRawH2Server(
   onStream: (conn: RawConn, streamId: number, connIndex: number) => void,
-  fn: (url: string, state: { connections: number }) => Promise<void>,
+  fn: (url: string, state: { connections: number; rst: Array<{ id: number; code: number }> }) => Promise<void>,
 ) {
-  const state = { connections: 0 };
+  const state = { connections: 0, rst: [] as Array<{ id: number; code: number }> };
   const server = nodetls.createServer({ ...tls, ALPNProtocols: ["h2"] }, socket => {
     const connIndex = state.connections++;
     const conn: RawConn = {
@@ -98,7 +98,7 @@ async function withRawH2Server(
         buf = buf.subarray(9 + len);
         if (type === 4 && !(flags & 1)) socket.write(frame(4, 1, 0)); // ack their SETTINGS
         if (type === 1) onStream(conn, id, connIndex); // HEADERS opens a stream
-        void payload;
+        if (type === 3) state.rst.push({ id, code: payload.readUInt32BE(0) });
       }
     });
     socket.on("error", () => {});
@@ -1246,6 +1246,29 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
           const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
           expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("client RSTs the stream when it abandons on a local error", async () => {
+      // handleResponseBody throws on invalid gzip; the catch path must send
+      // RST_STREAM(CANCEL) so the server doesn't keep the stream open
+      // counting against MAX_CONCURRENT_STREAMS.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-encoding", "gzip")]));
+          conn.data(id, Buffer.from("not gzip"));
+        },
+        async (url, state) => {
+          await using proc = spawnFetch(`
+            try { await (await fetch("${url}", { tls: { rejectUnauthorized: false } })).arrayBuffer(); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code ?? e.message); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout).toContain("rejected");
+          expect(exitCode).toBe(0);
+          // 0x8 = CANCEL
+          expect(state.rst).toEqual([{ id: 1, code: 8 }]);
         },
       );
     });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -150,6 +150,135 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     );
   });
 
+  test("concurrent requests multiplex on one h2 session", async () => {
+    let sessions = 0;
+    let maxOpen = 0;
+    let open = 0;
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      open++;
+      maxOpen = Math.max(maxOpen, open);
+      stream.on("close", () => open--);
+      // Hold each stream briefly so all 8 are open at once.
+      setTimeout(() => {
+        stream.respond({ ":status": 200 });
+        stream.end(String(headers[":path"]));
+      }, 100);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        // Warmup so the session exists before the concurrent burst.
+        await fetch(url + "/warmup", opts).then(r => r.text());
+        const results = await Promise.all(
+          Array.from({ length: 8 }, (_, i) => fetch(url + "/" + i, opts).then(r => r.text()))
+        );
+        console.log(results.join(","));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("/0,/1,/2,/3,/4,/5,/6,/7");
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(1);
+      expect(maxOpen).toBe(8);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("abort sends RST_STREAM; siblings on the session survive", async () => {
+    let sessions = 0;
+    const { promise: slowClosed, resolve: resolveSlowClosed } = Promise.withResolvers<number>();
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      if (headers[":path"] === "/slow") {
+        stream.on("close", () => resolveSlowClosed(stream.rstCode));
+        // never respond; client will abort
+      } else {
+        stream.respond({ ":status": 200 });
+        stream.end("survivor");
+      }
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        // Warmup so /slow, /fast, /after share one session.
+        await fetch(url + "/warmup", opts).then(r => r.text());
+        const ac = new AbortController();
+        const slow = fetch(url + "/slow", { ...opts, signal: ac.signal }).catch(e => "aborted:" + e.name);
+        const fast = fetch(url + "/fast", opts).then(r => r.text());
+        await fast;
+        ac.abort();
+        await slow;
+        const after = await fetch(url + "/after", opts).then(r => r.text());
+        console.log([await slow, await fast, after].join(","));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("aborted:AbortError,survivor,survivor");
+      expect(exitCode).toBe(0);
+      // Aborting one stream must not tear down the connection: all four
+      // requests rode one session, and /slow's stream closed (RST_STREAM)
+      // while /fast and /after on the same session completed.
+      expect(sessions).toBe(1);
+      await slowClosed;
+    } finally {
+      server.close();
+    }
+  });
+
+  test("server SETTINGS_MAX_CONCURRENT_STREAMS=1 is honoured per session", async () => {
+    const perSessionMax: number[] = [];
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false, settings: { maxConcurrentStreams: 1 } });
+    server.on("session", s => {
+      const idx = perSessionMax.push(0) - 1;
+      let open = 0;
+      s.on("stream", stream => {
+        open++;
+        perSessionMax[idx] = Math.max(perSessionMax[idx], open);
+        stream.on("close", () => open--);
+        setTimeout(() => {
+          stream.respond({ ":status": 200 });
+          stream.end("x");
+        }, 30);
+      });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        // First request alone so the server's SETTINGS arrives before the
+        // burst, then fire 4 concurrently against the cap.
+        await fetch(url, opts).then(r => r.text());
+        await Promise.all(Array.from({ length: 4 }, () => fetch(url, opts).then(r => r.text())));
+        console.log("ok");
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok");
+      expect(exitCode).toBe(0);
+      // The cap is per-connection: no session may ever see >1 open stream.
+      // Excess concurrent requests fan out to additional connections.
+      for (const max of perSessionMax) expect(max).toBe(1);
+      expect(perSessionMax.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      server.close();
+    }
+  });
+
   test("keep-alive: sequential requests reuse one h2 session", async () => {
     let sessions = 0;
     const seen: number[] = [];

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -563,6 +563,53 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test("await fetch() resolves on headers, before a content-length body is fully received", async () => {
+    let unblock!: () => void;
+    const gate = new Promise<void>(r => (unblock = r));
+    const server = makeH2Server();
+    server.on("stream", async stream => {
+      stream.respond({ ":status": 200, "content-length": "262144" });
+      stream.write(Buffer.alloc(64 * 1024));
+      // Hold the rest until JS proves it has the Response and a first chunk.
+      await gate;
+      stream.end(Buffer.alloc(192 * 1024));
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const r = await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } });
+        const reader = r.body.getReader();
+        let n = 0;
+        const { value } = await reader.read();
+        n += value.byteLength;
+        // Signal the server (via stderr so the test can unblock the rest).
+        process.stderr.write("first-chunk\\n");
+        while (true) {
+          const { value, done } = await reader.read();
+          if (value) n += value.byteLength;
+          if (done) break;
+        }
+        console.log(r.status, r.headers.get("content-length"), n);
+      `);
+      // Wait for the subprocess to prove it received the Response + first chunk
+      // BEFORE the server has written the full body.
+      let stderr = "";
+      for await (const chunk of proc.stderr) {
+        stderr += Buffer.from(chunk).toString();
+        if (stderr.includes("first-chunk")) break;
+      }
+      unblock();
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout.trim()).toBe("200 262144 262144");
+      expect(exitCode).toBe(0);
+    } finally {
+      unblock();
+      server.close();
+    }
+  });
+
   test("response body larger than initial window triggers WINDOW_UPDATE", async () => {
     const big = Buffer.alloc(20 * 1024 * 1024, 0x61);
     await withH2Server(

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -42,8 +42,11 @@ const u32be = (n: number) => {
   return b;
 };
 
-// HPACK static-table indices we need: :status 200 = 8, 204 = 9, 404 = 13.
-const hpackStatus = (code: 200 | 204 | 404) => Buffer.from([0x80 | { 200: 8, 204: 9, 404: 13 }[code]]);
+// HPACK static-table indices we need.
+const hpackStatus = (code: 100 | 200 | 204 | 404) =>
+  code === 100
+    ? Buffer.concat([Buffer.from([0x10, 7]), Buffer.from(":status"), Buffer.from([3]), Buffer.from("100")])
+    : Buffer.from([0x80 | { 200: 8, 204: 9, 404: 13 }[code]]);
 // Literal field never-indexed, new name (4-bit prefix 0001 0000): len(name) name len(value) value.
 const hpackLit = (name: string, value: string) =>
   Buffer.concat([Buffer.from([0x10, name.length]), Buffer.from(name), Buffer.from([value.length]), Buffer.from(value)]);
@@ -824,6 +827,29 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
           const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           expect(stderr).toBe("");
           expect(stdout.trim()).toBe("200 padded-body");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("1xx informational HEADERS are skipped, final response delivered", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, hpackStatus(100));
+          // separate write so 100 and 200 arrive in distinct onData passes
+          setTimeout(() => {
+            conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("x-after", "100")]));
+            conn.data(id, "final", true);
+          }, 10);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status, r.headers.get("x-after"), await r.text());
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 100 final");
           expect(exitCode).toBe(0);
         },
       );

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -479,6 +479,132 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
     );
   }, 30_000);
 
+  test("response trailers are consumed without breaking the body", async () => {
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200, "content-type": "text/plain" }, { waitForTrailers: true });
+      stream.on("wantTrailers", () => stream.sendTrailers({ "x-trailer": "hello" }));
+      stream.end("body-text");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const r = await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } });
+        console.log(r.status, await r.text());
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("200 body-text");
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  // Bun's node:http2 server currently emits an empty DATA+END_STREAM for
+  // stream.close(code) rather than RST_STREAM, so this also covers the
+  // RFC 9113 §8.1 "DATA before HEADERS" stream-error case.
+  test("server-reset stream fails that request; sibling on the session survives", async () => {
+    let sessions = 0;
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("session", () => sessions++);
+    server.on("stream", (stream, headers) => {
+      stream.on("error", () => {});
+      if (headers[":path"] === "/bad") {
+        stream.close(http2.constants.NGHTTP2_PROTOCOL_ERROR);
+        return;
+      }
+      setTimeout(() => {
+        stream.respond({ ":status": 200 });
+        stream.end("ok");
+      }, 50);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const opts = { tls: { rejectUnauthorized: false } };
+        const [good, bad] = await Promise.allSettled([
+          fetch(url + "/good", opts).then(r => r.text()),
+          fetch(url + "/bad", opts).then(r => r.text()),
+        ]);
+        console.log(good.status, good.value, bad.status);
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("fulfilled ok rejected");
+      expect(exitCode).toBe(0);
+      expect(sessions).toBe(1);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("connection-specific request headers are stripped before HPACK", async () => {
+    let seen: string[] = [];
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("stream", (stream, headers) => {
+      seen = Object.keys(headers).filter(k => !k.startsWith(":"));
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const r = await fetch("https://localhost:${port}", {
+          headers: {
+            "x-keep": "me",
+            "Connection": "keep-alive",
+            "Keep-Alive": "timeout=5",
+            "Proxy-Connection": "x",
+            "Transfer-Encoding": "chunked",
+            "Upgrade": "ws",
+          },
+          tls: { rejectUnauthorized: false },
+        });
+        console.log(r.status);
+      `);
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toBe("200");
+      expect(exitCode).toBe(0);
+      expect(seen).toContain("x-keep");
+      for (const bad of ["connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade"]) {
+        expect(seen).not.toContain(bad);
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  test("multiple Set-Cookie response headers survive HPACK decode", async () => {
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: false });
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200, "set-cookie": ["a=b", "c=d", "e=f"] });
+      stream.end();
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const r = await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } });
+        console.log(JSON.stringify(r.headers.getSetCookie()));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(`["a=b","c=d","e=f"]`);
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
   test("flag off: ALPN does not offer h2", async () => {
     let sawH2 = false;
     const server = http2.createSecureServer({ ...tls, allowHTTP1: true }, (req, res) => {

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -507,4 +507,61 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
       server.close();
     }
   });
+
+  test("protocol:'http2' forces h2 without the env flag", async () => {
+    await withH2Server(
+      (req, res) => {
+        res.writeHead(200);
+        res.end(req.httpVersion);
+      },
+      async url => {
+        // No BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT in env.
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "--no-warnings",
+            "-e",
+            `const r = await fetch("${url}", { protocol: "http2", tls: { rejectUnauthorized: false } });
+             console.log(r.status, await r.text());`,
+          ],
+          env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe("200 2.0");
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  test("protocol:'http2' against an h1-only server fails with HTTP2Unsupported", async () => {
+    const https = await import("node:https");
+    const server = https.createServer({ ...tls }, (_req, res) => res.end("h1"));
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--no-warnings",
+          "-e",
+          `try {
+             await fetch("https://localhost:${port}", { protocol: "http2", tls: { rejectUnauthorized: false } });
+             console.log("unexpected-ok");
+           } catch (e) { console.log(e.code || String(e)); }`,
+        ],
+        env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toContain("HTTP2Unsupported");
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
 });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1,0 +1,181 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tls } from "harness";
+import { once } from "node:events";
+import http2 from "node:http2";
+import zlib from "node:zlib";
+
+// allowHTTP1: false forces the server to reject anything that didn't
+// negotiate "h2" via ALPN, so these tests only pass when fetch actually
+// speaks HTTP/2 on the wire.
+async function withH2Server(
+  handler: (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => void,
+  fn: (url: string, server: http2.Http2SecureServer) => Promise<void>,
+) {
+  const server = http2.createSecureServer({ ...tls, allowHTTP1: false }, handler);
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("node:net").AddressInfo;
+  try {
+    await fn(`https://localhost:${port}`, server);
+  } finally {
+    server.close();
+  }
+}
+
+function spawnFetch(script: string) {
+  return Bun.spawn({
+    cmd: [bunExe(), "--no-warnings", "-e", script],
+    env: {
+      ...bunEnv,
+      BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT: "1",
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () => {
+  test("GET: status, headers and body round-trip", async () => {
+    await withH2Server(
+      (req, res) => {
+        res.setHeader("x-seen-path", req.url);
+        res.setHeader("x-seen-method", req.method);
+        res.setHeader("x-seen-foo", String(req.headers["x-foo"]));
+        res.setHeader("x-http-version", req.httpVersion);
+        res.writeHead(201, { "content-type": "text/plain" });
+        res.end("hello over h2");
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)} + "/hello?x=1", {
+            headers: { "X-Foo": "bar" },
+            tls: { rejectUnauthorized: false },
+          });
+          const body = await res.text();
+          console.log(JSON.stringify({
+            status: res.status,
+            ct: res.headers.get("content-type"),
+            seenPath: res.headers.get("x-seen-path"),
+            seenMethod: res.headers.get("x-seen-method"),
+            seenFoo: res.headers.get("x-seen-foo"),
+            httpVersion: res.headers.get("x-http-version"),
+            body,
+          }));
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        const out = JSON.parse(stdout);
+        expect(out).toEqual({
+          status: 201,
+          ct: "text/plain",
+          seenPath: "/hello?x=1",
+          seenMethod: "GET",
+          seenFoo: "bar",
+          httpVersion: "2.0",
+          body: "hello over h2",
+        });
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  test("POST: request body is delivered as DATA frames", async () => {
+    await withH2Server(
+      (req, res) => {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", c => (body += c));
+        req.on("end", () => {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ got: body, method: req.method }));
+        });
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)} + "/echo", {
+            method: "POST",
+            body: "the payload",
+            tls: { rejectUnauthorized: false },
+          });
+          process.stdout.write(await res.text());
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({ got: "the payload", method: "POST" });
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  test("response body larger than one DATA frame", async () => {
+    const big = "a".repeat(70_000);
+    await withH2Server(
+      (_req, res) => {
+        res.writeHead(200);
+        res.end(big);
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)}, { tls: { rejectUnauthorized: false } });
+          const buf = await res.arrayBuffer();
+          console.log(buf.byteLength);
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout.trim()).toBe(String(big.length));
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  test("gzip content-encoding is decompressed", async () => {
+    const payload = "compressed body via h2";
+    const gz = zlib.gzipSync(payload);
+    await withH2Server(
+      (_req, res) => {
+        res.writeHead(200, { "content-encoding": "gzip", "content-type": "text/plain" });
+        res.end(gz);
+      },
+      async url => {
+        await using proc = spawnFetch(`
+          const res = await fetch(${JSON.stringify(url)}, { tls: { rejectUnauthorized: false } });
+          process.stdout.write(await res.text());
+        `);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout).toBe(payload);
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
+
+  test("flag off: ALPN does not offer h2", async () => {
+    let sawH2 = false;
+    const server = http2.createSecureServer({ ...tls, allowHTTP1: true }, (req, res) => {
+      sawH2 = req.httpVersion === "2.0";
+      res.writeHead(200);
+      res.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--no-warnings",
+          "-e",
+          `await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } }).then(r => r.text());`,
+        ],
+        env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await proc.exited;
+      expect(sawH2).toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -564,15 +564,15 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   });
 
   test("await fetch() resolves on headers, before a content-length body is fully received", async () => {
-    let unblock!: () => void;
-    const gate = new Promise<void>(r => (unblock = r));
+    let heldStream: http2.ServerHttp2Stream | undefined;
     const server = makeH2Server();
-    server.on("stream", async stream => {
+    server.on("stream", stream => {
+      stream.on("error", () => {});
       stream.respond({ ":status": 200, "content-length": "262144" });
       stream.write(Buffer.alloc(64 * 1024));
-      // Hold the rest until JS proves it has the Response and a first chunk.
-      await gate;
-      stream.end(Buffer.alloc(192 * 1024));
+      // The remaining 192 KiB is written from the test body once the
+      // subprocess proves it already has the Response and a first read.
+      heldStream = stream;
     });
     server.listen(0);
     await once(server, "listening");
@@ -600,12 +600,12 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
         stderr += Buffer.from(chunk).toString();
         if (stderr.includes("first-chunk")) break;
       }
-      unblock();
+      heldStream!.end(Buffer.alloc(192 * 1024));
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       expect(stdout.trim()).toBe("200 262144 262144");
       expect(exitCode).toBe(0);
     } finally {
-      unblock();
+      heldStream?.destroy();
       server.close();
     }
   });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1152,6 +1152,44 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       );
     });
 
+    test("PING with length != 8 is a connection FRAME_SIZE_ERROR", async () => {
+      // RFC 9113 §6.7.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(frame(6, 0, 0, Buffer.alloc(4)));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2FrameSizeError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("PING on a non-zero stream id is a connection PROTOCOL_ERROR", async () => {
+      // RFC 9113 §6.7.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(frame(6, 0, 1, Buffer.alloc(8)));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try { await fetch("${url}", { tls: { rejectUnauthorized: false } }); console.log("ok"); }
+            catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
     test("RST_STREAM(NO_ERROR) before final HEADERS fails the request instead of hanging", async () => {
       await withRawH2Server(
         (conn, id) => {
@@ -1173,12 +1211,12 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   });
 
   test("flag off: ALPN does not offer h2", async () => {
-    let sawH2 = false;
-    const server = http2.createSecureServer({ ...tls, allowHTTP1: true }, (req, res) => {
-      sawH2 = req.httpVersion === "2.0";
-      res.writeHead(200);
-      res.end("ok");
+    let alpn: string | false | null = null;
+    const server = nodetls.createServer({ ...tls, ALPNProtocols: ["h2", "http/1.1"] }, sock => {
+      alpn = sock.alpnProtocol;
+      sock.end("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 2\r\n\r\nok");
     });
+    server.on("tlsClientError", () => {});
     server.listen(0);
     await once(server, "listening");
     const { port } = server.address() as import("node:net").AddressInfo;
@@ -1188,14 +1226,19 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
           bunExe(),
           "--no-warnings",
           "-e",
-          `await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } }).then(r => r.text());`,
+          `console.log(await fetch("https://localhost:${port}", { tls: { rejectUnauthorized: false } }).then(r => r.text()));`,
         ],
         env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
         stdout: "pipe",
         stderr: "pipe",
       });
-      await proc.exited;
-      expect(sawH2).toBe(false);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ok");
+      // The server prefers h2; if the client had offered it, ALPN would have
+      // selected it and the HTTP/1.1 response above would have failed parse.
+      expect(alpn).toBe("http/1.1");
+      expect(exitCode).toBe(0);
     } finally {
       server.close();
     }
@@ -1378,6 +1421,87 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("AbortError conns=1");
+    expect(exitCode).toBe(0);
+  });
+
+  test("SETTINGS_HEADER_TABLE_SIZE=0: encoder emits a Dynamic Table Size Update so request 2+ decodes", async () => {
+    // RFC 9113 §4.3.1 / RFC 7541 §6.3: a server that shrinks the encoder's
+    // dynamic table expects the next header block to begin with a 0x20-prefix
+    // size-update opcode. nghttp2 (which backs node:http2) enforces this and
+    // closes the connection with COMPRESSION_ERROR if the opcode is missing,
+    // so requests after the first hang/fail without the fix.
+    const server = http2.createSecureServer({ ...tls, settings: { headerTableSize: 0 } }, (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    server.on("sessionError", () => {});
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}";
+        const tls = { rejectUnauthorized: false };
+        for (let i = 0; i < 3; i++) {
+          const res = await fetch(url, { tls });
+          console.log(i, res.status, await res.text());
+        }
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("0 200 ok\n1 200 ok\n2 200 ok");
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("leader abort does not fail a coalesced force_http2 waiter with HTTP2Unsupported", async () => {
+    // Regression for resolvePendingH2 conflating "ALPN chose h1" with
+    // "leader failed pre-handshake". Server never speaks TLS, so the leader
+    // sits in handshake; the waiter coalesces onto its PendingConnect. When
+    // the leader is aborted, the waiter must retry as the new leader (a
+    // second TCP connect) rather than be told the server lacks h2.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-warnings",
+        "-e",
+        `import net from "node:net";
+         let conns = 0;
+         const { promise: accepted, resolve } = Promise.withResolvers();
+         const server = net.createServer(sock => { conns++; sock.on("error", () => {}); resolve(); });
+         server.listen(0, "127.0.0.1");
+         await new Promise(r => server.on("listening", r));
+         const url = "https://127.0.0.1:" + server.address().port + "/";
+         const opts = { protocol: "http2", tls: { rejectUnauthorized: false } };
+         const leaderAc = new AbortController();
+         const leader = fetch(url, { ...opts, signal: leaderAc.signal }).catch(e => e?.name || String(e));
+         const waiterAc = new AbortController();
+         const waiter = fetch(url, { ...opts, signal: waiterAc.signal }).then(
+           () => "unexpected-ok",
+           e => (typeof e?.code === "string" ? e.code : e?.name) || String(e),
+         );
+         await accepted;
+         await Bun.sleep(100);
+         const before = conns;
+         leaderAc.abort();
+         await leader;
+         await Bun.sleep(100);
+         const after = conns;
+         waiterAc.abort();
+         console.log(await waiter, "before=" + before, "after=" + after);
+         process.exit(0);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // before=1 proves the waiter coalesced; after=2 proves it retried as
+    // the new leader instead of being failed with HTTP2Unsupported.
+    expect(stdout.trim()).toBe("AbortError before=1 after=2");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1197,6 +1197,43 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     }
   });
 
+  test("ALPN h1 result re-dispatches coalesced waiters in parallel, not serial", async () => {
+    // h1-only TLS server: leader's ALPN resolves to http/1.1, so waiters
+    // re-dispatch. Each must open its own connection on the same loop turn
+    // rather than re-coalescing onto the first waiter's new PendingConnect.
+    let active = 0;
+    let peak = 0;
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const server = https.createServer({ ...tls }, (req, res) => {
+      active++;
+      peak = Math.max(peak, active);
+      if (active === 5) resolve();
+      promise.then(() => {
+        res.end("ok");
+        active--;
+      });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = spawnFetch(`
+        const url = "https://localhost:${port}/";
+        const tls = { rejectUnauthorized: false };
+        const rs = await Promise.all(Array.from({ length: 5 }, () => fetch(url, { tls }).then(r => r.text())));
+        console.log(rs.join(","));
+      `);
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toBe("ok,ok,ok,ok,ok");
+      expect(exitCode).toBe(0);
+      // If waiters re-coalesced, peak would be 1 (sequential); 5 means all
+      // five connections were open before any response was written.
+      expect(peak).toBe(5);
+    } finally {
+      server.close();
+    }
+  });
+
   test('protocol: "http1.1" overrides the env flag and pins ALPN to http/1.1', async () => {
     // Server is h2-only: the unpinned fetch (env flag on) negotiates h2, while
     // the pinned fetch advertises only http/1.1 and is rejected at ALPN —

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from "bun:test";
 import { bunEnv, bunExe, tls } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import https from "node:https";
 import nodetls from "node:tls";
 import zlib from "node:zlib";
 
@@ -125,7 +126,7 @@ function spawnFetch(script: string) {
   });
 }
 
-describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () => {
+describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () => {
   test("GET: status, headers and body round-trip", async () => {
     await withH2Server(
       (req, res) => {
@@ -199,7 +200,7 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
   });
 
   test("response body larger than one DATA frame", async () => {
-    const big = "a".repeat(70_000);
+    const big = Buffer.alloc(70_000, "a").toString();
     await withH2Server(
       (_req, res) => {
         res.writeHead(200);
@@ -967,7 +968,7 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
             const r = await fetch("${url}", {
               method: "POST",
               headers: { Expect: "100-continue" },
-              body: "x".repeat(50000),
+              body: Buffer.alloc(50000, "x").toString(),
               tls: { rejectUnauthorized: false },
             });
             console.log(r.status);
@@ -1014,6 +1015,76 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
           `);
           const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
           expect(stdout.trim()).toBe("rejected");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("Content-Length satisfied before END_STREAM doesn't dereference a freed client", async () => {
+      // Server sends body in one DATA frame without END_STREAM, then a
+      // separate empty DATA(END_STREAM). The first frame fully satisfies
+      // Content-Length, so progressUpdate fires and the JS callback frees
+      // the AsyncHTTP; the second frame must not touch a stale client ptr.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-length", "5")]));
+          conn.data(id, "hello", false);
+          // brief gap so the two frames hit separate onData calls
+          setTimeout(() => conn.data(id, "", true), 30);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+            console.log(r.status, await r.text());
+            await Bun.sleep(80);
+            console.log("survived");
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).not.toContain("panic");
+          expect(stdout.trim()).toBe("200 hello\nsurvived");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("SETTINGS_MAX_FRAME_SIZE below 16384 is rejected as a connection error", async () => {
+      // RFC 9113 §6.5.2: values outside [16384, 2^24-1] are PROTOCOL_ERROR.
+      // Without the lower bound a MAX_FRAME_SIZE of 0 made writeHeaderBlock
+      // loop forever emitting zero-length frames; with it the connection
+      // should fail promptly.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.socket.write(frame(4, 0, 0, Buffer.concat([Buffer.from([0, 5]), u32be(0)])));
+          conn.headers(id, hpackStatus(200), { endStream: true });
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              const r = await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              console.log("status", r.status);
+            } catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2ProtocolError");
+          expect(exitCode).toBe(0);
+        },
+      );
+    });
+
+    test("RST_STREAM(NO_ERROR) before final HEADERS fails the request instead of hanging", async () => {
+      await withRawH2Server(
+        (conn, id) => {
+          conn.rst(id, 0);
+        },
+        async url => {
+          await using proc = spawnFetch(`
+            try {
+              await fetch("${url}", { tls: { rejectUnauthorized: false } });
+              console.log("ok");
+            } catch (e) { console.log("rejected", e.code); }
+          `);
+          const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stdout.trim()).toBe("rejected HTTP2StreamReset");
           expect(exitCode).toBe(0);
         },
       );
@@ -1078,7 +1149,6 @@ describe("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT)", () 
   });
 
   test("protocol:'http2' against an h1-only server fails with HTTP2Unsupported", async () => {
-    const https = await import("node:https");
     const server = https.createServer({ ...tls }, (_req, res) => res.end("h1"));
     server.listen(0);
     await once(server, "listening");

--- a/test/js/web/fetch/fetch-http2-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-http2-leak-fixture.ts
@@ -74,12 +74,28 @@ async function one(i: number): Promise<number> {
   return (await r.arrayBuffer()).byteLength;
 }
 
+// Watchdog: if a batch wedges (CI darwin has shown a hard hang here), abort
+// the process with whatever we've observed so far instead of waiting for the
+// outer test's 90s timeout.
+let lastProgress = Date.now();
+let at = "init";
+const watchdog = setInterval(() => {
+  if (Date.now() - lastProgress > 30_000) {
+    console.error(`[watchdog] stuck at ${at} for >30s, ${JSON.stringify(liveCounts())}`);
+    process.exit(1);
+  }
+}, 5_000);
+
 let bytes = 0;
 for (let i = 0; i < COUNT; i += BATCH) {
+  at = `batch ${i}/${COUNT}`;
   const n = Math.min(BATCH, COUNT - i);
   const results = await Promise.all(Array.from({ length: n }, (_, j) => one(i + j)));
   for (const b of results) bytes += b;
+  lastProgress = Date.now();
 }
+at = "drain";
+clearInterval(watchdog);
 
 if (SCENARIO !== "abort" && bytes === 0) {
   throw new Error("no bytes received");

--- a/test/js/web/fetch/fetch-http2-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-http2-leak-fixture.ts
@@ -33,6 +33,42 @@ async function one(i: number): Promise<number> {
     } catch {}
     return 0;
   }
+  if (SCENARIO === "stream-response") {
+    const r = await fetch(SERVER, h2);
+    const reader = r.body!.getReader();
+    let n = 0;
+    while (true) {
+      const { value, done } = await reader.read();
+      if (value) n += value.byteLength;
+      // Cancel half the reads partway through to exercise the
+      // reader.cancel() → RST_STREAM cleanup path.
+      if (i & 1 && n > 16 * 1024) {
+        await reader.cancel();
+        break;
+      }
+      if (done) break;
+    }
+    return n;
+  }
+  if (SCENARIO === "stream-request") {
+    const chunk = Buffer.alloc(256, i & 0xff);
+    const body = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        for (let k = 0; k < 4; k++) ctrl.enqueue(chunk);
+        ctrl.close();
+      },
+    });
+    const r = await fetch(SERVER, { ...h2, method: "POST", body, duplex: "half" });
+    return (await r.arrayBuffer()).byteLength;
+  }
+  if (SCENARIO === "redirect") {
+    const r = await fetch(SERVER + "/redirect", h2);
+    return (await r.arrayBuffer()).byteLength;
+  }
+  if (SCENARIO === "gzip") {
+    const r = await fetch(SERVER + "/gzip", h2);
+    return (await r.arrayBuffer()).byteLength;
+  }
   // "get"
   const r = await fetch(SERVER, h2);
   return (await r.arrayBuffer()).byteLength;

--- a/test/js/web/fetch/fetch-http2-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-http2-leak-fixture.ts
@@ -74,14 +74,18 @@ async function one(i: number): Promise<number> {
   return (await r.arrayBuffer()).byteLength;
 }
 
-// Watchdog: if a batch wedges (CI darwin has shown a hard hang here), abort
-// the process with whatever we've observed so far instead of waiting for the
-// outer test's 90s timeout.
+// Watchdog: if a batch wedges, abort with whatever we've observed instead of
+// waiting for the outer test's 90s timeout. Prints which indices in the batch
+// haven't resolved so a recurrence shows whether the stuck set is contiguous
+// (write-buffer cutoff) or scattered (per-stream race).
 let lastProgress = Date.now();
 let at = "init";
+let pending = new Set<number>();
 const watchdog = setInterval(() => {
   if (Date.now() - lastProgress > 30_000) {
-    console.error(`[watchdog] stuck at ${at} for >30s, ${JSON.stringify(liveCounts())}`);
+    console.error(
+      `[watchdog] stuck at ${at} for >30s, ${JSON.stringify(liveCounts())}, pending=[${[...pending].sort((a, b) => a - b)}]`,
+    );
     process.exit(1);
   }
 }, 5_000);
@@ -90,7 +94,15 @@ let bytes = 0;
 for (let i = 0; i < COUNT; i += BATCH) {
   at = `batch ${i}/${COUNT}`;
   const n = Math.min(BATCH, COUNT - i);
-  const results = await Promise.all(Array.from({ length: n }, (_, j) => one(i + j)));
+  pending = new Set(Array.from({ length: n }, (_, j) => i + j));
+  const results = await Promise.all(
+    Array.from({ length: n }, (_, j) =>
+      one(i + j).then(b => {
+        pending.delete(i + j);
+        return b;
+      }),
+    ),
+  );
   for (const b of results) bytes += b;
   lastProgress = Date.now();
 }

--- a/test/js/web/fetch/fetch-http2-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-http2-leak-fixture.ts
@@ -1,0 +1,72 @@
+// Subprocess fixture for fetch-http2-leak.test.ts.
+//
+// Hammers an h2 endpoint and asserts that, once all responses are settled
+// and the server's sessions are torn down, the native ClientSession/Stream
+// counters return to zero and JS-side Response objects collect.
+
+import { fetchH2Internals } from "bun:internal-for-testing";
+import { heapStats } from "bun:jsc";
+
+const { liveCounts } = fetchH2Internals;
+
+const { SERVER, SCENARIO = "get" } = process.env;
+if (!SERVER) throw new Error("SERVER environment variable is not set");
+
+const COUNT = parseInt(process.env.COUNT || "200", 10);
+const BATCH = parseInt(process.env.BATCH || "20", 10);
+
+const tls = { rejectUnauthorized: false } as const;
+const h2 = { protocol: "http2", tls } as const;
+
+async function one(i: number): Promise<number> {
+  if (SCENARIO === "post") {
+    const body = Buffer.alloc(1024, i & 0xff);
+    const r = await fetch(SERVER, { ...h2, method: "POST", body });
+    return (await r.arrayBuffer()).byteLength;
+  }
+  if (SCENARIO === "abort") {
+    const ac = new AbortController();
+    const p = fetch(SERVER, { ...h2, signal: ac.signal }).then(r => r.arrayBuffer());
+    ac.abort();
+    try {
+      await p;
+    } catch {}
+    return 0;
+  }
+  // "get"
+  const r = await fetch(SERVER, h2);
+  return (await r.arrayBuffer()).byteLength;
+}
+
+let bytes = 0;
+for (let i = 0; i < COUNT; i += BATCH) {
+  const n = Math.min(BATCH, COUNT - i);
+  const results = await Promise.all(Array.from({ length: n }, (_, j) => one(i + j)));
+  for (const b of results) bytes += b;
+}
+
+if (SCENARIO !== "abort" && bytes === 0) {
+  throw new Error("no bytes received");
+}
+
+// Ask the server to destroy every Http2Session it accepted so the pooled
+// ClientSession's socket gets closed and the refcount drops.
+await fetch(SERVER + "/__destroy_sessions", h2).catch(() => {});
+
+// Wait for the http thread to observe the closes. Poll the native counters
+// instead of sleeping a fixed amount.
+let counts = liveCounts();
+for (let i = 0; i < 200 && (counts.sessions > 0 || counts.streams > 0); i++) {
+  await Bun.sleep(10);
+  counts = liveCounts();
+}
+
+Bun.gc(true);
+const responses = heapStats().objectTypeCounts.Response ?? 0;
+console.log(JSON.stringify({ scenario: SCENARIO, count: COUNT, bytes, ...counts, responses }));
+
+if (counts.streams !== 0) throw new Error(`leaked ${counts.streams} h2 Stream(s)`);
+if (counts.sessions !== 0) throw new Error(`leaked ${counts.sessions} h2 ClientSession(s)`);
+if (responses > 5) throw new Error(`leaked ${responses} Response object(s)`);
+
+console.log("--pass--");

--- a/test/js/web/fetch/fetch-http2-leak-server.ts
+++ b/test/js/web/fetch/fetch-http2-leak-server.ts
@@ -1,0 +1,59 @@
+// Standalone server for fetch-http2-leak.test.ts.
+//
+// Runs in its own process so the node:http2 event loop isn't sharing a thread
+// with the test's Bun.spawn() orchestration — when both live in one process the
+// server intermittently leaves a few streams unanswered under load (observed on
+// macOS 14 and aarch64 Linux), which is a node:http2-server-side issue
+// unrelated to the H2 client lifetimes the leak test is measuring.
+
+import { tls } from "harness";
+import { once } from "node:events";
+import http2 from "node:http2";
+import zlib from "node:zlib";
+
+const body = Buffer.alloc(64 * 1024, "x");
+const gzBody = zlib.gzipSync(body);
+const sessions = new Set<http2.ServerHttp2Session>();
+
+const server = http2.createSecureServer({ ...tls, allowHTTP1: false }, (req, res) => {
+  if (req.url === "/__destroy_sessions") {
+    for (const s of sessions) s.destroy();
+    sessions.clear();
+    return;
+  }
+  if (req.url === "/redirect") {
+    res.writeHead(307, { location: "/" });
+    res.end();
+    return;
+  }
+  if (req.url === "/gzip") {
+    res.writeHead(200, { "content-encoding": "gzip" });
+    res.end(gzBody);
+    return;
+  }
+  if (req.method === "POST") {
+    let n = 0;
+    req.on("data", c => (n += c.length));
+    req.on("end", () => res.end(Buffer.alloc(n)));
+    return;
+  }
+  res.end(body);
+});
+
+server.on("session", s => {
+  sessions.add(s);
+  s.on("close", () => sessions.delete(s));
+  s.on("error", () => {});
+});
+server.on("stream", s => s.on("error", () => {}));
+server.on("error", () => {});
+server.on("sessionError", () => {});
+server.on("clientError", () => {});
+server.on("secureConnection", sock => sock.on("error", () => {}));
+
+server.listen(0);
+await once(server, "listening");
+process.stdout.write(`https://localhost:${(server.address() as import("node:net").AddressInfo).port}\n`);
+
+// Stay alive until the parent kills us.
+process.stdin.resume();

--- a/test/js/web/fetch/fetch-http2-leak.test.ts
+++ b/test/js/web/fetch/fetch-http2-leak.test.ts
@@ -3,6 +3,7 @@ import { bunEnv, bunExe, tls } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import { join } from "node:path";
+import zlib from "node:zlib";
 
 let server: http2.Http2SecureServer;
 let url: string;
@@ -10,11 +11,22 @@ const sessions = new Set<http2.ServerHttp2Session>();
 
 beforeAll(async () => {
   const body = Buffer.alloc(64 * 1024, "x");
+  const gzBody = zlib.gzipSync(body);
   server = http2.createSecureServer({ ...tls, allowHTTP1: false }, (req, res) => {
     if (req.url === "/__destroy_sessions") {
       for (const s of sessions) s.destroy();
       sessions.clear();
       // The session carrying this request was just destroyed; no response.
+      return;
+    }
+    if (req.url === "/redirect") {
+      res.writeHead(307, { location: "/" });
+      res.end();
+      return;
+    }
+    if (req.url === "/gzip") {
+      res.writeHead(200, { "content-encoding": "gzip" });
+      res.end(gzBody);
       return;
     }
     if (req.method === "POST") {
@@ -46,7 +58,7 @@ afterAll(() => {
   server.close();
 });
 
-async function runFixture(scenario: "get" | "post" | "abort") {
+async function runFixture(scenario: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--smol", join(import.meta.dir, "fetch-http2-leak-fixture.ts")],
     env: { ...bunEnv, SERVER: url, SCENARIO: scenario, COUNT: "200", BATCH: "20" },
@@ -62,3 +74,7 @@ async function runFixture(scenario: "get" | "post" | "abort") {
 test("h2 ClientSession/Stream do not leak across batched GETs", () => runFixture("get"));
 test("h2 ClientSession/Stream do not leak across batched POSTs", () => runFixture("post"));
 test("h2 ClientSession/Stream do not leak across aborted requests", () => runFixture("abort"));
+test("h2 ClientSession/Stream do not leak across streamed-response reads", () => runFixture("stream-response"));
+test("h2 ClientSession/Stream do not leak across streamed-request uploads", () => runFixture("stream-request"));
+test("h2 ClientSession/Stream do not leak across same-origin redirects", () => runFixture("redirect"));
+test("h2 ClientSession/Stream do not leak across gzip-encoded responses", () => runFixture("gzip"));

--- a/test/js/web/fetch/fetch-http2-leak.test.ts
+++ b/test/js/web/fetch/fetch-http2-leak.test.ts
@@ -42,6 +42,7 @@ beforeAll(async () => {
     s.on("close", () => sessions.delete(s));
     s.on("error", () => {});
   });
+  server.on("stream", s => s.on("error", () => {}));
   // The abort scenario tears connections down mid-handshake; the server
   // surfaces those as ECONNRESET. They're expected, not test failures.
   server.on("error", () => {});
@@ -59,9 +60,13 @@ afterAll(() => {
 });
 
 async function runFixture(scenario: string) {
+  // BATCH is kept low: at 20 concurrent streams the macOS runner wedges with
+  // a handful of streams stuck mid-response (server-side node:http2 under
+  // load, not the client path being measured). The leak assertion only needs
+  // many sequential request lifetimes, not high parallelism.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--smol", join(import.meta.dir, "fetch-http2-leak-fixture.ts")],
-    env: { ...bunEnv, SERVER: url, SCENARIO: scenario, COUNT: "200", BATCH: "20" },
+    env: { ...bunEnv, SERVER: url, SCENARIO: scenario, COUNT: "200", BATCH: "8" },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/web/fetch/fetch-http2-leak.test.ts
+++ b/test/js/web/fetch/fetch-http2-leak.test.ts
@@ -1,69 +1,39 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, tls } from "harness";
-import { once } from "node:events";
-import http2 from "node:http2";
+import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
-import zlib from "node:zlib";
 
-let server: http2.Http2SecureServer;
+// The server runs in its own subprocess: when node:http2's event loop shares a
+// process with the test's Bun.spawn() pipe-reading, the server intermittently
+// leaves a few streams unanswered under load (macOS 14 / aarch64 Linux). That's
+// a node:http2-server-side issue unrelated to the H2 client lifetimes this test
+// is measuring; isolating the server removes it.
+let serverProc: ReturnType<typeof Bun.spawn>;
 let url: string;
-const sessions = new Set<http2.ServerHttp2Session>();
 
 beforeAll(async () => {
-  const body = Buffer.alloc(64 * 1024, "x");
-  const gzBody = zlib.gzipSync(body);
-  server = http2.createSecureServer({ ...tls, allowHTTP1: false }, (req, res) => {
-    if (req.url === "/__destroy_sessions") {
-      for (const s of sessions) s.destroy();
-      sessions.clear();
-      // The session carrying this request was just destroyed; no response.
-      return;
-    }
-    if (req.url === "/redirect") {
-      res.writeHead(307, { location: "/" });
-      res.end();
-      return;
-    }
-    if (req.url === "/gzip") {
-      res.writeHead(200, { "content-encoding": "gzip" });
-      res.end(gzBody);
-      return;
-    }
-    if (req.method === "POST") {
-      let n = 0;
-      req.on("data", c => (n += c.length));
-      req.on("end", () => res.end(Buffer.alloc(n)));
-      return;
-    }
-    res.end(body);
+  serverProc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fetch-http2-leak-server.ts")],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
   });
-  server.on("session", s => {
-    sessions.add(s);
-    s.on("close", () => sessions.delete(s));
-    s.on("error", () => {});
-  });
-  server.on("stream", s => s.on("error", () => {}));
-  // The abort scenario tears connections down mid-handshake; the server
-  // surfaces those as ECONNRESET. They're expected, not test failures.
-  server.on("error", () => {});
-  server.on("sessionError", () => {});
-  server.on("clientError", () => {});
-  server.on("secureConnection", sock => sock.on("error", () => {}));
-  server.listen(0);
-  await once(server, "listening");
-  url = `https://localhost:${(server.address() as import("node:net").AddressInfo).port}`;
+  const reader = serverProc.stdout.getReader();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error("server exited before printing URL");
+    line += Buffer.from(value).toString();
+  }
+  reader.releaseLock();
+  url = line.trim();
 });
 
 afterAll(() => {
-  for (const s of sessions) s.destroy();
-  server.close();
+  serverProc.kill();
 });
 
 async function runFixture(scenario: string) {
-  // BATCH is kept low: at 20 concurrent streams the macOS runner wedges with
-  // a handful of streams stuck mid-response (server-side node:http2 under
-  // load, not the client path being measured). The leak assertion only needs
-  // many sequential request lifetimes, not high parallelism.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--smol", join(import.meta.dir, "fetch-http2-leak-fixture.ts")],
     env: { ...bunEnv, SERVER: url, SCENARIO: scenario, COUNT: "200", BATCH: "8" },

--- a/test/js/web/fetch/fetch-http2-leak.test.ts
+++ b/test/js/web/fetch/fetch-http2-leak.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls } from "harness";
+import { once } from "node:events";
+import http2 from "node:http2";
+import { join } from "node:path";
+
+let server: http2.Http2SecureServer;
+let url: string;
+const sessions = new Set<http2.ServerHttp2Session>();
+
+beforeAll(async () => {
+  const body = Buffer.alloc(64 * 1024, "x");
+  server = http2.createSecureServer({ ...tls, allowHTTP1: false }, (req, res) => {
+    if (req.url === "/__destroy_sessions") {
+      for (const s of sessions) s.destroy();
+      sessions.clear();
+      // The session carrying this request was just destroyed; no response.
+      return;
+    }
+    if (req.method === "POST") {
+      let n = 0;
+      req.on("data", c => (n += c.length));
+      req.on("end", () => res.end(Buffer.alloc(n)));
+      return;
+    }
+    res.end(body);
+  });
+  server.on("session", s => {
+    sessions.add(s);
+    s.on("close", () => sessions.delete(s));
+    s.on("error", () => {});
+  });
+  // The abort scenario tears connections down mid-handshake; the server
+  // surfaces those as ECONNRESET. They're expected, not test failures.
+  server.on("error", () => {});
+  server.on("sessionError", () => {});
+  server.on("clientError", () => {});
+  server.on("secureConnection", sock => sock.on("error", () => {}));
+  server.listen(0);
+  await once(server, "listening");
+  url = `https://localhost:${(server.address() as import("node:net").AddressInfo).port}`;
+});
+
+afterAll(() => {
+  for (const s of sessions) s.destroy();
+  server.close();
+});
+
+async function runFixture(scenario: "get" | "post" | "abort") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "fetch-http2-leak-fixture.ts")],
+    env: { ...bunEnv, SERVER: url, SCENARIO: scenario, COUNT: "200", BATCH: "20" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Surface the fixture's JSON line on failure.
+  expect(stderr).not.toContain("leaked");
+  expect(stdout).toContain("--pass--");
+  expect(exitCode).toBe(0);
+}
+
+test("h2 ClientSession/Stream do not leak across batched GETs", () => runFixture("get"), 60_000);
+test("h2 ClientSession/Stream do not leak across batched POSTs", () => runFixture("post"), 60_000);
+test("h2 ClientSession/Stream do not leak across aborted requests", () => runFixture("abort"), 60_000);

--- a/test/js/web/fetch/fetch-http2-leak.test.ts
+++ b/test/js/web/fetch/fetch-http2-leak.test.ts
@@ -54,12 +54,11 @@ async function runFixture(scenario: "get" | "post" | "abort") {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  // Surface the fixture's JSON line on failure.
-  expect(stderr).not.toContain("leaked");
+  expect(stderr).toBe("");
   expect(stdout).toContain("--pass--");
   expect(exitCode).toBe(0);
 }
 
-test("h2 ClientSession/Stream do not leak across batched GETs", () => runFixture("get"), 60_000);
-test("h2 ClientSession/Stream do not leak across batched POSTs", () => runFixture("post"), 60_000);
-test("h2 ClientSession/Stream do not leak across aborted requests", () => runFixture("abort"), 60_000);
+test("h2 ClientSession/Stream do not leak across batched GETs", () => runFixture("get"));
+test("h2 ClientSession/Stream do not leak across batched POSTs", () => runFixture("post"));
+test("h2 ClientSession/Stream do not leak across aborted requests", () => runFixture("abort"));


### PR DESCRIPTION
Adds an HTTP/2 client path to `fetch()`, gated behind `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT=1` or per-request via `fetch(url, { protocol: "http2" })`.

## What this does

`fetch()` now offers `h2` in the TLS ALPN list when the feature is enabled. If the server selects it, the request runs over a multiplexed HTTP/2 session instead of HTTP/1.1. Multiple concurrent fetches to the same origin share one TCP+TLS connection.

```js
// Opt in globally:
//   BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT=1 bun run app.js
//   bun run --experimental-http2-fetch app.js

// Or per-request (works without the env flag):
const res = await fetch("https://example.com", { protocol: "http2" });
```

The HTTP/1.1 path is unchanged when the flag is off and `protocol` is not set.

## Architecture

- **`src/http/H2Client.zig`** — `ClientSession` (one per TCP connection, ref-counted) and `Stream` (one per request). The session owns the socket and its HPACK encoder/decoder; streams are entries in a hash map keyed by stream id. The socket-ext `TaggedPointerUnion` gains an `H2.ClientSession` variant alongside `HTTPClient`/`PooledSocket`/`DeadSocket`.
- **`src/http/HTTPContext.zig`** — `active_h2_sessions` registry for live multiplexed connections and `pending_h2_connects` for cold-start coalescing. `connect()` returns `?HTTPSocket`; `null` means the request was handed to the h2 machinery.
- **`src/http.zig`** — `firstCall` checks the negotiated ALPN protocol and either creates a `ClientSession` or proceeds on the existing h1 path. `Flags` gains `protocol: enum { http1_1, http2 }` and `force_http2: bool`.
- **`src/deps/boringssl.translated.zig`** — `configureHTTPClientWithALPN(ssl, host, AlpnOffer)` where `AlpnOffer` is `h1 | h1_or_h2 | h2_only`.

The design keeps h1 and h2 cleanly separated: `HTTPClient` carries `h2: ?*H2.Stream`, and every site that would close/pool the socket or call back into the result handler first checks `flags.protocol == .http2` so the multiplexed socket is never torn down by a single stream finishing.

## Features

### Multiplexing and connection coalescing
N parallel cold fetches to the same `(hostname, port, ssl_config)` share one TLS handshake. The first request opens the socket; the rest park in `PendingConnect.waiters` until ALPN resolves. If the server picks h2, all waiters attach to the new session; if not, they re-dispatch as independent h1 connections (or fail with `HTTP2Unsupported` if they set `protocol: "http2"`).

After the server's first SETTINGS arrives, requests are attached up to `MAX_CONCURRENT_STREAMS`; overflow waits in `pending_attach`.

### Keep-alive pooling
When all streams on a session drain and no GOAWAY/error is set, the socket is parked in the existing keep-alive pool with the `ClientSession` carried alongside (HPACK state survives). The next matching request reuses it directly.

### Streaming request bodies
`ReadableStream` bodies are sent as raw DATA frames (no chunked encoding) with proper send-side flow control: per-stream window from `SETTINGS_INITIAL_WINDOW_SIZE` + per-stream `WINDOW_UPDATE`, connection window from connection-level `WINDOW_UPDATE`. The §6.9.2 delta adjustment when the peer changes `SETTINGS_INITIAL_WINDOW_SIZE` is applied to all open streams.

### Forcing h2
`fetch(url, { protocol: "http2" })` (or `"h2"`) offers `h2` *only* in ALPN and rejects with `HTTP2Unsupported` if the server doesn't accept it. `"http1.1"`/`"h1"` pins h1 regardless of the env flag. Type defs in `packages/bun-types/globals.d.ts`.

### Protocol handling
- **HPACK**: lshpack via `vendor/lshpack`. Header blocks are decoded eagerly at parse time (per END_HEADERS) into per-stream storage so the connection-level dynamic table never desyncs even when 1xx + final + trailers arrive in one TLS read.
- **1xx informational** responses are decoded, dropped, and the stream waits for the final HEADERS.
- **`Expect: 100-continue`**: the request body is withheld until a 1xx arrives; if the final status arrives first, the body is dropped and the client half-closes with an empty DATA(END_STREAM).
- **Trailers** are decoded (to keep HPACK in sync) and discarded; no `Response.prototype.trailers`.
- **REFUSED_STREAM** and **graceful GOAWAY** (`NO_ERROR` with `last_stream_id < ours`): transparently retried on a new or the same connection, capped at 5 attempts, only for replayable `.bytes` bodies.
- **Content-Length** is enforced (RFC 9113 §8.1.1): mismatch with total DATA length → `HTTP2ContentLengthMismatch`.
- **DATA before HEADERS** → `HTTP2ProtocolError`.
- **`response.statusText`** is `""` (HTTP/2 has no reason phrase).

### Hardening (lifecycle / HPACK state)
- Detach the client before terminal `progressUpdate` when Content-Length is satisfied ahead of END_STREAM (trailing frames don't deref a freed `AsyncHTTP`).
- `SETTINGS_MAX_FRAME_SIZE` outside `[16384, 2^24-1]` → connection PROTOCOL_ERROR (a 0 here would otherwise spin the framer forever).
- HPACK decode failure is connection-fatal (RFC 9113 §4.3); the dynamic table is connection-scoped.
- HPACK *encode* failure marks the session encoder-poisoned (no new streams) and removes the never-opened stream without RST.
- Retries/redirects that re-dispatch onto the same session during its `onData` deliver loop park in `pending_attach` until iteration finishes — no `streams` mutation under iteration.
- HEADERS/CONTINUATION for a stream we already RST'd are still fed through HPACK via an orphan buffer so the dynamic table stays in sync.
- `RST_STREAM(NO_ERROR)` before final HEADERS fails the request rather than hanging.
- Header names that overflow the 256-byte stack scratch are heap-lowercased so mixed-case never reaches the wire (§8.2.1).

### fetch-spec fixes (protocol-agnostic, also benefit h1)
- **HTTP-redirect-fetch step 11**: a non-303 redirect with a `ReadableStream` body now rejects with `TypeError` (`RequestBodyNotReusable`); a 303 drops the body and follows. Previously every streaming-body redirect surfaced as `UnexpectedRedirect`, and on h2 the old `closeAndFail` tore down the shared session socket.
- **`AbortSignal.reason`** is now forwarded to the request body's `ReadableStream.cancel(reason)` — both via the `ResumableSink` cancel path (the JS `cancelStream` handler now reads the reason from the right argument slot) and via a new `ReadableStream__cancelWithReason` binding when abort fires before the sink is wired up.

## What's not in scope yet
- HTTP proxy / CONNECT tunneling (h2 falls back to h1 if a proxy is configured)
- Unix sockets
- Sendfile bodies
- Server push (`PUSH_PROMISE` is rejected; we send `SETTINGS_ENABLE_PUSH = 0`)
- h2c (cleartext) prior-knowledge

## Tests

| Suite | Tests | Result |
|---|---|---|
| `test/js/web/fetch/fetch-http2-client.test.ts` | 35 | 35 pass |
| `test/js/third_party/undici-h2/` (vendored `nodejs/undici@5878f54` `test/fetch/http2.js`) | 11 | 11 pass |
| `test/js/third_party/wpt-h2/` (vendored WPT `*.h2.any.js`) | 24 | 20 pass / 4 todo |

The unit suite includes a raw-frame `node:tls`+ALPN server that hand-writes h2 frames so protocol-violation cases nghttp2 won't emit (padded DATA, same-packet 1xx+final+trailers, REFUSED_STREAM, graceful GOAWAY, malicious SETTINGS, RST-before-HEADERS, CL-before-END_STREAM) are covered.

The vendored undici file is byte-identical to upstream apart from its `require()` block; a 100-line shim maps `t.plan`/`t.assert`/`t.after` onto `bun:test` (with `t.plan(n)` enforced via an assertion-counting Proxy) and routes undici's `fetch({dispatcher})` to `globalThis.fetch({protocol:"http2"})`.

The vendored WPT files are byte-identical to `wpt@ebf8e30`; a testharness shim maps `promise_test`/`assert_*` onto `bun:test`, and a small `node:http2` server stands in for the wptserve `.py` endpoints. The 4 `test.todo` entries are documented in `RESULTS.md`: `RequestInit.duplex` getter not read, string/null stream chunks coerced instead of TypeError, and the browser-only 401 credential-prompt behavior.