### PR TITLE
udp: fix heap OOB in sendMany when connect state changes mid-iteration

### DIFF
--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -609,12 +609,21 @@ pub const UDPSocket = struct {
             return globalThis.throwInvalidArgumentType("sendMany", "first argument", "array");
         }
 
+        // Cache the connection state before doing anything that can run user JS.
+        // Array index getters, `port.valueOf()`, and `address.toString()` can all
+        // call back into JS and connect/disconnect/close this socket. If we re-read
+        // `this.connect_info` on every iteration, a mid-loop flip changes how
+        // `slice_idx` is computed and which branch writes into `payloads`/`lens`/
+        // `addr_ptrs`, producing out-of-bounds writes (unconnected -> connected) or
+        // uninitialized slots (connected -> disconnected) in the arena buffers.
+        const connected = this.connect_info != null;
+
         const array_len = try arg.getLength(globalThis);
-        if (this.connect_info == null and array_len % 3 != 0) {
+        if (!connected and array_len % 3 != 0) {
             return globalThis.throwInvalidArguments("Expected 3 arguments for each packet", .{});
         }
 
-        const len = if (this.connect_info == null) array_len / 3 else array_len;
+        const len = if (connected) array_len else array_len / 3;
 
         var arena = std.heap.ArenaAllocator.init(bun.default_allocator);
         defer arena.deinit();
@@ -633,8 +642,8 @@ pub const UDPSocket = struct {
             if (i >= array_len) {
                 return globalThis.throwInvalidArguments("Mismatch between array length property and number of items", .{});
             }
-            const slice_idx = if (this.connect_info == null) i / 3 else i;
-            if (this.connect_info != null or i % 3 == 0) {
+            const slice_idx = if (connected) i else i / 3;
+            if (connected or i % 3 == 0) {
                 const slice = brk: {
                     if (val.asArrayBuffer(globalThis)) |arrayBuffer| {
                         break :brk arrayBuffer.slice();
@@ -647,7 +656,7 @@ pub const UDPSocket = struct {
                 payloads[slice_idx] = slice.ptr;
                 lens[slice_idx] = slice.len;
             }
-            if (this.connect_info != null) {
+            if (connected) {
                 addr_ptrs[slice_idx] = null;
                 continue;
             }

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -636,7 +636,7 @@ pub const UDPSocket = struct {
 
         var iter = try arg.arrayIterator(globalThis);
 
-        var i: u16 = 0;
+        var i: u32 = 0;
         var port: JSValue = .zero;
         while (try iter.next()) |val| : (i += 1) {
             if (i >= array_len) {

--- a/test/js/bun/udp/sendMany-reentrancy-fixture.ts
+++ b/test/js/bun/udp/sendMany-reentrancy-fixture.ts
@@ -1,0 +1,124 @@
+// Regression fixture: UDPSocket.sendMany() must snapshot the connected/
+// disconnected state before iterating the payload array. Array index getters,
+// port `valueOf()`, and address `toString()` can all re-enter JS and call
+// connect()/disconnect() on the socket. If sendMany re-reads `connect_info` on
+// every iteration, a mid-loop flip changes how slice indices are computed and
+// either writes past the end of the payload/addr arena buffers (unconnected ->
+// connected) or leaves slots uninitialized (connected -> disconnected).
+import dgram from "node:dgram";
+
+const direction = process.argv[2];
+if (direction !== "connect" && direction !== "disconnect") {
+  console.error("usage: sendMany-reentrancy-fixture.ts <connect|disconnect>");
+  process.exit(2);
+}
+
+function once<T>(socket: dgram.Socket, event: string) {
+  return new Promise<T>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.once(event, (arg: T) => {
+      socket.removeListener("error", reject);
+      resolve(arg);
+    });
+  });
+}
+
+// Extract the underlying Bun.udpSocket() instance from a node:dgram Socket.
+function getBunSocket(socket: dgram.Socket): any {
+  for (const sym of Object.getOwnPropertySymbols(socket)) {
+    const v = (socket as any)[sym];
+    if (v && typeof v === "object" && v.handle && "socket" in v.handle) {
+      return v.handle.socket;
+    }
+  }
+  throw new Error("could not find Bun UDPSocket on dgram socket");
+}
+
+// Synchronous lookup: makes dgram.Socket#connect() set `connect_info` before
+// it returns, so it can run to completion inside a valueOf()/getter callback.
+const syncLookup: dgram.SocketOptions["lookup"] = (_host, opts: any, cb: any) => {
+  if (typeof opts === "function") cb = opts;
+  cb(null, "127.0.0.1", 4);
+};
+
+const target = dgram.createSocket({ type: "udp4", lookup: syncLookup });
+target.bind(0, "127.0.0.1");
+await once(target, "listening");
+const targetPort = target.address().port;
+
+const sock = dgram.createSocket({ type: "udp4", lookup: syncLookup });
+sock.bind(0, "127.0.0.1");
+await once(sock, "listening");
+
+let flipped = false;
+
+if (direction === "connect") {
+  // Unconnected socket: array is parsed as [payload, port, address] triples.
+  // 9 elements -> 3 packets -> arena buffers sized for 3 entries.
+  // The first port's valueOf() synchronously connects the socket; without the
+  // fix, iteration i=3 uses slice_idx = i = 3 and writes payloads[3] past the
+  // end of a 3-element slice.
+  const bunSocket = getBunSocket(sock);
+  const evilPort = {
+    valueOf() {
+      if (!flipped) {
+        flipped = true;
+        sock.connect(targetPort, "127.0.0.1");
+      }
+      return targetPort;
+    },
+  };
+  // prettier-ignore
+  const packets: unknown[] = [
+    "a", evilPort,   "127.0.0.1",
+    "b", targetPort, "127.0.0.1",
+    "c", targetPort, "127.0.0.1",
+  ];
+
+  try {
+    bunSocket.sendMany(packets);
+  } catch {
+    // A thrown error is acceptable (e.g. EISCONN once the socket is connected);
+    // the only thing that is not acceptable is a crash.
+  }
+} else {
+  // Connected socket: every element is a payload and arena buffers are sized
+  // for `array.length` entries. A getter on index 0 synchronously disconnects;
+  // without the fix, the remaining iterations interpret the array as
+  // [payload, port, address] triples and only fill slots 0..2, leaving slots
+  // 3..8 uninitialized before they are handed to the native send path.
+  sock.connect(targetPort, "127.0.0.1");
+  await once(sock, "connect");
+  const bunSocket = getBunSocket(sock);
+
+  // prettier-ignore
+  const packets: unknown[] = [
+    "a", targetPort, "127.0.0.1",
+    "b", targetPort, "127.0.0.1",
+    "c", targetPort, "127.0.0.1",
+  ];
+  Object.defineProperty(packets, 0, {
+    get() {
+      if (!flipped) {
+        flipped = true;
+        sock.disconnect();
+      }
+      return "a";
+    },
+  });
+
+  try {
+    bunSocket.sendMany(packets);
+  } catch {
+    // EDESTADDRREQ or similar is fine; crashing is not.
+  }
+}
+
+if (!flipped) throw new Error("re-entrant callback never ran");
+
+try {
+  sock.close();
+} catch {}
+target.close();
+
+console.log("OK");

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -253,7 +253,15 @@ describe("udpSocket()", () => {
             stdout: "pipe",
             stderr: "pipe",
           });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          const [stdout, rawStderr, exitCode] = await Promise.all([
+            proc.stdout.text(),
+            proc.stderr.text(),
+            proc.exited,
+          ]);
+          const stderr = rawStderr
+            .split("\n")
+            .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+            .join("\n");
           expect(stderr).toBe("");
           expect(stdout).toBe("OK\n");
           expect(exitCode).toBe(0);

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,6 +1,7 @@
 import { udpSocket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { disableAggressiveGCScope, randomPort } from "harness";
+import { bunEnv, bunExe, disableAggressiveGCScope, randomPort } from "harness";
+import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
 describe("udpSocket()", () => {
@@ -236,4 +237,29 @@ describe("udpSocket()", () => {
       });
     }
   }
+
+  // sendMany() iterates the input array and may run user JS (array index
+  // getters, port `valueOf()`, address `toString()`). That user JS can
+  // connect or disconnect the socket; sendMany must snapshot the connection
+  // state up front so the arena buffer indexing cannot change mid-loop.
+  describe("sendMany does not crash when the connection state changes during iteration", () => {
+    for (const direction of ["connect", "disconnect"] as const) {
+      test(
+        direction,
+        async () => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), path.join(import.meta.dir, "sendMany-reentrancy-fixture.ts"), direction],
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout).toBe("OK\n");
+          expect(exitCode).toBe(0);
+        },
+        30_000,
+      );
+    }
+  });
 });


### PR DESCRIPTION
## What

`UDPSocket.sendMany()` computed the arena buffer size from `this.connect_info` once, but then re-read `this.connect_info` on every loop iteration to compute `slice_idx` and pick the payload/port/address branch. The loop can run arbitrary user JS (array index getters, `port.valueOf()`, `address.toString()`), and that JS can synchronously flip `connect_info` via `node:dgram`'s `connect()` (with a synchronous custom `lookup`) or `disconnect()`.

- **unconnected → connected mid-loop**: `slice_idx` jumps from `i / 3` to `i`, and every remaining element is written into `payloads[i]` / `lens[i]` / `addr_ptrs[i]` past the end of buffers sized for `array_len / 3` entries — heap OOB write.
- **connected → disconnected mid-loop**: remaining iterations fill only every third slot, leaving the rest uninitialized before they are handed to `us_udp_socket_send` → garbage pointer dereference.

## Repro

```js
import dgram from "node:dgram";

// custom lookup that completes synchronously so connect() finishes inline
const sock = dgram.createSocket({
  type: "udp4",
  lookup: (_h, o, cb) => (typeof o === "function" ? o : cb)(null, "127.0.0.1", 4),
});
sock.bind(0, "127.0.0.1", () => {
  const bunSocket = sock[Object.getOwnPropertySymbols(sock).find(s => sock[s]?.handle?.socket)].handle.socket;
  const evilPort = {
    valueOf() { sock.connect(12345, "127.0.0.1"); return 12345; },
  };
  bunSocket.sendMany(["a", evilPort, "127.0.0.1", "b", 12345, "127.0.0.1", "c", 12345, "127.0.0.1"]);
});
```

Before (debug):
```
panic(main thread): index out of bounds: index 3, len 3
bun.js.api.bun.udp_socket.UDPSocket.sendMany
src/bun.js/api/bun/udp_socket.zig:647:25
```

The reverse direction (`disconnect()` inside an index-0 getter on a connected socket) SEGVs in `bsd_udp_setup_sendbuf` dereferencing an uninitialized 0xAA-pattern pointer.

## Fix

Snapshot `const connected = this.connect_info != null` once before iterating and use that local everywhere inside the loop. The arena indexing scheme is now fixed for the duration of the call regardless of what user JS does to the socket. If the socket ends up in a mismatched state by the time we reach the syscall, that surfaces as a clean `EISCONN` / `EDESTADDRREQ` error instead of memory corruption.

## Verification

Added `test/js/bun/udp/sendMany-reentrancy-fixture.ts` exercising both directions, spawned from `udp_socket.test.ts`.

- `git stash push -- src/ && bun bd test test/js/bun/udp/udp_socket.test.ts -t "connection state"` → **2 fail** (panic + ASAN SEGV)
- `git stash pop && bun bd test test/js/bun/udp/udp_socket.test.ts -t "connection state"` → **2 pass**
- Full `udp_socket.test.ts` (169 tests) and `dgram.test.ts` (29 tests) pass.