### PR TITLE
ci: don't skip tests when GitHub PR-files API fails; cache via meta-data

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -23,6 +23,7 @@ import {
   isMainBranch,
   isMergeQueue,
   parseBoolean,
+  setBuildMetadata,
   spawnSafe,
   startGroup,
   toYaml,
@@ -1509,6 +1510,14 @@ async function main() {
       return;
     }
     options.changedFiles = allFiles;
+    // Publish the file lists as build meta-data so each test shard can read
+    // them instead of re-querying GitHub. With ~150 shards per build, this
+    // is the difference between 1 API call and 150, and the per-shard calls
+    // were exhausting the token's hourly rate limit under load.
+    if (allFiles.length > 0) {
+      await setBuildMetadata("pr-all-files", JSON.stringify(allFiles));
+      await setBuildMetadata("pr-new-files", JSON.stringify(newFiles));
+    }
   }
 
   startGroup("Generating pipeline...");

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -40,6 +40,7 @@ import {
   getArch,
   getBranch,
   getBuildLabel,
+  getBuildMetadata,
   getBuildUrl,
   getCommit,
   getDistro,
@@ -190,29 +191,53 @@ let allFiles = [];
 let newFiles = [];
 let prFileCount = 0;
 if (isBuildkite) {
-  try {
-    console.log("on buildkite: collecting new files from PR");
-    const per_page = 50;
-    const { BUILDKITE_PULL_REQUEST } = process.env;
-    for (let i = 1; i <= 10; i++) {
-      const res = await fetch(
-        `https://api.github.com/repos/oven-sh/bun/pulls/${BUILDKITE_PULL_REQUEST}/files?per_page=${per_page}&page=${i}`,
-        { headers: { Authorization: `Bearer ${getSecret("GITHUB_TOKEN")}` } },
-      );
-      const doc = await res.json();
-      console.log(`-> page ${i}, found ${doc.length} items`);
-      if (doc.length === 0) break;
-      for (const { filename, status } of doc) {
-        prFileCount += 1;
-        allFiles.push(filename);
-        if (status !== "added") continue;
-        newFiles.push(filename);
-      }
-      if (doc.length < per_page) break;
+  // The pipeline-upload step (.buildkite/ci.mjs) already fetched the PR file
+  // list once and stored it as build meta-data. Read it from there so each of
+  // the ~150 test shards doesn't repeat the GitHub API call and burn through
+  // the token's hourly rate limit.
+  const cachedAll = await getBuildMetadata("pr-all-files");
+  const cachedNew = await getBuildMetadata("pr-new-files");
+  if (cachedAll) {
+    try {
+      allFiles = JSON.parse(cachedAll);
+      newFiles = cachedNew ? JSON.parse(cachedNew) : [];
+      prFileCount = allFiles.length;
+      console.log(`- PR file list from build meta-data: ${prFileCount} files, ${newFiles.length} new files`);
+    } catch (e) {
+      console.error("Failed to parse pr-*-files meta-data:", e);
+      allFiles = [];
+      newFiles = [];
     }
-    console.log(`- PR ${BUILDKITE_PULL_REQUEST}, ${prFileCount} files, ${newFiles.length} new files`);
-  } catch (e) {
-    console.error(e);
+  }
+  if (allFiles.length === 0) {
+    try {
+      console.log("on buildkite: collecting new files from PR");
+      const per_page = 50;
+      const { BUILDKITE_PULL_REQUEST } = process.env;
+      for (let i = 1; i <= 10; i++) {
+        const res = await fetch(
+          `https://api.github.com/repos/oven-sh/bun/pulls/${BUILDKITE_PULL_REQUEST}/files?per_page=${per_page}&page=${i}`,
+          { headers: { Authorization: `Bearer ${getSecret("GITHUB_TOKEN")}` } },
+        );
+        const doc = await res.json();
+        if (!res.ok || !Array.isArray(doc)) {
+          console.error(`-> page ${i}: GitHub API ${res.status} ${res.statusText}:`, JSON.stringify(doc));
+          throw new Error(`GitHub API returned ${res.status}; cannot determine changed files`);
+        }
+        console.log(`-> page ${i}, found ${doc.length} items`);
+        if (doc.length === 0) break;
+        for (const { filename, status } of doc) {
+          prFileCount += 1;
+          allFiles.push(filename);
+          if (status !== "added") continue;
+          newFiles.push(filename);
+        }
+        if (doc.length < per_page) break;
+      }
+      console.log(`- PR ${BUILDKITE_PULL_REQUEST}, ${prFileCount} files, ${newFiles.length} new files`);
+    } catch (e) {
+      console.error(e);
+    }
   }
 }
 
@@ -2679,7 +2704,11 @@ export async function main() {
 
   let doRunTests = true;
   if (isCI) {
-    if (allFiles.every(filename => filename.startsWith("docs/"))) {
+    // allFiles can be empty if the GitHub API call failed (bad token, rate
+    // limit, non-PR build). [].every() is vacuously true, which would skip the
+    // entire suite and exit 0 — so require at least one file before treating
+    // the change set as docs-only.
+    if (allFiles.length > 0 && allFiles.every(filename => filename.startsWith("docs/"))) {
       doRunTests = false;
     }
   }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -2283,6 +2283,20 @@ export async function getBuildMetadata(name) {
 }
 
 /**
+ * @param {string} name
+ * @param {string} value
+ * @returns {Promise<void>}
+ */
+export async function setBuildMetadata(name, value) {
+  if (isBuildkite) {
+    const { error } = await spawn(["buildkite-agent", "meta-data", "set", name, value]);
+    if (error) {
+      console.error(`Failed to set build meta-data '${name}':`, error);
+    }
+  }
+}
+
+/**
  * @typedef ConnectOptions
  * @property {string} hostname
  * @property {number} port


### PR DESCRIPTION
## What

Two related fixes to `scripts/runner.node.mjs` and `.buildkite/ci.mjs`:

1. **Fail-closed instead of fail-open.** The docs-only-PR short-circuit used `allFiles.every(f => f.startsWith('docs/'))` without checking `allFiles.length`. When the GitHub `/pulls/{N}/files` call fails (rate limit, bad token, non-PR build), the surrounding `catch` leaves `allFiles = []`, and `[].every()` is vacuously true — so the runner set `doRunTests = false` and exited 0 without running a single test. Now requires `allFiles.length > 0`, and logs `res.status` + the response body when the API returns a non-array.

2. **Cache the PR file list in build meta-data.** Every test shard was independently calling the GitHub API for the same per-build data. `ci.mjs` already fetches it once at pipeline-upload time, so it now stores the result as `pr-all-files` / `pr-new-files` meta-data and `runner.node.mjs` reads from there first (falling back to the API only if meta-data is missing). Drops per-build API calls from ~150 to 1.

## Why

A build-volume spike pushed the shared GitHub token over its hourly rate limit. Shards that started after the limit was hit got `{"message":"API rate limit exceeded"}` instead of an array, threw `TypeError: doc is not iterable` (caught), fell through to the empty-array `every()`, and reported green without running anything. Queue-bottlenecked platforms (longest wait → latest start) were hit first and hardest, but all platforms were affected.

## How to verify

Retry any `test-bun` job that previously finished in <30s — it should now read the file list from meta-data (log line `PR file list from build meta-data: …`) and proceed to actually run tests. If meta-data isn't set (e.g. retrying a job from a build uploaded before this change) the API fallback runs, and a non-2xx response is now logged with its body instead of the opaque `doc is not iterable`.