### PR TITLE
Add BUN_DIE_WITH_PARENT env var: exit when parent process dies

### DIFF
--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -24,8 +24,7 @@ const exit_code: u8 = 128 + 1;
 pub fn install() void {
     if (comptime !Environment.isPosix) return;
 
-    const raw = bun.getenvZ("BUN_DIE_WITH_PARENT") orelse return;
-    if (raw.len == 0 or std.mem.eql(u8, raw, "0") or std.mem.eql(u8, raw, "false")) return;
+    if (!bun.env_var.BUN_DIE_WITH_PARENT.get()) return;
 
     const original_ppid = std.c.getppid();
     // Already orphaned (parent died before we got here, or launchd/init
@@ -41,10 +40,12 @@ pub fn install() void {
 
 fn installLinux(original_ppid: std.c.pid_t) void {
     if (comptime !Environment.isLinux) unreachable;
-    // PR_SET_PDEATHSIG: kernel sends SIGTERM when the *thread* that forked
+    // PR_SET_PDEATHSIG: kernel sends SIGKILL when the *thread* that forked
     // us exits. Persists across exec; cleared on fork (which is what we
-    // want — Bun's own children should not inherit it).
-    _ = std.posix.prctl(.SET_PDEATHSIG, .{std.posix.SIG.TERM}) catch return;
+    // want — Bun's own children should not inherit it). SIGKILL is
+    // uncatchable so user code can't swallow it, matching the macOS path
+    // which hard-_exit()s from the watchdog thread.
+    _ = std.posix.prctl(.SET_PDEATHSIG, .{std.posix.SIG.KILL}) catch return;
     // Race: parent may have died between getppid() above and prctl() taking
     // effect. If so we've already been reparented and the kernel will never
     // deliver the signal — exit now.

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -15,10 +15,11 @@
 //! closes that gap from Bun's side without requiring the shim to cooperate.
 //!
 //! Linux: `prctl(PR_SET_PDEATHSIG)` — kernel delivers a signal when the
-//! parent thread dies.
-//! macOS: no PDEATHSIG. A detached thread blocks on a kqueue
-//! `EVFILT_PROC`/`NOTE_EXIT` for the original ppid and calls `_exit` when
-//! it fires.
+//! parent thread dies. Single syscall, no thread.
+//! macOS: no PDEATHSIG. A `DISPATCH_SOURCE_TYPE_PROC` / `DISPATCH_PROC_EXIT`
+//! source on the original ppid calls `_exit` when it fires. libdispatch's
+//! manager thread owns the underlying kevent, so Bun does not spawn a thread
+//! of its own.
 
 /// Exit code used when the watchdog fires. 128 + SIGHUP, matching the
 /// convention for "terminated because the controlling end went away".
@@ -37,7 +38,7 @@ pub fn install() void {
     if (comptime Environment.isLinux) {
         installLinux(original_ppid);
     } else if (comptime Environment.isMac) {
-        installKqueue(original_ppid);
+        installDarwin(original_ppid);
     }
 }
 
@@ -47,7 +48,7 @@ fn installLinux(original_ppid: std.c.pid_t) void {
     // us exits. Persists across exec; cleared on fork (which is what we
     // want — Bun's own children should not inherit it). SIGKILL is
     // uncatchable so user code can't swallow it, matching the macOS path
-    // which hard-_exit()s from the watchdog thread.
+    // which hard-_exit()s from the dispatch handler.
     _ = std.posix.prctl(.SET_PDEATHSIG, .{std.posix.SIG.KILL}) catch return;
     // Race: parent may have died between getppid() above and prctl() taking
     // effect. If so we've already been reparented and the kernel will never
@@ -57,56 +58,18 @@ fn installLinux(original_ppid: std.c.pid_t) void {
     }
 }
 
-fn installKqueue(original_ppid: std.c.pid_t) void {
-    // Race: parent may have died between exec and here.
+extern "c" fn Bun__registerParentDeathDispatchSource(ppid: std.c.pid_t, exit_code: c_int) void;
+
+fn installDarwin(original_ppid: std.c.pid_t) void {
+    if (comptime !Environment.isMac) unreachable;
+    Bun__registerParentDeathDispatchSource(original_ppid, exit_code);
+    // Race: parent may have died between getppid() and the dispatch source
+    // arming. dispatch_source_create itself returns NULL for a dead pid (the
+    // C side handles that), but a death in the gap after a successful create
+    // and before resume is not guaranteed to fire — recheck.
     if (std.c.getppid() != original_ppid) {
         std.c._exit(exit_code);
     }
-    var thread = std.Thread.spawn(.{}, kqueueThread, .{original_ppid}) catch return;
-    thread.detach();
-}
-
-fn kqueueThread(original_ppid: std.c.pid_t) void {
-    // Don't let process-directed signals land on this thread and EINTR the
-    // kevent wait; the main thread owns signal handling.
-    var all = std.posix.sigfillset();
-    var old: std.c.sigset_t = undefined;
-    _ = std.c.pthread_sigmask(std.c.SIG.BLOCK, &all, &old);
-
-    bun.Output.Source.configureNamedThread("ParentDeathWatchdog");
-
-    const kq = std.posix.kqueue() catch return;
-    defer std.posix.close(kq);
-
-    var changes = [_]std.posix.Kevent{.{
-        .ident = @intCast(original_ppid),
-        .filter = std.c.EVFILT.PROC,
-        .flags = std.c.EV.ADD | std.c.EV.ONESHOT,
-        .fflags = std.c.NOTE.EXIT,
-        .data = 0,
-        .udata = 0,
-    }};
-    var events: [1]std.posix.Kevent = undefined;
-
-    // Register + block in one call. std.posix.kevent retries EINTR for us.
-    const n = std.posix.kevent(kq, &changes, &events, null) catch |err| switch (err) {
-        // ESRCH at the syscall level: parent already gone before we
-        // registered — treat as fired.
-        error.ProcessNotFound => {
-            std.c._exit(exit_code);
-        },
-        else => return,
-    };
-
-    if (n != 1) return;
-    if (events[0].flags & std.c.EV.ERROR != 0) {
-        // ESRCH delivered via EV_ERROR in the eventlist (kernel had room to
-        // report it inline rather than failing the syscall).
-        const errno: std.posix.E = @enumFromInt(events[0].data);
-        if (errno != .SRCH) return;
-    }
-
-    std.c._exit(exit_code);
 }
 
 const std = @import("std");

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -1,8 +1,11 @@
-//! Opt-in self-termination when our parent process dies.
+//! Opt-in self-termination when our parent goes away.
 //!
 //! Enabled via env var `BUN_DIE_WITH_PARENT`. When set, Bun captures its
-//! parent pid at startup and exits as soon as that process is gone — even if
-//! the parent was SIGKILLed and never got a chance to signal us.
+//! original parent pid at startup and exits as soon as that parent is
+//! gone — even if the parent was SIGKILLed and never got a chance to signal
+//! us. On Linux this is implemented with `PR_SET_PDEATHSIG`, which tracks
+//! the creating *thread* rather than the whole parent process; for the
+//! single-threaded shims this feature targets the distinction is moot.
 //!
 //! Motivation: process supervisors that wrap Bun in a thin shim (e.g. a
 //! macOS TCC "disclaimer" trampoline: Electron → shim → bun) can be

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -1,0 +1,110 @@
+//! Opt-in self-termination when our parent process dies.
+//!
+//! Enabled via env var `BUN_DIE_WITH_PARENT`. When set, Bun captures its
+//! parent pid at startup and exits as soon as that process is gone — even if
+//! the parent was SIGKILLed and never got a chance to signal us.
+//!
+//! Motivation: process supervisors that wrap Bun in a thin shim (e.g. a
+//! macOS TCC "disclaimer" trampoline: Electron → shim → bun) can be
+//! SIGKILLed by their own parent's timeout/abort logic. SIGKILL is
+//! uncatchable, so the shim can't forward it, and Bun is silently
+//! reparented to launchd/init where it keeps running forever. This watchdog
+//! closes that gap from Bun's side without requiring the shim to cooperate.
+//!
+//! Linux: `prctl(PR_SET_PDEATHSIG)` — kernel delivers a signal when the
+//! parent thread dies.
+//! macOS: no PDEATHSIG. A detached thread blocks on a kqueue
+//! `EVFILT_PROC`/`NOTE_EXIT` for the original ppid and calls `_exit` when
+//! it fires.
+
+/// Exit code used when the watchdog fires. 128 + SIGHUP, matching the
+/// convention for "terminated because the controlling end went away".
+const exit_code: u8 = 128 + 1;
+
+pub fn install() void {
+    if (comptime !Environment.isPosix) return;
+
+    const raw = bun.getenvZ("BUN_DIE_WITH_PARENT") orelse return;
+    if (raw.len == 0 or std.mem.eql(u8, raw, "0") or std.mem.eql(u8, raw, "false")) return;
+
+    const original_ppid = std.c.getppid();
+    // Already orphaned (parent died before we got here, or launchd/init
+    // spawned us directly) — nothing to watch.
+    if (original_ppid <= 1) return;
+
+    if (comptime Environment.isLinux) {
+        installLinux(original_ppid);
+    } else if (comptime Environment.isMac) {
+        installKqueue(original_ppid);
+    }
+}
+
+fn installLinux(original_ppid: std.c.pid_t) void {
+    if (comptime !Environment.isLinux) unreachable;
+    // PR_SET_PDEATHSIG: kernel sends SIGTERM when the *thread* that forked
+    // us exits. Persists across exec; cleared on fork (which is what we
+    // want — Bun's own children should not inherit it).
+    _ = std.posix.prctl(.SET_PDEATHSIG, .{std.posix.SIG.TERM}) catch return;
+    // Race: parent may have died between getppid() above and prctl() taking
+    // effect. If so we've already been reparented and the kernel will never
+    // deliver the signal — exit now.
+    if (std.c.getppid() != original_ppid) {
+        std.c._exit(exit_code);
+    }
+}
+
+fn installKqueue(original_ppid: std.c.pid_t) void {
+    // Race: parent may have died between exec and here.
+    if (std.c.getppid() != original_ppid) {
+        std.c._exit(exit_code);
+    }
+    var thread = std.Thread.spawn(.{}, kqueueThread, .{original_ppid}) catch return;
+    thread.detach();
+}
+
+fn kqueueThread(original_ppid: std.c.pid_t) void {
+    // Don't let process-directed signals land on this thread and EINTR the
+    // kevent wait; the main thread owns signal handling.
+    var all = std.posix.sigfillset();
+    var old: std.c.sigset_t = undefined;
+    _ = std.c.pthread_sigmask(std.c.SIG.BLOCK, &all, &old);
+
+    bun.Output.Source.configureNamedThread("ParentDeathWatchdog");
+
+    const kq = std.posix.kqueue() catch return;
+    defer std.posix.close(kq);
+
+    var changes = [_]std.posix.Kevent{.{
+        .ident = @intCast(original_ppid),
+        .filter = std.c.EVFILT.PROC,
+        .flags = std.c.EV.ADD | std.c.EV.ONESHOT,
+        .fflags = std.c.NOTE.EXIT,
+        .data = 0,
+        .udata = 0,
+    }};
+    var events: [1]std.posix.Kevent = undefined;
+
+    // Register + block in one call. std.posix.kevent retries EINTR for us.
+    const n = std.posix.kevent(kq, &changes, &events, null) catch |err| switch (err) {
+        // ESRCH at the syscall level: parent already gone before we
+        // registered — treat as fired.
+        error.ProcessNotFound => {
+            std.c._exit(exit_code);
+        },
+        else => return,
+    };
+
+    if (n != 1) return;
+    if (events[0].flags & std.c.EV.ERROR != 0) {
+        // ESRCH delivered via EV_ERROR in the eventlist (kernel had room to
+        // report it inline rather than failing the syscall).
+        const errno: std.posix.E = @enumFromInt(events[0].data);
+        if (errno != .SRCH) return;
+    }
+
+    std.c._exit(exit_code);
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const Environment = bun.Environment;

--- a/src/bun.js/bindings/c-bindings.cpp
+++ b/src/bun.js/bindings/c-bindings.cpp
@@ -155,6 +155,33 @@ extern "C" void dump_zone_malloc_stats()
 
 #endif
 
+#if OS(DARWIN)
+#include <dispatch/dispatch.h>
+
+// BUN_DIE_WITH_PARENT support: register a libdispatch PROC_EXIT source for
+// `ppid` that calls _exit(exit_code) when it fires. libdispatch's manager
+// thread owns the underlying kevent, so Bun doesn't spawn a thread itself —
+// JSC pulls libdispatch in regardless. The source is intentionally leaked
+// (process-lifetime); there is nothing to cancel.
+extern "C" void Bun__registerParentDeathDispatchSource(pid_t ppid, int exit_code)
+{
+    dispatch_source_t source = dispatch_source_create(
+        DISPATCH_SOURCE_TYPE_PROC,
+        static_cast<uintptr_t>(ppid),
+        DISPATCH_PROC_EXIT,
+        dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
+    if (!source) {
+        // ppid already gone (or not visible) — same outcome as the source
+        // firing immediately.
+        _exit(exit_code);
+    }
+    dispatch_source_set_event_handler(source, ^{
+        _exit(exit_code);
+    });
+    dispatch_resume(source);
+}
+#endif
+
 #if OS(WINDOWS)
 #define MS_PER_SEC 1000ULL // MS = milliseconds
 #define US_PER_MS 1000ULL // US = microseconds

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -239,6 +239,7 @@ pub const md = @import("./md/root.zig");
 
 pub const Output = @import("./output.zig");
 pub const Global = @import("./Global.zig");
+pub const ParentDeathWatchdog = @import("./ParentDeathWatchdog.zig");
 
 pub const FD = @import("./fd.zig").FD;
 pub const MovableIfWindowsFd = @import("./fd.zig").MovableIfWindowsFd;

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -50,6 +50,10 @@ pub const BUN_DEBUG_HASH_RANDOM_SEED = New(kind.unsigned, "BUN_DEBUG_HASH_RANDOM
 pub const BUN_DEBUG_QUIET_LOGS = New(kind.boolean, "BUN_DEBUG_QUIET_LOGS", .{});
 pub const BUN_DEBUG_TEST_TEXT_LOCKFILE = New(kind.boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", .{ .default = false });
 pub const BUN_DEV_SERVER_TEST_RUNNER = New(kind.string, "BUN_DEV_SERVER_TEST_RUNNER", .{});
+/// Opt-in: when truthy, Bun watches its original parent pid at startup and
+/// exits as soon as that process dies (even if the parent was SIGKILLed and
+/// couldn't forward a signal). See `src/ParentDeathWatchdog.zig`.
+pub const BUN_DIE_WITH_PARENT = New(kind.boolean, "BUN_DIE_WITH_PARENT", .{ .default = false });
 pub const BUN_ENABLE_CRASH_REPORTING = New(kind.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});
 pub const BUN_FEATURE_FLAG_DUMP_CODE = New(kind.string, "BUN_FEATURE_FLAG_DUMP_CODE", .{});
 /// TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,6 +61,7 @@ pub fn main() void {
     }
 
     _bun.StackCheck.configureThread();
+    _bun.ParentDeathWatchdog.install();
 
     _bun.cli.Cli.start(_bun.default_allocator);
     _bun.Global.exit(0);

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// BUN_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
+// process dies, even if the parent was SIGKILLed and couldn't signal us.
+// macOS uses kqueue NOTE_EXIT; Linux uses prctl(PR_SET_PDEATHSIG).
+//
+// Tree: test → sh (the "parent" we SIGKILL) → bun-debug.
+// We SIGKILL sh and observe whether bun survives.
+
+const isPosix = process.platform !== "win32";
+
+async function spawnTree(dieWithParent: string | undefined) {
+  // bun child writes "pid ppid" to stdout once it's up; the test reads sh's
+  // stdout (inherited by bun) before SIGKILLing sh.
+  const env: Record<string, string> = { ...bunEnv };
+  if (dieWithParent !== undefined) env.BUN_DIE_WITH_PARENT = dieWithParent;
+
+  const sh = Bun.spawn({
+    // Trailing `wait` defeats sh's implicit-exec-of-last-command so sh stays
+    // a distinct pid we can SIGKILL independently of bun.
+    cmd: [
+      "/bin/sh",
+      "-c",
+      `"${bunExe()}" -e 'console.log(process.pid, process.ppid); setInterval(()=>{}, 1000)' & wait`,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  const reader = sh.stdout.getReader();
+  const { value } = await reader.read();
+  reader.releaseLock();
+  const [bunPid, bunPpid] = new TextDecoder()
+    .decode(value)
+    .trim()
+    .split(" ")
+    .map(Number);
+  expect(bunPid).toBeGreaterThan(0);
+  expect(bunPpid).toBe(sh.pid);
+
+  return { sh, bunPid };
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+test.skipIf(!isPosix)(
+  "without BUN_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed",
+  async () => {
+    const { sh, bunPid } = await spawnTree(undefined);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    await sleep(1000);
+    const orphaned = isAlive(bunPid);
+    if (orphaned) process.kill(bunPid, "SIGKILL");
+    expect(orphaned).toBe(true);
+  },
+);
+
+test.skipIf(!isPosix)(
+  "BUN_DIE_WITH_PARENT=1: bun exits when its parent is SIGKILLed",
+  async () => {
+    const { sh, bunPid } = await spawnTree("1");
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    // kqueue NOTE_EXIT fires effectively immediately; allow scheduling slop.
+    await sleep(1000);
+    const alive = isAlive(bunPid);
+    if (alive) process.kill(bunPid, "SIGKILL");
+    expect(alive).toBe(false);
+  },
+);
+
+test.skipIf(!isPosix)(
+  "BUN_DIE_WITH_PARENT=0 is treated as unset",
+  async () => {
+    const { sh, bunPid } = await spawnTree("0");
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    await sleep(1000);
+    const alive = isAlive(bunPid);
+    if (alive) process.kill(bunPid, "SIGKILL");
+    expect(alive).toBe(true);
+  },
+);
+
+test.skipIf(!isPosix)(
+  "BUN_DIE_WITH_PARENT=1 does not fire while the parent is alive",
+  async () => {
+    const { sh, bunPid } = await spawnTree("1");
+    await sleep(1000);
+    expect(isAlive(bunPid)).toBe(true);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    await sleep(1000);
+    if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
+  },
+);

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -30,14 +30,18 @@ async function spawnTree(dieWithParent: string | undefined) {
     stderr: "ignore",
   });
 
+  // A single reader.read() can return a partial chunk; buffer until we see
+  // the newline that terminates the "pid ppid" line.
   const reader = sh.stdout.getReader();
-  const { value } = await reader.read();
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    line += decoder.decode(value, { stream: true });
+  }
   reader.releaseLock();
-  const [bunPid, bunPpid] = new TextDecoder()
-    .decode(value)
-    .trim()
-    .split(" ")
-    .map(Number);
+  const [bunPid, bunPpid] = line.trim().split(" ").map(Number);
   expect(bunPid).toBeGreaterThan(0);
   expect(bunPpid).toBe(sh.pid);
 
@@ -53,16 +57,31 @@ function isAlive(pid: number): boolean {
   }
 }
 
+/**
+ * Poll `isAlive(pid)` until it returns false or `timeoutMs` elapses.
+ * Returns true if the process died within the window, false if it was still
+ * alive when the window expired. Used both ways: "must die" asserts true,
+ * "must survive" asserts false.
+ */
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await sleep(25);
+  }
+  return !isAlive(pid);
+}
+
 test.skipIf(!isPosix)(
   "without BUN_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed",
   async () => {
     const { sh, bunPid } = await spawnTree(undefined);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
-    await sleep(1000);
-    const orphaned = isAlive(bunPid);
-    if (orphaned) process.kill(bunPid, "SIGKILL");
-    expect(orphaned).toBe(true);
+    // bun must NOT die: poll for death and expect the poll to time out.
+    const died = await waitUntilDead(bunPid, 1000);
+    if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
+    expect(died).toBe(false);
   },
 );
 
@@ -72,12 +91,13 @@ test.skipIf(!isPosix)(
     const { sh, bunPid } = await spawnTree("1");
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
-    // kqueue NOTE_EXIT fires effectively immediately; allow scheduling slop.
-    await sleep(1000);
-    const alive = isAlive(bunPid);
-    if (alive) process.kill(bunPid, "SIGKILL");
-    expect(alive).toBe(false);
+    // kqueue NOTE_EXIT / PDEATHSIG fire effectively immediately; poll until
+    // bun is gone rather than sleeping a fixed interval.
+    const died = await waitUntilDead(bunPid, 10000);
+    if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
+    expect(died).toBe(true);
   },
+  30000,
 );
 
 test.skipIf(!isPosix)(
@@ -86,10 +106,9 @@ test.skipIf(!isPosix)(
     const { sh, bunPid } = await spawnTree("0");
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
-    await sleep(1000);
-    const alive = isAlive(bunPid);
-    if (alive) process.kill(bunPid, "SIGKILL");
-    expect(alive).toBe(true);
+    const died = await waitUntilDead(bunPid, 1000);
+    if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
+    expect(died).toBe(false);
   },
 );
 
@@ -97,11 +116,13 @@ test.skipIf(!isPosix)(
   "BUN_DIE_WITH_PARENT=1 does not fire while the parent is alive",
   async () => {
     const { sh, bunPid } = await spawnTree("1");
-    await sleep(1000);
-    expect(isAlive(bunPid)).toBe(true);
+    // Parent is alive; bun must stay alive. Poll for premature death.
+    const diedEarly = await waitUntilDead(bunPid, 1000);
+    expect(diedEarly).toBe(false);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
-    await sleep(1000);
+    await waitUntilDead(bunPid, 10000);
     if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
   },
+  30000,
 );

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -127,8 +127,9 @@ test.skipIf(!isSupported)(
     expect(diedEarly).toBe(false);
     process.kill(sh.pid!, "SIGKILL");
     await sh.exited;
-    await waitUntilDead(bunPid, 10000);
+    const diedAfter = await waitUntilDead(bunPid, 10000);
     if (isAlive(bunPid)) process.kill(bunPid, "SIGKILL");
+    expect(diedAfter).toBe(true);
   },
   30000,
 );

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -4,7 +4,8 @@ import { setTimeout as sleep } from "node:timers/promises";
 
 // BUN_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
 // process dies, even if the parent was SIGKILLed and couldn't signal us.
-// macOS uses kqueue NOTE_EXIT; Linux uses prctl(PR_SET_PDEATHSIG).
+// macOS uses a libdispatch DISPATCH_SOURCE_TYPE_PROC source; Linux uses
+// prctl(PR_SET_PDEATHSIG).
 //
 // Tree: test → sh (the "parent" we SIGKILL) → bun-debug.
 // We SIGKILL sh and observe whether bun survives.

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -9,12 +9,17 @@ import { setTimeout as sleep } from "node:timers/promises";
 // Tree: test → sh (the "parent" we SIGKILL) → bun-debug.
 // We SIGKILL sh and observe whether bun survives.
 
-const isPosix = process.platform !== "win32";
+// The watchdog only installs on Linux (prctl) and macOS (kqueue); gate to
+// exactly those platforms rather than generic POSIX.
+const isSupported = process.platform === "linux" || process.platform === "darwin";
 
 async function spawnTree(dieWithParent: string | undefined) {
   // bun child writes "pid ppid" to stdout once it's up; the test reads sh's
   // stdout (inherited by bun) before SIGKILLing sh.
   const env: Record<string, string> = { ...bunEnv };
+  // bunEnv spreads process.env; make sure an ambient BUN_DIE_WITH_PARENT
+  // from the test runner doesn't leak into the "unset" case.
+  delete env.BUN_DIE_WITH_PARENT;
   if (dieWithParent !== undefined) env.BUN_DIE_WITH_PARENT = dieWithParent;
 
   const sh = Bun.spawn({
@@ -72,7 +77,7 @@ async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
   return !isAlive(pid);
 }
 
-test.skipIf(!isPosix)(
+test.skipIf(!isSupported)(
   "without BUN_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed",
   async () => {
     const { sh, bunPid } = await spawnTree(undefined);
@@ -85,7 +90,7 @@ test.skipIf(!isPosix)(
   },
 );
 
-test.skipIf(!isPosix)(
+test.skipIf(!isSupported)(
   "BUN_DIE_WITH_PARENT=1: bun exits when its parent is SIGKILLed",
   async () => {
     const { sh, bunPid } = await spawnTree("1");
@@ -100,7 +105,7 @@ test.skipIf(!isPosix)(
   30000,
 );
 
-test.skipIf(!isPosix)(
+test.skipIf(!isSupported)(
   "BUN_DIE_WITH_PARENT=0 is treated as unset",
   async () => {
     const { sh, bunPid } = await spawnTree("0");
@@ -112,7 +117,7 @@ test.skipIf(!isPosix)(
   },
 );
 
-test.skipIf(!isPosix)(
+test.skipIf(!isSupported)(
   "BUN_DIE_WITH_PARENT=1 does not fire while the parent is alive",
   async () => {
     const { sh, bunPid } = await spawnTree("1");


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in `BUN_DIE_WITH_PARENT` environment variable. When set, Bun captures its parent pid at startup and exits as soon as that process is gone — even if the parent was `SIGKILL`ed and never got a chance to signal Bun.

### Why?

Process supervisors that wrap Bun in a thin shim can themselves be `SIGKILL`ed (timeout escalation, OOM, Force Quit). `SIGKILL` is uncatchable, so the shim can't forward it, and Bun is silently reparented to `launchd`/`init` where it keeps running forever.

Concrete case: on macOS, an Electron app spawns Bun via a TCC responsibility-disclaiming trampoline (`Electron → shim → bun`). When Electron's `spawn({timeout, killSignal: 'SIGKILL'})` fires, the shim dies and Bun orphans to launchd. There's no fix possible in the shim — only Bun can observe its own reparenting.

### How?

- **macOS**: a detached thread blocks on `kqueue` `EVFILT_PROC`/`NOTE_EXIT` for the original ppid and calls `_exit(129)` when it fires. Handles the parent-already-dead race at both syscall-errno and `EV_ERROR`-in-eventlist paths.
- **Linux**: `prctl(PR_SET_PDEATHSIG, SIGTERM)` + a post-`prctl` ppid recheck for the same race.
- **Windows / unset / `=0` / `=false` / already-orphaned-at-startup**: no-op.

### Testing

`test/cli/run/die-with-parent.test.ts` — 4 tests:
- without the env var, Bun is orphaned when its parent is `SIGKILL`ed (baseline)
- with `BUN_DIE_WITH_PARENT=1`, Bun exits when its parent is `SIGKILL`ed
- `BUN_DIE_WITH_PARENT=0` is treated as unset
- the watchdog does not fire while the parent is still alive

```
bun test v1.3.14
 4 pass
 0 fail
```
