### PR TITLE
socket: guard onClose/onHandshake against poisoned handlers during VM teardown

### DIFF
--- a/src/runtime/socket/socket.zig
+++ b/src/runtime/socket/socket.zig
@@ -618,19 +618,28 @@ pub fn NewSocket(comptime ssl: bool) type {
             this.flags.handshake_complete = true;
             this.socket = s;
             if (this.socket.isDetached()) return;
+
+            const authorized = if (success == 1) true else false;
+            this.flags.authorized = authorized;
+
+            // During VM shutdown, the Listener (which embeds `handlers` for
+            // server sockets) may already have been finalized by the time
+            // uSockets fires this — `ctx.close()` in `Listener.deinit()` uses
+            // a clean TLS shutdown (code 0), which can leave the TCP socket
+            // open waiting for the peer's close_notify, and the subsequent
+            // `TLSSocket.finalize()` force-close then re-enters here via
+            // `us_internal_ssl_socket_close`. Resolve the VM via the global
+            // accessor (not `handlers.vm`) and bail before dereferencing
+            // `handlers` — mirrors the guard in `markInactive`.
+            if (jsc.VirtualMachine.get().isShuttingDown()) {
+                return;
+            }
+
             const handlers = this.getHandlers();
             log("onHandshake {s} ({d})", .{ if (handlers.mode == .server) "S" else "C", success });
 
-            const authorized = if (success == 1) true else false;
-
-            this.flags.authorized = authorized;
-
             var callback = handlers.onHandshake;
             var is_open = false;
-
-            if (handlers.vm.isShuttingDown()) {
-                return;
-            }
 
             // Use open callback when handshake is not provided
             if (callback == .zero) {
@@ -686,8 +695,6 @@ pub fn NewSocket(comptime ssl: bool) type {
 
         pub fn onClose(this: *This, socket: Socket, err: c_int, reason: ?*anyopaque) bun.JSError!void {
             jsc.markBinding(@src());
-            const handlers = this.getHandlers();
-            log("onClose {s}", .{if (handlers.mode == .server) "S" else "C"});
             this.detachNativeCallback();
             this.socket.detach();
             // The upgradeTLS raw twin shares the same us_socket_t so it never
@@ -705,17 +712,28 @@ pub fn NewSocket(comptime ssl: bool) type {
                 return;
             }
 
-            const vm = handlers.vm;
+            // During VM shutdown, the Listener (which embeds `handlers` for
+            // server sockets) may already have been finalized by the time
+            // uSockets fires this close — `ctx.close()` in `Listener.deinit()`
+            // uses a clean TLS shutdown (code 0), which can leave the TCP
+            // socket open waiting for the peer's close_notify, and the
+            // subsequent `TLSSocket.finalize()` force-close then re-enters
+            // here via `ssl_on_close`. Resolve the VM via the global accessor
+            // (not `handlers.vm`) and bail before dereferencing `handlers` —
+            // mirrors the guard in `markInactive`.
+            const vm = jsc.VirtualMachine.get();
             this.poll_ref.unref(vm);
+            if (vm.isShuttingDown()) {
+                return;
+            }
+
+            const handlers = this.getHandlers();
+            log("onClose {s}", .{if (handlers.mode == .server) "S" else "C"});
 
             const callback = handlers.onClose;
 
             if (callback == .zero)
                 return;
-
-            if (vm.isShuttingDown()) {
-                return;
-            }
 
             // the handlers must be kept alive for the duration of the function call
             // that way if we need to call the error handler, we can

--- a/test/js/node/http2/node-http2-tls-shutdown-uap-fixture.js
+++ b/test/js/node/http2/node-http2-tls-shutdown-uap-fixture.js
@@ -1,0 +1,41 @@
+// Reproduces the use-after-poison in TLSSocket onHandshake/onClose that fires
+// during VM teardown when the parent Listener has already been finalized.
+//
+// The process intentionally throws from every server 'stream' handler so the
+// VM exits with live TLS connections. With BUN_DESTRUCT_VM_ON_EXIT=1 the GC
+// runs finalizers in heap-layout order; with enough concurrent listeners some
+// Listener cells land in blocks swept before their child TLSSocket cells, and
+// `Listener.deinit()`'s clean-shutdown `ctx.close()` (code 0) can leave the
+// underlying TCP socket open waiting for the peer's close_notify. The later
+// `TLSSocket.finalize()` force-close then re-enters the Zig `onHandshake` /
+// `onClose` callbacks with `handlers` pointing into the freed Listener.
+"use strict";
+const h2 = require("http2");
+const tls = require("tls");
+const path = require("path");
+const fs = require("fs");
+
+const keysDir = process.env.KEYS_DIR;
+const key = fs.readFileSync(path.join(keysDir, "agent1-key.pem"));
+const cert = fs.readFileSync(path.join(keysDir, "agent1-cert.pem"));
+const ca = fs.readFileSync(path.join(keysDir, "ca1-cert.pem"));
+
+const N = parseInt(process.env.N || "30", 10);
+
+for (let i = 0; i < N; i++) {
+  const server = h2.createSecureServer({ cert, key });
+  server.on("stream", () => {
+    // Uncaught exception -> process begins exiting while connections are live.
+    throw new Error("boom " + i);
+  });
+  server.listen(0, () => {
+    const client = h2.connect(`https://localhost:${server.address().port}`, {
+      secureContext: tls.createSecureContext({ ca }),
+      servername: "agent1",
+    });
+    client.on("error", () => {});
+    const req = client.request();
+    req.on("error", () => {});
+    req.on("close", () => {});
+  });
+}

--- a/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
+++ b/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
@@ -38,11 +38,13 @@ test.skipIf(!(isASAN || isDebug))(
     // The fixture throws from every 'stream' handler, so stderr is full of
     // "error: boom N" traces — that's expected. The process should exit with
     // code 1 (unhandled exception) rather than abort (ASAN trap / signal).
+    // stderr is checked first so the ASAN trace is the failure message when
+    // the bug is present.
     expect(stderr).not.toContain("AddressSanitizer");
     expect(stderr).not.toContain("use-after-poison");
+    expect(stdout).toBe("");
     expect(proc.signalCode).toBeNull();
     expect(exitCode).toBe(1);
-    expect(stdout).toBe("");
   },
   30_000,
 );

--- a/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
+++ b/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import path from "node:path";
+
+// This exercises the VM-teardown ordering between Listener and its child
+// TLSSocket. Before the fix, `onHandshake`/`onClose` on the server-side
+// TLSSocket would read `handlers.mode` after the parent Listener had been
+// finalized (ASAN use-after-poison at socket.zig onHandshake/onClose).
+//
+// The crash only manifests under an ASAN-enabled build with
+// BUN_DESTRUCT_VM_ON_EXIT=1 so that `lastChanceToFinalize` actually sweeps
+// the remaining JS cells. Release builds read garbage but don't trap, so
+// skip there — the bug is the same, ASAN is just the canary.
+test.skipIf(!(isASAN || isDebug))(
+  "http2 secure server: TLSSocket close after Listener finalize during VM teardown does not use-after-poison",
+  async () => {
+    const fixture = path.join(import.meta.dir, "node-http2-tls-shutdown-uap-fixture.js");
+    const keysDir = path.join(import.meta.dir, "..", "test", "fixtures", "keys");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), fixture],
+      env: {
+        ...bunEnv,
+        KEYS_DIR: keysDir,
+        // 30 concurrent servers is enough to span multiple heap blocks so
+        // finalization order between Listener and TLSSocket varies.
+        N: "30",
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        BUN_GARBAGE_COLLECTOR_LEVEL: "1",
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:abort_on_error=1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The fixture throws from every 'stream' handler, so stderr is full of
+    // "error: boom N" traces — that's expected. The process should exit with
+    // code 1 (unhandled exception) rather than abort (ASAN trap / signal).
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stderr).not.toContain("use-after-poison");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+  },
+  30_000,
+);

--- a/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
+++ b/test/js/node/http2/node-http2-tls-shutdown-uap.test.ts
@@ -22,9 +22,10 @@ test.skipIf(!(isASAN || isDebug))(
       env: {
         ...bunEnv,
         KEYS_DIR: keysDir,
-        // 30 concurrent servers is enough to span multiple heap blocks so
-        // finalization order between Listener and TLSSocket varies.
-        N: "30",
+        // N≥10 reliably spans enough heap blocks for finalization order
+        // between Listener and TLSSocket to vary (0/5 repro at N<10, 5/5 at
+        // N≥10). 15 gives headroom without slowing the fixture further.
+        N: "15",
         BUN_DESTRUCT_VM_ON_EXIT: "1",
         BUN_GARBAGE_COLLECTOR_LEVEL: "1",
         ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:abort_on_error=1",
@@ -37,14 +38,21 @@ test.skipIf(!(isASAN || isDebug))(
 
     // The fixture throws from every 'stream' handler, so stderr is full of
     // "error: boom N" traces — that's expected. The process should exit with
-    // code 1 (unhandled exception) rather than abort (ASAN trap / signal).
-    // stderr is checked first so the ASAN trace is the failure message when
-    // the bug is present.
-    expect(stderr).not.toContain("AddressSanitizer");
-    expect(stderr).not.toContain("use-after-poison");
+    // code 1 (unhandled exception) rather than abort. With
+    // `ASAN_OPTIONS=abort_on_error=1`, an ASAN trap produces SIGABRT, so the
+    // signalCode/exitCode assertions are the load-bearing regression checks.
+    // Dump stderr so the ASAN report is visible in the failure output.
+    if (proc.signalCode !== null || exitCode !== 1) {
+      console.error(stderr);
+    }
     expect(stdout).toBe("");
     expect(proc.signalCode).toBeNull();
     expect(exitCode).toBe(1);
   },
+  // 15 concurrent TLS handshakes + h2 session setup + VM-destroy finalizer
+  // sweep under a debug ASAN build runs ~5–6s — above the 5s default. CI
+  // passes --timeout=90000 so this only matters for local `bun bd test`.
+  // Matches neighbouring socket.test.ts / socket-retention.test.ts which
+  // extend timeouts for the same reason.
   30_000,
 );


### PR DESCRIPTION
## What

Fixes an ASAN use-after-poison in `TLSSocket.onClose` / `TLSSocket.onHandshake` that fires during VM teardown when the parent `Listener` has already been finalized.

Originally surfaced by Node's `test-http2-create-client-secure-session` under `BUN_DESTRUCT_VM_ON_EXIT=1`:

```
==3875==ERROR: AddressSanitizer: use-after-poison on address 0x7126deb90149
READ of size 1 at 0x7126deb90149 thread T0
    #0 bun.js.api.bun.socket.NewSocket(true).onClose  src/bun.js/api/bun/socket.zig:638:46
    #1 deps.uws.socket.NewSocketHandler(true).configure.SocketHandler.on_close  src/deps/uws/socket.zig:859:47
    #2 ssl_on_close  packages/bun-usockets/src/crypto/openssl.c:445:43
```

## Cause

Server-side `TLSSocket`s hold `handlers = &listener.handlers` — a pointer into the embedding `Listener`. During `lastChanceToFinalize` the order in which `Listener` and `TLSSocket` cells are swept is heap-layout dependent (IsoSubspace / block order), not object-graph order.

When a `Listener` is swept first, `Listener.deinit()` calls `ctx.close(this.ssl)` to close live child sockets. For TLS that's `us_internal_ssl_socket_close(s, code=0)` (clean shutdown), which can return early **without closing the TCP socket** when `SSL_shutdown` sends close_notify but needs to wait for the peer (`handle_shutdown` returns `0` with `force_fast_shutdown=false`). `Listener.deinit()` then poisons `handlers` via `this.* = undefined` and frees itself.

When the child `TLSSocket.finalize()` is later swept, `this.socket.isClosed()` is still `false`, so it calls `closeAndDetach(.failure)` → `us_internal_ssl_socket_close(s, code=1)`, which fires:
- `on_handshake` (via `us_internal_trigger_handshake_callback_econnreset` if the handshake hadn't completed), and/or
- `ssl_on_close` → Zig `onClose`

Both callbacks read `handlers.mode` / `handlers.vm` **before** the existing `isShuttingDown()` check, dereferencing poisoned Listener memory.

`markInactive()` already has exactly this guard (socket.zig:410-420) — it fetches the VM via `jsc.VirtualMachine.get()` and bails before touching `handlers` when shutting down.

## Fix

Apply the same pattern to `onClose` and `onHandshake`: resolve the VM via `jsc.VirtualMachine.get()` and check `isShuttingDown()` **before** dereferencing `handlers`. No behavioral change outside of shutdown — the existing `isShuttingDown` check was already returning early, it just happened too late.

## Test

`test/js/node/http2/node-http2-tls-shutdown-uap.test.ts` spawns 30 concurrent h2 secure servers that each throw from their `stream` handler, so the VM exits with live TLS connections and `BUN_DESTRUCT_VM_ON_EXIT=1` sweeps them. 30 is enough to span multiple heap blocks so some Listeners reliably land ahead of their child sockets in sweep order. Gated to ASAN/debug builds since release reads garbage but doesn't trap.

Before fix: `SIGABRT`, `AddressSanitizer: use-after-poison` at `socket.zig:572` (`onHandshake`) every run.
After fix: exits with code 1 (the uncaught exceptions), no ASAN output, across 15 consecutive runs.