### PR TITLE
Fix null deref in forEachProperty when Proxy trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,33 @@ const fixture = [
         },
       },
     ),
+  () => {
+    class Foo {
+      bar() {}
+    }
+    const obj = new Foo();
+    const proto = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(proto, {
+        getPrototypeOf() {
+          throw new Error("trap");
+        },
+      }),
+    );
+    return obj;
+  },
+  () => {
+    class Foo {
+      get bar() {
+        throw new Error("getter");
+      }
+    }
+    const obj = new Foo();
+    const proto = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(obj, new Proxy(proto, {}));
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Found by Fuzzilli.

## What

`JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` / `console.log`) crashes with a null-pointer dereference when inspecting an object whose prototype chain contains a Proxy that throws from a trap.

```js
class Foo { bar() {} }
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {
  getPrototypeOf() { throw new Error("trap"); },
}));
Bun.inspect(obj); // crash
```

```
JSCJSValueCell.h:92:33: runtime error: member call on null pointer of type 'JSC::JSCell'
```

## Why

Two related issues in the prototype-chain walk:

1. `iterating->getPrototype(globalObject).getObject()` — when `getPrototype` throws (e.g. a Proxy `getPrototypeOf` trap), it returns an empty `JSValue`. An empty `JSValue` passes `isCell()` so `.getObject()` calls `nullptr->getObject()`.

2. When `getPropertySlot` returns `false` (which it does when a Proxy in the chain invokes a throwing getter via `performDefaultGet`), we `continue` without clearing the pending exception. That exception then causes the next `getPrototype` call to bail early with an empty value, hitting (1).

## Fix

- Clear exceptions before the `continue` when `getPropertySlot` returns false (matching the existing handling for the `true` case).
- Check for an empty/throwing result from `getPrototype` before calling `.getObject()`, and clear the exception (matching the pattern already used for the fast path a few lines above).