### PR TITLE
node:zlib: defer reset() while a threadpool write is in flight

### DIFF
--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -168,6 +168,7 @@ pub fn CompressionStream(comptime T: type) type {
 
             vm.eventLoop().runCallback(write_callback, global, this_value, &.{});
 
+            if (this.pending_reset) resetInternal(this, global, this_value);
             if (this.pending_close) _ = closeInternal(this);
         }
 
@@ -245,11 +246,25 @@ pub fn CompressionStream(comptime T: type) type {
         }
 
         pub fn reset(this: *T, globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) jsc.JSValue {
+            resetInternal(this, globalThis, callframe.this());
+            return .js_undefined;
+        }
+
+        fn resetInternal(this: *T, globalThis: *jsc.JSGlobalObject, this_value: jsc.JSValue) void {
+            // reset() destroys and re-creates the brotli/zstd encoder state (or
+            // mutates the z_stream). Doing so while an async write is running on
+            // the threadpool would be a use-after-free / data race, so defer it
+            // until the in-flight write completes (mirrors pending_close).
+            if (this.write_in_progress) {
+                this.pending_reset = true;
+                return;
+            }
+            this.pending_reset = false;
+            if (this.closed) return;
             const err = this.stream.reset();
             if (err.isError()) {
-                emitError(this, globalThis, callframe.this(), err);
+                emitError(this, globalThis, this_value, err);
             }
-            return .js_undefined;
         }
 
         pub fn close(this: *T, globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {

--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -317,6 +317,7 @@ pub fn CompressionStream(comptime T: type) type {
             vm.eventLoop().runCallback(callback, globalThis, this_value, &.{ msg_value, err_value, code_value });
 
             this.write_in_progress = false;
+            if (this.pending_reset) resetInternal(this, globalThis, this_value);
             if (this.pending_close) _ = closeInternal(this);
         }
 

--- a/src/bun.js/node/zlib/NativeBrotli.zig
+++ b/src/bun.js/node/zlib/NativeBrotli.zig
@@ -25,6 +25,7 @@ poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
+pending_reset: bool = false,
 closed: bool = false,
 task: jsc.WorkPoolTask = .{ .callback = undefined },
 

--- a/src/bun.js/node/zlib/NativeZlib.zig
+++ b/src/bun.js/node/zlib/NativeZlib.zig
@@ -25,6 +25,7 @@ poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
+pending_reset: bool = false,
 closed: bool = false,
 task: jsc.WorkPoolTask = .{ .callback = undefined },
 

--- a/src/bun.js/node/zlib/NativeZstd.zig
+++ b/src/bun.js/node/zlib/NativeZstd.zig
@@ -25,6 +25,7 @@ poll_ref: CountedKeepAlive = .{},
 this_value: jsc.Strong.Optional = .empty,
 write_in_progress: bool = false,
 pending_close: bool = false,
+pending_reset: bool = false,
 closed: bool = false,
 task: jsc.WorkPoolTask = .{ .callback = undefined },
 

--- a/test/js/node/zlib/zlib-reset-race.test.ts
+++ b/test/js/node/zlib/zlib-reset-race.test.ts
@@ -1,0 +1,128 @@
+// Regression test: calling .reset() on a zlib/brotli/zstd stream while an
+// async write is running on the threadpool must not use-after-free the
+// encoder state.
+//
+// Before the fix, CompressionStream.reset() called this.stream.reset()
+// unconditionally, which for brotli/zstd destroys and re-creates the encoder
+// instance and for zlib calls deflateReset()/inflateReset(). If the
+// threadpool thread was concurrently inside doWork() operating on that state,
+// zstd would read freed memory (heap-use-after-free under ASAN) and brotli
+// would silently corrupt or fail compression.
+//
+// After the fix, reset() is deferred until the in-flight write completes
+// (mirroring pending_close).
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const zstdFixture = /* js */ `
+  const zlib = require("zlib");
+  const crypto = require("crypto");
+
+  // Random data at a high compression level so each threadpool job is slow
+  // enough that reset() lands while ZSTD_compressStream2 is still running.
+  const buf = crypto.randomBytes(4 * 1024 * 1024);
+
+  let remaining = 0;
+  for (let i = 0; i < 8; i++) {
+    remaining++;
+    const z = zlib.createZstdCompress({
+      chunkSize: 4 * 1024 * 1024,
+      params: { [zlib.constants.ZSTD_c_compressionLevel]: 19 },
+    });
+    z.on("error", () => {});
+    z.on("data", () => {});
+    z.write(buf, () => {
+      z.end();
+      if (--remaining === 0) console.log("OK");
+    });
+    // Spin briefly so the threadpool starts ZSTD_compressStream2 before reset().
+    const start = Date.now();
+    while (Date.now() - start < 30) {}
+    // Before the fix this frees the ZSTD_CCtx while the worker thread is
+    // inside ZSTD_compressStream2 -> heap-use-after-free under ASAN.
+    z.reset();
+  }
+`;
+
+const brotliFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const buf = Buffer.alloc(8 * 1024 * 1024, "abcdefgh");
+
+  let remaining = 0;
+  for (let i = 0; i < 8; i++) {
+    remaining++;
+    const z = zlib.createBrotliCompress({
+      chunkSize: 1024 * 1024,
+      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 },
+    });
+    z.on("error", () => {});
+    z.on("data", () => {});
+    z.write(buf, () => {
+      z.end();
+      if (--remaining === 0) console.log("OK");
+    });
+    const start = Date.now();
+    while (Date.now() - start < 10) {}
+    // Before the fix this frees the BrotliEncoderState while the worker
+    // thread is inside BrotliEncoderCompressStream.
+    z.reset();
+  }
+`;
+
+const deflateFixture = /* js */ `
+  const zlib = require("zlib");
+  const crypto = require("crypto");
+
+  const buf = crypto.randomBytes(4 * 1024 * 1024);
+
+  let remaining = 0;
+  for (let i = 0; i < 8; i++) {
+    remaining++;
+    const z = zlib.createDeflate({ chunkSize: 4 * 1024 * 1024, level: 9 });
+    z.on("error", () => {});
+    z.on("data", () => {});
+    z.write(buf, () => {
+      z.end();
+      if (--remaining === 0) console.log("OK");
+    });
+    const start = Date.now();
+    while (Date.now() - start < 10) {}
+    // Before the fix this calls deflateReset() on the z_stream while the
+    // worker thread is inside deflate() -> data race / state corruption.
+    z.reset();
+  }
+`;
+
+async function run(fixture: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test("zstd: reset() while an async write is in flight does not use-after-free", async () => {
+  const { stdout, stderr, exitCode } = await run(zstdFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 60_000);
+
+test("brotli: reset() while an async write is in flight does not use-after-free", async () => {
+  const { stdout, stderr, exitCode } = await run(brotliFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 60_000);
+
+test("deflate: reset() while an async write is in flight does not race", async () => {
+  const { stdout, stderr, exitCode } = await run(deflateFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/node/zlib/zlib-reset-race.test.ts
+++ b/test/js/node/zlib/zlib-reset-race.test.ts
@@ -21,13 +21,13 @@ const zstdFixture = /* js */ `
 
   // Random data at a high compression level so each threadpool job is slow
   // enough that reset() lands while ZSTD_compressStream2 is still running.
-  const buf = crypto.randomBytes(4 * 1024 * 1024);
+  const buf = crypto.randomBytes(1024 * 1024);
 
   let remaining = 0;
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < 4; i++) {
     remaining++;
     const z = zlib.createZstdCompress({
-      chunkSize: 4 * 1024 * 1024,
+      chunkSize: 1024 * 1024,
       params: { [zlib.constants.ZSTD_c_compressionLevel]: 19 },
     });
     z.on("error", () => {});
@@ -48,10 +48,10 @@ const zstdFixture = /* js */ `
 const brotliFixture = /* js */ `
   const zlib = require("zlib");
 
-  const buf = Buffer.alloc(8 * 1024 * 1024, "abcdefgh");
+  const buf = Buffer.alloc(2 * 1024 * 1024, "abcdefgh");
 
   let remaining = 0;
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < 4; i++) {
     remaining++;
     const z = zlib.createBrotliCompress({
       chunkSize: 1024 * 1024,
@@ -75,12 +75,12 @@ const deflateFixture = /* js */ `
   const zlib = require("zlib");
   const crypto = require("crypto");
 
-  const buf = crypto.randomBytes(4 * 1024 * 1024);
+  const buf = crypto.randomBytes(2 * 1024 * 1024);
 
   let remaining = 0;
-  for (let i = 0; i < 8; i++) {
+  for (let i = 0; i < 4; i++) {
     remaining++;
-    const z = zlib.createDeflate({ chunkSize: 4 * 1024 * 1024, level: 9 });
+    const z = zlib.createDeflate({ chunkSize: 2 * 1024 * 1024, level: 9 });
     z.on("error", () => {});
     z.on("data", () => {});
     z.write(buf, () => {
@@ -95,6 +95,11 @@ const deflateFixture = /* js */ `
   }
 `;
 
+// These tests are intentionally sequential (not test.concurrent): each
+// subprocess launches several threadpool compression jobs at high quality
+// levels, and running three of them at once makes individual test wall
+// times highly variable under CPU contention. Sequential keeps each test
+// comfortably under the default timeout.
 async function run(fixture: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
@@ -111,18 +116,18 @@ test("zstd: reset() while an async write is in flight does not use-after-free", 
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-}, 60_000);
+});
 
 test("brotli: reset() while an async write is in flight does not use-after-free", async () => {
   const { stdout, stderr, exitCode } = await run(brotliFixture);
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-}, 60_000);
+});
 
 test("deflate: reset() while an async write is in flight does not race", async () => {
   const { stdout, stderr, exitCode } = await run(deflateFixture);
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
-}, 60_000);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a heap-use-after-free when `.reset()` is called on a `node:zlib` stream (zlib / brotli / zstd) while an async `.write()` is still running on the threadpool.

## Reproduction

```js
const zlib = require('zlib');
const z = zlib.createZstdCompress({
  chunkSize: 4 * 1024 * 1024,
  params: { [zlib.constants.ZSTD_c_compressionLevel]: 19 },
});
z.write(require('crypto').randomBytes(4 * 1024 * 1024));
// spin briefly so the threadpool picks up the job
const t = Date.now(); while (Date.now() - t < 30) {}
z.reset(); // ← frees ZSTD_CCtx while worker thread is inside ZSTD_compressStream2
```

Under ASAN:
```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 4 ... thread T11 (Bun Pool 0)
  in ZSTD_compressStream2 → NativeZstd.Context.doWork
     → CompressionStream.AsyncJob.run (threadpool)
freed by thread T0:
  in ZSTD_freeCCtx → NativeZstd.Context.deinitState
     → NativeZstd.Context.reset → CompressionStream.reset (JS thread)
```

## Root cause

`CompressionStream.reset()` in `src/bun.js/node/node_zlib_binding.zig` called `this.stream.reset()` unconditionally with no `write_in_progress` guard.

- **brotli** (`NativeBrotli.Context.reset`): calls `BrotliEncoderDestroyInstance` / `BrotliDecoderDestroyInstance` on the state pointer, then creates a new one. If the threadpool thread is inside `BrotliEncoderCompressStream` with the old pointer → UAF.
- **zstd** (`NativeZstd.Context.reset`): calls `ZSTD_freeCCtx` / `ZSTD_freeDCtx`, same UAF.
- **zlib** (`NativeZlib.Context.reset`): calls `deflateReset` / `inflateReset` on the same `z_stream` that the threadpool thread is running `deflate()` / `inflate()` on → data race on `internal_state` (also surfaces as heap-use-after-free under ASAN because zlib's internal state is heap-allocated and `deflateReset` reinitializes it).

`close()` already handled this correctly by deferring via `pending_close`; `reset()` did not.

## Fix

Mirror the `pending_close` pattern for `reset()`:
- Add `pending_reset: bool` to each native handle.
- If `write_in_progress`, set `pending_reset` and return without touching the stream.
- After the in-flight write's callback returns in `runFromJSThread`, if `pending_reset` is set, perform the reset (re-deferring if the callback scheduled another write).
- Also skip the reset if the stream was closed in the meantime.

## How did you verify your code works?

Added `test/js/node/zlib/zlib-reset-race.test.ts` which spawns subprocesses that race `.write()` against `.reset()` for zstd, brotli, and deflate. Without the fix, all three fail under the debug/ASAN build with heap-use-after-free; with the fix, all three complete cleanly.

`test-zlib-reset-before-write.js` and the rest of the node:zlib suite still pass.