### PR TITLE
server: destroy HTTPResponseSink on doRenderStream no-promise fallback

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1194,6 +1194,8 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 response_stream.sink.onFirstWrite = null;
 
                 response_stream.sink.finalize();
+                this.sink = null;
+                response_stream.sink.destroy();
                 return;
             }
             var response_body_readable_stream_ref = this.response_body_readable_stream_ref;
@@ -1207,6 +1209,13 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 if (jsc.WebCore.ReadableStream.fromJS(stream.value, globalThis) catch null) |comparator| { // TODO: properly propagate exception upwards
                     if (std.meta.activeTag(comparator.ptr) == std.meta.activeTag(stream.ptr)) {
                         streamLog("is not locked", .{});
+                        response_stream.sink.onFirstWrite = null;
+                        response_stream.sink.ctx = null;
+                        response_stream.detach(globalThis);
+                        response_stream.sink.markDone();
+                        response_stream.sink.finalize();
+                        this.sink = null;
+                        response_stream.sink.destroy();
                         this.renderMissing();
                         return;
                     }
@@ -1219,6 +1228,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             response_stream.detach(globalThis);
             stream.cancel(globalThis);
             response_stream.sink.markDone();
+            response_stream.sink.finalize();
+            this.sink = null;
+            response_stream.sink.destroy();
             this.renderMissing();
         }
 

--- a/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
@@ -1,0 +1,52 @@
+// Exercises the no-promise fallback path in doRenderStream().
+//
+// A direct ReadableStream whose pull() writes synchronously and returns a
+// non-promise value falls through to the "is in progress, but did not return
+// a Promise" branch. That branch must destroy the heap-allocated
+// HTTPServerWritable/JSSink it created a few lines earlier; otherwise each
+// request leaks the struct plus its buffer.
+import { memoryUsage } from "bun:jsc";
+
+const server = Bun.serve({
+  port: 0,
+  fetch() {
+    const stream = new ReadableStream({
+      type: "direct",
+      pull(controller: any) {
+        // Less than highWaterMark so it buffers instead of sending. pull()
+        // returns undefined (not a promise), so assignToStream() also returns
+        // undefined and doRenderStream drops into its no-promise fallback.
+        controller.write("x");
+      },
+    } as any);
+    return new Response(stream);
+  },
+});
+
+const url = server.url.href;
+
+async function once() {
+  const res = await fetch(url);
+  await res.arrayBuffer();
+}
+
+// Warm up: let JIT, caches, and pools settle before the baseline sample.
+for (let i = 0; i < 500; i++) await once();
+Bun.gc(true);
+await Bun.sleep(10);
+Bun.gc(true);
+const before = memoryUsage().currentCommit;
+
+const iterations = 10000;
+for (let i = 0; i < iterations; i++) {
+  await once();
+  if (i % 1000 === 0) Bun.gc(true);
+}
+Bun.gc(true);
+await Bun.sleep(10);
+Bun.gc(true);
+const after = memoryUsage().currentCommit;
+
+server.stop(true);
+
+process.stdout.write(JSON.stringify({ before, after, delta: after - before, iterations }));

--- a/test/js/bun/http/serve-response-stream-sink-leak.test.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// Regression: doRenderStream allocates a ResponseStream.JSSink on the heap
+// and stores it in RequestContext.sink. When assignToStream() returns
+// undefined (a direct stream drained synchronously with no pending promise)
+// the fallback branches detached the sink from JS but never called
+// sink.destroy(), and neither finalizeWithoutDeinit() nor deinit() touch
+// RequestContext.sink, so the allocation plus its pooled buffer leaked on
+// every such request.
+test("HTTPResponseSink is destroyed on doRenderStream no-promise fallback", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-response-stream-sink-leak-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { before, after, delta, iterations } = JSON.parse(stdout);
+  console.log({ before, after, delta, iterations, perRequest: (delta / iterations).toFixed(1) });
+
+  // currentCommit is mimalloc's committed bytes, so it tracks native
+  // allocations independent of the JS heap. Before the fix each request
+  // leaked the JSSink struct + its buffer, growing commit by ~4 MB (release)
+  // to ~10 MB (debug/ASAN) over 10k requests. After the fix it stays flat.
+  // Allow 2 MB of slack for allocator noise.
+  expect(delta).toBeLessThan(2 * 1024 * 1024);
+  expect(exitCode).toBe(0);
+}, 120_000);


### PR DESCRIPTION
## What

`doRenderStream()` heap-allocates a `ResponseStream.JSSink` at the top and stores it in `RequestContext.sink`. When `assignToStream()` returns undefined (a direct `ReadableStream` drained synchronously without a backpressure promise), three fallback branches returned without calling `sink.destroy()`:

| path | before |
|---|---|
| `isAbortedOrEnded()` | `detach()` + `finalize()` only |
| not-locked → `renderMissing()` | no sink cleanup at all |
| in-progress-no-promise → `renderMissing()` | `detach()` + `markDone()` only |

`finalize()` releases the internal buffer back to its pool but does not free the heap allocation — only `destroy()` calls `allocator.destroy()`. After `detach()` the JS controller's `m_sinkPtr` is nulled, so GC never touches it either. And `RequestContext.finalizeWithoutDeinit()` / `deinit()` never look at `this.sink`, so the next `create()` overwrites the dangling pointer and the allocation (plus its `ByteListPool` node and buffer) leaks on every such request.

## Fix

Match the cleanup sequence already used by `handleResolveStream` / `handleRejectStream` and the non-fallback branches in the same function: `detach()` → `finalize()` → `this.sink = null` → `destroy()`.

## Repro

A direct `ReadableStream` whose `pull()` writes less than `highWaterMark` and returns a non-promise hits the "is in progress, but did not return a Promise" branch every time:

```js
new Response(new ReadableStream({
  type: "direct",
  pull(controller) { controller.write("x"); },
}))
```

## Verification

New test `test/js/bun/http/serve-response-stream-sink-leak.test.ts` runs 10 000 of these requests in a subprocess and checks mimalloc's `currentCommit` (native allocation commit, independent of the JS heap) is flat.

| | mimalloc commit delta (10k reqs) |
|---|---|
| before | **+4.1 MB** release / **+10.7 MB** debug-ASAN |
| after | **≤ 0** |

Gate verified locally: fails on main, passes with the fix.