### PR TITLE
fs.watch: fix resolved_path leak on macOS FSEvents path

### DIFF
--- a/src/bun.js/node/path_watcher.zig
+++ b/src/bun.js/node/path_watcher.zig
@@ -795,7 +795,6 @@ pub const PathWatcher = struct {
                     bun.default_allocator.destroy(this);
                     return err;
                 };
-                this.resolved_path = resolved_path;
                 this.* = PathWatcher{
                     .path = path,
                     .callback = callback,
@@ -806,6 +805,7 @@ pub const PathWatcher = struct {
                         updateEndCallback,
                         bun.cast(*anyopaque, ctx),
                     ) catch |err| {
+                        bun.default_allocator.free(resolved_path);
                         bun.default_allocator.destroy(this);
                         return err;
                     },
@@ -815,6 +815,7 @@ pub const PathWatcher = struct {
                     .file_paths = .{},
                     .ctx = ctx,
                     .mutex = .{},
+                    .resolved_path = resolved_path,
                 };
 
                 errdefer this.deinit();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -793,24 +793,22 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
 // `null`. PathWatcher.deinit()'s `if (this.resolved_path) |p| free(p)` was
 // therefore a no-op, and FSEventsWatcher.deinit() does not own the buffer
 // either. Every fs.watch(<directory>) on macOS leaked ~path-length bytes.
-test.skipIf(!isMacOS)(
-  "fs.watch(dir) on macOS does not leak the resolved FSEvents path",
-  async () => {
-    // Use long nested directory names so the resolved absolute path (and thus
-    // the per-watch leak) is large enough to show up in RSS within a reasonable
-    // number of iterations.
-    const seg = Buffer.alloc(200, "p").toString();
-    using dir = tempDir("fs-watch-fsevents-leak", {
-      [`${seg}/${seg}/${seg}/.keep`]: "x",
-    });
-    const watchDir = path.join(String(dir), seg, seg, seg);
+test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvents path", async () => {
+  // Use long nested directory names so the resolved absolute path (and thus
+  // the per-watch leak) is large enough to show up in RSS within a reasonable
+  // number of iterations.
+  const seg = Buffer.alloc(200, "p").toString();
+  using dir = tempDir("fs-watch-fsevents-leak", {
+    [`${seg}/${seg}/${seg}/.keep`]: "x",
+  });
+  const watchDir = path.join(String(dir), seg, seg, seg);
 
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "--smol",
-        "-e",
-        /* ts */ `
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      /* ts */ `
         const fs = require("fs");
         const dir = process.argv[1];
 
@@ -832,18 +830,16 @@ test.skipIf(!isMacOS)(
           throw new Error("fs.watch(dir) leaked " + growthMB.toFixed(2) + " MB");
         }
       `,
-        watchDir,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+      watchDir,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(stdout).toContain("RSS growth:");
-    expect(exitCode).toBe(0);
-  },
-  60000,
-);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("RSS growth:");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from "bun";
-import { bunEnv, bunExe, bunRun, bunRunAsScript, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, bunRunAsScript, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
 import fs, { FSWatcher } from "node:fs";
 import path from "path";
 
@@ -786,3 +786,60 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0); // unpatched: exitCode is 3 (Windows segfault)
 });
+
+// The FSEvents path in PathWatcher.init() dupeZ's the resolved directory path
+// into `resolved_path`, but then immediately overwrote `this.*` with a struct
+// literal that did not include `.resolved_path`, resetting it to its default
+// `null`. PathWatcher.deinit()'s `if (this.resolved_path) |p| free(p)` was
+// therefore a no-op, and FSEventsWatcher.deinit() does not own the buffer
+// either. Every fs.watch(<directory>) on macOS leaked ~path-length bytes.
+test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvents path", async () => {
+  // Use long nested directory names so the resolved absolute path (and thus
+  // the per-watch leak) is large enough to show up in RSS within a reasonable
+  // number of iterations.
+  const seg = Buffer.alloc(200, "p").toString();
+  using dir = tempDir("fs-watch-fsevents-leak", {
+    [`${seg}/${seg}/${seg}/.keep`]: "x",
+  });
+  const watchDir = path.join(String(dir), seg, seg, seg);
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      /* ts */ `
+        const fs = require("fs");
+        const dir = process.argv[1];
+
+        // Warm up: let the FSEvents loop thread, mimalloc pools, and the
+        // PathWatcherManager fd cache reach steady state.
+        for (let i = 0; i < 2000; i++) fs.watch(dir, () => {}).close();
+        Bun.gc(true);
+        const before = process.memoryUsage.rss();
+
+        // With a ~700-byte resolved path, 20000 leaked dupeZ buffers is
+        // well over 10 MB of growth on unpatched builds.
+        for (let i = 0; i < 20000; i++) fs.watch(dir, () => {}).close();
+        Bun.gc(true);
+        const after = process.memoryUsage.rss();
+
+        const growthMB = (after - before) / 1024 / 1024;
+        console.log("RSS growth: " + growthMB.toFixed(2) + " MB");
+        if (growthMB > 8) {
+          throw new Error("fs.watch(dir) leaked " + growthMB.toFixed(2) + " MB");
+        }
+      `,
+      watchDir,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("RSS growth:");
+  expect(exitCode).toBe(0);
+}, 60000);

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -793,22 +793,24 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
 // `null`. PathWatcher.deinit()'s `if (this.resolved_path) |p| free(p)` was
 // therefore a no-op, and FSEventsWatcher.deinit() does not own the buffer
 // either. Every fs.watch(<directory>) on macOS leaked ~path-length bytes.
-test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvents path", async () => {
-  // Use long nested directory names so the resolved absolute path (and thus
-  // the per-watch leak) is large enough to show up in RSS within a reasonable
-  // number of iterations.
-  const seg = Buffer.alloc(200, "p").toString();
-  using dir = tempDir("fs-watch-fsevents-leak", {
-    [`${seg}/${seg}/${seg}/.keep`]: "x",
-  });
-  const watchDir = path.join(String(dir), seg, seg, seg);
+test.skipIf(!isMacOS)(
+  "fs.watch(dir) on macOS does not leak the resolved FSEvents path",
+  async () => {
+    // Use long nested directory names so the resolved absolute path (and thus
+    // the per-watch leak) is large enough to show up in RSS within a reasonable
+    // number of iterations.
+    const seg = Buffer.alloc(200, "p").toString();
+    using dir = tempDir("fs-watch-fsevents-leak", {
+      [`${seg}/${seg}/${seg}/.keep`]: "x",
+    });
+    const watchDir = path.join(String(dir), seg, seg, seg);
 
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "--smol",
-      "-e",
-      /* ts */ `
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--smol",
+        "-e",
+        /* ts */ `
         const fs = require("fs");
         const dir = process.argv[1];
 
@@ -830,16 +832,18 @@ test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvent
           throw new Error("fs.watch(dir) leaked " + growthMB.toFixed(2) + " MB");
         }
       `,
-      watchDir,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+        watchDir,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toContain("RSS growth:");
-  expect(exitCode).toBe(0);
-}, 60000);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("RSS growth:");
+    expect(exitCode).toBe(0);
+  },
+  60000,
+);


### PR DESCRIPTION
## What

`PathWatcher.init()` on macOS (the FSEvents code path for watching directories) leaked the `dupeZ`'d resolved path on every `fs.watch(<directory>)` call.

## Why

```zig
const resolved_path = bun.default_allocator.dupeZ(u8, resolved_path_temp) catch ...;
this.resolved_path = resolved_path;            // (1) assigned here
this.* = PathWatcher{                           // (2) then immediately overwritten
    .path = path,
    .callback = callback,
    .fsevents_watcher = FSEvents.watch(resolved_path, ...) catch |err| {
        bun.default_allocator.destroy(this);    // (3) also leaks resolved_path on error
        return err;
    },
    ...
    // .resolved_path NOT included -> reset to default null
};
```

The assignment at (1) is immediately clobbered by the struct literal at (2), which doesn't set `.resolved_path`, so the field falls back to its declared default `null`. `PathWatcher.deinit()` then sees `resolved_path == null` and never frees the buffer. `FSEventsWatcher` borrows the slice but doesn't own or free it either.

## Fix

- Include `.resolved_path = resolved_path` in the struct literal so `deinit()` actually frees it.
- Drop the dead pre-assignment.
- Free `resolved_path` in the `FSEvents.watch()` error path before destroying `this`.

## Verification

- `bun run zig:check-all` — compiles on all targets (macOS x64/arm64 debug+release included).
- Added a macOS-only RSS leak test in `test/js/node/watch/fs.watch.test.ts` that does 20k `fs.watch(dir).close()` cycles on a ~700-byte path; unpatched builds leak >10 MB, patched builds stay flat.
- Existing `fs.watch` tests unaffected on Linux.