### PR TITLE
Fix null deref in Bun.inspect with Proxy in prototype chain

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!nextProto || !nextProto.isObject())
+                break;
+            iterating = nextProto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,44 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("Proxy in prototype chain", () => {
+  it("does not crash when a getter accessed through a Proxy prototype throws", () => {
+    class Base {}
+    Object.defineProperty(Base.prototype, "bad", {
+      get() {
+        throw new Error("boom");
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    const obj = new Base();
+    const proto = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(obj, new Proxy(proto, {}));
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+
+  it("does not crash when a Proxy getPrototypeOf trap throws", () => {
+    const obj = { a: 1 };
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { b: 2 },
+        {
+          getPrototypeOf() {
+            throw new Error("proto boom");
+          },
+        },
+      ),
+    );
+    expect(() => Bun.inspect(obj)).not.toThrow();
+    expect(Bun.inspect(obj)).toContain("a: 1");
+  });
+
+  it("does not crash inspecting expect() with a Proxy prototype", () => {
+    const e = expect();
+    const proto = Object.getPrototypeOf(e);
+    Object.setPrototypeOf(e, new Proxy(proto, {}));
+    expect(() => Bun.inspect(e)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, error formatting, etc.) when the object being inspected has a `Proxy` in its prototype chain.

Two related issues:

1. When `getPropertySlot()` returns `false` because a getter invoked through a Proxy `[[Get]]` trap threw, the pending exception was not cleared before `continue`-ing to the next property. The `CLEAR_IF_EXCEPTION` was placed after the `continue` and was never reached. The leaked exception then caused the subsequent `iterating->getPrototype()` call on the Proxy to return an empty `JSValue`.

2. `iterating->getPrototype(globalObject).getObject()` was called without checking for an empty result. A Proxy `getPrototypeOf` trap that throws returns an empty `JSValue`, and calling `.getObject()` on that dereferences a null `JSCell*`.

### Repro

```js
class Base {}
Object.defineProperty(Base.prototype, 'bad', { get() { throw new Error('boom'); } });
const obj = new Base();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
Bun.inspect(obj); // crashed
```

```js
const obj = { a: 1 };
Object.setPrototypeOf(obj, new Proxy({ b: 2 }, { getPrototypeOf() { throw new Error('boom'); } }));
Bun.inspect(obj); // crashed
```

Found by Fuzzilli.

## How did you verify your code works?

Added regression tests to `test/js/bun/util/inspect.test.js` covering both the throwing-getter-via-proxy case and the throwing-`getPrototypeOf`-trap case. Verified the tests crash on the unfixed build and pass with the fix.