### PR TITLE
ReadableStream: per-instance closer array to fix concurrent stream race

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -1925,8 +1925,6 @@ export function readableStreamFromAsyncIterator(target, fn) {
 }
 
 export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultController {
-  const closer = [false];
-
   function callClose(controller: ReadableStreamDefaultController) {
     try {
       var source = controller.$underlyingSource;
@@ -2009,6 +2007,16 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
 
     autoAllocateChunkSize = 0;
     #closed = false;
+
+    // EOF signal array passed to `handle.pull(view, closer)`. Native code
+    // writes `closer[0] = true` synchronously on EOF and the pull callback
+    // reads it back (including after awaiting a pending pull promise).
+    // MUST be per-instance: if this were a factory-scope constant it would
+    // be shared across every NativeReadableStreamSource backed by the same
+    // prototype (e.g. stdin + a fetch() response body, or two concurrent
+    // fetch() bodies), and one instance's EOF could incorrectly close
+    // another. See #29787.
+    #closer: [boolean] = [false];
 
     $data?: Uint8Array;
 
@@ -2103,6 +2111,7 @@ export function createLazyLoadedStreamPrototype(): typeof ReadableStreamDefaultC
         this.#controller = new WeakRef(controller);
       }
 
+      const closer = this.#closer;
       closer[0] = false;
 
       if (this.$data) {

--- a/test/regression/issue/29787.test.ts
+++ b/test/regression/issue/29787.test.ts
@@ -1,0 +1,162 @@
+// https://github.com/oven-sh/bun/issues/29787
+//
+// NativeReadableStreamSource used a single `const closer = [false]` at
+// factory scope, so every instance backed by the same native-handle
+// prototype (e.g. `Bun.stdin.stream()` + `fetch(file://...)` bodies)
+// shared one EOF signal slot.
+//
+// Race:
+//   1. Stream A (stdin pipe) pulls → returns pending Promise. Its `.then`
+//      will later read `closer[0]` back.
+//   2. Stream B (fetch file body) pulls → returns synchronously
+//      `into_array_and_done`, which makes the native code write
+//      `closer[0] = true`.
+//   3. Data eventually arrives for A. A's `.then` fires, reads the stale
+//      `closer[0] === true` left behind by B, and calls `close()` on A's
+//      controller — closing stdin even though the pipe has more data and
+//      is not at EOF.
+//
+// This test spawns a child that reads `Bun.stdin.stream()`. The child
+// first issues many concurrent `fetch(file://...)` calls (each of which
+// sync-completes with EOF, flipping the shared `closer[0] = true`). The
+// child then signals the parent via stderr; the parent replies by
+// writing bytes down stdin. With the bug present, stdin's queued pending
+// pull reads the stale `true` when it resolves and closes itself — only
+// the first byte reaches `data` before a spurious `done` arrives, even
+// though the parent is still writing and never ended stdin.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { pathToFileURL } from "node:url";
+
+test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29787)", async () => {
+  const dir = tempDirWithFiles("issue-29787-stdin-race", {
+    "data.bin": Buffer.alloc(4096, 0x41).toString(),
+  });
+  const fileUrl = pathToFileURL(`${dir}/data.bin`).href;
+
+  const totalWrites = 5;
+
+  const childScript = `
+    const fileUrl = ${JSON.stringify(fileUrl)};
+    const events = [];
+    const reader = Bun.stdin.stream().getReader();
+
+    // Background drain of stdin — we'll check this record at the end.
+    (async () => {
+      try {
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) { events.push({ kind: "done" }); break; }
+          events.push({ kind: "data", bytes: value.byteLength });
+        }
+      } catch (err) {
+        events.push({ kind: "err", message: err.message });
+      }
+    })();
+
+    // Let stdin's first pull reach the pending-promise state before we
+    // trip the closer flag with concurrent file reads.
+    await Bun.sleep(50);
+
+    // Concurrent fetch(file://) bodies share the same
+    // NativeReadableStreamSource class as stdin. Each body sync-completes
+    // with EOF, flipping the (pre-fix) shared closer flag to true.
+    const fetches = [];
+    for (let i = 0; i < 100; i++) {
+      fetches.push((async () => {
+        const res = await fetch(fileUrl);
+        const rd = res.body.getReader();
+        while (true) {
+          const { done } = await rd.read();
+          if (done) break;
+        }
+      })());
+    }
+    await Promise.all(fetches);
+
+    // Signal the parent that the closer flag is now in its racy state.
+    // The parent will respond by writing bytes to stdin; with the bug,
+    // stdin's pending pull resolves and reads the stale closer=true,
+    // closing itself.
+    process.stderr.write("READY\\n");
+
+    // Give the parent time to write all bytes and for any spurious close
+    // to surface.
+    await Bun.sleep(1500);
+
+    process.stdout.write(JSON.stringify(events));
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", childScript],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Wait for the child's "READY" signal on stderr before writing to stdin.
+  const stderrReader = proc.stderr.getReader();
+  const decoder = new TextDecoder();
+  let stderrBuf = "";
+  while (!stderrBuf.includes("READY")) {
+    const { value, done } = await stderrReader.read();
+    if (done) break;
+    stderrBuf += decoder.decode(value);
+  }
+
+  // Now write bytes one at a time with small gaps. Each byte forces a
+  // fresh pending-pull cycle on the child's stdin; with the bug, the
+  // first pending pull resolves to close-the-stream because of the
+  // stale closer flag left by the earlier fetches, and the remaining
+  // bytes never reach the child.
+  for (let i = 0; i < totalWrites; i++) {
+    await Bun.sleep(40);
+    proc.stdin.write(Buffer.from([0x41 + i]));
+  }
+
+  // Give the child its tail sleep to flush events and exit.
+  await Bun.sleep(700);
+  proc.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    // Drain the rest of stderr (past "READY").
+    (async () => {
+      let rest = "";
+      while (true) {
+        const { value, done } = await stderrReader.read();
+        if (done) break;
+        rest += decoder.decode(value);
+      }
+      return stderrBuf + rest;
+    })(),
+    proc.exited,
+  ]);
+
+  expect(exitCode).toBe(0);
+
+  const events = JSON.parse(stdout) as (
+    | { kind: "data"; bytes: number }
+    | { kind: "done" }
+    | { kind: "err"; message: string }
+  )[];
+
+  // No internal errors from the stdin reader.
+  const err = events.find(e => e.kind === "err") as
+    | { kind: "err"; message: string }
+    | undefined;
+  expect(err).toBeUndefined();
+
+  // Every byte the parent wrote was delivered to the child. With the bug
+  // we'd see only one data event before a spurious `done`.
+  const dataBytes = events
+    .filter((e): e is { kind: "data"; bytes: number } => e.kind === "data")
+    .reduce((acc, e) => acc + e.bytes, 0);
+  expect(dataBytes).toBe(totalWrites);
+
+  // Extra sanity: stderr beyond "READY" should be empty — any warning or
+  // error there would mean some other regression.
+  expect(stderr.replace("READY\n", "")).toBe("");
+});

--- a/test/regression/issue/29787.test.ts
+++ b/test/regression/issue/29787.test.ts
@@ -120,22 +120,13 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
   await Bun.sleep(700);
   proc.stdin.end();
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    // Drain the rest of stderr (past "READY").
-    (async () => {
-      let rest = "";
-      while (true) {
-        const { value, done } = await stderrReader.read();
-        if (done) break;
-        rest += decoder.decode(value);
-      }
-      return stderrBuf + rest;
-    })(),
-    proc.exited,
-  ]);
+  // Release the stderr reader lock so `proc.stderr` can be drained elsewhere
+  // (or, more relevantly, so the `await using` cleanup doesn't trip on a
+  // still-locked stream). We don't care about stderr contents past READY —
+  // ASAN builds emit a warning there and that's fine.
+  stderrReader.releaseLock();
 
-  expect(exitCode).toBe(0);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
   const events = JSON.parse(stdout) as (
     | { kind: "data"; bytes: number }
@@ -154,7 +145,5 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
     .reduce((acc, e) => acc + e.bytes, 0);
   expect(dataBytes).toBe(totalWrites);
 
-  // Extra sanity: stderr beyond "READY" should be empty — any warning or
-  // error there would mean some other regression.
-  expect(stderr.replace("READY\n", "")).toBe("");
+  expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/29787.test.ts
+++ b/test/regression/issue/29787.test.ts
@@ -16,14 +16,22 @@
 //      controller — closing stdin even though the pipe has more data and
 //      is not at EOF.
 //
-// This test spawns a child that reads `Bun.stdin.stream()`. The child
-// first issues many concurrent `fetch(file://...)` calls (each of which
-// sync-completes with EOF, flipping the shared `closer[0] = true`). The
-// child then signals the parent via stderr; the parent replies by
-// writing bytes down stdin. With the bug present, stdin's queued pending
-// pull reads the stale `true` when it resolves and closes itself — only
-// the first byte reaches `data` before a spurious `done` arrives, even
-// though the parent is still writing and never ended stdin.
+// The test spawns a child that reads `Bun.stdin.stream()` concurrently
+// with 100 `fetch(file://...)` bodies — each body sync-completes with EOF,
+// flipping the (pre-fix) shared closer flag to true. Synchronization is
+// via stderr ACK/handshake, no wall-clock sleeps: the child signals
+// "READY" when fetches are done and writes one byte back on stderr for
+// each stdin chunk it receives. The parent writes bytes one-by-one,
+// waiting for each ack before sending the next, then closes stdin.
+//
+// With the bug, stdin's queued pending pull reads the stale closer=true
+// when the first parent write wakes it, and closes itself — the child's
+// reader pushes `done` and exits, so only one data event is recorded
+// and the second ack never arrives.
+//
+// With the fix, each instance owns its own closer array so all five
+// bytes round-trip and the final `done` comes from the parent's real
+// `stdin.end()`.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { pathToFileURL } from "node:url";
@@ -41,22 +49,24 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
     const events = [];
     const reader = Bun.stdin.stream().getReader();
 
-    // Background drain of stdin — we'll check this record at the end.
-    (async () => {
+    // reader.read() in the IIFE below runs synchronously up to its first
+    // await, so the native stdin pull reaches its pending state before
+    // this line returns — no sleep needed to set up the race window.
+    const readerLoop = (async () => {
       try {
         while (true) {
           const { value, done } = await reader.read();
           if (done) { events.push({ kind: "done" }); break; }
           events.push({ kind: "data", bytes: value.byteLength });
+          // Ack so the parent knows this chunk landed before it sends
+          // the next byte. Without acks, the parent has no way to know
+          // when the closer-flag race has resolved for this round.
+          process.stderr.write("A");
         }
       } catch (err) {
         events.push({ kind: "err", message: err.message });
       }
     })();
-
-    // Let stdin's first pull reach the pending-promise state before we
-    // trip the closer flag with concurrent file reads.
-    await Bun.sleep(50);
 
     // Concurrent fetch(file://) bodies share the same
     // NativeReadableStreamSource class as stdin. Each body sync-completes
@@ -74,16 +84,15 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
     }
     await Promise.all(fetches);
 
-    // Signal the parent that the closer flag is now in its racy state.
-    // The parent will respond by writing bytes to stdin; with the bug,
-    // stdin's pending pull resolves and reads the stale closer=true,
-    // closing itself.
+    // Closer flag is now in its racy state. Tell the parent to start
+    // writing; each byte will either reach the reader (fix) or trip the
+    // spurious close (bug).
     process.stderr.write("READY\\n");
 
-    // Give the parent time to write all bytes and for any spurious close
-    // to surface.
-    await Bun.sleep(1500);
-
+    // Exit only when the reader has actually terminated — real EOF from
+    // parent's stdin.end() (fix path) or spurious close from reading a
+    // stale closer[0] = true (bug path).
+    await readerLoop;
     process.stdout.write(JSON.stringify(events));
     process.exit(0);
   `;
@@ -96,34 +105,38 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
     stderr: "pipe",
   });
 
-  // Wait for the child's "READY" signal on stderr before writing to stdin.
   const stderrReader = proc.stderr.getReader();
   const decoder = new TextDecoder();
   let stderrBuf = "";
-  while (!stderrBuf.includes("READY")) {
-    const { value, done } = await stderrReader.read();
-    if (done) break;
-    stderrBuf += decoder.decode(value);
+  let childExited = false;
+  proc.exited.then(() => {
+    childExited = true;
+  });
+
+  // Pull stderr until `token` is in the buffer, OR the child has
+  // exited. The caller checks `stderrBuf.includes(token)` afterwards.
+  async function waitForStderrToken(token: string): Promise<void> {
+    while (!stderrBuf.includes(token) && !childExited) {
+      const { value, done } = await stderrReader.read();
+      if (done) return;
+      stderrBuf += decoder.decode(value);
+    }
   }
 
-  // Now write bytes one at a time with small gaps. Each byte forces a
-  // fresh pending-pull cycle on the child's stdin; with the bug, the
-  // first pending pull resolves to close-the-stream because of the
-  // stale closer flag left by the earlier fetches, and the remaining
-  // bytes never reach the child.
+  // Handshake before the first write.
+  await waitForStderrToken("READY\n");
+
+  // Write one byte, wait for exactly (i+1) acks, repeat. With the bug,
+  // the first ack never arrives after the first byte because the reader
+  // loop resolved with `done` — the child exits, `childExited` flips,
+  // the wait short-circuits, and `dataBytes` comes out < totalWrites.
   for (let i = 0; i < totalWrites; i++) {
-    await Bun.sleep(40);
     proc.stdin.write(Buffer.from([0x41 + i]));
+    await waitForStderrToken("READY\n" + "A".repeat(i + 1));
+    if (childExited) break;
   }
 
-  // Give the child its tail sleep to flush events and exit.
-  await Bun.sleep(700);
   proc.stdin.end();
-
-  // Release the stderr reader lock so `proc.stderr` can be drained elsewhere
-  // (or, more relevantly, so the `await using` cleanup doesn't trip on a
-  // still-locked stream). We don't care about stderr contents past READY —
-  // ASAN builds emit a warning there and that's fine.
   stderrReader.releaseLock();
 
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/regression/issue/29787.test.ts
+++ b/test/regression/issue/29787.test.ts
@@ -144,9 +144,7 @@ test("stdin stream stays open while concurrent fetch(file://) bodies finish (#29
   )[];
 
   // No internal errors from the stdin reader.
-  const err = events.find(e => e.kind === "err") as
-    | { kind: "err"; message: string }
-    | undefined;
+  const err = events.find(e => e.kind === "err") as { kind: "err"; message: string } | undefined;
   expect(err).toBeUndefined();
 
   // Every byte the parent wrote was delivered to the child. With the bug


### PR DESCRIPTION
Fixes #29787.

## Reproduction

The reporter's gist puts `process.stdin` into raw mode, starts reading, and
concurrently issues `fetch(file://...)` on a local file. Stdin closes on its
own — a subsequent `setRawMode` throws `EBADF`. Distilled:

```ts
// Child reads Bun.stdin.stream() while firing 100 concurrent
// fetch(file://) bodies. Parent sends bytes once the child signals
// "READY". Pre-fix: child sees only 1 byte then a spurious `done`.
const reader = Bun.stdin.stream().getReader();
// ... drain in background ...
await Promise.all(Array.from({ length: 100 }, async () => {
  const res = await fetch(fileUrl);
  const rd = res.body.getReader();
  while ((await rd.read()).done === false);
}));
process.stderr.write("READY\n");
```

## Cause

`createLazyLoadedStreamPrototype()` declared `const closer = [false]` once
at factory scope. `lazyLoadStream` caches the generated class per
native-handle prototype via `$lazyStreamPrototypeMap`, so every
`NativeReadableStreamSource` instance sharing that prototype — e.g.
`Bun.stdin.stream()` and every `fetch(file://...)` body — shared the
same `closer` slot.

Native `pull` writes `closer[0] = true` synchronously when the result is
`*_and_done` (`src/bun.js/webcore/ReadableStream.zig`, `processResult` at
line 663). `#pull` reads `closer[0]` back inside the `.then` continuation
of a pending pull promise (`ReadableStreamInternals.ts:2121`). Concurrent
pulls race:

1. Stream A (pipe, pending pull): `closer[0] = false` then returns the
   promise.
2. Stream B (file, sync EOF): `closer[0] = false`, native writes
   `closer[0] = true`. B closes correctly.
3. A's pending promise later resolves with real data. Its `.then` reads
   `closer[0]` — still `true` from B — and calls `close()` on A's
   controller, closing stdin.

## Fix

Move `closer` onto the instance:

```ts
class NativeReadableStreamSource {
  #closer: [boolean] = [false];
  // ...
  #pull(controller) {
    // ...
    const closer = this.#closer;
    closer[0] = false;
    const result = handle.pull(view, closer);
    // ...
  }
}
```

Native only writes `closer[0]` synchronously during `handle.pull` and never
retains a reference past that call (see `processResult` — it's a by-value
`JSValue` argument, not stored anywhere), so a per-instance array is
semantically identical to the shared one for the non-racing case and
eliminates cross-stream mutation.

## Verification

New regression test at `test/regression/issue/29787.test.ts`. Spawns a
child that reads `Bun.stdin.stream()` concurrently with 100
`fetch(file://)` bodies, synchronizes with the parent via stderr
`READY`, and then counts bytes delivered down stdin.

```
# Without fix:
Expected: 5
Received: 1
(fail) stdin stream stays open while concurrent fetch(file://) bodies finish (#29787)

# With fix:
(pass) stdin stream stays open while concurrent fetch(file://) bodies finish (#29787)
```

Pre-existing stream test suite failures (`Bun.file().stream() read text
from large file`, `handles exceptions during empty stream creation`,
`Bun.file > bad permissions throws *`) reproduce on `main` without this
change; not introduced here.