### PR TITLE
server: unprotect pending_flush when response stream rejects

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1634,7 +1634,14 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             streamLog("handleRejectStream", .{});
 
             if (req.sink) |wrapper| {
-                wrapper.sink.pending_flush = null;
+                if (wrapper.sink.pending_flush) |prom| {
+                    // The promise value was protected when pending_flush was
+                    // assigned (flushFromJS / endFromJS). Drop that root before
+                    // abandoning the pointer, otherwise it leaks for the
+                    // lifetime of the VM.
+                    prom.toJS().unprotect();
+                    wrapper.sink.pending_flush = null;
+                }
                 wrapper.sink.done = true;
                 req.flags.aborted = req.flags.aborted or wrapper.sink.aborted;
                 wrapper.sink.finalize();

--- a/src/bun.js/webcore/streams.zig
+++ b/src/bun.js/webcore/streams.zig
@@ -1257,6 +1257,13 @@ pub fn HTTPServerWritable(comptime ssl: bool, comptime http3: bool) type {
 
         pub fn destroy(this: *@This()) void {
             log("destroy()", .{});
+            // Callers may tear this sink down without routing through
+            // flushPromise() (e.g. handleResolveStream / handleRejectStream).
+            // Drop the GC root so the promise can be collected.
+            if (this.pending_flush) |prom| {
+                prom.toJS().unprotect();
+                this.pending_flush = null;
+            }
             this.buffer.deinit(this.allocator);
             this.unregisterAutoFlusher();
             this.allocator.destroy(this);

--- a/test/js/bun/http/serve-stream-reject-flush-leak-fixture.ts
+++ b/test/js/bun/http/serve-stream-reject-flush-leak-fixture.ts
@@ -1,0 +1,120 @@
+// Regression: when a direct ReadableStream used as a Response body rejects
+// while a controller.end() / flush(true) promise is parked under
+// backpressure, handleRejectStream() nulled `pending_flush` without
+// unprotecting the JSPromise, leaking one GC root per request for the
+// lifetime of the VM.
+//
+// Repro:
+//   1. Go async first (setImmediate) so RequestContext.toAsync() has already
+//      registered the uWS abort handler and doRenderStream is parked on the
+//      pending pull() promise (onResolveStream/onRejectStream wired up).
+//   2. Bump the sink's highWaterMark so write() buffers instead of draining
+//      straight to res.write() — this keeps isHttpWriteCalled() false so
+//      end() takes the tryEnd() path.
+//   3. Write a chunk large enough that tryEnd() hits socket backpressure on
+//      a non-reading client → pending_flush is created + protected.
+//   4. Throw, rejecting the pull() promise → onRejectStream →
+//      handleRejectStream() with pending_flush still set.
+//
+// Without the fix, protected Promise count grows by ~1 per iteration.
+
+import { heapStats } from "bun:jsc";
+import { connect } from "node:net";
+
+const CHUNK = Buffer.alloc(8 * 1024 * 1024, "x");
+
+let flushPending = 0;
+
+const server = Bun.serve({
+  port: 0,
+  idleTimeout: 0,
+  development: false,
+  error() {
+    return new Response("err", { status: 500 });
+  },
+  fetch() {
+    return new Response(
+      new ReadableStream({
+        type: "direct",
+        async pull(controller: any) {
+          await new Promise<void>(r => setImmediate(() => r()));
+          controller.start({ highWaterMark: CHUNK.length + 1 });
+          controller.write(CHUNK);
+          const p = controller.end();
+          if (p instanceof Promise && Bun.peek.status(p) === "pending") {
+            flushPending++;
+          }
+          throw new Error("boom");
+        },
+      } as any),
+    );
+  },
+});
+
+function protectedPromiseCount() {
+  Bun.gc(true);
+  return heapStats().protectedObjectTypeCounts.Promise ?? 0;
+}
+
+function oneRequest(): Promise<void> {
+  // Raw TCP client that sends the request line and then stops reading, so
+  // the server's first body write (tryEnd of 8 MiB) hits backpressure.
+  return new Promise(resolve => {
+    const socket = connect({ port: server.port, host: "127.0.0.1" }, () => {
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    });
+    socket.on("data", () => socket.destroy());
+    socket.on("close", () => resolve());
+    socket.on("error", () => {});
+  });
+}
+
+const ITERATIONS = 40;
+
+// Warm up so per-process one-time promise protections (module loader, etc.)
+// don't count against us.
+await oneRequest();
+await oneRequest();
+Bun.gc(true);
+
+const before = protectedPromiseCount();
+
+for (let i = 0; i < ITERATIONS; i++) {
+  await oneRequest();
+}
+
+for (let i = 0; i < 5; i++) {
+  await Bun.sleep(0);
+  Bun.gc(true);
+}
+
+const after = protectedPromiseCount();
+const delta = after - before;
+
+await server.stop(true);
+
+console.log(
+  JSON.stringify({
+    before,
+    after,
+    delta,
+    flushPending,
+    iterations: ITERATIONS,
+  }),
+);
+
+// The test must actually exercise the backpressure → pending_flush path.
+if (flushPending < ITERATIONS / 2) {
+  console.error(
+    `insufficient backpressure: only ${flushPending}/${ITERATIONS} end() calls returned a pending promise`,
+  );
+  process.exit(2);
+}
+// Before the fix: delta ≈ ITERATIONS (every pending_flush stays protected).
+// After the fix: delta stays near zero.
+if (delta > ITERATIONS / 2) {
+  console.error(`LEAK: ${delta} Promise objects stayed protected after ${ITERATIONS} rejected streams`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/test/js/bun/http/serve-stream-reject-flush-leak.test.ts
+++ b/test/js/bun/http/serve-stream-reject-flush-leak.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+test("handleRejectStream unprotects pending_flush (no Promise GC-root leak)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-stream-reject-flush-leak-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  // Sanity: we actually hit the backpressure → pending_flush path.
+  expect(result.flushPending).toBeGreaterThanOrEqual(result.iterations / 2);
+  // Without the fix, delta ≈ iterations (one protected Promise leaked per
+  // request). With the fix, it should be ~0. Allow a small constant for
+  // unrelated bookkeeping promises.
+  expect(result.delta).toBeLessThan(result.iterations / 2);
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## What

`handleRejectStream()` in `RequestContext.zig` nulled `HTTPServerWritable.pending_flush` without unprotecting the `JSPromise` that `flushFromJS()` / `endFromJS()` had previously `JSValueProtect`'d. That leaks one GC root per request whenever a response `ReadableStream` rejects while a `controller.end()` / `controller.flush(true)` promise is still parked on transport backpressure.

`HTTPServerWritable.destroy()` had the same gap for any teardown path that reaches it without routing through `flushPromise()` (e.g. `handleResolveStream`).

## Fix

- In `handleRejectStream`, unprotect the promise before clearing `pending_flush`.
- In `HTTPServerWritable.destroy()`, defensively unprotect any remaining `pending_flush` so every teardown path releases the root.

## Repro / Verification

New test `test/js/bun/http/serve-stream-reject-flush-leak.test.ts` spins a server whose `type: "direct"` stream:
1. awaits `setImmediate` so the request goes async and `onRejectStream` is wired,
2. bumps the sink's `highWaterMark` so `write()` buffers instead of draining,
3. writes 8 MiB and calls `controller.end()` → `tryEnd()` fails against a non-reading TCP client → `pending_flush` is created and protected,
4. throws, rejecting `pull()` → `handleRejectStream`.

It then counts `heapStats().protectedObjectTypeCounts.Promise` before and after 40 iterations.

| | protected Promise delta |
|---|---|
| before fix | **40** (one per request) |
| after fix | **0** |

Gate verified locally: test fails with src/ stashed, passes with the fix applied.