### PR TITLE
Implement EventSource as a Zig-generated class

### DIFF
--- a/src/event_loop/EventLoopTimer.zig
+++ b/src/event_loop/EventLoopTimer.zig
@@ -71,6 +71,7 @@ pub const Tag = enum {
     BunTest,
     EventLoopDelayMonitor,
     CronJob,
+    EventSourceReconnect,
 
     pub fn Type(comptime T: Tag) type {
         return switch (T) {
@@ -97,6 +98,7 @@ pub const Tag = enum {
             .BunTest => jsc.Jest.bun_test.BunTest,
             .EventLoopDelayMonitor => jsc.API.Timer.EventLoopDelayMonitor,
             .CronJob => bun.api.cron.CronJob,
+            .EventSourceReconnect => bun.webcore.EventSource,
         };
     }
 
@@ -197,6 +199,10 @@ pub fn fire(self: *Self, now: *const timespec, vm: *VirtualMachine) void {
         .CronJob => {
             const job = @as(*bun.api.cron.CronJob, @fieldParentPtr("event_loop_timer", self));
             job.onTimerFire(vm);
+        },
+        .EventSourceReconnect => {
+            const es = @as(*bun.webcore.EventSource, @alignCast(@fieldParentPtr("reconnect_timer", self)));
+            es.onReconnectTimer();
         },
         inline else => |t| {
             if (@FieldType(t.Type(), "event_loop_timer") != Self) {

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -372,15 +372,7 @@ const util = {
   },
 };
 
-class EventSource extends EventTarget {
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSED = 2;
-
-  constructor() {
-    super();
-  }
-}
+const EventSource = globalThis.EventSource;
 
 // Add missing cookie functions
 function deleteCookie() {

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -564,12 +564,13 @@ const ProcessWaiterThreadTask = if (Environment.isPosix) bun.spawn.process.Waite
 
 const log = bun.Output.scoped(.Task, .hidden);
 
+const EventSource = @import("../runtime/webcore/EventSource.zig");
+
 const JSCScheduler = @import("../jsc/JSCScheduler.zig");
 const JSCDeferredWorkTask = JSCScheduler.JSCDeferredWorkTask;
 
 const Fetch = @import("../runtime/webcore/fetch.zig");
 const FetchTasklet = Fetch.FetchTasklet;
-const EventSource = @import("../runtime/webcore/EventSource.zig");
 
 const bun = @import("bun");
 const Async = bun.Async;

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -22,6 +22,7 @@ pub const Task = TaggedPointerUnion(.{
     CopyFilePromiseTask,
     CppTask,
     Exists,
+    EventSource,
     Fchmod,
     FChown,
     Fdatasync,
@@ -219,6 +220,10 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
             @field(Task.Tag, @typeName(FetchTasklet)) => {
                 var fetch_task: *Fetch.FetchTasklet = task.get(Fetch.FetchTasklet).?;
                 try fetch_task.onProgressUpdate();
+            },
+            @field(Task.Tag, @typeName(EventSource)) => {
+                var es: *EventSource = task.get(EventSource).?;
+                es.onProgressUpdate();
             },
             @field(Task.Tag, @typeName(S3HttpSimpleTask)) => {
                 var s3_task: *S3HttpSimpleTask = task.get(S3HttpSimpleTask).?;
@@ -564,6 +569,7 @@ const JSCDeferredWorkTask = JSCScheduler.JSCDeferredWorkTask;
 
 const Fetch = @import("../runtime/webcore/fetch.zig");
 const FetchTasklet = Fetch.FetchTasklet;
+const EventSource = @import("../runtime/webcore/EventSource.zig");
 
 const bun = @import("bun");
 const Async = bun.Async;

--- a/src/jsc/bindings/EventSourceEvents.cpp
+++ b/src/jsc/bindings/EventSourceEvents.cpp
@@ -1,0 +1,74 @@
+#include "config.h"
+#include "root.h"
+
+#include "headers-handwritten.h"
+#include "ZigGlobalObject.h"
+#include "blob.h"
+#include "webcore/Event.h"
+#include "webcore/ErrorEvent.h"
+#include "webcore/MessageEvent.h"
+#include "webcore/JSEvent.h"
+#include "webcore/JSErrorEvent.h"
+#include "webcore/JSMessageEvent.h"
+#include "webcore/EventNames.h"
+
+using namespace JSC;
+using namespace WebCore;
+
+// Creates a MessageEvent for SSE dispatch with the given event type (typically
+// "message" or a custom event name from the server's `event:` field), data
+// (joined data lines), origin (the URL origin), and lastEventId.
+extern "C" EncodedJSValue Bun__createSSEMessageEvent(
+    JSGlobalObject* lexicalGlobalObject,
+    const BunString* eventType,
+    const BunString* data,
+    const BunString* origin,
+    const BunString* lastEventId)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    WTF::AtomString typeAtom = eventType->tag != BunStringTag::Empty
+        ? WTF::AtomString(eventType->toWTFString(BunString::ZeroCopy))
+        : eventNames().messageEvent;
+
+    WTF::String dataString = data->toWTFString(BunString::ZeroCopy);
+    WTF::String originString = origin->toWTFString(BunString::ZeroCopy);
+    WTF::String lastEventIdString = lastEventId->toWTFString(BunString::ZeroCopy);
+
+    auto event = MessageEvent::create(
+        typeAtom,
+        MessageEvent::DataType(WTF::move(dataString)),
+        WTF::move(originString),
+        WTF::move(lastEventIdString));
+
+    return JSValue::encode(toJS(lexicalGlobalObject, globalObject, event.ptr()));
+}
+
+// Creates a plain Event for "open" dispatch.
+extern "C" EncodedJSValue Bun__createSSEOpenEvent(JSGlobalObject* lexicalGlobalObject)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto event = Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No);
+    return JSValue::encode(toJS(lexicalGlobalObject, globalObject, event.ptr()));
+}
+
+// Creates an ErrorEvent for "error" dispatch. If message is empty, a plain
+// Event with type "error" is created instead (per spec, the error event in
+// EventSource is a simple Event, not an ErrorEvent — but we expose a message
+// when we have one as a Bun extension for better DX).
+extern "C" EncodedJSValue Bun__createSSEErrorEvent(
+    JSGlobalObject* lexicalGlobalObject,
+    const BunString* message)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+
+    if (message->tag == BunStringTag::Empty) {
+        auto event = Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No);
+        return JSValue::encode(toJS(lexicalGlobalObject, globalObject, event.ptr()));
+    }
+
+    ErrorEvent::Init init;
+    init.message = message->toWTFString(BunString::ZeroCopy);
+    auto event = ErrorEvent::create(eventNames().errorEvent, WTF::move(init), EventIsTrusted::Yes);
+    return JSValue::encode(toJS(lexicalGlobalObject, globalObject, event.ptr()));
+}

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -32,6 +32,7 @@
   process                         GlobalObject::m_processObject                        CellProperty
 
   Blob                            GlobalObject::m_JSBlob                               ClassStructure
+  EventSource                     GlobalObject::m_JSEventSource                        ClassStructure
   Buffer                          GlobalObject::m_JSBufferClassStructure               ClassStructure
   BuildError                      GlobalObject::m_JSBuildMessage                       ClassStructure
   BuildMessage                    GlobalObject::m_JSBuildMessage                       ClassStructure

--- a/src/jsc/generated_classes_list.zig
+++ b/src/jsc/generated_classes_list.zig
@@ -58,6 +58,7 @@ pub const Classes = struct {
     pub const UDPSocket = api.UDPSocket;
     pub const SocketAddress = api.SocketAddress;
     pub const TextDecoder = webcore.TextDecoder;
+    pub const EventSource = webcore.EventSource;
     pub const Timeout = api.Timer.TimeoutObject;
     pub const Immediate = api.Timer.ImmediateObject;
     pub const BuildArtifact = api.BuildArtifact;

--- a/src/runtime/webcore.zig
+++ b/src/runtime/webcore.zig
@@ -17,6 +17,7 @@ pub const AbortSignal = @import("../jsc/AbortSignal.zig").AbortSignal;
 pub const WebWorker = @import("../jsc/web_worker.zig");
 pub const AutoFlusher = @import("../event_loop/AutoFlusher.zig");
 pub const EncodingLabel = @import("./webcore/EncodingLabel.zig").EncodingLabel;
+pub const EventSource = @import("./webcore/EventSource.zig");
 pub const Fetch = @import("./webcore/fetch.zig");
 pub const Response = @import("./webcore/Response.zig");
 pub const BakeResponse = @import("./webcore/BakeResponse.zig");

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -93,6 +93,9 @@ event_type_buffer: std.ArrayListUnmanaged(u8) = .{},
 /// Whether the previous byte processed was '\r' (so a following '\n' is the
 /// second half of a CRLF and must be swallowed).
 last_byte_was_cr: bool = false,
+/// Whether we've received any body bytes on the current connection yet;
+/// used to strip one leading UTF-8 BOM per the spec's `stream = [bom] *event`.
+seen_body_bytes: bool = false,
 /// Whether we've announced the connection (fired "open") yet.
 announced: bool = false,
 
@@ -320,6 +323,7 @@ fn resetPerConnectionState(this: *EventSource) void {
     this.data_buffer.clearRetainingCapacity();
     this.event_type_buffer.clearRetainingCapacity();
     this.last_byte_was_cr = false;
+    this.seen_body_bytes = false;
     this.result_has_more = true;
     this.result_fail = null;
     this.result_status_code = 0;
@@ -538,6 +542,14 @@ fn goIdle(this: *EventSource) void {
 
 fn feed(this: *EventSource, bytes: []const u8) void {
     var i: usize = 0;
+    // Spec ABNF: `stream = [ bom ] *event`. Strip exactly one leading UTF-8
+    // BOM at the start of each connection's body.
+    if (!this.seen_body_bytes) {
+        this.seen_body_bytes = true;
+        if (bytes.len >= 3 and bytes[0] == 0xEF and bytes[1] == 0xBB and bytes[2] == 0xBF) {
+            i = 3;
+        }
+    }
     // Swallow the LF half of a CRLF that straddled the previous chunk.
     if (this.last_byte_was_cr and i < bytes.len and bytes[i] == '\n') i += 1;
     this.last_byte_was_cr = false;
@@ -755,10 +767,10 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
             if (!entry.isObject()) continue;
             const cb = entry.getOwn(global, "cb") catch continue orelse continue;
             if (cb.isUndefined()) continue;
-            filtered.push(global, entry) catch {};
+            filtered.push(global, entry) catch return;
         }
         var key = bun.String.init(event_type);
-        listeners_obj.putMayBeIndex(global, &key, filtered) catch {};
+        listeners_obj.putMayBeIndex(global, &key, filtered) catch return;
     }
 }
 
@@ -873,7 +885,7 @@ pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *js
     var arr = try listeners.getOwn(global, type_str) orelse JSValue.zero;
     if (arr == .zero or !arr.jsType().isArray()) {
         arr = try JSValue.createEmptyArray(global, 0);
-        listeners.putMayBeIndex(global, &type_str, arr) catch {};
+        try listeners.putMayBeIndex(global, &type_str, arr);
     }
     // Dedupe on callback identity (spec: same type + callback + capture).
     const len = try arr.getLength(global);
@@ -915,7 +927,7 @@ pub fn removeEventListener(_: *EventSource, global: *JSGlobalObject, callframe: 
         }
         try new_arr.push(global, entry);
     }
-    listeners.putMayBeIndex(global, &type_str, new_arr) catch {};
+    try listeners.putMayBeIndex(global, &type_str, new_arr);
     return .js_undefined;
 }
 

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -468,8 +468,12 @@ fn failConnectionPermanently(this: *EventSource, status: u16, ct_ok: bool) void 
         "EventSource: connection failed";
 
     this.ready_state = .closed;
-    this.goIdle();
+    // Dispatch the error while `this_value` is still a strong ref and
+    // `has_pending_activity` is still set — `goIdle()` downgrades both, after
+    // which a GC triggered by the ErrorEvent allocation could collect the
+    // wrapper before `dispatchToHandlers` reads it.
     this.dispatchErrorEvent(msg);
+    this.goIdle();
 }
 
 /// Per spec "reestablish the connection": queue an error event, wait the
@@ -566,9 +570,12 @@ fn processLine(this: *EventSource, line: []const u8) void {
     }
 
     if (strings.eqlComptime(field, "data")) {
-        if (this.data_buffer.items.len > 0)
-            bun.handleOom(this.data_buffer.append(bun.default_allocator, '\n'));
+        // Spec: append the field value, then append a single U+000A. Using
+        // the literal form (rather than a "join with \n" shortcut) preserves
+        // leading empty `data:` lines — `data:\ndata: x\n\n` → "\nx" and a
+        // bare `data:\n\n` still dispatches with data === "".
         bun.handleOom(this.data_buffer.appendSlice(bun.default_allocator, value));
+        bun.handleOom(this.data_buffer.append(bun.default_allocator, '\n'));
     } else if (strings.eqlComptime(field, "event")) {
         this.event_type_buffer.clearRetainingCapacity();
         bun.handleOom(this.event_type_buffer.appendSlice(bun.default_allocator, value));
@@ -600,7 +607,16 @@ fn dispatchPendingMessage(this: *EventSource) void {
         this.data_buffer.clearRetainingCapacity();
         this.event_type_buffer.clearRetainingCapacity();
     }
+    // Spec: "if the data buffer is an empty string, set the data buffer and
+    // the event type buffer to the empty string and return." Because every
+    // `data` line appends value+LF, an empty buffer here means no `data`
+    // field was seen at all.
     if (this.data_buffer.items.len == 0) return;
+    // Spec: "if the data buffer's last character is a U+000A LINE FEED (LF)
+    // character, remove the last character from the data buffer." It always
+    // is, given how processLine() appends.
+    bun.assert(this.data_buffer.items[this.data_buffer.items.len - 1] == '\n');
+    this.data_buffer.items.len -= 1;
 
     const event_type = if (this.event_type_buffer.items.len > 0)
         bun.String.cloneUTF8(this.event_type_buffer.items)
@@ -643,6 +659,27 @@ fn dispatchErrorEvent(this: *EventSource, message: []const u8) void {
     this.dispatchToHandlers("error", event);
 }
 
+/// Invoke a listener per the DOM "inner invoke" steps: a function is called
+/// with `thisArg` = the EventSource; an EventListener object has its
+/// `handleEvent` method called with `thisArg` = the listener object.
+fn invokeListener(global: *JSGlobalObject, this_js: JSValue, listener: JSValue, event: JSValue) void {
+    if (listener.isCallable()) {
+        _ = listener.call(global, this_js, &.{event}) catch |e|
+            global.reportActiveExceptionAsUnhandled(e);
+        return;
+    }
+    if (listener.isObject()) {
+        const handle = listener.getTruthy(global, "handleEvent") catch |e| {
+            global.reportActiveExceptionAsUnhandled(e);
+            return;
+        } orelse return;
+        if (handle.isCallable()) {
+            _ = handle.call(global, listener, &.{event}) catch |e|
+                global.reportActiveExceptionAsUnhandled(e);
+        }
+    }
+}
+
 fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue) void {
     const this_js = this.this_value.tryGet() orelse return;
     this_js.ensureStillAlive();
@@ -663,24 +700,54 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
         }
     }
 
-    // addEventListener-registered listeners.
-    if (js.listenersGetCached(this_js)) |listeners_obj| {
-        if (listeners_obj.isObject()) {
-            const maybe_arr = listeners_obj.getOwn(global, event_type) catch return;
-            if (maybe_arr) |arr| {
-                if (arr.jsType().isArray()) {
-                    const len = arr.getLength(global) catch return;
-                    var idx: u32 = 0;
-                    while (idx < len) : (idx += 1) {
-                        const listener = arr.getIndex(global, idx) catch continue;
-                        if (!listener.isCallable()) continue;
-                        _ = listener.call(global, this_js, &.{event}) catch |e|
-                            global.reportActiveExceptionAsUnhandled(e);
-                        if (this.ready_state == .closed) return;
-                    }
-                }
-            }
+    // addEventListener-registered listeners. Entries are stored as
+    // { cb: <fn|{handleEvent}>, once: <bool> }. Snapshot the list before
+    // invoking so mutations during dispatch don't affect this run (DOM
+    // "inner invoke" semantics).
+    const listeners_obj = js.listenersGetCached(this_js) orelse return;
+    if (!listeners_obj.isObject()) return;
+    const maybe_arr = listeners_obj.getOwn(global, event_type) catch return;
+    const arr = maybe_arr orelse return;
+    if (!arr.jsType().isArray()) return;
+
+    const len: u32 = @intCast(arr.getLength(global) catch return);
+    if (len == 0) return;
+
+    var had_once = false;
+    var idx: u32 = 0;
+    while (idx < len) : (idx += 1) {
+        const entry = arr.getIndex(global, idx) catch continue;
+        if (!entry.isObject()) continue;
+        const cb = entry.getOwn(global, "cb") catch continue orelse continue;
+        const once_val = entry.getOwn(global, "once") catch continue;
+        const is_once = once_val != null and once_val.?.toBoolean();
+        if (is_once) {
+            had_once = true;
+            // Mark before invoking so re-entrancy can't fire it again.
+            entry.put(global, bun.String.static("cb"), .js_undefined);
         }
+        invokeListener(global, this_js, cb, event);
+        if (this.ready_state == .closed) break;
+    }
+
+    if (had_once) {
+        // Rebuild the array without the consumed {once:true} entries. We do
+        // this after the loop (rather than splicing in place) so indices
+        // remain stable during iteration.
+        const live = listeners_obj.getOwn(global, event_type) catch return orelse return;
+        if (!live.jsType().isArray()) return;
+        const live_len: u32 = @intCast(live.getLength(global) catch return);
+        const filtered = JSValue.createEmptyArray(global, 0) catch return;
+        var j: u32 = 0;
+        while (j < live_len) : (j += 1) {
+            const entry = live.getIndex(global, j) catch continue;
+            if (!entry.isObject()) continue;
+            const cb = entry.getOwn(global, "cb") catch continue orelse continue;
+            if (cb.isUndefined()) continue;
+            filtered.push(global, entry) catch {};
+        }
+        var key = bun.String.init(event_type);
+        listeners_obj.putMayBeIndex(global, &key, filtered) catch {};
     }
 }
 
@@ -773,7 +840,19 @@ pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *js
     const args = callframe.arguments();
     if (args.len < 2) return .js_undefined;
     const listener = args[1];
-    if (!listener.isCallable()) return .js_undefined;
+    // Accept functions and EventListener objects ({ handleEvent }); per spec
+    // the `handleEvent` lookup is deferred to invoke time, so any object is
+    // permitted here. Only null/undefined/primitives are ignored.
+    if (listener.isUndefinedOrNull() or !(listener.isCallable() or listener.isObject()))
+        return .js_undefined;
+
+    // Flatten options: boolean is `capture` (no effect without a tree), or
+    // a dictionary with `once`. Other keys (`signal`, `passive`, `capture`)
+    // are not yet supported here.
+    var once = false;
+    if (args.len > 2 and args[2].isObject()) {
+        if (try args[2].getBooleanLoose(global, "once")) |o| once = o;
+    }
 
     const this_js = callframe.this();
     const type_str = try args[0].toBunString(global);
@@ -785,14 +864,19 @@ pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *js
         arr = try JSValue.createEmptyArray(global, 0);
         listeners.putMayBeIndex(global, &type_str, arr) catch {};
     }
-    // Dedupe (spec: registering the same listener twice is a no-op).
+    // Dedupe on callback identity (spec: same type + callback + capture).
     const len = try arr.getLength(global);
     var i: u32 = 0;
     while (i < len) : (i += 1) {
-        const existing = try arr.getIndex(global, i);
-        if (existing == listener) return .js_undefined;
+        const entry = try arr.getIndex(global, i);
+        if (!entry.isObject()) continue;
+        const cb = try entry.getOwn(global, "cb") orelse continue;
+        if (cb == listener) return .js_undefined;
     }
-    try arr.push(global, listener);
+    const entry = JSValue.createEmptyObject(global, 2);
+    entry.put(global, bun.String.static("cb"), listener);
+    entry.put(global, bun.String.static("once"), JSValue.jsBoolean(once));
+    try arr.push(global, entry);
     return .js_undefined;
 }
 
@@ -813,9 +897,12 @@ pub fn removeEventListener(_: *EventSource, global: *JSGlobalObject, callframe: 
     const new_arr = try JSValue.createEmptyArray(global, 0);
     var i: u32 = 0;
     while (i < len) : (i += 1) {
-        const existing = try arr.getIndex(global, i);
-        if (existing == listener) continue;
-        try new_arr.push(global, existing);
+        const entry = try arr.getIndex(global, i);
+        if (entry.isObject()) {
+            const cb = try entry.getOwn(global, "cb") orelse .js_undefined;
+            if (cb == listener) continue;
+        }
+        try new_arr.push(global, entry);
     }
     listeners.putMayBeIndex(global, &type_str, new_arr) catch {};
     return .js_undefined;
@@ -837,7 +924,14 @@ pub fn dispatchEvent(this: *EventSource, global: *JSGlobalObject, callframe: *js
     event_loop.enter();
     defer event_loop.exit();
     this.dispatchToHandlers(type_utf8.slice(), event);
-    return JSValue.jsBoolean(true);
+
+    // Per spec: return false if the event is cancelable and preventDefault()
+    // was called (i.e. defaultPrevented is true); true otherwise.
+    const default_prevented = blk: {
+        const dp = (event.getTruthy(global, "defaultPrevented") catch break :blk false) orelse break :blk false;
+        break :blk dp.toBoolean();
+    };
+    return JSValue.jsBoolean(!default_prevented);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -370,6 +370,18 @@ pub fn httpCallback(this: *EventSource, async_http: *http.AsyncHTTP, result: htt
                 break;
             }
         }
+        // Per spec, MessageEvent.origin must reflect the *final* URL after
+        // redirects. AsyncHTTP was created with `.follow`, and `metadata.url`
+        // carries that final URL — pick it up so future events and reconnects
+        // target the right place.
+        if (metadata.url.len > 0 and !strings.eql(metadata.url, this.url_href)) {
+            const new_href = bun.handleOom(bun.default_allocator.dupe(u8, metadata.url));
+            bun.default_allocator.free(this.url_href);
+            this.url_href = new_href;
+            this.url = ZigURL.parse(new_href);
+            bun.default_allocator.free(this.origin);
+            this.origin = bun.handleOom(bun.default_allocator.dupe(u8, this.url.origin));
+        }
         metadata.deinit(bun.default_allocator);
     }
 
@@ -532,8 +544,7 @@ fn feed(this: *EventSource, bytes: []const u8) void {
 
     while (i < bytes.len) {
         const slice = bytes[i..];
-        const nl = std.mem.indexOfAny(u8, slice, "\r\n");
-        if (nl) |pos| {
+        if (strings.indexOfAny(slice, "\r\n")) |pos| {
             bun.handleOom(this.line_buffer.appendSlice(bun.default_allocator, slice[0..pos]));
             const line = this.line_buffer.items;
             this.processLine(line);
@@ -914,15 +925,15 @@ pub fn dispatchEvent(this: *EventSource, global: *JSGlobalObject, callframe: *js
         return global.throwInvalidArguments("dispatchEvent requires an Event", .{});
     }
     const event = args[0];
-    const type_val = try event.getTruthy(global, "type") orelse return JSValue.jsBoolean(true);
+    const type_val = try event.getTruthy(global, "type") orelse return .true;
     const type_str = try type_val.toBunString(global);
     defer type_str.deref();
     const type_utf8 = type_str.toUTF8(bun.default_allocator);
     defer type_utf8.deinit();
 
-    const event_loop = this.vm.eventLoop();
-    event_loop.enter();
-    defer event_loop.exit();
+    // This is a JS-callable prototype method, so we're already inside a JS
+    // frame — no event_loop.enter()/exit() here (that pair is for native→JS
+    // entry points like onProgressUpdate).
     this.dispatchToHandlers(type_utf8.slice(), event);
 
     // Per spec: return false if the event is cancelable and preventDefault()

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -1,0 +1,862 @@
+//! EventSource (Server-Sent Events) client.
+//!
+//! https://html.spec.whatwg.org/multipage/server-sent-events.html
+//!
+//! This is a Zig-generated class that drives an HTTP GET request using the
+//! same `bun.http.AsyncHTTP` machinery that `FetchTasklet` uses: a
+//! `Signals.Store` for header-progress / body-streaming / abort, a
+//! `MutableString` pair for HTTP-thread → JS-thread body handoff, and a
+//! `ConcurrentTask` to hop back to the JS thread. Incoming body chunks are
+//! fed through an incremental SSE line parser and dispatched to JS as real
+//! `MessageEvent` objects.
+
+pub const EventSource = @This();
+
+const log = Output.scoped(.EventSource, .visible);
+
+const ReadyState = enum(u8) {
+    connecting = 0,
+    open = 1,
+    closed = 2,
+};
+
+const default_reconnection_time_ms: u32 = 3000;
+
+pub const js = jsc.Codegen.JSEventSource;
+pub const toJS = js.toJS;
+pub const fromJS = js.fromJS;
+pub const fromJSDirect = js.fromJSDirect;
+
+const RefCount = bun.ptr.RefCount(@This(), "ref_count", deinit, .{});
+pub const ref = RefCount.ref;
+pub const deref = RefCount.deref;
+
+// ---------------------------------------------------------------------------
+// Fields
+// ---------------------------------------------------------------------------
+
+ref_count: RefCount,
+
+globalThis: *JSGlobalObject,
+vm: *VirtualMachine,
+this_value: jsc.JSRef = jsc.JSRef.empty(),
+poll_ref: bun.Async.KeepAlive = .{},
+has_pending_activity: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+/// Normalized absolute URL (owned; also backs `url.href`).
+url_href: []const u8 = "",
+url: ZigURL = .{},
+/// scheme://host[:port] — derived from `url` so every MessageEvent carries it.
+origin: []const u8 = "",
+
+with_credentials: bool = false,
+ready_state: ReadyState = .connecting,
+
+/// Optional extra request headers supplied via `new EventSource(url, { headers })`.
+/// Kept as an immutable template; each connect builds a fresh `Headers` from it
+/// plus `Accept`, `Cache-Control`, and (on reconnect) `Last-Event-ID`.
+extra_headers: bun.http.Headers,
+
+/// Per-spec reconnection parameters.
+last_event_id: std.ArrayListUnmanaged(u8) = .{},
+reconnection_time_ms: u32 = default_reconnection_time_ms,
+reconnect_timer: EventLoopTimer = .{ .tag = .EventSourceReconnect, .next = .epoch },
+
+// --- HTTP state (FetchTasklet-style) --------------------------------------
+async_http: ?*http.AsyncHTTP = null,
+request_headers: bun.http.Headers,
+signal_store: http.Signals.Store = .{},
+signals: http.Signals = .{},
+/// Buffer the HTTP thread writes into for each socket read.
+response_buffer: MutableString = .{ .allocator = bun.default_allocator, .list = .{} },
+/// Bytes handed off from HTTP thread → JS thread under `mutex`.
+scheduled_response_buffer: MutableString = .{ .allocator = bun.default_allocator, .list = .{} },
+mutex: bun.Mutex = .{},
+has_schedule_callback: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+concurrent_task: jsc.ConcurrentTask = .{},
+
+/// HTTP result bookkeeping (updated on HTTP thread under `mutex`).
+result_has_more: bool = true,
+result_fail: ?anyerror = null,
+result_status_code: u16 = 0,
+result_content_type_ok: bool = false,
+/// True once the HTTP thread has delivered response metadata.
+got_metadata: bool = false,
+
+// --- SSE parser state (JS thread only) -------------------------------------
+/// Carry-over for a partial line that did not end in LF/CR yet.
+line_buffer: std.ArrayListUnmanaged(u8) = .{},
+/// `data` buffer per §9.2.6 (joined with '\n').
+data_buffer: std.ArrayListUnmanaged(u8) = .{},
+/// `event` field for the current in-progress message; empty → "message".
+event_type_buffer: std.ArrayListUnmanaged(u8) = .{},
+/// Whether the previous byte processed was '\r' (so a following '\n' is the
+/// second half of a CRLF and must be swallowed).
+last_byte_was_cr: bool = false,
+/// Whether we've announced the connection (fired "open") yet.
+announced: bool = false,
+
+// ---------------------------------------------------------------------------
+// C++ helpers (EventSourceEvents.cpp)
+// ---------------------------------------------------------------------------
+extern fn Bun__createSSEMessageEvent(
+    global: *JSGlobalObject,
+    event_type: *const bun.String,
+    data: *const bun.String,
+    origin: *const bun.String,
+    last_event_id: *const bun.String,
+) JSValue;
+extern fn Bun__createSSEOpenEvent(global: *JSGlobalObject) JSValue;
+extern fn Bun__createSSEErrorEvent(global: *JSGlobalObject, message: *const bun.String) JSValue;
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+pub fn constructor(globalThis: *JSGlobalObject, callframe: *jsc.CallFrame, js_this: JSValue) bun.JSError!*EventSource {
+    const args = callframe.arguments();
+    if (args.len < 1 or args[0].isUndefined()) {
+        return globalThis.throwNotEnoughArguments("EventSource", 1, args.len);
+    }
+
+    // Parse and normalize the URL (throws SyntaxError on failure per spec).
+    const url_bun_str = try args[0].toBunString(globalThis);
+    defer url_bun_str.deref();
+    const href_input = url_bun_str.toUTF8(bun.default_allocator);
+    defer href_input.deinit();
+
+    const url = ZigURL.fromUTF8(bun.default_allocator, href_input.slice()) catch {
+        return globalThis.throwDOMException(.SyntaxError, "EventSource: failed to parse URL \"{s}\"", .{href_input.slice()});
+    };
+    // `url.href` is owned by us (allocated inside fromUTF8).
+    errdefer bun.default_allocator.free(url.href);
+
+    if (!url.isHTTP() and !url.isHTTPS()) {
+        return globalThis.throwDOMException(.SyntaxError, "EventSource: URL must use http or https (got \"{s}\")", .{url.displayProtocol()});
+    }
+
+    var with_credentials = false;
+    var extra_headers = bun.http.Headers{ .allocator = bun.default_allocator };
+    errdefer extra_headers.deinit();
+
+    if (args.len > 1 and args[1].isObject()) {
+        const opts = args[1];
+        if (try opts.getBooleanLoose(globalThis, "withCredentials")) |wc| {
+            with_credentials = wc;
+        }
+        // Bun extension: allow passing extra request headers (e.g. Authorization).
+        if (try opts.getTruthy(globalThis, "headers")) |headers_value| {
+            if (headers_value.as(FetchHeaders)) |fh| {
+                extra_headers = try bun.http.Headers.from(fh, bun.default_allocator, .{});
+            } else if (headers_value.isObject()) {
+                if (try FetchHeaders.createFromJS(globalThis, headers_value)) |fh| {
+                    defer fh.deref();
+                    extra_headers = try bun.http.Headers.from(fh, bun.default_allocator, .{});
+                }
+            }
+            js.headersSetCached(js_this, globalThis, headers_value);
+        }
+    }
+
+    const origin_owned = bun.handleOom(bun.default_allocator.dupe(u8, url.origin));
+    errdefer bun.default_allocator.free(origin_owned);
+
+    const vm = globalThis.bunVM();
+    const this = bun.new(EventSource, .{
+        .ref_count = .init(),
+        .globalThis = globalThis,
+        .vm = vm,
+        .url_href = url.href,
+        .url = url,
+        .origin = origin_owned,
+        .with_credentials = with_credentials,
+        .extra_headers = extra_headers,
+        .request_headers = .{ .allocator = bun.default_allocator },
+    });
+
+    this.this_value = .initStrong(js_this, globalThis);
+    this.poll_ref.ref(vm);
+    this.has_pending_activity.store(1, .release);
+
+    this.connect();
+    return this;
+}
+
+pub fn finalize(this: *EventSource) void {
+    this.this_value.finalize();
+    this.deref();
+}
+
+fn deinit(this: *EventSource) void {
+    this.cancelReconnectTimer();
+    this.clearHttp();
+    if (this.url_href.len > 0) bun.default_allocator.free(this.url_href);
+    if (this.origin.len > 0) bun.default_allocator.free(this.origin);
+    this.extra_headers.deinit();
+    this.request_headers.deinit();
+    this.last_event_id.deinit(bun.default_allocator);
+    this.line_buffer.deinit(bun.default_allocator);
+    this.data_buffer.deinit(bun.default_allocator);
+    this.event_type_buffer.deinit(bun.default_allocator);
+    this.response_buffer.deinit();
+    this.scheduled_response_buffer.deinit();
+    this.poll_ref.unref(this.vm);
+    bun.destroy(this);
+}
+
+pub fn memoryCost(this: *const EventSource) usize {
+    return @sizeOf(EventSource) +
+        this.url_href.len +
+        this.origin.len +
+        this.extra_headers.memoryCost() +
+        this.request_headers.memoryCost() +
+        this.last_event_id.capacity +
+        this.line_buffer.capacity +
+        this.data_buffer.capacity +
+        this.event_type_buffer.capacity +
+        this.response_buffer.list.capacity +
+        this.scheduled_response_buffer.list.capacity;
+}
+
+pub fn hasPendingActivity(this: *EventSource) callconv(.c) bool {
+    return this.has_pending_activity.load(.acquire) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP connection lifecycle
+// ---------------------------------------------------------------------------
+
+fn buildRequestHeaders(this: *EventSource) void {
+    this.request_headers.deinit();
+    this.request_headers = .{ .allocator = bun.default_allocator };
+
+    // Copy user-supplied headers first so spec-required ones below take
+    // precedence via later `append`s (AsyncHTTP writes them in order).
+    {
+        const names = this.extra_headers.entries.items(.name);
+        const values = this.extra_headers.entries.items(.value);
+        for (names, values) |n, v| {
+            const name = this.extra_headers.asStr(n);
+            // Skip headers we always set ourselves.
+            if (strings.eqlCaseInsensitiveASCII(name, "accept", true) or
+                strings.eqlCaseInsensitiveASCII(name, "cache-control", true) or
+                strings.eqlCaseInsensitiveASCII(name, "last-event-id", true))
+                continue;
+            bun.handleOom(this.request_headers.append(name, this.extra_headers.asStr(v)));
+        }
+    }
+
+    bun.handleOom(this.request_headers.append("Accept", "text/event-stream"));
+    bun.handleOom(this.request_headers.append("Cache-Control", "no-cache"));
+    if (this.last_event_id.items.len > 0) {
+        bun.handleOom(this.request_headers.append("Last-Event-ID", this.last_event_id.items));
+    }
+}
+
+fn clearHttp(this: *EventSource) void {
+    if (this.async_http) |h| {
+        this.async_http = null;
+        h.clearData();
+        bun.default_allocator.destroy(h);
+    }
+}
+
+fn connect(this: *EventSource) void {
+    log("connect", .{});
+    bun.assert(this.ready_state != .closed);
+
+    this.clearHttp();
+    this.resetPerConnectionState();
+    this.buildRequestHeaders();
+
+    this.signal_store = .{};
+    this.signals = this.signal_store.to();
+    // Emit progress as soon as headers arrive and stream the body.
+    this.signal_store.header_progress.store(true, .monotonic);
+
+    const h = bun.handleOom(bun.default_allocator.create(http.AsyncHTTP));
+    this.async_http = h;
+
+    var proxy: ?ZigURL = null;
+    if (this.vm.transpiler.env.getHttpProxyFor(this.url)) |env_proxy| {
+        proxy = env_proxy;
+    }
+
+    h.* = http.AsyncHTTP.init(
+        bun.default_allocator,
+        .GET,
+        this.url,
+        this.request_headers.entries,
+        this.request_headers.buf.items,
+        &this.response_buffer,
+        "",
+        http.HTTPClientResult.Callback.New(*EventSource, EventSource.httpCallback).init(this),
+        .follow,
+        .{
+            .http_proxy = proxy,
+            .signals = this.signals,
+            .verbose = this.vm.getVerboseFetch(),
+            .reject_unauthorized = this.vm.getTLSRejectUnauthorized(),
+            // SSE connections are long-lived; rely on the server or .close().
+            .disable_timeout = true,
+        },
+    );
+    h.enableResponseBodyStreaming();
+
+    // Hold an extra ref for the in-flight HTTP request so that the struct
+    // cannot be destroyed while the HTTP thread still holds pointers into it.
+    this.ref();
+
+    http.HTTPThread.init(&.{});
+    var batch = bun.ThreadPool.Batch{};
+    h.schedule(bun.default_allocator, &batch);
+    http.http_thread.schedule(batch);
+}
+
+fn resetPerConnectionState(this: *EventSource) void {
+    this.response_buffer.reset();
+    this.scheduled_response_buffer.reset();
+    this.line_buffer.clearRetainingCapacity();
+    this.data_buffer.clearRetainingCapacity();
+    this.event_type_buffer.clearRetainingCapacity();
+    this.last_byte_was_cr = false;
+    this.result_has_more = true;
+    this.result_fail = null;
+    this.result_status_code = 0;
+    this.result_content_type_ok = false;
+    this.got_metadata = false;
+    this.announced = false;
+    this.has_schedule_callback.store(false, .monotonic);
+}
+
+fn abortHttp(this: *EventSource) void {
+    this.signal_store.aborted.store(true, .monotonic);
+    if (this.async_http) |h| http.http_thread.scheduleShutdown(h);
+}
+
+/// Runs on the HTTP thread. Mirrors `FetchTasklet.callback`: copy result state
+/// and any new body bytes into `scheduled_response_buffer` under `mutex`, then
+/// enqueue a JS-thread tick via `concurrent_task`.
+pub fn httpCallback(this: *EventSource, async_http: *http.AsyncHTTP, result: http.HTTPClientResult) void {
+    const is_done = !result.has_more;
+    this.mutex.lock();
+    defer this.mutex.unlock();
+
+    if (this.async_http) |h| {
+        h.* = async_http.*;
+        h.response_buffer = async_http.response_buffer;
+    }
+
+    this.result_has_more = result.has_more;
+    if (result.fail) |e| this.result_fail = e;
+
+    if (result.certificate_info) |*cert| cert.deinit(bun.default_allocator);
+
+    if (result.metadata) |m| {
+        var metadata = m;
+        this.got_metadata = true;
+        this.result_status_code = @truncate(metadata.response.status_code);
+        for (metadata.response.headers.list) |header| {
+            if (strings.eqlCaseInsensitiveASCII(header.name, "content-type", true)) {
+                // Per spec: MIME type must be text/event-stream (parameters ignored).
+                const v = strings.trim(header.value, " \t");
+                if (v.len >= "text/event-stream".len and
+                    strings.eqlCaseInsensitiveASCII(v[0.."text/event-stream".len], "text/event-stream", true))
+                {
+                    const rest = v["text/event-stream".len..];
+                    if (rest.len == 0 or rest[0] == ';' or rest[0] == ' ' or rest[0] == '\t')
+                        this.result_content_type_ok = true;
+                }
+                break;
+            }
+        }
+        metadata.deinit(bun.default_allocator);
+    }
+
+    if (result.body) |body| {
+        if (body.list.items.len > 0) {
+            _ = bun.handleOom(this.scheduled_response_buffer.write(body.list.items));
+        }
+        body.reset();
+    }
+
+    if (!is_done) {
+        // Don't wake the JS thread for an empty interim tick.
+        if (!this.got_metadata and this.scheduled_response_buffer.list.items.len == 0) return;
+    }
+
+    if (this.has_schedule_callback.cmpxchgStrong(false, true, .acquire, .monotonic)) |prev| {
+        if (prev) return;
+    }
+    if (this.vm.isShuttingDown()) return;
+    this.vm.eventLoop().enqueueTaskConcurrent(this.concurrent_task.from(this, .manual_deinit));
+}
+
+// ---------------------------------------------------------------------------
+// JS-thread progress
+// ---------------------------------------------------------------------------
+
+/// Called from the event loop task queue (JS thread). Drains any buffered body
+/// bytes into the SSE parser and handles connection-level state transitions.
+pub fn onProgressUpdate(this: *EventSource) void {
+    this.mutex.lock();
+    this.has_schedule_callback.store(false, .monotonic);
+
+    const has_more = this.result_has_more;
+    const fail = this.result_fail;
+    const got_metadata = this.got_metadata;
+    const status = this.result_status_code;
+    const ct_ok = this.result_content_type_ok;
+
+    // Steal the buffered body bytes; a fresh list replaces the shared buffer so
+    // the HTTP thread can keep appending without contending on the parser.
+    var chunk = this.scheduled_response_buffer;
+    this.scheduled_response_buffer = .{ .allocator = bun.default_allocator, .list = .{} };
+    this.mutex.unlock();
+    defer chunk.deinit();
+
+    const is_done = !has_more;
+    // Balance the ref taken in `connect()` once the request fully ends.
+    defer if (is_done) this.deref();
+
+    if (this.ready_state == .closed) return;
+
+    const event_loop = this.vm.eventLoop();
+    event_loop.enter();
+    defer event_loop.exit();
+
+    // Connection-level failure (socket error, TLS failure, abort, …).
+    if (fail) |err| {
+        if (is_done) {
+            // User-initiated abort (.close()) already set readyState = closed.
+            this.failAndMaybeReconnect(@errorName(err));
+        }
+        return;
+    }
+
+    if (got_metadata and !this.announced) {
+        // Per spec: 200 + text/event-stream → announce; anything else → fail.
+        if (status != 200 or !ct_ok) {
+            this.abortHttp();
+            this.failConnectionPermanently(status, ct_ok);
+            return;
+        }
+        this.announced = true;
+        this.ready_state = .open;
+        this.dispatchSimpleEvent(.open);
+        if (this.ready_state == .closed) return;
+    }
+
+    if (this.announced and chunk.list.items.len > 0) {
+        this.feed(chunk.list.items);
+        if (this.ready_state == .closed) return;
+    }
+
+    if (is_done) {
+        // Network error / clean close while stream was open → reconnect.
+        this.failAndMaybeReconnect(if (this.announced) null else "connection closed before headers");
+    }
+}
+
+fn failConnectionPermanently(this: *EventSource, status: u16, ct_ok: bool) void {
+    var buf: [160]u8 = undefined;
+    const msg = if (status != 200)
+        std.fmt.bufPrint(&buf, "EventSource: unexpected HTTP status {d}", .{status}) catch "EventSource: unexpected HTTP status"
+    else if (!ct_ok)
+        "EventSource: server did not respond with Content-Type: text/event-stream"
+    else
+        "EventSource: connection failed";
+
+    this.ready_state = .closed;
+    this.goIdle();
+    this.dispatchErrorEvent(msg);
+}
+
+/// Per spec "reestablish the connection": queue an error event, wait the
+/// reconnection time, then re-run the connect steps. A network error before
+/// the stream opened (no metadata) is treated the same way here — browsers
+/// also retry on connection refused.
+fn failAndMaybeReconnect(this: *EventSource, message: ?[]const u8) void {
+    if (this.ready_state == .closed) return;
+    this.ready_state = .connecting;
+    this.dispatchErrorEvent(message orelse "");
+    if (this.ready_state == .closed) return;
+    this.scheduleReconnect();
+}
+
+fn scheduleReconnect(this: *EventSource) void {
+    this.cancelReconnectTimer();
+    const ms: u32 = if (this.reconnection_time_ms == 0) 1 else this.reconnection_time_ms;
+    this.reconnect_timer.next = bun.timespec.msFromNow(.allow_mocked_time, @intCast(ms));
+    this.vm.timer.insert(&this.reconnect_timer);
+    this.ref();
+}
+
+fn cancelReconnectTimer(this: *EventSource) void {
+    if (this.reconnect_timer.state == .ACTIVE) {
+        this.vm.timer.remove(&this.reconnect_timer);
+        this.deref();
+    }
+}
+
+pub fn onReconnectTimer(this: *EventSource) void {
+    this.reconnect_timer.state = .FIRED;
+    this.ref();
+    defer this.deref();
+    // balance scheduleReconnect's ref
+    this.deref();
+    if (this.ready_state == .closed) return;
+    this.connect();
+}
+
+fn goIdle(this: *EventSource) void {
+    this.has_pending_activity.store(0, .release);
+    this.poll_ref.unref(this.vm);
+    this.cancelReconnectTimer();
+    if (this.this_value == .strong) this.this_value.downgrade();
+}
+
+// ---------------------------------------------------------------------------
+// SSE parser (https://html.spec.whatwg.org/#event-stream-interpretation)
+// ---------------------------------------------------------------------------
+
+fn feed(this: *EventSource, bytes: []const u8) void {
+    var i: usize = 0;
+    // Swallow the LF half of a CRLF that straddled the previous chunk.
+    if (this.last_byte_was_cr and i < bytes.len and bytes[i] == '\n') i += 1;
+    this.last_byte_was_cr = false;
+
+    while (i < bytes.len) {
+        const slice = bytes[i..];
+        const nl = std.mem.indexOfAny(u8, slice, "\r\n");
+        if (nl) |pos| {
+            bun.handleOom(this.line_buffer.appendSlice(bun.default_allocator, slice[0..pos]));
+            const line = this.line_buffer.items;
+            this.processLine(line);
+            this.line_buffer.clearRetainingCapacity();
+            if (this.ready_state == .closed) return;
+            i += pos + 1;
+            if (slice[pos] == '\r') {
+                if (i < bytes.len and bytes[i] == '\n') {
+                    i += 1;
+                } else if (i == bytes.len) {
+                    this.last_byte_was_cr = true;
+                }
+            }
+        } else {
+            bun.handleOom(this.line_buffer.appendSlice(bun.default_allocator, slice));
+            break;
+        }
+    }
+}
+
+fn processLine(this: *EventSource, line: []const u8) void {
+    if (line.len == 0) {
+        this.dispatchPendingMessage();
+        return;
+    }
+    if (line[0] == ':') return; // comment
+
+    var field: []const u8 = line;
+    var value: []const u8 = "";
+    if (std.mem.indexOfScalar(u8, line, ':')) |colon| {
+        field = line[0..colon];
+        value = line[colon + 1 ..];
+        if (value.len > 0 and value[0] == ' ') value = value[1..];
+    }
+
+    if (strings.eqlComptime(field, "data")) {
+        if (this.data_buffer.items.len > 0)
+            bun.handleOom(this.data_buffer.append(bun.default_allocator, '\n'));
+        bun.handleOom(this.data_buffer.appendSlice(bun.default_allocator, value));
+    } else if (strings.eqlComptime(field, "event")) {
+        this.event_type_buffer.clearRetainingCapacity();
+        bun.handleOom(this.event_type_buffer.appendSlice(bun.default_allocator, value));
+    } else if (strings.eqlComptime(field, "id")) {
+        // Per spec: ignore if the value contains U+0000.
+        if (std.mem.indexOfScalar(u8, value, 0) == null) {
+            this.last_event_id.clearRetainingCapacity();
+            bun.handleOom(this.last_event_id.appendSlice(bun.default_allocator, value));
+        }
+    } else if (strings.eqlComptime(field, "retry")) {
+        if (value.len > 0) {
+            var all_digits = true;
+            for (value) |c| {
+                if (c < '0' or c > '9') {
+                    all_digits = false;
+                    break;
+                }
+            }
+            if (all_digits) {
+                this.reconnection_time_ms = std.fmt.parseInt(u32, value, 10) catch this.reconnection_time_ms;
+            }
+        }
+    }
+    // Unknown fields are ignored per spec.
+}
+
+fn dispatchPendingMessage(this: *EventSource) void {
+    defer {
+        this.data_buffer.clearRetainingCapacity();
+        this.event_type_buffer.clearRetainingCapacity();
+    }
+    if (this.data_buffer.items.len == 0) return;
+
+    const event_type = if (this.event_type_buffer.items.len > 0)
+        bun.String.cloneUTF8(this.event_type_buffer.items)
+    else
+        bun.String.empty;
+    defer event_type.deref();
+    const data = bun.String.cloneUTF8(this.data_buffer.items);
+    defer data.deref();
+    const origin = bun.String.borrowUTF8(this.origin);
+    const last_id = bun.String.cloneUTF8(this.last_event_id.items);
+    defer last_id.deref();
+
+    const event = Bun__createSSEMessageEvent(this.globalThis, &event_type, &data, &origin, &last_id);
+    event.ensureStillAlive();
+
+    const type_slice: []const u8 = if (this.event_type_buffer.items.len > 0)
+        this.event_type_buffer.items
+    else
+        "message";
+    this.dispatchToHandlers(type_slice, event);
+}
+
+// ---------------------------------------------------------------------------
+// Event dispatch
+// ---------------------------------------------------------------------------
+
+fn dispatchSimpleEvent(this: *EventSource, comptime kind: enum { open }) void {
+    const event = switch (kind) {
+        .open => Bun__createSSEOpenEvent(this.globalThis),
+    };
+    event.ensureStillAlive();
+    this.dispatchToHandlers("open", event);
+}
+
+fn dispatchErrorEvent(this: *EventSource, message: []const u8) void {
+    const msg = if (message.len > 0) bun.String.cloneUTF8(message) else bun.String.empty;
+    defer msg.deref();
+    const event = Bun__createSSEErrorEvent(this.globalThis, &msg);
+    event.ensureStillAlive();
+    this.dispatchToHandlers("error", event);
+}
+
+fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue) void {
+    const this_js = this.this_value.tryGet() orelse return;
+    this_js.ensureStillAlive();
+    const global = this.globalThis;
+
+    // on<type> handler attribute.
+    const maybe_handler: ?JSValue = blk: {
+        if (strings.eqlComptime(event_type, "open")) break :blk js.onopenGetCached(this_js);
+        if (strings.eqlComptime(event_type, "message")) break :blk js.onmessageGetCached(this_js);
+        if (strings.eqlComptime(event_type, "error")) break :blk js.onerrorGetCached(this_js);
+        break :blk null;
+    };
+    if (maybe_handler) |handler| {
+        if (handler.isCallable()) {
+            _ = handler.call(global, this_js, &.{event}) catch |e|
+                global.reportActiveExceptionAsUnhandled(e);
+            if (this.ready_state == .closed) return;
+        }
+    }
+
+    // addEventListener-registered listeners.
+    if (js.listenersGetCached(this_js)) |listeners_obj| {
+        if (listeners_obj.isObject()) {
+            const maybe_arr = listeners_obj.getOwn(global, event_type) catch return;
+            if (maybe_arr) |arr| {
+                if (arr.jsType().isArray()) {
+                    const len = arr.getLength(global) catch return;
+                    var idx: u32 = 0;
+                    while (idx < len) : (idx += 1) {
+                        const listener = arr.getIndex(global, idx) catch continue;
+                        if (!listener.isCallable()) continue;
+                        _ = listener.call(global, this_js, &.{event}) catch |e|
+                            global.reportActiveExceptionAsUnhandled(e);
+                        if (this.ready_state == .closed) return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JS API: properties
+// ---------------------------------------------------------------------------
+
+pub fn getURL(this: *EventSource, globalThis: *JSGlobalObject) bun.JSError!JSValue {
+    return bun.String.createUTF8ForJS(globalThis, this.url_href);
+}
+
+pub fn getReadyState(this: *EventSource, _: *JSGlobalObject) JSValue {
+    return JSValue.jsNumber(@as(i32, @intFromEnum(this.ready_state)));
+}
+
+pub fn getWithCredentials(this: *EventSource, _: *JSGlobalObject) JSValue {
+    return JSValue.jsBoolean(this.with_credentials);
+}
+
+pub fn getConnecting(_: *EventSource, _: *JSGlobalObject) JSValue {
+    return JSValue.jsNumber(@as(i32, 0));
+}
+pub fn getOpen(_: *EventSource, _: *JSGlobalObject) JSValue {
+    return JSValue.jsNumber(@as(i32, 1));
+}
+pub fn getClosed(_: *EventSource, _: *JSGlobalObject) JSValue {
+    return JSValue.jsNumber(@as(i32, 2));
+}
+pub fn getStaticConnecting(_: *JSGlobalObject, _: JSValue, _: JSValue) JSValue {
+    return JSValue.jsNumber(@as(i32, 0));
+}
+pub fn getStaticOpen(_: *JSGlobalObject, _: JSValue, _: JSValue) JSValue {
+    return JSValue.jsNumber(@as(i32, 1));
+}
+pub fn getStaticClosed(_: *JSGlobalObject, _: JSValue, _: JSValue) JSValue {
+    return JSValue.jsNumber(@as(i32, 2));
+}
+
+pub fn getOnOpen(_: *EventSource, thisValue: JSValue, _: *JSGlobalObject) JSValue {
+    return js.onopenGetCached(thisValue) orelse .null;
+}
+pub fn setOnOpen(_: *EventSource, thisValue: JSValue, global: *JSGlobalObject, value: JSValue) void {
+    js.onopenSetCached(thisValue, global, if (value.isCallable()) value else .zero);
+}
+pub fn getOnMessage(_: *EventSource, thisValue: JSValue, _: *JSGlobalObject) JSValue {
+    return js.onmessageGetCached(thisValue) orelse .null;
+}
+pub fn setOnMessage(_: *EventSource, thisValue: JSValue, global: *JSGlobalObject, value: JSValue) void {
+    js.onmessageSetCached(thisValue, global, if (value.isCallable()) value else .zero);
+}
+pub fn getOnError(_: *EventSource, thisValue: JSValue, _: *JSGlobalObject) JSValue {
+    return js.onerrorGetCached(thisValue) orelse .null;
+}
+pub fn setOnError(_: *EventSource, thisValue: JSValue, global: *JSGlobalObject, value: JSValue) void {
+    js.onerrorSetCached(thisValue, global, if (value.isCallable()) value else .zero);
+}
+
+// ---------------------------------------------------------------------------
+// JS API: methods
+// ---------------------------------------------------------------------------
+
+pub fn doClose(this: *EventSource, _: *JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.ready_state == .closed) return .js_undefined;
+    this.ready_state = .closed;
+    this.abortHttp();
+    this.goIdle();
+    return .js_undefined;
+}
+
+pub fn doRef(this: *EventSource, _: *JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    if (this.ready_state != .closed) this.poll_ref.ref(this.vm);
+    return .js_undefined;
+}
+
+pub fn doUnref(this: *EventSource, _: *JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
+    this.poll_ref.unref(this.vm);
+    return .js_undefined;
+}
+
+fn ensureListeners(thisValue: JSValue, global: *JSGlobalObject) JSValue {
+    if (js.listenersGetCached(thisValue)) |existing| {
+        if (existing.isObject()) return existing;
+    }
+    const obj = JSValue.createEmptyObjectWithNullPrototype(global);
+    js.listenersSetCached(thisValue, global, obj);
+    return obj;
+}
+
+pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args = callframe.arguments();
+    if (args.len < 2) return .js_undefined;
+    const listener = args[1];
+    if (!listener.isCallable()) return .js_undefined;
+
+    const this_js = callframe.this();
+    const type_str = try args[0].toBunString(global);
+    defer type_str.deref();
+
+    const listeners = ensureListeners(this_js, global);
+    var arr = try listeners.getOwn(global, type_str) orelse JSValue.zero;
+    if (arr == .zero or !arr.jsType().isArray()) {
+        arr = try JSValue.createEmptyArray(global, 0);
+        listeners.putMayBeIndex(global, &type_str, arr) catch {};
+    }
+    // Dedupe (spec: registering the same listener twice is a no-op).
+    const len = try arr.getLength(global);
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const existing = try arr.getIndex(global, i);
+        if (existing == listener) return .js_undefined;
+    }
+    try arr.push(global, listener);
+    return .js_undefined;
+}
+
+pub fn removeEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args = callframe.arguments();
+    if (args.len < 2) return .js_undefined;
+    const listener = args[1];
+    const this_js = callframe.this();
+    const listeners = js.listenersGetCached(this_js) orelse return .js_undefined;
+    if (!listeners.isObject()) return .js_undefined;
+
+    const type_str = try args[0].toBunString(global);
+    defer type_str.deref();
+    const arr = try listeners.getOwn(global, type_str) orelse return .js_undefined;
+    if (!arr.jsType().isArray()) return .js_undefined;
+
+    const len = try arr.getLength(global);
+    const new_arr = try JSValue.createEmptyArray(global, 0);
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const existing = try arr.getIndex(global, i);
+        if (existing == listener) continue;
+        try new_arr.push(global, existing);
+    }
+    listeners.putMayBeIndex(global, &type_str, new_arr) catch {};
+    return .js_undefined;
+}
+
+pub fn dispatchEvent(this: *EventSource, global: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
+    const args = callframe.arguments();
+    if (args.len < 1 or !args[0].isObject()) {
+        return global.throwInvalidArguments("dispatchEvent requires an Event", .{});
+    }
+    const event = args[0];
+    const type_val = try event.getTruthy(global, "type") orelse return JSValue.jsBoolean(true);
+    const type_str = try type_val.toBunString(global);
+    defer type_str.deref();
+    const type_utf8 = type_str.toUTF8(bun.default_allocator);
+    defer type_utf8.deinit();
+
+    const event_loop = this.vm.eventLoop();
+    event_loop.enter();
+    defer event_loop.exit();
+    this.dispatchToHandlers(type_utf8.slice(), event);
+    return JSValue.jsBoolean(true);
+}
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+const std = @import("std");
+
+const bun = @import("bun");
+const Output = bun.Output;
+const strings = bun.strings;
+const MutableString = bun.MutableString;
+const http = bun.http;
+const ZigURL = bun.URL;
+
+const jsc = bun.jsc;
+const JSGlobalObject = jsc.JSGlobalObject;
+const JSValue = jsc.JSValue;
+const VirtualMachine = jsc.VirtualMachine;
+const FetchHeaders = bun.webcore.FetchHeaders;
+
+const EventLoopTimer = bun.api.Timer.EventLoopTimer;

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -80,6 +80,10 @@ result_has_more: bool = true,
 result_fail: ?anyerror = null,
 result_status_code: u16 = 0,
 result_content_type_ok: bool = false,
+/// Final post-redirect URL cloned from `metadata.url` on the HTTP thread;
+/// consumed (and applied to `url_href`/`url`/`origin`) on the JS thread so
+/// readers of those fields never race the free/reassign.
+result_final_url: ?[]const u8 = null,
 /// True once the HTTP thread has delivered response metadata.
 got_metadata: bool = false,
 
@@ -195,6 +199,7 @@ fn deinit(this: *EventSource) void {
     this.clearHttp();
     if (this.url_href.len > 0) bun.default_allocator.free(this.url_href);
     if (this.origin.len > 0) bun.default_allocator.free(this.origin);
+    if (this.result_final_url) |u| bun.default_allocator.free(u);
     this.extra_headers.deinit();
     this.request_headers.deinit();
     this.last_event_id.deinit(bun.default_allocator);
@@ -328,6 +333,10 @@ fn resetPerConnectionState(this: *EventSource) void {
     this.result_fail = null;
     this.result_status_code = 0;
     this.result_content_type_ok = false;
+    if (this.result_final_url) |u| {
+        bun.default_allocator.free(u);
+        this.result_final_url = null;
+    }
     this.got_metadata = false;
     this.announced = false;
     this.has_schedule_callback.store(false, .monotonic);
@@ -376,15 +385,12 @@ pub fn httpCallback(this: *EventSource, async_http: *http.AsyncHTTP, result: htt
         }
         // Per spec, MessageEvent.origin must reflect the *final* URL after
         // redirects. AsyncHTTP was created with `.follow`, and `metadata.url`
-        // carries that final URL — pick it up so future events and reconnects
-        // target the right place.
-        if (metadata.url.len > 0 and !strings.eql(metadata.url, this.url_href)) {
-            const new_href = bun.handleOom(bun.default_allocator.dupe(u8, metadata.url));
-            bun.default_allocator.free(this.url_href);
-            this.url_href = new_href;
-            this.url = ZigURL.parse(new_href);
-            bun.default_allocator.free(this.origin);
-            this.origin = bun.handleOom(bun.default_allocator.dupe(u8, this.url.origin));
+        // carries that final URL. We only stash a copy here under the mutex;
+        // the JS thread applies it in `onProgressUpdate` so that the free of
+        // the old `url_href`/`origin` can't race with `getURL()` / event
+        // dispatch / `memoryCost()` which read them unlocked.
+        if (metadata.url.len > 0 and this.result_final_url == null) {
+            this.result_final_url = bun.handleOom(bun.default_allocator.dupe(u8, metadata.url));
         }
         metadata.deinit(bun.default_allocator);
     }
@@ -423,6 +429,8 @@ pub fn onProgressUpdate(this: *EventSource) void {
     const got_metadata = this.got_metadata;
     const status = this.result_status_code;
     const ct_ok = this.result_content_type_ok;
+    const final_url = this.result_final_url;
+    this.result_final_url = null;
 
     // Steal the buffered body bytes; a fresh list replaces the shared buffer so
     // the HTTP thread can keep appending without contending on the parser.
@@ -430,6 +438,21 @@ pub fn onProgressUpdate(this: *EventSource) void {
     this.scheduled_response_buffer = .{ .allocator = bun.default_allocator, .list = .{} };
     this.mutex.unlock();
     defer chunk.deinit();
+
+    // Apply any redirect-updated URL now that we're on the JS thread — the
+    // free+reassign of `url_href`/`origin` must not race with `getURL()` or
+    // `dispatchPendingMessage()` (which borrow these slices unlocked).
+    if (final_url) |new_href| {
+        if (!strings.eql(new_href, this.url_href)) {
+            bun.default_allocator.free(this.url_href);
+            this.url_href = new_href;
+            this.url = ZigURL.parse(new_href);
+            bun.default_allocator.free(this.origin);
+            this.origin = bun.handleOom(bun.default_allocator.dupe(u8, this.url.origin));
+        } else {
+            bun.default_allocator.free(new_href);
+        }
+    }
 
     const is_done = !has_more;
     // Balance the ref taken in `connect()` once the request fully ends.
@@ -739,10 +762,10 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
     var had_once = false;
     var idx: u32 = 0;
     while (idx < len) : (idx += 1) {
-        const entry = arr.getIndex(global, idx) catch continue;
+        const entry = arr.getIndex(global, idx) catch return;
         if (!entry.isObject()) continue;
-        const cb = entry.getOwn(global, "cb") catch continue orelse continue;
-        const once_val = entry.getOwn(global, "once") catch continue;
+        const cb = entry.getOwn(global, "cb") catch return orelse continue;
+        const once_val = entry.getOwn(global, "once") catch return;
         const is_once = once_val != null and once_val.?.toBoolean();
         if (is_once) {
             had_once = true;
@@ -763,9 +786,9 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
         const filtered = JSValue.createEmptyArray(global, 0) catch return;
         var j: u32 = 0;
         while (j < live_len) : (j += 1) {
-            const entry = live.getIndex(global, j) catch continue;
+            const entry = live.getIndex(global, j) catch return;
             if (!entry.isObject()) continue;
-            const cb = entry.getOwn(global, "cb") catch continue orelse continue;
+            const cb = entry.getOwn(global, "cb") catch return orelse continue;
             if (cb.isUndefined()) continue;
             filtered.push(global, entry) catch return;
         }

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -847,16 +847,15 @@ pub fn dispatchEvent(this: *EventSource, global: *JSGlobalObject, callframe: *js
 const std = @import("std");
 
 const bun = @import("bun");
-const Output = bun.Output;
-const strings = bun.strings;
 const MutableString = bun.MutableString;
-const http = bun.http;
+const Output = bun.Output;
 const ZigURL = bun.URL;
+const http = bun.http;
+const strings = bun.strings;
+const FetchHeaders = bun.webcore.FetchHeaders;
+const EventLoopTimer = bun.api.Timer.EventLoopTimer;
 
 const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSValue = jsc.JSValue;
 const VirtualMachine = jsc.VirtualMachine;
-const FetchHeaders = bun.webcore.FetchHeaders;
-
-const EventLoopTimer = bun.api.Timer.EventLoopTimer;

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -461,8 +461,15 @@ pub fn onProgressUpdate(this: *EventSource) void {
     }
 
     const is_done = !has_more;
-    // Balance the ref taken in `connect()` once the request fully ends.
-    defer if (is_done) this.deref();
+    // Once the HTTP thread has delivered its terminal callback it will not
+    // touch `async_http` again, so this is the safe point to free it. Doing
+    // it here (rather than waiting for the next `connect()` or `deinit()`)
+    // means a closed-but-still-referenced EventSource doesn't retain the
+    // heap `AsyncHTTP` until GC. Also balances the ref taken in `connect()`.
+    defer if (is_done) {
+        this.clearHttp();
+        this.deref();
+    };
 
     if (this.ready_state == .closed) return;
 

--- a/src/runtime/webcore/EventSource.zig
+++ b/src/runtime/webcore/EventSource.zig
@@ -97,9 +97,14 @@ event_type_buffer: std.ArrayListUnmanaged(u8) = .{},
 /// Whether the previous byte processed was '\r' (so a following '\n' is the
 /// second half of a CRLF and must be swallowed).
 last_byte_was_cr: bool = false,
-/// Whether we've received any body bytes on the current connection yet;
-/// used to strip one leading UTF-8 BOM per the spec's `stream = [bom] *event`.
+/// Whether we've decided on the leading UTF-8 BOM for the current
+/// connection yet (spec's `stream = [bom] *event`). Stays false until
+/// we've seen three bytes or a non-BOM-prefix byte.
 seen_body_bytes: bool = false,
+/// How many of the 3 BOM bytes (EF BB BF) have matched so far at the very
+/// start of the body. Lets a BOM that's split across transport chunks be
+/// recognized and stripped.
+bom_prefix_len: u8 = 0,
 /// Whether we've announced the connection (fired "open") yet.
 announced: bool = false,
 
@@ -329,6 +334,7 @@ fn resetPerConnectionState(this: *EventSource) void {
     this.event_type_buffer.clearRetainingCapacity();
     this.last_byte_was_cr = false;
     this.seen_body_bytes = false;
+    this.bom_prefix_len = 0;
     this.result_has_more = true;
     this.result_fail = null;
     this.result_status_code = 0;
@@ -565,12 +571,27 @@ fn goIdle(this: *EventSource) void {
 
 fn feed(this: *EventSource, bytes: []const u8) void {
     var i: usize = 0;
-    // Spec ABNF: `stream = [ bom ] *event`. Strip exactly one leading UTF-8
-    // BOM at the start of each connection's body.
+    // Spec ABNF: `stream = [ bom ] *event`. The UTF-8 BOM (EF BB BF) can in
+    // principle be split across transport chunks, so accumulate up to three
+    // leading bytes before deciding. None of the BOM bytes is CR/LF, so if
+    // the prefix turns out not to be a BOM it's safe to replay it straight
+    // into `line_buffer` (it just becomes part of the first line).
     if (!this.seen_body_bytes) {
-        this.seen_body_bytes = true;
-        if (bytes.len >= 3 and bytes[0] == 0xEF and bytes[1] == 0xBB and bytes[2] == 0xBF) {
-            i = 3;
+        const bom: [3]u8 = .{ 0xEF, 0xBB, 0xBF };
+        while (this.bom_prefix_len < 3 and i < bytes.len and bytes[i] == bom[this.bom_prefix_len]) {
+            this.bom_prefix_len += 1;
+            i += 1;
+        }
+        if (this.bom_prefix_len == 3) {
+            this.seen_body_bytes = true; // full BOM — strip it
+        } else if (i < bytes.len) {
+            // Next byte doesn't continue the BOM prefix: the buffered bytes
+            // (if any) are real body content.
+            this.seen_body_bytes = true;
+            bun.handleOom(this.line_buffer.appendSlice(bun.default_allocator, bom[0..this.bom_prefix_len]));
+        } else {
+            // Entire chunk was consumed into the BOM prefix; wait for more.
+            return;
         }
     }
     // Swallow the LF half of a CRLF that straddled the previous chunk.
@@ -742,14 +763,16 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
         if (handler.isCallable()) {
             _ = handler.call(global, this_js, &.{event}) catch |e|
                 global.reportActiveExceptionAsUnhandled(e);
-            if (this.ready_state == .closed) return;
         }
     }
 
     // addEventListener-registered listeners. Entries are stored as
-    // { cb: <fn|{handleEvent}>, once: <bool> }. Snapshot the list before
-    // invoking so mutations during dispatch don't affect this run (DOM
-    // "inner invoke" semantics).
+    // { cb: <fn|{handleEvent}>, once: <bool>, capture: <bool> }. Snapshot the
+    // list before invoking so mutations during dispatch don't affect this
+    // run (DOM "inner invoke" semantics). We intentionally do *not* bail
+    // out if a listener calls `close()` — per spec, close() only aborts the
+    // fetch and sets readyState; it does not set a stop-immediate-propagation
+    // flag, so every snapshotted listener for this event still fires.
     const listeners_obj = js.listenersGetCached(this_js) orelse return;
     if (!listeners_obj.isObject()) return;
     const maybe_arr = listeners_obj.getOwn(global, event_type) catch return;
@@ -765,6 +788,9 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
         const entry = arr.getIndex(global, idx) catch return;
         if (!entry.isObject()) continue;
         const cb = entry.getOwn(global, "cb") catch return orelse continue;
+        // Tombstoned by `{once:true}` consumption or a concurrent
+        // `removeEventListener()` during this dispatch — skip.
+        if (cb.isUndefined()) continue;
         const once_val = entry.getOwn(global, "once") catch return;
         const is_once = once_val != null and once_val.?.toBoolean();
         if (is_once) {
@@ -773,7 +799,6 @@ fn dispatchToHandlers(this: *EventSource, event_type: []const u8, event: JSValue
             entry.put(global, bun.String.static("cb"), .js_undefined);
         }
         invokeListener(global, this_js, cb, event);
-        if (this.ready_state == .closed) break;
     }
 
     if (had_once) {
@@ -882,6 +907,19 @@ fn ensureListeners(thisValue: JSValue, global: *JSGlobalObject) JSValue {
     return obj;
 }
 
+/// DOM "flatten" step: a boolean 3rd arg is `capture`; otherwise read
+/// `options.capture`. Capture has no *dispatch* effect on EventSource (no
+/// tree), but it's still part of the listener identity for dedupe/remove.
+fn flattenCapture(global: *JSGlobalObject, args: []const JSValue) bun.JSError!bool {
+    if (args.len <= 2) return false;
+    const opt = args[2];
+    if (opt.isBoolean()) return opt.asBoolean();
+    if (opt.isObject()) {
+        if (try opt.getBooleanLoose(global, "capture")) |c| return c;
+    }
+    return false;
+}
+
 pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     const args = callframe.arguments();
     if (args.len < 2) return .js_undefined;
@@ -892,9 +930,9 @@ pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *js
     if (listener.isUndefinedOrNull() or !(listener.isCallable() or listener.isObject()))
         return .js_undefined;
 
-    // Flatten options: boolean is `capture` (no effect without a tree), or
-    // a dictionary with `once`. Other keys (`signal`, `passive`, `capture`)
-    // are not yet supported here.
+    // Flatten options: boolean → `capture`, or a dictionary with
+    // `once` / `capture`. `signal` and `passive` are not yet supported.
+    const capture = try flattenCapture(global, args);
     var once = false;
     if (args.len > 2 and args[2].isObject()) {
         if (try args[2].getBooleanLoose(global, "once")) |o| once = o;
@@ -910,18 +948,21 @@ pub fn addEventListener(_: *EventSource, global: *JSGlobalObject, callframe: *js
         arr = try JSValue.createEmptyArray(global, 0);
         try listeners.putMayBeIndex(global, &type_str, arr);
     }
-    // Dedupe on callback identity (spec: same type + callback + capture).
+    // Dedupe: per spec the identity is (type, callback, capture).
     const len = try arr.getLength(global);
     var i: u32 = 0;
     while (i < len) : (i += 1) {
         const entry = try arr.getIndex(global, i);
         if (!entry.isObject()) continue;
         const cb = try entry.getOwn(global, "cb") orelse continue;
-        if (cb == listener) return .js_undefined;
+        if (cb != listener) continue;
+        const cap = try entry.getOwn(global, "capture");
+        if ((cap != null and cap.?.toBoolean()) == capture) return .js_undefined;
     }
-    const entry = JSValue.createEmptyObject(global, 2);
+    const entry = JSValue.createEmptyObject(global, 3);
     entry.put(global, bun.String.static("cb"), listener);
     entry.put(global, bun.String.static("once"), JSValue.jsBoolean(once));
+    entry.put(global, bun.String.static("capture"), JSValue.jsBoolean(capture));
     try arr.push(global, entry);
     return .js_undefined;
 }
@@ -930,6 +971,7 @@ pub fn removeEventListener(_: *EventSource, global: *JSGlobalObject, callframe: 
     const args = callframe.arguments();
     if (args.len < 2) return .js_undefined;
     const listener = args[1];
+    const capture = try flattenCapture(global, args);
     const this_js = callframe.this();
     const listeners = js.listenersGetCached(this_js) orelse return .js_undefined;
     if (!listeners.isObject()) return .js_undefined;
@@ -941,12 +983,22 @@ pub fn removeEventListener(_: *EventSource, global: *JSGlobalObject, callframe: 
 
     const len = try arr.getLength(global);
     const new_arr = try JSValue.createEmptyArray(global, 0);
+    var removed = false;
     var i: u32 = 0;
     while (i < len) : (i += 1) {
         const entry = try arr.getIndex(global, i);
-        if (entry.isObject()) {
+        if (!removed and entry.isObject()) {
             const cb = try entry.getOwn(global, "cb") orelse .js_undefined;
-            if (cb == listener) continue;
+            const cap = try entry.getOwn(global, "capture");
+            if (cb == listener and (cap != null and cap.?.toBoolean()) == capture) {
+                // Spec: remove at most one listener per call.
+                removed = true;
+                // Tombstone the entry so any snapshot currently being
+                // iterated by `dispatchToHandlers` skips it without
+                // shifting indices.
+                entry.put(global, bun.String.static("cb"), .js_undefined);
+                continue;
+            }
         }
         try new_arr.push(global, entry);
     }

--- a/src/runtime/webcore/event_source.classes.ts
+++ b/src/runtime/webcore/event_source.classes.ts
@@ -1,0 +1,86 @@
+import { define } from "../../codegen/class-definitions";
+
+export default [
+  define({
+    name: "EventSource",
+    construct: true,
+    constructNeedsThis: true,
+    finalize: true,
+    hasPendingActivity: true,
+    configurable: false,
+    memoryCost: true,
+    JSType: "0b11101110",
+    klass: {
+      CONNECTING: {
+        getter: "getStaticConnecting",
+      },
+      OPEN: {
+        getter: "getStaticOpen",
+      },
+      CLOSED: {
+        getter: "getStaticClosed",
+      },
+    },
+    proto: {
+      url: {
+        getter: "getURL",
+        cache: true,
+      },
+      readyState: {
+        getter: "getReadyState",
+      },
+      withCredentials: {
+        getter: "getWithCredentials",
+      },
+      onopen: {
+        getter: "getOnOpen",
+        setter: "setOnOpen",
+        this: true,
+      },
+      onmessage: {
+        getter: "getOnMessage",
+        setter: "setOnMessage",
+        this: true,
+      },
+      onerror: {
+        getter: "getOnError",
+        setter: "setOnError",
+        this: true,
+      },
+      close: {
+        fn: "doClose",
+        length: 0,
+      },
+      addEventListener: {
+        fn: "addEventListener",
+        length: 2,
+      },
+      removeEventListener: {
+        fn: "removeEventListener",
+        length: 2,
+      },
+      dispatchEvent: {
+        fn: "dispatchEvent",
+        length: 1,
+      },
+      ref: {
+        fn: "doRef",
+        length: 0,
+      },
+      unref: {
+        fn: "doUnref",
+        length: 0,
+      },
+      CONNECTING: {
+        getter: "getConnecting",
+      },
+      OPEN: {
+        getter: "getOpen",
+      },
+      CLOSED: {
+        getter: "getClosed",
+      },
+    },
+    values: ["onopen", "onmessage", "onerror", "listeners", "headers"],
+  }),
+];

--- a/src/runtime/webcore/event_source.classes.ts
+++ b/src/runtime/webcore/event_source.classes.ts
@@ -24,7 +24,6 @@ export default [
     proto: {
       url: {
         getter: "getURL",
-        cache: true,
       },
       readyState: {
         getter: "getReadyState",

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -7,6 +7,9 @@ test/cli/create/create-jsx.test.ts [ FAIL ] # false > react spa (no tailwind) > 
 test/bundler/native-plugin.test.ts [ FAIL ] # prints name when plugin crashes
 test/cli/run/run-crash-handler.test.ts [ FAIL ] # automatic crash reporter > segfault should report
 
+# Node gates EventSource behind --experimental-eventsource; Bun exposes it as a global.
+test/js/node/test/parallel/test-eventsource-disabled.js [ SKIP ]
+
 # Tests that are flaky
 test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 

--- a/test/js/web/fetch/event-source.test.ts
+++ b/test/js/web/fetch/event-source.test.ts
@@ -94,8 +94,10 @@ describe("EventSource", () => {
       c.write(": this is ignored\n");
       // custom event type
       c.write("event: ping\ndata: pong\n\n");
-      // field with no value
+      // field with no value → empty-string data per spec
       c.write("data\n\n");
+      // leading empty data line is significant
+      c.write("data:\ndata: x\n\n");
       await c.flush();
       await new Promise(r => req.signal.addEventListener("abort", r));
     });
@@ -104,7 +106,7 @@ describe("EventSource", () => {
     const received: Array<[string, string]> = [];
     const done = new Promise<void>(resolve => {
       const check = () => {
-        if (received.length === 2) resolve();
+        if (received.length === 4) resolve();
       };
       es.onmessage = e => {
         received.push(["message", e.data]);
@@ -120,6 +122,8 @@ describe("EventSource", () => {
     expect(received).toEqual([
       ["message", "a\nb"],
       ["ping", "pong"],
+      ["message", ""],
+      ["message", "\nx"],
     ]);
     es.close();
   });
@@ -271,16 +275,59 @@ describe("EventSource", () => {
     es.close();
   });
 
-  test("dispatchEvent routes to on-handlers and listeners", () => {
+  test("dispatchEvent routes to on-handlers and listeners and returns !defaultPrevented", () => {
     const es = new EventSource("http://127.0.0.1:1/"); // will error async; fine
     let onmsgHit = 0;
     let listenerHit = 0;
     es.onmessage = () => onmsgHit++;
     es.addEventListener("message", () => listenerHit++);
     const ev = new MessageEvent("message", { data: "synthetic" });
-    es.dispatchEvent(ev);
+    expect(es.dispatchEvent(ev)).toBe(true);
     expect(onmsgHit).toBe(1);
     expect(listenerHit).toBe(1);
+
+    const cancelable = new Event("message", { cancelable: true });
+    es.addEventListener("message", e => e.preventDefault(), { once: true });
+    expect(es.dispatchEvent(cancelable)).toBe(false);
+    es.close();
+  });
+
+  test("addEventListener honours { once: true } and accepts { handleEvent } objects", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("data: 1\n\n");
+      c.write("data: 2\n\n");
+      c.write("data: 3\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href);
+    const onceHits: string[] = [];
+    const objHits: string[] = [];
+    let objThis: unknown;
+
+    es.addEventListener("message", (e: MessageEvent) => onceHits.push(e.data), { once: true });
+    const listenerObj = {
+      handleEvent(this: unknown, e: MessageEvent) {
+        objThis = this;
+        objHits.push(e.data);
+      },
+    };
+    es.addEventListener("message", listenerObj);
+
+    await new Promise<void>(resolve => {
+      es.onmessage = e => {
+        if (e.data === "3") resolve();
+      };
+    });
+
+    expect(onceHits).toEqual(["1"]);
+    expect(objHits).toEqual(["1", "2", "3"]);
+    expect(objThis).toBe(listenerObj);
+
+    es.removeEventListener("message", listenerObj);
+    es.dispatchEvent(new MessageEvent("message", { data: "4" }));
+    expect(objHits).toEqual(["1", "2", "3"]);
     es.close();
   });
 });

--- a/test/js/web/fetch/event-source.test.ts
+++ b/test/js/web/fetch/event-source.test.ts
@@ -1,0 +1,286 @@
+import { describe, test, expect } from "bun:test";
+
+function sseServer(handler: (controller: ReadableStreamDirectController, req: Request) => void | Promise<void>) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            await handler(controller, req);
+          },
+        }),
+        {
+          headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+        },
+      );
+    },
+  });
+}
+
+describe("EventSource", () => {
+  test("is exposed as a global constructor", () => {
+    expect(typeof EventSource).toBe("function");
+    expect(EventSource.name).toBe("EventSource");
+    expect(EventSource.CONNECTING).toBe(0);
+    expect(EventSource.OPEN).toBe(1);
+    expect(EventSource.CLOSED).toBe(2);
+  });
+
+  test("constructor throws SyntaxError for an invalid URL", () => {
+    expect(() => new EventSource("not a url")).toThrow();
+    try {
+      new EventSource("not a url");
+      expect.unreachable();
+    } catch (e: any) {
+      expect(e.name).toBe("SyntaxError");
+    }
+  });
+
+  test("receives open + message events and populates MessageEvent fields", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("data: hello\n\n");
+      c.write("id: abc\ndata: world\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href);
+    expect(es.url).toBe(server.url.href);
+    expect(es.withCredentials).toBe(false);
+    expect(es.readyState).toBe(EventSource.CONNECTING);
+
+    let opened: Event | undefined;
+    let openReadyState = -1;
+    es.onopen = e => {
+      opened = e;
+      openReadyState = es.readyState;
+    };
+
+    const messages: MessageEvent[] = [];
+    await new Promise<void>(resolve => {
+      es.onmessage = e => {
+        messages.push(e);
+        if (messages.length === 2) resolve();
+      };
+    });
+
+    expect(opened?.type).toBe("open");
+    expect(openReadyState).toBe(EventSource.OPEN);
+
+    expect(messages[0]).toBeInstanceOf(MessageEvent);
+    expect(messages[0].type).toBe("message");
+    expect(messages[0].data).toBe("hello");
+    expect(messages[0].lastEventId).toBe("");
+    expect(messages[0].origin).toBe(server.url.origin);
+
+    expect(messages[1].data).toBe("world");
+    expect(messages[1].lastEventId).toBe("abc");
+
+    es.close();
+    expect(es.readyState).toBe(EventSource.CLOSED);
+    expect(es.onmessage).toBeFunction();
+    expect(es.CONNECTING).toBe(0);
+    expect(es.OPEN).toBe(1);
+    expect(es.CLOSED).toBe(2);
+  });
+
+  test("parses multi-line data, custom event types, CRLF, and comments", async () => {
+    await using server = sseServer(async (c, req) => {
+      // CRLF line endings
+      c.write("data: a\r\ndata: b\r\n\r\n");
+      // comment line
+      c.write(": this is ignored\n");
+      // custom event type
+      c.write("event: ping\ndata: pong\n\n");
+      // field with no value
+      c.write("data\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href);
+    const received: Array<[string, string]> = [];
+    const done = new Promise<void>(resolve => {
+      const check = () => {
+        if (received.length === 2) resolve();
+      };
+      es.onmessage = e => {
+        received.push(["message", e.data]);
+        check();
+      };
+      es.addEventListener("ping", (e: MessageEvent) => {
+        received.push(["ping", e.data]);
+        check();
+      });
+    });
+    await done;
+
+    expect(received).toEqual([
+      ["message", "a\nb"],
+      ["ping", "pong"],
+    ]);
+    es.close();
+  });
+
+  test("reconnects after the stream ends and sends Last-Event-ID", async () => {
+    let connections = 0;
+    let sawLastEventId: string | null = null;
+    let retrySeen = false;
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        connections++;
+        const conn = connections;
+        if (conn === 2) sawLastEventId = req.headers.get("Last-Event-ID");
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(c) {
+              if (conn === 1) {
+                c.write("retry: 20\n");
+                c.write("id: evt-1\ndata: first\n\n");
+                await c.flush();
+                c.close(); // server closes → client should reconnect
+              } else {
+                c.write("data: second\n\n");
+                await c.flush();
+                await new Promise(r => req.signal.addEventListener("abort", r));
+              }
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        );
+      },
+    });
+
+    const es = new EventSource(server.url.href);
+    const msgs: string[] = [];
+    let errorFiredWhileConnecting = false;
+
+    es.onerror = () => {
+      if (es.readyState === EventSource.CONNECTING) errorFiredWhileConnecting = true;
+      retrySeen = true;
+    };
+
+    await new Promise<void>(resolve => {
+      es.onmessage = e => {
+        msgs.push(e.data);
+        if (msgs.length === 2) resolve();
+      };
+    });
+
+    expect(msgs).toEqual(["first", "second"]);
+    expect(connections).toBe(2);
+    expect(sawLastEventId).toBe("evt-1");
+    expect(retrySeen).toBe(true);
+    expect(errorFiredWhileConnecting).toBe(true);
+    es.close();
+  });
+
+  test("non-200 response fails the connection with readyState CLOSED", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("no", { status: 500 }),
+    });
+
+    const es = new EventSource(server.url.href);
+    const err = await new Promise<Event>(resolve => (es.onerror = resolve));
+    expect(err.type).toBe("error");
+    expect(es.readyState).toBe(EventSource.CLOSED);
+    es.close();
+  });
+
+  test("wrong Content-Type fails the connection with readyState CLOSED", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("hello", { headers: { "Content-Type": "text/plain" } }),
+    });
+
+    const es = new EventSource(server.url.href);
+    await new Promise<void>(resolve => (es.onerror = () => resolve()));
+    expect(es.readyState).toBe(EventSource.CLOSED);
+    es.close();
+  });
+
+  test("addEventListener / removeEventListener", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("data: 1\n\n");
+      c.write("data: 2\n\n");
+      c.write("data: 3\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href);
+    const hits: number[] = [];
+    const listener = (e: MessageEvent) => {
+      hits.push(Number(e.data));
+      if (e.data === "2") es.removeEventListener("message", listener);
+    };
+    es.addEventListener("message", listener);
+    // Adding the same listener twice should be a no-op.
+    es.addEventListener("message", listener);
+
+    await new Promise<void>(resolve => {
+      es.onmessage = e => {
+        if (e.data === "3") resolve();
+      };
+    });
+
+    // Listener saw 1 and 2 (once each); removed itself after 2.
+    expect(hits).toEqual([1, 2]);
+    es.close();
+  });
+
+  test("passes custom headers to the request (Bun extension)", async () => {
+    let gotAuth: string | null = null;
+    let gotAccept: string | null = null;
+    await using server = sseServer(async (c, req) => {
+      gotAuth = req.headers.get("Authorization");
+      gotAccept = req.headers.get("Accept");
+      c.write("data: ok\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href, {
+      // @ts-expect-error Bun extension
+      headers: { Authorization: "Bearer token-123" },
+    });
+    await new Promise<void>(r => (es.onmessage = () => r()));
+    expect(gotAuth).toBe("Bearer token-123");
+    expect(gotAccept).toBe("text/event-stream");
+    es.close();
+  });
+
+  test("ref() / unref() return undefined and don't throw", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("data: x\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+    const es = new EventSource(server.url.href);
+    // @ts-expect-error Bun extension
+    expect(es.unref()).toBeUndefined();
+    // @ts-expect-error Bun extension
+    expect(es.ref()).toBeUndefined();
+    await new Promise<void>(r => (es.onmessage = () => r()));
+    es.close();
+  });
+
+  test("dispatchEvent routes to on-handlers and listeners", () => {
+    const es = new EventSource("http://127.0.0.1:1/"); // will error async; fine
+    let onmsgHit = 0;
+    let listenerHit = 0;
+    es.onmessage = () => onmsgHit++;
+    es.addEventListener("message", () => listenerHit++);
+    const ev = new MessageEvent("message", { data: "synthetic" });
+    es.dispatchEvent(ev);
+    expect(onmsgHit).toBe(1);
+    expect(listenerHit).toBe(1);
+    es.close();
+  });
+});

--- a/test/js/web/fetch/event-source.test.ts
+++ b/test/js/web/fetch/event-source.test.ts
@@ -140,6 +140,28 @@ describe("EventSource", () => {
     es.close();
   });
 
+  test("strips a leading BOM even when its bytes span multiple chunks", async () => {
+    // Flush each BOM byte separately so the parser's chunk-boundary BOM
+    // buffering is exercised. If the transport happens to coalesce them
+    // the single-chunk BOM path is taken instead — either way the final
+    // assertion holds, so this test cannot flake false-positive.
+    await using server = sseServer(async (c, req) => {
+      c.write(new Uint8Array([0xef]));
+      await c.flush();
+      c.write(new Uint8Array([0xbb]));
+      await c.flush();
+      c.write(new Uint8Array([0xbf]));
+      await c.flush();
+      c.write("data: split-bom\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+    const es = new EventSource(server.url.href);
+    const msg = await new Promise<MessageEvent>(r => (es.onmessage = r));
+    expect(msg.data).toBe("split-bom");
+    es.close();
+  });
+
   test("reconnects after the stream ends and sends Last-Event-ID", async () => {
     let connections = 0;
     let sawLastEventId: string | null = null;
@@ -340,6 +362,81 @@ describe("EventSource", () => {
     es.removeEventListener("message", listenerObj);
     es.dispatchEvent(new MessageEvent("message", { data: "4" }));
     expect(objHits).toEqual(["1", "2", "3"]);
+    es.close();
+  });
+
+  test("close() inside a listener still delivers the in-flight event to remaining listeners", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("data: x\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+
+    const es = new EventSource(server.url.href);
+    const hits: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    // Per spec, EventSource#close() only aborts the fetch and sets
+    // readyState — it does not set the stop-immediate-propagation flag,
+    // so every listener snapshotted for this event must still fire.
+    es.onmessage = () => {
+      hits.push("onmessage");
+      es.close();
+    };
+    es.addEventListener("message", () => {
+      hits.push("listener-1");
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    });
+    es.addEventListener("message", () => {
+      hits.push("listener-2");
+      resolve();
+    });
+    await promise;
+    expect(hits).toEqual(["onmessage", "listener-1", "listener-2"]);
+    expect(es.readyState).toBe(EventSource.CLOSED);
+  });
+
+  test("listener identity includes the capture flag for dedupe and removal", () => {
+    const es = new EventSource("http://127.0.0.1:1/");
+    let hits = 0;
+    const fn = () => hits++;
+    // Same callback, different capture → two distinct registrations.
+    es.addEventListener("ping", fn, true);
+    es.addEventListener("ping", fn, false);
+    // Duplicate of the bubble registration → ignored.
+    es.addEventListener("ping", fn, { capture: false });
+    es.dispatchEvent(new Event("ping"));
+    expect(hits).toBe(2);
+
+    // Remove only the bubble one; the capture one remains.
+    es.removeEventListener("ping", fn, false);
+    es.dispatchEvent(new Event("ping"));
+    expect(hits).toBe(3);
+
+    // Removing with the wrong capture is a no-op.
+    es.removeEventListener("ping", fn, false);
+    es.dispatchEvent(new Event("ping"));
+    expect(hits).toBe(4);
+
+    // Removing with matching capture finally drops it.
+    es.removeEventListener("ping", fn, { capture: true });
+    es.dispatchEvent(new Event("ping"));
+    expect(hits).toBe(4);
+    es.close();
+  });
+
+  test("removeEventListener during dispatch skips the removed listener", () => {
+    const es = new EventSource("http://127.0.0.1:1/");
+    const hits: string[] = [];
+    const b = () => hits.push("b");
+    es.addEventListener("tick", () => {
+      hits.push("a");
+      es.removeEventListener("tick", b);
+    });
+    es.addEventListener("tick", b);
+    es.addEventListener("tick", () => hits.push("c"));
+    es.dispatchEvent(new Event("tick"));
+    // b was removed before its turn in the snapshot → skipped.
+    expect(hits).toEqual(["a", "c"]);
     es.close();
   });
 });

--- a/test/js/web/fetch/event-source.test.ts
+++ b/test/js/web/fetch/event-source.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 function sseServer(handler: (controller: ReadableStreamDirectController, req: Request) => void | Promise<void>) {
   return Bun.serve({

--- a/test/js/web/fetch/event-source.test.ts
+++ b/test/js/web/fetch/event-source.test.ts
@@ -128,6 +128,18 @@ describe("EventSource", () => {
     es.close();
   });
 
+  test("strips one leading UTF-8 BOM from the stream", async () => {
+    await using server = sseServer(async (c, req) => {
+      c.write("\uFEFFdata: bom\n\n");
+      await c.flush();
+      await new Promise(r => req.signal.addEventListener("abort", r));
+    });
+    const es = new EventSource(server.url.href);
+    const msg = await new Promise<MessageEvent>(r => (es.onmessage = r));
+    expect(msg.data).toBe("bom");
+    es.close();
+  });
+
   test("reconnects after the stream ends and sends Last-Event-ID", async () => {
     let connections = 0;
     let sawLastEventId: string | null = null;


### PR DESCRIPTION
## What

Adds `globalThis.EventSource` — a native Server-Sent Events client — as a Zig-generated class.

## How

The implementation lives in `src/bun.js/webcore/EventSource.zig` and is exposed through the `.classes.ts` codegen like `Blob`/`Response`/`TextDecoder`.

It sits on the same HTTP machinery `FetchTasklet` uses for `fetch()`:

- `http.AsyncHTTP` with a `Signals.Store` (`header_progress` + `response_body_streaming` so body bytes stream in as soon as headers arrive)
- a `MutableString` pair + mutex for HTTP-thread → JS-thread body handoff
- a `ConcurrentTask` to hop back to the JS thread (registered in `Task.zig`)
- `bun.Async.KeepAlive` + `jsc.JSRef` + atomic `hasPendingActivity` for lifetime/GC

On the JS thread every received chunk is fed through an incremental SSE line parser that implements the [event-stream interpretation](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) rules (CR/LF/CRLF line endings, `data:`/`event:`/`id:`/`retry:` fields, comments, multi-line `data` joining).

Events are dispatched as real WebCore `Event` / `MessageEvent` objects via three small C++ helpers in `EventSourceEvents.cpp`, so `e instanceof MessageEvent`, `e.data`, `e.origin`, `e.lastEventId` all behave as expected.

Reconnect is handled by a new `EventSourceReconnect` `EventLoopTimer` tag; the server-supplied `retry:` value is honoured and the `Last-Event-ID` header is sent on every reconnect.

### Extras

- `{ headers }` constructor option (Bun extension — useful for `Authorization`)
- `.ref()` / `.unref()` (Bun extension)
- `addEventListener` / `removeEventListener` / `dispatchEvent` alongside `onopen`/`onmessage`/`onerror` handler attributes
- `require("undici").EventSource` now resolves to the real global instead of an empty stub
- The class codegen's `WeakHandleOwner::isReachableFromOpaqueRoots` now null-checks `wrapped()` — `constructNeedsThis` leaves a wrapper with a null `m_ctx` behind when the Zig constructor throws, which previously crashed GC's `hasPendingActivity` call

## Verification

`test/js/web/fetch/event-source.test.ts` — 11 tests covering: constructor errors, open/message flow with `MessageEvent` field population, multi-line data + CRLF + comments + custom event types, reconnect with `retry:` + `Last-Event-ID`, non-200 and wrong-`Content-Type` failure modes, `addEventListener`/`removeEventListener`, custom headers, `ref`/`unref`, and `dispatchEvent`.

```
 11 pass
 0 fail
Ran 11 tests across 1 file.
```

All fail on current `main` with `ReferenceError: EventSource is not defined`.

Fixes #8474
