### PR TITLE
bundler: destroy JSBundler.Load in deinit()

### DIFF
--- a/src/runtime/api/JSBundler.zig
+++ b/src/runtime/api/JSBundler.zig
@@ -1431,6 +1431,7 @@ pub const JSBundler = struct {
         pub fn deinit(this: *Load) void {
             debug("Deinit Load(0{x}, {s})", .{ @intFromPtr(this), this.path });
             this.value.deinit();
+            bun.default_allocator.destroy(this);
         }
 
         const AnyTask = jsc.AnyTask.New(@This(), runOnJSThread);

--- a/test/bundler/plugin-onload-leak.test.ts
+++ b/test/bundler/plugin-onload-leak.test.ts
@@ -11,16 +11,14 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // mimalloc heap (seq 0) directly — bun.default_allocator allocates there.
 // Each unfreed Load struct is one live block; (moduleCount * iterations)
 // leaked blocks is an unambiguous signal that survives allocator noise.
-test(
-  "Bun.build onLoad plugin does not leak the Load struct per matched file",
-  async () => {
-    const moduleCount = 100;
-    const iterations = 20;
-    const imports = Array.from({ length: moduleCount }, (_, i) => `import "virtual:mod${i}";`).join("\n");
+test("Bun.build onLoad plugin does not leak the Load struct per matched file", async () => {
+  const moduleCount = 100;
+  const iterations = 20;
+  const imports = Array.from({ length: moduleCount }, (_, i) => `import "virtual:mod${i}";`).join("\n");
 
-    using dir = tempDir("bundler-onload-leak", {
-      "index.ts": imports + "\nexport const ok = 1;\n",
-      "build.ts": /* ts */ `
+  using dir = tempDir("bundler-onload-leak", {
+    "index.ts": imports + "\nexport const ok = 1;\n",
+    "build.ts": /* ts */ `
         import { heapStats } from "bun:jsc";
 
         const plugin: import("bun").BunPlugin = {
@@ -66,22 +64,20 @@ test(
           throw new Error("leaked " + delta + " live mimalloc blocks over " + ${iterations} + " builds (threshold " + threshold + ")");
         }
       `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", "build.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "build.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("leaked");
-    expect(stderr).not.toContain("build failed");
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(0);
-  },
-  120_000,
-);
+  expect(stderr).not.toContain("leaked");
+  expect(stderr).not.toContain("build failed");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+}, 120_000);

--- a/test/bundler/plugin-onload-leak.test.ts
+++ b/test/bundler/plugin-onload-leak.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// JSBundler.Load is heap-allocated (bun.default_allocator.create) for every
+// file an onLoad plugin matches, but Load.deinit() never destroyed the
+// allocation — unlike the sibling Resolve.deinit(). In a watch/dev-server
+// loop this is unbounded growth.
+//
+// RSS is too noisy for a ~200-byte-per-file leak in debug/ASAN builds, so we
+// use heapStats({dump:true}).mimallocDump to count live blocks in the main
+// mimalloc heap (seq 0) directly — bun.default_allocator allocates there.
+// Each unfreed Load struct is one live block; (moduleCount * iterations)
+// leaked blocks is an unambiguous signal that survives allocator noise.
+test(
+  "Bun.build onLoad plugin does not leak the Load struct per matched file",
+  async () => {
+    const moduleCount = 100;
+    const iterations = 20;
+    const imports = Array.from({ length: moduleCount }, (_, i) => `import "virtual:mod${i}";`).join("\n");
+
+    using dir = tempDir("bundler-onload-leak", {
+      "index.ts": imports + "\nexport const ok = 1;\n",
+      "build.ts": /* ts */ `
+        import { heapStats } from "bun:jsc";
+
+        const plugin: import("bun").BunPlugin = {
+          name: "virtual",
+          setup(build) {
+            build.onResolve({ filter: /^virtual:/ }, args => ({ path: args.path, namespace: "virtual" }));
+            build.onLoad({ filter: /.*/, namespace: "virtual" }, () => ({ contents: "export default 1;", loader: "js" }));
+          },
+        };
+
+        async function once() {
+          const result = await Bun.build({ entrypoints: ["./index.ts"], plugins: [plugin], target: "bun" });
+          if (!result.success) throw new AggregateError(result.logs, "build failed");
+        }
+
+        function liveBlocks(): number {
+          Bun.gc(true);
+          const dump = heapStats({ dump: true }).mimallocDump;
+          let total = 0;
+          for (const heap of dump.heaps) {
+            if (heap.seq !== 0) continue; // main heap == bun.default_allocator
+            for (const page of heap.pages) total += page.used;
+          }
+          return total;
+        }
+
+        // Warm up: let per-build heaps and caches reach steady state.
+        for (let i = 0; i < 3; i++) await once();
+        const before = liveBlocks();
+
+        for (let i = 0; i < ${iterations}; i++) await once();
+        const after = liveBlocks();
+
+        const delta = after - before;
+        const perOnLoad = ${moduleCount} * ${iterations};
+        console.error("live block delta:", delta, "over", ${iterations}, "builds (", perOnLoad, "onLoad matches )");
+        // There is a separate pre-existing ParseTask leak of ~perOnLoad blocks
+        // in the import-resolution path that is not addressed here; the
+        // threshold sits between "one per-onLoad leak" and "two per-onLoad
+        // leaks" so the Load-struct leak alone trips it.
+        const threshold = Math.floor(perOnLoad * 1.5);
+        if (delta > threshold) {
+          throw new Error("leaked " + delta + " live mimalloc blocks over " + ${iterations} + " builds (threshold " + threshold + ")");
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "build.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("leaked");
+    expect(stderr).not.toContain("build failed");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/bundler/plugin-onload-leak.test.ts
+++ b/test/bundler/plugin-onload-leak.test.ts
@@ -9,15 +9,26 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // RSS is too noisy for a ~200-byte-per-file leak in debug/ASAN builds, so we
 // use heapStats({dump:true}).mimallocDump to count live blocks in the main
 // mimalloc heap (seq 0) directly — bun.default_allocator allocates there.
-// Each unfreed Load struct is one live block; (moduleCount * iterations)
-// leaked blocks is an unambiguous signal that survives allocator noise.
+//
+// There is a separate pre-existing per-import ParseTask leak in
+// resolveImportRecords; to keep this test independent of that leak's state
+// we measure a control (real-file imports, no onLoad) and a test case
+// (virtual imports with onLoad) that share the same import-resolution work,
+// then assert on the difference — which isolates the Load-struct
+// contribution.
 test("Bun.build onLoad plugin does not leak the Load struct per matched file", async () => {
   const moduleCount = 100;
   const iterations = 20;
-  const imports = Array.from({ length: moduleCount }, (_, i) => `import "virtual:mod${i}";`).join("\n");
 
-  using dir = tempDir("bundler-onload-leak", {
-    "index.ts": imports + "\nexport const ok = 1;\n",
+  const files: Record<string, string> = {
+    // control entry: imports real files so ParseTask allocation matches the
+    // virtual case, but no onLoad is registered -> no Load structs created.
+    "control.ts":
+      Array.from({ length: moduleCount }, (_, i) => `import "./real/m${i}.ts";`).join("\n") +
+      "\nexport const ok = 1;\n",
+    // test entry: imports virtual modules that the onLoad plugin matches.
+    "virtual.ts":
+      Array.from({ length: moduleCount }, (_, i) => `import "virtual:m${i}";`).join("\n") + "\nexport const ok = 1;\n",
     "build.ts": /* ts */ `
         import { heapStats } from "bun:jsc";
 
@@ -28,11 +39,6 @@ test("Bun.build onLoad plugin does not leak the Load struct per matched file", a
             build.onLoad({ filter: /.*/, namespace: "virtual" }, () => ({ contents: "export default 1;", loader: "js" }));
           },
         };
-
-        async function once() {
-          const result = await Bun.build({ entrypoints: ["./index.ts"], plugins: [plugin], target: "bun" });
-          if (!result.success) throw new AggregateError(result.logs, "build failed");
-        }
 
         function liveBlocks(): number {
           Bun.gc(true);
@@ -45,26 +51,40 @@ test("Bun.build onLoad plugin does not leak the Load struct per matched file", a
           return total;
         }
 
-        // Warm up: let per-build heaps and caches reach steady state.
-        for (let i = 0; i < 3; i++) await once();
-        const before = liveBlocks();
+        async function measure(entry: string, plugins: import("bun").BunPlugin[]): Promise<number> {
+          async function once() {
+            const result = await Bun.build({ entrypoints: [entry], plugins, target: "bun" });
+            if (!result.success) throw new AggregateError(result.logs, "build failed");
+          }
+          // Warm up: let per-build heaps and caches reach steady state.
+          for (let i = 0; i < 3; i++) await once();
+          const before = liveBlocks();
+          for (let i = 0; i < ${iterations}; i++) await once();
+          return liveBlocks() - before;
+        }
 
-        for (let i = 0; i < ${iterations}; i++) await once();
-        const after = liveBlocks();
-
-        const delta = after - before;
+        const control = await measure("./control.ts", []);
+        const withOnLoad = await measure("./virtual.ts", [plugin]);
+        const onLoadContribution = withOnLoad - control;
         const perOnLoad = ${moduleCount} * ${iterations};
-        console.error("live block delta:", delta, "over", ${iterations}, "builds (", perOnLoad, "onLoad matches )");
-        // There is a separate pre-existing ParseTask leak of ~perOnLoad blocks
-        // in the import-resolution path that is not addressed here; the
-        // threshold sits between "one per-onLoad leak" and "two per-onLoad
-        // leaks" so the Load-struct leak alone trips it.
-        const threshold = Math.floor(perOnLoad * 1.5);
-        if (delta > threshold) {
-          throw new Error("leaked " + delta + " live mimalloc blocks over " + ${iterations} + " builds (threshold " + threshold + ")");
+
+        console.error("control:", control, " with onLoad:", withOnLoad, " onLoad contribution:", onLoadContribution, "(", perOnLoad, "matches )");
+
+        // With the leak, onLoadContribution is ~perOnLoad (one Load struct per
+        // match). Without the leak it is ~0. Threshold at half gives wide
+        // margin either side and stays correct whether or not the unrelated
+        // ParseTask leak is present.
+        const threshold = Math.floor(perOnLoad * 0.5);
+        if (onLoadContribution > threshold) {
+          throw new Error(
+            "onLoad leaked " + onLoadContribution + " live mimalloc blocks over " + ${iterations} + " builds (threshold " + threshold + ")",
+          );
         }
       `,
-  });
+  };
+  for (let i = 0; i < moduleCount; i++) files[`real/m${i}.ts`] = "export default 1;\n";
+
+  using dir = tempDir("bundler-onload-leak", files);
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--smol", "build.ts"],
@@ -80,5 +100,5 @@ test("Bun.build onLoad plugin does not leak the Load struct per matched file", a
   expect(stderr).not.toContain("build failed");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
-  // 23 Bun.build() calls take ~15s under debug ASAN; default 5s is not enough.
-}, 60_000);
+  // 46 Bun.build() calls take ~30s under debug ASAN; default 5s is not enough.
+}, 90_000);

--- a/test/bundler/plugin-onload-leak.test.ts
+++ b/test/bundler/plugin-onload-leak.test.ts
@@ -80,4 +80,5 @@ test("Bun.build onLoad plugin does not leak the Load struct per matched file", a
   expect(stderr).not.toContain("build failed");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
-});
+  // 23 Bun.build() calls take ~15s under debug ASAN; default 5s is not enough.
+}, 60_000);

--- a/test/bundler/plugin-onload-leak.test.ts
+++ b/test/bundler/plugin-onload-leak.test.ts
@@ -80,4 +80,4 @@ test("Bun.build onLoad plugin does not leak the Load struct per matched file", a
   expect(stderr).not.toContain("build failed");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
-}, 120_000);
+});


### PR DESCRIPTION
## What

`JSBundler.Load.deinit()` was missing `bun.default_allocator.destroy(this)`, leaking one `Load` struct per file matched by an `onLoad` plugin per `Bun.build()` call. The sibling `Resolve.deinit()` already had it.

## Repro

```ts
// 100 virtual modules, onLoad plugin matches each
// 20 builds → 2000 Load structs never freed
for (let i = 0; i < 20; i++) {
  await Bun.build({
    entrypoints: ["./index.ts"],
    plugins: [{
      name: "v",
      setup(b) {
        b.onResolve({ filter: /^virtual:/ }, a => ({ path: a.path, namespace: "virtual" }));
        b.onLoad({ filter: /.*/, namespace: "virtual" }, () => ({ contents: "export default 1;", loader: "js" }));
      },
    }],
  });
}
```

## Cause

`Load` is heap-allocated at `bundle_v2.zig:3364` via `bun.default_allocator.create(jsc.API.JSBundler.Load)`. The only cleanup paths are `defer load.deinit()` at `bundle_v2.zig:2509` and the fast-path `this.deinit()` at `JSBundler.zig:1487` — but `Load.deinit()` only called `this.value.deinit()` and never destroyed the allocation itself.

`Resolve.deinit()` at `JSBundler.zig:1293-1296` correctly calls `bun.default_allocator.destroy(this)`; `Load.deinit()` omitted it.

## Fix

Add the missing `bun.default_allocator.destroy(this)` to `Load.deinit()`, matching `Resolve.deinit()`.

## Verification

RSS is too noisy for a ~250-byte-per-file leak in debug/ASAN builds, so the test counts live blocks in the main mimalloc heap via `heapStats({dump:true}).mimallocDump` — each leaked `Load` is one live block on `bun.default_allocator` (heap seq 0).

With 100 virtual modules × 20 builds = 2000 onLoad matches:

| | live-block delta | threshold 3000 |
|---|---|---|
| before fix | ~4068 | fail |
| after fix | ~2035 | pass |

The remaining ~2000 delta is a separate pre-existing `ParseTask` leak in `resolveImportRecords` (`bundle_v2.zig:3665`/`:3931` allocate via `bun.default_allocator` but only the duplicate-entry branch at `:4026` ever destroys) — not addressed here.