### PR TITLE
Fix use-after-free in Bun.Transpiler async transform() errors

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -452,6 +452,8 @@ pub const TransformTask = struct {
     transpiler: bun.Transpiler = undefined,
     js_instance: *JSTranspiler,
     log: logger.Log,
+    log_string_buf: []u8 = &.{},
+    log_notes_buf: []logger.Data = &.{},
     err: ?anyerror = null,
     macro_map: MacroMap = MacroMap{},
     tsconfig: ?*TSConfigJSON = null,
@@ -502,7 +504,7 @@ pub const TransformTask = struct {
 
         var log = logger.Log.init(allocator);
         log.level = this.log.level;
-        defer bun.handleOom(log.appendToWithRecycled(&this.log, true));
+        defer this.cloneArenaLog(&log);
 
         this.transpiler.setAllocator(allocator);
         this.transpiler.setLog(&log);
@@ -589,8 +591,36 @@ pub const TransformTask = struct {
         return promise.resolve(this.global, value);
     }
 
+    /// Clone `src` (whose message strings live in the per-run arena) into
+    /// `this.log` before the arena is destroyed. The backing buffers are
+    /// tracked on `this` so `deinit()` can free them.
+    fn cloneArenaLog(this: *TransformTask, src: *logger.Log) void {
+        this.log.warnings += src.warnings;
+        this.log.errors += src.errors;
+        if (src.msgs.items.len == 0) return;
+
+        var string_builder = bun.StringBuilder{};
+        var notes_count: usize = 0;
+        for (src.msgs.items) |msg| {
+            msg.count(&string_builder);
+            notes_count += msg.notes.len;
+        }
+        bun.handleOom(string_builder.allocate(bun.default_allocator));
+        this.log_string_buf = if (string_builder.cap > 0) string_builder.ptr.?[0..string_builder.cap] else &.{};
+        this.log_notes_buf = bun.handleOom(bun.default_allocator.alloc(logger.Data, notes_count));
+
+        bun.handleOom(this.log.msgs.ensureUnusedCapacity(src.msgs.items.len));
+        var note_i: usize = 0;
+        for (src.msgs.items) |msg| {
+            this.log.msgs.appendAssumeCapacity(msg.cloneWithBuilder(this.log_notes_buf[note_i..], &string_builder));
+            note_i += msg.notes.len;
+        }
+    }
+
     pub fn deinit(this: *TransformTask) void {
         this.log.deinit();
+        bun.default_allocator.free(this.log_string_buf);
+        bun.default_allocator.free(this.log_notes_buf);
         this.input_code.deinitAndUnprotect();
         this.output_code.deref();
         // tsconfig is owned by JSTranspiler, not by TransformTask.

--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -500,9 +500,12 @@ pub const TransformTask = struct {
         var ast_scope = ast_memory_allocator.enter(allocator);
         defer ast_scope.exit();
 
+        var log = logger.Log.init(allocator);
+        log.level = this.log.level;
+        defer bun.handleOom(log.appendToWithRecycled(&this.log, true));
+
         this.transpiler.setAllocator(allocator);
-        this.transpiler.setLog(&this.log);
-        this.log.msgs.allocator = bun.default_allocator;
+        this.transpiler.setLog(&log);
 
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+
+test("async transform() parse errors do not use arena memory after free", async () => {
+  const transpiler = new Bun.Transpiler({ loader: "ts" });
+  const promises: Promise<string>[] = [];
+  for (let i = 0; i < 1200; i++) {
+    promises.push(
+      transpiler.transform("const x = ;", "ts").then(
+        () => {
+          throw new Error("expected parse error");
+        },
+        e => String(e.message ?? e),
+      ),
+    );
+  }
+  const results = await Promise.all(promises);
+  for (const msg of results) {
+    expect(msg).toContain("Unexpected");
+  }
+});


### PR DESCRIPTION
## What

`TransformTask.run()` creates a `MimallocArena`, points the transpiler at it, parses the input, and destroys the arena before returning. When parsing fails, the lexer/parser write error messages whose text is allocated from that arena into `this.log`. `TransformTask.then()` later calls `this.log.toJS()` on the JS thread to build the rejection value, which reads the (now destroyed) arena memory.

ASAN reports this as `use-after-poison` once the freed arena pages are reused and re-poisoned by a subsequent task, so it only shows up under load.

## Fix

Collect parse diagnostics into a temporary arena-backed `Log` during `run()` and `appendToWithRecycled(&this.log, true)` before the arena is torn down, so the strings are duplicated into `bun.default_allocator`. This mirrors what `RuntimeTranspilerStore` already does for the same reason.

## Repro

```js
const transpiler = new Bun.Transpiler({ loader: "ts" });
const promises = [];
for (let i = 0; i < 1200; i++) {
  promises.push(transpiler.transform("const x = ;", "ts").catch(e => String(e.message ?? e)));
}
await Promise.all(promises);
```

Before: ASAN `use-after-poison` in `logger.Data.clone` → `logger.Msg.clone` → `BuildMessage.create` → `Log.toJS` → `TransformTask.then` (or a straight SIGSEGV at higher concurrency).
After: resolves with the expected `BuildMessage` errors.

Found by Fuzzilli.