### PR TITLE
Fix crash when constructing jest.fn() mock that returns a non-object

### DIFF
--- a/src/bun.js/bindings/JSMockFunction.cpp
+++ b/src/bun.js/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,24 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* thisObject = JSC::constructEmptyObject(globalObject);
+    callframe->setThisValue(thisObject);
+
+    JSC::EncodedJSValue encodedResult = jsMockFunctionCall(lexicalGlobalObject, callframe);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = JSValue::decode(encodedResult);
+    if (!result.isObject())
+        return JSValue::encode(thisObject);
+    return encodedResult;
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,50 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+  describe("as constructor", () => {
+    test("Reflect.construct on mock wrapping Symbol does not crash", () => {
+      const fn = jest.fn(Symbol);
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+      expect(typeof fn.mock.results[0].value).toBe("symbol");
+    });
+    test("new on mock wrapping Symbol returns an object", () => {
+      const fn = jest.fn(Symbol);
+      const instance = new fn();
+      expect(typeof instance).toBe("object");
+    });
+    test("construct with mockReturnValue(primitive) returns an object", () => {
+      const fn = jest.fn();
+      fn.mockReturnValue(42);
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+    });
+    test("construct with no implementation returns an object", () => {
+      const fn = jest.fn();
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+    });
+    test("construct on mock returning a string returns an object", () => {
+      const fn = jest.fn(() => "hello");
+      const instance = Reflect.construct(fn, []);
+      expect(typeof instance).toBe("object");
+    });
+    test("construct on mock returning an object returns that object", () => {
+      const obj = { foo: "bar" };
+      const fn = jest.fn(() => obj);
+      const instance = Reflect.construct(fn, []);
+      expect(instance).toBe(obj);
+    });
+    test("implementation receives the new instance as this when constructed", () => {
+      let capturedThis;
+      const fn = jest.fn(function () {
+        capturedThis = this;
+      });
+      const instance = new fn();
+      expect(typeof capturedThis).toBe("object");
+      expect(capturedThis).toBe(instance);
+    });
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
## What

`JSMockFunction` registered `jsMockFunctionCall` as both its `[[Call]]` and `[[Construct]]` handler. When the mock's implementation returns a primitive (e.g. `jest.fn(Symbol)`), constructing the mock via `Reflect.construct` returned that primitive to `Interpreter::executeConstruct`, which then called `asObject()` on it and hit:

```
ASSERTION FAILED: cell->isObjectSlow()
JavaScriptCore/JSObject.h(1345) : JSObject *JSC::asObject(JSCell *)
```

Native `[[Construct]]` handlers must return an object.

## Fix

Add a dedicated `jsMockFunctionConstruct` that:
- allocates a fresh empty object to use as `this`,
- delegates to `jsMockFunctionCall` with that `this` (so `mock.contexts`, `mockReturnThis`, and implementations that read `this` all see the new instance),
- returns the new instance when the implementation's return value is not an object.

This matches ordinary JS `new` semantics (and Jest, where mock functions are plain JS functions and non-object returns are replaced by `this`).

## Repro

```js
const fn = Bun.jest().mock(Symbol);
Reflect.construct(fn, []); // previously: assertion failure in debug builds
```

Found by Fuzzilli.