### PR TITLE
sql(postgres): free previous fields on RowDescription in multi-statement simple queries

### DIFF
--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1606,6 +1606,22 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
             errdefer description.deinit();
             const request = this.current() orelse return error.ExpectedRequest;
             var statement = request.statement orelse return error.ExpectedStatement;
+            // A simple query can contain multiple statements, each producing
+            // its own RowDescription against the same PostgresSQLStatement.
+            // Free the previous fields before replacing them so we don't leak
+            // the prior result set's FieldDescription slice and owned column
+            // names, and reset the state derived from those fields so the
+            // next DataRow rebuilds the structure for the new result set.
+            if (statement.fields.len > 0) {
+                for (statement.fields) |*field| {
+                    field.deinit();
+                }
+                bun.default_allocator.free(statement.fields);
+                statement.cached_structure.deinit();
+                statement.cached_structure = .{};
+                statement.needs_duplicate_check = true;
+                statement.fields_flags = .{};
+            }
             statement.fields = description.fields;
         },
         .Authentication => {

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -1612,16 +1612,17 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
             // the prior result set's FieldDescription slice and owned column
             // names, and reset the state derived from those fields so the
             // next DataRow rebuilds the structure for the new result set.
-            if (statement.fields.len > 0) {
-                for (statement.fields) |*field| {
-                    field.deinit();
-                }
-                bun.default_allocator.free(statement.fields);
-                statement.cached_structure.deinit();
-                statement.cached_structure = .{};
-                statement.needs_duplicate_check = true;
-                statement.fields_flags = .{};
+            // A prior result set may have had zero fields (e.g. `SELECT;`)
+            // yet still populated cached_structure via DataRow, so reset the
+            // derived state unconditionally.
+            for (statement.fields) |*field| {
+                field.deinit();
             }
+            bun.default_allocator.free(statement.fields);
+            statement.cached_structure.deinit();
+            statement.cached_structure = .{};
+            statement.needs_duplicate_check = true;
+            statement.fields_flags = .{};
             statement.fields = description.fields;
         },
         .Authentication => {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1936,6 +1936,17 @@ if (isDockerEnabled()) {
       expect(result).toEqual([[{ a: 1 }], [{ b: 2, c: 3 }]]);
     });
 
+    test("simple query with multiple statements including a zero-column result set", async () => {
+      // `SELECT;` returns one row with zero columns. The zero-field
+      // RowDescription must still invalidate the cached structure so the
+      // following result set is built correctly.
+      const result = await sql`select;select 1 as a`.simple();
+      expect(result).toEqual([[{}], [{ a: 1 }]]);
+
+      const result2 = await sql`select 1 as a;select;select 2 as b`.simple();
+      expect(result2).toEqual([[{ a: 1 }], [{}], [{ b: 2 }]]);
+    });
+
     // t('listen and notify', async() => {
     //   const sql = postgres(options)
     //   const channel = 'hello'

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1917,6 +1917,25 @@ if (isDockerEnabled()) {
       expect(result[1][0].x).toEqual(2);
     });
 
+    test("simple query with multiple statements and different column names", async () => {
+      // Each statement in a simple query produces its own RowDescription.
+      // The second RowDescription replaces statement.fields; the previous
+      // fields must be freed and the cached structure invalidated so the
+      // second result set is built with the correct column names.
+      const result = await sql`select 1 as a;select 2 as b`.simple();
+      expect(result).toEqual([[{ a: 1 }], [{ b: 2 }]]);
+    });
+
+    test("simple query with multiple statements and different column counts", async () => {
+      const result = await sql`select 1 as a;select 2 as b, 3 as c;select 4 as d`.simple();
+      expect(result).toEqual([[{ a: 1 }], [{ b: 2, c: 3 }], [{ d: 4 }]]);
+    });
+
+    test("simple query using unsafe with multiple statements and different column names", async () => {
+      const result = await sql.unsafe("select 1 as a;select 2 as b, 3 as c");
+      expect(result).toEqual([[{ a: 1 }], [{ b: 2, c: 3 }]]);
+    });
+
     // t('listen and notify', async() => {
     //   const sql = postgres(options)
     //   const channel = 'hello'


### PR DESCRIPTION
## What

`statement.fields` was overwritten without freeing the previous allocation when a simple-mode query contains more than one SQL statement that returns rows.

## Repro

```ts
await sql`select 1 as a; select 2 as b`.simple();
```

For a simple query with multiple statements, Postgres sends one RowDescription per result set while the same `PostgresSQLStatement` stays `current()` until ReadyForQuery. The second RowDescription hit `statement.fields = description.fields` unconditionally, leaking the prior `[]FieldDescription` slice and each field's owned column-name `Data`.

Because `cached_structure`, `fields_flags` and `needs_duplicate_check` derived from the first result set were never invalidated either, subsequent result sets were also built against the wrong JS object structure:

| query | before | after |
|---|---|---|
| `select 1 as a;select 2 as b` | `[[{a:1}],[{a:2}]]` | `[[{a:1}],[{b:2}]]` |
| `select 1 as a;select 2 as b, 3 as c;select 4 as d` | `[[{a:1}],[{a:2}],[{a:4}]]` | `[[{a:1}],[{b:2,c:3}],[{d:4}]]` |

## Fix

When a RowDescription arrives and the statement already has fields, free the old field descriptions and reset the derived state (`cached_structure`, `needs_duplicate_check`, `fields_flags`) before taking ownership of the new ones. This matches the equivalent handling in `MySQLConnection.handleResultSet`.

## Verification

```
# without fix (src/ stashed, bun bd)
[[{"a":1}],[{"a":2}]]
[[{"a":1}],[{"a":2}],[{"a":4}]]
[[{"a":1}],[{"a":2}]]

# with fix (bun bd)
[[{"a":1}],[{"b":2}]]
[[{"a":1}],[{"b":2,"c":3}],[{"d":4}]]
[[{"a":1}],[{"b":2,"c":3}]]
```

Ran 200 iterations with >15-char column names (forcing heap-allocated `ByteList`) under the ASAN debug build — clean.