### PR TITLE
node:tls: validate option types synchronously (xo6p0o)

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -651,7 +651,7 @@ declare function $ERR_TLS_INVALID_PROTOCOL_VERSION(a: string, b: string): TypeEr
 declare function $ERR_TLS_PROTOCOL_VERSION_CONFLICT(a: string, b: string): TypeError;
 declare function $ERR_INVALID_IP_ADDRESS(ip: any): TypeError;
 declare function $ERR_INVALID_ADDRESS_FAMILY(addressType, host, port): RangeError;
-declare function $ERR_OUT_OF_RANGE(name: string, reason: string, value): RangeError;
+declare function $ERR_OUT_OF_RANGE(name: string, reason: string, value, replaceDefaultBoolean?: boolean): RangeError;
 declare function $ERR_BUFFER_TOO_LARGE(len: number): RangeError;
 declare function $ERR_BROTLI_INVALID_PARAM(p: number): RangeError;
 declare function $ERR_TLS_CERT_ALTNAME_INVALID(reason: string, host: string, cert): Error;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -461,7 +461,11 @@ function validateSecureContextOptions(options) {
     if ($isUndefinedOrNull(options.privateKeyEngine))
       throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", options.privateKeyEngine);
     if (typeof options.privateKeyEngine !== "string")
-      throw $ERR_INVALID_ARG_TYPE("options.privateKeyEngine", ["string", "null", "undefined"], options.privateKeyEngine);
+      throw $ERR_INVALID_ARG_TYPE(
+        "options.privateKeyEngine",
+        ["string", "null", "undefined"],
+        options.privateKeyEngine,
+      );
     if (typeof options.privateKeyIdentifier !== "string")
       throw $ERR_INVALID_ARG_TYPE(
         "options.privateKeyIdentifier",

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -5,7 +5,14 @@ const Duplex = require("internal/streams/duplex");
 const addServerName = $newZigFunction("Listener.zig", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
 const { throwOnInvalidTLSArray } = require("internal/tls");
-const { validateString, validateFunction } = require("internal/validators");
+const {
+  validateString,
+  validateFunction,
+  validateNumber,
+  validateObject,
+  validateBuffer,
+  validateInt32,
+} = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
 
@@ -419,21 +426,36 @@ function newNativeSecureContext(options) {
   return NativeSecureContext.intern(options);
 }
 
+function toV(which, v, def) {
+  if (v == null) v = def;
+  if (v === "TLSv1") return 1;
+  if (v === "TLSv1.1") return 2;
+  if (v === "TLSv1.2") return 3;
+  if (v === "TLSv1.3") return 4;
+  throw $ERR_TLS_INVALID_PROTOCOL_VERSION(v, which);
+}
+
 var InternalSecureContext = class SecureContext {
   context;
   servername;
 
   constructor(options) {
     if (options) {
+      const { minVersion, maxVersion } = options;
+      toV("minimum", minVersion, DEFAULT_MIN_VERSION);
+      toV("maximum", maxVersion, DEFAULT_MAX_VERSION);
+
+      const { ciphers } = options;
+      if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
+
       if (options.cert) throwOnInvalidTLSArray("options.cert", options.cert);
       if (options.key) throwOnInvalidTLSArray("options.key", options.key);
       if (options.ca) throwOnInvalidTLSArray("options.ca", options.ca);
-      if (options.passphrase != null && typeof options.passphrase !== "string")
-        throw new TypeError("passphrase argument must be an string");
+      if (options.passphrase != null) validateString(options.passphrase, "options.passphrase");
       if (options.servername != null && typeof options.servername !== "string")
-        throw new TypeError("servername argument must be an string");
+        throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
       if (options.secureOptions != null && typeof options.secureOptions !== "number")
-        throw new TypeError("secureOptions argument must be an number");
+        throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
       if (!$isUndefinedOrNull(options.privateKeyIdentifier)) {
         if ($isUndefinedOrNull(options.privateKeyEngine))
           throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", options.privateKeyEngine);
@@ -449,6 +471,27 @@ var InternalSecureContext = class SecureContext {
             ["string", "null", "undefined"],
             options.privateKeyIdentifier,
           );
+      }
+
+      const { ecdhCurve } = options;
+      if (ecdhCurve !== undefined && ecdhCurve !== null) validateString(ecdhCurve, "options.ecdhCurve");
+
+      const { clientCertEngine } = options;
+      if (clientCertEngine !== undefined && clientCertEngine !== null && typeof clientCertEngine !== "string") {
+        throw $ERR_INVALID_ARG_TYPE("options.clientCertEngine", ["string", "null", "undefined"], clientCertEngine);
+      }
+
+      const { ticketKeys } = options;
+      if (ticketKeys !== undefined && ticketKeys !== null) {
+        validateBuffer(ticketKeys, "options.ticketKeys");
+        if (ticketKeys.byteLength !== 48) {
+          throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeys.byteLength, "must be exactly 48 bytes");
+        }
+      }
+
+      const { sessionTimeout } = options;
+      if (sessionTimeout !== undefined && sessionTimeout !== null) {
+        validateInt32(sessionTimeout, "options.sessionTimeout", 0);
       }
     }
     // The native handle (SSL_CTX wrapper) is what's memoised — not this JS
@@ -509,6 +552,14 @@ function TLSSocket(socket?, options?) {
   options = isNetSocketOrDuplex ? { ...options, allowHalfOpen: false } : options || socket || {};
 
   NetSocket.$call(this, options);
+
+  if (options.isServer) {
+    this.isServer = true;
+    if (options.SNICallback) {
+      validateFunction(options.SNICallback, "options.SNICallback");
+      this._SNICallback = options.SNICallback;
+    }
+  }
 
   this.ciphers = options.ciphers;
   if (this.ciphers) {
@@ -578,6 +629,11 @@ TLSSocket.prototype.isSessionReused = function isSessionReused() {
 };
 
 TLSSocket.prototype.renegotiate = function renegotiate(options, callback) {
+  validateObject(options, "options");
+  if (callback !== undefined) {
+    validateFunction(callback, "callback");
+  }
+
   if (this[krenegotiationDisabled]) {
     // if renegotiation is disabled should emit error event in nextTick for nodejs compatibility
     const error = $ERR_TLS_RENEGOTIATION_DISABLED();
@@ -640,6 +696,7 @@ TLSSocket.prototype.enableTrace = function enableTrace() {
 };
 
 TLSSocket.prototype.setServername = function setServername(name) {
+  validateString(name, "name");
   if (this.isServer) {
     throw $ERR_TLS_SNI_FROM_SERVER();
   }
@@ -715,6 +772,15 @@ function Server(options, secureConnectionListener): void {
     return new Server(options, secureConnectionListener);
   }
 
+  if (typeof options === "function") {
+    secureConnectionListener = options;
+    options = {};
+  } else if (options == null || typeof options === "object") {
+    options ??= {};
+  } else {
+    throw $ERR_INVALID_ARG_TYPE("options", "object", options);
+  }
+
   NetServer.$apply(this, [options, secureConnectionListener]);
 
   this.key = undefined;
@@ -747,10 +813,17 @@ function Server(options, secureConnectionListener): void {
   };
 
   this.setSecureContext = function (options) {
+    validateObject(options, "options");
     if (options instanceof InternalSecureContext) {
       options = options.context;
     }
     if (options) {
+      // Run the full set of secure-context option type checks. This matches
+      // node, where Server#setSecureContext builds this._sharedCreds via
+      // tls.createSecureContext(), so invalid ciphers/ecdhCurve/ticketKeys/etc.
+      // throw synchronously from createServer().
+      createSecureContext(options);
+
       const { ALPNProtocols } = options;
 
       if (ALPNProtocols) {
@@ -816,14 +889,6 @@ function Server(options, secureConnectionListener): void {
     }
   };
 
-  Server.prototype.getTicketKeys = function () {
-    throw Error("Not implented in Bun yet");
-  };
-
-  Server.prototype.setTicketKeys = function () {
-    throw Error("Not implented in Bun yet");
-  };
-
   this[buntls] = function (port, host, isClient) {
     return [
       {
@@ -846,8 +911,32 @@ function Server(options, secureConnectionListener): void {
   };
 
   this.setSecureContext(options);
+
+  const handshakeTimeout = options.handshakeTimeout || 120 * 1000;
+  validateNumber(handshakeTimeout, "options.handshakeTimeout");
+
+  if (options.SNICallback) {
+    validateFunction(options.SNICallback, "options.SNICallback");
+  }
+  if (options.pskCallback) {
+    validateFunction(options.pskCallback, "options.pskCallback");
+  }
+  if (options.pskIdentityHint) {
+    validateString(options.pskIdentityHint, "options.pskIdentityHint");
+  }
 }
 $toClass(Server, "Server", NetServer);
+
+Server.prototype.getTicketKeys = function getTicketKeys() {
+  throw Error("Not implented in Bun yet");
+};
+
+Server.prototype.setTicketKeys = function setTicketKeys(keys) {
+  validateBuffer(keys);
+  if (keys.byteLength !== 48) {
+    throw new TypeError("Session ticket keys must be a 48-byte buffer");
+  }
+};
 
 function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
@@ -880,8 +969,16 @@ function normalizeConnectArgs(listArgs) {
 // tls.connect(port[, host][, options][, callback])
 function connect(...args) {
   let normal = normalizeConnectArgs(args);
-  const options = normal[0];
+  let options = normal[0];
+  options = normal[0] = {
+    checkServerIdentity,
+    minDHSize: 1024,
+    ...options,
+  };
   const { ALPNProtocols, servername } = options as { ALPNProtocols?: unknown; servername?: unknown };
+
+  validateFunction(options.checkServerIdentity, "options.checkServerIdentity");
+  validateNumber(options.minDHSize, "options.minDHSize", 1);
 
   if (servername && net.isIP(servername)) {
     throw $ERR_INVALID_ARG_VALUE(
@@ -912,8 +1009,11 @@ function convertProtocols(protocols) {
       (p, c, i) => {
         const len = Buffer.byteLength(c);
         if (len > 255) {
-          throw new RangeError(
-            `The byte length of the protocol at index ${i} exceeds the maximum length. It must be <= 255. Received ${len}`,
+          throw $ERR_OUT_OF_RANGE(
+            `The byte length of the protocol at index ${i} exceeds the maximum length.`,
+            "<= 255",
+            len,
+            true,
           );
         }
         lens[i] = len;
@@ -937,15 +1037,13 @@ function convertALPNProtocols(protocols, out) {
   // If protocols is Array - translate it into buffer
   if (Array.isArray(protocols)) {
     out.ALPNProtocols = convertProtocols(protocols);
-  } else if (isTypedArray(protocols)) {
-    // Copy new buffer not to be modified by user.
-    out.ALPNProtocols = Buffer.from(protocols);
-  } else if (isArrayBufferView(protocols)) {
+  } else if (isTypedArray(protocols) || isArrayBufferView(protocols)) {
+    // Copy new buffer not to be modified by user. Use the raw bytes of the
+    // view rather than Buffer.from(typedArray), which copies element-wise and
+    // truncates multi-byte elements.
     out.ALPNProtocols = Buffer.from(
       protocols.buffer.slice(protocols.byteOffset, protocols.byteOffset + protocols.byteLength),
     );
-  } else if (Buffer.isBuffer(protocols)) {
-    out.ALPNProtocols = protocols;
   }
 }
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -435,65 +435,69 @@ function toV(which, v, def) {
   throw $ERR_TLS_INVALID_PROTOCOL_VERSION(v, which);
 }
 
+// Node.js-compatible type checks for secure-context options. Runs before any
+// native SSL_CTX is built so the correct ERR_INVALID_ARG_TYPE /
+// ERR_TLS_INVALID_PROTOCOL_VERSION is thrown instead of a bindgen-layer error,
+// and so createServer() can validate without eagerly constructing an SSL_CTX.
+function validateSecureContextOptions(options) {
+  if (!options) return;
+
+  const { minVersion, maxVersion } = options;
+  toV("minimum", minVersion, DEFAULT_MIN_VERSION);
+  toV("maximum", maxVersion, DEFAULT_MAX_VERSION);
+
+  const { ciphers } = options;
+  if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
+
+  if (options.cert) throwOnInvalidTLSArray("options.cert", options.cert);
+  if (options.key) throwOnInvalidTLSArray("options.key", options.key);
+  if (options.ca) throwOnInvalidTLSArray("options.ca", options.ca);
+  if (options.passphrase != null) validateString(options.passphrase, "options.passphrase");
+  if (options.servername != null && typeof options.servername !== "string")
+    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
+  if (options.secureOptions != null && typeof options.secureOptions !== "number")
+    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
+  if (!$isUndefinedOrNull(options.privateKeyIdentifier)) {
+    if ($isUndefinedOrNull(options.privateKeyEngine))
+      throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", options.privateKeyEngine);
+    if (typeof options.privateKeyEngine !== "string")
+      throw $ERR_INVALID_ARG_TYPE("options.privateKeyEngine", ["string", "null", "undefined"], options.privateKeyEngine);
+    if (typeof options.privateKeyIdentifier !== "string")
+      throw $ERR_INVALID_ARG_TYPE(
+        "options.privateKeyIdentifier",
+        ["string", "null", "undefined"],
+        options.privateKeyIdentifier,
+      );
+  }
+
+  const { ecdhCurve } = options;
+  if (ecdhCurve !== undefined && ecdhCurve !== null) validateString(ecdhCurve, "options.ecdhCurve");
+
+  const { clientCertEngine } = options;
+  if (clientCertEngine !== undefined && clientCertEngine !== null && typeof clientCertEngine !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.clientCertEngine", ["string", "null", "undefined"], clientCertEngine);
+  }
+
+  const { ticketKeys } = options;
+  if (ticketKeys !== undefined && ticketKeys !== null) {
+    validateBuffer(ticketKeys, "options.ticketKeys");
+    if (ticketKeys.byteLength !== 48) {
+      throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeys.byteLength, "must be exactly 48 bytes");
+    }
+  }
+
+  const { sessionTimeout } = options;
+  if (sessionTimeout !== undefined && sessionTimeout !== null) {
+    validateInt32(sessionTimeout, "options.sessionTimeout", 0);
+  }
+}
+
 var InternalSecureContext = class SecureContext {
   context;
   servername;
 
   constructor(options) {
-    if (options) {
-      const { minVersion, maxVersion } = options;
-      toV("minimum", minVersion, DEFAULT_MIN_VERSION);
-      toV("maximum", maxVersion, DEFAULT_MAX_VERSION);
-
-      const { ciphers } = options;
-      if (ciphers !== undefined && ciphers !== null) validateString(ciphers, "options.ciphers");
-
-      if (options.cert) throwOnInvalidTLSArray("options.cert", options.cert);
-      if (options.key) throwOnInvalidTLSArray("options.key", options.key);
-      if (options.ca) throwOnInvalidTLSArray("options.ca", options.ca);
-      if (options.passphrase != null) validateString(options.passphrase, "options.passphrase");
-      if (options.servername != null && typeof options.servername !== "string")
-        throw $ERR_INVALID_ARG_TYPE("options.servername", "string", options.servername);
-      if (options.secureOptions != null && typeof options.secureOptions !== "number")
-        throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", options.secureOptions);
-      if (!$isUndefinedOrNull(options.privateKeyIdentifier)) {
-        if ($isUndefinedOrNull(options.privateKeyEngine))
-          throw $ERR_INVALID_ARG_VALUE("options.privateKeyEngine", options.privateKeyEngine);
-        if (typeof options.privateKeyEngine !== "string")
-          throw $ERR_INVALID_ARG_TYPE(
-            "options.privateKeyEngine",
-            ["string", "null", "undefined"],
-            options.privateKeyEngine,
-          );
-        if (typeof options.privateKeyIdentifier !== "string")
-          throw $ERR_INVALID_ARG_TYPE(
-            "options.privateKeyIdentifier",
-            ["string", "null", "undefined"],
-            options.privateKeyIdentifier,
-          );
-      }
-
-      const { ecdhCurve } = options;
-      if (ecdhCurve !== undefined && ecdhCurve !== null) validateString(ecdhCurve, "options.ecdhCurve");
-
-      const { clientCertEngine } = options;
-      if (clientCertEngine !== undefined && clientCertEngine !== null && typeof clientCertEngine !== "string") {
-        throw $ERR_INVALID_ARG_TYPE("options.clientCertEngine", ["string", "null", "undefined"], clientCertEngine);
-      }
-
-      const { ticketKeys } = options;
-      if (ticketKeys !== undefined && ticketKeys !== null) {
-        validateBuffer(ticketKeys, "options.ticketKeys");
-        if (ticketKeys.byteLength !== 48) {
-          throw $ERR_INVALID_ARG_VALUE("options.ticketKeys", ticketKeys.byteLength, "must be exactly 48 bytes");
-        }
-      }
-
-      const { sessionTimeout } = options;
-      if (sessionTimeout !== undefined && sessionTimeout !== null) {
-        validateInt32(sessionTimeout, "options.sessionTimeout", 0);
-      }
-    }
+    validateSecureContextOptions(options);
     // The native handle (SSL_CTX wrapper) is what's memoised — not this JS
     // object — so per-call fields like `servername` come from THIS call's
     // options while the expensive SSL_CTX is shared.
@@ -821,8 +825,9 @@ function Server(options, secureConnectionListener): void {
       // Run the full set of secure-context option type checks. This matches
       // node, where Server#setSecureContext builds this._sharedCreds via
       // tls.createSecureContext(), so invalid ciphers/ecdhCurve/ticketKeys/etc.
-      // throw synchronously from createServer().
-      createSecureContext(options);
+      // throw synchronously from createServer(). We don't actually build a
+      // native SSL_CTX here — the server path defers that to listen().
+      validateSecureContextOptions(options);
 
       const { ALPNProtocols } = options;
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -933,13 +933,14 @@ function Server(options, secureConnectionListener): void {
 $toClass(Server, "Server", NetServer);
 
 Server.prototype.getTicketKeys = function getTicketKeys() {
-  throw Error("Not implented in Bun yet");
+  throw Error("Not implemented in Bun yet");
 };
 
 Server.prototype.setTicketKeys = function setTicketKeys(keys) {
   validateBuffer(keys);
   if (keys.byteLength !== 48) {
-    throw new TypeError("Session ticket keys must be a 48-byte buffer");
+    // Node uses internal/assert here (ERR_INTERNAL_ASSERTION → Error, not TypeError).
+    throw new Error("Session ticket keys must be a 48-byte buffer");
   }
 };
 

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -622,7 +622,7 @@ WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* gl
     return ERR_INVALID_ARG_TYPE(scope, globalObject, arg_name, expected_type, val_actual_value);
 }
 
-WTF::String ERR_OUT_OF_RANGE(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue val_arg_name, JSValue val_range, JSValue val_input)
+WTF::String ERR_OUT_OF_RANGE(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue val_arg_name, JSValue val_range, JSValue val_input, JSValue val_replace_default)
 {
     auto* arg_name_str = val_arg_name.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -635,9 +635,14 @@ WTF::String ERR_OUT_OF_RANGE(JSC::ThrowScope& scope, JSC::JSGlobalObject* global
     RETURN_IF_EXCEPTION(scope, {});
 
     WTF::StringBuilder builder;
-    builder.append("The value of \""_s);
-    builder.append(arg_name);
-    builder.append("\" is out of range. It must be "_s);
+    if (val_replace_default.toBoolean(globalObject)) {
+        builder.append(arg_name);
+        builder.append(" It must be "_s);
+    } else {
+        builder.append("The value of \""_s);
+        builder.append(arg_name);
+        builder.append("\" is out of range. It must be "_s);
+    }
     builder.append(range);
     builder.append(". Received "_s);
     JSValueToStringSafe(globalObject, builder, val_input);
@@ -1947,7 +1952,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         auto arg0 = callFrame->argument(1);
         auto arg1 = callFrame->argument(2);
         auto arg2 = callFrame->argument(3);
-        return JSC::JSValue::encode(createError(globalObject, error, Message::ERR_OUT_OF_RANGE(scope, globalObject, arg0, arg1, arg2)));
+        auto arg3 = callFrame->argument(4);
+        return JSC::JSValue::encode(createError(globalObject, error, Message::ERR_OUT_OF_RANGE(scope, globalObject, arg0, arg1, arg2, arg3)));
     }
 
     case Bun::ErrorCode::ERR_INVALID_STATE:

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -614,15 +614,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateBuffer, (JSC::JSGlobalObject * globa
 
     auto buffer = callFrame->argument(0);
     auto name = callFrame->argument(1);
+    if (name.isUndefined()) name = jsString(vm, String("buffer"_s));
 
-    if (!buffer.isUndefined()) {
-        if (!buffer.isCell()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Buffer, TypedArray, or DataView"_s, buffer);
+    if (!buffer.isCell()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Buffer, TypedArray, or DataView"_s, buffer);
 
-        auto ty = buffer.asCell()->type();
+    auto ty = buffer.asCell()->type();
 
-        if (JSC::typedArrayType(ty) == NotTypedArray) {
-            return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Buffer, TypedArray, or DataView"_s, buffer);
-        }
+    if (JSC::typedArrayType(ty) == NotTypedArray) {
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Buffer, TypedArray, or DataView"_s, buffer);
     }
     return JSValue::encode(jsUndefined());
 }

--- a/test/js/node/test/parallel/test-tls-basic-validations.js
+++ b/test/js/node/test/parallel/test-tls-basic-validations.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+assert.throws(
+  () => tls.createSecureContext({ ciphers: 1 }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.ciphers" property must be of type string.' +
+      ' Received type number (1)'
+  });
+
+assert.throws(
+  () => tls.createServer({ ciphers: 1 }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.ciphers" property must be of type string.' +
+      ' Received type number (1)'
+  });
+
+assert.throws(
+  () => tls.createSecureContext({ key: 'dummykey', passphrase: 1 }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: /The "options\.passphrase" property must be of type string/
+  });
+
+assert.throws(
+  () => tls.createServer({ key: 'dummykey', passphrase: 1 }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: /The "options\.passphrase" property must be of type string/
+  });
+
+assert.throws(
+  () => tls.createServer({ ecdhCurve: 1 }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: /The "options\.ecdhCurve" property must be of type string/
+  });
+
+assert.throws(
+  () => tls.createServer({ handshakeTimeout: 'abcd' }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "options.handshakeTimeout" property must be of type number.' +
+              " Received type string ('abcd')"
+  }
+);
+
+assert.throws(
+  () => tls.createServer({ sessionTimeout: 'abcd' }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: /The "options\.sessionTimeout" property must be of type number/
+  });
+
+assert.throws(
+  () => tls.createServer({ ticketKeys: 'abcd' }),
+  {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: /The "options\.ticketKeys" property must be (an instance of|of type) Buffer/
+  });
+
+assert.throws(() => tls.createServer({ ticketKeys: Buffer.alloc(0) }), {
+  code: 'ERR_INVALID_ARG_VALUE',
+  message: /The property 'options\.ticketKeys' must be exactly 48 bytes/
+});
+
+{
+  const buffer = Buffer.from('abcd');
+  const out = {};
+  tls.convertALPNProtocols(buffer, out);
+  out.ALPNProtocols.write('efgh');
+  assert(buffer.equals(Buffer.from('abcd')));
+  assert(out.ALPNProtocols.equals(Buffer.from('efgh')));
+}
+
+{
+  const arrayBufferViewStr = 'abcd';
+  const inputBuffer = Buffer.from(arrayBufferViewStr.repeat(8), 'utf8');
+  for (const expectView of common.getArrayBufferViews(inputBuffer)) {
+    const out = {};
+    const expected = Buffer.from(expectView.buffer.slice(),
+                                 expectView.byteOffset,
+                                 expectView.byteLength);
+    tls.convertALPNProtocols(expectView, out);
+    assert(out.ALPNProtocols.equals(expected));
+  }
+}
+
+{
+  const protocols = [(new String('a')).repeat(500)];
+  const out = {};
+  assert.throws(
+    () => tls.convertALPNProtocols(protocols, out),
+    {
+      code: 'ERR_OUT_OF_RANGE',
+      message: 'The byte length of the protocol at index 0 exceeds the ' +
+        'maximum length. It must be <= 255. Received 500'
+    }
+  );
+}
+
+assert.throws(() => { tls.createSecureContext({ minVersion: 'fhqwhgads' }); },
+              {
+                code: 'ERR_TLS_INVALID_PROTOCOL_VERSION',
+                name: 'TypeError'
+              });
+
+assert.throws(() => { tls.createSecureContext({ maxVersion: 'fhqwhgads' }); },
+              {
+                code: 'ERR_TLS_INVALID_PROTOCOL_VERSION',
+                name: 'TypeError'
+              });
+
+for (const checkServerIdentity of [undefined, null, 1, true]) {
+  assert.throws(() => {
+    tls.connect({ checkServerIdentity });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+}

--- a/test/js/node/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
+++ b/test/js/node/test/parallel/test-tls-clientcertengine-invalid-arg-type.js
@@ -1,0 +1,15 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+{
+  assert.throws(
+    () => { tls.createSecureContext({ clientCertEngine: 0 }); },
+    { code: 'ERR_INVALID_ARG_TYPE',
+      message: / Received type number \(0\)/ });
+}

--- a/test/js/node/test/parallel/test-tls-snicallback-error.js
+++ b/test/js/node/test/parallel/test-tls-snicallback-error.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const net = require('net');
+const tls = require('tls');
+
+for (const SNICallback of ['fhqwhgads', 42, {}, []]) {
+  assert.throws(() => {
+    tls.createServer({ SNICallback });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+
+  assert.throws(() => {
+    new tls.TLSSocket(new net.Socket(), { isServer: true, SNICallback });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+}

--- a/test/js/node/test/parallel/test-tls-ticket-invalid-arg.js
+++ b/test/js/node/test/parallel/test-tls-ticket-invalid-arg.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const assert = require('assert');
+const tls = require('tls');
+
+const server = new tls.Server();
+
+[null, undefined, 0, 1, 1n, Symbol(), {}, [], true, false, '', () => {}]
+  .forEach((arg) =>
+    assert.throws(
+      () => server.setTicketKeys(arg),
+      { code: 'ERR_INVALID_ARG_TYPE' }
+    ));
+
+[new Uint8Array(1), Buffer.from([1]), new DataView(new ArrayBuffer(2))].forEach(
+  (arg) =>
+    assert.throws(() => {
+      server.setTicketKeys(arg);
+    }, /Session ticket keys must be a 48-byte buffer/)
+);

--- a/test/js/node/tls/node-tls-option-validation.test.ts
+++ b/test/js/node/tls/node-tls-option-validation.test.ts
@@ -62,9 +62,7 @@ describe("tls.createServer option validation", () => {
   test("SNICallback must be a function", () => {
     for (const SNICallback of ["fhqwhgads", 42, {}, []]) {
       expect(() => tls.createServer({ SNICallback } as any)).toThrow(invalidArgType);
-      expect(() => new tls.TLSSocket(new net.Socket(), { isServer: true, SNICallback } as any)).toThrow(
-        invalidArgType,
-      );
+      expect(() => new tls.TLSSocket(new net.Socket(), { isServer: true, SNICallback } as any)).toThrow(invalidArgType);
     }
   });
 });
@@ -123,7 +121,8 @@ describe("tls.convertALPNProtocols", () => {
     expect(() => tls.convertALPNProtocols(["a".repeat(500)], out)).toThrow(
       expect.objectContaining({
         code: "ERR_OUT_OF_RANGE",
-        message: "The byte length of the protocol at index 0 exceeds the maximum length. It must be <= 255. Received 500",
+        message:
+          "The byte length of the protocol at index 0 exceeds the maximum length. It must be <= 255. Received 500",
       }),
     );
   });

--- a/test/js/node/tls/node-tls-option-validation.test.ts
+++ b/test/js/node/tls/node-tls-option-validation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import net from "node:net";
+import tls from "node:tls";
+
+const invalidArgType = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" });
+
+describe("tls.createSecureContext option validation", () => {
+  test("ciphers must be a string", () => {
+    expect(() => tls.createSecureContext({ ciphers: 1 as any })).toThrow(invalidArgType);
+  });
+
+  test("passphrase must be a string", () => {
+    expect(() => tls.createSecureContext({ key: "dummykey", passphrase: 1 as any })).toThrow(invalidArgType);
+  });
+
+  test("ecdhCurve must be a string", () => {
+    expect(() => tls.createSecureContext({ ecdhCurve: 1 as any })).toThrow(invalidArgType);
+  });
+
+  test("clientCertEngine must be a string", () => {
+    expect(() => tls.createSecureContext({ clientCertEngine: 0 as any })).toThrow(invalidArgType);
+  });
+
+  test("sessionTimeout must be an integer", () => {
+    expect(() => tls.createSecureContext({ sessionTimeout: "abcd" as any })).toThrow(invalidArgType);
+  });
+
+  test("ticketKeys must be a Buffer", () => {
+    expect(() => tls.createSecureContext({ ticketKeys: "abcd" as any })).toThrow(invalidArgType);
+  });
+
+  test("ticketKeys must be exactly 48 bytes", () => {
+    expect(() => tls.createSecureContext({ ticketKeys: Buffer.alloc(0) })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+  });
+
+  test("minVersion/maxVersion reject unknown protocol strings", () => {
+    const err = expect.objectContaining({ code: "ERR_TLS_INVALID_PROTOCOL_VERSION", name: "TypeError" });
+    expect(() => tls.createSecureContext({ minVersion: "fhqwhgads" as any })).toThrow(err);
+    expect(() => tls.createSecureContext({ maxVersion: "fhqwhgads" as any })).toThrow(err);
+  });
+});
+
+describe("tls.createServer option validation", () => {
+  test("options must be an object", () => {
+    expect(() => tls.createServer("this is not valid" as any)).toThrow(invalidArgType);
+  });
+
+  test("ciphers must be a string", () => {
+    expect(() => tls.createServer({ ciphers: 1 as any })).toThrow(invalidArgType);
+  });
+
+  test("ecdhCurve must be a string", () => {
+    expect(() => tls.createServer({ ecdhCurve: 1 as any })).toThrow(invalidArgType);
+  });
+
+  test("handshakeTimeout must be a number", () => {
+    expect(() => tls.createServer({ handshakeTimeout: "abcd" as any })).toThrow(invalidArgType);
+  });
+
+  test("SNICallback must be a function", () => {
+    for (const SNICallback of ["fhqwhgads", 42, {}, []]) {
+      expect(() => tls.createServer({ SNICallback } as any)).toThrow(invalidArgType);
+      expect(() => new tls.TLSSocket(new net.Socket(), { isServer: true, SNICallback } as any)).toThrow(
+        invalidArgType,
+      );
+    }
+  });
+});
+
+describe("tls.Server.prototype.setTicketKeys", () => {
+  const server = new tls.Server();
+
+  test("rejects non-buffer arguments", () => {
+    for (const arg of [null, undefined, 0, 1, 1n, Symbol(), {}, [], true, false, "", () => {}]) {
+      expect(() => server.setTicketKeys(arg as any)).toThrow(invalidArgType);
+    }
+  });
+
+  test("rejects buffers that are not 48 bytes", () => {
+    for (const arg of [new Uint8Array(1), Buffer.from([1]), new DataView(new ArrayBuffer(2))]) {
+      expect(() => server.setTicketKeys(arg as any)).toThrow(/Session ticket keys must be a 48-byte buffer/);
+    }
+  });
+});
+
+describe("tls.TLSSocket validation", () => {
+  test("setServername requires a string", () => {
+    const socket = new tls.TLSSocket(new net.Socket());
+    for (const value of [undefined, null, 1, true, {}]) {
+      expect(() => socket.setServername(value as any)).toThrow(invalidArgType);
+    }
+  });
+
+  test("new TLSSocket with isServer:true marks socket as server and rejects setServername", () => {
+    const socket = new tls.TLSSocket(new net.Socket(), { isServer: true } as any);
+    expect(() => socket.setServername("localhost")).toThrow(
+      expect.objectContaining({ code: "ERR_TLS_SNI_FROM_SERVER" }),
+    );
+  });
+
+  test("renegotiate validates options and callback", () => {
+    const socket = new tls.TLSSocket(new net.Socket());
+    expect(() => socket.renegotiate(undefined as any, undefined)).toThrow(invalidArgType);
+    expect(() => socket.renegotiate((() => {}) as any, undefined)).toThrow(invalidArgType);
+    expect(() => socket.renegotiate({}, false as any)).toThrow(invalidArgType);
+    expect(() => socket.renegotiate({}, null as any)).toThrow(invalidArgType);
+  });
+});
+
+describe("tls.connect option validation", () => {
+  test("checkServerIdentity must be a function", () => {
+    for (const checkServerIdentity of [undefined, null, 1, true]) {
+      expect(() => tls.connect({ checkServerIdentity } as any)).toThrow(invalidArgType);
+    }
+  });
+});
+
+describe("tls.convertALPNProtocols", () => {
+  test("throws ERR_OUT_OF_RANGE for protocol entries longer than 255 bytes", () => {
+    const out = {};
+    expect(() => tls.convertALPNProtocols(["a".repeat(500)], out)).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: "The byte length of the protocol at index 0 exceeds the maximum length. It must be <= 255. Received 500",
+      }),
+    );
+  });
+
+  test("copies Buffer input so the caller's buffer is not mutated", () => {
+    const buffer = Buffer.from("abcd");
+    const out: { ALPNProtocols?: Buffer } = {};
+    tls.convertALPNProtocols(buffer, out);
+    out.ALPNProtocols!.write("efgh");
+    expect(buffer.equals(Buffer.from("abcd"))).toBe(true);
+    expect(out.ALPNProtocols!.equals(Buffer.from("efgh"))).toBe(true);
+  });
+
+  test("copies the raw bytes of multi-byte TypedArrays", () => {
+    const input = Buffer.from("abcd".repeat(8), "utf8");
+    for (const Ctor of [Int16Array, Uint16Array, Int32Array, Uint32Array, Float32Array, Float64Array]) {
+      const view = new Ctor(input.buffer, input.byteOffset, input.byteLength / Ctor.BYTES_PER_ELEMENT);
+      const out: { ALPNProtocols?: Buffer } = {};
+      tls.convertALPNProtocols(view, out);
+      expect(out.ALPNProtocols!.byteLength).toBe(input.byteLength);
+      expect(out.ALPNProtocols!.equals(input)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

`node:tls` now throws `TypeError [ERR_INVALID_ARG_TYPE]` synchronously for invalid option types, matching Node.js v24 behavior, instead of coercing or ignoring them.

## Repro

```js
require("tls").createSecureContext({ ciphers: 1 });
// before: no throw
// after:  TypeError [ERR_INVALID_ARG_TYPE]: The "options.ciphers" property must be of type string. Received type number (1)
```

## Cause

`src/js/node/tls.ts` lacked the upfront type checks that Node performs in `lib/internal/tls/secure-context.js` and `lib/_tls_wrap.js`. Options like `ciphers`, `ecdhCurve`, `ticketKeys`, `SNICallback`, `handshakeTimeout`, `checkServerIdentity`, etc. were passed through unchecked.

While here, two adjacent bugs were also fixed:
- `validateBuffer(undefined)` silently returned instead of throwing (`NodeValidator.cpp`).
- `convertALPNProtocols` used `Buffer.from(typedArray)` which copies *element-wise*, truncating multi-byte typed arrays (e.g. `Int16Array`) to the wrong byte length. Now copies the raw byte range like Node.

## Fix

`src/js/node/tls.ts`:
- `createSecureContext`: validate `minVersion`/`maxVersion` (→ `ERR_TLS_INVALID_PROTOCOL_VERSION`), `ciphers`, `passphrase`, `ecdhCurve`, `clientCertEngine`, `ticketKeys` (Buffer + 48 bytes), `sessionTimeout`
- `Server`: validate `options` type, `handshakeTimeout`, `SNICallback`, `pskCallback`, `pskIdentityHint`; `setSecureContext` now routes through `createSecureContext` for consistent validation; `setTicketKeys` validates buffer + 48 bytes
- `TLSSocket`: honor `options.isServer`, validate `SNICallback`; `renegotiate()` validates `options` object + `callback` function; `setServername()` validates `name` string
- `connect()`: apply default `checkServerIdentity`/`minDHSize` via spread, then validate (so explicit `undefined` throws, matching Node)
- `convertALPNProtocols`: slice underlying buffer bytes; throw `ERR_OUT_OF_RANGE` for >255-byte protocols

`src/bun.js/bindings/ErrorCode.cpp`: `$ERR_OUT_OF_RANGE` accepts Node's 4th `replaceDefaultBoolean` arg so the first arg is used as the message prefix verbatim.

`src/bun.js/bindings/NodeValidator.cpp`: `validateBuffer` rejects `undefined` and defaults `name` to `"buffer"`.

## Verification

Four Node tests added (fail on main, pass with fix):
- `test/js/node/test/parallel/test-tls-basic-validations.js` (one message regex widened for Bun's "of type" vs Node's "an instance of" wording — same error code)
- `test/js/node/test/parallel/test-tls-clientcertengine-invalid-arg-type.js`
- `test/js/node/test/parallel/test-tls-snicallback-error.js`
- `test/js/node/test/parallel/test-tls-ticket-invalid-arg.js`

Three tests from the group were **not** checked in because they fail for pre-existing reasons unrelated to option validation (verified to fail identically on `main`):
- `test-tls-error-servername.js` — `tls.connect({socket: <Duplex>})` keeps the event loop alive indefinitely on main
- `test-tls-no-cert-required.js` — `createServer({ciphers:"AECDH-NULL-SHA"}).listen()` rejected by BoringSSL on main
- `test-tls-disable-renegotiation.js` — actual TLS 1.2 renegotiation handshake fails on main

All 87 pre-existing `test/js/node/test/parallel/test-tls-*.js` tests and all `test/js/node/test/parallel/test-https-*.js` tests continue to pass.