### PR TITLE
event_loop: don't drop concurrent tasks when tasks FIFO wraps

### DIFF
--- a/src/event_loop/MiniEventLoop.zig
+++ b/src/event_loop/MiniEventLoop.zig
@@ -139,12 +139,12 @@ pub fn tickConcurrentWithCount(this: *MiniEventLoop) usize {
     }
 
     this.tasks.ensureUnusedCapacity(count) catch unreachable;
-    var writable = this.tasks.writableSlice(0);
     while (iter.next()) |task| {
-        writable[0] = task;
-        writable = writable[1..];
-        this.tasks.count += 1;
-        if (writable.len == 0) break;
+        // writeItemAssumeCapacity handles the case where the ring buffer's
+        // writable region wraps around. writableSlice(0) alone does not: it
+        // returns only the first contiguous chunk, which can be shorter than
+        // `count` when head > 0 and there are existing tasks in the FIFO.
+        this.tasks.writeItemAssumeCapacity(task);
     }
 
     return this.tasks.count - start_count;

--- a/src/jsc/event_loop.zig
+++ b/src/jsc/event_loop.zig
@@ -328,7 +328,6 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
     }
 
     this.tasks.ensureUnusedCapacity(count) catch unreachable;
-    var writable = this.tasks.writableSlice(0);
 
     // Defer destruction of the ConcurrentTask to avoid issues with pointer aliasing
     var to_destroy: ?*ConcurrentTask = null;
@@ -343,10 +342,11 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
             to_destroy = task;
         }
 
-        writable[0] = task.task;
-        writable = writable[1..];
-        this.tasks.count += 1;
-        if (writable.len == 0) break;
+        // writeItemAssumeCapacity handles the case where the ring buffer's
+        // writable region wraps around. writableSlice(0) alone does not: it
+        // returns only the first contiguous chunk, which can be shorter than
+        // `count` when head > 0 and there are existing tasks in the FIFO.
+        this.tasks.writeItemAssumeCapacity(task.task);
     }
 
     if (to_destroy) |dest| {

--- a/test/js/web/workers/concurrent-task-fifo-wrap-worker.js
+++ b/test/js/web/workers/concurrent-task-fifo-wrap-worker.js
@@ -1,10 +1,13 @@
 let sab;
 let received = [];
+let bc;
 
 self.onmessage = e => {
   const msg = e.data;
   if (msg.kind === "init") {
     sab = new Int32Array(msg.sab);
+    bc = new BroadcastChannel(msg.channel);
+    bc.onmessage = handleBroadcast;
     self.postMessage({ kind: "ready" });
     // Block here until main has posted the entire first burst. This
     // guarantees all N messages are in concurrent_tasks before the next
@@ -15,9 +18,13 @@ self.onmessage = e => {
   }
   if (msg.kind === "finalize") {
     self.postMessage({ kind: "done", received: received.slice().sort((a, b) => a - b) });
+    bc.close();
     return;
   }
+};
 
+function handleBroadcast(e) {
+  const msg = e.data;
   const id = msg.id;
   received.push(id);
 
@@ -49,4 +56,4 @@ self.onmessage = e => {
       Atomics.notify(sab, 2);
     }
   }
-};
+}

--- a/test/js/web/workers/concurrent-task-fifo-wrap-worker.js
+++ b/test/js/web/workers/concurrent-task-fifo-wrap-worker.js
@@ -1,0 +1,52 @@
+let sab;
+let received = [];
+
+self.onmessage = e => {
+  const msg = e.data;
+  if (msg.kind === "init") {
+    sab = new Int32Array(msg.sab);
+    self.postMessage({ kind: "ready" });
+    // Block here until main has posted the entire first burst. This
+    // guarantees all N messages are in concurrent_tasks before the next
+    // tickConcurrent pops them, so they land in the tasks FIFO as one batch
+    // regardless of thread scheduling.
+    while (Atomics.load(sab, 3) === 0) {}
+    return;
+  }
+  if (msg.kind === "finalize") {
+    self.postMessage({ kind: "done", received: received.slice().sort((a, b) => a - b) });
+    return;
+  }
+
+  const id = msg.id;
+  received.push(id);
+
+  // Messages 0..(reenterDepth-1) each force a reentrant tick() via an
+  // HTMLRewriter async element handler. Each level of reentrancy advances the
+  // tasks FIFO head by one before the inner tickConcurrent runs, widening the
+  // gap between writableSlice(0) and writableLength.
+  if (id < msg.reenterDepth) {
+    if (id === msg.reenterDepth - 1) {
+      // Deepest reentrant level: tell main to post the second burst, then
+      // spin until it has. The second burst lands in the worker's
+      // concurrent_tasks queue before waitForPromise -> tickConcurrent pops
+      // it.
+      Atomics.store(sab, 0, 1);
+      Atomics.notify(sab, 0);
+      while (Atomics.load(sab, 1) === 0) {}
+    }
+    new HTMLRewriter()
+      .on("*", {
+        async element() {
+          await 0;
+        },
+      })
+      .transform("<b>x</b>");
+    if (id === msg.reenterDepth - 1) {
+      // waitForPromise has returned: the reentrant tick has processed every
+      // task it was going to. Tell main it can send the finalize probe now.
+      Atomics.store(sab, 2, 1);
+      Atomics.notify(sab, 2);
+    }
+  }
+};

--- a/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
+++ b/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
@@ -61,8 +61,11 @@ test("tickConcurrent does not drop tasks when the FIFO writable region wraps", a
 
     // Block until the worker is REENTER_DEPTH tasks deep and about to reenter
     // tick(). Atomics.wait on the main thread is fine here: the worker is on
-    // its own thread.
-    Atomics.wait(flags, 0, 0);
+    // its own thread. Bounded wait so a worker-side failure surfaces as a test
+    // failure instead of parking the test runner in a futex forever (the
+    // event-loop-based per-test timeout cannot fire while this thread is
+    // blocked).
+    expect(Atomics.wait(flags, 0, 0, 10_000)).not.toBe("timed-out");
 
     // Second burst: M messages. These land in the worker's concurrent_tasks
     // queue and are popped by the reentrant tickConcurrent().
@@ -72,7 +75,7 @@ test("tickConcurrent does not drop tasks when the FIFO writable region wraps", a
     Atomics.store(flags, 1, 1);
 
     // Wait for the worker to finish its reentrant processing before probing.
-    Atomics.wait(flags, 2, 0);
+    expect(Atomics.wait(flags, 2, 0, 10_000)).not.toBe("timed-out");
 
     // The finalize probe goes through a fresh tickConcurrent() with head=0, so
     // it is never itself subject to the wrap. The worker replies with every

--- a/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
+++ b/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
@@ -6,13 +6,19 @@ import { expect, test } from "bun:test";
 // contiguous chunk and the loop `break`ed early, leaking the remaining tasks
 // and never running their wrapped CppTask/EventLoopTask.
 //
-// Reproduction: a Worker's onmessage handler triggers HTMLRewriter.transform()
-// with an async element handler. HTMLRewriter calls waitForPromise() which
-// reenters tick() -> tickConcurrent() while earlier sibling tasks are still in
-// the FIFO (so head > 0 and count > 0). A SharedArrayBuffer coordinates the
-// main thread to post a second burst of messages precisely before the reentrant
-// tickConcurrent runs, so the popped batch exceeds the first contiguous writable
-// chunk but still fits in total writable capacity (no realloc).
+// Reproduction: a Worker's BroadcastChannel onmessage handler triggers
+// HTMLRewriter.transform() with an async element handler. HTMLRewriter calls
+// waitForPromise() which reenters tick() -> tickConcurrent() while earlier
+// sibling tasks are still in the FIFO (so head > 0 and count > 0). A
+// SharedArrayBuffer coordinates the main thread to post a second burst of
+// messages precisely before the reentrant tickConcurrent runs, so the popped
+// batch exceeds the first contiguous writable chunk but still fits in total
+// writable capacity (no realloc).
+//
+// BroadcastChannel is used (not Worker.postMessage) because BroadcastChannel
+// creates one ConcurrentTask per postMessage per subscriber with no batching,
+// whereas Worker.postMessage batches all queued messages into a single drain
+// task.
 test("tickConcurrent does not drop tasks when the FIFO writable region wraps", async () => {
   // The tasks FIFO has an initial capacity of 64. Choose N so that after the
   // worker pops the first burst and reads reenterDepth tasks, the remaining
@@ -32,15 +38,17 @@ test("tickConcurrent does not drop tasks when the FIFO writable region wraps", a
 
   const sab = new SharedArrayBuffer(16);
   const flags = new Int32Array(sab);
+  const channel = "concurrent-task-fifo-wrap-" + Math.random().toString(36).slice(2);
 
   const worker = new Worker(new URL("./concurrent-task-fifo-wrap-worker.js", import.meta.url));
+  const bc = new BroadcastChannel(channel);
   try {
     await new Promise<void>((resolve, reject) => {
       worker.onerror = reject;
       worker.onmessage = e => {
         if (e.data.kind === "ready") resolve();
       };
-      worker.postMessage({ kind: "init", sab });
+      worker.postMessage({ kind: "init", sab, channel });
     });
 
     const doneP = new Promise<number[]>((resolve, reject) => {
@@ -50,12 +58,13 @@ test("tickConcurrent does not drop tasks when the FIFO writable region wraps", a
       };
     });
 
-    // First burst: N messages. These become N ConcurrentTasks that the worker
-    // pops in one tickConcurrent() into its tasks FIFO. The worker is blocked
-    // spinning inside its "init" handler until flags[3] is set below, so all
-    // N land in concurrent_tasks before any are popped.
+    // First burst: N messages. BroadcastChannel creates one ConcurrentTask per
+    // postMessage (no batching), pushed synchronously onto the worker's
+    // concurrent_tasks queue before postMessage returns. The worker is blocked
+    // spinning inside its "init" handler until flags[3] is set below, so all N
+    // land in concurrent_tasks before any are popped.
     for (let i = 0; i < N; i++) {
-      worker.postMessage({ kind: "msg", id: i, reenterDepth: REENTER_DEPTH });
+      bc.postMessage({ id: i, reenterDepth: REENTER_DEPTH });
     }
     Atomics.store(flags, 3, 1);
 
@@ -70,21 +79,22 @@ test("tickConcurrent does not drop tasks when the FIFO writable region wraps", a
     // Second burst: M messages. These land in the worker's concurrent_tasks
     // queue and are popped by the reentrant tickConcurrent().
     for (let i = N; i < TOTAL; i++) {
-      worker.postMessage({ kind: "msg", id: i, reenterDepth: REENTER_DEPTH });
+      bc.postMessage({ id: i, reenterDepth: REENTER_DEPTH });
     }
     Atomics.store(flags, 1, 1);
 
     // Wait for the worker to finish its reentrant processing before probing.
     expect(Atomics.wait(flags, 2, 0, 10_000)).not.toBe("timed-out");
 
-    // The finalize probe goes through a fresh tickConcurrent() with head=0, so
-    // it is never itself subject to the wrap. The worker replies with every
-    // message id it actually received.
+    // The finalize probe goes through Worker.postMessage (batched, fresh
+    // tickConcurrent with head=0), so it is never itself subject to the wrap.
+    // The worker replies with every message id it actually received.
     worker.postMessage({ kind: "finalize" });
 
     const received = await doneP;
     expect(received).toEqual(Array.from({ length: TOTAL }, (_, i) => i));
   } finally {
+    bc.close();
     worker.terminate();
   }
 });

--- a/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
+++ b/test/js/web/workers/concurrent-task-fifo-wrap.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test";
+
+// Regression test for tickConcurrentWithCount dropping ConcurrentTasks when the
+// tasks FIFO ring buffer's writable region is non-contiguous (head > 0 with
+// existing tasks queued). Previously writableSlice(0) returned only the first
+// contiguous chunk and the loop `break`ed early, leaking the remaining tasks
+// and never running their wrapped CppTask/EventLoopTask.
+//
+// Reproduction: a Worker's onmessage handler triggers HTMLRewriter.transform()
+// with an async element handler. HTMLRewriter calls waitForPromise() which
+// reenters tick() -> tickConcurrent() while earlier sibling tasks are still in
+// the FIFO (so head > 0 and count > 0). A SharedArrayBuffer coordinates the
+// main thread to post a second burst of messages precisely before the reentrant
+// tickConcurrent runs, so the popped batch exceeds the first contiguous writable
+// chunk but still fits in total writable capacity (no realloc).
+test("tickConcurrent does not drop tasks when the FIFO writable region wraps", async () => {
+  // The tasks FIFO has an initial capacity of 64. Choose N so that after the
+  // worker pops the first burst and reads reenterDepth tasks, the remaining
+  // writable region wraps around with a short first chunk.
+  //
+  // After K=reenterDepth readItems: head=K, count=N-K, tail=N.
+  //   first contiguous writable chunk = buf.len - tail = 64 - N
+  //   total writable = buf.len - count = 64 - N + K
+  // Pick M = total writable so ensureUnusedCapacity does not grow the buffer;
+  // then K of those M tasks land in the wrapped region and were previously
+  // dropped.
+  const BUF_LEN = 64;
+  const REENTER_DEPTH = 3;
+  const N = 50;
+  const M = BUF_LEN - N + REENTER_DEPTH; // 17
+  const TOTAL = N + M;
+
+  const sab = new SharedArrayBuffer(16);
+  const flags = new Int32Array(sab);
+
+  const worker = new Worker(new URL("./concurrent-task-fifo-wrap-worker.js", import.meta.url));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      worker.onerror = reject;
+      worker.onmessage = e => {
+        if (e.data.kind === "ready") resolve();
+      };
+      worker.postMessage({ kind: "init", sab });
+    });
+
+    const doneP = new Promise<number[]>((resolve, reject) => {
+      worker.onerror = reject;
+      worker.onmessage = e => {
+        if (e.data.kind === "done") resolve(e.data.received);
+      };
+    });
+
+    // First burst: N messages. These become N ConcurrentTasks that the worker
+    // pops in one tickConcurrent() into its tasks FIFO. The worker is blocked
+    // spinning inside its "init" handler until flags[3] is set below, so all
+    // N land in concurrent_tasks before any are popped.
+    for (let i = 0; i < N; i++) {
+      worker.postMessage({ kind: "msg", id: i, reenterDepth: REENTER_DEPTH });
+    }
+    Atomics.store(flags, 3, 1);
+
+    // Block until the worker is REENTER_DEPTH tasks deep and about to reenter
+    // tick(). Atomics.wait on the main thread is fine here: the worker is on
+    // its own thread.
+    Atomics.wait(flags, 0, 0);
+
+    // Second burst: M messages. These land in the worker's concurrent_tasks
+    // queue and are popped by the reentrant tickConcurrent().
+    for (let i = N; i < TOTAL; i++) {
+      worker.postMessage({ kind: "msg", id: i, reenterDepth: REENTER_DEPTH });
+    }
+    Atomics.store(flags, 1, 1);
+
+    // Wait for the worker to finish its reentrant processing before probing.
+    Atomics.wait(flags, 2, 0);
+
+    // The finalize probe goes through a fresh tickConcurrent() with head=0, so
+    // it is never itself subject to the wrap. The worker replies with every
+    // message id it actually received.
+    worker.postMessage({ kind: "finalize" });
+
+    const received = await doneP;
+    expect(received).toEqual(Array.from({ length: TOTAL }, (_, i) => i));
+  } finally {
+    worker.terminate();
+  }
+});


### PR DESCRIPTION
## What

`tickConcurrentWithCount` silently dropped and leaked `ConcurrentTask`s (and their wrapped `CppTask`/`EventLoopTask`) when the `tasks` FIFO ring buffer's writable region was non-contiguous.

## Why

```zig
this.tasks.ensureUnusedCapacity(count) catch unreachable;
var writable = this.tasks.writableSlice(0);
// ...
while (iter.next()) |task| {
    // ...
    writable[0] = task.task;
    writable = writable[1..];
    this.tasks.count += 1;
    if (writable.len == 0) break;  // ← drops remaining batch items
}
```

`ensureUnusedCapacity(count)` only guarantees *total* writable length, not *contiguous* length. `writableSlice(0)` returns only the first contiguous chunk: when `head > 0` and there are existing tasks queued, `tail = head + count` sits before the end of the buffer and the returned slice is `buf[tail..buf.len]`, which can be shorter than `count`. The loop then `break`s with batch items still un-iterated.

This is reachable whenever `tick()` is re-entered from inside a task handler (`waitForPromise` callers: HTMLRewriter async handlers, `Bun.build` plugins, async `expect` matchers) while sibling tasks are still in the FIFO, and also from the `HotReloadTask` early-return path under `--hot`/`--watch`, or after `error.JSTerminated` exits `tickQueueWithCount` early.

## Fix

Use `writeItemAssumeCapacity` which computes the wrapped tail index per item. Applied to both `EventLoop` and `MiniEventLoop`.

## Reproduction

The test uses BroadcastChannel (which creates one `ConcurrentTask` per `postMessage` per subscriber, unbatched) to post 50 messages to a Worker, filling 50 of the 64 FIFO slots. The worker's onmessage handler uses HTMLRewriter's async element handler to re-enter `tick()` 3 levels deep, advancing `head` to 3. A `SharedArrayBuffer` coordinates the main thread to post 17 more messages precisely before the reentrant `tickConcurrent` pops them: the batch of 17 fits in `writableLength() = 17` (so no realloc) but `writableSlice(0)` only has `64 - 50 = 14` slots. The worker spins inside its init handler until the first burst is fully posted so all 50 land as one batch.

Before: 3 messages (64, 65, 66) never delivered — 15/15 runs.
After: all 67 messages delivered — 15/15 runs.
