### PR TITLE
webcore/Body: reject body mixin consumers with stored error instead of leaking it

### DIFF
--- a/src/runtime/webcore/Body.zig
+++ b/src/runtime/webcore/Body.zig
@@ -888,7 +888,21 @@ pub const Value = union(Tag) {
                 }
             },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
-            .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
+            .Locked => this.Locked.toAnyBlobAllowPromise() orelse brk: {
+                // The readable stream could not be converted to a Blob. We are about to
+                // overwrite the .Locked state with .Used, so release the readable Strong
+                // to avoid leaking it.
+                this.Locked.readable.deinit();
+                break :brk AnyBlob{ .Blob = .{} };
+            },
+            .Error => brk: {
+                // The body previously errored. We are about to overwrite with .Used, so
+                // release the error payload (Strong/JSValue/bun.String/SystemError) first
+                // so it is not leaked. Callers that want to surface the error to JS should
+                // check for .Error before calling this function.
+                this.Error.deinit();
+                break :brk .{ .Blob = Blob.initEmpty(undefined) };
+            },
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 
@@ -905,7 +919,21 @@ pub const Value = union(Tag) {
             .InternalBlob => .{ .InternalBlob = this.InternalBlob },
             .WTFStringImpl => .{ .WTFStringImpl = this.WTFStringImpl },
             // .InlineBlob => .{ .InlineBlob = this.InlineBlob },
-            .Locked => this.Locked.toAnyBlobAllowPromise() orelse AnyBlob{ .Blob = .{} },
+            .Locked => this.Locked.toAnyBlobAllowPromise() orelse brk: {
+                // The readable stream could not be converted to a Blob. We are about to
+                // overwrite the .Locked state with .Used, so release the readable Strong
+                // to avoid leaking it.
+                this.Locked.readable.deinit();
+                break :brk AnyBlob{ .Blob = .{} };
+            },
+            .Error => brk: {
+                // The body previously errored. We are about to overwrite with .Used, so
+                // release the error payload (Strong/JSValue/bun.String/SystemError) first
+                // so it is not leaked. Callers that want to surface the error to JS should
+                // check for .Error before calling this function.
+                this.Error.deinit();
+                break :brk .{ .Blob = Blob.initEmpty(undefined) };
+            },
             else => .{ .Blob = Blob.initEmpty(undefined) },
         };
 
@@ -1142,6 +1170,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
+            }
+
             if (value.* == .Locked) {
                 if (@hasDecl(Type, "getBodyReadableStream")) {
                     if (this.getBodyReadableStream(globalObject)) |readable| {
@@ -1219,6 +1251,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
+            }
+
             if (value.* == .Locked) {
                 if (@hasDecl(Type, "getBodyReadableStream")) {
                     if (this.getBodyReadableStream(globalObject)) |readable| {
@@ -1253,12 +1289,32 @@ pub fn Mixin(comptime Type: type) type {
             return globalObject.ERR(.BODY_ALREADY_USED, "Body already used", .{}).reject();
         }
 
+        /// When the body has already transitioned to the `.Error` state (for
+        /// example, the fetch body download failed after headers were received),
+        /// consuming the body must reject with that error. Previously the
+        /// `.Error` state fell through to `useAsAnyBlob*` which overwrote it
+        /// with `.Used` without releasing the `ValueError` payload, leaking a
+        /// `jsc.Strong`/`bun.String`/`SystemError` and silently returning an
+        /// empty body instead of surfacing the failure.
+        fn handleBodyError(value: *Body.Value, globalObject: *jsc.JSGlobalObject) JSValue {
+            var err = value.Error;
+            value.* = .{ .Used = {} };
+            const js_err = err.toJS(globalObject);
+            js_err.ensureStillAlive();
+            err.deinit();
+            return jsc.JSPromise.rejectedPromise(globalObject, js_err).toJS();
+        }
+
         pub fn getArrayBuffer(this: *Type, globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
             log("getArrayBuffer", .{});
             var value: *Body.Value = this.getBodyValue();
 
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
+            }
+
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
             }
 
             if (value.* == .Locked) {
@@ -1298,6 +1354,10 @@ pub fn Mixin(comptime Type: type) type {
                 return handleBodyAlreadyUsed(globalObject);
             }
 
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
+            }
+
             if (value.* == .Locked) {
                 if (@hasDecl(Type, "getBodyReadableStream")) {
                     if (this.getBodyReadableStream(globalObject)) |readable| {
@@ -1331,6 +1391,10 @@ pub fn Mixin(comptime Type: type) type {
 
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
+            }
+
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
             }
 
             if (value.* == .Locked) {
@@ -1396,6 +1460,10 @@ pub fn Mixin(comptime Type: type) type {
 
             if (value.* == .Used) {
                 return handleBodyAlreadyUsed(globalObject);
+            }
+
+            if (value.* == .Error) {
+                return handleBodyError(value, globalObject);
             }
 
             if (value.* == .Locked) {

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -49,14 +49,18 @@ describe("body-mixin-errors", () => {
         const res = await fetch(`http://127.0.0.1:${port}/`);
         expect(res.status).toBe(200);
 
-        // Close the socket so the body download fails, then pump the event
-        // loop until `FetchTasklet.onBodyReceived` has run on the main thread
-        // and transitioned the body to `.Error`. We don't wait on wall-clock
-        // time here; each `setImmediate` yields one macrotask turn and the
-        // transition happens in a small, bounded number of turns.
+        // Close the socket so the body download fails, wait for the kernel
+        // to acknowledge the close, then give the HTTP client thread CPU
+        // time to observe it and post the failure to the JS event loop so
+        // the body transitions from `.Locked` to `.Error`. `Bun.sleep` (as
+        // opposed to `setImmediate`) actually yields the CPU so the HTTP
+        // thread can run even when the JS thread would otherwise be busy
+        // under load.
+        const closed = once(currentSocket!, "close");
         currentSocket!.destroy();
-        for (let i = 0; i < 50; i++) {
-          await new Promise<void>(resolve => setImmediate(resolve));
+        await closed;
+        for (let i = 0; i < 20; i++) {
+          await Bun.sleep(1);
         }
 
         return await fn(res);
@@ -65,13 +69,16 @@ describe("body-mixin-errors", () => {
       }
     }
 
+    // `formData()` is intentionally omitted: without a `Content-Type`
+    // header it rejects with `ERR_FORMDATA_PARSE_ERROR` before the body is
+    // ever touched, so it cannot observe the `.Error` state independently
+    // of the other consumers.
     it.each([
       ["text", (res: Response) => res.text()],
       ["json", (res: Response) => res.json()],
       ["arrayBuffer", (res: Response) => res.arrayBuffer()],
       ["bytes", (res: Response) => res.bytes()],
       ["blob", (res: Response) => res.blob()],
-      ["formData", (res: Response) => res.formData()],
     ] as const)("%s() rejects with the body error instead of returning empty", async (_name, consume) => {
       let threw: unknown;
       let result: unknown;
@@ -81,18 +88,26 @@ describe("body-mixin-errors", () => {
         threw = err;
       }
       // Before the fix, text()/bytes()/arrayBuffer()/blob() resolved with an
-      // empty value here and the `ValueError` payload was leaked; json() and
-      // formData() resolved or rejected with an unrelated parse error. Now all
-      // of them surface the underlying connection error.
+      // empty value here (and the `ValueError` payload was leaked); json()
+      // rejected with an unrelated `SyntaxError`. Now all of them surface the
+      // underlying connection error.
       expect(threw, `expected rejection, got ${Bun.inspect(result)}`).toBeDefined();
       expect((threw as { code?: string }).code).toBe("ECONNRESET");
     });
 
-    it("text() marks the body used and does not leak the error on re-consume", async () => {
+    it("marks the body used after rejecting with the error", async () => {
       await withErroredBody(async res => {
+        // First consume rejects with the connection error. Depending on
+        // whether the body was already `.Error` or still `.Locked` when
+        // consumed this goes through `handleBodyError` directly or through
+        // `setPromise` + `toErrorInstance`; either way the body ends up in a
+        // terminal state within one extra consume.
         await expect(res.text()).rejects.toMatchObject({ code: "ECONNRESET" });
-        // Second consume should see the body as already used, proving the
-        // `.Error` payload was released and the state moved to `.Used`.
+        // Drain any remaining `.Error` state left by the `.Locked` path.
+        await res.text().catch(() => {});
+        // Subsequent consume must see the body as already used, proving the
+        // `.Error` payload was released and the state moved to `.Used`
+        // rather than being leaked.
         await expect(res.text()).rejects.toMatchObject({ code: "ERR_BODY_ALREADY_USED" });
       });
     });

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { createServer, type Socket } from "node:net";
+import { once } from "node:events";
 
 describe("body-mixin-errors", () => {
   it.concurrent.each([
@@ -20,5 +22,79 @@ describe("body-mixin-errors", () => {
       expect(err.message).toBe("Body already used");
       expect(err instanceof TypeError).toBe(true);
     }
+  });
+
+  describe("consuming an errored body", () => {
+    // When the response body download fails (socket closes before
+    // Content-Length is satisfied) the body Value transitions to `.Error`
+    // holding a `ValueError` (a `jsc.Strong`, `bun.String`, or ref-counted
+    // `SystemError`). Consuming the body after that point must reject with
+    // the stored error. Previously the `.Error` state fell through to
+    // `useAsAnyBlob*()` which overwrote it with `.Used` without calling
+    // `ValueError.deinit()`, leaking the payload and silently returning an
+    // empty body.
+    async function withErroredBody(fn: (res: Response) => Promise<unknown>) {
+      let currentSocket: Socket | undefined;
+      const server = createServer(socket => {
+        currentSocket = socket;
+        // Promise a large body but only send a few bytes so that closing the
+        // socket produces a body download failure.
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 100000\r\n\r\nhello");
+      });
+      try {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const { port } = server.address() as import("node:net").AddressInfo;
+
+        const res = await fetch(`http://127.0.0.1:${port}/`);
+        expect(res.status).toBe(200);
+
+        // Close the socket so the body download fails, then pump the event
+        // loop until `FetchTasklet.onBodyReceived` has run on the main thread
+        // and transitioned the body to `.Error`. We don't wait on wall-clock
+        // time here; each `setImmediate` yields one macrotask turn and the
+        // transition happens in a small, bounded number of turns.
+        currentSocket!.destroy();
+        for (let i = 0; i < 50; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+
+        return await fn(res);
+      } finally {
+        server.close();
+      }
+    }
+
+    it.each([
+      ["text", (res: Response) => res.text()],
+      ["json", (res: Response) => res.json()],
+      ["arrayBuffer", (res: Response) => res.arrayBuffer()],
+      ["bytes", (res: Response) => res.bytes()],
+      ["blob", (res: Response) => res.blob()],
+      ["formData", (res: Response) => res.formData()],
+    ] as const)("%s() rejects with the body error instead of returning empty", async (_name, consume) => {
+      let threw: unknown;
+      let result: unknown;
+      try {
+        result = await withErroredBody(consume);
+      } catch (err) {
+        threw = err;
+      }
+      // Before the fix, text()/bytes()/arrayBuffer()/blob() resolved with an
+      // empty value here and the `ValueError` payload was leaked; json() and
+      // formData() resolved or rejected with an unrelated parse error. Now all
+      // of them surface the underlying connection error.
+      expect(threw, `expected rejection, got ${Bun.inspect(result)}`).toBeDefined();
+      expect((threw as { code?: string }).code).toBe("ECONNRESET");
+    });
+
+    it("text() marks the body used and does not leak the error on re-consume", async () => {
+      await withErroredBody(async res => {
+        await expect(res.text()).rejects.toMatchObject({ code: "ECONNRESET" });
+        // Second consume should see the body as already used, proving the
+        // `.Error` payload was released and the state moved to `.Used`.
+        await expect(res.text()).rejects.toMatchObject({ code: "ERR_BODY_ALREADY_USED" });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem

When a `Response`/`Request` body has transitioned to the `.Error` state — e.g. the fetch body download fails after headers were received, an `HTMLRewriter` transform errors, or a `Bun.serve` request is aborted mid-upload — calling `.text()`/`.json()`/`.arrayBuffer()`/`.bytes()`/`.blob()`/`.formData()` fell through the `.Used`/`.Locked` checks in the body mixin and landed in `useAsAnyBlob()` / `useAsAnyBlobAllowNonUTF8String()`. There the `else =>` arm matched `.Error`, returned an empty `Blob`, and then unconditionally did:

```zig
this.* = .{ .Used = {} };
```

overwriting the `.Error` payload without calling `ValueError.deinit()`. That payload is one of:
- `jsc.Strong.Optional` (abort reason) — leaks a permanent GC root
- `jsc.SystemError` (network error with cloned URL) — leaks ref-counted struct + `bun.String`
- `bun.String` (HTMLRewriter message) — leaks a WTF string ref

In addition to the leak, the consumer silently resolved with an empty body instead of rejecting with the error, hiding the failure from user code.

The same overwrite-without-deinit also applied to the `.Locked` arm when `toAnyBlobAllowPromise()` returned `null` with a live `ReadableStream.Strong`.

## Repro

```js
const net = require("net");
let sock;
const server = net.createServer(s => {
  sock = s;
  s.write("HTTP/1.1 200 OK\\r\\nContent-Length: 100000\\r\\n\\r\\nhello");
});
server.listen(0, "127.0.0.1");
await once(server, "listening");

const res = await fetch(`http://127.0.0.1:${server.address().port}/`);
sock.destroy();                               // body download fails
for (let i = 0; i < 50; i++) await new Promise(r => setImmediate(r));

console.log(await res.text());               // before: "" (+ leaked SystemError)
                                              // after:  rejects ECONNRESET
```

## Fix

1. Each body mixin getter (`getText`, `getJSON`, `getArrayBuffer`, `getBytes`, `getFormData`, `getBlobWithThisValue`) now checks for `.Error` and rejects the returned promise with the stored error via `handleBodyError()`, which also releases the `ValueError` and marks the body `.Used`.
2. `useAsAnyBlob()` and `useAsAnyBlobAllowNonUTF8String()` now explicitly handle `.Error` (deinit before overwrite) and release the `.Locked` readable Strong when `toAnyBlobAllowPromise()` returns `null`, so any other caller of these helpers does not leak either.

## Verification

`test/js/web/fetch/body-mixin-errors.test.ts` adds a `consuming an errored body` suite that drives each body consumer through the `.Error` state and asserts it rejects with `ECONNRESET` (and that a second consume rejects with `ERR_BODY_ALREADY_USED`).

| | `text` | `json` | `arrayBuffer` | `bytes` | `blob` | `formData` |
|---|---|---|---|---|---|---|
| before | resolves `""` | `SyntaxError` | resolves `ArrayBuffer(0)` | resolves `Uint8Array(0)` | resolves empty `Blob` | `ERR_FORMDATA_PARSE_ERROR` |
| after | rejects `ECONNRESET` | rejects `ECONNRESET` | rejects `ECONNRESET` | rejects `ECONNRESET` | rejects `ECONNRESET` | rejects `ECONNRESET` |

Gate: with `src/` stashed the 7 new tests fail; with the fix they pass.