### PR TITLE
Fix panic in Bun.file().writer() with invalid path/fd option

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2817,8 +2817,11 @@ pub fn getWriter(
     };
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
-        stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        const parsed = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
+        if (parsed == .FileSink) {
+            stream_start = parsed;
+            stream_start.FileSink.input_path = input_path;
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -193,6 +193,24 @@ it("end does close when not backed by a file descriptor", async () => {
   await Bun.sleep(10); // For the file descriptor leak checker.
 });
 
+it("writer() with invalid path option does not crash", async () => {
+  const x = tmpdirSync();
+  const target = path.join(x, "invalid-path-opt.txt");
+  const writer = Bun.file(target).writer({ path: 123 } as any);
+  await writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(target).text()).toBe("hello");
+});
+
+it("writer() with invalid fd option does not crash", async () => {
+  const x = tmpdirSync();
+  const target = path.join(x, "invalid-fd-opt.txt");
+  const writer = Bun.file(target).writer({ fd: "nope" } as any);
+  await writer.write("world");
+  await writer.end();
+  expect(await Bun.file(target).text()).toBe("world");
+});
+
 it("write result is not cumulative", async () => {
   using _ = fileDescriptorLeakChecker();
   const x = tmpdirSync();


### PR DESCRIPTION
## What does this PR do?

Fixes a Zig union safety panic in `Blob.getWriter` (aka `Bun.file().writer()`).

When calling `Bun.file(path).writer({ path: <non-string> })` or `.writer({ fd: <non-integer> })`, `streams.Start.fromJSWithTag(.FileSink)` returns the `.err` union variant. The caller then unconditionally accessed `stream_start.FileSink.input_path`, triggering:

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
```

Since the user-provided `path`/`fd` in the options object is always overwritten with the Blob's own path/fd on the next line anyway, the fix is to only apply the parsed options when the result is actually `.FileSink`, and otherwise keep the default.

### Repro

```js
Bun.file("/tmp/x.txt").writer({ path: 123 });
```

Found by Fuzzilli. Fingerprint `ee73146868a1b3ca`.

## How did you verify your code works?

- Minimal repro no longer panics and writes correctly to the Blob's path
- `highWaterMark` option still works
- Added regression tests in `test/js/bun/util/filesink.test.ts`
- All 41 tests in `filesink.test.ts` pass