### PR TITLE
MessagePortPipe: drain nested transferred-port closes iteratively

### DIFF
--- a/src/bun.js/bindings/webcore/MessagePortPipe.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortPipe.cpp
@@ -217,18 +217,42 @@ void MessagePortPipe::detach(uint8_t side)
 void MessagePortPipe::close(uint8_t side)
 {
     ASSERT(side < 2);
-    auto& s = m_sides[side];
-    Deque<MessageWithMessagePorts> dropped;
-    {
-        Locker locker { s.lock };
-        s.ctxId = 0;
-        s.port = nullptr;
-        // Closed is terminal; queued messages are dropped.
-        s.state.store(Closed, std::memory_order_release);
-        dropped = std::exchange(s.inbox, {});
+
+    // Dropped messages can carry TransferredMessagePorts, whose destructor
+    // calls close() on their pipe. Letting those destruct naturally recurses
+    // (close -> ~Deque -> ~TransferredMessagePort -> close -> ...), so a long
+    // chain of nested transferred ports overflows the native stack. Drain the
+    // cascade iteratively instead: steal transferred pipes from each batch of
+    // dropped messages into a stack-local worklist and close them in a loop.
+    Vector<std::pair<RefPtr<MessagePortPipe>, uint8_t>> worklist;
+    worklist.append({ this, side });
+
+    while (!worklist.isEmpty()) {
+        auto [pipe, sd] = worklist.takeLast();
+        auto& s = pipe->m_sides[sd];
+
+        Deque<MessageWithMessagePorts> dropped;
+        {
+            Locker locker { s.lock };
+            s.ctxId = 0;
+            s.port = nullptr;
+            // Closed is terminal; queued messages are dropped.
+            s.state.store(Closed, std::memory_order_release);
+            dropped = std::exchange(s.inbox, {});
+        }
+
+        // Harvest transferred pipes before `dropped` destructs so their
+        // ~TransferredMessagePort sees pipe == nullptr and is a no-op.
+        for (auto& message : dropped) {
+            for (auto& tp : message.transferredPorts) {
+                if (auto p = std::exchange(tp.pipe, nullptr))
+                    worklist.append({ WTF::move(p), tp.side });
+            }
+        }
+        // `dropped` (and the RefPtr in the structured binding) destruct
+        // outside the lock; they may hold the last ref to pipes whose
+        // destructors also take locks.
     }
-    // `dropped` destructs outside the lock; it may hold the last ref to
-    // transferred pipes whose destructors also take locks.
 }
 
 } // namespace WebCore

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -51,5 +51,120 @@ describe("MessagePortChannel closed port", () => {
     expect(stderr).toBe("");
     expect(stdout).toContain("PASS");
     expect(exitCode).toBe(0);
-  });
+  }, 60_000);
+
+  // A MessagePort transferred via postMessage(_, [port]) that is never received on the other
+  // side (because the carrying message is dropped) must not leak its channel. Previously the
+  // channel took a self-ref in disentanglePort() that was only released on re-entanglement.
+  for (const closeBeforePost of [false, true]) {
+    test(`transferred port dropped ${closeBeforePost ? "after" : "before"} receiver closed does not leak channel`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const closeBeforePost = ${closeBeforePost};
+            const ITERATIONS = 1000;
+            const PAYLOAD_SIZE = 128 * 1024;
+
+            function round() {
+              for (let i = 0; i < ITERATIONS; i++) {
+                const carrier = new MessageChannel();
+                const inner = new MessageChannel();
+
+                // Queue a large payload on the side of the inner channel that is about
+                // to be transferred. If the inner channel leaks, this payload leaks with it.
+                inner.port2.postMessage(Buffer.alloc(PAYLOAD_SIZE).toString());
+
+                if (closeBeforePost) {
+                  // Drop path: postMessageToRemote sees m_isClosed and drops the message
+                  // along with the transferred port.
+                  carrier.port2.close();
+                  carrier.port1.postMessage(null, [inner.port1]);
+                } else {
+                  // Drop path: closePort clears pending messages containing the
+                  // transferred port.
+                  carrier.port1.postMessage(null, [inner.port1]);
+                  carrier.port2.close();
+                }
+
+                inner.port2.close();
+                carrier.port1.close();
+              }
+              Bun.gc(true);
+              Bun.gc(true);
+            }
+
+            // Warm up to establish allocator high-water mark.
+            round();
+
+            const rssBefore = process.memoryUsage().rss;
+            round();
+            const rssAfter = process.memoryUsage().rss;
+            const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
+
+            // Without fix: ~130+ MB growth (1000 leaked channels each holding a 128KB string).
+            // With fix: ~0-10 MB.
+            if (deltaMB > 60) {
+              console.error("FAIL: RSS grew by", deltaMB.toFixed(2), "MB on second batch");
+              process.exit(1);
+            }
+            console.log("PASS: delta", deltaMB.toFixed(2), "MB");
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout).toContain("PASS");
+      expect(exitCode).toBe(0);
+    }, 60_000);
+  }
+
+  // Closing a port whose inbox holds a transferred port whose inbox holds a transferred
+  // port whose... must not overflow the native stack. ~TransferredMessagePort calls
+  // pipe->close(), which drops the inbox, whose destruction calls ~TransferredMessagePort
+  // again; MessagePortPipe::close() must drain that cascade iteratively.
+  test("deep chain of nested transferred ports does not overflow on close", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const DEPTH = 20_000;
+          let head = new MessageChannel();
+          const tail = head;
+          for (let i = 0; i < DEPTH; i++) {
+            const next = new MessageChannel();
+            // head.port1's inbox now holds next.port1; closing head.port1 must
+            // cascade to next.port1, whose inbox holds the following link, etc.
+            head.port2.postMessage(null, [next.port1]);
+            head.port2.close();
+            head = next;
+          }
+          tail.port1.close();
+          head.port2.close();
+          console.log("PASS");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Without the iterative drain the subprocess segfaults (stack overflow) during
+    // tail.port1.close() and never prints PASS.
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+      stdout: "PASS",
+      exitCode: 0,
+      signalCode: null,
+      stderr: "",
+    });
+  }, 60_000);
 });

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -54,8 +54,8 @@ describe("MessagePortChannel closed port", () => {
   }, 60_000);
 
   // A MessagePort transferred via postMessage(_, [port]) that is never received on the other
-  // side (because the carrying message is dropped) must not leak its channel. Previously the
-  // channel took a self-ref in disentanglePort() that was only released on re-entanglement.
+  // side (because the carrying message is dropped) must not leak its pipe. Cleanup relies on
+  // ~TransferredMessagePort calling pipe->close(side) when the carrying message is destroyed.
   for (const closeBeforePost of [false, true]) {
     test(`transferred port dropped ${closeBeforePost ? "after" : "before"} receiver closed does not leak channel`, async () => {
       await using proc = Bun.spawn({
@@ -77,13 +77,14 @@ describe("MessagePortChannel closed port", () => {
                 inner.port2.postMessage(Buffer.alloc(PAYLOAD_SIZE).toString());
 
                 if (closeBeforePost) {
-                  // Drop path: postMessageToRemote sees m_isClosed and drops the message
-                  // along with the transferred port.
+                  // Drop path: MessagePortPipe::send() sees the Closed state-bit on the
+                  // destination side and returns; the moved-in message destructs and
+                  // ~TransferredMessagePort closes the inner pipe side.
                   carrier.port2.close();
                   carrier.port1.postMessage(null, [inner.port1]);
                 } else {
-                  // Drop path: closePort clears pending messages containing the
-                  // transferred port.
+                  // Drop path: MessagePortPipe::close() swaps out the inbox; the dropped
+                  // message's TransferredMessagePort is harvested into the close worklist.
                   carrier.port1.postMessage(null, [inner.port1]);
                   carrier.port2.close();
                 }


### PR DESCRIPTION
## What

Fixes a stack overflow in `MessagePortPipe::close()` when a deep chain of nested transferred MessagePorts is closed, and adds regression coverage for the transferred-port-dropped leak that #29937's RAII `TransferredMessagePort` destructor now handles.

## Repro

```js
const DEPTH = 20_000;
let head = new MessageChannel();
const tail = head;
for (let i = 0; i < DEPTH; i++) {
  const next = new MessageChannel();
  head.port2.postMessage(null, [next.port1]); // next.port1 lands in head.port1's inbox
  head.port2.close();
  head = next;
}
tail.port1.close();  // SIGSEGV (stack overflow)
```

## Root cause

`TransferredMessagePort` is move-only and its destructor calls `pipe->close(side)` so an orphaned in-transit port gets cleaned up. `MessagePortPipe::close()` swaps the side's inbox into a local `Deque` and lets it destruct outside the lock. If those dropped messages carry transferred ports, the `Deque` destructor runs `~TransferredMessagePort` → `pipe->close()` → another `Deque` destructor → … one native stack frame per link. ~20k links overflows an 8 MB stack.

## Fix

`MessagePortPipe::close()` owns a stack-local `Vector<pair<RefPtr<MessagePortPipe>, uint8_t>>` worklist seeded with `{this, side}`. For each entry it closes the side under the lock, swaps out the inbox, then harvests transferred pipes from the dropped messages into the worklist (nulling `tp.pipe` so the subsequent `~TransferredMessagePort` is a no-op) before letting the batch destruct. O(1) stack regardless of chain depth; no static / thread_local / instance state.

## Verification

`test/js/web/workers/message-port-closed-leak.test.ts`:

| test | main (no fix) | this PR |
|--|--|--|
| transferred port dropped before receiver closed does not leak | pass (#29937) | pass |
| transferred port dropped after receiver closed does not leak | pass (#29937) | pass |
| **deep chain of nested transferred ports does not overflow on close** | **SIGSEGV, exit 139** | pass |

`message-channel.test.ts` (12 tests) passes unchanged.

## History

This PR originally targeted the self-ref leak in the old `MessagePortChannel` / `MessagePortChannelRegistry` stack (`disentanglePort()` parked a self-ref in `m_pendingMessagePortTransfers[i]` that was never released if the carrying message was dropped). #29937 replaced that whole stack with `MessagePortPipe` and fixed the leak via RAII — but the destructor-driven cascade it introduced recurses unboundedly. The first two tests are kept as regression guards for the leak; the deep-chain test is the fail-before for this fix.
