### PR TITLE
redis: verify TLS hostname when rejectUnauthorized is true

### DIFF
--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1532,12 +1532,19 @@ fn SocketHandler(comptime ssl: bool) type {
                     // sockets have no hostname to verify, so skip the identity check
                     // for redis+tls+unix:// / valkey+tls+unix:// connections.
                     const ssl_ptr: *BoringSSL.c.SSL = @ptrCast(this.client.socket.getNativeHandle());
-                    const hostname: []const u8 = if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername|
+                    var hostname: []const u8 = if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername|
                         servername[0..bun.len(servername)]
                     else switch (this.client.address) {
                         .host => |h| h.host,
                         .unix => "",
                     };
+                    // URL.host() serialises IPv6 literals with surrounding brackets
+                    // (e.g. "[::1]"). Strip them so checkServerIdentity can recognise
+                    // the value as an IP and match against IP SAN entries; this
+                    // mirrors what connectAnon already does before getaddrinfo.
+                    if (hostname.len >= 2 and hostname[0] == '[' and hostname[hostname.len - 1] == ']') {
+                        hostname = hostname[1 .. hostname.len - 1];
+                    }
                     if (hostname.len > 0 and !BoringSSL.checkServerIdentity(ssl_ptr, hostname)) {
                         const err = this.globalObject.ERR(.TLS_CERT_ALTNAME_INVALID, "Hostname/IP does not match certificate's altnames: Host: {s}", .{hostname}).toJS();
                         return try failHandshake(this, vm, err);

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1561,7 +1561,8 @@ fn SocketHandler(comptime ssl: bool) type {
         fn failHandshakeWithVerifyError(this: *JSValkeyClient, vm: *jsc.VirtualMachine, ssl_error: *const uws.us_bun_verify_error_t) bun.JSTerminated!void {
             const ssl_js_value = ssl_error.toJS(this.globalObject) catch |err| switch (err) {
                 error.JSTerminated => return error.JSTerminated,
-                else => {
+                error.OutOfMemory => bun.outOfMemory(),
+                error.JSError => {
                     // Clear any pending exception since we can't convert it to JS,
                     // but still fail-close the connection so we never fall through
                     // to the authenticated state after a rejected handshake.

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1528,12 +1528,16 @@ fn SocketHandler(comptime ssl: bool) type {
 
                     // Certificate chain is valid; verify the hostname matches the
                     // certificate. Prefer the SNI servername if one was set, otherwise
-                    // fall back to the host from the connection URL.
+                    // fall back to the host from the connection URL. Unix-domain
+                    // sockets have no hostname to verify, so skip the identity check
+                    // for redis+tls+unix:// / valkey+tls+unix:// connections.
                     const ssl_ptr: *BoringSSL.c.SSL = @ptrCast(this.client.socket.getNativeHandle());
-                    const hostname = if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername|
+                    const hostname: []const u8 = if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername|
                         servername[0..bun.len(servername)]
-                    else
-                        this.client.address.hostname();
+                    else switch (this.client.address) {
+                        .host => |h| h.host,
+                        .unix => "",
+                    };
                     if (hostname.len > 0 and !BoringSSL.checkServerIdentity(ssl_ptr, hostname)) {
                         const err = this.globalObject.ERR(.TLS_CERT_ALTNAME_INVALID, "Hostname/IP does not match certificate's altnames: Host: {s}", .{hostname}).toJS();
                         return try failHandshake(this, vm, err);

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1551,8 +1551,13 @@ fn SocketHandler(comptime ssl: bool) type {
             const ssl_js_value = ssl_error.toJS(this.globalObject) catch |err| switch (err) {
                 error.JSTerminated => return error.JSTerminated,
                 else => {
-                    // Clear any pending exception since we can't convert it to JS
+                    // Clear any pending exception since we can't convert it to JS,
+                    // but still fail-close the connection so we never fall through
+                    // to the authenticated state after a rejected handshake.
                     this.globalObject.clearException();
+                    this.client.flags.is_authenticated = false;
+                    this.client.flags.is_manually_closed = true;
+                    this.client.close();
                     return;
                 },
             };

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1517,38 +1517,56 @@ fn SocketHandler(comptime ssl: bool) type {
             this.ref();
             defer this.deref();
             defer this.updatePollRef();
+            const vm = this.client.vm;
             if (handshake_success) {
-                const vm = this.client.vm;
                 if (this.client.tls.rejectUnauthorized(vm)) {
+                    // only reject the connection if reject_unauthorized == true
                     if (ssl_error.error_no != 0) {
-                        // only reject the connection if reject_unauthorized == true
+                        // Certificate chain validation failed.
+                        return try failHandshakeWithVerifyError(this, vm, &ssl_error);
+                    }
 
-                        const ssl_ptr: *BoringSSL.c.SSL = @ptrCast(this.client.socket.getNativeHandle());
-                        if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername| {
-                            const hostname = servername[0..bun.len(servername)];
-                            if (!BoringSSL.checkServerIdentity(ssl_ptr, hostname)) {
-                                this.client.flags.is_authenticated = false;
-                                const loop = vm.eventLoop();
-                                loop.enter();
-                                defer loop.exit();
-                                this.client.flags.is_manually_closed = true;
-                                defer this.client.close();
-                                const ssl_js_value = ssl_error.toJS(this.globalObject) catch |err| switch (err) {
-                                    error.JSTerminated => return error.JSTerminated,
-                                    else => {
-                                        // Clear any pending exception since we can't convert it to JS
-                                        this.globalObject.clearException();
-                                        return;
-                                    },
-                                };
-                                try this.client.failWithJSValue(this.globalObject, ssl_js_value);
-                                return;
-                            }
-                        }
+                    // Certificate chain is valid; verify the hostname matches the
+                    // certificate. Prefer the SNI servername if one was set, otherwise
+                    // fall back to the host from the connection URL.
+                    const ssl_ptr: *BoringSSL.c.SSL = @ptrCast(this.client.socket.getNativeHandle());
+                    const hostname = if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername|
+                        servername[0..bun.len(servername)]
+                    else
+                        this.client.address.hostname();
+                    if (hostname.len > 0 and !BoringSSL.checkServerIdentity(ssl_ptr, hostname)) {
+                        const err = this.globalObject.ERR(.TLS_CERT_ALTNAME_INVALID, "Hostname/IP does not match certificate's altnames: Host: {s}", .{hostname}).toJS();
+                        return try failHandshake(this, vm, err);
                     }
                 }
                 try this.client.start();
+            } else {
+                // if we are here is because the server rejected us, and the error_no is the cause of this
+                // no matter if reject_unauthorized is false, because we were disconnected by the server
+                return try failHandshakeWithVerifyError(this, vm, &ssl_error);
             }
+        }
+
+        fn failHandshakeWithVerifyError(this: *JSValkeyClient, vm: *jsc.VirtualMachine, ssl_error: *const uws.us_bun_verify_error_t) bun.JSTerminated!void {
+            const ssl_js_value = ssl_error.toJS(this.globalObject) catch |err| switch (err) {
+                error.JSTerminated => return error.JSTerminated,
+                else => {
+                    // Clear any pending exception since we can't convert it to JS
+                    this.globalObject.clearException();
+                    return;
+                },
+            };
+            return try failHandshake(this, vm, ssl_js_value);
+        }
+
+        fn failHandshake(this: *JSValkeyClient, vm: *jsc.VirtualMachine, err_value: jsc.JSValue) bun.JSTerminated!void {
+            this.client.flags.is_authenticated = false;
+            const loop = vm.eventLoop();
+            loop.enter();
+            defer loop.exit();
+            this.client.flags.is_manually_closed = true;
+            defer this.client.close();
+            try this.client.failWithJSValue(this.globalObject, err_value);
         }
 
         pub const onHandshake = if (ssl) onHandshake_ else null;

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -84,6 +84,11 @@ export const TLS_REDIS_OPTIONS = {
     cert: Bun.file(path.join(import.meta.dir, "docker-unified", "server.crt")),
     key: Bun.file(path.join(import.meta.dir, "docker-unified", "server.key")),
     ca: Bun.file(path.join(import.meta.dir, "docker-unified", "server.crt")),
+    // This suite exercises Valkey commands over TLS, not certificate
+    // verification. The docker-unified cert only has SAN DNS:localhost while
+    // the docker helper connects to 127.0.0.1, so hostname verification (now
+    // enforced) would reject it. valkey-tls-verify.test.ts covers verification.
+    rejectUnauthorized: false,
   },
   tlsPaths: {
     cert: path.join(import.meta.dir, "docker-unified", "server.crt"),

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -15,17 +15,39 @@ const serverKey = fs.readFileSync(path.join(fixturesDir, "agent1-key.pem"));
 const serverCert = fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"));
 const ca = fs.readFileSync(path.join(fixturesDir, "ca1-cert.pem"));
 
+// Consume one complete RESP array (*N\r\n followed by N bulk strings) from the
+// front of `buf`. Returns the number of bytes consumed, or 0 if incomplete.
+function consumeRespArray(buf: Buffer): number {
+  if (buf.length < 4 || buf[0] !== 0x2a /* '*' */) return 0;
+  let eol = buf.indexOf("\r\n");
+  if (eol < 0) return 0;
+  const count = parseInt(buf.subarray(1, eol).toString("latin1"), 10);
+  let off = eol + 2;
+  for (let i = 0; i < count; i++) {
+    if (off >= buf.length || buf[off] !== 0x24 /* '$' */) return 0;
+    eol = buf.indexOf("\r\n", off);
+    if (eol < 0) return 0;
+    const len = parseInt(buf.subarray(off + 1, eol).toString("latin1"), 10);
+    off = eol + 2 + len + 2;
+    if (off > buf.length) return 0;
+  }
+  return off;
+}
+
 // Minimal Redis-ish server. It replies +OK to the first command (HELLO) so the
 // client's authentication handshake succeeds, then +PONG to everything else.
+// Buffers and frames RESP arrays so commands split across packets (or batched
+// into one) are each answered exactly once.
 async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>): Promise<T> {
   const server = tls.createServer(serverOpts, socket => {
-    let first = true;
-    socket.on("data", () => {
-      if (first) {
-        first = false;
-        socket.write("+OK\r\n");
-      } else {
-        socket.write("+PONG\r\n");
+    let buf = Buffer.alloc(0);
+    let seen = 0;
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      let consumed: number;
+      while ((consumed = consumeRespArray(buf)) > 0) {
+        buf = buf.subarray(consumed);
+        socket.write(seen++ === 0 ? "+OK\r\n" : "+PONG\r\n");
       }
     });
     socket.on("error", () => {});

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -1,8 +1,8 @@
 import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
 import { tls as localhostTls } from "harness";
-import fs from "node:fs";
 import { once } from "node:events";
+import fs from "node:fs";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import tls from "node:tls";

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -1,0 +1,155 @@
+import { RedisClient } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tls as localhostTls } from "harness";
+import fs from "node:fs";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import path from "node:path";
+import tls from "node:tls";
+
+// Server presents a cert for CN=agent1 (no SAN), signed by ca1.
+// A client connecting to host "localhost" with ca1 trusted will pass chain
+// verification but MUST fail hostname verification (localhost != agent1).
+const fixturesDir = path.join(import.meta.dirname, "..", "node", "tls", "fixtures");
+const serverKey = fs.readFileSync(path.join(fixturesDir, "agent1-key.pem"));
+const serverCert = fs.readFileSync(path.join(fixturesDir, "agent1-cert.pem"));
+const ca = fs.readFileSync(path.join(fixturesDir, "ca1-cert.pem"));
+
+// Minimal Redis-ish server. It replies +OK to the first command (HELLO) so the
+// client's authentication handshake succeeds, then +PONG to everything else.
+async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>): Promise<T> {
+  const server = tls.createServer(serverOpts, socket => {
+    let first = true;
+    socket.on("data", () => {
+      if (first) {
+        first = false;
+        socket.write("+OK\r\n");
+      } else {
+        socket.write("+PONG\r\n");
+      }
+    });
+    socket.on("error", () => {});
+  });
+  server.on("tlsClientError", () => {});
+  server.listen(0);
+  await once(server, "listening");
+  try {
+    return await fn((server.address() as AddressInfo).port);
+  } finally {
+    server.close();
+  }
+}
+
+describe("RedisClient TLS hostname verification", () => {
+  test("rejects a CA-trusted cert whose hostname does not match the URL host", async () => {
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      const client = new RedisClient(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          ca,
+          rejectUnauthorized: true,
+        },
+      });
+      let err: any;
+      try {
+        await client.send("PING", []);
+      } catch (e) {
+        err = e;
+      } finally {
+        client.close();
+      }
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+      expect(err.message).toContain("localhost");
+    });
+  }, 15000);
+
+  test("rejects a CA-trusted cert whose altnames do not match an IP host", async () => {
+    // The "harness" cert is valid for localhost/127.0.0.1. Connect via 127.0.0.1
+    // to a server presenting the agent1 cert (CN=agent1, signed by ca1).
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      const client = new RedisClient(`rediss://127.0.0.1:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          ca,
+          rejectUnauthorized: true,
+        },
+      });
+      let err: any;
+      try {
+        await client.send("PING", []);
+      } catch (e) {
+        err = e;
+      } finally {
+        client.close();
+      }
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+    });
+  }, 15000);
+
+  test("still rejects invalid certificate chains when rejectUnauthorized is true", async () => {
+    // Self-signed cert that the client does NOT trust.
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      const client = new RedisClient(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          rejectUnauthorized: true,
+        },
+      });
+      let err: any;
+      try {
+        await client.send("PING", []);
+      } catch (e) {
+        err = e;
+      } finally {
+        client.close();
+      }
+      expect(err).toBeInstanceOf(Error);
+      // Should be the BoringSSL verify error, not the hostname error.
+      expect(err.code).not.toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+    });
+  }, 15000);
+
+  test("allows mismatched hostname when rejectUnauthorized is false", async () => {
+    await withServer({ key: serverKey, cert: serverCert }, async port => {
+      const client = new RedisClient(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          ca,
+          rejectUnauthorized: false,
+        },
+      });
+      try {
+        const result = await client.send("PING", []);
+        expect(result).toBe("PONG");
+      } finally {
+        client.close();
+      }
+    });
+  }, 15000);
+
+  test("accepts a cert whose altnames match the URL host", async () => {
+    // The "harness" cert has SAN: DNS:localhost, IP:127.0.0.1, IP:::1
+    await withServer({ key: localhostTls.key, cert: localhostTls.cert }, async port => {
+      const client = new RedisClient(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          ca: localhostTls.cert,
+          rejectUnauthorized: true,
+        },
+      });
+      try {
+        const result = await client.send("PING", []);
+        expect(result).toBe("PONG");
+      } finally {
+        client.close();
+      }
+    });
+  }, 15000);
+});

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
-import { tls as localhostTls } from "harness";
+import { isWindows, tempDir, tls as localhostTls } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import type { AddressInfo } from "node:net";
@@ -38,7 +38,7 @@ function consumeRespArray(buf: Buffer): number {
 // client's authentication handshake succeeds, then +PONG to everything else.
 // Buffers and frames RESP arrays so commands split across packets (or batched
 // into one) are each answered exactly once.
-async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>): Promise<T> {
+function fakeServer(serverOpts: tls.TlsOptions): tls.Server {
   const server = tls.createServer(serverOpts, socket => {
     let buf = Buffer.alloc(0);
     let seen = 0;
@@ -53,10 +53,28 @@ async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => P
     socket.on("error", () => {});
   });
   server.on("tlsClientError", () => {});
+  return server;
+}
+
+async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>): Promise<T> {
+  const server = fakeServer(serverOpts);
   server.listen(0);
   await once(server, "listening");
   try {
     return await fn((server.address() as AddressInfo).port);
+  } finally {
+    server.close();
+  }
+}
+
+async function withUnixServer<T>(serverOpts: tls.TlsOptions, fn: (socketPath: string) => Promise<T>): Promise<T> {
+  using dir = tempDir("valkey-tls-unix", {});
+  const socketPath = path.join(String(dir), "r.sock");
+  const server = fakeServer(serverOpts);
+  server.listen(socketPath);
+  await once(server, "listening");
+  try {
+    return await fn(socketPath);
   } finally {
     server.close();
   }
@@ -85,7 +103,7 @@ describe("RedisClient TLS hostname verification", () => {
       expect(err.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
       expect(err.message).toContain("localhost");
     });
-  }, 15000);
+  });
 
   test("rejects a CA-trusted cert whose altnames do not match an IP host", async () => {
     // The "harness" cert is valid for localhost/127.0.0.1. Connect via 127.0.0.1
@@ -110,7 +128,7 @@ describe("RedisClient TLS hostname verification", () => {
       expect(err).toBeInstanceOf(Error);
       expect(err.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
     });
-  }, 15000);
+  });
 
   test("still rejects invalid certificate chains when rejectUnauthorized is true", async () => {
     // Self-signed cert that the client does NOT trust.
@@ -134,7 +152,7 @@ describe("RedisClient TLS hostname verification", () => {
       // Should be the BoringSSL verify error, not the hostname error.
       expect(err.code).not.toBe("ERR_TLS_CERT_ALTNAME_INVALID");
     });
-  }, 15000);
+  });
 
   test("allows mismatched hostname when rejectUnauthorized is false", async () => {
     await withServer({ key: serverKey, cert: serverCert }, async port => {
@@ -153,7 +171,7 @@ describe("RedisClient TLS hostname verification", () => {
         client.close();
       }
     });
-  }, 15000);
+  });
 
   test("accepts a cert whose altnames match the URL host", async () => {
     // The "harness" cert has SAN: DNS:localhost, IP:127.0.0.1, IP:::1
@@ -173,5 +191,26 @@ describe("RedisClient TLS hostname verification", () => {
         client.close();
       }
     });
-  }, 15000);
+  });
+
+  test.skipIf(isWindows)("skips hostname verification for redis+tls+unix:// sockets", async () => {
+    // Unix-domain sockets have no hostname; a CA-trusted cert for the wrong
+    // CN must still be accepted as long as the chain validates.
+    await withUnixServer({ key: serverKey, cert: serverCert }, async socketPath => {
+      const client = new RedisClient(`redis+tls+unix://${socketPath}`, {
+        autoReconnect: false,
+        connectionTimeout: 5000,
+        tls: {
+          ca,
+          rejectUnauthorized: true,
+        },
+      });
+      try {
+        const result = await client.send("PING", []);
+        expect(result).toBe("PONG");
+      } finally {
+        client.close();
+      }
+    });
+  });
 });

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tls as localhostTls, tempDir } from "harness";
+import { isIPv6, isWindows, tls as localhostTls, tempDir } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import type { AddressInfo } from "node:net";
@@ -174,7 +174,7 @@ describe("RedisClient TLS hostname verification", () => {
     });
   });
 
-  test("accepts a cert whose IP altnames match a bracketed IPv6 URL host", async () => {
+  test.skipIf(!isIPv6())("accepts a cert whose IP altnames match a bracketed IPv6 URL host", async () => {
     // The "harness" cert has SAN IP:::1. URL.host() serialises IPv6 literals
     // with brackets ("[::1]"), which must be stripped before IP SAN matching.
     await withServer(

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tempDir, tls as localhostTls } from "harness";
+import { isWindows, tls as localhostTls, tempDir } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import type { AddressInfo } from "node:net";

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -56,9 +56,9 @@ function fakeServer(serverOpts: tls.TlsOptions): tls.Server {
   return server;
 }
 
-async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>): Promise<T> {
+async function withServer<T>(serverOpts: tls.TlsOptions, fn: (port: number) => Promise<T>, host?: string): Promise<T> {
   const server = fakeServer(serverOpts);
-  server.listen(0);
+  server.listen(0, host);
   await once(server, "listening");
   try {
     return await fn((server.address() as AddressInfo).port);
@@ -171,6 +171,31 @@ describe("RedisClient TLS hostname verification", () => {
         client.close();
       }
     });
+  });
+
+  test("accepts a cert whose IP altnames match a bracketed IPv6 URL host", async () => {
+    // The "harness" cert has SAN IP:::1. URL.host() serialises IPv6 literals
+    // with brackets ("[::1]"), which must be stripped before IP SAN matching.
+    await withServer(
+      { key: localhostTls.key, cert: localhostTls.cert },
+      async port => {
+        const client = new RedisClient(`rediss://[::1]:${port}`, {
+          autoReconnect: false,
+          connectionTimeout: 5000,
+          tls: {
+            ca: localhostTls.cert,
+            rejectUnauthorized: true,
+          },
+        });
+        try {
+          const result = await client.send("PING", []);
+          expect(result).toBe("PONG");
+        } finally {
+          client.close();
+        }
+      },
+      "::1",
+    );
   });
 
   test("accepts a cert whose altnames match the URL host", async () => {

--- a/test/js/valkey/valkey-tls-verify.test.ts
+++ b/test/js/valkey/valkey-tls-verify.test.ts
@@ -150,7 +150,8 @@ describe("RedisClient TLS hostname verification", () => {
       }
       expect(err).toBeInstanceOf(Error);
       // Should be the BoringSSL verify error, not the hostname error.
-      expect(err.code).not.toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+      expect(err.code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      expect(err.message).toContain("self signed certificate");
     });
   });
 

--- a/test/js/valkey/valkey.connecting.fixture.ts
+++ b/test/js/valkey/valkey.connecting.fixture.ts
@@ -8,6 +8,7 @@ function getOptions() {
         key: Bun.file(paths.key),
         cert: Bun.file(paths.cert),
         ca: Bun.file(paths.ca),
+        rejectUnauthorized: false,
       },
     };
   }

--- a/test/js/valkey/valkey.failing-subscriber-no-ipc.ts
+++ b/test/js/valkey/valkey.failing-subscriber-no-ipc.ts
@@ -67,6 +67,7 @@ if (import.meta.main) {
           cert: Bun.file(runInfo.tlsPaths.cert),
           key: Bun.file(runInfo.tlsPaths.key),
           ca: Bun.file(runInfo.tlsPaths.ca),
+          rejectUnauthorized: false,
         }
       : undefined,
   });

--- a/test/js/valkey/valkey.failing-subscriber.ts
+++ b/test/js/valkey/valkey.failing-subscriber.ts
@@ -41,6 +41,7 @@ const subscriber = new RedisClient(url, {
         cert: Bun.file(tlsPaths.cert),
         key: Bun.file(tlsPaths.key),
         ca: Bun.file(tlsPaths.ca),
+        rejectUnauthorized: false,
       }
     : undefined,
 });


### PR DESCRIPTION
## Repro

```ts
import { RedisClient } from "bun";
// Server at 127.0.0.1:16379 presents a CA-signed cert for CN=wrong.example.com
const client = new RedisClient("rediss://127.0.0.1:16379", {
  tls: { ca, rejectUnauthorized: true },
});
console.log(await client.send("PING", []));
// before: "PONG"   <- hostname mismatch was ignored
// after:  Error [ERR_TLS_CERT_ALTNAME_INVALID]
```

## Cause

`onHandshake_` in `src/valkey/js_valkey.zig` had the certificate checks structured so they were effectively unreachable on the success path:

```zig
if (ssl_error.error_no != 0) {
    if (BoringSSL.c.SSL_get_servername(ssl_ptr, 0)) |servername| {
        if (!BoringSSL.checkServerIdentity(ssl_ptr, hostname)) { /* fail */ }
    }
}
```

1. `checkServerIdentity` was only reached when `ssl_error.error_no != 0`. A CA-signed cert for the wrong hostname gives `error_no == 0`, so hostname verification was skipped entirely.
2. When `error_no != 0` (chain invalid), the code only ran the hostname check — it never rejected on the chain error itself, so an untrusted self-signed cert was also accepted.
3. The Valkey client connects via `us_socket_context_connect` → `ssl_on_open_without_sni`, which never calls `SSL_set_tlsext_host_name`, so `SSL_get_servername` always returned `null` and the inner block was dead code regardless.
4. `handshake_success == false` was silently ignored.

## Fix

Restructure `onHandshake_` to match the Postgres/MySQL clients:

- `ssl_error.error_no != 0` → fail with the verify error.
- Otherwise always run `checkServerIdentity` against the SNI servername **or** the host from the connection URL. On mismatch, fail with `ERR_TLS_CERT_ALTNAME_INVALID`.
- `handshake_success == false` → fail with the verify error (server rejected us).

Edge cases handled for the URL-host fallback:
- `redis+tls+unix://` / `valkey+tls+unix://` — no hostname to verify, so the identity check is skipped (matches Node's behaviour for IPC sockets).
- `rediss://[::1]` — `URL.host()` serialises IPv6 literals with brackets; they are stripped before `checkServerIdentity` so `IP:::1` SAN entries match (mirrors `connectAnon`).

Extracted the failure path into `failHandshake` / `failHandshakeWithVerifyError` helpers.

## Verification

New `test/js/valkey/valkey-tls-verify.test.ts` uses an in-process `node:tls` server that speaks just enough RESP (`+OK` then `+PONG`) to let the client complete — no Docker required.

| test | without fix | with fix |
| --- | --- | --- |
| CA-trusted cert, wrong CN, connect via `localhost` | `PING` **succeeds** | rejects `ERR_TLS_CERT_ALTNAME_INVALID` |
| CA-trusted cert, wrong CN, connect via `127.0.0.1` | `PING` **succeeds** | rejects `ERR_TLS_CERT_ALTNAME_INVALID` |
| untrusted self-signed cert | `PING` **succeeds** | rejects `DEPTH_ZERO_SELF_SIGNED_CERT` |
| mismatched hostname + `rejectUnauthorized: false` | succeeds | succeeds |
| `rediss://[::1]` with matching `IP:::1` SAN | succeeds | succeeds |
| matching cert (SAN `localhost`) + `rejectUnauthorized: true` | succeeds | succeeds |
| `redis+tls+unix://` with wrong-CN cert | succeeds | succeeds |

- `bun bd test test/js/valkey/valkey-tls-verify.test.ts` → 7 pass
- `USE_SYSTEM_BUN=1` → 3 fail, 4 pass
- `bun run zig:check-all` → clean on all targets
