### PR TITLE
test(websocket-server): skip Malloc=1 on Windows in upgrade UAF test

### DIFF
--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,7 +1,7 @@
 import type { Server, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, forceGuardMalloc } from "harness";
+import { bunEnv, bunExe, forceGuardMalloc, isWindows } from "harness";
 import { isIP } from "node:net";
 import path from "node:path";
 
@@ -1120,8 +1120,11 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
     env: {
       ...bunEnv,
       // Route bmalloc through the system heap so ASAN can observe the
-      // StringImpl allocation in sanitizer-enabled builds.
-      Malloc: "1",
+      // StringImpl allocation in sanitizer-enabled builds. On Windows
+      // bmalloc's SystemHeap is unimplemented and would RELEASE_BASSERT,
+      // so leave bmalloc in place there — Windows builds have no ASAN
+      // lane anyway.
+      ...(isWindows ? {} : { Malloc: "1" }),
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -1138,4 +1141,4 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
     stderr: "",
   });
   expect(exitCode).toBe(0);
-}, 30_000);
+});


### PR DESCRIPTION
Follow-up to #29856.

## Problem

The regression test added in #29856 sets `Malloc=1` to route bmalloc through the system allocator so ASAN can observe the `StringImpl` allocation and catch the UAF. On Windows, bmalloc's `SystemHeap` is unimplemented and every allocation hits `RELEASE_BASSERT_NOT_REACHED()`, crashing the subprocess:

```
stderr: "============================================================
Bun Canary v1.3.14-canary.1 (64eeaad6) Windows ...
```

This makes `test/js/bun/websocket/websocket-server.test.ts` fail on both `windows-2019-x64` lanes.

## Fix

Only set `Malloc=1` on non-Windows. There's no Windows ASAN lane anyway, so the env var served no purpose there; Windows now just validates the header round-trips correctly through the (fixed) codepath.

Also drop the explicit `30_000` timeout per review on the original PR — the passing case completes in ~1s and the harness default is sufficient.