### PR TITLE
Fix crash when using Reflect.construct on a mock function

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -994,7 +994,12 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGloba
     if (result.isObject()) [[likely]]
         return encodedResult;
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::constructEmptyObject(lexicalGlobalObject)));
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSGlobalObject* functionGlobalObject = getFunctionRealm(lexicalGlobalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, {});
+    Structure* structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::constructEmptyObject(vm, structure)));
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,21 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    EncodedJSValue encodedResult = jsMockFunctionCall(lexicalGlobalObject, callframe);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = JSValue::decode(encodedResult);
+    if (result.isObject()) [[likely]]
+        return encodedResult;
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::constructEmptyObject(lexicalGlobalObject)));
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -806,8 +806,14 @@ describe("mock()", () => {
     const returnsObject = jest.fn(() => ({ x: 1 }));
     expect(Reflect.construct(returnsObject, [])).toEqual({ x: 1 });
 
-    const spied = spyOn({ foo: 42 }, "foo");
-    expect(typeof Reflect.construct(spied, [])).toBe("object");
+    class Base {}
+    expect(Reflect.construct(empty, [], Base)).toBeInstanceOf(Base);
+
+    if (isBun) {
+      // Jest doesn't allow spying on non-function properties
+      const spied = spyOn({ foo: 42 }, "foo");
+      expect(typeof Reflect.construct(spied, [])).toBe("object");
+    }
   });
 });
 

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,21 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  it("Reflect.construct on a mock returns an object", () => {
+    const empty = jest.fn();
+    expect(typeof Reflect.construct(empty, [])).toBe("object");
+    expect(empty).toHaveBeenCalledTimes(1);
+
+    const returnsPrimitive = jest.fn().mockReturnValue(42);
+    expect(typeof Reflect.construct(returnsPrimitive, [])).toBe("object");
+
+    const returnsObject = jest.fn(() => ({ x: 1 }));
+    expect(Reflect.construct(returnsObject, [])).toEqual({ x: 1 });
+
+    const spied = spyOn({ foo: 42 }, "foo");
+    expect(typeof Reflect.construct(spied, [])).toBe("object");
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes an assertion failure / crash when a `jest.fn()` / `spyOn()` mock is invoked via `Reflect.construct()` and its implementation would return a non-object (e.g. no implementation, `mockReturnValue(42)`, or a spy on a non-function property).

```js
const m = jest.fn();
Reflect.construct(m, []); // ASSERTION FAILED: isCell()
```

JSC requires native constructors to return an object — `Interpreter::executeConstruct` passes the result straight through `asObject()`. `JSMockFunction` was using the same host function for both `[[Call]]` and `[[Construct]]`, which can return `jsUndefined()` or other primitives.

This adds a dedicated construct handler that falls back to a fresh empty object when the mock would otherwise produce a non-object, matching ordinary `[[Construct]]` semantics (and Jest's behavior).

## How did you verify your code works?

- Added a regression test in `test/js/bun/test/mock-fn.test.js` covering empty mocks, `mockReturnValue` with a primitive, an implementation that returns an object, and `spyOn` of a non-function property.
- `bun bd test test/js/bun/test/mock-fn.test.js` — 73 pass, 0 fail
- Verified the test fails on `main` (assertion failure on debug, wrong return type on release).
- Original fuzzer repro no longer crashes.

Found by Fuzzilli. Fingerprint: `JSCJSValue.h(1044)`