### PR TITLE
udp: re-check socket after TTL coercion to avoid null deref

### DIFF
--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -586,7 +586,8 @@ pub const UDPSocket = struct {
         }
 
         const ttl = try arguments[0].coerceToInt32(globalThis);
-        const res = function(this.socket.?, ttl);
+        const socket = this.socket orelse return globalThis.throw("Socket is closed", .{});
+        const res = function(socket, ttl);
 
         if (getUSError(res, .setsockopt, true)) |err| {
             return globalThis.throwValue(try err.toJS(globalThis));

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -949,7 +949,8 @@ pub const UDPSocket = struct {
         const connect_port = connect_port_js.asInt32();
         const port: u16 = if (connect_port < 1 or connect_port > 0xffff) 0 else @as(u16, @intCast(connect_port));
 
-        if (this.socket.?.connect(connect_host, port) == -1) {
+        const socket = this.socket orelse return globalThis.throw("Socket is closed", .{});
+        if (socket.connect(connect_host, port) == -1) {
             return globalThis.throw("Failed to connect socket", .{});
         }
         this.connect_info = .{

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -32,7 +32,11 @@ describe("udpSocket()", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const stderr = rawStderr
+        .split("\n")
+        .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+        .join("\n");
       expect(stderr).toBe("");
       expect(stdout.trim()).toBe("OK");
       expect(exitCode).toBe(0);

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -5,6 +5,37 @@ import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
 describe("udpSocket()", () => {
+  test.each(["setTTL", "setMulticastTTL"])("%s does not crash when socket is closed during argument coercion", async method => {
+    // coerceToInt32 on the argument can run user JS (valueOf), which may close
+    // the socket before the native call. Previously this unwrapped a null
+    // socket pointer and crashed; now it should throw "Socket is closed".
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const s = await Bun.udpSocket({});
+          let err;
+          try {
+            s.${method}({ valueOf() { s.close(); return 1; } });
+          } catch (e) {
+            err = e;
+          }
+          if (!err) throw new Error("expected ${method} to throw");
+          if (!String(err.message).includes("closed")) throw new Error("expected 'closed' error, got: " + err.message);
+          console.log("OK");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
   test("connect with invalid hostname rejects", async () => {
     expect(async () =>
       udpSocket({

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -34,7 +34,7 @@ describe("udpSocket()", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("OK");
     expect(exitCode).toBe(0);
-  }, 30_000);
+  });
 
   test("connect with invalid hostname rejects", async () => {
     expect(async () =>

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -5,15 +5,17 @@ import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
 describe("udpSocket()", () => {
-  test.each(["setTTL", "setMulticastTTL"])("%s does not crash when socket is closed during argument coercion", async method => {
-    // coerceToInt32 on the argument can run user JS (valueOf), which may close
-    // the socket before the native call. Previously this unwrapped a null
-    // socket pointer and crashed; now it should throw "Socket is closed".
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+  test.each(["setTTL", "setMulticastTTL"])(
+    "%s does not crash when socket is closed during argument coercion",
+    async method => {
+      // coerceToInt32 on the argument can run user JS (valueOf), which may close
+      // the socket before the native call. Previously this unwrapped a null
+      // socket pointer and crashed; now it should throw "Socket is closed".
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
           const s = await Bun.udpSocket({});
           let err;
           try {
@@ -25,16 +27,17 @@ describe("udpSocket()", () => {
           if (!String(err.message).includes("closed")) throw new Error("expected 'closed' error, got: " + err.message);
           console.log("OK");
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  });
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test("connect with invalid hostname rejects", async () => {
     expect(async () =>


### PR DESCRIPTION
## Problem

`UDPSocket.setTTL()` and `UDPSocket.setMulticastTTL()` crash with a null pointer dereference when the argument is an object whose `valueOf` closes the socket:

```js
const s = await Bun.udpSocket({});
s.setTTL({ valueOf() { s.close(); return 1; } });
// => panic(main thread): Segmentation fault at address 0x0
```

## Cause

`setAnyTTL` checks `this.closed` first, then calls `arguments[0].coerceToInt32(globalThis)`, which performs JS ToInt32 and invokes `valueOf`/`Symbol.toPrimitive` on object arguments. If that user code calls `socket.close()`, `this.socket` is set to `null` synchronously. Control then returns to `setAnyTTL` which immediately does `function(this.socket.?, ttl)` — a null optional unwrap (safety-checked panic in Debug, null deref into `us_udp_socket_set_ttl` in ReleaseFast).

## Fix

Re-check `this.socket` after the coercion and throw `"Socket is closed"` if it was closed, matching the pattern already used by `setMembership`, `setSourceSpecificMembership`, `setMulticastInterface`, `send`, and `sendMany` in the same file.

## Verification

- Without fix (`bun bd` on unpatched src): both tests fail — subprocess panics on null unwrap at `udp_socket.zig:589`.
- With fix: both tests pass — `setTTL`/`setMulticastTTL` throw `"Socket is closed"`.
- Full `test/js/bun/udp/udp_socket.test.ts` suite: 169 pass, 0 fail.