### PR TITLE
fs.watch: fix pending_activity_count underflow leaking non-persistent FSWatcher

### DIFF
--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -216,6 +216,9 @@ pub const FSWatcher = struct {
 
         pub fn appendAbort(this: *FSWatchTaskWindows) void {
             const ctx = this.ctx;
+            // Balance the `ctx.unrefTask()` at the end of `run()` (matches
+            // `onPathUpdateWindows` and the posix `enqueue()` path).
+            if (!ctx.refTask()) return;
             const task = bun.new(FSWatchTaskWindows, .{
                 .ctx = ctx,
                 .event = .abort,

--- a/src/bun.js/node/node_fs_watcher.zig
+++ b/src/bun.js/node/node_fs_watcher.zig
@@ -420,7 +420,6 @@ pub const FSWatcher = struct {
     pub fn initJS(this: *FSWatcher, listener: jsc.JSValue) void {
         if (this.persistent) {
             this.poll_ref.ref(this.ctx);
-            _ = this.pending_activity_count.fetchAdd(1, .monotonic);
         }
 
         const js_this = this.toJS(this.globalThis);
@@ -575,7 +574,8 @@ pub const FSWatcher = struct {
         this.mutex.lock();
         defer this.mutex.unlock();
         // JSC eventually will free it
-        _ = this.pending_activity_count.fetchSub(1, .monotonic);
+        const prev = this.pending_activity_count.fetchSub(1, .monotonic);
+        bun.debugAssert(prev > 0);
     }
 
     pub fn close(this: *FSWatcher) void {
@@ -588,7 +588,10 @@ pub const FSWatcher = struct {
 
             if (js_this != .zero) {
                 if (FSWatcher.js.listenerGetCached(js_this)) |listener| {
-                    _ = this.refTask();
+                    // `closed` is already true so `refTask()` would return false without
+                    // incrementing; bump the counter directly so the `unrefTask()` below is
+                    // balanced and the count stays > 0 while the close event is emitted.
+                    _ = this.pending_activity_count.fetchAdd(1, .monotonic);
                     log("emit('close')", .{});
                     emitJS(listener, this.globalThis, .js_undefined, .close);
                     this.unrefTask();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -726,6 +726,60 @@ describe("immediately closing", () => {
   });
 });
 
+// FSWatcher.close() set `closed = true` before calling refTask(), so refTask() returned
+// false without incrementing pending_activity_count and the paired unrefTask() ran anyway.
+// For { persistent: false } watchers (count starts at 1), close() did a net -2, wrapping the
+// u32 to MAX. hasPendingActivity() then returned true forever, pinning the native FSWatcher
+// (and via its cached listener closure, the JS FSWatcher) as a GC root — a permanent leak
+// per watcher. Persistent watchers only landed at 0 by accident (start=2, -2).
+describe("closed FSWatcher is collectable", () => {
+  for (const persistent of [false, true]) {
+    test(`persistent: ${persistent}`, async () => {
+      using dir = tempDir("fswatch-gc", { "f.txt": "x" });
+      const watchDir = String(dir);
+
+      const fixture = /* js */ `
+        const fs = require("fs");
+
+        let collected = 0;
+        const registry = new FinalizationRegistry(() => { collected++; });
+
+        const ITERS = 64;
+        (function create() {
+          for (let i = 0; i < ITERS; i++) {
+            const w = fs.watch(${JSON.stringify(watchDir)}, { persistent: ${persistent} }, () => {});
+            registry.register(w);
+            w.close();
+          }
+        })();
+
+        (async () => {
+          for (let i = 0; i < 30 && collected < ITERS; i++) {
+            Bun.gc(true);
+            await Bun.sleep(10);
+          }
+          console.log(JSON.stringify({ collected, iters: ITERS }));
+        })();
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      const { collected, iters } = JSON.parse(stdout.trim());
+      // Before the fix, `collected` is 0 for persistent:false — every watcher leaks.
+      // After the fix, all of them are collectable; allow a little slack for GC timing.
+      expect(collected).toBeGreaterThanOrEqual(Math.floor(iters / 2));
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 // On Windows, if fs.watch() fails after getOrPut() inserts into the internal path->watcher
 // map (e.g. uv_fs_event_start fails on a dangling junction, an ACL-protected dir, or a
 // directory deleted mid-watch), an errdefer that was silently broken by a !*T -> Maybe(*T)


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent per-instance leak of `fs.watch(path, { persistent: false })` watchers after `.close()`.

## Reproduction

```js
const fs = require("fs");
let collected = 0;
const registry = new FinalizationRegistry(() => collected++);
for (let i = 0; i < 64; i++) {
  const w = fs.watch("/tmp", { persistent: false }, () => {});
  registry.register(w);
  w.close();
}
for (let i = 0; i < 30; i++) { Bun.gc(true); await Bun.sleep(10); }
console.log(collected); // before: 0, after: 64
```

Before this change, **0** of 64 are collected. With `{persistent: true}`, all 64 are collected (by accident, see below).

## Root cause

`pending_activity_count` starts at `1`. `initJS()` adds `+1` only when `persistent` is true (so non-persistent stays at `1`, persistent becomes `2`).

In `close()`:
1. `closed` is set to `true` under the mutex.
2. `_ = this.refTask()` is called — but `refTask()` checks `if (this.closed) return false` and does **not** increment. The return value is discarded.
3. `this.unrefTask()` runs anyway → `-1`.
4. Final `this.unrefTask()` → `-1`.

Net effect of `close()` is `-2`. For persistent (start = 2) this lands at `0` by coincidence. For non-persistent (start = 1) it wraps the `u32` to `4294967295`, so `hasPendingActivity()` returns `true` forever. The native `FSWatcher`, its cached listener closure, and the JS `FSWatcher` EventEmitter it closes over are all pinned as GC roots — a permanent leak per watcher.

## Fix

- **`close()`**: increment the counter directly via `fetchAdd` instead of calling `refTask()`, so the ref/unref pair around `emitJS(close)` is actually balanced (net 0). Matches the existing pattern in `emitAbort()`.
- **`initJS()`**: drop the persistent-gated `+1`. The initial count of `1` already keeps `hasPendingActivity()` true until `close()`; persistence is about the event-loop keep-alive (`poll_ref`), not GC reachability. This extra `+1` was only ever balanced by the broken `refTask()`/`unrefTask()` pair in `close()`, and it produced wrong counts when the user called `ref()`/`unref()` before `close()`.
- **`unrefTask()`**: add a `bun.debugAssert(prev > 0)` to catch future underflow in debug builds.

With the fix, the count is `1` until `close()` releases it (plus `+1` per in-flight `FSWatchTask`), regardless of persistence or `ref()`/`unref()`.

## Verification

- New test `closed FSWatcher is collectable > persistent: {false,true}` in `test/js/node/watch/fs.watch.test.ts` creates 64 watchers, closes them, and uses a `FinalizationRegistry` to assert ≥32 are collected. Without the fix, `persistent: false` collects 0.
- Full `fs.watch.test.ts` suite passes (including abort-signal tests, `immediately closing` with 100× persistent + 100× non-persistent, and `calling close from close event`).
- `bun run zig:check-all` passes on all targets.