### PR TITLE
http2: don't drop queued END_STREAM in noTrailers under backpressure

### DIFF
--- a/src/bun.js/api/bun/h2_frame_parser.zig
+++ b/src/bun.js/api/bun/h2_frame_parser.zig
@@ -3474,17 +3474,14 @@ pub const H2FrameParser = struct {
         };
 
         stream.waitForTrailers = false;
+        // sendData() drives the close itself: when the frame goes out
+        // immediately the defer at its top advances state and dispatches
+        // onStreamEnd; when it queues under backpressure, flushQueue() does
+        // the same once the frame is actually written. Doing it again here
+        // (the old code did) sets HALF_CLOSED_LOCAL/CLOSED before the queued
+        // frame is flushed, so canSendData() rejects it / freeResources()
+        // drops it and the peer never receives END_STREAM.
         this.sendData(stream, "", true, .js_undefined);
-
-        const identifier = stream.getIdentifier();
-        identifier.ensureStillAlive();
-        if (stream.state == .HALF_CLOSED_REMOTE) {
-            stream.state = .CLOSED;
-            stream.freeResources(this, false);
-        } else {
-            stream.state = .HALF_CLOSED_LOCAL;
-        }
-        this.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(stream.state)));
         return .js_undefined;
     }
 


### PR DESCRIPTION
## What does this PR do?

`H2FrameParser.noTrailers()` calls `sendData(stream, "", true)` to emit the trailing empty DATA+END_STREAM frame, then immediately sets `stream.state = .CLOSED` (or `.HALF_CLOSED_LOCAL`) and calls `freeResources()`.

When the socket has backpressure, `sendData` doesn't write — it queues the frame. The premature state change then prevents it from ever going out: `flushQueue` checks `canSendData()` which returns false for `HALF_CLOSED_LOCAL`/`CLOSED`, and `freeResources → cleanQueue` drops the queued frame entirely. The peer receives the full response body but never END_STREAM, so the request hangs until timeout.

`sendData`'s own `defer` (when the frame goes out immediately) and `flushQueue`'s `defer` (when a queued frame is finally written) already advance state and dispatch `onStreamEnd`, so the duplicate block in `noTrailers` is redundant in the fast path and harmful under backpressure.

This shows up most reliably on Windows, where libuv's socket-writable signaling makes `hasBackpressure()` true more often than epoll/kqueue — `fetch-http2-leak.test.ts` stalls at batch ~16/200 with the wire log showing a stream that received 65536 body bytes and nothing more.

## How did you verify your code works?

- `bun bd test test/js/web/fetch/fetch-http2-leak.test.ts` — 7/7 pass on Windows (was reliably stalling at batch 16/200 with `[watchdog] stuck at batch N/200 for >30s` before)
- `bun bd test test/js/node/http2/node-http2.test.js` — 244 pass (1 pre-existing unrelated `maxSessionMemory` timeout)
- `bun bd` Node parallel http2 trailer tests (`test-http2-compat-serverrequest-trailers.js`, `test-http2-no-wanttrailers-listener.js`, `test-http2-trailers.js`, `test-http2-sent-headers.js`) — all pass
- `bun run zig:check-all` — clean on every target