### PR TITLE
parser: pass ASTMemoryAllocator by pointer in append()

### DIFF
--- a/src/ast/ASTMemoryAllocator.zig
+++ b/src/ast/ASTMemoryAllocator.zig
@@ -69,7 +69,7 @@ pub fn pop(this: *ASTMemoryAllocator) void {
     this.previous = null;
 }
 
-pub fn append(this: ASTMemoryAllocator, comptime ValueType: type, value: anytype) *ValueType {
+pub fn append(this: *ASTMemoryAllocator, comptime ValueType: type, value: anytype) *ValueType {
     const ptr = this.bump_allocator.create(ValueType) catch unreachable;
     ptr.* = value;
     return ptr;


### PR DESCRIPTION
## Summary

`ASTMemoryAllocator` embeds an ~8KB `StackFallbackAllocator(8192)` buffer, which makes the whole struct ~8KB in size. The `append` method took `this: ASTMemoryAllocator` **by value**, so every AST node creation forced the compiler to memcpy the entire 8KB struct onto the call frame.

Every other reference to `ASTMemoryAllocator` in the codebase already holds it via a pointer (`*ASTMemoryAllocator` / `?*ASTMemoryAllocator`) — both `Stmt.Data.Store.append` and `Expr.Data.Store.append` pull a `*ASTMemoryAllocator` out of the threadlocal `memory_allocator` before calling `.append`. This was simply an oversight: the fix is to take `this` by pointer to match the rest of the code, no caller changes needed.

\`\`\`diff
-pub fn append(this: ASTMemoryAllocator, comptime ValueType: type, value: anytype) *ValueType {
+pub fn append(this: *ASTMemoryAllocator, comptime ValueType: type, value: anytype) *ValueType {
\`\`\`

## How this was found

Profiled \`bench/module-loader/import.mjs\` (500 ESM files) with \`samply\` and noticed \`_platform_memmove\` was eating 7.5% of self time on worker threads. The dominant callers were four monomorphizations of \`ast.ASTMemoryAllocator.append\`, accounting for ~127 samples combined. The 8KB-per-call value copy was the cause.

## Profile results (samply, 8000 Hz, \`bench/module-loader/import.mjs\`)

| metric | before | after |
| --- | --- | --- |
| \`_platform_memmove\` (self) | 7.50% | 2.91% |
| \`ast.ASTMemoryAllocator.append\` samples | 127 | 2 |

## Wall-clock benchmark (release build, cold runtime transpiler cache)

\`bench/module-loader/import.mjs\` median over 10 runs:

| | time |
| --- | --- |
| before | ~140 ms |
| after  | ~123 ms |

approx. **12% faster** for ESM module loading on this benchmark.

## Test plan

- [x] \`bun bd test test/js/bun/transpiler/repl-transform.test.ts\` (34 pass)
- [x] \`bun bd test test/bundler/bundler_naming.test.ts\` (10 pass, 3 todo)
- [x] \`bun bd test test/bundler/transpiler/transpiler-stack-overflow.test.ts\` (1 pass)
- [x] Re-profiled with samply to confirm \`_platform_memmove\` and \`append\` samples dropped as expected
- [ ] CI green