### PR TITLE
install: --force replaces existing global-store entries

### DIFF
--- a/src/install/isolated_install/Installer.zig
+++ b/src/install/isolated_install/Installer.zig
@@ -1708,21 +1708,62 @@ pub const Installer = struct {
         switch (sys.renameat(FD.cwd(), staging.sliceZ(), FD.cwd(), final.sliceZ())) {
             .result => return .success,
             .err => |err| {
-                const collided = switch (err.getErrno()) {
-                    .EXIST, .NOTEMPTY => true,
-                    // Windows maps a rename onto an in-use directory to
-                    // ERROR_ACCESS_DENIED; on POSIX PERM/ACCES are real
-                    // permission failures and must propagate.
-                    .PERM, .ACCES => Environment.isWindows,
-                    else => false,
-                };
+                if (!isRenameCollision(err)) {
+                    FD.cwd().deleteTree(staging.slice()) catch {};
+                    return .initErr(err);
+                }
+                // Under --force, the existing entry may be the corrupt one
+                // we were asked to replace. Swap it aside (atomic from a
+                // reader's POV: `final` is always either the old or the new
+                // tree, never missing), publish staging, then GC the old
+                // tree. Without --force, the existing entry came from a
+                // concurrent install and is content-identical — keep it and
+                // discard ours.
+                if (this.manager.options.enable.force_install) {
+                    var old: bun.AbsPath(.{ .sep = .auto }) = .init();
+                    defer old.deinit();
+                    old.append(this.global_store_path.?);
+                    old.appendFmt("{f}.old-{x}", .{
+                        Store.Entry.fmtGlobalStorePath(entry_id, this.store, this.lockfile),
+                        bun.fastRandom(),
+                    });
+                    if (sys.renameat(FD.cwd(), final.sliceZ(), FD.cwd(), old.sliceZ()).asErr()) |swap_err| {
+                        FD.cwd().deleteTree(staging.slice()) catch {};
+                        return .initErr(swap_err);
+                    }
+                    switch (sys.renameat(FD.cwd(), staging.sliceZ(), FD.cwd(), final.sliceZ())) {
+                        .result => {
+                            FD.cwd().deleteTree(old.slice()) catch {};
+                            return .success;
+                        },
+                        .err => |publish_err| {
+                            // Another --force install raced us in the window
+                            // between swap-out and publish. Theirs is fresh
+                            // too; clean up both temp trees.
+                            FD.cwd().deleteTree(staging.slice()) catch {};
+                            FD.cwd().deleteTree(old.slice()) catch {};
+                            return if (isRenameCollision(publish_err)) .success else .initErr(publish_err);
+                        },
+                    }
+                }
                 FD.cwd().deleteTree(staging.slice()) catch {};
                 // A concurrent install renamed first; both writers produced
                 // the same content-addressed bytes, so theirs is as good as
                 // ours.
-                return if (collided) .success else .initErr(err);
+                return .success;
             },
         }
+    }
+
+    fn isRenameCollision(err: sys.Error) bool {
+        return switch (err.getErrno()) {
+            .EXIST, .NOTEMPTY => true,
+            // Windows maps a rename onto an in-use directory to
+            // ERROR_ACCESS_DENIED; on POSIX PERM/ACCES are real
+            // permission failures and must propagate.
+            .PERM, .ACCES => Environment.isWindows,
+            else => false,
+        };
     }
 
     /// Project-local path `node_modules/.bun/<storepath>` (the symlink that

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readlinkSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
 import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
-import { join } from "path";
+import { dirname, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -1423,6 +1423,70 @@ describe("global virtual store", () => {
         ),
       ).json(),
     ).toMatchObject({ name: "two-range-deps", version: "1.0.0" });
+  });
+
+  test("--force replaces a corrupted global-store entry", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-force-heal",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    const entry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    const gvsTarget = readlinkSync(entry);
+    const pkgDir = join(gvsTarget, "node_modules", "no-deps");
+    const pkgJsonPath = join(pkgDir, "package.json");
+    const indexPath = join(pkgDir, "index.js");
+    const original = await file(pkgJsonPath).text();
+
+    // Corrupt the published global-store entry: delete files (the directory
+    // still exists, so the warm-hit `directoryExistsAt` check is satisfied
+    // and a plain reinstall takes the symlink-only fast path). The
+    // extraction cache the entry was hardlinked from keeps its own
+    // hardlinks, so the source bytes for --force to rebuild from are intact.
+    await rm(pkgJsonPath, { force: true });
+    await rm(indexPath, { force: true });
+
+    // Sanity: a non-force reinstall does NOT heal — it sees the directory
+    // present and reuses it. (This pins the warm-hit semantics so the
+    // assertion below is meaningful.)
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    expect(existsSync(pkgJsonPath)).toBe(false);
+
+    // --force must rebuild staging and swap it into place over the corrupt
+    // final directory instead of discarding the fresh tree on EEXIST.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--force"],
+        cwd: packageDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    expect(readlinkSync(entry)).toBe(gvsTarget);
+    expect(await file(pkgJsonPath).text()).toBe(original);
+    expect(existsSync(indexPath)).toBe(true);
+
+    // The swap-aside `.old-<rand>` tree is removed once publish succeeds, so
+    // the links/ directory is left with only final entries (no `.old-` and no
+    // `.tmp-` siblings).
+    const linksDir = dirname(gvsTarget);
+    const siblings = await readdirSorted(linksDir);
+    expect(siblings.some(n => n.includes(".old-") || n.includes(".tmp-"))).toBe(false);
   });
 
   test("can be disabled via BUN_INSTALL_GLOBAL_STORE=0", async () => {


### PR DESCRIPTION
## Summary
- `commitGlobalStoreEntry` discarded its freshly-built staging tree when the published global-store directory already existed (EEXIST/ENOTEMPTY → treated as a benign concurrent-install race). Under `--force` that meant a corrupted entry was never replaced, while the install summary still reported the package as installed.
- Under `--force`, a rename collision now swaps the existing entry aside (`<entry>` → `<entry>.old-<rand>`), publishes staging into `<entry>`, then deletes the swapped-aside tree. The two-step rename keeps `<entry>` resolvable at every instant for concurrent readers. Non-force behaviour is unchanged.
- Adds a `global virtual store > --force replaces a corrupted global-store entry` test that corrupts a published entry by deleting its files, confirms a plain reinstall does not heal, then asserts `--force` restores the files and leaves no `.old-`/`.tmp-` siblings in `links/`.

## Test plan
- [x] `bun bd test ./test/cli/install/isolated-install.test.ts -t "force replaces a corrupted"` — passes
- [x] `bun bd test ./test/cli/install/isolated-install.test.ts -t "global virtual store"` — 15/15 pass (14 existing + 1 new)
- [x] `USE_SYSTEM_BUN=1 bun test ./test/cli/install/isolated-install.test.ts -t "force replaces a corrupted"` — fails (validates the test exercises the fix)
- [ ] CI green (Windows path covered by `isRenameCollision` PERM/ACCES handling)