### PR TITLE
fs: free PathLike in fs.watch/watchFile and drop leaked WTF ref in PathLike.fromBunString

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.zig
+++ b/src/runtime/node/node_fs_stat_watcher.zig
@@ -257,10 +257,15 @@ pub const StatWatcher = struct {
 
         global_this: *jsc.JSGlobalObject,
 
+        pub fn deinit(this: *const Arguments) void {
+            this.path.deinit();
+        }
+
         pub fn fromJS(global: *jsc.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Arguments {
             const path = try PathLike.fromJSWithAllocator(global, arguments, bun.default_allocator) orelse {
                 return global.throwInvalidArguments("filename must be a string or TypedArray", .{});
             };
+            errdefer path.deinit();
 
             var listener: jsc.JSValue = .zero;
             var persistent: bool = true;

--- a/src/runtime/node/node_fs_watcher.zig
+++ b/src/runtime/node/node_fs_watcher.zig
@@ -332,6 +332,10 @@ pub const FSWatcher = struct {
         encoding: jsc.Node.Encoding,
         verbose: bool,
 
+        pub fn deinit(this: *const Arguments) void {
+            this.path.deinit();
+        }
+
         pub fn fromJS(ctx: *jsc.JSGlobalObject, arguments: *ArgumentsSlice) bun.JSError!Arguments {
             const path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArguments("filename must be a string or TypedArray", .{});

--- a/src/runtime/node/types.zig
+++ b/src/runtime/node/types.zig
@@ -771,7 +771,10 @@ pub const PathLike = union(enum) {
 
             sliced.reportExtraMemory(global.vm());
 
-            // It is expensive to keep both around.
+            // It is expensive to keep both around. toSlice() transferred the
+            // caller's ref into sliced.underlying; drop it now that we only
+            // keep the owned UTF-8 buffer.
+            sliced.underlying.deref();
             return .{ .encoded_slice = sliced.utf8 };
         }
     }

--- a/test/js/node/watch/fs.watch.leak.test.ts
+++ b/test/js/node/watch/fs.watch.leak.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+
+// FSWatcher.Arguments / StatWatcher.Arguments had no deinit(), so the
+// PathLike parsed from the JS path string was never released by the
+// `@hasDecl(Arguments, "deinit")` gate in node_fs_binding.zig.
+//
+// Separately, PathLike.fromBunString dropped `sliced.underlying` without
+// derefing it when returning `.encoded_slice` for non-Latin1 paths in sync
+// mode, leaking one WTF::StringImpl ref on every sync fs call.
+//
+// Non-ASCII path prefixes below force the `.encoded_slice` branch; the long
+// tail makes the per-call leak large enough to observe in RSS.
+
+const iterations = isDebug ? 10_000 : 40_000;
+const timeout = isDebug ? 180_000 : 60_000;
+
+async function run(code: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("growthMB=");
+  expect(exitCode).toBe(0);
+}
+
+function fixture(call: string, throwMsg: string): string {
+  return /* ts */ `
+    import fs from "node:fs";
+    const tail = Buffer.alloc(2048, "x").toString();
+    function makePath(i) {
+      return "/\u65b0\u5efa\u6587\u4ef6\u5939/does-not-exist-" + i + "-" + tail;
+    }
+    for (let i = 0; i < 500; i++) {
+      try { ${call} } catch {}
+    }
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+    for (let i = 0; i < ${iterations}; i++) {
+      try { ${call} } catch {}
+    }
+    Bun.gc(true);
+    const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+    console.log("growthMB=" + growthMB.toFixed(2));
+    if (growthMB > 40) {
+      throw new Error("${throwMsg}: " + growthMB.toFixed(2) + "MB");
+    }
+  `;
+}
+
+describe("fs.watch argument leaks", () => {
+  test(
+    "fs.watch does not leak path",
+    async () => {
+      // Directory does not exist so fs.watch throws, exercising the runSync
+      // cleanup path without touching inotify/kqueue limits.
+      await run(fixture(`fs.watch(makePath(i), () => {});`, "fs.watch leaked path arguments"));
+    },
+    timeout,
+  );
+
+  test(
+    "fs.watchFile does not leak path when argument parsing fails",
+    async () => {
+      // StatWatcher.Arguments.fromJS parses the path before validating
+      // `interval`, and previously had no errdefer for the path. Passing a
+      // non-number interval throws after the path allocation, leaking it.
+      await run(
+        fixture(`fs.watchFile(makePath(i), { interval: "bad" }, () => {});`, "fs.watchFile leaked path arguments"),
+      );
+    },
+    timeout,
+  );
+
+  test(
+    "sync fs calls do not leak underlying WTF string for non-Latin1 paths",
+    async () => {
+      // This exercises PathLike.fromBunString directly: existsSync already
+      // had Arguments.deinit, so the only leak here is the dropped
+      // sliced.underlying ref in the `.encoded_slice` branch.
+      await run(fixture(`fs.existsSync(makePath(i));`, "fs.existsSync leaked path arguments"));
+    },
+    timeout,
+  );
+});

--- a/test/js/node/watch/fs.watch.leak.test.ts
+++ b/test/js/node/watch/fs.watch.leak.test.ts
@@ -12,7 +12,7 @@ import { bunEnv, bunExe, isDebug } from "harness";
 // Non-ASCII path prefixes below force the `.encoded_slice` branch; the long
 // tail makes the per-call leak large enough to observe in RSS.
 
-const iterations = isDebug ? 10_000 : 40_000;
+const iterations = isDebug ? 15_000 : 40_000;
 const timeout = isDebug ? 180_000 : 60_000;
 
 async function run(code: string) {

--- a/test/js/node/watch/fs.watch.leak.test.ts
+++ b/test/js/node/watch/fs.watch.leak.test.ts
@@ -31,7 +31,10 @@ async function run(code: string) {
 function fixture(call: string, throwMsg: string): string {
   return /* ts */ `
     import fs from "node:fs";
-    const tail = Buffer.alloc(2048, "x").toString();
+    // Keep the total UTF-8 length under PATH_MAX so Valid.pathStringLength
+    // does not throw before reaching the code under test. macOS PATH_MAX is
+    // 1024; Linux/Windows are >= 4096.
+    const tail = Buffer.alloc(process.platform === "darwin" ? 900 : 2048, "x").toString();
     function makePath(i) {
       return "/\u65b0\u5efa\u6587\u4ef6\u5939/does-not-exist-" + i + "-" + tail;
     }
@@ -52,7 +55,7 @@ function fixture(call: string, throwMsg: string): string {
   `;
 }
 
-describe("fs.watch argument leaks", () => {
+describe.concurrent("fs.watch argument leaks", () => {
   test(
     "fs.watch does not leak path",
     async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes two path leaks in `node:fs`:

### 1. `fs.watch()` / `fs.watchFile()` never free their `PathLike` argument

`node_fs_binding.zig`'s `runSync` only calls `args.deinit()` when `@hasDecl(Arguments, "deinit")` is true. `FSWatcher.Arguments` and `StatWatcher.Arguments` had no `deinit`, so the defer was compiled out and the parsed `PathLike` leaked on every call. `FSWatcher.init` / `StatWatcher.init` copy the path into their own buffers, so the `PathLike` is safe to release once the call returns.

`StatWatcher.Arguments.fromJS` also lacked an `errdefer path.deinit()`, so the path leaked whenever option parsing threw (e.g. `{ interval: "bad" }`).

### 2. `PathLike.fromBunString` drops a WTF::StringImpl ref for non-Latin1 paths

Found while writing the test for (1). In the sync branch, `str.toSlice()` transfers the caller's ref into `sliced.underlying`. When the UTF-8 slice is not WTF-backed (any path containing non-Latin1 characters), the function returned `.{ .encoded_slice = sliced.utf8 }` and dropped `sliced.underlying` without derefing it. This affected **every** sync fs function (`existsSync`, `statSync`, `readFileSync`, ...) — one StringImpl ref pinned per call.

## How did you verify your code works?

New `test/js/node/watch/fs.watch.leak.test.ts` measures RSS growth across many calls with a ~2 KB non-ASCII path:

| | before | after |
|---|---|---|
| `fs.watch` (ENOENT path, 40k calls) | 286 MB | bounded |
| `fs.watchFile` (invalid interval, 40k calls) | 284 MB | bounded |
| `fs.existsSync` (40k calls) | 186 MB | bounded |

```
USE_SYSTEM_BUN=1 bun test test/js/node/watch/fs.watch.leak.test.ts  # 3 fail
bun bd test test/js/node/watch/fs.watch.leak.test.ts                # 3 pass
```

Also ran `test/js/node/watch/fs.watch.test.ts`, `fs.watchFile.test.ts`, `test/js/node/fs/cp.test.ts`, `fs-leak.test.js` — no regressions.
