### PR TITLE
Bun.inspect: fix null deref when prototype is a Proxy with throwing getter

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = nextProto ? nextProto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -692,6 +692,35 @@ it("CloseEvent", () => {
   `);
 });
 
+it("does not crash when the prototype is a Proxy wrapping a throwing getter", () => {
+  class Foo {
+    get bar() {
+      throw new Error("getter threw");
+    }
+  }
+  const obj = new Foo();
+  Object.setPrototypeOf(obj, new Proxy(Foo.prototype, {}));
+  expect(() => Bun.inspect(obj)).not.toThrow();
+});
+
+it("does not crash when the prototype is a Proxy with a throwing getPrototypeOf trap", () => {
+  class Foo {
+    get bar() {
+      return 1;
+    }
+  }
+  const obj = new Foo();
+  Object.setPrototypeOf(
+    obj,
+    new Proxy(Foo.prototype, {
+      getPrototypeOf() {
+        throw new Error("trap threw");
+      },
+    }),
+  );
+  expect(() => Bun.inspect(obj)).not.toThrow();
+});
+
 it("ErrorEvent", () => {
   const errorEvent = new ErrorEvent("error", {
     message: "Something went wrong",


### PR DESCRIPTION
## What does this PR do?

Fixes a null `JSCell` dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, and `expect` failure formatting) when inspecting an object whose prototype is a `Proxy` wrapping a target with a throwing getter.

### Root cause

When walking the prototype chain, `getPropertySlot` can return `false` with a pending exception — for example when a getter on the Proxy target throws during `[[Get]]`. The previous code did `continue` before reaching the `CLEAR_IF_EXCEPTION`, leaving the exception pending. On the next iteration, `iterating->getPrototype(globalObject)` on the `ProxyObject` short-circuits on the pending exception and returns an empty `JSValue{}`, and calling `.getObject()` on that dereferences a null `JSCell*`.

### Fix

- Clear the exception from `getPropertySlot` before checking its return value.
- Guard against an empty result from `getPrototype()` (and clear any exception from a throwing `getPrototypeOf` trap) before calling `.getObject()`.

### Repro

```js
class Foo {
  get bar() { throw new Error("getter threw"); }
}
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Foo.prototype, {}));
Bun.inspect(obj); // previously: UBSAN null-pointer member call
```

Found by Fuzzilli.