### PR TITLE
Bun.inspect: fix crash walking Proxy prototype chain

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -467,6 +467,39 @@ describe("crash testing", () => {
   }
 });
 
+it("Proxy prototype with throwing getter", () => {
+  const target = {
+    a: 1,
+    get x() {
+      throw new Error("boom");
+    },
+    z: 2,
+  };
+  const obj = {};
+  Object.setPrototypeOf(obj, new Proxy(target, {}));
+  const out = Bun.inspect(obj);
+  expect(out).toContain("a: 1");
+  expect(out).toContain("z: 2");
+});
+
+it("Proxy prototype with throwing getPrototypeOf trap", () => {
+  const obj = { own: 1 };
+  Object.setPrototypeOf(
+    obj,
+    new Proxy(
+      { x: 1 },
+      {
+        getPrototypeOf() {
+          throw new Error("proto trap");
+        },
+      },
+    ),
+  );
+  const out = Bun.inspect(obj);
+  expect(out).toContain("own: 1");
+  expect(out).toContain("x: 1");
+});
+
 it("possibly formatted emojis log", () => {
   expect(Bun.inspect("✔")).toBe('"✔"');
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a segfault in `Bun.inspect()` / `console.log()` when formatting an object whose prototype chain contains a `Proxy` that either:
- wraps a target with a throwing getter, or
- has a `getPrototypeOf` trap that throws.

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({ get x() { throw 0; } }, {}));
Bun.inspect(obj); // Segmentation fault at address 0x5
```

In `JSC__JSValue__forEachPropertyImpl`:
- `getPropertySlot()` returns `false` with a pending exception when a Proxy forwards `[[Get]]` to a throwing getter. The existing `CLEAR_IF_EXCEPTION` was placed after the `if (!...) continue;` branch, so the exception was never cleared and leaked into subsequent operations.
- `iterating->getPrototype(globalObject)` can throw (e.g. via a Proxy `getPrototypeOf` trap) and return an empty `JSValue`, after which `.getObject()` dereferenced a null `JSCell*`.

Both cases ended up at the same null deref in `JSCJSValueCell.h:92`.

## How did you verify your code works?

- Reproduced the UBSAN null deref with the fuzzer input and minimized it.
- Confirmed release bun segfaults on the minimal repro.
- Added two regression tests to `test/js/bun/util/inspect.test.js` that crash without the fix and pass with it.
- `bun bd test test/js/bun/util/inspect.test.js` → 74 pass, 0 fail.