### PR TITLE
inspect: handle throwing Proxy getPrototypeOf in forEachProperty

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5445,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps or leftover exceptions from the loop above.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto)
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -465,6 +465,34 @@ describe("crash testing", () => {
       }
     });
   }
+
+  it("inspecting object with Proxy prototype whose getPrototypeOf trap throws doesn't crash", () => {
+    const obj = { a: 1 };
+    const proto = new Proxy(
+      { b: 2 },
+      {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      },
+    );
+    Object.setPrototypeOf(obj, proto);
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+
+  it("inspecting object with Proxy prototype that leaves a pending exception during enumeration doesn't crash", () => {
+    const target = {
+      get first() {
+        return 1;
+      },
+      get second() {
+        throw new Error("getter threw");
+      },
+    };
+    const obj = { a: 1 };
+    Object.setPrototypeOf(obj, new Proxy(target, {}));
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
 });
 
 it("possibly formatted emojis log", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -481,17 +481,22 @@ describe("crash testing", () => {
   });
 
   it("inspecting object with Proxy prototype that leaves a pending exception during enumeration doesn't crash", () => {
+    // When a Proxy sits in the prototype chain, getPropertySlot uses InternalMethodType::Get
+    // which invokes [[Get]] on the Proxy and therefore runs getters on the target.
+    let getterCalled = false;
     const target = {
       get first() {
         return 1;
       },
       get second() {
+        getterCalled = true;
         throw new Error("getter threw");
       },
     };
     const obj = { a: 1 };
     Object.setPrototypeOf(obj, new Proxy(target, {}));
     expect(() => Bun.inspect(obj)).not.toThrow();
+    expect(getterCalled).toBeTrue();
   });
 });
 


### PR DESCRIPTION
Found by the fuzzer. Fingerprint: `f20677b52d4735c2`

## What

`JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`/`console.log` to enumerate properties) walks the prototype chain with:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

When `iterating` is a Proxy and either its `getPrototypeOf` trap throws, or a pending exception exists from the property loop above (a Proxy `get` trap can cause `getPropertySlot` to return `false` with a pending exception, which was only cleared on the `true` path), `getPrototype()` returns an empty `JSValue`. `JSValue::getObject()` on an empty value calls `asCell()->getObject()` where `asCell()` is `nullptr`, triggering a null-pointer member call.

## Repro

```js
const obj = { a: 1 };
const proto = new Proxy({ b: 2 }, {
  getPrototypeOf() { throw new Error("nope"); }
});
Object.setPrototypeOf(obj, proto);
Bun.inspect(obj);
```

## Fix

- Clear exceptions after `getPropertySlot` regardless of return value, so pending exceptions don't leak into later iterations.
- After `getPrototype`, clear exceptions and break if the result is empty before calling `getObject()`. This matches how the fast path in the same function already handles `getPrototype`.