### PR TITLE
bake(DevServer): don't mutate active_websocket_connections while iterating it in deinit

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -593,14 +593,31 @@ pub fn deinit(dev: *DevServer) void {
         .ssr_transpiler = {},
         .vm = {},
 
-        // WebSockets should be deinitialized before other parts
+        // WebSockets should be deinitialized before other parts.
+        //
+        // `websocket.close()` synchronously dispatches `HmrSocket.onClose`,
+        // which calls `dev.active_websocket_connections.remove(s)` and
+        // destroys the `HmrSocket`. Iterating the map directly while calling
+        // `close()` would therefore mutate the map mid-iteration and free the
+        // pointer the iterator just yielded. Snapshot the keys first so that
+        // `onClose` is free to mutate the live map.
         .active_websocket_connections = {
-            var it = dev.active_websocket_connections.keyIterator();
-            while (it.next()) |item| {
-                const s: *HmrSocket = item.*;
-                if (s.underlying) |websocket|
-                    websocket.close();
+            const count = dev.active_websocket_connections.count();
+            if (count > 0) {
+                const sockets = bun.handleOom(alloc.alloc(*HmrSocket, count));
+                defer alloc.free(sockets);
+                {
+                    var it = dev.active_websocket_connections.keyIterator();
+                    var i: usize = 0;
+                    while (it.next()) |item| : (i += 1) sockets[i] = item.*;
+                    bun.assert(i == count);
+                }
+                for (sockets) |s| {
+                    if (s.underlying) |websocket|
+                        websocket.close();
+                }
             }
+            bun.debugAssert(dev.active_websocket_connections.count() == 0);
             dev.active_websocket_connections.deinit(alloc);
         },
 

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -2,10 +2,12 @@ import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
-  Bun.spawnSync({
+  const result = Bun.spawnSync({
     cmd: [bunExe(), "test", path.join(import.meta.dir, "fixtures/deinitialization/test.ts")],
     env: bunEnv,
     stdio: ["inherit", "inherit", "inherit"],
     cwd: path.join(import.meta.dir, "fixtures/deinitialization"),
   });
+  expect(result.signalCode).toBeUndefined();
+  expect(result.exitCode).toBe(0);
 });

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -29,17 +29,21 @@ async function run({ closeActiveConnections = false, sendAnyRequests = true, web
     if (websocket > 0) {
       const opens: Promise<void>[] = [];
       for (let i = 0; i < websocket; i++) {
-        const { promise, resolve } = Promise.withResolvers<void>();
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
         const ws = new WebSocket(server.url.origin + "/_bun/hmr");
+        let opened = false;
         ws.onopen = () => {
+          opened = true;
           console.log("WebSocket opened");
           resolve();
         };
         ws.onerror = e => {
           e.preventDefault();
+          if (!opened) reject(new Error(`websocket ${i} failed before open`));
         };
         ws.onclose = () => {
           console.log("WebSocket closed");
+          if (!opened) reject(new Error(`websocket ${i} closed before open`));
         };
         sockets.push(ws);
         opens.push(promise);

--- a/test/bake/fixtures/deinitialization/test.ts
+++ b/test/bake/fixtures/deinitialization/test.ts
@@ -7,7 +7,7 @@ expect(process.cwd()).toBe(import.meta.dir);
 
 let promise;
 
-async function run({ closeActiveConnections = false, sendAnyRequests = true, websocket = false }) {
+async function run({ closeActiveConnections = false, sendAnyRequests = true, websocket = 0 }) {
   let lastDevServerDeinitCount = getDevServerDeinitCount();
 
   async function main() {
@@ -25,21 +25,26 @@ async function run({ closeActiveConnections = false, sendAnyRequests = true, web
 
     expect(globalThis.pluginLoaded).toBeUndefined();
 
-    let ws;
-    if (websocket) {
-      const { promise, resolve } = Promise.withResolvers();
-      ws = new WebSocket(server.url.origin + "/_bun/hmr");
-      ws.onopen = () => {
-        console.log("WebSocket opened");
-        resolve();
-      };
-      ws.onerror = e => {
-        e.preventDefault();
-      };
-      ws.onclose = () => {
-        console.log("WebSocket closed");
-      };
-      await promise;
+    let sockets: WebSocket[] = [];
+    if (websocket > 0) {
+      const opens: Promise<void>[] = [];
+      for (let i = 0; i < websocket; i++) {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        const ws = new WebSocket(server.url.origin + "/_bun/hmr");
+        ws.onopen = () => {
+          console.log("WebSocket opened");
+          resolve();
+        };
+        ws.onerror = e => {
+          e.preventDefault();
+        };
+        ws.onclose = () => {
+          console.log("WebSocket closed");
+        };
+        sockets.push(ws);
+        opens.push(promise);
+      }
+      await Promise.all(opens);
     }
 
     globalThis.callback = async () => {
@@ -85,13 +90,19 @@ async function run({ closeActiveConnections = false, sendAnyRequests = true, web
 
 // baseline do nothing
 const cases = [
-  { closeActiveConnections: false, sendAnyRequests: false, websocket: false },
-  { closeActiveConnections: false, sendAnyRequests: false, websocket: true },
-  { closeActiveConnections: true, sendAnyRequests: false, websocket: true },
-  { closeActiveConnections: false, sendAnyRequests: true, websocket: false },
-  { closeActiveConnections: false, sendAnyRequests: true, websocket: true },
-  { closeActiveConnections: true, sendAnyRequests: true, websocket: false },
-  { closeActiveConnections: true, sendAnyRequests: true, websocket: true },
+  { closeActiveConnections: false, sendAnyRequests: false, websocket: 0 },
+  { closeActiveConnections: false, sendAnyRequests: false, websocket: 1 },
+  { closeActiveConnections: true, sendAnyRequests: false, websocket: 1 },
+  { closeActiveConnections: false, sendAnyRequests: true, websocket: 0 },
+  { closeActiveConnections: false, sendAnyRequests: true, websocket: 1 },
+  { closeActiveConnections: true, sendAnyRequests: true, websocket: 0 },
+  { closeActiveConnections: true, sendAnyRequests: true, websocket: 1 },
+  // Multiple HMR sockets still open when DevServer.deinit runs. This exercises
+  // the path where deinit iterates active_websocket_connections and calls
+  // websocket.close() on each, which synchronously re-enters HmrSocket.onClose
+  // (removing from the map + destroying the HmrSocket).
+  { closeActiveConnections: false, sendAnyRequests: false, websocket: 8 },
+  { closeActiveConnections: true, sendAnyRequests: false, websocket: 8 },
 ];
 
 for (const { closeActiveConnections, sendAnyRequests, websocket } of cases) {
@@ -99,7 +110,7 @@ for (const { closeActiveConnections, sendAnyRequests, websocket } of cases) {
     "flags: " +
       Object.entries({ closeActiveConnections, sendAnyRequests, websocket })
         .filter(([key, value]) => value)
-        .map(([key]) => key)
+        .map(([key, value]) => (key === "websocket" ? `websocket=${value}` : key))
         .join(" "),
     async () => {
       await run({ closeActiveConnections, sendAnyRequests, websocket });


### PR DESCRIPTION
## What

`DevServer.deinit` iterates `active_websocket_connections.keyIterator()` and calls `websocket.close()` on each entry. `websocket.close()` → `uws_ws_close` → `us_socket_close` → the context's `on_close` lambda → `HmrSocket.onClose` is dispatched **synchronously**, and `onClose` does:

```zig
bun.debugAssert(s.dev.active_websocket_connections.remove(s));
s.dev.allocator().destroy(s);
```

i.e. it mutates the map being iterated and frees the `HmrSocket` whose pointer the iterator just yielded.

## Why this didn't crash

`std.AutoHashMapUnmanaged.remove()` uses **tombstones** (not backshift) — it marks the slot dead and writes `undefined` to `keys()[idx]` without moving any other entry. The `FieldIterator` returned by `keyIterator()` has already advanced past the slot before returning it, and the loop body doesn't touch `item`/`s` after `close()` returns. So the current pattern happens to work.

Verified under ASAN with 64 concurrent HMR sockets at `deinit`: no UAF, no leak (AllocationScope would panic on leaked sockets).

## Fix

That said, mutating a hash map during iteration is explicitly documented to invalidate the iterator, so this was relying on an implementation detail of the stdlib. Snapshot the keys into a temporary slice first, then close each socket. `onClose` still removes from the live map and destroys the socket; a `debugAssert(count() == 0)` at the end catches any socket that somehow wasn't closed.

## Tests

- `test/bake/fixtures/deinitialization/test.ts`: `websocket` option is now a count; added `websocket: 8` cases (with and without `closeActiveConnections`) so `DevServer.deinit` is exercised with multiple live HMR clients. With `server.stop(false)`, HMR sockets don't count toward `hasActiveWebSockets()`, so `deinitIfWeCan()` runs `dev.deinit()` while all 8 are still in the map.
- `test/bake/deinitialization.test.ts`: the outer test previously ignored the subprocess result entirely — it now asserts `exitCode === 0` so the inner fixture's assertions (and any ASAN crash) actually fail the test.

**Note:** since the original pattern doesn't cause an observable failure with the current Zig stdlib hash map, the new test cases pass on both old and new code. This is a defensive hardening of the re-entrancy pattern plus test coverage for a previously-untested shutdown path.