### PR TITLE
sql(postgres): free previous statement.fields on repeat RowDescription

### DIFF
--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1594,6 +1594,9 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
             try description.decodeInternal(Context, reader);
             const request = this.current() orelse return error.ExpectedRequest;
             var statement = request.statement orelse return error.ExpectedStatement;
+            if (statement.parameters.len > 0) {
+                bun.default_allocator.free(statement.parameters);
+            }
             statement.parameters = description.parameters;
             if (statement.status == .parsing) {
                 statement.status = .prepared;
@@ -1606,6 +1609,22 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
             errdefer description.deinit();
             const request = this.current() orelse return error.ExpectedRequest;
             var statement = request.statement orelse return error.ExpectedStatement;
+            // A simple-mode query containing multiple statements (e.g.
+            // "SELECT 1; SELECT a, b FROM t") receives one RowDescription per
+            // result set while the same statement stays current() until
+            // ReadyForQuery. Free any previous fields before overwriting and
+            // invalidate state derived from them so the next DataRow builds
+            // the correct structure instead of reusing a stale cached one.
+            if (statement.fields.len > 0) {
+                for (statement.fields) |*field| {
+                    field.deinit();
+                }
+                bun.default_allocator.free(statement.fields);
+                statement.cached_structure.deinit();
+                statement.cached_structure = .{};
+                statement.needs_duplicate_check = true;
+                statement.fields_flags = .{};
+            }
             statement.fields = description.fields;
         },
         .Authentication => {

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1592,6 +1592,7 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
         .ParameterDescription => {
             var description: protocol.ParameterDescription = undefined;
             try description.decodeInternal(Context, reader);
+            errdefer bun.default_allocator.free(description.parameters);
             const request = this.current() orelse return error.ExpectedRequest;
             var statement = request.statement orelse return error.ExpectedStatement;
             if (statement.parameters.len > 0) {

--- a/test/js/sql/postgres-multi-statement-fields.test.ts
+++ b/test/js/sql/postgres-multi-statement-fields.test.ts
@@ -1,0 +1,112 @@
+// When a simple-mode query contains multiple SQL statements separated by ';',
+// Postgres sends one RowDescription per result set while the same request
+// stays current until ReadyForQuery. Each RowDescription must free the
+// previous statement.fields allocation and invalidate derived state
+// (cached_structure / needs_duplicate_check / fields_flags) so later result
+// sets use the correct column names and the previous []FieldDescription is
+// not leaked.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import net from "net";
+
+function pkt(type: string, body: Buffer): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0);
+  header.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([header, body]);
+}
+
+function int16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeInt16BE(n, 0);
+  return b;
+}
+
+function int32(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeInt32BE(n, 0);
+  return b;
+}
+
+function cstr(s: string): Buffer {
+  return Buffer.concat([Buffer.from(s), Buffer.from([0])]);
+}
+
+function rowDescription(names: string[]): Buffer {
+  const fields = Buffer.concat(
+    names.map(name =>
+      Buffer.concat([
+        cstr(name), // column name
+        int32(0), // table oid
+        int16(0), // column attr number
+        int32(25), // type oid: text
+        int16(-1), // type size
+        int32(-1), // type modifier
+        int16(0), // format: text
+      ]),
+    ),
+  );
+  return pkt("T", Buffer.concat([int16(names.length), fields]));
+}
+
+function dataRow(values: string[]): Buffer {
+  const cols = Buffer.concat(
+    values.map(v => {
+      const bytes = Buffer.from(v);
+      return Buffer.concat([int32(bytes.length), bytes]);
+    }),
+  );
+  return pkt("D", Buffer.concat([int16(values.length), cols]));
+}
+
+const authenticationOk = pkt("R", int32(0));
+const readyForQuery = pkt("Z", Buffer.from("I"));
+const commandComplete = (tag: string) => pkt("C", cstr(tag));
+
+test("simple query with multiple statements uses each RowDescription's column names", async () => {
+  const server = net.createServer(socket => {
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([authenticationOk, readyForQuery]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' */) return;
+      // Respond to the simple query with two result sets that have different
+      // column names and shapes, then a third with yet another shape.
+      socket.write(
+        Buffer.concat([
+          rowDescription(["x"]),
+          dataRow(["1"]),
+          commandComplete("SELECT 1"),
+          rowDescription(["y"]),
+          dataRow(["2"]),
+          commandComplete("SELECT 1"),
+          rowDescription(["a", "b", "c"]),
+          dataRow(["3", "4", "5"]),
+          commandComplete("SELECT 1"),
+          readyForQuery,
+        ]),
+      );
+    });
+  });
+
+  await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as net.AddressInfo).port;
+
+  const sql = new SQL({
+    url: `postgres://u@127.0.0.1:${port}/db`,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+
+  try {
+    const result = await sql`select 1 as x; select 2 as y; select 3 as a, 4 as b, 5 as c`.simple();
+    expect(result).toEqual([[{ x: "1" }], [{ y: "2" }], [{ a: "3", b: "4", c: "5" }]]);
+  } finally {
+    await sql.close();
+    server.close();
+  }
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1917,6 +1917,19 @@ if (isDockerEnabled()) {
       expect(result[1][0].x).toEqual(2);
     });
 
+    test("simple query with multiple statements and different column names", async () => {
+      // Each result set has its own RowDescription; the statement's cached
+      // structure must be rebuilt for the second one instead of reusing the
+      // first (which would surface as {x: 2} below).
+      const result = await sql`select 1 as x;select 2 as y`.simple();
+      expect(result).toEqual([[{ x: 1 }], [{ y: 2 }]]);
+    });
+
+    test("simple query with multiple statements and different column counts", async () => {
+      const result = await sql.unsafe("select 1 as one; select 1 as a, 2 as b, 3 as c; select 'hi' as greeting");
+      expect(result).toEqual([[{ one: 1 }], [{ a: 1, b: 2, c: 3 }], [{ greeting: "hi" }]]);
+    });
+
     // t('listen and notify', async() => {
     //   const sql = postgres(options)
     //   const channel = 'hello'


### PR DESCRIPTION
## What

Free the previous `statement.fields` allocation (and invalidate the structure derived from it) when a second `RowDescription` arrives for the same `PostgresSQLQuery`, and do the same for `statement.parameters` on `ParameterDescription`.

## Why

For a simple-mode query containing multiple SQL statements — e.g. `sql.unsafe(\"SELECT 1 as x; SELECT a, b FROM t\")` — Postgres sends one `RowDescription` per result set while the same request/statement stays `current()` until `ReadyForQuery`. `PostgresSQLConnection.on(.RowDescription)` assigned `statement.fields = description.fields` unconditionally, which:

1. **Leaked** the previous `[]FieldDescription` array plus each field's `name_or_index` `Data`. `PostgresSQLStatement.deinit()` only frees the final value.
2. **Returned wrong results**: `statement.cached_structure`, `needs_duplicate_check` and `fields_flags` were not invalidated, so every subsequent `DataRow` in the same simple query reused the first result set's column names/structure.

### Before

```js
await sql`select 1 as x; select 2 as y`.simple()
// [[{x:1}], [{x:2}]]                      <- second row uses "x" instead of "y"

await sql.unsafe("select 1 as one; select 1 as a, 2 as b, 3 as c; select 'hi' as greeting")
// [[{one:1}], [{one:1}], [{one:"hi"}]]    <- all rows use "one", b/c dropped
```

### After

```js
await sql`select 1 as x; select 2 as y`.simple()
// [[{x:1}], [{y:2}]]

await sql.unsafe("select 1 as one; select 1 as a, 2 as b, 3 as c; select 'hi' as greeting")
// [[{one:1}], [{a:1, b:2, c:3}], [{greeting:"hi"}]]
```

## How

In `.RowDescription`, when `statement.fields.len > 0`:
- free each field's `name_or_index` and the slice itself
- `deinit()` and reset `statement.cached_structure`
- reset `needs_duplicate_check = true` and `fields_flags = .{}`

In `.ParameterDescription`, free any previous `statement.parameters` before overwriting.

## Tests

- `test/js/sql/postgres-multi-statement-fields.test.ts` — mock Postgres server sending three `RowDescription`s with different column names/counts for a single simple query; asserts each result set has its own column names. Runs without docker.
- `test/js/sql/sql.test.ts` — same coverage against real Postgres in CI (`simple query with multiple statements and different column names` / `...and different column counts`).

Verified fail-before / pass-after with `bun bd` and `USE_SYSTEM_BUN=1`.