### PR TITLE
inspect: clear exceptions when walking Proxy prototype chain

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5445,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!nextProto)
+                break;
+            iterating = nextProto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,52 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("Proxy in prototype chain", () => {
+  it("does not crash when a Proxy prototype has a throwing getter", () => {
+    const obj = {};
+    const proto = {
+      get ok() {
+        return 1;
+      },
+      get bad() {
+        throw new Error("nope");
+      },
+      get ok2() {
+        return 2;
+      },
+    };
+    Object.setPrototypeOf(obj, new Proxy(proto, {}));
+    const out = Bun.inspect(obj);
+    expect(out).toContain("ok");
+  });
+
+  it("does not crash when a Proxy prototype has a throwing getPrototypeOf trap", () => {
+    class Foo {
+      bar() {}
+      baz() {}
+    }
+    const obj = new Foo();
+    const originalPrototype = Object.getPrototypeOf(obj);
+    const newPrototype = new Proxy(originalPrototype, {
+      getPrototypeOf() {
+        throw new Error("boom");
+      },
+    });
+    Object.setPrototypeOf(obj, newPrototype);
+    const out = Bun.inspect(obj);
+    expect(out).toContain("bar");
+    expect(out).toContain("baz");
+  });
+
+  it("does not crash when formatting an expect() object with a Proxy prototype", () => {
+    const received = expect({});
+    const originalPrototype = Object.getPrototypeOf(received);
+    Object.setPrototypeOf(received, new Proxy(originalPrototype, {}));
+    try {
+      expect(typeof Bun.inspect(received)).toBe("string");
+    } finally {
+      Object.setPrototypeOf(received, originalPrototype);
+    }
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -789,7 +789,8 @@ describe("Proxy in prototype chain", () => {
     };
     Object.setPrototypeOf(obj, new Proxy(proto, {}));
     const out = Bun.inspect(obj);
-    expect(out).toContain("ok");
+    expect(out).toContain("ok: 1");
+    expect(out).toContain("ok2: 2");
   });
 
   it("does not crash when a Proxy prototype has a throwing getPrototypeOf trap", () => {


### PR DESCRIPTION
Fixes a null-pointer crash in `Bun.inspect` / `console.log` when an object's prototype is a `Proxy` and property access through that proxy throws.

### Root cause

In the slow-path property enumeration loop of `forEachProperty`:

1. `getPropertySlot()` invokes the Proxy `[[Get]]` internal method, which eagerly calls getters on the target. If a getter throws, `getPropertySlot()` returns `false` with a pending exception.
2. The code did `if (!getPropertySlot(...)) continue;` — skipping past the `CLEAR_IF_EXCEPTION` that follows, leaving the exception pending.
3. At the end of the iteration, `iterating->getPrototype(globalObject)` is called with the exception still pending. On a `ProxyObject` this short-circuits and returns an empty `JSValue`, and `.getObject()` on an empty value dereferences a null `JSCell`.

Additionally, `getPrototype()` itself can throw when a Proxy has a throwing `getPrototypeOf` trap, with the same result.

### Fix

- Clear the exception before `continue` when `getPropertySlot()` fails.
- Guard the `getPrototype()` result: clear any exception and `break` on an empty value before calling `.getObject()`.

### Repro

```js
const obj = {};
const proto = {
  get ok() { return 1; },
  get bad() { throw new Error("nope"); },
  get ok2() { return 2; },
};
Object.setPrototypeOf(obj, new Proxy(proto, {}));
Bun.inspect(obj); // used to crash, now prints { ok: 1, ok2: 2 }
```