### PR TITLE
bun:ffi: throw when calling a symbol after close() instead of jumping into freed JIT memory

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -104,6 +104,20 @@ extern "C" void Bun__FFIFunction_setDataPtr(JSC::EncodedJSValue jsValue, void* p
     function->dataPtr = ptr;
 }
 
+// Called from FFI.Function.deinit (ffi.zig) before the per-function TCC state
+// is deleted. Nulls out the native trampoline pointer so that any JS
+// references to this function which are invoked after the owning library is
+// closed will throw a TypeError instead of jumping into freed JIT memory.
+extern "C" void Bun__FFIFunction_setClosed(JSC::EncodedJSValue jsValue)
+{
+    Zig::JSFFIFunction* function = dynamicDowncast<Zig::JSFFIFunction>(JSC::JSValue::decode(jsValue));
+    if (!function)
+        return;
+
+    function->setFunction(nullptr);
+    function->symbolFromDynamicLibrary = nullptr;
+}
+
 extern "C" JSC::EncodedJSValue Bun__CreateFFIFunctionValue(Zig::GlobalObject* globalObject, const ZigString* symbolName, unsigned argCount, Zig::FFIFunction functionPointer, bool addPtrField, void* symbolFromDynamicLibrary)
 {
     if (addPtrField) {
@@ -158,23 +172,25 @@ JSFFIFunction* JSFFIFunction::create(VM& vm, Zig::GlobalObject* globalObject, un
     return function;
 }
 
-#if OS(WINDOWS)
-
 JSC_DEFINE_HOST_FUNCTION(JSFFIFunction::trampoline, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     const auto* function = uncheckedDowncast<JSFFIFunction>(callFrame->jsCallee());
-    return function->function()(globalObject, callFrame);
+    auto native = function->function();
+    if (!native) [[unlikely]] {
+        auto& vm = JSC::getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(globalObject, scope, "Cannot call an FFI function after the library has been closed"_s);
+    }
+    return native(globalObject, callFrame);
 }
-
-#endif
 
 JSFFIFunction* JSFFIFunction::createForFFI(VM& vm, Zig::GlobalObject* globalObject, unsigned length, const String& name, CFFIFunction FFIFunction)
 {
-#if OS(WINDOWS)
+    // Always route through the static trampoline so the TinyCC-compiled
+    // function pointer lives in the mutable m_function field instead of being
+    // baked into a NativeExecutable. This lets us safely detach the native
+    // code when the library is closed (see Bun__FFIFunction_setClosed).
     NativeExecutable* executable = vm.getHostFunction(trampoline, ImplementationVisibility::Public, NoIntrinsic, trampoline, nullptr, name);
-#else
-    NativeExecutable* executable = vm.getHostFunction(FFIFunction, ImplementationVisibility::Public, NoIntrinsic, FFIFunction, nullptr, name);
-#endif
     Structure* structure = globalObject->FFIFunctionStructure();
     JSFFIFunction* function = new (NotNull, allocateCell<JSFFIFunction>(vm)) JSFFIFunction(vm, executable, globalObject, structure, reinterpret_cast<CFFIFunction>(WTF::move(FFIFunction)));
     function->finishCreation(vm, executable, length, name);

--- a/src/jsc/bindings/JSFFIFunction.h
+++ b/src/jsc/bindings/JSFFIFunction.h
@@ -79,12 +79,13 @@ public:
     }
 
     const CFFIFunction function() const { return m_function; }
+    void setFunction(CFFIFunction function) { m_function = function; }
 
-#if OS(WINDOWS)
-
+    // All calls to FFI functions created via createForFFI() route through this
+    // trampoline, which dispatches to m_function. This indirection lets us
+    // null out m_function when the owning library is closed so that calling a
+    // symbol after close() throws instead of jumping into freed JIT memory.
     static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES trampoline(JSGlobalObject* globalObject, CallFrame* callFrame);
-
-#endif
 
     void* dataPtr;
     void* symbolFromDynamicLibrary { nullptr };

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -1474,12 +1474,20 @@ pub const FFI = struct {
             val.arg_types.clearAndFree(val.allocator);
 
             if (val.step == .compiled) {
-                // The JSFFIFunction may still be reachable from JS (e.g. the
-                // cached symbols object or a user-held reference). Detach its
-                // native trampoline before freeing the TCC state so calling
-                // it throws instead of jumping into freed JIT memory.
                 if (val.step.compiled.js_function != .zero) {
-                    Bun__FFIFunction_setClosed(val.step.compiled.js_function);
+                    // On the dlopen/linkSymbols/cc paths, js_function is the
+                    // JSFFIFunction we created for this symbol and whose
+                    // native trampoline lives in the TCC state about to be
+                    // freed. Detach it so calling it throws instead of
+                    // jumping into freed JIT memory.
+                    //
+                    // On the JSCallback path (ffi_callback_function_wrapper
+                    // != null), js_function is the user's callback which we
+                    // merely borrowed; it may itself be an unrelated FFI
+                    // symbol and must not be detached here.
+                    if (val.step.compiled.ffi_callback_function_wrapper == null) {
+                        Bun__FFIFunction_setClosed(val.step.compiled.js_function);
+                    }
                     val.step.compiled.js_function = .zero;
                 }
 

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -1459,9 +1459,11 @@ pub const FFI = struct {
         }
 
         extern "c" fn FFICallbackFunctionWrapper_destroy(*anyopaque) void;
+        extern "c" fn Bun__FFIFunction_setClosed(JSValue) void;
 
         pub fn deinit(val: *Function, globalThis: *jsc.JSGlobalObject) void {
             jsc.markBinding(@src());
+            _ = globalThis;
 
             if (val.base_name) |base_name| {
                 if (bun.asByteSlice(base_name).len > 0) {
@@ -1471,14 +1473,13 @@ pub const FFI = struct {
 
             val.arg_types.clearAndFree(val.allocator);
 
-            if (val.state) |state| {
-                state.deinit();
-                val.state = null;
-            }
-
             if (val.step == .compiled) {
+                // The JSFFIFunction may still be reachable from JS (e.g. the
+                // cached symbols object or a user-held reference). Detach its
+                // native trampoline before freeing the TCC state so calling
+                // it throws instead of jumping into freed JIT memory.
                 if (val.step.compiled.js_function != .zero) {
-                    _ = globalThis;
+                    Bun__FFIFunction_setClosed(val.step.compiled.js_function);
                     val.step.compiled.js_function = .zero;
                 }
 
@@ -1486,6 +1487,11 @@ pub const FFI = struct {
                     FFICallbackFunctionWrapper_destroy(wrapper);
                     val.step.compiled.ffi_callback_function_wrapper = null;
                 }
+            }
+
+            if (val.state) |state| {
+                state.deinit();
+                val.state = null;
             }
 
             if (val.step == .failed and val.step.failed.allocated) {

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -1117,8 +1117,7 @@ pub const FFI = struct {
                 const resolved_symbol = dylib.lookup(*anyopaque, function_name) orelse {
                     const ret = global.toInvalidArguments("Symbol \"{s}\" not found in \"{s}\"", .{ bun.asByteSlice(function_name), name });
                     for (symbols.values()) |*value| {
-                        bun.default_allocator.free(@constCast(bun.asByteSlice(value.base_name.?)));
-                        value.arg_types.clearAndFree(bun.default_allocator);
+                        value.deinit(global);
                     }
                     symbols.clearAndFree(bun.default_allocator);
                     dylib.close();
@@ -1233,8 +1232,7 @@ pub const FFI = struct {
             if (function.symbol_from_dynamic_library == null) {
                 const ret = global.toInvalidArguments("Symbol \"{s}\" is missing a \"ptr\" field. When using linkSymbols() or CFunction(), you must provide a \"ptr\" field with the memory address of the native function.", .{bun.asByteSlice(function_name)});
                 for (symbols.values()) |*value| {
-                    allocator.free(@constCast(bun.asByteSlice(value.base_name.?)));
-                    value.arg_types.clearAndFree(allocator);
+                    value.deinit(global);
                 }
                 symbols.clearAndFree(allocator);
                 return ret;
@@ -1253,20 +1251,16 @@ pub const FFI = struct {
             };
             switch (function.step) {
                 .failed => |err| {
-                    for (symbols.values()) |*value| {
-                        allocator.free(@constCast(bun.asByteSlice(value.base_name.?)));
-                        value.arg_types.clearAndFree(allocator);
-                    }
-
                     const res = ZigString.init(err.msg).toErrorInstance(global);
-                    function.deinit(global);
+                    for (symbols.values()) |*value| {
+                        value.deinit(global);
+                    }
                     symbols.clearAndFree(allocator);
                     return res;
                 },
                 .pending => {
                     for (symbols.values()) |*value| {
-                        allocator.free(@constCast(bun.asByteSlice(value.base_name.?)));
-                        value.arg_types.clearAndFree(allocator);
+                        value.deinit(global);
                     }
                     symbols.clearAndFree(allocator);
                     return ZigString.static("Failed to compile (nothing happend!)").toErrorInstance(global);

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -544,8 +544,12 @@ pub const FFI = struct {
     const SymbolsMap = struct {
         map: bun.StringArrayHashMapUnmanaged(Function) = .{},
         pub fn deinit(this: *SymbolsMap) void {
-            for (this.map.keys()) |key| {
-                bun.default_allocator.free(@constCast(key));
+            // Each map key aliases the Function's base_name allocation, which
+            // Function.deinit frees along with the per-symbol TCC state,
+            // arg_types, and (on the dlopen/linkSymbols/cc paths) the
+            // protect()ed JSFFIFunction root.
+            for (this.map.values()) |*value| {
+                value.deinitWithoutGlobal();
             }
             this.map.clearAndFree(bun.default_allocator);
         }
@@ -1470,9 +1474,12 @@ pub const FFI = struct {
         extern "c" fn FFICallbackFunctionWrapper_destroy(*anyopaque) void;
         extern "c" fn Bun__FFIFunction_setClosed(JSValue) void;
 
-        pub fn deinit(val: *Function, globalThis: *jsc.JSGlobalObject) void {
+        pub fn deinit(val: *Function, _: *jsc.JSGlobalObject) void {
+            val.deinitWithoutGlobal();
+        }
+
+        pub fn deinitWithoutGlobal(val: *Function) void {
             jsc.markBinding(@src());
-            _ = globalThis;
 
             if (val.base_name) |base_name| {
                 if (bun.asByteSlice(base_name).len > 0) {

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -810,6 +810,9 @@ pub const FFI = struct {
                         function.symbol_from_dynamic_library,
                     );
                     compiled.js_function = cb;
+                    // Rooted so Function.deinit can safely detach it on
+                    // close() even if it was removed from the symbols object.
+                    cb.protect();
                     obj.put(globalThis, &str, cb);
                 },
             }
@@ -1164,6 +1167,9 @@ pub const FFI = struct {
                         function.symbol_from_dynamic_library,
                     );
                     compiled.js_function = cb;
+                    // Rooted so Function.deinit can safely detach it on
+                    // close() even if it was removed from the symbols object.
+                    cb.protect();
                     obj.put(global, &str, cb);
                 },
             }
@@ -1273,6 +1279,9 @@ pub const FFI = struct {
                         function.symbol_from_dynamic_library,
                     );
                     compiled.js_function = cb;
+                    // Rooted so Function.deinit can safely detach it on
+                    // close() even if it was removed from the symbols object.
+                    cb.protect();
 
                     obj.put(global, name, cb);
                 },
@@ -1476,17 +1485,20 @@ pub const FFI = struct {
             if (val.step == .compiled) {
                 if (val.step.compiled.js_function != .zero) {
                     // On the dlopen/linkSymbols/cc paths, js_function is the
-                    // JSFFIFunction we created for this symbol and whose
-                    // native trampoline lives in the TCC state about to be
-                    // freed. Detach it so calling it throws instead of
-                    // jumping into freed JIT memory.
+                    // JSFFIFunction we created for this symbol (rooted via
+                    // protect() at creation time) whose native trampoline
+                    // lives in the TCC state about to be freed. Detach it so
+                    // calling it throws instead of jumping into freed JIT
+                    // memory, then release the GC root.
                     //
                     // On the JSCallback path (ffi_callback_function_wrapper
                     // != null), js_function is the user's callback which we
-                    // merely borrowed; it may itself be an unrelated FFI
-                    // symbol and must not be detached here.
+                    // merely borrowed — it is rooted via the wrapper's
+                    // Strong<JSFunction> and may itself be an unrelated FFI
+                    // symbol, so it must not be detached here.
                     if (val.step.compiled.ffi_callback_function_wrapper == null) {
                         Bun__FFIFunction_setClosed(val.step.compiled.js_function);
+                        val.step.compiled.js_function.unprotect();
                     }
                     val.step.compiled.js_function = .zero;
                 }

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -1142,11 +1142,10 @@ pub const FFI = struct {
             };
             switch (function.step) {
                 .failed => |err| {
-                    defer for (symbols.values()) |*other_function| {
-                        other_function.deinit(global);
-                    };
-
                     const res = ZigString.init(err.msg).toErrorInstance(global);
+                    for (symbols.values()) |*other_function| {
+                        other_function.deinit(global);
+                    }
                     symbols.clearAndFree(bun.default_allocator);
                     dylib.close();
                     return res;

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -8,6 +8,7 @@ import {
   CFunction,
   CString,
   JSCallback,
+  linkSymbols,
   ptr,
   read,
   suffix,
@@ -969,4 +970,68 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
       expect(lib.symbols.strlen(Buffer.from("bunbun\0", "ascii"))).toBe(6n);
     });
   }
+});
+
+describe("calling an FFI symbol after close()", () => {
+  // Regression test: calling a captured FFI symbol after its library has been
+  // closed must throw instead of jumping into the freed TinyCC JIT pages.
+  it("linkSymbols: throws instead of calling freed code", () => {
+    const cb = new JSCallback(x => x + 1, { args: ["i32"], returns: "i32" });
+    try {
+      const lib = linkSymbols({
+        inc: { args: ["i32"], returns: "i32", ptr: cb.ptr },
+      });
+      const inc = lib.symbols.inc;
+      const native = inc.native;
+      expect(inc(41)).toBe(42);
+      expect(native(41)).toBe(42);
+
+      lib.close();
+
+      expect(() => inc(1)).toThrow(TypeError);
+      expect(() => inc(1)).toThrow("Cannot call an FFI function after the library has been closed");
+      expect(() => native(1)).toThrow(TypeError);
+
+      // close() is idempotent
+      lib.close();
+      expect(() => inc(1)).toThrow(TypeError);
+    } finally {
+      cb.close();
+    }
+  });
+
+  it("linkSymbols: zero-arg function throws instead of calling freed code", () => {
+    const cb = new JSCallback(() => 7, { returns: "i32" });
+    try {
+      const lib = linkSymbols({
+        seven: { returns: "i32", ptr: cb.ptr },
+      });
+      // zero-arg functions are not wrapped by FFIBuilder, so the symbol IS
+      // the native JSFFIFunction itself.
+      const seven = lib.symbols.seven;
+      expect(seven()).toBe(7);
+
+      lib.close();
+
+      expect(() => seven()).toThrow(TypeError);
+      expect(() => seven()).toThrow("Cannot call an FFI function after the library has been closed");
+    } finally {
+      cb.close();
+    }
+  });
+
+  it.if(!!libPath)("dlopen: throws instead of calling freed code", () => {
+    const lib = _dlopen(libPath, { strlen: { args: ["ptr"], returns: "usize" } });
+    const strlen = lib.symbols.strlen;
+    const native = strlen.native;
+    expect(strlen(Buffer.from("bun\0"))).toBe(3n);
+
+    lib.close();
+
+    expect(() => strlen(Buffer.from("bun\0"))).toThrow(TypeError);
+    expect(() => strlen(Buffer.from("bun\0"))).toThrow(
+      "Cannot call an FFI function after the library has been closed",
+    );
+    expect(() => native(Buffer.from("bun\0"))).toThrow(TypeError);
+  });
 });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1045,6 +1045,30 @@ describe.skipIf(isWindows && isArm64)("calling an FFI symbol after close()", () 
     }
   });
 
+  it("mid-loop failure unroots and detaches already-compiled symbols", () => {
+    // If linkSymbols fails on symbol N after symbols 0..N-1 have been
+    // compiled + protected, the cleanup path must run Function.deinit on
+    // each earlier symbol (unprotect + setClosed) rather than only freeing
+    // base_name/arg_types. Otherwise each earlier JSFFIFunction becomes a
+    // permanent GC root and its TCC state leaks.
+    const cb = new JSCallback(() => 7, { returns: "i32" });
+    try {
+      let captured;
+      expect(() => {
+        captured = linkSymbols({
+          good: { returns: "i32", ptr: cb.ptr },
+          // missing `ptr` triggers the mid-loop error after `good` compiled
+          bad: { returns: "i32" },
+        });
+      }).toThrow(/"bad".*ptr/);
+      expect(captured).toBeUndefined();
+      // No observable side effects; primary regression signal is no ASAN
+      // leak report and (once the process exits) a balanced gcProtect table.
+    } finally {
+      cb.close();
+    }
+  });
+
   it("JSCallback.close() does not detach an FFI symbol passed as the callback", () => {
     // On the JSCallback path, Function.step.compiled.js_function holds the
     // user's callback (which may itself be a JSFFIFunction from another

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1021,6 +1021,30 @@ describe.skipIf(isWindows && isArm64)("calling an FFI symbol after close()", () 
     }
   });
 
+  it("close() after symbol was deleted from lib.symbols and GC'd does not read a freed cell", () => {
+    // compiled.js_function is stored in the Zig heap; it must be rooted so
+    // that close() can safely detach it even if the user removed it from
+    // the (mutable) symbols object and a GC ran in between.
+    const cb = new JSCallback(() => 7, { returns: "i32" });
+    try {
+      const lib = linkSymbols({ seven: { returns: "i32", ptr: cb.ptr } });
+      const seven = lib.symbols.seven;
+      expect(seven()).toBe(7);
+
+      delete lib.symbols.seven;
+      Bun.gc(true);
+
+      // Must not read a freed/reused GC cell.
+      lib.close();
+
+      // `seven` was kept alive by our local reference and must have been
+      // detached by close().
+      expect(() => seven()).toThrow(TypeError);
+    } finally {
+      cb.close();
+    }
+  });
+
   it("JSCallback.close() does not detach an FFI symbol passed as the callback", () => {
     // On the JSCallback path, Function.step.compiled.js_function holds the
     // user's callback (which may itself be a JSFFIFunction from another

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1029,9 +1029,7 @@ describe("calling an FFI symbol after close()", () => {
     lib.close();
 
     expect(() => strlen(Buffer.from("bun\0"))).toThrow(TypeError);
-    expect(() => strlen(Buffer.from("bun\0"))).toThrow(
-      "Cannot call an FFI function after the library has been closed",
-    );
+    expect(() => strlen(Buffer.from("bun\0"))).toThrow("Cannot call an FFI function after the library has been closed");
     expect(() => native(Buffer.from("bun\0"))).toThrow(TypeError);
   });
 });

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1021,6 +1021,30 @@ describe.skipIf(isWindows && isArm64)("calling an FFI symbol after close()", () 
     }
   });
 
+  it("JSCallback.close() does not detach an FFI symbol passed as the callback", () => {
+    // On the JSCallback path, Function.step.compiled.js_function holds the
+    // user's callback (which may itself be a JSFFIFunction from another
+    // still-open library). Closing the JSCallback must not null that
+    // symbol's trampoline.
+    const target = new JSCallback(() => 7, { returns: "i32" });
+    try {
+      const lib = linkSymbols({ seven: { returns: "i32", ptr: target.ptr } });
+      const seven = lib.symbols.seven; // raw JSFFIFunction
+      expect(seven()).toBe(7);
+
+      const wrapper = new JSCallback(seven, { returns: "i32" });
+      wrapper.close();
+
+      // lib is still open; seven must still work.
+      expect(seven()).toBe(7);
+
+      lib.close();
+      expect(() => seven()).toThrow(TypeError);
+    } finally {
+      target.close();
+    }
+  });
+
   it.if(!!libPath)("dlopen: throws instead of calling freed code", () => {
     const lib = _dlopen(libPath, { strlen: { args: ["ptr"], returns: "usize" } });
     const strlen = lib.symbols.strlen;

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { existsSync } from "fs";
-import { isGlibcVersionAtLeast } from "harness";
+import { isArm64, isGlibcVersionAtLeast, isWindows } from "harness";
 import { platform } from "os";
 
 import {
@@ -972,7 +972,8 @@ describe.if(!!libPath)("can open more than 63 symbols via", () => {
   }
 });
 
-describe("calling an FFI symbol after close()", () => {
+// TinyCC (which compiles the FFI trampolines) is disabled on Windows ARM64.
+describe.skipIf(isWindows && isArm64)("calling an FFI symbol after close()", () => {
   // Regression test: calling a captured FFI symbol after its library has been
   // closed must throw instead of jumping into the freed TinyCC JIT pages.
   it("linkSymbols: throws instead of calling freed code", () => {


### PR DESCRIPTION
## Problem

`dlopen()` / `cc()` / `linkSymbols()` create a `JSFFIFunction` for each symbol whose native entry point is TinyCC-JIT-compiled trampoline code living in a per-function `TCC.State`. On non-Windows, `JSFFIFunction::createForFFI` wrapped that trampoline address directly as the function's `NativeExecutable`.

`lib.close()` runs `tcc_delete` on every function's state, freeing/unmapping the JIT pages — but the `JSFFIFunction` objects are still reachable from JS (via the cached `symbols` object or any reference the user captured before closing), and their executables still point at the freed code. Calling one jumps straight into freed memory.

## Repro

```js
const { linkSymbols, JSCallback } = require("bun:ffi");
const cb = new JSCallback(x => x + 1, { args: ["i32"], returns: "i32" });
const lib = linkSymbols({ inc: { args: ["i32"], returns: "i32", ptr: cb.ptr } });
const inc = lib.symbols.inc;
inc(41);       // 42
lib.close();   // tcc_delete frees the trampoline pages
inc(1);        // SEGV — jump into freed JIT memory
```

```
panic(main thread): Segmentation fault at address 0x3CC1F383A04
```

## Fix

- `JSFFIFunction::createForFFI` now **always** routes through the static `trampoline` host function (previously Windows-only), so the TinyCC pointer lives in the mutable `m_function` field rather than being baked into a `NativeExecutable`.
- `trampoline` checks `m_function` for null and throws `TypeError: Cannot call an FFI function after the library has been closed` instead of dereferencing it.
- `Function.deinit` (called from `FFI.close()`) nulls `m_function` via a new `Bun__FFIFunction_setClosed` before freeing the TCC state.

The indirection is one load + one indirect call per FFI invocation — the same cost Windows was already paying — and makes the freed pointer unreachable from the JS call path.

This is independent of #29858, which keeps the FFI wrapper alive while any symbol is GC-reachable; that PR does not guard user-initiated `close()`.

## Verification

New tests in `test/js/bun/ffi/ffi.test.js` cover `linkSymbols` (with and without args so both the `FFIBuilder`-wrapped and raw `JSFFIFunction` paths are exercised) and `dlopen`:

| | `inc(1)` after `lib.close()` |
|---|---|
| before | ASAN SEGV in freed JIT pages |
| after | `TypeError: Cannot call an FFI function after the library has been closed` |

All existing `test/js/bun/ffi/*` tests pass.