### PR TITLE
webview: add backend.detached option

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -182,6 +182,18 @@ new Bun.WebView({
 
 The `"webkit"` backend accepts the same `stdout`/`stderr` options.
 
+#### Detaching the subprocess
+
+Some endpoint-protection software writes directly to the controlling terminal (`/dev/tty`) when it blocks a browser binary, which `stdout`/`stderr: "ignore"` cannot silence. `detached: true` spawns the browser in its own session (`setsid()`; a detached process without a console on Windows, as with `Bun.spawn`), so it has no terminal to write to:
+
+```ts
+new Bun.WebView({
+  backend: { type: "chrome", detached: true },
+});
+```
+
+The browser is spawned once per process, so only the first `Bun.WebView` decides this. Both backends accept it.
+
 ---
 
 ## Navigation
@@ -568,6 +580,7 @@ Operations on **different views** are fully independent and run in parallel — 
 | `url`    | `string` \| `false`       | (`chrome` only) `ws://` URL of an existing Chrome's DevTools endpoint, or `false` to skip auto-detect and always spawn. See [above](#existing-chrome). |
 | `stdout` | `"inherit"` \| `"ignore"` | Route the subprocess's stdout to Bun's. Default `"ignore"`.                                                                                            |
 | `stderr` | `"inherit"` \| `"ignore"` | Route the subprocess's stderr to Bun's. Default `"ignore"`.                                                                                            |
+| `detached` | `boolean`               | Spawn the subprocess in its own session, with no controlling terminal. See [above](#detaching-the-subprocess). Default `false`.                       |
 
 ### Instance properties
 

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -572,15 +572,15 @@ Operations on **different views** are fully independent and run in parallel — 
 
 #### `backend` object form
 
-| Option   | Type                      | Description                                                                                                                                            |
-| -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `type`   | `"chrome"` \| `"webkit"`  | **Required.** Which engine to use.                                                                                                                     |
-| `path`   | `string`                  | (`chrome` only) Path to the Chrome/Chromium executable. Forces spawn mode.                                                                             |
-| `argv`   | `string[]`                | (`chrome` only) Extra launch flags, appended after the defaults. Forces spawn mode.                                                                    |
-| `url`    | `string` \| `false`       | (`chrome` only) `ws://` URL of an existing Chrome's DevTools endpoint, or `false` to skip auto-detect and always spawn. See [above](#existing-chrome). |
-| `stdout` | `"inherit"` \| `"ignore"` | Route the subprocess's stdout to Bun's. Default `"ignore"`.                                                                                            |
-| `stderr` | `"inherit"` \| `"ignore"` | Route the subprocess's stderr to Bun's. Default `"ignore"`.                                                                                            |
-| `detached` | `boolean`               | Spawn the subprocess in its own session, with no controlling terminal. See [above](#detaching-the-subprocess). Default `false`.                       |
+| Option     | Type                      | Description                                                                                                                                            |
+| ---------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`     | `"chrome"` \| `"webkit"`  | **Required.** Which engine to use.                                                                                                                     |
+| `path`     | `string`                  | (`chrome` only) Path to the Chrome/Chromium executable. Forces spawn mode.                                                                             |
+| `argv`     | `string[]`                | (`chrome` only) Extra launch flags, appended after the defaults. Forces spawn mode.                                                                    |
+| `url`      | `string` \| `false`       | (`chrome` only) `ws://` URL of an existing Chrome's DevTools endpoint, or `false` to skip auto-detect and always spawn. See [above](#existing-chrome). |
+| `stdout`   | `"inherit"` \| `"ignore"` | Route the subprocess's stdout to Bun's. Default `"ignore"`.                                                                                            |
+| `stderr`   | `"inherit"` \| `"ignore"` | Route the subprocess's stderr to Bun's. Default `"ignore"`.                                                                                            |
+| `detached` | `boolean`                 | Spawn the subprocess in its own session, with no controlling terminal. See [above](#detaching-the-subprocess). Default `false`.                        |
 
 ### Instance properties
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9246,6 +9246,17 @@ declare module "bun" {
            * — the crash report lands here. @default "ignore"
            */
           stderr?: "inherit" | "ignore";
+          /**
+           * Run the subprocess in its own session (`setsid()`; on Windows a
+           * detached process with no console, as with `Bun.spawn`), so it
+           * has no controlling terminal. Some endpoint-protection / antivirus
+           * hooks write their rejection banner directly to `/dev/tty`,
+           * bypassing stdio redirection — detaching keeps that output off
+           * the parent's terminal. Only affects the first `Bun.WebView` in
+           * the process (subsequent views share the same subprocess).
+           * @default false
+           */
+          detached?: boolean;
         }
       | {
           type: "webkit";
@@ -9258,6 +9269,13 @@ declare module "bun" {
            * Route the host process's stderr to Bun's. @default "ignore"
            */
           stderr?: "inherit" | "ignore";
+          /**
+           * Run the host subprocess in its own session (via `setsid()`), so
+           * it has no controlling terminal. Only affects the first
+           * `Bun.WebView` in the process (subsequent views share the same
+           * subprocess). @default false
+           */
+          detached?: boolean;
         };
 
     /**

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -84,7 +84,7 @@ using namespace JSC;
 // terminated) appends after core flags. All pointers nullable.
 extern "C" int32_t Bun__Chrome__ensure(Zig::GlobalObject*, const char* userDataDir,
     const char* path, const char* const* extraArgv, uint32_t extraArgvLen,
-    bool stdoutInherit, bool stderrInherit);
+    bool stdoutInherit, bool stderrInherit, bool detached);
 #if OS(WINDOWS)
 // Copies and queues one chunk; a failure arrives later as Bun__Chrome__onPipeClosed.
 extern "C" void Bun__Chrome__writePipe(const char* data, size_t len);
@@ -276,7 +276,7 @@ static constexpr us_socket_vtable_t s_cdpVTable = {
 
 bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit)
+    bool stdoutInherit, bool stderrInherit, bool detached)
 {
     if (m_mode != TransportMode::None && !m_dead) return true;
     if (m_dead) {
@@ -305,7 +305,7 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
         pathC.length() ? pathC.data() : nullptr,
         argvPtrs.isEmpty() ? nullptr : argvPtrs.span().data(),
         static_cast<uint32_t>(argvPtrs.size()),
-        stdoutInherit, stderrInherit);
+        stdoutInherit, stderrInherit, detached);
     if (rc < 0) {
         m_dead = true;
         return false;
@@ -427,7 +427,7 @@ static void wsOnClose(void* ctx, unsigned short code)
         // let ensureSpawned's m_dead-reset clear it.
         auto pending = std::exchange(t.m_wsPending, {});
         if (t.ensureSpawned(t.m_global, t.m_fallbackUserDataDir, {}, {},
-                t.m_fallbackStdoutInherit, t.m_fallbackStderrInherit)) {
+                t.m_fallbackStdoutInherit, t.m_fallbackStderrInherit, t.m_fallbackDetached)) {
             // Replay over the pipe. Same cancellation check as wsOnOpen
             // — skip ids close() already removed. Append the NUL
             // terminator the pipe protocol needs.
@@ -453,7 +453,7 @@ static void wsOnClose(void* ctx, unsigned short code)
 }
 
 bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl, bool autoDetected,
-    const WTF::String& userDataDir, bool stdoutInherit, bool stderrInherit)
+    const WTF::String& userDataDir, bool stdoutInherit, bool stderrInherit, bool detached)
 {
     // Already connected — singleton semantics, first call wins.
     if (m_mode != TransportMode::None && !m_dead) return true;
@@ -472,6 +472,7 @@ bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl
         m_fallbackUserDataDir = userDataDir;
         m_fallbackStdoutInherit = stdoutInherit;
         m_fallbackStderrInherit = stderrInherit;
+        m_fallbackDetached = detached;
     }
 
     auto* ctx = zig->scriptExecutionContext();

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -381,7 +381,7 @@ public:
     // one Chrome, so mismatched args across views get the first-call's.
     bool ensureSpawned(Zig::GlobalObject*, const WTF::String& userDataDir = {},
         const WTF::String& path = {}, const WTF::Vector<WTF::String>& extraArgv = {},
-        bool stdoutInherit = false, bool stderrInherit = false);
+        bool stdoutInherit = false, bool stderrInherit = false, bool detached = false);
 
     // Connect to an already-running Chrome's DevTools endpoint. wsUrl is
     // a full ws:// URL (from DevToolsActivePort or user-supplied). Same
@@ -400,7 +400,8 @@ public:
     // confusing WebSocket error. autoDetected=false means explicit
     // backend.url; connect failure surfaces directly.
     bool ensureConnected(Zig::GlobalObject*, const WTF::String& wsUrl, bool autoDetected,
-        const WTF::String& userDataDir = {}, bool stdoutInherit = false, bool stderrInherit = false);
+        const WTF::String& userDataDir = {}, bool stdoutInherit = false, bool stderrInherit = false,
+        bool detached = false);
 
     // Next CDP id — caller uses it with Command(id, ...) then calls send().
     uint32_t nextId() { return m_nextId++; }
@@ -447,13 +448,11 @@ public:
     // constructor read DevToolsActivePort) — gates the stale-file
     // fallback in wsOnClose. False for explicit backend.url.
     bool m_wasAutoDetected = false;
-    // Stashed for the wsOnClose fallback spawn. Auto-detect only runs
-    // when path/argv are empty (createChrome branches to spawn-mode
-    // otherwise), so userDataDir + stdio are the only carry-over. Set in
-    // ensureConnected when autoDetected=true.
+    // Spawn args saved by ensureConnected for the wsOnClose fallback spawn.
     WTF::String m_fallbackUserDataDir;
     bool m_fallbackStdoutInherit = false;
     bool m_fallbackStderrInherit = false;
+    bool m_fallbackDetached = false;
     bool m_dead = false;
 
     uint32_t m_nextId = 1;

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -133,6 +133,7 @@ unsafe extern "C" fn Bun__Chrome__ensure(
     extra_argv_len: u32,
     stdout_inherit: bool,
     stderr_inherit: bool,
+    detached: bool,
 ) -> i32 {
     {
         if !INSTANCE.load(Ordering::Relaxed).is_null() {
@@ -165,6 +166,7 @@ unsafe extern "C" fn Bun__Chrome__ensure(
             extra,
             stdout_inherit,
             stderr_inherit,
+            detached,
         ) {
             Ok(rc) => rc,
             Err(err) => {
@@ -490,6 +492,7 @@ fn spawn(
     extra_argv: &[*const c_char],
     stdout_inherit: bool,
     stderr_inherit: bool,
+    detached: bool,
 ) -> crate::Result<i32> {
     {
         let chrome = find_chrome(explicit_path).ok_or(crate::Error::ChromeNotFound)?;
@@ -596,6 +599,7 @@ fn spawn(
             },
             extra_fds: endpoints.child_fds(), // dup2'd to child fd 3 and 4, in order
             argv0: Some(chrome.as_ptr()),
+            detached,
             #[cfg(windows)]
             windows: bun_spawn::WindowsOptions {
                 loop_: event_loop,

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -93,10 +93,11 @@ extern "C" fn Bun__WebViewHost__ensure(
     global: &JSGlobalObject,
     stdout_inherit: bool,
     stderr_inherit: bool,
+    detached: bool,
 ) -> i32 {
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (global, stdout_inherit, stderr_inherit);
+        let _ = (global, stdout_inherit, stderr_inherit, detached);
         return -1;
     }
     #[cfg(target_os = "macos")]
@@ -114,6 +115,7 @@ extern "C" fn Bun__WebViewHost__ensure(
             std::ptr::from_ref(global.bun_vm()).cast_mut(),
             stdout_inherit,
             stderr_inherit,
+            detached,
         ) {
             Ok(fd) => fd,
             Err(err) => {
@@ -153,10 +155,15 @@ bun_spawn::link_impl_ProcessExit! {
 }
 
 #[cfg(target_os = "macos")]
-fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
+fn spawn(
+    vm: *mut VirtualMachine,
+    stdout_inherit: bool,
+    stderr_inherit: bool,
+    detached: bool,
+) -> Result<Fd, Error> {
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (vm, stdout_inherit, stderr_inherit);
+        let _ = (vm, stdout_inherit, stderr_inherit, detached);
         return Err(crate::Error::Unsupported);
     }
     #[cfg(target_os = "macos")]
@@ -209,6 +216,7 @@ fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) ->
             },
             extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
             argv0: Some(exe.as_ptr()),
+            detached,
             ..SpawnOptions::default()
         };
 

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -298,11 +298,11 @@ void JSWebView::doClose()
 #if OS(DARWIN)
 JSWebView* JSWebView::createAndSend(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& persistDir,
-    bool stdoutInherit, bool stderrInherit)
+    bool stdoutInherit, bool stderrInherit, bool detached)
 {
     auto* zig = defaultGlobalObject(g);
     auto& c = WK::client();
-    if (!c.ensureSpawned(zig, stdoutInherit, stderrInherit)) return nullptr;
+    if (!c.ensureSpawned(zig, stdoutInherit, stderrInherit, detached)) return nullptr;
 
     auto impl = WebViewEventTarget::create(*zig->scriptExecutionContext());
     JSWebView* view = create(structure, zig, WTF::move(impl));
@@ -330,7 +330,7 @@ extern "C" size_t Bun__Chrome__autoDetect(char* out, size_t cap);
 JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl, bool skipAutoDetect)
+    bool stdoutInherit, bool stderrInherit, bool detached, const WTF::String& wsUrl, bool skipAutoDetect)
 {
     auto* zig = defaultGlobalObject(g);
     auto& t = CDP::transport();
@@ -348,7 +348,7 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     if (!wsUrl.isEmpty()) {
         ok = t.ensureConnected(zig, wsUrl, /* autoDetected */ false);
     } else if (skipAutoDetect || !path.isEmpty() || !extraArgv.isEmpty()) {
-        ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+        ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit, detached);
     } else {
         // Auto-detect. DevToolsActivePort URL caps at
         // ws://127.0.0.1:65535/devtools/browser/<36-char-uuid> ≈ 70B.
@@ -357,9 +357,9 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
         if (len > 0) {
             ok = t.ensureConnected(zig,
                 WTF::String::fromUTF8(std::span<const char>(buf, len)),
-                /* autoDetected */ true, userDataDir, stdoutInherit, stderrInherit);
+                /* autoDetected */ true, userDataDir, stdoutInherit, stderrInherit, detached);
         } else {
-            ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+            ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit, detached);
         }
     }
     if (!ok) return nullptr;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -182,7 +182,7 @@ public:
     // host spawn failed (caller throws).
     static JSWebView* createAndSend(JSC::JSGlobalObject*, JSC::Structure*,
         uint32_t width, uint32_t height, const WTF::String& persistDir,
-        bool stdoutInherit, bool stderrInherit);
+        bool stdoutInherit, bool stderrInherit, bool detached);
 #endif
 
     // Chrome constructor. Lazy-spawns Chrome; stores width/height for the
@@ -195,8 +195,8 @@ public:
     static JSWebView* createChrome(JSC::JSGlobalObject*, JSC::Structure*,
         uint32_t width, uint32_t height, const WTF::String& userDataDir,
         const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl = {},
-        bool skipAutoDetect = false);
+        bool stdoutInherit, bool stderrInherit, bool detached,
+        const WTF::String& wsUrl = {}, bool skipAutoDetect = false);
 
     void finishCreation(JSC::VM&);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -120,6 +120,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     WTF::Vector<WTF::String> chromeArgv;
     bool stdoutInherit = false;
     bool stderrInherit = false;
+    bool detached = false;
     bool consoleIsGlobal = false;
     JSObject* consoleCallback = nullptr;
 
@@ -267,6 +268,16 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             };
             if (!parseStdio("stdout"_s, stdoutInherit)) return {};
             if (!parseStdio("stderr"_s, stderrInherit)) return {};
+
+            // detached: setsid() the subprocess (see bun.d.ts for the rationale).
+            JSValue detachedOpt = beObj->get(globalObject, Identifier::fromString(vm, "detached"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (detachedOpt.isBoolean()) {
+                detached = detachedOpt.asBoolean();
+            } else if (!detachedOpt.isUndefined()) {
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                    "backend.detached must be a boolean"_s);
+            }
         }
 
         // Initial URL — the navigate() is fired off immediately after
@@ -349,8 +360,8 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
         }
         Bun__Feature__webview_chrome += 1;
         JSWebView* view = JSWebView::createChrome(globalObject, structure, width, height,
-            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, chromeWsUrl,
-            chromeSkipAutoDetect);
+            persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, detached,
+            chromeWsUrl, chromeSkipAutoDetect);
         if (!view) {
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
                 chromeWsUrl.isEmpty()
@@ -369,7 +380,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
 #else
     Bun__Feature__webview_webkit += 1;
     JSWebView* view = JSWebView::createAndSend(globalObject, structure, width, height, persistDir,
-        stdoutInherit, stderrInherit);
+        stdoutInherit, stderrInherit, detached);
     if (!view) {
         return Bun::throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
             "Failed to spawn WebView host process"_s);

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -40,7 +40,7 @@ using namespace JSC;
 using namespace WebViewProto;
 
 // Spawn + process-exit watch implemented in HostProcess.rs (EVFILT_PROC).
-extern "C" int32_t Bun__WebViewHost__ensure(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit);
+extern "C" int32_t Bun__WebViewHost__ensure(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit, bool detached);
 // Unpublishes and kills the host without reporting its exit back here.
 extern "C" void Bun__WebViewHost__retire();
 extern "C" void* Blob__fromMmapWithType(JSC::JSGlobalObject*, uint8_t* ptr, size_t len, const char* mime);
@@ -128,7 +128,7 @@ void HostClient::updateKeepAlive()
         WebCore::clientData(global->vm())->vmHandle, BunLoopKind::Regular, want ? 1 : -1);
 }
 
-bool HostClient::ensureSpawned(Zig::GlobalObject* zig, bool stdoutInherit, bool stderrInherit)
+bool HostClient::ensureSpawned(Zig::GlobalObject* zig, bool stdoutInherit, bool stderrInherit, bool detached)
 {
     if (sock && !dead) return true;
 
@@ -143,7 +143,7 @@ bool HostClient::ensureSpawned(Zig::GlobalObject* zig, bool stdoutInherit, bool 
         txQueue.clear();
     }
 
-    int fd = Bun__WebViewHost__ensure(zig, stdoutInherit, stderrInherit);
+    int fd = Bun__WebViewHost__ensure(zig, stdoutInherit, stderrInherit, detached);
     if (fd < 0) {
         dead = true;
         return false;

--- a/src/runtime/webview/WebKitBackend.h
+++ b/src/runtime/webview/WebKitBackend.h
@@ -51,7 +51,7 @@ struct HostClient {
     WTF::Vector<uint8_t> txQueue;
     bool sockRefd = false;
 
-    bool ensureSpawned(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit);
+    bool ensureSpawned(Zig::GlobalObject*, bool stdoutInherit, bool stderrInherit, bool detached);
     void writeFrame(WebViewProto::Op, uint32_t viewId, const uint8_t* payload, uint32_t len);
     void handleReply(const WebViewProto::Frame&, WebViewProto::Reader);
     void rejectAllAndMarkDead(const WTF::String& reason);

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, tempDir } from "harness";
+import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir } from "harness";
 
 // Chrome backend works on any platform with Chrome/Chromium installed.
 // Mark tests todo if no Chrome found (CI may not have it). Mirrors
@@ -7,7 +7,7 @@ import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, tempDir } from "h
 // paths, then the Playwright cache) so the test detects Chrome whenever the
 // runtime would. On Windows that is usually the preinstalled Edge.
 import { dlopen, FFIType, ptr } from "bun:ffi";
-import { accessSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
+import { accessSync, chmodSync, constants as fsConstants, readdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -1255,4 +1255,86 @@ test("the chrome backend is refused off the main thread", async () => {
   } finally {
     worker.terminate();
   }
+});
+
+// backend.detached — doesn't need real Chrome; we point backend.path at a
+// shell script that reports its own PID/PGID. setsid() (POSIX_SPAWN_SETSID)
+// makes the child its own session + process-group leader, so PID == PGID.
+// Without it the child inherits the spawner's group, so PID != PGID.
+// POSIX-only: on Windows the option maps to libuv's DETACHED_PROCESS (as in
+// Bun.spawn), which a /bin/sh fixture can't observe.
+test.skipIf(isWindows)("chrome: backend.detached runs the subprocess in its own session", async () => {
+  using dir = tempDir("webview-detached", {
+    // Write "<pid>,<pgid>" atomically (tmp + mv) so the poll below never
+    // observes a half-written file. Then block on fd 3 (Chrome's CDP read
+    // pipe) until the parent kills us.
+    //
+    // pgid lookup: on Linux, read /proc/$$/stat (field 3 after the last ')'
+    // is pgrp) — BusyBox ps on Alpine/musl doesn't support `-o pgid= -p`.
+    // On macOS (no /proc), use ps(1) which does support it.
+    "fake-chrome": [
+      "#!/bin/sh",
+      "if [ -r /proc/$$/stat ]; then",
+      '  pgid=$(sed "s/.*) //" /proc/$$/stat | cut -d" " -f3)',
+      "else",
+      '  pgid=$(ps -o pgid= -p $$ | tr -d " ")',
+      "fi",
+      'echo "$$,$pgid" > "$OUT_FILE.tmp"',
+      'mv "$OUT_FILE.tmp" "$OUT_FILE"',
+      "exec cat <&3 >/dev/null 2>&1",
+      "",
+    ].join("\n"),
+  });
+  const fakeChrome = join(String(dir), "fake-chrome");
+  chmodSync(fakeChrome, 0o755);
+
+  async function spawnWith(detached: boolean) {
+    const outFile = join(String(dir), `out-${detached}`);
+    // Subprocess per case — the Chrome transport is a process-wide
+    // singleton; first spawn wins and later backend options are ignored.
+    const script = `
+      const fs = require("node:fs");
+      new Bun.WebView({
+        backend: { type: "chrome", path: ${JSON.stringify(fakeChrome)}, url: false, detached: ${detached} },
+      });
+      const out = ${JSON.stringify(outFile)};
+      while (!fs.existsSync(out)) await Bun.sleep(5);
+      process.stdout.write(fs.readFileSync(out, "utf8"));
+      Bun.WebView.closeAll();
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, OUT_FILE: outFile },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const [pid, pgid] = stdout.trim().split(",");
+    expect(pid).toMatch(/^\d+$/);
+    expect(pgid).toMatch(/^\d+$/);
+    expect(exitCode).toBe(0);
+    return { pid, pgid };
+  }
+
+  // detached: true → setsid() → child is its own process-group leader.
+  const d = await spawnWith(true);
+  expect(d.pgid).toBe(d.pid);
+
+  // detached: false (default) → child inherits the bun subprocess's group.
+  const nd = await spawnWith(false);
+  expect(nd.pgid).not.toBe(nd.pid);
+});
+
+test("chrome: backend.detached validates", () => {
+  // Type validation happens before any platform-specific spawn code — runs
+  // identically on Windows. Matches the sibling backend.stderr/option
+  // validation tests which also use plain test().
+  expect(() => new Bun.WebView({ backend: { type: "chrome", url: false, detached: "yes" } } as any)).toThrow(
+    /backend\.detached must be a boolean/,
+  );
+  expect(() => new Bun.WebView({ backend: { type: "chrome", url: false, detached: 1 } } as any)).toThrow(
+    /backend\.detached must be a boolean/,
+  );
 });


### PR DESCRIPTION
## What

Adds `backend.detached: boolean` to `Bun.WebView` constructor options. When `true`, the browser subprocess (Chrome or the WebKit host) is spawned with `POSIX_SPAWN_SETSID`, putting it in its own session with no controlling terminal.

```ts
new Bun.WebView({
  backend: { type: "chrome", detached: true },
});
```

## Why

Some endpoint-protection / antivirus products hook `exec` and, when they decide to block the Chrome binary, print a rejection banner directly to `/dev/tty`, bypassing the `stdout: "ignore"` / `stderr: "ignore"` redirection that `Bun.WebView` already does. That output clobbers the parent CLI's terminal.

With `detached: true` the child runs in a fresh session (`setsid()`), so `open("/dev/tty")` fails in the child and the banner cannot reach the parent's terminal.

## How

`bun_spawn::SpawnOptions` already has a `detached` field that sets `POSIX_SPAWN_SETSID`; this threads a new option through `JSWebViewConstructor` -> `createChrome`/`createAndSend` -> `Transport::ensureSpawned`/`HostClient::ensureSpawned` -> `Bun__Chrome__ensure`/`Bun__WebViewHost__ensure` -> `SpawnOptions.detached`. Also carried through the auto-detect WebSocket-fallback path (`m_fallbackDetached`).

Defaults to `false`. Like the other spawn-time options (`path`, `argv`, `stdout`, `stderr`), only the first `Bun.WebView` in a process observes it; subsequent views share the already-spawned subprocess. The user-facing rationale is documented on the option in `bun.d.ts`.

## Verification

The test points `backend.path` at a shell script that reports its own `pid` and `pgid`:
- `detached: true` -> `setsid()` makes the child its own process-group leader -> `pgid == pid`
- `detached: false` -> child inherits the spawner's group -> `pgid != pid`

It needs no real Chrome install, so it runs on every POSIX lane; skipped on Windows (the Chrome backend is not implemented there). Locally, with a Chrome available, the full `webview-chrome.test.ts` suite (54 tests) passes on this branch, and the two new tests fail when the `src/` changes are removed.

`rust:check-all` passes for all 10 targets.

## Rebase notes

This PR predates the `src/` restructure and the Rust port, and has been rebased several times:

1. Onto the Rust port: the spawn-side changes moved from `ChromeProcess.zig` / `HostProcess.zig` (now non-compiled reference files, left untouched) into `src/runtime/webview/ChromeProcess.rs` and `HostProcess.rs`; the C++ / type / test changes were reapplied onto the relocated `src/runtime/webview/` paths. History was squashed to one commit.
2. Onto main after the webview spawn functions switched to the crate's typed `Error`: kept main's error types, added the `detached` parameter. The new comment lint flagged the explanatory comments added here; they were trimmed since the rationale lives in the `bun.d.ts` docblock.
3. Onto main after #39423 (Chrome spawn path on Windows), which rewrote `ChromeProcess.rs` around this change:
   - `Bun__Chrome__ensure` / `spawn` no longer have a Windows early-return, so `detached` is simply passed into the now cross-platform `SpawnOptions` literal. On Windows it maps to libuv's `DETACHED_PROCESS`, exactly as `Bun.spawn({ detached })` does; the Windows `WindowsOptions` block from main is kept alongside it.
   - `ChromeBackend.cpp`: kept main's `rc` return-code handling (0 on Windows, fd on POSIX) and the new `Bun__Chrome__writePipe` declaration, adding the `detached` argument.
   - The behavioral test stays POSIX-only (it proves `setsid()` via `pgid == pid`, which a `/bin/sh` fixture cannot express on Windows); its comment now says so instead of claiming Windows is unsupported. Main's new tests in the same file were kept.
   - Documented the option in the new `docs/runtime/webview.mdx` page and noted the Windows semantics in `bun.d.ts`.

Verified after the latest rebase: `webview-chrome.test.ts` 59/59 and `webview-chrome-pipe.test.ts` 7/7 locally, the two new tests fail without the `src/` changes, `rust:check-all` 12/12 targets (Windows included), and the bun-types test passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts

<!-- robobun:evidence:end -->