### PR TITLE
webcrypto: remove DeferredPromise from m_pendingPromises on unwrapKey JWK errors

### DIFF
--- a/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/bun.js/bindings/webcrypto/SubtleCrypto.cpp
@@ -1239,11 +1239,16 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
                     JSLockHolder locker(vm);
                     auto jwkObject = JSONParse(&state, jwkString);
                     if (!jwkObject) {
+                        weakThis->m_pendingPromises.remove(index);
                         promise->reject(DataError, "WrappedKey cannot be converted to a JSON object"_s);
                         return;
                     }
                     auto jwk = convert<IDLDictionary<JsonWebKey>>(state, jwkObject);
-                    RETURN_IF_EXCEPTION(scope, void());
+                    if (scope.exception()) [[unlikely]] {
+                        weakThis->m_pendingPromises.remove(index);
+                        promise->reject(Exception { ExistingExceptionError });
+                        return;
+                    }
                     normalizeJsonWebKey(jwk);
 
                     keyData = jwk;

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -104,6 +104,107 @@ describe("Web Crypto", () => {
     const isSigValid = await verifySignature(msg, signature, SECRET);
     expect(isSigValid).toBe(true);
   });
+
+  describe("unwrapKey JWK error handling", () => {
+    // Setup: AES-GCM key that can encrypt arbitrary bytes and also unwrap keys.
+    // We encrypt payloads that decrypt to invalid JWK data so the JWK parse path
+    // inside SubtleCrypto::unwrapKey fails.
+    async function setup(payload: Uint8Array) {
+      const keyData = new Uint8Array(32).fill(1);
+      const iv = new Uint8Array(12).fill(2);
+      const key = await crypto.subtle.importKey("raw", keyData, { name: "AES-GCM" }, false, [
+        "encrypt",
+        "decrypt",
+        "wrapKey",
+        "unwrapKey",
+      ]);
+      const wrapped = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, payload);
+      return { key, iv, wrapped };
+    }
+
+    it("rejects when wrapped bytes are not valid JSON", async () => {
+      const { key, iv, wrapped } = await setup(new TextEncoder().encode("not json {{{"));
+      const err = await crypto.subtle
+        .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
+        .then(
+          () => null,
+          e => e,
+        );
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.name).toBe("DataError");
+    });
+
+    // Previously this promise never settled: the TypeError from JsonWebKey
+    // dictionary conversion escaped as an uncaught exception and the
+    // DeferredPromise was left in m_pendingPromises forever.
+    it("rejects when wrapped bytes are valid JSON but not a valid JWK", async () => {
+      const { key, iv, wrapped } = await setup(new TextEncoder().encode(JSON.stringify({ foo: "bar" })));
+      const err = await crypto.subtle
+        .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
+        .then(
+          () => null,
+          e => e,
+        );
+      expect(err).toBeInstanceOf(TypeError);
+      expect(err.message).toContain("kty");
+    });
+
+    it("does not leak DeferredPromise in m_pendingPromises on JWK parse errors", async () => {
+      // Each leaked entry in m_pendingPromises holds a Ref<DeferredPromise>. On
+      // the dictionary-conversion error path the promise was never rejected, so
+      // DeferredPromise never removed itself from JSDOMGlobalObject's
+      // guardedObjects set and the JSPromise stayed alive. Count live Promise
+      // cells in the JSC heap to detect the leak.
+      const fixture = /* js */ `
+        const { heapStats } = require("bun:jsc");
+        const keyData = new Uint8Array(32).fill(1);
+        const iv = new Uint8Array(12).fill(2);
+        const key = await crypto.subtle.importKey("raw", keyData, { name: "AES-GCM" }, false, [
+          "encrypt", "decrypt", "wrapKey", "unwrapKey",
+        ]);
+        const wrapped = await crypto.subtle.encrypt(
+          { name: "AES-GCM", iv },
+          key,
+          new TextEncoder().encode(JSON.stringify({ foo: "bar" })),
+        );
+        async function once() {
+          await crypto.subtle
+            .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
+            .catch(() => {});
+        }
+        const batch = () => Promise.all(Array.from({ length: 50 }, once));
+        for (let i = 0; i < 4; i++) await batch();
+        Bun.gc(true);
+        await Bun.sleep(1);
+        Bun.gc(true);
+        const before = heapStats().objectTypeCounts.Promise ?? 0;
+        for (let i = 0; i < 40; i++) await batch();
+        Bun.gc(true);
+        await Bun.sleep(1);
+        Bun.gc(true);
+        await Bun.sleep(1);
+        Bun.gc(true);
+        const after = heapStats().objectTypeCounts.Promise ?? 0;
+        console.log(JSON.stringify({ before, after, growth: after - before }));
+        process.exit(0);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const { before, after, growth } = JSON.parse(stdout.trim());
+      // 2000 failing calls; previously each leaked ~3 Promise cells that were
+      // kept alive via guardedObjects, so growth was in the thousands.
+      expect(growth).toBeLessThan(200);
+      expect(exitCode).toBe(0);
+      void before;
+      void after;
+    }, 60_000);
+  });
 });
 
 describe("Ed25519", () => {


### PR DESCRIPTION
## Problem

`crypto.subtle.unwrapKey('jwk', ...)` leaks the `DeferredPromise` in `SubtleCrypto::m_pendingPromises` when JWK parsing fails.

The decrypt-success callback reads the promise with `m_pendingPromises.get(index)` (leaving the entry in place) so the inner `importKey` callbacks can later `.take()` it via `getPromise()`. But the two JWK error early-returns bail out before `importKey` is ever called:

1. **`JSONParse` returns null** (wrapped bytes aren't JSON): the promise is rejected, but `Ref<DeferredPromise>` stays in the map. Since `DeferredPromise::reject()` clears the guarded `JSPromise` weak ref, this is a native-heap-only leak (~200 bytes/call).

2. **`convert<IDLDictionary<JsonWebKey>>` throws** (e.g. JSON without required `kty`): `RETURN_IF_EXCEPTION` returns without rejecting at all. The promise never settles, the `TypeError` surfaces as an uncaught exception, and both the `DeferredPromise` and the `JSPromise` it guards leak. `heapStats().objectTypeCounts.Promise` grows ~3× per call.

## Repro

```js
const key = await crypto.subtle.importKey("raw", new Uint8Array(32), { name: "AES-GCM" }, false,
  ["encrypt", "decrypt", "wrapKey", "unwrapKey"]);
const iv = new Uint8Array(12);
const wrapped = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key,
  new TextEncoder().encode(JSON.stringify({ foo: "bar" }))); // valid JSON, missing "kty"

await crypto.subtle.unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv },
  { name: "AES-GCM" }, true, ["encrypt", "decrypt"]);
// before: never settles, "TypeError: Member JsonWebKey.kty is required..." printed to stderr
// after:  rejects with that TypeError
```

## Fix

On both JWK error paths, remove the entry from `m_pendingPromises` before rejecting. For the dictionary-conversion failure, replace the bare `RETURN_IF_EXCEPTION` with `promise->reject(Exception { ExistingExceptionError })` so the pending exception is routed into the promise rejection instead of escaping uncaught.

## Verification

Added to `test/js/web/crypto/web-crypto.test.ts`:
- `rejects when wrapped bytes are valid JSON but not a valid JWK` — previously hung with an uncaught `TypeError`; now rejects.
- `does not leak DeferredPromise in m_pendingPromises on JWK parse errors` — spawns a subprocess that does 2,200 failing `unwrapKey('jwk', …)` calls and asserts `heapStats().objectTypeCounts.Promise` growth is < 200 (previously grew by thousands).
- `rejects when wrapped bytes are not valid JSON` — covers the `JSONParse`-failure path; behaviour was already correct, kept for coverage of the added `.remove()` call.

```
(pass) unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON
(pass) unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK
(pass) unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors
```

Without the `src/` change, tests 2 and 3 fail (hang/uncaught + timeout).