### PR TITLE
Watcher: always own file_path in watchlist (fix onFileUpdate UAF)

### DIFF
--- a/src/Watcher.zig
+++ b/src/Watcher.zig
@@ -129,6 +129,9 @@ pub fn deinit(this: *Watcher, close_descriptors: bool) void {
                 fd.close();
             }
         }
+        for (this.watchlist.items(.file_path)) |p| {
+            this.allocator.free(p);
+        }
         this.watchlist.deinit(this.allocator);
         const allocator = this.allocator;
         allocator.destroy(this);
@@ -252,6 +255,9 @@ fn threadMain(this: *Watcher) !void {
             fd.close();
         }
     }
+    for (this.watchlist.items(.file_path)) |p| {
+        this.allocator.free(p);
+    }
     this.watchlist.deinit(this.allocator);
 
     // Close trace file if open
@@ -277,6 +283,7 @@ pub fn flushEvictions(this: *Watcher) void {
 
     var slice = this.watchlist.slice();
     const fds = slice.items(.fd);
+    const file_paths = slice.items(.file_path);
     var last_item = no_watch_item;
 
     for (this.evict_list[0..this.evict_list_i]) |item| {
@@ -292,6 +299,10 @@ pub fn flushEvictions(this: *Watcher) void {
                 fds[item].close();
             }
         }
+        // file_path was dupeZ'd in append{File,Directory}AssumeCapacity;
+        // swapRemove in the second pass overwrites the slot, so free here.
+        this.allocator.free(file_paths[item]);
+        file_paths[item] = "";
         last_item = item;
     }
 
@@ -393,12 +404,19 @@ fn appendFileAssumeCapacity(
         }
     }
 
+    _ = clone_file_path;
     const watchlist_id = this.watchlist.len;
 
-    const file_path_: string = if (comptime clone_file_path)
-        bun.asByteSlice(bun.handleOom(this.allocator.dupeZ(u8, file_path)))
-    else
-        file_path;
+    // Always own file_path. Callers that passed `clone_file_path = false`
+    // (path_watcher, DirectoryWatchStore, onMaybeWatchDirectory, bundle_v2
+    // on posix) free their buffer on their own schedule — borrowing left
+    // `watchlist.items(.file_path)` dangling between the caller's free and
+    // `flushEvictions()`, then `onFileUpdate()` on the watcher thread read
+    // freed memory. Owning our own copy decouples the lifetimes and lets
+    // `flushEvictions()` / teardown free it deterministically. Callers that
+    // already passed `true` are unchanged except that the dupe no longer
+    // leaks on eviction.
+    const file_path_: [:0]const u8 = bun.handleOom(this.allocator.dupeZ(u8, file_path));
 
     var item = WatchItem{
         .file_path = file_path_,
@@ -414,14 +432,11 @@ fn appendFileAssumeCapacity(
     if (comptime Environment.isKqueue) {
         this.addFileDescriptorToKQueueWithoutChecks(fd, watchlist_id);
     } else if (comptime Environment.isLinux) {
-        // var file_path_to_use_ = std.mem.trimRight(u8, file_path_, "/");
-        // var buf: [bun.MAX_PATH_BYTES+1]u8 = undefined;
-        // bun.copy(u8, &buf, file_path_to_use_);
-        // buf[file_path_to_use_.len] = 0;
-        var buf = file_path_.ptr;
-        const slice: [:0]const u8 = buf[0..file_path_.len :0];
-        item.eventlist_index = switch (this.platform.watchPath(slice)) {
-            .err => |err| return .{ .err = err },
+        item.eventlist_index = switch (this.platform.watchPath(file_path_)) {
+            .err => |err| {
+                this.allocator.free(file_path_);
+                return .{ .err = err };
+            },
             .result => |r| r,
         };
     }
@@ -453,10 +468,9 @@ fn appendDirectoryAssumeCapacity(
         };
     };
 
-    const file_path_: string = if (comptime clone_file_path)
-        bun.asByteSlice(bun.handleOom(this.allocator.dupeZ(u8, file_path)))
-    else
-        file_path;
+    _ = clone_file_path;
+    // See appendFileAssumeCapacity for why file_path is always owned.
+    const file_path_: [:0]const u8 = bun.handleOom(this.allocator.dupeZ(u8, file_path));
 
     const parent_hash = getHash(bun.fs.PathName.init(file_path_).dirWithTrailingSlash());
 
@@ -510,20 +524,23 @@ fn appendDirectoryAssumeCapacity(
         );
     } else if (Environment.isLinux) {
         const buf = bun.path_buffer_pool.get();
-        defer {
-            bun.path_buffer_pool.put(buf);
-        }
-        const path: [:0]const u8 = if (clone_file_path and file_path_.len > 0 and file_path_[file_path_.len - 1] == 0)
-            file_path_[0 .. file_path_.len - 1 :0]
+        defer bun.path_buffer_pool.put(buf);
+        // file_path_ is our dupeZ so it's NUL-terminated, but callers may
+        // include a trailing slash; trim it for inotify.
+        const trimmed = if (file_path_.len > 1) std.mem.trimRight(u8, file_path_, &.{ 0, '/' }) else file_path_;
+        const path: [:0]const u8 = if (trimmed.len == file_path_.len)
+            file_path_
         else brk: {
-            const trailing_slash = if (file_path_.len > 1) std.mem.trimRight(u8, file_path_, &.{ 0, '/' }) else file_path_;
-            @memcpy(buf[0..trailing_slash.len], trailing_slash);
-            buf[trailing_slash.len] = 0;
-            break :brk buf[0..trailing_slash.len :0];
+            @memcpy(buf[0..trimmed.len], trimmed);
+            buf[trimmed.len] = 0;
+            break :brk buf[0..trimmed.len :0];
         };
 
         item.eventlist_index = switch (this.platform.watchDir(path)) {
-            .err => |err| return .{ .err = err.withPath(file_path) },
+            .err => |err| {
+                this.allocator.free(file_path_);
+                return .{ .err = err.withPath(file_path) };
+            },
             .result => |r| r,
         };
     }

--- a/test/js/node/watch/fs.watch.watchlist-path-uaf.test.ts
+++ b/test/js/node/watch/fs.watch.watchlist-path-uaf.test.ts
@@ -65,11 +65,7 @@ test.skipIf(isWindows || isMacOS)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const filteredStderr = stderr
       .split("\n")

--- a/test/js/node/watch/fs.watch.watchlist-path-uaf.test.ts
+++ b/test/js/node/watch/fs.watch.watchlist-path-uaf.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir } from "harness";
+
+// Regression test for a use-after-free of `Watcher.watchlist.file_path`.
+//
+// `WatchItem.file_path` was conditionally owned based on the comptime
+// `clone_file_path` parameter to `addFile`/`addDirectory`. `path_watcher.zig`
+// always passed `false`, so the watchlist entry BORROWED the string owned
+// by `PathWatcherManager.file_paths`. On `close()`:
+//
+//   _decrementPathRefNoLock():
+//     main_watcher.remove(path.hash);   // only queues evict_list entry
+//     this.file_paths.remove(path_);
+//     bun.default_allocator.free(path_); // watchlist[idx].file_path dangles
+//
+// `remove()` only appends to `evict_list`; the watchlist entry survives
+// until `flushEvictions()`. If an inotify event for that entry arrives
+// first, the File-Watcher thread's `onFileUpdate()` reads
+// `watchlist.items(.file_path)[event.index]` → freed memory. Under ASAN:
+//
+//   AddressSanitizer: use-after-poison
+//   in mem.trimEnd  (std/mem.zig)
+//   PathWatcherManager.onFileUpdate  (path_watcher.zig:263)
+//   INotifyWatcher.processINotifyEventBatch
+//
+// The fix makes `Watcher` always own `file_path` (dupeZ on append, free in
+// flushEvictions/deinit) so the manager can free its copy independently.
+//
+// Windows uses win_watcher.zig (no shared watchlist); macOS directory
+// watches use FSEvents. File watches on macOS/FreeBSD go through
+// KEventWatcher but the event doesn't carry a watchlist index the same
+// way — the Linux inotify path is where this UAF is reliably hit.
+test.skipIf(isWindows || isMacOS)(
+  "onFileUpdate does not read freed watchlist file_path after close()",
+  async () => {
+    using dir = tempDir("fswatch-watchlist-uaf", { "f.txt": "x" });
+
+    // The subprocess delay between iterations lets the File-Watcher thread
+    // fully process each IN_MODIFY event (acquire and release both
+    // PathWatcherManager.mutex and Watcher.mutex) before the next close()
+    // contends for them — sidestepping a separate pre-existing AB/BA
+    // deadlock between those two mutexes that is out of scope here.
+    const fixture = /* js */ `
+      const fs = require("fs");
+      const path = require("path");
+      const target = path.join(process.argv[1], "f.txt");
+      (async () => {
+        const ITERS = 100;
+        for (let i = 0; i < ITERS; i++) {
+          const w = fs.watch(target, () => {});
+          w.close();
+          // watchlist entry for target is now pending eviction with a
+          // (pre-fix) dangling file_path; this write delivers an IN_MODIFY
+          // routed to that entry.
+          fs.writeFileSync(target, String(i));
+          await new Promise(r => setTimeout(r, 5));
+        }
+        console.log("ok " + ITERS);
+      })();
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture, String(dir)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+
+    expect({ stdout: stdout.trim(), stderr: filteredStderr, exitCode }).toEqual({
+      stdout: "ok 100",
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  30000,
+);


### PR DESCRIPTION
Follow-up to #29936 (first item in that PR's "Not fixed here" section). **Draft — see the AB/BA deadlock section below before merging.**

## What this fixes

`WatchItem.file_path` was conditionally owned based on the `comptime clone_file_path` parameter to `addFile`/`addDirectory`:

| Caller | `clone_file_path` | Result |
|---|---|---|
| `path_watcher.zig` (fs.watch) | `false` | watchlist **borrows** `PathWatcherManager.file_paths[k].path` |
| `DirectoryWatchStore.zig` (DevServer) | `false` | watchlist **borrows** `store.watches` key |
| `onMaybeWatchDirectory` (resolver) | `false` | borrows `DirnameStore` (process-lifetime, safe) |
| `bundle_v2.zig` (posix) | `false` | borrows `graph.input_files` (session-lifetime) |
| `ModuleLoader`, `RuntimeTranspilerStore`, `AsyncModule`, `bundle_v2` (win), `addFileByPathSlow` | `true` | Watcher dupes → **leaks** on eviction (flushEvictions never freed it) |

### UAF (`clone_file_path = false`)

`PathWatcherManager._decrementPathRefNoLock()` (and equivalently `DirectoryWatchStore.freeEntry()`) does:
```zig
this.main_watcher.remove(path.hash);   // only queues evict_list entry
_ = this.file_paths.remove(path_);
bun.default_allocator.free(path_);      // watchlist entry still borrows this
```
`remove()` only appends to `evict_list`; the watchlist entry survives until `flushEvictions()`. The File-Watcher thread's `onFileUpdate()` reads `watchlist.items(.file_path)[event.index]` → **use-after-free** (ASAN: `use-after-poison` in `mem.trimEnd` at `path_watcher.zig:263`).

### Leak (`clone_file_path = true`)

`flushEvictions()` only `close()`d the fd and `swapRemove()`d — it never freed `file_path`, so every cloned path leaked on eviction.

## Fix

Make `Watcher` the unconditional owner of `file_path`:
- `appendFileAssumeCapacity` / `appendDirectoryAssumeCapacity`: always `dupeZ`; free on `watchPath`/`watchDir` error.
- `flushEvictions()`: free `file_paths[item]` before `swapRemove`.
- `deinit()` / `threadMain()` teardown: free each `file_path` before `watchlist.deinit()`.
- `clone_file_path` parameter kept for source compatibility but now ignored.

No caller relies on pointer identity of the stored slice (all `onFileUpdate` consumers hash/compare/copy the bytes).

## ⚠️ Exposes a pre-existing AB/BA deadlock — needs a fix before merge

With the UAF gone, a `fs.watch(file).close(); writeFile(file)` stress loop **deadlocks** between `PathWatcherManager.mutex` and `Watcher.mutex`:

| Main thread (`close()`) | File-Watcher thread (event) |
|---|---|
| `unregisterWatcher()` → `Manager.mutex.lock()` | `processINotifyEventBatch()` → `Watcher.mutex.lock()` |
| `_decrementPathRefNoLock()` → `main_watcher.remove()` → **wait `Watcher.mutex`** | `onFileUpdate()` → **wait `Manager.mutex`** |

This lock inversion exists on `main` today; it's just masked under ASAN (the UAF aborts first) and rare on release. Removing the UAF removes the mask.

**Proposed fix** (not yet in this branch): in `_decrementPathRefNoLock()` / `unregisterWatcher()`, collect hashes to remove while holding `Manager.mutex`, release it, *then* call `main_watcher.remove(hash)` for each. That makes both lock orders `Watcher.mutex` → `Manager.mutex`.

Once the deadlock is resolved, the remaining `PathWatcher` `has_pending_directories` leak (from #29936's "Not fixed here") can be safely closed too — it was only left in place because fixing it exposed this UAF.

## Verification so far

- `bun run zig:check-all`: passes on all targets.
- `test/js/node/watch/fs.watch.test.ts`: 5/5 clean under ASAN (previously 5/5 clean too — the UAF needs write-after-close to trigger).
- Targeted UAF repro (`fs.watch(f); close(); writeFile(f)` × many) under ASAN: **no more use-after-poison**, but deadlocks instead (see above).