### PR TITLE
blob: skip undefined memset when freeing memfd-backed store

### DIFF
--- a/src/bun.js/webcore/blob/Store.zig
+++ b/src/bun.js/webcore/blob/Store.zig
@@ -541,7 +541,11 @@ pub const Bytes = struct {
     pub fn deinit(this: *Bytes) void {
         bun.default_allocator.free(this.stored_name.slice());
         if (this.ptr) |ptr| {
-            this.allocator.free(ptr[0..this.cap]);
+            // Use rawFree to skip std.mem.Allocator.free's @memset(undefined).
+            // For memfd-backed stores the mapping may no longer be fully backed
+            // (the fd can be truncated by user code), so touching every byte
+            // before munmap can SIGBUS. It is also wasted work for large blobs.
+            this.allocator.rawFree(ptr[0..this.cap], .@"1", @returnAddress());
         }
         this.ptr = null;
         this.len = 0;

--- a/test/js/web/fetch/blob-cow.test.ts
+++ b/test/js/web/fetch/blob-cow.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
 
 test("Blob.arrayBuffer copy-on-write is not shared", async () => {
   // 8 MB is the threshold for copy-on-write without --smol.
@@ -34,4 +35,43 @@ test("Blob.arrayBuffer copy-on-write is not shared", async () => {
   expect(buf2[0]).toBe(1);
   expect(buf3[0]).toBe(2);
   expect(buf4[0]).toBe(3);
+});
+
+test.skipIf(!isLinux)("Blob finalizer does not SIGBUS when memfd is truncated", async () => {
+  // Large blobs on Linux are backed by a memfd + shared mmap. If user code
+  // truncates that memfd via the fd, the mapping has pages with no backing
+  // store. Freeing the store must not write to those pages.
+  const src = /* js */ `
+    const { fstatSync, ftruncateSync } = require("node:fs");
+    function create() {
+      // Over the 8 MB memfd threshold.
+      new Blob(new Uint8Array(16 * 1024 * 1024));
+    }
+    create();
+    let fd = -1;
+    for (let i = 0; i < 64; i++) {
+      try {
+        if (fstatSync(i).size === 16 * 1024 * 1024) { fd = i; break; }
+      } catch {}
+    }
+    if (fd === -1) {
+      console.log("SKIP");
+      process.exit(0);
+    }
+    ftruncateSync(fd, 0);
+    Bun.gc(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("Sanitizer");
+  expect(stdout.trim()).toMatch(/^(OK|SKIP)$/);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a SIGBUS crash during GC finalization of large Blobs on Linux.

On Linux, Blobs larger than 8 MB are backed by a memfd + shared `mmap`. The memfd's file descriptor stays open while the Blob store is alive, so user code can reach it (e.g. `Bun.file(fd).write(...)`, `fs.ftruncateSync(fd, ...)`) and shrink the underlying file. After that, the existing mapping has pages past EOF with no backing store.

When the Blob is garbage-collected, `Store.Bytes.deinit` called `this.allocator.free(ptr[0..cap])`. In safe builds, `std.mem.Allocator.free` first does `@memset(ptr[0..len], undefined)` before invoking the vtable's `free`. Writing `0xAA` to the unbacked pages faults with SIGBUS inside the GC sweep:

```
#0 __memset_evex_unaligned_erms
#1 mem.Allocator.free ... Allocator.zig:445
#2 bun.js.webcore.blob.Store.Bytes.deinit ... Store.zig:544
#3 bun.js.webcore.blob.Store.deinit
...
#17 JSC::MarkedSpace::sweepPreciseAllocations
```

Fix: call `rawFree` directly so we skip the poison memset and go straight to `munmap`. The memory is about to be unmapped anyway, and for the non-memfd path this just avoids a pointless write over the whole buffer (which for large Blobs in debug builds was hundreds of MB).

Found by Fuzzilli (fingerprint `Address:BUS:libc.so.6+0x173614`). Minimal repro:

```js
const { fstatSync, ftruncateSync } = require("node:fs");
new Blob(new Uint8Array(16 * 1024 * 1024));
let fd = -1;
for (let i = 0; i < 64; i++) try { if (fstatSync(i).size === 16 * 1024 * 1024) { fd = i; break; } } catch {}
ftruncateSync(fd, 0);
Bun.gc(true);
```

## How did you verify your code works?

Added a regression test in `test/js/web/fetch/blob-cow.test.ts` that creates a memfd-backed Blob, truncates the memfd, and runs GC in a subprocess. Verified it crashes with SIGBUS before this change and passes after. Existing blob tests still pass.