### PR TITLE
fix(tls): don't leak file contents when passing Bun.file() as cert/key/ca

### DIFF
--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -67,8 +67,11 @@ fn readFromBlob(
         .result => |result| result,
         .err => |err| return global.throwValue(try err.toJS(global)),
     };
+    // `readFileWithOptions(.null_terminated)` transfers ownership of the
+    // returned buffer (allocated with `bun.default_allocator`) to the caller,
+    // so we can return it directly without duplicating.
     if (result.null_terminated.len == 0) return error.EmptyFile;
-    return bun.default_allocator.dupeZ(u8, result.null_terminated);
+    return result.null_terminated;
 }
 
 pub fn asUSockets(this: *const SSLConfig) uws.SocketContext.BunSocketContextOptions {

--- a/test/js/bun/http/tls-bunfile-leak-fixture.js
+++ b/test/js/bun/http/tls-bunfile-leak-fixture.js
@@ -1,0 +1,53 @@
+// Fixture for detecting the memory leak when TLS options (cert/key/ca) are
+// passed as Bun.file() blobs. Spawned as a subprocess with --smol for clean
+// memory measurement.
+//
+// Without the fix, SSLConfig.readFromBlob() duplicates the file contents
+// returned by readFileWithOptions() and orphans the original buffer, leaking
+// one buffer per cert/key per config parse.
+//
+// Uses Bun.listen (rather than Bun.serve) because it frees its SSLConfig
+// synchronously on stop() rather than waiting for GC finalization.
+//
+// Env: TLS_CERT_PATH, TLS_KEY_PATH - paths to (large) PEM files
+
+const certPath = process.env.TLS_CERT_PATH;
+const keyPath = process.env.TLS_KEY_PATH;
+const iterations = parseInt(process.env.ITERATIONS || "100", 10);
+const warmup = parseInt(process.env.WARMUP || "20", 10);
+
+if (!certPath || !keyPath) {
+  throw new Error("TLS_CERT_PATH and TLS_KEY_PATH env vars required");
+}
+
+function iterate() {
+  const server = Bun.listen({
+    port: 0,
+    hostname: "127.0.0.1",
+    tls: {
+      cert: Bun.file(certPath),
+      key: Bun.file(keyPath),
+    },
+    socket: { data() {} },
+  });
+  server.stop(true);
+}
+
+for (let i = 0; i < warmup; i++) iterate();
+Bun.gc(true);
+const baselineRss = process.memoryUsage.rss();
+
+for (let i = 0; i < iterations; i++) iterate();
+Bun.gc(true);
+const finalRss = process.memoryUsage.rss();
+
+const growthMB = (finalRss - baselineRss) / (1024 * 1024);
+
+console.log(
+  JSON.stringify({
+    baselineRss,
+    finalRss,
+    growthMB: Math.round(growthMB * 100) / 100,
+    iterations,
+  }),
+);

--- a/test/js/bun/http/tls-bunfile-leak.test.ts
+++ b/test/js/bun/http/tls-bunfile-leak.test.ts
@@ -43,4 +43,4 @@ test("passing Bun.file() as tls cert/key does not leak file contents", async () 
   // Without the fix this grows ~50MB; with the fix it should stay close to 0.
   expect(result.growthMB).toBeLessThan(15);
   expect(exitCode).toBe(0);
-}, 60_000);
+});

--- a/test/js/bun/http/tls-bunfile-leak.test.ts
+++ b/test/js/bun/http/tls-bunfile-leak.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, tls as validTls } from "harness";
+import { join } from "node:path";
+
+// SSLConfig.readFromBlob() used to dupeZ the buffer returned by
+// readFileWithOptions(.null_terminated) and never freed the original,
+// leaking one buffer the size of each cert/key file every time a TLS
+// option was passed as a Bun.file() blob.
+test("passing Bun.file() as tls cert/key does not leak file contents", async () => {
+  // PEM parsers ignore content after the -----END ...----- marker, so pad
+  // the files with trailing junk to make the leak measurable: ~256KB per
+  // file, two files per iteration, 100 iterations -> ~50MB expected growth
+  // without the fix.
+  const padding = Buffer.alloc(256 * 1024, "# padding\n").toString();
+  using dir = tempDir("tls-bunfile-leak", {
+    "cert.pem": validTls.cert + padding,
+    "key.pem": validTls.key + padding,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "tls-bunfile-leak-fixture.js")],
+    env: {
+      ...bunEnv,
+      TLS_CERT_PATH: join(String(dir), "cert.pem"),
+      TLS_KEY_PATH: join(String(dir), "key.pem"),
+      ITERATIONS: "100",
+      WARMUP: "20",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    console.error(stderr);
+  }
+  expect(stderr).toBe("");
+
+  const result = JSON.parse(stdout.trim());
+  console.log(`Bun.file() TLS config: ${result.iterations} iterations, growth: ${result.growthMB} MB`);
+
+  // Without the fix this grows ~50MB; with the fix it should stay close to 0.
+  expect(result.growthMB).toBeLessThan(15);
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## Problem

`SSLConfig.readFromBlob()` leaks the file-contents buffer returned by `readFileWithOptions`.

Every time a TLS option is passed as a `Bun.file()` blob — e.g. `Bun.listen({ tls: { cert: Bun.file('cert.pem'), key: Bun.file('key.pem') } })` or the same via `Bun.serve` / `Bun.connect` — one buffer the size of each cert/key/ca file is leaked per config parse.

## Cause

`readFileWithOptions(.null_terminated)` already returns a heap-allocated `[:0]const u8` (via `bun.default_allocator`) owned by the caller. `readFromBlob` then called `bun.default_allocator.dupeZ(u8, result.null_terminated)` to make a *second* copy and returned that copy, orphaning the first.

The duplicated copy is what gets stored in `SSLConfig` and later freed by `SSLConfig.deinit()`; the first allocation was never freed.

Before #23169 the code returned the buffer directly — the redundant `dupeZ` was introduced in that refactor.

## Fix

Return `result.null_terminated` directly instead of duplicating it.

## Verification

New test pads cert/key files to ~256 KB each (PEM parsers ignore content after the `-----END ...-----` marker) and creates/stops a `Bun.listen` TLS server 100 times.

| | RSS growth after 100 iterations |
|---|---|
| Before (main) | ~62 MB |
| After (this PR) | ~5 MB |

The test uses `Bun.listen` rather than `Bun.serve` because `Bun.listen` frees its `SSLConfig` synchronously on `stop()`, whereas `Bun.serve` defers until GC finalization of the server wrapper (and `ServerConfig.memoryCost()` currently omits `ssl_config`, so there's little GC pressure — a separate pre-existing issue).