### PR TITLE
node:zlib: clear write_in_progress before onerror to avoid UAF on re-entrant write

### DIFF
--- a/src/bun.js/node/node_zlib_binding.zig
+++ b/src/bun.js/node/node_zlib_binding.zig
@@ -304,6 +304,15 @@ pub fn CompressionStream(comptime T: type) type {
         }
 
         pub fn emitError(this: *T, globalThis: *jsc.JSGlobalObject, this_value: jsc.JSValue, err_: Error) void {
+            // Clear write_in_progress *before* invoking the onerror callback.
+            // The callback may re-enter write(), which sets write_in_progress=true
+            // and schedules a WorkPool task. If we cleared the flag after the
+            // callback, we would clobber that state and closeInternal()/resetInternal()
+            // below could free the native zlib/brotli/zstd state while a task is
+            // still queued, leading to a use-after-free when the worker thread
+            // runs doWork().
+            this.write_in_progress = false;
+
             var msg_str = bun.handleOom(bun.String.createFormat("{s}", .{std.mem.sliceTo(err_.msg, 0) orelse ""}));
             const msg_value = msg_str.transferToJS(globalThis) catch return;
             const err_value: jsc.JSValue = .jsNumber(err_.err);
@@ -316,7 +325,6 @@ pub fn CompressionStream(comptime T: type) type {
             const vm = globalThis.bunVM();
             vm.eventLoop().runCallback(callback, globalThis, this_value, &.{ msg_value, err_value, code_value });
 
-            this.write_in_progress = false;
             if (this.pending_reset) resetInternal(this, globalThis, this_value);
             if (this.pending_close) _ = closeInternal(this);
         }

--- a/test/js/node/zlib/zlib-onerror-reentrancy.test.ts
+++ b/test/js/node/zlib/zlib-onerror-reentrancy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Regression test for a re-entrancy bug in the native zlib/brotli/zstd
+// handle's emitError(): it used to clear `write_in_progress = false`
+// *after* invoking the onerror callback. If that callback issued a new
+// async write() (which sets write_in_progress=true and schedules a
+// WorkPool task) followed by close(), the post-callback clear clobbered
+// the flag and let closeInternal() free the native stream state while a
+// task was still queued — the worker thread then ran doWork() on freed
+// brotli/zstd/zlib state (use-after-free / `unreachable` panic).
+//
+// Correct behaviour: the close is deferred until the pending write
+// completes, and the second (re-entrant) write's error is delivered, so
+// onerror fires exactly twice.
+
+describe("zlib native handle onerror re-entrancy", () => {
+  const fixture = /* js */ `
+    const zlib = require("zlib");
+
+    const stream = zlib.createBrotliDecompress();
+    const handle = stream._handle;
+
+    const badInput = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    const out = Buffer.alloc(1024);
+    const FINISH = zlib.constants.BROTLI_OPERATION_FINISH;
+
+    let calls = 0;
+    handle.onerror = function (msg, errno, code) {
+      calls++;
+      if (calls > 1) return;
+      // Re-entrant async write from inside onerror.
+      this.write(FINISH, badInput, 0, badInput.length, out, 0, out.length);
+      // Request close while the re-entrant write is pending. closeInternal()
+      // must defer until that write completes.
+      this.close();
+    };
+
+    handle.write(FINISH, badInput, 0, badInput.length, out, 0, out.length);
+
+    process.on("exit", () => {
+      process.stdout.write("calls=" + calls + "\\n");
+    });
+  `;
+
+  // Run as a subprocess so a crash/SIGILL/SIGSEGV shows up as a non-zero
+  // exit code rather than taking down the test runner. The behaviour was
+  // timing-dependent (sometimes a worker-thread panic, sometimes a silently
+  // dropped write), so exercise it a few times.
+  for (let i = 0; i < 3; i++) {
+    test.concurrent(`re-entrant write()+close() from onerror completes both writes (iteration ${i})`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      // Both writes error, so onerror must fire twice. Before the fix the
+      // second write's completion was swallowed (or the process crashed) and
+      // this was "calls=1" at best.
+      expect(stdout).toBe("calls=2\n");
+      expect(exitCode).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## What

`CompressionStream.emitError()` (shared by the native zlib, brotli and zstd handles) invoked the user-settable `onerror` callback and then unconditionally set `write_in_progress = false`.

Because `runFromJSThread()` already clears `write_in_progress` *before* calling `checkError()`/`emitError()`, an `onerror` handler can legally call `handle.write()` again. That re-entrant write sets `write_in_progress = true`, `ref()`s, and schedules a `WorkPool` task on the handle's embedded task node. After the callback returned, `emitError` would clobber the flag back to `false`, breaking the invariant *`write_in_progress` ⇔ a WorkPool task is pending*.

With the invariant broken, a `close()` (either issued inside the handler via `pending_close`, or any time afterwards) would run `closeInternal()` immediately and free the brotli/zstd/zlib C state while the queued task was still pending. The worker thread would then run `doWork()` on that freed state.

## Repro

```js
const zlib = require("zlib");
const h = zlib.createBrotliDecompress()._handle;
const bad = Buffer.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
const out = Buffer.alloc(1024);
const FINISH = zlib.constants.BROTLI_OPERATION_FINISH;

let calls = 0;
h.onerror = function () {
  if (++calls > 1) return;
  this.write(FINISH, bad, 0, bad.length, out, 0, out.length); // re-entrant write
  this.close();                                               // sets pending_close
};
h.write(FINISH, bad, 0, bad.length, out, 0, out.length);

process.on("exit", () => console.log("calls=" + calls));
```

Before this change, each run either:
- segfaults at `0x80` in release / panics `reached unreachable code` in debug (worker ran `doWork()` with `mode = .NONE` after `stream.close()`), or
- prints `calls=1` (worker ran before the free; the second write's completion was then swallowed because `this_value` was cleared by `closeInternal`).

After this change it prints `calls=2` and exits cleanly every time.

## Fix

Move `this.write_in_progress = false` to the top of `emitError()`, *before* the callback is invoked. If the callback issues a re-entrant write, the flag it sets is preserved, and the `if (this.pending_close) closeInternal(this)` check that follows correctly defers the close (since `closeInternal` re-checks `write_in_progress`).

## Verification

- New test `test/js/node/zlib/zlib-onerror-reentrancy.test.ts` spawns the repro 5× and asserts `calls=2` with a clean exit.
- Gate: `git stash push -- src/ && bun bd test …` → 0 pass / 5 fail (panics + `calls=1`); `git stash pop && bun bd test …` → 5 pass / 0 fail.
- Existing `test/js/node/zlib/` tests and the node-compat `test-zlib-close-after-error`, `test-zlib-destroy`, `test-zlib-dictionary-fail`, `test-zlib-invalid-input` pass unchanged.