### PR TITLE
spawnSync: always finalize Subprocess on early return

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.zig
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.zig
@@ -867,21 +867,31 @@ pub fn spawnMaybeSync(
     defer if (comptime is_sync) {
         if (!subprocess.process.hasExited()) {
             // An error path bailed before the sync wait loop could reap
-            // the child. tryKill() was already called at the error site;
-            // reap now so onProcessExit drops its ref and closes IO.
-            subprocess.process.wait(true);
-            if (comptime Environment.isWindows) {
-                // Process.wait() is a no-op on Windows and watchOrReap()
-                // has not run yet, so drive the exit handler manually to
+            // the child. On POSIX, Process.kill() is a no-op while the
+            // poller is still .detached (watch() has not run yet on the
+            // sync path), so the tryKill() at the error site did not
+            // actually signal; send it directly by pid before blocking
+            // in wait4() so long-lived children do not hang us here.
+            if (comptime Environment.isPosix) {
+                _ = std.c.kill(subprocess.process.pid, @intCast(@intFromEnum(subprocess.killSignal)));
+                subprocess.process.wait(true);
+            } else {
+                // Windows: poller is already .uv from spawn so tryKill()
+                // did run, but Process.wait() is a no-op and watchOrReap()
+                // has not run yet; drive the exit handler manually to
                 // release the Process ref and close IO.
-                if (!subprocess.process.hasExited()) {
-                    subprocess.process.onExit(
-                        .{ .signaled = subprocess.killSignal },
-                        &std.mem.zeroes(Rusage),
-                    );
-                }
+                subprocess.process.onExit(
+                    .{ .signaled = subprocess.killSignal },
+                    &std.mem.zeroes(Rusage),
+                );
             }
         }
+        // finalize() → finalizeStreams() → Writable/Readable.finalize()
+        // closes any memfd that was copied out of stdio[] by
+        // Writable.init/Readable.init. Disarm the earlier-registered
+        // should_close_memfd defer so the same fd number is not closed
+        // twice on the pipe.start() error path.
+        should_close_memfd = false;
         subprocess.finalize();
     };
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.zig
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.zig
@@ -858,6 +858,33 @@ pub fn spawnMaybeSync(
         subprocess.toJS(globalThis)
     else
         JSValue.zero;
+
+    // For spawnSync no JS wrapper is created, so GC will never call
+    // finalize(). Every exit path from here on must reap the child and
+    // free the Subprocess, including pipe.start() failures below, a
+    // pending exception after the wait loop (e.g. worker termination or
+    // a bun:test timeout), and errors thrown while building the result.
+    defer if (comptime is_sync) {
+        if (!subprocess.process.hasExited()) {
+            // An error path bailed before the sync wait loop could reap
+            // the child. tryKill() was already called at the error site;
+            // reap now so onProcessExit drops its ref and closes IO.
+            subprocess.process.wait(true);
+            if (comptime Environment.isWindows) {
+                // Process.wait() is a no-op on Windows and watchOrReap()
+                // has not run yet, so drive the exit handler manually to
+                // release the Process ref and close IO.
+                if (!subprocess.process.hasExited()) {
+                    subprocess.process.onExit(
+                        .{ .signaled = subprocess.killSignal },
+                        &std.mem.zeroes(Rusage),
+                    );
+                }
+            }
+        }
+        subprocess.finalize();
+    };
+
     if (out != .zero) {
         subprocess.this_value.setWeak(out);
         // Immediately upgrade to strong if there's pending activity to prevent premature GC
@@ -1111,7 +1138,7 @@ pub fn spawnMaybeSync(
     const exitedDueToTimeout = did_timeout;
     const exitedDueToMaxBuffer = subprocess.exited_due_to_maxbuf;
     const resultPid = jsc.JSValue.jsNumberFromInt32(subprocess.pid());
-    subprocess.finalize();
+    // subprocess.finalize() is handled by the `defer if (is_sync)` above.
 
     const sync_value = jsc.JSValue.createEmptyObject(globalThis, 0);
     sync_value.put(globalThis, jsc.ZigString.static("exitCode"), exitCode);

--- a/test/js/bun/spawn/spawnSync-terminate-leak-fixture.ts
+++ b/test/js/bun/spawn/spawnSync-terminate-leak-fixture.ts
@@ -1,0 +1,59 @@
+// Fixture for spawnSync-terminate-leak.test.ts
+//
+// Each Worker posts "starting" and then blocks in Bun.spawnSync() on a child
+// that sleeps for a couple of seconds. While spawnSync is blocking we
+// terminate the Worker from the main thread; when the child finally exits,
+// spawnMaybeSync observes the pending termination exception (either at the
+// explicit hasException() check after the wait loop or at the first JS
+// allocation while building the result) and returns early.
+//
+// Prior to the fix that early return skipped subprocess.finalize(), leaking
+// the Subprocess (ref_count stuck at 1) along with its buffered stdout and
+// stderr. The test asserts that every spawnSync is matched by a Subprocess
+// finalize + deinit in the BUN_DEBUG_Subprocess log.
+
+import { Worker } from "node:worker_threads";
+
+const ITERATIONS = Number(process.env.ITERATIONS || 2);
+const SLEEP_SECS = process.env.SLEEP_SECS || "2";
+
+const workerSource = `
+  const { parentPort } = require("node:worker_threads");
+  parentPort.postMessage("starting");
+  Bun.spawnSync({
+    cmd: ["sleep", ${JSON.stringify(SLEEP_SECS)}],
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  // Unreachable once terminate() wins the race; if spawnSync somehow
+  // completes before terminate() lands we just did not exercise the path
+  // for this iteration, which the outer test tolerates.
+  parentPort.postMessage("done");
+`;
+
+async function once(): Promise<void> {
+  const worker = new Worker(workerSource, { eval: true });
+  const started = Promise.withResolvers<void>();
+  const exited = Promise.withResolvers<void>();
+  worker.on("message", msg => {
+    if (msg === "starting") started.resolve();
+  });
+  worker.on("error", () => started.resolve());
+  worker.on("exit", () => exited.resolve());
+  // Wait until the Worker is inside spawnSync so terminate()'s request is
+  // pending while spawnSync is building its result.
+  await started.promise;
+  await worker.terminate();
+  // terminate() resolves as soon as the exit notification is queued; the
+  // Worker thread is still blocked in native code until the child exits.
+  // Wait for the exit event so the Subprocess log lines for this iteration
+  // have been emitted before we move on / the process exits.
+  await exited.promise;
+}
+
+for (let i = 0; i < ITERATIONS; i++) {
+  await once();
+}
+
+process.stdout.write(`spawned=${ITERATIONS}\n`);

--- a/test/js/bun/spawn/spawnSync-terminate-leak.test.ts
+++ b/test/js/bun/spawn/spawnSync-terminate-leak.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
+import { join } from "node:path";
+
+// Bun.spawnSync buffers the child's stdout/stderr natively and only then
+// converts them to JS values. If a JS exception is already pending when the
+// sync wait loop exits — e.g. a Worker termination request, or a bun:test
+// timeout — spawnMaybeSync returns early. That early return used to skip
+// subprocess.finalize(); with no JS wrapper for spawnSync there is no GC
+// finalizer, so the Subprocess and its buffered output leaked.
+//
+// This test terminates a Worker while it is blocked in spawnSync and uses
+// the BUN_DEBUG_Subprocess log scope to verify that every Subprocess is
+// finalized and deinit'd. The log scope only exists in debug builds; the
+// child is POSIX `sleep`.
+test.skipIf(!isDebug || isWindows)(
+  "spawnSync does not leak the Subprocess when a termination exception is pending",
+  async () => {
+    const iterations = 2;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "spawnSync-terminate-leak-fixture.ts")],
+      env: {
+        ...bunEnv,
+        // Keep other scopes quiet; enable only the Subprocess scope. Scoped
+        // debug logs are written to the target process's stdout.
+        BUN_DEBUG_Subprocess: "1",
+        ITERATIONS: String(iterations),
+        SLEEP_SECS: "2",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const combined = stdout + stderr;
+    const count = (re: RegExp) => (combined.match(re) ?? []).length;
+
+    // One spawnSync per Worker iteration; each must be matched by a
+    // finalize + deinit.
+    const spawned = count(/\[subprocess\] spawn maxBuffer:/g);
+    const finalized = count(/\[subprocess\] finalize\n/g);
+    const deinited = count(/\[subprocess\] deinit\n/g);
+
+    expect(combined).toContain(`spawned=${iterations}`);
+    expect({ spawned, finalized, deinited }).toEqual({
+      spawned: iterations,
+      finalized: iterations,
+      deinited: iterations,
+    });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## What does this PR do?

Fixes a memory leak in `Bun.spawnSync` where the native `Subprocess` and its buffered stdout/stderr were never freed when `spawnMaybeSync` returned early with a pending exception.

### Trigger

- `Bun.spawnSync()` inside a Worker that is terminated while spawnSync is blocking
- a `bun:test` timeout that throws while spawnSync is waiting
- `stdin.buffer.start()` / `stdout.pipe.start()` / `stderr.pipe.start()` failing for spawnSync
- any JS allocation in the result-building path (`toBufferedValue`, `createResourceUsageObject`) throwing

### Root cause

For `is_sync = true` no JS wrapper is created (`out = .zero`), so the GC finalizer never runs; cleanup relies on the explicit `subprocess.finalize()` on the happy path. Commit 0db90b25 ("Implement isolated event loop for spawnSync") moved the `hasException()` check from *after* `finalize()` to *before* it:

```zig
// before 0db90b25
subprocess.finalize();
if (globalThis.hasException()) return .zero;

// after 0db90b25
if (globalThis.hasException()) return .zero;   // <- skips finalize()
...
subprocess.finalize();
```

The `try` calls that build the result object and the `pipe.start()` error paths have the same shape. Since sync starts at `ref_count = 2` and `onProcessExit` only drops one ref, the Subprocess stays alive forever along with whatever the child wrote to stdout/stderr.

### Fix

Replace the single explicit `finalize()` with a `defer if (is_sync)` right after the JS-wrapper decision so every sync exit path — success, pending exception, `try` failure, pipe-start failure — ends with `subprocess.finalize()`. If an error path bails before the sync wait loop reaped the child, the defer reaps it (`process.wait(true)` on POSIX; manual `process.onExit` on Windows where `wait()` is a no-op) so `onProcessExit` drops its ref and closes IO before `finalize()` runs.

### How did you verify your code works?

New `test/js/bun/spawn/spawnSync-terminate-leak.test.ts` terminates a Worker while it is blocked in `spawnSync` and asserts, via the `BUN_DEBUG_Subprocess` log scope, that every spawn is matched by a `finalize` + `deinit`:

- **before fix:** `{spawned: 2, finalized: 0, deinited: 0}` → fail
- **after fix:** `{spawned: 2, finalized: 2, deinited: 2}` → pass

On release `bun` the same fixture segfaults at process exit; with the fix it exits cleanly. The test is debug-only (uses the scoped log) and POSIX-only (uses `sleep`).

Also re-ran `test/cli/test/test-timeout-behavior.test.ts` and `test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts`, which exercise the affected code path.