### PR TITLE
Fix null deref in Bun.inspect when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5360,7 +5360,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -465,6 +465,20 @@ describe("crash testing", () => {
       }
     });
   }
+
+  it("Proxy prototype with throwing getPrototypeOf trap doesn't crash", () => {
+    const obj = { a: 1 };
+    class Foo {}
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(Foo.prototype, {
+        getPrototypeOf() {
+          throw new Error("trap!");
+        },
+      }),
+    );
+    expect(Bun.inspect(obj)).toContain("a: 1");
+  });
 });
 
 it("possibly formatted emojis log", () => {


### PR DESCRIPTION
## What

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, and expect matcher error formatting) when walking the prototype chain of an object whose prototype is a `Proxy` and `[[GetPrototypeOf]]` throws.

## Why

`JSObject::getPrototype()` can throw — either directly via a Proxy `getPrototypeOf` trap, or indirectly when there's a pending exception from a prior property access through the Proxy. When it throws, it returns an empty `JSValue`, and calling `.getObject()` on that empty value dereferences a null cell:

```cpp
iterating = iterating->getPrototype(globalObject).getObject();
```

The fast-path branch a few lines above already handles this correctly by checking the return value and clearing the exception; the slow-path loop did not.

## Repro

```js
const obj = { a: 1 };
class Foo {}
Object.setPrototypeOf(obj, new Proxy(Foo.prototype, {
  getPrototypeOf() { throw new Error("trap!"); }
}));
console.log(obj); // crashed with null deref; now prints { a: 1 }
```

Found by Fuzzilli (fingerprint `72a7516faba947a1`).