### PR TITLE
MessagePort: release jsRef() self-ref on context destruction

### DIFF
--- a/src/bun.js/bindings/webcore/MessagePort.cpp
+++ b/src/bun.js/bindings/webcore/MessagePort.cpp
@@ -113,6 +113,20 @@ void MessagePort::close()
     m_pipe->close(m_side);
 
     removeAllEventListeners();
+
+    // Release the self-reference taken by jsRef() (set when .onmessage is
+    // assigned or .ref() is called from JS). The JS .close() binding calls
+    // jsUnref() first, so m_hasRef is already false on that path; we only
+    // reach this branch when close() runs without a preceding jsUnref() —
+    // most importantly from contextDestroyed() during Worker teardown.
+    // Without this, the self-ref pins the MessagePort past the JS wrapper
+    // sweep and it leaks forever.
+    if (m_hasRef) {
+        m_hasRef = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
+        deref();
+    }
 }
 
 TransferredMessagePort MessagePort::disentangle()
@@ -124,6 +138,18 @@ TransferredMessagePort MessagePort::disentangle()
     // there would be nothing to unref.
     removeAllEventListeners();
     m_hasMessageEventListener = false;
+
+    // Release the self-reference taken by jsRef() on the sending side. After
+    // transfer this object is inert (the receiving side gets a fresh
+    // MessagePort for the same pipe endpoint) and is no longer a destruction
+    // observer, so nothing else will ever release a ref taken here.
+    // The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
+    if (m_hasRef) {
+        m_hasRef = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
+        deref();
+    }
 
     // Hand the pipe endpoint to its next owner. Messages that arrive while
     // in transit buffer in the pipe; the receiving context's entangle()
@@ -200,6 +226,12 @@ void MessagePort::dispatchEvent(Event& event)
 
 void MessagePort::contextDestroyed()
 {
+    // close() releases the jsRef() self-reference, which may be the last
+    // strong ref if the JS wrapper was already swept. Protect across the
+    // call so we can cleanly detach from the dying ScriptExecutionContext
+    // first — otherwise ~ContextDestructionObserver() would call back into
+    // it while it is mid-destruction.
+    Ref protectedThis { *this };
     close();
     ContextDestructionObserver::contextDestroyed();
 }
@@ -299,6 +331,13 @@ WebCoreOpaqueRoot root(MessagePort* port)
 
 void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
 {
+    // A closed or transferred-away port can never receive messages again, so
+    // taking a self-ref (and an event-loop ref) here would only leak:
+    // close()/disentangle() have already run and nothing will ever release a
+    // ref taken afterwards.
+    if (!isEntangled())
+        return;
+
     if (!m_hasRef) {
         m_hasRef = true;
         ref();

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// MessagePort::jsRef() takes a self-ref() on the C++ MessagePort (plus an
+// event-loop ref) when .onmessage is assigned or .ref() is called. The only
+// path that released it was an explicit .close()/.unref() from JS. When a
+// Worker (or any owning context) is torn down without that, contextDestroyed()
+// → close() ran but never dropped the self-ref, so every such MessagePort
+// leaked for the lifetime of the process — along with its entries in the
+// global allMessagePorts()/portToContextIdentifier() maps.
+//
+// Skipped on Windows: RSS there does not drop after worker threads exit (the
+// per-thread mimalloc arenas stay committed), so the allocator residue from
+// 11 workers alone exceeds the threshold regardless of whether ports leak.
+// The fix is platform-agnostic C++; Linux/macOS coverage is sufficient.
+test.skipIf(isWindows)(
+  "MessagePort self-ref is released when the owning context is destroyed",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const workerBody = ${JSON.stringify(`
+          const keep = [];
+          for (let i = 0; i < 8000; i++) {
+            const { port1, port2 } = new MessageChannel();
+            // Assigning onmessage calls MessagePort::jsRef() → self-ref().
+            port1.onmessage = () => {};
+            keep.push(port1, port2);
+          }
+          self.postMessage("ready");
+          // Intentionally never call port1.close()/port1.unref() — the
+          // terminate() from the parent is the only teardown path.
+        `)};
+        const url = "data:text/javascript," + encodeURIComponent(workerBody);
+
+        async function runWorker() {
+          const w = new Worker(url);
+          await new Promise(r => w.addEventListener("message", r, { once: true }));
+          w.terminate();
+          await new Promise(r => w.addEventListener("close", r, { once: true }));
+        }
+
+        // Warm up so the allocator high-water mark and per-thread caches are
+        // established before we start measuring.
+        for (let i = 0; i < 3; i++) await runWorker();
+        Bun.gc(true);
+        Bun.gc(true);
+
+        const rssBefore = process.memoryUsage().rss;
+        for (let i = 0; i < 8; i++) await runWorker();
+        Bun.gc(true);
+        Bun.gc(true);
+        const rssAfter = process.memoryUsage().rss;
+
+        const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
+        // 8 workers × 8000 ports: when leaking, each MessagePort plus its
+        // global-map bookkeeping is ~1 KB, so growth is ~60 MB. When fixed,
+        // growth is allocator noise (typically under 15 MB).
+        if (deltaMB > 30) {
+          console.error("LEAK: RSS grew " + deltaMB.toFixed(2) + " MB across 8 worker cycles");
+          process.exit(1);
+        }
+        console.log("PASS delta=" + deltaMB.toFixed(2) + "MB");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("PASS");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -6,8 +6,7 @@ import { bunEnv, bunExe, isWindows } from "harness";
 // path that released it was an explicit .close()/.unref() from JS. When a
 // Worker (or any owning context) is torn down without that, contextDestroyed()
 // → close() ran but never dropped the self-ref, so every such MessagePort
-// leaked for the lifetime of the process — along with its entries in the
-// global allMessagePorts()/portToContextIdentifier() maps.
+// leaked for the lifetime of the process.
 //
 // Skipped on Windows: RSS there does not drop after worker threads exit (the
 // per-thread mimalloc arenas stay committed), so the allocator residue from
@@ -56,7 +55,7 @@ test.skipIf(isWindows)(
 
         const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
         // 8 workers × 8000 ports: when leaking, each MessagePort plus its
-        // global-map bookkeeping is ~1 KB, so growth is ~60 MB. When fixed,
+        // pipe bookkeeping is ~1 KB, so growth is ~50 MB. When fixed,
         // growth is allocator noise (typically under 15 MB).
         if (deltaMB > 30) {
           console.error("LEAK: RSS grew " + deltaMB.toFixed(2) + " MB across 8 worker cycles");


### PR DESCRIPTION
## Problem

`MessagePort::jsRef()` (invoked when `port.onmessage = fn` is assigned or `port.ref()` is called) takes a self-`ref()` on the C++ `MessagePort` plus an event-loop ref. The only code path that released it was an explicit `.close()` / `.unref()` from JS — `jsUnref()` is called from the JS binding *before* `close()`.

When a Worker (or any owning context) is torn down without that explicit call, `contextDestroyed()` → `close()` runs but never drops the self-ref. The C++ `MessagePort` outlives the JS wrapper sweep and leaks for the lifetime of the process, along with its entries in the global `allMessagePorts()` / `portToContextIdentifier()` maps.

## Repro

```js
// Each worker creates ports with onmessage, then is terminated without
// closing them. Every such port leaks ~1 KB.
const body = `
  const keep = [];
  for (let i = 0; i < 8000; i++) {
    const { port1, port2 } = new MessageChannel();
    port1.onmessage = () => {};           // jsRef() → self-ref()
    keep.push(port1, port2);
  }
  self.postMessage("ready");
`;
for (let i = 0; i < 11; i++) {
  const w = new Worker("data:text/javascript," + encodeURIComponent(body));
  await new Promise(r => w.addEventListener("message", r, { once: true }));
  w.terminate();
  await new Promise(r => w.addEventListener("close", r, { once: true }));
}
// RSS grows ~60–90 MB over the 8 measured cycles.
```

## Fix

- `MessagePort::close()` now releases the `m_hasRef` self-reference (and the matching event-loop ref) if it's still held. The JS `.close()` path already clears `m_hasRef` via `jsUnref()` first, so this only fires for non-JS callers — most importantly `contextDestroyed()`.
- `MessagePort::contextDestroyed()` now holds a `Ref protectedThis` across `close()` and then explicitly detaches from the dying `ScriptExecutionContext` (`destroyedMessagePort` + base `contextDestroyed()`). This ensures that if the released self-ref was the last strong ref, `~MessagePort()` / `~ContextDestructionObserver()` don't call back into the context mid-destruction.

## Verification

`bun bd test test/js/web/workers/message-port-context-destroy-leak.test.ts`

| | RSS growth over 8 worker cycles |
|---|---|
| before | ~82–87 MB |
| after | ~10 MB |

Existing `message-channel.test.ts` and `test-worker-message-port-transfer-terminate.js` pass unchanged.