### PR TITLE
Fix BuildMessage/ResolveMessage leaking native struct on finalize

### DIFF
--- a/src/bun.js/BuildMessage.zig
+++ b/src/bun.js/BuildMessage.zig
@@ -184,6 +184,7 @@ pub const BuildMessage = struct {
 
     pub fn finalize(this: *BuildMessage) void {
         this.msg.deinit(bun.default_allocator);
+        this.allocator.destroy(this);
     }
 };
 

--- a/src/bun.js/ResolveMessage.zig
+++ b/src/bun.js/ResolveMessage.zig
@@ -229,6 +229,7 @@ pub const ResolveMessage = struct {
         if (this.referrer) |referrer| {
             this.allocator.free(referrer.text);
         }
+        this.allocator.destroy(this);
     }
 };
 

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -996,6 +996,7 @@ pub fn transformSync(
     this.transpiler.setAllocator(allocator);
     this.transpiler.macro_context = null;
     var log = logger.Log.init(arena.backingAllocator());
+    defer log.deinit();
     log.level = this.config.log.level;
     this.transpiler.setLog(&log);
 

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
 test("BuildError is modifiable", async () => {
   try {
     await import("../util/inspect-error-fixture-bad.js");
@@ -15,3 +18,49 @@ test("BuildError is modifiable", async () => {
   expect(error!.message).toBe("new message");
   expect(error!.message).not.toBe(message);
 });
+
+// BuildMessage is heap-allocated via allocator.create() in BuildMessage.create().
+// finalize() must destroy the struct itself, not just the inner logger.Msg.
+// Without the destroy, every transpile error leaked the native struct after GC
+// collected the JS wrapper. ResolveMessage had the same bug; both are fixed.
+test(
+  "BuildMessage does not leak native struct",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--smol",
+        "-e",
+        /* js */ `
+          const t = new Bun.Transpiler();
+          function once() {
+            try { t.transformSync("const x = ;"); } catch {}
+          }
+          // Warm up the JSC heap / mimalloc arenas enough to reach steady state
+          // so that RSS growth below reflects actual leaks rather than heap
+          // expansion.
+          for (let i = 0; i < 10000; i++) once();
+          Bun.gc(true);
+          await Bun.sleep(10);
+          Bun.gc(true);
+          const before = process.memoryUsage.rss();
+          for (let i = 0; i < 100000; i++) once();
+          Bun.gc(true);
+          await Bun.sleep(10);
+          Bun.gc(true);
+          const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+          if (growthMB > 15) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+          console.log("OK", growthMB.toFixed(2) + "MB");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("OK");
+    expect(exitCode).toBe(0);
+  },
+  180_000,
+);


### PR DESCRIPTION
## What

`BuildMessage.finalize()` and `ResolveMessage.finalize()` called `this.msg.deinit()` to free the inner `logger.Msg` contents but never called `allocator.destroy(this)` on the struct itself, which is heap-allocated via `allocator.create()` in `create()`. Every transpile or resolve error surfaced to JS leaked the native struct after GC collected the JS wrapper.

Also adds the missing `defer log.deinit()` in `Transpiler.transformSync()` so the log's `msgs` ArrayList backing storage is freed on the error path (`scan()` already had this).

## Repro

```js
const t = new Bun.Transpiler();
for (let i = 0; i < 100000; i++) {
  try { t.transformSync("const x = ;"); } catch {}
}
Bun.gc(true);
// RSS grows ~30MB — the BuildMessage struct is never destroyed
```

## Verification

10k warmup + 100k iterations of `transformSync` with a syntax error, measuring RSS delta:

| Build | RSS growth |
|---|---|
| Before (release) | ~30 MB |
| Before (debug/ASAN) | ~38 MB |
| After (debug/ASAN) | ~4 MB |

Test added to `test/js/bun/resolve/build-error.test.ts` with a 15 MB threshold.

Note: `Bun.resolveSync()` on a missing path has additional pre-existing leaks in `VirtualMachine.resolveMaybeNeedsTrailingSlash` (the formatted error text from `ResolveMessage.fmt` / log `Msg` contents are never freed) that are out of scope here — the `ResolveMessage` struct itself is now freed.