### PR TITLE
webcore: break Performance ↔ PerformanceObserver ref cycle on global teardown

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -979,6 +979,18 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, WebCore::Scri
 
 GlobalObject::~GlobalObject()
 {
+    // Break the Performance <-> PerformanceObserver reference cycle before the
+    // ScriptExecutionContext is torn down. Performance holds RefPtr<PerformanceObserver>
+    // in its registered-observer list and each PerformanceObserver holds RefPtr<Performance>,
+    // so neither is released unless the cycle is explicitly broken. WebKit does this from
+    // WorkerGlobalScope / LocalDOMWindow on removeAllEventListeners(); Bun has no equivalent
+    // hook, so this is the last point where the context is still fully alive. Doing it in
+    // Performance::contextDestroyed() instead is too late: dropping the last observer ref
+    // there cascades into ~ContextDestructionObserver() unregistering from the context while
+    // the context is already iterating observers in its own destructor.
+    if (m_performance)
+        m_performance->removeAllObservers();
+
     if (auto* ctx = scriptExecutionContext()) {
         ctx->removeFromContextsMap();
         ctx->deref();

--- a/test/js/web/workers/performance-observer-leak.test.ts
+++ b/test/js/web/workers/performance-observer-leak.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Performance <-> PerformanceObserver RefPtr cycle: Performance holds
+// RefPtr<PerformanceObserver> in its registered-observer list, and each
+// PerformanceObserver holds RefPtr<Performance>. When a Worker terminates
+// without the observer calling .disconnect(), the cycle keeps both objects
+// (and everything Performance owns, including the user-timing buffer) alive
+// past the global's destruction.
+test("PerformanceObserver without disconnect() does not leak Performance when Worker terminates", async () => {
+  using dir = tempDir("perf-observer-leak", {
+    "worker.js": `
+      const observer = new PerformanceObserver(() => {});
+      // Observe a type that won't match the mark below so no delivery task is
+      // posted (that task captures its own Ref<Performance> and would confound
+      // the measurement). The observer is still registered with Performance,
+      // creating the Performance <-> PerformanceObserver ref cycle.
+      observer.observe({ entryTypes: ["measure"] });
+      // Store a ~4 MB mark in Performance's user-timing buffer so the cycle's
+      // retained memory is visible in RSS. It is released only when the
+      // Performance object itself is freed.
+      performance.mark("m", { detail: new Uint8Array(4 * 1024 * 1024).fill(1) });
+      postMessage("ready");
+      // Intentionally never call observer.disconnect().
+    `,
+    "main.js": `
+      const workerPath = new URL("./worker.js", import.meta.url).href;
+
+      async function runOne() {
+        const w = new Worker(workerPath);
+        await new Promise((resolve, reject) => {
+          w.onmessage = resolve;
+          w.onerror = reject;
+        });
+        await w.terminate();
+      }
+
+      async function runBatch(n) {
+        for (let i = 0; i < n; i++) await runOne();
+        Bun.gc(true);
+        Bun.gc(true);
+      }
+
+      // Warm up: establish allocator / JIT high-water mark.
+      await runBatch(8);
+      const rssBefore = process.memoryUsage.rss();
+
+      // Measured batch: if each worker leaks ~4 MB via the Performance <->
+      // PerformanceObserver cycle, 20 iterations leak ~80 MB over baseline.
+      await runBatch(20);
+      const rssAfter = process.memoryUsage.rss();
+
+      const deltaMB = (rssAfter - rssBefore) / 1024 / 1024;
+      // Without fix: ~110+ MB (baseline ~30 MB + 20 * 4 MB leaked).
+      // With fix: ~30 MB (just baseline worker/VM churn).
+      if (deltaMB > 65) {
+        console.error("FAIL: RSS grew by " + deltaMB.toFixed(1) + " MB over 20 worker terminations");
+        process.exit(1);
+      }
+      console.log("PASS: RSS delta " + deltaMB.toFixed(1) + " MB");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("PASS");
+  expect(exitCode).toBe(0);
+}, 120_000);


### PR DESCRIPTION
## Problem

`Performance` holds `RefPtr<PerformanceObserver>` in `m_observers` (its registered-observer list), and each `PerformanceObserver` holds `RefPtr<Performance>` in `m_performance`. When a Worker terminates with an observer still registered — i.e. the user never called `.disconnect()` — neither object is released, leaking the `Performance` instance along with everything it owns (user-timing buffer, etc).

`Performance::removeAllObservers()` exists specifically to break this cycle, but nothing in Bun ever called it.

## Repro

```js
// worker.js
new PerformanceObserver(() => {}).observe({ entryTypes: ["mark"] });
postMessage("ready");
// never calls .disconnect()

// main.js
for (let i = 0; i < 5; i++) {
  const w = new Worker("./worker.js");
  await new Promise(r => w.onmessage = r);
  await w.terminate();
}
```

On a release build this segfaults on the second iteration (the leaked objects outlive their VM and are accessed during the next teardown). On debug, each worker's `Performance` instance is simply never freed.

## Fix

Call `m_performance->removeAllObservers()` in `~GlobalObject()` before the `ScriptExecutionContext` is deref'd. This mirrors WebKit, where `WorkerGlobalScope` / `LocalDOMWindow` call `removeAllObservers()` during `removeAllEventListeners()`; Bun has no equivalent hook, so the global destructor is the last point where the context is still fully alive.

Calling it from `Performance::contextDestroyed()` instead is too late: dropping the last observer ref there cascades into `~JSPerformanceObserverCallback()` → `~ContextDestructionObserver()`, which tries to unregister from the `ScriptExecutionContext` while that context is already inside its own destructor iterating observers, tripping `ASSERT(!m_inScriptExecutionContextDestructor)`.

## Verification

New test spawns 28 workers that each register an observer, store a 4 MB mark in `performance`'s user-timing buffer, and get terminated without `.disconnect()`. RSS of the second batch of 20 is compared against a warm baseline.

| | RSS delta (20 workers) | `~Performance()` runs |
|---|---|---|
| before | ~110 MB | 0 / N |
| after | ~28 MB | N / N |

- `USE_SYSTEM_BUN=1 bun test` → segfault (fail)
- `bun bd test` without src/ change → `RSS grew by 109.3 MB` (fail)
- `bun bd test` with fix → pass (×3)