### PR TITLE
node: expose `internal/*` under --expose-internals, implement `internal/errors` helpers [1v1cy7]

### DIFF
--- a/src/js/internal/error_serdes.ts
+++ b/src/js/internal/error_serdes.ts
@@ -1,0 +1,202 @@
+// Node.js `internal/error_serdes`. Serializes/deserializes errors for worker
+// message passing. Only reachable under --expose-internals.
+
+const { SafeSet } = require("internal/primordials");
+
+const ObjectAssign = Object.assign;
+const ObjectCreate = Object.create;
+const ObjectDefineProperty = Object.defineProperty;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
+const ObjectGetPrototypeOf = Object.getPrototypeOf;
+const ObjectKeys = Object.keys;
+const ObjectPrototypeToString = Object.prototype.toString;
+const ArrayPrototypeForEach = Array.prototype.forEach;
+const StringFromCharCode = String.fromCharCode;
+const StringPrototypeSubstring = String.prototype.substring;
+const SymbolFor = Symbol.for;
+const SymbolToStringTag = Symbol.toStringTag;
+const TypedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const TypedArrayPrototypeGetBuffer = TypedArrayPrototype.__lookupGetter__("buffer");
+const TypedArrayPrototypeGetByteLength = TypedArrayPrototype.__lookupGetter__("byteLength");
+const TypedArrayPrototypeGetByteOffset = TypedArrayPrototype.__lookupGetter__("byteOffset");
+
+const Buffer = require("node:buffer").Buffer;
+const customInspectSymbol = SymbolFor("nodejs.util.inspect.custom");
+
+const kSerializedError = 0;
+const kSerializedObject = 1;
+const kInspectedError = 2;
+const kInspectedSymbol = 3;
+const kCustomInspectedObject = 4;
+const kCircularReference = 5;
+
+const kSymbolStringLength = "Symbol(".length;
+
+const errors = {
+  Error,
+  TypeError,
+  RangeError,
+  URIError,
+  SyntaxError,
+  ReferenceError,
+  EvalError,
+};
+const errorConstructorNames = new SafeSet(ObjectKeys(errors));
+
+function TryGetAllProperties(object, target, rememberSet) {
+  const all = { __proto__: null };
+  if (object === null) return all;
+  ObjectAssign(all, TryGetAllProperties(ObjectGetPrototypeOf(object), target, rememberSet));
+  const keys = ObjectGetOwnPropertyNames(object);
+  ArrayPrototypeForEach.$call(keys, key => {
+    let descriptor;
+    try {
+      descriptor = ObjectGetOwnPropertyDescriptor(object, key);
+    } catch {
+      return;
+    }
+    const getter = descriptor.get;
+    if (getter && key !== "__proto__") {
+      try {
+        descriptor.value = getter.$call(target);
+        delete descriptor.get;
+        delete descriptor.set;
+      } catch {
+        // Ignore errors.
+      }
+    }
+    if (key === "cause") {
+      descriptor.value = serializeError(descriptor.value, rememberSet);
+      all[key] = descriptor;
+    } else if ("value" in descriptor && typeof descriptor.value !== "function" && typeof descriptor.value !== "symbol") {
+      all[key] = descriptor;
+    }
+  });
+  return all;
+}
+
+function GetConstructors(object) {
+  const constructors = [];
+
+  for (let current = object; current !== null; current = ObjectGetPrototypeOf(current)) {
+    const desc = ObjectGetOwnPropertyDescriptor(current, "constructor");
+    if (desc?.value) {
+      ObjectDefineProperty(constructors, constructors.length, {
+        __proto__: null,
+        value: desc.value,
+        enumerable: true,
+      });
+    }
+  }
+
+  return constructors;
+}
+
+function GetName(object) {
+  const desc = ObjectGetOwnPropertyDescriptor(object, "name");
+  return desc?.value;
+}
+
+let internalUtilInspect;
+function inspect(...args) {
+  internalUtilInspect ??= require("internal/util/inspect");
+  return internalUtilInspect.inspect(...args);
+}
+
+let serialize;
+function serializeError(error, rememberSet = new SafeSet()) {
+  serialize ??= require("node:v8").serialize;
+  if (typeof error === "symbol") {
+    return Buffer.from(StringFromCharCode(kInspectedSymbol) + inspect(error), "utf8");
+  }
+
+  try {
+    if (typeof error === "object" && ObjectPrototypeToString.$call(error) === "[object Error]") {
+      if (rememberSet.has(error)) {
+        return Buffer.from([kCircularReference]);
+      }
+      rememberSet.add(error);
+
+      const constructors = GetConstructors(error);
+      for (let i = 0; i < constructors.length; i++) {
+        const name = GetName(constructors[i]);
+        if (errorConstructorNames.has(name)) {
+          const serialized = serialize({
+            constructor: name,
+            properties: TryGetAllProperties(error, error, rememberSet),
+          });
+          return Buffer.concat([Buffer.from([kSerializedError]), serialized]);
+        }
+      }
+    }
+  } catch {
+    // Continue regardless of error.
+  }
+  try {
+    if (error != null && customInspectSymbol in error) {
+      return Buffer.from(StringFromCharCode(kCustomInspectedObject) + inspect(error), "utf8");
+    }
+  } catch {
+    // Continue regardless of error.
+  }
+  try {
+    const serialized = serialize(error);
+    return Buffer.concat([Buffer.from([kSerializedObject]), serialized]);
+  } catch {
+    // Continue regardless of error.
+  }
+  return Buffer.from(StringFromCharCode(kInspectedError) + inspect(error), "utf8");
+}
+
+function fromBuffer(error) {
+  return Buffer.from(
+    TypedArrayPrototypeGetBuffer.$call(error),
+    TypedArrayPrototypeGetByteOffset.$call(error) + 1,
+    TypedArrayPrototypeGetByteLength.$call(error) - 1,
+  );
+}
+
+let deserialize;
+function deserializeError(error) {
+  deserialize ??= require("node:v8").deserialize;
+  switch (error[0]) {
+    case kSerializedError: {
+      const { constructor, properties } = deserialize(error.subarray(1));
+      const ctor = errors[constructor];
+      ObjectDefineProperty(properties, SymbolToStringTag, {
+        __proto__: null,
+        value: { __proto__: null, value: "Error", configurable: true },
+        enumerable: true,
+      });
+      if ("cause" in properties && "value" in properties.cause) {
+        properties.cause.value = deserializeError(properties.cause.value);
+      }
+      return ObjectCreate(ctor.prototype, properties);
+    }
+    case kSerializedObject:
+      return deserialize(error.subarray(1));
+    case kInspectedError:
+      return fromBuffer(error).toString("utf8");
+    case kInspectedSymbol: {
+      const buf = fromBuffer(error);
+      return SymbolFor(StringPrototypeSubstring.$call(buf.toString("utf8"), kSymbolStringLength, buf.length - 1));
+    }
+    case kCustomInspectedObject:
+      return {
+        __proto__: null,
+        [customInspectSymbol]: () => fromBuffer(error).toString("utf8"),
+      };
+    case kCircularReference:
+      return {
+        __proto__: null,
+        [customInspectSymbol]: () => "[Circular object]",
+      };
+  }
+  require("node:assert").fail("This should not happen");
+}
+
+export default {
+  serializeError,
+  deserializeError,
+};

--- a/src/js/internal/error_serdes.ts
+++ b/src/js/internal/error_serdes.ts
@@ -69,7 +69,11 @@ function TryGetAllProperties(object, target, rememberSet) {
     if (key === "cause") {
       descriptor.value = serializeError(descriptor.value, rememberSet);
       all[key] = descriptor;
-    } else if ("value" in descriptor && typeof descriptor.value !== "function" && typeof descriptor.value !== "symbol") {
+    } else if (
+      "value" in descriptor &&
+      typeof descriptor.value !== "function" &&
+      typeof descriptor.value !== "symbol"
+    ) {
       all[key] = descriptor;
     }
   });

--- a/src/js/internal/errors.ts
+++ b/src/js/internal/errors.ts
@@ -336,7 +336,7 @@ function hideStackFrames(fn) {
     try {
       return fn.$apply(this, args);
     } catch (error) {
-      Error.stackTraceLimit && ErrorCaptureStackTrace(error, wrappedFn);
+      if (Error.stackTraceLimit) ErrorCaptureStackTrace(error, wrappedFn);
       throw error;
     }
   }
@@ -561,7 +561,7 @@ function determineSpecificType(value) {
       }
       return `${lazyInternalUtilInspect().inspect(value, { depth: -1 })}`;
     case "string":
-      value.length > 28 && (value = `${StringPrototypeSlice.$call(value, 0, 25)}...`);
+      if (value.length > 28) value = `${StringPrototypeSlice.$call(value, 0, 25)}...`;
       if (StringPrototypeIndexOf.$call(value, "'") === -1) {
         return `type string ('${value}')`;
       }

--- a/src/js/internal/errors.ts
+++ b/src/js/internal/errors.ts
@@ -1,22 +1,706 @@
-const { SafeArrayIterator } = require("internal/primordials");
+const { SafeArrayIterator, SafeMap } = require("internal/primordials");
 
 const ArrayIsArray = Array.isArray;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeUnshift = Array.prototype.unshift;
+const ArrayPrototypeJoin = Array.prototype.join;
+const ArrayPrototypeSlice = Array.prototype.slice;
+const ArrayPrototypeIncludes = Array.prototype.includes;
+const ArrayPrototypeForEach = Array.prototype.forEach;
+const ObjectDefineProperty = Object.defineProperty;
+const ObjectDefineProperties = Object.defineProperties;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectIsExtensible = Object.isExtensible;
+const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+const ObjectAssign = Object.assign;
+const ObjectKeys = Object.keys;
+const StringPrototypeSlice = String.prototype.slice;
+const StringPrototypeIndexOf = String.prototype.indexOf;
+const RegExpPrototypeExec = RegExp.prototype.exec;
+const MapPrototypeGet = Map.prototype.get;
+const JSONStringify = JSON.stringify;
+const ErrorCaptureStackTrace = Error.captureStackTrace;
+const SymbolFor = Symbol.for;
 
-function aggregateTwoErrors(innerError: Error | undefined, outerError: Error & { errors?: Error[] }) {
+const kIsNodeError = Symbol("kIsNodeError");
+
+const messages = new SafeMap();
+const codes = {};
+
+let util;
+let internalUtilInspect;
+function lazyInternalUtilInspect() {
+  internalUtilInspect ??= require("internal/util/inspect");
+  return internalUtilInspect;
+}
+
+let buffer;
+function lazyBuffer() {
+  buffer ??= require("node:buffer").Buffer;
+  return buffer;
+}
+
+let uvBinding;
+function lazyUv() {
+  uvBinding ??= process.binding("uv");
+  return uvBinding;
+}
+
+function assert(value, message) {
+  if (!value) {
+    throw $ERR_INTERNAL_ASSERTION(message);
+  }
+}
+
+function isErrorStackTraceLimitWritable() {
+  const desc = ObjectGetOwnPropertyDescriptor(Error, "stackTraceLimit");
+  if (desc === undefined) {
+    return ObjectIsExtensible(Error);
+  }
+  return ObjectPrototypeHasOwnProperty.$call(desc, "writable") ? desc.writable : desc.set !== undefined;
+}
+
+function aggregateTwoErrors(innerError, outerError) {
   if (innerError && outerError && innerError !== outerError) {
     if (ArrayIsArray(outerError.errors)) {
       // If `outerError` is already an `AggregateError`.
       ArrayPrototypePush.$call(outerError.errors, innerError);
       return outerError;
     }
-    const err = new AggregateError(new SafeArrayIterator([outerError, innerError]), outerError.message);
+    let err;
+    if (isErrorStackTraceLimitWritable()) {
+      const limit = Error.stackTraceLimit;
+      Error.stackTraceLimit = 0;
+      err = new AggregateError(new SafeArrayIterator([outerError, innerError]), outerError.message);
+      Error.stackTraceLimit = limit;
+      ErrorCaptureStackTrace(err, aggregateTwoErrors);
+    } else {
+      err = new AggregateError(new SafeArrayIterator([outerError, innerError]), outerError.message);
+    }
     err.code = outerError.code;
     return err;
   }
   return innerError || outerError;
 }
 
+// A specialized Error that includes an additional info property with
+// additional information about the error condition.
+class SystemError extends Error {
+  constructor(key, context) {
+    super();
+    const prefix = getMessage(key, [], this);
+    let message = `${prefix}: ${context.syscall} returned ` + `${context.code} (${context.message})`;
+
+    if (context.path !== undefined) message += ` ${context.path}`;
+    if (context.dest !== undefined) message += ` => ${context.dest}`;
+
+    this.code = key;
+
+    ObjectDefineProperties(this, {
+      [kIsNodeError]: {
+        __proto__: null,
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: true,
+      },
+      name: {
+        __proto__: null,
+        value: "SystemError",
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
+      message: {
+        __proto__: null,
+        value: message,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
+      info: {
+        __proto__: null,
+        value: context,
+        enumerable: true,
+        configurable: true,
+        writable: false,
+      },
+      errno: {
+        __proto__: null,
+        get() {
+          return context.errno;
+        },
+        set: value => {
+          context.errno = value;
+        },
+        enumerable: true,
+        configurable: true,
+      },
+      syscall: {
+        __proto__: null,
+        get() {
+          return context.syscall;
+        },
+        set: value => {
+          context.syscall = value;
+        },
+        enumerable: true,
+        configurable: true,
+      },
+    });
+
+    if (context.path !== undefined) {
+      ObjectDefineProperty(this, "path", {
+        __proto__: null,
+        get() {
+          return context.path != null ? context.path.toString() : context.path;
+        },
+        set: value => {
+          context.path = value ? lazyBuffer().from(value.toString()) : undefined;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+    }
+
+    if (context.dest !== undefined) {
+      ObjectDefineProperty(this, "dest", {
+        __proto__: null,
+        get() {
+          return context.dest != null ? context.dest.toString() : context.dest;
+        },
+        set: value => {
+          context.dest = value ? lazyBuffer().from(value.toString()) : undefined;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  toString() {
+    return `${this.name} [${this.code}]: ${this.message}`;
+  }
+
+  [SymbolFor("nodejs.util.inspect.custom")](recurseTimes, ctx) {
+    return lazyInternalUtilInspect().inspect(this, {
+      ...ctx,
+      getters: true,
+      customInspect: false,
+    });
+  }
+}
+
+function captureLargerStackTrace(err) {
+  const stackTraceLimitIsWritable = isErrorStackTraceLimitWritable();
+  let userStackTraceLimit;
+  if (stackTraceLimitIsWritable) {
+    userStackTraceLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = Infinity;
+  }
+  ErrorCaptureStackTrace(err);
+  if (stackTraceLimitIsWritable) Error.stackTraceLimit = userStackTraceLimit;
+  return err;
+}
+
+function makeSystemErrorWithCode(key) {
+  return class NodeError extends SystemError {
+    constructor(ctx) {
+      super(key, ctx);
+    }
+  };
+}
+
+// This is a special error type that is only used for the E function.
+class HideStackFramesError extends Error {}
+
+function makeNodeErrorForHideStackFrame(Base, clazz) {
+  class HideStackFramesError extends Base {
+    constructor(...args) {
+      if (isErrorStackTraceLimitWritable()) {
+        const limit = Error.stackTraceLimit;
+        Error.stackTraceLimit = 0;
+        super(...args);
+        Error.stackTraceLimit = limit;
+      } else {
+        super(...args);
+      }
+    }
+
+    get ["constructor"]() {
+      return clazz;
+    }
+  }
+
+  return HideStackFramesError;
+}
+
+function makeNodeErrorWithCode(Base, key) {
+  const msg = messages.get(key);
+  const expectedLength = typeof msg !== "string" ? -1 : getExpectedArgumentLength(msg);
+
+  switch (expectedLength) {
+    case 0: {
+      class NodeError extends Base {
+        code = key;
+
+        constructor(...args) {
+          assert(
+            args.length === 0,
+            `Code: ${key}; The provided arguments length (${args.length}) does not ` +
+              `match the required ones (${expectedLength}).`,
+          );
+          super(msg);
+        }
+
+        get ["constructor"]() {
+          return Base;
+        }
+
+        get [kIsNodeError]() {
+          return true;
+        }
+
+        toString() {
+          return `${this.name} [${key}]: ${this.message}`;
+        }
+      }
+      return NodeError;
+    }
+    case -1: {
+      class NodeError extends Base {
+        code = key;
+
+        constructor(...args) {
+          super();
+          ObjectDefineProperty(this, "message", {
+            __proto__: null,
+            value: getMessage(key, args, this),
+            enumerable: false,
+            writable: true,
+            configurable: true,
+          });
+        }
+
+        get ["constructor"]() {
+          return Base;
+        }
+
+        get [kIsNodeError]() {
+          return true;
+        }
+
+        toString() {
+          return `${this.name} [${key}]: ${this.message}`;
+        }
+      }
+      return NodeError;
+    }
+    default: {
+      class NodeError extends Base {
+        code = key;
+
+        constructor(...args) {
+          assert(
+            args.length === expectedLength,
+            `Code: ${key}; The provided arguments length (${args.length}) does not ` +
+              `match the required ones (${expectedLength}).`,
+          );
+
+          ArrayPrototypeUnshift.$call(args, msg);
+          super(lazyInternalUtilInspect().format.$apply(null, args));
+        }
+
+        get ["constructor"]() {
+          return Base;
+        }
+
+        get [kIsNodeError]() {
+          return true;
+        }
+
+        toString() {
+          return `${this.name} [${key}]: ${this.message}`;
+        }
+      }
+      return NodeError;
+    }
+  }
+}
+
+/**
+ * This function removes unnecessary frames from Node.js core errors.
+ */
+function hideStackFrames(fn) {
+  function wrappedFn(...args) {
+    try {
+      return fn.$apply(this, args);
+    } catch (error) {
+      Error.stackTraceLimit && ErrorCaptureStackTrace(error, wrappedFn);
+      throw error;
+    }
+  }
+  wrappedFn.withoutStackTrace = fn;
+  return wrappedFn;
+}
+
+// Utility function for registering the error codes. Exported *only* to allow
+// for testing.
+function E(sym, val, def, ...otherClasses) {
+  messages.set(sym, val);
+
+  const ErrClass = def === SystemError ? makeSystemErrorWithCode(sym) : makeNodeErrorWithCode(def, sym);
+
+  if (otherClasses.length !== 0) {
+    if (ArrayPrototypeIncludes.$call(otherClasses, HideStackFramesError)) {
+      if (otherClasses.length !== 1) {
+        ArrayPrototypeForEach.$call(otherClasses, clazz => {
+          if (clazz !== HideStackFramesError) {
+            ErrClass[clazz.name] = makeNodeErrorWithCode(clazz, sym);
+            ErrClass[clazz.name].HideStackFramesError = makeNodeErrorForHideStackFrame(ErrClass[clazz.name], clazz);
+          }
+        });
+      }
+    } else {
+      ArrayPrototypeForEach.$call(otherClasses, clazz => {
+        ErrClass[clazz.name] = makeNodeErrorWithCode(clazz, sym);
+      });
+    }
+  }
+
+  if (ArrayPrototypeIncludes.$call(otherClasses, HideStackFramesError)) {
+    ErrClass.HideStackFramesError = makeNodeErrorForHideStackFrame(ErrClass, def);
+  }
+
+  codes[sym] = ErrClass;
+}
+
+function getExpectedArgumentLength(msg) {
+  let expectedLength = 0;
+  const regex = /%[dfijoOs]/g;
+  while (RegExpPrototypeExec.$call(regex, msg) !== null) expectedLength++;
+  return expectedLength;
+}
+
+function getMessage(key, args, self) {
+  const msg = messages.get(key);
+
+  if (typeof msg === "function") {
+    assert(
+      msg.length <= args.length,
+      `Code: ${key}; The provided arguments length (${args.length}) does not ` +
+        `match the required ones (${msg.length}).`,
+    );
+    return msg.$apply(self, args);
+  }
+
+  const expectedLength = getExpectedArgumentLength(msg);
+  assert(
+    expectedLength === args.length,
+    `Code: ${key}; The provided arguments length (${args.length}) does not ` +
+      `match the required ones (${expectedLength}).`,
+  );
+  if (args.length === 0) return msg;
+
+  ArrayPrototypeUnshift.$call(args, msg);
+  return lazyInternalUtilInspect().format.$apply(null, args);
+}
+
+const uvUnmappedError = ["UNKNOWN", "unknown error"];
+
+function uvErrmapGet(name) {
+  const binding = lazyUv();
+  binding.errmap ??= binding.getErrorMap();
+  return MapPrototypeGet.$call(binding.errmap, name);
+}
+
+/**
+ * This creates an error compatible with errors produced in UVException.
+ */
+class UVException extends Error {
+  constructor(ctx) {
+    const [code, uvmsg] = uvErrmapGet(ctx.errno) || uvUnmappedError;
+    let message = `${code}: ${ctx.message || uvmsg}, ${ctx.syscall}`;
+
+    let path;
+    let dest;
+    if (ctx.path) {
+      path = ctx.path.toString();
+      message += ` '${path}'`;
+    }
+    if (ctx.dest) {
+      dest = ctx.dest.toString();
+      message += ` -> '${dest}'`;
+    }
+
+    super(message);
+
+    for (const prop of ObjectKeys(ctx)) {
+      if (prop === "message" || prop === "path" || prop === "dest") {
+        continue;
+      }
+      this[prop] = ctx[prop];
+    }
+
+    this.code = code;
+    if (path) this.path = path;
+    if (dest) this.dest = dest;
+  }
+
+  get ["constructor"]() {
+    return Error;
+  }
+}
+
+class UVExceptionWithHostPort extends Error {
+  constructor(err, syscall, address, port) {
+    const [code, uvmsg] = uvErrmapGet(err) || uvUnmappedError;
+    const message = `${syscall} ${code}: ${uvmsg}`;
+    let details = "";
+
+    if (port && port > 0) {
+      details = ` ${address}:${port}`;
+    } else if (address) {
+      details = ` ${address}`;
+    }
+
+    super(`${message}${details}`);
+
+    this.code = code;
+    this.errno = err;
+    this.syscall = syscall;
+    this.address = address;
+    if (port) {
+      this.port = port;
+    }
+  }
+
+  get ["constructor"]() {
+    return Error;
+  }
+}
+
+class DNSException extends Error {
+  constructor(code, syscall, hostname) {
+    let errno;
+    // If `code` is of type number, it is a libuv error number, else it is a
+    // c-ares error code.
+    if (typeof code === "number") {
+      errno = code;
+      const uv = lazyUv();
+      if (code === uv.UV_EAI_NODATA || code === uv.UV_EAI_NONAME) {
+        code = "ENOTFOUND"; // Fabricated error name.
+      } else {
+        util ??= require("node:util");
+        code = util.getSystemErrorName(code);
+      }
+    }
+    super(`${syscall} ${code}${hostname ? ` ${hostname}` : ""}`);
+    this.errno = errno;
+    this.code = code;
+    this.syscall = syscall;
+    if (hostname) {
+      this.hostname = hostname;
+    }
+  }
+
+  get ["constructor"]() {
+    return Error;
+  }
+}
+
+class AbortError extends Error {
+  constructor(message = "The operation was aborted", options = undefined) {
+    if (options !== undefined && typeof options !== "object") {
+      throw $ERR_INVALID_ARG_TYPE("options", "Object", options);
+    }
+    super(message, options);
+    this.code = "ABORT_ERR";
+    this.name = "AbortError";
+  }
+}
+
+const genericNodeError = hideStackFrames(function genericNodeError(message, errorProperties) {
+  const err = new Error(message);
+  ObjectAssign(err, errorProperties);
+  return err;
+});
+
+function determineSpecificType(value) {
+  if (value === null) {
+    return "null";
+  } else if (value === undefined) {
+    return "undefined";
+  }
+
+  const type = typeof value;
+
+  switch (type) {
+    case "bigint":
+      return `type bigint (${value}n)`;
+    case "number":
+      if (value === 0) {
+        return 1 / value === -Infinity ? "type number (-0)" : "type number (0)";
+      } else if (value !== value) {
+        return "type number (NaN)";
+      } else if (value === Infinity) {
+        return "type number (Infinity)";
+      } else if (value === -Infinity) {
+        return "type number (-Infinity)";
+      }
+      return `type number (${value})`;
+    case "boolean":
+      return value ? "type boolean (true)" : "type boolean (false)";
+    case "symbol":
+      return `type symbol (${String(value)})`;
+    case "function":
+      return `function ${value.name}`;
+    case "object":
+      if (value.constructor && "name" in value.constructor) {
+        return `an instance of ${value.constructor.name}`;
+      }
+      return `${lazyInternalUtilInspect().inspect(value, { depth: -1 })}`;
+    case "string":
+      value.length > 28 && (value = `${StringPrototypeSlice.$call(value, 0, 25)}...`);
+      if (StringPrototypeIndexOf.$call(value, "'") === -1) {
+        return `type string ('${value}')`;
+      }
+      return `type string (${JSONStringify(value)})`;
+    default:
+      value = lazyInternalUtilInspect().inspect(value, { colors: false });
+      if (value.length > 28) {
+        value = `${StringPrototypeSlice.$call(value, 0, 25)}...`;
+      }
+      return `type ${type} (${value})`;
+  }
+}
+
+/**
+ * Create a list string in the form like 'A and B' or 'A, B, ..., and Z'.
+ */
+function formatList(array, type = "and") {
+  switch (array.length) {
+    case 0:
+      return "";
+    case 1:
+      return `${array[0]}`;
+    case 2:
+      return `${array[0]} ${type} ${array[1]}`;
+    case 3:
+      return `${array[0]}, ${array[1]}, ${type} ${array[2]}`;
+    default:
+      return `${ArrayPrototypeJoin.$call(ArrayPrototypeSlice.$call(array, 0, -1), ", ")}, ${type} ${array[array.length - 1]}`;
+  }
+}
+
+const classRegExp = /^([A-Z][a-z0-9]*)+$/;
+const kTypes = ["string", "function", "number", "object", "Function", "Object", "boolean", "bigint", "symbol"];
+
+// Register the error codes tests rely on. More can be added as needed; this is
+// only reached under --expose-internals so it's not on any hot path.
+E(
+  "ERR_ACCESS_DENIED",
+  function (msg, permission = "", resource = "") {
+    this.permission = permission;
+    this.resource = resource;
+    return msg;
+  },
+  Error,
+  HideStackFramesError,
+);
+E(
+  "ERR_INVALID_ARG_TYPE",
+  (name, expected, actual) => {
+    assert(typeof name === "string", "'name' must be a string");
+    if (!ArrayIsArray(expected)) {
+      expected = [expected];
+    }
+
+    let msg = "The ";
+    if (name.endsWith(" argument")) {
+      msg += `${name} `;
+    } else {
+      const type = name.includes(".") ? "property" : "argument";
+      msg += `"${name}" ${type} `;
+    }
+    msg += "must be ";
+
+    const types = [];
+    const instances = [];
+    const other = [];
+
+    for (const value of expected) {
+      assert(typeof value === "string", "All expected entries have to be of type string");
+      if (ArrayPrototypeIncludes.$call(kTypes, value)) {
+        types.push(value.toLowerCase());
+      } else if (RegExpPrototypeExec.$call(classRegExp, value) !== null) {
+        instances.push(value);
+      } else {
+        assert(value !== "object", 'The value "object" should be written as "Object"');
+        other.push(value);
+      }
+    }
+
+    if (instances.length > 0) {
+      const pos = types.indexOf("object");
+      if (pos !== -1) {
+        types.splice(pos, 1);
+        instances.push("Object");
+      }
+    }
+
+    if (types.length > 0) {
+      msg += `${types.length > 1 ? "one of type" : "of type"} ${formatList(types, "or")}`;
+      if (instances.length > 0 || other.length > 0) msg += " or ";
+    }
+
+    if (instances.length > 0) {
+      msg += `an instance of ${formatList(instances, "or")}`;
+      if (other.length > 0) msg += " or ";
+    }
+
+    if (other.length > 0) {
+      if (other.length > 1) {
+        msg += `one of ${formatList(other, "or")}`;
+      } else {
+        if (other[0].toLowerCase() !== other[0]) msg += "an ";
+        msg += `${other[0]}`;
+      }
+    }
+
+    msg += `. Received ${determineSpecificType(actual)}`;
+
+    return msg;
+  },
+  TypeError,
+  HideStackFramesError,
+);
+
+let useOriginalName = false;
+
 export default {
+  AbortError,
   aggregateTwoErrors,
+  captureLargerStackTrace,
+  codes,
+  determineSpecificType,
+  DNSException,
+  E,
+  formatList,
+  genericNodeError,
+  getMessage,
+  hideStackFrames,
+  HideStackFramesError,
+  isErrorStackTraceLimitWritable,
+  kIsNodeError,
+  SystemError,
+  uvErrmapGet,
+  UVException,
+  UVExceptionWithHostPort,
+  get useOriginalName() {
+    return useOriginalName;
+  },
+  set useOriginalName(value) {
+    useOriginalName = value;
+  },
 };

--- a/src/js/internal/errors.ts
+++ b/src/js/internal/errors.ts
@@ -596,8 +596,10 @@ function formatList(array, type = "and") {
 const classRegExp = /^([A-Z][a-z0-9]*)+$/;
 const kTypes = ["string", "function", "number", "object", "Function", "Object", "boolean", "bigint", "symbol"];
 
-// Register the error codes tests rely on. More can be added as needed; this is
-// only reached under --expose-internals so it's not on any hot path.
+// Register the error codes --expose-internals tests rely on. Keep this list
+// minimal: this module is required by internal/streams/{destroy,pipeline,readable}
+// and so evaluates on first node:stream load in every process, not only under
+// the testing flag.
 E(
   "ERR_ACCESS_DENIED",
   function (msg, permission = "", resource = "") {

--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -1,0 +1,12 @@
+// Node.js `internal/test/binding`, only reachable under --expose-internals.
+// In Node this exposes the raw `internalBinding` function to tests; Bun
+// proxies to `process.binding` which covers the bindings tests need (`uv`,
+// `constants`, etc.).
+
+function internalBinding(name: string) {
+  return process.binding(name);
+}
+
+export default {
+  internalBinding,
+};

--- a/src/jsc/ModuleLoader.zig
+++ b/src/jsc/ModuleLoader.zig
@@ -18,6 +18,44 @@ comptime {
 
 pub var is_allowed_to_use_internal_testing_apis = false;
 
+/// Comptime-generated map from `internal/*` specifiers to their ResolvedSource.Tag.
+/// Bun's internal JS modules (src/js/internal/*.ts) are registered in the
+/// InternalModuleRegistry with tag names like `internal:errors`. Node.js tests with
+/// `// Flags: --expose-internals` expect `require("internal/errors")` to work. When
+/// `is_allowed_to_use_internal_testing_apis` is set (same gate as `bun:internal-for-testing`),
+/// we resolve `internal/xxx` -> the matching InternalModuleRegistry entry.
+pub const ExposedInternals = struct {
+    pub const map = bun.ComptimeStringMap(ResolvedSource.Tag, brk: {
+        @setEvalBranchQuota(100_000);
+        const fields = @typeInfo(ResolvedSource.Tag).@"enum".fields;
+        const prefix = "internal:";
+        var count: usize = 0;
+        for (fields) |f| {
+            if (f.name.len > prefix.len and std.mem.eql(u8, f.name[0..prefix.len], prefix)) {
+                count += 1;
+            }
+        }
+        var entries: [count]struct { []const u8, ResolvedSource.Tag } = undefined;
+        var i: usize = 0;
+        for (fields) |f| {
+            if (f.name.len > prefix.len and std.mem.eql(u8, f.name[0..prefix.len], prefix)) {
+                // expose as `internal/<name>` (Node.js spelling)
+                entries[i] = .{ "internal/" ++ f.name[prefix.len..], @field(ResolvedSource.Tag, f.name) };
+                i += 1;
+            }
+        }
+        const final = entries;
+        break :brk final;
+    });
+
+    pub fn get(specifier: bun.String) ?ResolvedSource.Tag {
+        if (!specifier.hasPrefixComptime("internal/")) return null;
+        const spec = specifier.toUTF8(bun.default_allocator);
+        defer spec.deinit();
+        return map.get(spec.slice());
+    }
+};
+
 /// This must be called after calling transpileSourceCode
 pub fn resetArena(this: *ModuleLoader, jsc_vm: *VirtualMachine) void {
     bun.assert(&jsc_vm.module_loader == this);
@@ -1173,6 +1211,12 @@ fn getHardcodedModule(jsc_vm: *VirtualMachine, specifier: bun.String, hardcoded:
 pub fn fetchBuiltinModule(jsc_vm: *VirtualMachine, specifier: bun.String) !?ResolvedSource {
     if (HardcodedModule.map.getWithEql(specifier, bun.String.eqlComptime)) |hardcoded| {
         return getHardcodedModule(jsc_vm, specifier, hardcoded);
+    }
+
+    if (Environment.isDebug or is_allowed_to_use_internal_testing_apis) {
+        if (ExposedInternals.get(specifier)) |tag| {
+            return jsSyntheticModule(tag, specifier);
+        }
     }
 
     if (specifier.hasPrefixComptime(js_ast.Macro.namespaceWithColon)) {

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1946,7 +1946,9 @@ pub fn resolveMaybeNeedsTrailingSlash(
         jsc.ModuleLoader.ExposedInternals.map.has(specifier_utf8.slice()))
     {
         // Node.js `--expose-internals`: allow `require("internal/errors")` etc.
-        res.* = ErrorableString.ok(specifier);
+        // Callers deref `res.result.value` on success *in addition to* their own
+        // borrowed specifier, so echo it back with a +1 (see HardcodedModule above).
+        res.* = ErrorableString.ok(specifier.dupeRef());
         return;
     }
 

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1748,6 +1748,13 @@ fn _resolve(
         ret.result = null;
         ret.path = result.path;
         return;
+    } else if ((Environment.isDebug or ModuleLoader.is_allowed_to_use_internal_testing_apis) and
+        jsc.ModuleLoader.ExposedInternals.map.has(specifier))
+    {
+        // Node.js `--expose-internals`: allow `require("internal/errors")` etc.
+        ret.result = null;
+        ret.path = try bun.default_allocator.dupe(u8, specifier);
+        return;
     } else if (jsc_vm.module_loader.eval_source != null and
         (strings.endsWithComptime(specifier, bun.pathLiteral("/[eval]")) or
             strings.endsWithComptime(specifier, bun.pathLiteral("/[stdin]"))))
@@ -1932,6 +1939,14 @@ pub fn resolveMaybeNeedsTrailingSlash(
             else
                 bun.String.init(hardcoded.path),
         );
+        return;
+    }
+
+    if ((Environment.isDebug or ModuleLoader.is_allowed_to_use_internal_testing_apis) and
+        jsc.ModuleLoader.ExposedInternals.map.has(specifier_utf8.slice()))
+    {
+        // Node.js `--expose-internals`: allow `require("internal/errors")` etc.
+        res.* = ErrorableString.ok(specifier);
         return;
     }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2488,7 +2488,7 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
     // }
     JSC::JSObject* config = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-    variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i18n_support"_s), JSC::jsNumber(1), 0);
+    variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i8n_support"_s), JSC::jsNumber(1), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "enable_lto"_s), JSC::jsBoolean(false), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "node_module_version"_s), JSC::jsNumber(REPORTED_NODEJS_ABI_VERSION), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "napi_build_version"_s), JSC::jsNumber(Napi::DEFAULT_NAPI_VERSION), 0);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2488,7 +2488,7 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
     // }
     JSC::JSObject* config = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-    variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i8n_support"_s), JSC::jsNumber(1), 0);
+    variables->putDirect(vm, JSC::Identifier::fromString(vm, "v8_enable_i18n_support"_s), JSC::jsNumber(1), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "enable_lto"_s), JSC::jsBoolean(false), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "node_module_version"_s), JSC::jsNumber(REPORTED_NODEJS_ABI_VERSION), 0);
     variables->putDirect(vm, JSC::Identifier::fromString(vm, "napi_build_version"_s), JSC::jsNumber(Napi::DEFAULT_NAPI_VERSION), 0);

--- a/test/js/node/module/expose-internals.test.ts
+++ b/test/js/node/module/expose-internals.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Node.js tests flagged `// Flags: --expose-internals` do
+// `require("internal/errors")` directly. Bun's src/js/internal/* modules are
+// bundled into the InternalModuleRegistry and normally only reachable from
+// other builtins. When BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING is set (same gate
+// as `bun:internal-for-testing`), the module loader should resolve
+// `internal/<name>` specifiers against that registry.
+
+test("internal/errors is requireable under the testing flag", async () => {
+  // bunEnv already sets BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING + the GC flag
+  // that unlocks it; the gate's stash-and-test wrapper will exercise the
+  // "module not found" path on a build without the fix.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const e = require("internal/errors");
+        const assert = require("assert");
+
+        // Surface area the Node parallel tests depend on.
+        assert.strictEqual(typeof e.E, "function");
+        assert.strictEqual(typeof e.SystemError, "function");
+        assert.strictEqual(typeof e.hideStackFrames, "function");
+        assert.strictEqual(typeof e.aggregateTwoErrors, "function");
+        assert.strictEqual(typeof e.determineSpecificType, "function");
+        assert.strictEqual(typeof e.formatList, "function");
+        assert.strictEqual(typeof e.DNSException, "function");
+        assert.strictEqual(typeof e.UVException, "function");
+        assert.strictEqual(typeof e.UVExceptionWithHostPort, "function");
+        assert.strictEqual(typeof e.AbortError, "function");
+        assert.strictEqual(typeof e.kIsNodeError, "symbol");
+        assert.strictEqual(typeof e.codes, "object");
+
+        // E() registers a code and makeNodeErrorWithCode wires it up.
+        e.E("ERR_EXPOSE_INTERNALS_TEST", "hello %s", Error, TypeError);
+        const err = new e.codes.ERR_EXPOSE_INTERNALS_TEST("world");
+        assert.strictEqual(err.code, "ERR_EXPOSE_INTERNALS_TEST");
+        assert.strictEqual(err.message, "hello world");
+        assert.ok(err instanceof Error);
+        assert.ok(new e.codes.ERR_EXPOSE_INTERNALS_TEST.TypeError("x") instanceof TypeError);
+
+        // SystemError shape.
+        e.E("ERR_EXPOSE_INTERNALS_SYS", "sys", e.SystemError);
+        const se = new e.codes.ERR_EXPOSE_INTERNALS_SYS({
+          code: "ETEST",
+          message: "m",
+          syscall: "s",
+        });
+        assert.strictEqual(se.name, "SystemError");
+        assert.strictEqual(se.code, "ERR_EXPOSE_INTERNALS_SYS");
+        assert.strictEqual(se.syscall, "s");
+        assert.strictEqual(se[e.kIsNodeError], true);
+
+        // UVException with an unmapped errno.
+        const uv = new e.UVException({ errno: 100, syscall: "open" });
+        assert.strictEqual(uv.code, "UNKNOWN");
+        assert.strictEqual(uv.errno, 100);
+
+        // formatList / determineSpecificType.
+        assert.strictEqual(e.formatList(["a", "b"]), "a and b");
+        assert.strictEqual(e.determineSpecificType(null), "null");
+
+        // Other internal/* modules route through the same mechanism.
+        assert.strictEqual(typeof require("internal/validators").validateInteger, "function");
+        assert.strictEqual(typeof require("internal/test/binding").internalBinding, "function");
+        assert.strictEqual(typeof require("internal/util/inspect").inspect, "function");
+
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+test("internal/errors is importable (ESM) under the testing flag", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--input-type=module",
+      "-e",
+      `
+        import errors from "internal/errors";
+        if (typeof errors.determineSpecificType !== "function") throw new Error("missing");
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+test("process.config.variables.v8_enable_i18n_support is set (was misspelled 'i8n')", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.log(process.config.variables.v8_enable_i18n_support)`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(stdout.trim()).toBe("1");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/module/expose-internals.test.ts
+++ b/test/js/node/module/expose-internals.test.ts
@@ -102,16 +102,3 @@ test("internal/errors is importable (ESM) under the testing flag", async () => {
   expect(stdout.trim()).toBe("ok");
   expect(exitCode).toBe(0);
 });
-
-test("process.config.variables.v8_enable_i18n_support is set (was misspelled 'i8n')", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `console.log(process.config.variables.v8_enable_i18n_support)`],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr.trim()).toBe("");
-  expect(stdout.trim()).toBe("1");
-  expect(exitCode).toBe(0);
-});

--- a/test/js/node/module/expose-internals.test.ts
+++ b/test/js/node/module/expose-internals.test.ts
@@ -76,9 +76,14 @@ test("internal/errors is requireable under the testing flag", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr.trim()).toBe("");
-  expect(stdout.trim()).toBe("ok");
-  expect(exitCode).toBe(0);
+  // stderr carries the ASAN "WARNING: ASAN interferes with JSC signal handlers"
+  // banner on the x64-asan lane; keep it in the diff for diagnostics but don't
+  // pin it. stdout == "ok" + exitCode == 0 is the regression guard.
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+    stdout: "ok",
+    exitCode: 0,
+    stderr: expect.any(String),
+  });
 });
 
 test("internal/errors is importable (ESM) under the testing flag", async () => {
@@ -98,7 +103,9 @@ test("internal/errors is importable (ESM) under the testing flag", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr.trim()).toBe("");
-  expect(stdout.trim()).toBe("ok");
-  expect(exitCode).toBe(0);
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toEqual({
+    stdout: "ok",
+    exitCode: 0,
+    stderr: expect.any(String),
+  });
 });

--- a/test/js/node/module/expose-internals.test.ts
+++ b/test/js/node/module/expose-internals.test.ts
@@ -8,7 +8,7 @@ import { bunEnv, bunExe } from "harness";
 // as `bun:internal-for-testing`), the module loader should resolve
 // `internal/<name>` specifiers against that registry.
 
-test("internal/errors is requireable under the testing flag", async () => {
+test.concurrent("internal/errors is requireable under the testing flag", async () => {
   // bunEnv already sets BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING + the GC flag
   // that unlocks it; the gate's stash-and-test wrapper will exercise the
   // "module not found" path on a build without the fix.
@@ -86,7 +86,7 @@ test("internal/errors is requireable under the testing flag", async () => {
   });
 });
 
-test("internal/errors is importable (ESM) under the testing flag", async () => {
+test.concurrent("internal/errors is importable (ESM) under the testing flag", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/test/parallel/test-dns-memory-error.js
+++ b/test/js/node/test/parallel/test-dns-memory-error.js
@@ -1,0 +1,18 @@
+// Flags: --expose-internals
+'use strict';
+
+// Check that if libuv reports a memory error on a DNS query, that the memory
+// error is passed through and not replaced with ENOTFOUND.
+
+require('../common');
+
+const assert = require('assert');
+const errors = require('internal/errors');
+const { internalBinding } = require('internal/test/binding');
+
+const { UV_EAI_MEMORY } = internalBinding('uv');
+const memoryError = new errors.DNSException(UV_EAI_MEMORY, 'fhqwhgads');
+
+assert.strictEqual(memoryError.code, 'EAI_MEMORY');
+const stack = memoryError.stack.split('\n');
+assert.match(stack[1], /^ {4}at (Object|<anonymous>)/);

--- a/test/js/node/test/parallel/test-error-aggregateTwoErrors.js
+++ b/test/js/node/test/parallel/test-error-aggregateTwoErrors.js
@@ -1,0 +1,71 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { aggregateTwoErrors } = require('internal/errors');
+
+assert.strictEqual(aggregateTwoErrors(null, null), null);
+
+{
+  const err = new Error();
+  assert.strictEqual(aggregateTwoErrors(null, err), err);
+}
+
+{
+  const err = new Error();
+  assert.strictEqual(aggregateTwoErrors(err, null), err);
+}
+
+{
+  const err0 = new Error('original');
+  const err1 = new Error('second error');
+
+  err0.code = 'ERR0';
+  err1.code = 'ERR1';
+
+  const chainedError = aggregateTwoErrors(err1, err0);
+  assert.strictEqual(chainedError.message, err0.message);
+  assert.strictEqual(chainedError.code, err0.code);
+  assert.deepStrictEqual(chainedError.errors, [err0, err1]);
+}
+
+{
+  const err0 = new Error('original');
+  const err1 = new Error('second error');
+  const err2 = new Error('third error');
+
+  err0.code = 'ERR0';
+  err1.code = 'ERR1';
+  err2.code = 'ERR2';
+
+  const chainedError = aggregateTwoErrors(err2, aggregateTwoErrors(err1, err0));
+  assert.strictEqual(chainedError.message, err0.message);
+  assert.strictEqual(chainedError.code, err0.code);
+  assert.deepStrictEqual(chainedError.errors, [err0, err1, err2]);
+}
+
+{
+  const err0 = new Error('original');
+  const err1 = new Error('second error');
+
+  err0.code = 'ERR0';
+  err1.code = 'ERR1';
+
+  const chainedError = aggregateTwoErrors(null, aggregateTwoErrors(err1, err0));
+  assert.strictEqual(chainedError.message, err0.message);
+  assert.strictEqual(chainedError.code, err0.code);
+  assert.deepStrictEqual(chainedError.errors, [err0, err1]);
+}
+
+{
+  const err0 = new Error('original');
+  const err1 = new Error('second error');
+
+  err0.code = 'ERR0';
+  err1.code = 'ERR1';
+
+  const chainedError = aggregateTwoErrors(null, aggregateTwoErrors(err1, err0));
+  const stack = chainedError.stack.split('\n');
+  assert.match(stack[1], /^ {4}at (Object|<anonymous>)/);
+}

--- a/test/js/node/test/parallel/test-error-format-list.js
+++ b/test/js/node/test/parallel/test-error-format-list.js
@@ -1,0 +1,20 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { formatList } = require('internal/errors');
+
+if (!common.hasIntl) common.skip('missing Intl');
+
+{
+  const and = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+  const or = new Intl.ListFormat('en', { style: 'long', type: 'disjunction' });
+
+  const input = ['apple', 'banana', 'orange', 'pear'];
+  for (let i = 0; i < input.length; i++) {
+    const slicedInput = input.slice(0, i);
+    assert.strictEqual(formatList(slicedInput), and.format(slicedInput));
+    assert.strictEqual(formatList(slicedInput, 'or'), or.format(slicedInput));
+  }
+}

--- a/test/js/node/test/parallel/test-error-value-type-detection.mjs
+++ b/test/js/node/test/parallel/test-error-value-type-detection.mjs
@@ -1,0 +1,211 @@
+// Flags: --expose-internals
+
+import '../common/index.mjs';
+import assert from 'node:assert';
+import errorsModule from 'internal/errors';
+
+
+const { determineSpecificType } = errorsModule;
+
+assert.strictEqual(
+  determineSpecificType(1n),
+  'type bigint (1n)',
+);
+
+assert.strictEqual(
+  determineSpecificType(true),
+  'type boolean (true)',
+);
+assert.strictEqual(
+  determineSpecificType(false),
+  'type boolean (false)',
+);
+
+assert.strictEqual(
+  determineSpecificType(2),
+  'type number (2)',
+);
+
+assert.strictEqual(
+  determineSpecificType(NaN),
+  'type number (NaN)',
+);
+
+assert.strictEqual(
+  determineSpecificType(Infinity),
+  'type number (Infinity)',
+);
+
+assert.strictEqual(
+  determineSpecificType({ __proto__: null }),
+  '[Object: null prototype] {}',
+);
+
+assert.strictEqual(
+  determineSpecificType(''),
+  "type string ('')",
+);
+
+assert.strictEqual(
+  determineSpecificType(''),
+  "type string ('')",
+);
+assert.strictEqual(
+  determineSpecificType("''"),
+  "type string (\"''\")",
+);
+assert.strictEqual(
+  determineSpecificType('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor'),
+  "type string ('Lorem ipsum dolor sit ame...')",
+);
+assert.strictEqual(
+  determineSpecificType("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor'"),
+  "type string ('Lorem ipsum dolor sit ame...')",
+);
+assert.strictEqual(
+  determineSpecificType("Lorem' ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"),
+  "type string (\"Lorem' ipsum dolor sit am...\")",
+);
+
+assert.strictEqual(
+  determineSpecificType(Symbol('foo')),
+  'type symbol (Symbol(foo))',
+);
+
+assert.strictEqual(
+  determineSpecificType(function foo() {}),
+  'function foo',
+);
+
+const implicitlyNamed = function() {}; // eslint-disable-line func-style
+assert.strictEqual(
+  determineSpecificType(implicitlyNamed),
+  'function implicitlyNamed',
+);
+assert.strictEqual(
+  determineSpecificType(() => {}),
+  'function ',
+);
+function noName() {}
+delete noName.name;
+assert.strictEqual(
+  noName.name,
+  '',
+);
+assert.strictEqual(
+  determineSpecificType(noName),
+  'function ',
+);
+
+function * generatorFn() {}
+assert.strictEqual(
+  determineSpecificType(generatorFn),
+  'function generatorFn',
+);
+
+async function asyncFn() {}
+assert.strictEqual(
+  determineSpecificType(asyncFn),
+  'function asyncFn',
+);
+
+assert.strictEqual(
+  determineSpecificType(null),
+  'null',
+);
+
+assert.strictEqual(
+  determineSpecificType(undefined),
+  'undefined',
+);
+
+assert.strictEqual(
+  determineSpecificType([]),
+  'an instance of Array',
+);
+
+assert.strictEqual(
+  determineSpecificType(new Array()),
+  'an instance of Array',
+);
+assert.strictEqual(
+  determineSpecificType(new BigInt64Array()),
+  'an instance of BigInt64Array',
+);
+assert.strictEqual(
+  determineSpecificType(new BigUint64Array()),
+  'an instance of BigUint64Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Int8Array()),
+  'an instance of Int8Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Int16Array()),
+  'an instance of Int16Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Int32Array()),
+  'an instance of Int32Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Float32Array()),
+  'an instance of Float32Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Float64Array()),
+  'an instance of Float64Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Uint8Array()),
+  'an instance of Uint8Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Uint8ClampedArray()),
+  'an instance of Uint8ClampedArray',
+);
+assert.strictEqual(
+  determineSpecificType(new Uint16Array()),
+  'an instance of Uint16Array',
+);
+assert.strictEqual(
+  determineSpecificType(new Uint32Array()),
+  'an instance of Uint32Array',
+);
+
+assert.strictEqual(
+  determineSpecificType(new Date()),
+  'an instance of Date',
+);
+
+assert.strictEqual(
+  determineSpecificType(new Map()),
+  'an instance of Map',
+);
+assert.strictEqual(
+  determineSpecificType(new WeakMap()),
+  'an instance of WeakMap',
+);
+
+assert.strictEqual(
+  determineSpecificType({}),
+  'an instance of Object',
+);
+assert.strictEqual(
+  determineSpecificType(new Object()),
+  'an instance of Object',
+);
+
+assert.strictEqual(
+  determineSpecificType(Promise.resolve('foo')),
+  'an instance of Promise',
+);
+
+assert.strictEqual(
+  determineSpecificType(new Set()),
+  'an instance of Set',
+);
+assert.strictEqual(
+  determineSpecificType(new WeakSet()),
+  'an instance of WeakSet',
+);

--- a/test/js/node/test/parallel/test-errors-aborterror.js
+++ b/test/js/node/test/parallel/test-errors-aborterror.js
@@ -1,0 +1,28 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { AbortError } = require('internal/errors');
+
+{
+  const err = new AbortError();
+  assert.strictEqual(err.message, 'The operation was aborted');
+  assert.strictEqual(err.cause, undefined);
+}
+
+{
+  const cause = new Error('boom');
+  const err = new AbortError('bang', { cause });
+  assert.strictEqual(err.message, 'bang');
+  assert.strictEqual(err.cause, cause);
+}
+
+{
+  assert.throws(() => new AbortError('', false), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => new AbortError('', ''), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+}

--- a/test/js/node/test/parallel/test-errors-systemerror-frozen-intrinsics.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-frozen-intrinsics.js
@@ -1,0 +1,24 @@
+// Flags: --expose-internals --frozen-intrinsics
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-custom-setter.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-custom-setter.js
@@ -1,0 +1,30 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+let stackTraceLimit;
+Reflect.defineProperty(Error, 'stackTraceLimit', {
+  get() { return stackTraceLimit; },
+  set(value) { stackTraceLimit = value; },
+});
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-deleted-and-Error-sealed.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-deleted-and-Error-sealed.js
@@ -1,0 +1,27 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+delete Error.stackTraceLimit;
+Object.seal(Error);
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-deleted.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-deleted.js
@@ -1,0 +1,26 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+delete Error.stackTraceLimit;
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-has-only-a-getter.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-has-only-a-getter.js
@@ -1,0 +1,26 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+Reflect.defineProperty(Error, 'stackTraceLimit', { get() { return 0; } });
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-not-writable.js
+++ b/test/js/node/test/parallel/test-errors-systemerror-stackTraceLimit-not-writable.js
@@ -1,0 +1,29 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes } = require('internal/errors');
+
+Reflect.defineProperty(Error, 'stackTraceLimit', {
+  writable: false,
+  value: Error.stackTraceLimit,
+});
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+const ctx = {
+  code: 'ETEST',
+  message: 'code message',
+  syscall: 'syscall_test',
+  path: '/str',
+  dest: '/str2'
+};
+assert.throws(
+  () => { throw new ERR_TEST(ctx); },
+  {
+    code: 'ERR_TEST',
+    name: 'SystemError',
+    info: ctx,
+  }
+);

--- a/test/js/node/test/parallel/test-errors-systemerror.js
+++ b/test/js/node/test/parallel/test-errors-systemerror.js
@@ -1,0 +1,410 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { E, SystemError, codes, kIsNodeError } = require('internal/errors');
+const { inspect } = require('internal/util/inspect');
+
+assert.throws(
+  () => { new SystemError(); },
+  {
+    name: 'TypeError',
+    message: /undefined/,
+  }
+);
+
+E('ERR_TEST', 'custom message', SystemError);
+const { ERR_TEST } = codes;
+
+{
+  const ctx = {
+    code: 'ETEST',
+    message: 'code message',
+    syscall: 'syscall_test',
+    path: '/str',
+    dest: '/str2'
+  };
+
+  assert.throws(
+    () => { throw new ERR_TEST(ctx); },
+    {
+      code: 'ERR_TEST',
+      name: 'SystemError',
+      message: 'custom message: syscall_test returned ETEST (code message)' +
+        ' /str => /str2',
+      info: ctx
+    }
+  );
+}
+
+{
+  const ctx = {
+    code: 'ETEST',
+    message: 'code message',
+    syscall: 'syscall_test',
+    path: Buffer.from('/buf'),
+    dest: '/str2'
+  };
+  assert.throws(
+    () => { throw new ERR_TEST(ctx); },
+    {
+      code: 'ERR_TEST',
+      name: 'SystemError',
+      message: 'custom message: syscall_test returned ETEST (code message)' +
+        ' /buf => /str2',
+      info: ctx
+    }
+  );
+}
+
+{
+  const ctx = {
+    code: 'ETEST',
+    message: 'code message',
+    syscall: 'syscall_test',
+    path: Buffer.from('/buf'),
+    dest: Buffer.from('/buf2')
+  };
+  assert.throws(
+    () => { throw new ERR_TEST(ctx); },
+    {
+      code: 'ERR_TEST',
+      name: 'SystemError',
+      message: 'custom message: syscall_test returned ETEST (code message)' +
+        ' /buf => /buf2',
+      info: ctx
+    }
+  );
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+    path: Buffer.from('a'),
+    dest: Buffer.from('b')
+  };
+  const err = new ERR_TEST(ctx);
+  assert.strictEqual(err.info, ctx);
+  assert.strictEqual(err.code, 'ERR_TEST');
+  err.code = 'test';
+  assert.strictEqual(err.code, 'test');
+
+  // Test legacy properties. These shouldn't be used anymore
+  // but let us make sure they still work
+  assert.strictEqual(err.errno, 123);
+  assert.strictEqual(err.syscall, 'syscall_test');
+  assert.strictEqual(err.path, 'a');
+  assert.strictEqual(err.dest, 'b');
+
+  // Make sure it's mutable
+  err.code = 'test';
+  err.errno = 321;
+  err.syscall = 'test';
+  err.path = 'path';
+  err.dest = 'path';
+
+  assert.strictEqual(err.errno, 321);
+  assert.strictEqual(err.syscall, 'test');
+  assert.strictEqual(err.path, 'path');
+  assert.strictEqual(err.dest, 'path');
+
+  assert.strictEqual(err.info.errno, 321);
+  assert.strictEqual(err.info.dest.toString(), 'path');
+  assert.strictEqual(err.info.path.toString(), 'path');
+  assert.strictEqual(err.info.syscall, 'test');
+}
+
+{
+  const ctx = {
+    code: 'ERR_TEST',
+    message: 'Error occurred',
+    syscall: 'syscall_test'
+  };
+  assert.throws(
+    () => {
+      const err = new ERR_TEST(ctx);
+      err.name = 'Foobar';
+      throw err;
+    },
+    {
+      code: 'ERR_TEST',
+      name: 'Foobar',
+      message: 'custom message: syscall_test returned ERR_TEST ' +
+        '(Error occurred)',
+      info: ctx
+    }
+  );
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // is set to true
+  assert.strictEqual(err[kIsNodeError], true);
+
+  // is not writable
+  assert.throws(
+    () => { err[kIsNodeError] = false; },
+    {
+      name: 'TypeError',
+      message: /Symbol\(kIsNodeError\)|readonly property/,
+    }
+  );
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, kIsNodeError), false);
+
+  // is configurable
+  delete err[kIsNodeError];
+  assert.strictEqual(kIsNodeError in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // is set to true
+  assert.strictEqual(err.name, 'SystemError');
+
+  // is writable
+  err.name = 'CustomError';
+  assert.strictEqual(err.name, 'CustomError');
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, 'name'), false);
+
+  // is configurable
+  delete err.name;
+  assert.strictEqual(err.name, 'Error');
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set with the correct message
+  assert.strictEqual(err.message, 'custom message: syscall_test returned ERR (something happened)');
+
+  // is writable
+  err.message = 'custom message';
+  assert.strictEqual(err.message, 'custom message');
+
+  // is not enumerable
+  assert.strictEqual(Object.prototype.propertyIsEnumerable.call(err, 'message'), false);
+
+  // is configurable
+  delete err.message;
+  assert.strictEqual(err.message, '');
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct syscall
+  assert.strictEqual(err.syscall, 'syscall_test');
+
+  // is writable
+  err.syscall = 'custom syscall';
+  assert.strictEqual(err.syscall, 'custom syscall');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'syscall'));
+
+  // is configurable
+  delete err.syscall;
+  assert.strictEqual('syscall' in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct errno
+  assert.strictEqual(err.errno, 123);
+
+  // is writable
+  err.errno = 'custom errno';
+  assert.strictEqual(err.errno, 'custom errno');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'errno'));
+
+  // is configurable
+  delete err.errno;
+  assert.strictEqual('errno' in err, false);
+}
+
+{
+  const ctx = {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  };
+  const err = new ERR_TEST(ctx);
+
+  // Is set to the correct info
+  assert.strictEqual(Object.keys(err.info).length, 4);
+  assert.strictEqual(err.info.errno, 123);
+  assert.strictEqual(err.info.code, 'ERR');
+  assert.strictEqual(err.info.message, 'something happened');
+  assert.strictEqual(err.info.syscall, 'syscall_test');
+
+  // is not writable
+  assert.throws(
+    () => {
+      err.info = {
+        ...ctx,
+        errno: 124
+      };
+    },
+    {
+      name: 'TypeError',
+      message: /'info'|readonly property/,
+    }
+  );
+
+  assert.strictEqual(Object.keys(err.info).length, 4);
+  assert.strictEqual(err.info.errno, 123);
+  assert.strictEqual(err.info.code, 'ERR');
+  assert.strictEqual(err.info.message, 'something happened');
+  assert.strictEqual(err.info.syscall, 'syscall_test');
+
+  // is enumerable
+  assert(Object.prototype.propertyIsEnumerable.call(err, 'info'));
+
+  // is configurable
+  delete err.info;
+
+  assert.strictEqual('info' in err, false);
+}
+
+{
+  // Make sure the stack trace does not contain SystemError
+  try {
+    throw new ERR_TEST({
+      code: 'ERR',
+      errno: 123,
+      message: 'something happened',
+      syscall: 'syscall_test',
+    });
+  } catch (e) {
+    assert.doesNotMatch(e.stack, /at new SystemError/);
+    assert.match(e.stack.split('\n')[1], /test-errors-systemerror\.js/);
+  }
+}
+
+{
+  // Make sure the stack trace has the correct number of frames
+  const limit = Error.stackTraceLimit;
+  Error.stackTraceLimit = 3;
+  function a() {
+    b();
+  }
+
+  function b() {
+    c();
+  }
+
+  function c() {
+    throw new ERR_TEST({
+      code: 'ERR',
+      errno: 123,
+      message: 'something happened',
+      syscall: 'syscall_test',
+    });
+  }
+  try {
+    a();
+  } catch (e) {
+    assert.doesNotMatch(e.stack, /at new SystemError/);
+    assert.match(e.stack.split('\n')[1], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[1], /at c \(/);
+    assert.match(e.stack.split('\n')[2], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[2], /at b \(/);
+    assert.match(e.stack.split('\n')[3], /test-errors-systemerror\.js/);
+    assert.match(e.stack.split('\n')[3], /at a \(/);
+    assert.strictEqual(e.stack.split('\n').length, 4);
+  } finally {
+    Error.stackTraceLimit = limit;
+  }
+}
+
+{
+  // Inspect should return the correct string
+  const err = new ERR_TEST({
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+    custom: 'custom'
+  });
+  let inspectedErr = inspect(err);
+
+  assert.ok(inspectedErr.includes(`info: {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+    custom: 'custom'
+  },`));
+
+  err.syscall = 'custom_syscall';
+
+  inspectedErr = inspect(err);
+
+  assert.ok(inspectedErr.includes(`info: {
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'custom_syscall',
+    custom: 'custom'
+  },`));
+}
+
+{
+  // toString should return the correct string
+
+  const err = new ERR_TEST({
+    code: 'ERR',
+    errno: 123,
+    message: 'something happened',
+    syscall: 'syscall_test',
+  });
+
+  assert.strictEqual(
+    err.toString(),
+    'SystemError [ERR_TEST]: custom message: syscall_test returned ERR (something happened)'
+  );
+}

--- a/test/js/node/test/parallel/test-internal-error-original-names.js
+++ b/test/js/node/test/parallel/test-internal-error-original-names.js
@@ -1,0 +1,35 @@
+// Flags: --expose-internals
+
+'use strict';
+
+// This tests `internal/errors.useOriginalName`
+// This testing feature is needed to allows us to assert the types of
+// errors without using instanceof, which is necessary in WPT harness.
+// Refs: https://github.com/nodejs/node/pull/22556
+
+require('../common');
+const assert = require('assert');
+const errors = require('internal/errors');
+
+
+errors.E('TEST_ERROR_1', 'Error for testing purposes: %s',
+         Error);
+{
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error');
+}
+
+{
+  errors.useOriginalName = true;
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error');
+}
+
+{
+  errors.useOriginalName = false;
+  const err = new errors.codes.TEST_ERROR_1('test');
+  assert(err instanceof Error);
+  assert.strictEqual(err.name, 'Error');
+}

--- a/test/js/node/test/parallel/test-uv-unmapped-exception.js
+++ b/test/js/node/test/parallel/test-uv-unmapped-exception.js
@@ -1,0 +1,26 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { UVException, UVExceptionWithHostPort } = require('internal/errors');
+
+{
+  const exception = new UVException({ errno: 100, syscall: 'open' });
+
+  assert.strictEqual(exception.message, 'UNKNOWN: unknown error, open');
+  assert.strictEqual(exception.errno, 100);
+  assert.strictEqual(exception.syscall, 'open');
+  assert.strictEqual(exception.code, 'UNKNOWN');
+}
+
+{
+  const exception = new UVExceptionWithHostPort(100, 'listen', '127.0.0.1', 80);
+
+  assert.strictEqual(exception.message,
+                     'listen UNKNOWN: unknown error 127.0.0.1:80');
+  assert.strictEqual(exception.code, 'UNKNOWN');
+  assert.strictEqual(exception.errno, 100);
+  assert.strictEqual(exception.syscall, 'listen');
+  assert.strictEqual(exception.address, '127.0.0.1');
+  assert.strictEqual(exception.port, 80);
+}


### PR DESCRIPTION
## What

Node tests flagged `// Flags: --expose-internals` do `require('internal/errors')` (and friends) directly. In Bun, `src/js/internal/*.ts` modules were only reachable from *other builtins* via the build-time `requireTransformer` → numeric `InternalModuleRegistry` IDs; userland `require('internal/errors')` failed with `Cannot find module`.

### Module loader

- `ModuleLoader.zig`: add `ExposedInternals` — a comptime-derived string map of every `internal:*` tag in `ResolvedSource.Tag` keyed as `internal/<name>`. When `is_allowed_to_use_internal_testing_apis` is set (same gate as `bun:internal-for-testing`; always on in debug builds), `fetchBuiltinModule` serves those specifiers straight from the `InternalModuleRegistry`.
- `VirtualMachine.zig`: let the same specifiers through both `_resolve` and `resolveMaybeNeedsTrailingSlash` under the same gate.

### `internal/errors`

Fills in `src/js/internal/errors.ts` with the surface area the Node tests exercise — previously it only exported `aggregateTwoErrors`:

- `E` / `codes` / `getMessage` / `makeNodeErrorWithCode` with arg-count assertion (`ERR_INTERNAL_ASSERTION`)
- `SystemError` (with `info`/`errno`/`syscall`/`path`/`dest` accessors, `kIsNodeError`, custom inspect/toString)
- `hideStackFrames` (+ `.withoutStackTrace`), `HideStackFramesError`
- `AbortError`, `genericNodeError`, `isErrorStackTraceLimitWritable`
- `determineSpecificType`, `formatList`
- `DNSException`, `UVException`, `UVExceptionWithHostPort`, `uvErrmapGet` (via `process.binding('uv')`)
- `kIsNodeError`, `captureLargerStackTrace`, `useOriginalName`
- `aggregateTwoErrors` now re-captures the caller's stack like Node does
- `codes.ERR_INVALID_ARG_TYPE` / `codes.ERR_ACCESS_DENIED` registered so `new codes.ERR_INVALID_ARG_TYPE(...)` works

### Other

- New `internal/test/binding` — thin `process.binding` proxy (Node's `internalBinding` for tests).
- New `internal/error_serdes` — error serializer used by worker message passing tests.

## Tests (14/18 from group `1v1cy7`)

```
test-dns-memory-error.js
test-error-aggregateTwoErrors.js
test-error-format-list.js
test-error-value-type-detection.mjs
test-errors-aborterror.js
test-errors-systemerror-frozen-intrinsics.js
test-errors-systemerror-stackTraceLimit-custom-setter.js
test-errors-systemerror-stackTraceLimit-deleted-and-Error-sealed.js
test-errors-systemerror-stackTraceLimit-deleted.js
test-errors-systemerror-stackTraceLimit-has-only-a-getter.js
test-errors-systemerror-stackTraceLimit-not-writable.js
test-errors-systemerror.js
test-internal-error-original-names.js
test-uv-unmapped-exception.js
```

Regression test: `test/js/node/module/expose-internals.test.ts`.

Three tests had superficial edits for engine-specific wording only (never `error.code`, never assertion intent):
- `test-errors-systemerror.js`: V8's `"Cannot read properties of undefined (reading 'syscall')"` / `"…read only property 'Symbol(kIsNodeError)'"` → regexes that also match JSC's phrasing.
- `test-error-aggregateTwoErrors.js`, `test-dns-memory-error.js`: top-of-module frame label `at Object` (Node CJS wrapper) → also accept `at <anonymous>`. Still asserts the internal frame was stripped and the caller's frame is first.

### Deferred (each is an unrelated Bun gap)

- `test-error-serdes.js` — `util.isDeepStrictEqual` rejects `Object.create(Error.prototype, …)` vs a real `ErrorInstance` (`Bun__deepEquals` `ErrorInstanceType` branch in `bindings.cpp`).
- `test-errors-hide-stack-frames.js` — native `validateInteger` shows up in caught-error `.stack`; Node wraps its JS validator in `hideStackFrames`.
- `test-internal-errors.js` — `console.log` doesn't route through `process.stdout.write`, so `hijackStdout` captures nothing.
- `test-webstream-readablestream-pipeto.js` — `pipeTo` rejects with the raw abort reason instead of a `DOMException('AbortError')` wrapper.

### Dropped from this PR

- The `process.config.variables.v8_enable_i8n_support` → `v8_enable_i18n_support` typo fix was reverted (afc51b2): fixing it un-skips 11 unrelated `hasIntl`-gated tests (`test-icu-*`, `test-url-format*`, `test-whatwg-*`) that each need their own work. That belongs in a separate PR.

## Verify

```sh
bun bd
node ./scripts/runner.node.mjs --quiet --exec-path=./build/debug/bun-debug --node-tests \
  test-dns-memory-error test-error-aggregateTwoErrors test-error-format-list \
  test-error-value-type-detection test-errors-aborterror test-errors-systemerror \
  test-errors-systemerror-frozen-intrinsics test-errors-systemerror-stackTraceLimit-custom-setter \
  test-errors-systemerror-stackTraceLimit-deleted test-errors-systemerror-stackTraceLimit-deleted-and-Error-sealed \
  test-errors-systemerror-stackTraceLimit-has-only-a-getter test-errors-systemerror-stackTraceLimit-not-writable \
  test-internal-error-original-names test-uv-unmapped-exception
bun bd test test/js/node/module/expose-internals.test.ts
```
