### PR TITLE
bun:ffi: free CompileC option strings on cc() success path

### DIFF
--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -620,11 +620,12 @@ pub const FFI = struct {
         const object = arguments[0];
 
         var compile_c = CompileC{};
-        defer {
-            if (globalThis.hasException()) {
-                compile_c.deinit();
-            }
-        }
+        // Always deinit. On the success path, `compile_c.symbols` is moved into
+        // the returned FFI object and reset to `.{}` before we get here, so this
+        // only frees the transient option strings (source, libraries, include
+        // dirs, defines, flags, deferred errors) which are not needed after
+        // compilation.
+        defer compile_c.deinit();
 
         const symbols_object: JSValue = try object.getOwn(globalThis, "symbols") orelse .js_undefined;
         if (!globalThis.hasException() and (symbols_object == .zero or !symbols_object.isObject())) {

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -24,7 +24,7 @@
   "allocator.ptr ==": 0,
   "global.hasException": 29,
   "globalObject.hasException": 47,
-  "globalThis.hasException": 126,
+  "globalThis.hasException": 125,
   "std.StringArrayHashMap(": 1,
   "std.StringArrayHashMapUnmanaged(": 11,
   "std.StringHashMap(": 0,

--- a/test/js/bun/ffi/cc-leak-fixture.js
+++ b/test/js/bun/ffi/cc-leak-fixture.js
@@ -4,13 +4,20 @@
 // exception was pending, so every successful cc() call leaked all of these
 // duped strings.
 //
-// We make the `define` value large so the leak is easily observable via
-// RSS growth compared to a baseline run with a tiny value. Taking the
-// delta cancels out per-call overhead that is unrelated to the leaked
-// option strings (TinyCC allocations, ASAN quarantine, JIT code, etc).
+// We pass the payload via `flags` (whitespace-padded) rather than `define`
+// so the measurement isolates the Zig-side dup of the options string: Bun
+// copies the full flags string into CompileC.flags, while TinyCC only
+// *parses* it (tcc_set_options) and does not retain the whole string. Using
+// `define` would also make TinyCC copy the value into its macro table,
+// which on some platforms (observed on macOS aarch64) is not returned to
+// RSS after tcc_delete and would be misattributed to this leak.
+//
+// The delta between a run with a large padding and a run with a tiny one
+// cancels out per-call overhead that is unrelated to the leaked option
+// strings (TinyCC allocations, ASAN quarantine, JIT code, etc).
 //
 // The C source path is passed in argv[2] by cc.test.ts, which owns the
-// temp directory (via tempDirWithFiles) and cleans it up.
+// temp directory and cleans it up.
 import { cc } from "bun:ffi";
 
 const source = process.argv[2];
@@ -20,15 +27,16 @@ const ITERATIONS = 30;
 const WARMUP = 5;
 const BIG_BYTES = 4 * 1024 * 1024;
 
-const bigValue = Buffer.alloc(BIG_BYTES, "x").toString();
+const bigPadding = " ".repeat(BIG_BYTES);
 
-function once(value) {
+function once(padding) {
   const lib = cc({
     source,
-    define: {
-      BIG_MACRO: value,
-    },
-    flags: ["-DFROM_FLAGS=1"],
+    define: { SMALL_MACRO: "1" },
+    // Array form: Bun concatenates default TCC options + these entries into
+    // a single owned [:0]u8 stored in CompileC.flags. TinyCC's option parser
+    // skips the whitespace and does not keep a copy of the full string.
+    flags: ["-DFROM_FLAGS=1", padding],
     symbols: {
       add: {
         args: ["int", "int"],
@@ -42,19 +50,19 @@ function once(value) {
   lib.close();
 }
 
-function measure(value) {
-  for (let i = 0; i < WARMUP; i++) once(value);
+function measure(padding) {
+  for (let i = 0; i < WARMUP; i++) once(padding);
   Bun.gc(true);
   const before = process.memoryUsage.rss();
-  for (let i = 0; i < ITERATIONS; i++) once(value);
+  for (let i = 0; i < ITERATIONS; i++) once(padding);
   Bun.gc(true);
   return process.memoryUsage.rss() - before;
 }
 
 // Baseline first so the second run inherits any allocator high-water mark
 // from the first, not the other way around.
-const baselineGrowth = measure("x");
-const bigGrowth = measure(bigValue);
+const baselineGrowth = measure(" ");
+const bigGrowth = measure(bigPadding);
 
 const deltaMB = (bigGrowth - baselineGrowth) / 1024 / 1024;
 console.log(

--- a/test/js/bun/ffi/cc-leak-fixture.js
+++ b/test/js/bun/ffi/cc-leak-fixture.js
@@ -8,14 +8,13 @@
 // RSS growth compared to a baseline run with a tiny value. Taking the
 // delta cancels out per-call overhead that is unrelated to the leaked
 // option strings (TinyCC allocations, ASAN quarantine, JIT code, etc).
+//
+// The C source path is passed in argv[2] by cc.test.ts, which owns the
+// temp directory (via tempDirWithFiles) and cleans it up.
 import { cc } from "bun:ffi";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
 
-const dir = mkdtempSync(path.join(tmpdir(), "bun-ffi-cc-leak-"));
-const source = path.join(dir, "add.c");
-writeFileSync(source, "int add(int a, int b) { return a + b; }\n");
+const source = process.argv[2];
+if (!source) throw new Error("usage: bun cc-leak-fixture.js <path/to/add.c>");
 
 const ITERATIONS = 30;
 const WARMUP = 5;

--- a/test/js/bun/ffi/cc-leak-fixture.js
+++ b/test/js/bun/ffi/cc-leak-fixture.js
@@ -1,0 +1,67 @@
+// Exercises bun:ffi cc() with option strings that get duped on the native
+// side (source, include, define, flags) and verifies they are freed on the
+// success path. Before the fix, CompileC.deinit() was only called when an
+// exception was pending, so every successful cc() call leaked all of these
+// duped strings.
+//
+// We make the `define` value large so the leak is easily observable via
+// RSS growth compared to a baseline run with a tiny value. Taking the
+// delta cancels out per-call overhead that is unrelated to the leaked
+// option strings (TinyCC allocations, ASAN quarantine, JIT code, etc).
+import { cc } from "bun:ffi";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dir = mkdtempSync(path.join(tmpdir(), "bun-ffi-cc-leak-"));
+const source = path.join(dir, "add.c");
+writeFileSync(source, "int add(int a, int b) { return a + b; }\n");
+
+const ITERATIONS = 30;
+const WARMUP = 5;
+const BIG_BYTES = 4 * 1024 * 1024;
+
+const bigValue = Buffer.alloc(BIG_BYTES, "x").toString();
+
+function once(value) {
+  const lib = cc({
+    source,
+    define: {
+      BIG_MACRO: value,
+    },
+    flags: ["-DFROM_FLAGS=1"],
+    symbols: {
+      add: {
+        args: ["int", "int"],
+        returns: "int",
+      },
+    },
+  });
+  if (lib.symbols.add(1, 2) !== 3) {
+    throw new Error("add(1, 2) !== 3");
+  }
+  lib.close();
+}
+
+function measure(value) {
+  for (let i = 0; i < WARMUP; i++) once(value);
+  Bun.gc(true);
+  const before = process.memoryUsage.rss();
+  for (let i = 0; i < ITERATIONS; i++) once(value);
+  Bun.gc(true);
+  return process.memoryUsage.rss() - before;
+}
+
+// Baseline first so the second run inherits any allocator high-water mark
+// from the first, not the other way around.
+const baselineGrowth = measure("x");
+const bigGrowth = measure(bigValue);
+
+const deltaMB = (bigGrowth - baselineGrowth) / 1024 / 1024;
+console.log(
+  JSON.stringify({
+    baselineMB: +(baselineGrowth / 1024 / 1024).toFixed(2),
+    bigMB: +(bigGrowth / 1024 / 1024).toFixed(2),
+    deltaMB: +deltaMB.toFixed(2),
+  }),
+);

--- a/test/js/bun/ffi/cc-leak-fixture.js
+++ b/test/js/bun/ffi/cc-leak-fixture.js
@@ -27,7 +27,7 @@ const ITERATIONS = 30;
 const WARMUP = 5;
 const BIG_BYTES = 4 * 1024 * 1024;
 
-const bigPadding = " ".repeat(BIG_BYTES);
+const bigPadding = Buffer.alloc(BIG_BYTES, " ").toString();
 
 function once(padding) {
   const lib = cc({

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -202,26 +202,30 @@ describe.skip("given a strlen(cstring) function", () => {
 // Kept at the end of the file: the fixture subprocess briefly allocates a
 // few hundred MiB, which on slow machines can push adjacent tests with short
 // timeouts over the edge if it runs first.
-it.skipIf(isFFIUnavailable)("cc() does not leak option strings on success", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  let result;
-  try {
-    result = JSON.parse(stdout);
-  } catch {
-    throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
-  }
-  const { baselineMB, bigMB, deltaMB } = result;
-  // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
-  // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
-  expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
-  expect(exitCode).toBe(0);
-}, 60_000);
+it.skipIf(isFFIUnavailable)(
+  "cc() does not leak option strings on success",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    let result;
+    try {
+      result = JSON.parse(stdout);
+    } catch {
+      throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+    }
+    const { baselineMB, bigMB, deltaMB } = result;
+    // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
+    // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
+    expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
 
 // =============================================================================
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1,7 +1,7 @@
 import { cc, CString, ptr, type FFIFunction, type Library } from "bun:ffi";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { promises as fs } from "fs";
-import { bunEnv, bunExe, isArm64, isASAN, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isArm64, isASAN, isWindows, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 // TinyCC (and all of bun:ffi) is disabled on Windows ARM64
@@ -205,11 +205,11 @@ describe.skip("given a strlen(cstring) function", () => {
 it.skipIf(isFFIUnavailable)(
   "cc() does not leak option strings on success",
   async () => {
-    const dir = tempDirWithFiles("bun-ffi-cc-leak", {
+    using dir = tempDir("bun-ffi-cc-leak", {
       "add.c": "int add(int a, int b) { return a + b; }\n",
     });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js"), path.join(dir, "add.c")],
+      cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js"), path.join(String(dir), "add.c")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -192,6 +192,37 @@ describe.skip("given a strlen(cstring) function", () => {
   });
 }); // </given a strlen(cstring) function>
 
+// Every successful cc() used to leak all of its option strings (source path,
+// include dirs, define key/values, flags, libraries) because CompileC.deinit()
+// was only called when an exception was pending. The fixture passes a 4 MiB
+// `define` value and measures RSS growth relative to a baseline run with a
+// tiny value so per-call overhead unrelated to the leaked strings (TinyCC
+// internals, ASAN quarantine, JIT) cancels out.
+//
+// Kept at the end of the file: the fixture subprocess briefly allocates a
+// few hundred MiB, which on slow machines can push adjacent tests with short
+// timeouts over the edge if it runs first.
+it.skipIf(isFFIUnavailable)("cc() does not leak option strings on success", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let result;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+  }
+  const { baselineMB, bigMB, deltaMB } = result;
+  // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
+  // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
+  expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
+  expect(exitCode).toBe(0);
+}, 60_000);
+
 // =============================================================================
 
 function makeValidCase<Fns extends Record<string, FFIFunction>>(

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -194,10 +194,11 @@ describe.skip("given a strlen(cstring) function", () => {
 
 // Every successful cc() used to leak all of its option strings (source path,
 // include dirs, define key/values, flags, libraries) because CompileC.deinit()
-// was only called when an exception was pending. The fixture passes a 4 MiB
-// `define` value and measures RSS growth relative to a baseline run with a
-// tiny value so per-call overhead unrelated to the leaked strings (TinyCC
-// internals, ASAN quarantine, JIT) cancels out.
+// was only called when an exception was pending. The fixture pads `flags`
+// with 4 MiB of whitespace — Bun dupes the full string into CompileC.flags
+// (the leak), while TinyCC only parses it and does not retain a copy — and
+// measures RSS growth relative to a baseline run with a tiny padding so
+// per-call overhead unrelated to the leaked strings cancels out.
 //
 // Kept at the end of the file: the fixture subprocess briefly allocates a
 // few hundred MiB, which on slow machines can push adjacent tests with short
@@ -222,7 +223,7 @@ it.skipIf(isFFIUnavailable)(
       throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
     }
     const { baselineMB, bigMB, deltaMB } = result;
-    // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
+    // Without the fix: ~115-120 MiB.
     // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
     expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
     expect(exitCode).toBe(0);

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -202,30 +202,29 @@ describe.skip("given a strlen(cstring) function", () => {
 // Kept at the end of the file: the fixture subprocess briefly allocates a
 // few hundred MiB, which on slow machines can push adjacent tests with short
 // timeouts over the edge if it runs first.
-it.skipIf(isFFIUnavailable)(
-  "cc() does not leak option strings on success",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    let result;
-    try {
-      result = JSON.parse(stdout);
-    } catch {
-      throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
-    }
-    const { baselineMB, bigMB, deltaMB } = result;
-    // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
-    // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
-    expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+it.skipIf(isFFIUnavailable)("cc() does not leak option strings on success", async () => {
+  const dir = tempDirWithFiles("bun-ffi-cc-leak", {
+    "add.c": "int add(int a, int b) { return a + b; }\n",
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js"), path.join(dir, "add.c")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  let result;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+  }
+  const { baselineMB, bigMB, deltaMB } = result;
+  // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
+  // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
+  expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
+  expect(exitCode).toBe(0);
+}, 60_000);
 
 // =============================================================================
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -202,29 +202,33 @@ describe.skip("given a strlen(cstring) function", () => {
 // Kept at the end of the file: the fixture subprocess briefly allocates a
 // few hundred MiB, which on slow machines can push adjacent tests with short
 // timeouts over the edge if it runs first.
-it.skipIf(isFFIUnavailable)("cc() does not leak option strings on success", async () => {
-  const dir = tempDirWithFiles("bun-ffi-cc-leak", {
-    "add.c": "int add(int a, int b) { return a + b; }\n",
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js"), path.join(dir, "add.c")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  let result;
-  try {
-    result = JSON.parse(stdout);
-  } catch {
-    throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
-  }
-  const { baselineMB, bigMB, deltaMB } = result;
-  // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
-  // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
-  expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
-  expect(exitCode).toBe(0);
-}, 60_000);
+it.skipIf(isFFIUnavailable)(
+  "cc() does not leak option strings on success",
+  async () => {
+    const dir = tempDirWithFiles("bun-ffi-cc-leak", {
+      "add.c": "int add(int a, int b) { return a + b; }\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", path.join(__dirname, "cc-leak-fixture.js"), path.join(dir, "add.c")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    let result;
+    try {
+      result = JSON.parse(stdout);
+    } catch {
+      throw new Error(`fixture did not produce JSON\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+    }
+    const { baselineMB, bigMB, deltaMB } = result;
+    // Without the fix: ~120 MiB on release, ~87 MiB on debug+ASAN.
+    // With the fix: ≤ 0 MiB (second run reuses first run's high-water mark).
+    expect(deltaMB, `baseline ${baselineMB} MiB, big ${bigMB} MiB`).toBeLessThan(40);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
 
 // =============================================================================
 


### PR DESCRIPTION
## What

`Bun__FFI__cc()` only ran `compile_c.deinit()` when `globalThis.hasException()` was true:

```zig
var compile_c = CompileC{};
defer {
    if (globalThis.hasException()) {
        compile_c.deinit();
    }
}
```

On the **success** path, `compile_c.symbols.map` is moved into the returned `FFI` struct and `compile_c.symbols` is reset, but the function returns without an exception set — so the defer condition is false and `CompileC.deinit()` never runs. Every successful `cc({ source, library, include, define, flags, ... })` call leaked:

- `source` file path(s)
- `libraries` / `library_dirs` / `include_dirs` string arrays
- `define` key/value pairs
- `flags` string
- `deferred_errors` buffer

The same applied to `error.OutOfMemory` / `error.JSTerminated` returns from `compile_c.compile()`, where no JS exception is set.

## Fix

Make the defer unconditional:

```zig
defer compile_c.deinit();
```

On success, `compile_c.symbols` has already been moved out and reset to `.{}` before the defer runs, so `deinit()` only frees the transient option strings that are no longer needed after compilation. All `CompileC` sub-deinits are safe to call on empty/default state.

## Repro

```js
import { cc } from "bun:ffi";
// write add.c ...
const bigValue = Buffer.alloc(4 * 1024 * 1024, "x").toString();
for (let i = 0; i < 30; i++) {
  const lib = cc({
    source,
    define: { BIG_MACRO: bigValue },
    symbols: { add: { args: ["int", "int"], returns: "int" } },
  });
  lib.close();
}
// RSS grows ~120 MiB on release, none of it recovered
```

## Verification

New test in `test/js/bun/ffi/cc.test.ts` spawns `cc-leak-fixture.js`, which measures RSS growth over 30 `cc()` calls with a 4 MiB `define` value, relative to a baseline run with a tiny value (so per-call TinyCC/ASAN overhead cancels out).

| build | delta (big − baseline) | result |
|---|---|---|
| release, **before** | ~119 MiB | fail |
| debug+ASAN, **before** | ~66–87 MiB | fail |
| debug+ASAN, **after** | ~−35 MiB | pass |

All existing `test/js/bun/ffi/cc.test.ts` and `ffi.test.js` tests pass.

(Distinct from #29858 which fixes the empty `FFI.finalize()` — that leaks the `FFI` struct itself on GC; this leaks the compile-time option strings on every call.)