### PR TITLE
build: drop top-level await from fetch-cli.ts

### DIFF
--- a/scripts/build/fetch-cli.ts
+++ b/scripts/build/fetch-cli.ts
@@ -277,17 +277,18 @@ function applyPatch(dest: string, patchPath: string, patchBody: string): void {
 
 // Only run if this file is the entry point (not imported as a module).
 // fetch-cli.ts is ALSO imported by source.ts/zig.ts to get fetchCliPath —
-// that import should NOT execute main().
+// that import should NOT execute main(). No top-level await: it would mark
+// this module HasTLA and force every importer (and the {config,webkit,flags,
+// source} cycle) onto the async-evaluation path for code that's dead on
+// import anyway.
 if (process.argv[1] === import.meta.filename) {
-  try {
-    await main();
-  } catch (err) {
-    // Format BuildError nicely; let anything else bubble to bun's default
+  main().catch(err => {
+    // Format BuildError nicely; rethrow anything else to bun's default
     // uncaught handler (gets a stack trace, which is what you want for bugs).
     if (err instanceof BuildError) {
       process.stderr.write(err.format());
       process.exit(1);
     }
     throw err;
-  }
+  });
 }


### PR DESCRIPTION
`fetch-cli.ts` is imported by `source.ts`/`zig.ts` as a library (for `fetchCliPath`) and also runs as a CLI. The guarded `await main()` marks the module `HasTLA`, which forces every importer — and the `{config,webkit,flags,source}` cycle — onto the spec's async-evaluation path for code that's dead on import. Replace with `main().catch(...)` so the module stays sync when imported.

This is the immediate trigger for the `ReferenceError: Cannot access 'webkit' before initialization` crash a freshly-built bun hits running `scripts/build.ts`, which several open `farm/*` branches (#29725, #29731, #29733, #29749, #29756, #28512) each work around by relocating `WEBKIT_VERSION`. Supersedes the `scripts/build/` portions of those.

The underlying loader regression (the `depWasAlreadyEvaluatingAsync` skip in `innerModuleEvaluation` over-firing for sibling static imports) is fixed in oven-sh/WebKit#202; tests + `WEBKIT_VERSION` bump are in #29770. This change is independently correct and lands first so the farm stops thrashing.

Verified: `build/debug/bun-debug scripts/build.ts --help` (was crashing, now works), `fetch-cli.ts` CLI usage and BuildError/non-BuildError exit codes unchanged.