### PR TITLE
http: fix ASAN use-after-poison in onHandshake after checkServerIdentity reject u9sf0l

### DIFF
--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -414,12 +414,12 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
                                 return;
                             }
 
-                            // if checkServerIdentity returns false, we dont call firstCall — the connection was rejected
+                            // checkServerIdentity returning false means it already ran
+                            // closeAndFail → fail → result callback → ThreadlocalAsyncHTTP
+                            // deinit, so `client` is freed and the socket is terminated.
+                            // Touching either here is a use-after-free.
                             const ssl_ptr = @as(*BoringSSL.SSL, @ptrCast(socket.getNativeHandle()));
                             if (!client.checkServerIdentity(comptime ssl, socket, handshake_error, ssl_ptr, true)) {
-                                client.flags.did_have_handshaking_error = true;
-                                client.unregisterAbortTracker();
-                                if (!socket.isClosed()) terminateSocket(socket);
                                 return;
                             }
                         }

--- a/src/http/ProxyTunnel.zig
+++ b/src/http/ProxyTunnel.zig
@@ -160,21 +160,19 @@ fn onHandshake(this: *HTTPClient, handshake_success: bool, ssl_error: uws.us_bun
                 bun.assert(proxy.wrapper != null);
                 const ssl_ptr = proxy.wrapper.?.ssl orelse return;
 
+                // checkServerIdentity returning false has already run closeAndFail
+                // → fail → result callback → ThreadlocalAsyncHTTP deinit, so `this`
+                // (the HTTPClient) is freed. Touching it here is a use-after-free.
                 switch (proxy.socket) {
                     .ssl => |socket| {
                         if (!this.checkServerIdentity(true, socket, handshake_error, ssl_ptr, false)) {
                             log("ProxyTunnel onHandshake checkServerIdentity failed", .{});
-                            this.flags.did_have_handshaking_error = true;
-
-                            this.unregisterAbortTracker();
                             return;
                         }
                     },
                     .tcp => |socket| {
                         if (!this.checkServerIdentity(false, socket, handshake_error, ssl_ptr, false)) {
                             log("ProxyTunnel onHandshake checkServerIdentity failed", .{});
-                            this.flags.did_have_handshaking_error = true;
-                            this.unregisterAbortTracker();
                             return;
                         }
                     },

--- a/test/js/node/http/node-https-checkServerIdentity-uaf-fixture.ts
+++ b/test/js/node/http/node-https-checkServerIdentity-uaf-fixture.ts
@@ -1,0 +1,65 @@
+// Triggers the checkServerIdentity()==false path in HTTPContext.onHandshake:
+// the CA chain verifies, but the server cert's identity doesn't match the
+// request hostname, so the native fast path calls closeAndFail() and returns
+// false. Before the fix, the caller then wrote to client.flags on an
+// HTTPClient that closeAndFail → fail → result callback had already freed,
+// tripping ASAN use-after-poison on the HTTP thread.
+//
+// Several requests are issued so the process outlives the first failure and
+// ASAN has time to abort before the main thread exits.
+
+import fs from "node:fs";
+import https from "node:https";
+import path from "node:path";
+
+const keysDir = path.join(import.meta.dir, "..", "test", "fixtures", "keys");
+// agent1-cert is CN=agent1 (signed by ca1), so connecting as "localhost" with
+// ca1 trusted passes chain verification but fails hostname matching.
+const serverKey = fs.readFileSync(path.join(keysDir, "agent1-key.pem"));
+const serverCert = fs.readFileSync(path.join(keysDir, "agent1-cert.pem"));
+const ca = fs.readFileSync(path.join(keysDir, "ca1-cert.pem"));
+
+const N = 8;
+let remaining = N;
+let failed = false;
+
+const server = https
+  .createServer({ key: serverKey, cert: serverCert }, (req, res) => {
+    // Should never be reached: the client rejects during handshake.
+    failed = true;
+    res.writeHead(200);
+    res.end();
+  })
+  .listen(0, () => {
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    for (let i = 0; i < N; i++) {
+      const req = https.request(
+        { host: "localhost", port, rejectUnauthorized: true, ca, agent: false },
+        () => {
+          console.error("unexpected response");
+          failed = true;
+          done();
+        },
+      );
+      req.on("error", err => {
+        if ((err as NodeJS.ErrnoException).code !== "ERR_TLS_CERT_ALTNAME_INVALID") {
+          console.error("unexpected error", err);
+          failed = true;
+        }
+        done();
+      });
+      req.end();
+    }
+  });
+
+function done() {
+  if (--remaining === 0) {
+    server.close();
+    // Give the HTTP thread a tick to finish any in-flight handshake callback
+    // before the main thread races to exit.
+    setImmediate(() => {
+      if (failed) process.exit(1);
+      console.log("ok");
+    });
+  }
+}

--- a/test/js/node/http/node-https-checkServerIdentity-uaf.test.ts
+++ b/test/js/node/http/node-https-checkServerIdentity-uaf.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+// HTTPContext.onHandshake used to touch `client` after checkServerIdentity()
+// returned false — but that path has already run closeAndFail → fail →
+// result callback, which frees the ThreadlocalAsyncHTTP that owns the client.
+// ASAN catches the stale read-modify-write of client.flags as use-after-poison
+// on the HTTP thread.
+test("https request rejected by checkServerIdentity doesn't UAF in onHandshake", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "node-https-checkServerIdentity-uaf-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`HTTPContext.onHandshake` (and the mirror in `ProxyTunnel.onHandshake`) touched the `HTTPClient` after `checkServerIdentity()` returned `false`, but that path has already freed it.

## Repro

Any `node:https` request whose CA chain verifies but whose hostname doesn't match the server cert's SAN — e.g. connecting to `localhost` with a cert for `CN=agent1` and `ca1` trusted — takes the native `checkX509ServerIdentity` fast path, which fails and returns `false` from `HTTPClient.checkServerIdentity`:

```
==…==ERROR: AddressSanitizer: use-after-poison on address 0x… thread T12 (HTTP Client)
READ of size 2 at 0x…
    #0 … http.HTTPContext.NewHTTPContext(true).Handler.onHandshake … src/http/HTTPContext.zig:420
    #1 … deps.uws.socket.NewSocketHandler(true).configure….on_handshake … src/deps/uws/socket.zig:955
    #2 … us_internal_trigger_handshake_callback … packages/bun-usockets/src/crypto/openssl.c:351
```

Surfaced by `test-https-agent-additional-options`, `test-https-agent-session-injection`, `test-https-agent-session-reuse`, `test-https-agent-sockets-leak`, `test-https-client-checkServerIdentity`, `test-https-client-reject`, `test-tls-set-secure-context` under release-asan.

## Cause

`HTTPClient.checkServerIdentity` returning `false` means it already called `closeAndFail`:

```
closeAndFail → terminateSocket + fail
  fail → unregisterAbortTracker + result_callback.run
    onAsyncHTTPCallback → ThreadlocalAsyncHTTP.deinit()  // bun.destroy of the struct that CONTAINS the HTTPClient
```

So by the time control returns to `onHandshake`, `client` points into freed (poisoned) memory. The next lines did a read-modify-write of the packed `client.flags` (the 2-byte read ASAN caught), called `client.unregisterAbortTracker()` again, and re-terminated the already-terminated socket.

## Fix

Just `return` when `checkServerIdentity` yields `false`. Everything those lines did is already done inside `closeAndFail`/`fail`:
- `terminateSocket` — `closeAndFail` already called it
- `unregisterAbortTracker` — first thing `fail()` does
- `did_have_handshaking_error = true` — dead store; the only reads of that flag are `… and !reject_unauthorized`, and this branch is inside `if (reject_unauthorized)`

Same change applied to the proxy-tunnel handshake which had the identical pattern.

## Test

`test/js/node/http/node-https-checkServerIdentity-uaf.test.ts` spawns a fixture that fires 8 concurrent `https.request`s whose CA verifies but hostname doesn't, and asserts they all surface `ERR_TLS_CERT_ALTNAME_INVALID` and exit 0. Under `bun bd` without this fix the fixture aborts with the ASAN report above; with it, the error events fire and the process exits cleanly.

## Note on the Node tests

The 7 Node tests above no longer crash under ASAN but still time out for an unrelated reason: `_http_client.ts` doesn't forward `checkServerIdentity` into `fetchOptions.tls`, so `node:https` always uses the native fast path, which (unlike Node's `tls.checkServerIdentity`) doesn't fall back to Subject CN when no SAN is present. That's a separate compat gap and not addressed here, so those tests aren't checked in.