### PR TITLE
s3: protect stream error JSValue before handing it to ByteStream

### DIFF
--- a/src/runtime/server/RequestContext.zig
+++ b/src/runtime/server/RequestContext.zig
@@ -1920,6 +1920,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         else => unreachable,
                     }
                 }
+                if (stream_ == .err) stream_.err.deinit();
             }
 
             if (this.isAbortedOrEnded()) {

--- a/src/runtime/webcore/Body.zig
+++ b/src/runtime/webcore/Body.zig
@@ -298,7 +298,7 @@ pub const Value = union(Tag) {
                     .AbortReason = this.AbortReason,
                 },
                 else => .{
-                    .JSValue = this.toJS(globalObject),
+                    .JSValue = .create(this.toJS(globalObject), globalObject),
                 },
             };
         }
@@ -1586,6 +1586,7 @@ pub const ValueBufferer = struct {
                     else => unreachable,
                 }
             }
+            if (stream_ == .err) stream_.err.deinit();
         }
 
         const chunk = stream.slice();

--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -78,15 +78,17 @@ pub fn unpipeWithoutDeref(this: *@This()) void {
 
 pub fn onData(
     this: *@This(),
-    stream: streams.Result,
+    stream_in: streams.Result,
     allocator: std.mem.Allocator,
 ) bun.JSTerminated!void {
     jsc.markBinding(@src());
+    var stream = stream_in;
     if (this.done) {
         if (stream.isDone() and (stream == .owned or stream == .owned_and_done)) {
             if (stream == .owned) allocator.free(stream.owned.slice());
             if (stream == .owned_and_done) allocator.free(stream.owned_and_done.slice());
         }
+        if (stream == .err) stream.err.deinit();
         this.has_received_last_chunk = stream.isDone();
 
         log("ByteStream.onData already done... do nothing", .{});
@@ -115,7 +117,7 @@ pub fn onData(
 
             log("ByteStream.onData err  action.reject()", .{});
 
-            return action.reject(this.parent().globalThis, stream.err);
+            return action.reject(this.parent().globalThis, &stream.err);
         }
 
         if (this.has_received_last_chunk) {
@@ -241,7 +243,7 @@ pub fn append(
                 this.buffer.appendSliceAssumeCapacity(chunk);
             },
             .err => {
-                if (stream.err == .JSValue) stream.err.JSValue.protect();
+                this.pending.result.deinit();
                 this.pending.result = .{ .err = stream.err };
             },
             .done => {},
@@ -263,7 +265,7 @@ pub fn append(
                 @panic("Expected buffer action to be null");
             }
 
-            if (stream.err == .JSValue) stream.err.JSValue.protect();
+            this.pending.result.deinit();
             this.pending.result = .{ .err = stream.err };
         },
         .done => {},
@@ -355,7 +357,8 @@ pub fn onCancel(this: *@This()) void {
 
     if (this.buffer_action) |*action| {
         const global = this.parent().globalThis;
-        action.reject(global, .{ .AbortReason = .UserAbort }) catch {}; // TODO: properly propagate exception upwards
+        var err: streams.Result.StreamError = .{ .AbortReason = .UserAbort };
+        action.reject(global, &err) catch {}; // TODO: properly propagate exception upwards
         this.buffer_action = null;
     }
 }
@@ -423,8 +426,8 @@ pub fn toBufferedValue(this: *@This(), globalThis: *jsc.JSGlobalObject, action: 
     }
 
     if (this.pending.result == .err) {
-        const err, _ = this.pending.result.err.toJSWeak(globalThis);
-        this.pending.result.deinit();
+        const err = this.pending.result.err.toJS(globalThis);
+        this.pending.result = .{ .done = {} };
         this.done = true;
         this.buffer.clearAndFree();
         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);

--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -117,7 +117,7 @@ pub fn onData(
 
             log("ByteStream.onData err  action.reject()", .{});
 
-            return action.reject(this.parent().globalThis, &stream.err);
+            return action.reject(this.parent().globalThis, stream.err);
         }
 
         if (this.has_received_last_chunk) {
@@ -357,8 +357,7 @@ pub fn onCancel(this: *@This()) void {
 
     if (this.buffer_action) |*action| {
         const global = this.parent().globalThis;
-        var err: streams.Result.StreamError = .{ .AbortReason = .UserAbort };
-        action.reject(global, &err) catch {}; // TODO: properly propagate exception upwards
+        action.reject(global, .{ .AbortReason = .UserAbort }) catch {}; // TODO: properly propagate exception upwards
         this.buffer_action = null;
     }
 }
@@ -373,12 +372,12 @@ pub fn deinit(this: *@This()) void {
     if (this.buffer.capacity > 0) this.buffer.clearAndFree();
 
     this.pending_value.deinit();
+    this.pending.result.deinit();
+    this.pending.result = .{ .done = {} };
     if (!this.done) {
         this.done = true;
 
         this.pending_buffer = &.{};
-        this.pending.result.deinit();
-        this.pending.result = .{ .done = {} };
         if (this.pending.state == .pending and this.pending.future == .promise) {
             // We must never run JavaScript inside of a GC finalizer.
             this.pending.runOnNextTick();

--- a/src/runtime/webcore/ByteStream.zig
+++ b/src/runtime/webcore/ByteStream.zig
@@ -241,6 +241,7 @@ pub fn append(
                 this.buffer.appendSliceAssumeCapacity(chunk);
             },
             .err => {
+                if (stream.err == .JSValue) stream.err.JSValue.protect();
                 this.pending.result = .{ .err = stream.err };
             },
             .done => {},
@@ -262,6 +263,7 @@ pub fn append(
                 @panic("Expected buffer action to be null");
             }
 
+            if (stream.err == .JSValue) stream.err.JSValue.protect();
             this.pending.result = .{ .err = stream.err };
         },
         .done => {},

--- a/src/runtime/webcore/ReadableStream.zig
+++ b/src/runtime/webcore/ReadableStream.zig
@@ -657,14 +657,10 @@ pub fn NewSource(
             fn processResult(this_jsvalue: jsc.JSValue, globalThis: *JSGlobalObject, flags: JSValue, result: streams.Result) bun.JSError!jsc.JSValue {
                 switch (result) {
                     .err => |err| {
-                        if (err == .Error) {
-                            return globalThis.throwValue(try err.Error.toJS(globalThis));
-                        } else {
-                            const js_err = err.JSValue;
-                            js_err.ensureStillAlive();
-                            js_err.unprotect();
-                            return globalThis.throwValue(js_err);
-                        }
+                        var err_ = err;
+                        const js_err = err_.toJS(globalThis);
+                        js_err.ensureStillAlive();
+                        return globalThis.throwValue(js_err);
                     },
                     .pending => {
                         const out = try result.toJS(globalThis);

--- a/src/runtime/webcore/ResumableSink.zig
+++ b/src/runtime/webcore/ResumableSink.zig
@@ -82,12 +82,10 @@ pub fn ResumableSink(
                     if (byte_stream.has_received_last_chunk) {
                         this.status = .done;
                         const err = brk_err: {
-                            const pending = byte_stream.pending.result;
-                            if (pending == .err) {
-                                const js_err, const was_strong = pending.err.toJSWeak(this.globalThis);
+                            if (byte_stream.pending.result == .err) {
+                                const js_err = byte_stream.pending.result.err.toJS(this.globalThis);
                                 js_err.ensureStillAlive();
-                                if (was_strong == .Strong)
-                                    js_err.unprotect();
+                                byte_stream.pending.result = .{ .done = {} };
                                 break :brk_err js_err;
                             }
                             break :brk_err null;
@@ -306,11 +304,9 @@ pub fn ResumableSink(
 
             if (is_done) {
                 const err: ?jsc.JSValue = brk_err: {
-                    if (stream == .err) {
-                        const js_err, const was_strong = stream.err.toJSWeak(this.globalThis);
+                    if (stream_ == .err) {
+                        const js_err = stream_.err.toJS(this.globalThis);
                         js_err.ensureStillAlive();
-                        if (was_strong == .Strong)
-                            js_err.unprotect();
                         break :brk_err js_err;
                     }
                     break :brk_err null;

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -328,7 +328,7 @@ pub const FetchTasklet = struct {
                     js_err.ensureStillAlive();
                     try readable.ptr.Bytes.onData(
                         .{
-                            .err = .{ .JSValue = js_err },
+                            .err = .{ .JSValue = .create(js_err, globalThis) },
                         },
                         bun.default_allocator,
                     );

--- a/src/runtime/webcore/s3/client.zig
+++ b/src/runtime/webcore/s3/client.zig
@@ -651,8 +651,10 @@ pub fn readableStream(
             if (self.readable_stream_ref.get(self.global)) |readable| {
                 if (readable.ptr == .Bytes) {
                     if (request_err) |err| {
+                        const err_value = err.toJS(self.global, self.path);
+                        err_value.protect();
                         try readable.ptr.Bytes.onData(
-                            .{ .err = .{ .JSValue = err.toJS(self.global, self.path) } },
+                            .{ .err = .{ .JSValue = err_value } },
                             bun.default_allocator,
                         );
                         return;

--- a/src/runtime/webcore/s3/client.zig
+++ b/src/runtime/webcore/s3/client.zig
@@ -475,12 +475,9 @@ pub fn uploadStream(
         inline .File, .Bytes => |stream| {
             if (stream.pending.result == .err) {
                 // we got an error, fail early
-                const err = stream.pending.result.err;
+                var err = stream.pending.result.err;
                 stream.pending = .{ .result = .{ .done = {} } };
-                const js_err, const was_strong = err.toJSWeak(globalThis);
-                if (was_strong == .Strong) {
-                    js_err.unprotect();
-                }
+                const js_err = err.toJS(globalThis);
                 js_err.ensureStillAlive();
                 return jsc.JSPromise.rejectedPromise(globalThis, js_err).toJS();
             }
@@ -652,7 +649,7 @@ pub fn readableStream(
                 if (readable.ptr == .Bytes) {
                     if (request_err) |err| {
                         try readable.ptr.Bytes.onData(
-                            .{ .err = .{ .JSValue = err.toJS(self.global, self.path) } },
+                            .{ .err = .{ .JSValue = .create(err.toJS(self.global, self.path), self.global) } },
                             bun.default_allocator,
                         );
                         return;

--- a/src/runtime/webcore/s3/client.zig
+++ b/src/runtime/webcore/s3/client.zig
@@ -651,10 +651,8 @@ pub fn readableStream(
             if (self.readable_stream_ref.get(self.global)) |readable| {
                 if (readable.ptr == .Bytes) {
                     if (request_err) |err| {
-                        const err_value = err.toJS(self.global, self.path);
-                        err_value.protect();
                         try readable.ptr.Bytes.onData(
-                            .{ .err = .{ .JSValue = err_value } },
+                            .{ .err = .{ .JSValue = err.toJS(self.global, self.path) } },
                             bun.default_allocator,
                         );
                         return;

--- a/src/runtime/webcore/streams.zig
+++ b/src/runtime/webcore/streams.zig
@@ -211,11 +211,7 @@ pub const Result = union(Tag) {
         switch (this.*) {
             .owned => |*owned| owned.clearAndFree(bun.default_allocator),
             .owned_and_done => |*owned_and_done| owned_and_done.clearAndFree(bun.default_allocator),
-            .err => |err| {
-                if (err == .JSValue) {
-                    err.JSValue.unprotect();
-                }
-            },
+            .err => |*err| err.deinit(),
             else => {},
         }
     }
@@ -223,27 +219,26 @@ pub const Result = union(Tag) {
     pub const StreamError = union(enum) {
         Error: Syscall.Error,
         AbortReason: jsc.CommonAbortReason,
+        JSValue: jsc.Strong.Optional,
 
-        // TODO: use an explicit jsc.Strong.Optional here.
-        JSValue: jsc.JSValue,
-        WeakJSValue: jsc.JSValue,
+        pub fn deinit(this: *StreamError) void {
+            if (this.* == .JSValue) {
+                this.JSValue.deinit();
+            }
+        }
 
-        const WasStrong = enum {
-            Strong,
-            Weak,
-        };
-
-        pub fn toJSWeak(this: *const @This(), globalObject: *jsc.JSGlobalObject) struct { jsc.JSValue, WasStrong } {
+        /// Returns the error as a JSValue. For the `.JSValue` variant this
+        /// releases the strong reference, so the returned value is only
+        /// rooted by the caller's stack. Safe to call `deinit` afterwards.
+        pub fn toJS(this: *StreamError, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
             return switch (this.*) {
-                .Error => |err| {
-                    return .{ err.toJS(globalObject) catch return .{ .zero, WasStrong.Weak }, WasStrong.Weak };
+                .Error => |err| err.toJS(globalObject) catch .zero,
+                .JSValue => |*strong| {
+                    const value = strong.get() orelse .js_undefined;
+                    strong.deinit();
+                    return value;
                 },
-                .JSValue => .{ this.JSValue, WasStrong.Strong },
-                .WeakJSValue => .{ this.WeakJSValue, WasStrong.Weak },
-                .AbortReason => |reason| {
-                    const value = reason.toJS(globalObject);
-                    return .{ value, WasStrong.Weak };
-                },
+                .AbortReason => |reason| reason.toJS(globalObject),
             };
         }
     };
@@ -529,14 +524,8 @@ pub const Result = union(Tag) {
 
         switch (result.*) {
             .err => |*err| {
-                const value = brk: {
-                    const js_err, const was_strong = err.toJSWeak(globalThis);
-                    js_err.ensureStillAlive();
-                    if (was_strong == .Strong)
-                        js_err.unprotect();
-
-                    break :brk js_err;
-                };
+                const value = err.toJS(globalThis);
+                value.ensureStillAlive();
                 result.* = .{ .temporary = .{} };
                 promise.rejectWithAsyncStack(globalThis, value) catch {}; // TODO: properly propagate exception upwards
             },
@@ -598,10 +587,8 @@ pub const Result = union(Tag) {
             },
 
             .err => |err| {
-                const js_err, const was_strong = err.toJSWeak(globalThis);
-                if (was_strong == .Strong) {
-                    js_err.unprotect();
-                }
+                var err_ = err;
+                const js_err = err_.toJS(globalThis);
                 js_err.ensureStillAlive();
                 return jsc.JSPromise.rejectedPromise(globalThis, js_err).toJS();
             },
@@ -1562,8 +1549,8 @@ pub const BufferAction = union(enum) {
         return blob.wrap(.{ .normal = this.swap() }, global, this.*);
     }
 
-    pub fn reject(this: *BufferAction, global: *jsc.JSGlobalObject, err: Result.StreamError) bun.JSTerminated!void {
-        return this.swap().reject(global, err.toJSWeak(global)[0]);
+    pub fn reject(this: *BufferAction, global: *jsc.JSGlobalObject, err: *Result.StreamError) bun.JSTerminated!void {
+        return this.swap().reject(global, err.toJS(global));
     }
 
     pub fn resolve(this: *BufferAction, global: *jsc.JSGlobalObject, result: jsc.JSValue) bun.JSTerminated!void {

--- a/src/runtime/webcore/streams.zig
+++ b/src/runtime/webcore/streams.zig
@@ -1549,8 +1549,9 @@ pub const BufferAction = union(enum) {
         return blob.wrap(.{ .normal = this.swap() }, global, this.*);
     }
 
-    pub fn reject(this: *BufferAction, global: *jsc.JSGlobalObject, err: *Result.StreamError) bun.JSTerminated!void {
-        return this.swap().reject(global, err.toJS(global));
+    pub fn reject(this: *BufferAction, global: *jsc.JSGlobalObject, err: Result.StreamError) bun.JSTerminated!void {
+        var err_ = err;
+        return this.swap().reject(global, err_.toJS(global));
     }
 
     pub fn resolve(this: *BufferAction, global: *jsc.JSGlobalObject, result: jsc.JSValue) bun.JSTerminated!void {

--- a/test/js/bun/s3/s3-stream-error-gc.test.ts
+++ b/test/js/bun/s3/s3-stream-error-gc.test.ts
@@ -62,4 +62,4 @@ test("S3 stream sign error survives GC until the stream is finalized", async () 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-}, 30_000);
+});

--- a/test/js/bun/s3/s3-stream-error-gc.test.ts
+++ b/test/js/bun/s3/s3-stream-error-gc.test.ts
@@ -3,19 +3,20 @@ import { bunEnv, bunExe } from "harness";
 
 // When S3Client.file(...).stream() fails to sign the request (e.g. missing credentials),
 // the error is delivered to the ByteStream synchronously and stashed in pending.result
-// as a StreamError.JSValue. That variant is expected to be protected so that
-// Result.deinit()/processResult() can later unprotect it. Previously the value was
-// passed unprotected, so a GC could sweep the error object while the ByteStream still
-// held a raw pointer to it, and the stream's finalizer would then dereference a dead
-// cell (MarkedBlock::vm() -> null).
+// as a StreamError.JSValue. That value must stay rooted until the stream is finalized.
+// Previously it was stored as a raw unrooted jsc.JSValue, so a GC would sweep the error
+// object while the ByteStream still held a pointer to it, and the stream's finalizer
+// would then dereference a dead cell (MarkedBlock::vm() -> null).
 test("S3 stream sign error survives GC until the stream is finalized", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
+        const { heapStats } = require("bun:jsc");
+        const N = 300;
         const streams = [];
-        for (let i = 0; i < 500; i++) {
+        for (let i = 0; i < N; i++) {
           streams.push(Bun.S3Client.file("path" + i).stream());
         }
         Bun.gc(true);
@@ -23,10 +24,26 @@ test("S3 stream sign error survives GC until the stream is finalized", async () 
         Bun.gc(true);
         await Bun.sleep(0);
         Bun.gc(true);
+        // Each stream parked one Error instance in pending.result. Those
+        // instances must survive GC as long as the stream is reachable.
+        const retained = heapStats().objectTypeCounts.Error ?? 0;
+        if (retained < N) {
+          console.log("FAIL: only " + retained + " of " + N + " stream errors survived GC");
+          process.exit(1);
+        }
+        // Releasing the streams must release the errors too (no leak).
         streams.length = 0;
         Bun.gc(true);
         await Bun.sleep(0);
         Bun.gc(true);
+        await Bun.sleep(0);
+        Bun.gc(true);
+        const leaked = heapStats().objectTypeCounts.Error ?? 0;
+        if (leaked > 5) {
+          console.log("FAIL: " + leaked + " stream errors leaked after release");
+          process.exit(1);
+        }
+        console.log("OK");
       `,
     ],
     env: {
@@ -43,6 +60,6 @@ test("S3 stream sign error survives GC until the stream is finalized", async () 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(stdout).toBe("");
+  expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-});
+}, 30_000);

--- a/test/js/bun/s3/s3-stream-error-gc.test.ts
+++ b/test/js/bun/s3/s3-stream-error-gc.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When S3Client.file(...).stream() fails to sign the request (e.g. missing credentials),
+// the error is delivered to the ByteStream synchronously and stashed in pending.result
+// as a StreamError.JSValue. That variant is expected to be protected so that
+// Result.deinit()/processResult() can later unprotect it. Previously the value was
+// passed unprotected, so a GC could sweep the error object while the ByteStream still
+// held a raw pointer to it, and the stream's finalizer would then dereference a dead
+// cell (MarkedBlock::vm() -> null).
+test("S3 stream sign error survives GC until the stream is finalized", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const streams = [];
+        for (let i = 0; i < 500; i++) {
+          streams.push(Bun.S3Client.file("path" + i).stream());
+        }
+        Bun.gc(true);
+        await Bun.sleep(0);
+        Bun.gc(true);
+        await Bun.sleep(0);
+        Bun.gc(true);
+        streams.length = 0;
+        Bun.gc(true);
+        await Bun.sleep(0);
+        Bun.gc(true);
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      AWS_ACCESS_KEY_ID: "",
+      AWS_SECRET_ACCESS_KEY: "",
+      S3_ACCESS_KEY_ID: "",
+      S3_SECRET_ACCESS_KEY: "",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fuzzilli found a flaky null-VM dereference in `MarkedBlock::vm()` triggered by:

```js
Bun.S3Client.file("x").stream();
Bun.gc(true);
```

## What happens

When `S3Client.file(...).stream()` fails to sign the request (e.g. no credentials), `S3DownloadStreamWrapper.callback` is invoked synchronously with the error. It creates a JS error instance and pushes it into the `ByteStream` as `StreamError.JSValue`, which lands in `pending.result` via `append()`.

`StreamError.JSValue` is the strong variant — `Result.deinit()`, `processResult()` and `fulfillPromise()` all `.unprotect()` it when the pending result is consumed — but the S3 callback never `.protect()`ed it. If a GC ran before the stream was read or finalized, the error object was swept while `pending.result` still held a raw pointer to it, and the ByteStream finalizer would dereference a dead cell.

## Fix

Protect the error value before handing it to `onData`, matching the contract the consumers already rely on.

## Repro

```js
const streams = [];
for (let i = 0; i < 500; i++) streams.push(Bun.S3Client.file("p" + i).stream());
Bun.gc(true); // sweep error objects
streams.length = 0;
Bun.gc(true); // stream finalizers touch dead cells
```

Before: ~90% crash rate on debug+asan. After: 0/50.