### PR TITLE
build: emit PDB for Windows debug builds

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -750,6 +750,11 @@ export const linkerFlags: Flag[] = [
     desc: "18MB stack reserve (JSC uses deep recursion), no error limit",
   },
   {
+    flag: "/DEBUG:FULL",
+    when: c => c.windows && c.debug,
+    desc: "Emit PDB so the crash handler can symbolize stack traces",
+  },
+  {
     flag: [
       "/LTCG",
       "/OPT:REF",


### PR DESCRIPTION
## Summary
- Add `/DEBUG:FULL` to `linkFlags` for `c.windows && c.debug` in `scripts/build/flags.ts`
- Debug builds were producing no `.pdb`, so the crash handler printed raw addresses instead of `file:line`

## Regression from #27973
Bun's CMake config never *explicitly* passed `/DEBUG` for debug builds — only release had it (since #10203). But CMake's `Windows-MSVC` platform module defaults `CMAKE_EXE_LINKER_FLAGS_DEBUG` to `/debug /INCREMENTAL`, so debug builds got a PDB implicitly. The TypeScript ninja generator in #27973 has no such defaults, so the debug PDB silently stopped being produced when that landed.

(`/INCREMENTAL` is not needed: we link with lld-link, which doesn't implement it, and it's orthogonal to PDB generation anyway.)

## Notes
std's PDB parser currently fails with `InvalidBlockIndex` on this PDB, but `pdb-addr2line` resolves symbols against it correctly.

## Test plan
- [x] `bunx tsc --noEmit -p scripts/build/tsconfig.json`
- [x] `bun bd --version` succeeds and produces `build/debug/bun-debug.pdb` (~624 MB)
- [x] `/DEBUG:FULL` present in `build/debug/build.ninja` ldflags