### PR TITLE
console: fix null deref in forEachProperty with Proxy prototype

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextPrototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = nextPrototype ? nextPrototype.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,26 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(obj, new Proxy(URL.prototype, {}));
+    return obj;
+  },
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { yolo: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
Fuzzer fingerprint: `e727eeb81cddcdbd`

### What

`Bun.inspect` / `console.log` crashed with a null pointer dereference when formatting an object whose prototype chain contains a Proxy wrapping a prototype with native accessors.

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy(URL.prototype, {}));
console.log(obj); // crash
```

### Why

In `JSC__JSValue__forEachPropertyImpl`, when walking an object's prototype chain through a Proxy:

1. `getPropertySlot` with `InternalMethodType::Get` on a Proxy triggers the Proxy `[[Get]]` path, which invokes native accessors (e.g. `URL.prototype.href`) with the original object as the receiver.
2. The accessor throws a `TypeError` because the receiver is not of the expected type, and `getPropertySlot` returns `false` with a pending exception.
3. The code did `if (!getPropertySlot(...)) continue;` followed by `CLEAR_IF_EXCEPTION(scope)` — so the exception was never cleared on the `continue` path.
4. With the exception still pending, a later `iterating->getPrototype(globalObject)` on the Proxy bailed out via `RETURN_IF_EXCEPTION` and returned an empty `JSValue`, and `.getObject()` on an empty `JSValue` dereferences a null cell.

### How

- Clear the exception from `getPropertySlot` before `continue`.
- Guard `getPrototype()` against throwing Proxy `getPrototypeOf` traps by clearing the exception and null-checking the result.