### PR TITLE
usockets: fire on_handshake when SSL_read completes the initial handshake

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -591,6 +591,16 @@ restart:
       // node:http2/grpc-js session setup against the first preface bytes
       // (see closed PR #25946); server callers query SSL_is_init_finished
       // directly instead (PR #26086).
+      //
+      // The callback may write (e.g. the HTTP/2 client preface) and
+      // us_internal_ssl_socket_write zeroes ssl_read_input_length, which
+      // would drop any TLS records still queued in this on_data buffer.
+      // BoringSSL ignores SSL_CTX_set_read_ahead, so each SSL_read consumes
+      // exactly one record from the BIO and the remainder really is still in
+      // ssl_read_input — preserve it across the callback.
+      char *saved_input = loop_ssl_data->ssl_read_input;
+      unsigned int saved_length = loop_ssl_data->ssl_read_input_length;
+      unsigned int saved_offset = loop_ssl_data->ssl_read_input_offset;
       us_internal_trigger_handshake_callback(s, 1);
       // the on_handshake callback runs user code which may close this socket
       // (us_internal_ssl_socket_close -> ssl_on_close frees s->ssl). if that
@@ -598,6 +608,10 @@ restart:
       if (us_internal_ssl_socket_is_closed(s)) {
         return NULL;
       }
+      loop_ssl_data->ssl_read_input = saved_input;
+      loop_ssl_data->ssl_read_input_length = saved_length;
+      loop_ssl_data->ssl_read_input_offset = saved_offset;
+      loop_ssl_data->ssl_socket = &s->s;
     }
 
     read += just_read;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -580,12 +580,17 @@ restart:
 
         break;
       }
-    } else if (s->handshake_state != HANDSHAKE_COMPLETED) {
-      // SSL_read returned application data, so the handshake (initial or
-      // renegotiation) has finished inside SSL_read. Fire on_handshake before
-      // delivering data so the caller can inspect ALPN and re-tag the socket
-      // — otherwise a TLS 1.3 server that sends Finished + app data in one
-      // flight (e.g. an HTTP/2 SETTINGS frame) bypasses on_handshake entirely.
+    } else if (s->handshake_state == HANDSHAKE_RENEGOTIATION_PENDING ||
+               (s->handshake_state == HANDSHAKE_PENDING && !SSL_is_server(s->ssl))) {
+      // SSL_read returned application data, so the handshake has finished
+      // inside SSL_read. Fire on_handshake before delivering data so the
+      // caller can inspect ALPN and re-tag the socket — otherwise a TLS 1.3
+      // server that sends Finished + app data in one flight (e.g. an HTTP/2
+      // SETTINGS frame) bypasses on_handshake entirely. Gated to clients
+      // because firing on_handshake mid-read on the server side reorders
+      // node:http2/grpc-js session setup against the first preface bytes
+      // (see closed PR #25946); server callers query SSL_is_init_finished
+      // directly instead (PR #26086).
       us_internal_trigger_handshake_callback(s, 1);
       // the on_handshake callback runs user code which may close this socket
       // (us_internal_ssl_socket_close -> ssl_on_close frees s->ssl). if that

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -580,8 +580,12 @@ restart:
 
         break;
       }
-    } else if (s->handshake_state == HANDSHAKE_RENEGOTIATION_PENDING) {
-      // renegotiation ended successfully call on_handshake
+    } else if (s->handshake_state != HANDSHAKE_COMPLETED) {
+      // SSL_read returned application data, so the handshake (initial or
+      // renegotiation) has finished inside SSL_read. Fire on_handshake before
+      // delivering data so the caller can inspect ALPN and re-tag the socket
+      // — otherwise a TLS 1.3 server that sends Finished + app data in one
+      // flight (e.g. an HTTP/2 SETTINGS frame) bypasses on_handshake entirely.
       us_internal_trigger_handshake_callback(s, 1);
       // the on_handshake callback runs user code which may close this socket
       // (us_internal_ssl_socket_close -> ssl_on_close frees s->ssl). if that

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -896,9 +896,7 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     test("DATA after only a 1xx HEADERS is a stream PROTOCOL_ERROR (RFC 9113 §8.1)", async () => {
       await withRawH2Server(
         (conn, id) => {
-          conn.socket.write(
-            Buffer.concat([frame(1, 4, id, hpackStatus(100)), frame(0, 1, id, Buffer.from("body"))]),
-          );
+          conn.socket.write(Buffer.concat([frame(1, 4, id, hpackStatus(100)), frame(0, 1, id, Buffer.from("body"))]));
         },
         async url => {
           await using proc = spawnFetch(`
@@ -1313,11 +1311,9 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       await withRawH2Server(
         (conn, id) => {
           if (id === 1) {
-            conn.headers(
-              id,
-              Buffer.concat([hpackLit(":status", "303"), hpackLit("location", "/target")]),
-              { endStream: true },
-            );
+            conn.headers(id, Buffer.concat([hpackLit(":status", "303"), hpackLit("location", "/target")]), {
+              endStream: true,
+            });
           } else {
             conn.headers(id, hpackStatus(200), { endStream: true });
           }
@@ -1759,6 +1755,23 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     // before=1 proves the waiter coalesced; after=2 proves it retried as
     // the new leader instead of being failed with HTTP2Unsupported.
     expect(stdout.trim()).toBe("AbortError before=1 after=2");
+    expect(exitCode).toBe(0);
+  });
+
+  // Cloudflare sends its SETTINGS frame as TLS 1.3 0.5-RTT data, so the
+  // client's first SSL_read that returns app data is also the call that
+  // completes the handshake. ssl_on_data must fire on_handshake there or the
+  // socket never gets re-tagged for h2 and the frame bytes hit the HTTP/1.1
+  // parser as Malformed_HTTP_Response. Neither node:tls nor Bun.listen exposes
+  // the 0.5-RTT write window, so this hits a real Cloudflare-fronted origin.
+  test("GET https://registry.npmjs.org over protocol: http2", async () => {
+    await using proc = spawnFetch(`
+      const r = await fetch("https://registry.npmjs.org", { protocol: "http2" });
+      console.log(r.status);
+    `);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("200");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1763,16 +1763,27 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
   // completes the handshake. ssl_on_data must fire on_handshake there or the
   // socket never gets re-tagged for h2 and the frame bytes hit the HTTP/1.1
   // parser as Malformed_HTTP_Response. Neither node:tls nor Bun.listen exposes
-  // the 0.5-RTT write window, so this hits a real Cloudflare-fronted origin.
+  // the 0.5-RTT write window, so this hits a real Cloudflare-fronted origin —
+  // tolerate network blips by only failing on the specific regression code.
   test("GET https://registry.npmjs.org over protocol: http2", async () => {
     await using proc = spawnFetch(`
-      const r = await fetch("https://registry.npmjs.org", { protocol: "http2" });
-      console.log(r.status);
+      try {
+        const r = await fetch("https://registry.npmjs.org", { protocol: "http2" });
+        console.log("status", r.status);
+      } catch (e) { console.log("error", e?.code ?? e?.name ?? String(e)); }
     `);
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("200");
     expect(exitCode).toBe(0);
+    const out = stdout.trim();
+    // The bug under test surfaces as Malformed_HTTP_Response — DNS/connect
+    // failures or 5xx are environmental, not regressions.
+    expect(out).not.toContain("Malformed_HTTP_Response");
+    if (!out.startsWith("status")) {
+      console.warn(`skipping live h2 assertion: ${out}`);
+      return;
+    }
+    expect(out).toBe("status 200");
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes `fetch(url, { protocol: "http2" })` returning `Malformed_HTTP_Response` against Cloudflare-fronted origins (e.g. `registry.npmjs.org`).

`ssl_on_data` only fired `on_handshake` when `handshake_state == HANDSHAKE_RENEGOTIATION_PENDING`, missing the initial-handshake case. Cloudflare sends its HTTP/2 SETTINGS frame as TLS 1.3 0.5-RTT data appended to the server flight; when that flight gets TCP-fragmented, the second `ssl_on_data` call's `SSL_read` both completes the handshake **and** returns the SETTINGS bytes while `handshake_state` is still `HANDSHAKE_PENDING`. Since `on_handshake` never fired, the socket was never re-tagged for h2 and the frame bytes flowed into the HTTP/1.1 header parser.

The fix fires `on_handshake` for the initial-handshake case too, **gated to client sockets** (`!SSL_is_server`). The server path is left unchanged because firing `on_handshake` mid-read on a server socket reorders `node:http2`/`grpc-js` session setup against the first preface bytes — this was tried in #25946 and broke `test-http2-cancel-while-client-reading`, `test-http2-close-while-writing`, and `grpc-js/test-channel-credentials` across all platforms; server callers query `SSL_is_init_finished` directly per #26086 instead.

This was latent before the experimental HTTP/2 client landed because HTTP/1.1 servers never write before the client sends a request.

## How did you verify your code works?

- `bun bd --eval 'fetch("https://registry.npmjs.org", {protocol: "http2"}).then(r => console.log(r.status))'` → 200 (was `Malformed_HTTP_Response`)
- New test in `fetch-http2-client.test.ts` hits `registry.npmjs.org` over h2 — fails on `main` with `Malformed_HTTP_Response`, passes here. (A deterministic local repro requires a TLS server that writes 0.5-RTT app data, which neither `node:tls` nor `Bun.listen` exposes.)
- `bun bd test test/js/web/fetch/fetch-http2-client.test.ts` → 58 pass
- `bun bd test/js/node/test/parallel/test-http2-cancel-while-client-reading.js` → exit 0 (hangs without the client gate)
- `bun bd test/js/node/test/parallel/test-http2-close-while-writing.js` → exit 0 (hangs without the client gate)
- `bun bd test test/js/third_party/grpc-js/test-channel-credentials.test.ts` → 9 pass
- `bun bd test test/js/web/fetch/fetch.tls.test.ts test/js/node/tls/node-tls-server.test.ts test/js/node/http2/node-http2.test.js` → 342 pass