### PR TITLE
Fix crash in visible width calculation on invalid UTF-8 lead bytes

### DIFF
--- a/src/string/immutable/visible.zig
+++ b/src/string/immutable/visible.zig
@@ -843,7 +843,7 @@ pub const visible = struct {
                 else => unreachable,
             };
 
-            const cp = decodeWTF8RuneTMultibyte(&cp_bytes, skip, u32, unicode_replacement);
+            const cp = if (skip > 1) decodeWTF8RuneTMultibyte(&cp_bytes, skip, u32, unicode_replacement) else unicode_replacement;
             len += visibleCodepointWidth(cp, false);
 
             bytes = bytes[@min(i + skip, bytes.len)..];
@@ -1353,7 +1353,7 @@ pub const visible = struct {
                 },
                 else => unreachable,
             };
-            const cp = decodeWTF8RuneTMultibyte(&cp_bytes, skip, u32, unicode_replacement);
+            const cp = if (skip > 1) decodeWTF8RuneTMultibyte(&cp_bytes, skip, u32, unicode_replacement) else unicode_replacement;
             const cw = visibleCodepointWidth(cp, false);
             if (w.* + cw > max_width) {
                 return (@intFromPtr(bytes.ptr) - @intFromPtr(input.ptr)) + i;

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -58,6 +58,18 @@ describe("fuzzer-like edge cases", () => {
     expect(typeof Markdown.html(buf)).toBe("string");
   });
 
+  test("ansi: invalid UTF-8 lead bytes do not crash", () => {
+    // Lone continuation bytes and bytes >= 0xF8 are non-ASCII but not valid
+    // multi-byte lead bytes; previously hit an assert in the width calculator.
+    for (const b of [0x80, 0xbf, 0xf8, 0xff]) {
+      expect(typeof Markdown.ansi(Buffer.from([b]))).toBe("string");
+    }
+    const buf = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++) buf[i] = i;
+    expect(typeof Markdown.ansi(buf)).toBe("string");
+    expect(typeof Markdown.ansi(buf, { columns: 4 })).toBe("string");
+  });
+
   // ---- Deeply nested structures ----
 
   test("deeply nested blockquotes", () => {


### PR DESCRIPTION
## What does this PR do?

`visibleUTF8WidthFn` and `utf8WalkRun` in `src/string/immutable/visible.zig` called `decodeWTF8RuneTMultibyte` unconditionally on the first non-ASCII byte found. However, `wtf8ByteSequenceLengthWithInvalid` returns `1` for bytes that are non-ASCII but not valid multi-byte lead bytes (lone continuation bytes `0x80-0xBF` and `0xF8-0xFF`). `decodeWTF8RuneTMultibyte` asserts `len > 1`, so passing a Buffer containing such bytes to `Bun.markdown.ansi()` crashed in debug builds.

When `skip == 1` for a non-ASCII byte, it's an invalid byte — treat it as U+FFFD instead of calling the multibyte decoder.

## How did you verify your code works?

Added a regression test in `test/js/bun/md/md-edge-cases.test.ts` that covers `Bun.markdown.ansi()` with lone continuation bytes, `0xF8-0xFF`, and the full `0..255` byte range (including with narrow columns to exercise `utf8WalkRun`).

Fingerprint: `2407d17783f076e9`