### PR TITLE
test/bake: add nested-consumer regression test for #29781

### DIFF
--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -814,3 +814,55 @@ devTest("barrel optimization: two import statements from the same barrel (#28886
     await c.expectMessage("got: ALPHA BETA");
   },
 });
+
+// Regression: #29781 — same root cause as #28886, but with the duplicate
+// imports nested in a transitive dependency. This is the shape
+// `@apollo/client/cache/inmemory/policies.js` takes: the entry imports
+// from a consumer module, which itself has two `import { ... } from
+// '<barrel>'` statements. Seeding of `requested_exports[barrel]` happens
+// via scheduleBarrelDeferredImports reading the consumer's named_imports,
+// so the stale-index path is exercised one link deeper than #28886's
+// fixture covers.
+devTest("barrel optimization: nested consumer with two imports from the same barrel (#29781)", {
+  // Same darwin flake as the #28886 test above; fix is platform-agnostic.
+  skip: ["darwin"],
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      import { run } from 'consumer-lib';
+      console.log('result: ' + run());
+    `,
+    "node_modules/consumer-lib/package.json": JSON.stringify({
+      name: "consumer-lib",
+      version: "1.0.0",
+      main: "./index.js",
+    }),
+    "node_modules/consumer-lib/index.js": `
+      import { One } from 'barrel-lib';
+      import { Two, Three } from 'barrel-lib';
+      export function run() {
+        return [One(), Two(), Three()].join(',');
+      }
+    `,
+    "node_modules/barrel-lib/package.json": JSON.stringify({
+      name: "barrel-lib",
+      version: "1.0.0",
+      main: "./index.js",
+      sideEffects: false,
+    }),
+    "node_modules/barrel-lib/index.js": `
+      export { One } from './one.js';
+      export { Two } from './two.js';
+      export { Three } from './three.js';
+      export { Four } from './four.js';
+    `,
+    "node_modules/barrel-lib/one.js": `export function One() { return 'one'; }`,
+    "node_modules/barrel-lib/two.js": `export function Two() { return 'two'; }`,
+    "node_modules/barrel-lib/three.js": `export function Three() { return 'three'; }`,
+    "node_modules/barrel-lib/four.js": `export function Four() { return 'four'; }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("result: one,two,three");
+  },
+});


### PR DESCRIPTION
Fixes #29781.

## Context

#29781 is the same root-cause bug as #28886 — a file with two `import { ... } from "<barrel>"` statements breaks HMR bundles because `ConvertESMExportsForHmr` marks the second record `is_unused` and its path never gets resolved. `scheduleBarrelDeferredImports` then fails to seed `requested_exports[barrel]` for those bindings and the barrel emits empty-object shims.

That root cause was fixed on main by #28888 (`fix(hmr): redirect named_imports after import dedup (#28886)`), which adds a fallback lookup in `src/bundler/barrel_imports.zig` for `is_unused` records.

## This PR

With the fix already in place, my earlier `src/ast/ConvertESMExportsForHmr.zig` change became redundant and was dropped on rebase. What remains is the regression test, repositioned as **additional coverage** for the nested-consumer shape:

- #28886's test (merged) covers the direct case — duplicate imports in the entry module.
- #29781's test (this PR) covers the nested case — duplicate imports live in a transitive consumer package. This is the shape `@apollo/client/cache/inmemory/policies.js` takes in the real-world reproduction, and exercises `scheduleBarrelDeferredImports` one link deeper than the direct fixture.

## Verification

- Test passes with the #28888 fix in place (main HEAD).
- Test fails if the #28888 fix is reverted (`git checkout 47826b3be9 -- src/bundler/barrel_imports.zig`), confirming it exercises the same code path.
- All 21 tests in `test/bake/dev/bundle.test.ts` pass.

## Rebase notes

Rebased on top of main's #28888 merge. Single conflict in `test/bake/dev/bundle.test.ts` where both PRs added their test case at the same file position — resolved by keeping main's #28886 test and appending #29781's test after it.