### PR TITLE
Fix null deref in forEachProperty with Proxy in prototype chain

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasSlot = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasSlot)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5445,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = nextProto ? nextProto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,29 @@ const fixture = [
         },
       },
     ),
+  () =>
+    Object.create(
+      new Proxy(
+        {
+          get foo() {
+            throw new Error("boom");
+          },
+          bar: 1,
+        },
+        {},
+      ),
+    ),
+  () =>
+    Object.create(
+      new Proxy(
+        { foo: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      ),
+    ),
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` / `console.log`) when the object being inspected has a `Proxy` in its prototype chain.

### Repro

```js
const proto = {
  get foo() { throw new Error("boom"); },
};
const obj = Object.create(new Proxy(proto, {}));
console.log(obj); // crashed
```

```js
const obj = Object.create(new Proxy({ foo: 1 }, {
  getPrototypeOf() { throw new Error("trap"); },
}));
console.log(obj); // crashed
```

### Root cause

1. When a `Proxy` sits in the prototype chain, `getPropertySlot()` with `InternalMethodType::Get` invokes the proxy's `[[Get]]`, which (with the default trap) evaluates getters on the target. If a getter throws, `getPropertySlot()` returns `false` with the exception still pending. The code did `if (!getPropertySlot(...)) continue;`, skipping the `CLEAR_IF_EXCEPTION` that follows, so the exception stayed pending into the next prototype-walk step.
2. `iterating->getPrototype(globalObject)` on a `ProxyObject` then bails out early due to the pending exception (or because its own `getPrototypeOf` trap throws) and returns an empty `JSValue`. Calling `.getObject()` on an empty `JSValue` passes `isCell()` and dereferences a null `JSCell`.

### Fix

- Clear the exception before `continue`, matching what `forEachPropertyOrdered` already does.
- Guard the prototype walk against an empty return from `getPrototype()` and clear any exception from the `getPrototypeOf` trap, matching the fast-path branch just above.

## How did you verify your code works?

Added inspect crash-test fixtures covering both a throwing getter behind a `Proxy` prototype and a throwing `getPrototypeOf` trap.

Found by Fuzzilli (`JSCJSValueCell.h:92:33: member call on null pointer of type 'JSC::JSCell'`).