### PR TITLE
test(Bun.serve): regression test for per-SNI HttpRouter leak + drop stale LSAN suppression

### DIFF
--- a/test/js/bun/http/bun-serve-sni-leak-fixture.js
+++ b/test/js/bun/http/bun-serve-sni-leak-fixture.js
@@ -1,0 +1,91 @@
+// Fixture for Bun.serve() SNI domainRouter leak detection.
+// Spawned as a subprocess with --smol for clean memory measurement.
+//
+// Each SNI hostname passed to Bun.serve() allocates an HttpRouter that is
+// attached to the per-hostname SSL_CTX. On server teardown the SSL_CTX is
+// freed by the SNI tree destructor, but the attached router used to be
+// leaked. This fixture creates and tears down many servers with several SNI
+// hostnames each and reports RSS growth.
+//
+// Env: TLS_CERT, TLS_KEY - PEM cert/key for the server
+//      ITERATIONS - number of create/stop cycles (default 250)
+//      SNI_NAMES - number of SNI hostnames per server (default 12)
+
+const cert = process.env.TLS_CERT;
+const key = process.env.TLS_KEY;
+const iterations = parseInt(process.env.ITERATIONS || "250", 10);
+const sniNames = parseInt(process.env.SNI_NAMES || "12", 10);
+
+if (!cert || !key) {
+  throw new Error("TLS_CERT and TLS_KEY env vars required");
+}
+
+// Build a tls array with many SNI hostnames. The first entry becomes the
+// main SSL context; subsequent entries each allocate a per-hostname
+// HttpRouter inside uWS.
+function makeTlsConfig() {
+  const tls = [];
+  for (let i = 0; i < sniNames; i++) {
+    tls.push({ cert, key, serverName: `host${i}.example.com` });
+  }
+  return tls;
+}
+
+// Routes add handlers (and tree nodes) to every per-SNI router, so leaked
+// routers hold meaningfully more than just the base struct.
+const routes = {
+  "/a": () => new Response("a"),
+  "/b": () => new Response("b"),
+  "/c": () => new Response("c"),
+  "/d": () => new Response("d"),
+};
+
+async function cycle() {
+  const server = Bun.serve({
+    port: 0,
+    tls: makeTlsConfig(),
+    routes,
+    fetch: () => new Response("ok"),
+    development: false,
+  });
+  server.stop(true);
+}
+
+// The uWS app (and its SNI routers) is only destroyed once the JS Server
+// object has been finalized and a follow-up task runs on the event loop. Run
+// batches, force GC, and yield so deferred deinit tasks can execute.
+async function runBatches(total) {
+  const batch = 25;
+  for (let done = 0; done < total; done += batch) {
+    const n = Math.min(batch, total - done);
+    for (let i = 0; i < n; i++) await cycle();
+    Bun.gc(true);
+    await Bun.sleep(0);
+    Bun.gc(true);
+    await Bun.sleep(0);
+  }
+  // Final drain for any lingering deferred tasks.
+  for (let i = 0; i < 4; i++) {
+    Bun.gc(true);
+    await Bun.sleep(0);
+  }
+}
+
+// Warmup so baseline includes one-time SSL library allocations, mimalloc
+// arena growth, etc.
+await runBatches(40);
+const baselineRss = process.memoryUsage.rss();
+
+await runBatches(iterations);
+const finalRss = process.memoryUsage.rss();
+const growthMB = (finalRss - baselineRss) / (1024 * 1024);
+
+console.log(
+  JSON.stringify({
+    baselineRss,
+    finalRss,
+    growthMB: Math.round(growthMB * 100) / 100,
+    iterations,
+    sniNames,
+  }),
+);

--- a/test/js/bun/http/bun-serve-sni-leak-fixture.js
+++ b/test/js/bun/http/bun-serve-sni-leak-fixture.js
@@ -11,6 +11,13 @@
 //      ITERATIONS - number of create/stop cycles (default 250)
 //      SNI_NAMES - number of SNI hostnames per server (default 12)
 
+// On macOS, process.memoryUsage.rss() counts MADV_FREE_REUSABLE pages that
+// the allocator has already returned to the OS. Use the phys_footprint
+// accessor there so freed churn does not inflate the measurement.
+const rss =
+  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
+    ? Bun.unsafe.memoryFootprint
+    : process.memoryUsage.rss;
 const cert = process.env.TLS_CERT;
 const key = process.env.TLS_KEY;
 const iterations = parseInt(process.env.ITERATIONS || "250", 10);
@@ -74,10 +81,10 @@ async function runBatches(total) {
 // Warmup so baseline includes one-time SSL library allocations, mimalloc
 // arena growth, etc.
 await runBatches(40);
-const baselineRss = process.memoryUsage.rss();
+const baselineRss = rss();
 
 await runBatches(iterations);
-const finalRss = process.memoryUsage.rss();
+const finalRss = rss();
 const growthMB = (finalRss - baselineRss) / (1024 * 1024);
 
 console.log(

--- a/test/js/bun/http/bun-serve-sni-leak.test.ts
+++ b/test/js/bun/http/bun-serve-sni-leak.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as validTls } from "harness";
+import { join } from "node:path";
+
+// Each SNI hostname in Bun.serve({ tls: [...] }) heap-allocates an HttpRouter
+// inside uWS. Prior to the pendingServerNames ownership model in
+// TemplatedApp, the router was stashed as ex_data on the per-hostname
+// SSL_CTX and never freed on teardown (only the SSL_CTX was), leaking one
+// router + its route handler tree per hostname per server. Repeatedly
+// creating and stopping an SNI server should therefore not grow RSS
+// unboundedly.
+test("Bun.serve() with SNI hostnames does not leak per-hostname HttpRouter on stop()", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "bun-serve-sni-leak-fixture.js")],
+    env: {
+      ...bunEnv,
+      TLS_CERT: validTls.cert,
+      TLS_KEY: validTls.key,
+      ITERATIONS: "250",
+      SNI_NAMES: "12",
+      // On ASAN builds, freed memory sits in the quarantine and inflates
+      // RSS even though it has been released. Disable quarantine so RSS
+      // tracks live allocations. Release builds ignore ASAN_OPTIONS.
+      ASAN_OPTIONS: "quarantine_size_mb=0:allow_user_segv_handler=1:detect_leaks=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Surface the subprocess's own failure before attempting to parse its
+  // output so a crash doesn't present as an opaque JSON.parse error.
+  if (!stdout.trim()) {
+    throw new Error(`fixture produced no output (exit ${exitCode}):\n${stderr}`);
+  }
+
+  const result = JSON.parse(stdout.trim());
+  console.log(
+    `SNI leak check: ${result.iterations} iterations x ${result.sniNames} hostnames, ` +
+      `growth: ${result.growthMB} MB`,
+  );
+
+  // Without the fix each iteration leaks ~12 HttpRouter instances (3.3 KB
+  // each) plus their route handler trees; 250 iterations pushes well past
+  // 80 MB on release and ~140 MB on debug. With the fix, steady-state
+  // growth after warmup is under 15 MB.
+  expect(result.growthMB).toBeLessThan(50);
+  expect(exitCode).toBe(0);
+}, 120_000);

--- a/test/js/bun/http/bun-serve-sni-leak.test.ts
+++ b/test/js/bun/http/bun-serve-sni-leak.test.ts
@@ -21,7 +21,7 @@ test("Bun.serve() with SNI hostnames does not leak per-hostname HttpRouter on st
       // On ASAN builds, freed memory sits in the quarantine and inflates
       // RSS even though it has been released. Disable quarantine so RSS
       // tracks live allocations. Release builds ignore ASAN_OPTIONS.
-      ASAN_OPTIONS: "quarantine_size_mb=0:allow_user_segv_handler=1:detect_leaks=0",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "detect_leaks=0"].filter(Boolean).join(":"),
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -63,7 +63,6 @@ leak:JSC::arrayProtoFuncSort
 leak:bindgen_Fmt_jsFmtString
 leak:runtime.dns_jsc.dns.GetAddrInfoRequest.run
 leak:Zig::ImportMetaObject::finishCreation
-leak:uws_add_server_name_with_options
 leak:runtime.webcore.Body.Value.fromJS
 leak:sys_jsc.error_jsc.errorToSystemError
 leak:runtime.webcore.Blob.getNameString


### PR DESCRIPTION
### Problem
- `Bun.serve({ tls: [{ serverName }, ...] })` allocates one `HttpRouter` per SNI hostname inside `uWS::TemplatedApp::addServerName`. Before #29932 the router was stored as ex_data on the per-hostname `SSL_CTX` and never freed on teardown. Each create/stop cycle leaked about 3.3 KB plus the route tree per hostname. LSAN reported it as `Direct leak ... addServerName App.h:113` under the frame `uws_add_server_name_with_options`.
- #29932 fixed the leak (`pendingServerNames` owns the routers and `~TemplatedApp` deletes them). Main still has no regression test for it, and `test/leaksan.supp` still carries `leak:uws_add_server_name_with_options`. That entry now only hides a future regression under that frame.

### Fix
- Add `test/js/bun/http/bun-serve-sni-leak.test.ts` and its fixture. The fixture runs 250 create/stop cycles with 12 SNI hostnames each under `--smol` with the ASAN quarantine disabled, then reports RSS growth. The test asserts growth under 50 MB.
- Remove `leak:uws_add_server_name_with_options` from `test/leaksan.supp`. LSAN with `detect_leaks=1` and the suppression removed reports no allocation under `addServerName` on current main.
- The result is bimodal. A leaking build grows 87 MB (release) to 143 MB (debug). A fixed build grows 7 to 9 MB. The 50 MB gate sits between them.
- Verified: `bun bd test test/js/bun/http/bun-serve-sni-leak.test.ts` on main 6f27257bb2 passes at 7 MB. `USE_SYSTEM_BUN=1 bun test` on the pre-#29932 build 6c21a7e7f fails at 87 MB. `test/js/bun/http/bun-serve-ssl.test.ts` still passes.

### Background
- SNI (Server Name Indication) lets one TLS listener serve several hostnames. uWS keeps one `SSL_CTX` and one `HttpRouter` per hostname, so each hostname can have its own routes.
- `test/leaksan.supp` is the LeakSanitizer suppression list that CI passes through `LSAN_OPTIONS`. A `leak:<symbol>` line drops every report whose stack contains that symbol.
- ASAN keeps freed memory in a quarantine, so RSS does not drop when memory is freed. The test sets `quarantine_size_mb=0` in the child so RSS tracks live allocations. Release builds ignore the option.

<details><summary>Notes</summary>

- The first version of this PR fixed the leak in `packages/bun-uws/src/App.h` with a `domainRouters` vector. #29932 landed on main during review and fixed the same leak in a different shape. The App.h change was dropped and the PR became test-only.
- The original fail-before numbers: 89 MB on release bun 1.3.14-canary (db12b449), 180 MB on the debug build with quarantine, 143 MB with quarantine off. LSAN on the same build: `Direct leak of 33600 byte(s) in 10 object(s)` from `addServerName App.h:113` plus `Indirect leak of 31680 byte(s) in 360 object(s)` from `HttpRouter::getNode`.
- The explicit 120 s test timeout stays. The fixture takes 14 to 18 s under the debug ASAN build. The default 5 s per-test timeout would fail it locally. CI passes `--timeout=90000`, so CI is not affected either way. Neighboring leak tests in this directory use the same pattern.
- The PR went stale after two CI builds (51659, 51774) collapsed on agent provisioning. Both reviewers approved the test-only version before that.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/bun-serve-sni-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/bun-serve-sni-leak.test.ts
bun test v1.4.1 (a6c4cc276)

test/js/bun/http/bun-serve-sni-leak.test.ts:
SNI leak check: 250 iterations x 12 hostnames, growth: 7 MB
(pass) Bun.serve() with SNI hostnames does not leak per-hostname HttpRouter on stop() [14511.32ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [16.90s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/bun-serve-sni-leak-fixture.js | 98 ++++++++++++++++++++++++++
 test/js/bun/http/bun-serve-sni-leak.test.ts    | 50 +++++++++++++
 test/leaksan.supp                              |  1 -
 3 files changed, 148 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
test/js/bun/http/bun-serve-sni-leak-fixture.js      1      2      2
test/js/bun/http/bun-serve-sni-leak.test.ts         1      1      2
test/leaksan.supp                                   0      0      2
```

</details>

**root cause** · written by the author bot

When Bun.serve() was configured with multiple SNI hostnames, each per-hostname SSL_CTX received its own HttpRouter, but the SNI tree destructor invoked on server teardown only freed the SSL_CTX itself and never released the attached router, so every create and stop cycle leaked one router per extra hostname along with its route tree. The fix releases the attached HttpRouter inside the per-context cleanup path that the SNI tree destructor runs, ensuring the router and its handlers are freed together with their SSL_CTX. A subprocess leak test that churns hundreds of multi-hostname server life…

<!-- robobun:evidence:end -->