### PR TITLE
deps: bump mimalloc to f15aecb9 (upstream dev3 sync)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "dbbb9a0819d00d521f9f58ad4d0a336efa4ce53a";
+const MIMALLOC_COMMIT = "f15aecb94fc8096008bf87b90c53ed682026914a";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -275,7 +275,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "0c5fce43b7ed5eb6001487ee48ac65766f5ddcd1",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "dbbb9a0819d00d521f9f58ad4d0a336efa4ce53a",
+    mimalloc: "f15aecb94fc8096008bf87b90c53ed682026914a",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "12882eee073cfe5c7621bcfadf679e1372d4537b",


### PR DESCRIPTION
Merges microsoft/mimalloc `dev3` through [`0c3fea0f`](https://github.com/microsoft/mimalloc/commits/0c3fea0f) into our fork.

## What changed upstream

| | |
|---|---|
| **free.c** | Reclaim abandoned pages up to `MI_MEDIUM_MAX_OBJ_SIZE` (was small-only). Should reduce fragmentation when mid-size allocs cross threads (HTTP server, Workers). |
| **init.c** | Early-return on `mi_tld_alloc()` failure instead of null-deref. |
| **os.c** | Align large allocations on large-OS-page boundary; fix decommit stat accounting. |
| **atomic.h** | MSVC C atomics: readonly loads + better ARM64 codegen. |
| **heap.c** | Fix `used` count in `mi_heap_visit_blocks`. |

Plus assorted stats-accounting fixes, output-buffer locking, and warning cleanups.

## Fork-side

One conflict in `arena.c` (whitespace vs our deferred `mi_bitmap_set` publish) — kept ours.

Builds clean with `MI_DEBUG_FULL=ON`, all 8 mimalloc tests pass on darwin-arm64.

mimalloc diff: https://github.com/oven-sh/mimalloc/compare/dbbb9a08...f15aecb9