### PR TITLE
http3: read listen-socket port from cached sockaddr instead of ls->udp

### DIFF
--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -758,7 +758,11 @@ void us_quic_listen_socket_close(us_quic_listen_socket_t *ls) {
 }
 
 int us_quic_listen_socket_port(us_quic_listen_socket_t *ls) {
-    return us_udp_socket_bound_port(ls->udp);
+    /* ls->udp goes NULL in udp_on_close while ls itself survives until
+     * context_free; read from the cached getsockname() result instead. */
+    return ntohs(ls->local.ss_family == AF_INET6
+        ? ((struct sockaddr_in6 *) &ls->local)->sin6_port
+        : ((struct sockaddr_in *) &ls->local)->sin_port);
 }
 
 int us_quic_listen_socket_local_address(us_quic_listen_socket_t *ls, char *buf, int len) {


### PR DESCRIPTION
### What does this PR do?

`us_quic_listen_socket_port` returned `us_udp_socket_bound_port(ls->udp)`, but `us_quic_udp_on_close` nulls `ls->udp` while `ls` itself survives until `us_quic_socket_context_free`. If the QUIC server's UDP fd is closed by the loop's error path (e.g. on Windows, an ICMP port-unreachable from a vanished client surfaces as `WSAECONNRESET` on the next recv and loop.c closes the socket) and JS then reads `server.port`, `us_udp_socket_bound_port(NULL)` dereferences offset `0x48` and segfaults.

`ls->local` is filled from `getsockname()` at socket creation and never cleared, so read the port from there instead — same approach `us_quic_listen_socket_local_address` already uses for the address.

### How did you verify your code works?

- Reproduced the segfault on Windows by reverting the `SIO_UDP_CONNRESET` handling on the h3-fetch branch and running `fetch-http3-client.test.ts`; symbolized the `0x48` crash to `us_udp_socket_bound_port` (udp.c:75) ← `us_quic_listen_socket_port` (quic.c) ← `getPort` (server.zig:1331).
- With this change, the same scenario fails the request cleanly instead of crashing.
- Verified `Bun.serve({h3: true, h1: false, port: 0}).port` still returns the bound ephemeral port on `main`.

No new test: the crash path requires the kernel to close the UDP fd out from under the listen socket while `h3_listener` is still set, which only happens via loop.c's UDP error handling. `stopListening` nulls `h3_listener` before closing, so it can't be triggered from JS. The happy path (port read matches bound port) is already exercised by every `serve-http3.test.ts` case.