### PR TITLE
Bun.serve: server-side WebTransport over HTTP/3

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -1115,7 +1115,7 @@ int us_quic_stream_send_datagram(us_quic_stream_t *session,
      * dropped there, so reject up front. 1200 is the QUIC default initial
      * max_udp_payload_size minus headers — conservative but predictable. */
     if (total > 1200) return -1;
-    if (max_queued && session->wt_dgram_bytes + total > max_queued) return -1;
+    if (max_queued && session->wt_dgram_bytes + total > max_queued) return -2;
     struct us_quic_dgram *d = (struct us_quic_dgram *) malloc(sizeof(*d) + total);
     if (!d) return -1;
     d->next = NULL;

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -5,6 +5,12 @@
 /* lsquic.h gates on WIN32 (not _WIN32) to pick <vc_compat.h> over <sys/uio.h>. */
 #define WIN32 1
 #endif
+/* lsquic gates es_webtransport_server / lsquic_stream_*webtransport* behind
+ * this. The lsquic build flips it via -D in scripts/build/deps/lsquic.ts; it
+ * has to be repeated for any TU that includes lsquic.h. */
+#ifndef LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+#define LSQUIC_WEBTRANSPORT_SERVER_SUPPORT 1
+#endif
 #include "lsquic.h"
 #include "lsxpack_header.h"
 #include <openssl/ssl.h>
@@ -40,6 +46,15 @@ struct us_quic_sni {
     SSL_CTX *ctx;
 };
 
+/* One QUIC DATAGRAM queued on a connection. The Quarter Stream ID varint
+ * is already prepended so on_dg_write is a single memcpy. */
+struct us_quic_dgram {
+    struct us_quic_dgram *next;
+    struct us_quic_stream_s *session;
+    unsigned int len;
+    /* payload follows */
+};
+
 struct us_quic_socket_context_s {
     struct us_loop_t *loop;
     lsquic_engine_t *engine;
@@ -70,6 +85,9 @@ struct us_quic_socket_context_s {
     void (*on_stream_data)(us_quic_stream_t *, const char *, unsigned int, int);
     void (*on_stream_writable)(us_quic_stream_t *);
     void (*on_stream_close)(us_quic_stream_t *);
+    void (*on_wt_stream_data)(us_quic_stream_t *, us_quic_stream_t *, const char *, unsigned int, int);
+    void (*on_wt_stream_close)(us_quic_stream_t *, us_quic_stream_t *);
+    void (*on_datagram)(us_quic_stream_t *, const char *, unsigned int);
 
     char read_buf[US_QUIC_READ_BUF];
     /* ext follows */
@@ -85,6 +103,15 @@ struct us_quic_listen_socket_s {
 struct us_quic_socket_s {
     lsquic_conn_t *conn;
     us_quic_socket_context_t *ctx;
+    /* WebTransport sessions on this connection (intrusive list of CONNECT
+     * streams via wt_next_on_conn). Scanned on incoming WT bidi streams and
+     * datagrams to resolve Session ID; size bounded by
+     * es_max_webtransport_server_streams so a linear walk is fine. */
+    struct us_quic_stream_s *wt_sessions;
+    /* Outgoing datagram FIFO; on_dg_write pops from head. dgram_bytes
+     * is summed across all sessions on the conn. */
+    struct us_quic_dgram *dgram_head, *dgram_tail;
+    unsigned int dgram_bytes;
     /* ext follows */
 };
 
@@ -94,6 +121,13 @@ struct us_quic_stream_s {
     struct us_quic_hset *hset;
     int headers_delivered;
     int fin_delivered;
+    /* WebTransport bookkeeping. wt_kind: 0 = HTTP, 1 = CONNECT session,
+     * 2 = client bidi data stream. wt_session_id is the CONNECT stream id
+     * for kind 2 (cached so we can route after resolve). */
+    unsigned char wt_kind;
+    lsquic_stream_id_t wt_session_id;
+    struct us_quic_stream_s *wt_next_on_conn; /* session list link for kind 1 */
+    unsigned int wt_dgram_bytes;              /* per-session buffered datagram bytes */
     /* ext follows */
 };
 
@@ -469,6 +503,11 @@ static void us_quic_on_conn_closed(lsquic_conn_t *conn) {
     us_quic_socket_context_t *ctx = qs->ctx;
     if (ctx->on_close) ctx->on_close(qs);
     lsquic_conn_set_ctx(conn, NULL);
+    for (struct us_quic_dgram *d = qs->dgram_head; d; ) {
+        struct us_quic_dgram *next = d->next;
+        free(d);
+        d = next;
+    }
     free(qs);
 #ifndef LIBUS_USE_LIBUV
     ctx->loop->num_polls--;
@@ -494,33 +533,69 @@ static lsquic_stream_ctx_t *us_quic_on_new_stream(void *if_ctx, lsquic_stream_t 
     return (lsquic_stream_ctx_t *) s;
 }
 
+static us_quic_stream_t *us_quic_find_wt_session(us_quic_socket_t *qs, lsquic_stream_id_t id) {
+    if (!qs) return NULL;
+    for (us_quic_stream_t *s = qs->wt_sessions; s; s = s->wt_next_on_conn)
+        if (lsquic_stream_id(s->stream) == id) return s;
+    return NULL;
+}
+
 static void us_quic_on_read(lsquic_stream_t *stream, lsquic_stream_ctx_t *h) {
     us_quic_stream_t *s = (us_quic_stream_t *) h;
     us_quic_socket_context_t *ctx = s->ctx;
 
     if (!s->headers_delivered) {
-        struct us_quic_hset *hset = (struct us_quic_hset *) lsquic_stream_get_hset(stream);
-        if (hset) {
-            us_quic_hset_finalize(hset);
-            s->hset = hset;
+        /* lsquic's hq filter parses the 0x41 + Session ID prefix on the first
+         * read, marks the stream as a WT bidi stream, and disables HTTP
+         * framing — there is no header set to claim. Route subsequent reads
+         * to the WT data callback instead of the HTTP body path. */
+        if (s->wt_kind == 0 && lsquic_stream_is_webtransport_client_bidi_stream(stream)) {
+            s->wt_kind = 2;
             s->headers_delivered = 1;
-            if (ctx->on_stream_headers) ctx->on_stream_headers(s);
-            /* on_stream_headers may have closed us */
-            if (!s->stream) return;
+            s->wt_session_id = (lsquic_stream_id_t)
+                lsquic_stream_get_webtransport_session_stream_id(stream);
+        } else {
+            struct us_quic_hset *hset = (struct us_quic_hset *) lsquic_stream_get_hset(stream);
+            if (hset) {
+                us_quic_hset_finalize(hset);
+                s->hset = hset;
+                s->headers_delivered = 1;
+                if (ctx->on_stream_headers) ctx->on_stream_headers(s);
+                /* on_stream_headers may have closed us */
+                if (!s->stream) return;
+            }
         }
+    }
+
+    /* Re-resolve the session on every read instead of caching across calls:
+     * the CONNECT stream can close mid-transfer and there's no back-pointer
+     * to invalidate. The session list is bounded (≤16) so the walk is cheap. */
+    us_quic_stream_t *session = NULL;
+    if (s->wt_kind == 2) {
+        us_quic_socket_t *qs = (us_quic_socket_t *) lsquic_conn_get_ctx(lsquic_stream_conn(stream));
+        session = us_quic_find_wt_session(qs, s->wt_session_id);
     }
 
     ssize_t r;
     while ((r = lsquic_stream_read(stream, ctx->read_buf, US_QUIC_READ_BUF)) > 0) {
-        if (ctx->on_stream_data)
+        if (s->wt_kind == 2) {
+            if (ctx->on_wt_stream_data)
+                ctx->on_wt_stream_data(s, session, ctx->read_buf, (unsigned int) r, 0);
+        } else if (ctx->on_stream_data) {
             ctx->on_stream_data(s, ctx->read_buf, (unsigned int) r, 0);
+        }
         if (!s->stream) return;
     }
     if (r == 0 && !s->fin_delivered) {
         s->fin_delivered = 1;
         lsquic_stream_wantread(stream, 0);
         lsquic_stream_shutdown(stream, 0);
-        if (ctx->on_stream_data) ctx->on_stream_data(s, ctx->read_buf, 0, 1);
+        if (s->wt_kind == 2) {
+            if (ctx->on_wt_stream_data)
+                ctx->on_wt_stream_data(s, session, ctx->read_buf, 0, 1);
+        } else if (ctx->on_stream_data) {
+            ctx->on_stream_data(s, ctx->read_buf, 0, 1);
+        }
     }
 }
 
@@ -528,12 +603,46 @@ static void us_quic_on_write(lsquic_stream_t *stream, lsquic_stream_ctx_t *h) {
     us_quic_stream_t *s = (us_quic_stream_t *) h;
     lsquic_stream_wantwrite(stream, 0);
     if (s->ctx->on_stream_writable) s->ctx->on_stream_writable(s);
+    /* lsquic_stream_send_headers stashes the QPACK block and writes it from
+     * dispatch_write_events into sm_buf, then hands control back here. With
+     * a body the next lsquic_stream_write packs it alongside; without one
+     * (WebTransport 200, future 1xx-then-wait) it sits buffered. Flush so a
+     * STREAM frame is generated regardless. No-op when already flushed. */
+    if (s->stream) lsquic_stream_flush(stream);
 }
 
 static void us_quic_on_close(lsquic_stream_t *stream, lsquic_stream_ctx_t *h) {
     (void) stream;
     us_quic_stream_t *s = (us_quic_stream_t *) h;
     if (!s) return;
+    if (s->wt_kind == 1) {
+        /* Unlink from the connection's session list and drop any datagrams
+         * we queued for it before the C++ layer learns the session is gone. */
+        us_quic_socket_t *qs = us_quic_stream_socket(s);
+        if (qs) {
+            for (us_quic_stream_t **pp = &qs->wt_sessions; *pp; pp = &(*pp)->wt_next_on_conn) {
+                if (*pp == s) { *pp = s->wt_next_on_conn; break; }
+            }
+            for (struct us_quic_dgram **pp = &qs->dgram_head; *pp; ) {
+                struct us_quic_dgram *d = *pp;
+                if (d->session == s) {
+                    *pp = d->next;
+                    qs->dgram_bytes -= d->len;
+                    free(d);
+                } else pp = &d->next;
+            }
+            qs->dgram_tail = NULL;
+            for (struct us_quic_dgram *d = qs->dgram_head; d; d = d->next) qs->dgram_tail = d;
+        }
+    }
+    if (s->wt_kind == 2) {
+        /* RESET_STREAM never delivers fin=1, so the C++ layer's reassembly
+         * entry survives. Give it a chance to drop the entry before the
+         * stream id is recycled. */
+        us_quic_socket_t *qs = us_quic_stream_socket(s);
+        us_quic_stream_t *session = qs ? us_quic_find_wt_session(qs, s->wt_session_id) : NULL;
+        if (s->ctx->on_wt_stream_close) s->ctx->on_wt_stream_close(s, session);
+    }
     if (s->ctx->on_stream_close) s->ctx->on_stream_close(s);
     s->stream = NULL;
     us_quic_hset_free(s->hset);
@@ -546,6 +655,72 @@ static void us_quic_on_reset(lsquic_stream_t *stream, lsquic_stream_ctx_t *h, in
     if (h && stream) lsquic_stream_close(stream);
 }
 
+/* ───── datagrams (RFC 9221 frame, RFC 9297 HTTP wrapping) ───── */
+
+/* QUIC varint: read a single value from [p,end). Returns bytes consumed, or
+ * 0 if truncated. */
+static unsigned int us_quic_varint_read(const unsigned char *p, const unsigned char *end, uint64_t *out) {
+    if (p >= end) return 0;
+    unsigned int len = 1u << (*p >> 6);
+    if ((unsigned int)(end - p) < len) return 0;
+    uint64_t v = *p & 0x3f;
+    for (unsigned int i = 1; i < len; i++) v = (v << 8) | p[i];
+    *out = v;
+    return len;
+}
+
+static unsigned int us_quic_varint_write(unsigned char *p, uint64_t v) {
+    if (v < 64) { p[0] = (unsigned char) v; return 1; }
+    if (v < 16384) { p[0] = (unsigned char)(0x40 | (v >> 8)); p[1] = (unsigned char) v; return 2; }
+    if (v < 1073741824) {
+        p[0] = (unsigned char)(0x80 | (v >> 24)); p[1] = (unsigned char)(v >> 16);
+        p[2] = (unsigned char)(v >> 8);           p[3] = (unsigned char) v;
+        return 4;
+    }
+    p[0] = (unsigned char)(0xc0 | (v >> 56));
+    for (int i = 1; i < 8; i++) p[i] = (unsigned char)(v >> (8 * (7 - i)));
+    return 8;
+}
+
+static ssize_t us_quic_on_dg_write(lsquic_conn_t *conn, void *buf, size_t sz) {
+    us_quic_socket_t *qs = (us_quic_socket_t *) lsquic_conn_get_ctx(conn);
+    if (!qs) return -1;
+    /* lsquic's contract: nw >= 0 means "wrote nw bytes" (no skip semantics),
+     * so 0 would serialise an empty DATAGRAM frame — invalid HTTP/3 datagram
+     * (no Quarter-Stream-ID). Pop oversize entries until one fits or the
+     * queue empties; only ever return >0 or -1. */
+    for (;;) {
+        struct us_quic_dgram *d = qs->dgram_head;
+        if (!d) { lsquic_conn_want_datagram_write(conn, 0); return -1; }
+        qs->dgram_head = d->next;
+        if (!qs->dgram_head) qs->dgram_tail = NULL;
+        qs->dgram_bytes -= d->len;
+        if (d->session) d->session->wt_dgram_bytes -= d->len;
+        if (d->len <= sz) {
+            memcpy(buf, d + 1, d->len);
+            ssize_t r = (ssize_t) d->len;
+            free(d);
+            if (qs->dgram_head) lsquic_conn_want_datagram_write(conn, 1);
+            return r;
+        }
+        free(d);
+    }
+}
+
+static void us_quic_on_datagram(lsquic_conn_t *conn, const void *buf, size_t sz) {
+    us_quic_socket_t *qs = (us_quic_socket_t *) lsquic_conn_get_ctx(conn);
+    if (!qs || !qs->ctx->on_datagram) return;
+    /* RFC 9297 §2.1: payload is Quarter Stream ID varint + HTTP Datagram
+     * Payload. Session ID is QSID * 4 (client-initiated bidi). */
+    uint64_t qsid;
+    unsigned int n = us_quic_varint_read((const unsigned char *) buf,
+        (const unsigned char *) buf + sz, &qsid);
+    if (!n) return;
+    us_quic_stream_t *session = us_quic_find_wt_session(qs, (lsquic_stream_id_t)(qsid * 4));
+    if (!session) return;
+    qs->ctx->on_datagram(session, (const char *) buf + n, (unsigned int)(sz - n));
+}
+
 /* ───── public API ───── */
 
 static const struct lsquic_stream_if us_quic_stream_if = {
@@ -556,6 +731,8 @@ static const struct lsquic_stream_if us_quic_stream_if = {
     .on_write = us_quic_on_write,
     .on_close = us_quic_on_close,
     .on_reset = us_quic_on_reset,
+    .on_dg_write = us_quic_on_dg_write,
+    .on_datagram = us_quic_on_datagram,
 };
 
 static const struct lsquic_hset_if us_quic_hset_if = {
@@ -629,6 +806,14 @@ us_quic_socket_context_t *us_create_quic_socket_context(
      * 9218 scheduler and the patched determine_bpt short-circuits the O(N)
      * stream-hash walk on every write. */
     ctx->settings.es_ext_http_prio = 0;
+    /* WebTransport: lsquic copies es_* at engine_new time, so flip these
+     * unconditionally. Harmless when no wt() route is registered — the
+     * SETTINGS frame advertises support, but on_datagram drops anything that
+     * doesn't match a registered session and the 0x41 prefix path falls
+     * through to a no-op on_wt_stream_data. */
+    ctx->settings.es_webtransport_server = 1;
+    ctx->settings.es_max_webtransport_server_streams = 16;
+    ctx->settings.es_datagrams = 1;
     if (idle_timeout_s) ctx->settings.es_idle_timeout = idle_timeout_s > 600 ? 600 : idle_timeout_s;
 
     struct lsquic_engine_api api;
@@ -781,7 +966,17 @@ DEF_CB(on_stream_headers, void (*cb)(us_quic_stream_t *))
 DEF_CB(on_stream_data, void (*cb)(us_quic_stream_t *, const char *, unsigned int, int))
 DEF_CB(on_stream_writable, void (*cb)(us_quic_stream_t *))
 DEF_CB(on_stream_close, void (*cb)(us_quic_stream_t *))
+DEF_CB(on_datagram, void (*cb)(us_quic_stream_t *, const char *, unsigned int))
 #undef DEF_CB
+
+void us_quic_socket_context_on_wt_stream_data(us_quic_socket_context_t *ctx,
+    void (*cb)(us_quic_stream_t *, us_quic_stream_t *, const char *, unsigned int, int)) {
+    ctx->on_wt_stream_data = cb;
+}
+void us_quic_socket_context_on_wt_stream_close(us_quic_socket_context_t *ctx,
+    void (*cb)(us_quic_stream_t *, us_quic_stream_t *)) {
+    ctx->on_wt_stream_close = cb;
+}
 
 int us_quic_stream_write(us_quic_stream_t *s, const char *data, unsigned int len) {
     if (!s->stream) return -1;
@@ -850,10 +1045,12 @@ int us_quic_stream_send_headers(us_quic_stream_t *s,
     int r = lsquic_stream_send_headers(s->stream, &lh, end_stream);
     if (buf != stackbuf) free(buf);
     if (xh != stackh) free(xh);
-    if (end_stream && r == 0) lsquic_stream_shutdown(s->stream, 1);
-    /* Mark the context dirty so drainQuicIfNecessary picks up header-only
-     * responses (204/304) that never call us_quic_stream_write. */
-    if (r == 0) s->ctx->pending_write_bytes += (unsigned int) total + 1;
+    if (r == 0) {
+        if (end_stream) lsquic_stream_shutdown(s->stream, 1);
+        /* Mark the context dirty so drainQuicIfNecessary picks up header-only
+         * responses (204/304) that never call us_quic_stream_write. */
+        s->ctx->pending_write_bytes += (unsigned int) total + 1;
+    }
     return r;
 }
 
@@ -881,6 +1078,66 @@ us_quic_socket_t *us_quic_stream_socket(us_quic_stream_t *s) {
 }
 
 us_quic_socket_context_t *us_quic_stream_context(us_quic_stream_t *s) { return s->ctx; }
+
+unsigned long long us_quic_stream_id(us_quic_stream_t *s) {
+    return s->stream ? (unsigned long long) lsquic_stream_id(s->stream) : (unsigned long long) -1;
+}
+
+void us_quic_stream_set_webtransport_session(us_quic_stream_t *s) {
+    if (!s->stream || s->wt_kind == 1) return;
+    lsquic_stream_set_webtransport_session(s->stream);
+    s->wt_kind = 1;
+    /* The 200 HEADERS we just queued via lsquic_stream_send_headers gets
+     * stashed and written from lsquic's internal header-block on_write,
+     * which then restores our callback but leaves the bytes sitting in
+     * sm_buf with wantwrite cleared. Re-arm wantwrite so us_quic_on_write
+     * runs once afterwards and flushes them — otherwise the client never
+     * sees the 2xx and the session looks half-open. */
+    lsquic_stream_wantwrite(s->stream, 1);
+    us_quic_socket_t *qs = us_quic_stream_socket(s);
+    if (!qs) return;
+    s->wt_next_on_conn = qs->wt_sessions;
+    qs->wt_sessions = s;
+}
+
+int us_quic_stream_send_datagram(us_quic_stream_t *session,
+    const char *data, unsigned int len, unsigned int max_queued)
+{
+    if (!session->stream || session->wt_kind != 1) return -1;
+    us_quic_socket_t *qs = us_quic_stream_socket(session);
+    if (!qs) return -1;
+    /* Prepend Quarter Stream ID (CONNECT stream id / 4). */
+    unsigned char prefix[8];
+    unsigned int plen = us_quic_varint_write(prefix,
+        (uint64_t) lsquic_stream_id(session->stream) / 4);
+    unsigned int total = plen + len;
+    /* lsquic offers an MTU-bounded buffer in on_dg_write; anything larger is
+     * dropped there, so reject up front. 1200 is the QUIC default initial
+     * max_udp_payload_size minus headers — conservative but predictable. */
+    if (total > 1200) return -1;
+    if (max_queued && session->wt_dgram_bytes + total > max_queued) return -1;
+    struct us_quic_dgram *d = (struct us_quic_dgram *) malloc(sizeof(*d) + total);
+    if (!d) return -1;
+    d->next = NULL;
+    d->session = session;
+    d->len = total;
+    memcpy(d + 1, prefix, plen);
+    memcpy((char *)(d + 1) + plen, data, len);
+    if (qs->dgram_tail) qs->dgram_tail->next = d; else qs->dgram_head = d;
+    qs->dgram_tail = d;
+    qs->dgram_bytes += total;
+    int prev = (int) session->wt_dgram_bytes;
+    session->wt_dgram_bytes += total;
+    lsquic_conn_want_datagram_write(qs->conn, 1);
+    /* Same flush gating as stream writes: bytes go out at the next
+     * process_conns, not inline. */
+    session->ctx->pending_write_bytes += total;
+    return prev;
+}
+
+unsigned int us_quic_stream_datagram_buffered(us_quic_stream_t *session) {
+    return session->wt_dgram_bytes;
+}
 
 
 unsigned int us_quic_stream_header_count(us_quic_stream_t *s) {

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -88,6 +88,7 @@ struct us_quic_socket_context_s {
     void (*on_wt_stream_data)(us_quic_stream_t *, us_quic_stream_t *, const char *, unsigned int, int);
     void (*on_wt_stream_close)(us_quic_stream_t *, us_quic_stream_t *);
     void (*on_datagram)(us_quic_stream_t *, const char *, unsigned int);
+    void (*on_datagram_drain)(us_quic_stream_t *);
 
     char read_buf[US_QUIC_READ_BUF];
     /* ext follows */
@@ -695,15 +696,29 @@ static ssize_t us_quic_on_dg_write(lsquic_conn_t *conn, void *buf, size_t sz) {
         qs->dgram_head = d->next;
         if (!qs->dgram_head) qs->dgram_tail = NULL;
         qs->dgram_bytes -= d->len;
-        if (d->session) d->session->wt_dgram_bytes -= d->len;
+        us_quic_stream_t *drained = NULL;
+        if (d->session) {
+            d->session->wt_dgram_bytes -= d->len;
+            if (d->session->wt_dgram_bytes == 0) drained = d->session;
+        }
         if (d->len <= sz) {
             memcpy(buf, d + 1, d->len);
             ssize_t r = (ssize_t) d->len;
             free(d);
             if (qs->dgram_head) lsquic_conn_want_datagram_write(conn, 1);
+            /* Fire drain after the datagram is handed to lsquic so a
+             * ws.send() inside the handler queues behind this one rather
+             * than racing it. The session's stream slot is still live
+             * (wt_session only clears in on_stream_close). */
+            if (drained && qs->ctx->on_datagram_drain)
+                qs->ctx->on_datagram_drain(drained);
             return r;
         }
         free(d);
+        /* Oversize entry dropped; if it was the last one for this session
+         * the queue is still drained from the caller's perspective. */
+        if (drained && qs->ctx->on_datagram_drain)
+            qs->ctx->on_datagram_drain(drained);
     }
 }
 
@@ -967,6 +982,7 @@ DEF_CB(on_stream_data, void (*cb)(us_quic_stream_t *, const char *, unsigned int
 DEF_CB(on_stream_writable, void (*cb)(us_quic_stream_t *))
 DEF_CB(on_stream_close, void (*cb)(us_quic_stream_t *))
 DEF_CB(on_datagram, void (*cb)(us_quic_stream_t *, const char *, unsigned int))
+DEF_CB(on_datagram_drain, void (*cb)(us_quic_stream_t *))
 #undef DEF_CB
 
 void us_quic_socket_context_on_wt_stream_data(us_quic_socket_context_t *ctx,

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -84,6 +84,24 @@ void us_quic_socket_context_on_stream_writable(us_quic_socket_context_t *ctx,
 void us_quic_socket_context_on_stream_close(us_quic_socket_context_t *ctx,
     void (*on_close)(us_quic_stream_t *));
 
+/* WebTransport (draft-ietf-webtrans-http3). es_webtransport_server /
+ * es_datagrams are flipped unconditionally in us_create_quic_socket_context
+ * (lsquic snapshots settings at engine_new), so these registrations only
+ * arm the callbacks. on_wt_stream_data fires for client-initiated bidi
+ * streams that opened with the 0x41 signal value; `session` is the CONNECT
+ * stream (looked up via Session ID), or NULL if the session arrived later /
+ * was already closed. on_datagram fires for raw QUIC DATAGRAM payloads with
+ * the Quarter Stream ID prefix already stripped. */
+void us_quic_socket_context_on_wt_stream_data(us_quic_socket_context_t *ctx,
+    void (*on_wt_data)(us_quic_stream_t *, us_quic_stream_t *session,
+        const char *, unsigned int, int fin));
+/* Fires once for each 0x41 bidi stream when it closes (FIN or RESET).
+ * `session` is resolved at close time (NULL if already gone). */
+void us_quic_socket_context_on_wt_stream_close(us_quic_socket_context_t *ctx,
+    void (*on_wt_close)(us_quic_stream_t *, us_quic_stream_t *session));
+void us_quic_socket_context_on_datagram(us_quic_socket_context_t *ctx,
+    void (*on_datagram)(us_quic_stream_t *session, const char *, unsigned int));
+
 /* Stream I/O. Read happens via on_stream_data; write returns bytes accepted
  * (may be < len under flow-control backpressure). */
 int us_quic_stream_write(us_quic_stream_t *s, const char *data, unsigned int len);
@@ -102,6 +120,23 @@ int us_quic_stream_has_unacked(us_quic_stream_t *s);
 void *us_quic_stream_ext(us_quic_stream_t *s);
 us_quic_socket_t *us_quic_stream_socket(us_quic_stream_t *s);
 us_quic_socket_context_t *us_quic_stream_context(us_quic_stream_t *s);
+unsigned long long us_quic_stream_id(us_quic_stream_t *s);
+
+/* Promote a CONNECT stream to a WebTransport session: links it into the
+ * connection's session list so incoming WT bidi streams and datagrams can
+ * be routed by Session ID. Call once, after sending the 2xx HEADERS. */
+void us_quic_stream_set_webtransport_session(us_quic_stream_t *s);
+/* Queue a QUIC DATAGRAM with the session's Quarter Stream ID prefix. The
+ * payload is copied; total (prefix + len) must fit in one frame, i.e. ~1200
+ * bytes after QUIC packet overhead. Returns -1 if the session is closed, the
+ * queue is full (max_queued reached), or len exceeds MTU; otherwise returns
+ * the per-session queued byte count *before* this enqueue (0 ⇒ first in
+ * queue, caller may report SUCCESS rather than BACKPRESSURE). */
+int us_quic_stream_send_datagram(us_quic_stream_t *session,
+    const char *data, unsigned int len, unsigned int max_queued);
+/* Outstanding queued bytes (for getBufferedAmount); 0 once on_dg_write
+ * has consumed everything we queued. */
+unsigned int us_quic_stream_datagram_buffered(us_quic_stream_t *session);
 
 /* Drive every QUIC engine on `loop` and re-arm the per-loop fallthrough
  * timer to the soonest earliest_adv_tick. Called from us_internal_loop_post

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -128,8 +128,9 @@ unsigned long long us_quic_stream_id(us_quic_stream_t *s);
 void us_quic_stream_set_webtransport_session(us_quic_stream_t *s);
 /* Queue a QUIC DATAGRAM with the session's Quarter Stream ID prefix. The
  * payload is copied; total (prefix + len) must fit in one frame, i.e. ~1200
- * bytes after QUIC packet overhead. Returns -1 if the session is closed, the
- * queue is full (max_queued reached), or len exceeds MTU; otherwise returns
+ * bytes after QUIC packet overhead. Returns -1 if the session is closed or
+ * len exceeds MTU; -2 if the per-session queue would exceed max_queued
+ * (the only case that should trigger closeOnBackpressureLimit); otherwise
  * the per-session queued byte count *before* this enqueue (0 ⇒ first in
  * queue, caller may report SUCCESS rather than BACKPRESSURE). */
 int us_quic_stream_send_datagram(us_quic_stream_t *session,

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -101,6 +101,11 @@ void us_quic_socket_context_on_wt_stream_close(us_quic_socket_context_t *ctx,
     void (*on_wt_close)(us_quic_stream_t *, us_quic_stream_t *session));
 void us_quic_socket_context_on_datagram(us_quic_socket_context_t *ctx,
     void (*on_datagram)(us_quic_stream_t *session, const char *, unsigned int));
+/* Fires once a session's outgoing datagram queue transitions to empty.
+ * Lets the WebSocket-shaped drain() handler actually track datagram
+ * backpressure instead of the CONNECT stream's (unrelated) writability. */
+void us_quic_socket_context_on_datagram_drain(us_quic_socket_context_t *ctx,
+    void (*on_datagram_drain)(us_quic_stream_t *session));
 
 /* Stream I/O. Read happens via on_stream_data; write returns bytes accepted
  * (may be < len under flow-control backpressure). */

--- a/packages/bun-uws/src/Http3App.h
+++ b/packages/bun-uws/src/Http3App.h
@@ -44,6 +44,64 @@ struct H3App {
     H3_METHOD(any, "*")
 #undef H3_METHOD
 
+    /* WebSocket-shaped behaviour but no upgrade callback: the CONNECT
+     * request is routed like any other "connect"-method handler so the
+     * application can inspect headers (Origin, WT-Available-Protocols) and
+     * decide whether to res->upgradeWebTransport(). open/message/drain/close
+     * are stored on the context and dispatched from the WT stream/datagram
+     * callbacks. */
+    struct WebTransportBehavior {
+        unsigned int maxPayloadLength = 16 * 1024;
+        unsigned int maxBackpressure = 64 * 1024;
+        bool closeOnBackpressureLimit = false;
+        MoveOnlyFunction<void(Http3Response *, Http3Request *)> upgrade = nullptr;
+        MoveOnlyFunction<void(WebTransportSession *)> open = nullptr;
+        MoveOnlyFunction<void(WebTransportSession *, std::string_view, OpCode)> message = nullptr;
+        MoveOnlyFunction<void(WebTransportSession *)> drain = nullptr;
+        MoveOnlyFunction<void(WebTransportSession *, int, std::string_view)> close = nullptr;
+    };
+
+    H3App &&wt(std::string_view pattern, WebTransportBehavior &&behavior) {
+        WebTransportContextData *cd = &http3Context->getContextData()->wt;
+        cd->maxPayloadLength = behavior.maxPayloadLength;
+        cd->maxBackpressure = behavior.maxBackpressure;
+        cd->closeOnBackpressureLimit = behavior.closeOnBackpressureLimit;
+        cd->openHandler = std::move(behavior.open);
+        cd->messageHandler = std::move(behavior.message);
+        cd->drainHandler = std::move(behavior.drain);
+        cd->closeHandler = std::move(behavior.close);
+        if (!cd->topicTree) {
+            cd->topicTree = new TopicTree<TopicTreeMessage, TopicTreeBigMessage>(
+                [](Subscriber *s, TopicTreeMessage &m, auto) {
+                    ((WebTransportSession *) s->user)->send(m.message, (OpCode) m.opCode);
+                    return false;
+                });
+        }
+        /* Route the CONNECT itself. The handler is what decides 200 vs 404
+         * vs 403; the spec's :protocol check happens here so non-WT CONNECTs
+         * (e.g. RFC 9220 websocket-over-h3) fall through to the next route. */
+        http3Context->onHttp("connect", pattern,
+            [upgrade = std::move(behavior.upgrade)](Http3Response *res, Http3Request *req) mutable {
+                std::string_view proto = req->getHeader(":protocol");
+                if (proto != "webtransport" && proto != "webtransport-h3") {
+                    req->setYield(true);
+                    return;
+                }
+                if (upgrade) upgrade(res, req);
+                else res->upgradeWebTransport(nullptr);
+            });
+        return std::move(*this);
+    }
+
+    bool publish(std::string_view topic, std::string_view message, OpCode opCode = BINARY, bool = false) {
+        WebTransportContextData *cd = &http3Context->getContextData()->wt;
+        if (!cd->topicTree) return false;
+        return cd->topicTree->publishBig(nullptr, topic, {message, opCode, false},
+            [](Subscriber *s, TopicTreeBigMessage &m) {
+                ((WebTransportSession *) s->user)->send(m.message, (OpCode) m.opCode);
+            });
+    }
+
     H3App &&listen(const std::string &host, int port, int /*options*/,
                    MoveOnlyFunction<void(us_quic_listen_socket_t *)> &&cb) {
         cb(http3Context->listen(host.empty() ? nullptr : host.c_str(), port));

--- a/packages/bun-uws/src/Http3App.h
+++ b/packages/bun-uws/src/Http3App.h
@@ -102,6 +102,13 @@ struct H3App {
             });
     }
 
+    unsigned numSubscribers(std::string_view topic) {
+        WebTransportContextData *cd = &http3Context->getContextData()->wt;
+        if (!cd->topicTree) return 0;
+        Topic *t = cd->topicTree->lookupTopic(topic);
+        return t ? (unsigned) t->size() : 0;
+    }
+
     H3App &&listen(const std::string &host, int port, int /*options*/,
                    MoveOnlyFunction<void(us_quic_listen_socket_t *)> &&cb) {
         cb(http3Context->listen(host.empty() ? nullptr : host.c_str(), port));

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -39,28 +39,190 @@ struct Http3Context {
         us_quic_socket_context_on_stream_data(ctx, [](us_quic_stream_t *s, const char *data, unsigned len, int fin) {
             Http3Response *res = (Http3Response *) s;
             Http3ResponseData *rd = res->getHttpResponseData();
+            if (rd->wt) {
+                /* CONNECT-stream body after upgrade is the Capsule Protocol
+                 * (RFC 9297). The only capsule we act on is WT_CLOSE_SESSION;
+                 * everything else (WT_DRAIN_SESSION, flow-control capsules,
+                 * unknown types) is parsed for length and skipped. */
+                Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
+                handleConnectStreamData(cd, (WebTransportSession *) s, rd->wt, data, len, fin != 0);
+                return;
+            }
             if (rd->inStream) rd->inStream(res, data, len, fin != 0, rd->userData);
+        });
+
+        us_quic_socket_context_on_wt_stream_data(ctx, [](us_quic_stream_t *s, us_quic_stream_t *session,
+                                                         const char *data, unsigned len, int fin) {
+            Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
+            WebTransportSessionData *d = session
+                ? ((Http3ResponseData *) us_quic_stream_ext(session))->wt : nullptr;
+            if (!d || d->isShuttingDown) {
+                /* §4.6: stream arrived before its CONNECT (or after the
+                 * session closed). We don't buffer; reject with
+                 * WT_BUFFERED_STREAM_REJECTED semantics by closing now —
+                 * waiting for FIN would let a hostile client hold the slot
+                 * and stream indefinitely. */
+                us_quic_stream_close(s);
+                return;
+            }
+            /* Reassemble into a per-stream buffer until FIN, then deliver as
+             * one BINARY message — the WebSocket message handler expects
+             * whole frames. inflight is keyed by stream id (not pointer):
+             * a RESET_STREAM never delivers fin=1 so the entry would
+             * otherwise survive, and the next calloc'd us_quic_stream_t can
+             * reuse the same address, splicing two streams' bytes together. */
+            unsigned long long sid = us_quic_stream_id(s);
+            std::string *buf = nullptr;
+            for (auto &i : d->inflight) if (i.id == sid) { buf = &i.buf; break; }
+            if (!buf) { d->inflight.push_back({sid, {}}); buf = &d->inflight.back().buf; }
+            if (buf->length() + len > cd->wt.maxPayloadLength) {
+                us_quic_stream_close(s);
+                for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
+                    if (it->id == sid) { d->inflight.erase(it); break; }
+                return;
+            }
+            buf->append(data, len);
+            if (fin) {
+                std::string msg = std::move(*buf);
+                for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
+                    if (it->id == sid) { d->inflight.erase(it); break; }
+                if (cd->wt.messageHandler)
+                    cd->wt.messageHandler((WebTransportSession *) session, msg, BINARY);
+                us_quic_stream_shutdown(s);
+            }
+        });
+
+        us_quic_socket_context_on_wt_stream_close(ctx, [](us_quic_stream_t *s, us_quic_stream_t *session) {
+            if (!session) return;
+            WebTransportSessionData *d = ((Http3ResponseData *) us_quic_stream_ext(session))->wt;
+            if (!d) return;
+            unsigned long long sid = us_quic_stream_id(s);
+            for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
+                if (it->id == sid) { d->inflight.erase(it); break; }
+        });
+
+        us_quic_socket_context_on_datagram(ctx, [](us_quic_stream_t *session, const char *data, unsigned len) {
+            Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(session));
+            WebTransportSessionData *d = ((Http3ResponseData *) us_quic_stream_ext(session))->wt;
+            if (!d || d->isShuttingDown || !cd->wt.messageHandler) return;
+            cd->wt.messageHandler((WebTransportSession *) session, std::string_view{data, len}, BINARY);
         });
 
         us_quic_socket_context_on_stream_writable(ctx, [](us_quic_stream_t *s) {
             Http3Response *res = (Http3Response *) s;
+            Http3ResponseData *rd = res->getHttpResponseData();
+            if (rd->wt) {
+                Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
+                if (cd->wt.drainHandler && !rd->wt->isShuttingDown)
+                    cd->wt.drainHandler((WebTransportSession *) s);
+                return;
+            }
             if (!res->drain()) us_quic_stream_want_write(s, 1);
         });
 
         us_quic_socket_context_on_stream_close(ctx, [](us_quic_stream_t *s) {
             Http3Response *res = (Http3Response *) s;
             Http3ResponseData *rd = res->getHttpResponseData();
-            /* Fire onAborted for both real aborts and post-completion stream
-             * teardown. The handler distinguishes via hasResponded(); for the
-             * completed case it just drops its pointer so it doesn't outlive
-             * this destructor. */
-            if (rd->onAborted) {
+            if (rd->wt) {
+                Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
+                WebTransportSession *ws = (WebTransportSession *) s;
+                WebTransportSessionData *d = rd->wt;
+                if (!d->isShuttingDown) {
+                    d->isShuttingDown = true;
+                    if (d->subscriber) {
+                        cd->wt.topicTree->freeSubscriber(d->subscriber);
+                        d->subscriber = nullptr;
+                    }
+                    if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1006, {});
+                }
+                delete d;
+                rd->wt = nullptr;
+            } else if (rd->onAborted) {
+                /* Fire onAborted for both real aborts and post-completion stream
+                 * teardown. The handler distinguishes via hasResponded(); for the
+                 * completed case it just drops its pointer so it doesn't outlive
+                 * this destructor. */
                 rd->onAborted(res, rd->userData);
             }
             rd->~Http3ResponseData();
         });
 
         return (Http3Context *) ctx;
+    }
+
+    /* Capsule Protocol parsing on the CONNECT stream body. Only
+     * WT_CLOSE_SESSION (0x2843) is acted on; everything else is skipped by
+     * length. The wire is varint type, varint length, payload — but we may
+     * receive it in arbitrary chunks, so accumulate in d->capsuleBuf until a
+     * full capsule is available. */
+    static void handleConnectStreamData(Http3ContextData *cd, WebTransportSession *ws,
+                                        WebTransportSessionData *d,
+                                        const char *data, unsigned len, bool fin) {
+        if (d->isShuttingDown) return;
+        /* RFC 9297 §3.3: an endpoint MUST reset the data stream if it
+         * receives a Capsule Length exceeding what it is willing to buffer.
+         * The same cap applies to slow-dripping a capsule body — without
+         * this a single client can append forever and OOM the process. */
+        if (d->capsuleBuf.length() + len > cd->wt.maxPayloadLength) {
+            d->isShuttingDown = true;
+            if (d->subscriber) {
+                cd->wt.topicTree->freeSubscriber(d->subscriber);
+                d->subscriber = nullptr;
+            }
+            if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1009, {});
+            us_quic_stream_close((us_quic_stream_t *) ws);
+            return;
+        }
+        d->capsuleBuf.append(data, len);
+        const unsigned char *p = (const unsigned char *) d->capsuleBuf.data();
+        const unsigned char *end = p + d->capsuleBuf.size();
+        auto readVarint = [](const unsigned char *&p, const unsigned char *end, uint64_t &out) -> bool {
+            if (p >= end) return false;
+            unsigned n = 1u << (*p >> 6);
+            if ((unsigned)(end - p) < n) return false;
+            out = *p & 0x3f;
+            for (unsigned i = 1; i < n; i++) out = (out << 8) | p[i];
+            p += n; return true;
+        };
+        while (p < end) {
+            const unsigned char *start = p;
+            uint64_t type, clen;
+            if (!readVarint(p, end, type) || !readVarint(p, end, clen)) { p = start; break; }
+            if ((uint64_t)(end - p) < clen) { p = start; break; }
+            if (type == 0x2843 /* WT_CLOSE_SESSION */) {
+                int code = 0; std::string_view msg;
+                if (clen >= 4) {
+                    code = (int)((uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 |
+                                 (uint32_t)p[2] << 8  | (uint32_t)p[3]);
+                    msg = {(const char *)(p + 4), (size_t)(clen - 4)};
+                }
+                d->isShuttingDown = true;
+                if (d->subscriber) {
+                    cd->wt.topicTree->freeSubscriber(d->subscriber);
+                    d->subscriber = nullptr;
+                }
+                if (cd->wt.closeHandler) cd->wt.closeHandler(ws, code, msg);
+                us_quic_stream_shutdown((us_quic_stream_t *) ws);
+                d->capsuleBuf.clear();
+                return;
+            }
+            p += clen;
+        }
+        d->capsuleBuf.erase(0, (size_t)(p - (const unsigned char *) d->capsuleBuf.data()));
+        if (fin) {
+            /* Clean FIN with no WT_CLOSE_SESSION ≡ {0, ""}. Mirror the
+             * capsule branch above and shut our write side too — lsquic only
+             * schedules on_close once both U_READ_DONE and U_WRITE_DONE are
+             * set, so leaving the write side open would leak the stream and
+             * its WebTransportSessionData until connection teardown. */
+            d->isShuttingDown = true;
+            if (d->subscriber) {
+                cd->wt.topicTree->freeSubscriber(d->subscriber);
+                d->subscriber = nullptr;
+            }
+            if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 0, {});
+            us_quic_stream_shutdown((us_quic_stream_t *) ws);
+        }
     }
 
     void free() {

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -119,6 +119,13 @@ struct Http3Context {
             Http3Response *res = (Http3Response *) s;
             Http3ResponseData *rd = res->getHttpResponseData();
             if (rd->wt) {
+                /* WebTransportSession::end() may have stashed a partial
+                 * WT_CLOSE_SESSION capsule in backpressure; flush + FIN via
+                 * the same path the HTTP body uses. */
+                if (rd->backpressure.length() || rd->endAfterDrain) {
+                    if (!res->drain()) us_quic_stream_want_write(s, 1);
+                    return;
+                }
                 Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
                 if (cd->wt.drainHandler && !rd->wt->isShuttingDown)
                     cd->wt.drainHandler((WebTransportSession *) s);

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -75,15 +75,22 @@ struct Http3Context {
             std::string *buf = nullptr;
             for (auto &i : d->inflight) if (i.id == sid) { buf = &i.buf; break; }
             if (!buf) { d->inflight.push_back({sid, {}}); buf = &d->inflight.back().buf; }
-            if (buf->length() + len > cd->wt.maxPayloadLength) {
+            /* maxPayloadLength caps each stream; maxBackpressure caps the
+             * session aggregate so opening many streams just under the
+             * per-stream cap can't sidestep the budget. */
+            if (buf->length() + len > cd->wt.maxPayloadLength
+                || d->inflightBytes + len > cd->wt.maxBackpressure) {
                 us_quic_stream_close(s);
+                d->inflightBytes -= buf->length();
                 for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
                     if (it->id == sid) { d->inflight.erase(it); break; }
                 return;
             }
             buf->append(data, len);
+            d->inflightBytes += len;
             if (fin) {
                 std::string msg = std::move(*buf);
+                d->inflightBytes -= msg.length();
                 for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
                     if (it->id == sid) { d->inflight.erase(it); break; }
                 if (cd->wt.messageHandler)
@@ -98,7 +105,7 @@ struct Http3Context {
             if (!d) return;
             unsigned long long sid = us_quic_stream_id(s);
             for (auto it = d->inflight.begin(); it != d->inflight.end(); ++it)
-                if (it->id == sid) { d->inflight.erase(it); break; }
+                if (it->id == sid) { d->inflightBytes -= it->buf.length(); d->inflight.erase(it); break; }
         });
 
         us_quic_socket_context_on_datagram(ctx, [](us_quic_stream_t *session, const char *data, unsigned len) {

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -112,6 +112,7 @@ struct Http3Context {
             Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(session));
             WebTransportSessionData *d = ((Http3ResponseData *) us_quic_stream_ext(session))->wt;
             if (!d || d->isShuttingDown || !cd->wt.messageHandler) return;
+            if (len > cd->wt.maxPayloadLength) return;
             cd->wt.messageHandler((WebTransportSession *) session, std::string_view{data, len}, BINARY);
         });
 
@@ -202,6 +203,20 @@ struct Http3Context {
             const unsigned char *start = p;
             uint64_t type, clen;
             if (!readVarint(p, end, type) || !readVarint(p, end, clen)) { p = start; break; }
+            if (clen > cd->wt.maxPayloadLength) {
+                /* RFC 9297 §3.3: reset on a Capsule Length we won't buffer.
+                 * Do this on the advertised length so a header-only attack
+                 * (huge clen, never send the body) can't sit out the idle
+                 * timeout. */
+                d->isShuttingDown = true;
+                if (d->subscriber) {
+                    cd->wt.topicTree->freeSubscriber(d->subscriber);
+                    d->subscriber = nullptr;
+                }
+                if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1009, {});
+                us_quic_stream_close((us_quic_stream_t *) ws);
+                return;
+            }
             if ((uint64_t)(end - p) < clen) { p = start; break; }
             if (type == 0x2843 /* WT_CLOSE_SESSION */) {
                 int code = 0; std::string_view msg;

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -188,6 +188,23 @@ struct Http3Context {
         return (Http3Context *) ctx;
     }
 
+    /* Synchronous-close helper shared by the CONNECT-stream capsule
+     * paths below and WebTransportSession::end(). Sets closeFired so the
+     * later on_stream_close (which fires once lsquic tears the stream
+     * down) doesn't invoke the user's close() a second time with the
+     * default 1006/"" — a regression the deferred-close refactor would
+     * otherwise introduce for every client-initiated WT close. */
+    static void fireClose(Http3ContextData *cd, WebTransportSession *ws,
+                          WebTransportSessionData *d, int code, std::string_view msg) {
+        d->isShuttingDown = true;
+        if (d->subscriber) {
+            cd->wt.topicTree->freeSubscriber(d->subscriber);
+            d->subscriber = nullptr;
+        }
+        d->closeFired = true;
+        if (cd->wt.closeHandler) cd->wt.closeHandler(ws, code, msg);
+    }
+
     /* Capsule Protocol parsing on the CONNECT stream body. Only
      * WT_CLOSE_SESSION (0x2843) is acted on; everything else is skipped by
      * length. The wire is varint type, varint length, payload — but we may
@@ -202,12 +219,7 @@ struct Http3Context {
          * The same cap applies to slow-dripping a capsule body — without
          * this a single client can append forever and OOM the process. */
         if (d->capsuleBuf.length() + len > cd->wt.maxPayloadLength) {
-            d->isShuttingDown = true;
-            if (d->subscriber) {
-                cd->wt.topicTree->freeSubscriber(d->subscriber);
-                d->subscriber = nullptr;
-            }
-            if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1009, {});
+            fireClose(cd, ws, d, 1009, {});
             us_quic_stream_close((us_quic_stream_t *) ws);
             return;
         }
@@ -231,12 +243,7 @@ struct Http3Context {
                  * Do this on the advertised length so a header-only attack
                  * (huge clen, never send the body) can't sit out the idle
                  * timeout. */
-                d->isShuttingDown = true;
-                if (d->subscriber) {
-                    cd->wt.topicTree->freeSubscriber(d->subscriber);
-                    d->subscriber = nullptr;
-                }
-                if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1009, {});
+                fireClose(cd, ws, d, 1009, {});
                 us_quic_stream_close((us_quic_stream_t *) ws);
                 return;
             }
@@ -248,12 +255,7 @@ struct Http3Context {
                                  (uint32_t)p[2] << 8  | (uint32_t)p[3]);
                     msg = {(const char *)(p + 4), (size_t)(clen - 4)};
                 }
-                d->isShuttingDown = true;
-                if (d->subscriber) {
-                    cd->wt.topicTree->freeSubscriber(d->subscriber);
-                    d->subscriber = nullptr;
-                }
-                if (cd->wt.closeHandler) cd->wt.closeHandler(ws, code, msg);
+                fireClose(cd, ws, d, code, msg);
                 us_quic_stream_shutdown((us_quic_stream_t *) ws);
                 d->capsuleBuf.clear();
                 return;
@@ -267,12 +269,7 @@ struct Http3Context {
              * schedules on_close once both U_READ_DONE and U_WRITE_DONE are
              * set, so leaving the write side open would leak the stream and
              * its WebTransportSessionData until connection teardown. */
-            d->isShuttingDown = true;
-            if (d->subscriber) {
-                cd->wt.topicTree->freeSubscriber(d->subscriber);
-                d->subscriber = nullptr;
-            }
-            if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 0, {});
+            fireClose(cd, ws, d, 0, {});
             us_quic_stream_shutdown((us_quic_stream_t *) ws);
         }
     }

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -155,13 +155,23 @@ struct Http3Context {
                 Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
                 WebTransportSession *ws = (WebTransportSession *) s;
                 WebTransportSessionData *d = rd->wt;
-                if (!d->isShuttingDown) {
-                    d->isShuttingDown = true;
-                    if (d->subscriber) {
-                        cd->wt.topicTree->freeSubscriber(d->subscriber);
-                        d->subscriber = nullptr;
-                    }
-                    if (cd->wt.closeHandler) cd->wt.closeHandler(ws, 1006, {});
+                d->isShuttingDown = true;
+                /* Subscriber cleanup and closeHandler live here — not in
+                 * end() alone — so send()'s closeOnBackpressureLimit path
+                 * (which can run from inside TopicTree::publishBig()'s
+                 * range-for over the Topic set) can defer to this point
+                 * via us_quic_stream_close() instead of mutating the set
+                 * it's iterating. end() nulls d->subscriber and sets
+                 * closeFired, so a user-initiated ws.close() still runs
+                 * them synchronously and this becomes a no-op. */
+                if (d->subscriber) {
+                    cd->wt.topicTree->freeSubscriber(d->subscriber);
+                    d->subscriber = nullptr;
+                }
+                if (!d->closeFired) {
+                    d->closeFired = true;
+                    if (cd->wt.closeHandler)
+                        cd->wt.closeHandler(ws, d->closeCode, d->closeReason);
                 }
                 delete d;
                 rd->wt = nullptr;

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -116,20 +116,33 @@ struct Http3Context {
             cd->wt.messageHandler((WebTransportSession *) session, std::string_view{data, len}, BINARY);
         });
 
+        /* ws.send() backpressure is the per-session datagram queue, not the
+         * CONNECT stream's flow control, so drain() is driven off the queue
+         * going empty rather than on_stream_writable. Gate on hadBackpressure
+         * so the first send() (which reports SUCCESS) doesn't fire drain()
+         * once it leaves the queue. */
+        us_quic_socket_context_on_datagram_drain(ctx, [](us_quic_stream_t *session) {
+            WebTransportSessionData *d = ((Http3ResponseData *) us_quic_stream_ext(session))->wt;
+            if (!d || d->isShuttingDown || !d->hadBackpressure) return;
+            d->hadBackpressure = false;
+            Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(session));
+            if (cd->wt.drainHandler) cd->wt.drainHandler((WebTransportSession *) session);
+        });
+
         us_quic_socket_context_on_stream_writable(ctx, [](us_quic_stream_t *s) {
             Http3Response *res = (Http3Response *) s;
             Http3ResponseData *rd = res->getHttpResponseData();
             if (rd->wt) {
                 /* WebTransportSession::end() may have stashed a partial
                  * WT_CLOSE_SESSION capsule in backpressure; flush + FIN via
-                 * the same path the HTTP body uses. */
+                 * the same path the HTTP body uses. CONNECT-stream
+                 * writability is otherwise unrelated to datagram drainage
+                 * (handled by on_datagram_drain above), so there is nothing
+                 * to do here for an open session — the one guaranteed
+                 * callback is the post-upgrade flush of the 2xx HEADERS. */
                 if (rd->backpressure.length() || rd->endAfterDrain) {
                     if (!res->drain()) us_quic_stream_want_write(s, 1);
-                    return;
                 }
-                Http3ContextData *cd = (Http3ContextData *) us_quic_socket_context_ext(us_quic_stream_context(s));
-                if (cd->wt.drainHandler && !rd->wt->isShuttingDown)
-                    cd->wt.drainHandler((WebTransportSession *) s);
                 return;
             }
             if (!res->drain()) us_quic_stream_want_write(s, 1);

--- a/packages/bun-uws/src/Http3ContextData.h
+++ b/packages/bun-uws/src/Http3ContextData.h
@@ -2,6 +2,7 @@
 #define UWS_H3CONTEXTDATA_H
 
 #include "HttpRouter.h"
+#include "WebTransportSession.h"
 
 namespace uWS {
 
@@ -14,7 +15,17 @@ struct Http3ContextData {
         Http3Request *httpRequest;
     };
     HttpRouter<RouterData> router;
+
+    /* Populated by H3App::wt(). The CONNECT request still goes through
+     * `router` (so wt() registers a "connect" route), but the stream/
+     * datagram callbacks dispatch via wt directly since they have no path. */
+    WebTransportContextData wt;
 };
+
+inline WebTransportContextData *WebTransportSession::getContextData() {
+    return &((Http3ContextData *) us_quic_socket_context_ext(
+        us_quic_stream_context((us_quic_stream_t *) this)))->wt;
+}
 
 }
 

--- a/packages/bun-uws/src/Http3Request.h
+++ b/packages/bun-uws/src/Http3Request.h
@@ -32,6 +32,8 @@ struct Http3Request {
                 query = q == std::string_view::npos ? std::string_view{} : value.substr(q);
             } else if (name == ":authority") {
                 authority = value;
+            } else if (name == ":protocol") {
+                protocol = value;
             } else if (authority.empty() && name.size() == 4 && equalsIgnoreCase(name, "host")) {
                 /* RFC 9114 §4.3.1: a request must contain :authority OR a
                  * Host field. Promote the literal Host so getHeader("host"),
@@ -66,8 +68,11 @@ struct Http3Request {
         return {methodLower, n};
     }
 
+    std::string_view getProtocol() { return protocol; }
+
     std::string_view getHeader(std::string_view lowerCasedHeader) {
         if (lowerCasedHeader == "host") return authority;
+        if (lowerCasedHeader == ":protocol") return protocol;
         unsigned int n = us_quic_stream_header_count(stream);
         for (unsigned int i = 0; i < n; i++) {
             const us_quic_header_t *h = us_quic_stream_header(stream, i);
@@ -112,7 +117,7 @@ private:
     }
 
     us_quic_stream_t *stream;
-    std::string_view method, url, fullUrl, query, authority;
+    std::string_view method, url, fullUrl, query, authority, protocol;
     std::pair<int, std::string_view *> params{-1, nullptr};
     char methodLower[32];
     bool yield = false;

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -152,7 +152,11 @@ struct Http3Response {
      * as `this`) or nullptr if the stream was already responded to. */
     struct WebTransportSession *upgradeWebTransport(void *userData) {
         Http3ResponseData *d = getHttpResponseData();
-        if (d->state & Http3ResponseData::HTTP_WRITE_CALLED) return nullptr;
+        /* endWithoutBody()/the zero-body internalEnd() path complete the
+         * response without ever setting HTTP_WRITE_CALLED, so gate on
+         * HTTP_RESPONSE_PENDING — the bit markDone() always clears. */
+        if (!(d->state & Http3ResponseData::HTTP_RESPONSE_PENDING)
+            || (d->state & Http3ResponseData::HTTP_WRITE_CALLED)) return nullptr;
         writeStatus("200 OK");
         writeHeader("sec-webtransport-http3-draft", "draft02");
         sendBufferedHeaders(d, false);

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -4,6 +4,7 @@
 #include "quic.h"
 #include "Http3ResponseData.h"
 #include "HttpResponseData.h"
+#include "WebTransportSession.h"
 
 #include <charconv>
 #include <optional>
@@ -143,6 +144,26 @@ struct Http3Response {
 
     void close() { us_quic_stream_close((us_quic_stream_t *) this); }
     void *getNativeHandle() { return this; }
+
+    /* Accept an extended-CONNECT WebTransport request: send 200, mark the
+     * lsquic stream as a session so the 0x41 bidi prefix and Quarter Stream
+     * ID datagram routing resolve to it, and swap this stream's ext over to
+     * the WebTransportSession path. Returns the session pointer (same memory
+     * as `this`) or nullptr if the stream was already responded to. */
+    struct WebTransportSession *upgradeWebTransport(void *userData) {
+        Http3ResponseData *d = getHttpResponseData();
+        if (d->state & Http3ResponseData::HTTP_WRITE_CALLED) return nullptr;
+        writeStatus("200 OK");
+        writeHeader("sec-webtransport-http3-draft", "draft02");
+        sendBufferedHeaders(d, false);
+        d->state |= Http3ResponseData::HTTP_WRITE_CALLED;
+        d->state &= ~Http3ResponseData::HTTP_RESPONSE_PENDING;
+        d->onAborted = nullptr;
+        us_quic_stream_set_webtransport_session((us_quic_stream_t *) this);
+        d->wt = new WebTransportSessionData;
+        d->wt->userData = userData;
+        return (struct WebTransportSession *) this;
+    }
     void *getSocketData() { return getHttpResponseData()->socketData; }
     bool isConnectRequest() { return false; }
     void setTimeout(uint8_t) {}

--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -11,6 +11,7 @@
 namespace uWS {
 
 struct Http3Response;
+struct WebTransportSessionData;
 
 struct Http3ResponseData {
     /* Same callback signatures as HttpResponseData so the C ABI matches. */
@@ -58,6 +59,12 @@ struct Http3ResponseData {
     /* Body bytes the QUIC stream couldn't accept yet. */
     BackPressure backpressure;
     bool endAfterDrain = false;
+
+    /* Set by Http3Response::upgradeWebTransport() once the CONNECT is
+     * accepted; the stream then routes through WebTransportSession instead
+     * of the HTTP body path. Heap-allocated so non-WT requests don't pay the
+     * std::vector / std::string footprint. */
+    WebTransportSessionData *wt = nullptr;
 
     uint64_t offset = 0;
     uint64_t totalSize = 0;

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -40,6 +40,10 @@ struct WebTransportSessionData {
      * could splice a dead stream's bytes onto a fresh one. */
     struct InflightStream { unsigned long long id; std::string buf; };
     std::vector<InflightStream> inflight;
+    /* Sum of inflight[].buf.length(); per-stream is capped at maxPayloadLength
+     * but without an aggregate the client could open N streams each at the
+     * cap-minus-one. */
+    size_t inflightBytes = 0;
     bool isShuttingDown = false;
     /* Incoming WT_CLOSE_SESSION capsule reassembly on the CONNECT stream. */
     std::string capsuleBuf;

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -88,13 +88,24 @@ struct WebTransportSession {
      * there is no per-frame opcode on the wire (RFC 9297 §2.1). DROPPED is
      * returned when the message is too large for one frame or the per-session
      * queue exceeds maxBackpressure. */
+    /* Conservative QUIC DATAGRAM payload cap: RFC 9000's default
+     * max_udp_payload_size minus short-header + AEAD + DATAGRAM-type
+     * overhead. us_quic_stream_send_datagram rejects above this; pre-check
+     * here so an oversize message reports DROPPED without being mistaken for
+     * backpressure (and thus never trips closeOnBackpressureLimit). */
+    static constexpr unsigned MAX_DATAGRAM_PAYLOAD = 1192;
+
     SendStatus send(std::string_view message, OpCode = BINARY, bool = false, bool = true) {
         WebTransportSessionData *d = getSessionData();
         if (!d || d->isShuttingDown) return DROPPED;
+        if (message.length() > MAX_DATAGRAM_PAYLOAD) return DROPPED;
         WebTransportContextData *cd = getContextData();
         int r = us_quic_stream_send_datagram((us_quic_stream_t *) this,
                 message.data(), (unsigned) message.length(), cd->maxBackpressure);
         if (r < 0) {
+            /* Only the maxBackpressure cap (or a dead session) reaches here;
+             * MTU was filtered above, so closeOnBackpressureLimit is the
+             * caller's intended signal. */
             if (cd->closeOnBackpressureLimit) end(1009, "Backpressure limit");
             return DROPPED;
         }
@@ -132,9 +143,21 @@ struct WebTransportSession {
             *p++ = (unsigned char)(c >> 8);  *p++ = (unsigned char) c;
             memcpy(p, message.data(), message.length()); p += message.length();
         }
-        us_quic_stream_write((us_quic_stream_t *) this, (const char *) capsule,
-            (unsigned)(p - capsule));
-        us_quic_stream_shutdown((us_quic_stream_t *) this);
+        unsigned total = (unsigned)(p - capsule);
+        int w = us_quic_stream_write((us_quic_stream_t *) this, (const char *) capsule, total);
+        if (w < 0) w = 0;
+        if ((unsigned) w < total) {
+            /* lsquic_stream_write may accept fewer bytes under flow control.
+             * Reuse the Http3ResponseData backpressure path so the WT
+             * on_stream_writable handler (which now calls drain()) flushes
+             * the tail and FINs once empty. */
+            Http3ResponseData *rd = getResponseData();
+            rd->backpressure.append((const char *) capsule + w, total - (unsigned) w);
+            rd->endAfterDrain = true;
+            us_quic_stream_want_write((us_quic_stream_t *) this, 1);
+        } else {
+            us_quic_stream_shutdown((us_quic_stream_t *) this);
+        }
 
         WebTransportContextData *cd = getContextData();
         if (d->subscriber) {

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -1,0 +1,213 @@
+#ifndef UWS_WEBTRANSPORTSESSION_H
+#define UWS_WEBTRANSPORTSESSION_H
+
+/* WebSocket-shaped façade over a WebTransport session (draft-ietf-webtrans-
+ * http3). The session IS the CONNECT stream; send() ships QUIC DATAGRAMs,
+ * end() emits a WT_CLOSE_SESSION capsule on the CONNECT stream then FINs it.
+ * Same SendStatus / OpCode surface as WebSocket<SSL,true,USERDATA> so the C
+ * ABI in libuwsockets_h3.cpp can pattern-match uws_ws_* and the Zig
+ * AnyWebSocket union dispatches without per-method special cases.
+ *
+ * The struct is a zero-member overlay on us_quic_stream_t (the CONNECT
+ * stream); per-session state lives in WebTransportSessionData stored in the
+ * stream's ext (the same slot as Http3ResponseData — see Http3ResponseData::wt).
+ */
+
+#include "quic.h"
+#include "TopicTree.h"
+#include "WebSocketContextData.h"
+#include "Http3ResponseData.h"
+
+#include <string>
+#include <string_view>
+
+namespace uWS {
+
+struct WebTransportSession;
+
+/* Stored in Http3ResponseData::wt once Http3Response::upgradeWebTransport()
+ * accepts the CONNECT. Heap-allocated so the per-stream ext stays the size of
+ * a plain HTTP response. */
+struct WebTransportSessionData {
+    void *userData = nullptr;
+    Subscriber *subscriber = nullptr;
+    /* Reassembly buffer for in-flight client bidi streams. WebTransport
+     * gives the client unlimited stream count, but the WebSocket message API
+     * delivers whole frames — accumulate until FIN, hand the buffer to the
+     * message handler, then drop. Keyed by QUIC stream id (not pointer): a
+     * RESET_STREAM never produces a FIN read, and us_quic_stream_t lives in
+     * a fixed-size calloc slot that mimalloc recycles LIFO, so a pointer key
+     * could splice a dead stream's bytes onto a fresh one. */
+    struct InflightStream { unsigned long long id; std::string buf; };
+    std::vector<InflightStream> inflight;
+    bool isShuttingDown = false;
+    /* Incoming WT_CLOSE_SESSION capsule reassembly on the CONNECT stream. */
+    std::string capsuleBuf;
+};
+
+/* One per H3App. Mirrors WebSocketContextData<SSL,USERDATA> minus the
+ * compression / ping machinery that has no WT equivalent. Shares the
+ * TopicTree shape (TopicTreeMessage / TopicTreeBigMessage) so a future
+ * cross-transport publish can fan out from one tree if desired; for now the
+ * H3App owns its own tree. */
+struct WebTransportContextData {
+    using Session = WebTransportSession;
+
+    MoveOnlyFunction<void(Session *)> openHandler = nullptr;
+    MoveOnlyFunction<void(Session *, std::string_view, OpCode)> messageHandler = nullptr;
+    MoveOnlyFunction<void(Session *)> drainHandler = nullptr;
+    MoveOnlyFunction<void(Session *, int, std::string_view)> closeHandler = nullptr;
+
+    unsigned int maxPayloadLength = 16 * 1024;
+    unsigned int maxBackpressure = 64 * 1024;
+    bool closeOnBackpressureLimit = false;
+
+    TopicTree<TopicTreeMessage, TopicTreeBigMessage> *topicTree = nullptr;
+
+    ~WebTransportContextData() { delete topicTree; }
+};
+
+struct WebTransportSession {
+
+    enum SendStatus : int { BACKPRESSURE, SUCCESS, DROPPED };
+
+    Http3ResponseData *getResponseData() {
+        return (Http3ResponseData *) us_quic_stream_ext((us_quic_stream_t *) this);
+    }
+    WebTransportSessionData *getSessionData() { return getResponseData()->wt; }
+    WebTransportContextData *getContextData();
+
+    void *getUserData() { return getSessionData()->userData; }
+
+    /* WebTransport messaging is QUIC DATAGRAMs — unreliable, unordered, MTU-
+     * bounded. opCode/compress/fin are accepted for API parity but ignored:
+     * there is no per-frame opcode on the wire (RFC 9297 §2.1). DROPPED is
+     * returned when the message is too large for one frame or the per-session
+     * queue exceeds maxBackpressure. */
+    SendStatus send(std::string_view message, OpCode = BINARY, bool = false, bool = true) {
+        WebTransportSessionData *d = getSessionData();
+        if (!d || d->isShuttingDown) return DROPPED;
+        WebTransportContextData *cd = getContextData();
+        int r = us_quic_stream_send_datagram((us_quic_stream_t *) this,
+                message.data(), (unsigned) message.length(), cd->maxBackpressure);
+        if (r < 0) {
+            if (cd->closeOnBackpressureLimit) end(1009, "Backpressure limit");
+            return DROPPED;
+        }
+        /* r is the queued bytes *before* this send. Datagrams always queue
+         * (they go out at the next process_conns), so the post-send buffered
+         * amount is never zero; report SUCCESS when the queue was empty so a
+         * single send() doesn't immediately trip the JS backpressure path. */
+        return r == 0 ? SUCCESS : BACKPRESSURE;
+    }
+
+    /* draft-ietf-webtrans-http3 §6: WT_CLOSE_SESSION (0x2843) capsule —
+     * 32-bit application error code + UTF-8 message (≤1024 bytes) — then FIN
+     * the CONNECT stream. WebSocket close codes are 16-bit; map 0/1005 to 0
+     * to match WebSocket::end's "no payload" behaviour. */
+    void end(int code = 0, std::string_view message = {}) {
+        WebTransportSessionData *d = getSessionData();
+        if (!d || d->isShuttingDown) return;
+        d->isShuttingDown = true;
+
+        if (message.length() > 1024) message = message.substr(0, 1024);
+        unsigned char capsule[2 + 8 + 4 + 1024];
+        unsigned char *p = capsule;
+        *p++ = 0x80 | (0x2843 >> 24); *p++ = (0x2843 >> 16) & 0xff;
+        *p++ = (0x2843 >> 8) & 0xff;  *p++ = 0x2843 & 0xff;
+        /* Only RFC 6455 close codes that have a wire payload carry an
+         * application error code; 0/1005/1006 mean "none supplied", which the
+         * spec says is equivalent to {0, ""}. */
+        bool hasCode = code != 0 && code != 1005 && code != 1006;
+        uint64_t bodyLen = hasCode ? 4 + message.length() : 0;
+        if (bodyLen < 64) { *p++ = (unsigned char) bodyLen; }
+        else { *p++ = 0x40 | (unsigned char)(bodyLen >> 8); *p++ = (unsigned char) bodyLen; }
+        if (hasCode) {
+            uint32_t c = (uint32_t) code;
+            *p++ = (unsigned char)(c >> 24); *p++ = (unsigned char)(c >> 16);
+            *p++ = (unsigned char)(c >> 8);  *p++ = (unsigned char) c;
+            memcpy(p, message.data(), message.length()); p += message.length();
+        }
+        us_quic_stream_write((us_quic_stream_t *) this, (const char *) capsule,
+            (unsigned)(p - capsule));
+        us_quic_stream_shutdown((us_quic_stream_t *) this);
+
+        WebTransportContextData *cd = getContextData();
+        if (d->subscriber) {
+            cd->topicTree->freeSubscriber(d->subscriber);
+            d->subscriber = nullptr;
+        }
+        if (cd->closeHandler) cd->closeHandler(this, code, message);
+    }
+
+    void close() {
+        WebTransportSessionData *d = getSessionData();
+        if (d && !d->isShuttingDown) end(1006, {});
+        us_quic_stream_close((us_quic_stream_t *) this);
+    }
+
+    void cork(MoveOnlyFunction<void()> &&fn) { fn(); }
+
+    size_t getBufferedAmount() {
+        return getResponseData()->backpressure.length()
+             + us_quic_stream_datagram_buffered((us_quic_stream_t *) this);
+    }
+
+    size_t memoryCost() {
+        return getBufferedAmount() + sizeof(WebTransportSessionData);
+    }
+
+    /* TopicTree hookup mirrors WebSocket<>; only the send path differs. */
+    bool subscribe(std::string_view topic, bool = false) {
+        WebTransportContextData *cd = getContextData();
+        WebTransportSessionData *d = getSessionData();
+        if (!d) return false;
+        if (!d->subscriber) {
+            d->subscriber = cd->topicTree->createSubscriber();
+            d->subscriber->user = this;
+        }
+        cd->topicTree->subscribe(d->subscriber, topic);
+        return true;
+    }
+
+    bool unsubscribe(std::string_view topic, bool = false) {
+        WebTransportContextData *cd = getContextData();
+        WebTransportSessionData *d = getSessionData();
+        if (!d || !d->subscriber) return false;
+        auto [ok, last, newCount] = cd->topicTree->unsubscribe(d->subscriber, topic);
+        (void) newCount;
+        if (ok && last) {
+            cd->topicTree->freeSubscriber(d->subscriber);
+            d->subscriber = nullptr;
+        }
+        return ok;
+    }
+
+    bool isSubscribed(std::string_view topic) {
+        WebTransportContextData *cd = getContextData();
+        WebTransportSessionData *d = getSessionData();
+        if (!d || !d->subscriber) return false;
+        Topic *t = cd->topicTree->lookupTopic(topic);
+        return t && t->count(d->subscriber);
+    }
+
+    void iterateTopics(MoveOnlyFunction<void(std::string_view)> cb) {
+        WebTransportSessionData *d = getSessionData();
+        if (!d || !d->subscriber) return;
+        for (Topic *t : d->subscriber->topics) cb({t->name.data(), t->name.length()});
+    }
+
+    bool publish(std::string_view topic, std::string_view message, OpCode opCode = BINARY, bool = false) {
+        WebTransportContextData *cd = getContextData();
+        WebTransportSessionData *d = getSessionData();
+        if (!d || !d->subscriber) return false;
+        return cd->topicTree->publishBig(d->subscriber, topic, {message, opCode, false},
+            [](Subscriber *s, TopicTreeBigMessage &m) {
+                ((WebTransportSession *) s->user)->send(m.message, (OpCode) m.opCode);
+            });
+    }
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -103,10 +103,10 @@ struct WebTransportSession {
         int r = us_quic_stream_send_datagram((us_quic_stream_t *) this,
                 message.data(), (unsigned) message.length(), cd->maxBackpressure);
         if (r < 0) {
-            /* Only the maxBackpressure cap (or a dead session) reaches here;
-             * MTU was filtered above, so closeOnBackpressureLimit is the
-             * caller's intended signal. */
-            if (cd->closeOnBackpressureLimit) end(1009, "Backpressure limit");
+            /* -2 is the only "queue would exceed maxBackpressure" return; -1
+             * means the session is gone (or OOM). closeOnBackpressureLimit
+             * should never tear the session down for the latter. */
+            if (r == -2 && cd->closeOnBackpressureLimit) end(1009, "Backpressure limit");
             return DROPPED;
         }
         /* r is the queued bytes *before* this send. Datagrams always queue

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -45,6 +45,11 @@ struct WebTransportSessionData {
      * cap-minus-one. */
     size_t inflightBytes = 0;
     bool isShuttingDown = false;
+    /* Set once send() reports BACKPRESSURE; cleared when the datagram queue
+     * drains. Gates drainHandler so a fresh session (whose CONNECT stream
+     * gets one post-upgrade wantwrite to flush the 2xx HEADERS) doesn't
+     * surface a spurious drain() with bufferedAmount == 0. */
+    bool hadBackpressure = false;
     /* Incoming WT_CLOSE_SESSION capsule reassembly on the CONNECT stream. */
     std::string capsuleBuf;
 };
@@ -113,7 +118,9 @@ struct WebTransportSession {
          * (they go out at the next process_conns), so the post-send buffered
          * amount is never zero; report SUCCESS when the queue was empty so a
          * single send() doesn't immediately trip the JS backpressure path. */
-        return r == 0 ? SUCCESS : BACKPRESSURE;
+        if (r == 0) return SUCCESS;
+        d->hadBackpressure = true;
+        return BACKPRESSURE;
     }
 
     /* draft-ietf-webtrans-http3 §6: WT_CLOSE_SESSION (0x2843) capsule —

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -50,6 +50,13 @@ struct WebTransportSessionData {
      * gets one post-upgrade wantwrite to flush the 2xx HEADERS) doesn't
      * surface a spurious drain() with bufferedAmount == 0. */
     bool hadBackpressure = false;
+    /* Set once closeHandler has run so on_stream_close doesn't fire it a
+     * second time after end(). Carries the code/reason for the deferred
+     * path (send()'s closeOnBackpressureLimit) where closeHandler must
+     * wait until on_stream_close to avoid TopicTree reentrancy. */
+    bool closeFired = false;
+    int closeCode = 1006;
+    std::string closeReason;
     /* Incoming WT_CLOSE_SESSION capsule reassembly on the CONNECT stream. */
     std::string capsuleBuf;
 };
@@ -117,8 +124,24 @@ struct WebTransportSession {
         if (r < 0) {
             /* -2 is the only "queue would exceed maxBackpressure" return; -1
              * means the session is gone (or OOM). closeOnBackpressureLimit
-             * should never tear the session down for the latter. */
-            if (r == -2 && cd->closeOnBackpressureLimit) end(1009, "Backpressure limit");
+             * should never tear the session down for the latter.
+             *
+             * send() runs from inside TopicTree::publishBig()'s range-for
+             * over the Topic (an unordered_set<Subscriber*>), so calling
+             * end() here — which would freeSubscriber() and fire the JS
+             * close handler synchronously — invalidates that iterator.
+             * Mirror WebSocket<>::send()'s us_socket_shutdown_read(): mark
+             * the session dead so subsequent sends drop, stash the close
+             * code, and close the stream. lsquic schedules on_close for
+             * the next service pass (maybe_schedule_call_on_close), and
+             * on_stream_close does the subscriber cleanup + closeHandler
+             * once we're outside the iteration. */
+            if (r == -2 && cd->closeOnBackpressureLimit) {
+                d->isShuttingDown = true;
+                d->closeCode = 1009;
+                d->closeReason = "Backpressure limit";
+                us_quic_stream_close((us_quic_stream_t *) this);
+            }
             return DROPPED;
         }
         /* r is the queued bytes *before* this send. Datagrams always queue
@@ -178,6 +201,7 @@ struct WebTransportSession {
             cd->topicTree->freeSubscriber(d->subscriber);
             d->subscriber = nullptr;
         }
+        d->closeFired = true;
         if (cd->closeHandler) cd->closeHandler(this, code, message);
     }
 

--- a/packages/bun-uws/src/WebTransportSession.h
+++ b/packages/bun-uws/src/WebTransportSession.h
@@ -89,10 +89,11 @@ struct WebTransportSession {
     void *getUserData() { return getSessionData()->userData; }
 
     /* WebTransport messaging is QUIC DATAGRAMs — unreliable, unordered, MTU-
-     * bounded. opCode/compress/fin are accepted for API parity but ignored:
-     * there is no per-frame opcode on the wire (RFC 9297 §2.1). DROPPED is
-     * returned when the message is too large for one frame or the per-session
-     * queue exceeds maxBackpressure. */
+     * bounded. compress/fin are accepted for API parity but ignored (no
+     * per-frame opcode/extension on the wire, RFC 9297 §2.1); opCode is
+     * used only to reject control frames. DROPPED is returned for control
+     * opcodes, when the message is too large for one frame, or when the
+     * per-session queue would exceed maxBackpressure. */
     /* Conservative QUIC DATAGRAM payload cap: RFC 9000's default
      * max_udp_payload_size minus short-header + AEAD + DATAGRAM-type
      * overhead. us_quic_stream_send_datagram rejects above this; pre-check
@@ -100,9 +101,15 @@ struct WebTransportSession {
      * backpressure (and thus never trips closeOnBackpressureLimit). */
     static constexpr unsigned MAX_DATAGRAM_PAYLOAD = 1192;
 
-    SendStatus send(std::string_view message, OpCode = BINARY, bool = false, bool = true) {
+    SendStatus send(std::string_view message, OpCode opCode = BINARY, bool = false, bool = true) {
         WebTransportSessionData *d = getSessionData();
         if (!d || d->isShuttingDown) return DROPPED;
+        /* ws.ping()/ws.pong() route through here with a control opcode.
+         * WebTransport has no control frames — QUIC owns keepalive — so
+         * shipping the payload as an application datagram would surface it
+         * in the peer's message() handler. Drop instead; the receive side
+         * already nulls .ping/.pong in applyH3 for the same reason. */
+        if (opCode != TEXT && opCode != BINARY) return DROPPED;
         if (message.length() > MAX_DATAGRAM_PAYLOAD) return DROPPED;
         WebTransportContextData *cd = getContextData();
         int r = us_quic_stream_send_datagram((us_quic_stream_t *) this,

--- a/patches/lsquic/webtransport-settings.patch
+++ b/patches/lsquic/webtransport-settings.patch
@@ -1,0 +1,106 @@
+--- a/src/liblsquic/lsquic_stream.c
++++ b/src/liblsquic/lsquic_stream.c
+@@ -4375,25 +4375,25 @@
+ #if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+ void
+ lsquic_stream_set_webtransport_session(lsquic_stream_t *s) {
+-    s->stream_flags |= SMBF_WEBTRANSPORT_SESSION_STREAM;
++    s->sm_bflags |= SMBF_WEBTRANSPORT_SESSION_STREAM;
+ }
+
+
+ int
+ lsquic_stream_is_webtransport_session(const lsquic_stream_t *s) {
+-    return (s->stream_flags & SMBF_WEBTRANSPORT_SESSION_STREAM);
++    return (s->sm_bflags & SMBF_WEBTRANSPORT_SESSION_STREAM);
+ }
+
+
+ int
+ lsquic_stream_is_webtransport_client_bidi_stream(const lsquic_stream_t *s) {
+-    return (s->stream_flags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM);
++    return (s->sm_bflags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM);
+ }
+
+
+ int
+ lsquic_stream_get_webtransport_session_stream_id(const lsquic_stream_t *s) {
+-    if(s->stream_flags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM)
++    if(s->sm_bflags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM)
+     {
+         return s->webtransport_session_stream_id;
+     }
+@@ -4942,7 +4942,7 @@
+                     // check webtransport_session_stream_id availability as well SMBF_WEBTRANSPORT_SESSION_STREAM
+                     // flag for webtransport_session_stream_id stream in app code
+                     stream->webtransport_session_stream_id = filter->hqfi_webtransport_session_id;
+-                    stream->stream_flags |= SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM;
++                    stream->sm_bflags |= SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM;
+                     // disable header processing as we will not have any headers for this stream anymore
+                     stream->sm_bflags &= ~SMBF_USE_HEADERS;
+                     filter->hqfi_type = HQFT_DATA;
+--- a/src/liblsquic/lsquic_hcso_writer.c
++++ b/src/liblsquic/lsquic_hcso_writer.c
+@@ -131,25 +131,14 @@
+     unsigned char *p;
+     unsigned bits;
+     int was_empty;
+-#ifdef NDEBUG
+-#   define frame_size_len 1
+-#else
+-    /* Need to use two bytes for frame length, as randomization may require
+-     * more than 63 bytes.
+-     */
+-#   define frame_size_len 2
+-#endif
++    /* WebTransport settings push the SETTINGS payload past 63 bytes
++     * (4-byte setting IDs), so always reserve a 2-byte length varint. */
++#define frame_size_len 2
+     unsigned char buf[1 /* Frame type */ + /* Frame size */ frame_size_len
+-        /* There are maximum seven settings that need to be written out and
+-         * each value can be encoded in maximum 8 bytes:
++        /* Up to nine settings; both the setting id (large WT codepoints) and
++         * the value can occupy a full 8-byte varint:
+          */
+-        + 7 * (
+-#ifdef NDEBUG
+-            1   /* Each setting needs 1-byte varint number, */
+-#else
+-            8   /* but it can be up to 8 bytes when randomized */
+-#endif
+-              + 8) ];
++        + 9 * (8 + 8) ];
+
+     p = buf;
+     *p++ = HQFT_SETTINGS;
+@@ -201,6 +190,18 @@
+         vint_write(p, SETTINGS_ENABLE_WEBTRANSPORT_VALUE, bits, 1 << bits);
+         p += 1 << bits;
+
++        /* draft-ietf-webtrans-http3-15 renames the setting to
++         * SETTINGS_WT_ENABLED and assigns a new codepoint. Advertise both so
++         * draft-02 (Chrome stable) and draft-15 clients can negotiate. */
++#define SETTINGS_WT_ENABLED (0x2c7cf000)
++#define SETTINGS_WT_ENABLED_VALUE (1)
++        bits = hcso_setting_type2bits(writer, SETTINGS_WT_ENABLED);
++        vint_write(p, SETTINGS_WT_ENABLED, bits, 1 << bits);
++        p += 1 << bits;
++        bits = vint_val2bits(SETTINGS_WT_ENABLED_VALUE);
++        vint_write(p, SETTINGS_WT_ENABLED_VALUE, bits, 1 << bits);
++        p += 1 << bits;
++
+         /* Write out SETTINGS_ENABLE_WEBTRANSPORT */
+ #define WEBTRANSPORT_MAX_SESSIONS (0x2b603743)
+         bits = hcso_setting_type2bits(writer, WEBTRANSPORT_MAX_SESSIONS);
+@@ -232,11 +233,7 @@
+     }
+ #endif
+
+-#ifdef NDEBUG
+-    buf[1] = p - buf - 2;
+-#else
+     vint_write(buf + 1, p - buf - 3, 1, 2);
+-#endif
+
+     was_empty = lsquic_frab_list_empty(&writer->how_fral);
+

--- a/scripts/build/deps/lsquic.ts
+++ b/scripts/build/deps/lsquic.ts
@@ -116,6 +116,7 @@ export const lsquic: Dependency = {
     "patches/lsquic/versions-to-string.patch",
     "patches/lsquic/allow-no-sni.patch",
     "patches/lsquic/skip-priority-walk.patch",
+    "patches/lsquic/webtransport-settings.patch",
   ],
 
   fetchDeps: ["zlib", "lshpack", "lsqpack", "boringssl"],
@@ -151,7 +152,7 @@ export const lsquic: Dependency = {
         LSQUIC_DEBUG_NEXT_ADV_TICK: 0,
         LSQUIC_CONN_STATS: 0,
         LSQUIC_QIR: 0,
-        LSQUIC_WEBTRANSPORT_SERVER_SUPPORT: 0,
+        LSQUIC_WEBTRANSPORT_SERVER_SUPPORT: 1,
       },
       // -w: lsquic emits a lot of -Wsign-compare and -Wunused under -Wall;
       // upstream builds with -Werror disabled. Treat as a third-party lib.

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1119,7 +1119,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             resp.clearTimeout();
             upgrader.deref();
 
-            if (resp.upgradeWebTransport(ws) == null) return .false;
+            if (resp.upgradeWebTransport(ws) == null) {
+                // The C++ gate (HTTP_RESPONSE_PENDING / HTTP_WRITE_CALLED) can
+                // trip if user headers already ended the response. init() took
+                // a Strong ref on the JS wrapper; downgrade it so GC can run
+                // finalize() — otherwise both the native struct and the JS
+                // value leak forever.
+                ws.abandonAfterFailedUpgrade();
+                return .false;
+            }
             return .true;
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -853,6 +853,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return globalThis.throwInvalidArguments("upgrade requires a Request object", .{});
             };
 
+            // WebTransport (extended-CONNECT over H3). The H3 RequestContext
+            // is a distinct concrete type in AnyRequestContext, so try it
+            // first; the RFC 6455 path below has no overlap.
+            if (comptime has_h3) {
+                if (request.request_context.get(H3RequestContext)) |h3| {
+                    return this.upgradeWebTransport(h3, request, optional, globalThis);
+                }
+            }
+
             var upgrader = request.request_context.get(RequestContext) orelse return .false;
 
             if (upgrader.isAbortedOrEnded()) {
@@ -1038,6 +1047,79 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 ctx,
             );
 
+            return .true;
+        }
+
+        /// `server.upgrade(req, {data, headers})` for an H3 request whose
+        /// `:protocol` is `webtransport`. There is no Sec-WebSocket-Key
+        /// handshake; accepting is just a 2xx HEADERS, so the only options
+        /// that make sense are `data` (attached to the ServerWebSocket) and
+        /// extra `headers` (e.g. WT-Protocol).
+        fn upgradeWebTransport(
+            this: *ThisServer,
+            upgrader: *H3RequestContext,
+            request: *Request,
+            optional: ?JSValue,
+            globalThis: *jsc.JSGlobalObject,
+        ) bun.JSError!jsc.JSValue {
+            if (comptime !has_h3) unreachable;
+            if (upgrader.isAbortedOrEnded()) return .false;
+            if (upgrader.upgrade_context == null or
+                @intFromPtr(upgrader.upgrade_context) == std.math.maxInt(usize)) return .false;
+            const resp = upgrader.resp orelse return .false;
+
+            var data_value: jsc.JSValue = .zero;
+            var fetch_headers_to_deref: ?*WebCore.FetchHeaders = null;
+            defer if (fetch_headers_to_deref) |fh| fh.deref();
+
+            if (optional) |opts| getter: {
+                if (opts.isEmptyOrUndefinedOrNull()) break :getter;
+                if (!opts.isObject())
+                    return globalThis.throwInvalidArguments("upgrade options must be an object", .{});
+                if (try opts.fastGet(globalThis, .data)) |v| data_value = v;
+                if (globalThis.hasException()) return error.JSError;
+                if (try opts.fastGet(globalThis, .headers)) |hv| {
+                    if (!hv.isEmptyOrUndefinedOrNull()) {
+                        const fh: *WebCore.FetchHeaders = hv.as(WebCore.FetchHeaders) orelse brk: {
+                            if (hv.isObject()) {
+                                if (try WebCore.FetchHeaders.createFromJS(globalThis, hv)) |created| {
+                                    fetch_headers_to_deref = created;
+                                    break :brk created;
+                                }
+                            }
+                            return globalThis.throwInvalidArguments(
+                                "upgrade options.headers must be a Headers or an object",
+                                .{},
+                            );
+                        };
+                        // Http3Response::upgradeWebTransport writes :status 200
+                        // itself, so emit user headers first; they're appended
+                        // to the same HEADERS frame buffer.
+                        fh.toUWSResponse(.h3, @ptrCast(resp));
+                    }
+                }
+                if (globalThis.hasException()) return error.JSError;
+            }
+
+            // Past here: no throws (mirrors the RFC 6455 path).
+            upgrader.upgrade_context = @as(*uws.SocketContext, @ptrFromInt(std.math.maxInt(usize)));
+            const signal = upgrader.signal;
+            upgrader.signal = null;
+            upgrader.resp = null;
+            request.request_context = AnyRequestContext.Null;
+            upgrader.request_weakref.deref();
+
+            data_value.ensureStillAlive();
+            const ws = ServerWebSocket.init(&this.config.websocket.?.handler, data_value, signal);
+            data_value.ensureStillAlive();
+
+            resp.clearAborted();
+            resp.clearOnData();
+            resp.clearOnWritable();
+            resp.clearTimeout();
+            upgrader.deref();
+
+            if (resp.upgradeWebTransport(ws) == null) return .false;
             return .true;
         }
 
@@ -2518,29 +2600,53 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         }
 
         /// Extended-CONNECT with `:protocol = webtransport` reached a route
-        /// that has a `websocket:` handler. Unlike RFC 6455 there is no
-        /// Sec-WebSocket-Key handshake and no `server.upgrade()` round-trip:
-        /// accepting is just a 2xx HEADERS, so do it inline. A handler that
-        /// wants to reject can `ws.close()` from `open`.
-        pub fn onWebTransportUpgrade(this: *ThisServer, resp: *uws.H3.Response, req: *uws.H3.Request, _: *uws.SocketContext, _: usize) void {
+        /// that has a `websocket:` handler. Mirror onWebSocketUpgrade: hand
+        /// the request to the user's fetch/route callback with
+        /// `upgrade_context` set so `server.upgrade(req, {data})` can accept.
+        /// Auto-accepting here would bypass any auth/Origin checks the
+        /// route does for the RFC 6455 path.
+        pub fn onWebTransportUpgrade(this: *ThisServer, resp: *uws.H3.Response, req: *uws.H3.Request, upgrade_ctx: *uws.SocketContext, id: usize) void {
+            if (comptime !has_h3) unreachable;
             jsc.markBinding(@src());
-            _ = req;
-            const websocket = &(this.config.websocket orelse {
+            if (this.config.websocket == null) {
                 resp.writeStatus("404 Not Found");
                 resp.endWithoutBody(false);
                 return;
-            });
-            if (websocket.handler.onOpen == .zero and websocket.handler.onMessage == .zero) {
+            }
+
+            if (id == 1) {
+                // ctx is *UserRoute when id==1 (set by uws_h3_ws below).
+                const user_route: *UserRoute = @ptrCast(@alignCast(this));
+                const server = user_route.server;
+                var should_deinit_context = false;
+                var prepared = server.prepareJsRequestContextFor(H3RequestContext, req, resp, &should_deinit_context, .no, switch (user_route.route.method) {
+                    .any => null,
+                    .specific => |m| m,
+                }) orelse return;
+                prepared.ctx.upgrade_context = upgrade_ctx;
+                const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
+                const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRouteH3, .{ server.globalThis, user_route.id, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
+                server.handleRequestFor(H3RequestContext, &should_deinit_context, prepared, req, response_value);
+                return;
+            }
+
+            // id==0 fallback route — ctx is *ThisServer.
+            bun.assert(id == 0);
+            if (this.config.onRequest == .zero) {
                 resp.writeStatus("403 Forbidden");
                 resp.endWithoutBody(false);
                 return;
             }
-            websocket.handler.globalObject = this.globalThis;
-            const ws = ServerWebSocket.init(&websocket.handler, .js_undefined, null);
-            if (resp.upgradeWebTransport(ws) == null) {
-                resp.writeStatus("500 Internal Server Error");
-                resp.endWithoutBody(false);
-            }
+            var should_deinit_context = false;
+            var prepared = this.prepareJsRequestContextFor(H3RequestContext, req, resp, &should_deinit_context, .yes, null) orelse return;
+            prepared.ctx.upgrade_context = upgrade_ctx;
+            const js_value = this.jsValueAssertAlive();
+            const response_value = this.config.onRequest.call(
+                this.globalThis,
+                js_value,
+                &.{ prepared.js_request, js_value },
+            ) catch |err| this.globalThis.takeException(err);
+            this.handleRequestFor(H3RequestContext, &should_deinit_context, prepared, req, response_value);
         }
 
         pub fn onWebSocketUpgrade(this: *ThisServer, resp: *App.Response, req: *uws.Request, upgrade_ctx: *uws.SocketContext, id: usize) void {
@@ -2738,6 +2844,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (this.config.websocket) |*websocket| {
                 websocket.globalObject = this.globalThis;
                 websocket.handler.app = app;
+                websocket.handler.h3_app = if (comptime has_h3) this.h3_app else null;
                 websocket.handler.flags.ssl = ssl_enabled;
             }
 
@@ -2781,7 +2888,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             );
                             if (comptime has_h3) if (this.h3_app) |h3_app| h3_app.ws(
                                 user_route.route.path,
-                                this,
+                                user_route,
                                 1,
                                 ServerWebSocket.behaviorH3(ThisServer, websocket.toBehavior()),
                             );
@@ -2805,6 +2912,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                     user_route,
                                     1, // id 1 means is a user route
                                     ServerWebSocket.behavior(ThisServer, ssl_enabled, websocket.toBehavior()),
+                                );
+                                // WebTransport's CONNECT also matches the
+                                // GET-scoped route so the user's per-route
+                                // handler runs (and can reject) for both.
+                                if (comptime has_h3) if (this.h3_app) |h3_app| h3_app.ws(
+                                    user_route.route.path,
+                                    user_route,
+                                    1,
+                                    ServerWebSocket.behaviorH3(ThisServer, websocket.toBehavior()),
                                 );
                             }
                         }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1644,6 +1644,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             {
                 if (this.config.websocket) |*ws| {
                     ws.handler.app = null;
+                    ws.handler.h3_app = null;
                 }
                 this.unref();
 
@@ -1711,6 +1712,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             } else if (!this.flags.terminated) {
                 if (this.config.websocket) |*ws| {
                     ws.handler.app = null;
+                    ws.handler.h3_app = null;
                 }
                 this.flags.terminated = true;
                 this.app.?.close();
@@ -2627,10 +2629,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 const user_route: *UserRoute = @ptrCast(@alignCast(this));
                 const server = user_route.server;
                 var should_deinit_context = false;
-                var prepared = server.prepareJsRequestContextFor(H3RequestContext, req, resp, &should_deinit_context, .no, switch (user_route.route.method) {
-                    .any => null,
-                    .specific => |m| m,
-                }) orelse return;
+                var prepared = server.prepareJsRequestContextFor(H3RequestContext, req, resp, &should_deinit_context, .no, null) orelse return;
                 prepared.ctx.upgrade_context = upgrade_ctx;
                 const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
                 const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), Bun__ServerRouteList__callRouteH3, .{ server.globalThis, user_route.id, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2517,6 +2517,32 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             server.handleRequest(&should_deinit_context, prepared, req, response_value);
         }
 
+        /// Extended-CONNECT with `:protocol = webtransport` reached a route
+        /// that has a `websocket:` handler. Unlike RFC 6455 there is no
+        /// Sec-WebSocket-Key handshake and no `server.upgrade()` round-trip:
+        /// accepting is just a 2xx HEADERS, so do it inline. A handler that
+        /// wants to reject can `ws.close()` from `open`.
+        pub fn onWebTransportUpgrade(this: *ThisServer, resp: *uws.H3.Response, req: *uws.H3.Request, _: *uws.SocketContext, _: usize) void {
+            jsc.markBinding(@src());
+            _ = req;
+            const websocket = &(this.config.websocket orelse {
+                resp.writeStatus("404 Not Found");
+                resp.endWithoutBody(false);
+                return;
+            });
+            if (websocket.handler.onOpen == .zero and websocket.handler.onMessage == .zero) {
+                resp.writeStatus("403 Forbidden");
+                resp.endWithoutBody(false);
+                return;
+            }
+            websocket.handler.globalObject = this.globalThis;
+            const ws = ServerWebSocket.init(&websocket.handler, .js_undefined, null);
+            if (resp.upgradeWebTransport(ws) == null) {
+                resp.writeStatus("500 Internal Server Error");
+                resp.endWithoutBody(false);
+            }
+        }
+
         pub fn onWebSocketUpgrade(this: *ThisServer, resp: *App.Response, req: *uws.Request, upgrade_ctx: *uws.SocketContext, id: usize) void {
             jsc.markBinding(@src());
             if (id == 1) {
@@ -2753,6 +2779,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                                 1, // id 1 means is a user route
                                 ServerWebSocket.behavior(ThisServer, ssl_enabled, websocket.toBehavior()),
                             );
+                            if (comptime has_h3) if (this.h3_app) |h3_app| h3_app.ws(
+                                user_route.route.path,
+                                this,
+                                1,
+                                ServerWebSocket.behaviorH3(ThisServer, websocket.toBehavior()),
+                            );
                         }
                     },
                     .specific => |method_val| { // method_val is HTTP.Method here
@@ -2880,6 +2912,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         this,
                         0, // id 0 means is a fallback route and ctx is the server
                         ServerWebSocket.behavior(ThisServer, ssl_enabled, websocket.toBehavior()),
+                    );
+                    if (comptime has_h3) if (this.h3_app) |h3_app| h3_app.ws(
+                        "/*",
+                        this,
+                        0,
+                        ServerWebSocket.behaviorH3(ThisServer, websocket.toBehavior()),
                     );
                 }
             }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1077,7 +1077,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 if (!opts.isObject())
                     return globalThis.throwInvalidArguments("upgrade options must be an object", .{});
                 if (try opts.fastGet(globalThis, .data)) |v| data_value = v;
-                if (globalThis.hasException()) return error.JSError;
                 if (try opts.fastGet(globalThis, .headers)) |hv| {
                     if (!hv.isEmptyOrUndefinedOrNull()) {
                         const fh: *WebCore.FetchHeaders = hv.as(WebCore.FetchHeaders) orelse brk: {
@@ -1098,7 +1097,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         fh.toUWSResponse(.h3, @ptrCast(resp));
                     }
                 }
-                if (globalThis.hasException()) return error.JSError;
             }
 
             // Past here: no throws (mirrors the RFC 6455 path).

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -2618,14 +2618,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         pub fn onWebTransportUpgrade(this: *ThisServer, resp: *uws.H3.Response, req: *uws.H3.Request, upgrade_ctx: *uws.SocketContext, id: usize) void {
             if (comptime !has_h3) unreachable;
             jsc.markBinding(@src());
-            if (this.config.websocket == null) {
-                resp.writeStatus("404 Not Found");
-                resp.endWithoutBody(false);
-                return;
-            }
-
+            // `this` is type-punned: when id == 1 the pointer registered with
+            // h3_app.ws() was a *UserRoute, not a *ThisServer. Do NOT touch
+            // `this.*` until id has been checked. (h3_app.ws() is only ever
+            // registered inside `if (this.config.websocket) |*websocket|`, so
+            // the old null-check this replaced was both wrong and dead.)
             if (id == 1) {
-                // ctx is *UserRoute when id==1 (set by uws_h3_ws below).
                 const user_route: *UserRoute = @ptrCast(@alignCast(this));
                 const server = user_route.server;
                 var should_deinit_context = false;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -634,7 +634,27 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return JSValue.jsNumber(0);
             }
 
-            return JSValue.jsNumber((this.app.?.numSubscribers(topic.slice())));
+            return JSValue.jsNumber(this.numSubscribersTotal(topic.slice()));
+        }
+
+        /// WebTransport sessions subscribe onto a separate TopicTree owned
+        /// by the H3App, so server.subscriberCount() and server.publish()
+        /// must sum / fan out over both trees when `h3: true` is set.
+        pub fn numSubscribersTotal(this: *ThisServer, topic: []const u8) u32 {
+            var n: u32 = this.app.?.numSubscribers(topic);
+            if (comptime has_h3) if (this.h3_app) |h3| {
+                n += h3.numSubscribers(topic);
+            };
+            return n;
+        }
+
+        pub fn publishAllTrees(this: *ThisServer, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+            const ok_tcp = uws.AnyWebSocket.publishWithOptions(ssl_enabled, this.app.?, topic, message, opcode, compress);
+            var ok_h3 = false;
+            if (comptime has_h3) if (this.h3_app) |h3| {
+                ok_h3 = h3.publishWithOptions(topic, message, opcode, compress);
+            };
+            return ok_tcp or ok_h3;
         }
 
         pub fn constructor(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!*ThisServer {
@@ -711,8 +731,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (this.config.websocket == null)
                 return JSValue.jsNumber(0);
 
-            const app = this.app.?;
-
             if (topic.len == 0) {
                 httplog("publish() topic invalid", .{});
                 return globalThis.throw("publish requires a topic string", .{});
@@ -732,7 +750,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return JSValue.jsNumber(
                     // if 0, return 0
                     // else return number of bytes sent
-                    @as(i32, @intFromBool(uws.AnyWebSocket.publishWithOptions(ssl_enabled, app, topic_slice.slice(), buffer.slice(), .binary, compress))) * @as(i32, @intCast(@as(u31, @truncate(buffer.len)))),
+                    @as(i32, @intFromBool(this.publishAllTrees(topic_slice.slice(), buffer.slice(), .binary, compress))) * @as(i32, @intCast(@as(u31, @truncate(buffer.len)))),
                 );
             }
 
@@ -748,7 +766,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 return JSValue.jsNumber(
                     // if 0, return 0
                     // else return number of bytes sent
-                    @as(i32, @intFromBool(uws.AnyWebSocket.publishWithOptions(ssl_enabled, app, topic_slice.slice(), buffer, .text, compress))) * @as(i32, @intCast(@as(u31, @truncate(buffer.len)))),
+                    @as(i32, @intFromBool(this.publishAllTrees(topic_slice.slice(), buffer, .text, compress))) * @as(i32, @intCast(@as(u31, @truncate(buffer.len)))),
                 );
             }
         }
@@ -3645,10 +3663,10 @@ pub const AnyServer = struct {
 
     pub fn publish(this: AnyServer, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
         return switch (this.ptr.tag()) {
-            Ptr.case(HTTPServer) => this.ptr.as(HTTPServer).app.?.publish(topic, message, opcode, compress),
-            Ptr.case(HTTPSServer) => this.ptr.as(HTTPSServer).app.?.publish(topic, message, opcode, compress),
-            Ptr.case(DebugHTTPServer) => this.ptr.as(DebugHTTPServer).app.?.publish(topic, message, opcode, compress),
-            Ptr.case(DebugHTTPSServer) => this.ptr.as(DebugHTTPSServer).app.?.publish(topic, message, opcode, compress),
+            Ptr.case(HTTPServer) => this.ptr.as(HTTPServer).publishAllTrees(topic, message, opcode, compress),
+            Ptr.case(HTTPSServer) => this.ptr.as(HTTPSServer).publishAllTrees(topic, message, opcode, compress),
+            Ptr.case(DebugHTTPServer) => this.ptr.as(DebugHTTPServer).publishAllTrees(topic, message, opcode, compress),
+            Ptr.case(DebugHTTPSServer) => this.ptr.as(DebugHTTPSServer).publishAllTrees(topic, message, opcode, compress),
             else => bun.unreachablePanic("Invalid pointer tag", .{}),
         };
     }
@@ -3687,10 +3705,10 @@ pub const AnyServer = struct {
     }
     pub fn numSubscribers(this: AnyServer, topic: []const u8) u32 {
         return switch (this.ptr.tag()) {
-            Ptr.case(HTTPServer) => this.ptr.as(HTTPServer).app.?.numSubscribers(topic),
-            Ptr.case(HTTPSServer) => this.ptr.as(HTTPSServer).app.?.numSubscribers(topic),
-            Ptr.case(DebugHTTPServer) => this.ptr.as(DebugHTTPServer).app.?.numSubscribers(topic),
-            Ptr.case(DebugHTTPSServer) => this.ptr.as(DebugHTTPSServer).app.?.numSubscribers(topic),
+            Ptr.case(HTTPServer) => this.ptr.as(HTTPServer).numSubscribersTotal(topic),
+            Ptr.case(HTTPSServer) => this.ptr.as(HTTPSServer).numSubscribersTotal(topic),
+            Ptr.case(DebugHTTPServer) => this.ptr.as(DebugHTTPServer).numSubscribersTotal(topic),
+            Ptr.case(DebugHTTPSServer) => this.ptr.as(DebugHTTPSServer).numSubscribersTotal(topic),
             else => bun.unreachablePanic("Invalid pointer tag", .{}),
         };
     }

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -30,6 +30,19 @@ inline fn websocket(this: *const ServerWebSocket) uws.AnyWebSocket {
     return this.#flags.websocket();
 }
 
+/// App-level publish (the publish_to_self / closed-socket fallback). H3
+/// WebTransport sessions live under a separate TopicTree on the H3App, so
+/// route by `kind` instead of `flags.ssl` — otherwise WT subscribers miss
+/// every message that goes through the fallback.
+inline fn appPublish(this: *const ServerWebSocket, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+    if (this.#flags.kind == .h3_wt) {
+        const h3_app: *uws.H3.App = @ptrCast(@alignCast(this.#handler.h3_app orelse return false));
+        return h3_app.publishWithOptions(topic, message, opcode, compress);
+    }
+    const app = this.#handler.app orelse return false;
+    return uws.AnyWebSocket.publishWithOptions(this.#handler.flags.ssl, app, topic, message, opcode, compress);
+}
+
 pub const js = jsc.Codegen.JSServerWebSocket;
 pub const toJS = js.toJS;
 pub const fromJS = js.fromJS;
@@ -394,9 +407,8 @@ pub fn publish(
         log("publish() closed", .{});
         return JSValue.jsNumber(0);
     };
-    const flags = this.#handler.flags;
-    const ssl = flags.ssl;
-    const publish_to_self = flags.publish_to_self;
+    _ = app;
+    const publish_to_self = this.#handler.flags.publish_to_self;
 
     const topic_value = args.ptr[0];
     const message_value = args.ptr[1];
@@ -430,7 +442,7 @@ pub fn publish(
         const result = if (!publish_to_self and !this.isClosed())
             this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
         else
-            uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .binary, compress);
+            this.appPublish(topic_slice.slice(), buffer, .binary, compress);
 
         return JSValue.jsNumber(
             // if 0, return 0
@@ -452,7 +464,7 @@ pub fn publish(
         const result = if (!publish_to_self and !this.isClosed())
             this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
         else
-            uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .text, compress);
+            this.appPublish(topic_slice.slice(), buffer, .text, compress);
 
         return JSValue.jsNumber(
             // if 0, return 0
@@ -478,9 +490,8 @@ pub fn publishText(
         log("publish() closed", .{});
         return JSValue.jsNumber(0);
     };
-    const flags = this.#handler.flags;
-    const ssl = flags.ssl;
-    const publish_to_self = flags.publish_to_self;
+    _ = app;
+    const publish_to_self = this.#handler.flags.publish_to_self;
 
     const topic_value = args.ptr[0];
     const message_value = args.ptr[1];
@@ -516,7 +527,7 @@ pub fn publishText(
     const result = if (!publish_to_self and !this.isClosed())
         this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
     else
-        uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .text, compress);
+        this.appPublish(topic_slice.slice(), buffer, .text, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -541,9 +552,8 @@ pub fn publishBinary(
         log("publish() closed", .{});
         return JSValue.jsNumber(0);
     };
-    const flags = this.#handler.flags;
-    const ssl = flags.ssl;
-    const publish_to_self = flags.publish_to_self;
+    _ = app;
+    const publish_to_self = this.#handler.flags.publish_to_self;
     const topic_value = args.ptr[0];
     const message_value = args.ptr[1];
     const compress_value = args.ptr[2];
@@ -577,7 +587,7 @@ pub fn publishBinary(
     const result = if (!publish_to_self and !this.isClosed())
         this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
     else
-        uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .binary, compress);
+        this.appPublish(topic_slice.slice(), buffer, .binary, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -596,9 +606,8 @@ pub fn publishBinaryWithoutTypeChecks(
         log("publish() closed", .{});
         return JSValue.jsNumber(0);
     };
-    const flags = this.#handler.flags;
-    const ssl = flags.ssl;
-    const publish_to_self = flags.publish_to_self;
+    _ = app;
+    const publish_to_self = this.#handler.flags.publish_to_self;
 
     var topic_slice = topic_str.toSlice(globalThis, bun.default_allocator);
     defer topic_slice.deinit();
@@ -616,7 +625,7 @@ pub fn publishBinaryWithoutTypeChecks(
     const result = if (!publish_to_self and !this.isClosed())
         this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
     else
-        uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .binary, compress);
+        this.appPublish(topic_slice.slice(), buffer, .binary, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -635,9 +644,8 @@ pub fn publishTextWithoutTypeChecks(
         log("publish() closed", .{});
         return JSValue.jsNumber(0);
     };
-    const flags = this.#handler.flags;
-    const ssl = flags.ssl;
-    const publish_to_self = flags.publish_to_self;
+    _ = app;
+    const publish_to_self = this.#handler.flags.publish_to_self;
 
     var topic_slice = topic_str.toSlice(globalThis, bun.default_allocator);
     defer topic_slice.deinit();
@@ -658,7 +666,7 @@ pub fn publishTextWithoutTypeChecks(
     const result = if (!publish_to_self and !this.isClosed())
         this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
     else
-        uws.AnyWebSocket.publishWithOptions(ssl, app, topic_slice.slice(), buffer, .text, compress);
+        this.appPublish(topic_slice.slice(), buffer, .text, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -380,6 +380,14 @@ pub fn constructor(globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSE
     return globalObject.throw("Cannot construct ServerWebSocket", .{});
 }
 
+/// Release the Strong ref taken by init() when an upgrade is aborted before
+/// onOpen ever fires (so onClose's normal downgrade path is unreachable).
+/// GC then collects the JS wrapper and finalize() frees the native struct.
+pub fn abandonAfterFailedUpgrade(this: *ServerWebSocket) void {
+    this.#flags.closed = true;
+    if (this.#this_value.isNotEmpty()) this.#this_value.downgrade();
+}
+
 pub fn finalize(this: *ServerWebSocket) void {
     log("finalize", .{});
     this.#this_value.finalize();

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -380,11 +380,18 @@ pub fn constructor(globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSE
     return globalObject.throw("Cannot construct ServerWebSocket", .{});
 }
 
-/// Release the Strong ref taken by init() when an upgrade is aborted before
-/// onOpen ever fires (so onClose's normal downgrade path is unreachable).
-/// GC then collects the JS wrapper and finalize() frees the native struct.
+/// Release everything init() acquired when an upgrade is aborted before
+/// onOpen ever fires (so onClose's normal downgrade path is unreachable):
+/// the Strong ref on the JS wrapper *and* ownership of the AbortSignal that
+/// was transferred from the request context. GC then collects the wrapper
+/// and finalize() frees the native struct.
 pub fn abandonAfterFailedUpgrade(this: *ServerWebSocket) void {
     this.#flags.closed = true;
+    if (this.#signal) |signal| {
+        this.#signal = null;
+        signal.pendingActivityUnref();
+        signal.unref();
+    }
     if (this.#this_value.isNotEmpty()) this.#this_value.downgrade();
 }
 

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -7,20 +7,21 @@ const ServerWebSocket = @This();
 
 // We pack the per-socket data into this struct below
 const Flags = packed struct(u64) {
-    ssl: bool = false,
+    kind: Kind = .tcp,
     closed: bool = false,
     opened: bool = false,
     binary_type: jsc.ArrayBuffer.BinaryType = .Buffer,
-    packed_websocket_ptr: u57 = 0,
+    packed_websocket_ptr: u56 = 0,
+
+    const Kind = enum(u2) { tcp, ssl, h3_wt, _ };
 
     inline fn websocket(this: Flags) uws.AnyWebSocket {
         // Ensure those other bits are zeroed out
         const that = Flags{ .packed_websocket_ptr = this.packed_websocket_ptr };
-
-        return if (this.ssl) .{
-            .ssl = @ptrFromInt(@as(usize, that.packed_websocket_ptr)),
-        } else .{
-            .tcp = @ptrFromInt(@as(usize, that.packed_websocket_ptr)),
+        return switch (this.kind) {
+            .ssl => .{ .ssl = @ptrFromInt(@as(usize, that.packed_websocket_ptr)) },
+            .h3_wt => .{ .h3_wt = @ptrFromInt(@as(usize, that.packed_websocket_ptr)) },
+            else => .{ .tcp = @ptrFromInt(@as(usize, that.packed_websocket_ptr)) },
         };
     }
 };
@@ -65,7 +66,11 @@ pub fn onOpen(this: *ServerWebSocket, ws: uws.AnyWebSocket) void {
 
     this.#flags.packed_websocket_ptr = @truncate(@intFromPtr(ws.raw()));
     this.#flags.closed = false;
-    this.#flags.ssl = ws == .ssl;
+    this.#flags.kind = switch (ws) {
+        .ssl => .ssl,
+        .tcp => .tcp,
+        .h3_wt => .h3_wt,
+    };
 
     var handler = this.#handler;
     const vm = this.#handler.vm;
@@ -352,6 +357,10 @@ pub fn onClose(this: *ServerWebSocket, _: uws.AnyWebSocket, code: i32, message: 
 
 pub fn behavior(comptime ServerType: type, comptime ssl: bool, opts: uws.WebSocketBehavior) uws.WebSocketBehavior {
     return uws.WebSocketBehavior.Wrap(ServerType, @This(), ssl).apply(opts);
+}
+
+pub fn behaviorH3(comptime ServerType: type, opts: uws.WebSocketBehavior) uws.WebSocketBehavior {
+    return uws.WebSocketBehavior.Wrap(ServerType, @This(), true).applyH3(opts);
 }
 
 pub fn constructor(globalObject: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!*ServerWebSocket {

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -30,10 +30,10 @@ inline fn websocket(this: *const ServerWebSocket) uws.AnyWebSocket {
     return this.#flags.websocket();
 }
 
-/// App-level publish (the publish_to_self / closed-socket fallback). H3
-/// WebTransport sessions live under a separate TopicTree on the H3App, so
-/// route by `kind` instead of `flags.ssl` — otherwise WT subscribers miss
-/// every message that goes through the fallback.
+/// App-level publish on the sender's own-transport TopicTree (the
+/// publish_to_self / closed-socket fallback). H3 WebTransport sessions
+/// live under a separate TopicTree on the H3App, so route by `kind`
+/// instead of `flags.ssl`.
 inline fn appPublish(this: *const ServerWebSocket, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
     if (this.#flags.kind == .h3_wt) {
         const h3_app: *uws.H3.App = @ptrCast(@alignCast(this.#handler.h3_app orelse return false));
@@ -41,6 +41,32 @@ inline fn appPublish(this: *const ServerWebSocket, topic: []const u8, message: [
     }
     const app = this.#handler.app orelse return false;
     return uws.AnyWebSocket.publishWithOptions(this.#handler.flags.ssl, app, topic, message, opcode, compress);
+}
+
+/// App-level publish on the *other* transport's TopicTree. The sender
+/// cannot be subscribed there, so no exclusion is needed. Lets
+/// ws.publish() reach subscribers regardless of whether they arrived
+/// over RFC 6455 or WebTransport.
+inline fn crossPublish(this: *const ServerWebSocket, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+    if (this.#flags.kind == .h3_wt) {
+        const app = this.#handler.app orelse return false;
+        return uws.AnyWebSocket.publishWithOptions(this.#handler.flags.ssl, app, topic, message, opcode, compress);
+    }
+    const h3_app: *uws.H3.App = @ptrCast(@alignCast(this.#handler.h3_app orelse return false));
+    return h3_app.publishWithOptions(topic, message, opcode, compress);
+}
+
+/// ws.publish() and friends: publish on the sender's own tree (with
+/// sender exclusion when the socket is live and publish_to_self is
+/// off), then fan out to the other-transport tree so a mixed WS+WT
+/// room isn't silently partitioned by transport.
+inline fn doPublish(this: *const ServerWebSocket, publish_to_self: bool, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+    const own = if (!publish_to_self and !this.isClosed())
+        this.websocket().publish(topic, message, opcode, compress)
+    else
+        this.appPublish(topic, message, opcode, compress);
+    const cross = this.crossPublish(topic, message, opcode, compress);
+    return own or cross;
 }
 
 pub const js = jsc.Codegen.JSServerWebSocket;
@@ -454,10 +480,7 @@ pub fn publish(
     if (message_value.asArrayBuffer(globalThis)) |array_buffer| {
         const buffer = array_buffer.slice();
 
-        const result = if (!publish_to_self and !this.isClosed())
-            this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
-        else
-            this.appPublish(topic_slice.slice(), buffer, .binary, compress);
+        const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .binary, compress);
 
         return JSValue.jsNumber(
             // if 0, return 0
@@ -476,10 +499,7 @@ pub fn publish(
 
         const buffer = slice.slice();
 
-        const result = if (!publish_to_self and !this.isClosed())
-            this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
-        else
-            this.appPublish(topic_slice.slice(), buffer, .text, compress);
+        const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .text, compress);
 
         return JSValue.jsNumber(
             // if 0, return 0
@@ -539,10 +559,7 @@ pub fn publishText(
 
     const buffer = slice.slice();
 
-    const result = if (!publish_to_self and !this.isClosed())
-        this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
-    else
-        this.appPublish(topic_slice.slice(), buffer, .text, compress);
+    const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .text, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -599,10 +616,7 @@ pub fn publishBinary(
     };
     const buffer = array_buffer.slice();
 
-    const result = if (!publish_to_self and !this.isClosed())
-        this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
-    else
-        this.appPublish(topic_slice.slice(), buffer, .binary, compress);
+    const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .binary, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -637,10 +651,7 @@ pub fn publishBinaryWithoutTypeChecks(
         return jsc.JSValue.jsNumber(0);
     }
 
-    const result = if (!publish_to_self and !this.isClosed())
-        this.websocket().publish(topic_slice.slice(), buffer, .binary, compress)
-    else
-        this.appPublish(topic_slice.slice(), buffer, .binary, compress);
+    const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .binary, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0
@@ -678,10 +689,7 @@ pub fn publishTextWithoutTypeChecks(
         return jsc.JSValue.jsNumber(0);
     }
 
-    const result = if (!publish_to_self and !this.isClosed())
-        this.websocket().publish(topic_slice.slice(), buffer, .text, compress)
-    else
-        this.appPublish(topic_slice.slice(), buffer, .text, compress);
+    const result = this.doPublish(publish_to_self, topic_slice.slice(), buffer, .text, compress);
 
     return JSValue.jsNumber(
         // if 0, return 0

--- a/src/bun.js/api/server/WebSocketServerContext.zig
+++ b/src/bun.js/api/server/WebSocketServerContext.zig
@@ -22,6 +22,10 @@ pub const Handler = struct {
     onPong: jsc.JSValue = .zero,
 
     app: ?*anyopaque = null,
+    /// The H3App when `h3: true`; used by ServerWebSocket.publish*'s
+    /// app-level fallback so WebTransport subscribers receive messages even
+    /// when publish_to_self is set or the session is already closed.
+    h3_app: ?*anyopaque = null,
 
     // Always set manually.
     vm: *jsc.VirtualMachine = undefined,

--- a/src/bun.js/bindings/uws_bindings.cpp
+++ b/src/bun.js/bindings/uws_bindings.cpp
@@ -6,6 +6,7 @@
 #include "JavaScriptCore/ObjectConstructor.h"
 #include "wtf/text/WTFString.h"
 #include <bun-uws/src/App.h>
+#include <bun-uws/src/Http3ContextData.h>
 #include <span>
 #include <string_view>
 
@@ -44,4 +45,17 @@ extern "C" JSC::EncodedJSValue uws_ws_get_topics_as_js_array(int ssl, uws_websoc
   } else {
     return uws_ws_get_topics_as_js_array_impl<false>(ws, globalObject);
   }
+}
+
+extern "C" JSC::EncodedJSValue uws_h3_wt_get_topics_as_js_array(uws_websocket_t *ws, void* globalObject) {
+  JSC::JSGlobalObject* global = reinterpret_cast<JSC::JSGlobalObject*>(globalObject);
+  JSC::VM& vm = global->vm();
+  JSC::MarkedArgumentBuffer args;
+  reinterpret_cast<uWS::WebTransportSession*>(ws)->iterateTopics([&](std::string_view topic) {
+    auto str = WTF::String::fromUTF8ReplacingInvalidSequences(std::span {
+      reinterpret_cast<const unsigned char*>(topic.data()), topic.length()
+    });
+    args.append(JSC::jsString(vm, str));
+  });
+  return JSC::JSValue::encode(JSC::constructArray(global, static_cast<JSC::ArrayAllocationProfile*>(nullptr), args));
 }

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -419,7 +419,7 @@ void uws_h3_wt_iterate_topics(uws_websocket_t* ws,
     void (*cb)(const char*, size_t, void*), void* user_data)
 {
     ((WebTransportSession*)ws)->iterateTopics([cb, user_data](std::string_view t) {
-        cb(t.data(), t.length(), user_data);
+        cb(t.empty() ? "" : t.data(), t.length(), user_data);
     });
 }
 

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -322,13 +322,13 @@ void uws_h3_ws(uws_h3_app_t* app, void* upgradeCtx, const char* pattern,
         b.open = [behavior](WebTransportSession* ws) { behavior.open((uws_websocket_t*)ws); };
     if (behavior.message)
         b.message = [behavior](WebTransportSession* ws, std::string_view m, uWS::OpCode op) {
-            behavior.message((uws_websocket_t*)ws, m.data(), m.length(), (uws_opcode_t)op);
+            behavior.message((uws_websocket_t*)ws, m.empty() ? "" : m.data(), m.length(), (uws_opcode_t)op);
         };
     if (behavior.drain)
         b.drain = [behavior](WebTransportSession* ws) { behavior.drain((uws_websocket_t*)ws); };
     if (behavior.close)
         b.close = [behavior](WebTransportSession* ws, int code, std::string_view m) {
-            behavior.close((uws_websocket_t*)ws, code, m.data(), m.length());
+            behavior.close((uws_websocket_t*)ws, code, m.empty() ? "" : m.data(), m.length());
         };
     ((H3App*)app)->wt(sv(pattern, pattern_len), std::move(b));
 }

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -20,6 +20,7 @@ using uWS::H3App;
 using uWS::Http3Request;
 using uWS::Http3Response;
 using uWS::Http3ResponseData;
+using uWS::WebTransportSession;
 
 static inline std::string_view sv(const char* p, size_t n) { return p ? std::string_view { p, n } : std::string_view {}; }
 
@@ -295,6 +296,128 @@ size_t uws_h3_req_get_query(uws_h3_req_t* req, const char* key, size_t key_len, 
 size_t uws_h3_req_get_parameter(uws_h3_req_t* req, unsigned short index, const char** dest)
 {
     return ffi_sv(((Http3Request*)req)->getParameter(index), dest);
+}
+
+/* ───── WebTransport ─────
+ *
+ * Mirrors uws_ws / uws_ws_* so the Zig AnyWebSocket union can carry an
+ * .h3_wt arm with the same method shapes. Same uws_socket_behavior_t struct;
+ * compression/idleTimeout/ping/pong fields are ignored (WT has no
+ * permessage-deflate and QUIC owns keepalive). */
+
+void uws_h3_ws(uws_h3_app_t* app, void* upgradeCtx, const char* pattern,
+    size_t pattern_len, size_t id, const uws_socket_behavior_t* behavior_)
+{
+    uws_socket_behavior_t behavior = *behavior_;
+    H3App::WebTransportBehavior b;
+    b.maxPayloadLength = behavior.maxPayloadLength;
+    b.maxBackpressure = behavior.maxBackpressure;
+    b.closeOnBackpressureLimit = behavior.closeOnBackpressureLimit;
+    if (behavior.upgrade)
+        b.upgrade = [behavior, upgradeCtx, id](Http3Response* res, Http3Request* req) {
+            behavior.upgrade(upgradeCtx, (uws_res_t*)res, (uws_req_t*)req,
+                (uws_socket_context_t*)us_quic_stream_context((us_quic_stream_t*)res), id);
+        };
+    if (behavior.open)
+        b.open = [behavior](WebTransportSession* ws) { behavior.open((uws_websocket_t*)ws); };
+    if (behavior.message)
+        b.message = [behavior](WebTransportSession* ws, std::string_view m, uWS::OpCode op) {
+            behavior.message((uws_websocket_t*)ws, m.data(), m.length(), (uws_opcode_t)op);
+        };
+    if (behavior.drain)
+        b.drain = [behavior](WebTransportSession* ws) { behavior.drain((uws_websocket_t*)ws); };
+    if (behavior.close)
+        b.close = [behavior](WebTransportSession* ws, int code, std::string_view m) {
+            behavior.close((uws_websocket_t*)ws, code, m.data(), m.length());
+        };
+    ((H3App*)app)->wt(sv(pattern, pattern_len), std::move(b));
+}
+
+/* Accept the CONNECT and fire open. Mirrors uws_res_upgrade except there's
+ * no Sec-WebSocket-* handshake — the 2xx HEADERS is the whole acceptance. */
+void* uws_h3_res_upgrade(uws_h3_res_t* res, void* userData)
+{
+    Http3Response* r = (Http3Response*)res;
+    WebTransportSession* ws = r->upgradeWebTransport(userData);
+    if (!ws) return nullptr;
+    auto* cd = ws->getContextData();
+    if (cd->openHandler) cd->openHandler(ws);
+    return ws;
+}
+
+void* uws_h3_wt_get_user_data(uws_websocket_t* ws)
+{
+    auto* d = ((WebTransportSession*)ws)->getSessionData();
+    return d ? d->userData : nullptr;
+}
+
+void uws_h3_wt_close(uws_websocket_t* ws) { ((WebTransportSession*)ws)->close(); }
+
+int uws_h3_wt_send(uws_websocket_t* ws, const char* msg, size_t len,
+    uws_opcode_t op, bool /*compress*/, bool /*fin*/)
+{
+    return (int)((WebTransportSession*)ws)->send(sv(msg, len), (uWS::OpCode)op);
+}
+
+void uws_h3_wt_end(uws_websocket_t* ws, int code, const char* msg, size_t len)
+{
+    ((WebTransportSession*)ws)->end(code, sv(msg, len));
+}
+
+void uws_h3_wt_cork(uws_websocket_t* ws, void (*cb)(void*), void* user_data)
+{
+    ((WebTransportSession*)ws)->cork([cb, user_data]() { cb(user_data); });
+}
+
+bool uws_h3_wt_subscribe(uws_websocket_t* ws, const char* topic, size_t len)
+{
+    return ((WebTransportSession*)ws)->subscribe(sv(topic, len));
+}
+bool uws_h3_wt_unsubscribe(uws_websocket_t* ws, const char* topic, size_t len)
+{
+    return ((WebTransportSession*)ws)->unsubscribe(sv(topic, len));
+}
+bool uws_h3_wt_is_subscribed(uws_websocket_t* ws, const char* topic, size_t len)
+{
+    return ((WebTransportSession*)ws)->isSubscribed(sv(topic, len));
+}
+bool uws_h3_wt_publish(uws_websocket_t* ws, const char* topic, size_t topic_len,
+    const char* msg, size_t msg_len, uws_opcode_t op, bool /*compress*/)
+{
+    return ((WebTransportSession*)ws)->publish(sv(topic, topic_len), sv(msg, msg_len), (uWS::OpCode)op);
+}
+bool uws_h3_publish(uws_h3_app_t* app, const char* topic, size_t topic_len,
+    const char* msg, size_t msg_len, uws_opcode_t op, bool /*compress*/)
+{
+    return ((H3App*)app)->publish(sv(topic, topic_len), sv(msg, msg_len), (uWS::OpCode)op);
+}
+
+size_t uws_h3_wt_get_buffered_amount(uws_websocket_t* ws)
+{
+    return ((WebTransportSession*)ws)->getBufferedAmount();
+}
+size_t uws_h3_wt_memory_cost(uws_websocket_t* ws)
+{
+    return ((WebTransportSession*)ws)->memoryCost();
+}
+
+size_t uws_h3_wt_get_remote_address(uws_websocket_t* ws, const char** dest)
+{
+    static thread_local char b[64];
+    int len = 0, port = 0, ipv6 = 0;
+    us_quic_socket_t* qs = us_quic_stream_socket((us_quic_stream_t*)ws);
+    if (!qs) { *dest = b; return 0; }
+    us_quic_socket_remote_address(qs, b, &len, &port, &ipv6);
+    *dest = b;
+    return (size_t)len;
+}
+
+void uws_h3_wt_iterate_topics(uws_websocket_t* ws,
+    void (*cb)(const char*, size_t, void*), void* user_data)
+{
+    ((WebTransportSession*)ws)->iterateTopics([cb, user_data](std::string_view t) {
+        cb(t.data(), t.length(), user_data);
+    });
 }
 
 } // extern "C"

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -406,7 +406,10 @@ size_t uws_h3_wt_get_remote_address(uws_websocket_t* ws, const char** dest)
     static thread_local char b[64];
     int len = 0, port = 0, ipv6 = 0;
     us_quic_socket_t* qs = us_quic_stream_socket((us_quic_stream_t*)ws);
-    if (!qs) { *dest = b; return 0; }
+    if (!qs) {
+        *dest = b;
+        return 0;
+    }
     us_quic_socket_remote_address(qs, b, &len, &port, &ipv6);
     *dest = b;
     return (size_t)len;

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -353,10 +353,15 @@ void* uws_h3_wt_get_user_data(uws_websocket_t* ws)
 
 void uws_h3_wt_close(uws_websocket_t* ws) { ((WebTransportSession*)ws)->close(); }
 
-int uws_h3_wt_send(uws_websocket_t* ws, const char* msg, size_t len,
+uws_sendstatus_t uws_h3_wt_send(uws_websocket_t* ws, const char* msg, size_t len,
     uws_opcode_t op, bool /*compress*/, bool /*fin*/)
 {
-    return (int)((WebTransportSession*)ws)->send(sv(msg, len), (uWS::OpCode)op);
+    // WebTransportSession::SendStatus is value-identical to uws_sendstatus_t
+    // ({BACKPRESSURE,SUCCESS,DROPPED} = {0,1,2}); same cast as uws_ws_send().
+    static_assert((int)WebTransportSession::BACKPRESSURE == (int)BACKPRESSURE
+        && (int)WebTransportSession::SUCCESS == (int)SUCCESS
+        && (int)WebTransportSession::DROPPED == (int)DROPPED);
+    return (uws_sendstatus_t)((WebTransportSession*)ws)->send(sv(msg, len), (uWS::OpCode)op);
 }
 
 void uws_h3_wt_end(uws_websocket_t* ws, int code, const char* msg, size_t len)

--- a/src/deps/libuwsockets_h3.cpp
+++ b/src/deps/libuwsockets_h3.cpp
@@ -396,6 +396,10 @@ bool uws_h3_publish(uws_h3_app_t* app, const char* topic, size_t topic_len,
 {
     return ((H3App*)app)->publish(sv(topic, topic_len), sv(msg, msg_len), (uWS::OpCode)op);
 }
+unsigned uws_h3_num_subscribers(uws_h3_app_t* app, const char* topic, size_t topic_len)
+{
+    return ((H3App*)app)->numSubscribers(sv(topic, topic_len));
+}
 
 size_t uws_h3_wt_get_buffered_amount(uws_websocket_t* ws)
 {

--- a/src/deps/uws/WebSocket.zig
+++ b/src/deps/uws/WebSocket.zig
@@ -89,49 +89,53 @@ pub const RawWebSocket = opaque {
 pub const AnyWebSocket = union(enum) {
     ssl: *uws.NewApp(true).WebSocket,
     tcp: *uws.NewApp(false).WebSocket,
+    h3_wt: *uws.H3.WebTransportSession,
 
     pub fn raw(this: AnyWebSocket) *RawWebSocket {
         return switch (this) {
-            .ssl => this.ssl.raw(),
-            .tcp => this.tcp.raw(),
+            inline else => |w| w.raw(),
         };
     }
     pub fn as(this: AnyWebSocket, comptime Type: type) ?*Type {
         @setRuntimeSafety(false);
         return switch (this) {
-            .ssl => this.ssl.as(Type),
-            .tcp => this.tcp.as(Type),
+            inline else => |w| w.as(Type),
         };
     }
 
     pub fn memoryCost(this: AnyWebSocket) usize {
         return switch (this) {
-            .ssl => this.ssl.memoryCost(),
-            .tcp => this.tcp.memoryCost(),
+            inline else => |w| w.memoryCost(),
         };
     }
 
     pub fn close(this: AnyWebSocket) void {
-        const ssl_flag = @intFromBool(this == .ssl);
-        return c.uws_ws_close(ssl_flag, this.raw());
+        switch (this) {
+            .ssl => c.uws_ws_close(1, this.raw()),
+            .tcp => c.uws_ws_close(0, this.raw()),
+            .h3_wt => |w| w.close(),
+        }
     }
 
     pub fn send(this: AnyWebSocket, message: []const u8, opcode: Opcode, compress: bool, fin: bool) SendStatus {
         return switch (this) {
             .ssl => c.uws_ws_send_with_options(1, this.ssl.raw(), message.ptr, message.len, opcode, compress, fin),
             .tcp => c.uws_ws_send_with_options(0, this.tcp.raw(), message.ptr, message.len, opcode, compress, fin),
+            .h3_wt => |w| w.sendWithOptions(message, opcode, compress, fin),
         };
     }
     pub fn sendLastFragment(this: AnyWebSocket, message: []const u8, compress: bool) SendStatus {
-        switch (this) {
-            .tcp => return c.uws_ws_send_last_fragment(0, this.raw(), message.ptr, message.len, compress),
-            .ssl => return c.uws_ws_send_last_fragment(1, this.raw(), message.ptr, message.len, compress),
-        }
+        return switch (this) {
+            .tcp => c.uws_ws_send_last_fragment(0, this.raw(), message.ptr, message.len, compress),
+            .ssl => c.uws_ws_send_last_fragment(1, this.raw(), message.ptr, message.len, compress),
+            .h3_wt => |w| w.sendLastFragment(message, compress),
+        };
     }
     pub fn end(this: AnyWebSocket, code: i32, message: []const u8) void {
         switch (this) {
             .tcp => c.uws_ws_end(0, this.tcp.raw(), code, message.ptr, message.len),
             .ssl => c.uws_ws_end(1, this.ssl.raw(), code, message.ptr, message.len),
+            .h3_wt => |w| w.end(code, message),
         }
     }
     pub fn cork(this: AnyWebSocket, ctx: anytype, comptime callback: anytype) void {
@@ -145,39 +149,42 @@ pub const AnyWebSocket = union(enum) {
         switch (this) {
             .ssl => c.uws_ws_cork(1, this.raw(), Wrapper.wrap, ctx),
             .tcp => c.uws_ws_cork(0, this.raw(), Wrapper.wrap, ctx),
+            .h3_wt => |w| w.cork(ctx, callback),
         }
     }
     pub fn subscribe(this: AnyWebSocket, topic: []const u8) bool {
         return switch (this) {
             .ssl => c.uws_ws_subscribe(1, this.ssl.raw(), topic.ptr, topic.len),
             .tcp => c.uws_ws_subscribe(0, this.tcp.raw(), topic.ptr, topic.len),
+            .h3_wt => |w| w.subscribe(topic),
         };
     }
     pub fn unsubscribe(this: AnyWebSocket, topic: []const u8) bool {
         return switch (this) {
             .ssl => c.uws_ws_unsubscribe(1, this.raw(), topic.ptr, topic.len),
             .tcp => c.uws_ws_unsubscribe(0, this.raw(), topic.ptr, topic.len),
+            .h3_wt => |w| w.unsubscribe(topic),
         };
     }
     pub fn isSubscribed(this: AnyWebSocket, topic: []const u8) bool {
         return switch (this) {
             .ssl => c.uws_ws_is_subscribed(1, this.raw(), topic.ptr, topic.len),
             .tcp => c.uws_ws_is_subscribed(0, this.raw(), topic.ptr, topic.len),
+            .h3_wt => |w| w.isSubscribed(topic),
         };
     }
     pub fn getTopicsAsJSArray(this: AnyWebSocket, globalObject: *JSGlobalObject) JSValue {
         return switch (this) {
             .ssl => c.uws_ws_get_topics_as_js_array(1, this.raw(), globalObject),
             .tcp => c.uws_ws_get_topics_as_js_array(0, this.raw(), globalObject),
+            .h3_wt => c.uws_h3_wt_get_topics_as_js_array(this.raw(), globalObject),
         };
     }
-    // pub fn iterateTopics(this: AnyWebSocket) {
-    //     return uws_ws_iterate_topics(ssl_flag, this.raw(), callback: ?*const fn ([*c]const u8, usize, ?*anyopaque) callconv(.c) void, user_data: ?*anyopaque) void;
-    // }
     pub fn publish(this: AnyWebSocket, topic: []const u8, message: []const u8, opcode: Opcode, compress: bool) bool {
         return switch (this) {
             .ssl => c.uws_ws_publish_with_options(1, this.ssl.raw(), topic.ptr, topic.len, message.ptr, message.len, opcode, compress),
             .tcp => c.uws_ws_publish_with_options(0, this.tcp.raw(), topic.ptr, topic.len, message.ptr, message.len, opcode, compress),
+            .h3_wt => |w| w.publishWithOptions(topic, message, opcode, compress),
         };
     }
 
@@ -191,13 +198,13 @@ pub const AnyWebSocket = union(enum) {
         return switch (this) {
             .ssl => c.uws_ws_get_buffered_amount(1, this.ssl.raw()),
             .tcp => c.uws_ws_get_buffered_amount(0, this.tcp.raw()),
+            .h3_wt => |w| w.getBufferedAmount(),
         };
     }
 
     pub fn getRemoteAddress(this: AnyWebSocket, buf: []u8) []u8 {
         return switch (this) {
-            .ssl => this.ssl.getRemoteAddress(buf),
-            .tcp => this.tcp.getRemoteAddress(buf),
+            inline else => |w| w.getRemoteAddress(buf),
         };
     }
 };
@@ -301,6 +308,63 @@ pub const WebSocketBehavior = extern struct {
                 });
             }
 
+            /// Same handler set, but the upgrade callback receives an
+            /// H3.Response/H3.Request and the open/message/close/drain
+            /// wrappers tag the AnyWebSocket as `.h3_wt`. ping/pong are
+            /// dropped — WebTransport has no control frames; QUIC owns
+            /// keepalive.
+            pub fn applyH3(behavior: WebSocketBehavior) WebSocketBehavior {
+                const H3 = struct {
+                    fn onOpen(raw_ws: *RawWebSocket) callconv(.c) void {
+                        const ws: AnyWebSocket = .{ .h3_wt = @ptrCast(raw_ws) };
+                        @call(bun.callmod_inline, Type.onOpen, .{ ws.as(Type).?, ws });
+                    }
+                    fn onMessage(raw_ws: *RawWebSocket, msg: [*c]const u8, len: usize, op: Opcode) callconv(.c) void {
+                        const ws: AnyWebSocket = .{ .h3_wt = @ptrCast(raw_ws) };
+                        @call(bun.callmod_inline, Type.onMessage, .{
+                            ws.as(Type).?, ws, if (len > 0) msg[0..len] else "", op,
+                        });
+                    }
+                    fn onDrain(raw_ws: *RawWebSocket) callconv(.c) void {
+                        const ws: AnyWebSocket = .{ .h3_wt = @ptrCast(raw_ws) };
+                        @call(bun.callmod_inline, Type.onDrain, .{ ws.as(Type).?, ws });
+                    }
+                    fn onClose(raw_ws: *RawWebSocket, code: i32, msg: [*c]const u8, len: usize) callconv(.c) void {
+                        const ws: AnyWebSocket = .{ .h3_wt = @ptrCast(raw_ws) };
+                        @call(bun.callmod_inline, Type.onClose, .{
+                            ws.as(Type).?,                                    ws, code,
+                            if (len > 0 and msg != null) msg[0..len] else "",
+                        });
+                    }
+                    fn onUpgrade(ptr: *anyopaque, res: *uws_res, req: *Request, context: *uws.SocketContext, id: usize) callconv(.c) void {
+                        @call(bun.callmod_inline, Server.onWebTransportUpgrade, .{
+                            bun.cast(*Server, ptr),
+                            @as(*uws.H3.Response, @ptrCast(res)),
+                            @as(*uws.H3.Request, @ptrCast(req)),
+                            context,
+                            id,
+                        });
+                    }
+                };
+                return .{
+                    .compression = behavior.compression,
+                    .maxPayloadLength = behavior.maxPayloadLength,
+                    .idleTimeout = behavior.idleTimeout,
+                    .maxBackpressure = behavior.maxBackpressure,
+                    .closeOnBackpressureLimit = behavior.closeOnBackpressureLimit,
+                    .resetIdleTimeoutOnSend = behavior.resetIdleTimeoutOnSend,
+                    .sendPingsAutomatically = behavior.sendPingsAutomatically,
+                    .maxLifetime = behavior.maxLifetime,
+                    .upgrade = H3.onUpgrade,
+                    .open = H3.onOpen,
+                    .message = if (@hasDecl(Type, "onMessage")) H3.onMessage else null,
+                    .drain = if (@hasDecl(Type, "onDrain")) H3.onDrain else null,
+                    .ping = null,
+                    .pong = null,
+                    .close = H3.onClose,
+                };
+            }
+
             pub fn apply(behavior: WebSocketBehavior) WebSocketBehavior {
                 return .{
                     .compression = behavior.compression,
@@ -348,6 +412,7 @@ pub const c = struct {
     pub extern fn uws_ws_is_subscribed(ssl: i32, ws: ?*RawWebSocket, topic: [*c]const u8, length: usize) bool;
     pub extern fn uws_ws_iterate_topics(ssl: i32, ws: ?*RawWebSocket, callback: ?*const fn ([*c]const u8, usize, ?*anyopaque) callconv(.c) void, user_data: ?*anyopaque) void;
     pub extern fn uws_ws_get_topics_as_js_array(ssl: i32, ws: *RawWebSocket, globalObject: *JSGlobalObject) JSValue;
+    pub extern fn uws_h3_wt_get_topics_as_js_array(ws: *RawWebSocket, globalObject: *JSGlobalObject) JSValue;
     pub extern fn uws_ws_publish(ssl: i32, ws: ?*RawWebSocket, topic: [*]const u8, topic_length: usize, message: [*]const u8, message_length: usize) bool;
     pub extern fn uws_ws_publish_with_options(ssl: i32, ws: ?*RawWebSocket, topic: [*c]const u8, topic_length: usize, message: [*c]const u8, message_length: usize, opcode: Opcode, compress: bool) bool;
     pub extern fn uws_ws_get_buffered_amount(ssl: i32, ws: ?*RawWebSocket) usize;

--- a/src/deps/uws/h3.zig
+++ b/src/deps/uws/h3.zig
@@ -164,6 +164,9 @@ pub const Response = opaque {
     pub fn forceClose(this: *Response) void {
         c.uws_h3_res_force_close(this);
     }
+    pub fn upgradeWebTransport(this: *Response, user_data: *anyopaque) ?*WebTransportSession {
+        return c.uws_h3_res_upgrade(this, user_data);
+    }
 
     pub fn onWritable(
         this: *Response,
@@ -335,6 +338,18 @@ pub const App = opaque {
         }
     }
 
+    /// Register a WebTransport route. Same WebSocketBehavior shape as
+    /// `App.ws()`; ping/pong/compression are accepted but ignored. The
+    /// upgrade callback receives an H3 Response/Request, and on accept calls
+    /// `Response.upgradeWebTransport(*ServerWebSocket)`.
+    pub fn ws(this: *App, pattern: []const u8, ctx: *anyopaque, id: usize, behavior: uws.WebSocketBehavior) void {
+        var b = behavior;
+        c.uws_h3_ws(this, ctx, pattern.ptr, pattern.len, id, &b);
+    }
+    pub fn publishWithOptions(this: *App, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+        return c.uws_h3_publish(this, topic.ptr, topic.len, message.ptr, message.len, opcode, compress);
+    }
+
     pub fn listenWithConfig(
         this: *App,
         comptime UD: type,
@@ -355,6 +370,66 @@ pub const ListenConfig = extern struct {
     port: u16,
     host: ?[*:0]const u8 = null,
     options: i32 = 0,
+};
+
+/// WebTransport session — overlays the CONNECT us_quic_stream_t. API mirrors
+/// `NewApp(ssl).WebSocket` so AnyWebSocket can carry it as a third arm.
+pub const WebTransportSession = opaque {
+    pub fn raw(this: *WebTransportSession) *uws.RawWebSocket {
+        return @ptrCast(this);
+    }
+    pub fn as(this: *WebTransportSession, comptime T: type) ?*T {
+        return @ptrCast(@alignCast(c.uws_h3_wt_get_user_data(@ptrCast(this))));
+    }
+    pub fn close(this: *WebTransportSession) void {
+        c.uws_h3_wt_close(@ptrCast(this));
+    }
+    pub fn send(this: *WebTransportSession, message: []const u8, opcode: uws.Opcode) uws.SendStatus {
+        return c.uws_h3_wt_send(@ptrCast(this), message.ptr, message.len, opcode, false, true);
+    }
+    pub fn sendWithOptions(this: *WebTransportSession, message: []const u8, opcode: uws.Opcode, compress: bool, fin: bool) uws.SendStatus {
+        return c.uws_h3_wt_send(@ptrCast(this), message.ptr, message.len, opcode, compress, fin);
+    }
+    pub fn sendLastFragment(this: *WebTransportSession, message: []const u8, _: bool) uws.SendStatus {
+        return c.uws_h3_wt_send(@ptrCast(this), message.ptr, message.len, .binary, false, true);
+    }
+    pub fn end(this: *WebTransportSession, code: i32, message: []const u8) void {
+        c.uws_h3_wt_end(@ptrCast(this), code, message.ptr, message.len);
+    }
+    pub fn cork(this: *WebTransportSession, ctx: anytype, comptime callback: anytype) void {
+        const ContextType = @TypeOf(ctx);
+        const W = struct {
+            fn wrap(ud: ?*anyopaque) callconv(.c) void {
+                @call(bun.callmod_inline, callback, .{bun.cast(ContextType, ud.?)});
+            }
+        };
+        c.uws_h3_wt_cork(@ptrCast(this), W.wrap, ctx);
+    }
+    pub fn subscribe(this: *WebTransportSession, topic: []const u8) bool {
+        return c.uws_h3_wt_subscribe(@ptrCast(this), topic.ptr, topic.len);
+    }
+    pub fn unsubscribe(this: *WebTransportSession, topic: []const u8) bool {
+        return c.uws_h3_wt_unsubscribe(@ptrCast(this), topic.ptr, topic.len);
+    }
+    pub fn isSubscribed(this: *WebTransportSession, topic: []const u8) bool {
+        return c.uws_h3_wt_is_subscribed(@ptrCast(this), topic.ptr, topic.len);
+    }
+    pub fn publishWithOptions(this: *WebTransportSession, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
+        return c.uws_h3_wt_publish(@ptrCast(this), topic.ptr, topic.len, message.ptr, message.len, opcode, compress);
+    }
+    pub fn getBufferedAmount(this: *WebTransportSession) usize {
+        return c.uws_h3_wt_get_buffered_amount(@ptrCast(this));
+    }
+    pub fn memoryCost(this: *WebTransportSession) usize {
+        return c.uws_h3_wt_memory_cost(@ptrCast(this));
+    }
+    pub fn getRemoteAddress(this: *WebTransportSession, buf: []u8) []u8 {
+        var ptr: [*]const u8 = undefined;
+        const len = c.uws_h3_wt_get_remote_address(@ptrCast(this), &ptr);
+        const n = @min(len, buf.len);
+        @memcpy(buf[0..n], ptr[0..n]);
+        return buf[0..n];
+    }
 };
 
 const c = struct {
@@ -422,6 +497,22 @@ const c = struct {
     extern fn uws_h3_req_get_query(*Request, [*c]const u8, usize, *[*]const u8) usize;
     extern fn uws_h3_req_get_parameter(*Request, u16, *[*]const u8) usize;
     extern fn uws_h3_req_for_each_header(*Request, HeaderCb, ?*anyopaque) void;
+
+    extern fn uws_h3_ws(*App, ?*anyopaque, [*]const u8, usize, usize, *const uws.WebSocketBehavior) void;
+    extern fn uws_h3_publish(*App, [*]const u8, usize, [*]const u8, usize, uws.Opcode, bool) bool;
+    extern fn uws_h3_res_upgrade(*Response, *anyopaque) ?*WebTransportSession;
+    extern fn uws_h3_wt_get_user_data(*uws.RawWebSocket) ?*anyopaque;
+    extern fn uws_h3_wt_close(*uws.RawWebSocket) void;
+    extern fn uws_h3_wt_send(*uws.RawWebSocket, [*]const u8, usize, uws.Opcode, bool, bool) uws.SendStatus;
+    extern fn uws_h3_wt_end(*uws.RawWebSocket, i32, [*]const u8, usize) void;
+    extern fn uws_h3_wt_cork(*uws.RawWebSocket, *const fn (?*anyopaque) callconv(.c) void, ?*anyopaque) void;
+    extern fn uws_h3_wt_subscribe(*uws.RawWebSocket, [*]const u8, usize) bool;
+    extern fn uws_h3_wt_unsubscribe(*uws.RawWebSocket, [*]const u8, usize) bool;
+    extern fn uws_h3_wt_is_subscribed(*uws.RawWebSocket, [*]const u8, usize) bool;
+    extern fn uws_h3_wt_publish(*uws.RawWebSocket, [*]const u8, usize, [*]const u8, usize, uws.Opcode, bool) bool;
+    extern fn uws_h3_wt_get_buffered_amount(*uws.RawWebSocket) usize;
+    extern fn uws_h3_wt_memory_cost(*uws.RawWebSocket) usize;
+    extern fn uws_h3_wt_get_remote_address(*uws.RawWebSocket, *[*]const u8) usize;
 };
 
 const bun = @import("bun");

--- a/src/deps/uws/h3.zig
+++ b/src/deps/uws/h3.zig
@@ -349,6 +349,9 @@ pub const App = opaque {
     pub fn publishWithOptions(this: *App, topic: []const u8, message: []const u8, opcode: uws.Opcode, compress: bool) bool {
         return c.uws_h3_publish(this, topic.ptr, topic.len, message.ptr, message.len, opcode, compress);
     }
+    pub fn numSubscribers(this: *App, topic: []const u8) u32 {
+        return c.uws_h3_num_subscribers(this, topic.ptr, topic.len);
+    }
 
     pub fn listenWithConfig(
         this: *App,
@@ -500,6 +503,7 @@ const c = struct {
 
     extern fn uws_h3_ws(*App, ?*anyopaque, [*]const u8, usize, usize, *const uws.WebSocketBehavior) void;
     extern fn uws_h3_publish(*App, [*]const u8, usize, [*]const u8, usize, uws.Opcode, bool) bool;
+    extern fn uws_h3_num_subscribers(*App, [*]const u8, usize) u32;
     extern fn uws_h3_res_upgrade(*Response, *anyopaque) ?*WebTransportSession;
     extern fn uws_h3_wt_get_user_data(*uws.RawWebSocket) ?*anyopaque;
     extern fn uws_h3_wt_close(*uws.RawWebSocket) void;

--- a/test/js/bun/http/fixtures/.gitignore
+++ b/test/js/bun/http/fixtures/.gitignore
@@ -1,0 +1,2 @@
+wtclient
+libwtdeps.a

--- a/test/js/bun/http/fixtures/wtclient.c
+++ b/test/js/bun/http/fixtures/wtclient.c
@@ -195,8 +195,14 @@ static struct lsxpack_header *hsi_prepare(void *h, struct lsxpack_header *xh, si
 static int hsi_process(void *h, struct lsxpack_header *xh) {
     if (!xh) return 0;
     struct hset *hs = h;
-    if (xh->name_len == 7 && memcmp(xh->buf + xh->name_offset, ":status", 7) == 0)
-        hs->status = atoi(xh->buf + xh->val_offset);
+    if (xh->name_len == 7 && memcmp(xh->buf + xh->name_offset, ":status", 7) == 0) {
+        hs->status = 0;
+        for (unsigned i = 0; i < xh->val_len; i++) {
+            unsigned char c = (unsigned char) xh->buf[xh->val_offset + i];
+            if (c < '0' || c > '9') break;
+            hs->status = hs->status * 10 + (c - '0');
+        }
+    }
     return 0;
 }
 static void hsi_discard(void *h) { free(h); }
@@ -231,6 +237,7 @@ static void send_connect_headers(lsquic_stream_t *s) {
     struct lsxpack_header xh[7];
     for (unsigned i = 0; i < 7; i++) {
         size_t nl = strlen(H[i].n), vl = strlen(H[i].v);
+        if (off + nl + vl > sizeof(flat)) die("headers-too-large");
         memcpy(flat + off, H[i].n, nl);
         memcpy(flat + off + nl, H[i].v, vl);
         lsxpack_header_set_offset2(&xh[i], flat, off, nl, off + nl, vl);

--- a/test/js/bun/http/fixtures/wtclient.c
+++ b/test/js/bun/http/fixtures/wtclient.c
@@ -130,8 +130,13 @@ static unsigned vint_read(const unsigned char *p, const unsigned char *end, uint
 static unsigned vint_write(unsigned char *p, uint64_t v) {
     if (v < 64) { p[0] = (unsigned char) v; return 1; }
     if (v < 16384) { p[0] = 0x40 | (v >> 8); p[1] = (unsigned char) v; return 2; }
-    p[0] = 0x80 | (v >> 24); p[1] = v >> 16; p[2] = v >> 8; p[3] = (unsigned char) v;
-    return 4;
+    if (v < 1073741824) {
+        p[0] = 0x80 | (v >> 24); p[1] = v >> 16; p[2] = v >> 8; p[3] = (unsigned char) v;
+        return 4;
+    }
+    p[0] = (unsigned char)(0xc0 | (v >> 56));
+    for (int i = 1; i < 8; i++) p[i] = (unsigned char)(v >> (8 * (7 - i)));
+    return 8;
 }
 
 static struct buf *buf_new(const unsigned char *prefix, size_t plen,

--- a/test/js/bun/http/fixtures/wtclient.c
+++ b/test/js/bun/http/fixtures/wtclient.c
@@ -137,6 +137,7 @@ static unsigned vint_write(unsigned char *p, uint64_t v) {
 static struct buf *buf_new(const unsigned char *prefix, size_t plen,
                            const unsigned char *data, size_t dlen) {
     struct buf *b = malloc(sizeof(*b) + plen + dlen);
+    if (!b) die("oom");
     b->next = NULL;
     b->len = plen + dlen;
     memcpy(b->data, prefix, plen);
@@ -318,15 +319,19 @@ static void on_read(lsquic_stream_t *s, lsquic_stream_ctx_t *h) {
 static void on_close(lsquic_stream_t *s, lsquic_stream_ctx_t *h) {}
 
 static ssize_t on_dg_write(lsquic_conn_t *c, void *buf, size_t sz) {
-    struct buf *b = g_dg_head;
-    if (!b) { lsquic_conn_want_datagram_write(c, 0); return -1; }
-    if (b->len > sz) { g_dg_head = b->next; free(b); return 0; }
-    memcpy(buf, b->data, b->len);
-    ssize_t r = (ssize_t) b->len;
-    g_dg_head = b->next;
-    if (!g_dg_head) g_dg_tail = NULL;
-    free(b);
-    return r;
+    for (;;) {
+        struct buf *b = g_dg_head;
+        if (!b) { g_dg_tail = NULL; lsquic_conn_want_datagram_write(c, 0); return -1; }
+        g_dg_head = b->next;
+        if (b->len <= sz) {
+            memcpy(buf, b->data, b->len);
+            ssize_t r = (ssize_t) b->len;
+            if (!g_dg_head) g_dg_tail = NULL;
+            free(b);
+            return r;
+        }
+        free(b);
+    }
 }
 
 static void on_datagram(lsquic_conn_t *c, const void *buf, size_t sz) {

--- a/test/js/bun/http/fixtures/wtclient.c
+++ b/test/js/bun/http/fixtures/wtclient.c
@@ -1,0 +1,497 @@
+// Minimal WebTransport-over-HTTP/3 client for Bun.serve tests.
+//
+// Links against Bun's already-built lsquic/BoringSSL objects (same trick as
+// packages/h3blast). Single connection, single CONNECT stream; speaks a tiny
+// line protocol on stdio so the JS test can drive it deterministically:
+//
+//   stdout (one event per line, payload base64url so newlines/NULs survive):
+//     open                      — 2xx received on the CONNECT stream
+//     dgram <b64>               — incoming HTTP datagram for our session
+//     close <code> <b64>        — WT_CLOSE_SESSION capsule received
+//     error <text>              — anything fatal
+//   stdin commands:
+//     dgram <b64>               — queue one QUIC DATAGRAM (QSID-prefixed)
+//     stream <b64>              — open a bidi WT stream (0x41 + sid), write, FIN
+//     close <code> <b64>        — send WT_CLOSE_SESSION + FIN, then quit
+//
+// Only what the tests need: no uni streams, no flow-control capsules, no
+// reconnection. Runs the lsquic event loop on a 1 ms timer plus poll on the
+// UDP fd and stdin.
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define LSQUIC_WEBTRANSPORT_SERVER_SUPPORT 1
+#include "lsquic.h"
+#include "lsxpack_header.h"
+#include <openssl/ssl.h>
+
+static int g_fd = -1;
+static struct sockaddr_in g_local, g_peer;
+static lsquic_engine_t *g_engine;
+static lsquic_conn_t *g_conn;
+static lsquic_stream_t *g_connect; /* the CONNECT/session stream */
+static lsquic_stream_id_t g_session_id;
+static int g_open, g_done;
+static const char *g_path = "/";
+
+/* Outgoing queues: datagrams (QSID-prefixed payloads) and pending bidi
+ * streams (0x41 + sid prefixed payloads). */
+struct buf { struct buf *next; size_t len; unsigned char data[]; };
+static struct buf *g_dg_head, *g_dg_tail;
+static struct buf *g_stream_pending; /* one at a time is enough for tests */
+
+/* Capsule reassembly on the CONNECT stream. */
+static unsigned char g_cap[2048];
+static size_t g_caplen;
+
+/* Outgoing close capsule, written once the CONNECT stream becomes writable. */
+static unsigned char g_close[1100];
+static size_t g_closelen;
+
+/* ───── helpers ───── */
+
+static void die(const char *msg) {
+    printf("error %s\n", msg);
+    fflush(stdout);
+    exit(1);
+}
+
+static const char B64[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+static void b64enc(const unsigned char *in, size_t n, char *out) {
+    size_t i = 0, o = 0;
+    while (i + 3 <= n) {
+        unsigned v = (in[i] << 16) | (in[i+1] << 8) | in[i+2];
+        out[o++] = B64[(v >> 18) & 63]; out[o++] = B64[(v >> 12) & 63];
+        out[o++] = B64[(v >> 6) & 63];  out[o++] = B64[v & 63];
+        i += 3;
+    }
+    if (i + 1 == n) {
+        unsigned v = in[i] << 16;
+        out[o++] = B64[(v >> 18) & 63]; out[o++] = B64[(v >> 12) & 63];
+    } else if (i + 2 == n) {
+        unsigned v = (in[i] << 16) | (in[i+1] << 8);
+        out[o++] = B64[(v >> 18) & 63]; out[o++] = B64[(v >> 12) & 63];
+        out[o++] = B64[(v >> 6) & 63];
+    }
+    out[o] = 0;
+}
+
+static int b64idx(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '-' || c == '+') return 62;
+    if (c == '_' || c == '/') return 63;
+    return -1;
+}
+
+static size_t b64dec(const char *in, unsigned char *out) {
+    size_t o = 0;
+    int q[4], n = 0;
+    for (; *in; in++) {
+        int v = b64idx(*in);
+        if (v < 0) continue;
+        q[n++] = v;
+        if (n == 4) {
+            out[o++] = (q[0] << 2) | (q[1] >> 4);
+            out[o++] = (q[1] << 4) | (q[2] >> 2);
+            out[o++] = (q[2] << 6) | q[3];
+            n = 0;
+        }
+    }
+    if (n >= 2) out[o++] = (q[0] << 2) | (q[1] >> 4);
+    if (n >= 3) out[o++] = (q[1] << 4) | (q[2] >> 2);
+    return o;
+}
+
+static unsigned vint_read(const unsigned char *p, const unsigned char *end, uint64_t *out) {
+    if (p >= end) return 0;
+    unsigned len = 1u << (*p >> 6);
+    if ((unsigned)(end - p) < len) return 0;
+    uint64_t v = *p & 0x3f;
+    for (unsigned i = 1; i < len; i++) v = (v << 8) | p[i];
+    *out = v;
+    return len;
+}
+
+static unsigned vint_write(unsigned char *p, uint64_t v) {
+    if (v < 64) { p[0] = (unsigned char) v; return 1; }
+    if (v < 16384) { p[0] = 0x40 | (v >> 8); p[1] = (unsigned char) v; return 2; }
+    p[0] = 0x80 | (v >> 24); p[1] = v >> 16; p[2] = v >> 8; p[3] = (unsigned char) v;
+    return 4;
+}
+
+static struct buf *buf_new(const unsigned char *prefix, size_t plen,
+                           const unsigned char *data, size_t dlen) {
+    struct buf *b = malloc(sizeof(*b) + plen + dlen);
+    b->next = NULL;
+    b->len = plen + dlen;
+    memcpy(b->data, prefix, plen);
+    memcpy(b->data + plen, data, dlen);
+    return b;
+}
+
+/* ───── lsquic plumbing ───── */
+
+static int packets_out(void *ctx, const struct lsquic_out_spec *specs, unsigned n) {
+    unsigned sent = 0;
+    for (; sent < n; sent++) {
+        struct msghdr m = {0};
+        m.msg_name = (void *) specs[sent].dest_sa;
+        m.msg_namelen = sizeof(struct sockaddr_in);
+        m.msg_iov = specs[sent].iov;
+        m.msg_iovlen = specs[sent].iovlen;
+        if (sendmsg(g_fd, &m, 0) < 0) break;
+    }
+    return (int) sent;
+}
+
+static SSL_CTX *g_ssl;
+static SSL_CTX *get_ssl_ctx(void *p, const struct sockaddr *l) { return g_ssl; }
+
+static lsquic_conn_ctx_t *on_new_conn(void *c, lsquic_conn_t *conn) {
+    g_conn = conn;
+    return (lsquic_conn_ctx_t *)(uintptr_t) 1;
+}
+static void on_conn_closed(lsquic_conn_t *c) {
+    if (!g_done) printf("close 1006 \n");
+    g_done = 1;
+    lsquic_conn_set_ctx(c, NULL);
+}
+static void on_hsk_done(lsquic_conn_t *c, enum lsquic_hsk_status s) {
+    if (s != LSQ_HSK_OK && s != LSQ_HSK_RESUMED_OK) die("handshake-failed");
+    lsquic_conn_make_stream(c);
+}
+
+/* hset interface — lsquic decodes QPACK before on_read; we only care about
+ * :status. */
+struct hset { int status; struct lsxpack_header xh; char buf[512]; };
+static void *hsi_create(void *c, lsquic_stream_t *s, int p) { return calloc(1, sizeof(struct hset)); }
+static struct lsxpack_header *hsi_prepare(void *h, struct lsxpack_header *xh, size_t space) {
+    struct hset *hs = h;
+    if (space > sizeof(hs->buf)) return NULL;
+    lsxpack_header_prepare_decode(&hs->xh, hs->buf, 0, space);
+    return &hs->xh;
+}
+static int hsi_process(void *h, struct lsxpack_header *xh) {
+    if (!xh) return 0;
+    struct hset *hs = h;
+    if (xh->name_len == 7 && memcmp(xh->buf + xh->name_offset, ":status", 7) == 0)
+        hs->status = atoi(xh->buf + xh->val_offset);
+    return 0;
+}
+static void hsi_discard(void *h) { free(h); }
+
+static lsquic_stream_ctx_t *on_new_stream(void *c, lsquic_stream_t *s) {
+    if (!s) return NULL;
+    /* lsquic also fires this for crypto streams (~0ULL ids) and the H3
+     * control / QPACK uni streams (id % 4 != 0). Only client-initiated bidi
+     * streams (id ≡ 0 mod 4) carry our CONNECT and WT data. */
+    lsquic_stream_id_t id = lsquic_stream_id(s);
+    if ((id & 3) != 0 || id > (1ull << 60)) return NULL;
+    if (!g_connect) {
+        g_connect = s;
+        g_session_id = id;
+        lsquic_stream_wantwrite(s, 1);
+        return (lsquic_stream_ctx_t *)(uintptr_t) 1; /* tag: CONNECT */
+    }
+    /* WT bidi data stream we asked for. */
+    lsquic_stream_wantwrite(s, 1);
+    return (lsquic_stream_ctx_t *)(uintptr_t) 2;
+}
+
+static void send_connect_headers(lsquic_stream_t *s) {
+    char hostbuf[32];
+    snprintf(hostbuf, sizeof(hostbuf), "localhost:%d", ntohs(g_peer.sin_port));
+    struct { const char *n, *v; } H[] = {
+        {":method", "CONNECT"}, {":scheme", "https"}, {":authority", hostbuf},
+        {":path", g_path}, {":protocol", "webtransport"},
+        {"sec-webtransport-http3-draft", "draft02"}, {"origin", "https://localhost"},
+    };
+    char flat[512]; size_t off = 0;
+    struct lsxpack_header xh[7];
+    for (unsigned i = 0; i < 7; i++) {
+        size_t nl = strlen(H[i].n), vl = strlen(H[i].v);
+        memcpy(flat + off, H[i].n, nl);
+        memcpy(flat + off + nl, H[i].v, vl);
+        lsxpack_header_set_offset2(&xh[i], flat, off, nl, off + nl, vl);
+        off += nl + vl;
+    }
+    lsquic_http_headers_t lh = { .count = 7, .headers = xh };
+    if (lsquic_stream_send_headers(s, &lh, 0) != 0) die("send-headers");
+    lsquic_stream_flush(s);
+    lsquic_stream_wantread(s, 1);
+}
+
+static void on_write(lsquic_stream_t *s, lsquic_stream_ctx_t *h) {
+    if (h == NULL) { lsquic_stream_wantwrite(s, 0); return; }
+    if ((uintptr_t) h == 1) {
+        if (!g_open) {
+            send_connect_headers(s);
+            lsquic_stream_wantwrite(s, 0);
+        } else if (g_closelen) {
+            lsquic_stream_write(s, (char *) g_close, g_closelen);
+            lsquic_stream_shutdown(s, 1);
+            g_closelen = 0;
+            lsquic_stream_wantwrite(s, 0);
+        }
+    } else if ((uintptr_t) h == 2 && g_stream_pending) {
+        struct buf *b = g_stream_pending; g_stream_pending = NULL;
+        lsquic_stream_write(s, (char *) b->data, b->len);
+        lsquic_stream_shutdown(s, 1);
+        lsquic_stream_wantwrite(s, 0);
+        free(b);
+    }
+}
+
+static void parse_capsules(void) {
+    const unsigned char *p = g_cap, *end = g_cap + g_caplen;
+    while (p < end) {
+        const unsigned char *start = p;
+        uint64_t type, clen;
+        unsigned n = vint_read(p, end, &type); if (!n) break; p += n;
+        n = vint_read(p, end, &clen); if (!n) { p = start; break; }
+        p += n;
+        if ((uint64_t)(end - p) < clen) { p = start; break; }
+        if (type == 0x2843) {
+            int code = 0; char b64[2048] = "";
+            if (clen >= 4) {
+                code = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
+                b64enc(p + 4, clen - 4, b64);
+            }
+            printf("close %d %s\n", code, b64);
+            g_done = 1;
+        }
+        p += clen;
+    }
+    size_t left = end - p;
+    memmove(g_cap, p, left);
+    g_caplen = left;
+}
+
+static void on_read(lsquic_stream_t *s, lsquic_stream_ctx_t *h) {
+    if ((uintptr_t) h != 1) {
+        char tmp[256]; ssize_t r;
+        while ((r = lsquic_stream_read(s, tmp, sizeof(tmp))) > 0);
+        if (r == 0) lsquic_stream_shutdown(s, 0);
+        return;
+    }
+    if (!g_open) {
+        struct hset *hs = lsquic_stream_get_hset(s);
+        if (hs) {
+            int status = hs->status ? hs->status : 200;
+            free(hs);
+            if (status / 100 != 2) {
+                printf("error status-%d\n", status);
+                g_done = 1; return;
+            }
+            g_open = 1;
+            printf("open\n");
+        } else if (getenv("WTCLIENT_DEBUG")) {
+            fprintf(stderr, "[wtclient] on_read stream 0, no hset yet\n");
+        }
+    }
+    ssize_t r;
+    while ((r = lsquic_stream_read(s, (char *)(g_cap + g_caplen), sizeof(g_cap) - g_caplen)) > 0) {
+        g_caplen += (size_t) r;
+        parse_capsules();
+    }
+    if (r == 0) {
+        if (!g_done) printf("close 0 \n");
+        g_done = 1;
+    }
+}
+
+static void on_close(lsquic_stream_t *s, lsquic_stream_ctx_t *h) {}
+
+static ssize_t on_dg_write(lsquic_conn_t *c, void *buf, size_t sz) {
+    struct buf *b = g_dg_head;
+    if (!b) { lsquic_conn_want_datagram_write(c, 0); return -1; }
+    if (b->len > sz) { g_dg_head = b->next; free(b); return 0; }
+    memcpy(buf, b->data, b->len);
+    ssize_t r = (ssize_t) b->len;
+    g_dg_head = b->next;
+    if (!g_dg_head) g_dg_tail = NULL;
+    free(b);
+    return r;
+}
+
+static void on_datagram(lsquic_conn_t *c, const void *buf, size_t sz) {
+    uint64_t qsid;
+    unsigned n = vint_read(buf, (const unsigned char *) buf + sz, &qsid);
+    if (!n || qsid * 4 != g_session_id) return;
+    /* The server queues its 200 HEADERS and the open()-handler datagrams in
+     * the same process_conns tick, so the DATAGRAM frame can land in an
+     * earlier QUIC packet than the STREAM frame carrying :status. Tests want
+     * a deterministic "open" first; treat the first matching datagram as
+     * implicit confirmation if the headers haven't arrived yet. */
+    if (!g_open) { g_open = 1; printf("open\n"); }
+    char b64[2048];
+    b64enc((const unsigned char *) buf + n, sz - n, b64);
+    printf("dgram %s\n", b64);
+}
+
+/* ───── stdin command processing ───── */
+
+static void handle_cmd(char *line) {
+    char *sp = strchr(line, ' ');
+    if (sp) *sp++ = 0;
+    if (strcmp(line, "dgram") == 0 && sp && g_open) {
+        unsigned char payload[1400], prefix[8];
+        size_t dlen = b64dec(sp, payload);
+        unsigned plen = vint_write(prefix, g_session_id / 4);
+        struct buf *b = buf_new(prefix, plen, payload, dlen);
+        if (g_dg_tail) g_dg_tail->next = b; else g_dg_head = b;
+        g_dg_tail = b;
+        lsquic_conn_want_datagram_write(g_conn, 1);
+    } else if (strcmp(line, "stream") == 0 && sp && g_open) {
+        unsigned char payload[8192], prefix[16];
+        size_t dlen = b64dec(sp, payload);
+        prefix[0] = 0x40; prefix[1] = 0x41; /* 2-byte varint for the type */
+        unsigned slen = vint_write(prefix + 2, g_session_id);
+        g_stream_pending = buf_new(prefix, 2 + slen, payload, dlen);
+        lsquic_conn_make_stream(g_conn);
+    } else if (strcmp(line, "capsule") == 0 && sp && g_open) {
+        /* Raw bytes on the CONNECT stream (no FIN). lsquic wraps them in a
+         * DATA frame; the server's capsule parser sees them as body. */
+        unsigned char payload[16384];
+        size_t dlen = b64dec(sp, payload);
+        lsquic_stream_write(g_connect, (char *) payload, dlen);
+        lsquic_stream_flush(g_connect);
+    } else if (strcmp(line, "close") == 0) {
+        int code = 0; const char *b64 = "";
+        if (sp) { code = atoi(sp); char *sp2 = strchr(sp, ' '); if (sp2) b64 = sp2 + 1; }
+        unsigned char msg[1024]; size_t mlen = b64dec(b64, msg);
+        unsigned char *p = g_close;
+        *p++ = 0x80; *p++ = 0x00; *p++ = 0x28; *p++ = 0x43;
+        uint64_t blen = (code || mlen) ? 4 + mlen : 0;
+        p += vint_write(p, blen);
+        if (blen) {
+            *p++ = code >> 24; *p++ = code >> 16; *p++ = code >> 8; *p++ = (unsigned char) code;
+            memcpy(p, msg, mlen); p += mlen;
+        }
+        g_closelen = p - g_close;
+        lsquic_stream_wantwrite(g_connect, 1);
+    }
+}
+
+/* ───── main loop ───── */
+
+static void process(void) {
+    lsquic_engine_process_conns(g_engine);
+    fflush(stdout);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) die("usage: wtclient <port> [path]");
+    int port = atoi(argv[1]);
+    if (argc >= 3) g_path = argv[2];
+
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    lsquic_global_init(LSQUIC_GLOBAL_CLIENT);
+    if (getenv("WTCLIENT_DEBUG")) {
+        static const struct lsquic_logger_if lif = { .log_buf =
+            (int (*)(void *, const char *, size_t)) (void *) write };
+        lsquic_logger_init(&lif, (void *)(uintptr_t) 2, LLTS_HHMMSSUS);
+        lsquic_set_log_level("debug");
+    }
+
+    g_ssl = SSL_CTX_new(TLS_method());
+    SSL_CTX_set_min_proto_version(g_ssl, TLS1_3_VERSION);
+    SSL_CTX_set_verify(g_ssl, SSL_VERIFY_NONE, NULL);
+    SSL_CTX_set_alpn_protos(g_ssl, (const unsigned char *)"\x02h3", 3);
+
+    g_fd = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+    g_local.sin_family = AF_INET;
+    bind(g_fd, (struct sockaddr *) &g_local, sizeof(g_local));
+    socklen_t sl = sizeof(g_local);
+    getsockname(g_fd, (struct sockaddr *) &g_local, &sl);
+    g_peer.sin_family = AF_INET;
+    g_peer.sin_port = htons(port);
+    inet_pton(AF_INET, "127.0.0.1", &g_peer.sin_addr);
+
+    struct lsquic_engine_settings es;
+    lsquic_engine_init_settings(&es, LSENG_HTTP);
+    es.es_versions = LSQUIC_DF_VERSIONS & LSQUIC_IETF_VERSIONS;
+    es.es_datagrams = 1;
+    es.es_ecn = 0;
+    es.es_init_max_streams_bidi = 100;
+
+    static const struct lsquic_stream_if sif = {
+        .on_new_conn = on_new_conn, .on_conn_closed = on_conn_closed,
+        .on_new_stream = on_new_stream, .on_read = on_read,
+        .on_write = on_write, .on_close = on_close,
+        .on_hsk_done = on_hsk_done,
+        .on_dg_write = on_dg_write, .on_datagram = on_datagram,
+    };
+    static const struct lsquic_hset_if hif = {
+        .hsi_create_header_set = hsi_create, .hsi_prepare_decode = hsi_prepare,
+        .hsi_process_header = hsi_process, .hsi_discard_header_set = hsi_discard,
+    };
+    struct lsquic_engine_api api = {
+        .ea_settings = &es, .ea_stream_if = &sif, .ea_stream_if_ctx = NULL,
+        .ea_packets_out = packets_out, .ea_packets_out_ctx = NULL,
+        .ea_get_ssl_ctx = get_ssl_ctx, .ea_hsi_if = &hif, .ea_alpn = "h3",
+    };
+    g_engine = lsquic_engine_new(LSENG_HTTP, &api);
+    if (!g_engine) die("engine");
+
+    if (!lsquic_engine_connect(g_engine, N_LSQVER,
+            (struct sockaddr *) &g_local, (struct sockaddr *) &g_peer,
+            (void *)(uintptr_t) 1, NULL, "localhost", 0, NULL, 0, NULL, 0))
+        die("connect");
+    process();
+
+    char line[32768]; size_t llen = 0;
+    struct pollfd pfds[2] = {{g_fd, POLLIN, 0}, {0, POLLIN, 0}};
+    int npfds = 2;
+    fcntl(0, F_SETFL, fcntl(0, F_GETFL) | O_NONBLOCK);
+    while (!g_done) {
+        int diff = 0, t = 50;
+        if (lsquic_engine_earliest_adv_tick(g_engine, &diff))
+            t = diff <= 0 ? 0 : (diff + 999) / 1000;
+        poll(pfds, npfds, t);
+        if (pfds[0].revents & POLLIN) {
+            unsigned char buf[2048]; struct sockaddr_in peer; socklen_t pl = sizeof(peer);
+            ssize_t r;
+            while ((r = recvfrom(g_fd, buf, sizeof(buf), 0,
+                                 (struct sockaddr *) &peer, &pl)) > 0) {
+                lsquic_engine_packet_in(g_engine, buf, (size_t) r,
+                    (struct sockaddr *) &g_local, (struct sockaddr *) &peer,
+                    (void *)(uintptr_t) 1, 0);
+            }
+        }
+        if (npfds > 1 && (pfds[1].revents & (POLLIN | POLLHUP))) {
+            ssize_t r = read(0, line + llen, sizeof(line) - 1 - llen);
+            if (r == 0) npfds = 1; /* EOF: stop polling stdin, keep running */
+            else if (r < 0) { if (errno != EAGAIN) npfds = 1; }
+            else {
+                llen += (size_t) r;
+                char *nl;
+                while ((nl = memchr(line, '\n', llen))) {
+                    *nl = 0;
+                    handle_cmd(line);
+                    size_t used = (size_t)(nl + 1 - line);
+                    memmove(line, nl + 1, llen - used);
+                    llen -= used;
+                }
+            }
+        }
+        process();
+    }
+    fflush(stdout);
+    return 0;
+}

--- a/test/js/bun/http/fixtures/wtclient.c
+++ b/test/js/bun/http/fixtures/wtclient.c
@@ -98,7 +98,7 @@ static int b64idx(char c) {
     return -1;
 }
 
-static size_t b64dec(const char *in, unsigned char *out) {
+static size_t b64dec(const char *in, unsigned char *out, size_t cap) {
     size_t o = 0;
     int q[4], n = 0;
     for (; *in; in++) {
@@ -106,14 +106,15 @@ static size_t b64dec(const char *in, unsigned char *out) {
         if (v < 0) continue;
         q[n++] = v;
         if (n == 4) {
+            if (o + 3 > cap) return o;
             out[o++] = (q[0] << 2) | (q[1] >> 4);
             out[o++] = (q[1] << 4) | (q[2] >> 2);
             out[o++] = (q[2] << 6) | q[3];
             n = 0;
         }
     }
-    if (n >= 2) out[o++] = (q[0] << 2) | (q[1] >> 4);
-    if (n >= 3) out[o++] = (q[1] << 4) | (q[2] >> 2);
+    if (n >= 2 && o < cap) out[o++] = (q[0] << 2) | (q[1] >> 4);
+    if (n >= 3 && o < cap) out[o++] = (q[1] << 4) | (q[2] >> 2);
     return o;
 }
 
@@ -280,12 +281,16 @@ static void parse_capsules(void) {
         p += n;
         if ((uint64_t)(end - p) < clen) { p = start; break; }
         if (type == 0x2843) {
-            int code = 0; char b64[2048] = "";
+            int code = 0; size_t mlen = 0;
             if (clen >= 4) {
                 code = (p[0] << 24) | (p[1] << 16) | (p[2] << 8) | p[3];
-                b64enc(p + 4, clen - 4, b64);
+                mlen = (size_t)(clen - 4);
             }
+            char *b64 = malloc((mlen + 2) / 3 * 4 + 1);
+            if (!b64) die("oom");
+            b64enc(p + 4, mlen, b64);
             printf("close %d %s\n", code, b64);
+            free(b64);
             g_done = 1;
         }
         p += clen;
@@ -368,7 +373,7 @@ static void handle_cmd(char *line) {
     if (sp) *sp++ = 0;
     if (strcmp(line, "dgram") == 0 && sp && g_open) {
         unsigned char payload[1400], prefix[8];
-        size_t dlen = b64dec(sp, payload);
+        size_t dlen = b64dec(sp, payload, sizeof(payload));
         unsigned plen = vint_write(prefix, g_session_id / 4);
         struct buf *b = buf_new(prefix, plen, payload, dlen);
         if (g_dg_tail) g_dg_tail->next = b; else g_dg_head = b;
@@ -376,7 +381,7 @@ static void handle_cmd(char *line) {
         lsquic_conn_want_datagram_write(g_conn, 1);
     } else if (strcmp(line, "stream") == 0 && sp && g_open) {
         unsigned char payload[8192], prefix[16];
-        size_t dlen = b64dec(sp, payload);
+        size_t dlen = b64dec(sp, payload, sizeof(payload));
         prefix[0] = 0x40; prefix[1] = 0x41; /* 2-byte varint for the type */
         unsigned slen = vint_write(prefix + 2, g_session_id);
         g_stream_pending = buf_new(prefix, 2 + slen, payload, dlen);
@@ -385,13 +390,13 @@ static void handle_cmd(char *line) {
         /* Raw bytes on the CONNECT stream (no FIN). lsquic wraps them in a
          * DATA frame; the server's capsule parser sees them as body. */
         unsigned char payload[16384];
-        size_t dlen = b64dec(sp, payload);
+        size_t dlen = b64dec(sp, payload, sizeof(payload));
         lsquic_stream_write(g_connect, (char *) payload, dlen);
         lsquic_stream_flush(g_connect);
     } else if (strcmp(line, "close") == 0) {
         int code = 0; const char *b64 = "";
         if (sp) { code = atoi(sp); char *sp2 = strchr(sp, ' '); if (sp2) b64 = sp2 + 1; }
-        unsigned char msg[1024]; size_t mlen = b64dec(b64, msg);
+        unsigned char msg[1024]; size_t mlen = b64dec(b64, msg, sizeof(msg));
         unsigned char *p = g_close;
         *p++ = 0x80; *p++ = 0x00; *p++ = 0x28; *p++ = 0x43;
         uint64_t blen = (code || mlen) ? 4 + mlen : 0;

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -285,7 +285,7 @@ describe("WebTransport over HTTP/3", () => {
     const c = spawnClient(server.port);
     try {
       await c.expectEvent("open");
-      for (const msg of ["a", "bb", "ccc", "x".repeat(500)]) {
+      for (const msg of ["a", "bb", "ccc", Buffer.alloc(500, "x").toString()]) {
         c.sendDatagram(msg);
         const e = await c.expectEvent("dgram");
         expect(fromB64u(e[1]).toString()).toBe(msg);
@@ -382,20 +382,74 @@ describe("WebTransport over HTTP/3", () => {
     }
   });
 
-  itWT("non-WT CONNECT does not hit websocket handler", async () => {
-    // The H3 wt() route gates on :protocol; a CONNECT without it should fall
-    // through to the next router match (404 here, since fetch only handles
-    // GET via server.upgrade falling back to "ok").
-    await using server = await spawnServer(`open(ws) { console.log("BUG"); }, message() {}, close() {}`);
-    // wtclient always sends :protocol=webtransport, so for the negative case
-    // hit the H3 listener with curl-h3 if available; otherwise just assert
-    // the WT path still works (the gate is exercised by the C++ unit path).
-    const c = spawnClient(server.port);
-    try {
-      await c.expectEvent("open");
-    } finally {
-      c.kill();
-    }
+  // wtclient always sends :protocol=webtransport, so the negative branch in
+  // H3App::wt() (yield to the next route on a non-WT CONNECT) isn't reachable
+  // from this fixture. Covered once wtclient grows a configurable :protocol.
+  test.todo("non-WT CONNECT does not hit websocket handler");
+
+  itWT("rejected upgrade returns the fetch response", async () => {
+    // The CONNECT routes through fetch; if fetch declines to call
+    // server.upgrade() the websocket handlers must not fire and the client
+    // must see the non-2xx status.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { tls } = require("harness");
+        const server = Bun.serve({
+          tls, port: 0, h3: true,
+          fetch(req, server) {
+            if (!new URL(req.url).pathname.startsWith("/deny"))
+              if (server.upgrade(req, { data: { tag: "ok" } })) return;
+            return new Response("denied", { status: 403 });
+          },
+          websocket: {
+            open(ws) { console.log("opened " + ws.data.tag); },
+            message() {}, close() {},
+          },
+        });
+        console.log(JSON.stringify({ port: server.port }));
+        process.stdin.on("end", () => server.stop(true));
+        process.stdin.resume();
+        `,
+      ],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    let buf = "";
+    const readLine = async () => {
+      while (true) {
+        const nl = buf.indexOf("\n");
+        if (nl >= 0) {
+          const l = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          return l;
+        }
+        const { value, done } = await reader.read();
+        if (done) throw new Error("server exited");
+        buf += Buffer.from(value).toString();
+      }
+    };
+    const port = JSON.parse(await readLine()).port;
+
+    // Allowed path: open() fires with the per-request data attached.
+    const a = spawnClient(port, "/allow");
+    await a.expectEvent("open");
+    expect(await readLine()).toBe("opened ok");
+    a.kill();
+
+    // Denied path: client sees 403, server never logs "opened".
+    const d = spawnClient(port, "/deny");
+    const e = await d.expectEvent("error");
+    expect(e[1]).toBe("status-403");
+    d.kill();
+
+    proc.stdin.end();
   });
 
   itWT("many sequential datagrams survive reordering", async () => {

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, unlinkSync } from "fs";
 import { bunEnv, bunExe, isLinux } from "harness";
 import path from "path";
 
@@ -27,17 +28,16 @@ beforeAll(async () => {
   const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "zlib"];
   const libdeps = path.join(fixtureDir, "libwtdeps.a");
 
-  const fs = await import("fs");
-  if (!fs.existsSync(path.join(objRoot, "lsquic")) || !fs.existsSync(path.join(vendor, "lsquic/include/lsquic.h"))) {
+  if (!existsSync(path.join(objRoot, "lsquic")) || !existsSync(path.join(vendor, "lsquic/include/lsquic.h"))) {
     console.warn("serve-webtransport: skipping (no debug-profile dep objects under build/debug/obj/vendor)");
     return;
   }
 
   // The dep .o files are built with -gz=zstd; system ld may not understand
   // that, so use the same llvm-ar/clang the build used.
-  const llvm = (t: string) => (fs.existsSync(`/opt/llvm-21/bin/${t}`) ? `/opt/llvm-21/bin/${t}` : t);
+  const llvm = (t: string) => (existsSync(`/opt/llvm-21/bin/${t}`) ? `/opt/llvm-21/bin/${t}` : t);
 
-  if (!fs.existsSync(libdeps)) {
+  if (!existsSync(libdeps)) {
     const objs: string[] = [];
     for (const d of deps) {
       for await (const f of new Bun.Glob("**/*.o").scan({ cwd: path.join(objRoot, d), absolute: true })) {
@@ -86,22 +86,18 @@ afterAll(() => {
   // Leave the .a for subsequent test runs (it's content-stable); drop the
   // executable so a stale debug build doesn't mask a regression.
   try {
-    require("fs").unlinkSync(wtclientBin);
+    unlinkSync(wtclientBin);
   } catch {}
 });
 
-const itWT: typeof test = ((name: string, fn: any, timeout?: number) =>
-  test(
-    name,
-    async () => {
-      if (!canRunClient) {
-        console.warn("skipping (no wtclient; needs Linux + debug build deps)");
-        return;
-      }
-      return fn();
-    },
-    timeout,
-  )) as any;
+const itWT: typeof test = ((name: string, fn: any) =>
+  test(name, async () => {
+    if (!canRunClient) {
+      console.warn("skipping (no wtclient; needs Linux + debug build deps)");
+      return;
+    }
+    return fn();
+  })) as any;
 
 const b64u = (s: string | Uint8Array) =>
   Buffer.from(s).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
@@ -402,34 +398,29 @@ describe("WebTransport over HTTP/3", () => {
     }
   });
 
-  itWT(
-    "many sequential datagrams survive reordering",
-    async () => {
-      await using server = await spawnServer(`
+  itWT("many sequential datagrams survive reordering", async () => {
+    await using server = await spawnServer(`
       open() {},
       message(ws, m) { ws.send(m); },
       close() {},
     `);
-      const c = spawnClient(server.port);
-      try {
-        await c.expectEvent("open");
-        const N = 50;
-        for (let i = 0; i < N; i++) c.sendDatagram(String(i));
-        const seen = new Set<string>();
-        // Datagrams may drop; require ≥80% delivery on loopback.
-        const deadline = Date.now() + 5000;
-        while (seen.size < N && Date.now() < deadline) {
-          const e = await Promise.race([c.next(), Bun.sleep(200).then(() => null)]);
-          if (!e) break;
-          if (e[0] === "dgram") seen.add(fromB64u(e[1]).toString());
-        }
-        expect(seen.size).toBeGreaterThanOrEqual(Math.floor(N * 0.8));
-      } finally {
-        c.kill();
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      const N = 50;
+      for (let i = 0; i < N; i++) c.sendDatagram(String(i));
+      const seen = new Set<string>();
+      // Datagrams may drop; require ≥80% delivery on loopback.
+      while (seen.size < N) {
+        const e = await Promise.race([c.next(), Bun.sleep(500).then(() => null)]);
+        if (!e) break;
+        if (e[0] === "dgram") seen.add(fromB64u(e[1]).toString());
       }
-    },
-    20000,
-  );
+      expect(seen.size).toBeGreaterThanOrEqual(Math.floor(N * 0.8));
+    } finally {
+      c.kill();
+    }
+  });
 
   itWT("first ws.send() returns SUCCESS (byte count), not backpressure", async () => {
     await using server = await spawnServer(`
@@ -535,7 +526,8 @@ test("server with h3+websocket exits when stopped", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [_, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("panic");
+  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
   expect(code).toBe(0);
 });

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -1,0 +1,541 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux } from "harness";
+import path from "path";
+
+// WebTransport over HTTP/3 (draft-ietf-webtrans-http3). Bun.serve advertises
+// WT support whenever `h3: true` is set; routes are taken from the same
+// `websocket:` handler block as RFC 6455 sockets, so a ServerWebSocket
+// arriving over a WT session sees the identical open/message/close API.
+//
+// There is no in-tree WT-capable curl, so the end-to-end tests compile a
+// tiny lsquic-based client (fixtures/wtclient.c) against the dep objects the
+// debug build already produced. Compilation is Linux-only because the client
+// uses poll()+recvfrom directly; the protocol layer it exercises is
+// platform-independent.
+
+const fixtureDir = path.join(import.meta.dir, "fixtures");
+const wtclientBin = path.join(fixtureDir, "wtclient");
+
+let canRunClient = false;
+
+beforeAll(async () => {
+  if (!isLinux) return;
+  // Debug-profile dep objects live under build/debug/obj/vendor; bundle the
+  // ones lsquic needs into one .a so the cc command line stays short.
+  const objRoot = path.resolve(import.meta.dir, "../../../../build/debug/obj/vendor");
+  const vendor = path.resolve(import.meta.dir, "../../../../vendor");
+  const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "zlib"];
+  const libdeps = path.join(fixtureDir, "libwtdeps.a");
+
+  const fs = await import("fs");
+  if (!fs.existsSync(path.join(objRoot, "lsquic")) || !fs.existsSync(path.join(vendor, "lsquic/include/lsquic.h"))) {
+    console.warn("serve-webtransport: skipping (no debug-profile dep objects under build/debug/obj/vendor)");
+    return;
+  }
+
+  // The dep .o files are built with -gz=zstd; system ld may not understand
+  // that, so use the same llvm-ar/clang the build used.
+  const llvm = (t: string) => (fs.existsSync(`/opt/llvm-21/bin/${t}`) ? `/opt/llvm-21/bin/${t}` : t);
+
+  if (!fs.existsSync(libdeps)) {
+    const objs: string[] = [];
+    for (const d of deps) {
+      for await (const f of new Bun.Glob("**/*.o").scan({ cwd: path.join(objRoot, d), absolute: true })) {
+        objs.push(f);
+      }
+    }
+    const ar = Bun.spawnSync({ cmd: [llvm("llvm-ar"), "rcs", libdeps, ...objs] });
+    if (ar.exitCode !== 0) {
+      console.warn("serve-webtransport: skipping (ar failed)", ar.stderr.toString());
+      return;
+    }
+  }
+
+  const cc = Bun.spawnSync({
+    cmd: [
+      process.env.CC ?? llvm("clang"),
+      "-fuse-ld=lld",
+      "-std=c11",
+      "-O1",
+      "-g",
+      "-fsanitize=address",
+      "-fno-pie",
+      "-no-pie",
+      "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
+      `-I${vendor}/lsquic/include`,
+      `-I${vendor}/lshpack`,
+      `-I${vendor}/boringssl/include`,
+      "-o",
+      wtclientBin,
+      path.join(fixtureDir, "wtclient.c"),
+      libdeps,
+      "-lstdc++",
+      "-lm",
+      "-lpthread",
+    ],
+    stderr: "pipe",
+  });
+  if (cc.exitCode !== 0) {
+    console.warn("serve-webtransport: skipping (compile failed)\n" + cc.stderr.toString());
+    return;
+  }
+  canRunClient = true;
+});
+
+afterAll(() => {
+  // Leave the .a for subsequent test runs (it's content-stable); drop the
+  // executable so a stale debug build doesn't mask a regression.
+  try {
+    require("fs").unlinkSync(wtclientBin);
+  } catch {}
+});
+
+const itWT: typeof test = ((name: string, fn: any, timeout?: number) =>
+  test(
+    name,
+    async () => {
+      if (!canRunClient) {
+        console.warn("skipping (no wtclient; needs Linux + debug build deps)");
+        return;
+      }
+      return fn();
+    },
+    timeout,
+  )) as any;
+
+const b64u = (s: string | Uint8Array) =>
+  Buffer.from(s).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+const fromB64u = (s: string) => Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+
+/** Thin async iterator over the wtclient stdio protocol. */
+function spawnClient(port: number, urlPath = "/") {
+  const proc = Bun.spawn({
+    cmd: [wtclientBin, String(port), urlPath],
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
+    env: bunEnv,
+  });
+  const writer = proc.stdin;
+  const events: string[][] = [];
+  const waiters: ((e: string[]) => void)[] = [];
+  let leftover = "";
+  (async () => {
+    for await (const chunk of proc.stdout) {
+      leftover += Buffer.from(chunk).toString();
+      let nl: number;
+      while ((nl = leftover.indexOf("\n")) >= 0) {
+        const line = leftover.slice(0, nl);
+        leftover = leftover.slice(nl + 1);
+        const parts = line.split(" ");
+        const w = waiters.shift();
+        if (w) w(parts);
+        else events.push(parts);
+      }
+    }
+  })();
+  const next = (): Promise<string[]> =>
+    events.length ? Promise.resolve(events.shift()!) : new Promise(r => waiters.push(r));
+  const expectEvent = async (kind: string) => {
+    const e = await Promise.race([
+      next(),
+      Bun.sleep(8000).then(() => {
+        throw new Error(`timed out waiting for "${kind}"`);
+      }),
+    ]);
+    expect(e[0]).toBe(kind);
+    return e;
+  };
+  return {
+    proc,
+    next,
+    expectEvent,
+    sendDatagram: (d: string | Uint8Array) => writer.write(`dgram ${b64u(d)}\n`),
+    sendStream: (d: string | Uint8Array) => writer.write(`stream ${b64u(d)}\n`),
+    close: (code = 0, msg: string | Uint8Array = "") => writer.write(`close ${code} ${b64u(msg)}\n`),
+    kill: () => {
+      writer.end();
+      proc.kill();
+    },
+  };
+}
+
+/** Spawn a Bun.serve subprocess so a server-side crash surfaces as a test
+ * failure instead of taking the test runner down. */
+async function spawnServer(handlers: string) {
+  const src = `
+    const { tls } = require("harness");
+    const server = Bun.serve({
+      tls, port: 0, h3: true,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("ok");
+      },
+      websocket: { ${handlers} },
+    });
+    console.log(JSON.stringify({ port: server.port }));
+    process.stdin.on("end", () => server.stop(true));
+    process.stdin.resume();
+  `;
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    cwd: import.meta.dir,
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const reader = proc.stdout.getReader();
+  const lines: string[] = [];
+  let buf = "";
+  let port = 0;
+  const readLine = async (): Promise<string> => {
+    while (true) {
+      const nl = buf.indexOf("\n");
+      if (nl >= 0) {
+        const l = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        return l;
+      }
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited:\n" + lines.join("\n") + buf);
+      buf += Buffer.from(value).toString();
+    }
+  };
+  const first = await readLine();
+  port = JSON.parse(first).port;
+  return {
+    port,
+    readLine,
+    proc,
+    [Symbol.dispose]() {
+      proc.stdin.end();
+      proc.kill();
+    },
+  };
+}
+
+// ───── lifecycle ─────
+
+test("h3+websocket server starts and stops cleanly", async () => {
+  // No client needed: this guards against the WT context-data placement-new
+  // and TopicTree teardown leaking or crashing on a hot reload path.
+  await using server = await spawnServer(`open(ws) {}, message(ws, m) {}, close(ws) {}`);
+  expect(server.port).toBeGreaterThan(0);
+});
+
+// ───── end-to-end ─────
+
+describe("WebTransport over HTTP/3", () => {
+  itWT("session establishes and open() fires", async () => {
+    await using server = await spawnServer(`
+      open(ws) { console.log("open " + (ws.remoteAddress ? "addr" : "noaddr")); },
+      message(ws, m) {},
+      close(ws, code, reason) { console.log("close " + code + " " + reason); },
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toMatch(/^open addr$/);
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("client → server datagram fires message()", async () => {
+    await using server = await spawnServer(`
+      open(ws) {},
+      message(ws, m) {
+        console.log("msg " + (typeof m === "string" ? m : Buffer.from(m).toString()));
+      },
+      close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      c.sendDatagram("hello-dgram");
+      expect(await server.readLine()).toBe("msg hello-dgram");
+      c.sendDatagram("second");
+      expect(await server.readLine()).toBe("msg second");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("server → client datagram via ws.send()", async () => {
+    await using server = await spawnServer(`
+      open(ws) { ws.send("from-server"); ws.send(new Uint8Array([1,2,3,4])); },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      const d1 = await c.expectEvent("dgram");
+      const d2 = await c.expectEvent("dgram");
+      const got = [fromB64u(d1[1]).toString(), fromB64u(d2[1]).toString("hex")].sort();
+      // Datagrams are unordered; assert on the set.
+      expect(got).toEqual(["01020304", "from-server"].sort());
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("echo: send() inside message()", async () => {
+    await using server = await spawnServer(`
+      open() {},
+      message(ws, m) { ws.send(m); },
+      close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      for (const msg of ["a", "bb", "ccc", "x".repeat(500)]) {
+        c.sendDatagram(msg);
+        const e = await c.expectEvent("dgram");
+        expect(fromB64u(e[1]).toString()).toBe(msg);
+      }
+    } finally {
+      c.kill();
+    }
+  });
+
+  // The 0x41-prefixed bidi stream path is implemented server-side (lsquic's
+  // hq filter recognises the signal value, quic.c routes via on_wt_stream_data,
+  // and Http3Context reassembles to a single message() call). wtclient can't
+  // exercise it because lsquic in HTTP client mode wraps every write in a
+  // DATA frame — there's no public API to emit raw stream bytes. A real
+  // browser (Chromium WebTransport) does write the raw prefix; this is left
+  // for a Playwright fixture or once lsquic grows a bypass.
+  test.todo("client bidi stream (0x41) delivers as one message");
+
+  itWT("ws.close(code, reason) sends WT_CLOSE_SESSION", async () => {
+    await using server = await spawnServer(`
+      open(ws) {},
+      message(ws, m) { ws.close(4001, "bye-" + Buffer.from(m).toString()); },
+      close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      c.sendDatagram("now");
+      const e = await c.expectEvent("close");
+      expect(e[1]).toBe("4001");
+      expect(fromB64u(e[2]).toString()).toBe("bye-now");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("client WT_CLOSE_SESSION fires close(code, reason)", async () => {
+    await using server = await spawnServer(`
+      open() {},
+      message() {},
+      close(ws, code, reason) { console.log("closed " + code + " " + reason); },
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      c.close(4321, "client-says-goodbye");
+      expect(await server.readLine()).toBe("closed 4321 client-says-goodbye");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("subscribe / publish across two sessions", async () => {
+    await using server = await spawnServer(`
+      open(ws) { ws.subscribe("room"); console.log("joined"); },
+      message(ws, m) { ws.publish("room", m); },
+      close() {},
+    `);
+    const a = spawnClient(server.port);
+    const b = spawnClient(server.port);
+    try {
+      await a.expectEvent("open");
+      await b.expectEvent("open");
+      expect(await server.readLine()).toBe("joined");
+      expect(await server.readLine()).toBe("joined");
+      a.sendDatagram("hi-from-a");
+      const e = await b.expectEvent("dgram");
+      expect(fromB64u(e[1]).toString()).toBe("hi-from-a");
+    } finally {
+      a.kill();
+      b.kill();
+    }
+  });
+
+  itWT("ws.send() returns DROPPED for over-MTU payload", async () => {
+    await using server = await spawnServer(`
+      open(ws) {
+        const r1 = ws.send("x".repeat(64));
+        const r2 = ws.send("x".repeat(2000));
+        // ServerWebSocket.send returns bytes-written on success, -1 on
+        // backpressure, 0 on drop. Datagrams queue (so r1 is 64 or -1); the
+        // 2000-byte one exceeds the 1200-byte QUIC DATAGRAM cap and is
+        // dropped synchronously.
+        console.log("send " + (r1 !== 0 ? "ok" : "drop") + " " + (r2 === 0 ? "drop" : "ok"));
+      },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("send ok drop");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("non-WT CONNECT does not hit websocket handler", async () => {
+    // The H3 wt() route gates on :protocol; a CONNECT without it should fall
+    // through to the next router match (404 here, since fetch only handles
+    // GET via server.upgrade falling back to "ok").
+    await using server = await spawnServer(`open(ws) { console.log("BUG"); }, message() {}, close() {}`);
+    // wtclient always sends :protocol=webtransport, so for the negative case
+    // hit the H3 listener with curl-h3 if available; otherwise just assert
+    // the WT path still works (the gate is exercised by the C++ unit path).
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT(
+    "many sequential datagrams survive reordering",
+    async () => {
+      await using server = await spawnServer(`
+      open() {},
+      message(ws, m) { ws.send(m); },
+      close() {},
+    `);
+      const c = spawnClient(server.port);
+      try {
+        await c.expectEvent("open");
+        const N = 50;
+        for (let i = 0; i < N; i++) c.sendDatagram(String(i));
+        const seen = new Set<string>();
+        // Datagrams may drop; require ≥80% delivery on loopback.
+        const deadline = Date.now() + 5000;
+        while (seen.size < N && Date.now() < deadline) {
+          const e = await Promise.race([c.next(), Bun.sleep(200).then(() => null)]);
+          if (!e) break;
+          if (e[0] === "dgram") seen.add(fromB64u(e[1]).toString());
+        }
+        expect(seen.size).toBeGreaterThanOrEqual(Math.floor(N * 0.8));
+      } finally {
+        c.kill();
+      }
+    },
+    20000,
+  );
+
+  itWT("first ws.send() returns SUCCESS (byte count), not backpressure", async () => {
+    await using server = await spawnServer(`
+      open(ws) {
+        const r = ws.send("first");
+        console.log("send " + r);
+      },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      // ServerWebSocket.send → length on SUCCESS, -1 on BACKPRESSURE.
+      // Prior to the fix the C++ layer always reported BACKPRESSURE because
+      // the queue depth was sampled *after* enqueue.
+      expect(await server.readLine()).toBe("send 5");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("ws.subscriptions reflects subscribe()/unsubscribe()", async () => {
+    await using server = await spawnServer(`
+      open(ws) {
+        ws.subscribe("a"); ws.subscribe("b");
+        const t = ws.subscriptions; t.sort();
+        console.log("topics " + JSON.stringify(t));
+      },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe('topics ["a","b"]');
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("oversized capsule on CONNECT stream resets the session", async () => {
+    // RFC 9297 §3.3: reject capsule lengths beyond what we'll buffer. The
+    // client streams a capsule header advertising 2^30 bytes followed by
+    // junk; the server must close (1009) instead of buffering forever.
+    await using server = await spawnServer(`
+      maxPayloadLength: 4096,
+      open() { console.log("opened"); },
+      message() {},
+      close(ws, code) { console.log("closed " + code); },
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("opened");
+      // Unknown-type capsule with a 4-byte length varint = ~1 GiB, then keep
+      // streaming body; the cap fires once buffered bytes exceed 4 KiB.
+      c.proc.stdin.write(`capsule ${b64u(Buffer.from([0x78, 0xae, 0xbf, 0xff, 0xff, 0xff]))}\n`);
+      for (let i = 0; i < 8; i++) c.proc.stdin.write(`capsule ${b64u("X".repeat(1024))}\n`);
+      const line = await server.readLine();
+      expect(line).toMatch(/^closed (1009|1006)$/);
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("getBufferedAmount reflects queued datagrams", async () => {
+    await using server = await spawnServer(`
+      open(ws) {
+        ws.send("a".repeat(800));
+        ws.send("b".repeat(800));
+        console.log("buffered " + (ws.getBufferedAmount() > 0));
+      },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("buffered true");
+    } finally {
+      c.kill();
+    }
+  });
+});
+
+// Guard regressions in the in-process path: starting an h3+websocket server
+// and tearing it down should leave no dangling refs that keep the loop alive.
+test("server with h3+websocket exits when stopped", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { tls } = require("harness");
+      const server = Bun.serve({
+        tls, port: 0, h3: true,
+        fetch: () => new Response("ok"),
+        websocket: { open() {}, message() {}, close() {} },
+      });
+      server.stop(true);
+      `,
+    ],
+    cwd: import.meta.dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [_, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("panic");
+  expect(code).toBe(0);
+});

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -202,10 +202,11 @@ async function spawnServer(handlers: string) {
       if (nl >= 0) {
         const l = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
+        lines.push(l);
         return l;
       }
       const { value, done } = await reader.read();
-      if (done) throw new Error("server exited:\n" + lines.join("\n") + buf);
+      if (done) throw new Error("server exited:\n" + lines.join("\n") + "\n" + buf);
       buf += Buffer.from(value).toString();
     }
   };
@@ -368,6 +369,84 @@ describe("WebTransport over HTTP/3", () => {
     } finally {
       a.kill();
       b.kill();
+    }
+  });
+
+  itWT("ws.publish() crosses the WT/WS TopicTree boundary", async () => {
+    // A mixed room (one RFC 6455 client + one WebTransport client) must
+    // not be partitioned by transport: ws.publish() from either side has
+    // to reach subscribers on the other tree.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { tls } = require("harness");
+        const server = Bun.serve({
+          tls, port: 0, h3: true,
+          fetch(req, s) { if (s.upgrade(req)) return; return new Response("ok"); },
+          websocket: {
+            open(ws) { ws.subscribe("room"); console.log("joined"); },
+            message(ws, m) { ws.publish("room", "relay:" + m); },
+            close() {},
+          },
+        });
+        console.log(JSON.stringify({ port: server.port }));
+        // In-process RFC 6455 client on the SSL app's tree.
+        const wc = new WebSocket("wss://localhost:" + server.port + "/", {
+          tls: { rejectUnauthorized: false },
+        });
+        wc.onmessage = e => console.log("ws-recv " + e.data);
+        wc.onopen = () => console.log("ws-open");
+        process.stdin.on("data", d => {
+          const s = d.toString().trim();
+          if (s === "ws-send") wc.send("from-ws");
+        });
+        process.stdin.on("end", () => { wc.close(); server.stop(true); });
+        process.stdin.resume();
+      `,
+      ],
+      cwd: import.meta.dir,
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    let buf = "";
+    const readLine = async () => {
+      while (true) {
+        const nl = buf.indexOf("\n");
+        if (nl >= 0) {
+          const l = buf.slice(0, nl);
+          buf = buf.slice(nl + 1);
+          return l;
+        }
+        const { value, done } = await reader.read();
+        if (done) throw new Error("server exited:\n" + buf);
+        buf += Buffer.from(value).toString();
+      }
+    };
+    const { port } = JSON.parse(await readLine());
+    // The in-process WS client connects first; wait for both the
+    // server-side open() ("joined") and the client-side onopen
+    // ("ws-open") — order between them isn't guaranteed.
+    expect([await readLine(), await readLine()].sort()).toEqual(["joined", "ws-open"]);
+    const c = spawnClient(port);
+    try {
+      await c.expectEvent("open");
+      // WT client's open() → second "joined".
+      expect(await readLine()).toBe("joined");
+      // WT → WS: publish from the WT session must reach the WS client.
+      c.sendDatagram("from-wt");
+      expect(await readLine()).toBe("ws-recv relay:from-wt");
+      // WS → WT: publish from the WS session must reach the WT client.
+      proc.stdin.write("ws-send\n");
+      const d = await c.expectEvent("dgram");
+      expect(fromB64u(d[1]).toString()).toBe("relay:from-ws");
+    } finally {
+      c.kill();
+      proc.stdin.end();
     }
   });
 

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -334,11 +334,17 @@ describe("WebTransport over HTTP/3", () => {
     }
   });
 
-  itWT("client WT_CLOSE_SESSION fires close(code, reason)", async () => {
+  itWT("client WT_CLOSE_SESSION fires close(code, reason) exactly once", async () => {
+    // The capsule path fires close() synchronously; on_stream_close (which
+    // lsquic schedules for the next service pass) must not fire it again
+    // with (1006, ""). Count invocations and probe via a second session.
     await using server = await spawnServer(`
       open() {},
-      message() {},
-      close(ws, code, reason) { console.log("closed " + code + " " + reason); },
+      message(ws, m) { console.log("closes=" + globalThis.__n); },
+      close(ws, code, reason) {
+        globalThis.__n = (globalThis.__n ?? 0) + 1;
+        console.log("closed " + code + " " + reason);
+      },
     `);
     const c = spawnClient(server.port);
     try {
@@ -347,6 +353,18 @@ describe("WebTransport over HTTP/3", () => {
       expect(await server.readLine()).toBe("closed 4321 client-says-goodbye");
     } finally {
       c.kill();
+    }
+    // By the time a fresh session's datagram round-trips, lsquic has
+    // long since dispatched c's on_stream_close. A double-fire would
+    // show up as an extra "closed ..." line before "closes=1", and/or
+    // as closes=2.
+    const c2 = spawnClient(server.port);
+    try {
+      await c2.expectEvent("open");
+      c2.sendDatagram("probe");
+      expect(await server.readLine()).toBe("closes=1");
+    } finally {
+      c2.kill();
     }
   });
 

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -371,6 +371,64 @@ describe("WebTransport over HTTP/3", () => {
     }
   });
 
+  itWT("server.publish() and subscriberCount() reach the H3 TopicTree", async () => {
+    // WT sessions subscribe onto the H3App's tree, not the TCP/SSL app's;
+    // the server-level APIs must fan out to / sum from both.
+    await using server = await spawnServer(`
+      open(ws) {
+        ws.subscribe("room");
+        console.log("subs " + server.subscriberCount("room"));
+      },
+      message(ws, m) {
+        const r = server.publish("room", "broadcast:" + m);
+        console.log("publish " + (r > 0 ? "ok" : "zero"));
+      },
+      close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("subs 1");
+      c.sendDatagram("ping");
+      expect(await server.readLine()).toBe("publish ok");
+      const e = await c.expectEvent("dgram");
+      expect(fromB64u(e[1]).toString()).toBe("broadcast:ping");
+    } finally {
+      c.kill();
+    }
+  });
+
+  itWT("drain() fires only after backpressure, not on open", async () => {
+    // open() does one send (SUCCESS) so hadBackpressure stays false across
+    // the post-upgrade wantwrite flush; message() then queues two sends so
+    // the second reports BACKPRESSURE and drain fires once the queue empties.
+    await using server = await spawnServer(`
+      open(ws) { ws.send("hello"); console.log("opened"); },
+      message(ws) {
+        ws.send(Buffer.alloc(800, "a").toString());
+        ws.send(Buffer.alloc(800, "b").toString());
+        console.log("queued " + (ws.getBufferedAmount() > 0));
+      },
+      drain(ws) { console.log("drain " + ws.getBufferedAmount()); },
+      close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("opened");
+      // Consume the open()-time send, then trigger the backpressure path.
+      const first = await c.expectEvent("dgram");
+      expect(fromB64u(first[1]).toString()).toBe("hello");
+      c.sendDatagram("go");
+      // If drain fired on the post-upgrade flush it would appear before
+      // "queued", so the first line after "opened" must be "queued true".
+      expect(await server.readLine()).toBe("queued true");
+      expect(await server.readLine()).toBe("drain 0");
+    } finally {
+      c.kill();
+    }
+  });
+
   itWT("ws.send() returns DROPPED for over-MTU payload", async () => {
     await using server = await spawnServer(`
       open(ws) {

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -33,9 +33,15 @@ beforeAll(async () => {
     return;
   }
 
-  // The dep .o files are built with -gz=zstd; system ld may not understand
-  // that, so use the same llvm-ar/clang the build used.
-  const llvm = (t: string) => (existsSync(`/opt/llvm-21/bin/${t}`) ? `/opt/llvm-21/bin/${t}` : t);
+  // The dep .o files are built with -gz=zstd; the system ld.lld may have
+  // been built without zstd support, so use the same llvm toolchain the
+  // build used. Matches the search paths in scripts/build/tools.ts.
+  const llvmDirs = ["/opt/llvm-21/bin", "/usr/lib/llvm-21/bin", "/usr/lib/llvm21/bin"];
+  const llvm = (t: string) => {
+    for (const d of llvmDirs) if (existsSync(`${d}/${t}`)) return `${d}/${t}`;
+    return t;
+  };
+  const lld = llvm("ld.lld");
 
   if (!existsSync(libdeps)) {
     const objs: string[] = [];
@@ -46,15 +52,19 @@ beforeAll(async () => {
     }
     const ar = Bun.spawnSync({ cmd: [llvm("llvm-ar"), "rcs", libdeps, ...objs] });
     if (ar.exitCode !== 0) {
-      console.warn("serve-webtransport: skipping (ar failed)", ar.stderr.toString());
-      return;
+      // The dep objects exist, so failing to archive them is a real error
+      // rather than an environment-shaped skip.
+      throw new Error("serve-webtransport: llvm-ar failed\n" + ar.stderr.toString());
     }
   }
 
   const cc = Bun.spawnSync({
     cmd: [
       process.env.CC ?? llvm("clang"),
-      "-fuse-ld=lld",
+      // -fuse-ld=lld resolves via PATH, which may pick up an lld that
+      // can't read zstd-compressed debug sections; pin to the same one
+      // the build used when we found it.
+      lld !== "ld.lld" ? `--ld-path=${lld}` : "-fuse-ld=lld",
       "-std=c11",
       "-O1",
       "-g",
@@ -76,8 +86,9 @@ beforeAll(async () => {
     stderr: "pipe",
   });
   if (cc.exitCode !== 0) {
-    console.warn("serve-webtransport: skipping (compile failed)\n" + cc.stderr.toString());
-    return;
+    // Same as above: once the prerequisites exist, a compile failure is a
+    // hard error so the suite cannot silently pass with a broken fixture.
+    throw new Error("serve-webtransport: wtclient.c compile failed\n" + cc.stderr.toString());
   }
   canRunClient = true;
 });
@@ -363,8 +374,8 @@ describe("WebTransport over HTTP/3", () => {
   itWT("ws.send() returns DROPPED for over-MTU payload", async () => {
     await using server = await spawnServer(`
       open(ws) {
-        const r1 = ws.send("x".repeat(64));
-        const r2 = ws.send("x".repeat(2000));
+        const r1 = ws.send(Buffer.alloc(64, "x").toString());
+        const r2 = ws.send(Buffer.alloc(2000, "x").toString());
         // ServerWebSocket.send returns bytes-written on success, -1 on
         // backpressure, 0 on drop. Datagrams queue (so r1 is 64 or -1); the
         // 2000-byte one exceeds the 1200-byte QUIC DATAGRAM cap and is
@@ -531,7 +542,8 @@ describe("WebTransport over HTTP/3", () => {
       // Unknown-type capsule with a 4-byte length varint = ~1 GiB, then keep
       // streaming body; the cap fires once buffered bytes exceed 4 KiB.
       c.proc.stdin.write(`capsule ${b64u(Buffer.from([0x78, 0xae, 0xbf, 0xff, 0xff, 0xff]))}\n`);
-      for (let i = 0; i < 8; i++) c.proc.stdin.write(`capsule ${b64u("X".repeat(1024))}\n`);
+      const kib = b64u(Buffer.alloc(1024, "X"));
+      for (let i = 0; i < 8; i++) c.proc.stdin.write(`capsule ${kib}\n`);
       const line = await server.readLine();
       expect(line).toMatch(/^closed (1009|1006)$/);
     } finally {
@@ -542,8 +554,8 @@ describe("WebTransport over HTTP/3", () => {
   itWT("getBufferedAmount reflects queued datagrams", async () => {
     await using server = await spawnServer(`
       open(ws) {
-        ws.send("a".repeat(800));
-        ws.send("b".repeat(800));
+        ws.send(Buffer.alloc(800, "a").toString());
+        ws.send(Buffer.alloc(800, "b").toString());
         console.log("buffered " + (ws.getBufferedAmount() > 0));
       },
       message() {}, close() {},

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -631,15 +631,21 @@ describe("WebTransport over HTTP/3", () => {
 
     // Allowed path: open() fires with the per-request data attached.
     const a = spawnClient(port, "/allow");
-    await a.expectEvent("open");
-    expect(await readLine()).toBe("opened ok");
-    a.kill();
+    try {
+      await a.expectEvent("open");
+      expect(await readLine()).toBe("opened ok");
+    } finally {
+      a.kill();
+    }
 
     // Denied path: client sees 403, server never logs "opened".
     const d = spawnClient(port, "/deny");
-    const e = await d.expectEvent("error");
-    expect(e[1]).toBe("status-403");
-    d.kill();
+    try {
+      const e = await d.expectEvent("error");
+      expect(e[1]).toBe("status-403");
+    } finally {
+      d.kill();
+    }
 
     proc.stdin.end();
   });

--- a/test/js/bun/http/serve-webtransport.test.ts
+++ b/test/js/bun/http/serve-webtransport.test.ts
@@ -451,6 +451,32 @@ describe("WebTransport over HTTP/3", () => {
     }
   });
 
+  itWT("ws.ping()/ws.pong() are no-ops (DROPPED), not application datagrams", async () => {
+    // WebTransport has no control frames; QUIC owns keepalive. A shared
+    // websocket:{} block that calls ws.ping() for RFC 6455 liveness must
+    // not leak a payload into the WT peer's message() handler.
+    await using server = await spawnServer(`
+      open(ws) {
+        const p1 = ws.ping("probe");
+        const p2 = ws.pong();
+        console.log("ping " + p1 + " pong " + p2);
+        ws.send("real");
+      },
+      message() {}, close() {},
+    `);
+    const c = spawnClient(server.port);
+    try {
+      await c.expectEvent("open");
+      expect(await server.readLine()).toBe("ping 0 pong 0");
+      // Only the explicit send() reaches the peer; if ping/pong had been
+      // forwarded as datagrams they'd arrive first.
+      const d = await c.expectEvent("dgram");
+      expect(fromB64u(d[1]).toString()).toBe("real");
+    } finally {
+      c.kill();
+    }
+  });
+
   // wtclient always sends :protocol=webtransport, so the negative branch in
   // H3App::wt() (yield to the next route on a non-WT CONNECT) isn't reachable
   // from this fixture. Covered once wtclient grows a configurable :protocol.


### PR DESCRIPTION
## Summary

WebTransport sessions (draft-ietf-webtrans-http3-15) now route through the existing `websocket:` handler block when `h3: true` is set. A `ServerWebSocket` arriving over a WT session sees the same `open`/`message`/`close`/`send`/`subscribe`/`publish` surface as an RFC 6455 socket — `send()` ships QUIC DATAGRAMs, `close(code, reason)` emits a WT_CLOSE_SESSION capsule.

```js
Bun.serve({
  tls, h3: true,
  websocket: {
    open(ws)          { ws.send("hello"); },
    message(ws, m)    { ws.send(m); },
    close(ws, c, r)   { ... },
  },
});
```

### Layers touched

- **lsquic** (`scripts/build/deps/lsquic.ts`, `patches/lsquic/webtransport-settings.patch`): enable `LSQUIC_WEBTRANSPORT_SERVER_SUPPORT`, advertise the draft-15 `SETTINGS_WT_ENABLED` (0x2c7cf000) codepoint alongside draft-02, and fix an upstream bug where `lsquic_stream_set_webtransport_session()` writes `SMBF_*` flags into `stream_flags` (aliasing `STREAM_HEAD_IN_FIN`, which caused all subsequent CONNECT-stream data to be rejected).
- **usockets** (`quic.c/h`): per-connection WT session list keyed by CONNECT stream id, QUIC DATAGRAM send queue with Quarter-Stream-ID prefixing, `on_wt_stream_data` / `on_wt_stream_close` / `on_datagram` callbacks, and a header-block flush from `on_write` so a 2xx with no body actually leaves lsquic's `sm_buf`.
- **uWS** (`WebTransportSession.h`, `Http3App/Context/Response/Request`): `WebTransportSession` mirrors `WebSocket<>`; `H3App::wt()` registers a CONNECT route gated on `:protocol = webtransport[-h3]`; `Http3Response::upgradeWebTransport()` accepts the session; the context routes datagrams + 0x41 bidi streams to `message()` and parses `WT_CLOSE_SESSION` (0x2843) to `close(code, reason)`. Capsule reassembly is capped at `maxPayloadLength` (RFC 9297 §3.3); inflight bidi buffers are keyed by stream id and dropped on RESET.
- **C ABI / Zig** (`libuwsockets_h3.cpp`, `h3.zig`, `WebSocket.zig`, `ServerWebSocket.zig`, `server.zig`, `uws_bindings.cpp`): `uws_h3_ws()` + `uws_h3_wt_*` mirror `uws_ws_*`; `AnyWebSocket` grows a `.h3_wt` arm; `ServerWebSocket.Flags` widens `ssl: bool` → `kind: enum{tcp,ssl,h3_wt}`; `setRoutes()` registers WT routes on `h3_app` alongside each `app.ws()` call.

### Tests

`test/js/bun/http/serve-webtransport.test.ts` + a small lsquic-based WT client (`fixtures/wtclient.c`) compiled against the debug build's dep objects, driven over stdio. Covers:

- [x] session establishment, `open()` fires
- [x] client → server datagram → `message()`
- [x] server → client datagram via `ws.send()`
- [x] echo (`send()` inside `message()`)
- [x] `ws.close(code, reason)` → WT_CLOSE_SESSION capsule
- [x] client WT_CLOSE_SESSION → `close(code, reason)`
- [x] pub/sub across two sessions
- [x] over-MTU `send()` returns DROPPED; first send returns SUCCESS
- [x] `getBufferedAmount` reflects queued datagrams
- [x] `ws.subscriptions` for WT sessions
- [x] oversized capsule on CONNECT stream resets the session
- [x] many sequential datagrams survive reordering
- [x] lifecycle: h3+websocket server starts/stops cleanly, exits when stopped
- [ ] 0x41 bidi stream → `message()` — implemented server-side; `test.todo` because the lsquic *client* in HTTP mode can't bypass HQ framing to write the raw 0x41 prefix (needs Chromium / Playwright)

All 44 existing `serve-http3` tests still pass.