### PR TITLE
test(fetch-http2-client): deflake 'client RSTs on local error' via same-session barrier

### DIFF
--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -1385,20 +1385,39 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
       // counting against MAX_CONCURRENT_STREAMS.
       await withRawH2Server(
         (conn, id) => {
-          conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-encoding", "gzip")]));
-          conn.data(id, Buffer.from("not gzip"));
+          if (id === 1) {
+            conn.headers(id, Buffer.concat([hpackStatus(200), hpackLit("content-encoding", "gzip")]));
+            conn.data(id, Buffer.from("not gzip"));
+          } else {
+            // Barrier request — see subprocess comment below.
+            conn.headers(id, hpackStatus(204), { endStream: true });
+          }
         },
         async (url, state) => {
           await using proc = await spawnFetch(`
-            try { await (await fetch("${url}", { tls: { rejectUnauthorized: false } })).arrayBuffer(); console.log("ok"); }
+            const tls = { rejectUnauthorized: false };
+            try { await (await fetch("${url}", { tls })).arrayBuffer(); console.log("ok"); }
             catch (e) { console.log("rejected", e.code ?? e.message); }
+            // Second request on the same pooled session acts as a delivery
+            // barrier: RST_STREAM(1) is queued ahead of HEADERS(3) on the one
+            // socket, so the 204 arriving back proves the RST reached the
+            // server. Without this the subprocess can exit while the RST is
+            // still in the TLS/TCP send buffer, which Windows drops on
+            // process death (abortive close) — leaving state.rst empty.
+            console.log((await fetch("${url}", { tls })).status);
           `);
           const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          expect(stdout).toContain("rejected");
+          const out = stdout.trim().split("\n");
+          expect(out[0]).toContain("rejected");
+          expect(out[1]).toBe("204");
           expect(exitCode).toBe(0);
           await state.allClosed();
-          // 0x8 = CANCEL
-          expect(state.rst).toEqual([{ id: 1, code: 8 }]);
+          // 0x8 = CANCEL. connections=1 proves the barrier rode the same
+          // socket, so ordering actually applies.
+          expect({ rst: state.rst, connections: state.connections }).toEqual({
+            rst: [{ id: 1, code: 8 }],
+            connections: 1,
+          });
         },
       );
     });


### PR DESCRIPTION
## Flake

`fetch() over HTTP/2 > raw frame server > client RSTs the stream when it abandons on a local error` fails on Windows (2019 x64, 2019 x64-baseline, 11 aarch64 — occasionally macOS ASAN) with:

```
expect(state.rst).toEqual([{ id: 1, code: 8 }])
- Expected: [{ code: 8, id: 1 }]
+ Received: []
```

Seen in 25+ of the last 65 completed BuildKite runs across branches (builds 48962-49247).

## Cause

The subprocess script is:

```js
try { await (await fetch(url, { tls })).arrayBuffer(); console.log("ok"); }
catch (e) { console.log("rejected", e.code ?? e.message); }
```

After `handleResponseBody` throws on the invalid gzip payload, the h2 client writes a 13-byte `RST_STREAM(CANCEL)` frame to the session's write buffer and flushes it to the TLS socket. But "flushed to the TLS socket" only means accepted into the BoringSSL/uSockets layer — not that it's on the wire. The catch block then prints and the script ends, so the event loop drains and the process exits.

On Windows, process termination does an abortive close (TCP RST) on open sockets, dropping anything still in the TLS write buffer / kernel send queue. The raw server's `socket.on('data')` never sees the RST_STREAM frame; `state.allClosed()` resolves on the abrupt close; `state.rst` is `[]`.

## Fix

Add a second fetch on the same pooled session after the error. The session survives a stream-level body-parse failure (only the stream is RST'd and removed; `maybeRelease()` pools the socket), so the follow-up request reuses it as stream 3.

`RST_STREAM(1)` is FIFO-queued ahead of `HEADERS(3)` on that one socket, so the 204 response arriving back at the subprocess proves the RST reached the server before the process exits. The test also asserts `state.connections === 1` so the ordering argument actually holds (barrier rode the same socket).

This is the same pattern the neighbouring `303 redirect on a streaming-body POST RSTs the half-open upload stream` test already relies on — there the RST for stream 1 is naturally followed by the redirect's follow-up GET on stream 3 before the subprocess exits.

## Verification

- Full file: 58 pass / 0 fail, ×3 runs
- Fixed case in isolation: 20/20 pass