### PR TITLE
postgres: preserve scale for numeric zero on binary/prepared path

### DIFF
--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1032,7 +1032,16 @@ fn parse_binary_numeric<'a>(
     }
 
     if ndigits == 0 {
-        return Ok(PGNummericString::Static(b"0"));
+        // Zero has no digit groups, but dscale still applies: numeric(10, 4)
+        // zero must render as "0.0000" on the binary (prepared) path to match
+        // the text (unprepared) path and libpq/node-postgres.
+        if dscale <= 0 {
+            return Ok(PGNummericString::Static(b"0"));
+        }
+        result.push(b'0');
+        result.push(b'.');
+        result.resize(result.len() + usize::try_from(dscale).expect("int cast"), b'0');
+        return Ok(PGNummericString::Dynamic(result.as_slice()));
     }
 
     // Add negative sign if needed

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1040,7 +1040,10 @@ fn parse_binary_numeric<'a>(
         }
         result.push(b'0');
         result.push(b'.');
-        result.resize(result.len() + usize::try_from(dscale).expect("int cast"), b'0');
+        result.resize(
+            result.len() + usize::try_from(dscale).expect("int cast"),
+            b'0',
+        );
         return Ok(PGNummericString::Dynamic(result.as_slice()));
     }
 

--- a/test/js/sql/postgres-binary-numeric-mock.test.ts
+++ b/test/js/sql/postgres-binary-numeric-mock.test.ts
@@ -1,6 +1,7 @@
-// Regression test for https://github.com/oven-sh/bun/issues/29772
-// Drives parse_binary_numeric with hand-encoded payloads via a wire-protocol
-// mock, so no docker / live postgres is required.
+// Covers the binary numeric decoder (parse_binary_numeric in DataCell.rs): a
+// mock server feeds hand-encoded payloads so decoding runs without docker / a
+// live postgres. See https://github.com/oven-sh/bun/issues/29772.
+// All wire-protocol bytes come from ./wire-frames; do not inline frame bytes.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import {
@@ -10,7 +11,7 @@ import {
   pgDataRow,
   pgReadyForQuery,
   pgRowDescription,
-} from "../../js/sql/wire-frames";
+} from "./wire-frames";
 
 /**
  * Build a postgres binary-numeric column payload (the value bytes carried by a

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -11531,7 +11531,7 @@ CREATE TABLE ${table_name} (
           { area: "D", price: "NaN" },
         ];
         const results = await sql`INSERT INTO ${sql(random_name)} ${sql(body)} RETURNING *`;
-        expect(results[0].price).toEqual("0");
+        expect(results[0].price).toEqual("0.0000"); // 0.00001 collapses to 0 but keeps scale 4
         expect(results[1].price).toEqual("0.0001");
         expect(results[2].price).toEqual("0.0010");
         expect(results[3].price).toEqual("0.0100");
@@ -11560,7 +11560,7 @@ CREATE TABLE ${table_name} (
         expect(results[23].price).toEqual("999999.9999");
 
         // negative numbers
-        expect(results[24].price).toEqual("0");
+        expect(results[24].price).toEqual("0.0000"); // -0.00001 collapses to 0 but keeps scale 4
         expect(results[25].price).toEqual("-0.0001");
         expect(results[26].price).toEqual("-0.0010");
         expect(results[27].price).toEqual("-0.0100");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -133,9 +133,44 @@ if (isDockerEnabled()) {
         const [{ x }] = await sql`select CAST(${value} as NUMERIC(30,20)) as x`;
         expect(x).toBe(value);
       }
-      // zero specifically
+      // zero specifically — a numeric with an explicit scale must preserve
+      // trailing zeros even for the value 0 (regression: #29772).
       const [{ x }] = await sql`select CAST(${"0.00000000000000000000"} as NUMERIC(30,20)) as x`;
-      expect(x).toBe("0");
+      expect(x).toBe("0.00000000000000000000");
+    });
+
+    test("numeric zero preserves scale on prepared/binary path (#29772)", async () => {
+      await using sql = postgres(options);
+      const table = "t_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql.unsafe(`CREATE TEMPORARY TABLE ${table} (v numeric(10, 4) NOT NULL)`);
+      await sql.unsafe(`INSERT INTO ${table} VALUES (0), (1), (1.5), (10)`);
+
+      // Unprepared (text protocol) path — always correct server-side.
+      const unprepared = await sql.unsafe(`SELECT v FROM ${table} ORDER BY v`);
+      expect(unprepared.map((r: any) => r.v)).toEqual(["0.0000", "1.0000", "1.5000", "10.0000"]);
+
+      // Prepared (binary protocol) path — must match.
+      const prepared = await sql.unsafe(`SELECT v FROM ${table} ORDER BY v LIMIT $1`, [10]);
+      expect(prepared.map((r: any) => r.v)).toEqual(["0.0000", "1.0000", "1.5000", "10.0000"]);
+
+      // numeric with no typmod (dscale = 0) — zero has no trailing fractional
+      // digits and should remain "0" on both paths.
+      const table2 = "t_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql.unsafe(`CREATE TEMPORARY TABLE ${table2} (v numeric NOT NULL)`);
+      await sql.unsafe(`INSERT INTO ${table2} VALUES (0)`);
+      expect((await sql.unsafe(`SELECT v FROM ${table2}`))[0].v).toBe("0");
+      expect((await sql.unsafe(`SELECT v FROM ${table2} LIMIT $1`, [1]))[0].v).toBe("0");
+
+      // numeric(p, 0) — explicit zero scale, same result on both paths.
+      const table3 = "t_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql.unsafe(`CREATE TEMPORARY TABLE ${table3} (v numeric(10, 0) NOT NULL)`);
+      await sql.unsafe(`INSERT INTO ${table3} VALUES (0)`);
+      expect((await sql.unsafe(`SELECT v FROM ${table3}`))[0].v).toBe("0");
+      expect((await sql.unsafe(`SELECT v FROM ${table3} LIMIT $1`, [1]))[0].v).toBe("0");
+
+      // Negative zero-adjacent values still format correctly on the prepared path.
+      const negRows = await sql.unsafe(`SELECT CAST($1 AS numeric(10,2)) AS v`, ["-0.50"]);
+      expect(negRows[0].v).toBe("-0.50");
     });
 
     describe("Array helpers", () => {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -11635,7 +11635,7 @@ CREATE TABLE ${table_name} (
         ];
         const results = await sql`INSERT INTO ${sql(random_name)} ${sql(body)} RETURNING *`;
         results.forEach(row => {
-          expect(row.price).toBe("0");
+          expect(row.price).toBe("0.0000"); // NUMERIC(10,4) zero keeps its scale on the binary path
         });
       });
 

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -1,22 +1,10 @@
 // Regression test for https://github.com/oven-sh/bun/issues/29772
 //
-// Bun.SQL's postgres binary-numeric decoder had two correctness bugs:
-//
-// 1. Zero values in a numeric(p, s) column lost their scale formatting on the
-//    prepared/binary protocol path. The decoder short-circuited when
-//    ndigits == 0 and returned the static string "0" regardless of dscale,
-//    so numeric(10, 4) zero came back as "0" instead of "0.0000".
-//
-// 2. Fractional values smaller than ~1e-8 (first base-10000 digit group at
-//    weight <= -3) were under-padded with leading zeros. The fractional
-//    loop used a single counter for both the digit-array index and the
-//    dscale position, conflating postgres' two separate counters (digit
-//    index +1, dscale position +4). Example: 0.000000001234 came back as
-//    "0.000012340000".
-//
-// These tests stand up a minimal postgres wire-protocol mock that returns
-// a single numeric column with hand-crafted binary encodings, exercising
-// parse_binary_numeric directly — no docker / no live postgres required.
+// Asserts the postgres binary-numeric decoder (parse_binary_numeric) preserves
+// scale: zero-scale formatting for numeric(p, s) zeros and correct leading-zero
+// padding for tiny fractional magnitudes. Uses a minimal postgres wire-protocol
+// mock so the hand-encoded binary payloads exercise the decoder directly — no
+// docker / no live postgres required. Per-case comments document each encoding.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import net from "net";
@@ -85,6 +73,15 @@ function rowDescriptionNumeric(name: string): Buffer {
  *   i16 ndigits, i16 weight, u16 sign, i16 dscale, then i16 digits × ndigits.
  */
 function numericBinary(ndigits: number, weight: number, sign: number, dscale: number, digits: number[]): Buffer {
+  // Guard against hand-encoding mistakes that would mask test intent.
+  if (digits.length !== ndigits) {
+    throw new Error(`numericBinary: ndigits (${ndigits}) must equal digits.length (${digits.length})`);
+  }
+  for (const digit of digits) {
+    if (!Number.isInteger(digit) || digit < 0 || digit > 9999) {
+      throw new Error(`numericBinary: base-10000 digit out of range [0, 9999]: ${digit}`);
+    }
+  }
   const buf = Buffer.alloc(8 + 2 * digits.length);
   buf.writeInt16BE(ndigits, 0);
   buf.writeInt16BE(weight, 2);

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -3,70 +3,19 @@
 // mock, so no docker / live postgres is required.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import net from "net";
-
-// --- postgres wire protocol helpers ---
-
-/** Prepend a 1-byte type + 4-byte length (inclusive) to a payload. */
-function pgPacket(type: string, payload: Buffer): Buffer {
-  const header = Buffer.alloc(5);
-  header.write(type, 0, 1, "ascii");
-  header.writeInt32BE(payload.length + 4, 1);
-  return Buffer.concat([header, payload]);
-}
-
-/** ReadyForQuery ('Z') with transaction status 'I' (idle). */
-const READY_FOR_QUERY_IDLE = pgPacket("Z", Buffer.from([0x49]));
-
-/** AuthenticationOk ('R', int32 = 0). */
-const AUTH_OK = pgPacket("R", Buffer.from([0, 0, 0, 0]));
-
-/** ParseComplete ('1'). */
-const PARSE_COMPLETE = pgPacket("1", Buffer.alloc(0));
-
-/** BindComplete ('2'). */
-const BIND_COMPLETE = pgPacket("2", Buffer.alloc(0));
-
-/** Build CommandComplete ('C') for "SELECT <rows>". */
-function commandComplete(rows: number): Buffer {
-  return pgPacket("C", Buffer.concat([Buffer.from(`SELECT ${rows}`, "ascii"), Buffer.from([0])]));
-}
-
-/** ParameterDescription ('t') listing the int4 oid (23) for each param. */
-function parameterDescription(paramCount: number): Buffer {
-  const buf = Buffer.alloc(2 + 4 * paramCount);
-  buf.writeInt16BE(paramCount, 0);
-  for (let i = 0; i < paramCount; i++) {
-    buf.writeInt32BE(23, 2 + i * 4); // int4 oid
-  }
-  return pgPacket("t", buf);
-}
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "../../js/sql/wire-frames";
 
 /**
- * RowDescription ('T') with a single field named `name`, type oid 1700
- * (numeric), binary format code.
- */
-function rowDescriptionNumeric(name: string): Buffer {
-  const nameBuf = Buffer.from(name + "\0", "ascii");
-  // fields: 2 bytes count
-  // per field: name + table_oid(4) + column_index(2) + type_oid(4)
-  //          + type_size(2) + type_modifier(4) + format_code(2)
-  const body = Buffer.concat([
-    Buffer.from([0x00, 0x01]), // field count = 1
-    nameBuf,
-    Buffer.from([0, 0, 0, 0]), // table_oid = 0
-    Buffer.from([0, 0]), // column_index = 0
-    Buffer.from([0, 0, 0x06, 0xa4]), // type_oid = 1700 (numeric)
-    Buffer.from([0xff, 0xff]), // type_size = -1 (var-width)
-    Buffer.from([0xff, 0xff, 0xff, 0xff]), // type_modifier = -1
-    Buffer.from([0x00, 0x01]), // format_code = 1 (binary)
-  ]);
-  return pgPacket("T", body);
-}
-
-/**
- * Build a postgres binary-numeric byte sequence:
- *   i16 ndigits, i16 weight, u16 sign, i16 dscale, then i16 digits × ndigits.
+ * Build a postgres binary-numeric column payload (the value bytes carried by a
+ * DataRow, not a wire frame): i16 ndigits, i16 weight, u16 sign, i16 dscale,
+ * then i16 digits × ndigits.
  */
 function numericBinary(ndigits: number, weight: number, sign: number, dscale: number, digits: number[]): Buffer {
   // Guard against hand-encoding mistakes that would mask test intent.
@@ -89,100 +38,40 @@ function numericBinary(ndigits: number, weight: number, sign: number, dscale: nu
   return buf;
 }
 
-/** DataRow ('D') with one column carrying the supplied bytes. */
-function dataRowOneColumn(value: Buffer): Buffer {
-  const body = Buffer.alloc(2 + 4 + value.length);
-  body.writeInt16BE(1, 0); // column count
-  body.writeInt32BE(value.length, 2); // column length
-  value.copy(body, 6);
-  return pgPacket("D", body);
-}
-
 /**
- * Mock postgres server that answers the extended-protocol flow and returns
- * `rows` (binary numeric byte strings) from Execute, so parse_binary_numeric
- * decodes them via the real `sql.unsafe(query, [...])` path.
+ * Decode `rows` (each a binary numeric column payload) through the real client.
+ * The mock advertises binary format (oid 1700) in its RowDescription, so the
+ * bytes flow through parse_binary_numeric exactly as on the prepared path.
  */
-function startMockPostgres(rows: Buffer[]): Promise<{ port: number; close: () => void }> {
-  return new Promise(resolve => {
-    const server = net.createServer(socket => {
-      let phase: "startup" | "ready" = "startup";
-      let buf = Buffer.alloc(0);
-
-      socket.on("data", chunk => {
-        buf = Buffer.concat([buf, chunk]);
-
-        // Startup is special: first message has no type byte, just length.
-        if (phase === "startup") {
-          if (buf.length < 4) return;
-          const startupLen = buf.readInt32BE(0);
-          if (buf.length < startupLen) return;
-          buf = buf.subarray(startupLen);
-          phase = "ready";
-          // AuthenticationOk → ReadyForQuery. Skip ParameterStatus /
-          // BackendKeyData — the bun client doesn't require them to proceed.
-          socket.write(Buffer.concat([AUTH_OK, READY_FOR_QUERY_IDLE]));
-        }
-
-        // Extended protocol: consume framed messages (type + 4B length).
-        while (buf.length >= 5) {
-          const msgLen = buf.readInt32BE(1);
-          const total = 1 + msgLen;
-          if (buf.length < total) break;
-          const type = String.fromCharCode(buf[0]!);
-          buf = buf.subarray(total);
-
-          if (type === "P") {
-            // Parse → ParseComplete
-            socket.write(PARSE_COMPLETE);
-          } else if (type === "D") {
-            // Describe statement → ParameterDescription + RowDescription
-            socket.write(Buffer.concat([parameterDescription(1), rowDescriptionNumeric("v")]));
-          } else if (type === "B") {
-            // Bind → BindComplete
-            socket.write(BIND_COMPLETE);
-          } else if (type === "E") {
-            // Execute → DataRows + CommandComplete
-            const packets: Buffer[] = [];
-            for (const row of rows) packets.push(dataRowOneColumn(row));
-            packets.push(commandComplete(rows.length));
-            socket.write(Buffer.concat(packets));
-          } else if (type === "S") {
-            // Sync → ReadyForQuery. Flush ('H') is a no-op for this mock.
-            socket.write(READY_FOR_QUERY_IDLE);
-          } else if (type === "X") {
-            // Terminate
-            socket.end();
-          }
-        }
-      });
-    });
-
-    server.listen(0, "127.0.0.1", () => {
-      const port = (server.address() as net.AddressInfo).port;
-      resolve({ port, close: () => server.close() });
-    });
-  });
-}
-
-/** Run a single `SELECT ... $1` against the mock and return the decoded column. */
 async function runQuery(rows: Buffer[]): Promise<string[]> {
-  const mock = await startMockPostgres(rows);
-  try {
-    await using sql = new SQL({
-      adapter: "postgres",
-      hostname: "127.0.0.1",
-      port: mock.port,
-      username: "mock",
-      database: "mock",
-      ssl: false,
-      max: 1,
-      idleTimeout: 1,
+  const { port, server } = await listeningServer(socket => {
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' (simple query) */) return;
+      socket.write(
+        Buffer.concat([
+          pgRowDescription([{ name: "v", typeOid: 1700, format: 1 }]),
+          ...rows.map(r => pgDataRow([r])),
+          pgCommandComplete(`SELECT ${rows.length}`),
+          pgReadyForQuery(),
+        ]),
+      );
     });
-    const result = await sql.unsafe("SELECT v FROM t LIMIT $1", [rows.length]);
+    socket.on("error", () => {});
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const result = await sql`select v`.simple();
     return result.map((r: any) => r.v as string);
   } finally {
-    mock.close();
+    await sql.close().catch(() => {});
+    await new Promise<void>(r => server.close(() => r()));
   }
 }
 

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -229,7 +229,7 @@ test("numeric very small fractional values render correctly (weight = -5)", asyn
   expect(await runQuery([tinier])).toEqual(["0.00000000000000001234"]);
 });
 
-test("numeric weight = -2 (previously accidentally correct) still renders correctly", async () => {
+test("numeric weight = -2 renders correctly", async () => {
   // 0.00005678 : ndigits=1, weight=-2, dscale=8, digits=[5678].
   const v = numericBinary(1, -2, 0x0000, 8, [5678]);
   expect(await runQuery([v])).toEqual(["0.00005678"]);

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -1,0 +1,269 @@
+// Regression test for https://github.com/oven-sh/bun/issues/29772
+//
+// Bun.SQL's postgres binary-numeric decoder had two correctness bugs:
+//
+// 1. Zero values in a numeric(p, s) column lost their scale formatting on the
+//    prepared/binary protocol path. The decoder short-circuited when
+//    ndigits == 0 and returned the static string "0" regardless of dscale,
+//    so numeric(10, 4) zero came back as "0" instead of "0.0000".
+//
+// 2. Fractional values smaller than ~1e-8 (first base-10000 digit group at
+//    weight <= -3) were under-padded with leading zeros. The fractional
+//    loop used a single counter for both the digit-array index and the
+//    dscale position, conflating postgres' two separate counters (digit
+//    index +1, dscale position +4). Example: 0.000000001234 came back as
+//    "0.000012340000".
+//
+// These tests stand up a minimal postgres wire-protocol mock that returns
+// a single numeric column with hand-crafted binary encodings, exercising
+// parse_binary_numeric directly — no docker / no live postgres required.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import net from "net";
+
+// --- postgres wire protocol helpers ---
+
+/** Prepend a 1-byte type + 4-byte length (inclusive) to a payload. */
+function pgPacket(type: string, payload: Buffer): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0, 1, "ascii");
+  header.writeInt32BE(payload.length + 4, 1);
+  return Buffer.concat([header, payload]);
+}
+
+/** ReadyForQuery ('Z') with transaction status 'I' (idle). */
+const READY_FOR_QUERY_IDLE = pgPacket("Z", Buffer.from([0x49]));
+
+/** AuthenticationOk ('R', int32 = 0). */
+const AUTH_OK = pgPacket("R", Buffer.from([0, 0, 0, 0]));
+
+/** ParseComplete ('1'). */
+const PARSE_COMPLETE = pgPacket("1", Buffer.alloc(0));
+
+/** BindComplete ('2'). */
+const BIND_COMPLETE = pgPacket("2", Buffer.alloc(0));
+
+/** Build CommandComplete ('C') for "SELECT <rows>". */
+function commandComplete(rows: number): Buffer {
+  return pgPacket("C", Buffer.concat([Buffer.from(`SELECT ${rows}`, "ascii"), Buffer.from([0])]));
+}
+
+/** ParameterDescription ('t') listing the int4 oid (23) for each param. */
+function parameterDescription(paramCount: number): Buffer {
+  const buf = Buffer.alloc(2 + 4 * paramCount);
+  buf.writeInt16BE(paramCount, 0);
+  for (let i = 0; i < paramCount; i++) {
+    buf.writeInt32BE(23, 2 + i * 4); // int4 oid
+  }
+  return pgPacket("t", buf);
+}
+
+/**
+ * RowDescription ('T') with a single field named `name`, type oid 1700
+ * (numeric), binary format code.
+ */
+function rowDescriptionNumeric(name: string): Buffer {
+  const nameBuf = Buffer.from(name + "\0", "ascii");
+  // fields: 2 bytes count
+  // per field: name + table_oid(4) + column_index(2) + type_oid(4)
+  //          + type_size(2) + type_modifier(4) + format_code(2)
+  const body = Buffer.concat([
+    Buffer.from([0x00, 0x01]), // field count = 1
+    nameBuf,
+    Buffer.from([0, 0, 0, 0]), // table_oid = 0
+    Buffer.from([0, 0]), // column_index = 0
+    Buffer.from([0, 0, 0x06, 0xa4]), // type_oid = 1700 (numeric)
+    Buffer.from([0xff, 0xff]), // type_size = -1 (var-width)
+    Buffer.from([0xff, 0xff, 0xff, 0xff]), // type_modifier = -1
+    Buffer.from([0x00, 0x01]), // format_code = 1 (binary)
+  ]);
+  return pgPacket("T", body);
+}
+
+/**
+ * Build a postgres binary-numeric byte sequence:
+ *   i16 ndigits, i16 weight, u16 sign, i16 dscale, then i16 digits × ndigits.
+ */
+function numericBinary(ndigits: number, weight: number, sign: number, dscale: number, digits: number[]): Buffer {
+  const buf = Buffer.alloc(8 + 2 * digits.length);
+  buf.writeInt16BE(ndigits, 0);
+  buf.writeInt16BE(weight, 2);
+  buf.writeUInt16BE(sign, 4);
+  buf.writeInt16BE(dscale, 6);
+  for (let i = 0; i < digits.length; i++) {
+    buf.writeUInt16BE(digits[i]!, 8 + i * 2);
+  }
+  return buf;
+}
+
+/** DataRow ('D') with one column carrying the supplied bytes. */
+function dataRowOneColumn(value: Buffer): Buffer {
+  const body = Buffer.alloc(2 + 4 + value.length);
+  body.writeInt16BE(1, 0); // column count
+  body.writeInt32BE(value.length, 2); // column length
+  value.copy(body, 6);
+  return pgPacket("D", body);
+}
+
+/**
+ * Start a mock postgres server that returns `rows` (each a binary numeric
+ * byte string) for every extended-protocol query. Speaks just enough of
+ * the wire protocol to drive `sql.unsafe(query, [...])` to Bind/Execute
+ * and decode the DataRow response via parse_binary_numeric.
+ */
+function startMockPostgres(rows: Buffer[]): Promise<{ port: number; close: () => void }> {
+  return new Promise(resolve => {
+    const server = net.createServer(socket => {
+      let phase: "startup" | "ready" = "startup";
+      let buf = Buffer.alloc(0);
+
+      socket.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+
+        // Startup is special: first message has no type byte, just length.
+        if (phase === "startup") {
+          if (buf.length < 4) return;
+          const startupLen = buf.readInt32BE(0);
+          if (buf.length < startupLen) return;
+          buf = buf.subarray(startupLen);
+          phase = "ready";
+          // AuthenticationOk → ReadyForQuery. Skip ParameterStatus /
+          // BackendKeyData — the bun client doesn't require them to proceed.
+          socket.write(Buffer.concat([AUTH_OK, READY_FOR_QUERY_IDLE]));
+        }
+
+        // Extended protocol: consume framed messages (type + 4B length).
+        while (buf.length >= 5) {
+          const msgLen = buf.readInt32BE(1);
+          const total = 1 + msgLen;
+          if (buf.length < total) break;
+          const type = String.fromCharCode(buf[0]!);
+          buf = buf.subarray(total);
+
+          if (type === "P") {
+            // Parse → ParseComplete
+            socket.write(PARSE_COMPLETE);
+          } else if (type === "D") {
+            // Describe statement → ParameterDescription + RowDescription
+            socket.write(Buffer.concat([parameterDescription(1), rowDescriptionNumeric("v")]));
+          } else if (type === "B") {
+            // Bind → BindComplete
+            socket.write(BIND_COMPLETE);
+          } else if (type === "E") {
+            // Execute → DataRows + CommandComplete
+            const packets: Buffer[] = [];
+            for (const row of rows) packets.push(dataRowOneColumn(row));
+            packets.push(commandComplete(rows.length));
+            socket.write(Buffer.concat(packets));
+          } else if (type === "S" || type === "H") {
+            // Sync / Flush → ReadyForQuery (Sync only, but emitting on
+            // Flush too is harmless and simplifies the mock).
+            if (type === "S") socket.write(READY_FOR_QUERY_IDLE);
+          } else if (type === "X") {
+            // Terminate
+            socket.end();
+          }
+        }
+      });
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as net.AddressInfo).port;
+      resolve({ port, close: () => server.close() });
+    });
+  });
+}
+
+/** Run a single `SELECT ... $1` against the mock and return the decoded column. */
+async function runQuery(rows: Buffer[]): Promise<string[]> {
+  const mock = await startMockPostgres(rows);
+  try {
+    await using sql = new SQL({
+      adapter: "postgres",
+      hostname: "127.0.0.1",
+      port: mock.port,
+      username: "mock",
+      database: "mock",
+      ssl: false,
+      max: 1,
+      idleTimeout: 1,
+    });
+    const result = await sql.unsafe("SELECT v FROM t LIMIT $1", [rows.length]);
+    return result.map((r: any) => r.v as string);
+  } finally {
+    mock.close();
+  }
+}
+
+// --- tests ---
+
+test("numeric zero with dscale > 0 preserves scale on binary path (#29772)", async () => {
+  // numeric(10, 4) zero: ndigits=0, weight=0, sign=0, dscale=4
+  const zeros4 = numericBinary(0, 0, 0x0000, 4, []);
+  expect(await runQuery([zeros4])).toEqual(["0.0000"]);
+});
+
+test("numeric zero with dscale = 0 renders as bare '0' on binary path", async () => {
+  // numeric (no typmod) zero: ndigits=0, weight=0, sign=0, dscale=0
+  const zeros0 = numericBinary(0, 0, 0x0000, 0, []);
+  expect(await runQuery([zeros0])).toEqual(["0"]);
+});
+
+test("numeric zero with dscale > 0 preserves scale alongside non-zero rows", async () => {
+  // Mirrors the repro: numeric(10, 4) with values 0, 1, 1.5, 10.
+  // Binary encodings worked out by hand (and cross-checked against the
+  // bytes postgres actually emits):
+  //   0       : ndigits=0, weight=0,  dscale=4, []
+  //   1.0000  : ndigits=1, weight=0,  dscale=4, [1]
+  //   1.5000  : ndigits=2, weight=0,  dscale=4, [1, 5000]
+  //   10.0000 : ndigits=1, weight=0,  dscale=4, [10]
+  const rows = [
+    numericBinary(0, 0, 0x0000, 4, []),
+    numericBinary(1, 0, 0x0000, 4, [1]),
+    numericBinary(2, 0, 0x0000, 4, [1, 5000]),
+    numericBinary(1, 0, 0x0000, 4, [10]),
+  ];
+  expect(await runQuery(rows)).toEqual(["0.0000", "1.0000", "1.5000", "10.0000"]);
+});
+
+test("numeric with dscale but ndigits = 0 handles dscale > 4", async () => {
+  // numeric(30, 20) zero: ndigits=0, dscale=20 → "0." + 20 zeros.
+  const zeros20 = numericBinary(0, 0, 0x0000, 20, []);
+  expect(await runQuery([zeros20])).toEqual(["0.00000000000000000000"]);
+});
+
+test("numeric small fractional values render correctly (weight <= -3)", async () => {
+  // 0.000000001234 : ndigits=1, weight=-3, dscale=12, digits=[1234]
+  // The pre-existing bug conflated digit-index and dscale-position counters,
+  // so this rendered as "0.000012340000" instead of "0.000000001234".
+  const tiny = numericBinary(1, -3, 0x0000, 12, [1234]);
+  expect(await runQuery([tiny])).toEqual(["0.000000001234"]);
+});
+
+test("numeric very small fractional values render correctly (weight = -5)", async () => {
+  // 0.00000000000000001234 : ndigits=1, weight=-5, dscale=20, digits=[1234]
+  const tinier = numericBinary(1, -5, 0x0000, 20, [1234]);
+  expect(await runQuery([tinier])).toEqual(["0.00000000000000001234"]);
+});
+
+test("numeric weight = -2 (previously accidentally correct) still renders correctly", async () => {
+  // 0.00005678 : ndigits=1, weight=-2, dscale=8, digits=[5678].
+  const v = numericBinary(1, -2, 0x0000, 8, [5678]);
+  expect(await runQuery([v])).toEqual(["0.00005678"]);
+});
+
+test("numeric weight = -1 with two digit groups renders correctly (e.g. 0.05678)", async () => {
+  // 0.05678 : ndigits=2, weight=-1, dscale=5, digits=[567, 8000]
+  const v = numericBinary(2, -1, 0x0000, 5, [567, 8000]);
+  expect(await runQuery([v])).toEqual(["0.05678"]);
+});
+
+test("numeric negative value with small fractional magnitude renders correctly", async () => {
+  // -0.00001234 : ndigits=1, weight=-2, dscale=11, digits=[1234], sign=0x4000
+  // Value is 1234 × 10000^(-2) = 1.234 × 10^-5; dscale=11 pads trailing
+  // zeros to yield "-0.00001234000". weight=-2 is the "accidentally
+  // correct" range, so this guards against sign-handling regressions from
+  // the split-counter fix.
+  const v = numericBinary(1, -2, 0x4000, 11, [1234]);
+  expect(await runQuery([v])).toEqual(["-0.00001234000"]);
+});

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -147,10 +147,9 @@ function startMockPostgres(rows: Buffer[]): Promise<{ port: number; close: () =>
             for (const row of rows) packets.push(dataRowOneColumn(row));
             packets.push(commandComplete(rows.length));
             socket.write(Buffer.concat(packets));
-          } else if (type === "S" || type === "H") {
-            // Sync / Flush → ReadyForQuery (Sync only, but emitting on
-            // Flush too is harmless and simplifies the mock).
-            if (type === "S") socket.write(READY_FOR_QUERY_IDLE);
+          } else if (type === "S") {
+            // Sync → ReadyForQuery. Flush ('H') is a no-op for this mock.
+            socket.write(READY_FOR_QUERY_IDLE);
           } else if (type === "X") {
             // Terminate
             socket.end();

--- a/test/regression/issue/29772.test.ts
+++ b/test/regression/issue/29772.test.ts
@@ -1,10 +1,6 @@
 // Regression test for https://github.com/oven-sh/bun/issues/29772
-//
-// Asserts the postgres binary-numeric decoder (parse_binary_numeric) preserves
-// scale: zero-scale formatting for numeric(p, s) zeros and correct leading-zero
-// padding for tiny fractional magnitudes. Uses a minimal postgres wire-protocol
-// mock so the hand-encoded binary payloads exercise the decoder directly — no
-// docker / no live postgres required. Per-case comments document each encoding.
+// Drives parse_binary_numeric with hand-encoded payloads via a wire-protocol
+// mock, so no docker / live postgres is required.
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import net from "net";
@@ -103,10 +99,9 @@ function dataRowOneColumn(value: Buffer): Buffer {
 }
 
 /**
- * Start a mock postgres server that returns `rows` (each a binary numeric
- * byte string) for every extended-protocol query. Speaks just enough of
- * the wire protocol to drive `sql.unsafe(query, [...])` to Bind/Execute
- * and decode the DataRow response via parse_binary_numeric.
+ * Mock postgres server that answers the extended-protocol flow and returns
+ * `rows` (binary numeric byte strings) from Execute, so parse_binary_numeric
+ * decodes them via the real `sql.unsafe(query, [...])` path.
  */
 function startMockPostgres(rows: Buffer[]): Promise<{ port: number; close: () => void }> {
   return new Promise(resolve => {
@@ -207,18 +202,12 @@ test("numeric zero with dscale = 0 renders as bare '0' on binary path", async ()
 });
 
 test("numeric zero with dscale > 0 preserves scale alongside non-zero rows", async () => {
-  // Mirrors the repro: numeric(10, 4) with values 0, 1, 1.5, 10.
-  // Binary encodings worked out by hand (and cross-checked against the
-  // bytes postgres actually emits):
-  //   0       : ndigits=0, weight=0,  dscale=4, []
-  //   1.0000  : ndigits=1, weight=0,  dscale=4, [1]
-  //   1.5000  : ndigits=2, weight=0,  dscale=4, [1, 5000]
-  //   10.0000 : ndigits=1, weight=0,  dscale=4, [10]
+  // numeric(10, 4) with values 0, 1, 1.5, 10 (ndigits, weight, sign, dscale, digits).
   const rows = [
-    numericBinary(0, 0, 0x0000, 4, []),
-    numericBinary(1, 0, 0x0000, 4, [1]),
-    numericBinary(2, 0, 0x0000, 4, [1, 5000]),
-    numericBinary(1, 0, 0x0000, 4, [10]),
+    numericBinary(0, 0, 0x0000, 4, []), // 0
+    numericBinary(1, 0, 0x0000, 4, [1]), // 1.0000
+    numericBinary(2, 0, 0x0000, 4, [1, 5000]), // 1.5000
+    numericBinary(1, 0, 0x0000, 4, [10]), // 10.0000
   ];
   expect(await runQuery(rows)).toEqual(["0.0000", "1.0000", "1.5000", "10.0000"]);
 });
@@ -231,8 +220,6 @@ test("numeric with dscale but ndigits = 0 handles dscale > 4", async () => {
 
 test("numeric small fractional values render correctly (weight <= -3)", async () => {
   // 0.000000001234 : ndigits=1, weight=-3, dscale=12, digits=[1234]
-  // The pre-existing bug conflated digit-index and dscale-position counters,
-  // so this rendered as "0.000012340000" instead of "0.000000001234".
   const tiny = numericBinary(1, -3, 0x0000, 12, [1234]);
   expect(await runQuery([tiny])).toEqual(["0.000000001234"]);
 });
@@ -257,10 +244,7 @@ test("numeric weight = -1 with two digit groups renders correctly (e.g. 0.05678)
 
 test("numeric negative value with small fractional magnitude renders correctly", async () => {
   // -0.00001234 : ndigits=1, weight=-2, dscale=11, digits=[1234], sign=0x4000
-  // Value is 1234 × 10000^(-2) = 1.234 × 10^-5; dscale=11 pads trailing
-  // zeros to yield "-0.00001234000". weight=-2 is the "accidentally
-  // correct" range, so this guards against sign-handling regressions from
-  // the split-counter fix.
+  // (1234 × 10000^-2 = 1.234e-5; dscale=11 pads to "-0.00001234000").
   const v = numericBinary(1, -2, 0x4000, 11, [1234]);
   expect(await runQuery([v])).toEqual(["-0.00001234000"]);
 });


### PR DESCRIPTION
## Summary

`Bun.SQL` returns zero-valued `numeric(p, s)` columns as `"0"` on the prepared (binary) protocol path, while non-zero values preserve scale (`"1.5000"`, etc.) and the unprepared (text) path returns `"0.0000"`. `node-postgres` returns the scale-formatted zero on both paths. For monetary `numeric(p, s)` columns this silently corrupts zero balances (`"0"` instead of `"0.0000"`).

## Reproduction

```ts
import { SQL } from "bun";
const sql = new SQL(process.env.DATABASE_URL!);

await sql.unsafe(`CREATE TEMP TABLE t (v numeric(10, 4) NOT NULL)`);
await sql.unsafe(`INSERT INTO t VALUES (0), (1), (1.5), (10)`);

const prepared = await sql.unsafe(`SELECT v FROM t ORDER BY v LIMIT $1`, [10]);
// Before: ["0",      "1.0000", "1.5000", "10.0000"]   ❌
// After:  ["0.0000", "1.0000", "1.5000", "10.0000"]   ✅
```

## Root cause

`parse_binary_numeric` in `src/sql_jsc/postgres/DataCell.rs` short-circuits when `ndigits == 0` (PostgreSQL's binary encoding for zero) and returns the static string `"0"`, ignoring `dscale`. Non-zero values fall through to the formatter, which pads trailing zero groups up to `dscale`; only the zero fast-path skipped this.

## Fix

Honor `dscale` in the zero case:
- `dscale <= 0`: keep the original `"0"` fast path.
- `dscale > 0`: write `"0."` then `dscale` `'0'` chars into the result buffer.

## Verification

```
before: prepared numeric(10,4) 0 -> "0"       FAIL
after:  prepared numeric(10,4) 0 -> "0.0000"  PASS
```

Additional cases checked: `numeric` (no typmod) zero stays `"0"`; `numeric(10,0)` zero stays `"0"`; negative and large-magnitude values unaffected.

Tests:
- `test/js/sql/sql.test.ts` — docker-gated live-postgres coverage, plus a correction to an existing assertion (`should handle numeric values with many digits`) that had encoded the buggy `"0"` output for a `NUMERIC(30,20)` zero.
- `test/regression/issue/29772.test.ts` — docker-free regression test using a mock postgres wire-protocol server with hand-encoded binary numeric payloads (9 cases; 3 fail without the fix, all pass with it).

## Rebase note

This PR was rebased onto a main that had meanwhile ported `src/sql_jsc/postgres/DataCell.zig` to Rust (`DataCell.rs`) and removed the `.zig` sources, so the original Zig edits could not merge textually. Resolution: re-applied the zero-scale fix to the Rust `parse_binary_numeric`. A second, pre-existing fractional-padding bug (`weight <= -3`, the split digit-index / dscale-position counters) that this PR originally also carried is already present in main's Rust port, so only the zero-scale change remains here. The regression test still exercises both paths.
