### PR TITLE
http: disable ECH GREASE in fetch TLS ClientHello

### DIFF
--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -19068,7 +19068,14 @@ pub const SSL = opaque {
         SSL_enable_signed_cert_timestamps(ssl);
         SSL_enable_ocsp_stapling(ssl);
 
-        SSL_set_enable_ech_grease(ssl, 1);
+        // ECH GREASE (RFC 9460/9180 draft, extension type 0xfe0d) adds ~200-300
+        // bytes of random-looking payload to the ClientHello. Some servers and
+        // middleboxes drop or hang connections that carry this extension (they
+        // treat an unknown large extension with a reserved type as hostile and
+        // silently stop responding — see issue #29780 for one such server).
+        // curl, Node's undici, and Bun's own node:tls all omit it, so our fetch
+        // is the outlier. Leave it off to match their interop profile; we can
+        // re-enable when ECH is finalized and widely deployed.
     }
 
     pub fn handshake(this: *SSL) Error!void {

--- a/src/deps/boringssl.translated.zig
+++ b/src/deps/boringssl.translated.zig
@@ -19067,15 +19067,6 @@ pub const SSL = opaque {
 
         SSL_enable_signed_cert_timestamps(ssl);
         SSL_enable_ocsp_stapling(ssl);
-
-        // ECH GREASE (RFC 9460/9180 draft, extension type 0xfe0d) adds ~200-300
-        // bytes of random-looking payload to the ClientHello. Some servers and
-        // middleboxes drop or hang connections that carry this extension (they
-        // treat an unknown large extension with a reserved type as hostile and
-        // silently stop responding — see issue #29780 for one such server).
-        // curl, Node's undici, and Bun's own node:tls all omit it, so our fetch
-        // is the outlier. Leave it off to match their interop profile; we can
-        // re-enable when ECH is finalized and widely deployed.
     }
 
     pub fn handshake(this: *SSL) Error!void {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -456,5 +457,88 @@ describe.concurrent("fetch-tls", () => {
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
     }
+  });
+
+  // Parses the TLS ClientHello out of a raw TCP byte stream and returns the
+  // set of extension type IDs it advertises. Returns null if no ClientHello
+  // was received. See RFC 8446 §4.1.2 for the message format.
+  function parseClientHelloExtensions(bytes: Buffer): number[] | null {
+    // TLSPlaintext: type(1) legacy_version(2) length(2) = 5 bytes
+    if (bytes.length < 5 || bytes[0] !== 0x16) return null; // 0x16 = handshake
+    const recordLen = bytes.readUInt16BE(3);
+    if (bytes.length < 5 + recordLen) return null;
+    // Handshake: msg_type(1) length(3) = 4 bytes, then ClientHello
+    let p = 5;
+    if (bytes[p] !== 0x01) return null; // 0x01 = client_hello
+    p += 4;
+    p += 2; // legacy_version
+    p += 32; // random
+    const sessionIdLen = bytes[p];
+    p += 1 + sessionIdLen;
+    const cipherSuitesLen = bytes.readUInt16BE(p);
+    p += 2 + cipherSuitesLen;
+    const compressionLen = bytes[p];
+    p += 1 + compressionLen;
+    if (p + 2 > bytes.length) return [];
+    const extensionsLen = bytes.readUInt16BE(p);
+    p += 2;
+    const extensionsEnd = p + extensionsLen;
+    const types: number[] = [];
+    while (p + 4 <= extensionsEnd) {
+      const extType = bytes.readUInt16BE(p);
+      const extLen = bytes.readUInt16BE(p + 2);
+      types.push(extType);
+      p += 4 + extLen;
+    }
+    return types;
+  }
+
+  // Regression test for https://github.com/oven-sh/bun/issues/29780
+  //
+  // Bun's fetch HTTP client used to enable ECH GREASE (extension type 0xfe0d,
+  // RFC 9460/9180 draft) on every TLS ClientHello. That extension carries
+  // 200-300 bytes of random payload that some servers/middleboxes treat as
+  // hostile: they complete the TCP + TLS handshake and then silently hold
+  // the connection open without responding to the HTTP request. curl, Node's
+  // undici, and Bun's own node:tls all omit ECH GREASE, so our fetch was the
+  // odd one out.
+  //
+  // This verifies the ClientHello no longer advertises 0xfe0d.
+  it("fetch TLS ClientHello does not include ECH GREASE extension (#29780)", async () => {
+    const { promise: helloPromise, resolve: resolveHello } =
+      Promise.withResolvers<Buffer>();
+
+    await using server = net.createServer(socket => {
+      const chunks: Buffer[] = [];
+      socket.on("data", chunk => {
+        chunks.push(chunk);
+        // The ClientHello arrives in the first record; capture it and close
+        // so fetch rejects quickly instead of hanging on TLS.
+        resolveHello(Buffer.concat(chunks));
+        socket.destroy();
+      });
+      socket.on("error", () => {});
+    });
+
+    const { promise: listening, resolve: onListen } =
+      Promise.withResolvers<void>();
+    server.listen(0, "127.0.0.1", () => onListen());
+    await listening;
+    const port = (server.address() as net.AddressInfo).port;
+
+    // fetch will fail (the server just drops the connection) — we only care
+    // about the ClientHello bytes it sent.
+    await fetch(`https://127.0.0.1:${port}/`, {
+      tls: { rejectUnauthorized: false },
+    }).catch(() => {});
+
+    const hello = await helloPromise;
+    const extensions = parseClientHelloExtensions(hello);
+    expect(extensions).not.toBeNull();
+    // 0xfe0d = encrypted_client_hello (ECH). Must be absent.
+    expect(extensions).not.toContain(0xfe0d);
+    // Sanity: the ClientHello is well-formed (ALPN = 16, SNI = 0 should be
+    // present) so we know the parser actually walked the extensions list.
+    expect(extensions).toContain(16); // application_layer_protocol_negotiation
   });
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -537,8 +537,9 @@ describe.concurrent("fetch-tls", () => {
     expect(extensions).not.toBeNull();
     // 0xfe0d = encrypted_client_hello (ECH). Must be absent.
     expect(extensions).not.toContain(0xfe0d);
-    // Sanity: the ClientHello is well-formed (ALPN = 16, SNI = 0 should be
-    // present) so we know the parser actually walked the extensions list.
+    // Sanity: ALPN (16) should be present so we know the parser actually
+    // walked the extensions list. SNI (0) is intentionally omitted because
+    // the request targets an IP literal — see RFC 6066 §3.
     expect(extensions).toContain(16); // application_layer_protocol_negotiation
   });
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
-import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -457,89 +456,5 @@ describe.concurrent("fetch-tls", () => {
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
     }
-  });
-
-  // Parses the TLS ClientHello out of a raw TCP byte stream and returns the
-  // set of extension type IDs it advertises. Returns null if no ClientHello
-  // was received. See RFC 8446 §4.1.2 for the message format.
-  function parseClientHelloExtensions(bytes: Buffer): number[] | null {
-    // TLSPlaintext: type(1) legacy_version(2) length(2) = 5 bytes
-    if (bytes.length < 5 || bytes[0] !== 0x16) return null; // 0x16 = handshake
-    const recordLen = bytes.readUInt16BE(3);
-    if (bytes.length < 5 + recordLen) return null;
-    // Handshake: msg_type(1) length(3) = 4 bytes, then ClientHello
-    let p = 5;
-    if (bytes[p] !== 0x01) return null; // 0x01 = client_hello
-    p += 4;
-    p += 2; // legacy_version
-    p += 32; // random
-    const sessionIdLen = bytes[p];
-    p += 1 + sessionIdLen;
-    const cipherSuitesLen = bytes.readUInt16BE(p);
-    p += 2 + cipherSuitesLen;
-    const compressionLen = bytes[p];
-    p += 1 + compressionLen;
-    if (p + 2 > bytes.length) return [];
-    const extensionsLen = bytes.readUInt16BE(p);
-    p += 2;
-    const extensionsEnd = p + extensionsLen;
-    const types: number[] = [];
-    while (p + 4 <= extensionsEnd) {
-      const extType = bytes.readUInt16BE(p);
-      const extLen = bytes.readUInt16BE(p + 2);
-      types.push(extType);
-      p += 4 + extLen;
-    }
-    return types;
-  }
-
-  // Regression test for https://github.com/oven-sh/bun/issues/29780
-  //
-  // Bun's fetch HTTP client used to enable ECH GREASE (extension type 0xfe0d,
-  // RFC 9460/9180 draft) on every TLS ClientHello. That extension carries
-  // 200-300 bytes of random payload that some servers/middleboxes treat as
-  // hostile: they complete the TCP + TLS handshake and then silently hold
-  // the connection open without responding to the HTTP request. curl, Node's
-  // undici, and Bun's own node:tls all omit ECH GREASE, so our fetch was the
-  // odd one out.
-  //
-  // This verifies the ClientHello no longer advertises 0xfe0d.
-  it("fetch TLS ClientHello does not include ECH GREASE extension (#29780)", async () => {
-    const { promise: helloPromise, resolve: resolveHello } =
-      Promise.withResolvers<Buffer>();
-
-    await using server = net.createServer(socket => {
-      const chunks: Buffer[] = [];
-      socket.on("data", chunk => {
-        chunks.push(chunk);
-        // The ClientHello arrives in the first record; capture it and close
-        // so fetch rejects quickly instead of hanging on TLS.
-        resolveHello(Buffer.concat(chunks));
-        socket.destroy();
-      });
-      socket.on("error", () => {});
-    });
-
-    const { promise: listening, resolve: onListen } =
-      Promise.withResolvers<void>();
-    server.listen(0, "127.0.0.1", () => onListen());
-    await listening;
-    const port = (server.address() as net.AddressInfo).port;
-
-    // fetch will fail (the server just drops the connection) — we only care
-    // about the ClientHello bytes it sent.
-    await fetch(`https://127.0.0.1:${port}/`, {
-      tls: { rejectUnauthorized: false },
-    }).catch(() => {});
-
-    const hello = await helloPromise;
-    const extensions = parseClientHelloExtensions(hello);
-    expect(extensions).not.toBeNull();
-    // 0xfe0d = encrypted_client_hello (ECH). Must be absent.
-    expect(extensions).not.toContain(0xfe0d);
-    // Sanity: ALPN (16) should be present so we know the parser actually
-    // walked the extensions list. SNI (0) is intentionally omitted because
-    // the request targets an IP literal — see RFC 6066 §3.
-    expect(extensions).toContain(16); // application_layer_protocol_negotiation
   });
 });

--- a/test/regression/issue/29780.test.ts
+++ b/test/regression/issue/29780.test.ts
@@ -53,11 +53,20 @@ test("fetch TLS ClientHello does not include ECH GREASE extension", async () => 
 
   await using server = net.createServer(socket => {
     const chunks: Buffer[] = [];
+    let captured = false;
     socket.on("data", chunk => {
+      if (captured) return;
       chunks.push(chunk);
-      // The ClientHello arrives in the first record; capture it and close
-      // so fetch rejects quickly instead of hanging on TLS.
-      resolveHello(Buffer.concat(chunks));
+      // Accumulate until we have a full TLSPlaintext record (type + version +
+      // length header = 5 bytes, then `length` bytes of payload). TCP chunks
+      // can split the ClientHello; resolving on the first chunk would be racy.
+      const buf = Buffer.concat(chunks);
+      if (buf.length < 5) return;
+      const recordLen = buf.readUInt16BE(3);
+      if (buf.length < 5 + recordLen) return;
+      captured = true;
+      resolveHello(buf.subarray(0, 5 + recordLen));
+      // Close the socket so fetch rejects quickly instead of hanging on TLS.
       socket.destroy();
     });
     socket.on("error", () => {});

--- a/test/regression/issue/29780.test.ts
+++ b/test/regression/issue/29780.test.ts
@@ -1,0 +1,86 @@
+// https://github.com/oven-sh/bun/issues/29780
+//
+// Bun's fetch HTTP client used to enable ECH GREASE (encrypted_client_hello
+// extension, type 0xfe0d, RFC 9460/9180 draft) on every TLS ClientHello.
+// That extension carries ~200-300 bytes of random-looking payload that some
+// servers and middleboxes treat as hostile: the TCP + TLS handshake completes,
+// the request bytes arrive, but the server silently holds the connection open
+// without responding. curl, Node's undici, and Bun's own node:tls all omit
+// ECH GREASE, so our fetch was the outlier.
+//
+// Regression surfaced in 1.3.13 after the BoringSSL upgrade — reporter
+// observed node:tls against the same host worked on the same Bun process.
+//
+// This verifies fetch's ClientHello no longer advertises extension 0xfe0d.
+import { expect, test } from "bun:test";
+import net from "node:net";
+
+// Parses a TLS ClientHello out of a raw TCP byte stream and returns the
+// list of extension type IDs it advertises. See RFC 8446 §4.1.2.
+function parseClientHelloExtensions(bytes: Buffer): number[] | null {
+  // TLSPlaintext: type(1) legacy_version(2) length(2) = 5 bytes
+  if (bytes.length < 5 || bytes[0] !== 0x16) return null; // 0x16 = handshake
+  const recordLen = bytes.readUInt16BE(3);
+  if (bytes.length < 5 + recordLen) return null;
+  // Handshake: msg_type(1) length(3) = 4 bytes, then ClientHello
+  let p = 5;
+  if (bytes[p] !== 0x01) return null; // 0x01 = client_hello
+  p += 4;
+  p += 2; // legacy_version
+  p += 32; // random
+  const sessionIdLen = bytes[p];
+  p += 1 + sessionIdLen;
+  const cipherSuitesLen = bytes.readUInt16BE(p);
+  p += 2 + cipherSuitesLen;
+  const compressionLen = bytes[p];
+  p += 1 + compressionLen;
+  if (p + 2 > bytes.length) return [];
+  const extensionsLen = bytes.readUInt16BE(p);
+  p += 2;
+  const extensionsEnd = p + extensionsLen;
+  const types: number[] = [];
+  while (p + 4 <= extensionsEnd) {
+    const extType = bytes.readUInt16BE(p);
+    const extLen = bytes.readUInt16BE(p + 2);
+    types.push(extType);
+    p += 4 + extLen;
+  }
+  return types;
+}
+
+test("fetch TLS ClientHello does not include ECH GREASE extension", async () => {
+  const { promise: helloPromise, resolve: resolveHello } = Promise.withResolvers<Buffer>();
+
+  await using server = net.createServer(socket => {
+    const chunks: Buffer[] = [];
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      // The ClientHello arrives in the first record; capture it and close
+      // so fetch rejects quickly instead of hanging on TLS.
+      resolveHello(Buffer.concat(chunks));
+      socket.destroy();
+    });
+    socket.on("error", () => {});
+  });
+
+  const { promise: listening, resolve: onListen } = Promise.withResolvers<void>();
+  server.listen(0, "127.0.0.1", () => onListen());
+  await listening;
+  const port = (server.address() as net.AddressInfo).port;
+
+  // fetch will fail (the server just drops the connection) — we only care
+  // about the ClientHello bytes it sent.
+  await fetch(`https://127.0.0.1:${port}/`, {
+    tls: { rejectUnauthorized: false },
+  }).catch(() => {});
+
+  const hello = await helloPromise;
+  const extensions = parseClientHelloExtensions(hello);
+  expect(extensions).not.toBeNull();
+  // 0xfe0d = encrypted_client_hello (ECH). Must be absent.
+  expect(extensions).not.toContain(0xfe0d);
+  // Sanity: ALPN (16) should be present so we know the parser actually
+  // walked the extensions list. SNI (0) is intentionally omitted because
+  // the request targets an IP literal — see RFC 6066 §3.
+  expect(extensions).toContain(16); // application_layer_protocol_negotiation
+});


### PR DESCRIPTION
## Bug

Bun's `fetch()` silently hangs against some hosts (e.g. `api.fortnox.se`) while `curl`, Node's `fetch`, Node's `undici`, and Bun's own `node:tls` all complete the request successfully. The TCP connection and TLS handshake complete, the request bytes are sent (visible via `BUN_CONFIG_VERBOSE_FETCH=curl`), but the server never sends a response back.

## Cause

`configureHTTPClient` in `src/deps/boringssl.translated.zig` calls `SSL_set_enable_ech_grease(ssl, 1)` on every TLS connection, adding the `encrypted_client_hello` extension (type `0xfe0d`, RFC 9460/9180 draft) with ~200–300 bytes of random-looking payload.

Some servers and middleboxes treat an unknown extension with a reserved-range type and a large random body as hostile:

- The TLS handshake still completes cleanly.
- The HTTP request reaches the server.
- The server then silently holds the TCP connection open without responding.

Bun's `node:tls` socket (`src/bun.js/api/bun/socket.zig`) does not call `configureHTTPClient` — it never enables ECH GREASE — which is why replaying the same byte stream through `node:tls` succeeds on the same Bun process.

curl's `--ech` is opt-in. Node's `undici` sits on OpenSSL and never sends ECH GREASE. Bun's HTTP client was the outlier.

## Fix

Remove the `SSL_set_enable_ech_grease` call. This aligns Bun's fetch TLS fingerprint with curl, Node, and Bun's own `node:tls`, and unblocks traffic to any host that rejects the extension.

## Test

`test/js/web/fetch/fetch.tls.test.ts` — new case `fetch TLS ClientHello does not include ECH GREASE extension (#29780)`. Stands up a raw TCP server with `net.createServer`, captures the ClientHello, parses the extensions list (RFC 8446 §4.1.2) and asserts extension type `0xfe0d` is absent.

Verified:
- **Without fix** — the test fails: `Expected to not contain: 65037 / Received: [65037, 23, 65281, 10, 11, 35, 16, 5, 13, 18, 51, 45, 43, 21]`
- **With fix** — the test passes.

Fixes #29780