### PR TITLE
server: fix UAF of Sec-WebSocket-Protocol/Extensions in onUpgrade

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -781,6 +781,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 var sec_websocket_protocol = ZigString.Empty;
                 var sec_websocket_extensions = ZigString.Empty;
 
+                // Owned backing storage for the above when they come from options.headers.
+                // fastGet returns a ZigString that borrows from the header map entry's
+                // StringImpl, which fastRemove then frees — so we must copy the bytes
+                // before removing the entry.
+                var sec_websocket_protocol_owned = ZigString.Slice.empty;
+                defer sec_websocket_protocol_owned.deinit();
+                var sec_websocket_extensions_owned = ZigString.Slice.empty;
+                defer sec_websocket_extensions_owned.deinit();
+
                 if (optional) |opts| {
                     getter: {
                         if (opts.isEmptyOrUndefinedOrNull()) {
@@ -824,13 +833,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             }
 
                             if (fetch_headers_to_use.fastGet(.SecWebSocketProtocol)) |protocol| {
-                                sec_websocket_protocol = protocol;
+                                // Clone before fastRemove frees the backing StringImpl.
+                                sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                                sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
                                 // Remove from headers so it's not written twice (once here and once by upgrade())
                                 fetch_headers_to_use.fastRemove(.SecWebSocketProtocol);
                             }
 
-                            if (fetch_headers_to_use.fastGet(.SecWebSocketExtensions)) |protocol| {
-                                sec_websocket_extensions = protocol;
+                            if (fetch_headers_to_use.fastGet(.SecWebSocketExtensions)) |extensions| {
+                                // Clone before fastRemove frees the backing StringImpl.
+                                sec_websocket_extensions_owned = bun.handleOom(extensions.toSliceClone(bun.default_allocator));
+                                sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
                                 // Remove from headers so it's not written twice (once here and once by upgrade())
                                 fetch_headers_to_use.fastRemove(.SecWebSocketExtensions);
                             }
@@ -914,6 +927,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 }
             }
 
+            // Owned backing storage for sec_websocket_protocol/extensions when they come
+            // from options.headers. fastGet returns a ZigString that borrows from the header
+            // map entry's StringImpl, which fastRemove then frees — so we must copy the
+            // bytes before removing the entry.
+            var sec_websocket_protocol_owned = ZigString.Slice.empty;
+            defer sec_websocket_protocol_owned.deinit();
+            var sec_websocket_extensions_owned = ZigString.Slice.empty;
+            defer sec_websocket_extensions_owned.deinit();
+
             var fetch_headers_to_use: ?*WebCore.FetchHeaders = null;
 
             if (optional) |opts| {
@@ -959,13 +981,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         }
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol)) |protocol| {
-                            sec_websocket_protocol = protocol;
+                            // Clone before fastRemove frees the backing StringImpl.
+                            sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                            sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
                             // Remove from headers so it's not written twice (once here and once by upgrade())
                             fetch_headers_to_use.?.fastRemove(.SecWebSocketProtocol);
                         }
 
-                        if (fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions)) |protocol| {
-                            sec_websocket_extensions = protocol;
+                        if (fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions)) |extensions| {
+                            // Clone before fastRemove frees the backing StringImpl.
+                            sec_websocket_extensions_owned = bun.handleOom(extensions.toSliceClone(bun.default_allocator));
+                            sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
                             // Remove from headers so it's not written twice (once here and once by upgrade())
                             fetch_headers_to_use.?.fastRemove(.SecWebSocketExtensions);
                         }

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1065,3 +1065,77 @@ it("you can call server.subscriberCount() when its not a websocket server", asyn
   });
   expect(server.subscriberCount("boop")).toBe(0);
 });
+
+// Regression: onUpgrade stored the ZigString returned by FetchHeaders.fastGet()
+// (which borrows directly from the header map entry's WTF::StringImpl) and then
+// called fastRemove(), which frees that StringImpl when the map holds the only
+// reference. The dangling pointer was later read in toSlice() and written to the
+// socket as the Sec-WebSocket-Protocol response header.
+//
+// To make the map entry the sole owner of the StringImpl (so fastRemove actually
+// frees it), we append() twice: the second append causes FetchHeaders to combine
+// the values with ", " via makeString(), producing a fresh StringImpl that no JS
+// string references. `Malloc=1` routes bmalloc through the system allocator so
+// ASAN-enabled builds detect the use-after-free; release builds fall through and
+// validate the header value round-trips correctly.
+it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use-after-free the header value", async () => {
+  const part = Buffer.alloc(128, "abcdefghijklmnopqrstuvwxyz0123456789").toString();
+
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const part = ${JSON.stringify(part)};
+        using server = Bun.serve({
+          port: 0,
+          websocket: { message() {} },
+          fetch(req, server) {
+            const h = new Headers();
+            // Double-append so the stored value is a freshly-combined StringImpl
+            // owned solely by the header map.
+            h.append("Sec-WebSocket-Protocol", part);
+            h.append("Sec-WebSocket-Protocol", "tail");
+            h.set("X-Custom", "hello");
+            if (server.upgrade(req, { headers: h })) return;
+            return new Response("no upgrade", { status: 400 });
+          },
+        });
+        const res = await fetch(server.url, {
+          headers: {
+            "Upgrade": "websocket",
+            "Connection": "Upgrade",
+            "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+            "Sec-WebSocket-Version": "13",
+            "Sec-WebSocket-Protocol": "client-offered",
+          },
+        });
+        console.log(JSON.stringify({
+          status: res.status,
+          protocol: res.headers.get("sec-websocket-protocol"),
+          custom: res.headers.get("x-custom"),
+        }));
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      // Route bmalloc through the system heap so ASAN can observe the
+      // StringImpl allocation in sanitizer-enabled builds.
+      Malloc: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // uWS selects the first subprotocol (substring before the first comma) from
+  // the value passed to resp.upgrade(), so the expected response protocol is
+  // `part`, not the combined "part, tail".
+  const expected = JSON.stringify({ status: 101, protocol: part, custom: "hello" });
+  expect({ stdout: stdout.trim(), stderr: stderr.split("\n", 3).join("\n").trim() }).toEqual({
+    stdout: expected,
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## Problem

`onUpgrade` in `src/bun.js/api/server.zig` reads `Sec-WebSocket-Protocol` / `Sec-WebSocket-Extensions` from the user's upgrade headers via `FetchHeaders.fastGet`, then immediately calls `fastRemove` on the same entry so the header isn't written twice.

`fastGet` returns a `ZigString` whose pointer borrows directly from the header map entry's `WTF::StringImpl` buffer (no ref taken). `fastRemove` erases the map entry, dropping the last reference and freeing that `StringImpl` when nothing else holds one. The dangling `ZigString` is then dereferenced later in `toSlice()` and the freed bytes are written to the socket via `resp.upgrade()`.

Introduced in 12243b971 (#26118).

## Repro

```js
using server = Bun.serve({
  port: 0,
  websocket: { message() {} },
  fetch(req, server) {
    const h = new Headers();
    h.append("Sec-WebSocket-Protocol", "a".repeat(128));
    h.append("Sec-WebSocket-Protocol", "tail"); // map now solely owns the combined StringImpl
    if (server.upgrade(req, { headers: h })) return;
    return new Response("no", { status: 400 });
  },
});
await fetch(server.url, {
  headers: {
    Upgrade: "websocket", Connection: "Upgrade",
    "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
    "Sec-WebSocket-Version": "13", "Sec-WebSocket-Protocol": "x",
  },
});
```

With `Malloc=1` (routes bmalloc through the system allocator) under an ASAN build:

```
==ERROR: AddressSanitizer: heap-use-after-free
  #6 ZigString.toSlice             src/bun.js/bindings/ZigString.zig:677
  #7 server.onUpgrade              src/bun.js/api/server.zig:1020
```

## Fix

Clone the header value into an owned `ZigString.Slice` via `toSliceClone` **before** calling `fastRemove`, and point the `ZigString` at the owned buffer. The owned slice is freed by `defer` at scope exit, so the later `toSlice()` / `resp.upgrade()` read valid memory. Applied to both the `Bun.serve` Request path and the `node:http` upgrade path.

## Verification

- New regression test in `test/js/bun/websocket/websocket-server.test.ts` double-appends `Sec-WebSocket-Protocol` so the combined `makeString` result is solely owned by the header map, and runs the subprocess with `Malloc=1` so ASAN observes the `StringImpl` allocation.
- `git stash -- src/ && bun bd test <file> -t 'does not use-after-free'` → **FAIL** (`AddressSanitizer: heap-use-after-free`)
- `git stash pop && bun bd test <file> -t 'does not use-after-free'` → **PASS**
- `test/regression/issue/3613.test.ts` (original #26118 fix) still passes.