### PR TITLE
Free param_map in MatchedRoute.deinit()

### DIFF
--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -450,6 +450,9 @@ pub const MatchedRoute = struct {
         if (this.query_string_map) |*map| {
             map.deinit();
         }
+        if (this.param_map) |*map| {
+            map.deinit();
+        }
         if (this.needs_deinit) {
             if (this.route.pathname.len > 0 and bun.mimalloc.mi_is_in_heap_region(this.route.pathname.ptr)) {
                 bun.mimalloc.mi_free(@constCast(this.route.pathname.ptr));

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1,7 +1,7 @@
 import { FileSystemRouter } from "bun";
 import { expect, it } from "bun:test";
 import fs, { mkdirSync, rmSync } from "fs";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import path, { dirname } from "path";
 
 function createTree(basedir: string, paths: string[]) {
@@ -468,3 +468,45 @@ it("origin should be validated", async () => {
     });
   }).toThrow("Expected origin to be a string");
 });
+
+it("MatchedRoute.params does not leak", async () => {
+  using dir = tempDir("fsr-params-leak", {
+    "pages/[a]/[b]/[c]/[d].tsx": "export default 1;",
+  });
+
+  // Each match()+.params access lazily allocates a QueryStringMap (param name/value
+  // buffer + MultiArrayList of params) which must be freed when the MatchedRoute is
+  // garbage-collected. Use long segment values so any leak is large enough to
+  // dominate RSS noise.
+  const code = /* ts */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(path.join(String(dir), "pages"))},
+      style: "nextjs",
+      fileExtensions: [".tsx"],
+    });
+    const seg = "x".repeat(512);
+    const url = "/" + seg + "/" + seg + "/" + seg + "/" + seg;
+
+    // warm up
+    for (let i = 0; i < 1000; i++) router.match(url).params;
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+
+    for (let i = 0; i < 30000; i++) router.match(url).params;
+    Bun.gc(true);
+    const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+    console.error("RSS growth: " + growthMB.toFixed(2) + "MB");
+    if (growthMB > 20) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("leaked");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## What

`MatchedRoute` has two optional `QueryStringMap` fields: `query_string_map` and `param_map`. `deinit()` only freed the first one.

`param_map` is lazily allocated by the cached `.params` getter via `QueryStringMap.initWithScanner`, which heap-allocates a `Param.List` (MultiArrayList) and a `u8` buffer. When the `MatchedRoute` is garbage-collected, `finalize()` → `deinit()` never released these, so every `router.match(path).params` access on a dynamic route leaked.

## Repro

```js
const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
for (let i = 0; i < 30000; i++) router.match("/" + seg + "/" + seg + "/" + seg + "/" + seg).params;
Bun.gc(true);
// RSS grows ~90MB
```

## Fix

Call `param_map.deinit()` alongside `query_string_map.deinit()`.

## Verification

| | RSS growth (30k matches, 4×512-byte segments) |
|---|---|
| before | ~89–95 MB |
| after | ~7 MB |

Added an RSS-growth test to `test/js/bun/util/filesystem_router.test.ts` that spawns a subprocess, warms up, measures RSS delta over 30k iterations, and asserts <20MB growth.