### PR TITLE
windows: flush all loaded CRTs then TerminateProcess on exit

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -1590,6 +1590,7 @@ pub fn reloadProcess(
     if (comptime Environment.isWindows) {
         // on windows we assume that we have a parent process that is monitoring us and will restart us if we exit with a magic exit code
         // see becomeWatcherManager
+        Global.Bun__flushAllCRTs();
         const rc = c.TerminateProcess(c.GetCurrentProcess(), windows.watcher_reload_exit);
         if (rc == 0) {
             const err = bun.windows.GetLastError();

--- a/src/bun_core/Global.zig
+++ b/src/bun_core/Global.zig
@@ -67,6 +67,12 @@ pub inline fn getStartTime() i128 {
 
 extern "kernel32" fn SetThreadDescription(thread: std.os.windows.HANDLE, name: [*:0]const u16) callconv(.winapi) std.os.windows.HRESULT;
 
+/// Flush stdio for every CRT instance loaded in the process (Bun's static /MT
+/// CRT plus any /MD ucrtbase/msvcrt brought in by native addons). Called before
+/// TerminateProcess, which otherwise skips the CRT teardown that would flush
+/// these. Defined in c-bindings.cpp.
+pub extern "c" fn Bun__flushAllCRTs() void;
+
 pub fn setThreadName(name: [:0]const u8) void {
     if (Environment.isLinux) {
         _ = std.posix.prctl(.SET_NAME, .{@intFromPtr(name.ptr)}) catch 0;
@@ -128,7 +134,22 @@ pub fn exit(code: u32) noreturn {
         .mac => std.c.exit(@bitCast(code)),
         .windows => {
             Bun__onExit();
-            std.os.windows.kernel32.ExitProcess(code);
+            // ExitProcess walks every loaded DLL's DLL_PROCESS_DETACH, which is
+            // both slow and a recurring source of crashes when third-party
+            // modules (native addons that statically link their own allocator,
+            // injected AV/overlay DLLs, etc.) fault during teardown.
+            // TerminateProcess skips all of that. The one thing we lose is the
+            // CRT-side stdio flush that DETACH would have done for dynamically-
+            // linked CRTs (ucrtbase/msvcrt) used by /MD-built native addons —
+            // Bun__flushAllCRTs() does that explicitly.
+            Bun__flushAllCRTs();
+            _ = std.os.windows.kernel32.TerminateProcess(
+                std.os.windows.kernel32.GetCurrentProcess(),
+                code,
+            );
+            // TerminateProcess on the current process should not return; if it
+            // somehow does, hang rather than fall through into UB.
+            while (true) std.atomic.spinLoopHint();
         },
         else => {
             if (Environment.enable_asan) {

--- a/src/bun_core/Global.zig
+++ b/src/bun_core/Global.zig
@@ -67,11 +67,15 @@ pub inline fn getStartTime() i128 {
 
 extern "kernel32" fn SetThreadDescription(thread: std.os.windows.HANDLE, name: [*:0]const u16) callconv(.winapi) std.os.windows.HRESULT;
 
-/// Flush stdio for every CRT instance loaded in the process (Bun's static /MT
-/// CRT plus any /MD ucrtbase/msvcrt brought in by native addons). Called before
-/// TerminateProcess, which otherwise skips the CRT teardown that would flush
-/// these. Defined in c-bindings.cpp.
+/// Flush stdio for every dynamically-linked CRT loaded in the process (Bun's
+/// own /MT CRT plus ucrtbase/msvcrt). Cannot reach /MT-linked .node addon CRTs.
+/// Defined in c-bindings.cpp.
 pub extern "c" fn Bun__flushAllCRTs() void;
+
+/// SEH-wrapped ExitProcess: runs DLL_PROCESS_DETACH for every module (so each
+/// /MT addon CRT flushes itself), falling through to TerminateProcess if any
+/// DETACH handler faults. Defined in c-bindings.cpp.
+pub extern "c" fn Bun__exitProcessWindows(code: u32) noreturn;
 
 pub fn setThreadName(name: [:0]const u8) void {
     if (Environment.isLinux) {
@@ -134,22 +138,32 @@ pub fn exit(code: u32) noreturn {
         .mac => std.c.exit(@bitCast(code)),
         .windows => {
             Bun__onExit();
-            // ExitProcess walks every loaded DLL's DLL_PROCESS_DETACH, which is
-            // both slow and a recurring source of crashes when third-party
-            // modules (native addons that statically link their own allocator,
-            // injected AV/overlay DLLs, etc.) fault during teardown.
-            // TerminateProcess skips all of that. The one thing we lose is the
-            // CRT-side stdio flush that DETACH would have done for dynamically-
-            // linked CRTs (ucrtbase/msvcrt) used by /MD-built native addons —
-            // Bun__flushAllCRTs() does that explicitly.
-            Bun__flushAllCRTs();
-            _ = std.os.windows.kernel32.TerminateProcess(
-                std.os.windows.kernel32.GetCurrentProcess(),
-                code,
-            );
-            // TerminateProcess on the current process should not return; if it
-            // somehow does, hang rather than fall through into UB.
-            while (true) std.atomic.spinLoopHint();
+            // Fast path: no native addon was dlopen'd. There are no foreign
+            // /MT CRTs with buffered stdio, so skip the DLL_PROCESS_DETACH
+            // walk entirely — it's both slow (every loaded system DLL) and a
+            // recurring source of crashes from injected AV/overlay DLLs.
+            // Bun__flushAllCRTs() still drains any dynamic CRT (ucrtbase) that
+            // got pulled in.
+            //
+            // Addon path: at least one .node was loaded. node-gyp builds /MT
+            // by default, so the addon has a private static CRT we cannot
+            // flush from outside; the only way its stdio reaches the pipe is
+            // its own DLL_PROCESS_DETACH. Take the ExitProcess path, but
+            // wrapped in SEH so a faulting DETACH (e.g. an addon bundling its
+            // own allocator) degrades to TerminateProcess with the right code
+            // instead of a crash. The dlopen already cost more than the few
+            // ms of DETACH this adds.
+            if (bun.analytics.Features.process_dlopen == 0) {
+                Bun__flushAllCRTs();
+                _ = std.os.windows.kernel32.TerminateProcess(
+                    std.os.windows.kernel32.GetCurrentProcess(),
+                    code,
+                );
+                // TerminateProcess on the current process should not return;
+                // if it somehow does, hang rather than fall through into UB.
+                while (true) std.atomic.spinLoopHint();
+            }
+            Bun__exitProcessWindows(code);
         },
         else => {
             if (Environment.enable_asan) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -487,7 +487,8 @@ extern "C" __declspec(noreturn) void Bun__exitProcessWindows(UINT code)
         TerminateProcess(GetCurrentProcess(), code);
     }
     // Neither call returns on the current process; satisfy noreturn.
-    for (;;) { }
+    for (;;) {
+    }
 }
 #endif
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -19,6 +19,7 @@
 #include <uv.h>
 #include <windows.h>
 #include <corecrt_io.h>
+#include <psapi.h>
 #endif // !OS(WINDOWS)
 #include <lshpack.h>
 
@@ -426,6 +427,38 @@ extern "C" ssize_t pwritev2(int fd, const struct iovec* iov, int iovcnt,
 #endif
 
 extern "C" void Bun__onExit();
+
+#if OS(WINDOWS)
+// Bun links the CRT statically (/MT) but native addons built with node-gyp use
+// /MD and get their stdio FILE* from ucrtbase.dll (or msvcrt.dll for older
+// toolchains). Those are separate stream tables; fflush/setvbuf from Bun's CRT
+// cannot reach them. ExitProcess used to flush them as a side effect of each
+// CRT's DLL_PROCESS_DETACH, but TerminateProcess skips that — so we do it
+// explicitly: walk every loaded module and call its _flushall if it exports one.
+//
+// GetModuleHandle/GetProcAddress/EnumProcessModules are loader-data reads and
+// safe to call here (no loader lock held; nothing has been detached yet).
+extern "C" void Bun__flushAllCRTs()
+{
+    // Our own static CRT first. stdout/stderr are _IONBF (set in
+    // bun_initialize_process) so this is normally a no-op, but cheap.
+    _flushall();
+
+    HMODULE mods[512];
+    DWORD needed = 0;
+    if (!EnumProcessModules(GetCurrentProcess(), mods, sizeof(mods), &needed)) {
+        return;
+    }
+    const DWORD count = needed / sizeof(HMODULE);
+    using flushall_t = int(__cdecl*)(void);
+    for (DWORD i = 0; i < count && i < (sizeof(mods) / sizeof(mods[0])); i++) {
+        if (auto fn = reinterpret_cast<flushall_t>(GetProcAddress(mods[i], "_flushall"))) {
+            fn();
+        }
+    }
+}
+#endif
+
 extern "C" int32_t bun_stdio_tty[3];
 #if !OS(WINDOWS)
 static termios termios_to_restore_later[3];

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -429,12 +429,16 @@ extern "C" ssize_t pwritev2(int fd, const struct iovec* iov, int iovcnt,
 extern "C" void Bun__onExit();
 
 #if OS(WINDOWS)
-// Bun links the CRT statically (/MT) but native addons built with node-gyp use
-// /MD and get their stdio FILE* from ucrtbase.dll (or msvcrt.dll for older
-// toolchains). Those are separate stream tables; fflush/setvbuf from Bun's CRT
-// cannot reach them. ExitProcess used to flush them as a side effect of each
-// CRT's DLL_PROCESS_DETACH, but TerminateProcess skips that — so we do it
-// explicitly: walk every loaded module and call its _flushall if it exports one.
+// Bun links the CRT statically (/MT). Any module that links a *dynamic* CRT
+// (ucrtbase.dll, msvcrt.dll — e.g. injected DLLs or /MD-built addons) has its
+// own stdio FILE* table that Bun's _flushall() cannot reach. Walk loaded
+// modules and call each exported _flushall so those streams drain before a
+// TerminateProcess.
+//
+// This does NOT cover node-gyp addons: common.gypi defaults to /MT, so each
+// .node carries its own static CRT whose _flushall is not exported and is
+// unreachable from here. Flushing those requires running the DLL's
+// DLL_PROCESS_DETACH — see Bun__exitProcessWindows.
 //
 // GetModuleHandle/GetProcAddress/EnumProcessModules are loader-data reads and
 // safe to call here (no loader lock held; nothing has been detached yet).
@@ -456,6 +460,34 @@ extern "C" void Bun__flushAllCRTs()
             fn();
         }
     }
+}
+
+// ExitProcess wrapped in SEH: try a normal exit (every loaded DLL — including
+// /MT-linked .node addons with private CRTs — runs DLL_PROCESS_DETACH and
+// flushes its own stdio). If a DETACH handler faults (e.g. a native addon
+// statically bundling its own allocator that crashes on teardown, or an
+// injected AV/overlay DLL), swallow the exception and hard-terminate with the
+// intended code instead of surfacing a crash dialog / wrong status.
+//
+// DETACH handlers run on this thread under the loader lock, so the __try frame
+// is live for the fault. After ExitProcess has begun all other threads are
+// already terminated and TerminateProcess does not need the loader lock, so
+// calling it from the filter is safe even with LDR state half-torn-down.
+//
+// Kept free of C++ objects so __try/__except is valid here under /EHsc.
+extern "C" __declspec(noreturn) void Bun__exitProcessWindows(UINT code)
+{
+    // Flush reachable dynamic CRTs first so that if a DETACH handler faults
+    // before they run, /MD output still made it out.
+    Bun__flushAllCRTs();
+
+    __try {
+        ExitProcess(code);
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        TerminateProcess(GetCurrentProcess(), code);
+    }
+    // Neither call returns on the current process; satisfy noreturn.
+    for (;;) { }
 }
 #endif
 


### PR DESCRIPTION
## What

Re-applies the `ExitProcess` → `TerminateProcess` switch from #27829 with a fix for the NAPI stdout regression that caused its revert.

`ExitProcess` walks `DLL_PROCESS_DETACH` for every loaded module. That's slow and a recurring crash source when third-party DLLs fault during teardown — native addons that statically link their own allocator (rspack's `@rspack/binding-win32-arm64-msvc` bundles mimalloc v3; skia-canvas), injected AV/overlay code, etc. `TerminateProcess` skips all of it.

## Why #27971's `fflush` isn't enough

Bun links the CRT statically (`/MT`, `cmake/CompilerFlags.cmake`). Native addons built with node-gyp link `/MD` against `ucrtbase.dll`. These are **separate CRT instances with separate `FILE*` stream tables** — `fflush(stdout)` from Bun's code touches Bun's static CRT only; addon `printf` output sitting in ucrtbase's buffer is unreachable. `ExitProcess` happened to flush it because ucrtbase's own `DLL_PROCESS_DETACH` does so.

## Fix

`Bun__flushAllCRTs()` walks every loaded module via `EnumProcessModules` and calls `_flushall` on any that export it. This reaches ucrtbase/ucrtbased/msvcrt and any other CRT a `.node` brings along, without running the rest of their DETACH teardown. Then `TerminateProcess`.

`GetModuleHandle`/`GetProcAddress`/`EnumProcessModules` are loader-data reads — safe at this point (no loader lock held, nothing detached).

## Coverage gap

Addons that statically link their *own* CRT (`/MT`) don't export `_flushall` and won't be reached. Rare for node-gyp output; would need a deliberate build config change.

Supersedes #27971.