### PR TITLE
node:vm: allocate dynamic-import rejection error in the vm realm

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -228,6 +228,13 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     return JSC::ErrorInstance::create(vm, structure, messageString, cause, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
 }
 
+static JSObject* createErrorWithoutCache(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code, const String& message)
+{
+    const auto& data = errors[static_cast<size_t>(code)];
+    auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
+    return JSC::ErrorInstance::create(vm, structure, message, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
+}
+
 JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, const String& message)
 {
     return errorCache(globalObject)->createError(vm, globalObject, code, jsString(vm, message), jsUndefined());
@@ -240,7 +247,10 @@ JSObject* createError(Zig::GlobalObject* globalObject, ErrorCode code, const Str
 
 JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code, const String& message)
 {
-    return createError(vm, defaultGlobalObject(globalObject), code, message);
+    if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
+        return createError(vm, zigGlobalObject, code, message);
+
+    return createErrorWithoutCache(vm, globalObject, code, message);
 }
 
 JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code, JSValue message)
@@ -248,12 +258,11 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
-    auto* structure = createErrorStructure(vm, globalObject, errors[static_cast<size_t>(code)].type, errors[static_cast<size_t>(code)].name, errors[static_cast<size_t>(code)].code);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
     if (scope.exception() && !vm.hasPendingTerminationException())
         (void)scope.tryClearException();
-    return JSC::ErrorInstance::create(vm, structure, messageString, JSValue(), nullptr, JSC::RuntimeType::TypeNothing, errors[static_cast<size_t>(code)].type, true);
+    return createErrorWithoutCache(vm, globalObject, code, messageString);
 }
 
 JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options)

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1179,6 +1179,66 @@ describe("DONT_CONTEXTIFY", () => {
   });
 });
 
+test("ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING is allocated in the vm realm", async () => {
+  // Errors injected into a vm context by the host must be created using the
+  // vm realm's intrinsics. Otherwise guest code can observe host-realm
+  // objects via the error's prototype chain (e.constructor.constructor is the
+  // host Function constructor).
+  const context = createContext({});
+  const guestError = runInContext("Error", context);
+  const guestTypeError = runInContext("TypeError", context);
+  const guestFunction = runInContext("Function", context);
+
+  // import() from code evaluated via vm.Script (runInContext wraps code in
+  // a Script internally, so the source origin carries a NodeVMScriptFetcher).
+  const err1 = await runInContext(`import("x").catch(e => e)`, context);
+  expect({
+    code: err1.code,
+    hostError: err1 instanceof Error,
+    hostTypeError: err1 instanceof TypeError,
+    guestError: err1 instanceof guestError,
+    guestTypeError: err1 instanceof guestTypeError,
+    ctorCtorIsGuestFunction: err1.constructor.constructor === guestFunction,
+    ctorCtorIsHostFunction: err1.constructor.constructor === Function,
+  }).toEqual({
+    code: "ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING",
+    hostError: false,
+    hostTypeError: false,
+    guestError: true,
+    guestTypeError: true,
+    ctorCtorIsGuestFunction: true,
+    ctorCtorIsHostFunction: false,
+  });
+
+  // Verify that guest code running entirely inside the context cannot reach
+  // the host `process` via the rejection's prototype chain.
+  const escaped = await runInContext(
+    `import("x").catch(e => {
+      try {
+        return e.constructor.constructor("return typeof process")();
+      } catch {
+        return "threw";
+      }
+    })`,
+    context,
+  );
+  expect(escaped).toBe("undefined");
+
+  // import() from a source origin with no NodeVM script fetcher (indirect
+  // eval discards the outer Script's fetcher), which takes the fallback
+  // path through NodeVMGlobalObject::moduleLoaderImportModule.
+  const err2 = await runInContext(`(0, eval)("import('x')").catch(e => e)`, context);
+  expect({
+    code: err2.code,
+    hostError: err2 instanceof Error,
+    guestError: err2 instanceof guestError,
+  }).toEqual({
+    code: "ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING",
+    hostError: false,
+    guestError: true,
+  });
+});
+
 test("Loader is not defined in vm context", () => {
   // Test with empty context - internal Loader should not leak through
   const emptyContext = createContext({});


### PR DESCRIPTION
### Problem
- Inside a `node:vm` context, `import("x")` without `importModuleDynamically` rejects with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`, but the error object is built from the host realm: in the context, `e instanceof Error` is `false`, and `e.constructor.constructor` is the host `Function`, so `e.constructor.constructor("return process")()` returns the host `process`.
- Cause: `createError(VM&, JSC::JSGlobalObject*, ErrorCode, const String&)` (`src/jsc/bindings/ErrorCode.cpp:250`) calls `defaultGlobalObject(globalObject)`, which returns the host global whenever the passed global is not a `Zig::GlobalObject`. `NodeVMGlobalObject` is a `Bun::GlobalScope`, not a `Zig::GlobalObject`, so every coded error emitted into a vm context through this overload lands in the host realm.
- The sibling overload taking a `JSValue` message already did the right thing (built the structure against the passed global); only the `String` overload redirected.

### Fix
- Extract the `JSValue` overload's existing non-Zig branch into `createErrorWithoutCache()`, which builds the error structure against the global it is given, and make the `String` overload use it instead of `defaultGlobalObject()`. The `Zig::GlobalObject` path (the cached structures) is unchanged.
- Correct because the prototype chain of an `ErrorInstance` is determined solely by the structure it is created with; building that structure from the vm context's own `Error`/`TypeError` prototypes is exactly what the cached path does for the host realm.
- Verified with `test/js/node/vm/vm.test.ts` ("ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING is allocated in the vm realm"), which covers both emission sites (script-fetcher path via `runInContext`, and the no-fetcher fallback via an indirect-`eval` import) and asserts guest-realm `instanceof` plus that the guest cannot reach `process` through the error.
  - `USE_SYSTEM_BUN=1 bun test test/js/node/vm/vm.test.ts -t "ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING is allocated"`: fails
  - `BUN_JSC_validateExceptionChecks=1 bun bd test test/js/node/vm/vm.test.ts`: 251 pass, 0 fail
  - `test/js/node/test/parallel/test-vm-*.{js,mjs}` under `BUN_JSC_validateExceptionChecks=1`: 96/97 pass; the one failure (`test-vm-module-referrer-realm.mjs`) is a pre-existing unchecked-exception in `NodeVM.cpp` that this PR does not touch and is already tracked separately (#34743).

### Background
- A realm is one global object plus its set of intrinsics (`Object.prototype`, `Error`, `Function`, ...). `node:vm` contexts are separate realms inside the same JSC `VM`; `instanceof` compares against the realm's own constructors, so an object created from another realm's prototypes fails `instanceof` checks and exposes that other realm's intrinsics through its prototype chain.
- Bun's coded errors (`ERR_*`) are created through `createError`. For the host realm (`Zig::GlobalObject`) the per-code error structures are cached on the global (`ErrorCodeCache`); there is no such cache for vm-context globals, so those structures are built on demand, which is what the new helper does.
- Node has the same realm leak for this particular rejection; `node:vm` is documented as not being a security boundary. This PR fixes the `instanceof` semantics rather than claiming a sandbox guarantee.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 22 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (79680517b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [27.29ms]
(pass) vm > runInContext() > can return a value [18.00ms]
(pass) vm > runInContext() > can return a complex value [17.19ms]
(pass) vm > runInContext() > can return the last value [16.32ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [25.68ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [19.31ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [16.72ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [16.41ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.96ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.80ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.30ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.50ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 23 failed, 62 skipped
bun test v1.4.0-canary.1 (b7a043103)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.40ms]
(pass) vm > runInContext() > can return a value [0.21ms]
(pass) vm > runInContext() > can return a complex value [0.22ms]
(pass) vm > runInContext() > can return the last value [0.16ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.18ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.20ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.15ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.17ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.16ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.14ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (79680517b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [21.27ms]
(pass) vm > runInContext() > can return a value [15.06ms]
(pass) vm > runInContext() > can return a complex value [16.19ms]
(pass) vm > runInContext() > can return the last value [15.01ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.98ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [13.81ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.76ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [15.83ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [15.71ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [15.34ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [14.92ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.06ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/74] gen ErrorCode+*.h
[2/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 18s
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.0-canary.1+79680517b
[build] done
bun test v1.4.0-canary.1 (79680517b)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.38ms]
(pass) vm > runInContext() > can return a value [0.25ms]
(pass) vm > runInContext() > can return a complex value [0.22ms]
(pass) vm > runInContext() > can return the last value [0.18ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.24ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't cr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp | 15 ++++++++---
 test/js/node/vm/vm.test.ts     | 60 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 72 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 22

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/jsc/bindings/ErrorCode.cpp      2      6     29
test/js/node/vm/vm.test.ts          4      5     29
```

</details>

<!-- robobun:evidence:end -->