### PR TITLE
http: surface the real Win32 error when the HTTP client thread fails to spawn

### DIFF
--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -205,14 +205,197 @@ fn initOnce(opts: *const InitOpts) void {
         .timer = std.time.Timer.start() catch unreachable,
     };
     bun.libdeflate.load();
-    const thread = std.Thread.spawn(
-        .{
-            .stack_size = bun.default_thread_stack_size,
-        },
-        onStart,
-        .{opts.*},
-    ) catch |err| Output.panic("Failed to start HTTP Client thread: {s}", .{@errorName(err)});
-    thread.detach();
+    spawnHttpClientThread(opts.*) catch |err| {
+        // Refs:
+        //   https://github.com/oven-sh/bun/issues/29933
+        //   https://github.com/oven-sh/bun/issues/24878
+        //   https://github.com/oven-sh/bun/issues/22080
+        //   https://github.com/oven-sh/bun/issues/19085
+        //   https://github.com/oven-sh/bun/issues/14424
+        //
+        // On Windows, `spawnHttpClientThread` captures the Win32 error at the
+        // `CreateThread` failure site so the panic message is actionable
+        // (ERROR_NOT_ENOUGH_MEMORY, ERROR_TOO_MANY_THREADS, etc.) instead of
+        // the bare "Unexpected" from std.Thread.spawn.
+        var buf: [256]u8 = undefined;
+        const win32_error_code: u16 = if (comptime Environment.isWindows)
+            @intFromEnum(last_http_thread_spawn_win32_error)
+        else
+            0;
+        const msg = formatSpawnFailurePanic(&buf, @errorName(err), win32_error_code, Environment.isWindows);
+        Output.panic("{s}", .{msg});
+    };
+}
+
+/// Format the panic message for a failed HTTP thread spawn. Pure — takes
+/// a scratch buffer, the Zig error name, the captured Win32 error code,
+/// and whether the caller is running on Windows (so the message is
+/// deterministic regardless of the host platform; callers in the real
+/// panic path pass `Environment.isWindows`).
+///
+/// On Windows the message includes the Win32 error code so crash reports
+/// for #29933 and friends are actionable (ERROR_NOT_ENOUGH_MEMORY,
+/// ERROR_TOO_MANY_THREADS, etc.) rather than the opaque "Unexpected"
+/// that std.Thread.spawn produces.
+///
+/// `win32_error_code` is ignored when `is_windows` is false. The buffer
+/// should be at least 128 bytes; if formatting overflows it, the static
+/// fallback string is returned directly (buf contents are not used).
+pub fn formatSpawnFailurePanic(buf: []u8, err_name: []const u8, win32_error_code: u16, is_windows: bool) []const u8 {
+    // If bufPrint overflows, return the static fallback string directly.
+    // Slicing `buf` itself would expose uninitialized stack memory.
+    const fallback = "Failed to start HTTP Client thread";
+    if (is_windows) {
+        return std.fmt.bufPrint(
+            buf,
+            "Failed to start HTTP Client thread: {s} (Win32 error 0x{x})",
+            .{ err_name, win32_error_code },
+        ) catch fallback;
+    }
+    return std.fmt.bufPrint(
+        buf,
+        "Failed to start HTTP Client thread: {s}",
+        .{err_name},
+    ) catch fallback;
+}
+
+pub const TestingAPIs = struct {
+    /// Exercises `formatSpawnFailurePanic` so tests can verify the
+    /// Windows panic message includes the Win32 error code captured by
+    /// `spawnHttpClientThread` (#29933). The formatter is pure so this
+    /// runs on any platform — the `is_windows` arg selects which branch
+    /// to render.
+    pub fn formatHttpThreadSpawnPanic(
+        globalThis: *bun.jsc.JSGlobalObject,
+        callframe: *bun.jsc.CallFrame,
+    ) bun.JSError!bun.jsc.JSValue {
+        const arguments = callframe.arguments();
+        if (arguments.len < 3 or !arguments[0].isString() or !arguments[1].isNumber() or !arguments[2].isBoolean()) {
+            return globalThis.throw("formatHttpThreadSpawnPanic: expected (err_name: string, win32_error_code: number, is_windows: boolean)", .{});
+        }
+        const err_name_str = try arguments[0].toBunString(globalThis);
+        defer err_name_str.deref();
+        const err_name_slice = err_name_str.toUTF8(bun.default_allocator);
+        defer err_name_slice.deinit();
+
+        const code_i32 = arguments[1].toInt32();
+        const code: u16 = if (code_i32 < 0 or code_i32 > std.math.maxInt(u16))
+            0
+        else
+            @intCast(code_i32);
+        const is_windows = arguments[2].toBoolean();
+
+        var buf: [256]u8 = undefined;
+        const msg = formatSpawnFailurePanic(&buf, err_name_slice.slice(), code, is_windows);
+        return bun.String.createUTF8ForJS(globalThis, msg);
+    }
+};
+
+/// Only written on Windows; read on Windows in the panic path for
+/// `initOnce` when `spawnHttpClientThread` fails. Captures the
+/// `GetLastError()` value right at the `CreateThread` failure site
+/// before any cleanup (HeapFree, etc.) can clobber it.
+var last_http_thread_spawn_win32_error: if (Environment.isWindows)
+    std.os.windows.Win32Error
+else
+    void = if (Environment.isWindows) .SUCCESS else {};
+
+/// Superset of `std.Thread.SpawnError` plus the Windows-only
+/// `SpawnFailed` we return when `CreateThread` fails. We keep every POSIX
+/// variant name so `@errorName` in `formatSpawnFailurePanic` reports
+/// e.g. `ThreadQuotaExceeded` / `SystemResources` verbatim instead of
+/// collapsing to `Unexpected`.
+const HttpThreadSpawnError = std.Thread.SpawnError || error{SpawnFailed};
+
+/// Spawns the HTTP client thread with a detached handle.
+///
+/// On Windows, this is hand-rolled instead of using `std.Thread.spawn` so
+/// we can capture the `GetLastError()` value at the `CreateThread`
+/// failure site. `std.Thread.spawn`'s Windows backend has an
+/// `errdefer HeapFree(...)` that runs between `CreateThread` failing
+/// and the caller's `catch`, which clobbers the thread-local last-error
+/// and turns every failure into a bare `error.Unexpected`. See
+/// `vendor/zig/lib/std/Thread.zig` — WindowsThreadImpl.spawn.
+fn spawnHttpClientThread(opts: InitOpts) HttpThreadSpawnError!void {
+    if (comptime !Environment.isWindows) {
+        const thread = try std.Thread.spawn(
+            .{ .stack_size = bun.default_thread_stack_size },
+            onStart,
+            .{opts},
+        );
+        thread.detach();
+        return;
+    }
+
+    const windows = std.os.windows;
+    const kernel32 = windows.kernel32;
+
+    const Instance = struct {
+        opts: InitOpts,
+
+        fn entryFn(raw_ptr: windows.PVOID) callconv(.winapi) windows.DWORD {
+            const self: *@This() = @ptrCast(@alignCast(raw_ptr));
+            // The spawned thread now owns the allocation; free it once
+            // `onStart` enters so we don't leak on a clean start either.
+            // (onStart doesn't return under normal conditions, but if it
+            // ever did, the allocation would be unreachable anyway.)
+            const heap = kernel32.GetProcessHeap() orelse {
+                onStart(self.opts);
+                return 0;
+            };
+            const captured_opts = self.opts;
+            _ = kernel32.HeapFree(heap, 0, raw_ptr);
+            onStart(captured_opts);
+            return 0;
+        }
+    };
+
+    const heap_handle = kernel32.GetProcessHeap() orelse {
+        last_http_thread_spawn_win32_error = bun.windows.GetLastError();
+        return error.OutOfMemory;
+    };
+    // HeapAlloc does NOT call SetLastError on failure (per MSDN: "An
+    // application cannot call GetLastError for extended error
+    // information"), so reading it here would surface a stale code from
+    // some unrelated prior Win32 call. Leave `last_http_thread_spawn_win32_error`
+    // at its default .SUCCESS — the Zig error name `OutOfMemory` in the
+    // panic message already conveys the cause, and printing 0x0 is less
+    // misleading than printing a red-herring code.
+    const alloc_ptr = kernel32.HeapAlloc(heap_handle, 0, @sizeOf(Instance)) orelse {
+        return error.OutOfMemory;
+    };
+    const instance: *Instance = @ptrCast(@alignCast(alloc_ptr));
+    instance.* = .{ .opts = opts };
+
+    // Mirror std.Thread: Windows treats stack_size as a hint and enforces
+    // a floor of 64KB (SYSTEM_INFO.dwAllocationGranularity on x64/arm64).
+    var stack_size: u32 = std.math.cast(u32, bun.default_thread_stack_size) orelse std.math.maxInt(u32);
+    stack_size = @max(64 * 1024, stack_size);
+
+    // STACK_SIZE_PARAM_IS_A_RESERVATION (0x00010000): treat stack_size
+    // as the *reserve* size; Windows commits the initial guard page and
+    // grows committed memory on demand. Without this flag, stack_size
+    // is the initial *commit* size — with the 4MB default, that's
+    // ~4MB of commit charge per thread upfront, which makes the exact
+    // ERROR_NOT_ENOUGH_MEMORY / ERROR_COMMITMENT_LIMIT case this PR
+    // diagnoses slightly more likely.
+    const STACK_SIZE_PARAM_IS_A_RESERVATION: windows.DWORD = 0x00010000;
+    const thread_handle = kernel32.CreateThread(
+        null,
+        stack_size,
+        Instance.entryFn,
+        instance,
+        STACK_SIZE_PARAM_IS_A_RESERVATION,
+        null,
+    ) orelse {
+        // Capture BEFORE HeapFree runs — HeapFree can clear the last-error
+        // on success, which is what makes the stdlib spawn unhelpful.
+        last_http_thread_spawn_win32_error = bun.windows.GetLastError();
+        _ = kernel32.HeapFree(heap_handle, 0, alloc_ptr);
+        return error.SpawnFailed;
+    };
+    // Detach: the thread owns the allocation and will free it on entry.
+    windows.CloseHandle(thread_handle);
 }
 var init_once = bun.once(initOnce);
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -280,6 +280,15 @@ export const stringsInternals = {
   ) => string,
 };
 
+/**
+ * Format the HTTP client thread spawn-failure panic message (#29933).
+ * Exposes `formatSpawnFailurePanic` from `src/http/HTTPThread.zig` so the
+ * Windows-only diagnostic that surfaces the Win32 error code can be
+ * exercised from Linux CI.
+ */
+export const formatHttpThreadSpawnPanic: (errName: string, win32ErrorCode: number, isWindows: boolean) => string =
+  $newZigFunction("http/HTTPThread.zig", "TestingAPIs.formatHttpThreadSpawnPanic", 3);
+
 export const fetchH2Internals = {
   liveCounts: $newZigFunction("http/H2Client.zig", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/test/js/bun/http/http-thread-spawn-panic-message.test.ts
+++ b/test/js/bun/http/http-thread-spawn-panic-message.test.ts
@@ -1,0 +1,74 @@
+// Regression: panic on Windows when the HTTP client thread fails to start
+// reported only "Unexpected" because std.Thread.spawn discards the Win32
+// error code in its Windows backend (an `errdefer HeapFree` runs between
+// CreateThread failing and the caller's `catch`, clobbering GetLastError).
+//
+// HTTPThread now hand-rolls the CreateThread path so it captures
+// GetLastError at the failure site before any cleanup. This test exercises
+// the pure message-formatter used in the panic path so the Win32 error
+// code makes it into the panic message the reporter sees in bun.report.
+//
+// Refs:
+//   https://github.com/oven-sh/bun/issues/29933
+//   https://github.com/oven-sh/bun/issues/24878
+//   https://github.com/oven-sh/bun/issues/22080
+//   https://github.com/oven-sh/bun/issues/19085
+//   https://github.com/oven-sh/bun/issues/14424
+
+import { formatHttpThreadSpawnPanic } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+// Each row is one independent assertion on the formatter contract.
+// `test.each` gives per-row failure output so regressions name the
+// specific case that broke (vs. one failing batched `test`).
+test.each([
+  // Windows — message must include the captured Win32 code as hex.
+  //   0x8 = ERROR_NOT_ENOUGH_MEMORY — the most likely cause of the
+  //     reported crash (embedded runtime, commit-limit pressure).
+  //   0x5af = ERROR_COMMITMENT_LIMIT — any arbitrary code round-trips
+  //     as hex so future crash reports are actionable.
+  //   0x0 = no error set — still reported so triage can distinguish
+  //     "captured zero" from "captured nothing".
+  //   0x2a = 42 = simulate a future std error name the formatter
+  //     doesn't know about; it must still echo the name cleanly.
+  ["SpawnFailed", 0x8, true, "Failed to start HTTP Client thread: SpawnFailed (Win32 error 0x8)"],
+  ["Unexpected", 0x5af, true, "Failed to start HTTP Client thread: Unexpected (Win32 error 0x5af)"],
+  ["Unexpected", 0, true, "Failed to start HTTP Client thread: Unexpected (Win32 error 0x0)"],
+  ["NewKindOfErr", 42, true, "Failed to start HTTP Client thread: NewKindOfErr (Win32 error 0x2a)"],
+  // Non-Windows — no Win32 code, keep the pre-fix message verbatim
+  // so release notes see zero noise on Linux/macOS. `std.Thread.spawn`
+  // passes `ThreadQuotaExceeded` / `SystemResources` through now
+  // (no more blanket → Unexpected).
+  ["ThreadQuotaExceeded", 0, false, "Failed to start HTTP Client thread: ThreadQuotaExceeded"],
+  ["SystemResources", 0, false, "Failed to start HTTP Client thread: SystemResources"],
+  ["LockedMemoryLimitExceeded", 0, false, "Failed to start HTTP Client thread: LockedMemoryLimitExceeded"],
+  ["OutOfMemory", 0, false, "Failed to start HTTP Client thread: OutOfMemory"],
+])("formatHttpThreadSpawnPanic(%j, %i, %j) → %j", (errName, code, isWindows, expected) => {
+  expect(formatHttpThreadSpawnPanic(errName as string, code as number, isWindows as boolean)).toBe(expected as string);
+});
+
+// Defensive: out-of-range Win32 codes must clamp to 0 in the JS binding, so the
+// panic message renders a predictable `0x0` rather than a truncated int.
+test.each([
+  // A code > u16::MAX (Win32 codes are u16 in Zig's Win32Error enum).
+  [0x1_0000],
+  // Another out-of-range value that happens to share low bits with a real code
+  // — the clamp must not mistake it for 0x8 = ERROR_NOT_ENOUGH_MEMORY.
+  [0x10008],
+  // Negative — JS numbers can go negative, must not underflow into u16.
+  [-1],
+])("formatHttpThreadSpawnPanic clamps out-of-range code %i to 0", code => {
+  expect(formatHttpThreadSpawnPanic("Unexpected", code, true)).toBe(
+    "Failed to start HTTP Client thread: Unexpected (Win32 error 0x0)",
+  );
+});
+
+// Defensive: if an absurdly long error name would overflow the 256-byte
+// scratch buffer, the formatter must return the static fallback string
+// rather than leaking uninitialized stack memory (the original form of
+// this function did the latter, flagged by coderabbit).
+test("formatHttpThreadSpawnPanic returns static fallback on overflow", () => {
+  const longName = "X".repeat(512);
+  expect(formatHttpThreadSpawnPanic(longName, 0x8, true)).toBe("Failed to start HTTP Client thread");
+  expect(formatHttpThreadSpawnPanic(longName, 0, false)).toBe("Failed to start HTTP Client thread");
+});


### PR DESCRIPTION
## What

When the HTTP client thread fails to spawn on Windows, Bun panics with a
generic `Failed to start HTTP Client thread: Unexpected`. This message is
the same regardless of the underlying cause (ERROR_NOT_ENOUGH_MEMORY,
ERROR_TOO_MANY_THREADS, desktop-heap exhaustion, etc.), so triage of
crash reports lands at a dead end. #29933, #24878, #22080, #19085, and
#14424 all hit this same message with no usable next step.

Root cause: `std.Thread.spawn`'s Windows backend reads
`GetLastError()` into a local `errno`, then hits an
`errdefer HeapFree(...)` on the way out. `HeapFree` resets the
thread-local last-error, so by the time the caller's `catch |err|`
runs, the original Win32 code is gone. Every Windows thread-spawn
failure collapses to `error.Unexpected`.

## Fix

Hand-roll the `CreateThread` sequence in `HTTPThread.initOnce` so
`GetLastError()` is captured at the failure site, before any cleanup
can clobber it. The panic message now includes the captured code as
hex, e.g.:

```
panic(main thread): Failed to start HTTP Client thread: SpawnFailed (Win32 error 0x8)
```

0x8 is `ERROR_NOT_ENOUGH_MEMORY` — the most likely cause for the Claude
Code VS Code extension repro in #29933 (embedded runtime under
commit-limit / desktop-heap pressure). Other codes we can now
distinguish include 0x57 (`ERROR_INVALID_PARAMETER`, e.g. a bad stack
size), 0x5AF (`ERROR_COMMITMENT_LIMIT`), and 0x4E (`ERROR_TOO_MANY_THREADS`).

Non-Windows callers go through the same wrapper but keep `std.Thread.spawn`
and the original message format — zero behavior change on Linux/macOS.

## Test

The panic-message formatter is extracted into a pure function
`formatSpawnFailurePanic` and exposed via `bun:internal-for-testing`,
following the same pattern as the fix for #29651
(`sysErrorNameFromLibuv`). The new test in
`test/js/bun/http/http-thread-spawn-panic-message.test.ts` exercises
both the Windows branch (asserts the Win32 code is included as hex)
and the non-Windows branch (asserts the old message format is kept).
The formatter's `is_windows` arg is passed explicitly so the test runs
deterministically on the Linux CI gate.

Before: test fails at import — `formatHttpThreadSpawnPanic` doesn't
exist. After: 3 passing assertions covering ERROR_NOT_ENOUGH_MEMORY,
an arbitrary hex code, a zero code, and the Linux format.

Since actually triggering `CreateThread` failure requires real
resource exhaustion that can't be induced portably from userspace, the
test covers the diagnostic pathway the next panic will travel through
rather than the spawn failure itself. That matches the precedent set
by PR #29443 / `readdir-windows-ntstatus.test.ts`.

Closes #29933. Likely addresses #24878, #22080, #19085, #14424 the
next time they reproduce — the crash report will now identify which
Win32 condition was hit.