### PR TITLE
fuzzilli: don't clobber ASAN's SIGSEGV handler

### DIFF
--- a/src/bun.js/bindings/FuzzilliREPRL.cpp
+++ b/src/bun.js/bindings/FuzzilliREPRL.cpp
@@ -33,6 +33,25 @@ static void fuzzilliSignalHandler(int sig)
     raise(sig);
 }
 
+// Install our flush handler only if no handler (e.g. ASAN's) is already
+// present. Overwriting ASAN's SIGSEGV/SIGILL/SIGFPE handler and re-raising
+// with SIG_DFL loses the sanitizer report entirely, collapsing every such
+// crash into an opaque "TERMSIG: 11" with empty stderr. When ASAN owns the
+// signal it prints its report and then abort()s, and our SIGABRT handler
+// flushes any remaining stdio buffers.
+static void installSignalHandlerIfDefault(int sig)
+{
+    struct sigaction prev;
+    if (sigaction(sig, nullptr, &prev) != 0)
+        return;
+    bool hasHandler = (prev.sa_flags & SA_SIGINFO)
+        ? prev.sa_sigaction != nullptr
+        : (prev.sa_handler != SIG_DFL && prev.sa_handler != SIG_IGN);
+    if (hasHandler)
+        return;
+    signal(sig, fuzzilliSignalHandler);
+}
+
 // Implementation of the global fuzzilli() function for Bun
 // This function is used by Fuzzilli to:
 // 1. Test crash detection with fuzzilli('FUZZILLI_CRASH', type)
@@ -259,12 +278,12 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
 
-    // Install signal handlers to ensure output is flushed before crashes
-    // This is important for ASAN output to be captured
-    signal(SIGABRT, fuzzilliSignalHandler);
-    signal(SIGSEGV, fuzzilliSignalHandler);
-    signal(SIGILL, fuzzilliSignalHandler);
-    signal(SIGFPE, fuzzilliSignalHandler);
+    // Install signal handlers to ensure output is flushed before crashes.
+    // Skip signals already claimed by ASAN/UBSAN so their reports survive.
+    installSignalHandlerIfDefault(SIGABRT);
+    installSignalHandlerIfDefault(SIGSEGV);
+    installSignalHandlerIfDefault(SIGILL);
+    installSignalHandlerIfDefault(SIGFPE);
 
     globalObject->putDirectNativeFunction(
         vm,

--- a/test/js/bun/fuzzilli/fuzzilli.test.ts
+++ b/test/js/bun/fuzzilli/fuzzilli.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // These tests only make sense in a FUZZILLI_ENABLED build, where the

--- a/test/js/bun/fuzzilli/fuzzilli.test.ts
+++ b/test/js/bun/fuzzilli/fuzzilli.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// These tests only make sense in a FUZZILLI_ENABLED build, where the
+// `fuzzilli()` builtin and the REPRL signal handlers are compiled in.
+const isFuzzilliBuild = typeof (globalThis as any).fuzzilli === "function";
+
+// The REPRL flush-on-crash signal handler must not replace ASAN's SIGSEGV
+// handler. The Fuzzilli profile runs with allow_user_segv_handler=1, which
+// lets signal(SIGSEGV, ...) actually take effect; if our handler overwrites
+// ASAN's and re-raises with SIG_DFL, every segfault dies as a bare signal 11
+// with empty stderr and no sanitizer report.
+test.skipIf(!isFuzzilliBuild)("fuzzilli signal handler preserves ASAN SIGSEGV report", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `fuzzilli("FUZZILLI_CRASH", 5);`],
+    env: {
+      ...bunEnv,
+      // Match the Fuzzilli profile's ASAN options so the interceptor allows
+      // user code to install a SIGSEGV handler (the condition for the bug).
+      ASAN_OPTIONS:
+        "allow_user_segv_handler=1:allocator_may_return_null=1:abort_on_error=1:symbolize=false:detect_leaks=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("FUZZILLI_CRASH: 5");
+  // ASAN must have been allowed to print its DEADLYSIGNAL/SEGV report.
+  expect(stderr).toContain("AddressSanitizer");
+  expect(stderr).toContain("SEGV");
+  // ASAN aborts after reporting; the process must not have died with a raw
+  // SIGSEGV (which is what happens when the report is suppressed).
+  expect(proc.signalCode).not.toBe("SIGSEGV");
+  expect(exitCode).not.toBe(0);
+});
+
+// Sanity: heap errors reported by ASAN's allocator hooks must still crash
+// and carry a report under the REPRL signal-handler setup.
+test.skipIf(!isFuzzilliBuild)("fuzzilli signal handler preserves ASAN heap-use-after-free report", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `fuzzilli("FUZZILLI_CRASH", 4);`],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS:
+        "allow_user_segv_handler=1:allocator_may_return_null=1:abort_on_error=1:symbolize=false:detect_leaks=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("FUZZILLI_CRASH: 4");
+  expect(stderr).toContain("AddressSanitizer");
+  expect(stderr).toContain("heap-use-after-free");
+  expect(exitCode).not.toBe(0);
+});


### PR DESCRIPTION
## What

Fuzzilli has been reporting a recurring "flaky" crash (fingerprint `eca795eab2cca849`) with:

```
// TERMSIG: 11
// STDERR:
// STDOUT:
```

i.e. a bare SIGSEGV with zero diagnostic output. The minimized repro (`Bun.listen` + `Bun.jest().expect.rejectsTo.closeTo(...)` + `Bun.gc(true)`) does not reproduce after several thousand REPRL iterations, and since it's tagged flaky the minimizer may well have removed the real trigger.

The reason there's nothing to go on is that `Bun__REPRL__registerFuzzilliFunctions` unconditionally installs its own handler for `SIGSEGV`/`SIGILL`/`SIGFPE`/`SIGABRT`:

```cpp
signal(SIGSEGV, fuzzilliSignalHandler);  // flush; signal(sig, SIG_DFL); raise(sig);
```

The Bun fuzzilli profile sets `ASAN_OPTIONS=allow_user_segv_handler=1`, so this call *replaces* ASAN's handler instead of being rejected. On a real fault, our handler runs, flushes (nothing buffered), resets to `SIG_DFL`, and re-raises — the process dies with signal 11 and ASAN never prints. Every SIGSEGV in the fuzzer, regardless of origin, collapses into the same opaque fingerprint.

## How

Check the current disposition first and only install the flush handler when nothing else is registered. In practice ASAN (chained behind JSC's `jscSignalHandler`) already owns `SIGSEGV`/`SIGILL`/`SIGFPE` by the time the global object is created, so we leave those alone; ASAN prints its report and then `abort()`s.

### Before
```
fuzzilli('FUZZILLI_CRASH', 5)   // *nullptr = 42
→ status=11 sig=11
→ stderr: (empty)
```

### After
```
fuzzilli('FUZZILLI_CRASH', 5)
→ status=6 sig=6
→ stderr:
  AddressSanitizer:DEADLYSIGNAL
  ==…==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x…)
  ==…==The signal is caused by a WRITE memory access.
      #0 0x… functionFuzzilli …/FuzzilliREPRL.cpp
  ==…==Register values: …
  SUMMARY: AddressSanitizer: SEGV …
```

All `FUZZILLI_CRASH 0..7` startup tests still crash as expected (signals 4/6); `FUZZILLI_PRINT` still succeeds.

This doesn't fix whatever rare underlying fault produced `eca795eab2cca849` — it makes the next occurrence actually tell us where it happened so it can be fixed. The change is behind `#ifdef FUZZILLI_ENABLED` and has no effect on non-fuzzilli builds.