### PR TITLE
node:http: don't leak NodeHTTPResponse when ondata is re-registered after body completes

### DIFF
--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -1046,7 +1046,10 @@ fn clearOnDataCallback(this: *NodeHTTPResponse, thisValue: jsc.JSValue, globalOb
 }
 
 pub fn setOnData(this: *NodeHTTPResponse, thisValue: jsc.JSValue, globalObject: *jsc.JSGlobalObject, value: JSValue) void {
-    if (value.isUndefined() or this.flags.ended or this.flags.socket_closed or this.body_read_state == .none or this.flags.is_data_buffered_during_pause_last or this.flags.upgraded) {
+    // Only `.pending` accepts a callback. `.done` means either uSockets delivered last=true or JS
+    // previously cleared `ondata` (which already called clearOnData()); either way, there is no
+    // more body to read, so don't re-register with uSockets or churn refs.
+    if (value.isUndefined() or this.flags.ended or this.flags.socket_closed or this.body_read_state != .pending or this.flags.is_data_buffered_during_pause_last or this.flags.upgraded) {
         js.onDataSetCached(thisValue, globalObject, .js_undefined);
         defer {
             if (this.body_read_ref.has) {
@@ -1075,14 +1078,11 @@ pub fn setOnData(this: *NodeHTTPResponse, thisValue: jsc.JSValue, globalObject: 
     }
     this.flags.is_data_buffered_during_pause = false;
 
-    // Every site that unrefs `body_read_ref` also transitions `body_read_state` out of
-    // `.pending` (to `.done` or `.none`) or sets `is_data_buffered_during_pause_last`. Since
-    // `.none` and `is_data_buffered_during_pause_last` are rejected by the guard above, reaching
-    // here with `!body_read_ref.has` implies `body_read_state == .done`: the body has been fully
-    // received and uSockets will not deliver more data. Do not re-acquire `body_read_ref` (event
-    // loop keep-alive) or `this.ref()` in that case — there is nothing left to wait for and no
-    // code path would release them, leaking the NodeHTTPResponse.
-    bun.debugAssert(this.body_read_ref.has or this.body_read_state == .done);
+    // Every site that unrefs `body_read_ref` also transitions `body_read_state` out of `.pending`
+    // or sets `is_data_buffered_during_pause_last`, both of which are rejected by the guard above.
+    // So reaching here, `body_read_ref` is still held from create(). Do not re-acquire it or
+    // `this.ref()` — there would be no balancing release (PR #18564 removed the paired derefs).
+    bun.debugAssert(this.body_read_ref.has);
 }
 
 pub fn write(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {

--- a/src/bun.js/api/server/NodeHTTPResponse.zig
+++ b/src/bun.js/api/server/NodeHTTPResponse.zig
@@ -1075,10 +1075,14 @@ pub fn setOnData(this: *NodeHTTPResponse, thisValue: jsc.JSValue, globalObject: 
     }
     this.flags.is_data_buffered_during_pause = false;
 
-    if (!this.body_read_ref.has) {
-        this.ref();
-        this.body_read_ref.ref(globalObject.bunVM());
-    }
+    // Every site that unrefs `body_read_ref` also transitions `body_read_state` out of
+    // `.pending` (to `.done` or `.none`) or sets `is_data_buffered_during_pause_last`. Since
+    // `.none` and `is_data_buffered_during_pause_last` are rejected by the guard above, reaching
+    // here with `!body_read_ref.has` implies `body_read_state == .done`: the body has been fully
+    // received and uSockets will not deliver more data. Do not re-acquire `body_read_ref` (event
+    // loop keep-alive) or `this.ref()` in that case — there is nothing left to wait for and no
+    // code path would release them, leaking the NodeHTTPResponse.
+    bun.debugAssert(this.body_read_ref.has or this.body_read_state == .done);
 }
 
 pub fn write(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -243,11 +243,11 @@ const IncomingMessagePrototype = {
     } else if ((internalRequest = this[kHandle])) {
       const bodyReadState = internalRequest.hasBody;
 
-      const isDone =
+      if (
         (bodyReadState & NodeHTTPBodyReadState.done) !== 0 ||
         bodyReadState === NodeHTTPBodyReadState.none ||
-        this._dumped;
-      if (isDone) {
+        this._dumped
+      ) {
         emitEOFIncomingMessage(this);
       }
 
@@ -258,10 +258,7 @@ const IncomingMessagePrototype = {
         }
       }
 
-      // Don't re-register ondata once the body is done/dumped — the native side has
-      // already released body_read_ref and re-registering would just churn uWS state
-      // for a stream that's about to EOF.
-      if (!isDone && !internalRequest.ondata) {
+      if (!internalRequest.ondata) {
         internalRequest.ondata = onDataIncomingMessage.bind(this);
         internalRequest.hasCustomOnData = false;
       }

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -243,11 +243,11 @@ const IncomingMessagePrototype = {
     } else if ((internalRequest = this[kHandle])) {
       const bodyReadState = internalRequest.hasBody;
 
-      if (
+      const isDone =
         (bodyReadState & NodeHTTPBodyReadState.done) !== 0 ||
         bodyReadState === NodeHTTPBodyReadState.none ||
-        this._dumped
-      ) {
+        this._dumped;
+      if (isDone) {
         emitEOFIncomingMessage(this);
       }
 
@@ -258,7 +258,10 @@ const IncomingMessagePrototype = {
         }
       }
 
-      if (!internalRequest.ondata) {
+      // Don't re-register ondata once the body is done/dumped — the native side has
+      // already released body_read_ref and re-registering would just churn uWS state
+      // for a stream that's about to EOF.
+      if (!isDone && !internalRequest.ondata) {
         internalRequest.ondata = onDataIncomingMessage.bind(this);
         internalRequest.hasCustomOnData = false;
       }

--- a/test/js/node/http/node-http-ondata-reregister-leak.fixture.js
+++ b/test/js/node/http/node-http-ondata-reregister-leak.fixture.js
@@ -1,0 +1,78 @@
+// NodeHTTPResponse.setOnData used to take an unbalanced `this.ref()` and re-acquire the
+// `body_read_ref` event-loop keep-alive when JS re-assigned `ondata` after the request
+// body had already completed (body_read_state == .done). No code path released either
+// ref, so the native NodeHTTPResponse leaked and vm.active_tasks was inflated.
+//
+// This fixture re-assigns ondata after the body has been fully consumed and asserts
+// that activeTasks does not increase.
+const http = require("node:http");
+const { getEventLoopStats } = require("bun:internal-for-testing");
+
+process.exitCode = 1;
+
+const server = http.createServer(async (req, res) => {
+  // Locate the internal NodeHTTPResponse handle (stored under a private Symbol("handle"))
+  // before anything can clear it.
+  let handle;
+  for (const sym of Object.getOwnPropertySymbols(req)) {
+    if (sym.description !== "handle") continue;
+    const val = req[sym];
+    if (val && typeof val === "object" && "hasBody" in val && "hasCustomOnData" in val) {
+      handle = val;
+      break;
+    }
+  }
+  if (!handle) {
+    console.error("FAIL: could not find internal handle");
+    process.exit(1);
+  }
+
+  // Consume the full body so body_read_state becomes .done and body_read_ref is released.
+  await new Promise(resolve => {
+    req.on("data", () => {});
+    req.on("end", resolve);
+  });
+
+  const before = getEventLoopStats().activeTasks;
+
+  // Clearing then re-assigning ondata after the body is done used to call
+  // `this.ref()` + `body_read_ref.ref(vm)` with no balancing deref/unref anywhere.
+  handle.ondata = undefined;
+  handle.ondata = () => {};
+
+  const after = getEventLoopStats().activeTasks;
+  if (after !== before) {
+    console.error(`FAIL: activeTasks leaked: before=${before} after=${after}`);
+    process.exit(1);
+  }
+
+  // Do it a few more times; the unbalanced `this.ref()` would accumulate one
+  // extra ref on the NodeHTTPResponse per round even though activeTasks
+  // oscillates (body_read_ref is a boolean).
+  for (let i = 0; i < 8; i++) {
+    handle.ondata = undefined;
+    handle.ondata = () => {};
+  }
+
+  const afterLoop = getEventLoopStats().activeTasks;
+  if (afterLoop !== before) {
+    console.error(`FAIL: activeTasks leaked after loop: before=${before} after=${afterLoop}`);
+    process.exit(1);
+  }
+
+  res.end("ok");
+  process.exitCode = 0;
+});
+
+server.listen(0, async () => {
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/`, {
+    method: "POST",
+    body: "hello world",
+    headers: { connection: "close" },
+  });
+  await response.text();
+  server.close(() => {
+    console.log("CLOSED");
+  });
+});

--- a/test/js/node/http/node-http-ondata-reregister-leak.test.ts
+++ b/test/js/node/http/node-http-ondata-reregister-leak.test.ts
@@ -19,4 +19,4 @@ test("re-registering ondata after request body completes does not leak NodeHTTPR
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("CLOSED");
   expect(exitCode).toBe(0);
-});
+}, 30_000);

--- a/test/js/node/http/node-http-ondata-reregister-leak.test.ts
+++ b/test/js/node/http/node-http-ondata-reregister-leak.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// NodeHTTPResponse.setOnData used to take an unbalanced `this.ref()` and re-acquire the
+// `body_read_ref` event-loop keep-alive when JS cleared and then re-assigned `ondata`
+// after the request body had finished. No code path released either ref, so the
+// NodeHTTPResponse leaked and `vm.active_tasks` never reached zero — the process hung.
+test("re-registering ondata after request body completes does not leak NodeHTTPResponse", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "node-http-ondata-reregister-leak.fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("CLOSED");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`NodeHTTPResponse.setOnData` took an unbalanced `this.ref()` and re-acquired the `body_read_ref` event-loop keep-alive whenever JS cleared and then re-assigned `ondata` after the request body had already been fully received. Neither ref had a corresponding release anywhere:

- `this.ref()` was never paired with `this.deref()`, so the native `NodeHTTPResponse` struct (along with its `buffered_request_body_data_during_pause` ByteList and Strong promise) leaked for every such request.
- `body_read_ref.ref(vm)` inflated `vm.active_tasks` with nothing guaranteed to bring it back down on every path.

## Root cause

The initial `body_read_ref.ref(vm)` in `create()` is released at one of the `body_read_ref.unref()` sites (lines ~218/723/774/942/1052), but **every one of those sites also transitions `body_read_state` out of `.pending`** (to `.done` or `.none`) or sets `is_data_buffered_during_pause_last`. Since the guard at the top of `setOnData` already rejects `.none` and `is_data_buffered_during_pause_last`, reaching the `if (!this.body_read_ref.has)` block implies `body_read_state == .done`: the body has been fully received and uSockets will not deliver any more data. Taking either ref at that point keeps the object / event loop alive for nothing, and no code path ever releases it.

This is reachable from `node:http` JS via `IncomingMessage._dump()` → `resume()` → `_read()` (which re-assigns `ondata` without an early return after `emitEOFIncomingMessage`), or by toggling `handle.ondata` directly.

## Fix

Remove the `if (!this.body_read_ref.has) { this.ref(); this.body_read_ref.ref(vm); }` block and replace it with a `debugAssert` documenting the invariant (`body_read_ref.has or body_read_state == .done`).

## Verification

The regression test consumes a POST body, then toggles `ondata` on the internal handle and asserts via `getEventLoopStats().activeTasks` that no extra keep-alive is acquired.

- `USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http-ondata-reregister-leak.test.ts` → **FAIL** (`activeTasks leaked: before=1 after=2`)
- `bun bd test test/js/node/http/node-http-ondata-reregister-leak.test.ts` → **PASS**
- Gate (stash src/ → fail, unstash → pass): verified.