### PR TITLE
Free FFI struct and native resources in finalize()

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -104,6 +104,19 @@ extern "C" void Bun__FFIFunction_setDataPtr(JSC::EncodedJSValue jsValue, void* p
     function->dataPtr = ptr;
 }
 
+extern "C" void Bun__FFIFunction_setOwner(Zig::GlobalObject* globalObject, JSC::EncodedJSValue jsValue, JSC::EncodedJSValue owner)
+{
+    Zig::JSFFIFunction* function = dynamicDowncast<Zig::JSFFIFunction>(JSC::JSValue::decode(jsValue));
+    if (!function)
+        return;
+
+    JSC::JSObject* ownerObject = JSC::JSValue::decode(owner).getObject();
+    if (!ownerObject)
+        return;
+
+    function->m_owner.set(globalObject->vm(), function, ownerObject);
+}
+
 extern "C" JSC::EncodedJSValue Bun__CreateFFIFunctionValue(Zig::GlobalObject* globalObject, const ZigString* symbolName, unsigned argCount, Zig::FFIFunction functionPointer, bool addPtrField, void* symbolFromDynamicLibrary)
 {
     if (addPtrField) {
@@ -139,6 +152,7 @@ void JSFFIFunction::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     JSFFIFunction* thisObject = uncheckedDowncast<JSFFIFunction>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    visitor.append(thisObject->m_owner);
 }
 
 DEFINE_VISIT_CHILDREN(JSFFIFunction);

--- a/src/jsc/bindings/JSFFIFunction.h
+++ b/src/jsc/bindings/JSFFIFunction.h
@@ -89,6 +89,12 @@ public:
     void* dataPtr;
     void* symbolFromDynamicLibrary { nullptr };
 
+    // Keeps the owning FFI wrapper (the result of dlopen/linkSymbols/cc)
+    // alive for as long as this function is reachable. The wrapper owns the
+    // TCC-relocated trampoline memory that m_function points into, so if it
+    // were collected first the next call would jump into freed memory.
+    JSC::WriteBarrier<JSC::JSObject> m_owner;
+
 private:
     JSFFIFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, CFFIFunction&&);
     void finishCreation(VM&, NativeExecutable*, unsigned length, const String& name);

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -66,7 +66,32 @@ pub const FFI = struct {
     closed: bool = false,
     shared_state: ?*TCC.State = null,
 
-    pub fn finalize(_: *FFI) callconv(.c) void {}
+    pub fn finalize(this: *FFI) callconv(.c) void {
+        this.deinit();
+        bun.destroy(this);
+    }
+
+    fn deinit(this: *FFI) void {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+
+        if (this.dylib) |*dylib| {
+            dylib.close();
+            this.dylib = null;
+        }
+
+        if (this.shared_state) |state| {
+            this.shared_state = null;
+            state.deinit();
+        }
+
+        for (this.functions.values()) |*val| {
+            val.deinit();
+        }
+        this.functions.deinit(bun.default_allocator);
+    }
 
     const CompileC = struct {
         source: Source = .{ .file = "" },
@@ -815,13 +840,11 @@ pub const FFI = struct {
             }
         }
 
-        // TODO: pub const new = bun.TrivialNew(FFI)
-        var lib = bun.handleOom(bun.default_allocator.create(FFI));
-        lib.* = .{
+        const lib = bun.new(FFI, .{
             .dylib = null,
             .shared_state = tcc_state,
             .functions = compile_c.symbols.map,
-        };
+        });
         tcc_state = null;
         compile_c.symbols = .{};
 
@@ -831,8 +854,9 @@ pub const FFI = struct {
     }
 
     pub fn closeCallback(globalThis: *JSGlobalObject, ctx: JSValue) JSValue {
+        _ = globalThis;
         var function: *Function = @ptrFromInt(ctx.asPtrAddress());
-        function.deinit(globalThis);
+        function.deinit();
         return .js_undefined;
     }
 
@@ -866,12 +890,12 @@ pub const FFI = struct {
             .failed => |err| {
                 const message = ZigString.init(err.msg).toErrorInstance(globalThis);
 
-                func.deinit(globalThis);
+                func.deinit();
 
                 return message;
             },
             .pending => {
-                func.deinit(globalThis);
+                func.deinit();
                 return ZigString.init("Failed to compile, but not sure why. Please report this bug").toErrorInstance(globalThis);
             },
             .compiled => {
@@ -890,31 +914,11 @@ pub const FFI = struct {
 
     pub fn close(
         this: *FFI,
-        globalThis: *jsc.JSGlobalObject,
+        _: *jsc.JSGlobalObject,
         _: *jsc.CallFrame,
     ) bun.JSError!JSValue {
         jsc.markBinding(@src());
-        if (this.closed) {
-            return .js_undefined;
-        }
-        this.closed = true;
-        if (this.dylib) |*dylib| {
-            dylib.close();
-            this.dylib = null;
-        }
-
-        if (this.shared_state) |state| {
-            this.shared_state = null;
-            state.deinit();
-        }
-
-        const allocator = VirtualMachine.get().allocator;
-
-        for (this.functions.values()) |*val| {
-            val.deinit(globalThis);
-        }
-        this.functions.deinit(allocator);
-
+        this.deinit();
         return .js_undefined;
     }
 
@@ -1128,7 +1132,7 @@ pub const FFI = struct {
                     name,
                 });
                 for (symbols.values()) |*value| {
-                    value.deinit(global);
+                    value.deinit();
                 }
                 symbols.clearAndFree(bun.default_allocator);
                 dylib.close();
@@ -1137,7 +1141,7 @@ pub const FFI = struct {
             switch (function.step) {
                 .failed => |err| {
                     defer for (symbols.values()) |*other_function| {
-                        other_function.deinit(global);
+                        other_function.deinit();
                     };
 
                     const res = ZigString.init(err.msg).toErrorInstance(global);
@@ -1147,7 +1151,7 @@ pub const FFI = struct {
                 },
                 .pending => {
                     for (symbols.values()) |*other_function| {
-                        other_function.deinit(global);
+                        other_function.deinit();
                     }
                     symbols.clearAndFree(bun.default_allocator);
                     dylib.close();
@@ -1236,7 +1240,7 @@ pub const FFI = struct {
                     bun.asByteSlice(function_name),
                 });
                 for (symbols.values()) |*value| {
-                    value.deinit(global);
+                    value.deinit();
                 }
                 symbols.clearAndFree(allocator);
                 return ret;
@@ -1249,7 +1253,7 @@ pub const FFI = struct {
                     }
 
                     const res = ZigString.init(err.msg).toErrorInstance(global);
-                    function.deinit(global);
+                    function.deinit();
                     symbols.clearAndFree(allocator);
                     return res;
                 },
@@ -1460,7 +1464,7 @@ pub const FFI = struct {
 
         extern "c" fn FFICallbackFunctionWrapper_destroy(*anyopaque) void;
 
-        pub fn deinit(val: *Function, globalThis: *jsc.JSGlobalObject) void {
+        pub fn deinit(val: *Function) void {
             jsc.markBinding(@src());
 
             if (val.base_name) |base_name| {
@@ -1477,10 +1481,7 @@ pub const FFI = struct {
             }
 
             if (val.step == .compiled) {
-                if (val.step.compiled.js_function != .zero) {
-                    _ = globalThis;
-                    val.step.compiled.js_function = .zero;
-                }
+                val.step.compiled.js_function = .zero;
 
                 if (val.step.compiled.ffi_callback_function_wrapper) |wrapper| {
                     FFICallbackFunctionWrapper_destroy(wrapper);

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -71,6 +71,22 @@ pub const FFI = struct {
         bun.destroy(this);
     }
 
+    extern "c" fn Bun__FFIFunction_setOwner(*JSGlobalObject, jsc.JSValue, jsc.JSValue) void;
+
+    /// Each compiled symbol is exposed as a JSFFIFunction whose native entry
+    /// point lives in TCC-relocated (or dlopen'd) memory owned by this FFI
+    /// wrapper. Give every such function a strong GC edge back to the
+    /// wrapper so that extracting a symbol and dropping the wrapper (the
+    /// documented `const { symbols: { fn } } = dlopen(...)` pattern) cannot
+    /// let finalize() free the code page while `fn` is still callable.
+    fn setFunctionOwners(this: *FFI, globalThis: *JSGlobalObject, js_object: jsc.JSValue) void {
+        for (this.functions.values()) |*function| {
+            if (function.step == .compiled and function.step.compiled.js_function != .zero) {
+                Bun__FFIFunction_setOwner(globalThis, function.step.compiled.js_function, js_object);
+            }
+        }
+    }
+
     fn deinit(this: *FFI) void {
         if (this.closed) {
             return;
@@ -849,6 +865,7 @@ pub const FFI = struct {
         compile_c.symbols = .{};
 
         const js_object = lib.toJS(globalThis);
+        lib.setFunctionOwners(globalThis, js_object);
         jsc.Codegen.JSFFI.symbolsValueSetCached(js_object, globalThis, obj);
         return js_object;
     }
@@ -1179,6 +1196,7 @@ pub const FFI = struct {
         });
 
         const js_object = lib.toJS(global);
+        lib.setFunctionOwners(global, js_object);
         jsc.Codegen.JSFFI.symbolsValueSetCached(js_object, global, obj);
         return js_object;
     }
@@ -1289,6 +1307,7 @@ pub const FFI = struct {
         });
 
         const js_object = lib.toJS(global);
+        lib.setFunctionOwners(global, js_object);
         jsc.Codegen.JSFFI.symbolsValueSetCached(js_object, global, obj);
         return js_object;
     }

--- a/test/js/bun/ffi/ffi-leak.test.ts
+++ b/test/js/bun/ffi/ffi-leak.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isArm64, isWindows } from "harness";
+
+// TinyCC (and therefore JSCallback/linkSymbols) is unavailable on Windows aarch64.
+const isFFIUnavailable = isWindows && isArm64;
 
 // Each linkSymbols() call allocates a native FFI struct plus per-symbol
 // TinyCC compiler state. Before the fix, FFI.finalize() was empty, so none
@@ -8,7 +11,7 @@ import { bunEnv, bunExe } from "harness";
 // We GC periodically so that, when finalize() does its job, the freed
 // native memory is reused by the next batch and RSS stays flat. When
 // finalize() is a no-op the TCC state simply piles up and RSS climbs.
-test("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
+test.skipIf(isFFIUnavailable)("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
   const code = /* js */ `
     const { linkSymbols, JSCallback } = require("bun:ffi");
 
@@ -58,7 +61,7 @@ test("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
 // trampoline while the symbol is still callable. The JSFFIFunction keeps a
 // strong reference to the wrapper so it survives GC until every symbol is
 // unreachable.
-test("extracted symbol keeps FFI wrapper alive across GC", async () => {
+test.skipIf(isFFIUnavailable)("extracted symbol keeps FFI wrapper alive across GC", async () => {
   const code = /* js */ `
     const { linkSymbols, JSCallback } = require("bun:ffi");
     const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });

--- a/test/js/bun/ffi/ffi-leak.test.ts
+++ b/test/js/bun/ffi/ffi-leak.test.ts
@@ -11,8 +11,10 @@ const isFFIUnavailable = isWindows && isArm64;
 // We GC periodically so that, when finalize() does its job, the freed
 // native memory is reused by the next batch and RSS stays flat. When
 // finalize() is a no-op the TCC state simply piles up and RSS climbs.
-test.skipIf(isFFIUnavailable)("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
-  const code = /* js */ `
+test.skipIf(isFFIUnavailable)(
+  "linkSymbols() does not leak FFI struct and TCC state on GC",
+  async () => {
+    const code = /* js */ `
     const { linkSymbols, JSCallback } = require("bun:ffi");
 
     const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
@@ -40,22 +42,24 @@ test.skipIf(isFFIUnavailable)("linkSymbols() does not leak FFI struct and TCC st
     cb.close();
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", "-e", code],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  const { growthMB } = JSON.parse(stdout.trim());
-  // Without the finalize fix this grows >30 MB (release) / >100 MB (debug+ASAN).
-  // With the fix it stays under ~10 MB.
-  expect(growthMB).toBeLessThan(25);
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(stderr).toBe("");
+    const { growthMB } = JSON.parse(stdout.trim());
+    // Without the finalize fix this grows >30 MB (release) / >100 MB (debug+ASAN).
+    // With the fix it stays under ~10 MB.
+    expect(growthMB).toBeLessThan(25);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
 
 // Extracting a symbol and dropping the FFI wrapper must not free the TCC
 // trampoline while the symbol is still callable. The JSFFIFunction keeps a

--- a/test/js/bun/ffi/ffi-leak.test.ts
+++ b/test/js/bun/ffi/ffi-leak.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Each linkSymbols() call allocates a native FFI struct plus per-symbol
+// TinyCC compiler state. Before the fix, FFI.finalize() was empty, so none
+// of that memory was released when the JS wrapper was garbage collected.
+//
+// We GC periodically so that, when finalize() does its job, the freed
+// native memory is reused by the next batch and RSS stays flat. When
+// finalize() is a no-op the TCC state simply piles up and RSS climbs.
+test("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
+  const code = /* js */ `
+    const { linkSymbols, JSCallback } = require("bun:ffi");
+
+    const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+    const ptr = cb.ptr;
+
+    function churn(iterations) {
+      for (let i = 0; i < iterations; i++) {
+        linkSymbols({
+          fn: { returns: "int32_t", args: [], ptr },
+        });
+        if (i % 100 === 0) Bun.gc(true);
+      }
+      Bun.gc(true);
+    }
+
+    // Warm up: let the allocator and JIT stabilise.
+    churn(500);
+    const before = process.memoryUsage.rss();
+    churn(3000);
+    const after = process.memoryUsage.rss();
+
+    const growthMB = (after - before) / 1024 / 1024;
+    console.log(JSON.stringify({ growthMB }));
+
+    cb.close();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { growthMB } = JSON.parse(stdout.trim());
+  // Without the finalize fix this grows ~50 MB (release) / ~90 MB (debug+ASAN).
+  // With the fix it stays under ~10 MB.
+  expect(growthMB).toBeLessThan(30);
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/bun/ffi/ffi-leak.test.ts
+++ b/test/js/bun/ffi/ffi-leak.test.ts
@@ -26,9 +26,9 @@ test("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
     }
 
     // Warm up: let the allocator and JIT stabilise.
-    churn(500);
+    churn(300);
     const before = process.memoryUsage.rss();
-    churn(3000);
+    churn(2000);
     const after = process.memoryUsage.rss();
 
     const growthMB = (after - before) / 1024 / 1024;
@@ -48,8 +48,45 @@ test("linkSymbols() does not leak FFI struct and TCC state on GC", async () => {
 
   expect(stderr).toBe("");
   const { growthMB } = JSON.parse(stdout.trim());
-  // Without the finalize fix this grows ~50 MB (release) / ~90 MB (debug+ASAN).
+  // Without the finalize fix this grows >30 MB (release) / >100 MB (debug+ASAN).
   // With the fix it stays under ~10 MB.
-  expect(growthMB).toBeLessThan(30);
+  expect(growthMB).toBeLessThan(25);
   expect(exitCode).toBe(0);
-}, 60_000);
+}, 30_000);
+
+// Extracting a symbol and dropping the FFI wrapper must not free the TCC
+// trampoline while the symbol is still callable. The JSFFIFunction keeps a
+// strong reference to the wrapper so it survives GC until every symbol is
+// unreachable.
+test("extracted symbol keeps FFI wrapper alive across GC", async () => {
+  const code = /* js */ `
+    const { linkSymbols, JSCallback } = require("bun:ffi");
+    const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
+
+    globalThis.fn = (function () {
+      return linkSymbols({ fn: { returns: "int32_t", args: [], ptr: cb.ptr } }).symbols.fn;
+    })();
+
+    for (let i = 0; i < 10; i++) Bun.gc(true);
+
+    // With the wrapper collected this would jump into freed code.
+    for (let i = 0; i < 100; i++) {
+      if (fn() !== 42) throw new Error("wrong result");
+    }
+    console.log("ok");
+    cb.close();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ok");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`FFI.finalize()` at `src/bun.js/api/ffi.zig:69` was an empty function:

```zig
pub fn finalize(_: *FFI) callconv(.c) void {}
```

`ffi.classes.ts` sets `finalize: true`, so the generated C++ destructor calls into this Zig function expecting it to free the native struct and any owned resources. Since it did nothing:

- the heap `FFI` struct (from `bun.new(FFI, ...)`) was leaked on every GC of a `dlopen()` / `cc()` / `linkSymbols()` result
- if the user never called `.close()` first, the dylib handle, the shared TCC state, and every per-symbol TCC compiler state + `arg_types` array leaked as well

## Repro

```js
const { linkSymbols, JSCallback } = require("bun:ffi");
const cb = new JSCallback(() => 42, { returns: "int32_t", args: [] });
for (let i = 0; i < 20000; i++) {
  linkSymbols({ fn: { returns: "int32_t", args: [], ptr: cb.ptr } });
  if (i % 100 === 0) Bun.gc(true);
}
```

RSS grows ~315 MB on release / ~230 MB on debug+ASAN over 20k calls.

## Fix

### Release resources in `finalize()`
- Extract the cleanup from `close()` into a private `deinit()` (same dylib/TCC/functions teardown, guarded by `closed`).
- `finalize()` now calls `deinit()` then `bun.destroy(this)`.
- Drop the unused `globalThis` parameter from `Function.deinit()` (it was literally `_ = globalThis;`) so it can be invoked from the finalizer.
- Switch the `cc()` allocation site from `default_allocator.create(FFI)` to `bun.new(FFI, ...)` so it pairs with `bun.destroy()`.

### Keep the wrapper alive while any symbol is reachable
Tearing down TCC/dylib memory is only safe once every `JSFFIFunction` that points into it is unreachable, but the documented pattern `const { symbols: { fn } } = dlopen(...)` drops the wrapper immediately. `JSFFIFunction` held only a raw entry-point pointer with no GC edge back to the wrapper, so GC could run `finalize()` and unmap the trampoline while `fn` was still callable (segfaulted `test/napi/napi-value-ffi.test.ts`).

- Add `WriteBarrier<JSObject> m_owner` to `JSFFIFunction`, visited in `visitChildren`.
- After `lib.toJS()` in each of `dlopen`/`cc`/`linkSymbols`, point every compiled symbol's `m_owner` at the FFI wrapper via a new `Bun__FFIFunction_setOwner`.
- The wrapper is now kept alive as long as any extracted symbol is; `finalize()` only runs once the last one is collected.

## Verification

`test/js/bun/ffi/ffi-leak.test.ts` has two tests:
1. churns 2000 `linkSymbols()` calls with periodic GC and asserts RSS growth < 25 MB (before: >30 MB release / >100 MB debug+ASAN; after: <10 MB)
2. extracts a symbol, drops the wrapper, forces GC, then calls the symbol 100× — this segfaulted without the owner edge

`BUN_DEBUG_alloc=1` shows a matching `destroy(FFI)` for every `new(FFI)`, and the wrapper survives GC while an extracted symbol is held:

```
[alloc] new(FFI) = ...@70e85d0b0050
result: 42
[alloc] destroy(FFI) = ...@70e85d0b0050   // only after fn is dropped
```

All existing `test/js/bun/ffi/*` tests pass.
