### PR TITLE
fs: reuse DirEntry in bustEntriesCache instead of orphaning it

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1002,8 +1002,9 @@ where
 
                         let affected_len: usize = 'brk: {
                             if IS_KQUEUE {
-                                // SAFETY: hot-reload runs single-threaded on the JS thread;
-                                // no other live `&mut EntriesOption` for this key here.
+                                // Index lookup only (`BSSMap::get` locks internally). The slot's
+                                // contents can be rewritten in place by a JS-thread resolve, so
+                                // they are read only under `entries_mutex` ('locked block below).
                                 if let Some(existing) = rfs.entries.get(file_path) {
                                     self.put_tombstone(file_path, existing);
                                     entries_option = Some(existing);
@@ -1103,10 +1104,6 @@ where
                             }
                         }
 
-                        let _ = self.ctx_mut().bust_dir_cache(
-                            strings::paths::without_trailing_slash_windows_path(file_path),
-                        );
-
                         // The watched entrypoint has a per-file inotify watch on its inode.
                         // An atomic rename (`rename(tmp, entrypoint)`) or a rm+recreate over
                         // the entrypoint replaces that inode, so the kernel drops the
@@ -1155,10 +1152,24 @@ where
                             }
                         }
 
-                        if let Some(dir_ent) = entries_option {
+                        'locked: {
+                            let Some(dir_ent) = entries_option else {
+                                break 'locked;
+                            };
+                            // `bust_entries_cache` now marks the `DirEntry` stale in place
+                            // instead of orphaning the slot. That means a concurrent resolve
+                            // (under `entries_mutex`) can rewrite this exact `DirEntry`/
+                            // `EntryMap` via the `in_place` path — including one triggered by
+                            // a *previous* directory event's bust that is still in flight.
+                            // Serialize with those writers so the `dir_ent.entries().get(...)`
+                            // reads below see a consistent map.
+                            let _entries_g = rfs.entries_mutex.lock_guard();
                             // SAFETY: dir_ent points into rfs.entries (or a tombstoned copy);
                             // both outlive this loop iteration.
                             let dir_ent = unsafe { &mut *dir_ent };
+                            if !matches!(dir_ent, Fs::EntriesOption::Entries(_)) {
+                                break 'locked;
+                            }
                             let mut last_file_hash: bun_watcher::HashType =
                                 bun_watcher::HashType::MAX;
 
@@ -1283,6 +1294,12 @@ where
                                 }
                             }
                         }
+
+                        // Bust after releasing `entries_mutex` — `bust_entries_cache`
+                        // takes it internally and the lock is non-recursive.
+                        let _ = self.ctx_mut().bust_dir_cache(
+                            strings::paths::without_trailing_slash_windows_path(file_path),
+                        );
 
                         if self.verbose {
                             Self::debug(format_args!(

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -563,6 +563,11 @@ pub struct DirEntry {
     pub dir: &'static [u8],
     pub fd: Fd,
     pub generation: Generation,
+    /// Set by `RealFS::bust_entries_cache`. Forces the next read to go through
+    /// the `in_place` re-scan path regardless of generation, so the existing
+    /// `DirEntry` allocation and its `Entry`/`FilenameStore` slots are reused
+    /// instead of being orphaned.
+    pub stale: bool,
     pub data: dir_entry::EntryMap,
 }
 
@@ -575,6 +580,7 @@ impl DirEntry {
             dir,
             data: dir_entry::EntryMap::default(),
             generation,
+            stale: false,
             fd: Fd::INVALID,
         }
     }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1254,7 +1254,7 @@ pub mod fs {
                         // scrutinee directly so no second `&mut *cached_ptr` is materialized
                         // while the first is on the borrow stack (Stacked Borrows hygiene).
                         match unsafe { &mut *cached_ptr } {
-                            EntriesOption::Entries(e) if e.generation < generation => {
+                            EntriesOption::Entries(e) if e.stale || e.generation < generation => {
                                 in_place = Some(std::ptr::from_mut::<DirEntry>(*e));
                             }
                             cached => return Ok(cached),
@@ -1360,16 +1360,35 @@ pub mod fs {
             })))
         }
 
-        /// Evicts `file_path` from the directory-entry cache; returns whether
-        /// an entry was removed.
+        /// Invalidates `file_path` in the directory-entry cache; returns
+        /// whether an entry was invalidated.
         pub fn bust_entries_cache(&mut self, file_path: &[u8]) -> bool {
-            // `entries` is the process-global
-            // BSSMap singleton and `remove` mutates it; callers (transpiler /
-            // hot-reloader / VM) reach this without `RESOLVER_MUTEX`, so take
-            // `entries_mutex` to satisfy `EntriesMap::inner`'s aliasing
-            // invariant. No caller already holds it (no re-entry from
+            // `entries` is the process-global BSSMap singleton; callers
+            // (transpiler / hot-reloader / VM) reach this without
+            // `RESOLVER_MUTEX`. `read_directory_with_iterator` and
+            // `dir_info_cached_maybe_log` hold `entries_mutex` while
+            // reading/overwriting slot contents, so taking it here keeps the
+            // tag check, the `.stale` write, and the `remove` fallback from
+            // racing an in-place overwrite (`EntriesMap::inner`'s aliasing
+            // invariant). No caller already holds it (no re-entry from
             // `read_directory`/`dir_info_cached_maybe_log`).
             let _g = self.entries_mutex.lock_guard();
+
+            // `BSSMap::remove()` only drops the hash→index mapping; the backing
+            // slot (and the heap `DirEntry` it points at) are orphaned, and the
+            // next lookup allocates a fresh slot + fresh `DirEntry`. That skips
+            // the `in_place` re-scan, so every bust leaked the `DirEntry`, its
+            // `EntryMap`, and grew `EntryStore`/`FilenameStore` by one entry per
+            // file in the directory.
+            //
+            // Instead, keep the slot and flag the `DirEntry` so the next read
+            // takes the `in_place` path and reuses all of those allocations.
+            if let Some(EntriesOption::Entries(entries)) = self.entries.get(file_path) {
+                entries.stale = true;
+                return true;
+            }
+            // `Err` slots and `NotFound` sentinels hold no `DirEntry`; fall back
+            // to dropping the key so the next read re-checks disk.
             self.entries.remove(file_path)
         }
 
@@ -1631,6 +1650,11 @@ pub mod fs {
             let result_ptr = std::ptr::from_mut::<EntriesOption>(self.entries.at_index(index)?);
             // SAFETY: BSSMap-owned slot; uniquely held under `entries_mutex`.
             if let EntriesOption::Entries(existing) = unsafe { &mut *result_ptr } {
+                // `DirEntry.stale` is deliberately not honored here: this serves the
+                // `DirInfo::get_entries*` accessors, and after a bust they keep their
+                // `DirInfo`'s listing (as they kept the orphaned one) until the next
+                // directory-level read (`read_directory_with_iterator`,
+                // `dir_info_cached_miss`, `dir_info_for_resolution`) refreshes it.
                 if existing.generation < generation {
                     let e_ptr: *mut DirEntry = std::ptr::from_mut::<DirEntry>(*existing);
                     // SAFETY: BSSMap-owned `DirEntry` (boxed/leaked into `EntriesOption`); `entries_mutex` held.
@@ -1655,9 +1679,15 @@ pub mod fs {
                     // SAFETY: see above — exclusive `&mut` on the prev map for the duration of `readdir`.
                     let prev = Some(unsafe { &mut (*e_ptr).data });
                     match self.readdir(false, prev, dir, generation, handle, ()) {
-                        Ok(new_entry) => {
+                        Ok(mut new_entry) => {
                             // SAFETY: see above.
                             unsafe { (*e_ptr).data.clear() };
+                            // `readdir(store_fd=false, …)` leaves `new_entry.fd = INVALID`;
+                            // carry over any previously-stored descriptor so callers that
+                            // cached it (e.g. `DirInfo::get_file_descriptor`) keep working
+                            // and the old handle isn't silently leaked.
+                            // SAFETY: see above.
+                            new_entry.fd = unsafe { (*e_ptr).fd };
                             // SAFETY: see above — slot is exclusively owned here.
                             unsafe { *e_ptr = new_entry };
                         }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3493,7 +3493,7 @@ impl<'a> Resolver<'a> {
 
         if let Some(cached_entry) = rfs!().entries.at_index(cached_dir_entry_result.index) {
             if let Fs::file_system::real_fs::EntriesOption::Entries(entries) = cached_entry {
-                if entries.generation >= self.generation {
+                if !entries.stale && entries.generation >= self.generation {
                     dir_entries_option = cached_entry;
                     needs_iter = false;
                 } else {
@@ -4562,7 +4562,7 @@ impl<'a> Resolver<'a> {
 
             if let Some(cached_entry) = rfs!().entries.at_index(cached_dir_entry_result.index) {
                 if let Fs::file_system::real_fs::EntriesOption::Entries(entries) = cached_entry {
-                    if entries.generation >= self.generation {
+                    if !entries.stale && entries.generation >= self.generation {
                         dir_entries_option = cached_entry;
                         needs_iter = false;
                     } else {

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -917,3 +917,71 @@ it("loads routes from a directory already cached by Bun.build()", async () => {
     signalCode: proc.signalCode,
   }).toEqual({ stdout: "/a /b /sub/c /b", stderr: "", exitCode: 0, signalCode: null });
 });
+
+// bust_entries_cache used to drop the BSSMap key, orphaning the backing slot
+// and the heap DirEntry it pointed at. The next lookup then allocated a fresh
+// slot + DirEntry, skipping the in_place reuse — so every reload() leaked one
+// DirEntry + EntryMap per directory and appended N Entry/FilenameStore slots
+// per directory entry, unbounded.
+it("reload() should not leak directory entry caches", async () => {
+  // The DirEntry/EntryStore/FilenameStore leak scales with the number of
+  // directory entries seen by readdir — not with the number of routes — so
+  // most files deliberately do NOT match `fileExtensions`. That keeps the
+  // route count (and any unrelated per-route/reload overhead) small while the
+  // directory-entry signal stays large. Long names push past the inline
+  // small-string limit so the old code had to hit FilenameStore on every
+  // re-read.
+  const files: Record<string, string> = {};
+  for (let d = 0; d < 4; d++) {
+    files[`directory_with_a_long_name_${d}/index.tsx`] = "export default 0;\n";
+    for (let f = 0; f < 100; f++) {
+      files[`directory_with_a_long_name_${d}/asset_with_a_long_file_name_number_${f}.txt`] = "x\n";
+    }
+  }
+  using dir = tempDir("fsrouter-reload-leak", files);
+
+  const script = /* js */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(String(dir))},
+      style: "nextjs",
+      fileExtensions: [".tsx"],
+    });
+
+    // Settle any one-time growth from the first few scans.
+    for (let i = 0; i < 20; i++) router.reload();
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+
+    for (let i = 0; i < 400; i++) router.reload();
+    Bun.gc(true);
+    const after = process.memoryUsage.rss();
+
+    console.log(JSON.stringify({
+      before,
+      after,
+      deltaKB: Math.round((after - before) / 1024),
+      routes: Object.keys(router.routes).length,
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", script],
+    // ASAN's quarantine retains freed allocations (default 256 MB) so the
+    // per-reload freed EntryMap/snapshot buffers inflate RSS under bun-asan.
+    // Disable it in the child so the RSS delta reflects retained allocations.
+    env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":") },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { deltaKB, routes } = JSON.parse(stdout.trim());
+  expect(routes).toBe(4);
+  // Before the fix this grew by ~100 MB over 400 reloads (4 DirEntries +
+  // ~400 Entry structs + ~800 FilenameStore strings orphaned per reload) and
+  // eventually aborted once the BSSMap/EntryStore overflow lists filled up.
+  // After, those allocations are reused in place and RSS is flat.
+  expect(deltaKB).toBeLessThan(32 * 1024);
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
## What

`RealFS::bust_entries_cache()` leaked a heap `DirEntry` (plus its `EntryMap`) per call and forced append-only growth of `EntryStore`/`FilenameStore`. Triggered on every HMR/watch file change and every `FileSystemRouter.reload()`.

## Repro

```js
const router = new Bun.FileSystemRouter({ dir, style: "nextjs", fileExtensions: [".tsx"] });
for (let i = 0; i < 500; i++) router.reload();
```

4 subdirs x 20 files grow RSS by tens of MB over 500 reloads and keep growing without bound.

## Cause

`BSSMap::remove()` only drops the hash to index mapping. The backing slot, and the `EntriesOption::Entries(&mut DirEntry)` it holds, stays behind, orphaned. On the next `get_or_put()` the key is gone, so `at_index()` returns `None`, `in_place = None`, and the read paths allocate a fresh `DirEntry` and consume a fresh `BSSMap` slot. The old `DirEntry` (with its `EntryMap`) is never freed, and because `prev_map` is `None`, every file in the directory gets a new `Entry` appended to `EntryStore` and (for long names) new strings appended to `FilenameStore`.

## Fix

Do not remove the key. Flag the existing `DirEntry` as `stale` and let the next locked directory read take the `in_place` path that already exists for the generation-bump case: it reuses the `DirEntry` allocation, passes the old `EntryMap` as `prev_map` so `Entry` structs and filename strings are reused, and writes back to the same `BSSMap` slot. `Err` / `NotFound` entries (no `DirEntry`) still fall back to `remove()`.

`stale` is honored only by the rebuild paths that run under `entries_mutex`:

- `RealFS::read_directory_with_iterator` (locks internally)
- `Resolver::dir_info_cached_miss` (already held the lock)
- `Resolver::dir_info_for_resolution` (now takes the lock like its sibling; its in-place rewrite previously ran unlocked)

It is deliberately ignored by `RealFS::entries_at`, the accessor behind `DirInfo::get_entries*`. Those readers run without `entries_mutex` (and on other threads), so rebuilding there would free the map out from under them. They keep seeing their `DirInfo`'s listing until the next locked read, which is exactly what they saw before this change, when the bust orphaned the slot they kept reading.

Because the orphaned slot was previously never written again (accidental RCU), callers that captured a `*DirEntry` and read its `EntryMap` across calls that can now trigger an in-place rewrite need explicit synchronization. The route-load and bust walks already snapshot the entry pointers under `entries_mutex` since #33056; the remaining one was the watcher thread:

- `hot_reloader::on_file_update`: hold `entries_mutex` around the `dir_ent.entries` reads, and bust after releasing the lock since `bust_entries_cache` takes it internally.
- `entries_at`: carry over the previous `DirEntry.fd` through a generation refresh so `DirInfo::get_file_descriptor` keeps working.

## Verification

| | RSS growth over 400 `reload()`s (4 dirs x ~100 entries) |
|---|---|
| before | ~65+ MB, eventually aborts when the BSSMap overflow list fills |
| after | ~17 MB |

`test/js/bun/util/filesystem_router.test.ts` passes, including the new leak regression test and the `reload() while Bun.build() resolves the same directory` race test from #33056. That test was load-bearing here: an earlier revision of this branch also honored `stale` in `entries_at`, and the test caught it as an AddressSanitizer heap-buffer-overflow (`RouteLoader::load` iterating an `EntryMap` that a bundler-thread `finalize_result` -> `get_entries_ref` -> `entries_at` rebuild had just freed, without the lock). With `entries_at` left read-only for `stale`, that run is 40/40 locally under ASAN.

## Rebase notes

- #33056 landed the snapshot-under-`entries_mutex` iteration for `RouteLoader::load` and `bust_dir_cache_recursive`, plus the per-entry `Entry.mutex` discipline. This PR no longer touches `src/router/lib.rs` or the bust walk.
- #34271 landed the `entries_at` locking fix this PR previously carried (self-locking `entries_at` with a `_locked` variant for callers already under `entries_mutex`, and `dir_info_for_resolution` now holds `entries_mutex` across its in-place rewrite). The redundant guard this PR had added there was removed on rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 38 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->