### PR TITLE
http: free previous redirect URL buffer on each hop

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -616,6 +616,11 @@ allow_retry: bool = false,
 h2_retries: u8 = 0,
 redirect_type: FetchRedirect = FetchRedirect.follow,
 redirect: []u8 = &.{},
+/// The previous hop's `redirect` buffer, parked by `handleResponseMetadata`
+/// when it overwrites `redirect`. `connected_url` may still borrow from it
+/// until `doRedirect` has released the socket, so it is freed there rather
+/// than at the assignment site. Also freed in `deinit` for error paths.
+prev_redirect: []u8 = &.{},
 progress_node: ?*Progress.Node = null,
 
 flags: Flags = Flags{},
@@ -655,6 +660,10 @@ pub fn deinit(this: *HTTPClient) void {
     if (this.redirect.len > 0) {
         bun.default_allocator.free(this.redirect);
         this.redirect = &.{};
+    }
+    if (this.prev_redirect.len > 0) {
+        bun.default_allocator.free(this.prev_redirect);
+        this.prev_redirect = &.{};
     }
     if (this.proxy_authorization) |auth| {
         this.allocator.free(auth);
@@ -1101,6 +1110,12 @@ pub fn doRedirect(
         NewHTTPContext(is_ssl).closeSocket(socket);
     }
     this.connected_url = URL{};
+    // connected_url was the last borrower of the previous hop's URL buffer
+    // (handleResponseMetadata already repointed this.url at the new one).
+    if (this.prev_redirect.len > 0) {
+        bun.default_allocator.free(this.prev_redirect);
+        this.prev_redirect = &.{};
+    }
 
     // TODO: should this check be before decrementing the redirect count?
     // the current logic will allow one less redirect than requested
@@ -2301,6 +2316,10 @@ fn doRedirectMultiplexed(this: *HTTPClient) void {
     assert(this.redirect_type == FetchRedirect.follow);
     this.unregisterAbortTracker();
     this.connected_url = URL{};
+    if (this.prev_redirect.len > 0) {
+        bun.default_allocator.free(this.prev_redirect);
+        this.prev_redirect = &.{};
+    }
     if (this.remaining_redirect_count == 0) {
         this.fail(error.TooManyRedirects);
         return;
@@ -2934,10 +2953,11 @@ pub fn handleResponseMetadata(
                             const new_url = URL.parse(normalized_url_str);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
                             this.url = new_url;
-                            // The previous hop's URL buffer (which backed this.url until the
-                            // line above) is no longer referenced. Free it so multi-hop
-                            // redirect chains don't leak every intermediate URL.
-                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
+                            // connected_url still borrows from the previous hop's buffer
+                            // until doRedirect releases the socket, so park it in
+                            // prev_redirect for doRedirect to free instead of leaking it.
+                            bun.debugAssert(this.prev_redirect.len == 0);
+                            this.prev_redirect = this.redirect;
                             this.redirect = normalized_url_str;
                         } else if (strings.hasPrefixComptime(location, "//")) {
                             var string_builder = bun.StringBuilder{};
@@ -2978,7 +2998,8 @@ pub fn handleResponseMetadata(
                             const new_url = URL.parse(normalized_url_str);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
                             this.url = new_url;
-                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
+                            bun.debugAssert(this.prev_redirect.len == 0);
+                            this.prev_redirect = this.redirect;
                             this.redirect = normalized_url_str;
                         } else {
                             const original_url = this.url;
@@ -2998,9 +3019,8 @@ pub fn handleResponseMetadata(
                             };
                             this.url = URL.parse(new_url);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(this.url.origin), strings.withoutTrailingSlash(original_url.origin), true);
-                            // original_url borrowed from the previous this.redirect buffer; the
-                            // same-origin check above is its last read, so it is now safe to free.
-                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
+                            bun.debugAssert(this.prev_redirect.len == 0);
+                            this.prev_redirect = this.redirect;
                             this.redirect = new_url;
                         }
                     }

--- a/src/http.zig
+++ b/src/http.zig
@@ -2934,6 +2934,10 @@ pub fn handleResponseMetadata(
                             const new_url = URL.parse(normalized_url_str);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
                             this.url = new_url;
+                            // The previous hop's URL buffer (which backed this.url until the
+                            // line above) is no longer referenced. Free it so multi-hop
+                            // redirect chains don't leak every intermediate URL.
+                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
                             this.redirect = normalized_url_str;
                         } else if (strings.hasPrefixComptime(location, "//")) {
                             var string_builder = bun.StringBuilder{};
@@ -2974,6 +2978,7 @@ pub fn handleResponseMetadata(
                             const new_url = URL.parse(normalized_url_str);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(new_url.origin), strings.withoutTrailingSlash(this.url.origin), true);
                             this.url = new_url;
+                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
                             this.redirect = normalized_url_str;
                         } else {
                             const original_url = this.url;
@@ -2993,6 +2998,9 @@ pub fn handleResponseMetadata(
                             };
                             this.url = URL.parse(new_url);
                             is_same_origin = strings.eqlCaseInsensitiveASCII(strings.withoutTrailingSlash(this.url.origin), strings.withoutTrailingSlash(original_url.origin), true);
+                            // original_url borrowed from the previous this.redirect buffer; the
+                            // same-origin check above is its last read, so it is now safe to free.
+                            if (this.redirect.len > 0) bun.default_allocator.free(this.redirect);
                             this.redirect = new_url;
                         }
                     }

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // https://github.com/oven-sh/bun/issues/12701
 it("fetch() preserves body on redirect", async () => {
@@ -30,3 +31,75 @@ it("fetch() preserves body on redirect", async () => {
   expect(res.status).toBe(200);
   expect(await res.text()).toBe("hello");
 });
+
+// The HTTP client allocates a new URL buffer for every Location hop and stores
+// it in HTTPClient.redirect so HTTPClient.url can borrow slices from it. Prior
+// to the fix, assigning the new buffer did not free the previous one, so only
+// the final hop was released in deinit() and every intermediate URL leaked.
+it("fetch() does not leak intermediate redirect URLs in multi-hop chains", async () => {
+  const HOPS = 10;
+  // Pad the redirect URL so each leaked intermediate buffer is large enough
+  // to move RSS measurably. The padding goes in the fragment so the client
+  // allocates the full URL into HTTPClient.redirect while the request sent
+  // on the wire stays tiny (fragments are never transmitted), which keeps
+  // the server under its request-line limit and lets keep-alive reuse one
+  // socket for every hop. Stays under MAX_REDIRECT_URL_LENGTH (128 KiB).
+  const PAD = Buffer.alloc(96 * 1024, "a").toString();
+
+  // Server runs in the parent so its allocations are excluded from the
+  // child's RSS measurement.
+  using server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      const m = pathname.match(/^\/hop\/(\d+)/);
+      const hop = m ? Number(m[1]) : 0;
+      if (hop < HOPS) {
+        return new Response(null, {
+          status: 302,
+          headers: { Location: `${server.url.origin}/hop/${hop + 1}#${PAD}` },
+        });
+      }
+      return new Response("ok");
+    },
+  });
+
+  // Run the fetch loop in a child process so server-side buffers don't
+  // pollute the RSS we measure. The child samples RSS after warmup and
+  // again after two equal batches so we can assert on steady-state growth.
+  const script = `
+    const url = "${server.url.origin}/hop/0";
+    async function once() {
+      const res = await fetch(url, { redirect: "follow" });
+      if (await res.text() !== "ok") throw new Error("unexpected body: " + res.status);
+    }
+    function sample() { Bun.gc(true); return process.memoryUsage.rss(); }
+    for (let i = 0; i < 15; i++) await once();
+    const rss0 = sample();
+    for (let i = 0; i < 25; i++) await once();
+    const rss1 = sample();
+    for (let i = 0; i < 25; i++) await once();
+    const rss2 = sample();
+    console.log(JSON.stringify({ rss0, rss1, rss2 }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  const { rss0, rss1, rss2 } = JSON.parse(stdout.trim());
+  const secondHalfMiB = (rss2 - rss1) / 1024 / 1024;
+  // With the bug, (HOPS - 1) intermediate ~96 KiB URL buffers leak per fetch:
+  // roughly 864 KiB * 50 ≈ 42 MiB total, split evenly across both halves
+  // (~21 MiB each). Without it, allocator growth plateaus after warmup so
+  // the second half stays near zero. Asserting on the second half avoids
+  // counting one-off arena growth that can still occur shortly after warmup.
+  expect(secondHalfMiB).toBeLessThan(12);
+}, 60_000);


### PR DESCRIPTION
## What

`handleResponseMetadata` allocates a fresh URL string via `toOwnedSlice()` for every `Location` hop and stores it in `HTTPClient.redirect` so that `HTTPClient.url` can borrow slices from it. The previous buffer was never freed before the reassignment, so only the final hop's buffer was released in `deinit()` and every intermediate URL leaked.

With the default limit of 127 redirects and URLs up to 128 KiB, a single `fetch()` following a long redirect chain could leak megabytes.

## Fix

`handleResponseMetadata` parks the previous `redirect` buffer in a new `prev_redirect` field (at all three assignment sites) instead of dropping it. `connected_url` also borrows from that buffer and is still read by `doRedirect` for the keep-alive `releaseSocket()` call, so the free is deferred to `doRedirect`/`doRedirectMultiplexed` right after `connected_url` is cleared — the last point at which anything borrows from the old buffer. `deinit()` also frees `prev_redirect` for error paths that never reach the redirect.

## Verification

The test runs a 10-hop redirect chain whose `Location` URLs carry ~96 KiB of padding in the **fragment** (so the client allocates the full URL but the request line sent on the wire stays tiny). The client runs as a subprocess so only its RSS is measured; after 15 warmup iterations it samples RSS across two batches of 25 and asserts steady-state growth stays < 12 MiB.

| build | second-half RSS growth | result |
| --- | --- | --- |
| without fix (release) | ~22 MiB | fail |
| without fix (debug+ASAN) | ~21–25 MiB | fail |
| with fix (debug+ASAN) | −1.7 to +1.3 MiB | pass |
