### PR TITLE
Fix null deref in Bun object lazy PropertyCallbacks on exception

### DIFF
--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -94,7 +94,8 @@ FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 
 // definition of the C++ wrapper to call the Zig function
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
-    return JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    JSC::JSValue result = JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    return result.isEmpty() ? JSC::jsUndefined() : result; \
 } \
 
 FOR_EACH_GETTER(DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -316,11 +316,12 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (!sqlValue || !sqlValue.isObject()) [[unlikely]]
+        return jsUndefined();
+    JSValue result = sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword);
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    RELEASE_AND_RETURN(scope, result);
 }
 
 static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
@@ -328,12 +329,13 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    if (!sqlValue || !sqlValue.isObject()) [[unlikely]]
+        return jsUndefined();
     auto clientData = WebCore::clientData(vm);
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
+    JSValue result = sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName());
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    RELEASE_AND_RETURN(scope, result);
 }
 
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
@@ -366,20 +368,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/test/js/bun/util/bun-object-lazy-stack-overflow.test.ts
+++ b/test/js/bun/util/bun-object-lazy-stack-overflow.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Lazy PropertyCallback initializers on the Bun object (e.g. Bun.$, Bun.SQL)
+// call into JavaScript which can throw a RangeError when the stack is nearly
+// exhausted. Previously the callback returned an empty JSValue on exception,
+// which was passed to JSObject::putDirect and triggered a null JSCell deref.
+test.concurrent.each(["$", "SQL", "sql", "postgres"])(
+  "accessing Bun.%s for the first time near stack limit does not crash",
+  async property => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `function f() { try { f(); } catch {} Bun[${JSON.stringify(property)}]; }
+try { f(); } catch {}
+console.log("OK");`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("runtime error");
+    expect(stderr).not.toContain("panic");
+    expect(stdout).toBe("OK\n");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/util/bun-object-lazy-stack-overflow.test.ts
+++ b/test/js/bun/util/bun-object-lazy-stack-overflow.test.ts
@@ -18,13 +18,11 @@ console.log("OK");`,
       ],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "pipe",
+      stderr: "inherit",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-    expect(stderr).not.toContain("runtime error");
-    expect(stderr).not.toContain("panic");
     expect(stdout).toBe("OK\n");
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
Several `Bun` object lazy `PropertyCallback` initializers (`Bun.$`, `Bun.SQL`, `Bun.sql`, `Bun.postgres`) call into JavaScript during reification via `JSC::call` / `InternalModuleRegistry::requireId`. When that call throws — e.g. a `RangeError` near the stack limit — the callback returned an empty `JSValue`, which `JSC::reifyStaticProperty` passed straight to `putDirect`:

```
JSCJSValueCell.h:67:34: runtime error: member call on null pointer of type 'JSC::JSCell'
  JSC::JSValue::isGetterSetter()
  JSC::JSObject::putDirect
  JSC::reifyStaticProperty            Lookup.h:541
  JSC::setUpStaticFunctionSlot        Lookup.cpp:61
```

Minimal repro:
```js
function f() {
  try { f(); } catch {}
  Bun.$;
}
f();
```

### Changes

- `constructBunShell`, `defaultBunSQLObject`, `constructBunSQLObject`: return `jsUndefined()` instead of `{}` on the exception paths so `putDirect` receives a valid value while the pending exception still propagates to the caller. Guard the follow-up `getObject()` against a non-object module value.
- `DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER`: same guard for the Zig-bridged lazy property wrappers.
- Drop the `BUN_DEBUG`-only `reportUncaughtExceptionAtEventLoop` call in the SQL callbacks. It re-entered JS with a pending exception, cleared it as a side effect, and set the process exit code — leaving an empty module value that was then dereferenced.

Adds a regression test that spawns a subprocess, recurses to the stack limit, then accesses each affected property for the first time.


Fixes #19650
