### PR TITLE
zstd: free partial output buffer when streaming decompression fails

### DIFF
--- a/src/deps/zstd.zig
+++ b/src/deps/zstd.zig
@@ -53,6 +53,9 @@ pub fn decompressAlloc(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
     // 2. Reported size exceeds safety limit (to prevent malicious inputs claiming huge sizes)
     if (size == ZSTD_CONTENTSIZE_UNKNOWN or size > MAX_PREALLOCATE_SIZE) {
         var list = std.ArrayListUnmanaged(u8){};
+        // `reader.deinit()` below does not free `list`; free it ourselves on any error
+        // (init failure, readAll failure, or toOwnedSlice failure).
+        errdefer list.deinit(allocator);
         const reader = try ZstdReaderArrayList.init(src, &list, allocator);
         defer reader.deinit();
 
@@ -67,10 +70,8 @@ pub fn decompressAlloc(allocator: std.mem.Allocator, src: []const u8) ![]u8 {
     const result = decompress(output, src);
     return switch (result) {
         .success => |actual_size| output[0..actual_size],
-        .err => {
-            allocator.free(output);
-            return error.DecompressionFailed;
-        },
+        // `output` is freed by the errdefer above.
+        .err => error.DecompressionFailed,
     };
 }
 

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -34,50 +34,46 @@ describe("Zstandard compression", async () => {
     expect(() => zstdDecompressSync(valid)).toThrow();
   });
 
-  it(
-    "does not leak on streaming decompression error (unknown content size + corrupt stream)",
-    () => {
-      // Zstd frame header with content size *unknown* so decompressAlloc takes the streaming path:
-      //   28 B5 2F FD - magic
-      //   00          - Frame_Header_Descriptor: FCS_flag=0, Single_Segment=0 → content size not present
-      //   58          - Window_Descriptor
-      // followed by garbage block data so ZSTD_decompressStream errors after the output buffer
-      // has already been allocated.
-      const bad = Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+  it("does not leak on streaming decompression error (unknown content size + corrupt stream)", () => {
+    // Zstd frame header with content size *unknown* so decompressAlloc takes the streaming path:
+    //   28 B5 2F FD - magic
+    //   00          - Frame_Header_Descriptor: FCS_flag=0, Single_Segment=0 → content size not present
+    //   58          - Window_Descriptor
+    // followed by garbage block data so ZSTD_decompressStream errors after the output buffer
+    // has already been allocated.
+    const bad = Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
 
-      // Ensure this input actually hits the streaming error path (not InvalidZstdData / fast path).
-      expect(() => zstdDecompressSync(bad)).toThrowError(/ZstdDecompressionError/);
+    // Ensure this input actually hits the streaming error path (not InvalidZstdData / fast path).
+    expect(() => zstdDecompressSync(bad)).toThrowError(/ZstdDecompressionError/);
 
-      const iterations = 10000;
-      function batch() {
-        for (let i = 0; i < iterations; i++) {
-          try {
-            zstdDecompressSync(bad);
-          } catch {}
-        }
-        Bun.gc(true);
-        return process.memoryUsage.rss();
+    const iterations = 10000;
+    function batch() {
+      for (let i = 0; i < iterations; i++) {
+        try {
+          zstdDecompressSync(bad);
+        } catch {}
       }
+      Bun.gc(true);
+      return process.memoryUsage.rss();
+    }
 
-      // Warm up until RSS stabilizes (allocator / ASAN quarantine reach steady state).
-      // Without the fix each call leaks the ~4 KiB partial output buffer, so growth never
-      // converges and every batch adds ~40+ MiB.
-      let prev = batch();
-      let growthMiB = Infinity;
-      for (let round = 0; round < 5; round++) {
-        const cur = batch();
-        growthMiB = (cur - prev) / 1024 / 1024;
-        prev = cur;
-        if (growthMiB < 10) break;
-      }
+    // Warm up until RSS stabilizes (allocator / ASAN quarantine reach steady state).
+    // Without the fix each call leaks the ~4 KiB partial output buffer, so growth never
+    // converges and every batch adds ~40+ MiB.
+    let prev = batch();
+    let growthMiB = Infinity;
+    for (let round = 0; round < 5; round++) {
+      const cur = batch();
+      growthMiB = (cur - prev) / 1024 / 1024;
+      prev = cur;
+      if (growthMiB < 10) break;
+    }
 
-      expect(
-        growthMiB,
-        `RSS grew by ${growthMiB.toFixed(1)} MiB over ${iterations} failed zstd decompressions after warmup`,
-      ).toBeLessThan(10);
-    },
-    60_000,
-  );
+    expect(
+      growthMiB,
+      `RSS grew by ${growthMiB.toFixed(1)} MiB over ${iterations} failed zstd decompressions after warmup`,
+    ).toBeLessThan(10);
+  }, 60_000);
 
   // Test with known zstd-compressed data
   describe("zstd CLI compatibility", () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -34,6 +34,51 @@ describe("Zstandard compression", async () => {
     expect(() => zstdDecompressSync(valid)).toThrow();
   });
 
+  it(
+    "does not leak on streaming decompression error (unknown content size + corrupt stream)",
+    () => {
+      // Zstd frame header with content size *unknown* so decompressAlloc takes the streaming path:
+      //   28 B5 2F FD - magic
+      //   00          - Frame_Header_Descriptor: FCS_flag=0, Single_Segment=0 → content size not present
+      //   58          - Window_Descriptor
+      // followed by garbage block data so ZSTD_decompressStream errors after the output buffer
+      // has already been allocated.
+      const bad = Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+      // Ensure this input actually hits the streaming error path (not InvalidZstdData / fast path).
+      expect(() => zstdDecompressSync(bad)).toThrowError(/ZstdDecompressionError/);
+
+      const iterations = 10000;
+      function batch() {
+        for (let i = 0; i < iterations; i++) {
+          try {
+            zstdDecompressSync(bad);
+          } catch {}
+        }
+        Bun.gc(true);
+        return process.memoryUsage.rss();
+      }
+
+      // Warm up until RSS stabilizes (allocator / ASAN quarantine reach steady state).
+      // Without the fix each call leaks the ~4 KiB partial output buffer, so growth never
+      // converges and every batch adds ~40+ MiB.
+      let prev = batch();
+      let growthMiB = Infinity;
+      for (let round = 0; round < 5; round++) {
+        const cur = batch();
+        growthMiB = (cur - prev) / 1024 / 1024;
+        prev = cur;
+        if (growthMiB < 10) break;
+      }
+
+      expect(
+        growthMiB,
+        `RSS grew by ${growthMiB.toFixed(1)} MiB over ${iterations} failed zstd decompressions after warmup`,
+      ).toBeLessThan(10);
+    },
+    60_000,
+  );
+
   // Test with known zstd-compressed data
   describe("zstd CLI compatibility", () => {
     for (const { name, compressed, original } of [


### PR DESCRIPTION
## What

`bun.zstd.decompressAlloc` leaks its partial output buffer when streaming decompression fails, and double-frees the output buffer when fast-path decompression fails.

## Repro

```js
// frame header with unknown content size → streaming path; corrupt block → error
const bad = Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
for (let i = 0; i < 20000; i++) try { Bun.zstdDecompressSync(bad); } catch {}
// RSS +~100 MiB
```

## Cause

The streaming path in `decompressAlloc` (taken when frame content size is unknown or >16 MiB) creates an `ArrayListUnmanaged` and passes it to `ZstdReaderArrayList`. `readAll()` grows the list via `ensureUnusedCapacity(4096)` *before* calling `ZSTD_decompressStream`, so when the stream is corrupt/truncated and `readAll()` returns `error.ZstdDecompressionError`, the list already owns memory. `reader.deinit()` frees only the dstream and the reader struct — not the list — and there was no `errdefer` on the list itself, so each failed `Bun.zstdDecompressSync` / `Bun.zstdDecompress` call leaked the buffer.

Separately, the known-size fast path had both `errdefer allocator.free(output)` and an explicit `allocator.free(output)` in the `.err` branch right before `return error.DecompressionFailed`, which is a double-free on that error return.

## Fix

- Add `errdefer list.deinit(allocator)` in the streaming path so the partial buffer is freed if `init`, `readAll`, or `toOwnedSlice` fail.
- Remove the redundant explicit free in the fast-path `.err` branch; the `errdefer` already handles it.

## Verification

New leak test in `test/js/bun/util/zstd.test.ts` crafts a zstd frame with unknown content size followed by a corrupt block, calls `zstdDecompressSync` in batches of 10k, and asserts RSS growth converges below 10 MiB per batch after warmup.

- Without fix: ~48 MiB growth per 10k iterations, never converges → FAIL
- With fix: converges to <1 MiB per batch → PASS

Full `zstd.test.ts` suite and `test/regression/issue/23314/` pass.