### PR TITLE
webcore: revoke ObjectURLRegistry entries on Worker teardown

### DIFF
--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -1332,6 +1332,13 @@ pub inline fn assertOnJSThread(vm: *const VirtualMachine) void {
     }
 }
 
+/// The ScriptExecutionContext identifier for this VM's global. Main thread is
+/// always 1; workers get a unique id allocated by ScriptExecutionContext::
+/// generateIdentifier() in C++.
+pub inline fn scriptExecutionContextId(vm: *const VirtualMachine) u32 {
+    return @intCast(vm.initial_script_execution_context_identifier);
+}
+
 fn configureDebugger(this: *VirtualMachine, cli_flag: bun.cli.Command.Debugger) void {
     if (bun.env_var.HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET.get() != null) {
         return;

--- a/src/jsc/web_worker.zig
+++ b/src/jsc/web_worker.zig
@@ -729,6 +729,11 @@ fn shutdown(this: *WebWorker) noreturn {
         // closeAll() fires on_close → JS callbacks. RareData.deinit() runs
         // after teardownJSCVM and only deinit()s (asserts empty in debug).
         if (vm.rare_data) |rare| rare.closeAllSocketGroups(vm);
+        // Auto-revoke blob: URLs created by this worker. The registry is
+        // process-global, so without this the duped Blob entries would outlive
+        // the worker. Runs before WebWorker__dispatchExit so the parent's close
+        // event observes the URLs as already gone.
+        bun.webcore.ObjectURLRegistry.singleton().revokeEntriesForContext(this.execution_context_id);
         exit_code = vm.exit_handler.exit_code;
         globalObject = vm.global;
     }

--- a/src/runtime/webcore/ObjectURLRegistry.zig
+++ b/src/runtime/webcore/ObjectURLRegistry.zig
@@ -5,11 +5,17 @@ map: std.AutoHashMap(UUID, *Entry) = std.AutoHashMap(UUID, *Entry).init(bun.defa
 
 pub const Entry = struct {
     blob: jsc.WebCore.Blob,
+    /// ScriptExecutionContext that registered this URL. Used to auto-revoke
+    /// all URLs created by a Worker when that Worker terminates, matching
+    /// the spec's "remove entries whose environment is the worker's settings
+    /// object" step and WebKit's BlobURLRegistry::unregisterURLsForContext.
+    context_id: u32,
 
     pub const new = bun.TrivialNew(@This());
-    pub fn init(blob: *const jsc.WebCore.Blob) *Entry {
+    pub fn init(blob: *const jsc.WebCore.Blob, context_id: u32) *Entry {
         return Entry.new(.{
             .blob = blob.dupeWithContentType(true),
+            .context_id = context_id,
         });
     }
 
@@ -21,12 +27,37 @@ pub const Entry = struct {
 
 pub fn register(this: *ObjectURLRegistry, vm: *jsc.VirtualMachine, blob: *const jsc.WebCore.Blob) UUID {
     const uuid = vm.rareData().nextUUID();
-    const entry = Entry.init(blob);
+    const entry = Entry.init(blob, vm.scriptExecutionContextId());
 
     this.lock.lock();
     defer this.lock.unlock();
     bun.handleOom(this.map.put(uuid, entry));
     return uuid;
+}
+
+/// Revoke every blob URL registered by the given ScriptExecutionContext.
+/// Called from worker teardown so entries created by a Worker don't leak
+/// after the Worker is terminated.
+pub fn revokeEntriesForContext(this: *ObjectURLRegistry, context_id: u32) void {
+    this.lock.lock();
+    defer this.lock.unlock();
+
+    // HashMap iteration does not support removal; collect keys first.
+    var to_remove: std.array_list.Managed(UUID) = .init(bun.default_allocator);
+    defer to_remove.deinit();
+
+    var it = this.map.iterator();
+    while (it.next()) |kv| {
+        if (kv.value_ptr.*.context_id == context_id) {
+            bun.handleOom(to_remove.append(kv.key_ptr.*));
+        }
+    }
+
+    for (to_remove.items) |uuid| {
+        if (this.map.fetchRemove(uuid)) |removed| {
+            removed.value.deinit();
+        }
+    }
 }
 
 pub fn singleton() *ObjectURLRegistry {

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { resolveObjectURL } from "node:buffer";
 
 test("Worker from a Blob", async () => {
   const worker = new Worker(
@@ -123,4 +124,73 @@ test("Worker on a revoked blob still works", async () => {
   });
 
   expect(revoked).toBe("revoked.");
+});
+
+test("blob URLs created inside a Worker are revoked when the worker terminates", async () => {
+  // A blob URL created on the main thread; must survive the worker's teardown.
+  const parentUrl = URL.createObjectURL(new Blob(["from parent"]));
+
+  const worker = new Worker(
+    URL.createObjectURL(
+      new Blob(
+        [
+          `
+          const urls = [];
+          for (let i = 0; i < 4; i++) {
+            urls.push(URL.createObjectURL(new Blob(["from worker " + i])));
+          }
+          self.postMessage(urls);
+          // Stay alive until the parent terminates us.
+          setInterval(() => {}, 1_000_000);
+          `,
+        ],
+        { type: "application/javascript" },
+      ),
+    ),
+  );
+
+  const urls = await new Promise<string[]>(resolve => {
+    worker.onmessage = e => resolve(e.data);
+  });
+  expect(urls).toHaveLength(4);
+
+  // While the worker is alive, its blob URLs are resolvable from the parent.
+  const live = resolveObjectURL(urls[0]);
+  expect(live).toBeInstanceOf(Blob);
+  expect(await live!.text()).toBe("from worker 0");
+
+  const closed = new Promise<void>(resolve => worker.addEventListener("close", () => resolve(), { once: true }));
+  worker.terminate();
+  await closed;
+
+  // After termination, every URL the worker created must be auto-revoked.
+  // Previously these stayed in the process-global ObjectURLRegistry forever.
+  for (const url of urls) {
+    expect(resolveObjectURL(url)).toBeUndefined();
+  }
+
+  // URLs created by the parent context are unaffected.
+  const stillThere = resolveObjectURL(parentUrl);
+  expect(stillThere).toBeInstanceOf(Blob);
+  expect(await stillThere!.text()).toBe("from parent");
+  URL.revokeObjectURL(parentUrl);
+});
+
+test("blob URLs created inside a Worker are revoked when the worker exits naturally", async () => {
+  const worker = new Worker(
+    URL.createObjectURL(
+      new Blob(
+        [`self.postMessage(URL.createObjectURL(new Blob(["bye"])));`],
+        { type: "application/javascript" },
+      ),
+    ),
+  );
+
+  const url = await new Promise<string>(resolve => {
+    worker.onmessage = e => resolve(e.data);
+  });
+
+  await new Promise<void>(resolve => worker.addEventListener("close", () => resolve(), { once: true }));
+
+  expect(resolveObjectURL(url)).toBeUndefined();
 });

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -179,10 +179,7 @@ test("blob URLs created inside a Worker are revoked when the worker terminates",
 test("blob URLs created inside a Worker are revoked when the worker exits naturally", async () => {
   const worker = new Worker(
     URL.createObjectURL(
-      new Blob(
-        [`self.postMessage(URL.createObjectURL(new Blob(["bye"])));`],
-        { type: "application/javascript" },
-      ),
+      new Blob([`self.postMessage(URL.createObjectURL(new Blob(["bye"])));`], { type: "application/javascript" }),
     ),
   );
 


### PR DESCRIPTION
## What

`URL.createObjectURL(blob)` stores a duped `Blob` in a process-global `ObjectURLRegistry`. When called inside a Worker, those entries were never removed if the worker exited (naturally or via `terminate()`) without an explicit `URL.revokeObjectURL()`, so the Blob data leaked for the lifetime of the process.

## Repro

```js
import { resolveObjectURL } from "node:buffer";
import { Worker } from "node:worker_threads";

const w = new Worker(`
  const { parentPort } = require("node:worker_threads");
  parentPort.postMessage(URL.createObjectURL(new Blob(["x"])));
  setInterval(() => {}, 1e6);
`, { eval: true });

const url = await new Promise(r => w.once("message", r));
await w.terminate();
console.log(resolveObjectURL(url)); // before: Blob, after: undefined
```

## Cause

`ObjectURLRegistry` is a singleton `UUID → Entry` map with no notion of which context created the entry. `WebWorker.exitAndDeinit()` tears down the worker's VM but never touches the registry, so every worker-created entry is orphaned.

## Fix

- Tag each `Entry` with the creating VM's `ScriptExecutionContext` id (via a new `VirtualMachine.scriptExecutionContextId()` helper).
- Add `ObjectURLRegistry.revokeEntriesForContext(context_id)` which drops all matching entries under the registry lock.
- Call it from `WebWorker.exitAndDeinit()` alongside the existing `CronJob.clearAllForVM` cleanup, before `WebWorker__dispatchExit` so the parent's `close` event observes the URLs as already revoked.

This mirrors WebKit's `BlobURLRegistry::unregisterURLsForContext` / `PublicURLManager::stop()` and the FileAPI spec's unloading-cleanup step for blob URL stores.

## Verification

New tests in `test/js/web/workers/worker_blob.test.ts`:
- `blob URLs created inside a Worker are revoked when the worker terminates` — creates several blob URLs in a worker, confirms they resolve while alive, then asserts they're gone after `terminate()`. Also asserts a parent-context URL is left alone.
- `blob URLs created inside a Worker are revoked when the worker exits naturally` — same for natural worker exit.

Both fail on `main` (`Received: Blob (N bytes)` where `undefined` is expected) and pass with this change.