### PR TITLE
Free intermediate URL buffer in server.fetch(string)

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1195,7 +1195,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (first_arg.isString()) {
                 const url_zig_str = try arguments[0].toSlice(ctx, bun.default_allocator);
                 defer url_zig_str.deinit();
-                var temp_url_str = url_zig_str.slice();
+                const temp_url_str = url_zig_str.slice();
 
                 if (temp_url_str.len == 0) {
                     const fetch_error = jsc.WebCore.Fetch.fetch_error_blank_url;
@@ -1204,14 +1204,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                 var url = URL.parse(temp_url_str);
 
-                if (url.hostname.len == 0) {
-                    url = URL.parse(
-                        strings.append(this.allocator, this.base_url_string_for_joining, url.pathname) catch unreachable,
-                    );
-                } else {
-                    temp_url_str = this.allocator.dupe(u8, temp_url_str) catch unreachable;
-                    url = URL.parse(temp_url_str);
-                }
+                // Both branches produce a heap-owned buffer that `url.href` borrows.
+                // `bun.String.cloneUTF8(url.href)` below makes its own copy, so this
+                // buffer must be freed before we leave the block.
+                const owned_url_buf: []const u8 = if (url.hostname.len == 0)
+                    bun.handleOom(strings.append(this.allocator, this.base_url_string_for_joining, url.pathname))
+                else
+                    bun.handleOom(this.allocator.dupe(u8, temp_url_str));
+                defer this.allocator.free(owned_url_buf);
+                url = URL.parse(owned_url_buf);
 
                 if (arguments.len >= 2 and arguments[1].isObject()) {
                     var opts = arguments[1];

--- a/test/js/bun/http/leaks-test.test.ts
+++ b/test/js/bun/http/leaks-test.test.ts
@@ -10,3 +10,7 @@ test("request error doesn't leak", async () => {
 test("response error doesn't leak", async () => {
   expect([join(import.meta.dir, "response-constructor-leak-fixture.js")]).toRun();
 });
+
+test("server.fetch(string) doesn't leak the URL buffer", async () => {
+  expect([join(import.meta.dir, "server-fetch-string-leak-fixture.js")]).toRun();
+});

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -1,0 +1,39 @@
+// This test is meant to cause large RSS growth if server.fetch("<string url>")
+// leaks the intermediate URL buffer it heap-allocates before cloning into a
+// bun.String. Both code paths are exercised:
+//   - absolute URL with a hostname (dupe branch)
+//   - relative path with no hostname (append-to-base-url branch)
+using server = Bun.serve({
+  port: 0,
+  fetch() {
+    return new Response("ok");
+  },
+});
+
+const longPath = "/" + Buffer.alloc(32 * 1024, "p").toString();
+const absolute = `http://${server.hostname}:${server.port}${longPath}`;
+
+// Warm up so RSS baseline stabilizes before we measure.
+for (let i = 0; i < 64; i++) {
+  await server.fetch(absolute);
+  await server.fetch(longPath);
+}
+Bun.gc(true);
+const before = process.memoryUsage.rss();
+
+for (let i = 0; i < 4096; i++) {
+  await server.fetch(absolute);
+  await server.fetch(longPath);
+}
+Bun.gc(true);
+const after = process.memoryUsage.rss();
+
+const deltaMB = (after - before) / 1024 / 1024;
+console.log("RSS delta:", deltaMB.toFixed(1), "MB");
+
+// 4096 iterations * 2 calls * ~32 KiB = ~256 MiB leaked when broken.
+// With the fix, growth is a few MiB of allocator jitter at most.
+if (deltaMB > 64) {
+  console.error("server.fetch(string) leaked URL buffers");
+  process.exit(1);
+}


### PR DESCRIPTION
## What

`server.fetch("<string url>")` leaked ~`len(URL)` bytes on every call.

## Why

In `onFetch` (`src/bun.js/api/server.zig`), when the first argument is a string both branches heap-allocate a URL buffer via the server's mimalloc allocator:

- no hostname → `strings.append(this.allocator, base_url, url.pathname)`
- with hostname → `this.allocator.dupe(u8, temp_url_str)`

`URL.parse` only stores a *borrowed* slice into the input (`url.href = base`), so nothing takes ownership. The href is then cloned into a `bun.String` via `bun.String.cloneUTF8(url.href)`, but the original buffer from `append`/`dupe` is never freed — no `defer`, no field holding it.

## Fix

Store the allocated buffer in a named `const` and `defer this.allocator.free(...)` so it is released on every exit path (normal return, invalid-body early return, `try` failures). Also swapped `catch unreachable` → `bun.handleOom`.

## Verification

Added `test/js/bun/http/server-fetch-string-leak-fixture.js` which runs 8192 `server.fetch()` calls with a 32 KiB URL (covering both branches) and asserts RSS growth stays under 64 MiB.

| | RSS delta (8192 calls × 32 KiB) |
|---|---|
| before | **324 MB** (release) / **362 MB** (debug ASAN) |
| after | ~0 MB (release) / ~40 MB (debug ASAN, allocator jitter) |

Existing `server.fetch` correctness tests in `bun-server.test.ts`, `bun-serve-routes.test.ts`, and `bun-serve-fetch-invalid-args.test.ts` continue to pass.