### PR TITLE
bake(DevServer): fix stale Assets.path_map index after swapRemove

### DIFF
--- a/src/bake/DevServer/Assets.zig
+++ b/src/bake/DevServer/Assets.zig
@@ -124,6 +124,18 @@ pub fn unrefByIndex(assets: *Assets, index: EntryIndex, dec_count: u32) void {
         assets.files.values()[index.get()].deref();
         assets.files.swapRemoveAt(index.get());
         _ = assets.refs.swapRemove(index.get());
+        // `swapRemove` moved the entry that was at the old last index into
+        // `index`'s slot. Any `path_map` value that still points at the old
+        // last index (now equal to `files.count()`) must be patched to point
+        // at the new slot, otherwise the next lookup for that path would read
+        // past the end of `files`/`refs`, or alias an unrelated asset if a
+        // new entry is appended afterwards.
+        const moved_from: u30 = @intCast(assets.files.count());
+        if (moved_from != index.get()) {
+            for (assets.path_map.values()) |*entry_index| {
+                if (entry_index.get() == moved_from) entry_index.* = index;
+            }
+        }
     }
 }
 

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -241,6 +241,74 @@ devTest("circular css imports handle hot reload", {
     await client.style(".b").color.expect.toBe("#00f");
   },
 });
+devTest("asset index stays valid after another css root is freed", {
+  // Two independent CSS roots each get an entry in `DevServer.Assets`.
+  // When the first one is freed (via a syntax error), its slot is removed
+  // with `swapRemoveAt`, which moves the second entry into the first slot.
+  // The second CSS file's `path_map` entry must be patched to the new slot
+  // so the next edit does not read past the end of the asset array.
+  files: {
+    "first.html": emptyHtmlFile({
+      styles: ["first.css"],
+      body: `<div class="first">hello</div>`,
+    }),
+    "second.html": emptyHtmlFile({
+      styles: ["second.css"],
+      body: `<div class="second">hello</div>`,
+    }),
+    "first.css": `
+      .first { color: red; }
+    `,
+    "second.css": `
+      .second { color: blue; }
+    `,
+  },
+  async test(dev) {
+    // Bundle /first before /second so that `first.css` is registered at
+    // a lower asset index than `second.css`.
+    {
+      await using c1 = await dev.client("/first");
+      await c1.style(".first").color.expect.toBe("red");
+    }
+    await using c2 = await dev.client("/second");
+    await c2.style(".second").color.expect.toBe("#00f");
+
+    // Failing `first.css` frees its asset slot via `unrefByPath`, which
+    // swap-removes it and moves the data for `second.css` into its slot.
+    await dev.write(
+      "first.css",
+      `
+        .first { color: red; }}
+      `,
+      { errors: null },
+    );
+
+    // Editing `second.css` now goes through `replacePath`, which looks up
+    // its `path_map` entry. Previously this index was stale (pointed at
+    // `files.len`), causing an out-of-bounds read into `refs`/`files`.
+    await dev.write(
+      "second.css",
+      `
+        .second { color: green; }
+      `,
+      { errors: null },
+    );
+    await c2.style(".second").color.expect.toBe("green");
+
+    // Fix the first file and ensure both pages still work afterwards.
+    await dev.write(
+      "first.css",
+      `
+        .first { color: yellow; }
+      `,
+    );
+    await c2.style(".second").color.expect.toBe("green");
+    {
+      await using c1 = await dev.client("/first");
+      await c1.style(".first").color.expect.toBe("#ff0");
+    }
+  },
+});
 devTest("multiple stylesheets importing same dependency", {
   files: {
     "first.html": emptyHtmlFile({


### PR DESCRIPTION
## What

`DevServer.Assets.path_map` maps absolute paths to an `EntryIndex` into the parallel `files` / `refs` arrays. `unrefByIndex` removes an entry with `swapRemoveAt` when its refcount hits zero, which moves the *last* entry into the freed slot and shrinks `len`. Other `path_map` entries that referenced the old last index were never patched, so the next lookup for those paths would index past the end of `files` / `refs`.

In safe builds this panics; in release it is an out-of-bounds heap read. Worse, the past-`len` slot still holds the *moved* entry's `*StaticRoute` (copied during the swap), so `replacePath`'s replace-in-place path `deref()`s the live route that `files.values()[new_slot]` still points at — leaving a dangling pointer that `onAssetRequest` later dereferences (`Invalid pointer tag`).

Fixes #21106

## Repro

With two independent CSS roots `first.css` (asset index 0) and `second.css` (asset index 1):

1. Introduce a syntax error in `first.css` → `IncrementalGraph.insertFailure` → `freeFileContent(.unref_css)` → `Assets.unrefByPath("first.css")` → refcount hits 0 → `files.swapRemoveAt(0)` moves `second.css`'s data to slot 0, `files.len == 1`. `path_map` still has `{ second.css → 1 }`.
2. Edit `second.css` → `Assets.replacePath("second.css", ...)` → `path_map` lookup returns index 1 → `refs.items[1]` on a slice of length 1.

```
panic(main thread): index out of bounds: index 1, len 1
bake.DevServer.Assets.replacePath
src/bake/DevServer/Assets.zig:62:30
```

## Fix

After `swapRemoveAt` moves the last entry into the freed slot, scan `path_map` and retarget any value that still points at the old last index (`files.count()` after the remove) to the new slot. When the removed entry was already last, nothing moved and no fixup is needed.

## Test

`test/bake/dev/css.test.ts` → *"asset index stays valid after another css root is freed"*: bundles `/first` then `/second`, fails `first.css` with a CSS parse error, then edits `second.css` and verifies the update applies and both pages still work afterwards.

- without fix (`bun bd`): panics with `index out of bounds: index 1, len 1` at `Assets.replacePath`
- with fix: passes along with the rest of `css.test.ts`
