### PR TITLE
fix(s3): clamp queueSize with @min instead of @max

### DIFF
--- a/src/s3/credentials.zig
+++ b/src/s3/credentials.zig
@@ -191,7 +191,7 @@ pub const S3Credentials = struct {
                             .field_name = "queueSize",
                         });
                     } else {
-                        new_credentials.options.queueSize = @intCast(@max(queueSize, std.math.maxInt(u8)));
+                        new_credentials.options.queueSize = @intCast(@min(queueSize, std.math.maxInt(u8)));
                     }
                 }
 

--- a/test/js/bun/s3/s3-queueSize-validation.test.ts
+++ b/test/js/bun/s3/s3-queueSize-validation.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+
+test("S3Client does not crash with queueSize > 255", () => {
+  expect(() => new Bun.S3Client({ queueSize: 256 })).not.toThrow();
+  expect(() => new Bun.S3Client({ queueSize: 1000 })).not.toThrow();
+  expect(() => new Bun.S3Client({ queueSize: 2147483647 })).not.toThrow();
+});
+
+test("S3Client throws RangeError with queueSize < 1", () => {
+  expect(() => new Bun.S3Client({ queueSize: 0 })).toThrow(RangeError);
+  expect(() => new Bun.S3Client({ queueSize: -1 })).toThrow(RangeError);
+});

--- a/test/js/bun/s3/s3-queueSize-validation.test.ts
+++ b/test/js/bun/s3/s3-queueSize-validation.test.ts
@@ -8,7 +8,7 @@ test("S3Client preserves queueSize instead of forcing it to 255", () => {
 });
 
 test("S3Client does not crash with queueSize > 255", () => {
-  const { exitCode, stdout, stderr } = Bun.spawnSync({
+  const { exitCode, stdout } = Bun.spawnSync({
     cmd: [
       bunExe(),
       "-e",
@@ -26,7 +26,6 @@ test("S3Client does not crash with queueSize > 255", () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(stderr.toString()).not.toContain("panic");
   expect(stdout.toString().trim()).toBe("ok");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/s3/s3-queueSize-validation.test.ts
+++ b/test/js/bun/s3/s3-queueSize-validation.test.ts
@@ -1,9 +1,34 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("S3Client preserves queueSize instead of forcing it to 255", () => {
+  expect(Bun.inspect(new Bun.S3Client({ queueSize: 10 }))).toContain("queueSize: 10");
+  expect(Bun.inspect(new Bun.S3Client({ queueSize: 1 }))).toContain("queueSize: 1");
+  expect(Bun.inspect(new Bun.S3Client({ queueSize: 255 }))).toContain("queueSize: 255");
+});
 
 test("S3Client does not crash with queueSize > 255", () => {
-  expect(() => new Bun.S3Client({ queueSize: 256 })).not.toThrow();
-  expect(() => new Bun.S3Client({ queueSize: 1000 })).not.toThrow();
-  expect(() => new Bun.S3Client({ queueSize: 2147483647 })).not.toThrow();
+  const { exitCode, stdout, stderr } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        for (const n of [256, 1000, 2147483647]) {
+          const c = new Bun.S3Client({ queueSize: n });
+          if (!Bun.inspect(c).includes("queueSize: 255")) {
+            throw new Error("queueSize " + n + " was not clamped to 255");
+          }
+        }
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stderr.toString()).not.toContain("panic");
+  expect(stdout.toString().trim()).toBe("ok");
+  expect(exitCode).toBe(0);
 });
 
 test("S3Client throws RangeError with queueSize < 1", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in `new Bun.S3Client({ queueSize: N })` when `N > 255`:

```
panic(main thread): integer does not fit in destination type
/workspace/bun/src/s3/credentials.zig:194:61
```

The code used `@intCast(@max(queueSize, std.math.maxInt(u8)))` to clamp the value into a `u8`, but `@max` returns the *larger* of the two operands. When `queueSize > 255`, `@max` returns `queueSize`, and `@intCast` to `u8` panics.

Changed to `@min`, which correctly clamps to `255`.

This also fixes a secondary bug where any valid `queueSize` (1..255) was silently overridden to `255`, since `@max(n, 255)` is always `255` when `n <= 255`.

### Before
```js
new Bun.S3Client({ queueSize: 10 });   // queueSize silently set to 255
new Bun.S3Client({ queueSize: 256 });  // panic
```

### After
```js
new Bun.S3Client({ queueSize: 10 });   // queueSize = 10
new Bun.S3Client({ queueSize: 256 });  // queueSize = 255 (clamped)
```

## How did you verify your code works?

Added `test/js/bun/s3/s3-queueSize-validation.test.ts`.

Found by Fuzzilli (fingerprint `7d06fde38e802697`).