### PR TITLE
lowerDecorators: give each auto-accessor its own WeakMap binding

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -414,6 +414,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         v.into_bump_slice()
     }
 
+    /// Bump-format `_{n}_{key}`. Counter-first so the name can never equal a
+    /// non-accessor private binding `_{ident}` (identifiers can't start with a
+    /// digit), and is injective over (counter, key) since the counter is unique.
+    fn bump_accessor_name(&self, key: &[u8], n: usize) -> &'a [u8] {
+        let mut v = BumpVec::<u8>::new_in(self.arena);
+        v.push(b'_');
+        let s = bun_alloc::arena_format!(in self.arena, "{}", n);
+        v.extend_from_slice(s.as_bytes());
+        v.push(b'_');
+        v.extend_from_slice(key);
+        v.into_bump_slice()
+    }
+
+    /// `bump_accessor_name` with a trailing literal, e.g. `_{n}_{key}_acc` for
+    /// the decorated private accessor descriptor ref.
+    fn bump_accessor_name_with_suffix(&self, key: &[u8], suffix: &[u8], n: usize) -> &'a [u8] {
+        let mut v = BumpVec::<u8>::new_in(self.arena);
+        v.push(b'_');
+        let s = bun_alloc::arena_format!(in self.arena, "{}", n);
+        v.extend_from_slice(s.as_bytes());
+        v.push(b'_');
+        v.extend_from_slice(key);
+        v.extend_from_slice(suffix);
+        v.into_bump_slice()
+    }
+
     // ── Generic tree rewriter ────────────────────────────
 
     fn rewrite_expr(&mut self, expr: &mut Expr, kind: RewriteKind) {
@@ -1385,7 +1411,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
@@ -1537,18 +1562,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // Undecorated auto-accessor → WeakMap + getter/setter
                 if prop.kind == PropertyKind::AutoAccessor {
+                    let storage_id = p.accessor_storage_counter;
+                    p.accessor_storage_counter += 1;
                     let accessor_name: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
-                            if let js_ast::ExprData::EString(s) = &k.data
-                                && s.is_utf8()
-                            {
-                                break 'brk p.bump_name2(b"_", &s.data);
+                            // Embed the key only when UTF-8 and a valid identifier;
+                            // otherwise the var binding would be unparseable or hold
+                            // raw UTF-16 bytes. Fall through to the synthetic name.
+                            if let Some(mut s) = k.data.e_string() {
+                                if s.is_utf8() && s.is_identifier(p.arena) {
+                                    break 'brk p.bump_accessor_name(&s.data, storage_id);
+                                }
                             }
                         }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
+                        p.bump_accessor_name(b"accessor_storage", storage_id)
                     };
                     let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
                     let wme = p.new_weak_map_expr(loc);
@@ -1759,16 +1786,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
                     dec_arg_count = 5;
                 } else if k == 4 {
-                    let nm = p.bump_name2(b"_", &private_orig[1..]);
+                    // Decorated private auto-accessor → WeakMap + descriptor.
+                    // Shares the counter: two classes with `accessor #x` would
+                    // otherwise emit colliding module-scope `_x` bindings.
+                    let storage_id = p.accessor_storage_counter;
+                    p.accessor_storage_counter += 1;
+                    let nm = p.bump_accessor_name(&private_orig[1..], storage_id);
                     let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, nm);
                     private_storage_ref = Some(wm_ref);
-                    let acc_nm = {
-                        let mut v = BumpVec::<u8>::new_in(bump);
-                        v.push(b'_');
-                        v.extend_from_slice(&private_orig[1..]);
-                        v.extend_from_slice(b"_acc");
-                        v.into_bump_slice()
-                    };
+                    let acc_nm =
+                        p.bump_accessor_name_with_suffix(&private_orig[1..], b"_acc", storage_id);
                     let acc_ref = p.new_sym(js_ast::symbol::Kind::Other, acc_nm);
                     private_method_fn_ref = Some(acc_ref);
                     private_lowered_map.insert(
@@ -1787,15 +1814,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             } else if k == 4 {
                 // Decorated public auto-accessor → WeakMap
+                let storage_id = p.accessor_storage_counter;
+                p.accessor_storage_counter += 1;
                 let accessor_name: &'a [u8] = 'brk: {
-                    if let js_ast::ExprData::EString(s) = &key_expr.data
-                        && s.is_utf8()
-                    {
-                        break 'brk p.bump_name2(b"_", &s.data);
+                    // Embed key only when UTF-8 + valid identifier (see undecorated path).
+                    if let Some(mut s) = key_expr.data.e_string() {
+                        if s.is_utf8() && s.is_identifier(p.arena) {
+                            break 'brk p.bump_accessor_name(&s.data, storage_id);
+                        }
                     }
-                    let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                    accessor_storage_counter += 1;
-                    name
+                    p.bump_accessor_name(b"accessor_storage", storage_id)
                 };
                 let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
                 private_extra_ref = Some(wm_ref);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -549,6 +549,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
+    // Module-scoped counter for auto-accessor WeakMap storage names, so each
+    // `accessor foo` gets its own binding; sharing `_foo` across a base and
+    // derived class double-adds to one WeakMap during decorator lowering.
+    pub accessor_storage_counter: usize,
+
     // When bundling, hoisted top-level local variables declared with "var" in
     // nested scopes are moved up to be declared in the top-level scope instead.
     // The old "var" statements are turned into regular assignments instead. This
@@ -9172,6 +9177,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             await_target: None,
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
+            accessor_storage_counter: 0,
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1062,4 +1062,189 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe("auto-accessor in subclass", () => {
+    test("subclass can override auto-accessor of same name (issue #29837)", async () => {
+      // Each class's `accessor name = ...` desugars to its own private
+      // storage slot per TC39 Decorators proposal. Reusing one WeakMap
+      // for the base AND derived class causes super()'s __privateAdd
+      // to populate the map and the subclass's own __privateAdd to
+      // throw "Cannot add the same private member more than once".
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A {
+          accessor name = "A";
+        }
+        class B extends A {
+          accessor name = "B";
+          logName() {
+            console.log(this.name);
+            console.log(super.name);
+          }
+        }
+        new B().logName();
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("B\nA\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("multiple auto-accessors with same name across classes", async () => {
+      // Exercises several same-named accessors to confirm each class
+      // gets its own WeakMap binding regardless of property order.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class X {
+          accessor a = 1;
+          accessor b = 2;
+        }
+        class Y extends X {
+          accessor a = 10;
+          accessor b = 20;
+          check() {
+            return [this.a, this.b, super.a, super.b];
+          }
+        }
+        console.log(JSON.stringify(new Y().check()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[10,20,1,2]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated auto-accessor in subclass with same name", async () => {
+      // Same collision happens on the decorated path — verify the
+      // decorator runs once per class and the values stay distinct.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function tag(target, ctx) {
+          return target;
+        }
+        class A {
+          @tag accessor name = "A";
+        }
+        class B extends A {
+          @tag accessor name = "B";
+          both() {
+            return this.name + "/" + super.name;
+          }
+        }
+        console.log(new B().both());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("B/A\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("auto-accessor with string key that is not a valid identifier", async () => {
+      // A non-identifier key like "foo-bar" can't be embedded (would be
+      // unparseable), so it falls back to the synthetic storage name.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A {
+          accessor "foo-bar" = "hi";
+        }
+        const a = new A();
+        console.log(a["foo-bar"]);
+        a["foo-bar"] = "bye";
+        console.log(a["foo-bar"]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("hi\nbye\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("auto-accessor with non-ASCII string key", async () => {
+      // Non-ASCII quoted keys are stored as UTF-16 in E.String. `isIdentifier`
+      // alone would accept "café" (é is ID_Continue) and the format string
+      // would then splice raw UTF-16 bytes into the symbol name, producing
+      // invalid JS with embedded NULs. The additional `isUTF8()` guard
+      // routes these to the safe fallback.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A {
+          accessor "café" = "yes";
+        }
+        const a = new A();
+        console.log(a["café"]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("yes\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated private auto-accessor in subclass with same name", async () => {
+      // Same collision as the public case, on the `is_private && k == 4`
+      // branch of the decorated lowering path. Each class's `accessor #x`
+      // must get its own WeakMap binding.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function tag(target, ctx) {
+          return target;
+        }
+        class A {
+          @tag accessor #x = "A";
+          getA() { return this.#x; }
+        }
+        class B extends A {
+          @tag accessor #x = "B";
+          getB() { return this.#x; }
+        }
+        const b = new B();
+        console.log(b.getA(), b.getB());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("A B\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("digit-suffixed key does not collide with later counter value", async () => {
+      // `accessor x1` and `accessor x` must not map to the same storage name
+      // even when the counter digits line up. Needs >=11 accessors to trigger.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A { accessor x1 = "A"; }
+        class F1 { accessor a = 0; accessor b = 0; accessor c = 0; }
+        class F2 { accessor a = 0; accessor b = 0; accessor c = 0; }
+        class F3 { accessor a = 0; accessor b = 0; accessor c = 0; }
+        class K extends A {
+          accessor x = "K";
+          log() { console.log(this.x, super.x1); }
+        }
+        new K().log();
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("K A\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("accessor storage does not collide with a same-named digit-suffixed private field", async () => {
+      // Counter-first storage names (`_0_x`) can't equal a non-accessor private
+      // binding (`_x_0`): identifiers can't start with a digit, so the two
+      // namespaces are disjoint.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(t, c) { return t; }
+        class A {
+          @dec accessor #x = 1;
+          #x_0 = 2;
+          read() { return [this.#x, this.#x_0]; }
+        }
+        console.log(JSON.stringify(new A().read()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[1,2]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("fallback storage does not collide with an #accessor_storage private field", async () => {
+      // A non-identifier-keyed accessor uses the synthetic fallback, which is
+      // also counter-first (`_0_accessor_storage`), so it can't equal a field
+      // lowered to `_accessor_storage_0`.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(t, c) { return t; }
+        class A {
+          @dec accessor "foo-bar" = 1;
+          #accessor_storage_0 = 2;
+          read() { return [this["foo-bar"], this.#accessor_storage_0]; }
+        }
+        console.log(JSON.stringify(new A().read()));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[1,2]\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

```ts
class A { accessor name = "A" }
class B extends A {
  accessor name = "B"
  logName() { console.log(this.name); console.log(super.name) }
}
new B().logName()
// TypeError: Cannot add the same private member more than once
```

## Root cause

Each `accessor foo = ...` desugars to a getter/setter pair plus a module-scoped `var _foo = new WeakMap` as private storage. The storage name was derived solely from the property key, so A and B both emitted `var _name = new WeakMap` bound to the same symbol. `new B()` ran A's constructor-inject `__privateAdd(this, _name, "A")` via `super()`, then B's own `__privateAdd(this, _name, "B")` — same WeakMap, same `this` — throws.

## Fix

Give each accessor's WeakMap a unique name via a module-scoped counter on `P` (`accessor_storage_counter`). All three auto-accessor paths (undecorated, decorated-public, decorated-private) share it, so names stay unique across classes. A and B now emit `_0_name` / `_1_name`; `super.name` still reads from the first via A's getter, `this.name` from the second via B's.

Naming details:
- **Counter-first `_{n}_{key}`**: identifiers can't start with a digit, so accessor storage names (`_0_name`) are provably disjoint from the non-accessor private bindings this pass also emits (`_{ident}`), and the unique counter keeps accessor names mutually distinct. The synthetic fallback is counter-first too (`_{n}_accessor_storage`).
- **UTF-8 / identifier guard**: `accessor "foo-bar"` or `accessor "café"` would splice an invalid or UTF-16-backed key into the symbol name, so those fall back to the synthetic name.

## Files

- `src/js_parser/p.rs` — new `accessor_storage_counter` field on the parser.
- `src/js_parser/lower/lower_decorators.rs` — three auto-accessor paths updated; `bump_accessor_name` / `bump_accessor_name_with_suffix` helpers.
- `test/bundler/transpiler/es-decorators.test.ts` — 9 new cases under `auto-accessor in subclass`.

## Verification

`test/bundler/transpiler/es-decorators.test.ts` — new tests under `auto-accessor in subclass`:

- `subclass can override auto-accessor of same name` (issue #29837) — the exact repro, logs `"B"` then `"A"`.
- `multiple auto-accessors with same name across classes`.
- `decorated auto-accessor in subclass with same name`.
- `decorated private auto-accessor in subclass with same name` — `@dec accessor #x` in A and B.
- `auto-accessor with string key that is not a valid identifier` — `accessor "foo-bar"` falls back.
- `auto-accessor with non-ASCII string key` — `accessor "café"` falls back.
- `digit-suffixed key does not collide with later counter value`.
- `accessor storage does not collide with a same-named digit-suffixed private field` — `@dec accessor #x` + `#x_0`.
- `fallback storage does not collide with an #accessor_storage private field` — `@dec accessor "foo-bar"` + `#accessor_storage_0`.

All 56 `es-decorators` + 147 `es-decorators-esbuild` tests pass.

Fixes #29837.
