### PR TITLE
lint: delete unreachable code in _http_agent.ts and sql/postgres.ts

### DIFF
--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -273,28 +273,6 @@ initPostgres(
         last_result.push(result);
       }
     }
-    return;
-
-    /// prepared statements
-    $assert(result instanceof SQLResultArray, "Invalid result array");
-    if (typeof commandTag === "string") {
-      if (commandTag.length > 0) {
-        result.command = commandTag;
-      }
-    } else {
-      result.command = cmds[commandTag];
-    }
-
-    result.count = count || 0;
-    if (queries) {
-      const queriesIndex = queries.indexOf(query);
-      if (queriesIndex !== -1) {
-        queries.splice(queriesIndex, 1);
-      }
-    }
-    try {
-      query.resolve(result);
-    } catch {}
   },
 
   function onRejectPostgresQuery(

--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -192,62 +192,8 @@ function handleSocketAfterProxy(err, req) {
   }
 }
 
-Agent.prototype.addRequest = function addRequest(req, options, port /* legacy */, localAddress /* legacy */) {
+Agent.prototype.addRequest = function addRequest(_req, _options, _port /* legacy */, _localAddress /* legacy */) {
   $debug("WARN: Agent.addRequest is a no-op");
-  return; // TODO:
-
-  // Legacy API: addRequest(req, host, port, localAddress)
-  if (typeof options === "string") {
-    options = {
-      __proto__: null,
-      host: options,
-      port,
-      localAddress,
-    };
-  }
-
-  // Here the agent options will override per-request options.
-  options = { __proto__: null, ...options, ...this.options };
-  if (options.socketPath) options.path = options.socketPath;
-
-  normalizeServerName(options, req);
-
-  const name = this.getName(options);
-  this.sockets[name] ||= [];
-
-  const freeSockets = this.freeSockets[name];
-  let socket;
-  if (freeSockets) {
-    while (freeSockets.length && freeSockets[0].destroyed) {
-      freeSockets.shift();
-    }
-    socket = this.scheduling === "fifo" ? freeSockets.shift() : freeSockets.pop();
-    if (!freeSockets.length) delete this.freeSockets[name];
-  }
-
-  const freeLen = freeSockets ? freeSockets.length : 0;
-  const sockLen = freeLen + this.sockets[name].length;
-
-  if (socket) {
-    this.reuseSocket(socket, req);
-    setRequestSocket(this, req, socket);
-    this.sockets[name].push(socket);
-  } else if (sockLen < this.maxSockets && this.totalSocketCount < this.maxTotalSockets) {
-    this.createSocket(req, options, (err, socket) => {
-      if (err) {
-        handleSocketAfterProxy(err, req);
-        $debug("call onSocket", sockLen, freeLen);
-        req.onSocket(socket, err);
-        return;
-      }
-      setRequestSocket(this, req, socket);
-    });
-  } else {
-    $debug("wait for socket");
-    this.requests[name] ||= [];
-    req[kRequestOptions] = options;
-    this.requests[name].push(req);
-  }
 };
 
 Agent.prototype.createSocket = function createSocket(req, options, cb) {


### PR DESCRIPTION
oxlint 1.62.0 (released today) tightened `no-unreachable` to catch code after an unconditional `return;`, which now flags two long-standing "stash the implementation behind an early return" blocks. The lint workflow runs unpinned `bunx oxlint`, so this currently fails every PR.

- `Agent.prototype.addRequest` (`src/js/node/_http_agent.ts`) has been a debug-warning no-op since the rewrite; the ~50 lines of Node.js connection-pool logic after `return; // TODO:` have never executed.
- `onResolvePostgresQuery` (`src/js/internal/sql/postgres.ts`) had a trailing `return;` followed by a `/// prepared statements` block duplicating the live path's resolve/splice; never reached.

Delete the dead code rather than pin the linter or sprinkle disable comments. Verified `bunx oxlint@1.62.0 --config=oxlint.json src/js` → 0 errors; no symbols became newly-unused.