### PR TITLE
resolver: reuse BSSMap slots and PackageJSON/TSConfigJSON on bustDirCache

### DIFF
--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -617,8 +617,11 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             self.mutex.lock();
             defer self.mutex.unlock();
 
+            // Leave any reclaimable slot in place: getOrPut early-returns on
+            // NotFound before consulting reclaimable, so keeping the entry lets
+            // a delete→recreate→bust cycle reuse the original slot instead of
+            // permanently orphaning it.
             self.index.put(self.allocator, result.hash, NotFound) catch unreachable;
-            _ = self.reclaimable.remove(result.hash);
         }
 
         pub fn atIndex(self: *Self, index: IndexType) ?*ValueType {

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -61,7 +61,10 @@ pub const Result = struct {
     status: ItemStatus,
 
     pub fn hasCheckedIfExists(r: *const Result) bool {
-        return r.index.index != Unassigned.index;
+        // A reclaimed slot (status == .unknown but index is a real slot) must be
+        // treated as "never looked up" so callers re-resolve instead of returning
+        // stale data. See BSSMap.remove / BSSMap.getOrPut.
+        return r.status != .unknown;
     }
 
     pub fn isOverflowing(r: *const Result, comptime count: usize) bool {
@@ -526,6 +529,11 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
         mutex: Mutex = .{},
         backing_buf: [count]ValueType,
         backing_buf_used: u16,
+        /// Slots freed by `remove()` that can be reused by the next `put()` for
+        /// the same key. Without this, every remove+getOrPut+put cycle consumes
+        /// a fresh `backing_buf` slot (and eventually overflows to the heap),
+        /// leaking the old slot and whatever heap pointers it owned.
+        reclaimable: std.AutoHashMapUnmanaged(HashKeyType, IndexType),
 
         pub var instance: *Self = undefined;
 
@@ -542,6 +550,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
                 instance.overflow_list.zero();
                 instance.backing_buf_used = 0;
                 instance.mutex = .{};
+                instance.reclaimable = .{};
                 loaded = true;
             }
 
@@ -550,6 +559,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
 
         pub fn deinit(self: *Self) void {
             self.index.deinit(self.allocator);
+            self.reclaimable.deinit(self.allocator);
             bun.default_allocator.destroy(instance);
             loaded = false;
         }
@@ -567,17 +577,25 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             const index = try self.index.getOrPut(self.allocator, _key);
 
             if (index.found_existing) {
+                switch (index.value_ptr.index) {
+                    NotFound.index => return Result{ .hash = _key, .index = index.value_ptr.*, .status = .not_found },
+                    Unassigned.index => {},
+                    else => return Result{ .hash = _key, .index = index.value_ptr.*, .status = .exists },
+                }
+            } else {
+                index.value_ptr.* = Unassigned;
+            }
+
+            // status is .unknown — if this key previously had a real slot that was
+            // invalidated via remove(), hand it back so put() overwrites in place
+            // instead of burning a fresh slot.
+            if (self.reclaimable.get(_key)) |slot| {
                 return Result{
                     .hash = _key,
-                    .index = index.value_ptr.*,
-                    .status = switch (index.value_ptr.index) {
-                        NotFound.index => .not_found,
-                        Unassigned.index => .unknown,
-                        else => .exists,
-                    },
+                    .index = slot,
+                    .status = .unknown,
                 };
             }
-            index.value_ptr.* = Unassigned;
 
             return Result{
                 .hash = _key,
@@ -600,6 +618,7 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             defer self.mutex.unlock();
 
             self.index.put(self.allocator, result.hash, NotFound) catch unreachable;
+            _ = self.reclaimable.remove(result.hash);
         }
 
         pub fn atIndex(self: *Self, index: IndexType) ?*ValueType {
@@ -626,6 +645,8 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
                 }
             }
 
+            _ = self.reclaimable.remove(result.hash);
+
             try self.index.put(self.allocator, result.hash, result.index);
 
             if (result.index.is_overflow) {
@@ -643,7 +664,15 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             }
         }
 
-        /// Returns true if the entry was removed
+        /// Invalidate the cache entry for `key` so the next `getOrPut` returns
+        /// `.unknown`. The backing slot (and its value) is preserved in
+        /// `reclaimable` so the next `put()` for the same key overwrites it in
+        /// place instead of consuming a fresh slot. We do not `deinit()` the
+        /// value here because other cache entries may still hold raw pointers
+        /// into it (e.g. DirInfo.enclosing_package_json references a parent
+        /// directory's PackageJSON).
+        ///
+        /// Returns true if the entry was removed.
         pub fn remove(self: *Self, denormalized_key: []const u8) bool {
             self.mutex.lock();
             defer self.mutex.unlock();
@@ -654,28 +683,11 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
                 denormalized_key;
 
             const _key = bun.hash(key);
-            return self.index.remove(_key);
-            // const index = self.index.get(_key) orelse return;
-            // switch (index) {
-            //     Unassigned.index, NotFound.index => {
-            //         self.index.remove(_key);
-            //     },
-            //     0...max_index => {
-            //         if (comptime hasDeinit(ValueType)) {
-            //             instance.backing_buf[index].deinit();
-            //         }
-
-            //         instance.backing_buf[index] = undefined;
-            //     },
-            //     else => {
-            //         const i = index - count;
-            //         if (hasDeinit(ValueType)) {
-            //             self.overflow_list.items[i].deinit();
-            //         }
-            //         self.overflow_list.items[index - count] = undefined;
-            //     },
-            // }
-
+            const kv = self.index.fetchRemove(_key) orelse return false;
+            if (kv.value.index != NotFound.index and kv.value.index != Unassigned.index) {
+                self.reclaimable.put(self.allocator, _key, kv.value) catch {};
+            }
+            return true;
         }
 
         pub fn values(self: *Self) []ValueType {

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -697,6 +697,10 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             const _key = bun.hash(key);
             const kv = self.index.fetchRemove(_key) orelse return false;
             if (kv.value.index != NotFound.index and kv.value.index != Unassigned.index) {
+                // Best-effort: if we can't stash the hint, degrade to the
+                // pre-reclaim behavior (leak one slot) rather than crash
+                // mid–cache-bust. Unlike index.put in markNotFound above,
+                // this is a leak-reduction hint, not load-bearing state.
                 self.reclaimable.put(self.allocator, _key, kv.value) catch {};
             }
             return true;

--- a/src/bun_alloc/bun_alloc.zig
+++ b/src/bun_alloc/bun_alloc.zig
@@ -638,17 +638,26 @@ pub fn BSSMap(comptime ValueType: type, comptime count: anytype, comptime store_
             self.mutex.lock();
             defer self.mutex.unlock();
 
+            // Consume any parked slot for this key up front. If the caller's
+            // result came from getOrPut() it already carries the reclaimed
+            // index, but getOrPut() early-returns on NotFound without
+            // consulting reclaimable — so a put() after markNotFound() would
+            // otherwise burn a fresh slot while the parked one is discarded.
+            const reclaimed = self.reclaimable.fetchRemove(result.hash);
+
             if (result.index.index == NotFound.index or result.index.index == Unassigned.index) {
-                result.index.is_overflow = instance.backing_buf_used > max_index;
-                if (result.index.is_overflow) {
-                    result.index.index = self.overflow_list.len();
+                if (reclaimed) |kv| {
+                    result.index = kv.value;
                 } else {
-                    result.index.index = instance.backing_buf_used;
-                    instance.backing_buf_used += 1;
+                    result.index.is_overflow = instance.backing_buf_used > max_index;
+                    if (result.index.is_overflow) {
+                        result.index.index = self.overflow_list.len();
+                    } else {
+                        result.index.index = instance.backing_buf_used;
+                        instance.backing_buf_used += 1;
+                    }
                 }
             }
-
-            _ = self.reclaimable.remove(result.hash);
 
             try self.index.put(self.allocator, result.hash, result.index);
 

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3084,6 +3084,14 @@ pub const Resolver = struct {
             // its heap-allocated PackageJSON / TSConfigJSON instead of leaking
             // them. atIndex() returns null for Unassigned/NotFound, so this is a
             // no-op on first population.
+            //
+            // Note: if the file was deleted (or fails to parse) between busts,
+            // dirInfoUncached never consumes these and the allocations are
+            // orphaned. That's a one-off leak per delete event, not per save;
+            // freeing here would UAF through child DirInfo.enclosing_* aliases,
+            // and parking the pointer back on the new DirInfo would make the
+            // resolver think the file still exists. Accepting the bounded leak
+            // is the conservative choice.
             var reuse_package_json: ?*PackageJSON = null;
             var reuse_tsconfig_json: ?*TSConfigJSON = null;
             if (r.dir_cache.atIndex(queue_top.result.index)) |prev| {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2728,9 +2728,14 @@ pub const Resolver = struct {
             switch (prev.side_effects) {
                 .unspecified, .false => {},
                 .map => |*m| m.deinit(alloc),
-                .glob => |*g| g.deinit(alloc),
+                .glob => |*g| {
+                    // Each pattern is separately duped by normalizePathForGlob.
+                    for (g.items) |s| alloc.free(s);
+                    g.deinit(alloc);
+                },
                 .mixed => |*m| {
                     m.exact.deinit(alloc);
+                    for (m.globs.items) |s| alloc.free(s);
                     m.globs.deinit(alloc);
                 },
             }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2705,6 +2705,31 @@ pub const Resolver = struct {
         }
 
         if (reuse) |prev| {
+            // Release the previous value's owned heap before overwriting so
+            // each hot-reload doesn't leak the prior file text and map backing
+            // arrays. StringMap.put() dupes values, so main_fields/browser_map
+            // own their value strings; name/version are explicitly duped in
+            // PackageJSON.parse(); dependencies.source_buf aliases
+            // source.contents so is covered by that free. exports/imports tree
+            // nodes and scripts/config are left alone — there is no recursive
+            // deinit for ExportsMap yet and they are uncommon compared to the
+            // per-reload file-contents leak this is primarily closing.
+            const alloc = bun.default_allocator;
+            if (prev.source.contents.len > 0) alloc.free(prev.source.contents);
+            if (prev.name.len > 0) alloc.free(prev.name);
+            if (prev.version.len > 0) alloc.free(prev.version);
+            prev.main_fields.deinit();
+            prev.browser_map.deinit();
+            prev.dependencies.map.deinit(alloc);
+            switch (prev.side_effects) {
+                .unspecified, .false => {},
+                .map => |*m| m.deinit(alloc),
+                .glob => |*g| g.deinit(alloc),
+                .mixed => |*m| {
+                    m.exact.deinit(alloc);
+                    m.globs.deinit(alloc);
+                },
+            }
             prev.* = pkg;
             return prev;
         }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2272,7 +2272,10 @@ pub const Resolver = struct {
 
         if (rfs.entries.atIndex(cached_dir_entry_result.index)) |cached_entry| {
             if (cached_entry.* == .entries) {
-                if (cached_entry.entries.generation >= r.generation) {
+                // A reclaimed slot (status == .unknown) was busted — its data is
+                // stale regardless of generation, but the DirEntry allocation can
+                // still be reused in place.
+                if (cached_dir_entry_result.status == .exists and cached_entry.entries.generation >= r.generation) {
                     dir_entries_option = cached_entry;
                     needs_iter = false;
                 } else {
@@ -2316,6 +2319,13 @@ pub const Resolver = struct {
             }) catch unreachable;
         }
 
+        var reuse_package_json: ?*PackageJSON = null;
+        var reuse_tsconfig_json: ?*TSConfigJSON = null;
+        if (r.dir_cache.atIndex(dir_cache_info_result.index)) |prev| {
+            reuse_package_json = prev.package_json;
+            reuse_tsconfig_json = prev.tsconfig_json;
+        }
+
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
         const dir_info_ptr = r.dir_cache.put(&dir_cache_info_result, .{}) catch unreachable;
@@ -2336,6 +2346,8 @@ pub const Resolver = struct {
             allocators.NotFound,
             open_dir,
             package_id,
+            reuse_package_json,
+            reuse_tsconfig_json,
         );
         return dir_info_ptr;
     }
@@ -2601,6 +2613,11 @@ pub const Resolver = struct {
         r: *ThisResolver,
         file: string,
         dirname_fd: FD,
+        /// When re-reading a directory whose cache was busted, pass the
+        /// previous heap allocation so we overwrite it in place instead of
+        /// leaking it. Child DirInfo.enclosing_tsconfig_json pointers keep
+        /// working because the address is preserved.
+        reuse: ?*TSConfigJSON,
     ) !?*TSConfigJSON {
         // Since tsconfig.json is cached permanently, in our DirEntries cache
         // we must use the global allocator
@@ -2639,6 +2656,13 @@ pub const Resolver = struct {
             result.base_url_for_paths = r.fs.dirname_store.append(string, r.fs.absBuf(&paths, bufs(.tsconfig_base_url))) catch unreachable;
         }
 
+        if (reuse) |prev| {
+            prev.paths.deinit();
+            prev.* = result.*;
+            bun.destroy(result);
+            return prev;
+        }
+
         return result;
     }
 
@@ -2652,6 +2676,11 @@ pub const Resolver = struct {
         file: string,
         dirname_fd: FD,
         package_id: ?Install.PackageID,
+        /// When re-reading a directory whose cache was busted, pass the
+        /// previous heap allocation so we overwrite it in place instead of
+        /// leaking it. Child DirInfo.enclosing_package_json pointers keep
+        /// working because the address is preserved.
+        reuse: ?*PackageJSON,
         comptime allow_dependencies: bool,
     ) !?*PackageJSON {
         var pkg: PackageJSON = undefined;
@@ -2673,6 +2702,11 @@ pub const Resolver = struct {
                 .include_scripts,
                 if (allow_dependencies) .local else .none,
             ) orelse return null;
+        }
+
+        if (reuse) |prev| {
+            prev.* = pkg;
+            return prev;
         }
 
         return PackageJSON.new(pkg);
@@ -2980,7 +3014,10 @@ pub const Resolver = struct {
 
             if (rfs.entries.atIndex(cached_dir_entry_result.index)) |cached_entry| {
                 if (cached_entry.* == .entries) {
-                    if (cached_entry.entries.generation >= r.generation) {
+                    // A reclaimed slot (status == .unknown) was busted — its data is
+                    // stale regardless of generation, but the DirEntry allocation can
+                    // still be reused in place.
+                    if (cached_dir_entry_result.status == .exists and cached_entry.entries.generation >= r.generation) {
                         dir_entries_option = cached_entry;
                         needs_iter = false;
                     } else {
@@ -3018,6 +3055,17 @@ pub const Resolver = struct {
                 bun.fs.debug("readdir({f}, {s}) = {d}", .{ open_dir, dir_path, dir_entries_ptr.data.count() });
             }
 
+            // If this key previously had a slot (busted via bustDirCache), reuse
+            // its heap-allocated PackageJSON / TSConfigJSON instead of leaking
+            // them. atIndex() returns null for Unassigned/NotFound, so this is a
+            // no-op on first population.
+            var reuse_package_json: ?*PackageJSON = null;
+            var reuse_tsconfig_json: ?*TSConfigJSON = null;
+            if (r.dir_cache.atIndex(queue_top.result.index)) |prev| {
+                reuse_package_json = prev.package_json;
+                reuse_tsconfig_json = prev.tsconfig_json;
+            }
+
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
             const dir_info_ptr = try r.dir_cache.put(&queue_top.result, DirInfo{});
@@ -3032,6 +3080,8 @@ pub const Resolver = struct {
                 top_parent.index,
                 open_dir,
                 null,
+                reuse_package_json,
+                reuse_tsconfig_json,
             );
 
             if (queue_slice.len == 0) {
@@ -3998,6 +4048,10 @@ pub const Resolver = struct {
         parent_index: allocators.IndexType,
         fd: FileDescriptorType,
         package_id: ?Install.PackageID,
+        /// Previous heap allocations to overwrite in place when re-populating
+        /// a DirInfo slot after bustDirCache(). Null on first population.
+        reuse_package_json: ?*PackageJSON,
+        reuse_tsconfig_json: ?*TSConfigJSON,
     ) anyerror!void {
         const result = _result;
 
@@ -4152,9 +4206,9 @@ pub const Resolver = struct {
                 const entry = lookup.entry;
                 if (entry.kind(rfs, r.store_fd) == .file) {
                     info.package_json = if (r.usePackageManager() and !info.hasNodeModules() and !info.isNodeModules())
-                        r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .invalid, package_id, true) catch null
+                        r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .invalid, package_id, reuse_package_json, true) catch null
                     else
-                        r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .invalid, null, false) catch null;
+                        r.parsePackageJSON(path, if (FeatureFlags.store_file_descriptors) fd else .invalid, null, reuse_package_json, false) catch null;
 
                     if (info.package_json) |pkg| {
                         if (pkg.browser_map.count() > 0) {
@@ -4207,6 +4261,7 @@ pub const Resolver = struct {
                 info.tsconfig_json = r.parseTSConfig(
                     tsconfigpath,
                     if (FeatureFlags.store_file_descriptors) fd else .zero,
+                    reuse_tsconfig_json,
                 ) catch |err| brk: {
                     const pretty = tsconfigpath;
                     if (err == error.ENOENT or err == error.FileNotFound) {
@@ -4223,7 +4278,7 @@ pub const Resolver = struct {
                     while (current.extends.len > 0) {
                         const ts_dir_name = Dirname.dirname(current.abs_path);
                         const abs_path = ResolvePath.joinAbsStringBuf(ts_dir_name, bufs(.tsconfig_path_abs), &[_]string{ ts_dir_name, current.extends }, .auto);
-                        const parent_config_maybe = r.parseTSConfig(abs_path, bun.invalid_fd) catch |err| {
+                        const parent_config_maybe = r.parseTSConfig(abs_path, bun.invalid_fd, null) catch |err| {
                             r.log.addDebugFmt(null, logger.Loc.Empty, r.allocator, "{s} loading tsconfig.json extends {f}", .{
                                 @errorName(err),
                                 bun.fmt.QuotedFormatter{

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2723,6 +2723,10 @@ pub const Resolver = struct {
             if (prev.name.len > 0) alloc.free(prev.name);
             if (prev.version.len > 0) alloc.free(prev.version);
             prev.main_fields.deinit();
+            // browser_map has dupe_keys=false but its keys are caller-duped
+            // via allocator.dupe(u8, fs.normalize(...)) in PackageJSON.parse;
+            // main_fields keys are static slices from r.opts.main_fields.
+            for (prev.browser_map.map.keys()) |k| alloc.free(k);
             prev.browser_map.deinit();
             prev.dependencies.map.deinit(alloc);
             switch (prev.side_effects) {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2657,6 +2657,10 @@ pub const Resolver = struct {
         }
 
         if (reuse) |prev| {
+            // Each value is a []string slice separately heap-allocated in
+            // TSConfigJSON.parse(); free them before the map backing itself
+            // (matches the extends-merge cleanup in dirInfoUncached).
+            for (prev.paths.values()) |v| bun.default_allocator.free(v);
             prev.paths.deinit();
             prev.* = result.*;
             bun.destroy(result);
@@ -4372,7 +4376,24 @@ pub const Resolver = struct {
                         // without this, every intermediate config in an extends chain leaks on
                         // each dirInfoUncached() call, which is especially bad under HMR where
                         // bustDirCache triggers a re-parse of the whole chain on every reload.
-                        bun.destroy(parent_config);
+                        //
+                        // Exception: the reused allocation must survive because child
+                        // DirInfos that weren't busted still alias it via
+                        // enclosing_tsconfig_json. It's handled below instead.
+                        if (parent_config != reuse_tsconfig_json) {
+                            bun.destroy(parent_config);
+                        }
+                    }
+                    // Preserve the reused allocation's address: if the merged
+                    // result landed in a fresh base-config allocation, move it
+                    // into the reused struct so child enclosing_tsconfig_json
+                    // pointers stay valid.
+                    if (reuse_tsconfig_json) |prev| {
+                        if (merged_config != prev) {
+                            prev.* = merged_config.*;
+                            bun.destroy(merged_config);
+                            merged_config = prev;
+                        }
                     }
                     info.tsconfig_json = merged_config;
                 }

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -2662,6 +2662,15 @@ pub const Resolver = struct {
             // (matches the extends-merge cleanup in dirInfoUncached).
             for (prev.paths.values()) |v| bun.default_allocator.free(v);
             prev.paths.deinit();
+            // jsx.factory/.fragment are heap []string from
+            // parseMemberExpressionForJSX when set in JSON; the defaults are
+            // static slices, so only free when jsx_flags records they were
+            // parsed. Remaining per-field allocations (jsx.import_source,
+            // the tsconfig file-text buffer) need a TSConfigJSON contents
+            // handle / centralized deinitOwnedFields() to close fully and
+            // are tracked as follow-ups alongside the ExportsMap gap.
+            if (prev.jsx_flags.contains(.factory)) bun.default_allocator.free(prev.jsx.factory);
+            if (prev.jsx_flags.contains(.fragment)) bun.default_allocator.free(prev.jsx.fragment);
             prev.* = result.*;
             bun.destroy(result);
             return prev;

--- a/test/js/bun/resolve/bust-dir-cache-leak.test.ts
+++ b/test/js/bun/resolve/bust-dir-cache-leak.test.ts
@@ -31,8 +31,8 @@ test("bustDirCache reuses DirInfo and EntriesOption slots across repeated reload
       });
       void router.routes;
 
-      const warmup = 200;
-      const iters = 4000;
+      const warmup = 50;
+      const iters = 1000;
 
       for (let i = 0; i < warmup; i++) router.reload();
       Bun.gc(true);
@@ -60,10 +60,13 @@ test("bustDirCache reuses DirInfo and EntriesOption slots across repeated reload
   expect(stderr).toBe("");
   const { perIter } = JSON.parse(stdout.trim().split("\n").at(-1)!);
   // Without slot reuse, each reload() of this 9-directory tree leaks roughly
-  // 14 KB/iteration in release (9 DirInfo + 9 EntriesOption structs in overflow
-  // blocks, plus DirnameStore duplicates). With the fix, slots are overwritten
-  // in place and growth drops to the low single-digit KB from unrelated
-  // dirname-store appends.
+  // 14 KB/iteration (9 DirInfo + 9 EntriesOption structs in overflow blocks,
+  // plus DirnameStore/FilenameStore duplicates). With the fix, slots are
+  // overwritten in place and growth drops to the low single-digit KB from
+  // unrelated dirname-store appends.
   expect(perIter).toBeLessThan(7 * 1024);
   expect(exitCode).toBe(0);
-});
+  // Spawning a debug+ASAN subprocess has several seconds of startup overhead
+  // before the reload loop even runs; the default 5s per-test budget isn't
+  // enough for that plus ~1s of iterations.
+}, 30_000);

--- a/test/js/bun/resolve/bust-dir-cache-leak.test.ts
+++ b/test/js/bun/resolve/bust-dir-cache-leak.test.ts
@@ -66,4 +66,4 @@ test("bustDirCache reuses DirInfo and EntriesOption slots across repeated reload
   // dirname-store appends.
   expect(perIter).toBeLessThan(7 * 1024);
   expect(exitCode).toBe(0);
-}, 60_000);
+});

--- a/test/js/bun/resolve/bust-dir-cache-leak.test.ts
+++ b/test/js/bun/resolve/bust-dir-cache-leak.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Resolver.bustDirCache() only dropped the hash→index mapping in BSSMap; the
+// backing DirInfo slot was orphaned (along with whatever heap pointers it
+// owned), and the next lookup of the same directory allocated a fresh slot.
+// Over a long --hot / --watch / FileSystemRouter.reload() session this grew
+// without bound — first exhausting the 2048-entry BSS backing_buf, then
+// spilling into heap overflow blocks forever. The fix reclaims the slot so
+// put() overwrites it in place.
+test("bustDirCache reuses DirInfo and EntriesOption slots across repeated reloads", async () => {
+  // A tree of route directories so each reload() busts and re-resolves many
+  // DirInfo + EntriesOption slots. FileSystemRouter.reload() calls
+  // bustDirCacheRecursive which readDirInfo()s every directory, busts it, then
+  // re-resolves from the root — exactly the bust/getOrPut/put cycle that used
+  // to burn a fresh backing_buf slot.
+  using dir = tempDir("bust-dir-cache-leak", {
+    "pages/index.tsx": "export default 1;",
+    "pages/a/index.tsx": "export default 1;",
+    "pages/a/n/index.tsx": "export default 1;",
+    "pages/b/index.tsx": "export default 1;",
+    "pages/b/n/index.tsx": "export default 1;",
+    "pages/c/index.tsx": "export default 1;",
+    "pages/c/n/index.tsx": "export default 1;",
+    "pages/d/index.tsx": "export default 1;",
+    "pages/d/n/index.tsx": "export default 1;",
+    "run.ts": `
+      const router = new Bun.FileSystemRouter({
+        dir: import.meta.dir + "/pages",
+        style: "nextjs",
+      });
+      void router.routes;
+
+      const warmup = 200;
+      const iters = 4000;
+
+      for (let i = 0; i < warmup; i++) router.reload();
+      Bun.gc(true);
+      const before = process.memoryUsage.rss();
+
+      for (let i = 0; i < iters; i++) router.reload();
+      Bun.gc(true);
+      const after = process.memoryUsage.rss();
+
+      const perIter = Math.round((after - before) / iters);
+      console.log(JSON.stringify({ perIter }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { perIter } = JSON.parse(stdout.trim().split("\n").at(-1)!);
+  // Without slot reuse, each reload() of this 9-directory tree leaks roughly
+  // 14 KB/iteration in release (9 DirInfo + 9 EntriesOption structs in overflow
+  // blocks, plus DirnameStore duplicates). With the fix, slots are overwritten
+  // in place and growth drops to the low single-digit KB from unrelated
+  // dirname-store appends.
+  expect(perIter).toBeLessThan(7 * 1024);
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## What

`Resolver.bustDirCache()` leaked one `DirInfo` BSSMap slot (and the heap-allocated `*PackageJSON` / `*TSConfigJSON` it owned) per call. Triggered on every file change in `--hot` / `--watch`, every DevServer hot-reload event, every `FileSystemRouter.reload()`, and the runtime ENOENT-retry path — so growth was unbounded over a dev session.

## Cause

`BSSMap.remove()` only does `self.index.remove(hash)`; the backing slot stays in `backing_buf` at its old index with live `*PackageJSON` / `*TSConfigJSON` pointers. The next `getOrPut()` for the same key finds nothing, returns `Unassigned`, and `put()` takes a **fresh** slot (`backing_buf_used += 1`). `dirInfoUncached()` then heap-allocates a brand-new `PackageJSON` / `TSConfigJSON`. The old slot and its heap objects are never reclaimed.

The same applies to the `EntriesOption` map (`bustEntriesCache` goes through the same `BSSMap.remove()`).

## Fix

* `BSSMap.remove()` now stashes the old slot in a per-key `reclaimable` map instead of dropping it on the floor.
* `getOrPut()` returns a reclaimed slot with `status = .unknown` so callers still re-resolve, but `put()` writes back to the **same** slot instead of incrementing `backing_buf_used`.
* Before overwriting a reclaimed `DirInfo`, the resolver captures the old `package_json` / `tsconfig_json` heap pointers and threads them through to `parsePackageJSON` / `parseTSConfig`, which overwrite the existing allocation in place rather than calling `.new()`. Child `DirInfo.enclosing_package_json` / `enclosing_tsconfig_json` pointers keep working because the address is preserved.
* The two `rfs.entries.atIndex(...)` checks in `resolver.zig` now gate on `status == .exists` so a reclaimed slot is treated as stale (re-iterate the directory, reuse the `DirEntry` via the `in_place` path) rather than returning the old listing.
* `hasCheckedIfExists()` now tests `status != .unknown` so a reclaimed-but-unresolved slot reads as "never looked up".

Because reclaim is **per-key** (not a generic free list), a directory always goes back to the slot it came from. Child `DirInfo.parent` indices therefore remain valid — this is the concern that #29919 raised when it skipped the `dir_cache` half of this leak.

## Verification

`FileSystemRouter.reload()` over a 9-directory tree, 4000 iterations:

| | per-iteration RSS growth |
|---|---|
| before | ~15 KB |
| after  | ~2 KB |

The residual is unrelated `DirnameStore` appends along the re-resolve path.

New test: `test/js/bun/resolve/bust-dir-cache-leak.test.ts`

Related: #29919 handles the `*DirEntry` / `EntryStore` side of the same bust cycle with a `stale` flag on `DirEntry`; this PR handles the `DirInfo` / `PackageJSON` / `TSConfigJSON` side at the `BSSMap` layer. They touch the same two generation checks in `resolver.zig` but are otherwise independent.