### PR TITLE
node:http: implement Agent#addRequest socket accounting (1vs0v5)

### DIFF
--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -126,9 +126,13 @@ function maybeEnableKeylog(this: Agent, eventName) {
       agent.emit("keylog", keylog, this);
     };
     // Existing sockets will start listening on keylog now.
+    // this.sockets is { name: Socket[] }, so Object.values returns Socket[][].
     const sockets = Object.values(this.sockets);
     for (let i = 0; i < sockets.length; i++) {
-      sockets[i]!.on("keylog", this[kOnKeylog]);
+      const list = sockets[i]!;
+      for (let j = 0; j < list.length; j++) {
+        list[j].on("keylog", this[kOnKeylog]);
+      }
     }
   }
 }
@@ -182,18 +186,65 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   return name;
 };
 
-function handleSocketAfterProxy(err, req) {
-  if (err.code === "ERR_PROXY_TUNNEL") {
-    if (err.proxyTunnelTimeout) {
-      req.emit("timeout"); // Propagate the timeout from the tunnel to the request.
-    } else {
-      req.emit("error", err);
-    }
+Agent.prototype.addRequest = function addRequest(req, options, port /* legacy */, localAddress /* legacy */) {
+  // Legacy API: addRequest(req, host, port, localAddress)
+  if (typeof options === "string") {
+    options = {
+      __proto__: null,
+      host: options,
+      port,
+      localAddress,
+    };
   }
-}
 
-Agent.prototype.addRequest = function addRequest(_req, _options, _port /* legacy */, _localAddress /* legacy */) {
-  $debug("WARN: Agent.addRequest is a no-op");
+  options = { __proto__: null, ...options, ...this.options };
+  if (options.socketPath) options.path = options.socketPath;
+
+  normalizeServerName(options, req);
+
+  const name = this.getName(options);
+  this.sockets[name] ||= [];
+
+  const freeSockets = this.freeSockets[name];
+  let socket;
+  if (freeSockets) {
+    while (freeSockets.length && freeSockets[0].destroyed) {
+      freeSockets.shift();
+    }
+    socket = this.scheduling === "fifo" ? freeSockets.shift() : freeSockets.pop();
+    if (!freeSockets.length) delete this.freeSockets[name];
+  }
+
+  const freeLen = freeSockets ? freeSockets.length : 0;
+  const sockLen = freeLen + this.sockets[name].length;
+
+  if (socket) {
+    this.reuseSocket(socket, req);
+    setRequestSocket(this, req, socket);
+    this.sockets[name].push(socket);
+  } else if (sockLen < this.maxSockets && this.totalSocketCount < this.maxTotalSockets) {
+    $debug("call onSocket", sockLen, freeLen);
+    // Bun's ClientRequest uses an internal fetch-based transport, so the
+    // request's socket is a FakeSocket used only for Node.js API surface.
+    // Track it here so agent.sockets / agent.requests observe Node's
+    // bookkeeping, and so maxSockets throttling works.
+    socket = req.socket;
+    socket._httpMessage = req;
+    this.sockets[name].push(socket);
+    this.totalSocketCount++;
+    $debug("sockets", name, this.sockets[name].length, this.totalSocketCount);
+    installListeners(this, socket, options);
+    setRequestSocket(this, req, socket);
+  } else {
+    $debug("wait for socket");
+    // We are over limit so we'll add it to the queue.
+    this.requests[name] ||= [];
+
+    // Used to create sockets for pending requests from different origin
+    req[kRequestOptions] = options;
+
+    this.requests[name].push(req);
+  }
 };
 
 Agent.prototype.createSocket = function createSocket(req, options, cb) {
@@ -327,6 +378,7 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
   }
 
   let req;
+  let reqName = name;
   if (this.requests[name]?.length) {
     $debug("removeSocket, have a request, make a socket");
     req = this.requests[name][0];
@@ -338,21 +390,33 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
       $debug("removeSocket, have a request with different origin, make a socket");
       req = this.requests[prop][0];
       options = req[kRequestOptions];
+      reqName = prop;
       break;
     }
   }
 
   if (req && options) {
     req[kRequestOptions] = undefined;
-    this.createSocket(req, options, (err, socket) => {
-      if (err) {
-        handleSocketAfterProxy(err, req);
-        req.onSocket(null, err);
-        return;
+    // Remove the request from the queue now that it will be serviced.
+    const reqs = this.requests[reqName];
+    if (reqs) {
+      const idx = reqs.indexOf(req);
+      if (idx !== -1) {
+        reqs.splice(idx, 1);
+        if (reqs.length === 0) delete this.requests[reqName];
       }
-
-      socket.emit("free");
-    });
+    }
+    // Bun's ClientRequest uses an internal fetch-based transport, so the
+    // request's socket is a FakeSocket used only for Node.js API surface.
+    // Track it here instead of opening a real socket via createConnection().
+    const socket = req.socket;
+    socket._httpMessage = req;
+    this.sockets[reqName] ||= [];
+    this.sockets[reqName].push(socket);
+    this.totalSocketCount++;
+    $debug("sockets", reqName, this.sockets[reqName].length, this.totalSocketCount);
+    installListeners(this, socket, options);
+    setRequestSocket(this, req, socket);
   }
 };
 
@@ -404,7 +468,12 @@ Agent.prototype.destroy = function destroy() {
     const set = sets[s];
     const keys = Object.keys(set);
     for (let v = 0; v < keys.length; v++) {
-      const setName = set[keys[v]];
+      // Snapshot before iterating: destroying a FakeSocket runs
+      // req.destroy() → abort() → onAbort → releaseAgentSocket() →
+      // 'agentRemove' → removeSocket synchronously, which splices this
+      // array in place. Iterating the live array by index would skip
+      // every other entry.
+      const setName = set[keys[v]].slice();
       for (let n = 0; n < setName.length; n++) {
         setName[n].destroy();
       }

--- a/src/js/node/_http_agent.ts
+++ b/src/js/node/_http_agent.ts
@@ -386,7 +386,13 @@ Agent.prototype.removeSocket = function removeSocket(s, options) {
     const keys = Object.keys(this.requests);
     for (let i = 0; i < keys.length; i++) {
       const prop = keys[i];
-      if (this.sockets[prop]?.length) break;
+      // If this origin already has active sockets it's at its own maxSockets
+      // limit, so skip it and try the next origin. (This loop only runs when a
+      // slot freed for `name` but `name` has no queued request — the queued
+      // request we can now service was held back by maxTotalSockets under a
+      // different origin.) Node uses `continue` here; `break` would stall that
+      // request behind the first origin that happens to have a socket open.
+      if (this.sockets[prop]?.length) continue;
       $debug("removeSocket, have a request with different origin, make a socket");
       req = this.requests[prop][0];
       options = req[kRequestOptions];

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -334,6 +334,16 @@ function ClientRequest(input, options, cb) {
       return false;
     }
 
+    // Never dispatch an already-aborted request (matches Node's addAbortSignal,
+    // which destroys synchronously). A pre-aborted options.signal schedules its
+    // abort on a nextTick that runs after this synchronous send()/startFetch()
+    // path, so without this guard the fetch would be posted and then torn down
+    // one tick later. The pending onSignalAbort (or a later destroy()) handles
+    // teardown; bail before wiring the AbortController / posting the fetch.
+    if (this.aborted) {
+      return false;
+    }
+
     fetching = true;
 
     // Every entry point that dispatches the request (send(), flushHeaders(),
@@ -730,6 +740,10 @@ function ClientRequest(input, options, cb) {
   };
 
   const maybeEmitPrefinish = () => {
+    // Don't emit 'prefinish'/'finish' after the request was destroyed (e.g. an
+    // already-aborted signal tears it down and emits 'close' before send()'s
+    // deferred finish tick runs). 'close' is terminal — nothing follows it.
+    if (this.destroyed) return;
     maybeEmitSocket();
 
     if (!(this[kEmitState] & (1 << ClientRequestEmitState.prefinish))) {
@@ -739,6 +753,7 @@ function ClientRequest(input, options, cb) {
   };
 
   const maybeEmitFinish = () => {
+    if (this.destroyed) return;
     maybeEmitPrefinish();
 
     if (!(this[kEmitState] & (1 << ClientRequestEmitState.finish))) {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -100,6 +100,12 @@ function ClientRequest(input, options, cb) {
   let writeCount = 0;
   let resolveNextChunk: ((end: boolean) => void) | undefined = _end => {};
 
+  // Detaches the options.signal 'abort' listener once the request is done, so
+  // a long-lived shared signal (e.g. AbortSignal.timeout for a batch) neither
+  // retains completed requests nor fires a spurious abort on them. Reassigned
+  // in the signal block below; a no-op when there is no signal.
+  let removeSignalAbortListener = () => {};
+
   // Node sends headers + first chunk immediately on the first write(). We
   // defer by a tick so that `write(chunk); end();` in the same tick still
   // takes the non-duplex fast path via send(). If end() hasn't been called by
@@ -282,6 +288,7 @@ function ClientRequest(input, options, cb) {
 
   const socketCloseListener = () => {
     this.destroyed = true;
+    removeSignalAbortListener();
 
     const res = this.res;
     if (res) {
@@ -742,6 +749,7 @@ function ClientRequest(input, options, cb) {
 
   const maybeEmitClose = () => {
     maybeEmitPrefinish();
+    removeSignalAbortListener();
 
     if (!this._closed) {
       process.nextTick(emitCloseNTAndComplete, this);
@@ -844,7 +852,11 @@ function ClientRequest(input, options, cb) {
     // signal (the `aborted` getter reads kSignal.aborted), so guard on the
     // internal abortedSymbol to stay idempotent with req.abort().
     const onSignalAbort = () => {
-      if (this[abortedSymbol]) return;
+      // A shared signal (e.g. AbortSignal.timeout for a batch) may fire after
+      // this request already finished — don't re-emit 'abort' or destroy() a
+      // completed request. Node avoids this by removing the listener on stream
+      // finish; we do both (remove below, guard here).
+      if (this[abortedSymbol] || this._closed || this?.res?.complete) return;
       this[abortedSymbol] = true;
       process.nextTick(emitAbortNextTick, this);
       this[kAbortController]?.abort?.();
@@ -859,6 +871,7 @@ function ClientRequest(input, options, cb) {
       process.nextTick(onSignalAbort);
     } else {
       signal.addEventListener("abort", onSignalAbort, { once: true });
+      removeSignalAbortListener = () => signal.removeEventListener("abort", onSignalAbort);
     }
   }
   let method = options.method;

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -833,11 +833,23 @@ function ClientRequest(input, options, cb) {
 
   const signal = options.signal;
   if (signal) {
-    //We still want to control abort function and timeout so signal call our AbortController
+    // Mirror req.abort(): emit 'abort', cancel the in-flight fetch via the
+    // AbortController, and destroy() the request. destroy() also drops a
+    // still-queued request (one waiting behind maxSockets, whose
+    // AbortController hasn't been created yet) from agent.requests so it is
+    // never dispatched once a slot frees. Aborting only the AbortController
+    // would be a no-op for that queued window. We can't call this.abort()
+    // here because its `this.aborted` guard is already satisfied by the
+    // signal (the `aborted` getter reads kSignal.aborted), so guard on the
+    // internal abortedSymbol to stay idempotent with req.abort().
     signal.addEventListener(
       "abort",
       () => {
-        this[kAbortController]?.abort();
+        if (this[abortedSymbol]) return;
+        this[abortedSymbol] = true;
+        process.nextTick(emitAbortNextTick, this);
+        this[kAbortController]?.abort?.();
+        this.destroy();
       },
       { once: true },
     );

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -833,6 +833,7 @@ function ClientRequest(input, options, cb) {
 
   const signal = options.signal;
   if (signal) {
+    this[kSignal] = signal;
     // Mirror req.abort(): emit 'abort', cancel the in-flight fetch via the
     // AbortController, and destroy() the request. destroy() also drops a
     // still-queued request (one waiting behind maxSockets, whose
@@ -842,18 +843,23 @@ function ClientRequest(input, options, cb) {
     // here because its `this.aborted` guard is already satisfied by the
     // signal (the `aborted` getter reads kSignal.aborted), so guard on the
     // internal abortedSymbol to stay idempotent with req.abort().
-    signal.addEventListener(
-      "abort",
-      () => {
-        if (this[abortedSymbol]) return;
-        this[abortedSymbol] = true;
-        process.nextTick(emitAbortNextTick, this);
-        this[kAbortController]?.abort?.();
-        this.destroy();
-      },
-      { once: true },
-    );
-    this[kSignal] = signal;
+    const onSignalAbort = () => {
+      if (this[abortedSymbol]) return;
+      this[abortedSymbol] = true;
+      process.nextTick(emitAbortNextTick, this);
+      this[kAbortController]?.abort?.();
+      this.destroy();
+    };
+    // addEventListener('abort') never fires for an already-aborted signal, so
+    // handle that case explicitly (matching Node's addAbortSignal). Defer to a
+    // tick so the request is first registered with the agent below — destroy()
+    // then splices it out of agent.requests instead of running before it's
+    // queued.
+    if (signal.aborted) {
+      process.nextTick(onSignalAbort);
+    } else {
+      signal.addEventListener("abort", onSignalAbort, { once: true });
+    }
   }
   let method = options.method;
   const methodIsString = typeof method === "string";

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -114,7 +114,12 @@ function ClientRequest(input, options, cb) {
 
   const pushChunk = chunk => {
     this[kBodyChunks].push(chunk);
-    if (writeCount > 1) {
+    if (!socketAssigned) {
+      // Request is queued in the agent waiting for a socket slot
+      // (maxSockets). Buffer the chunk; onSocket() will flush and start
+      // the fetch once a slot opens.
+      deferredFlush = true;
+    } else if (writeCount > 1) {
       startFetch();
     } else if (writeCount === 1) {
       process.nextTick(startFetchAfterFirstWriteNT, this);
@@ -207,6 +212,10 @@ function ClientRequest(input, options, cb) {
 
   this.flushHeaders = function () {
     if (!fetching) {
+      if (!socketAssigned) {
+        deferredFlush = true;
+        return;
+      }
       startFetch();
     }
   };
@@ -229,8 +238,39 @@ function ClientRequest(input, options, cb) {
     }
 
     // If request is destroyed we abort the current response
+    const hadAbortController = this[kAbortController] != null;
     this[kAbortController]?.abort?.();
     this.socket.destroy(err);
+
+    // Remove from agent bookkeeping. If the request was still queued
+    // (never got a socket slot), drop it from agent.requests so it won't
+    // be dispatched later.
+    if (!socketAssigned) {
+      const agent = this[kAgent];
+      const requests = agent?.requests;
+      if (requests) {
+        // agent.requests is created with { __proto__: null } so for...in is
+        // safe and avoids the (tamperable) global Object.keys lookup.
+        for (const key in requests) {
+          const reqs = requests[key];
+          const idx = reqs.indexOf(this);
+          if (idx !== -1) {
+            reqs.splice(idx, 1);
+            if (reqs.length === 0) delete requests[key];
+            break;
+          }
+        }
+      }
+    }
+    releaseAgentSocket();
+
+    // If there was no AbortController (request was queued behind maxSockets
+    // and never reached send()/flushHeaders(), or was never ended), the
+    // abort() → onAbort → socketCloseListener() path above was a no-op.
+    // Emit 'close' directly so consumers awaiting it don't hang.
+    if (!hadAbortController) {
+      socketCloseListener();
+    }
 
     return this;
   };
@@ -268,6 +308,11 @@ function ClientRequest(input, options, cb) {
 
   const onAbort = (_err?: Error) => {
     this[kClearTimeout]?.();
+    // Release the agent slot before socketCloseListener() emits 'close' on
+    // the socket. The 'agentRemove' listener (see installListeners in
+    // _http_agent.ts) removes the agent's 'close' listener, so doing this
+    // first prevents both listeners from decrementing totalSocketCount.
+    releaseAgentSocket();
     socketCloseListener();
     if (!this[abortedSymbol] && !this?.res?.complete) {
       process.nextTick(emitAbortNextTick, this);
@@ -415,6 +460,10 @@ function ClientRequest(input, options, cb) {
       //@ts-ignore
       this[kFetchRequest] = nodeHttpClient(url, fetchOptions).then(response => {
         if (this.aborted) {
+          // The res 'end'/'close' release hooks below are never installed on
+          // this path, and .catch→finally won't run (promise resolved), so
+          // release the agent slot directly.
+          releaseAgentSocket();
           maybeEmitClose();
           return;
         }
@@ -433,6 +482,12 @@ function ClientRequest(input, options, cb) {
           setIsNextIncomingMessageHTTPS(prevIsHTTPS);
           res.req = this;
           res.setTimeout = clientResponseSetTimeout;
+          // Once the response body is fully consumed, release the agent
+          // socket slot so the next queued request can proceed. Do this on
+          // the next tick so user 'end' listeners see the socket still
+          // tracked in agent.sockets[name] (Node.js behavior).
+          res.once("end", () => process.nextTick(releaseAgentSocket));
+          res.once("close", releaseAgentSocket);
           process.nextTick(
             (self, res) => {
               // If the user did not listen for the 'response' event, then they
@@ -443,6 +498,10 @@ function ClientRequest(input, options, cb) {
                 emitErrorEventNT(self, $HPE_UNEXPECTED_CONTENT_LENGTH("Parse Error"));
 
                 res.complete = true;
+                // res is never handed to the user on this path, so the
+                // res 'end'/'close' hooks above won't fire. Release the
+                // agent slot directly so it doesn't leak.
+                releaseAgentSocket();
                 maybeEmitClose();
                 return;
               }
@@ -511,6 +570,8 @@ function ClientRequest(input, options, cb) {
               this.emit("error", err);
             } catch (_err) {
               void _err;
+            } finally {
+              releaseAgentSocket();
             }
           })
           .finally(() => {
@@ -537,6 +598,7 @@ function ClientRequest(input, options, cb) {
         if (err) {
           if (!!$debug) globalReportError(err);
           process.nextTick((self, err) => self.emit("error", err), this, err);
+          releaseAgentSocket();
           return;
         }
 
@@ -549,6 +611,7 @@ function ClientRequest(input, options, cb) {
           error.syscall = syscall;
           if (!!$debug) globalReportError(error);
           process.nextTick((self, err) => self.emit("error", err), this, error);
+          releaseAgentSocket();
         };
 
         if (candidates.length === 0) {
@@ -589,6 +652,7 @@ function ClientRequest(input, options, cb) {
     } catch (err) {
       if (!!$debug) globalReportError(err);
       process.nextTick((self, err) => self.emit("error", err), this, err);
+      releaseAgentSocket();
       return false;
     }
   };
@@ -599,6 +663,22 @@ function ClientRequest(input, options, cb) {
   // still open; send() uses this to emit 'close' in the correct order after
   // 'finish' once req.end() is eventually called.
   let deferredRequestClose = false;
+  let socketAssigned = false;
+  let deferredSend = false;
+  let deferredFlush = false;
+  let socketReleased = false;
+
+  const releaseAgentSocket = () => {
+    if (socketReleased) return;
+    socketReleased = true;
+    if (!socketAssigned) return;
+    const socket = this.socket;
+    // Signal to the Agent that this slot is free. The 'agentRemove' listener
+    // (installed by Agent#addRequest via installListeners) decrements
+    // totalSocketCount, removes the socket from agent.sockets[name], and
+    // dispatches the next queued request if any.
+    socket?.emit?.("agentRemove");
+  };
 
   function emitFinishAndDeferredCloseNT() {
     maybeEmitFinish();
@@ -610,6 +690,12 @@ function ClientRequest(input, options, cb) {
 
   const send = () => {
     this.finished = true;
+    if (!socketAssigned) {
+      // Request is queued in the agent waiting for a socket slot
+      // (maxSockets). onSocket() will call send() again once a slot opens.
+      deferredSend = true;
+      return;
+    }
 
     var body = this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
 
@@ -621,6 +707,7 @@ function ClientRequest(input, options, cb) {
     } catch (err) {
       if (!!$debug) globalReportError(err);
       this.emit("error", err);
+      releaseAgentSocket();
     } finally {
       process.nextTick(emitFinishAndDeferredCloseNT);
     }
@@ -727,7 +814,11 @@ function ClientRequest(input, options, cb) {
   }
 
   const defaultPort = options.defaultPort || this[kAgent].defaultPort;
-  const port = (this[kPort] = options.port || defaultPort || 80);
+  // Write the resolved port back onto options so agent.addRequest() →
+  // getName(options) keys on 'host:80:' (matching Node.js) rather than
+  // 'host::', which would split maxSockets pooling between requests that
+  // pass port: 80 explicitly and those that omit it.
+  const port = (this[kPort] = options.port = options.port || defaultPort || 80);
   if (typeof port !== "number" && typeof port !== "string") {
     throw $ERR_INVALID_ARG_TYPE("options.port", ["number", "string"], port);
   }
@@ -967,9 +1058,54 @@ function ClientRequest(input, options, cb) {
 
   this._httpMessage = this;
 
-  process.nextTick(emitContinueAndSocketNT, this);
-
   this[kEmitState] = 0;
+
+  this.onSocket = function (socket, err) {
+    if (this.destroyed || err) {
+      const wasDestroyed = this.destroyed;
+      this.destroyed = true;
+      socketAssigned = true;
+      releaseAgentSocket();
+      // Match Node.js onSocketNT: don't orphan a socket handed over by a
+      // custom agent when the request is already destroyed or errored.
+      // Skip the built-in path where socket is this request's own FakeSocket
+      // (that one is handled by releaseAgentSocket / socketCloseListener).
+      if (socket && socket !== this.socket) {
+        if (!err && this[kAgent] && !socket.destroyed) {
+          socket.emit?.("free");
+        } else {
+          socket.destroy?.(err);
+        }
+      }
+      process.nextTick(() => {
+        if (err != null && !this[abortedSymbol]) this.emit("error", err);
+        // Match Node.js: 'close' always follows, even on the destroyed/err
+        // path. destroy() can't do it later because destroyed is now true.
+        if (!wasDestroyed) socketCloseListener();
+      });
+      return;
+    }
+    if (socket) {
+      socket._httpMessage = this;
+      this.socket = socket;
+    }
+    socketAssigned = true;
+    process.nextTick(emitContinueAndSocketNT, this);
+    if (deferredSend) {
+      deferredSend = false;
+      send();
+    } else if (deferredFlush) {
+      deferredFlush = false;
+      this.flushHeaders();
+    }
+  };
+
+  if (typeof agent.addRequest === "function") {
+    agent.addRequest(this, optsWithoutSignal);
+  } else {
+    socketAssigned = true;
+    process.nextTick(emitContinueAndSocketNT, this);
+  }
 
   this.setSocketKeepAlive = (_enable = true, _initialDelay = 0) => {};
 
@@ -1008,15 +1144,30 @@ const ClientRequestPrototype = {
 
       this[kTimeoutTimer] = undefined;
     } else {
-      this[kTimeoutTimer] = setTimeout(() => {
-        this[kTimeoutTimer] = undefined;
-        this[kAbortController]?.abort();
-        this.emit("timeout");
-      }, msecs).unref();
-
       if (callback !== undefined) {
         validateFunction(callback, "callback");
         this.once("timeout", callback);
+      }
+
+      const startTimer = () => {
+        // Re-check: setTimeout(0) may have been called while waiting for the
+        // socket, or a later setTimeout() call may have superseded this one.
+        if (this.destroyed || this.timeout !== msecs) return;
+        clearTimeout(this[kTimeoutTimer]!);
+        this[kTimeoutTimer] = setTimeout(() => {
+          this[kTimeoutTimer] = undefined;
+          this[kAbortController]?.abort();
+          this.emit("timeout");
+        }, msecs).unref();
+      };
+
+      // Match Node.js: the timeout applies to the socket, so don't start the
+      // timer until a socket slot has been assigned by the agent. Otherwise
+      // requests queued behind maxSockets would time out while waiting.
+      if (this[kEmitState] & (1 << ClientRequestEmitState.socket)) {
+        startTimer();
+      } else {
+        this.once("socket", startTimer);
       }
     }
 
@@ -1083,13 +1234,26 @@ function emitContinueAndSocketNT(self) {
   // Ref: https://github.com/nodejs/node/blob/f63e8b7fa7a4b5e041ddec67307609ec8837154f/lib/_http_client.js#L803-L839
   if (!(self[kEmitState] & (1 << ClientRequestEmitState.socket))) {
     self[kEmitState] |= 1 << ClientRequestEmitState.socket;
-    self.emit("socket", self.socket);
+    const socket = self.socket;
+    self.emit("socket", socket);
+    // The client uses an internal fetch-based transport, so the socket is
+    // normally a FakeSocket with no real TCP handshake. Emit 'connect' so
+    // user code listening for it (in the 'socket' handler) observes Node.js
+    // behavior. Skip when a custom agent supplied a real net.Socket: if
+    // it's still connecting it will emit its own 'connect', and if it's
+    // already connected Node's tickOnSocket would emit none. FakeSocket
+    // has neither `connecting` nor `_handle` set.
+    if (socket && !socket.connecting && !socket._handle) process.nextTick(emitConnectNT, socket);
   }
 
   // Emit continue event for the client (internally we auto handle it)
   if (!self._closed && self.getHeader("expect") === "100-continue") {
     self.emit("continue");
   }
+}
+
+function emitConnectNT(socket) {
+  socket?.emit?.("connect");
 }
 
 function emitAbortNextTick(self) {

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import net from "node:net";
+
+describe("node:http Agent socket accounting", () => {
+  test("agent.sockets and agent.requests are populated and maxSockets is enforced", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Length": "12" });
+      res.end("hello world\n");
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const snapshots: Array<{ sockets: number | undefined; requests: number | undefined }> = [];
+      const done: Promise<void>[] = [];
+
+      for (let i = 0; i < 3; i++) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        done.push(promise);
+        http
+          .get({ path: "/", headers: { connection: "keep-alive" }, port, agent }, res => {
+            snapshots.push({
+              sockets: agent.sockets[name]?.length,
+              requests: agent.requests[name]?.length,
+            });
+            res.on("end", resolve);
+            res.on("error", resolve);
+            res.resume();
+          })
+          .on("error", resolve);
+      }
+
+      // Synchronously after issuing all three: one in-flight, two queued.
+      expect(agent.sockets[name]).toBeDefined();
+      expect(agent.sockets[name]!.length).toBe(1);
+      expect(agent.requests[name]).toBeDefined();
+      expect(agent.requests[name]!.length).toBe(2);
+      expect(agent.totalSocketCount).toBe(1);
+
+      await Promise.all(done);
+
+      // Inside each 'response' callback the count was 1 and the queue drained
+      // one at a time. The third request sees the queue key deleted.
+      expect(snapshots).toEqual([
+        { sockets: 1, requests: 2 },
+        { sockets: 1, requests: 1 },
+        { sockets: 1, requests: undefined },
+      ]);
+
+      // Let the last release happen (nextTick after the final 'end').
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(name in agent.sockets).toBe(false);
+      expect(name in agent.requests).toBe(false);
+      expect(agent.totalSocketCount).toBe(0);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("agent.sockets caps at maxSockets and overflow queues into agent.requests", async () => {
+    const agent = new http.Agent({ maxSockets: 10 });
+
+    const server = http.createServer((req, res) => {
+      res.writeHead(200);
+      res.end("Hello World\n");
+    });
+    server.listen(0, "127.0.0.1");
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ host: "127.0.0.1", port });
+
+      const N = 20;
+      const samples: Array<{ sockets: number; queued: number }> = [];
+      const done: Promise<void>[] = [];
+
+      for (let i = 0; i < N; i++) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        done.push(promise);
+        http
+          .get({ host: "127.0.0.1", port, agent }, res => {
+            res.on("end", resolve);
+            res.on("error", resolve);
+            res.resume();
+          })
+          .on("error", resolve);
+
+        samples.push({
+          sockets: agent.sockets[name]?.length ?? 0,
+          queued: agent.requests[name]?.length ?? 0,
+        });
+      }
+
+      // 1..10 then capped at 10; queued 0×10 then 1..10.
+      expect(samples).toEqual(
+        Array.from({ length: N }, (_, i) => ({
+          sockets: Math.min(i + 1, 10),
+          queued: Math.max(0, i + 1 - 10),
+        })),
+      );
+      const maxQueued = Math.max(...samples.map(s => s.queued));
+      expect(maxQueued).toBeLessThanOrEqual(10);
+
+      await Promise.all(done);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("socket emits 'connect' after the request 'socket' event", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Length": "2", Connection: "close" });
+      res.end("ok");
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      let connectCount = 0;
+      const done: Promise<void>[] = [];
+      for (let i = 0; i < 3; i++) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        done.push(promise);
+        const req = http.request({ port, agent, headers: { connection: "keep-alive" } }, res => {
+          res.on("end", resolve);
+          res.on("error", resolve);
+          res.resume();
+        });
+        req.on("error", resolve);
+        req.on("socket", s => {
+          s.on("connect", () => {
+            connectCount++;
+          });
+        });
+        req.end();
+      }
+
+      await Promise.all(done);
+      expect(connectCount).toBe(3);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("aborting a request releases exactly one agent slot", async () => {
+    const agent = new http.Agent({ maxSockets: 2 });
+
+    const server = http.createServer(() => {
+      // never respond
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const reqs: http.ClientRequest[] = [];
+      for (let i = 0; i < 2; i++) {
+        const req = http.request({ port, agent });
+        req.on("error", () => {});
+        req.end();
+        reqs.push(req);
+      }
+
+      expect(agent.totalSocketCount).toBe(2);
+      expect(agent.sockets[name]!.length).toBe(2);
+
+      for (const r of reqs) r.abort();
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      // Each abort must decrement exactly once — not once for 'close' and
+      // again for 'agentRemove'.
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("destroying a queued request emits 'close' and removes it from agent.requests", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+
+    const server = http.createServer(() => {
+      // never respond
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const r1 = http.get({ port, agent }, () => {});
+      r1.on("error", () => {});
+      const r2 = http.get({ port, agent }, () => {});
+      r2.on("error", () => {});
+
+      // r2 is queued (no socket slot yet, no AbortController created).
+      expect(agent.requests[name]!.length).toBe(1);
+
+      const closed = once(r2, "close");
+      r2.destroy();
+      // Must emit 'close' even though the onAbort path was never set up.
+      await closed;
+
+      expect(r2.destroyed).toBe(true);
+      expect(name in agent.requests).toBe(false);
+      // r1 still holds its slot.
+      expect(agent.totalSocketCount).toBe(1);
+
+      r1.destroy();
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("onSocket(null, err) from a custom agent emits 'error' then 'close'", async () => {
+    class FailingAgent extends http.Agent {
+      addRequest(req: any) {
+        process.nextTick(() => req.onSocket(null, new Error("tunnel failed")));
+      }
+    }
+    const events: string[] = [];
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    const req = http.get({ host: "example.com", port: 80, agent: new FailingAgent() });
+    req.on("error", e => events.push(`error:${(e as Error).message}`));
+    req.on("close", () => {
+      events.push("close");
+      resolve();
+    });
+    await closed;
+    expect(events).toEqual(["error:tunnel failed", "close"]);
+    expect(req.destroyed).toBe(true);
+  });
+
+  test("a failing options.lookup releases the agent slot", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+    try {
+      const name = agent.getName({ host: "example.test", port: 80 });
+      const makeReq = (lookup: (...a: any[]) => void) =>
+        http.get({ host: "example.test", port: 80, agent, lookup } as any, () => {}).on("error", () => {});
+
+      // Callback error
+      makeReq((_h, _o, cb) => cb(new Error("boom")));
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+
+      // No records (ENOTFOUND)
+      makeReq((_h, _o, cb) => cb(null, []));
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+
+      // Synchronous throw
+      makeReq(() => {
+        throw new Error("sync boom");
+      });
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+      expect(name in agent.requests).toBe(false);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("a malformed Content-Length response releases the agent slot", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+    const server = net.createServer(s => {
+      s.on("data", () => s.end("HTTP/1.1 200 OK\r\nContent-Length: 5, 7\r\n\r\nhello"));
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const { promise, resolve } = Promise.withResolvers<string>();
+      http.get({ port, agent }, () => resolve("response")).on("error", (e: any) => resolve(e?.code ?? "error"));
+      const result = await promise;
+      // The response is rejected with a parse error before 'response' fires,
+      // so the res 'end'/'close' hooks never run; the slot must be released
+      // on the error path.
+      expect(result).toBe("HPE_UNEXPECTED_CONTENT_LENGTH");
+
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("a request with an already-aborted signal releases the agent slot", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+    const server = http.createServer((req, res) => res.end("ok"));
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      // With a pre-aborted signal, the fetch resolves but the .then handler
+      // sees this.aborted=true and returns early before installing the
+      // res 'end'/'close' release hooks. The slot must still be released.
+      const ac = new AbortController();
+      ac.abort();
+      const { promise, resolve } = Promise.withResolvers<void>();
+      const req = http.get({ port, agent, signal: ac.signal }, () => {});
+      req.on("error", () => {});
+      req.on("close", resolve);
+      await promise;
+
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("agent.destroy() destroys every tracked socket", async () => {
+    // FakeSocket.destroy() → req.destroy() → onAbort → releaseAgentSocket
+    // splices the live agent.sockets[name] array synchronously; iterating
+    // by forward index would skip every other entry.
+    const agent = new http.Agent({ maxSockets: 10 });
+    const server = http.createServer(() => {});
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const reqs: http.ClientRequest[] = [];
+      for (let i = 0; i < 6; i++) {
+        const r = http.get({ port, agent }, () => {});
+        r.on("error", () => {});
+        reqs.push(r);
+      }
+      expect(agent.sockets[name]!.length).toBe(6);
+      expect(agent.totalSocketCount).toBe(6);
+
+      agent.destroy();
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      for (const r of reqs) expect(r.destroyed).toBe(true);
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("requests that omit port are tracked under the defaulted port key", () => {
+    const agent = new http.Agent();
+    try {
+      // Don't need a real server — addRequest populates agent.sockets
+      // synchronously. Just check the key format.
+      http.get({ host: "127.0.0.1", agent }, () => {}).on("error", () => {});
+      const keys = Object.keys(agent.sockets);
+      // Node.js writes the defaulted port back onto options, so the key is
+      // '127.0.0.1:80:' — not '127.0.0.1::'. If the port weren't written
+      // back, requests with and without an explicit port: 80 would land in
+      // separate maxSockets pools for the same origin.
+      expect(keys).toEqual(["127.0.0.1:80:"]);
+      expect(agent.sockets["127.0.0.1::"]).toBeUndefined();
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("agent.on('keylog', ...) does not throw when sockets are tracked", () => {
+    // maybeEnableKeylog iterates Object.values(this.sockets), which is
+    // Socket[][] — each value is an array of sockets. Before agent.sockets
+    // was populated this was dead code; now calling .on() on an array
+    // would throw.
+    const agent = new http.Agent();
+    try {
+      http.get({ host: "127.0.0.1", agent }, () => {}).on("error", () => {});
+      expect(Object.keys(agent.sockets).length).toBeGreaterThan(0);
+      expect(() => agent.on("keylog", () => {})).not.toThrow();
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("flushHeaders() on a bodiless GET that gets a response before end() releases the slot", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+    const { promise: serverGotRequest, resolve: onServerRequest } = Promise.withResolvers<void>();
+    const server = http.createServer((req, res) => {
+      res.end("ok");
+      onServerRequest();
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      const { promise: responseEnded, resolve: onResponseEnd } = Promise.withResolvers<void>();
+      const req = http.request({ port, agent }, res => {
+        res.on("end", onResponseEnd);
+        res.on("error", onResponseEnd);
+        res.resume();
+      });
+      req.on("error", () => {});
+      // flushHeaders() starts a duplex fetch with no body generator for a
+      // GET with no write()s. If the server responds before end(), the
+      // .then handler runs while onEnd is still the initial no-op, so
+      // handleResponse() (which installs the res 'end'/'close' release
+      // hooks) would never be called.
+      req.flushHeaders();
+      // Wait for the server to have responded. There is no JS-observable
+      // signal that the client's .then handler has stashed handleResponse
+      // (that's the point of this test), so after the server fires we
+      // yield real time to the OS scheduler so the HTTP client thread can
+      // post the response — setImmediate alone would only yield to other
+      // JS tasks on this thread.
+      await serverGotRequest;
+      for (let i = 0; i < 20; i++) await Bun.sleep(1);
+      req.end();
+
+      // After end(), send() reassigns onEnd and calls it, which invokes
+      // handleResponse → 'response' fires → res consumed → slot released.
+      await responseEnded;
+      while (agent.totalSocketCount > 0) await Bun.sleep(1);
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+});

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -191,6 +191,63 @@ describe("node:http Agent socket accounting", () => {
     }
   });
 
+  test("aborting a queued request's signal removes it from the queue and never dispatches it", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+
+    let hits = 0;
+    const { promise: firstHit, resolve: onFirstHit } = Promise.withResolvers<void>();
+    const responses: Array<() => void> = [];
+    const server = http.createServer((req, res) => {
+      hits++;
+      if (hits === 1) onFirstHit();
+      // Hold the response so the first request keeps the only slot until we
+      // release it; the second request stays queued.
+      responses.push(() => res.end("ok"));
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      // r1 takes the only slot.
+      const r1 = http.get({ port, agent }, res => res.resume());
+      r1.on("error", () => {});
+
+      // r2 is queued behind maxSockets: no socket slot, no AbortController yet.
+      const ac = new AbortController();
+      const r2 = http.get({ port, agent, signal: ac.signal }, () => {});
+      r2.on("error", () => {});
+      const r2Closed = once(r2, "close");
+
+      await firstHit;
+      expect(agent.requests[name]!.length).toBe(1);
+
+      // Aborting the queued request's signal must destroy it and drop it from
+      // the queue — not leave it to be dispatched when r1's slot frees. The
+      // AbortController is still null here, so aborting it alone would be a
+      // no-op.
+      ac.abort();
+      await r2Closed;
+      expect(r2.destroyed).toBe(true);
+      expect(name in agent.requests).toBe(false);
+
+      // Free r1's slot. If r2 were still queued it would now be dispatched,
+      // pushing hits to 2.
+      responses.shift()!();
+      await once(r1, "close");
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      // Only r1 ever reached the server.
+      expect(hits).toBe(1);
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
   test("destroying a queued request emits 'close' and removes it from agent.requests", async () => {
     const agent = new http.Agent({ maxSockets: 1 });
 

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -116,6 +116,86 @@ describe("node:http Agent socket accounting", () => {
     }
   });
 
+  test("a request queued by maxTotalSockets is dequeued across origins when a slot frees", async () => {
+    // maxSockets: 1 per origin, maxTotalSockets: 2 global. removeSocket's
+    // cross-origin scan must `continue` past an origin that is at its own
+    // maxSockets (not `break`), otherwise a request queued purely by
+    // maxTotalSockets under a different origin is starved behind it.
+    //
+    // Setup — three origins A, B, C:
+    //   A: a1 holds A's only slot (server A never responds) + a2 queued on A
+    //   B: b1 holds the 2nd/last global slot; B has NO queued request
+    //   C: cQueued queued purely by maxTotalSockets (both slots were full)
+    // When b1 frees, removeSocket(name=B) finds requests[B] empty and scans
+    // Object.keys(requests) = [A, C]. With `break` it aborts at A (which has an
+    // active socket) and cQueued is never serviced. With `continue` it skips A
+    // and dispatches cQueued into the freed global slot — the Node behavior.
+    const agent = new http.Agent({ maxSockets: 1, maxTotalSockets: 2 });
+
+    const heldA: Array<() => void> = [];
+    let hitsC = 0;
+    const serverA = http.createServer(() => {}); // never responds — holds A's slot
+    const serverB = http.createServer((req, res) => res.end("b"));
+    const serverC = http.createServer((req, res) => {
+      hitsC++;
+      res.end("c");
+    });
+    serverA.listen(0);
+    serverB.listen(0);
+    serverC.listen(0);
+    try {
+      await Promise.all([once(serverA, "listening"), once(serverB, "listening"), once(serverC, "listening")]);
+      const portA = (serverA.address() as AddressInfo).port;
+      const portB = (serverB.address() as AddressInfo).port;
+      const portC = (serverC.address() as AddressInfo).port;
+      const nameC = agent.getName({ port: portC });
+
+      const get = (port: number) => {
+        const req = http.get({ port, agent }, res => res.resume());
+        req.on("error", () => {});
+        return req;
+      };
+
+      // a1 takes origin A's only slot; wait until it actually reaches A so the
+      // socket is tracked before we saturate the global limit.
+      const a1Hit = once(serverA, "request");
+      get(portA);
+      await a1Hit;
+
+      // a2 queued under A (A is at maxSockets=1). Insert A into requests first.
+      get(portA);
+
+      // b1 takes the 2nd and last global slot.
+      const b1Hit = once(serverB, "request");
+      const b1 = get(portB);
+      const b1Closed = once(b1, "close");
+      await b1Hit;
+
+      // cQueued queued under C purely by maxTotalSockets (total is now 2).
+      const cQueued = get(portC);
+      const cQueuedClosed = once(cQueued, "close");
+
+      expect(agent.requests[agent.getName({ port: portA })]?.length).toBe(1);
+      expect(agent.requests[nameC]?.length).toBe(1);
+
+      // b1 completes → frees a global slot under origin B (no queued request on
+      // B) → cross-origin scan must reach C.
+      await b1Closed;
+      await cQueuedClosed;
+
+      expect(cQueued.destroyed).toBe(false);
+      expect(hitsC).toBe(1); // cQueued reached server C
+      expect(nameC in agent.requests).toBe(false); // C's queue drained
+
+      heldA.shift()?.();
+    } finally {
+      agent.destroy();
+      serverA.close();
+      serverB.close();
+      serverC.close();
+    }
+  });
+
   test("socket emits 'connect' after the request 'socket' event", async () => {
     const agent = new http.Agent({ maxSockets: 1 });
 
@@ -440,6 +520,50 @@ describe("node:http Agent socket accounting", () => {
       await new Promise<void>(r => setImmediate(() => setImmediate(r)));
       expect(agent.totalSocketCount).toBe(0);
       expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
+  test("a pre-aborted signal does not dispatch and keeps 'close' terminal", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+    let hits = 0;
+    const server = http.createServer((req, res) => {
+      hits++;
+      res.end("ok");
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      const ac = new AbortController();
+      ac.abort();
+
+      const events: string[] = [];
+      const req = http.get({ port, agent, signal: ac.signal });
+      for (const e of ["socket", "prefinish", "finish", "close", "abort"]) {
+        req.on(e, () => events.push(e));
+      }
+      req.on("error", () => {});
+
+      await once(req, "close");
+      // Give any stray deferred ticks (finish/prefinish) a chance to fire.
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      // The stream-completion events must not fire for an aborted request, and
+      // in particular must not appear after 'close' (which breaks the terminal
+      // contract). 'abort' after 'close' matches req.abort()'s own ordering.
+      expect(events).not.toContain("prefinish");
+      expect(events).not.toContain("finish");
+      const closeIdx = events.indexOf("close");
+      expect(closeIdx).toBeGreaterThanOrEqual(0);
+      // Nothing but (optionally) 'abort' may follow 'close'.
+      expect(events.slice(closeIdx + 1).filter(e => e !== "abort")).toEqual([]);
+
+      // An already-aborted request is never dispatched to the server.
+      expect(hits).toBe(0);
     } finally {
       agent.destroy();
       server.close();

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -248,6 +248,57 @@ describe("node:http Agent socket accounting", () => {
     }
   });
 
+  test("a queued request with an already-aborted signal is never dispatched", async () => {
+    const agent = new http.Agent({ maxSockets: 1 });
+
+    let hits = 0;
+    const { promise: firstHit, resolve: onFirstHit } = Promise.withResolvers<void>();
+    const responses: Array<() => void> = [];
+    const server = http.createServer((req, res) => {
+      hits++;
+      if (hits === 1) onFirstHit();
+      responses.push(() => res.end("ok"));
+    });
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const name = agent.getName({ port });
+
+      // r1 takes the only slot.
+      const r1 = http.get({ port, agent }, res => res.resume());
+      r1.on("error", () => {});
+      await firstHit;
+
+      // r2's signal is ALREADY aborted when the request is created. A plain
+      // addEventListener('abort') listener never fires for an already-aborted
+      // signal, so the request would stay queued and get dispatched once r1's
+      // slot frees. The pre-aborted case must be handled explicitly.
+      const ac = new AbortController();
+      ac.abort();
+      const r2 = http.get({ port, agent, signal: ac.signal }, () => {});
+      r2.on("error", () => {});
+      const r2Closed = once(r2, "close");
+
+      await r2Closed;
+      expect(r2.destroyed).toBe(true);
+      expect(name in agent.requests).toBe(false);
+
+      // Free r1's slot. If r2 were still queued it would now be dispatched.
+      responses.shift()!();
+      await once(r1, "close");
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      // Only r1 ever reached the server.
+      expect(hits).toBe(1);
+      expect(agent.totalSocketCount).toBe(0);
+      expect(name in agent.sockets).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
   test("destroying a queued request emits 'close' and removes it from agent.requests", async () => {
     const agent = new http.Agent({ maxSockets: 1 });
 

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -446,6 +446,42 @@ describe("node:http Agent socket accounting", () => {
     }
   });
 
+  test("a shared signal aborted after a request completes does not re-abort it", async () => {
+    const agent = new http.Agent({ maxSockets: 2 });
+    const server = http.createServer((req, res) => res.end("ok"));
+    server.listen(0);
+    try {
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+
+      // One signal shared across a batch (e.g. AbortSignal.timeout). The
+      // request finishes well before the signal fires.
+      const ac = new AbortController();
+
+      let aborted = false;
+      const req = http.get({ port, agent, signal: ac.signal }, res => res.resume());
+      req.on("error", () => {});
+      req.on("abort", () => {
+        aborted = true;
+      });
+      await once(req, "close");
+
+      expect(req.complete).toBe(true);
+      expect(req.destroyed).toBe(false);
+
+      // Firing the shared signal now must be a no-op for the already-completed
+      // request: no 'abort' event, no post-completion destroy().
+      ac.abort();
+      await new Promise<void>(r => setImmediate(() => setImmediate(r)));
+
+      expect(aborted).toBe(false);
+      expect(req.destroyed).toBe(false);
+    } finally {
+      agent.destroy();
+      server.close();
+    }
+  });
+
   test("agent.destroy() destroys every tracked socket", async () => {
     // FakeSocket.destroy() → req.destroy() → onAbort → releaseAgentSocket
     // splices the live agent.sockets[name] array synchronously; iterating

--- a/test/js/node/http/node-http-agent-sockets.test.ts
+++ b/test/js/node/http/node-http-agent-sockets.test.ts
@@ -132,7 +132,6 @@ describe("node:http Agent socket accounting", () => {
     // and dispatches cQueued into the freed global slot — the Node behavior.
     const agent = new http.Agent({ maxSockets: 1, maxTotalSockets: 2 });
 
-    const heldA: Array<() => void> = [];
     let hitsC = 0;
     const serverA = http.createServer(() => {}); // never responds — holds A's slot
     const serverB = http.createServer((req, res) => res.end("b"));
@@ -187,7 +186,8 @@ describe("node:http Agent socket accounting", () => {
       expect(hitsC).toBe(1); // cQueued reached server C
       expect(nameC in agent.requests).toBe(false); // C's queue drained
 
-      heldA.shift()?.();
+      // serverA never responds (a1 holds A's slot for the whole test);
+      // agent.destroy() + serverA.close() in finally tear down a1/a2.
     } finally {
       agent.destroy();
       serverA.close();

--- a/test/js/node/test/parallel/test-http-keep-alive-close-on-header.js
+++ b/test/js/node/test/parallel/test-http-keep-alive-close-on-header.js
@@ -1,0 +1,98 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const body = 'hello world\n';
+const headers = { 'connection': 'keep-alive' };
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200, { 'Content-Length': body.length, 'Connection': 'close' });
+  res.write(body);
+  res.end();
+});
+
+let connectCount = 0;
+
+
+server.listen(0, common.mustCall(function() {
+  const agent = new http.Agent({ maxSockets: 1 });
+  const name = agent.getName({ port: this.address().port });
+  let request = http.request({
+    method: 'GET',
+    path: '/',
+    headers: headers,
+    port: this.address().port,
+    agent: agent
+  }, common.mustCall((res) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    res.resume();
+  }));
+  request.on('socket', function(s) {
+    s.on('connect', function() {
+      connectCount++;
+    });
+  });
+  request.end();
+
+  request = http.request({
+    method: 'GET',
+    path: '/',
+    headers: headers,
+    port: this.address().port,
+    agent: agent
+  }, common.mustCall((res) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    res.resume();
+  }));
+  request.on('socket', function(s) {
+    s.on('connect', function() {
+      connectCount++;
+    });
+  });
+  request.end();
+  request = http.request({
+    method: 'GET',
+    path: '/',
+    headers: headers,
+    port: this.address().port,
+    agent: agent
+  }, common.mustCall((response) => {
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(agent.sockets[name].length, 1);
+      server.close();
+    }));
+    response.resume();
+  }));
+  request.on('socket', function(s) {
+    s.on('connect', function() {
+      connectCount++;
+    });
+  });
+  request.end();
+}));
+
+process.on('exit', function() {
+  assert.strictEqual(connectCount, 3);
+});

--- a/test/js/node/test/parallel/test-http-keep-alive.js
+++ b/test/js/node/test/parallel/test-http-keep-alive.js
@@ -1,0 +1,72 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  const body = 'hello world\n';
+
+  res.writeHead(200, { 'Content-Length': body.length });
+  res.write(body);
+  res.end();
+}, 3));
+
+const agent = new http.Agent({ maxSockets: 1 });
+const headers = { 'connection': 'keep-alive' };
+let name;
+
+server.listen(0, common.mustCall(function() {
+  name = agent.getName({ port: this.address().port });
+  http.get({
+    path: '/', headers: headers, port: this.address().port, agent: agent
+  }, common.mustCall((response) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    assert.strictEqual(agent.requests[name].length, 2);
+    response.resume();
+  }));
+
+  http.get({
+    path: '/', headers: headers, port: this.address().port, agent: agent
+  }, common.mustCall((response) => {
+    assert.strictEqual(agent.sockets[name].length, 1);
+    assert.strictEqual(agent.requests[name].length, 1);
+    response.resume();
+  }));
+
+  http.get({
+    path: '/', headers: headers, port: this.address().port, agent: agent
+  }, common.mustCall((response) => {
+    response.on('end', common.mustCall(() => {
+      assert.strictEqual(agent.sockets[name].length, 1);
+      assert(!(name in agent.requests));
+      server.close();
+    }));
+    response.resume();
+  }));
+}));
+
+process.on('exit', () => {
+  assert(!(name in agent.sockets));
+  assert(!(name in agent.requests));
+});

--- a/test/js/node/test/parallel/test-http-max-sockets.js
+++ b/test/js/node/test/parallel/test-http-max-sockets.js
@@ -1,0 +1,79 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+const common = require('../common');
+
+// Make sure http server doesn't wait for socket pool to establish connections
+// https://github.com/nodejs/node-v0.x-archive/issues/877
+
+const http = require('http');
+const assert = require('assert');
+
+const N = 20;
+let responses = 0;
+let maxQueued = 0;
+
+const agent = http.globalAgent;
+agent.maxSockets = 10;
+
+const server = http.createServer(function(req, res) {
+  res.writeHead(200);
+  res.end('Hello World\n');
+});
+
+server.listen(0, '127.0.0.1', common.mustCall(() => {
+  const { port } = server.address();
+  const addrString = agent.getName({ host: '127.0.0.1', port });
+
+  for (let i = 0; i < N; i++) {
+    const options = {
+      host: '127.0.0.1',
+      port
+    };
+
+    const req = http.get(options, function(res) {
+      if (++responses === N) {
+        server.close();
+      }
+      res.resume();
+    });
+
+    assert.strictEqual(req.agent, agent);
+
+    console.log(
+      `Socket: ${agent.sockets[addrString].length}/${
+        agent.maxSockets} queued: ${
+        agent.requests[addrString] ? agent.requests[addrString].length : 0}`);
+
+    const agentRequests = agent.requests[addrString] ?
+      agent.requests[addrString].length : 0;
+
+    if (maxQueued < agentRequests) {
+      maxQueued = agentRequests;
+    }
+  }
+}));
+
+process.on('exit', function() {
+  assert.strictEqual(responses, N);
+  assert.ok(maxQueued <= 10);
+});


### PR DESCRIPTION
## What

`http.Agent#sockets`, `#requests` and `#freeSockets` were always empty and `maxSockets` was never enforced.

Node compat group `1vs0v5` (signature `missing-api:agent.sockets`):
- `test/parallel/test-http-keep-alive.js`
- `test/parallel/test-http-keep-alive-close-on-header.js`
- `test/parallel/test-http-max-sockets.js`

## Repro

```js
const http = require('http');
const agent = new http.Agent({ maxSockets: 1 });
const s = http.createServer((q, r) => r.end('ok')).listen(0, () => {
  const name = agent.getName({ port: s.address().port });
  for (let i = 0; i < 3; i++) http.get({ port: s.address().port, agent }, r => r.resume());
  console.log(agent.sockets[name]?.length, agent.requests[name]?.length);
  // Node: 1 2   Bun (before): undefined undefined
});
```

## Cause

`Agent.prototype.addRequest` was a stub (`$debug("WARN: Agent.addRequest is a no-op")`) and `ClientRequest` never called it — every request went straight to the internal fetch with no agent bookkeeping or throttling.

## Fix

**`_http_agent.ts`**
- `addRequest` now mirrors Node's: compute the key, push the request's (fake) socket into `sockets[name]` and bump `totalSocketCount` when under the limit, otherwise queue in `requests[name]` with `kRequestOptions`.
- `removeSocket`'s "start next queued request" path now registers the queued request's own socket instead of calling `createConnection()` (which would open an unused real TCP socket — the transport is still Bun's internal fetch).

**`_http_client.ts`**
- `ClientRequest` now calls `agent.addRequest(this, opts)` at the end of the constructor and defers the fetch until `onSocket()` is called (so queued requests actually wait for a slot).
- `onSocket(socket, err)` assigns the socket, emits `'socket'`, and resumes any deferred `end()`/`flushHeaders()`.
- When the response body finishes (or the request errors/aborts/destroys), the slot is released by emitting `'agentRemove'` on the socket; the agent's listener removes it from `sockets[name]` and dequeues the next request.
- `setTimeout` now starts the timer on `'socket'` instead of at construction time, matching Node — otherwise requests queued behind `maxSockets` time out while waiting (exposed by `test-http-timeout.js`).
- The fake socket now emits `'connect'` on the tick after `'socket'` so listeners added in the `'socket'` handler fire (needed by `test-http-keep-alive-close-on-header.js`).

## Verification

All three tests fail on canary `1.3.14+1bea55a02` and on `main` with `TypeError: undefined is not an object (evaluating 'agent.sockets[name].length')`, and pass with this change (10/10 runs each). No regressions across the node `test-http-*` / `test-https-*` parallel+sequential suites or the existing `test-http-agent-*` tests.