### PR TITLE
bake: fix use-after-free in DirectoryWatchStore when a client component boundary is demoted

### DIFF
--- a/src/bake/DevServer/DirectoryWatchStore.zig
+++ b/src/bake/DevServer/DirectoryWatchStore.zig
@@ -219,8 +219,46 @@ pub fn freeEntry(store: *DirectoryWatchStore, alloc: Allocator, entry_index: usi
     store.watches.swapRemoveAt(entry_index);
 
     if (store.watches.entries.len == 0) {
-        assert(store.dependencies.items.len == 0);
+        // Every remaining dependency slot must be in the free list.
+        assert(store.dependencies.items.len == store.dependencies_free_list.items.len);
+        store.dependencies.clearRetainingCapacity();
         store.dependencies_free_list.clearRetainingCapacity();
+    }
+}
+
+/// Removes all dependencies whose `source_file_path` is the exact slice
+/// `file_path`, compared by pointer identity since the slice is shared with
+/// IncrementalGraph.bundled_files. Called before IncrementalGraph frees a
+/// file's key string so that no `Dep` is left holding a dangling pointer.
+pub fn removeDependenciesForFile(store: *DirectoryWatchStore, alloc: Allocator, file_path: []const u8) void {
+    if (store.watches.count() == 0) return;
+
+    debug.log("DirectoryWatchStore.removeDependenciesForFile({f})", .{
+        bun.fmt.quote(file_path),
+    });
+
+    // Iterate in reverse since `freeEntry` uses swapRemoveAt.
+    var watch_index = store.watches.count();
+    while (watch_index > 0) {
+        watch_index -= 1;
+        const entry = &store.watches.values()[watch_index];
+        var new_chain: Dep.Index.Optional = .none;
+        var it: ?Dep.Index = entry.first_dep;
+        while (it) |index| {
+            const dep = &store.dependencies.items[index.get()];
+            it = dep.next.unwrap();
+            if (dep.source_file_path.ptr == file_path.ptr) {
+                bun.handleOom(store.freeDependencyIndex(alloc, index));
+            } else {
+                dep.next = new_chain;
+                new_chain = index.toOptional();
+            }
+        }
+        if (new_chain.unwrap()) |new_first_dep| {
+            entry.first_dep = new_first_dep;
+        } else {
+            store.freeEntry(alloc, watch_index);
+        }
     }
 }
 

--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -1924,8 +1924,13 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
             }
 
             const keys = g.bundled_files.keys();
+            const key = keys[file_index.get()];
 
-            g.allocator().free(keys[file_index.get()]);
+            // DirectoryWatchStore.Dep.source_file_path borrows this key; remove
+            // any such dependencies before freeing it so they do not dangle.
+            g.owner().directory_watchers.removeDependenciesForFile(g.allocator(), key);
+
+            g.allocator().free(key);
             keys[file_index.get()] = ""; // cannot be `undefined` as it may be read by hashmap logic
 
             assert_eql(g.first_dep.items[file_index.get()], .none);

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -274,6 +274,90 @@ devTest("deleting imported file shows error then recovers", {
     });
   },
 });
+// Regression test: DirectoryWatchStore.Dep.source_file_path borrows the key
+// string from IncrementalGraph.bundled_files. When a client-component boundary
+// is demoted (its "use client" directive is removed) the server graph calls
+// client_graph.disconnectAndDeleteFile which frees that key. Previously the
+// Dep was left pointing at freed memory, and the next directory-watch event
+// that re-resolved that Dep read it (use-after-free, caught by ASAN).
+devTest("removing 'use client' from a component with a pending resolution failure", {
+  // separateSSRGraph is required so the "use client" file is parsed with the
+  // browser target; otherwise the resolution failure is attributed to the
+  // server graph and the client-graph key is never borrowed.
+  framework: {
+    ...minimalFramework,
+    serverComponents: {
+      ...minimalFramework.serverComponents!,
+      separateSSRGraph: true,
+    },
+  },
+  files: {
+    "routes/index.ts": `
+      import * as Comp from '../components/Comp';
+      import '../components/Sibling';
+      export default function (req, meta) {
+        return new Response('page: ' + (typeof Comp.marker));
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      export const marker = "initial";
+    `,
+    // Sibling.ts keeps a second, stable client-graph Dep on the
+    // components/ directory watch so the watch survives after the
+    // Comp.ts-owned Dep is cleaned up.
+    "components/Sibling.ts": `
+      "use client";
+      import './sibling-missing';
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    // Initial bundle: Comp.ts compiles cleanly as a client-component
+    // boundary, so the server graph records is_client_component_boundary
+    // and the client graph owns the key string for Comp.ts. Sibling.ts
+    // fails to resolve './sibling-missing' under the browser target,
+    // leaving a client-graph Dep on the components/ directory watch.
+    await dev.fetch("/");
+
+    // Re-bundle Comp.ts with a failing import while it is still a CCB.
+    // With separateSSRGraph the re-parse runs under the browser target,
+    // so trackResolutionFailure inserts a second Dep whose
+    // source_file_path is the client graph's key for Comp.ts.
+    await dev.write(
+      "components/Comp.ts",
+      `
+        "use client";
+        import { value } from './missing';
+        export const marker = value;
+      `,
+      { errors: null },
+    );
+
+    // Drop the directive and the failing import so the server parse
+    // succeeds. server_graph.receiveChunk now sees scb=false with
+    // was_ccb=true and calls client_graph.disconnectAndDeleteFile, which
+    // frees the key string that the Comp.ts Dep still references.
+    await dev.write(
+      "components/Comp.ts",
+      `
+        export const marker = "no-client";
+      `,
+      { errors: null },
+    );
+
+    // Create the previously-missing file. The components/ directory watch
+    // is still alive (Sibling's Dep), so HotReloadEvent.processFileList
+    // walks every Dep for components/ and dereferences each
+    // source_file_path. Under ASAN the stale Comp.ts client-graph Dep is
+    // a heap-use-after-free here and the dev server aborts.
+    await dev.write("components/missing.ts", `export const value = "ok";`, { errors: null });
+
+    // The server must still be alive and responding.
+    const res = await dev.fetch("/");
+    expect(res).toBeInstanceOf(Response);
+  },
+});
 devTest("importing html file", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
## Problem

`DirectoryWatchStore.Dep.source_file_path` borrows the key slice from `IncrementalGraph.bundled_files` (via `insertEmpty`, see the comment at `DirectoryWatchStore.zig:69-71`). When a client-component boundary loses its `"use client"` directive, `server_graph.receiveChunk` detects the demotion and calls `client_graph.disconnectAndDeleteFile`, which frees that key string and overwrites the slot with `""`. The `Dep` is never notified, so it keeps pointing at freed memory.

The next time the directory watcher fires for that directory, `HotReloadEvent.processFileList` walks the dep chain and does

```zig
bun.path.dirname(dep.source_file_path, .auto)
```

on the freed slice, then (on resolution success) hashes it into `event.files` and passes it to `IncrementalGraph.invalidate`. Under ASAN this is a `use-after-poison` at `mem.lastIndexOfScalar` → `resolve_path.dirname` → `HotReloadEvent.processFileList:106`.

## Repro

Requires `separateSSRGraph: true` so a `"use client"` file's imports are resolved under the browser target (and therefore its resolution-failure `Dep` borrows the **client** graph's key):

1. `Comp.ts` compiles cleanly as a CCB — `is_client_component_boundary = true` in the server graph, client graph owns the key.
2. Edit `Comp.ts` to import `'./missing'` while still `"use client"` — `trackResolutionFailure(.client, Comp.ts, './missing')` inserts a `Dep` whose `source_file_path` is the client-graph key for `Comp.ts`.
3. Edit `Comp.ts` to drop both the directive and the failing import — server parse succeeds, `receiveChunk` sees `scb=false && was_ccb=true` → `client_graph.disconnectAndDeleteFile` frees the key. The `Dep` from (2) now dangles.
4. Create `components/missing.ts` — the directory watcher fires, `processFileList` reads `dep.source_file_path` → freed memory.

## Fix

- Add `DirectoryWatchStore.removeDependenciesForFile(alloc, file_path)` which walks every watch and drops any `Dep` whose `source_file_path.ptr == file_path.ptr` (pointer identity, since the slice is shared), freeing the watch if it becomes empty.
- Call it from `disconnectAndDeleteFile` just before `g.allocator().free(key)`.
- Relax the cleanup assertion in `freeEntry` to `dependencies.items.len == dependencies_free_list.items.len` (and clear both) so non-sequential dependency frees don't trip the debug assert.

## Verification

```
# without the fix (bun bd, ASAN):
==8747==ERROR: AddressSanitizer: use-after-poison on address 0x74d289f06db2
    #4 bake.DevServer.HotReloadEvent.processFileList (HotReloadEvent.zig:106)
(fail) DEV:bundle-8: removing 'use client' from a component with a pending resolution failure

# with the fix:
(pass) DEV:bundle-8: removing 'use client' from a component with a pending resolution failure [4232ms]
```

All 18 tests in `test/bake/dev/bundle.test.ts` pass.