### PR TITLE
bootstrap: install HTTP/3-capable curl as `curl-h3` + CURL_HTTP3

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,4 +1,4 @@
-# Version: 18
+# Version: 19
 # A script that installs the dependencies needed to build and test Bun on Windows.
 # Supports both x64 and ARM64 using Scoop for package management.
 # Used by Azure [build images] pipeline.
@@ -484,6 +484,29 @@ function Install-Visual-Studio {
   }
 }
 
+function Install-CurlH3 {
+  # Installs a static curl built with nghttp3/ngtcp2 as `curl-h3.exe` so the
+  # HTTP/3 server tests (test/js/bun/http/serve-http3.test.ts, fetch-h3.ts)
+  # can run in CI. The bundled C:\Windows\System32\curl.exe has no HTTP/3.
+  # Tests discover this via $env:CURL_HTTP3, then `curl-h3` in PATH.
+  if (Which curl-h3) {
+    return
+  }
+  $version = "8.19.0" # https://github.com/stunnel/static-curl/releases
+  $archName = if ($script:IsARM64) { "aarch64" } else { "x86_64" }
+  Write-Output "Installing curl-h3 $version ($archName)..."
+  $tar = Download-File "https://github.com/stunnel/static-curl/releases/download/$version/curl-windows-$archName-$version.tar.xz" -Name "curl-h3.tar.xz"
+  $extractDir = "$env:TEMP\curl-h3-extract"
+  New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+  & tar -xf $tar -C $extractDir
+  Copy-Item "$extractDir\curl.exe" "C:\Windows\System32\curl-h3.exe" -Force
+  Copy-Item "$extractDir\curl-ca-bundle.crt" "C:\Windows\System32\curl-ca-bundle.crt" -Force
+  Remove-Item $tar -ErrorAction SilentlyContinue
+  Remove-Item $extractDir -Recurse -ErrorAction SilentlyContinue
+  Set-Env CURL_HTTP3 "C:\Windows\System32\curl-h3.exe"
+  & curl-h3 --version | Select-Object -First 1 | Write-Output
+}
+
 function Install-PdbAddr2line {
   cargo install --examples "pdb-addr2line@0.11.2"
   # Also copy to System32 so it's always on PATH (like bun.exe)
@@ -680,6 +703,7 @@ if (-not $script:IsARM64) {
 Install-Pwsh
 Install-OpenSSH
 Install-Bun
+Install-CurlH3
 Install-Ccache
 Install-Rust
 Install-Visual-Studio

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -498,7 +498,10 @@ function Install-CurlH3 {
   $tar = Download-File "https://github.com/stunnel/static-curl/releases/download/$version/curl-windows-$archName-$version.tar.xz" -Name "curl-h3.tar.xz"
   $extractDir = "$env:TEMP\curl-h3-extract"
   New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
-  & tar -xf $tar -C $extractDir
+  # Server 2019's bundled bsdtar (3.3.2) has no liblzma, so `tar -xf foo.tar.xz`
+  # can't decode it (Win11's 3.5+ can). 7z is already installed via scoop.
+  & 7z x $tar "-o$extractDir" -y | Out-Null
+  & 7z x "$extractDir\curl-h3.tar" "-o$extractDir" -y | Out-Null
   Copy-Item "$extractDir\curl.exe" "C:\Windows\System32\curl-h3.exe" -Force
   Copy-Item "$extractDir\curl-ca-bundle.crt" "C:\Windows\System32\curl-ca-bundle.crt" -Force
   Remove-Item $tar -ErrorAction SilentlyContinue

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -988,6 +988,11 @@ install_curl_h3() {
 	*) return ;;
 	esac
 
+	case "$pm" in
+	apt) install_packages xz-utils ;;
+	apk | dnf | yum | zypper) install_packages xz ;;
+	esac
+
 	curl_h3_url="https://github.com/stunnel/static-curl/releases/download/$(curl_h3_version)/$curl_h3_asset-$(curl_h3_version).tar.xz"
 	curl_h3_tar="$(download_file "$curl_h3_url")"
 	curl_h3_dir="$(dirname "$curl_h3_tar")"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -967,21 +967,28 @@ curl_h3_version() {
 # run in CI. Kept separate from the system `curl` so nothing else changes
 # behavior. Tests discover it via $CURL_HTTP3, then `curl-h3` in PATH.
 install_curl_h3() {
-	if [ "$os" != "linux" ]; then
-		return
-	fi
-
 	case "$arch" in
 	x64) curl_h3_arch="x86_64" ;;
 	aarch64) curl_h3_arch="aarch64" ;;
 	*) return ;;
 	esac
-	case "$abi" in
-	musl) curl_h3_libc="musl" ;;
-	*) curl_h3_libc="glibc" ;;
+	case "$os" in
+	linux)
+		case "$abi" in
+		musl) curl_h3_asset="curl-linux-$curl_h3_arch-musl" ;;
+		*) curl_h3_asset="curl-linux-$curl_h3_arch-glibc" ;;
+		esac
+		;;
+	darwin)
+		case "$arch" in
+		aarch64) curl_h3_asset="curl-macos-arm64" ;;
+		*) curl_h3_asset="curl-macos-x86_64" ;;
+		esac
+		;;
+	*) return ;;
 	esac
 
-	curl_h3_url="https://github.com/stunnel/static-curl/releases/download/$(curl_h3_version)/curl-linux-$curl_h3_arch-$curl_h3_libc-$(curl_h3_version).tar.xz"
+	curl_h3_url="https://github.com/stunnel/static-curl/releases/download/$(curl_h3_version)/$curl_h3_asset-$(curl_h3_version).tar.xz"
 	curl_h3_tar="$(download_file "$curl_h3_url")"
 	curl_h3_dir="$(dirname "$curl_h3_tar")"
 	execute tar -xJf "$curl_h3_tar" -C "$curl_h3_dir" curl

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 33
+# Version: 34
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.
@@ -774,6 +774,7 @@ install_common_software() {
 	install_rosetta
 	install_nodejs
 	install_bun
+	install_curl_h3
 	install_tailscale
 	install_buildkite
 }
@@ -954,6 +955,42 @@ setup_node_gyp_cache() {
 
 bun_version_exact() {
 	print "1.3.13"
+}
+
+curl_h3_version() {
+	# https://github.com/stunnel/static-curl/releases
+	print "8.19.0"
+}
+
+# Installs a fully-static curl built with nghttp3/ngtcp2 as `curl-h3` so the
+# HTTP/3 server tests (test/js/bun/http/serve-http3.test.ts, fetch-h3.ts) can
+# run in CI. Kept separate from the system `curl` so nothing else changes
+# behavior. Tests discover it via $CURL_HTTP3, then `curl-h3` in PATH.
+install_curl_h3() {
+	if [ "$os" != "linux" ]; then
+		return
+	fi
+
+	case "$arch" in
+	x64) curl_h3_arch="x86_64" ;;
+	aarch64) curl_h3_arch="aarch64" ;;
+	*) return ;;
+	esac
+	case "$abi" in
+	musl) curl_h3_libc="musl" ;;
+	*) curl_h3_libc="glibc" ;;
+	esac
+
+	curl_h3_url="https://github.com/stunnel/static-curl/releases/download/$(curl_h3_version)/curl-linux-$curl_h3_arch-$curl_h3_libc-$(curl_h3_version).tar.xz"
+	curl_h3_tar="$(download_file "$curl_h3_url")"
+	curl_h3_dir="$(dirname "$curl_h3_tar")"
+	execute tar -xJf "$curl_h3_tar" -C "$curl_h3_dir" curl
+	execute mv "$curl_h3_dir/curl" "$curl_h3_dir/curl-h3"
+	move_to_bin "$curl_h3_dir/curl-h3"
+
+	curl_h3_bin="$(which curl-h3)"
+	append_to_profile "export CURL_HTTP3=$curl_h3_bin"
+	execute "$curl_h3_bin" --version | head -n1
 }
 
 install_bun() {

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1205,6 +1205,34 @@ async function buildWindowsImageWithPacker({ os, arch, release, command, ci, age
     throw new Error(`Failed to create gallery image definition: ${defResponse.status} ${await defResponse.text()}`);
   }
 
+  // Packer's azure-arm shared_image_gallery_destination always writes
+  // image_version 1.0.0 and 409s if it already exists, so a re-run of
+  // [publish images] would fail on every Windows variant that already
+  // succeeded. Match the AWS path's deregister-then-recreate.
+  const versionPath = `${galleryPath}/versions/1.0.0`;
+  const existing = await fetch(`https://management.azure.com${versionPath}?api-version=2024-03-03`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (existing.ok) {
+    console.log(`[packer] Deleting existing gallery image version 1.0.0 of ${imageDefName} before re-publish`);
+    const del = await fetch(`https://management.azure.com${versionPath}?api-version=2024-03-03`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (del.status === 202) {
+      const op = del.headers.get("Azure-AsyncOperation") ?? del.headers.get("Location");
+      for (let i = 0; op && i < 120; i++) {
+        await new Promise(r => setTimeout(r, 10_000));
+        const poll = await fetch(op, { headers: { Authorization: `Bearer ${token}` } });
+        const body = await poll.json().catch(() => ({}));
+        if (body.status === "Succeeded") break;
+        if (body.status === "Failed") throw new Error(`Delete of ${versionPath} failed: ${JSON.stringify(body)}`);
+      }
+    } else if (!del.ok && del.status !== 404) {
+      throw new Error(`Failed to delete existing gallery image version: ${del.status} ${await del.text()}`);
+    }
+  }
+
   // Install Packer if not available
   const packerBin = await ensurePacker();
 

--- a/test/js/bun/http/fetch-h3.ts
+++ b/test/js/bun/http/fetch-h3.ts
@@ -8,8 +8,8 @@
  * by swapping the function reference.
  *
  * Discovery: `CURL_HTTP3` env, then `curl-h3`, then plain `curl` if it
- * advertises `HTTP3` in `--version`. `hasFetchH3()` lets describe.each gates
- * skip the H3 iteration on machines without a capable curl.
+ * advertises `HTTP3` in `--version`. CI provisions `curl-h3` via
+ * scripts/bootstrap.{sh,ps1}; locally `brew install curl` works.
  */
 import { which } from "bun";
 import { tls } from "harness";
@@ -28,10 +28,6 @@ function findCurlH3(): string | null {
     if (/\bHTTP3\b/.test(proc.stdout.toString())) return (resolved = bin);
   }
   return (resolved = null);
-}
-
-export function hasFetchH3(): boolean {
-  return findCurlH3() !== null;
 }
 
 type Init = {
@@ -154,11 +150,8 @@ export function httpProtocols(): Array<{
   /** Serve options to spread into Bun.serve() for this protocol. */
   serve: { tls?: object; h3?: boolean };
 }> {
-  const rows: ReturnType<typeof httpProtocols> = [
+  return [
     { protocol: "http/1.1", fetch: (u, i) => fetch(u, i as RequestInit), serve: {} },
+    { protocol: "http/3", fetch: fetchH3, serve: { tls, h3: true } },
   ];
-  if (hasFetchH3()) {
-    rows.push({ protocol: "http/3", fetch: fetchH3, serve: { tls, h3: true } });
-  }
-  return rows;
 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -5,10 +5,9 @@ import { bunEnv, bunExe, tempDir, tls } from "harness";
 import { join } from "path";
 
 // HTTP/3 needs a curl that was built with nghttp3/ngtcp2. CI provisions one
-// as `curl-h3`; locally fall back to whichever `curl` reports HTTP3 in
-// --version. Everything is skipped otherwise so the suite stays green on
-// stock macOS/Windows curl.
-let curlH3: string | null = null;
+// as `curl-h3` (scripts/bootstrap.{sh,ps1}); locally point CURL_HTTP3 at one
+// or `brew install curl` (Homebrew curl has HTTP3).
+let curlH3: string;
 
 beforeAll(async () => {
   for (const candidate of [process.env.CURL_HTTP3, "curl-h3", "curl"]) {
@@ -20,19 +19,11 @@ beforeAll(async () => {
     await proc.exited;
     if (/\bHTTP3\b/.test(out)) {
       curlH3 = bin;
-      break;
-    }
-  }
-});
-
-const itH3: typeof test = ((name: string, fn: any) =>
-  test(name, async () => {
-    if (!curlH3) {
-      console.warn("skipping (no HTTP/3-capable curl in PATH; set CURL_HTTP3=/path/to/curl)");
       return;
     }
-    return fn();
-  })) as any;
+  }
+  throw new Error("no HTTP/3-capable curl found (checked $CURL_HTTP3, curl-h3, curl); set CURL_HTTP3=/path/to/curl");
+});
 
 /** Spawn `curl --http3-only` against the given port+path. */
 async function curl3(
@@ -43,7 +34,7 @@ async function curl3(
 ): Promise<{ stdout: string; stderr: string; exitCode: number; raw: Uint8Array }> {
   const proc = Bun.spawn({
     cmd: [
-      curlH3!,
+      curlH3,
       "-sk",
       "--http3-only",
       "--connect-timeout",
@@ -250,7 +241,7 @@ async function withServer(
 }
 
 describe("Bun.serve HTTP/3", () => {
-  itH3("basic GET", async () => {
+  test("basic GET", async () => {
     await withServer(async port => {
       const { stdout, exitCode, stderr } = await curl3(port, "/hello", ["-D", "-"]);
       expect(stderr).toBe("");
@@ -261,7 +252,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("POST echoes body, status, request headers", async () => {
+  test("POST echoes body, status, request headers", async () => {
     await withServer(async port => {
       const body = "the quick brown fox jumps over the lazy dog";
       const { stdout, exitCode } = await curl3(port, "/echo", [
@@ -283,7 +274,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("204 with no body", async () => {
+  test("204 with no body", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/status", ["-D", "-"]);
       expect(stdout).toContain("HTTP/3 204");
@@ -291,7 +282,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("query string is preserved", async () => {
+  test("query string is preserved", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/query?q=hello%20world&x=1");
       expect(stdout).toBe("hello world");
@@ -299,7 +290,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("large response body crosses multiple QUIC packets", async () => {
+  test("large response body crosses multiple QUIC packets", async () => {
     await withServer(async port => {
       const { raw, exitCode } = await curl3(port, "/big");
       expect(raw.length).toBe(512 * 1024);
@@ -310,7 +301,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("concurrent requests across separate connections", async () => {
+  test("concurrent requests across separate connections", async () => {
     await withServer(async port => {
       const results = await Promise.all(Array.from({ length: 8 }, (_, i) => curl3(port, `/query?q=r${i}`)));
       for (let i = 0; i < results.length; i++) {
@@ -320,7 +311,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("client abort mid-response does not crash the server", async () => {
+  test("client abort mid-response does not crash the server", async () => {
     await withServer(async port => {
       // First request: tiny timeout forces curl to abort during /slow
       const aborted = await curl3(port, "/slow", ["--max-time", "0.01"]);
@@ -332,14 +323,14 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("h1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
+  test("h1: false rejects HTTP/1.1 but accepts HTTP/3", async () => {
     await withServer(
       async port => {
         const h3 = await curl3(port, "/hello");
         expect(h3.stdout).toContain("hello over h3");
         // TCP listener should not be bound at all
         const proc = Bun.spawn({
-          cmd: [curlH3!, "-sk", "--http1.1", "--connect-timeout", "2", `https://127.0.0.1:${port}/hello`],
+          cmd: [curlH3, "-sk", "--http1.1", "--connect-timeout", "2", `https://127.0.0.1:${port}/hello`],
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -352,7 +343,7 @@ describe("Bun.serve HTTP/3", () => {
 
   // With h1:false the TCP listen socket is never created, so server.url /
   // server.address / server.stop() must consult the QUIC listener.
-  itH3("h1: false — url/address/stop see the QUIC listener", async () => {
+  test("h1: false — url/address/stop see the QUIC listener", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -387,7 +378,7 @@ describe("Bun.serve HTTP/3", () => {
   // RFC 9114 §4.2.2: Content-Length is optional on H3. The up-front 413
   // check only sees CL, so without it the per-chunk cap in
   // onBufferedBodyChunk is what enforces maxRequestBodySize.
-  itH3("maxRequestBodySize is enforced for H3 bodies without Content-Length", async () => {
+  test("maxRequestBodySize is enforced for H3 bodies without Content-Length", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -425,7 +416,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("unknown route returns 404", async () => {
+  test("unknown route returns 404", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/nope", ["-D", "-"]);
       expect(stdout).toContain("HTTP/3 404");
@@ -434,7 +425,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("routes: handler with :params", async () => {
+  test("routes: handler with :params", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/api/abc%20123", ["-D", "-"]);
       expect(stdout).toContain("HTTP/3 200");
@@ -444,7 +435,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("routes: per-method handler", async () => {
+  test("routes: per-method handler", async () => {
     await withServer(async port => {
       const post = await curl3(port, "/route-only", ["-X", "POST"]);
       expect(post.stdout).toBe("posted");
@@ -456,7 +447,7 @@ describe("Bun.serve HTTP/3", () => {
 
   // A method-specific "/*" must not suppress the fetch() fallback for the
   // other methods on the H3 router (it doesn't on H1).
-  itH3("routes: method-specific '/*' falls through to fetch() on other methods", async () => {
+  test("routes: method-specific '/*' falls through to fetch() on other methods", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -477,7 +468,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("ReadableStream response body", async () => {
+  test("ReadableStream response body", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/stream");
       expect(stdout).toBe("one two three");
@@ -485,7 +476,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("Bun.file response body", async () => {
+  test("Bun.file response body", async () => {
     await withServer(async port => {
       const { raw, exitCode } = await curl3(port, "/file");
       expect(raw.length).toBe(200 * 1024);
@@ -507,7 +498,7 @@ describe("Bun.serve HTTP/3", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  itH3("static route (Response value) is mirrored onto H3", async () => {
+  test("static route (Response value) is mirrored onto H3", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/static", ["-D", "-"]);
       expect(stdout).toContain("HTTP/3 200");
@@ -520,7 +511,7 @@ describe("Bun.serve HTTP/3", () => {
     });
   });
 
-  itH3("file route (Bun.file value) streams over H3", async () => {
+  test("file route (Bun.file value) streams over H3", async () => {
     await withServer(async port => {
       const { raw, exitCode } = await curl3(port, "/file-route");
       expect(raw.length).toBe(200 * 1024);
@@ -552,7 +543,7 @@ describe("Bun.serve HTTP/3", () => {
 describe("Bun.serve HTTP/3 adversarial", () => {
   const md5 = (b: Uint8Array | ArrayBuffer) => createHash("md5").update(Buffer.from(b)).digest("hex");
 
-  itH3("64 concurrent streams on one connection", async () => {
+  test("64 concurrent streams on one connection", async () => {
     // h2o uses 1000; 64 stays inside lsquic's default initial-max-streams
     // and the debug-build 5s budget while still being 4× the existing
     // 16-concurrent coverage.
@@ -561,7 +552,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
       const url = `https://127.0.0.1:${port}/hello`;
       const proc = Bun.spawn({
         cmd: [
-          curlH3!,
+          curlH3,
           "-sk",
           "--http3-only",
           "--connect-timeout",
@@ -586,7 +577,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("large request headers (7k value + 50×100B) reach handler", async () => {
+  test("large request headers (7k value + 50×100B) reach handler", async () => {
     await withServer(async port => {
       const big = Buffer.alloc(7000, "H").toString();
       const small = Buffer.alloc(100, "v").toString();
@@ -602,7 +593,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("8 MB POST body echoes byte-exact", async () => {
+  test("8 MB POST body echoes byte-exact", async () => {
     await withServer(async port => {
       // Patterned (not crypto-random) so the test is deterministic but still
       // crosses many QUIC packets and stresses the recvmmsg/sendmmsg paths.
@@ -620,7 +611,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("slow client read (--limit-rate) drains streamed response", async () => {
+  test("slow client read (--limit-rate) drains streamed response", async () => {
     await withServer(async port => {
       // Body is tiny ("one two three") so 1 KB/s is fine; the point is the
       // server sees backpressure from the QUIC flow-control window and the
@@ -631,11 +622,11 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("204 then 200 on the same connection", async () => {
+  test("204 then 200 on the same connection", async () => {
     await withServer(async port => {
       const proc = Bun.spawn({
         cmd: [
-          curlH3!,
+          curlH3,
           "-sk",
           "--http3-only",
           "-D",
@@ -655,7 +646,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("HEAD on /big returns content-length and no body", async () => {
+  test("HEAD on /big returns content-length and no body", async () => {
     await withServer(async port => {
       const { stdout, raw, exitCode } = await curl3(port, "/big", ["-I"]);
       expect(stdout).toContain("HTTP/3 200");
@@ -668,7 +659,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("lying content-length doesn't take down the listener", async () => {
+  test("lying content-length doesn't take down the listener", async () => {
     await withServer(async port => {
       // RFC 9114 §4.1.2: a request whose payload doesn't match content-length
       // is malformed. lsquic/nghttp3 may RESET_STREAM here — we don't care
@@ -682,7 +673,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("client RST mid-/big does not break the listener", async () => {
+  test("client RST mid-/big does not break the listener", async () => {
     await withServer(async port => {
       // --limit-rate keeps curl reading at 10 KB/s so the 512 KB body is
       // guaranteed to be mid-drain when --max-time fires; pure --max-time
@@ -744,16 +735,16 @@ describe("Bun.serve HTTP/3 adversarial", () => {
   // window. Separate curl process per stream = separate QUIC connection,
   // so this checks per-connection state isolation too. Aliasing bugs
   // reproduce at any N≥2; 8 fits the debug-build 5s default.
-  itH3("per-stream body isolation: 8 concurrent 96KB transformed echoes", async () => {
+  test("per-stream body isolation: 8 concurrent 96KB transformed echoes", async () => {
     await withServer(port => isolationRound(port, 8, 96 * 1024));
   });
 
   // 3 × 300KB — forces Http3Response backpressure → onWritable → drain.
-  itH3("per-stream body isolation: 3 concurrent 300KB transformed echoes", async () => {
+  test("per-stream body isolation: 3 concurrent 300KB transformed echoes", async () => {
     await withServer(port => isolationRound(port, 3, 300 * 1024));
   });
 
-  itH3("Response(subprocess.stdout) streams over H3", async () => {
+  test("Response(subprocess.stdout) streams over H3", async () => {
     await withServer(async port => {
       const { raw, exitCode } = await curl3(port, "/spawn");
       expect(raw.length).toBe(40 * 1001);
@@ -765,7 +756,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("Response(req.body) passthrough echoes byte-exact", async () => {
+  test("Response(req.body) passthrough echoes byte-exact", async () => {
     await withServer(async port => {
       const body = new Uint8Array(randomBytes(80 * 1024));
       const { raw, stdout, exitCode } = await curl3(
@@ -784,7 +775,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("req.{url,method,headers,params} survive micro/macrotask awaits", async () => {
+  test("req.{url,method,headers,params} survive micro/macrotask awaits", async () => {
     // uws.H3.Request lives on the on_stream_headers stack frame; the JS
     // Request must have copied everything before the first await returns.
     await withServer(async port => {
@@ -824,7 +815,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
     });
   });
 
-  itH3("Response(Bun.file().stream()) goes through H3ResponseSink", async () => {
+  test("Response(Bun.file().stream()) goes through H3ResponseSink", async () => {
     await withServer(async (port, dir) => {
       const { raw, exitCode } = await curl3(port, "/file-stream");
       expect(raw.length).toBe(200 * 1024);
@@ -836,7 +827,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
 
   // bughunt #4: canSendfile() must not pick the sendfile() path for H3 — it
   // has no socket fd. A 2 MB file is over the 1 MiB sendfile threshold.
-  itH3("Bun.file >=1 MiB takes the reader path, not sendfile", async () => {
+  test("Bun.file >=1 MiB takes the reader path, not sendfile", async () => {
     await withServer(async port => {
       const { raw, exitCode } = await curl3(port, "/huge-file");
       expect(raw.length).toBe(2 * 1024 * 1024);
@@ -846,7 +837,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
   });
 
   // bughunt #5: getRemoteSocketInfo must return a slice with a valid length.
-  itH3("server.requestIP(req) returns the peer address", async () => {
+  test("server.requestIP(req) returns the peer address", async () => {
     await withServer(async port => {
       const { stdout, exitCode } = await curl3(port, "/remote");
       const ip = JSON.parse(stdout);
@@ -859,7 +850,7 @@ describe("Bun.serve HTTP/3 adversarial", () => {
 
   // bughunt #6: H3 bodies are FIN-terminated; Content-Length is optional.
   // `curl -T -` streams from stdin without setting Content-Length.
-  itH3("POST body without Content-Length still reaches the handler", async () => {
+  test("POST body without Content-Length still reaches the handler", async () => {
     await withServer(async port => {
       const body = Buffer.alloc(40_000, "noCL");
       const { raw, stdout, exitCode } = await curl3(
@@ -936,7 +927,7 @@ async function withCustomServer(
 describe("Bun.serve HTTP/3 lifecycle", () => {
   // bughunt #2: server.reload() must clear the H3 router so removed routes
   // fall through to the fetch handler instead of dereferencing freed pointers.
-  itH3("server.reload() clears stale H3 routes", async () => {
+  test("server.reload() clears stale H3 routes", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       let server = Bun.serve({
@@ -972,7 +963,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   // bughunt #3: server.stop() must not leave the lsquic engine pointing at a
   // freed listen-socket. The follow-up GET should cleanly fail to connect,
   // and the process must still be alive to exit 0 on its own.
-  itH3("server.stop() with live H3 connections does not UAF", async () => {
+  test("server.stop() with live H3 connections does not UAF", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({
@@ -1006,7 +997,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   // finish before the engine tears down. lsquic_engine_cooldown drops mini
   // (still-handshaking) conns immediately, so we wait until the server has
   // actually entered every handler before stopping — no arbitrary sleep.
-  itH3("graceful stop: in-flight H3 requests complete after server.stop()", async () => {
+  test("graceful stop: in-flight H3 requests complete after server.stop()", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       let stopping = false, inflight = 0;
@@ -1060,7 +1051,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   // Each QUIC connection counts as a virtual poll (loop->num_polls); after
   // server.stop() drains, the last conn close releases the UDP fd and the
   // loop has no polls left — the process exits without process.exit().
-  itH3("h3-only server exits naturally after stop() drains", async () => {
+  test("h3-only server exits naturally after stop() drains", async () => {
     using dir = tempDir("serve-http3-exit", {
       "server.mjs": `
         const server = Bun.serve({
@@ -1098,7 +1089,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
   });
 
   // C: req.signal fires when the client resets the H3 stream mid-request.
-  itH3("req.signal aborts on client RST", async () => {
+  test("req.signal aborts on client RST", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       let aborted = 0;
@@ -1137,7 +1128,7 @@ describe("Bun.serve HTTP/3 lifecycle", () => {
 
 describe("Bun.serve HTTP/3 production", () => {
   // E: H1 responses advertise the H3 endpoint so browsers can discover it.
-  itH3("Alt-Svc emitted on HTTP/1.1 responses when h3 is enabled", async () => {
+  test("Alt-Svc emitted on HTTP/1.1 responses when h3 is enabled", async () => {
     await withServer(async port => {
       // The fetch()/static-route/file-route response paths each write
       // headers from a different place; all three must advertise h3.
@@ -1157,7 +1148,7 @@ describe("Bun.serve HTTP/3 production", () => {
 
   // I: server.upgrade() returns false over H3 instead of crashing, and the
   // handler can still send a normal response.
-  itH3("server.upgrade(req) over H3 returns false cleanly", async () => {
+  test("server.upgrade(req) over H3 returns false cleanly", async () => {
     const script = `
       const tls = ${JSON.stringify(tls)};
       const server = Bun.serve({

--- a/test/js/bun/http/serve-protocols.test.ts
+++ b/test/js/bun/http/serve-protocols.test.ts
@@ -1,8 +1,6 @@
 /**
  * Protocol-agnostic Bun.serve coverage. Each block is written once and run
- * for every entry in `httpProtocols()` — currently HTTP/1.1 (native fetch)
- * and HTTP/3 (curl --http3-only via fetchH3). The H3 row only appears when
- * an H3-capable curl is on PATH, so the file passes everywhere.
+ * over HTTP/1.1 (native fetch) and HTTP/3 (curl --http3-only via fetchH3).
  *
  * Shape borrowed from h2o's t/40http3/test.pl: hello-world, large file
  * round-trip with checksum, POST echoes at several sizes, headers, status.
@@ -10,7 +8,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "crypto";
 import { bunEnv, bunExe, tempDir, tls } from "harness";
-import { fetchH3, hasFetchH3 } from "./fetch-h3";
+import { fetchH3 } from "./fetch-h3";
 
 type Proto = "http/1.1" | "http/3";
 
@@ -19,18 +17,15 @@ const cases: Array<{
   fetch: (url: string | URL, init?: any) => Promise<Response>;
   scheme: "https" | "http";
   serve: { tls?: typeof tls; h3?: boolean };
-}> = [{ protocol: "http/1.1", fetch, scheme: "http", serve: {} }];
-
-if (hasFetchH3()) {
-  cases.push({ protocol: "http/3", fetch: fetchH3, scheme: "https", serve: { tls, h3: true } });
-} else {
-  console.warn("[serve-protocols] no HTTP/3-capable curl; H3 cases will be skipped");
-}
+}> = [
+  { protocol: "http/1.1", fetch, scheme: "http", serve: {} },
+  { protocol: "http/3", fetch: fetchH3, scheme: "https", serve: { tls, h3: true } },
+];
 
 const md5 = (b: ArrayBuffer | Uint8Array) => createHash("md5").update(Buffer.from(b)).digest("hex");
 
 /** Each test spawns its own server so failures don't cascade and concurrency
- * is safe; the H3 row only runs when an HTTP/3-capable curl is available. */
+ * is safe. */
 function fixtureFor(serve: object) {
   return `
     const server = Bun.serve({


### PR DESCRIPTION
Bun.serve HTTP/3 support landed in #29768; the server tests in `test/js/bun/http/serve-http3.test.ts` and `serve-protocols.test.ts` shell out to `curl --http3-only` and currently **skip on every CI platform** because system curl lacks HTTP/3. Test discovery (see `test/js/bun/http/fetch-h3.ts`): `$CURL_HTTP3` → `curl-h3` in PATH → plain `curl` if `--version` includes `HTTP3`.

This installs the [stunnel/static-curl](https://github.com/stunnel/static-curl) 8.19.0 release — fully static, built with ngtcp2 + nghttp3 — as `curl-h3` alongside the system curl, and sets `CURL_HTTP3` pointing at it:

- **Linux** (`bootstrap.sh`): glibc/musl × x64/aarch64 → `/usr/{local/,}bin/curl-h3`, `CURL_HTTP3` exported via `append_to_profile`
- **Windows** (`bootstrap.ps1`): x64/aarch64 → `C:\Windows\System32\curl-h3.exe` (so it survives Sysprep), `CURL_HTTP3` set machine-wide

System curl is left untouched. Bootstrap versions bumped: ps1 18→19, sh 33→34.

This also republishes the Windows v18→v19 images that #29568's `[publish images]` never landed (those builds failed on the southcentralus IP quota; cleared in robobun#46), so it doubles as the Windows-CI unblock.

Verified `Features: ... HTTP3 ...` is present in the binary's `--version` output (the test gates on that exact token).