### PR TITLE
server: guard onUpgrade against re-entrant server.upgrade()

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -879,6 +879,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             const resp = upgrader.resp.?;
             const ctx = upgrader.upgrade_context.?;
 
+            // Keep the upgrader alive across option getters below, which run
+            // arbitrary user JS. A re-entrant server.upgrade(req) from a getter
+            // would otherwise be able to deref this context out from under us.
+            upgrader.ref();
+            defer upgrader.deref();
+
             var sec_websocket_key_str = ZigString.Empty;
 
             var sec_websocket_protocol = ZigString.Empty;
@@ -1001,6 +1007,15 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         return error.JSError;
                     }
                 }
+            }
+
+            // Option getters above may have run arbitrary JS, including a
+            // re-entrant server.upgrade(req) on this same request. If that
+            // happened the upgrade has already been consumed and the cached
+            // `resp`/`ctx` locals now point at a socket that has been turned
+            // into a WebSocket — using them again would be UB.
+            if (upgrader.isAbortedOrEnded() or upgrader.didUpgradeWebSocket()) {
+                return .false;
             }
 
             var cookies_to_write: ?*WebCore.CookieMap = null;

--- a/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
+++ b/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// server.upgrade(req, opts) reads opts.data / opts.headers via property
+// access, which can invoke user getters. A getter that calls
+// server.upgrade(req) again on the same request used to perform a second
+// upgrade on a uws response that had already been converted into a
+// WebSocket, double-deref'ing the RequestContext in the process.
+
+for (const via of ["data", "headers"] as const) {
+  test(`server.upgrade() is safe against re-entrant upgrade from options.${via} getter`, async () => {
+    using dir = tempDir("ws-upgrade-reentrant", {
+      "index.ts": `
+        let opens = 0;
+        const server = Bun.serve({
+          port: 0,
+          fetch(req, server) {
+            let once = false;
+            const outer = server.upgrade(req, {
+              get ${via}() {
+                if (!once) {
+                  once = true;
+                  const inner = server.upgrade(req);
+                  console.log("inner=" + inner);
+                }
+                return ${via === "data" ? "{ tag: 'outer' }" : "undefined"};
+              },
+            });
+            console.log("outer=" + outer);
+            if (!outer) return new Response("no upgrade");
+          },
+          websocket: {
+            open(ws) {
+              opens++;
+              ws.send("hello");
+            },
+            message(ws) {
+              ws.close();
+            },
+            close() {},
+          },
+        });
+
+        const ws = new WebSocket(server.url.href.replace("http", "ws"));
+        await new Promise<void>((resolve, reject) => {
+          ws.onopen = () => ws.send("ping");
+          ws.onmessage = () => {
+            ws.close();
+            resolve();
+          };
+          ws.onerror = (e) => reject(new Error("ws error"));
+          ws.onclose = () => resolve();
+        });
+
+        console.log("opens=" + opens);
+        server.stop(true);
+        process.exit(0);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // The inner (re-entrant) upgrade consumes the request; the outer call
+    // must observe this and return false instead of upgrading again.
+    expect(stdout).toContain("inner=true");
+    expect(stdout).toContain("outer=false");
+    // Exactly one WebSocket connection should have been opened.
+    expect(stdout).toContain("opens=1");
+    expect(exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
## Problem

`server.upgrade(req, opts)` reads `opts.data` and `opts.headers` via property access, which can invoke user-defined getters. `onUpgrade` caches `upgrader.resp` and `upgrader.upgrade_context` as locals *before* those getters run, and never re-checks them afterwards.

A getter that calls `server.upgrade(req)` again on the same request passes the top-of-function guards (the upgrade hasn't happened yet), performs the upgrade — setting `upgrader.resp = null`, `upgrader.upgrade_context = maxInt`, `upgrader.request_weakref.deref()`, `upgrader.deref()`, and `resp.upgrade(...)` — and returns. Control then returns to the outer call which proceeds with its stale `resp`/`ctx` locals and repeats the whole sequence on a uws response that has already been converted into a WebSocket.

## Repro

```js
Bun.serve({
  fetch(req, server) {
    let once = false;
    server.upgrade(req, {
      get data() {
        if (!once) { once = true; server.upgrade(req); }
        return null;
      },
    });
  },
  websocket: { open(ws) { console.log("open", ws.data); } },
});
```

On a release build the second `resp.upgrade()` goes through and **`open` fires twice** for a single connection. On a debug build the second `upgrader.deref()` underflows the u8 ref_count and panics with `integer overflow`.

## Fix

- Take an extra ref on the `RequestContext` for the duration of `onUpgrade` so the pointer stays valid even if a re-entrant call derefs it.
- After the options block (where user JS may have run), re-check `isAbortedOrEnded()` / `didUpgradeWebSocket()` and return `false` if the request was already consumed — matching the behaviour of the existing top-of-function guard.

## Verification

New test `test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts` exercises both the `data` and `headers` getter paths. Without the fix, the spawned server panics (`integer overflow`) in debug and double-fires `open` in release; with the fix, the inner upgrade returns `true`, the outer returns `false`, and `open` fires exactly once.