### PR TITLE
fs.watch(mac): hold loop.mutex in FSEvents _events_cb

### DIFF
--- a/src/bun.js/node/fs_events.zig
+++ b/src/bun.js/node/fs_events.zig
@@ -335,6 +335,15 @@ pub const FSEventsLoop = struct {
         var loop = bun.cast(*FSEventsLoop, info);
         const event_flags = bun.cast([*]FSEventStreamEventFlags, eventFlags);
 
+        // Hold the mutex for the whole iteration. `unregisterWatcher` on the
+        // main thread nulls the entry under this same mutex and then the
+        // caller immediately frees the FSEventsWatcher (and its path buffer),
+        // so without this lock we can read `handle.path` / call `handle.emit`
+        // on freed memory. Holding the lock also prevents `registerWatcher`
+        // from reallocating the `watchers` buffer mid-iteration.
+        loop.mutex.lock();
+        defer loop.mutex.unlock();
+
         for (loop.watchers.slice()) |watcher| {
             if (watcher) |handle| {
                 const handle_path = handle.path;
@@ -518,6 +527,16 @@ pub const FSEventsLoop = struct {
                     break;
                 }
             }
+        }
+
+        // Rebuild the FSEventStream on the CF thread so it stops firing for
+        // the path we just removed. Without this the stream keeps delivering
+        // events for freed paths until another register happens to
+        // reschedule. `_events_cb` tolerates the interim (it sees `null` and
+        // skips) because both sides hold `this.mutex`.
+        if (!this.has_scheduled_watchers) {
+            this.has_scheduled_watchers = true;
+            this.enqueueTaskConcurrent(Task.New(FSEventsLoop, _schedule).init(this));
         }
     }
 

--- a/test/js/node/watch/fs.watch.events-cb-race.test.ts
+++ b/test/js/node/watch/fs.watch.events-cb-race.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+
+// Regression test for FSEvents `_events_cb` iterating `loop.watchers`
+// without holding `loop.mutex`.
+//
+// `_events_cb` runs on the dedicated CoreFoundation thread. Before the fix
+// it sliced `loop.watchers` and dereferenced each `FSEventsWatcher` (reading
+// `handle.path`, calling `handle.emit`) without taking `loop.mutex`. At the
+// same time the JS thread can call `watcher.close()` → `FSEventsWatcher.deinit()`
+// → `unregisterWatcher()` (which nulls the entry under the mutex) and then
+// immediately `destroy()` the watcher and free its path buffer. Nothing
+// synchronised the in-flight CF-thread iteration with that destroy, so the
+// CF thread could read freed memory.
+//
+// The race window is small; this test floods the directory with writes
+// (so `_events_cb` fires continuously) while rapidly creating/closing
+// watchers on the same directory (so destroys land mid-iteration). Under
+// ASAN on an unpatched build this reliably reports heap-use-after-free.
+//
+// macOS-only: the FSEvents code path doesn't exist on other platforms.
+test.skipIf(!isMacOS)("FSEvents: closing watchers while events fire does not UAF", async () => {
+  using dir = tempDir("fsevents-events-cb-race", {
+    "a.txt": "x",
+    "b.txt": "x",
+    "c.txt": "x",
+  });
+
+  const script = /* js */ `
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.argv[1];
+
+    let writes = 0;
+    let stopped = false;
+
+    // Writer: hammer the directory so the CF thread's _events_cb fires
+    // as often as possible. Runs until we explicitly stop it.
+    function writeLoop() {
+      if (stopped) return;
+      try {
+        fs.writeFileSync(path.join(dir, "a.txt"), String(writes));
+        fs.writeFileSync(path.join(dir, "b.txt"), String(writes));
+        fs.writeFileSync(path.join(dir, "c.txt"), String(writes));
+      } catch {}
+      writes++;
+      setImmediate(writeLoop);
+    }
+    setImmediate(writeLoop);
+
+    // Churn watchers: each iteration creates a few watchers on the same
+    // directory (so the watchers list has multiple live entries, and
+    // registerWatcher may reallocate the backing buffer) then closes them
+    // on the next tick while _events_cb is likely mid-iteration.
+    const iterations = 400;
+    let i = 0;
+    function churn() {
+      if (i++ >= iterations) {
+        stopped = true;
+        // Let any in-flight CF callbacks drain before declaring success.
+        setTimeout(() => {
+          console.log("OK " + i + " " + writes);
+          process.exit(0);
+        }, 100);
+        return;
+      }
+      const ws = [];
+      for (let j = 0; j < 4; j++) {
+        ws.push(fs.watch(dir, () => {}));
+      }
+      setImmediate(() => {
+        for (const w of ws) w.close();
+        setImmediate(churn);
+      });
+    }
+    setImmediate(churn);
+
+    // Watchdog: if we deadlock or hang, bail with a distinctive message.
+    const wd = setTimeout(() => {
+      process.stderr.write("HUNG after 30s (i=" + i + ", writes=" + writes + ")\\n");
+      process.exit(1);
+    }, 30000);
+    wd.unref();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script, String(dir)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("HUNG");
+  expect(stdout).toStartWith("OK");
+  expect(exitCode).toBe(0);
+}, 60000);

--- a/test/js/node/watch/fs.watch.events-cb-race.test.ts
+++ b/test/js/node/watch/fs.watch.events-cb-race.test.ts
@@ -59,11 +59,10 @@ test.skipIf(!isMacOS)(
     function churn() {
       if (i++ >= iterations) {
         stopped = true;
-        // Let any in-flight CF callbacks drain before declaring success.
-        setTimeout(() => {
+        setImmediate(() => {
           console.log("OK " + i + " " + writes);
           process.exit(0);
-        }, 100);
+        });
         return;
       }
       const ws = [];

--- a/test/js/node/watch/fs.watch.events-cb-race.test.ts
+++ b/test/js/node/watch/fs.watch.events-cb-race.test.ts
@@ -19,14 +19,16 @@ import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 // ASAN on an unpatched build this reliably reports heap-use-after-free.
 //
 // macOS-only: the FSEvents code path doesn't exist on other platforms.
-test.skipIf(!isMacOS)("FSEvents: closing watchers while events fire does not UAF", async () => {
-  using dir = tempDir("fsevents-events-cb-race", {
-    "a.txt": "x",
-    "b.txt": "x",
-    "c.txt": "x",
-  });
+test.skipIf(!isMacOS)(
+  "FSEvents: closing watchers while events fire does not UAF",
+  async () => {
+    using dir = tempDir("fsevents-events-cb-race", {
+      "a.txt": "x",
+      "b.txt": "x",
+      "c.txt": "x",
+    });
 
-  const script = /* js */ `
+    const script = /* js */ `
     const fs = require("fs");
     const path = require("path");
     const dir = process.argv[1];
@@ -83,16 +85,18 @@ test.skipIf(!isMacOS)("FSEvents: closing watchers while events fire does not UAF
     wd.unref();
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script, String(dir)],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script, String(dir)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).not.toContain("HUNG");
-  expect(stdout).toStartWith("OK");
-  expect(exitCode).toBe(0);
-}, 60000);
+    expect(stderr).not.toContain("HUNG");
+    expect(stdout).toStartWith("OK");
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);


### PR DESCRIPTION
## What

Fix a use-after-free race on macOS where `FSEventsLoop._events_cb` iterated `loop.watchers` on the CoreFoundation thread without holding `loop.mutex`, while the JS thread could concurrently null and destroy an `FSEventsWatcher`.

## Why

`_events_cb` is registered as the `FSEventStream` callback and runs on the dedicated CF thread. It did:

```zig
for (loop.watchers.slice()) |watcher| {            // no lock
    if (watcher) |handle| {
        const handle_path = handle.path;           // UAF
        ...
        handle.emit(event_type.toEvent(path), is_file);
        handle.flush();
    }
}
```

Meanwhile on the JS thread, `watcher.close()` → `FSWatcher.detach()` → `PathWatcher.deinit()` → `FSEventsWatcher.deinit()` does:

```zig
loop.unregisterWatcher(this);   // locks mutex, sets watchers[i] = null, unlocks
bun.default_allocator.destroy(this);
```

…and `PathWatcher.deinit` then frees `resolved_path` (which `handle.path` aliases). Since `_events_cb` never took the mutex, `unregisterWatcher` could return and the watcher could be freed while the CF thread still held a live `handle` pointer and was reading `handle.path` / calling `handle.emit()`.

A concurrent `registerWatcher` could also reallocate the `BabyList` backing buffer while `_events_cb` held a slice into the old one.

`unregisterWatcher` also never rescheduled the `FSEventStream`, so after the last watcher on a path was removed the stream kept firing `_events_cb` for that path indefinitely.

## How

- `_events_cb` now holds `loop.mutex` for the entire iteration, matching `_schedule`. `unregisterWatcher` therefore blocks until the CF thread is done with the watcher, so by the time it returns (and the caller destroys the watcher + path) the CF thread is guaranteed to see `null` on the next pass.
- `unregisterWatcher` now enqueues `_schedule` (same coalescing as `registerWatcher`) so the `FSEventStream` is rebuilt without the removed path instead of firing for it forever.

Lock ordering is safe: the CF thread takes `loop.mutex` → `FSWatcher.mutex` (via `emit` → `refTask`). The JS thread's `close()` releases `FSWatcher.mutex` *before* calling `detach()` → `unregisterWatcher` (which takes `loop.mutex`), so there's no AB-BA cycle.

## Verification

Added `test/js/node/watch/fs.watch.events-cb-race.test.ts` (macOS-only) that floods a watched directory with writes while rapidly creating and closing watchers on it. Under ASAN on an unpatched build the CF thread hits heap-use-after-free; with the fix it completes cleanly.

`zig:check-all` passes on all targets. Existing `fs.watch.test.ts` and `fs.watch.deadlock.test.ts` still pass (the two permission-test failures in `fs.watch.test.ts` are pre-existing on main and happen because the container runs as root).