### PR TITLE
test: clear pending JS exception when diff formatting throws

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,31 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+            {
+                let _ = global_this.clear_exception_except_termination();
+            }
 
-            let _ = JestPrettyFormat::format(
+            if JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .is_err()
+            {
+                let _ = global_this.clear_exception_except_termination();
+            }
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/test/js/bun/test/expect-diff-format-throw-crash.test.ts
+++ b/test/js/bun/test/expect-diff-format-throw-crash.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test.concurrent.each(["received", "expected"])(
+  "expect diff formatter does not crash when formatting the %s value throws",
+  async side => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const throwing = new Proxy({ a: 1 }, {
+            ownKeys() { throw new Error("boom"); },
+          });
+          const { expect } = Bun.jest();
+          let err;
+          try {
+            if (${JSON.stringify(side)} === "received") {
+              expect(throwing).toStrictEqual({ b: 2 });
+            } else {
+              expect({ b: 2 }).toStrictEqual(throwing);
+            }
+          } catch (e) {
+            err = e;
+          }
+          console.log(err.message.split("\\n")[0]);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("expect(received).toStrictEqual(expected)\n");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## What does this PR do?

Fixes an `assertNoExceptionExceptTermination` debug assertion (and wrong error surfaced in release) when `expect()` matchers that use `DiffFormatter` encounter a value whose pretty-printing throws.

`DiffFormatter` calls `JestPrettyFormat::format` twice (once for the received value, once for the expected value) and discarded the error result. That discarded the Rust error but left the JS exception pending on the VM. The next call back into JSC (formatting the other value, then creating the matcher's error instance) then observed the stale exception: in debug builds it tripped the assertion, and in release builds the leaked exception replaced the matcher's own assertion error, so `expect(proxy).toStrictEqual({...})` threw the proxy trap's error instead of the `expect(received).toStrictEqual(expected)` message.

Stack at the assertion:
```
JSC::ExceptionScope::assertNoExceptionExceptTermination()
JSC__JSValue__getOwn
JestPrettyFormat Tag::get
JestPrettyFormat::format
DiffFormatter
...
Expect.throw
toStrictEqual
```

The fix clears the pending exception after a failed format call in `src/runtime/test_runner/diff_format.rs`, matching what `create_error_instance` already does for the same situation. (Earlier revisions also patched `diff_format.zig`; that file was since removed from main with the rest of the Zig porting references.)

## How did you verify your code works?

New test covering both positions (throwing value on the received side and on the expected side). Each case fails on an unfixed build (prints the proxy trap's "boom") and passes with the fix; deleting either of the two clear calls breaks the corresponding case.

Found by Fuzzilli (fingerprint `561fd7b58897e040`).