### PR TITLE
Add BUN_FEATURE_FLAG_DIE_WITH_PARENT / [run] dieWithParent: exit with parent + reap descendants

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -864,7 +864,7 @@ elide-lines = 10
 
 When `true`, Bun watches the process that spawned it and exits as soon as that parent goes away — even if the parent was `SIGKILL`ed and never got a chance to forward a signal. On its own exit, Bun also recursively `SIGKILL`s every descendant process so nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
 
-POSIX only (no-op on Windows). Equivalent to the `BUN_FEATURE_FLAG_DIE_WITH_PARENT=1` environment variable.
+Linux and macOS only (no-op on Windows and other platforms). Equivalent to the `BUN_FEATURE_FLAG_DIE_WITH_PARENT=1` environment variable.
 
 ```toml title="bunfig.toml" icon="settings"
 [run]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -859,3 +859,14 @@ The number of lines of script output shown per script when using `--filter`. Def
 [run]
 elide-lines = 10
 ```
+
+### `run.dieWithParent` - exit when the parent process dies
+
+When `true`, Bun watches the process that spawned it and exits as soon as that parent goes away — even if the parent was `SIGKILL`ed and never got a chance to forward a signal. On its own exit, Bun also recursively `SIGKILL`s every descendant process so nothing it spawned outlives it. Useful when Bun is launched by a supervisor (Electron, a CI runner, a thin shim) that may be force-killed.
+
+POSIX only (no-op on Windows). Equivalent to the `BUN_FEATURE_FLAG_DIE_WITH_PARENT=1` environment variable.
+
+```toml title="bunfig.toml" icon="settings"
+[run]
+dieWithParent = true
+```

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -18,7 +18,7 @@
 //!        loop are short-lived enough not to need it.
 //!
 //!   2. On any clean exit (`Global.exit` → `Bun__onExit`), walks the process
-//!      tree rooted at `getpid()` and SIGTERMs every descendant so children
+//!      tree rooted at `getpid()` and SIGKILLs every descendant so children
 //!      Bun spawned don't outlive it.
 //!      - macOS: libproc `proc_listchildpids()`.
 //!      - Linux: `/proc/<pid>/task/*/children`.
@@ -133,7 +133,7 @@ fn onProcessExit() callconv(.c) void {
     killDescendants();
 }
 
-/// Walk the process tree rooted at `getpid()` and SIGTERM every descendant.
+/// Walk the process tree rooted at `getpid()` and SIGKILL every descendant.
 ///
 /// Pid-reuse safety: enumeration is a point-in-time snapshot, so a pid we
 /// collect could exit and be recycled by an unrelated process before we
@@ -144,9 +144,9 @@ fn onProcessExit() callconv(.c) void {
 ///      longer `parent`, the pid was recycled in the (microsecond) window
 ///      between enumerate and STOP — undo with SIGCONT and skip. Otherwise
 ///      `c` is now frozen and confirmed ours; recurse into it.
-///   3. Once the whole tree is frozen, SIGTERM + SIGCONT each pid
-///      (leaves-first so a parent isn't woken before its children are
-///      signalled).
+///   3. Once the whole tree is frozen, SIGKILL each pid (leaves-first).
+///      SIGKILL terminates stopped processes directly — no SIGCONT needed —
+///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
 /// verify step sufficient. The only forking process is `self`, and we're in
@@ -163,7 +163,7 @@ pub fn killDescendants() void {
 
     to_visit.append(bun.default_allocator, self_pid) catch return;
 
-    var buf: [256]std.c.pid_t = undefined;
+    var buf: [4096]std.c.pid_t = undefined;
     // Hard cap on tree size so a fork bomb under us can't make exit hang.
     while (to_visit.items.len > 0 and to_kill.items.len < 4096) {
         const parent = to_visit.swapRemove(to_visit.items.len - 1);
@@ -182,13 +182,11 @@ pub fn killDescendants() void {
         }
     }
 
-    // Reverse: leaves first. SIGTERM then SIGCONT so the (now-pending) TERM
-    // is delivered as soon as the process is unfrozen.
+    // Reverse: leaves first. SIGKILL terminates stopped processes directly.
     var i = to_kill.items.len;
     while (i > 0) {
         i -= 1;
-        _ = std.c.kill(to_kill.items[i], std.posix.SIG.TERM);
-        _ = std.c.kill(to_kill.items[i], std.posix.SIG.CONT);
+        _ = std.c.kill(to_kill.items[i], std.posix.SIG.KILL);
     }
 }
 

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -1,0 +1,295 @@
+//! Opt-in self-termination when our parent goes away, plus recursive
+//! descendant cleanup on exit.
+//!
+//! Enabled via env var `BUN_DIE_WITH_PARENT`. When set, Bun:
+//!
+//!   1. Captures its original parent pid at startup and exits as soon as that
+//!      parent is gone — even if the parent was SIGKILLed and never got a
+//!      chance to signal us.
+//!      - Linux: `prctl(PR_SET_PDEATHSIG, SIGKILL)`. Kernel-delivered, no
+//!        polling, no thread. Fires when the *thread* that forked us exits;
+//!        for the single-threaded shims this targets that distinction is moot.
+//!      - macOS: `EVFILT_PROC`/`NOTE_EXIT` on the original ppid, registered on
+//!        the existing event loop's kqueue via `bun.Async.FilePoll` (same
+//!        path Bun already uses to watch *child* process exits — see
+//!        `bun.spawn.Process.watch`). No dedicated thread, no extra kqueue fd.
+//!        Installed lazily from `VirtualMachine.init` so it only arms when the
+//!        JS runtime actually starts; commands that never spin up an event
+//!        loop are short-lived enough not to need it.
+//!
+//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), walks the process
+//!      tree rooted at `getpid()` and SIGTERMs every descendant so children
+//!      Bun spawned don't outlive it.
+//!      - macOS: libproc `proc_listchildpids()`.
+//!      - Linux: `/proc/<pid>/task/*/children`.
+//!
+//! Motivation: process supervisors that wrap Bun in a thin shim (e.g. a macOS
+//! TCC "disclaimer" trampoline: Electron → shim → bun) can be SIGKILLed by
+//! their own parent's timeout/abort logic. SIGKILL is uncatchable, so the shim
+//! can't forward it, and Bun is silently reparented to launchd/init where it
+//! keeps running forever — along with anything Bun itself spawned. This
+//! watchdog closes both gaps from Bun's side without requiring the shim to
+//! cooperate.
+
+pub const ParentDeathWatchdog = @This();
+
+/// Exit code used when the watchdog fires. 128 + SIGHUP, matching the
+/// convention for "terminated because the controlling end went away".
+const exit_code: u8 = 128 + 1;
+
+var enabled: bool = false;
+var original_ppid: std.c.pid_t = 0;
+
+/// Whether `BUN_DIE_WITH_PARENT` was set at startup. Read by the spawn path to
+/// decide whether to default `linux_pdeathsig` on children.
+pub fn isEnabled() bool {
+    return enabled;
+}
+var event_loop_installed = std.atomic.Value(bool).init(false);
+/// Singleton instance — `FilePoll.Owner` needs a real pointer, but we have no
+/// per-instance state.
+var instance: ParentDeathWatchdog = .{};
+
+pub fn install() void {
+    if (comptime !Environment.isPosix) return;
+
+    if (!bun.env_var.BUN_DIE_WITH_PARENT.get()) return;
+
+    enabled = true;
+    // Descendant cleanup runs on every clean exit regardless of whether we end
+    // up watching a parent (Bun may have been spawned directly by launchd/init).
+    bun.Global.addExitCallback(&onProcessExit);
+
+    original_ppid = std.c.getppid();
+    // Already orphaned (parent died before we got here, or launchd/init
+    // spawned us directly) — nothing to watch.
+    if (original_ppid <= 1) return;
+
+    if (comptime Environment.isLinux) {
+        // PR_SET_PDEATHSIG: kernel sends SIGKILL when the thread that forked
+        // us exits. Persists across exec; cleared on fork (Bun's own children
+        // do not inherit it). SIGKILL is uncatchable so user code can't
+        // swallow it. The macOS path goes through Global.exit instead and so
+        // also runs the descendant reaper; on Linux the SIGKILL case relies on
+        // env-var inheritance — Bun-spawning-Bun chains self-reap because each
+        // link sets its own PDEATHSIG.
+        _ = std.posix.prctl(.SET_PDEATHSIG, .{std.posix.SIG.KILL}) catch return;
+        // Race: parent may have died between getppid() above and prctl()
+        // taking effect. If so we've already been reparented and the kernel
+        // will never deliver the signal — exit now.
+        if (std.c.getppid() != original_ppid) {
+            killDescendants();
+            std.c._exit(exit_code);
+        }
+    }
+    // macOS: parent watch installs lazily via installOnEventLoop() once the
+    // event loop's kqueue exists.
+}
+
+/// Register `EVFILT_PROC`/`NOTE_EXIT` for the original parent on the main
+/// event loop's kqueue. Called from `VirtualMachine.init` once the uws loop is
+/// up. macOS-only; no-op elsewhere and on subsequent calls.
+pub fn installOnEventLoop(handle: jsc.EventLoopHandle) void {
+    if (comptime !Environment.isMac) return;
+    if (!enabled or original_ppid <= 1) return;
+    if (event_loop_installed.swap(true, .monotonic)) return;
+
+    // Race: parent may have died between install() and now (before the event
+    // loop existed). We've been reparented; kqueue would ESRCH — exit now.
+    if (std.c.getppid() != original_ppid) {
+        bun.Global.exit(exit_code);
+    }
+
+    const poll = bun.Async.FilePoll.init(handle, .fromNative(original_ppid), .{}, ParentDeathWatchdog, &instance);
+    switch (poll.register(handle.loop(), .process, true)) {
+        .result => {
+            // Do not keep the event loop alive on this poll's behalf — the
+            // watchdog must never prevent Bun from exiting when there is no
+            // other work. `register()` only bumps the *active* count when
+            // `.keeps_event_loop_alive` was set beforehand, which we didn't.
+        },
+        .err => |err| {
+            // ESRCH: parent already gone before we registered — treat as fired.
+            if (err.getErrno() == .SRCH) {
+                bun.Global.exit(exit_code);
+            }
+            // Any other registration error: best-effort feature, just don't watch.
+        },
+    }
+}
+
+/// `FilePoll.Owner` dispatch target — see the `ParentDeathWatchdog` arm in
+/// `posix_event_loop.zig`'s `onUpdate`. The kqueue `NOTE_EXIT` for our parent
+/// fired.
+pub fn onParentExit(_: *ParentDeathWatchdog) void {
+    // Global.exit → Bun__onExit → onProcessExit → killDescendants.
+    bun.Global.exit(exit_code);
+}
+
+/// Registered with `Global.addExitCallback` so it runs from `Bun__onExit`
+/// (atexit on macOS, at_quick_exit on Linux, and the explicit `Global.exit`
+/// path). C calling convention because that's the exit-callback ABI.
+fn onProcessExit() callconv(.c) void {
+    killDescendants();
+}
+
+/// Walk the process tree rooted at `getpid()` and SIGTERM every descendant.
+///
+/// Pid-reuse safety: enumeration is a point-in-time snapshot, so a pid we
+/// collect could exit and be recycled by an unrelated process before we
+/// signal it. To avoid killing an innocent process we use a
+/// stop-verify-kill pattern:
+///   1. Enumerate children of `parent`.
+///   2. For each child `c`: SIGSTOP it, then re-read `c`'s ppid. If it's no
+///      longer `parent`, the pid was recycled in the (microsecond) window
+///      between enumerate and STOP — undo with SIGCONT and skip. Otherwise
+///      `c` is now frozen and confirmed ours; recurse into it.
+///   3. Once the whole tree is frozen, SIGTERM + SIGCONT each pid
+///      (leaves-first so a parent isn't woken before its children are
+///      signalled).
+/// A frozen process can neither exit (so its pid can't be reused) nor fork
+/// (so its child set is stable while we recurse), which is what makes the
+/// verify step sufficient. The only forking process is `self`, and we're in
+/// the exit handler — not forking.
+pub fn killDescendants() void {
+    if (comptime !Environment.isPosix) return;
+
+    const self_pid = std.c.getpid();
+
+    var to_visit: std.ArrayListUnmanaged(std.c.pid_t) = .{};
+    defer to_visit.deinit(bun.default_allocator);
+    var to_kill: std.ArrayListUnmanaged(std.c.pid_t) = .{};
+    defer to_kill.deinit(bun.default_allocator);
+
+    to_visit.append(bun.default_allocator, self_pid) catch return;
+
+    var buf: [256]std.c.pid_t = undefined;
+    // Hard cap on tree size so a fork bomb under us can't make exit hang.
+    while (to_visit.items.len > 0 and to_kill.items.len < 4096) {
+        const parent = to_visit.swapRemove(to_visit.items.len - 1);
+        const n = listChildPids(parent, &buf) orelse continue;
+        for (buf[0..n]) |child| {
+            if (child == self_pid or child <= 1) continue;
+            // Freeze first, then confirm it's still the process we enumerated.
+            if (std.c.kill(child, std.posix.SIG.STOP) != 0) continue;
+            if (parentPidOf(child) != parent) {
+                // Recycled between enumerate and STOP — undo and skip.
+                _ = std.c.kill(child, std.posix.SIG.CONT);
+                continue;
+            }
+            to_kill.append(bun.default_allocator, child) catch break;
+            to_visit.append(bun.default_allocator, child) catch break;
+        }
+    }
+
+    // Reverse: leaves first. SIGTERM then SIGCONT so the (now-pending) TERM
+    // is delivered as soon as the process is unfrozen.
+    var i = to_kill.items.len;
+    while (i > 0) {
+        i -= 1;
+        _ = std.c.kill(to_kill.items[i], std.posix.SIG.TERM);
+        _ = std.c.kill(to_kill.items[i], std.posix.SIG.CONT);
+    }
+}
+
+/// Best-effort ppid lookup for an arbitrary pid. Returns 0 if the process
+/// doesn't exist or the lookup failed (which the caller treats as "not the
+/// parent we expected").
+fn parentPidOf(pid: std.c.pid_t) std.c.pid_t {
+    if (comptime Environment.isMac) {
+        var info: bun.darwin.proc_bsdinfo = undefined;
+        const rc = bun.darwin.proc_pidinfo(pid, bun.darwin.PROC_PIDTBSDINFO, 0, &info, bun.darwin.PROC_PIDTBSDINFO_SIZE);
+        if (rc != bun.darwin.PROC_PIDTBSDINFO_SIZE) return 0;
+        return @intCast(info.pbi_ppid);
+    }
+    if (comptime Environment.isLinux) {
+        var path_buf: [64]u8 = undefined;
+        const path = std.fmt.bufPrintZ(&path_buf, "/proc/{d}/stat", .{pid}) catch return 0;
+        var read_buf: [512]u8 = undefined;
+        const stat = readFileOnce(path, &read_buf) orelse return 0;
+        // Format: "pid (comm) state ppid …". `comm` may contain spaces and
+        // parens; the *last* ')' terminates it. Field 1 after that is state,
+        // field 2 is ppid.
+        const rparen = std.mem.lastIndexOfScalar(u8, stat, ')') orelse return 0;
+        var it = std.mem.tokenizeScalar(u8, stat[rparen + 1 ..], ' ');
+        _ = it.next(); // state
+        const ppid_str = it.next() orelse return 0;
+        return std.fmt.parseInt(std.c.pid_t, ppid_str, 10) catch 0;
+    }
+    return 0;
+}
+
+/// Enumerate direct children of `parent` into `out`. Returns the number of
+/// pids written, or null if enumeration failed / is unsupported. May truncate
+/// to `out.len`.
+fn listChildPids(parent: std.c.pid_t, out: []std.c.pid_t) ?usize {
+    if (comptime Environment.isMac) {
+        // proc_listchildpids returns the *count* of pids written (libproc.c
+        // already divides the kernel's byte count by sizeof(int)); buffersize
+        // is in bytes.
+        const rc = bun.darwin.proc_listchildpids(parent, out.ptr, @intCast(out.len * @sizeOf(std.c.pid_t)));
+        if (rc <= 0) return null;
+        return @intCast(@min(@as(usize, @intCast(rc)), out.len));
+    }
+    if (comptime Environment.isLinux) {
+        return listChildPidsLinux(parent, out);
+    }
+    return null;
+}
+
+/// Linux: read `/proc/<parent>/task/<tid>/children` for every thread of
+/// `parent`. Each file is a space-separated list of child pids whose
+/// `getppid()` is `parent` and which were created by that specific thread.
+/// Requires CONFIG_PROC_CHILDREN (enabled on every distro kernel that matters).
+fn listChildPidsLinux(parent: std.c.pid_t, out: []std.c.pid_t) ?usize {
+    if (comptime !Environment.isLinux) unreachable;
+
+    var path_buf: [64]u8 = undefined;
+    const task_path = std.fmt.bufPrint(&path_buf, "/proc/{d}/task", .{parent}) catch return null;
+
+    const task_fd = switch (bun.openDirForIteration(bun.FD.cwd(), task_path)) {
+        .result => |fd| fd,
+        .err => return null,
+    };
+    defer task_fd.close();
+    var task_dir = task_fd.stdDir();
+
+    var written: usize = 0;
+    var read_buf: [4096]u8 = undefined;
+    var it = task_dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (written >= out.len) break;
+        // Each entry is a tid (numeric directory).
+        const tid = std.fmt.parseInt(std.c.pid_t, entry.name, 10) catch continue;
+        const children_path = std.fmt.bufPrintZ(&path_buf, "/proc/{d}/task/{d}/children", .{ parent, tid }) catch continue;
+        const data = readFileOnce(children_path, &read_buf) orelse continue;
+        var tok = std.mem.tokenizeAny(u8, data, " \n");
+        while (tok.next()) |pid_str| {
+            if (written >= out.len) break;
+            const child = std.fmt.parseInt(std.c.pid_t, pid_str, 10) catch continue;
+            out[written] = child;
+            written += 1;
+        }
+    }
+    return written;
+}
+
+/// Single-shot open+read+close into `buf`. Exit-handler helper — avoids
+/// allocating (so no `File.readFrom`) and swallows the `bun.sys` error info
+/// we don't need.
+fn readFileOnce(path: [:0]const u8, buf: []u8) ?[]const u8 {
+    const file = switch (bun.sys.File.open(path, bun.O.RDONLY, 0)) {
+        .result => |f| f,
+        .err => return null,
+    };
+    defer file.close();
+    return switch (file.readAll(buf)) {
+        .result => |n| buf[0..n],
+        .err => null,
+    };
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const jsc = bun.jsc;
+const Environment = bun.Environment;

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -39,11 +39,24 @@ const exit_code: u8 = 128 + 1;
 
 var enabled: bool = false;
 var original_ppid: std.c.pid_t = 0;
+var install_thread_id: std.Thread.Id = 0;
 
 /// Whether `BUN_DIE_WITH_PARENT` was set at startup. Read by the spawn path to
 /// decide whether to default `linux_pdeathsig` on children.
 pub fn isEnabled() bool {
     return enabled;
+}
+
+/// Whether the spawn-side `linux_pdeathsig` default should apply to a child
+/// being spawned *right now*. `PR_SET_PDEATHSIG` is thread-scoped: it fires
+/// when the *thread* that vforked the child exits, not when the parent
+/// process exits. A `Bun.spawn()` from a JS `Worker` vforks on that Worker's
+/// OS thread, so defaulting PDEATHSIG there would kill the child on
+/// `worker.terminate()` while Bun itself is still alive. Restricting the
+/// default to the main thread keeps "die with Bun" semantics; Workers can
+/// still opt in explicitly via the (Zig-level) `linux_pdeathsig` option.
+pub fn shouldDefaultSpawnPdeathsig() bool {
+    return enabled and std.Thread.getCurrentId() == install_thread_id;
 }
 var event_loop_installed = std.atomic.Value(bool).init(false);
 /// Singleton instance — `FilePoll.Owner` needs a real pointer, but we have no
@@ -56,6 +69,7 @@ pub fn install() void {
     if (!bun.env_var.BUN_DIE_WITH_PARENT.get()) return;
 
     enabled = true;
+    install_thread_id = std.Thread.getCurrentId();
     // Descendant cleanup runs on every clean exit regardless of whether we end
     // up watching a parent (Bun may have been spawned directly by launchd/init).
     bun.Global.addExitCallback(&onProcessExit);
@@ -177,7 +191,12 @@ pub fn killDescendants() void {
                 _ = std.c.kill(child, std.posix.SIG.CONT);
                 continue;
             }
-            to_kill.append(bun.default_allocator, child) catch break;
+            to_kill.append(bun.default_allocator, child) catch {
+                // OOM after we've already STOPped+verified this child — kill it
+                // now rather than leaving it frozen and absent from to_kill.
+                _ = std.c.kill(child, std.posix.SIG.KILL);
+                break;
+            };
             to_visit.append(bun.default_allocator, child) catch break;
         }
     }

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -283,15 +283,14 @@ fn listChildPidsLinux(parent: std.c.pid_t, out: []std.c.pid_t) ?usize {
         .err => return null,
     };
     defer task_fd.close();
-    var task_dir = task_fd.stdDir();
 
     var written: usize = 0;
     var read_buf: [4096]u8 = undefined;
-    var it = task_dir.iterate();
-    while (it.next() catch null) |entry| {
+    var it = bun.iterateDir(task_fd);
+    while (it.next().unwrap() catch null) |entry| {
         if (written >= out.len) break;
         // Each entry is a tid (numeric directory).
-        const tid = std.fmt.parseInt(std.c.pid_t, entry.name, 10) catch continue;
+        const tid = std.fmt.parseInt(std.c.pid_t, entry.name.slice(), 10) catch continue;
         const children_path = std.fmt.bufPrintZ(&path_buf, "/proc/{d}/task/{d}/children", .{ parent, tid }) catch continue;
         const data = readFileOnce(children_path, &read_buf) orelse continue;
         var tok = std.mem.tokenizeAny(u8, data, " \n");

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -197,9 +197,10 @@ pub fn killDescendants() void {
 /// parent we expected").
 fn parentPidOf(pid: std.c.pid_t) std.c.pid_t {
     if (comptime Environment.isMac) {
-        var info: bun.darwin.proc_bsdinfo = undefined;
-        const rc = bun.darwin.proc_pidinfo(pid, bun.darwin.PROC_PIDTBSDINFO, 0, &info, bun.darwin.PROC_PIDTBSDINFO_SIZE);
-        if (rc != bun.darwin.PROC_PIDTBSDINFO_SIZE) return 0;
+        var info: bun.c.struct_proc_bsdinfo = undefined;
+        const size: c_int = @sizeOf(bun.c.struct_proc_bsdinfo);
+        const rc = bun.c.proc_pidinfo(pid, bun.c.PROC_PIDTBSDINFO, 0, &info, size);
+        if (rc != size) return 0;
         return @intCast(info.pbi_ppid);
     }
     if (comptime Environment.isLinux) {
@@ -227,7 +228,7 @@ fn listChildPids(parent: std.c.pid_t, out: []std.c.pid_t) ?usize {
         // proc_listchildpids returns the *count* of pids written (libproc.c
         // already divides the kernel's byte count by sizeof(int)); buffersize
         // is in bytes.
-        const rc = bun.darwin.proc_listchildpids(parent, out.ptr, @intCast(out.len * @sizeOf(std.c.pid_t)));
+        const rc = bun.c.proc_listchildpids(parent, out.ptr, @intCast(out.len * @sizeOf(std.c.pid_t)));
         if (rc <= 0) return null;
         return @intCast(@min(@as(usize, @intCast(rc)), out.len));
     }

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -285,7 +285,9 @@ fn listChildPidsLinux(parent: std.c.pid_t, out: []std.c.pid_t) ?usize {
     defer task_fd.close();
 
     var written: usize = 0;
-    var read_buf: [4096]u8 = undefined;
+    // Sized so a single read can saturate the 4096-pid `out` buffer
+    // (~8 bytes per "1234567 " entry × 4096).
+    var read_buf: [32 * 1024]u8 = undefined;
     var it = bun.iterateDir(task_fd);
     while (it.next().unwrap() catch null) |entry| {
         if (written >= out.len) break;

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -290,6 +290,7 @@ fn readFileOnce(path: [:0]const u8, buf: []u8) ?[]const u8 {
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
-const jsc = bun.jsc;
 const Environment = bun.Environment;
+const jsc = bun.jsc;

--- a/src/ParentDeathWatchdog.zig
+++ b/src/ParentDeathWatchdog.zig
@@ -1,7 +1,8 @@
 //! Opt-in self-termination when our parent goes away, plus recursive
 //! descendant cleanup on exit.
 //!
-//! Enabled via env var `BUN_DIE_WITH_PARENT`. When set, Bun:
+//! Enabled via env var `BUN_FEATURE_FLAG_DIE_WITH_PARENT` or
+//! `bunfig.toml` `[run] dieWithParent = true`. When set, Bun:
 //!
 //!   1. Captures its original parent pid at startup and exits as soon as that
 //!      parent is gone — even if the parent was SIGKILLed and never got a
@@ -41,7 +42,7 @@ var enabled: bool = false;
 var original_ppid: std.c.pid_t = 0;
 var install_thread_id: std.Thread.Id = 0;
 
-/// Whether `BUN_DIE_WITH_PARENT` was set at startup. Read by the spawn path to
+/// Whether `BUN_FEATURE_FLAG_DIE_WITH_PARENT` was set at startup. Read by the spawn path to
 /// decide whether to default `linux_pdeathsig` on children.
 pub fn isEnabled() bool {
     return enabled;
@@ -63,10 +64,22 @@ var event_loop_installed = std.atomic.Value(bool).init(false);
 /// per-instance state.
 var instance: ParentDeathWatchdog = .{};
 
+/// Called from `main()` before the CLI starts. Checks the env var and enables
+/// the watchdog as early as possible so the Linux `prctl` window is minimal.
+/// `bunfig.toml`'s `[run] dieWithParent` calls `enable()` directly later in
+/// startup if the env var wasn't set.
 pub fn install() void {
     if (comptime !Environment.isPosix) return;
+    if (!bun.env_var.BUN_FEATURE_FLAG_DIE_WITH_PARENT.get()) return;
+    enable();
+}
 
-    if (!bun.env_var.BUN_DIE_WITH_PARENT.get()) return;
+/// Idempotent. Arms the watchdog: Linux `prctl(PR_SET_PDEATHSIG)`, exit-time
+/// descendant reaper, and (lazily) the macOS kqueue parent watch. Safe to call
+/// from `main()` (env-var path) and again from bunfig parsing.
+pub fn enable() void {
+    if (comptime !Environment.isPosix) return;
+    if (enabled) return;
 
     enabled = true;
     install_thread_id = std.Thread.getCurrentId();

--- a/src/async/posix_event_loop.zig
+++ b/src/async/posix_event_loop.zig
@@ -164,6 +164,7 @@ pub const FilePoll = struct {
     const Request = bun.api.dns.internal.Request;
     const LifecycleScriptSubprocessOutputReader = bun.install.LifecycleScriptSubprocess.OutputReader;
     const BufferedReader = bun.io.BufferedReader;
+    const ParentDeathWatchdog = bun.ParentDeathWatchdog;
 
     pub const Owner = bun.TaggedPointerUnion(.{
         FileSink,
@@ -192,6 +193,7 @@ pub const FilePoll = struct {
         Process,
         ShellBufferedWriter, // i do not know why, but this has to be here otherwise compiler will complain about dependency loop
         TerminalPoll,
+        ParentDeathWatchdog,
     });
 
     pub const AllocatorType = enum {
@@ -433,6 +435,11 @@ pub const FilePoll = struct {
                 log("onUpdate " ++ kqueue_or_epoll ++ " (fd: {f}) Terminal", .{poll.fd});
                 var handler: *TerminalPoll = ptr.as(TerminalPoll);
                 handler.onPoll(size_or_offset, poll.flags.contains(.hup));
+            },
+            @field(Owner.Tag, @typeName(ParentDeathWatchdog)) => {
+                if (comptime !Environment.isMac) unreachable;
+                log("onUpdate " ++ kqueue_or_epoll ++ " (fd: {f}) ParentDeathWatchdog", .{poll.fd});
+                ptr.as(ParentDeathWatchdog).onParentExit();
             },
             else => {
                 const possible_name = Owner.typeNameFromTag(@intFromEnum(ptr.tag()));

--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1157,6 +1157,7 @@ pub fn initWithModuleGraph(
     vm.regular_event_loop.global = vm.global;
     vm.jsc_vm = vm.global.vm();
     uws.Loop.get().internal_loop_data.jsc_vm = vm.jsc_vm;
+    bun.ParentDeathWatchdog.installOnEventLoop(jsc.EventLoopHandle.init(vm));
 
     vm.configureDebugger(opts.debugger);
     vm.body_value_hive_allocator = Body.Value.HiveAllocator.init(bun.typedAllocator(jsc.WebCore.Body.Value));
@@ -1281,6 +1282,7 @@ pub fn init(opts: Options) !*VirtualMachine {
     uws.Loop.get().internal_loop_data.jsc_vm = vm.jsc_vm;
     vm.smol = opts.smol;
     vm.dns_result_order = opts.dns_result_order;
+    if (opts.is_main_thread) bun.ParentDeathWatchdog.installOnEventLoop(jsc.EventLoopHandle.init(vm));
 
     if (opts.smol)
         is_smol_mode = opts.smol;

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1059,9 +1059,9 @@ pub const PosixSpawnOptions = struct {
     pseudoconsole: void = {},
     /// Linux only. When non-null, the child sets PR_SET_PDEATHSIG to this
     /// signal between vfork and exec in posix_spawn_bun, so the kernel kills
-    /// it when the spawning thread dies. When null, defaults to whatever this
-    /// process itself has set (so a worker with PDEATHSIG propagates it to
-    /// children automatically). Not exposed to JS yet.
+    /// it when the spawning thread dies. When null, defaults to SIGKILL if
+    /// `BUN_DIE_WITH_PARENT` is enabled (see `ParentDeathWatchdog`), else 0
+    /// (no PDEATHSIG). Not exposed to JS yet.
     linux_pdeathsig: ?u8 = null,
 
     pub const Stdio = union(enum) {
@@ -1369,13 +1369,13 @@ pub fn spawnProcessPosix(
 
     if (Environment.isLinux) {
         // Explicit per-spawn value wins; otherwise BUN_DIE_WITH_PARENT defaults
-        // every child to SIGTERM-on-parent-death so non-Bun descendants are
+        // every child to SIGKILL-on-parent-death so non-Bun descendants are
         // covered without relying on env-var inheritance, and the prctl happens
         // in the vfork child before exec so there's no startup race.
         attr.linux_pdeathsig = if (options.linux_pdeathsig) |sig|
             @intCast(sig)
         else if (bun.ParentDeathWatchdog.isEnabled())
-            std.posix.SIG.TERM
+            std.posix.SIG.KILL
         else
             0;
     }

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1368,7 +1368,16 @@ pub fn spawnProcessPosix(
     attr.new_process_group = options.new_process_group;
 
     if (Environment.isLinux) {
-        attr.linux_pdeathsig = if (options.linux_pdeathsig) |sig| @intCast(sig) else 0;
+        // Explicit per-spawn value wins; otherwise BUN_DIE_WITH_PARENT defaults
+        // every child to SIGTERM-on-parent-death so non-Bun descendants are
+        // covered without relying on env-var inheritance, and the prctl happens
+        // in the vfork child before exec so there's no startup race.
+        attr.linux_pdeathsig = if (options.linux_pdeathsig) |sig|
+            @intCast(sig)
+        else if (bun.ParentDeathWatchdog.isEnabled())
+            std.posix.SIG.TERM
+        else
+            0;
     }
 
     if (options.cwd.len > 0) {

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1374,7 +1374,7 @@ pub fn spawnProcessPosix(
         // in the vfork child before exec so there's no startup race.
         attr.linux_pdeathsig = if (options.linux_pdeathsig) |sig|
             @intCast(sig)
-        else if (bun.ParentDeathWatchdog.isEnabled())
+        else if (bun.ParentDeathWatchdog.shouldDefaultSpawnPdeathsig())
             std.posix.SIG.KILL
         else
             0;

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -1060,7 +1060,7 @@ pub const PosixSpawnOptions = struct {
     /// Linux only. When non-null, the child sets PR_SET_PDEATHSIG to this
     /// signal between vfork and exec in posix_spawn_bun, so the kernel kills
     /// it when the spawning thread dies. When null, defaults to SIGKILL if
-    /// `BUN_DIE_WITH_PARENT` is enabled (see `ParentDeathWatchdog`), else 0
+    /// `BUN_FEATURE_FLAG_DIE_WITH_PARENT` is enabled (see `ParentDeathWatchdog`), else 0
     /// (no PDEATHSIG). Not exposed to JS yet.
     linux_pdeathsig: ?u8 = null,
 
@@ -1368,7 +1368,7 @@ pub fn spawnProcessPosix(
     attr.new_process_group = options.new_process_group;
 
     if (Environment.isLinux) {
-        // Explicit per-spawn value wins; otherwise BUN_DIE_WITH_PARENT defaults
+        // Explicit per-spawn value wins; otherwise BUN_FEATURE_FLAG_DIE_WITH_PARENT defaults
         // every child to SIGKILL-on-parent-death so non-Bun descendants are
         // covered without relying on env-var inheritance, and the prctl happens
         // in the vfork child before exec so there's no startup race.

--- a/src/bun.zig
+++ b/src/bun.zig
@@ -239,6 +239,7 @@ pub const md = @import("./md/root.zig");
 
 pub const Output = @import("./output.zig");
 pub const Global = @import("./Global.zig");
+pub const ParentDeathWatchdog = @import("./ParentDeathWatchdog.zig");
 
 pub const FD = @import("./fd.zig").FD;
 pub const MovableIfWindowsFd = @import("./fd.zig").MovableIfWindowsFd;

--- a/src/bunfig.zig
+++ b/src/bunfig.zig
@@ -886,6 +886,14 @@ pub const Bunfig = struct {
                             try this.addError(bun_flag.loc, "Expected boolean");
                         }
                     }
+
+                    if (run_expr.get("dieWithParent")) |dwp| {
+                        if (dwp.asBool()) |value| {
+                            if (value) bun.ParentDeathWatchdog.enable();
+                        } else {
+                            try this.addError(dwp.loc, "Expected boolean");
+                        }
+                    }
                 }
 
                 if (json.get("console")) |console_expr| {

--- a/src/c-headers-for-zig.h
+++ b/src/c-headers-for-zig.h
@@ -39,6 +39,7 @@
 
 #if DARWIN
 #include <copyfile.h>
+#include <libproc.h>
 #include <mach/mach_host.h>
 #include <mach/processor_info.h>
 #include <net/if_dl.h>

--- a/src/darwin.zig
+++ b/src/darwin.zig
@@ -101,5 +101,41 @@ pub const OSLog = opaque {
     };
 };
 
+/// libproc: enumerate the direct children of `ppid`. `buffersize` is in
+/// *bytes*; return value is the *count* of pids written (libproc.c divides the
+/// kernel's byte count by `sizeof(int)` for you), or -1 on error. Passing a
+/// null buffer / zero size returns the count needed.
+pub extern "c" fn proc_listchildpids(ppid: std.c.pid_t, buffer: ?[*]std.c.pid_t, buffersize: c_int) c_int;
+
+/// libproc: per-pid info. `flavor` selects the struct returned in `buffer`.
+pub extern "c" fn proc_pidinfo(pid: std.c.pid_t, flavor: c_int, arg: u64, buffer: *anyopaque, buffersize: c_int) c_int;
+
+pub const PROC_PIDTBSDINFO: c_int = 3;
+
+/// Prefix of `struct proc_bsdinfo` from `<sys/proc_info.h>` — only the leading
+/// fields we read. `proc_pidinfo` is given the full `PROC_PIDTBSDINFO_SIZE` so
+/// the kernel fills past these; we just don't name the tail.
+pub const proc_bsdinfo = extern struct {
+    pbi_flags: u32,
+    pbi_status: u32,
+    pbi_xstatus: u32,
+    pbi_pid: u32,
+    pbi_ppid: u32,
+    // … 0x40 bytes total before the two MAXCOMLEN name arrays.
+    _tail: [PROC_PIDTBSDINFO_SIZE - 5 * @sizeOf(u32)]u8 = undefined,
+};
+
+/// `sizeof(struct proc_bsdinfo)` — required as `buffersize` for
+/// `PROC_PIDTBSDINFO`; the syscall rejects anything smaller.
+pub const PROC_PIDTBSDINFO_SIZE: c_int = 136;
+
+comptime {
+    bun.assertf(
+        @sizeOf(proc_bsdinfo) == PROC_PIDTBSDINFO_SIZE,
+        "proc_bsdinfo size drifted from PROC_PIDTBSDINFO_SIZE",
+        .{},
+    );
+}
+
 const bun = @import("bun");
 const std = @import("std");

--- a/src/darwin.zig
+++ b/src/darwin.zig
@@ -101,41 +101,5 @@ pub const OSLog = opaque {
     };
 };
 
-/// libproc: enumerate the direct children of `ppid`. `buffersize` is in
-/// *bytes*; return value is the *count* of pids written (libproc.c divides the
-/// kernel's byte count by `sizeof(int)` for you), or -1 on error. Passing a
-/// null buffer / zero size returns the count needed.
-pub extern "c" fn proc_listchildpids(ppid: std.c.pid_t, buffer: ?[*]std.c.pid_t, buffersize: c_int) c_int;
-
-/// libproc: per-pid info. `flavor` selects the struct returned in `buffer`.
-pub extern "c" fn proc_pidinfo(pid: std.c.pid_t, flavor: c_int, arg: u64, buffer: *anyopaque, buffersize: c_int) c_int;
-
-pub const PROC_PIDTBSDINFO: c_int = 3;
-
-/// Prefix of `struct proc_bsdinfo` from `<sys/proc_info.h>` — only the leading
-/// fields we read. `proc_pidinfo` is given the full `PROC_PIDTBSDINFO_SIZE` so
-/// the kernel fills past these; we just don't name the tail.
-pub const proc_bsdinfo = extern struct {
-    pbi_flags: u32,
-    pbi_status: u32,
-    pbi_xstatus: u32,
-    pbi_pid: u32,
-    pbi_ppid: u32,
-    // … 0x40 bytes total before the two MAXCOMLEN name arrays.
-    _tail: [PROC_PIDTBSDINFO_SIZE - 5 * @sizeOf(u32)]u8 = undefined,
-};
-
-/// `sizeof(struct proc_bsdinfo)` — required as `buffersize` for
-/// `PROC_PIDTBSDINFO`; the syscall rejects anything smaller.
-pub const PROC_PIDTBSDINFO_SIZE: c_int = 136;
-
-comptime {
-    bun.assertf(
-        @sizeOf(proc_bsdinfo) == PROC_PIDTBSDINFO_SIZE,
-        "proc_bsdinfo size drifted from PROC_PIDTBSDINFO_SIZE",
-        .{},
-    );
-}
-
 const bun = @import("bun");
 const std = @import("std");

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -50,6 +50,11 @@ pub const BUN_DEBUG_HASH_RANDOM_SEED = New(kind.unsigned, "BUN_DEBUG_HASH_RANDOM
 pub const BUN_DEBUG_QUIET_LOGS = New(kind.boolean, "BUN_DEBUG_QUIET_LOGS", .{});
 pub const BUN_DEBUG_TEST_TEXT_LOCKFILE = New(kind.boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", .{ .default = false });
 pub const BUN_DEV_SERVER_TEST_RUNNER = New(kind.string, "BUN_DEV_SERVER_TEST_RUNNER", .{});
+/// Opt-in: when truthy, Bun watches its original parent pid and exits as soon
+/// as that process dies (even if the parent was SIGKILLed and couldn't forward
+/// a signal), and on its own clean exit recursively SIGTERMs every descendant
+/// so nothing it spawned outlives it. See `src/ParentDeathWatchdog.zig`.
+pub const BUN_DIE_WITH_PARENT = New(kind.boolean, "BUN_DIE_WITH_PARENT", .{ .default = false });
 pub const BUN_ENABLE_CRASH_REPORTING = New(kind.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});
 pub const BUN_FEATURE_FLAG_DUMP_CODE = New(kind.string, "BUN_FEATURE_FLAG_DUMP_CODE", .{});
 /// TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -52,7 +52,7 @@ pub const BUN_DEBUG_TEST_TEXT_LOCKFILE = New(kind.boolean, "BUN_DEBUG_TEST_TEXT_
 pub const BUN_DEV_SERVER_TEST_RUNNER = New(kind.string, "BUN_DEV_SERVER_TEST_RUNNER", .{});
 /// Opt-in: when truthy, Bun watches its original parent pid and exits as soon
 /// as that process dies (even if the parent was SIGKILLed and couldn't forward
-/// a signal), and on its own clean exit recursively SIGTERMs every descendant
+/// a signal), and on its own clean exit recursively SIGKILLs every descendant
 /// so nothing it spawned outlives it. See `src/ParentDeathWatchdog.zig`.
 pub const BUN_DIE_WITH_PARENT = New(kind.boolean, "BUN_DIE_WITH_PARENT", .{ .default = false });
 pub const BUN_ENABLE_CRASH_REPORTING = New(kind.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});

--- a/src/env_var.zig
+++ b/src/env_var.zig
@@ -50,12 +50,12 @@ pub const BUN_DEBUG_HASH_RANDOM_SEED = New(kind.unsigned, "BUN_DEBUG_HASH_RANDOM
 pub const BUN_DEBUG_QUIET_LOGS = New(kind.boolean, "BUN_DEBUG_QUIET_LOGS", .{});
 pub const BUN_DEBUG_TEST_TEXT_LOCKFILE = New(kind.boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", .{ .default = false });
 pub const BUN_DEV_SERVER_TEST_RUNNER = New(kind.string, "BUN_DEV_SERVER_TEST_RUNNER", .{});
+pub const BUN_ENABLE_CRASH_REPORTING = New(kind.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});
 /// Opt-in: when truthy, Bun watches its original parent pid and exits as soon
 /// as that process dies (even if the parent was SIGKILLed and couldn't forward
 /// a signal), and on its own clean exit recursively SIGKILLs every descendant
 /// so nothing it spawned outlives it. See `src/ParentDeathWatchdog.zig`.
-pub const BUN_DIE_WITH_PARENT = New(kind.boolean, "BUN_DIE_WITH_PARENT", .{ .default = false });
-pub const BUN_ENABLE_CRASH_REPORTING = New(kind.boolean, "BUN_ENABLE_CRASH_REPORTING", .{});
+pub const BUN_FEATURE_FLAG_DIE_WITH_PARENT = New(kind.boolean, "BUN_FEATURE_FLAG_DIE_WITH_PARENT", .{ .default = false });
 pub const BUN_FEATURE_FLAG_DUMP_CODE = New(kind.string, "BUN_FEATURE_FLAG_DUMP_CODE", .{});
 /// TODO(markovejnovic): It's unclear why the default here is 100_000, but this was legacy behavior
 /// so we'll keep it for now.

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,6 +61,7 @@ pub fn main() void {
     }
 
     _bun.StackCheck.configureThread();
+    _bun.ParentDeathWatchdog.install();
 
     _bun.cli.Cli.start(_bun.default_allocator);
     _bun.Global.exit(0);

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -1,0 +1,231 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { setTimeout as sleep } from "node:timers/promises";
+
+// BUN_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
+// process dies, even if the parent was SIGKILLed and couldn't signal us. On
+// the way out it also recursively SIGTERMs every descendant so nothing it
+// spawned outlives it. Linux uses prctl(PR_SET_PDEATHSIG); macOS registers
+// EVFILT_PROC/NOTE_EXIT on the existing event loop's kqueue (no thread).
+//
+// Tree under test: test → sh (the "parent" we SIGKILL) → bun-debug → grandchild.
+// We SIGKILL sh and observe bun-debug and the grandchild.
+
+const isSupported = process.platform === "linux" || process.platform === "darwin";
+
+// Shared fixture dir — child.js spawns grandchild.js, prints
+// "<self> <ppid> <grandchild>", then idles. Kept on disk so we can pass it
+// through /bin/sh without fighting shell quoting of an inline -e payload.
+const fixture = tempDir("die-with-parent", {
+  // The grandchild must finish its own ParentDeathWatchdog.install() (and on
+  // Linux, prctl) before the test SIGKILLs sh, otherwise the cascade can miss
+  // it. install() runs in main() before any JS, so once this process has
+  // produced a byte on stdout we know its prctl is in place.
+  "grandchild.js": `
+    process.stdout.write("r");
+    setInterval(()=>{}, 1000);
+  `,
+  "child.js": `
+    const gc = Bun.spawn({
+      cmd: [process.execPath, "grandchild.js"],
+      cwd: import.meta.dir,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // Block on the grandchild's readiness byte before announcing pids — the
+    // test reads our line as the "go" signal.
+    await gc.stdout.getReader().read();
+    console.log(process.pid, process.ppid, gc.pid);
+    setInterval(()=>{}, 1000);
+  `,
+  // Same shape as child.js, but the grandchild is plain /bin/sh — never calls
+  // prctl itself, so reaping it proves the spawn-side linux_pdeathsig (Linux)
+  // and the libproc walk (macOS) cover non-Bun descendants.
+  "child-nonbun.js": `
+    const gc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", "echo r; while :; do sleep 1; done"],
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    await gc.stdout.getReader().read();
+    console.log(process.pid, process.ppid, gc.pid);
+    setInterval(()=>{}, 1000);
+  `,
+  // Spawns a grandchild, prints its pid, then exits cleanly. Exercises the
+  // descendant reaper independently of the parent-watch path.
+  "clean-exit.js": `
+    const gc = Bun.spawn({
+      cmd: [process.execPath, "grandchild.js"],
+      cwd: import.meta.dir,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    await gc.stdout.getReader().read();
+    gc.unref();
+    console.log(gc.pid);
+    process.exit(0);
+  `,
+});
+
+async function spawnTree(dieWithParent: string | undefined, childScript = "child.js") {
+  const env: Record<string, string> = { ...bunEnv };
+  // bunEnv spreads process.env; make sure an ambient BUN_DIE_WITH_PARENT from
+  // the test runner doesn't leak into the "unset" case.
+  delete env.BUN_DIE_WITH_PARENT;
+  if (dieWithParent !== undefined) env.BUN_DIE_WITH_PARENT = dieWithParent;
+
+  const sh = Bun.spawn({
+    // Trailing `wait` defeats sh's implicit-exec-of-last-command so sh stays a
+    // distinct pid we can SIGKILL independently of bun.
+    cmd: ["/bin/sh", "-c", `"${bunExe()}" "${String(fixture)}/${childScript}" & wait`],
+    env,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+
+  // A single reader.read() can return a partial chunk; buffer until we see the
+  // newline that terminates the "pid ppid grandchild" line.
+  const reader = sh.stdout.getReader();
+  const decoder = new TextDecoder();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    line += decoder.decode(value, { stream: true });
+  }
+  reader.releaseLock();
+  const [bunPid, bunPpid, grandchildPid] = line.trim().split(" ").map(Number);
+  expect(bunPid).toBeGreaterThan(0);
+  expect(bunPpid).toBe(sh.pid);
+  expect(grandchildPid).toBeGreaterThan(0);
+
+  return { sh, bunPid, grandchildPid };
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Poll `isAlive(pid)` until it returns false or `timeoutMs` elapses.
+ * Returns true if the process died within the window. Used both ways:
+ * "must die" asserts true, "must survive" asserts false.
+ */
+async function waitUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await sleep(25);
+  }
+  return !isAlive(pid);
+}
+
+function reap(...pids: number[]) {
+  for (const pid of pids) {
+    if (isAlive(pid)) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+  }
+}
+
+test.skipIf(!isSupported)("without BUN_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed", async () => {
+  const { sh, bunPid, grandchildPid } = await spawnTree(undefined);
+  process.kill(sh.pid!, "SIGKILL");
+  await sh.exited;
+  // bun must NOT die: poll for death and expect the poll to time out.
+  const died = await waitUntilDead(bunPid, 1000);
+  reap(bunPid, grandchildPid);
+  expect(died).toBe(false);
+});
+
+test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: bun exits when its parent is SIGKILLed", async () => {
+  const { sh, bunPid, grandchildPid } = await spawnTree("1");
+  process.kill(sh.pid!, "SIGKILL");
+  await sh.exited;
+  // kqueue NOTE_EXIT / PDEATHSIG fire effectively immediately; poll until
+  // bun is gone rather than sleeping a fixed interval.
+  const died = await waitUntilDead(bunPid, 10000);
+  reap(bunPid, grandchildPid);
+  expect(died).toBe(true);
+});
+
+test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: grandchildren are reaped when bun dies with its parent", async () => {
+  const { sh, bunPid, grandchildPid } = await spawnTree("1");
+  expect(isAlive(grandchildPid)).toBe(true);
+  process.kill(sh.pid!, "SIGKILL");
+  await sh.exited;
+  const bunDied = await waitUntilDead(bunPid, 10000);
+  // macOS: bun's NOTE_EXIT fires → Global.exit → libproc walk SIGTERMs the
+  // grandchild. Linux: bun gets SIGKILL via PDEATHSIG, but the grandchild is
+  // also Bun with the env var inherited and so has its own PDEATHSIG.
+  const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+  reap(bunPid, grandchildPid);
+  expect(bunDied).toBe(true);
+  expect(grandchildDied).toBe(true);
+});
+
+// The grandchild here is plain /bin/sh — it never calls prctl itself. On
+// Linux this is covered by Bun setting linux_pdeathsig on every spawn when
+// BUN_DIE_WITH_PARENT is enabled (prctl in the vfork child before exec). On
+// macOS it's covered by the libproc descendant walk in the exit handler.
+test.skipIf(!isSupported)(
+  "BUN_DIE_WITH_PARENT=1: non-Bun grandchildren are reaped when bun dies with its parent",
+  async () => {
+    const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
+    expect(isAlive(grandchildPid)).toBe(true);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    const bunDied = await waitUntilDead(bunPid, 10000);
+    const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+    reap(bunPid, grandchildPid);
+    expect(bunDied).toBe(true);
+    expect(grandchildDied).toBe(true);
+  },
+);
+
+test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=0 is treated as unset", async () => {
+  const { sh, bunPid, grandchildPid } = await spawnTree("0");
+  process.kill(sh.pid!, "SIGKILL");
+  await sh.exited;
+  const died = await waitUntilDead(bunPid, 1000);
+  reap(bunPid, grandchildPid);
+  expect(died).toBe(false);
+});
+
+test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1 does not fire while the parent is alive", async () => {
+  const { sh, bunPid, grandchildPid } = await spawnTree("1");
+  // Parent is alive; bun must stay alive. Poll for premature death.
+  const diedEarly = await waitUntilDead(bunPid, 1000);
+  expect(diedEarly).toBe(false);
+  process.kill(sh.pid!, "SIGKILL");
+  await sh.exited;
+  const died = await waitUntilDead(bunPid, 10000);
+  reap(bunPid, grandchildPid);
+  expect(died).toBe(true);
+});
+
+// Descendant cleanup must not depend on the parent-watch path. With the env
+// var set, a Bun that exits *cleanly* should still SIGTERM its children. On
+// macOS this is the only place the libproc walk is exercised independently of
+// NOTE_EXIT.
+test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: clean exit reaps descendants", async () => {
+  const env: Record<string, string> = { ...bunEnv, BUN_DIE_WITH_PARENT: "1" };
+  const proc = Bun.spawn({
+    cmd: [bunExe(), `${String(fixture)}/clean-exit.js`],
+    env,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const out = await proc.stdout.text();
+  await proc.exited;
+  const gcPid = Number(out.trim());
+  expect(gcPid).toBeGreaterThan(0);
+  const died = await waitUntilDead(gcPid, 10000);
+  reap(gcPid);
+  expect(proc.exitCode).toBe(0);
+  expect(died).toBe(true);
+});

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -232,8 +232,8 @@ test.skipIf(!isSupported)("BUN_FEATURE_FLAG_DIE_WITH_PARENT=1: clean exit reaps 
   expect(gcPid).toBeGreaterThan(0);
   const died = await waitUntilDead(gcPid, 10000);
   reap(gcPid);
-  expect(proc.exitCode).toBe(0);
   expect(died).toBe(true);
+  expect(proc.exitCode).toBe(0);
 });
 
 // Same as the clean-exit test but enabled via bunfig.toml instead of the env
@@ -269,6 +269,6 @@ test.skipIf(!isSupported)("bunfig [run] dieWithParent = true: clean exit reaps d
   expect(gcPid).toBeGreaterThan(0);
   const died = await waitUntilDead(gcPid, 10000);
   reap(gcPid);
-  expect(proc.exitCode).toBe(0);
   expect(died).toBe(true);
+  expect(proc.exitCode).toBe(0);
 });

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { setTimeout as sleep } from "node:timers/promises";
 
-// BUN_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
+// BUN_FEATURE_FLAG_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
 // process dies, even if the parent was SIGKILLed and couldn't signal us. On
 // the way out it also recursively SIGKILLs every descendant so nothing it
 // spawned outlives it. Linux uses prctl(PR_SET_PDEATHSIG); macOS registers
@@ -66,10 +66,10 @@ const fixture = tempDir("die-with-parent", {
 
 async function spawnTree(dieWithParent: string | undefined, childScript = "child.js") {
   const env: Record<string, string> = { ...bunEnv };
-  // bunEnv spreads process.env; make sure an ambient BUN_DIE_WITH_PARENT from
+  // bunEnv spreads process.env; make sure an ambient BUN_FEATURE_FLAG_DIE_WITH_PARENT from
   // the test runner doesn't leak into the "unset" case.
-  delete env.BUN_DIE_WITH_PARENT;
-  if (dieWithParent !== undefined) env.BUN_DIE_WITH_PARENT = dieWithParent;
+  delete env.BUN_FEATURE_FLAG_DIE_WITH_PARENT;
+  if (dieWithParent !== undefined) env.BUN_FEATURE_FLAG_DIE_WITH_PARENT = dieWithParent;
 
   const sh = Bun.spawn({
     // Trailing `wait` defeats sh's implicit-exec-of-last-command so sh stays a
@@ -132,17 +132,20 @@ function reap(...pids: number[]) {
   }
 }
 
-test.skipIf(!isSupported)("without BUN_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed", async () => {
-  const { sh, bunPid, grandchildPid } = await spawnTree(undefined);
-  process.kill(sh.pid!, "SIGKILL");
-  await sh.exited;
-  // bun must NOT die: poll for death and expect the poll to time out.
-  const died = await waitUntilDead(bunPid, 1000);
-  reap(bunPid, grandchildPid);
-  expect(died).toBe(false);
-});
+test.skipIf(!isSupported)(
+  "without BUN_FEATURE_FLAG_DIE_WITH_PARENT, bun is orphaned when its parent is SIGKILLed",
+  async () => {
+    const { sh, bunPid, grandchildPid } = await spawnTree(undefined);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    // bun must NOT die: poll for death and expect the poll to time out.
+    const died = await waitUntilDead(bunPid, 1000);
+    reap(bunPid, grandchildPid);
+    expect(died).toBe(false);
+  },
+);
 
-test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: bun exits when its parent is SIGKILLed", async () => {
+test.skipIf(!isSupported)("BUN_FEATURE_FLAG_DIE_WITH_PARENT=1: bun exits when its parent is SIGKILLed", async () => {
   const { sh, bunPid, grandchildPid } = await spawnTree("1");
   process.kill(sh.pid!, "SIGKILL");
   await sh.exited;
@@ -153,27 +156,30 @@ test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: bun exits when its parent is S
   expect(died).toBe(true);
 });
 
-test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: grandchildren are reaped when bun dies with its parent", async () => {
-  const { sh, bunPid, grandchildPid } = await spawnTree("1");
-  expect(isAlive(grandchildPid)).toBe(true);
-  process.kill(sh.pid!, "SIGKILL");
-  await sh.exited;
-  const bunDied = await waitUntilDead(bunPid, 10000);
-  // macOS: bun's NOTE_EXIT fires → Global.exit → libproc walk SIGKILLs the
-  // grandchild. Linux: bun gets SIGKILL via PDEATHSIG, but the grandchild is
-  // also Bun with the env var inherited and so has its own PDEATHSIG.
-  const grandchildDied = await waitUntilDead(grandchildPid, 10000);
-  reap(bunPid, grandchildPid);
-  expect(bunDied).toBe(true);
-  expect(grandchildDied).toBe(true);
-});
+test.skipIf(!isSupported)(
+  "BUN_FEATURE_FLAG_DIE_WITH_PARENT=1: grandchildren are reaped when bun dies with its parent",
+  async () => {
+    const { sh, bunPid, grandchildPid } = await spawnTree("1");
+    expect(isAlive(grandchildPid)).toBe(true);
+    process.kill(sh.pid!, "SIGKILL");
+    await sh.exited;
+    const bunDied = await waitUntilDead(bunPid, 10000);
+    // macOS: bun's NOTE_EXIT fires → Global.exit → libproc walk SIGKILLs the
+    // grandchild. Linux: bun gets SIGKILL via PDEATHSIG, but the grandchild is
+    // also Bun with the env var inherited and so has its own PDEATHSIG.
+    const grandchildDied = await waitUntilDead(grandchildPid, 10000);
+    reap(bunPid, grandchildPid);
+    expect(bunDied).toBe(true);
+    expect(grandchildDied).toBe(true);
+  },
+);
 
 // The grandchild here is plain /bin/sh — it never calls prctl itself. On
 // Linux this is covered by Bun setting linux_pdeathsig on every spawn when
-// BUN_DIE_WITH_PARENT is enabled (prctl in the vfork child before exec). On
+// BUN_FEATURE_FLAG_DIE_WITH_PARENT is enabled (prctl in the vfork child before exec). On
 // macOS it's covered by the libproc descendant walk in the exit handler.
 test.skipIf(!isSupported)(
-  "BUN_DIE_WITH_PARENT=1: non-Bun grandchildren are reaped when bun dies with its parent",
+  "BUN_FEATURE_FLAG_DIE_WITH_PARENT=1: non-Bun grandchildren are reaped when bun dies with its parent",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun.js");
     expect(isAlive(grandchildPid)).toBe(true);
@@ -187,7 +193,7 @@ test.skipIf(!isSupported)(
   },
 );
 
-test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=0 is treated as unset", async () => {
+test.skipIf(!isSupported)("BUN_FEATURE_FLAG_DIE_WITH_PARENT=0 is treated as unset", async () => {
   const { sh, bunPid, grandchildPid } = await spawnTree("0");
   process.kill(sh.pid!, "SIGKILL");
   await sh.exited;
@@ -196,7 +202,7 @@ test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=0 is treated as unset", async () 
   expect(died).toBe(false);
 });
 
-test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1 does not fire while the parent is alive", async () => {
+test.skipIf(!isSupported)("BUN_FEATURE_FLAG_DIE_WITH_PARENT=1 does not fire while the parent is alive", async () => {
   const { sh, bunPid, grandchildPid } = await spawnTree("1");
   // Parent is alive; bun must stay alive. Poll for premature death.
   const diedEarly = await waitUntilDead(bunPid, 1000);
@@ -212,11 +218,48 @@ test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1 does not fire while the parent 
 // var set, a Bun that exits *cleanly* should still SIGKILL its children. On
 // macOS this is the only place the libproc walk is exercised independently of
 // NOTE_EXIT.
-test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: clean exit reaps descendants", async () => {
-  const env: Record<string, string> = { ...bunEnv, BUN_DIE_WITH_PARENT: "1" };
+test.skipIf(!isSupported)("BUN_FEATURE_FLAG_DIE_WITH_PARENT=1: clean exit reaps descendants", async () => {
+  const env: Record<string, string> = { ...bunEnv, BUN_FEATURE_FLAG_DIE_WITH_PARENT: "1" };
   const proc = Bun.spawn({
     cmd: [bunExe(), `${String(fixture)}/clean-exit.js`],
     env,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const out = await proc.stdout.text();
+  await proc.exited;
+  const gcPid = Number(out.trim());
+  expect(gcPid).toBeGreaterThan(0);
+  const died = await waitUntilDead(gcPid, 10000);
+  reap(gcPid);
+  expect(proc.exitCode).toBe(0);
+  expect(died).toBe(true);
+});
+
+// Same as the clean-exit test but enabled via bunfig.toml instead of the env
+// var, exercising the second `enable()` call site.
+test.skipIf(!isSupported)("bunfig [run] dieWithParent = true: clean exit reaps descendants", async () => {
+  using dir = tempDir("die-with-parent-bunfig", {
+    "bunfig.toml": "[run]\ndieWithParent = true\n",
+    "grandchild.js": `process.stdout.write("r"); setInterval(()=>{}, 1000);`,
+    "clean-exit.js": `
+      const gc = Bun.spawn({
+        cmd: [process.execPath, "grandchild.js"],
+        cwd: import.meta.dir,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      await gc.stdout.getReader().read();
+      gc.unref();
+      console.log(gc.pid);
+      process.exit(0);
+    `,
+  });
+  const env: Record<string, string> = { ...bunEnv };
+  delete env.BUN_FEATURE_FLAG_DIE_WITH_PARENT;
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "clean-exit.js"],
+    env,
+    cwd: String(dir),
     stdout: "pipe",
     stderr: "ignore",
   });

--- a/test/cli/run/die-with-parent.test.ts
+++ b/test/cli/run/die-with-parent.test.ts
@@ -4,7 +4,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 
 // BUN_DIE_WITH_PARENT: Bun watches its original ppid and exits when that
 // process dies, even if the parent was SIGKILLed and couldn't signal us. On
-// the way out it also recursively SIGTERMs every descendant so nothing it
+// the way out it also recursively SIGKILLs every descendant so nothing it
 // spawned outlives it. Linux uses prctl(PR_SET_PDEATHSIG); macOS registers
 // EVFILT_PROC/NOTE_EXIT on the existing event loop's kqueue (no thread).
 //
@@ -159,7 +159,7 @@ test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: grandchildren are reaped when 
   process.kill(sh.pid!, "SIGKILL");
   await sh.exited;
   const bunDied = await waitUntilDead(bunPid, 10000);
-  // macOS: bun's NOTE_EXIT fires → Global.exit → libproc walk SIGTERMs the
+  // macOS: bun's NOTE_EXIT fires → Global.exit → libproc walk SIGKILLs the
   // grandchild. Linux: bun gets SIGKILL via PDEATHSIG, but the grandchild is
   // also Bun with the env var inherited and so has its own PDEATHSIG.
   const grandchildDied = await waitUntilDead(grandchildPid, 10000);
@@ -209,7 +209,7 @@ test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1 does not fire while the parent 
 });
 
 // Descendant cleanup must not depend on the parent-watch path. With the env
-// var set, a Bun that exits *cleanly* should still SIGTERM its children. On
+// var set, a Bun that exits *cleanly* should still SIGKILL its children. On
 // macOS this is the only place the libproc walk is exercised independently of
 // NOTE_EXIT.
 test.skipIf(!isSupported)("BUN_DIE_WITH_PARENT=1: clean exit reaps descendants", async () => {


### PR DESCRIPTION
Supersedes #29859 — redesigned per review feedback to avoid spawning a pthread on start, extended to reap descendants, and exposed via both env var and bunfig.

### Enabling

- Env var: `BUN_FEATURE_FLAG_DIE_WITH_PARENT=1`
- bunfig: `[run] dieWithParent = true`

### Die when the original parent dies — no thread

- **Linux**: `prctl(PR_SET_PDEATHSIG, SIGKILL)` + ppid race recheck.
- **macOS**: register `EVFILT_PROC`/`NOTE_EXIT` for the original ppid on the **existing event loop's kqueue** via `bun.Async.FilePoll` — the same mechanism Bun already uses to watch *child* process exits. Installed lazily from `VirtualMachine.init()`; fires into `Global.exit(129)`. No dedicated pthread, no extra kqueue fd, doesn't keep the loop alive.

### Recursively kill all descendants on clean exit

Registered via `Global.addExitCallback` (`Bun__onExit`).

- **macOS**: `bun.c.proc_listchildpids()` to enumerate, `bun.c.proc_pidinfo(PROC_PIDTBSDINFO)` to verify ppid (libproc bindings via translate-c — `<libproc.h>` added to `c-headers-for-zig.h`).
- **Linux**: `/proc/<pid>/task/*/children` to enumerate, `/proc/<pid>/stat` to verify ppid.

**Stop-verify-kill** for pid-reuse safety: SIGSTOP each enumerated descendant → re-read its ppid → if it no longer matches, SIGCONT and skip (the pid was recycled in the enumerate→STOP window). A frozen process can't exit or fork, so once verified its pid is pinned until we SIGKILL it. 4096-pid per-parent buffer; tree size hard-capped at 4096.

### Spawn-side PDEATHSIG default (Linux, main thread only)

When enabled, `spawnProcessPosix` defaults `linux_pdeathsig=SIGKILL` for children spawned from the **main thread** (`Bun.spawn`, `spawnSync`, shell, `--filter`, etc.) so non-Bun descendants are covered even when Bun's exit handler doesn't run. Gated to the main thread because `PR_SET_PDEATHSIG` is thread-scoped — applying it from a JS `Worker` would kill the child on `worker.terminate()` instead of on Bun exit.

### Tests

`test/cli/run/die-with-parent.test.ts` — 8 cases covering baseline orphan, die-with-parent, Bun and non-Bun grandchild reaping, `=0` is unset, no premature fire, clean-exit reaping, and the bunfig path.

```
 8 pass, 0 fail
```