### PR TITLE
module-loader: don't skip async-dep wait for sibling static imports

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "bdf6aab38a9c6f99df3fd1486406ab6b74180fbb";
+export const WEBKIT_VERSION = "137c59666cfb02c45d04dcfd4b3852e27f78cffc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -36,3 +36,89 @@ test("dynamic import inside TLA whose target imports the awaiter back does not d
   expect(stdout.trim()).toBe("chunk loaded: 43");
   expect(exitCode).toBe(0);
 });
+
+// Same self-deadlock pattern, but the awaiting module is not the Evaluate()
+// entry — it's a static dependency of the entry. The cycle root re-entered by
+// the chunk has no TopLevelCapability of its own, so the discriminator must
+// be "has its body started" (pendingAsyncDependencies == 0), not "is it the
+// Evaluate() entry".
+test("dynamic import inside TLA of a non-entry module whose target imports it back does not deadlock", async () => {
+  using dir = tempDir("dyn-tla-cycle-nonentry", {
+    "entry.mjs": `
+      import { result } from "./mid.mjs";
+      console.log("result:", result);
+    `,
+    "mid.mjs": `
+      export const x = 42;
+      const chunk = await import("./chunk.mjs");
+      export const result = chunk.handler();
+    `,
+    "chunk.mjs": `
+      import { x } from "./mid.mjs";
+      export const handler = () => x + 1;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("result: 43");
+  expect(exitCode).toBe(0);
+});
+
+// The deadlock-avoidance above must NOT fire for sibling static imports in the
+// same Evaluate() pass. Here `entry` first imports `a` (in an SCC {a,c} with
+// an async dep), popping the SCC to EvaluatingAsync, then imports `b` which
+// reads a binding from `c`. `b` must wait for the SCC; previously the
+// EvaluatingAsync check made it skip the wait and run with `c`'s bindings
+// still in TDZ. Node and pre-rewrite Bun both wait.
+test("static sibling import waits for an async-pending SCC from the same Evaluate()", async () => {
+  using dir = tempDir("static-sibling-async-scc", {
+    "entry.mjs": `
+      import "./a.mjs";
+      import { read } from "./b.mjs";
+      console.log("got:", read);
+    `,
+    "a.mjs": `
+      import { C_VAL } from "./c.mjs";
+      export function aFn() { return C_VAL; }
+    `,
+    "c.mjs": `
+      import { aFn } from "./a.mjs"; // closes the cycle
+      import "./tla.mjs";
+      export const C_VAL = "c";
+    `,
+    "tla.mjs": `
+      // Runtime-false guard: marks the module HasTLA without ever suspending.
+      // Mirrors the "if (process.argv[1] === import.meta.filename) await main()"
+      // pattern in dual CLI/library files.
+      if (globalThis.__never) await 0;
+    `,
+    "b.mjs": `
+      import { C_VAL } from "./c.mjs";
+      export const read = C_VAL;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("got: c");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to `137c59666cfb` (oven-sh/WebKit#202) and adds the regression tests. The fetch-cli.ts workaround that unblocks the build independently is split out to #29771.

## What

- **`scripts/build/deps/webkit.ts`**: `WEBKIT_VERSION` → `137c59666cfb02c45d04dcfd4b3852e27f78cffc`.
- **`test/js/bun/resolve/dynamic-import-tla-cycle.test.ts`**: two new cases.
  - **static sibling import waits for an async-pending SCC** — the regression repro: entry imports A then B; A↔C cycle; C imports a HasTLA module; B reads a binding from C at top-level. Works in Node and 1.3.13, TDZ's on main since #29393.
  - **non-entry TLA self-import** — same Nitro deadlock pattern as the existing test, but the awaiting module is a static dep of the entry rather than the entry itself. Locks in why the discriminator is `pendingAsyncDependencies == 0` (cycle root's body has been entered), not `topLevelCapability` (only set on the `Evaluate()` entry).

## Why

The `depWasAlreadyEvaluatingAsync` patch in `innerModuleEvaluation` (added for the Nitro `await import()`-re-enters-its-own-awaiter deadlock) skips the spec's async-dep wait whenever a dependency is already `EvaluatingAsync`. That also fires for **sibling static imports in the same `Evaluate()` pass**: an earlier sibling pops an SCC to `EvaluatingAsync`, then a later sibling that imports an SCC member sees `status == EvaluatingAsync`, skips the wait, and runs with the SCC's bindings still in TDZ.

oven-sh/WebKit#202 narrows the skip to also require the cycle root's `pendingAsyncDependencies == 0` — i.e. its body has been entered (the Nitro case, where bindings before the await are initialised). For an SCC still queued behind an async dep the count is `> 0`, so the wait is preserved.

Verified locally with `build:local`: all 3 tests in this file + both `require-esm-transitive-tla` tests pass; `scripts/build.ts --help` works without #29771.