### PR TITLE
Add HTTP/2 server support to Bun.serve()

### DIFF
--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -765,6 +765,17 @@ declare module "bun" {
       http3?: boolean;
 
       /**
+       * Also accept HTTP/2 on the same TLS listener. Requires {@link tls}
+       * and {@link http1} to be enabled (h2c is not supported; the HTTP/2
+       * context shares the HTTP/1.1 listener via ALPN). The server offers
+       * `h2,http/1.1` via ALPN; clients that negotiate `h2` are served
+       * over HTTP/2, everything else over HTTP/1.1.
+       * @default false
+       * @experimental
+       */
+      http2?: boolean;
+
+      /**
        * Listen for HTTP/1.1 over TCP. Set to `false` together with
        * `http3: true` to serve HTTP/3 only.
        * @default true

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -154,6 +154,14 @@ public:
                 if (success) *success = false;
                 return std::move(*this);
             }
+            /* sni_cb swaps ssl->ctx to this per-SNI SSL_CTX *before*
+             * BoringSSL reads alpn_select_cb, so the h2 ALPN callback
+             * on the root sslCtx never fires for SNI-routed
+             * connections. Install it on the fresh domainCtx too
+             * (no-op at select time if h2Context isn't live). */
+            if (httpContext->getSocketContextData()->hasH2()) {
+                installH2Alpn<SSL>(domainCtx, httpContext->getSocketContextData());
+            }
             /* Queue for any listeners not yet created. We hold one SSL_CTX ref;
              * each listen socket took its own via SSL_CTX_up_ref. */
             pendingServerNames.push_back({hostname_pattern, domainCtx, domainRouter});
@@ -196,6 +204,16 @@ public:
     /* Returns the SSL_CTX* of this app, or nullptr. */
     void *getNativeHandle() {
         return sslCtx;
+    }
+
+    /* H2App reaches in to install the ALPN cb on every SSL_CTX this
+     * app might serve a connection from. Kept here rather than
+     * widening `sslCtx`/`pendingServerNames` to public. */
+    struct ssl_ctx_st *getSslCtx() { return sslCtx; }
+    HttpContext<SSL> *getHttpContext() { return httpContext; }
+    template <typename Fn>
+    void forEachPendingServerNameSslCtx(Fn &&fn) {
+        if constexpr (SSL) for (auto &p : pendingServerNames) fn(p.ctx);
     }
 
     /* Attaches a "filter" function to track socket connections/disconnections */
@@ -349,6 +367,14 @@ public:
         us_socket_group_close_all(httpContext->getSocketGroup());
         for (us_socket_group_t *g : webSocketGroups) {
             us_socket_group_close_all(g);
+        }
+        if constexpr (SSL) {
+            /* H2 adopts sockets out of httpContext into its own group
+             * (via us_socket_adopt), so closing httpContext alone
+             * leaves those connections open. Mirror the WS walk. */
+            if (auto *child = httpContext->getSocketContextData()->h2Context) {
+                uws_internal_h2_close_all(child);
+            }
         }
 
         return std::move(*this);

--- a/packages/bun-uws/src/Http2App.h
+++ b/packages/bun-uws/src/Http2App.h
@@ -1,0 +1,338 @@
+#ifndef UWS_H2APP_H
+#define UWS_H2APP_H
+// clang-format off
+
+#include "App.h"
+#include "Http2Context.h"
+
+#include <openssl/ssl.h>
+
+namespace uWS {
+
+/* TemplatedApp-shaped front for HTTP/2. Route registration mirrors SSLApp
+ * so the C ABI in libuwsockets_h2.cpp can stay 1:1 with the existing
+ * uws_app_* surface.
+ *
+ * Unlike H3App (which opens its own UDP socket), H2App attaches to an
+ * existing SSLApp: it creates its own socket group, installs an ALPN
+ * select callback offering "h2,http/1.1" on the parent's SSL_CTX (and
+ * each per-SNI SSL_CTX via addServerName), and takes over sockets that
+ * negotiate "h2" at the top of HttpContext<true>::onData. The SSL* stays
+ * on the adopted socket, so TLS decryption continues transparently. */
+struct H2App {
+    Http2Context *http2Context;
+    /* Kept so the destructor can null the parent's adoption hook — the
+     * H1 context typically outlives H2App by a few frames (server.zig
+     * destroys h2_app before app), and a late on_data on a connected
+     * socket would otherwise consult freed memory. */
+    HttpContextData<true> *parentData;
+
+    /* `parentApp` is the HTTP/1 SSLApp; we read its root sslCtx and any
+     * already-queued per-SNI ctxs to install the ALPN cb on each (sni_cb
+     * swaps ssl->ctx before BoringSSL reads alpn_select_cb, so every
+     * SSL_CTX that can serve a connection needs a copy). Subsequent SNI
+     * entries are covered by TemplatedApp::addServerName. */
+    static H2App *create(TemplatedApp<true> *parentApp, unsigned idleTimeoutS = 0) {
+        if (!parentApp || parentApp->constructorFailed()) return nullptr;
+        Http2Context *ctx = Http2Context::create(Loop::get(), idleTimeoutS);
+        if (!ctx) return nullptr;
+        auto *parentData = parentApp->getHttpContext()->getSocketContextData();
+        installH2Alpn<true>(parentApp->getSslCtx(), parentData);
+        parentApp->forEachPendingServerNameSslCtx([&](SSL_CTX *sniCtx) {
+            installH2Alpn<true>(sniCtx, parentData);
+        });
+        parentData->h2Context = ctx;
+        return new H2App{ctx, parentData};
+    }
+
+    bool constructorFailed() { return http2Context == nullptr; }
+    ~H2App() {
+        if (parentData && parentData->h2Context == http2Context) {
+            parentData->h2Context = nullptr;
+        }
+        if (http2Context) http2Context->free();
+    }
+
+#define H2_METHOD(name, verb)                                                            \
+    H2App &&name(std::string_view pattern,                                               \
+                 MoveOnlyFunction<void(Http2Response *, Http2Request *)> &&handler) {    \
+        http2Context->onHttp(verb, pattern, std::move(handler));                         \
+        return std::move(*this);                                                         \
+    }
+    H2_METHOD(get, "get")
+    H2_METHOD(post, "post")
+    H2_METHOD(put, "put")
+    H2_METHOD(del, "delete")
+    H2_METHOD(patch, "patch")
+    H2_METHOD(head, "head")
+    H2_METHOD(options, "options")
+    H2_METHOD(connect, "connect")
+    H2_METHOD(trace, "trace")
+    H2_METHOD(any, "*")
+#undef H2_METHOD
+
+    void clearRoutes() {
+        http2Context->getContextData()->router =
+            decltype(http2Context->getContextData()->router){};
+    }
+    /* GOAWAY + drain. The child context is freed in the destructor. */
+    void close() { http2Context->shutdown(); }
+    void *getNativeHandle() { return http2Context; }
+
+    /* Called from HttpContext<true>::onData (declared extern there so
+     * HttpContext.h doesn't include this file). Inspects ALPN and, if
+     * "h2", destructs the H1 ext, adopts the socket into our group,
+     * and dispatches the initial bytes (the preface + client SETTINGS
+     * that arrived in the same read). Returns the possibly relocated
+     * socket, or null if the socket stays in the H1 group untouched. */
+    static us_socket_t *adoptIfNegotiated(Http2Context *ctx,
+                                          us_socket_t *s, int oldExtSize,
+                                          char *data, int length) {
+        SSL *ssl = (SSL *) us_socket_get_native_handle(s);
+        if (!ssl) return nullptr;
+        const unsigned char *proto = nullptr; unsigned int protoLen = 0;
+        SSL_get0_alpn_selected(ssl, &proto, &protoLen);
+        if (!(protoLen == 2 && proto[0] == 'h' && proto[1] == '2')) return nullptr;
+
+        /* Tear down the H1 per-socket state before realloc. */
+        ((HttpResponseData<true> *) us_socket_ext(s))->~HttpResponseData<true>();
+
+        /* kind .dynamic → dispatch via group.vtable (h2VTable). The SSL*
+         * stays on the socket, so TLS decryption continues. */
+        us_socket_t *ns = us_socket_adopt(s, ctx->getSocketGroup(),
+            US_SOCKET_KIND_DYNAMIC, oldExtSize, sizeof(Http2Connection));
+        /* us_socket_adopt doesn't fire on_open for an already-open
+         * socket, so initialise the new ext and send our SETTINGS here. */
+        new (us_socket_ext(ns)) Http2Connection();
+        auto *c = Http2Context::conn(ns);
+        c->initHpack();
+        ((AsyncSocket<true> *) ns)->cork();
+        ctx->sendServerPreface(ns);
+        c->dispatchDepth++;
+        if (length > 0) ctx->onData(ns, data, length);
+        if (!us_socket_is_closed(ns)) {
+            c->dispatchDepth--;
+            ctx->sweep(ns);
+            ((AsyncSocket<true> *) ns)->uncork();
+            us_socket_timeout(ns, ctx->getContextData()->idleTimeoutS);
+        }
+        return ns;
+    }
+};
+
+/* ─────── Http2Response out-of-line methods that need Http2Context ─────── */
+
+inline void Http2Response::sendBufferedHeaders(bool endStream) {
+    context()->writeHeaders(socket, id, &data, endStream);
+}
+
+inline Http2Response *Http2Response::writeContinue() {
+    /* RFC 9113 §8.1: a 1xx is its own HEADERS frame without END_STREAM. */
+    Http2ResponseData tmp;
+    tmp.appendHeader(":status", 7, "100", 3);
+    context()->writeHeaders(socket, id, &tmp, false);
+    return this;
+}
+
+inline Http2Response *Http2Response::cork(MoveOnlyFunction<void()> &&fn) {
+    /* Cache the socket: once fn() returns, `this` may be in
+     * pendingDelete. We do NOT sweep here — the caller above cork()
+     * (StaticRoute.on, RequestContext paths) still holds `resp` and
+     * touches it right after cork returns, and sweep()'s
+     * goaway-close would fire on_close → ~Http2Connection → free
+     * pendingDelete (including `this`) under the caller. H3 gets the
+     * same guarantee because lsquic defers stream teardown to the next
+     * process_conns(). */
+    us_socket_t *s = socket;
+    Http2Connection *c = Http2Context::conn(s);
+    auto *as = (AsyncSocket<true> *) s;
+    bool was = as->isCorked();
+    if (!was) as->cork();
+    fn();
+    if (!us_socket_is_closed(s)) {
+        if (!was && as->isCorked()) as->uncork();
+        /* The async-resolve path reaches here outside any uSockets
+         * event (dispatchDepth == 0), so there is no on_data/on_writable
+         * epilogue to call sweep() for us. If this response was the
+         * last stream on a GOAWAY connection, close the write side now
+         * so the client receives EOF after the final END_STREAM and
+         * hangs up, which in turn fires on_end → on_close → cleanup.
+         * Shutdown is safe here where sweep()'s us_socket_close() is
+         * not: it doesn't free anything or fire on_close synchronously,
+         * so the caller can still touch `this` after cork() returns. */
+        if (c->dispatchDepth == 0 && c->goaway && c->streams.empty() &&
+            !us_socket_is_shut_down(s)) {
+            us_socket_shutdown(s);
+        }
+    }
+    return this;
+}
+
+inline Http2Response *Http2Response::resume() {
+    if (!paused) return this;
+    paused = false;
+    if (recvWindow < h2::LOCAL_INIT_WINDOW / 2) {
+        uint32_t inc = (uint32_t)(h2::LOCAL_INIT_WINDOW - recvWindow);
+        context()->writeWindowUpdate(socket, id, inc);
+        recvWindow = h2::LOCAL_INIT_WINDOW;
+        ((AsyncSocket<true> *) socket)->uncork();
+    }
+    return this;
+}
+
+inline bool Http2Response::write(std::string_view body, size_t *writtenPtr) {
+    flushHeaders();
+    if (data.backpressure.length() != 0) {
+        data.backpressure.append(body.data(), body.length());
+        if (writtenPtr) *writtenPtr = 0;
+        return false;
+    }
+    size_t w = context()->writeData(socket, this, body.data(), body.length(), false);
+    data.offset += (uint64_t) w;
+    if (writtenPtr) *writtenPtr = w;
+    if (w < body.length()) {
+        data.backpressure.append(body.data() + w, body.length() - w);
+        return false;
+    }
+    return ((AsyncSocket<true> *) socket)->getBufferedAmount() < 256 * 1024;
+}
+
+inline void Http2Response::endWithoutBody(std::optional<size_t> cl, bool) {
+    if (cl.has_value() && !(data.state & Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+        writeHeader("content-length", (uint64_t) *cl);
+    }
+    if (data.state & Http2ResponseData::HTTP_WRITE_CALLED) {
+        context()->writeData(socket, this, "", 0, true);
+    } else {
+        writeStatus("200 OK");
+        sendBufferedHeaders(true);
+    }
+    markDone();
+}
+
+inline bool Http2Response::sendTerminatingChunk(bool) {
+    flushHeaders();
+    if (data.backpressure.length() != 0) {
+        data.endAfterDrain = true;
+        return false;
+    }
+    context()->writeData(socket, this, "", 0, true);
+    markDone();
+    return true;
+}
+
+inline bool Http2Response::internalEnd(std::string_view body, uint64_t totalSize,
+                                        bool optional, bool, bool) {
+    data.totalSize = totalSize;
+    if (!(data.state & Http2ResponseData::HTTP_WRITE_CALLED)) {
+        writeStatus("200 OK");
+        if (!(data.state & Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER) && totalSize) {
+            writeHeader("content-length", totalSize);
+            data.state |= Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+        }
+        if (body.empty() && data.offset == totalSize) {
+            sendBufferedHeaders(true);
+            markDone();
+            return true;
+        }
+        sendBufferedHeaders(false);
+        data.state |= Http2ResponseData::HTTP_WRITE_CALLED;
+    }
+
+    if (data.backpressure.length() != 0) {
+        if (optional) return false;
+        data.backpressure.append(body.data(), body.length());
+        data.endAfterDrain = true;
+        return false;
+    }
+
+    size_t w = body.empty() ? 0
+        : context()->writeData(socket, this, body.data(), body.length(), false);
+    data.offset += (uint64_t) w;
+    if (w < body.length()) {
+        if (optional) return false;
+        data.backpressure.append(body.data() + w, body.length() - w);
+        data.endAfterDrain = true;
+        return false;
+    }
+
+    if (data.offset >= totalSize) {
+        context()->writeData(socket, this, "", 0, true);
+        markDone();
+        return true;
+    }
+    return false;
+}
+
+inline bool Http2Response::drain() {
+    while (data.backpressure.length() != 0) {
+        size_t w = context()->writeData(socket, this, data.backpressure.data(),
+                                         data.backpressure.length(), false);
+        if (w == 0) return false;
+        data.offset += (uint64_t) w;
+        data.backpressure.erase((unsigned) w);
+    }
+    if (data.endAfterDrain) {
+        data.endAfterDrain = false;
+        context()->writeData(socket, this, "", 0, true);
+        markDone();
+        return true;
+    }
+    if (data.onWritable) {
+        return data.onWritable(this, data.offset, data.writableUserData);
+    }
+    return true;
+}
+
+inline void Http2Response::markDone() {
+    data.onWritable = nullptr;
+    data.inStream = nullptr;
+    data.state |= Http2ResponseData::HTTP_END_CALLED;
+    data.state &= ~Http2ResponseData::HTTP_RESPONSE_PENDING;
+    /* §8.1: a server MAY send RST_STREAM(NO_ERROR) after a complete
+     * response to stop the client pushing a body we won't read. */
+    if (!data.remoteClosed) {
+        context()->writeRstStream(socket, id, h2::ERR_NO_ERROR);
+        data.remoteClosed = true;
+    }
+    maybeDestroy();
+}
+
+inline void Http2Response::close() {
+    if (!us_socket_is_closed(socket)) {
+        context()->writeRstStream(socket, id, h2::ERR_CANCEL);
+    }
+    data.remoteClosed = true;
+    data.state &= ~Http2ResponseData::HTTP_RESPONSE_PENDING;
+    data.state |= Http2ResponseData::HTTP_END_CALLED;
+    maybeDestroy();
+}
+
+inline void Http2Response::maybeDestroy() {
+    if (!hasResponded() || !data.remoteClosed) return;
+    if (dead) return;
+    dead = true;
+    Http2Connection *c = Http2Context::conn(socket);
+    c->streams.erase(id);
+    /* Like H3: fire onAborted so the holder drops its pointer — it
+     * distinguishes via hasResponded(). */
+    if (data.onAborted) {
+        auto cb = data.onAborted;
+        data.onAborted = nullptr;
+        cb(this, data.userData);
+    }
+    /* The caller may still hold `this` on its stack (e.g. Zig's
+     * StaticRoute calls clearAborted() right after tryEnd(), and the
+     * async render path touches `resp` after the promise resolves).
+     * Always defer the free to the next sweep() — on_data/on_writable
+     * exit for the sync path, connection close for anything that
+     * slips through. The GOAWAY last-stream close also stays in
+     * sweep(): closing here would run on_close → ~Http2Connection →
+     * free pendingDelete (including `this`) while the caller is still
+     * on the stack. */
+    c->pendingDelete.append(this);
+}
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -608,6 +608,9 @@ struct Http2Context {
             switch (id) {
             case 1: /* HEADER_TABLE_SIZE */
                 lshpack_enc_set_max_capacity(&c->enc, v); break;
+            case 2: /* ENABLE_PUSH — §6.5.2: MUST be 0 or 1 */
+                if (v > 1) return protocolError(s, h2::ERR_PROTOCOL);
+                break;
             case 4: { /* INITIAL_WINDOW_SIZE — §6.9.2 also adjusts open streams */
                 if (v > 0x7fffffff) return protocolError(s, h2::ERR_FLOW_CONTROL);
                 int32_t delta = (int32_t) v - c->remoteInitialWindow;

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -1,0 +1,990 @@
+#ifndef UWS_H2CONTEXT_H
+#define UWS_H2CONTEXT_H
+// clang-format off
+
+/* HTTP/2 server for Bun.serve(). Built on the same uSockets TLS socket as
+ * the HTTP/1 context: an ALPN select cb offers "h2,http/1.1" and, after the
+ * handshake, sockets that negotiated "h2" are adopted into this child
+ * context. Per-connection state (HPACK codecs, flow control, stream map,
+ * frame-parse buffer) lives in the socket ext; each stream is a
+ * heap-allocated Http2Response.
+ *
+ * Public surface (Http2App/Response/Request) mirrors Http3* so Zig's
+ * AnyResponse/AnyRequest `inline else` dispatch works unchanged.
+ *
+ * RFC 9113 (framing, flow control, §6.*), RFC 7541/lshpack (HPACK). Minimal
+ * but conformant: SETTINGS/PING/WINDOW_UPDATE handled, PRIORITY and
+ * PUSH_PROMISE are acknowledged-and-ignored (server push disabled), HPACK
+ * errors and framing violations tear the connection down with GOAWAY. */
+
+#include "Loop.h"
+#include "AsyncSocket.h"
+#include "AsyncSocketData.h"
+#include "Http2ContextData.h"
+#include "Http2ResponseData.h"
+#include "MoveOnlyFunction.h"
+
+#include <lshpack.h>
+
+#include <wtf/Vector.h>
+#include <map>
+#include <cstring>
+#include <string_view>
+
+namespace uWS {
+
+struct Http2Request;
+struct Http2Response;
+struct Http2Context;
+
+/* ─────── wire constants (RFC 9113 §6) ─────── */
+namespace h2 {
+    static constexpr std::string_view PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    static constexpr int32_t DEFAULT_WINDOW   = 65535;
+    static constexpr uint32_t DEFAULT_FRAME   = 16384;
+    static constexpr size_t FRAME_HEADER_SIZE = 9;
+    static constexpr uint32_t MAX_HEADER_LIST = 64 * 1024;
+    static constexpr uint32_t MAX_STREAMS     = 128;
+    /* Advertise a generous per-stream window so downloads aren't throttled
+     * by the spec default. Connection window is also bumped on open. */
+    static constexpr int32_t LOCAL_INIT_WINDOW = 1024 * 1024;
+
+    enum FrameType : uint8_t {
+        DATA = 0, HEADERS = 1, PRIORITY = 2, RST_STREAM = 3, SETTINGS = 4,
+        PUSH_PROMISE = 5, PING = 6, GOAWAY = 7, WINDOW_UPDATE = 8, CONTINUATION = 9,
+    };
+    enum Flags : uint8_t {
+        END_STREAM = 0x1, ACK = 0x1, END_HEADERS = 0x4, PADDED = 0x8, PRIO = 0x20,
+    };
+    /* Prefixed — winerror.h on Windows #defines NO_ERROR, and several of
+     * the others collide with other platform headers. */
+    enum ErrorCode : uint32_t {
+        ERR_NO_ERROR = 0, ERR_PROTOCOL = 1, ERR_INTERNAL = 2, ERR_FLOW_CONTROL = 3,
+        ERR_STREAM_CLOSED = 5, ERR_FRAME_SIZE = 6, ERR_REFUSED_STREAM = 7, ERR_CANCEL = 8,
+        ERR_COMPRESSION = 9, ERR_ENHANCE_YOUR_CALM = 11,
+    };
+
+    static inline void writeFrameHeader(char *dst, uint32_t len, uint8_t type,
+                                        uint8_t flags, uint32_t stream) {
+        dst[0] = (char)((len >> 16) & 0xff);
+        dst[1] = (char)((len >> 8) & 0xff);
+        dst[2] = (char)(len & 0xff);
+        dst[3] = (char) type;
+        dst[4] = (char) flags;
+        dst[5] = (char)((stream >> 24) & 0x7f);
+        dst[6] = (char)((stream >> 16) & 0xff);
+        dst[7] = (char)((stream >> 8) & 0xff);
+        dst[8] = (char)(stream & 0xff);
+    }
+}
+
+/* ─────── per-connection state (socket ext) ─────── */
+struct Http2Connection : AsyncSocketData<true> {
+    struct lshpack_enc enc;
+    struct lshpack_dec dec;
+    bool hpackInit = false;
+    bool prefaceConsumed = false;
+    bool sentPreface = false;
+    bool goaway = false;
+
+    /* Frame-parse accumulator. Bytes are appended here until a complete
+     * 9-byte header + payload is available, then drained. */
+    std::string rx;
+    /* Header-block-fragment accumulator across HEADERS + CONTINUATION.
+     * `continuationStream` is the only stream allowed to send frames until
+     * END_HEADERS (§6.10). */
+    std::string headerBlock;
+    uint32_t continuationStream = 0;
+    bool continuationEndStream = false;
+
+    /* Flow control. */
+    int32_t connSendWindow = h2::DEFAULT_WINDOW;
+    int32_t connRecvWindow = h2::LOCAL_INIT_WINDOW;
+    /* Peer's SETTINGS. */
+    uint32_t remoteMaxFrame = h2::DEFAULT_FRAME;
+    int32_t remoteInitialWindow = h2::DEFAULT_WINDOW;
+
+    /* Highest client stream ID seen; used for GOAWAY. */
+    uint32_t lastStreamId = 0;
+
+    /* Live streams, keyed by client-initiated odd IDs. std::map over
+     * HashMap for ordered iteration (drain fairness) and stable pointers
+     * across insert. */
+    std::map<uint32_t, Http2Response *> streams;
+    /* Streams that completed while a callback was on the stack. We can't
+     * `delete` inside markDone() because the caller (Zig's StaticRoute,
+     * RequestContext.renderBytes, …) still holds the pointer and calls
+     * clearAborted()/clearOnWritable() right after tryEnd() returns.
+     * H3 gets away with this because lsquic defers stream teardown to
+     * the next process_conns(); we mimic that by sweeping at the end of
+     * each frame-dispatch pass. */
+    WTF::Vector<Http2Response *, 4> pendingDelete;
+    int dispatchDepth = 0;
+
+    /* Scratch for HPACK decode; one per connection avoids per-header
+     * allocation. Sized to the advertised MAX_HEADER_LIST_SIZE. */
+    char hpackBuf[h2::MAX_HEADER_LIST];
+
+    ~Http2Connection();
+
+    void initHpack() {
+        if (hpackInit) return;
+        lshpack_enc_init(&enc);
+        lshpack_dec_init(&dec);
+        hpackInit = true;
+    }
+};
+
+}
+
+/* Http2Response needs Http2Connection defined, and Http2Context needs both. */
+#include "Http2Response.h"
+#include "Http2Request.h"
+
+namespace uWS {
+
+inline Http2Connection::~Http2Connection() {
+    for (auto &kv : streams) delete kv.second;
+    streams.clear();
+    for (auto *r : pendingDelete) delete r;
+    pendingDelete.shrink(0);
+    if (hpackInit) {
+        lshpack_enc_cleanup(&enc);
+        lshpack_dec_cleanup(&dec);
+    }
+}
+
+/* Heap-allocated owner of one H2 server's socket group + router. Mirrors
+ * HttpContext<SSL>'s shape: `group.ext` points back to `this` so vtable
+ * handlers recover the typed context via fromSocket(). Sockets are adopted
+ * into `group` from HttpContext<true>::onData once ALPN negotiates h2; the
+ * SSL* stays on the socket, so TLS decryption continues transparently. */
+struct Http2Context {
+
+    us_socket_group_t group{};
+    Http2ContextData data;
+
+    Http2ContextData *getContextData() { return &data; }
+    us_socket_group_t *getSocketGroup() { return &group; }
+
+    static Http2Context *fromSocket(us_socket_t *s) {
+        return (Http2Context *) us_socket_group_ext(us_socket_group(s));
+    }
+    static Http2ContextData *getContextData(us_socket_t *s) {
+        return &fromSocket(s)->data;
+    }
+    static Http2Connection *conn(us_socket_t *s) {
+        return (Http2Connection *) us_socket_ext(s);
+    }
+
+    /* ── vtable handlers ────────────────────────────────────────────── */
+
+    static us_socket_t *onOpen(us_socket_t *s, int, char *, int) {
+        new (us_socket_ext(s)) Http2Connection();
+        conn(s)->initHpack();
+        fromSocket(s)->sendServerPreface(s);
+        us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        return s;
+    }
+
+    static us_socket_t *onClose(us_socket_t *s, int, void *) {
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        Http2Connection *c = conn(s);
+        /* onAborted may re-enter JS → drainMicrotasks → resolve a
+         * *sibling* stream's pending response → end() →
+         * maybeDestroy() → c->streams.erase(sibling). That can free
+         * the map node any map iterator points at, so snapshot the
+         * response pointers first and iterate the snapshot.
+         * dispatchDepth keeps the Http2Response heap objects alive
+         * (parked in pendingDelete) until ~Http2Connection frees
+         * everything in one pass. */
+        c->dispatchDepth++;
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            Http2ResponseData *d = r->getHttpResponseData();
+            if (d->onAborted) d->onAborted(r, d->userData);
+        }
+        c->~Http2Connection();
+        return s;
+    }
+
+    static us_socket_t *onSocketData(us_socket_t *s, char *data, int length) {
+        if (us_socket_is_shut_down(s)) return s;
+        us_socket_ref(s);
+        ((AsyncSocket<true> *) s)->cork();
+        Http2Connection *c = conn(s);
+        c->dispatchDepth++;
+        fromSocket(s)->onData(s, data, length);
+        if (!us_socket_is_closed(s)) {
+            c->dispatchDepth--;
+            fromSocket(s)->sweep(s);
+            us_socket_unref(s);
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        }
+        return s;
+    }
+
+    static us_socket_t *onWritable(us_socket_t *s) {
+        auto *as = (AsyncSocket<true> *) s;
+        if (as->getBufferedAmount() > 0) {
+            as->flush();
+            if (as->getBufferedAmount() > 0) {
+                us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+                return s;
+            }
+        }
+        Http2Connection *c = conn(s);
+        c->dispatchDepth++;
+        fromSocket(s)->drainStreams(s);
+        if (!us_socket_is_closed(s)) {
+            c->dispatchDepth--;
+            fromSocket(s)->sweep(s);
+            us_socket_timeout(s, getContextData(s)->idleTimeoutS);
+        }
+        return s;
+    }
+
+    static us_socket_t *onEnd(us_socket_t *s) {
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        return us_socket_close(s, 0, nullptr);
+    }
+
+    static us_socket_t *onTimeout(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        /* Same iterator-safety as onClose: onTimeout can re-enter
+         * JS and erase a sibling stream from the map. */
+        c->dispatchDepth++;
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            Http2ResponseData *d = r->getHttpResponseData();
+            if (d->onTimeout) d->onTimeout(r, d->userData);
+        }
+        c->dispatchDepth--;
+        ((AsyncSocket<true> *) s)->uncorkWithoutSending();
+        return us_socket_close(s, 0, nullptr);
+    }
+
+    static inline const us_socket_vtable_t h2VTable = {
+        /* on_open */         &onOpen,
+        /* on_data */         &onSocketData,
+        /* on_fd */           nullptr,
+        /* on_writable */     &onWritable,
+        /* on_close */        &onClose,
+        /* on_timeout */      &onTimeout,
+        /* on_long_timeout */ nullptr,
+        /* on_end */          &onEnd,
+        /* on_connect_error */nullptr,
+        /* on_connecting_error */ nullptr,
+        /* on_handshake */    nullptr,
+    };
+
+    /* No listener of its own — sockets are adopted from the parent
+     * HttpContext<true> once ALPN picks h2. The group just carries the
+     * vtable and collects adopted sockets for close-all/timeout-sweep. */
+    static Http2Context *create(Loop *loop, unsigned int idleTimeoutS) {
+        auto *ctx = new Http2Context;
+        us_socket_group_init(&ctx->group, (us_loop_t *) loop, &h2VTable, ctx);
+        ctx->data.idleTimeoutS = idleTimeoutS ? idleTimeoutS : 10;
+        return ctx;
+    }
+
+    void free() {
+        us_socket_group_deinit(&group);
+        delete this;
+    }
+
+    /* GOAWAY every live connection. The group itself is freed in free(). */
+    void shutdown() {
+        for (us_socket_t *s = group.head_sockets; s;) {
+            us_socket_t *next = s->next;
+            if (!us_socket_is_closed(s)) {
+                writeGoaway(s, conn(s)->lastStreamId, h2::ERR_NO_ERROR);
+                ((AsyncSocket<true> *) s)->flush();
+                if (conn(s)->streams.empty()) us_socket_close(s, 0, nullptr);
+                else conn(s)->goaway = true;
+            }
+            s = next;
+        }
+    }
+
+    void onHttp(std::string_view method, std::string_view pattern,
+                MoveOnlyFunction<void(Http2Response *, Http2Request *)> &&handler) {
+        Http2ContextData *cd = getContextData();
+        std::vector<std::string_view> methods =
+            method == "*" ? std::vector<std::string_view>{"*"} : std::vector<std::string_view>{method};
+        cd->router.add(methods, pattern, [handler = std::move(handler)](auto *router) mutable {
+            auto &ud = router->getUserData();
+            ud.httpRequest->setYield(false);
+            ud.httpRequest->setParameters(router->getParameters());
+            handler(ud.httpResponse, ud.httpRequest);
+            return !ud.httpRequest->getYield();
+        }, method == "*" ? cd->router.LOW_PRIORITY : cd->router.MEDIUM_PRIORITY);
+    }
+
+    /* ─────── outbound framing ─────── */
+
+    void writeFrame(us_socket_t *s, uint8_t type, uint8_t flags,
+                    uint32_t stream, const char *payload, uint32_t len) {
+        char hdr[h2::FRAME_HEADER_SIZE];
+        h2::writeFrameHeader(hdr, len, type, flags, stream);
+        auto *as = (AsyncSocket<true> *) s;
+        as->write(hdr, (int) sizeof(hdr), false, (int) len);
+        if (len) as->write(payload, (int) len, false, 0);
+    }
+
+    void sendServerPreface(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        if (c->sentPreface) return;
+        c->sentPreface = true;
+        /* SETTINGS_MAX_CONCURRENT_STREAMS, SETTINGS_INITIAL_WINDOW_SIZE,
+         * SETTINGS_MAX_FRAME_SIZE (matches the 1 MiB enforced in onData so
+         * §4.2's advertised↔enforced limits agree), SETTINGS_MAX_HEADER_LIST_SIZE.
+         * Push stays at its default (1) but a PUSH_PROMISE from a client is
+         * a protocol error regardless. */
+        unsigned char p[24];
+        auto put = [&](int off, uint16_t id, uint32_t v) {
+            p[off] = (unsigned char)(id >> 8); p[off+1] = (unsigned char) id;
+            p[off+2] = (unsigned char)(v >> 24); p[off+3] = (unsigned char)(v >> 16);
+            p[off+4] = (unsigned char)(v >> 8); p[off+5] = (unsigned char) v;
+        };
+        put(0, 3, h2::MAX_STREAMS);
+        put(6, 4, (uint32_t) h2::LOCAL_INIT_WINDOW);
+        put(12, 5, 1u << 20);
+        put(18, 6, h2::MAX_HEADER_LIST);
+        writeFrame(s, h2::SETTINGS, 0, 0, (const char *) p, sizeof(p));
+        /* Connection window starts at 64KiB regardless of SETTINGS; open it
+         * to match the per-stream window so the first upload isn't
+         * throttled before our first WINDOW_UPDATE. */
+        writeWindowUpdate(s, 0, (uint32_t)(h2::LOCAL_INIT_WINDOW - h2::DEFAULT_WINDOW));
+    }
+
+    void writeWindowUpdate(us_socket_t *s, uint32_t stream, uint32_t inc) {
+        if (inc == 0) return;
+        unsigned char p[4] = {(unsigned char)(inc >> 24), (unsigned char)(inc >> 16),
+                              (unsigned char)(inc >> 8), (unsigned char) inc};
+        writeFrame(s, h2::WINDOW_UPDATE, 0, stream, (const char *) p, 4);
+    }
+
+    void writeRstStream(us_socket_t *s, uint32_t stream, uint32_t code) {
+        unsigned char p[4] = {(unsigned char)(code >> 24), (unsigned char)(code >> 16),
+                              (unsigned char)(code >> 8), (unsigned char) code};
+        writeFrame(s, h2::RST_STREAM, 0, stream, (const char *) p, 4);
+    }
+
+    void writeGoaway(us_socket_t *s, uint32_t lastStream, uint32_t code) {
+        unsigned char p[8] = {
+            (unsigned char)((lastStream >> 24) & 0x7f), (unsigned char)(lastStream >> 16),
+            (unsigned char)(lastStream >> 8), (unsigned char) lastStream,
+            (unsigned char)(code >> 24), (unsigned char)(code >> 16),
+            (unsigned char)(code >> 8), (unsigned char) code,
+        };
+        writeFrame(s, h2::GOAWAY, 0, 0, (const char *) p, 8);
+    }
+
+    /* Serialise a HEADERS frame via HPACK. Headers larger than
+     * remoteMaxFrame are split into HEADERS + CONTINUATION. */
+    void writeHeaders(us_socket_t *s, uint32_t stream, Http2ResponseData *d,
+                      bool endStream) {
+        Http2Connection *c = conn(s);
+        static thread_local WTF::Vector<unsigned char, 4096> buf;
+        buf.shrink(0);
+        const char *base = d->hdrBuf.span().data();
+        for (auto &h : d->hdrs) {
+            /* lsxpack wants name+value contiguous; hdrBuf is laid out that
+             * way (appendHeader lowercases the name in-place). lshpack
+             * narrows offsets/lengths to lsxpack_strlen_t (uint16_t), so
+             * pass a per-header base instead of a cumulative offset —
+             * otherwise crossing 64 KiB of response headers wraps the
+             * offset and encodes garbage. A single header whose name+
+             * value exceeds 64 KiB is clamped for the same reason. */
+            size_t nameOff = (size_t)(uintptr_t) h.name;
+            unsigned nlen = h.name_len;
+            unsigned vlen = h.value_len;
+            if (nlen > LSXPACK_MAX_STRLEN) nlen = LSXPACK_MAX_STRLEN;
+            if ((size_t) nlen + vlen > LSXPACK_MAX_STRLEN)
+                vlen = (unsigned)(LSXPACK_MAX_STRLEN - nlen);
+            struct lsxpack_header xh;
+            lsxpack_header_set_offset2(&xh, base + nameOff, 0, nlen, nlen, vlen);
+            /* Worst case is one literal byte per input byte plus ~6 bytes
+             * of varint framing. */
+            size_t need = buf.size() + h.name_len + h.value_len + 32;
+            if (buf.capacity() < need) buf.reserveCapacity(need);
+            buf.grow(buf.capacity());
+            unsigned char *out = buf.mutableSpan().data();
+            unsigned char *p = lshpack_enc_encode(&c->enc, out + (need - (h.name_len + h.value_len + 32)),
+                                                  out + buf.size(), &xh);
+            buf.shrink((size_t)(p - out));
+        }
+        d->hdrBuf.shrink(0);
+        d->hdrs.shrink(0);
+
+        const unsigned char *block = buf.span().data();
+        size_t remaining = buf.size();
+        bool first = true;
+        do {
+            size_t chunk = remaining < c->remoteMaxFrame ? remaining : c->remoteMaxFrame;
+            bool last = chunk == remaining;
+            uint8_t flags = last ? h2::END_HEADERS : 0;
+            if (first && endStream) flags |= h2::END_STREAM;
+            writeFrame(s, first ? h2::HEADERS : h2::CONTINUATION, flags, stream,
+                       (const char *) block, (uint32_t) chunk);
+            block += chunk; remaining -= chunk; first = false;
+        } while (remaining);
+    }
+
+    /* Push body bytes into DATA frames under both flow-control windows and
+     * the socket's backpressure. Returns bytes framed; END_STREAM is set on
+     * the final frame only if `end` and everything fit. */
+    size_t writeData(us_socket_t *s, Http2Response *r, const char *data,
+                     size_t len, bool end) {
+        Http2Connection *c = conn(s);
+        size_t sent = 0;
+        while (true) {
+            int32_t window = c->connSendWindow < r->sendWindow ? c->connSendWindow : r->sendWindow;
+            if (window <= 0 && len > sent) break;
+            size_t room = (size_t)(window < 0 ? 0 : window);
+            size_t chunk = len - sent;
+            if (chunk > room) chunk = room;
+            if (chunk > c->remoteMaxFrame) chunk = c->remoteMaxFrame;
+            bool last = (sent + chunk == len);
+            uint8_t flags = (last && end) ? h2::END_STREAM : 0;
+            writeFrame(s, h2::DATA, flags, r->id, data + sent, (uint32_t) chunk);
+            c->connSendWindow -= (int32_t) chunk;
+            r->sendWindow -= (int32_t) chunk;
+            sent += chunk;
+            if (last) break;
+            /* Don't keep copying into AsyncSocket backpressure once the
+             * kernel stopped accepting — onWritable resumes us. */
+            if (((AsyncSocket<true> *) s)->getBufferedAmount() > 256 * 1024) break;
+        }
+        return sent;
+    }
+
+    /* Free streams that completed while a handler was on the stack, and
+     * close the connection if GOAWAY was sent and the last stream just
+     * drained. The close check is independent of pendingDelete so a
+     * late event can still close after the list drained earlier. */
+    void sweep(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        if (c->dispatchDepth > 0) return;
+        if (!c->pendingDelete.isEmpty()) {
+            for (auto *r : c->pendingDelete) delete r;
+            c->pendingDelete.shrink(0);
+        }
+        if (c->goaway && c->streams.empty() && !us_socket_is_closed(s)) {
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_close(s, 0, nullptr);
+        }
+    }
+
+    /* Called from on_writable once TCP drained. Flush each stream's
+     * backpressure then give onWritable a turn. drain() → onWritable
+     * can re-enter JS → drainMicrotasks → complete a *sibling* stream
+     * → c->streams.erase(sibling), so iterate a snapshot instead of
+     * the live map. dispatchDepth (set in the caller) keeps the heap
+     * objects alive in pendingDelete until sweep(). */
+    void drainStreams(us_socket_t *s) {
+        Http2Connection *c = conn(s);
+        WTF::Vector<Http2Response *, 16> live;
+        live.reserveCapacity(c->streams.size());
+        for (auto &kv : c->streams) live.append(kv.second);
+        for (auto *r : live) {
+            if (r->dead) continue;
+            if (!r->drain()) continue;
+            /* drain() may have completed the response and closed the
+             * socket via GOAWAY-last-stream. */
+            if (us_socket_is_closed(s)) return;
+        }
+    }
+
+    /* ─────── inbound framing ─────── */
+
+    void protocolError(us_socket_t *s, uint32_t code) {
+        writeGoaway(s, conn(s)->lastStreamId, code);
+        ((AsyncSocket<true> *) s)->uncork();
+        us_socket_shutdown(s);
+        us_socket_close(s, 0, nullptr);
+    }
+
+    void onData(us_socket_t *s, const char *data, int length) {
+        Http2Connection *c = conn(s);
+        c->rx.append(data, (size_t) length);
+
+        if (!c->prefaceConsumed) {
+            if (c->rx.size() < h2::PREFACE.size()) return;
+            if (memcmp(c->rx.data(), h2::PREFACE.data(), h2::PREFACE.size()) != 0) {
+                return protocolError(s, h2::ERR_PROTOCOL);
+            }
+            c->rx.erase(0, h2::PREFACE.size());
+            c->prefaceConsumed = true;
+        }
+
+        size_t off = 0;
+        while (c->rx.size() - off >= h2::FRAME_HEADER_SIZE) {
+            const unsigned char *p = (const unsigned char *) c->rx.data() + off;
+            uint32_t len = ((uint32_t) p[0] << 16) | ((uint32_t) p[1] << 8) | p[2];
+            uint8_t type = p[3], flags = p[4];
+            uint32_t stream = (((uint32_t) p[5] & 0x7f) << 24) |
+                              ((uint32_t) p[6] << 16) | ((uint32_t) p[7] << 8) | p[8];
+            if (len > (1u << 20)) { /* hard cap regardless of advertised */
+                return protocolError(s, h2::ERR_FRAME_SIZE);
+            }
+            if (c->rx.size() - off < h2::FRAME_HEADER_SIZE + len) break;
+            const char *payload = c->rx.data() + off + h2::FRAME_HEADER_SIZE;
+
+            /* §6.10: once a HEADERS without END_HEADERS is received, only
+             * CONTINUATION for that stream is allowed until END_HEADERS. */
+            if (c->continuationStream &&
+                !(type == h2::CONTINUATION && stream == c->continuationStream)) {
+                return protocolError(s, h2::ERR_PROTOCOL);
+            }
+
+            switch (type) {
+            case h2::SETTINGS:
+                /* §6.5: stream ID MUST be 0. */
+                if (stream != 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handleSettings(s, flags, payload, len);
+                break;
+            case h2::WINDOW_UPDATE: handleWindowUpdate(s, stream, payload, len); break;
+            case h2::PING:
+                /* §6.7: stream ID MUST be 0. */
+                if (stream != 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handlePing(s, flags, payload, len);
+                break;
+            case h2::HEADERS: handleHeaders(s, stream, flags, payload, len); break;
+            case h2::CONTINUATION: handleContinuation(s, stream, flags, payload, len); break;
+            case h2::DATA: handleData(s, stream, flags, payload, len); break;
+            case h2::RST_STREAM:
+                /* §6.4: stream ID MUST NOT be 0. */
+                if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+                handleRstStream(s, stream, payload, len);
+                break;
+            case h2::GOAWAY:
+                /* §6.8: stream ID MUST be 0; payload ≥ 8 (debug data
+                 * MAY follow the 8-byte fixed prefix). */
+                if (stream != 0 || len < 8) return protocolError(s, h2::ERR_PROTOCOL);
+                conn(s)->goaway = true;
+                if (conn(s)->streams.empty()) {
+                    ((AsyncSocket<true> *) s)->uncork();
+                    us_socket_close(s, 0, nullptr);
+                    return;
+                }
+                break;
+            case h2::PRIORITY:
+                /* §6.3: stream ID MUST NOT be 0. */
+                if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+                if (len != 5) return protocolError(s, h2::ERR_FRAME_SIZE);
+                break;
+            case h2::PUSH_PROMISE:
+                return protocolError(s, h2::ERR_PROTOCOL);
+            default: /* §4.1: unknown types MUST be ignored. */ break;
+            }
+            if (us_socket_is_closed(s)) return;
+            off += h2::FRAME_HEADER_SIZE + len;
+        }
+        if (off) c->rx.erase(0, off);
+    }
+
+    void handleSettings(us_socket_t *s, uint8_t flags, const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (flags & h2::ACK) {
+            if (len != 0) return protocolError(s, h2::ERR_FRAME_SIZE);
+            return;
+        }
+        if (len % 6 != 0) return protocolError(s, h2::ERR_FRAME_SIZE);
+        bool windowGrew = false;
+        for (uint32_t i = 0; i < len; i += 6) {
+            const unsigned char *e = (const unsigned char *) p + i;
+            uint16_t id = ((uint16_t) e[0] << 8) | e[1];
+            uint32_t v = ((uint32_t) e[2] << 24) | ((uint32_t) e[3] << 16) |
+                         ((uint32_t) e[4] << 8) | e[5];
+            switch (id) {
+            case 1: /* HEADER_TABLE_SIZE */
+                lshpack_enc_set_max_capacity(&c->enc, v); break;
+            case 4: { /* INITIAL_WINDOW_SIZE — §6.9.2 also adjusts open streams */
+                if (v > 0x7fffffff) return protocolError(s, h2::ERR_FLOW_CONTROL);
+                int32_t delta = (int32_t) v - c->remoteInitialWindow;
+                c->remoteInitialWindow = (int32_t) v;
+                for (auto &kv : c->streams) {
+                    /* §6.9.2: a delta that pushes any window past 2³¹-1
+                     * is a connection FLOW_CONTROL_ERROR. Widen to
+                     * int64 like the WINDOW_UPDATE paths so a prior
+                     * WINDOW_UPDATE to INT32_MAX can't drive this add
+                     * into signed overflow. Going negative is
+                     * explicitly allowed. */
+                    if ((int64_t) kv.second->sendWindow + delta > 0x7fffffff)
+                        return protocolError(s, h2::ERR_FLOW_CONTROL);
+                    kv.second->sendWindow += delta;
+                }
+                if (delta > 0) windowGrew = true;
+                break;
+            }
+            case 5: /* MAX_FRAME_SIZE */
+                if (v < h2::DEFAULT_FRAME || v > 0xffffff)
+                    return protocolError(s, h2::ERR_PROTOCOL);
+                c->remoteMaxFrame = v; break;
+            default: break; /* §6.5.2: unknown settings MUST be ignored */
+            }
+        }
+        writeFrame(s, h2::SETTINGS, h2::ACK, 0, nullptr, 0);
+        /* A raised INITIAL_WINDOW_SIZE is the SETTINGS-path equivalent
+         * of a per-stream WINDOW_UPDATE (§6.9.2 is explicit that both
+         * adjust the same window). Clients that BDP-autotune —
+         * nghttp2, Chrome — open the window this way. Drain now so
+         * streams parked on flow-control backpressure resume,
+         * mirroring handleWindowUpdate. */
+        if (windowGrew) drainStreams(s);
+    }
+
+    void handlePing(us_socket_t *s, uint8_t flags, const char *p, uint32_t len) {
+        if (len != 8) return protocolError(s, h2::ERR_FRAME_SIZE);
+        if (flags & h2::ACK) return;
+        writeFrame(s, h2::PING, h2::ACK, 0, p, 8);
+    }
+
+    /* Server-initiated stream reset: emit RST_STREAM on the wire AND tear
+     * the stream down locally (erase, fire onAborted so the handler drops
+     * its pointer, park for sweep). Called from on_data so dispatchDepth
+     * keeps the heap object alive in pendingDelete; sweep() runs the
+     * goaway-last-stream close at a safe point. */
+    void abortStream(us_socket_t *s, uint32_t stream, uint32_t code) {
+        writeRstStream(s, stream, code);
+        Http2Connection *c = conn(s);
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) return;
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        c->streams.erase(it);
+        r->dead = true;
+        d->remoteClosed = true;
+        /* Park in pendingDelete *before* the JS-reentrant callback so a
+         * server.stop() in an abort listener that happened to fire
+         * on_close synchronously would still free `r` cleanly via
+         * ~Http2Connection — same defensive shape as handleRstStream's
+         * is_closed guard. dispatchDepth>0 keeps sweep() from freeing
+         * it mid-callback. */
+        c->pendingDelete.append(r);
+        if (d->onAborted) {
+            auto cb = d->onAborted;
+            d->onAborted = nullptr;
+            cb(r, d->userData);
+        }
+    }
+
+    void handleWindowUpdate(us_socket_t *s, uint32_t stream, const char *p, uint32_t len) {
+        if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
+        uint32_t inc = (((uint32_t)(unsigned char) p[0] & 0x7f) << 24) |
+                       ((uint32_t)(unsigned char) p[1] << 16) |
+                       ((uint32_t)(unsigned char) p[2] << 8) |
+                       (uint32_t)(unsigned char) p[3];
+        if (inc == 0) {
+            if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+            abortStream(s, stream, h2::ERR_PROTOCOL);
+            return;
+        }
+        Http2Connection *c = conn(s);
+        if (stream == 0) {
+            if ((int64_t) c->connSendWindow + inc > 0x7fffffff)
+                return protocolError(s, h2::ERR_FLOW_CONTROL);
+            c->connSendWindow += (int32_t) inc;
+            drainStreams(s);
+        } else if (auto it = c->streams.find(stream); it != c->streams.end()) {
+            if ((int64_t) it->second->sendWindow + inc > 0x7fffffff) {
+                abortStream(s, stream, h2::ERR_FLOW_CONTROL);
+                return;
+            }
+            it->second->sendWindow += (int32_t) inc;
+            it->second->drain();
+        }
+    }
+
+    void handleHeaders(us_socket_t *s, uint32_t stream, uint8_t flags,
+                       const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (stream == 0 || (stream & 1) == 0)
+            return protocolError(s, h2::ERR_PROTOCOL);
+        /* Strip PADDED and PRIORITY prefixes before collecting the HPACK block. */
+        uint32_t pad = 0;
+        if (flags & h2::PADDED) {
+            if (len < 1) return protocolError(s, h2::ERR_FRAME_SIZE);
+            pad = (uint8_t) p[0]; p++; len--;
+        }
+        if (flags & h2::PRIO) {
+            if (len < 5) return protocolError(s, h2::ERR_FRAME_SIZE);
+            p += 5; len -= 5;
+        }
+        if (pad > len) return protocolError(s, h2::ERR_PROTOCOL);
+        len -= pad;
+
+        c->headerBlock.assign(p, len);
+        c->continuationEndStream = (flags & h2::END_STREAM) != 0;
+        if (!(flags & h2::END_HEADERS)) {
+            c->continuationStream = stream;
+            return;
+        }
+        dispatchHeaders(s, stream, c->continuationEndStream);
+    }
+
+    void handleContinuation(us_socket_t *s, uint32_t stream, uint8_t flags,
+                            const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        /* §6.10: CONTINUATION without a preceding HEADERS-in-progress
+         * is a connection PROTOCOL_ERROR. The equality check below
+         * doesn't cover this when both are 0 (idle), which would
+         * otherwise fall through to dispatchHeaders(s, 0, …) and
+         * emit RST_STREAM on stream 0 — itself a §6.4 violation. */
+        if (c->continuationStream == 0 || stream != c->continuationStream)
+            return protocolError(s, h2::ERR_PROTOCOL);
+        c->headerBlock.append(p, len);
+        if (c->headerBlock.size() > h2::MAX_HEADER_LIST)
+            return protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
+        if (flags & h2::END_HEADERS) {
+            c->continuationStream = 0;
+            dispatchHeaders(s, stream, c->continuationEndStream);
+        }
+    }
+
+    void dispatchHeaders(us_socket_t *s, uint32_t stream, bool endStream) {
+        Http2Connection *c = conn(s);
+
+        /* Trailers on an open stream: decode (HPACK state is connection-
+         * scoped) but only deliver the FIN. */
+        if (auto it = c->streams.find(stream); it != c->streams.end()) {
+            Http2Response *r = it->second;
+            if (!decodeHeaderBlock(s, nullptr)) return;
+            if (r->getHttpResponseData()->remoteClosed) {
+                /* §5.1: HEADERS in half-closed(remote) → STREAM_CLOSED.
+                 * Tear down locally too: once we RST we MUST NOT write
+                 * further frames (§6.4), so the handler's eventual
+                 * response would be a protocol violation. */
+                abortStream(s, stream, h2::ERR_STREAM_CLOSED);
+            } else if (endStream) {
+                deliverFin(s, r);
+            } else {
+                /* §8.1: a second HEADERS that doesn't terminate the
+                 * stream is a malformed request (trailers MUST carry
+                 * END_STREAM). */
+                writeRstStream(s, stream, h2::ERR_PROTOCOL);
+                deliverFin(s, r);
+            }
+            return;
+        }
+
+        if (stream <= c->lastStreamId) {
+            /* §5.1.1: new stream IDs MUST monotonically increase; an
+             * unexpected stream identifier is a connection error of
+             * type PROTOCOL_ERROR (h2spec 5.1.1/2 expects GOAWAY). */
+            return protocolError(s, h2::ERR_PROTOCOL);
+        }
+        c->lastStreamId = stream;
+
+        if (c->goaway || c->streams.size() >= h2::MAX_STREAMS) {
+            if (!decodeHeaderBlock(s, nullptr)) return;
+            writeRstStream(s, stream, h2::ERR_REFUSED_STREAM);
+            return;
+        }
+
+        WTF::Vector<Http2Header, 32> hdrs;
+        std::string store;
+        if (!decodeHeaderBlock(s, &hdrs, &store)) return;
+
+        auto *res = new Http2Response(s, stream, c->remoteInitialWindow);
+        res->getHttpResponseData()->reset();
+        res->getHttpResponseData()->remoteClosed = endStream;
+        c->streams.emplace(stream, res);
+
+        Http2Request req(hdrs, store, res);
+        /* §8.3.1: :method and :path MUST be present (unless CONNECT,
+         * which this server doesn't support). A request omitting
+         * either is malformed → stream PROTOCOL_ERROR per §8.1.1. */
+        if (req.getCaseSensitiveMethod().empty() || req.getFullUrl().empty()) {
+            abortStream(s, stream, h2::ERR_PROTOCOL);
+            return;
+        }
+        if (req.getHeader("expect") == "100-continue") res->writeContinue();
+
+        Http2ContextData *cd = getContextData();
+        cd->router.getUserData() = {res, &req};
+        if (!cd->router.route(req.getMethod(), req.getUrl())) {
+            res->writeStatus("404 Not Found");
+            res->end({}, false);
+            return;
+        }
+        if (us_socket_is_closed(s)) return;
+
+        /* The handler may have responded synchronously, in which case
+         * markDone() → maybeDestroy() already freed `res`. Re-look it
+         * up; if gone, we're done. */
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) return;
+        Http2ResponseData *d = it->second->getHttpResponseData();
+        if (endStream && d->inStream) {
+            d->inStream(it->second, "", 0, true, d->userData);
+        }
+    }
+
+    /* Decode the accumulated header block into `out` (name/value views into
+     * `store`). Returns false on HPACK error (connection already torn down).
+     * When out==nullptr only the decoder state is advanced. */
+    bool decodeHeaderBlock(us_socket_t *s, WTF::Vector<Http2Header, 32> *out,
+                           std::string *store = nullptr) {
+        Http2Connection *c = conn(s);
+        const unsigned char *src = (const unsigned char *) c->headerBlock.data();
+        const unsigned char *end = src + c->headerBlock.size();
+        if (store) store->reserve(c->headerBlock.size() * 2 + 256);
+        size_t used = 0;
+        while (src < end) {
+            struct lsxpack_header xh;
+            lsxpack_header_prepare_decode(&xh, c->hpackBuf, 0, sizeof(c->hpackBuf));
+            int rc = lshpack_dec_decode(&c->dec, &src, end, &xh);
+            if (rc != 0) {
+                protocolError(s, h2::ERR_COMPRESSION);
+                return false;
+            }
+            if (!out) continue;
+            size_t nlen = xh.name_len, vlen = xh.val_len;
+            if (used + nlen + vlen > h2::MAX_HEADER_LIST) {
+                protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
+                return false;
+            }
+            store->append(c->hpackBuf + xh.name_offset, nlen);
+            store->append(c->hpackBuf + xh.val_offset, vlen);
+            out->append({(const char *)(uintptr_t) used, (unsigned) nlen,
+                         (const char *)(uintptr_t)(used + nlen), (unsigned) vlen});
+            used += nlen + vlen;
+        }
+        c->headerBlock.clear();
+        if (out) {
+            const char *base = store->data();
+            for (auto &h : *out) {
+                h.name = base + (uintptr_t) h.name;
+                h.value = base + (uintptr_t) h.value;
+            }
+        }
+        return true;
+    }
+
+    void handleData(us_socket_t *s, uint32_t stream, uint8_t flags,
+                    const char *p, uint32_t len) {
+        Http2Connection *c = conn(s);
+        if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
+        uint32_t flowLen = len;
+        uint32_t pad = 0;
+        if (flags & h2::PADDED) {
+            if (len < 1) return protocolError(s, h2::ERR_FRAME_SIZE);
+            pad = (uint8_t) p[0]; p++; len--;
+        }
+        if (pad > len) return protocolError(s, h2::ERR_PROTOCOL);
+        len -= pad;
+
+        /* §6.9: connection window is consumed even for unknown/reset streams. */
+        c->connRecvWindow -= (int32_t) flowLen;
+        if (c->connRecvWindow < h2::LOCAL_INIT_WINDOW / 2) {
+            writeWindowUpdate(s, 0, (uint32_t)(h2::LOCAL_INIT_WINDOW - c->connRecvWindow));
+            c->connRecvWindow = h2::LOCAL_INIT_WINDOW;
+        }
+
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) {
+            /* DATA for a stream we already finished or refused. §6.1:
+             * STREAM_CLOSED. Don't blow the connection. */
+            if (stream <= c->lastStreamId)
+                writeRstStream(s, stream, h2::ERR_STREAM_CLOSED);
+            else
+                return protocolError(s, h2::ERR_PROTOCOL);
+            return;
+        }
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        if (d->remoteClosed) {
+            /* §5.1: DATA in half-closed(remote) is a STREAM_CLOSED stream
+             * error. The stream is still in c->streams because the
+             * server's response hasn't completed yet. Tear down locally
+             * too so the handler sees an abort — once we RST we MUST
+             * NOT write further frames on this stream (§6.4). */
+            abortStream(s, stream, h2::ERR_STREAM_CLOSED);
+            return;
+        }
+        bool fin = (flags & h2::END_STREAM) != 0;
+        r->recvWindow -= (int32_t) flowLen;
+        /* Flag half-closed(remote) *before* dispatching the final chunk so
+         * a handler that responds synchronously inside inStream reaches
+         * markDone() with remoteClosed set and doesn't emit the §8.1
+         * early-RST(NO_ERROR) for a body the client already ended. */
+        if (fin) d->remoteClosed = true;
+
+        if (d->inStream) {
+            d->inStream(r, p, len, fin, d->userData);
+            if (us_socket_is_closed(s)) return;
+            /* inStream may have responded synchronously and freed `r`. */
+            it = c->streams.find(stream);
+            if (it == c->streams.end()) return;
+            r = it->second;
+            if (!fin && r->recvWindow < h2::LOCAL_INIT_WINDOW / 2 && !r->paused) {
+                writeWindowUpdate(s, stream, (uint32_t)(h2::LOCAL_INIT_WINDOW - r->recvWindow));
+                r->recvWindow = h2::LOCAL_INIT_WINDOW;
+            }
+        } else if (!fin && len > 0) {
+            /* Handler never armed onData (GET/HEAD/… per
+             * hasRequestBody()); drop the upload rather than buffer
+             * unboundedly. Route through abortStream so the local
+             * side is torn down too — deliverFin would only set
+             * remoteClosed, and with hasResponded()==false
+             * maybeDestroy() returns early, so the handler's later
+             * response would write to a stream we already RST'd. */
+            abortStream(s, stream, h2::ERR_CANCEL);
+            return;
+        }
+        if (fin) r->maybeDestroy();
+    }
+
+    /* Terminate the request body: mark half-closed(remote), deliver
+     * last=true to inStream so `await req.text()`/ReadableStream
+     * resolve, then maybeDestroy. remoteClosed is set *before* the
+     * dispatch so a handler that responds synchronously inside
+     * inStream reaches markDone() with the client side marked closed
+     * and doesn't emit the §8.1 early RST(NO_ERROR). */
+    void deliverFin(us_socket_t *s, Http2Response *r) {
+        Http2ResponseData *d = r->getHttpResponseData();
+        d->remoteClosed = true;
+        if (d->inStream) {
+            d->inStream(r, "", 0, true, d->userData);
+            if (us_socket_is_closed(s)) return;
+            /* inStream may have responded synchronously; maybeDestroy()
+             * is idempotent via `dead`. */
+        }
+        r->maybeDestroy();
+    }
+
+    void handleRstStream(us_socket_t *s, uint32_t stream, const char *, uint32_t len) {
+        if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
+        Http2Connection *c = conn(s);
+        auto it = c->streams.find(stream);
+        if (it == c->streams.end()) return;
+        Http2Response *r = it->second;
+        Http2ResponseData *d = r->getHttpResponseData();
+        c->streams.erase(it);
+        if (d->onAborted) d->onAborted(r, d->userData);
+        delete r;
+        /* onAborted re-enters JS; a server.stop() in an abort listener
+         * can close this socket. Check before touching `c` — `r` is
+         * ours regardless (erased from the map before the callback),
+         * so delete it above either way. */
+        if (us_socket_is_closed(s)) return;
+        if (c->goaway && c->streams.empty()) {
+            ((AsyncSocket<true> *) s)->uncork();
+            us_socket_close(s, 0, nullptr);
+        }
+    }
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -683,16 +683,32 @@ struct Http2Context {
 
     void handleWindowUpdate(us_socket_t *s, uint32_t stream, const char *p, uint32_t len) {
         if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
+        Http2Connection *c = conn(s);
+        /* §5.1: any frame other than HEADERS/PRIORITY on an idle stream
+         * is a connection PROTOCOL_ERROR. On a *closed* stream
+         * WINDOW_UPDATE is a permitted race (§5.1 "An endpoint MUST
+         * ignore WINDOW_UPDATE or RST_STREAM frames received in this
+         * state") — falls through to the find()-miss below. Checking
+         * here also stops abortStream() in the inc==0 branch from
+         * emitting an RST_STREAM on an idle stream, which is itself a
+         * §6.4 violation. */
+        if (stream != 0 && stream > c->lastStreamId)
+            return protocolError(s, h2::ERR_PROTOCOL);
         uint32_t inc = (((uint32_t)(unsigned char) p[0] & 0x7f) << 24) |
                        ((uint32_t)(unsigned char) p[1] << 16) |
                        ((uint32_t)(unsigned char) p[2] << 8) |
                        (uint32_t)(unsigned char) p[3];
         if (inc == 0) {
+            /* §6.9: zero increment is a connection error on stream 0,
+             * a stream error otherwise. Idle is rejected above; on a
+             * closed stream §5.1 says MUST ignore, so don't let
+             * abortStream's unconditional RST fire on a stream we
+             * already forgot. */
             if (stream == 0) return protocolError(s, h2::ERR_PROTOCOL);
-            abortStream(s, stream, h2::ERR_PROTOCOL);
+            if (c->streams.find(stream) != c->streams.end())
+                abortStream(s, stream, h2::ERR_PROTOCOL);
             return;
         }
-        Http2Connection *c = conn(s);
         if (stream == 0) {
             if ((int64_t) c->connSendWindow + inc > 0x7fffffff)
                 return protocolError(s, h2::ERR_FLOW_CONTROL);
@@ -977,7 +993,14 @@ struct Http2Context {
         if (len != 4) return protocolError(s, h2::ERR_FRAME_SIZE);
         Http2Connection *c = conn(s);
         auto it = c->streams.find(stream);
-        if (it == c->streams.end()) return;
+        if (it == c->streams.end()) {
+            /* §6.4/§5.1: RST_STREAM on an idle stream is a connection
+             * PROTOCOL_ERROR; on a closed stream it's a permitted race
+             * ("An endpoint MUST ignore … RST_STREAM frames received
+             * in this state"). */
+            if (stream > c->lastStreamId) return protocolError(s, h2::ERR_PROTOCOL);
+            return;
+        }
         Http2Response *r = it->second;
         Http2ResponseData *d = r->getHttpResponseData();
         c->streams.erase(it);

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -121,10 +121,6 @@ struct Http2Connection : AsyncSocketData<true> {
     WTF::Vector<Http2Response *, 4> pendingDelete;
     int dispatchDepth = 0;
 
-    /* Scratch for HPACK decode; one per connection avoids per-header
-     * allocation. Sized to the advertised MAX_HEADER_LIST_SIZE. */
-    char hpackBuf[h2::MAX_HEADER_LIST];
-
     ~Http2Connection();
 
     void initHpack() {
@@ -854,6 +850,12 @@ struct Http2Context {
      * When out==nullptr only the decoder state is advanced. */
     bool decodeHeaderBlock(us_socket_t *s, WTF::Vector<Http2Header, 32> *out,
                            std::string *store = nullptr) {
+        /* Decode scratch. Decoded bytes are copied into `store` before the
+         * next loop iteration and never read after return; lshpack is pure
+         * C so there's no JS re-entry mid-decode. Same lifetime as
+         * writeHeaders()'s thread_local encode buffer — saves 64 KiB per
+         * connection vs. embedding this in the socket ext. */
+        static thread_local char hpackBuf[h2::MAX_HEADER_LIST];
         Http2Connection *c = conn(s);
         const unsigned char *src = (const unsigned char *) c->headerBlock.data();
         const unsigned char *end = src + c->headerBlock.size();
@@ -861,7 +863,7 @@ struct Http2Context {
         size_t used = 0;
         while (src < end) {
             struct lsxpack_header xh;
-            lsxpack_header_prepare_decode(&xh, c->hpackBuf, 0, sizeof(c->hpackBuf));
+            lsxpack_header_prepare_decode(&xh, hpackBuf, 0, sizeof(hpackBuf));
             int rc = lshpack_dec_decode(&c->dec, &src, end, &xh);
             if (rc != 0) {
                 protocolError(s, h2::ERR_COMPRESSION);
@@ -873,8 +875,8 @@ struct Http2Context {
                 protocolError(s, h2::ERR_ENHANCE_YOUR_CALM);
                 return false;
             }
-            store->append(c->hpackBuf + xh.name_offset, nlen);
-            store->append(c->hpackBuf + xh.val_offset, vlen);
+            store->append(hpackBuf + xh.name_offset, nlen);
+            store->append(hpackBuf + xh.val_offset, vlen);
             out->append({(const char *)(uintptr_t) used, (unsigned) nlen,
                          (const char *)(uintptr_t)(used + nlen), (unsigned) vlen});
             used += nlen + vlen;

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -261,6 +261,12 @@ struct Http2Context {
             if (r->dead) continue;
             Http2ResponseData *d = r->getHttpResponseData();
             if (d->onTimeout) d->onTimeout(r, d->userData);
+            /* A `timeout` listener (or a microtask it drained) may have
+             * called server.stop(true) → us_socket_group_close_all →
+             * force-drain → onClose(s) → ~Http2Connection(), which
+             * deleted every Http2Response* this snapshot holds and
+             * destructed `c` in place. Same guard as drainStreams(). */
+            if (us_socket_is_closed(s)) return s;
         }
         c->dispatchDepth--;
         ((AsyncSocket<true> *) s)->uncorkWithoutSending();

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -886,6 +886,9 @@ struct Http2Context {
 
         /* §6.9: connection window is consumed even for unknown/reset streams. */
         c->connRecvWindow -= (int32_t) flowLen;
+        /* §6.9.1: a receiver MAY treat overshoot as FLOW_CONTROL_ERROR. We
+         * do — h2spec 6.9.1/1-2 expect it, and nginx/nghttp2 enforce it. */
+        if (c->connRecvWindow < 0) return protocolError(s, h2::ERR_FLOW_CONTROL);
         if (c->connRecvWindow < h2::LOCAL_INIT_WINDOW / 2) {
             writeWindowUpdate(s, 0, (uint32_t)(h2::LOCAL_INIT_WINDOW - c->connRecvWindow));
             c->connRecvWindow = h2::LOCAL_INIT_WINDOW;
@@ -914,6 +917,10 @@ struct Http2Context {
         }
         bool fin = (flags & h2::END_STREAM) != 0;
         r->recvWindow -= (int32_t) flowLen;
+        if (r->recvWindow < 0) {
+            abortStream(s, stream, h2::ERR_FLOW_CONTROL);
+            return;
+        }
         /* Flag half-closed(remote) *before* dispatching the final chunk so
          * a handler that responds synchronously inside inStream reaches
          * markDone() with remoteClosed set and doesn't emit the §8.1

--- a/packages/bun-uws/src/Http2ContextData.h
+++ b/packages/bun-uws/src/Http2ContextData.h
@@ -1,0 +1,23 @@
+#ifndef UWS_H2CONTEXTDATA_H
+#define UWS_H2CONTEXTDATA_H
+
+#include "HttpRouter.h"
+
+namespace uWS {
+
+struct Http2Response;
+struct Http2Request;
+
+/* Mirrors Http3ContextData so the H3 routing shape applies unchanged. */
+struct Http2ContextData {
+    struct RouterData {
+        Http2Response *httpResponse;
+        Http2Request *httpRequest;
+    };
+    HttpRouter<RouterData> router;
+    unsigned int idleTimeoutS = 10;
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Request.h
+++ b/packages/bun-uws/src/Http2Request.h
@@ -1,0 +1,118 @@
+#ifndef UWS_H2REQUEST_H
+#define UWS_H2REQUEST_H
+// clang-format off
+
+#include "Http2ResponseData.h"
+#include "QueryParser.h"
+
+#include <wtf/Vector.h>
+#include <string_view>
+#include <utility>
+
+namespace uWS {
+
+struct Http2Response;
+
+/* Mirrors Http3Request so the router/handler shape is identical. Backed by
+ * a decoded HPACK header list; pseudo headers (:method, :path, :authority)
+ * become method/url/host. */
+struct Http2Request {
+
+    Http2Request(WTF::Vector<Http2Header, 32> &headers, std::string & /*store*/,
+                 Http2Response *r)
+        : hdrs(headers), response(r) {
+        for (auto &h : hdrs) {
+            std::string_view name{h.name, h.name_len};
+            std::string_view value{h.value, h.value_len};
+            if (name == ":method") {
+                method = value;
+            } else if (name == ":path") {
+                fullUrl = value;
+                size_t q = value.find('?');
+                url = q == std::string_view::npos ? value : value.substr(0, q);
+                /* Keep the leading '?' — getDecodedQueryValue drops it. */
+                query = q == std::string_view::npos ? std::string_view{} : value.substr(q);
+            } else if (name == ":authority") {
+                authority = value;
+            } else if (authority.empty() && name.size() == 4 && equalsIgnoreCase(name, "host")) {
+                /* RFC 9113 §8.3.1: a request MUST include :authority OR a
+                 * Host field. Promote the literal Host so getHeader("host"),
+                 * req.url, and the forEachHeader synthesis all agree. HPACK
+                 * delivers pseudo-headers first, so :authority (if any)
+                 * always wins. */
+                authority = value;
+            }
+        }
+    }
+
+    bool isAncient() { return false; }
+    bool getYield() { return yield; }
+    void setYield(bool y) { yield = y; }
+
+    std::string_view getUrl() { return url; }
+    std::string_view getFullUrl() { return fullUrl; }
+    std::string_view getQuery() { return query.empty() ? query : query.substr(1); }
+    std::string_view getQuery(std::string_view key) { return getDecodedQueryValue(key, query); }
+    std::string_view getCaseSensitiveMethod() { return method; }
+    Http2Response *getResponse() { return response; }
+
+    /* HttpRequest::getMethod() lowercases in place; we own no writable
+     * buffer, so write into a per-request scratch instead. */
+    std::string_view getMethod() {
+        size_t n = method.size() < sizeof(methodLower) ? method.size() : sizeof(methodLower);
+        for (size_t i = 0; i < n; i++) {
+            char c = method[i];
+            methodLower[i] = (char)(c | ((unsigned char)(c - 'A') < 26 ? 0x20 : 0));
+        }
+        return {methodLower, n};
+    }
+
+    std::string_view getHeader(std::string_view lowerCasedHeader) {
+        if (lowerCasedHeader == "host") return authority;
+        for (auto &h : hdrs) {
+            if (h.name_len == lowerCasedHeader.size() &&
+                equalsIgnoreCase({h.name, h.name_len}, lowerCasedHeader)) {
+                return {h.value, h.value_len};
+            }
+        }
+        return {};
+    }
+
+    template <typename Fn> void forEachHeader(Fn &&fn) {
+        for (auto &h : hdrs) {
+            std::string_view name{h.name, h.name_len};
+            if (!name.empty() && name[0] == ':') continue;
+            /* Drop the literal Host — :authority is synthesised below so
+             * req.headers.get('host') matches req.url and isn't
+             * comma-joined. */
+            if (!authority.empty() && name.size() == 4 && equalsIgnoreCase(name, "host")) continue;
+            fn(name, std::string_view{h.value, h.value_len});
+        }
+        if (!authority.empty()) fn(std::string_view{"host"}, authority);
+    }
+
+    void setParameters(std::pair<int, std::string_view *> p) { params = p; }
+    std::string_view getParameter(unsigned short index) {
+        return (int) index > params.first ? std::string_view{} : params.second[index];
+    }
+
+private:
+    static bool equalsIgnoreCase(std::string_view a, std::string_view b) {
+        if (a.size() != b.size()) return false;
+        for (size_t i = 0; i < a.size(); i++) {
+            if ((a[i] | 0x20) != (b[i] | 0x20)) return false;
+        }
+        return true;
+    }
+
+    WTF::Vector<Http2Header, 32> &hdrs;
+    Http2Response *response;
+    std::string_view method, url, fullUrl, query, authority;
+    std::pair<int, std::string_view *> params{-1, nullptr};
+    char methodLower[32];
+    bool yield = false;
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2Response.h
+++ b/packages/bun-uws/src/Http2Response.h
@@ -1,0 +1,159 @@
+#ifndef UWS_H2RESPONSE_H
+#define UWS_H2RESPONSE_H
+// clang-format off
+
+#include "Http2ResponseData.h"
+#include "AsyncSocket.h"
+#include "LoopData.h"
+
+#include <charconv>
+#include <optional>
+#include <string_view>
+
+namespace uWS {
+
+struct Http2Context;
+struct Http2Connection;
+
+/* API mirror of Http3Response / HttpResponse<SSL>. Heap-allocated per
+ * stream (the socket ext holds the connection, not the stream), so unlike
+ * the H1/H3 variants `this` is an actual object rather than an overlay on
+ * a uSockets handle. */
+struct Http2Response {
+    us_socket_t *socket;
+    uint32_t id;
+    int32_t sendWindow;
+    int32_t recvWindow;
+    bool paused = false;
+    bool dead = false;
+    Http2ResponseData data;
+
+    Http2Response(us_socket_t *s, uint32_t stream, int32_t remoteInitWin)
+        : socket(s), id(stream), sendWindow(remoteInitWin),
+          recvWindow((int32_t) 1024 * 1024) {}
+
+    Http2ResponseData *getHttpResponseData() { return &data; }
+    Http2Context *context() {
+        return (Http2Context *) us_socket_group_ext(us_socket_group(socket));
+    }
+
+    Http2Response *writeStatus(std::string_view status) {
+        if (data.state & Http2ResponseData::HTTP_STATUS_CALLED) return this;
+        data.state |= Http2ResponseData::HTTP_STATUS_CALLED;
+        /* Zig hands us "200 OK"; HTTP/2 wants only the 3-digit code. */
+        std::string_view code = status.size() >= 3 ? status.substr(0, 3) : std::string_view{"200"};
+        data.appendHeader(":status", 7, code.data(), (unsigned) code.size());
+        return this;
+    }
+
+    Http2Response *writeHeader(std::string_view key, std::string_view value) {
+        writeStatus("200 OK");
+        data.appendHeader(key.data(), (unsigned) key.size(),
+                          value.data(), (unsigned) value.size());
+        return this;
+    }
+
+    Http2Response *writeHeader(std::string_view key, uint64_t value) {
+        char buf[24];
+        auto r = std::to_chars(buf, buf + sizeof(buf), value);
+        return writeHeader(key, std::string_view{buf, (size_t)(r.ptr - buf)});
+    }
+
+    void writeMark() {
+        if (data.state & Http2ResponseData::HTTP_WROTE_DATE_HEADER) return;
+        data.state |= Http2ResponseData::HTTP_WROTE_DATE_HEADER;
+        LoopData *ld = (LoopData *) us_loop_ext(us_socket_group_loop(us_socket_group(socket)));
+        writeHeader("date", std::string_view{ld->date, 29});
+    }
+
+    Http2Response *writeContinue();
+
+    void flushHeaders(bool /*immediately*/ = false) {
+        if (!(data.state & Http2ResponseData::HTTP_WRITE_CALLED)) {
+            writeStatus("200 OK");
+            sendBufferedHeaders(false);
+            data.state |= Http2ResponseData::HTTP_WRITE_CALLED;
+        }
+    }
+
+    bool write(std::string_view body, size_t *writtenPtr = nullptr);
+    void end(std::string_view body = {}, bool closeConnection = false) {
+        internalEnd(body, body.length(), false, true, closeConnection);
+    }
+    std::pair<bool, bool> tryEnd(std::string_view body, uint64_t totalSize = 0, bool close = false) {
+        bool ok = internalEnd(body, totalSize, true, true, close);
+        return {ok, ok || hasResponded()};
+    }
+    void endWithoutBody(std::optional<size_t> reportedContentLength = std::nullopt,
+                        bool /*closeConnection*/ = false);
+    bool sendTerminatingChunk(bool /*closeConnection*/ = false);
+
+    bool hasResponded() {
+        return !(data.state & Http2ResponseData::HTTP_RESPONSE_PENDING);
+    }
+
+    uint64_t getWriteOffset() { return data.offset; }
+    void overrideWriteOffset(uint64_t o) { data.offset = o; }
+    void setWriteOffset(uint64_t o) { data.offset = o; }
+    size_t getBufferedAmount() {
+        return data.backpressure.length() +
+               ((AsyncSocket<true> *) socket)->getBufferedAmount();
+    }
+
+    Http2Response *pause() { paused = true; return this; }
+    Http2Response *resume();
+
+    Http2Response *cork(MoveOnlyFunction<void()> &&fn);
+    void uncork() {}
+    bool isCorked() { return false; }
+
+    void close();
+    void *getNativeHandle() { return this; }
+    void *getSocketData() { return data.socketData; }
+    bool isConnectRequest() { return false; }
+    void setTimeout(uint8_t) {}
+    void resetTimeout() {}
+    void prepareForSendfile() {}
+
+    Http2Response *onWritable(void *ud, Http2ResponseData::OnWritableCallback h) {
+        data.writableUserData = ud; data.onWritable = h; return this;
+    }
+    Http2Response *clearOnWritable() {
+        data.onWritable = nullptr; data.writableUserData = nullptr; return this;
+    }
+    Http2Response *onAborted(void *ud, Http2ResponseData::OnAbortedCallback h) {
+        data.userData = ud; data.onAborted = h; return this;
+    }
+    Http2Response *clearOnAborted() { data.onAborted = nullptr; return this; }
+    Http2Response *onTimeout(void *ud, Http2ResponseData::OnTimeoutCallback h) {
+        data.onTimeout = h; if (h) data.userData = ud; return this;
+    }
+    Http2Response *clearOnTimeout() { data.onTimeout = nullptr; return this; }
+    void onData(void *ud, Http2ResponseData::OnDataCallback h) {
+        data.inStream = h; if (h) data.userData = ud;
+    }
+    Http2Response *clearOnWritableAndAborted() {
+        /* Like H3: leave onAborted armed so the holder learns when the
+         * stream object is freed post-completion. */
+        data.onWritable = nullptr; return this;
+    }
+
+    bool drain();
+    void maybeDestroy();
+    std::string_view getRemoteAddressAsText() {
+        return ((AsyncSocket<true> *) socket)->getRemoteAddressAsText();
+    }
+    std::string_view getRemoteAddress() {
+        return ((AsyncSocket<true> *) socket)->getRemoteAddress();
+    }
+
+private:
+    void sendBufferedHeaders(bool endStream);
+    bool internalEnd(std::string_view body, uint64_t totalSize, bool optional,
+                     bool allowContentLength, bool closeConnection);
+    void markDone();
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/Http2ResponseData.h
+++ b/packages/bun-uws/src/Http2ResponseData.h
@@ -1,0 +1,103 @@
+#ifndef UWS_H2RESPONSEDATA_H
+#define UWS_H2RESPONSEDATA_H
+
+#include "AsyncSocketData.h"
+
+#include <wtf/Vector.h>
+#include <cstdint>
+#include <cstring>
+
+namespace uWS {
+
+struct Http2Response;
+
+/* One name/value pair for the outgoing header block. Same shape as
+ * us_quic_header_t so the Zig side and the tests can reason about both
+ * transports identically. */
+struct Http2Header {
+    const char *name;
+    unsigned int name_len;
+    const char *value;
+    unsigned int value_len;
+};
+
+/* Per-stream response state. Same bit values and callback shapes as
+ * HttpResponseData / Http3ResponseData so Zig's State enum and the
+ * uws_res_* C ABI stay 1:1. Heap-allocated (one per stream, many per
+ * connection). */
+struct Http2ResponseData {
+    using OnWritableCallback = bool (*)(Http2Response *, uint64_t, void *);
+    using OnAbortedCallback = void (*)(Http2Response *, void *);
+    using OnTimeoutCallback = void (*)(Http2Response *, void *);
+    using OnDataCallback = void (*)(Http2Response *, const char *, size_t, bool, void *);
+
+    enum : uint8_t {
+        HTTP_STATUS_CALLED = 1,
+        HTTP_WRITE_CALLED = 2,
+        HTTP_END_CALLED = 4,
+        HTTP_RESPONSE_PENDING = 8,
+        HTTP_CONNECTION_CLOSE = 16,
+        HTTP_WROTE_CONTENT_LENGTH_HEADER = 32,
+        HTTP_WROTE_DATE_HEADER = 64,
+    };
+
+    void *userData = nullptr;
+    /* See Http3ResponseData for why onWritable gets its own userData. */
+    void *writableUserData = nullptr;
+    void *socketData = nullptr;
+    OnWritableCallback onWritable = nullptr;
+    OnAbortedCallback onAborted = nullptr;
+    OnDataCallback inStream = nullptr;
+    OnTimeoutCallback onTimeout = nullptr;
+
+    /* Outgoing headers buffered until the first body write/end so they go
+     * out as one HEADERS frame. Inline capacity keeps typical responses
+     * off the heap. Offsets stored as pointers (cast through uintptr_t)
+     * so hdrBuf can realloc; resolved against hdrBuf.data() at send. */
+    WTF::Vector<char, 256> hdrBuf;
+    WTF::Vector<Http2Header, 16> hdrs;
+
+    /* Body bytes the stream's send window (or TCP) couldn't accept yet. */
+    BackPressure backpressure;
+    bool endAfterDrain = false;
+    bool remoteClosed = false;
+
+    uint64_t offset = 0;
+    uint64_t totalSize = 0;
+    uint8_t state = 0;
+
+    void appendHeader(const char *name, unsigned nlen, const char *value, unsigned vlen) {
+        size_t off = hdrBuf.size();
+        hdrBuf.grow(off + nlen + vlen);
+        char *dst = hdrBuf.mutableSpan().data() + off;
+        for (unsigned i = 0; i < nlen; i++) {
+            /* RFC 9113 §8.2.1: field names MUST be lowercase. */
+            char c = name[i];
+            dst[i] = (char)(c | ((unsigned char)(c - 'A') < 26 ? 0x20 : 0));
+        }
+        memcpy(dst + nlen, value, vlen);
+        hdrs.append({(const char *)(uintptr_t) off, nlen,
+                     (const char *)(uintptr_t)(off + nlen), vlen});
+    }
+
+    void reset() {
+        userData = nullptr;
+        writableUserData = nullptr;
+        onWritable = nullptr;
+        onAborted = nullptr;
+        inStream = nullptr;
+        onTimeout = nullptr;
+        hdrBuf.shrink(0);
+        hdrs.shrink(0);
+        backpressure.clear();
+        endAfterDrain = false;
+        remoteClosed = false;
+        offset = 0;
+        totalSize = 0;
+        state = HTTP_RESPONSE_PENDING;
+    }
+};
+
+}
+
+#endif

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -37,8 +37,65 @@
 #include <array>
 #include <mutex>
 
+/* Defined in libuwsockets_h2.cpp; called from the SSL on_data hook when
+ * h2Context is set. Takes the Http2Context* as void* so this header
+ * doesn't include Http2App.h. Declared out here (C linkage, global)
+ * rather than inside the function body so the name isn't mangled. */
+extern "C" us_socket_t *uws_internal_h2_adopt(
+    void *h2Context, us_socket_t *s, int oldExtSize,
+    char *data, int length);
+extern "C" void uws_internal_h2_close_all(void *h2Context);
+
+/* Forward decl; SSL_CTX_set_alpn_select_cb signature is stable across
+ * OpenSSL/BoringSSL so avoid pulling the full openssl headers here. */
+extern "C" void SSL_CTX_set_alpn_select_cb(
+    struct ssl_ctx_st *ctx,
+    int (*cb)(struct ssl_st *ssl, const unsigned char **out, unsigned char *outlen,
+              const unsigned char *in, unsigned int inlen, void *arg),
+    void *arg);
 
 namespace uWS {
+
+/* ALPN select cb for the h2: true path. Walks the client's wire-format
+ * list by hand (SSL_select_next_proto isn't available on every BoringSSL
+ * build we ship). Gated on parentData->h2Context being live so
+ * connections that race ~H2App fall back to http/1.1 instead of
+ * negotiating h2 with nowhere to adopt into. Declared here (not in
+ * Http2App.h) so TemplatedApp can install it on the root SSL_CTX and on
+ * each per-SNI SSL_CTX — sni_cb swaps ssl->ctx before BoringSSL reads
+ * alpn_select_cb, so every context that can serve a connection needs a
+ * copy. */
+template <bool SSL>
+inline void installH2Alpn(struct ssl_ctx_st *sslCtx, HttpContextData<SSL> *parentData) {
+    if constexpr (SSL) {
+        if (!sslCtx) return;
+        SSL_CTX_set_alpn_select_cb(sslCtx,
+            [](struct ssl_st *, const unsigned char **out, unsigned char *outlen,
+               const unsigned char *in, unsigned int inlen, void *arg) -> int {
+                auto *pd = (HttpContextData<true> *) arg;
+                bool offerH2 = pd && pd->hasH2();
+                if (offerH2) for (unsigned int i = 0; i + 1 <= inlen;) {
+                    unsigned int l = in[i];
+                    if (i + 1 + l > inlen) break;
+                    if (l == 2 && in[i+1] == 'h' && in[i+2] == '2') {
+                        *out = in + i + 1; *outlen = 2;
+                        return 0; /* SSL_TLSEXT_ERR_OK */
+                    }
+                    i += 1 + l;
+                }
+                for (unsigned int i = 0; i + 1 <= inlen;) {
+                    unsigned int l = in[i];
+                    if (i + 1 + l > inlen) break;
+                    if (l == 8 && memcmp(in + i + 1, "http/1.1", 8) == 0) {
+                        *out = in + i + 1; *outlen = 8;
+                        return 0; /* SSL_TLSEXT_ERR_OK */
+                    }
+                    i += 1 + l;
+                }
+                return 3; /* SSL_TLSEXT_ERR_NOACK */
+            }, parentData);
+    }
+}
 
 namespace detail {
 
@@ -240,6 +297,30 @@ private:
     }
 
     static us_socket_t *onData(us_socket_t *s, char *data, int length) {
+        if constexpr (SSL) {
+            /* If an H2App attached to us and the client picked "h2"
+             * via ALPN, hand the socket to the H2 group before the
+             * HTTP/1 parser ever sees the preface. on_handshake
+             * isn't a reliable hook (openssl.c defers it behind the
+             * first app-data read for servers, so a TLS 1.3 flight
+             * that bundles Finished + preface delivers here first),
+             * so check at the top of on_data instead. The adopter
+             * does its own ALPN check and returns null when the
+             * socket isn't h2 — a two-pointer read from the SSL
+             * object, so taking it on every on_data for http/1.1
+             * sockets is negligible. When it does adopt, it
+             * destructs our ext in place and returns the (possibly
+             * relocated) socket, whose own on_data takes over for
+             * subsequent reads. */
+            HttpContextData<SSL> *hcd = getSocketContextDataS(s);
+            if (hcd->h2Context && !us_socket_is_shut_down(s)) {
+                us_socket_t *ns = uws_internal_h2_adopt(
+                    hcd->h2Context, s, sizeof(HttpResponseData<SSL>),
+                    data, length);
+                if (ns) return ns;
+            }
+        }
+
         // ref the socket to make sure we process it entirely before it is closed
         us_socket_ref(s);
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -41,6 +41,11 @@ struct alignas(16) HttpContextData {
     template <bool> friend struct HttpContext;
     template <bool> friend struct HttpResponse;
     template <bool> friend struct TemplatedApp;
+    friend struct H2App;
+public:
+    /* Read by the ALPN select cb (a plain C function pointer, so it
+     * can't be a friend) to gate offering "h2". */
+    bool hasH2() const { return h2Context != nullptr; }
 private:
     std::vector<MoveOnlyFunction<void(HttpResponse<SSL> *, int)>> filterHandlers;
     using OnSocketDataCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, const char *data, int length, bool last);
@@ -68,6 +73,11 @@ private:
     OnSocketDataCallback onSocketData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
+    /* Populated by H2App::create(). When set, HttpContext::onData
+     * checks ALPN and hands sockets that negotiated "h2" to this
+     * context (an Http2Context*; held as void* to avoid the include)
+     * instead of the HTTP/1 parser. */
+    void *h2Context = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
 

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -6,6 +6,7 @@ const classes = [
   "HTTPResponseSink",
   "HTTPSResponseSink",
   "H3ResponseSink",
+  "H2ResponseSink",
   "NetworkSink",
 ];
 

--- a/src/jsc/FetchHeaders.zig
+++ b/src/jsc/FetchHeaders.zig
@@ -22,6 +22,7 @@ pub const FetchHeaders = opaque {
     extern fn WebCore__FetchHeaders__toJS(arg0: *FetchHeaders, arg1: *JSGlobalObject) JSValue;
     extern fn WebCore__FetchHeaders__toUWSResponse(arg0: *FetchHeaders, kind: bun.uws.ResponseKind, arg2: ?*anyopaque) void;
     extern fn WebCore__FetchHeaders__createFromH3(arg0: *anyopaque) *FetchHeaders;
+    extern fn WebCore__FetchHeaders__createFromH2(arg0: *anyopaque) *FetchHeaders;
 
     pub fn createValue(
         global: *JSGlobalObject,
@@ -110,6 +111,14 @@ pub const FetchHeaders = opaque {
     ) *FetchHeaders {
         return WebCore__FetchHeaders__createFromH3(
             h3_request,
+        );
+    }
+
+    pub fn createFromH2(
+        h2_request: *anyopaque,
+    ) *FetchHeaders {
+        return WebCore__FetchHeaders__createFromH2(
+            h2_request,
         );
     }
 

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -2,6 +2,7 @@
 #include "JSCookieMap.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
+#include <bun-uws/src/Http2App.h>
 #include "helpers.h"
 #include <wtf/text/ParsingUtilities.h>
 #include <JavaScriptCore/ObjectConstructor.h>
@@ -34,6 +35,9 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
         break;
     case UWSResponseKind::H3:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
+        break;
+    case UWSResponseKind::H2:
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http2Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -45,6 +45,8 @@ public:
         BodyValueBufferer,
         HTTPSServerH3RequestContext,
         DebugHTTPSServerH3RequestContext,
+        HTTPSServerH2RequestContext,
+        DebugHTTPSServerH2RequestContext,
     };
 
     static NativePromiseContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Tag tag);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -15,6 +15,7 @@
 #include "JSDOMExceptionHandling.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
+#include <bun-uws/src/Http2App.h>
 #include "ZigGeneratedClasses.h"
 #include "ScriptExecutionContext.h"
 #include "AsyncContextFrame.h"
@@ -1021,7 +1022,11 @@ JSValue createNodeHTTPInternalBinding(Zig::GlobalObject* globalObject)
     return obj;
 }
 
-static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::Http3Response* res)
+/* Shared H2/H3 path — both expose the same getHttpResponseData()/
+ * writeHeader()/writeMark() surface and the same state-flag enum, so
+ * only the ResponseData type differs. */
+template<typename ResponseData, typename Response>
+static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, Response* res)
 {
     auto& internalHeaders = headers.internalHeaders();
     auto* data = res->getHttpResponseData();
@@ -1058,13 +1063,13 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
 
     for (const auto& header : internalHeaders.commonHeaders()) {
         if (header.key == WebCore::HTTPHeaderName::ContentLength) {
-            if (!(data->state & uWS::Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
-                data->state |= uWS::Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+            if (!(data->state & ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
+                data->state |= ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
                 res->writeMark();
             }
         }
         if (header.key == WebCore::HTTPHeaderName::Date) {
-            data->state |= uWS::Http3ResponseData::HTTP_WROTE_DATE_HEADER;
+            data->state |= ResponseData::HTTP_WROTE_DATE_HEADER;
         }
         // HTTP/3 has no Transfer-Encoding; if a user header reaches here it
         // was already stripped by doWriteHeaders().
@@ -1086,7 +1091,10 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
         writeFetchHeadersToUWSResponse<true>(*arg0, reinterpret_cast<uWS::HttpResponse<true>*>(arg2));
         break;
     case UWSResponseKind::H3:
-        writeFetchHeadersToH3Response(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
+        writeFetchHeadersToH3Response<uWS::Http3ResponseData>(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
+        break;
+    case UWSResponseKind::H2:
+        writeFetchHeadersToH3Response<uWS::Http2ResponseData>(*arg0, reinterpret_cast<uWS::Http2Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -5,6 +5,7 @@
 #include <JavaScriptCore/Structure.h>
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Request.h>
+#include <bun-uws/src/Http2Request.h>
 #include "ZigGeneratedClasses.h"
 #include "AsyncContextFrame.h"
 #include "ServerRouteList.h"
@@ -287,6 +288,20 @@ extern "C" JSC::EncodedJSValue Bun__ServerRouteList__callRouteH3(
     JSC::EncodedJSValue routeListObject,
     JSC::EncodedJSValue* requestObject,
     uWS::Http3Request* req)
+{
+    JSValue routeListValue = JSValue::decode(routeListObject);
+    ServerRouteList* routeList = uncheckedDowncast<ServerRouteList>(routeListValue);
+    return JSValue::encode(routeList->callRoute(globalObject, index, requestPtr, serverObject, requestObject, req));
+}
+
+extern "C" JSC::EncodedJSValue Bun__ServerRouteList__callRouteH2(
+    Zig::GlobalObject* globalObject,
+    uint32_t index,
+    void* requestPtr,
+    JSC::EncodedJSValue serverObject,
+    JSC::EncodedJSValue routeListObject,
+    JSC::EncodedJSValue* requestObject,
+    uWS::Http2Request* req)
 {
     JSValue routeListValue = JSValue::decode(routeListObject);
     ServerRouteList* routeList = uncheckedDowncast<ServerRouteList>(routeListValue);

--- a/src/jsc/bindings/Sink.h
+++ b/src/jsc/bindings/Sink.h
@@ -11,9 +11,10 @@ enum SinkID : uint8_t {
     HTTPSResponseSink = 5,
     NetworkSink = 6,
     H3ResponseSink = 7,
+    H2ResponseSink = 8,
 
 };
 static constexpr unsigned numberOfSinkIDs
-    = 8;
+    = 9;
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2481,6 +2481,16 @@ void GlobalObject::finishCreation(VM& vm)
             init.setConstructor(constructor);
         });
 
+    m_JSH2ResponseSinkClassStructure.initLater(
+        [](LazyClassStructure::Initializer& init) {
+            auto* prototype = createJSSinkPrototype(init.vm, init.global, WebCore::SinkID::H2ResponseSink);
+            auto* structure = JSH2ResponseSink::createStructure(init.vm, init.global, prototype);
+            auto* constructor = JSH2ResponseSinkConstructor::create(init.vm, init.global, JSH2ResponseSinkConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
+            init.setPrototype(prototype);
+            init.setStructure(structure);
+            init.setConstructor(constructor);
+        });
+
     m_JSBufferClassStructure.initLater(
         [](LazyClassStructure::Initializer& init) {
             auto* prototype = WebCore::createBufferPrototype(init.vm, init.global);
@@ -3768,6 +3778,22 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolve;
     } else if (handler == Bun__HTTPRequestContextDebugH3__onResolveStream) {
         return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH3__onResolveStream;
+    } else if (handler == Bun__HTTPRequestContextH2__onReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onReject;
+    } else if (handler == Bun__HTTPRequestContextH2__onRejectStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onRejectStream;
+    } else if (handler == Bun__HTTPRequestContextH2__onResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onResolve;
+    } else if (handler == Bun__HTTPRequestContextH2__onResolveStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextH2__onResolveStream;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onReject) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onReject;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onRejectStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onRejectStream;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onResolve) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onResolve;
+    } else if (handler == Bun__HTTPRequestContextDebugH2__onResolveStream) {
+        return GlobalObject::PromiseFunctions::Bun__HTTPRequestContextDebugH2__onResolveStream;
     } else {
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -250,6 +250,10 @@ public:
     JSC::Structure* H3ResponseSinkStructure() const { return m_JSH3ResponseSinkClassStructure.getInitializedOnMainThread(this); }
     JSC::JSObject* H3ResponseSink() { return m_JSH3ResponseSinkClassStructure.constructorInitializedOnMainThread(this); }
     JSC::JSValue H3ResponseSinkPrototype() const { return m_JSH3ResponseSinkClassStructure.prototypeInitializedOnMainThread(this); }
+
+    JSC::Structure* H2ResponseSinkStructure() const { return m_JSH2ResponseSinkClassStructure.getInitializedOnMainThread(this); }
+    JSC::JSObject* H2ResponseSink() { return m_JSH2ResponseSinkClassStructure.constructorInitializedOnMainThread(this); }
+    JSC::JSValue H2ResponseSinkPrototype() const { return m_JSH2ResponseSinkClassStructure.prototypeInitializedOnMainThread(this); }
     JSC::JSValue JSReadableNetworkSinkControllerPrototype() const { return m_JSFetchTaskletChunkedRequestControllerPrototype.getInitializedOnMainThread(this); }
 
     JSC::Structure* JSBufferListStructure() const { return m_JSBufferListClassStructure.getInitializedOnMainThread(this); }
@@ -413,8 +417,16 @@ public:
         Bun__HTTPRequestContextDebugH3__onRejectStream,
         Bun__HTTPRequestContextDebugH3__onResolve,
         Bun__HTTPRequestContextDebugH3__onResolveStream,
+        Bun__HTTPRequestContextH2__onReject,
+        Bun__HTTPRequestContextH2__onRejectStream,
+        Bun__HTTPRequestContextH2__onResolve,
+        Bun__HTTPRequestContextH2__onResolveStream,
+        Bun__HTTPRequestContextDebugH2__onReject,
+        Bun__HTTPRequestContextDebugH2__onRejectStream,
+        Bun__HTTPRequestContextDebugH2__onResolve,
+        Bun__HTTPRequestContextDebugH2__onResolveStream,
     };
-    static constexpr size_t promiseFunctionsSize = 42;
+    static constexpr size_t promiseFunctionsSize = 50;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 
@@ -563,6 +575,7 @@ public:
     V(private, LazyClassStructure, m_JSHTTPSResponseSinkClassStructure)                                      \
     V(private, LazyClassStructure, m_JSNetworkSinkClassStructure)                                            \
     V(private, LazyClassStructure, m_JSH3ResponseSinkClassStructure)                                         \
+    V(private, LazyClassStructure, m_JSH2ResponseSinkClassStructure)                                         \
                                                                                                              \
     V(private, LazyClassStructure, m_JSStringDecoderClassStructure)                                          \
     V(private, LazyClassStructure, m_NapiClassStructure)                                                     \

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -101,6 +101,7 @@
 #include <string_view>
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Request.h>
+#include <bun-uws/src/Http2Request.h>
 #include <bun-usockets/src/internal/internal.h>
 #include "IDLTypes.h"
 #include "JSDOMBinding.h"
@@ -2008,10 +2009,14 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
     headers->setInternalHeaders(WTF::move(map));
     return headers;
 }
-WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
-{
-    auto* req = reinterpret_cast<uWS::Http3Request*>(arg1);
 
+} // extern "C"
+
+/* Shared H2/H3 path — both expose the same forEachHeader() surface.
+ * Templates can't have C linkage; the extern "C" wrappers below forward. */
+template<typename Req>
+static WebCore::FetchHeaders* createFetchHeadersFromMultiplexedRequest(Req* req)
+{
     auto* headers = new WebCore::FetchHeaders({ WebCore::FetchHeaders::Guard::None, {} });
     headers->relaxAdoptionRequirement();
 
@@ -2032,6 +2037,17 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
     });
     headers->setInternalHeaders(WTF::move(map));
     return headers;
+}
+
+extern "C" {
+
+WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
+{
+    return createFetchHeadersFromMultiplexedRequest(reinterpret_cast<uWS::Http3Request*>(arg1));
+}
+WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH2(void* arg1)
+{
+    return createFetchHeadersFromMultiplexedRequest(reinterpret_cast<uWS::Http2Request*>(arg1));
 }
 void WebCore__FetchHeaders__deref(WebCore::FetchHeaders* arg0)
 {

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -52,6 +52,7 @@ enum class UWSResponseKind : int32_t {
     TCP = 0,
     SSL = 1,
     H3 = 2,
+    H2 = 3,
 };
 #endif
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -598,6 +598,26 @@ ZIG_DECL void H3ResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(H3ResponseSink__write);
 #endif
 
+CPP_DECL JSC::EncodedJSValue H2ResponseSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
+CPP_DECL JSC::EncodedJSValue H2ResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
+CPP_DECL void H2ResponseSink__detachPtr(JSC::EncodedJSValue JSValue0);
+CPP_DECL void* H2ResponseSink__fromJS(JSC::EncodedJSValue JSValue1);
+CPP_DECL void H2ResponseSink__onClose(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);
+CPP_DECL void H2ResponseSink__onReady(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::EncodedJSValue JSValue2);
+
+#ifdef __cplusplus
+
+ZIG_DECL JSC::EncodedJSValue H2ResponseSink__close(JSC::JSGlobalObject* arg0, void* arg1);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__construct);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__end);
+ZIG_DECL JSC::EncodedJSValue SYSV_ABI SYSV_ABI H2ResponseSink__endWithSink(void* arg0, JSC::JSGlobalObject* arg1);
+ZIG_DECL void H2ResponseSink__finalize(void* arg0);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__flush);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__start);
+ZIG_DECL void H2ResponseSink__updateRef(void* arg0, bool arg1);
+BUN_DECLARE_HOST_FUNCTION(H2ResponseSink__write);
+#endif
+
 #ifdef __cplusplus
 
 ZIG_DECL void Bun__WebSocketHTTPClient__cancel(WebSocketHTTPClient* arg0);
@@ -738,6 +758,15 @@ BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onResolve);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onReject);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onResolveStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH3__onRejectStream);
+
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onReject);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextH2__onRejectStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onResolve);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onReject);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onResolveStream);
+BUN_DECLARE_HOST_FUNCTION(Bun__HTTPRequestContextDebugH2__onRejectStream);
 
 BUN_DECLARE_HOST_FUNCTION(Bun__FileSink__onResolveStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__FileSink__onRejectStream);

--- a/src/runtime/api/NativePromiseContext.zig
+++ b/src/runtime/api/NativePromiseContext.zig
@@ -31,6 +31,8 @@ pub const Tag = enum(u8) {
     BodyValueBufferer,
     HTTPSServerH3RequestContext,
     DebugHTTPSServerH3RequestContext,
+    HTTPSServerH2RequestContext,
+    DebugHTTPSServerH2RequestContext,
 
     pub fn fromType(comptime T: type) Tag {
         return switch (T) {
@@ -40,6 +42,8 @@ pub const Tag = enum(u8) {
             server.DebugHTTPSServer.RequestContext => .DebugHTTPSServerRequestContext,
             server.HTTPSServer.H3RequestContext => .HTTPSServerH3RequestContext,
             server.DebugHTTPSServer.H3RequestContext => .DebugHTTPSServerH3RequestContext,
+            server.HTTPSServer.H2RequestContext => .HTTPSServerH2RequestContext,
+            server.DebugHTTPSServer.H2RequestContext => .DebugHTTPSServerH2RequestContext,
             bun.webcore.Body.ValueBufferer => .BodyValueBufferer,
             else => @compileError("NativePromiseContext.Tag: unsupported type " ++ @typeName(T)),
         };
@@ -84,13 +88,13 @@ comptime {
 /// outside the sweep phase.
 ///
 /// Zero-allocation: the ctx pointer and our Tag are packed into the task's
-/// `_ptr` slot (pointer in high bits, tag in low 3 bits — the target types
-/// are all >= 8-byte aligned). See PosixSignalTask for the same trick with
+/// `_ptr` slot (pointer in high bits, tag in low 4 bits — the target types
+/// are all >= 16-byte aligned). See PosixSignalTask for the same trick with
 /// signal numbers.
 ///
 /// Layout inside jsc.Task's packed u64 after setUintptr:
 ///
-///     bits 63..49  bits 48..3           bits 2..0
+///     bits 63..49  bits 48..4           bits 3..0
 ///     ┌──────────┬────────────────────┬─────────┐
 ///     │ data=u15 │ ctx ptr (aligned)  │ our Tag │
 ///     └──────────┴────────────────────┴─────────┘
@@ -103,20 +107,27 @@ comptime {
 ///
 /// setUintptr only writes _ptr; the Task discriminant in data that
 /// Task.init(&marker) stamped stays put. @truncate to u49 keeps the low
-/// bits, so both the ctx pointer (bits 3..48) and our Tag (bits 0..2)
+/// bits, so both the ctx pointer (bits 4..48) and our Tag (bits 0..3)
 /// survive.
 pub const DeferredDerefTask = struct {
-    const tag_mask: usize = 0b111;
+    const tag_mask: usize = 0b1111;
     comptime {
-        // Low 3 bits hold the tag; verify both capacity and alignment
+        // Low 4 bits hold the tag; verify both capacity and alignment
         // slack so adding a tag or a packed field can't silently break
-        // the packing.
+        // the packing. RequestContext is explicitly align(16); for
+        // BodyValueBufferer the enclosing HTMLRewriter BufferOutputSink is
+        // heap-allocated via mimalloc, which 16-aligns everything ≥ 16
+        // bytes, so the runtime debugAssert in schedule() is the real
+        // guard there.
         bun.assert(@typeInfo(Tag).@"enum".fields.len <= tag_mask + 1);
         bun.assert(@alignOf(server.HTTPServer.RequestContext) > tag_mask);
         bun.assert(@alignOf(server.HTTPSServer.RequestContext) > tag_mask);
         bun.assert(@alignOf(server.DebugHTTPServer.RequestContext) > tag_mask);
         bun.assert(@alignOf(server.DebugHTTPSServer.RequestContext) > tag_mask);
-        bun.assert(@alignOf(bun.webcore.Body.ValueBufferer) > tag_mask);
+        bun.assert(@alignOf(server.HTTPSServer.H3RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.DebugHTTPSServer.H3RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.HTTPSServer.H2RequestContext) > tag_mask);
+        bun.assert(@alignOf(server.DebugHTTPSServer.H2RequestContext) > tag_mask);
     }
 
     pub fn schedule(ctx: *anyopaque, tag: Tag) void {
@@ -152,6 +163,8 @@ pub const DeferredDerefTask = struct {
             },
             .HTTPSServerH3RequestContext => @as(*server.HTTPSServer.H3RequestContext, @ptrCast(@alignCast(ctx))).deref(),
             .DebugHTTPSServerH3RequestContext => @as(*server.DebugHTTPSServer.H3RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .HTTPSServerH2RequestContext => @as(*server.HTTPSServer.H2RequestContext, @ptrCast(@alignCast(ctx))).deref(),
+            .DebugHTTPSServerH2RequestContext => @as(*server.DebugHTTPSServer.H2RequestContext, @ptrCast(@alignCast(ctx))).deref(),
         }
     }
 };

--- a/src/runtime/api/html_rewriter.zig
+++ b/src/runtime/api/html_rewriter.zig
@@ -406,7 +406,10 @@ pub const HTMLRewriter = struct {
         context: *LOLHTMLContext,
         response: *Response,
         response_value: jsc.Strong.Optional = .empty,
-        bodyValueBufferer: ?jsc.WebCore.Body.ValueBufferer = null,
+        /// NativePromiseContext.DeferredDerefTask packs a 4-bit tag into
+        /// `&bodyValueBufferer`'s low bits, so the field offset must stay
+        /// 16-aligned regardless of what precedes it.
+        bodyValueBufferer: ?jsc.WebCore.Body.ValueBufferer align(16) = null,
         tmp_sync_error: ?*jsc.JSValue = null,
 
         // const log = bun.Output.scoped(.BufferOutputSink, .visible);

--- a/src/runtime/server/AnyRequestContext.zig
+++ b/src/runtime/server/AnyRequestContext.zig
@@ -10,6 +10,8 @@ pub const Pointer = bun.TaggedPointerUnion(.{
     DebugHTTPSServer.RequestContext,
     HTTPSServer.H3RequestContext,
     DebugHTTPSServer.H3RequestContext,
+    HTTPSServer.H2RequestContext,
+    DebugHTTPSServer.H2RequestContext,
 });
 
 tagged_pointer: Pointer,
@@ -99,7 +101,7 @@ pub fn detachRequest(self: AnyRequestContext) void {
 pub fn setRequest(self: AnyRequestContext, req: *uws.Request) void {
     self.dispatch(void, {}, struct {
         fn f(comptime T: type, ctx: anytype, r: *uws.Request) void {
-            if (comptime T.is_h3) return; // H3 populates url/headers eagerly
+            if (comptime T.is_stream) return; // H2/H3 populate url/headers eagerly
             ctx.req = r;
         }
     }.f, .{req});
@@ -108,7 +110,7 @@ pub fn setRequest(self: AnyRequestContext, req: *uws.Request) void {
 pub fn getRequest(self: AnyRequestContext) ?*uws.Request {
     return self.dispatch(?*uws.Request, null, struct {
         fn f(comptime T: type, ctx: anytype) ?*uws.Request {
-            if (comptime T.is_h3) return null; // url/headers already on the Request
+            if (comptime T.is_stream) return null; // url/headers already on the Request
             return ctx.req;
         }
     }.f, .{});

--- a/src/runtime/server/FileRoute.zig
+++ b/src/runtime/server/FileRoute.zig
@@ -138,7 +138,7 @@ fn writeStatusCode(_: *FileRoute, status: u16, resp: AnyResponse) void {
     switch (resp) {
         .SSL => |r| writeStatus(true, r, status),
         .TCP => |r| writeStatus(false, r, status),
-        .H3 => |r| {
+        inline .H3, .H2 => |r| {
             var b: [16]u8 = undefined;
             r.writeStatus(std.fmt.bufPrint(&b, "{d}", .{status}) catch unreachable);
         },

--- a/src/runtime/server/HTMLBundle.zig
+++ b/src/runtime/server/HTMLBundle.zig
@@ -150,7 +150,7 @@ pub const Route = struct {
                 // but stay defensive.
                 switch (req) {
                     .h1 => |h1| bun.handleOom(dev.respondForHTMLBundle(this, h1, resp)),
-                    .h3 => {
+                    .h3, .h2 => {
                         resp.writeStatus("503 Service Unavailable");
                         resp.end("DevServer HMR is HTTP/1.1 only", true);
                     },

--- a/src/runtime/server/NodeHTTPResponse.zig
+++ b/src/runtime/server/NodeHTTPResponse.zig
@@ -503,6 +503,7 @@ fn writeHeadInternal(response: uws.AnyResponse, globalObject: *jsc.JSGlobalObjec
         .TCP => NodeHTTPServer__writeHead_http(globalObject, status_message.ptr, status_message.len, headers, @ptrCast(response.TCP)),
         .SSL => NodeHTTPServer__writeHead_https(globalObject, status_message.ptr, status_message.len, headers, @ptrCast(response.SSL)),
         .H3 => bun.Output.panic("node:http does not support HTTP/3 responses", .{}),
+        .H2 => bun.Output.panic("node:http does not support HTTP/2 responses", .{}),
     }
 }
 

--- a/src/runtime/server/RequestContext.zig
+++ b/src/runtime/server/RequestContext.zig
@@ -18,26 +18,59 @@ pub const AdditionalOnAbortCallback = struct {
     }
 };
 
-pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comptime ThisServer: type, comptime http3: bool) type {
+pub const Transport = enum { h1, h2, h3 };
+
+pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, comptime ThisServer: type, comptime transport: Transport) type {
+    // Shared stream-multiplexed semantics: H2 and H3 both deliver request
+    // bodies via per-stream frames terminated by the peer's END_STREAM/FIN
+    // (RFC 9113 §8.1, RFC 9114 §4.1), forbid connection-specific headers
+    // (Transfer-Encoding, Connection, Upgrade), and fire onAborted once
+    // the stream object is torn down even after a completed response.
+    // `http3` here means exactly that shared contract; `is_h3`/`is_h2`
+    // pick the concrete Response/Request types and the few lines that
+    // really are protocol-specific (Alt-Svc, export names, pool slot).
+    const http3 = transport != .h1;
     return struct {
         const RequestContext = @This();
 
-        const App = if (http3) struct {
-            pub const Response = uws.H3.Response;
-        } else uws.NewApp(ssl_enabled);
-        /// uWS request type for this transport. The H3 wrapper mirrors
+        const App = switch (transport) {
+            .h3 => struct {
+                pub const Response = uws.H3.Response;
+            },
+            .h2 => struct {
+                pub const Response = uws.H2.Response;
+            },
+            .h1 => uws.NewApp(ssl_enabled),
+        };
+        /// uWS request type for this transport. The H2/H3 wrappers mirror
         /// uws.Request's surface so callers stay duck-typed.
-        pub const Req = if (http3) uws.H3.Request else uws.Request;
+        pub const Req = switch (transport) {
+            .h3 => uws.H3.Request,
+            .h2 => uws.H2.Request,
+            .h1 => uws.Request,
+        };
         pub const Resp = App.Response;
-        pub const is_h3 = http3;
-        const resp_kind = uws.ResponseKind.from(ssl_enabled, http3);
+        pub const is_h3 = transport == .h3;
+        pub const is_h2 = transport == .h2;
+        /// Shared stream-multiplexed semantics flag — see the block comment
+        /// on `http3` above for what the H2/H3 codepaths share.
+        pub const is_stream = transport != .h1;
+        const resp_kind: uws.ResponseKind = switch (transport) {
+            .h3 => .h3,
+            .h2 => .h2,
+            .h1 => if (ssl_enabled) .ssl else .tcp,
+        };
         pub threadlocal var pool: ?*RequestContext.RequestContextStackAllocator = null;
-        pub const ResponseStream = jsc.WebCore.HTTPServerWritable(ssl_enabled, http3);
+        pub const ResponseStream = jsc.WebCore.HTTPServerWritable(ssl_enabled, transport);
 
         // This pre-allocates up to 2,048 RequestContext structs.
         // It costs about 655,632 bytes.
         pub const RequestContextStackAllocator = bun.HiveArray(RequestContext, if (bun.heap_breakdown.enabled) 0 else 2048).Fallback;
 
+        /// NativePromiseContext.DeferredDerefTask packs a 4-bit tag into
+        /// this pointer's low bits; bumped from 3 when the ninth
+        /// transport variant (H2) was added.
+        _align: void align(16) = {},
         server: ?*ThisServer,
         resp: ?*App.Response,
         /// thread-local default heap allocator
@@ -303,7 +336,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
             if (this.server) |server| {
                 this.server = null;
-                if (comptime http3) server.h3_request_pool_allocator.put(this) else server.request_pool_allocator.put(this);
+                switch (comptime transport) {
+                    .h3 => server.h3_request_pool_allocator.put(this),
+                    .h2 => server.h2_request_pool_allocator.put(this),
+                    .h1 => server.request_pool_allocator.put(this),
+                }
                 server.onRequestComplete();
             }
         }
@@ -585,7 +622,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         }
 
         inline fn anyResponse(r: *App.Response) uws.AnyResponse {
-            return if (comptime http3) .{ .H3 = r } else if (comptime ssl_enabled) .{ .SSL = r } else .{ .TCP = r };
+            return switch (comptime transport) {
+                .h3 => .{ .H3 = r },
+                .h2 => .{ .H2 = r },
+                .h1 => if (comptime ssl_enabled) .{ .SSL = r } else .{ .TCP = r },
+            };
         }
 
         pub fn create(this: *RequestContext, server: *ThisServer, req: *Req, resp: *App.Response, should_deinit_context: ?*bool, method: ?bun.http.Method) void {
@@ -596,7 +637,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 .method = method orelse HTTP.Method.which(req.method()) orelse .GET,
                 .server = server,
                 .defer_deinit_until_callback_completes = should_deinit_context,
-                .range = RangeRequest.rawFromRequest(if (comptime http3) .{ .h3 = req } else .{ .h1 = req }),
+                .range = RangeRequest.rawFromRequest(switch (comptime transport) {
+                    .h3 => .{ .h3 = req },
+                    .h2 => .{ .h2 = req },
+                    .h1 => .{ .h1 = req },
+                }),
             };
 
             ctxLog("create<d> ({*})<r>", .{this});
@@ -793,7 +838,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             const this: *RequestContext = @ptrCast(@alignCast(ctx));
             // Route through the real onAbort so flags.aborted, request.signal,
             // and additional_on_abort fire exactly as they did pre-consolidation.
-            this.onAbort(if (comptime http3) resp.H3 else if (comptime ssl_enabled) resp.SSL else resp.TCP);
+            this.onAbort(switch (comptime transport) {
+                .h3 => resp.H3,
+                .h2 => resp.H2,
+                .h1 => if (comptime ssl_enabled) resp.SSL else resp.TCP,
+            });
         }
 
         fn onFileStreamError(ctx: *anyopaque, resp: uws.AnyResponse, _: bun.sys.Error) void {
@@ -2248,7 +2297,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // Advertise the QUIC endpoint on H1/H2 responses so browsers can
             // discover it (RFC 7838). Multiple Alt-Svc fields are valid, so a
             // user-supplied one composes rather than conflicts.
-            if (comptime !http3 and @hasDecl(ThisServer, "h3AltSvc")) {
+            if (comptime transport != .h3 and @hasDecl(ThisServer, "h3AltSvc")) {
                 if (this.server.?.h3AltSvc()) |alt| resp.writeHeader("alt-svc", alt);
             }
 
@@ -2599,7 +2648,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         }
 
         comptime {
-            const export_prefix = "Bun__HTTPRequestContext" ++ (if (debug_mode) "Debug" else "") ++ (if (http3) "H3" else if (ThisServer.ssl_enabled) "TLS" else "");
+            const export_prefix = "Bun__HTTPRequestContext" ++ (if (debug_mode) "Debug" else "") ++ switch (transport) {
+                .h3 => "H3",
+                .h2 => "H2",
+                .h1 => if (ThisServer.ssl_enabled) "TLS" else "",
+            };
             if (bun.Environment.export_cpp_apis) {
                 @export(&jsc.toJSHostFn(onResolve), .{ .name = export_prefix ++ "__onResolve" });
                 @export(&jsc.toJSHostFn(onReject), .{ .name = export_prefix ++ "__onReject" });

--- a/src/runtime/server/ServerConfig.zig
+++ b/src/runtime/server/ServerConfig.zig
@@ -891,7 +891,6 @@ pub fn fromJS(
         if (try arg.get(global, "http2")) |v| {
             args.http2 = v.toBoolean();
         }
-        if (global.hasException()) return error.JSError;
 
         if (try arg.get(global, "http1")) |v| {
             args.http1 = v.toBoolean();

--- a/src/runtime/server/ServerConfig.zig
+++ b/src/runtime/server/ServerConfig.zig
@@ -53,6 +53,7 @@ id: []const u8 = "",
 allow_hot: bool = true,
 ipv6_only: bool = false,
 http3: bool = false,
+http2: bool = false,
 http1: bool = true,
 
 is_node_http: bool = false,
@@ -253,6 +254,26 @@ pub fn applyStaticRouteH3(server: AnyServer, app: *uws.H3.App, comptime T: type,
         }
         pub fn HEAD(route: T, req: *uws.H3.Request, resp: *uws.H3.Response) void {
             route.onHEADRequest(.{ .h3 = req }, .{ .H3 = resp });
+        }
+    };
+    app.head(path, T, entry, handler_wrap.HEAD);
+    switch (method) {
+        .any => app.any(path, T, entry, handler_wrap.handler),
+        .method => |*m| {
+            var iter = m.iterator();
+            while (iter.next()) |method_| app.method(method_, path, T, entry, handler_wrap.handler);
+        },
+    }
+}
+
+pub fn applyStaticRouteH2(server: AnyServer, app: *uws.H2.App, comptime T: type, entry: T, path: []const u8, method: HTTP.Method.Optional) void {
+    entry.server = server;
+    const handler_wrap = struct {
+        pub fn handler(route: T, req: *uws.H2.Request, resp: *uws.H2.Response) void {
+            route.onRequest(.{ .h2 = req }, .{ .H2 = resp });
+        }
+        pub fn HEAD(route: T, req: *uws.H2.Request, resp: *uws.H2.Response) void {
+            route.onHEADRequest(.{ .h2 = req }, .{ .H2 = resp });
         }
     };
     app.head(path, T, entry, handler_wrap.HEAD);
@@ -867,6 +888,11 @@ pub fn fromJS(
         }
         if (global.hasException()) return error.JSError;
 
+        if (try arg.get(global, "http2")) |v| {
+            args.http2 = v.toBoolean();
+        }
+        if (global.hasException()) return error.JSError;
+
         if (try arg.get(global, "http1")) |v| {
             args.http1 = v.toBoolean();
         }
@@ -989,6 +1015,16 @@ pub fn fromJS(
             }
         } else if (!args.http1) {
             return global.throwInvalidArguments("Cannot disable http1 without enabling http3", .{});
+        }
+        if (args.http2) {
+            if (args.ssl_config == null) {
+                return global.throwInvalidArguments("HTTP/2 requires 'tls' to be set (h2c is not supported)", .{});
+            }
+            // http2 shares the http1 TLS listener via ALPN; one without the
+            // other has no socket to adopt from.
+            if (!args.http1) {
+                return global.throwInvalidArguments("http2 requires http1: it shares the HTTP/1.1 TLS listener via ALPN", .{});
+            }
         }
         if (!args.http1 and args.address == .unix) {
             return global.throwInvalidArguments("Cannot disable http1 with a unix socket — HTTP/3 over AF_UNIX is not supported", .{});

--- a/src/runtime/server/StaticRoute.zig
+++ b/src/runtime/server/StaticRoute.zig
@@ -316,7 +316,7 @@ fn doWriteStatus(_: *StaticRoute, status: u16, resp: AnyResponse) void {
     switch (resp) {
         .SSL => |r| writeStatus(true, r, status),
         .TCP => |r| writeStatus(false, r, status),
-        .H3 => |r| {
+        inline .H3, .H2 => |r| {
             var b: [16]u8 = undefined;
             r.writeStatus(std.fmt.bufPrint(&b, "{d}", .{status}) catch unreachable);
         },

--- a/src/runtime/server/server.zig
+++ b/src/runtime/server/server.zig
@@ -532,9 +532,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         pub const debug_mode = development_kind == .debug;
 
         const ThisServer = @This();
-        pub const RequestContext = NewRequestContext(ssl_enabled, debug_mode, @This(), false);
+        pub const RequestContext = NewRequestContext(ssl_enabled, debug_mode, @This(), .h1);
         const has_h3 = ssl_enabled;
-        pub const H3RequestContext = if (has_h3) NewRequestContext(ssl_enabled, debug_mode, @This(), true) else void;
+        const has_h2 = ssl_enabled;
+        pub const H3RequestContext = if (has_h3) NewRequestContext(ssl_enabled, debug_mode, @This(), .h3) else void;
+        pub const H2RequestContext = if (has_h2) NewRequestContext(ssl_enabled, debug_mode, @This(), .h2) else void;
 
         pub const App = uws.NewApp(ssl_enabled);
         app: ?*App = null,
@@ -544,6 +546,8 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         /// Cached `h3=":<port>"; ma=86400` value for Alt-Svc on H1 responses;
         /// formatted once in onH3Listen so renderMetadata doesn't reformat.
         h3_alt_svc: if (has_h3) [:0]const u8 else void = if (has_h3) "" else {},
+        /// H2 rides the H1 TLS listener via ALPN (no separate listen socket).
+        h2_app: if (has_h2) ?*uws.H2.App else void = if (has_h2) null else {},
         js_value: jsc.JSRef = jsc.JSRef.empty(),
         /// Potentially null before listen() is called, and once .destroy() is called.
         vm: *jsc.VirtualMachine,
@@ -553,6 +557,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         pending_requests: usize = 0,
         request_pool_allocator: *RequestContext.RequestContextStackAllocator = undefined,
         h3_request_pool_allocator: if (has_h3) *H3RequestContext.RequestContextStackAllocator else void = if (has_h3) undefined else {},
+        h2_request_pool_allocator: if (has_h2) *H2RequestContext.RequestContextStackAllocator else void = if (has_h2) undefined else {},
         all_closed_promise: jsc.JSPromise.Strong = .{},
 
         listen_callback: jsc.AnyTask = undefined,
@@ -1111,6 +1116,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             this.app.?.clearRoutes();
             if (comptime has_h3) if (this.h3_app) |h3a| h3a.clearRoutes();
+            if (comptime has_h2) if (this.h2_app) |h2a| h2a.clearRoutes();
 
             // only reload those two, but ignore if they're not specified.
             if (this.config.onRequest != new_config.onRequest and (new_config.onRequest != .zero and !new_config.onRequest.isUndefined())) {
@@ -1202,6 +1208,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             this.config = try this.config.cloneForReloadingStaticRoutes();
             this.app.?.clearRoutes();
             if (comptime has_h3) if (this.h3_app) |h3a| h3a.clearRoutes();
+            if (comptime has_h2) if (this.h2_app) |h2a| h2a.clearRoutes();
             const route_list_value = this.setRoutes();
             if (route_list_value != .zero) {
                 if (this.js_value.tryGet()) |server_js_value| {
@@ -1649,6 +1656,14 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
         pub fn stopListening(this: *ThisServer, abrupt: bool) void {
             httplog("stopListening", .{});
+            if (comptime has_h2) {
+                // H2 shares the H1 listener; GOAWAY on graceful stop so
+                // live connections can drain. Abrupt falls through to
+                // this.app.?.close() below — TemplatedApp::close() walks
+                // h2ChildContext alongside webSocketContexts and
+                // force-closes every adopted H2 socket.
+                if (!abrupt) if (this.h2_app) |h2a| h2a.close();
+            }
             if (comptime has_h3) {
                 if (this.h3_listener) |h3l| {
                     this.h3_listener = null;
@@ -1770,6 +1785,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     h3a.destroy();
                 }
             }
+            if (comptime has_h2) {
+                if (this.h2_app) |h2a| {
+                    this.h2_app = null;
+                    h2a.destroy();
+                }
+            }
             if (comptime has_h3) if (this.h3_alt_svc.len > 0)
                 bun.default_allocator.free(this.h3_alt_svc);
             if (this.app) |app| {
@@ -1833,6 +1854,17 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     );
                 }
                 server.h3_request_pool_allocator = H3RequestContext.pool.?;
+            }
+
+            if (comptime has_h2) {
+                if (H2RequestContext.pool == null) {
+                    H2RequestContext.pool = bun.create(
+                        server.allocator,
+                        H2RequestContext.RequestContextStackAllocator,
+                        H2RequestContext.RequestContextStackAllocator.init(bun.typedAllocator(H2RequestContext)),
+                    );
+                }
+                server.h2_request_pool_allocator = H2RequestContext.pool.?;
             }
 
             if (comptime ssl_enabled) {
@@ -1993,6 +2025,23 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
         pub fn onH3404(_: *ThisServer, _: *uws.H3.Request, resp: *uws.H3.Response) void {
             if (comptime !has_h3) unreachable;
+            resp.writeStatus("404 Not Found");
+            resp.end("", false);
+        }
+
+        pub fn onH2Request(this: *ThisServer, req: *uws.H2.Request, resp: *uws.H2.Response) void {
+            if (comptime !has_h2) unreachable;
+            if (this.config.onRequest == .zero) return onH2404(this, req, resp);
+            this.onRequestFor(H2RequestContext, req, resp);
+        }
+
+        pub fn onH2UserRouteRequest(user_route: *UserRoute, req: *uws.H2.Request, resp: *uws.H2.Response) void {
+            if (comptime !has_h2) unreachable;
+            onUserRouteRequestFor(H2RequestContext, user_route, req, resp);
+        }
+
+        pub fn onH2404(_: *ThisServer, _: *uws.H2.Request, resp: *uws.H2.Response) void {
+            if (comptime !has_h2) unreachable;
             resp.writeStatus("404 Not Found");
             resp.end("", false);
         }
@@ -2249,7 +2298,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             }) orelse return;
 
             const server_request_list = js.routeListGetCached(server.jsValueAssertAlive()).?;
-            const callRoute = if (Ctx.is_h3) Bun__ServerRouteList__callRouteH3 else Bun__ServerRouteList__callRoute;
+            const callRoute = if (Ctx.is_h3) Bun__ServerRouteList__callRouteH3 else if (Ctx.is_h2) Bun__ServerRouteList__callRouteH2 else Bun__ServerRouteList__callRoute;
             const response_value = bun.jsc.fromJSHostCall(server.globalThis, @src(), callRoute, .{ server.globalThis, index, prepared.request_object, server.jsValueAssertAlive(), server_request_list, &prepared.js_request, req }) catch |err| server.globalThis.takeException(err);
 
             server.handleRequestFor(Ctx, &should_deinit_context, prepared, req, response_value);
@@ -2383,7 +2432,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     req: *Ctx.Req,
                     resp: *Ctx.Resp,
                 ) SavedRequest {
-                    if (comptime Ctx.is_h3) @compileError("PreparedRequest.save is HTTP/1-only");
+                    if (comptime Ctx.is_stream) @compileError("PreparedRequest.save is HTTP/1-only");
                     // By saving a request, all information from `req` must be
                     // copied since the provided uws.Request will be re-used for
                     // future requests (stack allocated).
@@ -2427,9 +2476,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             //
             // We first validate the self-reported request body length so that
             // we avoid needing to worry as much about what memory to free.
-            // RFC 9114 §4.2: an HTTP/3 message containing a transfer-encoding
-            // header field is malformed.
-            if (comptime Ctx.is_h3) if (req.header("transfer-encoding") != null) {
+            // RFC 9113 §8.2.2 / RFC 9114 §4.2: an HTTP/2 or HTTP/3 message
+            // containing a transfer-encoding header field is malformed.
+            if (comptime Ctx.is_stream) if (req.header("transfer-encoding") != null) {
                 resp.writeStatus("400 Bad Request");
                 resp.endWithoutBody(false);
                 return null;
@@ -2445,12 +2494,13 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         break :brk 0;
                     };
 
-                    // Abort the request very early. For H3 a per-request error
-                    // is a stream error (RFC 9114 §4.1.2); close_connection
-                    // would CONNECTION_CLOSE every sibling stream on the conn.
+                    // Abort the request very early. For H2/H3 a per-request
+                    // error is a stream error (RFC 9113 §8.1.1, RFC 9114
+                    // §4.1.2); close_connection would tear down every
+                    // sibling stream on the conn.
                     if (len > this.config.max_request_body_size) {
                         resp.writeStatus("413 Request Entity Too Large");
-                        resp.endWithoutBody(comptime !Ctx.is_h3);
+                        resp.endWithoutBody(comptime !Ctx.is_stream);
                         return null;
                     }
 
@@ -2484,7 +2534,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 }.warn, &did_send_idletimeout_warning_once);
             }
 
-            const pool_allocator = if (comptime Ctx.is_h3) this.h3_request_pool_allocator else this.request_pool_allocator;
+            const pool_allocator = if (comptime Ctx.is_h3) this.h3_request_pool_allocator else if (comptime Ctx.is_h2) this.h2_request_pool_allocator else this.request_pool_allocator;
             const ctx = bun.handleOom(pool_allocator.tryGet());
             ctx.create(this, req, resp, should_deinit_context, method);
             this.vm.jsc_vm.reportExtraMemory(@sizeOf(Ctx));
@@ -2505,11 +2555,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             ctx.request_weakref = .initRef(request_object);
 
             // The lazy `getRequest()` path that backs Request.url / .headers
-            // is `*uws.Request`-typed; for HTTP/3 we populate both eagerly so
-            // the rest of the pipeline never needs to know which transport
-            // delivered the bytes.
-            if (comptime Ctx.is_h3) {
-                request_object.setFetchHeaders(.createFromH3(req));
+            // is `*uws.Request`-typed; for HTTP/2 and HTTP/3 we populate both
+            // eagerly so the rest of the pipeline never needs to know which
+            // transport delivered the bytes.
+            if (comptime Ctx.is_stream) {
+                request_object.setFetchHeaders(if (comptime Ctx.is_h2) .createFromH2(req) else .createFromH3(req));
                 const path = req.url();
                 if (path.len > 0 and path[0] == '/') {
                     if (req.header("host")) |host| {
@@ -2539,10 +2589,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (request_body_length) |req_len| {
                 ctx.request_body_content_len = req_len;
                 ctx.flags.is_transfer_encoding = req.header("transfer-encoding") != null;
-                // HTTP/3 (RFC 9114 §4.2.2): Content-Length is optional and
-                // Transfer-Encoding is forbidden; the body is terminated by
-                // the QUIC stream FIN, so always arm onData for body methods.
-                if (req_len > 0 or ctx.flags.is_transfer_encoding or comptime Ctx.is_h3) {
+                // HTTP/2 (RFC 9113 §8.1) and HTTP/3 (RFC 9114 §4.2.2):
+                // Content-Length is optional and Transfer-Encoding is
+                // forbidden; the body is terminated by the stream
+                // END_STREAM/FIN, so always arm onData for body methods.
+                if (req_len > 0 or ctx.flags.is_transfer_encoding or comptime Ctx.is_stream) {
                     // we defer pre-allocating the body until we receive the first chunk
                     // that way if the client is lying about how big the body is or the client aborts
                     // we don't waste memory
@@ -2810,6 +2861,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         if (comptime has_h3) {
                             if (this.h3_app) |h3_app| h3_app.any(user_route.route.path, *UserRoute, user_route, onH3UserRouteRequest);
                         }
+                        if (comptime has_h2) {
+                            if (this.h2_app) |h2_app| h2_app.any(user_route.route.path, *UserRoute, user_route, onH2UserRouteRequest);
+                        }
                         if (is_star_path) {
                             star_methods_covered_by_user = .initFull();
                         }
@@ -2830,6 +2884,9 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         app.method(method_val, user_route.route.path, *UserRoute, user_route, onUserRouteRequest);
                         if (comptime has_h3) {
                             if (this.h3_app) |h3_app| h3_app.method(method_val, user_route.route.path, *UserRoute, user_route, onH3UserRouteRequest);
+                        }
+                        if (comptime has_h2) {
+                            if (this.h2_app) |h2_app| h2_app.method(method_val, user_route.route.path, *UserRoute, user_route, onH2UserRouteRequest);
                         }
                         if (is_star_path) {
                             star_methods_covered_by_user.insert(method_val);
@@ -2859,6 +2916,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     if (this.h3_app) |h3_app| {
                         h3_app.head(route_path, *ThisServer, this, onH3Request);
                         h3_app.any(route_path, *ThisServer, this, onH3Request);
+                    }
+                }
+                if (comptime has_h2) {
+                    if (this.h2_app) |h2_app| {
+                        h2_app.head(route_path, *ThisServer, this, onH2Request);
+                        h2_app.any(route_path, *ThisServer, this, onH2Request);
                     }
                 }
             }
@@ -2892,16 +2955,22 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             ServerConfig.applyStaticRoute(any_server, ssl_enabled, app, *StaticRoute, static_route, entry.path, entry.method);
                             if (comptime has_h3) if (this.h3_app) |h3_app|
                                 ServerConfig.applyStaticRouteH3(any_server, h3_app, *StaticRoute, static_route, entry.path, entry.method);
+                            if (comptime has_h2) if (this.h2_app) |h2_app|
+                                ServerConfig.applyStaticRouteH2(any_server, h2_app, *StaticRoute, static_route, entry.path, entry.method);
                         },
                         .file => |file_route| {
                             ServerConfig.applyStaticRoute(any_server, ssl_enabled, app, *FileRoute, file_route, entry.path, entry.method);
                             if (comptime has_h3) if (this.h3_app) |h3_app|
                                 ServerConfig.applyStaticRouteH3(any_server, h3_app, *FileRoute, file_route, entry.path, entry.method);
+                            if (comptime has_h2) if (this.h2_app) |h2_app|
+                                ServerConfig.applyStaticRouteH2(any_server, h2_app, *FileRoute, file_route, entry.path, entry.method);
                         },
                         .html => |html_bundle_route| {
                             ServerConfig.applyStaticRoute(any_server, ssl_enabled, app, *HTMLBundle.Route, html_bundle_route.data, entry.path, entry.method);
                             if (comptime has_h3) if (this.h3_app) |h3_app|
                                 ServerConfig.applyStaticRouteH3(any_server, h3_app, *HTMLBundle.Route, html_bundle_route.data, entry.path, entry.method);
+                            if (comptime has_h2) if (this.h2_app) |h2_app|
+                                ServerConfig.applyStaticRouteH2(any_server, h2_app, *HTMLBundle.Route, html_bundle_route.data, entry.path, entry.method);
                             if (dev_server) |dev| {
                                 bun.handleOom(dev.html_router.put(dev.allocator(), entry.path, html_bundle_route.data));
                             }
@@ -3012,6 +3081,31 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 }
             }
 
+            // H2 fallback — same rule as H3 above; DevServer routes are
+            // also not mirrored to H2.
+            if (comptime has_h2) {
+                if (this.h2_app) |h2_app| {
+                    if (h3_star_covered.eql(bun.http.Method.Set.initFull())) {
+                        // covered
+                    } else if (has_any_user_route_for_star_path or has_static_route_for_star_path) {
+                        var uncovered = h3_star_covered;
+                        uncovered.toggleAll();
+                        var iter = uncovered.iterator();
+                        while (iter.next()) |m| {
+                            if (this.config.onRequest != .zero) {
+                                h2_app.method(m, "/*", *ThisServer, this, onH2Request);
+                            } else {
+                                h2_app.method(m, "/*", *ThisServer, this, onH2404);
+                            }
+                        }
+                    } else if (this.config.onRequest != .zero) {
+                        h2_app.any("/*", *ThisServer, this, onH2Request);
+                    } else {
+                        h2_app.any("/*", *ThisServer, this, onH2404);
+                    }
+                }
+            }
+
             if (should_add_chrome_devtools_json_route) {
                 app.get(chrome_devtools_route, *ThisServer, this, onChromeDevToolsJSONRequest);
             }
@@ -3066,6 +3160,23 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                             if (!globalThis.hasException()) {
                                 globalThis.throw("Failed to create HTTP/3 server", .{}) catch {};
                             }
+                            this.deinit();
+                            return .zero;
+                        };
+                    }
+                }
+
+                if (comptime has_h2) {
+                    if (this.config.http2) {
+                        // H2 attaches to the H1 TLS listener: creates a child
+                        // socket context that shares its SSL_CTX and installs
+                        // an ALPN select cb offering "h2,http/1.1". No
+                        // separate listen() — sockets that negotiate "h2"
+                        // are adopted out of the H1 context on first on_data.
+                        this.h2_app = uws.H2.App.create(app, this.config.idleTimeout) orelse {
+                            // H2.App.create is a C call that doesn't touch JS,
+                            // so there is no prior exception to check for.
+                            globalThis.throw("Failed to create HTTP/2 server", .{}) catch {};
                             this.deinit();
                             return .zero;
                         };
@@ -3777,6 +3888,16 @@ extern "c" fn Bun__ServerRouteList__callRoute(
 ) jsc.JSValue;
 
 extern "c" fn Bun__ServerRouteList__callRouteH3(
+    globalObject: *jsc.JSGlobalObject,
+    index: u32,
+    requestPtr: *Request,
+    serverObject: jsc.JSValue,
+    routeListObject: jsc.JSValue,
+    requestObject: *jsc.JSValue,
+    req: *anyopaque,
+) jsc.JSValue;
+
+extern "c" fn Bun__ServerRouteList__callRouteH2(
     globalObject: *jsc.JSGlobalObject,
     index: u32,
     requestPtr: *Request,

--- a/src/runtime/webcore.zig
+++ b/src/runtime/webcore.zig
@@ -48,6 +48,7 @@ pub const NetworkSink = streams.NetworkSink;
 pub const HTTPResponseSink = streams.HTTPResponseSink;
 pub const HTTPSResponseSink = streams.HTTPSResponseSink;
 pub const H3ResponseSink = streams.H3ResponseSink;
+pub const H2ResponseSink = streams.H2ResponseSink;
 pub const HTTPServerWritable = streams.HTTPServerWritable;
 
 comptime {

--- a/src/runtime/webcore/streams.zig
+++ b/src/runtime/webcore/streams.zig
@@ -11,6 +11,7 @@ pub const Start = union(Tag) {
     HTTPSResponseSink: void,
     HTTPResponseSink: void,
     H3ResponseSink: void,
+    H2ResponseSink: void,
     NetworkSink: void,
     ready: void,
     owned_and_done: bun.ByteList,
@@ -25,6 +26,7 @@ pub const Start = union(Tag) {
         HTTPSResponseSink,
         HTTPResponseSink,
         H3ResponseSink,
+        H2ResponseSink,
         NetworkSink,
         ready,
         owned_and_done,
@@ -172,7 +174,7 @@ pub const Start = union(Tag) {
                     },
                 };
             },
-            .NetworkSink, .HTTPSResponseSink, .HTTPResponseSink, .H3ResponseSink => {
+            .NetworkSink, .HTTPSResponseSink, .HTTPResponseSink, .H3ResponseSink, .H2ResponseSink => {
                 var empty = true;
                 var chunk_size: Blob.SizeType = 2048;
 
@@ -700,9 +702,13 @@ pub const Signal = struct {
     };
 };
 
-pub fn HTTPServerWritable(comptime ssl: bool, comptime http3: bool) type {
+pub fn HTTPServerWritable(comptime ssl: bool, comptime transport: RequestContextTransport) type {
     return struct {
-        const UWSResponse = if (http3) uws.H3.Response else uws.NewApp(ssl).Response;
+        const UWSResponse = switch (transport) {
+            .h3 => uws.H3.Response,
+            .h2 => uws.H2.Response,
+            .h1 => uws.NewApp(ssl).Response,
+        };
         res: ?*UWSResponse,
         buffer: bun.ByteList,
         pooled_buffer: ?*WebCore.ByteListPool.Node = null,
@@ -1329,13 +1335,18 @@ pub fn HTTPServerWritable(comptime ssl: bool, comptime http3: bool) type {
             }
         }
 
-        pub const name = if (http3) "H3ResponseSink" else if (ssl) "HTTPSResponseSink" else "HTTPResponseSink";
+        pub const name = switch (transport) {
+            .h3 => "H3ResponseSink",
+            .h2 => "H2ResponseSink",
+            .h1 => if (ssl) "HTTPSResponseSink" else "HTTPResponseSink",
+        };
         pub const JSSink = Sink.JSSink(@This(), name);
     };
 }
-pub const HTTPSResponseSink = HTTPServerWritable(true, false);
-pub const HTTPResponseSink = HTTPServerWritable(false, false);
-pub const H3ResponseSink = HTTPServerWritable(true, true);
+pub const HTTPSResponseSink = HTTPServerWritable(true, .h1);
+pub const HTTPResponseSink = HTTPServerWritable(false, .h1);
+pub const H3ResponseSink = HTTPServerWritable(true, .h3);
+pub const H2ResponseSink = HTTPServerWritable(true, .h2);
 pub const NetworkSink = struct {
     pub const new = bun.TrivialNew(@This());
     pub const deinit = bun.TrivialDeinit(@This());
@@ -1634,6 +1645,7 @@ pub const ReadResult = union(enum) {
 };
 
 const std = @import("std");
+const RequestContextTransport = @import("../server/RequestContext.zig").Transport;
 
 const bun = @import("bun");
 const FeatureFlags = bun.FeatureFlags;

--- a/src/uws/uws.zig
+++ b/src/uws/uws.zig
@@ -43,6 +43,7 @@ pub const State = @import("../uws_sys/Response.zig").State;
 pub const Loop = @import("../uws_sys/Loop.zig").Loop;
 pub const udp = @import("../uws_sys/udp.zig");
 pub const BodyReaderMixin = @import("../uws_sys/BodyReaderMixin.zig").BodyReaderMixin;
+pub const H2 = @import("../uws_sys/h2.zig");
 pub const H3 = @import("../uws_sys/h3.zig");
 pub const quic = @import("../uws_sys/quic.zig");
 
@@ -52,6 +53,7 @@ pub const ResponseKind = enum(i32) {
     tcp = 0,
     ssl = 1,
     h3 = 2,
+    h2 = 3,
 
     pub fn from(comptime ssl: bool, comptime http3: bool) ResponseKind {
         return if (http3) .h3 else if (ssl) .ssl else .tcp;

--- a/src/uws_sys/Request.zig
+++ b/src/uws_sys/Request.zig
@@ -1,9 +1,10 @@
 /// Transport-agnostic request handle. Static/file routes (and RangeRequest)
-/// take this so the same handler body serves HTTP/1.1 and HTTP/3 without
-/// `anytype` — `inline else` keeps dispatch monomorphic.
+/// take this so the same handler body serves HTTP/1.1, HTTP/2 and HTTP/3
+/// without `anytype` — `inline else` keeps dispatch monomorphic.
 pub const AnyRequest = union(enum) {
     h1: *Request,
     h3: *uws.H3.Request,
+    h2: *uws.H2.Request,
 
     pub fn header(this: AnyRequest, name: []const u8) ?[]const u8 {
         return switch (this) {

--- a/src/uws_sys/Response.zig
+++ b/src/uws_sys/Response.zig
@@ -331,20 +331,19 @@ pub const AnyResponse = union(enum) {
     SSL: *uws.NewApp(true).Response,
     TCP: *uws.NewApp(false).Response,
     H3: *H3Response,
+    H2: *H2Response,
 
     pub fn assertSSL(this: AnyResponse) *uws.NewApp(true).Response {
         return switch (this) {
             .SSL => |resp| resp,
-            .TCP => bun.Output.panic("Expected SSL response, got TCP response", .{}),
-            .H3 => bun.Output.panic("Expected SSL response, got H3 response", .{}),
+            inline else => |_, tag| bun.Output.panic("Expected SSL response, got {s} response", .{@tagName(tag)}),
         };
     }
 
     pub fn assertNoSSL(this: AnyResponse) *uws.NewApp(false).Response {
         return switch (this) {
-            .SSL => bun.Output.panic("Expected TCP response, got SSL response", .{}),
             .TCP => |resp| resp,
-            .H3 => bun.Output.panic("Expected TCP response, got H3 response", .{}),
+            inline else => |_, tag| bun.Output.panic("Expected TCP response, got {s} response", .{@tagName(tag)}),
         };
     }
 
@@ -375,6 +374,7 @@ pub const AnyResponse = union(enum) {
     pub fn socket(this: AnyResponse) *c.uws_res {
         return switch (this) {
             .H3 => bun.Output.panic("socket() is not available for HTTP/3 responses", .{}),
+            .H2 => bun.Output.panic("socket() is not available for HTTP/2 responses", .{}),
             inline else => |resp| resp.downcast(),
         };
     }
@@ -432,6 +432,7 @@ pub const AnyResponse = union(enum) {
             *uws.NewApp(true).Response => .{ .SSL = response },
             *uws.NewApp(false).Response => .{ .TCP = response },
             *H3Response => .{ .H3 = response },
+            *H2Response => .{ .H2 = response },
             else => @compileError("unreachable"),
         };
     }
@@ -451,6 +452,11 @@ pub const AnyResponse = union(enum) {
             }.onDataCallback, optional_data),
             .H3 => |resp| resp.onData(UserDataType, struct {
                 pub fn onDataCallback(user_data: UserDataType, _: *H3Response, data: []const u8, last: bool) void {
+                    @call(bun.callmod_inline, handler, .{ user_data, data, last });
+                }
+            }.onDataCallback, optional_data),
+            .H2 => |resp| resp.onData(UserDataType, struct {
+                pub fn onDataCallback(user_data: UserDataType, _: *H2Response, data: []const u8, last: bool) void {
                     @call(bun.callmod_inline, handler, .{ user_data, data, last });
                 }
             }.onDataCallback, optional_data),
@@ -522,12 +528,13 @@ pub const AnyResponse = union(enum) {
             .SSL => |resp| resp.downcastSocket().close(.failure),
             .TCP => |resp| resp.downcastSocket().close(.failure),
             .H3 => |resp| resp.forceClose(),
+            .H2 => |resp| resp.forceClose(),
         }
     }
 
     pub fn getNativeHandle(this: AnyResponse) bun.FD {
         return switch (this) {
-            .H3 => bun.invalid_fd,
+            .H3, .H2 => bun.invalid_fd,
             inline else => |resp| resp.getNativeHandle(),
         };
     }
@@ -549,11 +556,15 @@ pub const AnyResponse = union(enum) {
             pub fn h3_handler(user_data: UserDataType, offset: u64, resp: *H3Response) bool {
                 return handler(user_data, offset, .{ .H3 = resp });
             }
+            pub fn h2_handler(user_data: UserDataType, offset: u64, resp: *H2Response) bool {
+                return handler(user_data, offset, .{ .H2 = resp });
+            }
         };
         switch (this) {
             .SSL => |resp| resp.onWritable(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onWritable(UserDataType, wrapper.tcp_handler, optional_data),
             .H3 => |resp| resp.onWritable(UserDataType, wrapper.h3_handler, optional_data),
+            .H2 => |resp| resp.onWritable(UserDataType, wrapper.h2_handler, optional_data),
         }
     }
 
@@ -568,12 +579,16 @@ pub const AnyResponse = union(enum) {
             pub fn h3_handler(user_data: UserDataType, resp: *H3Response) void {
                 handler(user_data, .{ .H3 = resp });
             }
+            pub fn h2_handler(user_data: UserDataType, resp: *H2Response) void {
+                handler(user_data, .{ .H2 = resp });
+            }
         };
 
         switch (this) {
             .SSL => |resp| resp.onTimeout(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onTimeout(UserDataType, wrapper.tcp_handler, optional_data),
             .H3 => |resp| resp.onTimeout(UserDataType, wrapper.h3_handler, optional_data),
+            .H2 => |resp| resp.onTimeout(UserDataType, wrapper.h2_handler, optional_data),
         }
     }
 
@@ -588,11 +603,15 @@ pub const AnyResponse = union(enum) {
             pub fn h3_handler(user_data: UserDataType, resp: *H3Response) void {
                 handler(user_data, .{ .H3 = resp });
             }
+            pub fn h2_handler(user_data: UserDataType, resp: *H2Response) void {
+                handler(user_data, .{ .H2 = resp });
+            }
         };
         switch (this) {
             .SSL => |resp| resp.onAborted(UserDataType, wrapper.ssl_handler, optional_data),
             .TCP => |resp| resp.onAborted(UserDataType, wrapper.tcp_handler, optional_data),
             .H3 => |resp| resp.onAborted(UserDataType, wrapper.h3_handler, optional_data),
+            .H2 => |resp| resp.onAborted(UserDataType, wrapper.h2_handler, optional_data),
         }
     }
 
@@ -653,15 +672,16 @@ pub const AnyResponse = union(enum) {
         ctx: ?*uws.WebSocketUpgradeContext,
     ) *Socket {
         return switch (this) {
-            // server.upgrade() returns false before reaching here for H3
-            // (request_context.get(RequestContext) is null — the H3 ctx is a
-            // different type and upgrade_context is never set).
-            .H3 => unreachable,
+            // server.upgrade() returns false before reaching here for H2/H3
+            // (request_context.get(RequestContext) is null — the H2/H3 ctx
+            // is a different type and upgrade_context is never set).
+            .H3, .H2 => unreachable,
             inline else => |resp| resp.upgrade(Data, data, sec_web_socket_key, sec_web_socket_protocol, sec_web_socket_extensions, ctx),
         };
     }
 };
 
+pub const H2Response = uws.H2.Response;
 pub const H3Response = uws.H3.Response;
 
 pub const State = enum(u8) {

--- a/src/uws_sys/h2.zig
+++ b/src/uws_sys/h2.zig
@@ -1,0 +1,397 @@
+//! HTTP/2 server bindings. Method names mirror NewApp/NewResponse/h3.zig
+//! 1:1 so the comptime callers in server.zig and the `inline else` arms in
+//! AnyResponse see the same surface regardless of transport.
+//!
+//! Unlike H3 (separate UDP socket), H2 shares the parent SSLApp's TLS
+//! listener via ALPN — `App.create` takes the parent `*uws.NewApp(true)`
+//! rather than TLS options, and there is no `listen()`.
+
+pub const Request = opaque {
+    pub fn isAncient(_: *Request) bool {
+        return false;
+    }
+    pub fn getYield(this: *Request) bool {
+        return c.uws_h2_req_get_yield(this);
+    }
+    pub fn setYield(this: *Request, y: bool) void {
+        c.uws_h2_req_set_yield(this, y);
+    }
+    pub fn url(this: *Request) []const u8 {
+        var p: [*]const u8 = undefined;
+        return p[0..c.uws_h2_req_get_url(this, &p)];
+    }
+    pub fn method(this: *Request) []const u8 {
+        var p: [*]const u8 = undefined;
+        return p[0..c.uws_h2_req_get_method(this, &p)];
+    }
+    pub fn header(this: *Request, name: []const u8) ?[]const u8 {
+        var p: [*]const u8 = undefined;
+        const n = c.uws_h2_req_get_header(this, name.ptr, name.len, &p);
+        return if (n == 0) null else p[0..n];
+    }
+    pub fn dateForHeader(this: *Request, name: []const u8) bun.JSError!?u64 {
+        const value = this.header(name) orelse return null;
+        var s = bun.String.init(value);
+        defer s.deref();
+        const ms = try s.parseDate(bun.jsc.VirtualMachine.get().global);
+        if (!std.math.isNan(ms) and std.math.isFinite(ms) and ms >= 0) return @intFromFloat(ms);
+        return null;
+    }
+    pub fn query(this: *Request, name: []const u8) []const u8 {
+        var p: [*]const u8 = undefined;
+        return p[0..c.uws_h2_req_get_query(this, name.ptr, name.len, &p)];
+    }
+    pub fn parameter(this: *Request, idx: u16) []const u8 {
+        var p: [*]const u8 = undefined;
+        return p[0..c.uws_h2_req_get_parameter(this, idx, &p)];
+    }
+    pub fn forEachHeader(
+        this: *Request,
+        comptime Ctx: type,
+        comptime cb: fn (ctx: Ctx, name: []const u8, value: []const u8) void,
+        ctx: Ctx,
+    ) void {
+        const Wrap = struct {
+            fn each(n: [*]const u8, nl: usize, v: [*]const u8, vl: usize, ud: ?*anyopaque) callconv(.c) void {
+                cb(@ptrCast(@alignCast(ud.?)), n[0..nl], v[0..vl]);
+            }
+        };
+        c.uws_h2_req_for_each_header(this, Wrap.each, ctx);
+    }
+};
+
+pub const Response = opaque {
+    pub fn end(this: *Response, data: []const u8, close_connection: bool) void {
+        c.uws_h2_res_end(this, data.ptr, data.len, close_connection);
+    }
+    pub fn tryEnd(this: *Response, data: []const u8, total: usize, close_connection: bool) bool {
+        return c.uws_h2_res_try_end(this, data.ptr, data.len, total, close_connection);
+    }
+    pub fn endWithoutBody(this: *Response, close_connection: bool) void {
+        c.uws_h2_res_end_without_body(this, close_connection);
+    }
+    pub fn endStream(this: *Response, close_connection: bool) void {
+        c.uws_h2_res_end_stream(this, close_connection);
+    }
+    pub fn endSendFile(this: *Response, write_offset: u64, close_connection: bool) void {
+        c.uws_h2_res_end_sendfile(this, write_offset, close_connection);
+    }
+    pub fn write(this: *Response, data: []const u8) WriteResult {
+        var len: usize = data.len;
+        return if (c.uws_h2_res_write(this, data.ptr, &len)) .{ .want_more = len } else .{ .backpressure = len };
+    }
+    pub fn writeStatus(this: *Response, status: []const u8) void {
+        c.uws_h2_res_write_status(this, status.ptr, status.len);
+    }
+    pub fn writeHeader(this: *Response, key: []const u8, value: []const u8) void {
+        c.uws_h2_res_write_header(this, key.ptr, key.len, value.ptr, value.len);
+    }
+    pub fn writeHeaderInt(this: *Response, key: []const u8, value: u64) void {
+        c.uws_h2_res_write_header_int(this, key.ptr, key.len, value);
+    }
+    pub fn writeMark(this: *Response) void {
+        c.uws_h2_res_write_mark(this);
+    }
+    pub fn markWroteContentLengthHeader(this: *Response) void {
+        c.uws_h2_res_mark_wrote_content_length_header(this);
+    }
+    pub fn writeContinue(this: *Response) void {
+        c.uws_h2_res_write_continue(this);
+    }
+    pub fn flushHeaders(this: *Response, immediate: bool) void {
+        c.uws_h2_res_flush_headers(this, immediate);
+    }
+    pub fn pause(this: *Response) void {
+        c.uws_h2_res_pause(this);
+    }
+    pub fn @"resume"(this: *Response) void {
+        c.uws_h2_res_resume(this);
+    }
+    pub fn timeout(this: *Response, seconds: u8) void {
+        c.uws_h2_res_timeout(this, seconds);
+    }
+    pub fn resetTimeout(this: *Response) void {
+        c.uws_h2_res_reset_timeout(this);
+    }
+    pub fn getWriteOffset(this: *Response) u64 {
+        return c.uws_h2_res_get_write_offset(this);
+    }
+    pub fn overrideWriteOffset(this: *Response, off: u64) void {
+        c.uws_h2_res_override_write_offset(this, off);
+    }
+    pub fn getBufferedAmount(this: *Response) u64 {
+        return c.uws_h2_res_get_buffered_amount(this);
+    }
+    pub fn hasResponded(this: *Response) bool {
+        return c.uws_h2_res_has_responded(this);
+    }
+    pub fn state(this: *Response) State {
+        return c.uws_h2_res_state(this);
+    }
+    pub fn shouldCloseConnection(this: *Response) bool {
+        return this.state().isHttpConnectionClose();
+    }
+    pub fn isCorked(_: *Response) bool {
+        return false;
+    }
+    pub fn uncork(_: *Response) void {}
+    pub fn isConnectRequest(_: *Response) bool {
+        return false;
+    }
+    pub fn prepareForSendfile(_: *Response) void {}
+    pub fn markNeedsMore(_: *Response) void {}
+    pub fn getSocketData(this: *Response) ?*anyopaque {
+        return c.uws_h2_res_get_socket_data(this);
+    }
+    pub fn getRemoteSocketInfo(this: *Response) ?SocketAddress {
+        var addr: SocketAddress = .{ .ip = undefined, .port = undefined, .is_ipv6 = undefined };
+        var ip_ptr: [*]const u8 = undefined;
+        const len = c.uws_h2_res_get_remote_address_info(this, &ip_ptr, &addr.port, &addr.is_ipv6);
+        if (len == 0) return null;
+        addr.ip = ip_ptr[0..len];
+        return addr;
+    }
+    pub fn forceClose(this: *Response) void {
+        c.uws_h2_res_force_close(this);
+    }
+
+    pub fn onWritable(
+        this: *Response,
+        comptime UD: type,
+        comptime handler: fn (UD, u64, *Response) bool,
+        ud: UD,
+    ) void {
+        const W = struct {
+            fn cb(r: *Response, off: u64, p: ?*anyopaque) callconv(.c) bool {
+                return handler(@ptrCast(@alignCast(p.?)), off, r);
+            }
+        };
+        c.uws_h2_res_on_writable(this, W.cb, ud);
+    }
+    pub fn clearOnWritable(this: *Response) void {
+        c.uws_h2_res_clear_on_writable(this);
+    }
+    pub fn onAborted(
+        this: *Response,
+        comptime UD: type,
+        comptime handler: fn (UD, *Response) void,
+        ud: UD,
+    ) void {
+        const W = struct {
+            fn cb(r: *Response, p: ?*anyopaque) callconv(.c) void {
+                handler(@ptrCast(@alignCast(p.?)), r);
+            }
+        };
+        c.uws_h2_res_on_aborted(this, W.cb, ud);
+    }
+    pub fn clearAborted(this: *Response) void {
+        c.uws_h2_res_on_aborted(this, null, null);
+    }
+    pub fn onTimeout(
+        this: *Response,
+        comptime UD: type,
+        comptime handler: fn (UD, *Response) void,
+        ud: UD,
+    ) void {
+        const W = struct {
+            fn cb(r: *Response, p: ?*anyopaque) callconv(.c) void {
+                handler(@ptrCast(@alignCast(p.?)), r);
+            }
+        };
+        c.uws_h2_res_on_timeout(this, W.cb, ud);
+    }
+    pub fn clearTimeout(this: *Response) void {
+        c.uws_h2_res_on_timeout(this, null, null);
+    }
+    pub fn onData(
+        this: *Response,
+        comptime UD: type,
+        comptime handler: fn (UD, *Response, []const u8, bool) void,
+        ud: UD,
+    ) void {
+        const W = struct {
+            fn cb(r: *Response, ptr: [*c]const u8, len: usize, last: bool, p: ?*anyopaque) callconv(.c) void {
+                handler(@ptrCast(@alignCast(p.?)), r, if (len > 0) ptr[0..len] else "", last);
+            }
+        };
+        c.uws_h2_res_on_data(this, W.cb, ud);
+    }
+    pub fn clearOnData(this: *Response) void {
+        c.uws_h2_res_on_data(this, null, null);
+    }
+    pub fn corked(this: *Response, comptime handler: anytype, args: std.meta.ArgsTuple(@TypeOf(handler))) void {
+        _ = this;
+        @call(.auto, handler, args);
+    }
+    pub fn runCorkedWithType(this: *Response, comptime UD: type, comptime handler: fn (UD) void, ud: UD) void {
+        const W = struct {
+            fn cb(p: ?*anyopaque) callconv(.c) void {
+                handler(@ptrCast(@alignCast(p.?)));
+            }
+        };
+        c.uws_h2_res_cork(this, ud, W.cb);
+    }
+};
+
+pub const App = opaque {
+    /// Attach to an existing SSLApp. Installs the ALPN callback on its
+    /// SSL_CTX and creates a child socket context that takes over
+    /// connections which negotiated "h2".
+    pub fn create(parent: *uws.NewApp(true), idle_timeout_s: u32) ?*App {
+        return c.uws_h2_create_app(@ptrCast(parent), idle_timeout_s);
+    }
+    pub fn destroy(this: *App) void {
+        c.uws_h2_app_destroy(this);
+    }
+    pub fn close(this: *App) void {
+        c.uws_h2_app_close(this);
+    }
+    pub fn clearRoutes(this: *App) void {
+        c.uws_h2_app_clear_routes(this);
+    }
+
+    fn route(
+        comptime which: @TypeOf(.x),
+        this: *App,
+        pattern: []const u8,
+        comptime UD: type,
+        ud: UD,
+        comptime handler: fn (UD, *Request, *Response) void,
+    ) void {
+        const W = struct {
+            fn cb(res: *Response, req: *Request, p: ?*anyopaque) callconv(.c) void {
+                handler(@ptrCast(@alignCast(p.?)), req, res);
+            }
+        };
+        const f = switch (which) {
+            .get => c.uws_h2_app_get,
+            .post => c.uws_h2_app_post,
+            .put => c.uws_h2_app_put,
+            .delete => c.uws_h2_app_delete,
+            .patch => c.uws_h2_app_patch,
+            .head => c.uws_h2_app_head,
+            .options => c.uws_h2_app_options,
+            .connect => c.uws_h2_app_connect,
+            .trace => c.uws_h2_app_trace,
+            .any => c.uws_h2_app_any,
+            else => unreachable,
+        };
+        f(this, pattern.ptr, pattern.len, W.cb, ud);
+    }
+
+    pub fn get(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.get, this, p, UD, ud, h);
+    }
+    pub fn post(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.post, this, p, UD, ud, h);
+    }
+    pub fn put(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.put, this, p, UD, ud, h);
+    }
+    pub fn delete(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.delete, this, p, UD, ud, h);
+    }
+    pub fn patch(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.patch, this, p, UD, ud, h);
+    }
+    pub fn head(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.head, this, p, UD, ud, h);
+    }
+    pub fn options(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.options, this, p, UD, ud, h);
+    }
+    pub fn any(this: *App, p: []const u8, comptime UD: type, ud: UD, comptime h: fn (UD, *Request, *Response) void) void {
+        route(.any, this, p, UD, ud, h);
+    }
+    pub fn method(
+        this: *App,
+        m: bun.http.Method,
+        p: []const u8,
+        comptime UD: type,
+        ud: UD,
+        comptime h: fn (UD, *Request, *Response) void,
+    ) void {
+        switch (m) {
+            .GET => this.get(p, UD, ud, h),
+            .POST => this.post(p, UD, ud, h),
+            .PUT => this.put(p, UD, ud, h),
+            .DELETE => this.delete(p, UD, ud, h),
+            .PATCH => this.patch(p, UD, ud, h),
+            .OPTIONS => this.options(p, UD, ud, h),
+            .HEAD => this.head(p, UD, ud, h),
+            .CONNECT => route(.connect, this, p, UD, ud, h),
+            .TRACE => route(.trace, this, p, UD, ud, h),
+            else => {},
+        }
+    }
+};
+
+const c = struct {
+    const Handler = ?*const fn (*Response, *Request, ?*anyopaque) callconv(.c) void;
+    const HeaderCb = *const fn ([*]const u8, usize, [*]const u8, usize, ?*anyopaque) callconv(.c) void;
+
+    extern fn uws_h2_create_app(?*anyopaque, u32) ?*App;
+    extern fn uws_h2_app_destroy(*App) void;
+    extern fn uws_h2_app_close(*App) void;
+    extern fn uws_h2_app_clear_routes(*App) void;
+    extern fn uws_h2_app_get(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_post(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_put(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_delete(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_patch(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_head(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_options(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_connect(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_trace(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+    extern fn uws_h2_app_any(*App, [*]const u8, usize, Handler, ?*anyopaque) void;
+
+    extern fn uws_h2_res_state(*Response) State;
+    extern fn uws_h2_res_end(*Response, [*c]const u8, usize, bool) void;
+    extern fn uws_h2_res_end_stream(*Response, bool) void;
+    extern fn uws_h2_res_force_close(*Response) void;
+    extern fn uws_h2_res_try_end(*Response, [*c]const u8, usize, usize, bool) bool;
+    extern fn uws_h2_res_end_without_body(*Response, bool) void;
+    extern fn uws_h2_res_pause(*Response) void;
+    extern fn uws_h2_res_resume(*Response) void;
+    extern fn uws_h2_res_write_continue(*Response) void;
+    extern fn uws_h2_res_write_status(*Response, [*c]const u8, usize) void;
+    extern fn uws_h2_res_write_header(*Response, [*c]const u8, usize, [*c]const u8, usize) void;
+    extern fn uws_h2_res_write_header_int(*Response, [*c]const u8, usize, u64) void;
+    extern fn uws_h2_res_mark_wrote_content_length_header(*Response) void;
+    extern fn uws_h2_res_write_mark(*Response) void;
+    extern fn uws_h2_res_flush_headers(*Response, bool) void;
+    extern fn uws_h2_res_write(*Response, ?[*]const u8, *usize) bool;
+    extern fn uws_h2_res_get_write_offset(*Response) u64;
+    extern fn uws_h2_res_override_write_offset(*Response, u64) void;
+    extern fn uws_h2_res_has_responded(*Response) bool;
+    extern fn uws_h2_res_get_buffered_amount(*Response) u64;
+    extern fn uws_h2_res_reset_timeout(*Response) void;
+    extern fn uws_h2_res_timeout(*Response, u8) void;
+    extern fn uws_h2_res_end_sendfile(*Response, u64, bool) void;
+    extern fn uws_h2_res_get_socket_data(*Response) ?*anyopaque;
+    extern fn uws_h2_res_on_writable(*Response, ?*const fn (*Response, u64, ?*anyopaque) callconv(.c) bool, ?*anyopaque) void;
+    extern fn uws_h2_res_clear_on_writable(*Response) void;
+    extern fn uws_h2_res_on_aborted(*Response, ?*const fn (*Response, ?*anyopaque) callconv(.c) void, ?*anyopaque) void;
+    extern fn uws_h2_res_on_timeout(*Response, ?*const fn (*Response, ?*anyopaque) callconv(.c) void, ?*anyopaque) void;
+    extern fn uws_h2_res_on_data(*Response, ?*const fn (*Response, [*c]const u8, usize, bool, ?*anyopaque) callconv(.c) void, ?*anyopaque) void;
+    extern fn uws_h2_res_cork(*Response, ?*anyopaque, *const fn (?*anyopaque) callconv(.c) void) void;
+    extern fn uws_h2_res_get_remote_address_info(*Response, *[*]const u8, *i32, *bool) usize;
+
+    extern fn uws_h2_req_get_yield(*Request) bool;
+    extern fn uws_h2_req_set_yield(*Request, bool) void;
+    extern fn uws_h2_req_get_url(*Request, *[*]const u8) usize;
+    extern fn uws_h2_req_get_method(*Request, *[*]const u8) usize;
+    extern fn uws_h2_req_get_header(*Request, [*c]const u8, usize, *[*]const u8) usize;
+    extern fn uws_h2_req_get_query(*Request, [*c]const u8, usize, *[*]const u8) usize;
+    extern fn uws_h2_req_get_parameter(*Request, u16, *[*]const u8) usize;
+    extern fn uws_h2_req_for_each_header(*Request, HeaderCb, ?*anyopaque) void;
+};
+
+const bun = @import("bun");
+const std = @import("std");
+
+const State = @import("./Response.zig").State;
+const WriteResult = @import("./Response.zig").WriteResult;
+
+const uws = bun.uws;
+const SocketAddress = uws.SocketAddress;

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -1,0 +1,285 @@
+// HTTP/2 C ABI for Zig. Mirrors the uws_h3_* surface in libuwsockets_h3.cpp
+// 1:1 (same parameter shapes, same callback signatures) so the Zig side can
+// pattern-match NewApp/NewResponse/H3 without protocol-specific branches.
+// Kept in its own TU so HTTP/1.1, HTTP/2 and HTTP/3 stay file-level
+// separable.
+
+// clang-format off
+#include "_libusockets.h"
+
+#include <bun-uws/src/App.h>
+#include <bun-uws/src/Http2App.h>
+#include <bun-uws/src/Http2Response.h>
+#include <bun-uws/src/Http2Request.h>
+#include <string_view>
+#include <string.h>
+// clang-format on
+
+extern "C" const char* ares_inet_ntop(int af, const char* src, char* dst, size_t size);
+
+using uWS::H2App;
+using uWS::Http2Request;
+using uWS::Http2Response;
+using uWS::Http2ResponseData;
+
+/* Unified-build: libuwsockets_h3.cpp defines h2sv()/h2out() at file scope
+ * in the same TU. Keep ours in an anonymous namespace so they don't
+ * collide. */
+namespace {
+inline std::string_view h2sv(const char* p, size_t n) { return p ? std::string_view { p, n } : std::string_view {}; }
+inline size_t h2out(std::string_view v, const char** dest)
+{
+    *dest = v.empty() ? "" : v.data();
+    return v.length();
+}
+}
+
+/* Bridges invoked from HttpContext<true>/TemplatedApp so those TUs don't
+ * need to include Http2App.h. */
+extern "C" us_socket_t* uws_internal_h2_adopt(void* h2Context,
+    us_socket_t* s, int oldExtSize, char* data, int length)
+{
+    return H2App::adoptIfNegotiated((uWS::Http2Context*)h2Context, s, oldExtSize, data, length);
+}
+
+extern "C" void uws_internal_h2_close_all(void* h2Context)
+{
+    us_socket_group_close_all(((uWS::Http2Context*)h2Context)->getSocketGroup());
+}
+
+extern "C" {
+
+typedef struct uws_h2_app_s uws_h2_app_t;
+typedef struct uws_h2_res_s uws_h2_res_t;
+typedef struct uws_h2_req_s uws_h2_req_t;
+
+typedef void (*uws_h2_method_handler)(uws_h2_res_t*, uws_h2_req_t*, void*);
+
+/* ───── app ───── */
+
+uws_h2_app_t* uws_h2_create_app(uws_app_t* parent, unsigned int idle_timeout_s)
+{
+    auto* sslApp = (uWS::TemplatedApp<true>*)parent;
+    return (uws_h2_app_t*)H2App::create(sslApp, idle_timeout_s);
+}
+
+void uws_h2_app_destroy(uws_h2_app_t* app) { delete (H2App*)app; }
+bool uws_h2_constructor_failed(uws_h2_app_t* app) { return !app || ((H2App*)app)->constructorFailed(); }
+void uws_h2_app_close(uws_h2_app_t* app) { ((H2App*)app)->close(); }
+void uws_h2_app_clear_routes(uws_h2_app_t* app) { ((H2App*)app)->clearRoutes(); }
+void* uws_h2_get_native_handle(uws_h2_app_t* app) { return ((H2App*)app)->getNativeHandle(); }
+
+#define H2_ROUTE(name, method)                                                                         \
+    void uws_h2_app_##name(uws_h2_app_t* app, const char* pattern, size_t pattern_len,                 \
+        uws_h2_method_handler handler, void* user_data)                                                \
+    {                                                                                                  \
+        if (handler == nullptr) return;                                                                \
+        ((H2App*)app)->method(h2sv(pattern, pattern_len), [handler, user_data](auto* res, auto* req) { \
+            handler((uws_h2_res_t*)res, (uws_h2_req_t*)req, user_data);                                \
+        });                                                                                            \
+    }
+H2_ROUTE(get, get)
+H2_ROUTE(post, post)
+H2_ROUTE(options, options)
+H2_ROUTE(delete, del)
+H2_ROUTE(patch, patch)
+H2_ROUTE(put, put)
+H2_ROUTE(head, head)
+H2_ROUTE(connect, connect)
+H2_ROUTE(trace, trace)
+H2_ROUTE(any, any)
+#undef H2_ROUTE
+
+/* ───── response ───── */
+
+int uws_h2_res_state(uws_h2_res_t* res) { return ((Http2Response*)res)->getHttpResponseData()->state; }
+
+void uws_h2_res_end(uws_h2_res_t* res, const char* data, size_t length, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->end(h2sv(data, length), close_connection);
+}
+
+void uws_h2_res_end_stream(uws_h2_res_t* res, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->sendTerminatingChunk(close_connection);
+}
+
+void uws_h2_res_force_close(uws_h2_res_t* res)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->close();
+}
+
+bool uws_h2_res_try_end(uws_h2_res_t* res, const char* bytes, size_t len, size_t total_len, bool close)
+{
+    return ((Http2Response*)res)->tryEnd(h2sv(bytes, len), total_len, close).first;
+}
+
+void uws_h2_res_end_without_body(uws_h2_res_t* res, bool close_connection)
+{
+    Http2Response* r = (Http2Response*)res;
+    r->clearOnWritableAndAborted();
+    r->endWithoutBody(std::nullopt, close_connection);
+}
+
+void uws_h2_res_pause(uws_h2_res_t* res) { ((Http2Response*)res)->pause(); }
+void uws_h2_res_resume(uws_h2_res_t* res) { ((Http2Response*)res)->resume(); }
+void uws_h2_res_write_continue(uws_h2_res_t* res) { ((Http2Response*)res)->writeContinue(); }
+
+void uws_h2_res_write_status(uws_h2_res_t* res, const char* status, size_t length)
+{
+    ((Http2Response*)res)->writeStatus(h2sv(status, length));
+}
+
+void uws_h2_res_write_header(uws_h2_res_t* res, const char* key, size_t key_len,
+    const char* value, size_t value_len)
+{
+    ((Http2Response*)res)->writeHeader(h2sv(key, key_len), h2sv(value, value_len));
+}
+
+void uws_h2_res_write_header_int(uws_h2_res_t* res, const char* key, size_t key_len, uint64_t value)
+{
+    ((Http2Response*)res)->writeHeader(h2sv(key, key_len), value);
+}
+
+void uws_h2_res_mark_wrote_content_length_header(uws_h2_res_t* res)
+{
+    ((Http2Response*)res)->getHttpResponseData()->state |= Http2ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;
+}
+
+void uws_h2_res_write_mark(uws_h2_res_t* res) { ((Http2Response*)res)->writeMark(); }
+void uws_h2_res_flush_headers(uws_h2_res_t* res, bool) { ((Http2Response*)res)->flushHeaders(); }
+
+bool uws_h2_res_write(uws_h2_res_t* res, const char* data, size_t* length)
+{
+    size_t written = 0;
+    bool ok = ((Http2Response*)res)->write(h2sv(data, *length), &written);
+    *length = written;
+    return ok;
+}
+
+uint64_t uws_h2_res_get_write_offset(uws_h2_res_t* res) { return ((Http2Response*)res)->getWriteOffset(); }
+void uws_h2_res_override_write_offset(uws_h2_res_t* res, uint64_t off) { ((Http2Response*)res)->overrideWriteOffset(off); }
+bool uws_h2_res_has_responded(uws_h2_res_t* res) { return ((Http2Response*)res)->hasResponded(); }
+size_t uws_h2_res_get_buffered_amount(uws_h2_res_t* res) { return ((Http2Response*)res)->getBufferedAmount(); }
+
+void uws_h2_res_reset_timeout(uws_h2_res_t*) {}
+void uws_h2_res_timeout(uws_h2_res_t*, uint8_t) {}
+void uws_h2_res_end_sendfile(uws_h2_res_t* res, uint64_t, bool close)
+{
+    ((Http2Response*)res)->sendTerminatingChunk(close);
+}
+void uws_h2_res_prepare_for_sendfile(uws_h2_res_t*) {}
+bool uws_h2_res_is_connect_request(uws_h2_res_t*) { return false; }
+void* uws_h2_res_get_native_handle(uws_h2_res_t* res) { return res; }
+void* uws_h2_res_get_socket_data(uws_h2_res_t* res) { return ((Http2Response*)res)->getSocketData(); }
+
+void uws_h2_res_on_writable(uws_h2_res_t* res, bool (*h)(uws_h2_res_t*, uint64_t, void*), void* opt)
+{
+    ((Http2Response*)res)->onWritable(opt, (Http2ResponseData::OnWritableCallback)h);
+}
+void uws_h2_res_clear_on_writable(uws_h2_res_t* res) { ((Http2Response*)res)->clearOnWritable(); }
+void uws_h2_res_on_aborted(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, void*), void* opt)
+{
+    if (h)
+        ((Http2Response*)res)->onAborted(opt, (Http2ResponseData::OnAbortedCallback)h);
+    else
+        ((Http2Response*)res)->clearOnAborted();
+}
+void uws_h2_res_on_timeout(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, void*), void* opt)
+{
+    if (h)
+        ((Http2Response*)res)->onTimeout(opt, (Http2ResponseData::OnTimeoutCallback)h);
+    else
+        ((Http2Response*)res)->clearOnTimeout();
+}
+void uws_h2_res_on_data(uws_h2_res_t* res, void (*h)(uws_h2_res_t*, const char*, size_t, bool, void*), void* opt)
+{
+    ((Http2Response*)res)->onData(opt, (Http2ResponseData::OnDataCallback)h);
+}
+
+void uws_h2_res_cork(uws_h2_res_t* res, void* ctx, void (*corker)(void*))
+{
+    ((Http2Response*)res)->cork([ctx, corker]() { corker(ctx); });
+}
+void uws_h2_res_uncork(uws_h2_res_t*) {}
+bool uws_h2_res_is_corked(uws_h2_res_t*) { return false; }
+
+uint64_t uws_h2_res_get_remote_address_info(uws_h2_res_t* res, const char** dest, int* port, bool* is_ipv6)
+{
+    /* Http2Response wraps a real us_socket_t. Mirror
+     * uws_res_get_remote_address_info (libuwsockets.cpp) and the H3
+     * wrapper: us_get_remote_address_info only memcpy()s raw
+     * in_addr/in6_addr bytes into b and sets *port — dest/is_ipv6 are
+     * vestigial — so stringify with inet_ntop here so the Zig side
+     * gets a text slice, not raw address bytes. */
+    static thread_local char b[64];
+    Http2Response* r = (Http2Response*)res;
+    int ipv6 = 0;
+    auto length = us_get_remote_address_info(b, r->socket, dest, port, &ipv6);
+    if (length == 0) {
+        *dest = b;
+        *is_ipv6 = false;
+        return 0;
+    }
+    if (length == 4) {
+        ares_inet_ntop(AF_INET, b, &b[4], 64 - 4);
+        *dest = &b[4];
+        *is_ipv6 = false;
+    } else {
+        ares_inet_ntop(AF_INET6, b, &b[16], 64 - 16);
+        *dest = &b[16];
+        *is_ipv6 = true;
+    }
+    return (uint64_t)strlen(*dest);
+}
+
+/* ───── request ───── */
+
+bool uws_h2_req_is_ancient(uws_h2_req_t*) { return false; }
+bool uws_h2_req_get_yield(uws_h2_req_t* req) { return ((Http2Request*)req)->getYield(); }
+void uws_h2_req_set_yield(uws_h2_req_t* req, bool y) { ((Http2Request*)req)->setYield(y); }
+
+size_t uws_h2_req_get_url(uws_h2_req_t* req, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getFullUrl(), dest);
+}
+
+size_t uws_h2_req_get_method(uws_h2_req_t* req, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getMethod(), dest);
+}
+
+size_t uws_h2_req_get_header(uws_h2_req_t* req, const char* lower, size_t lower_len, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getHeader(h2sv(lower, lower_len)), dest);
+}
+
+void uws_h2_req_for_each_header(uws_h2_req_t* req,
+    void (*cb)(const char*, size_t, const char*, size_t, void*),
+    void* user_data)
+{
+    ((Http2Request*)req)->forEachHeader([cb, user_data](std::string_view name, std::string_view value) {
+        cb(name.empty() ? "" : name.data(), name.length(),
+            value.empty() ? "" : value.data(), value.length(), user_data);
+    });
+}
+
+size_t uws_h2_req_get_query(uws_h2_req_t* req, const char* key, size_t key_len, const char** dest)
+{
+    return h2out(key ? ((Http2Request*)req)->getQuery(h2sv(key, key_len))
+                     : ((Http2Request*)req)->getQuery(),
+        dest);
+}
+
+size_t uws_h2_req_get_parameter(uws_h2_req_t* req, unsigned short index, const char** dest)
+{
+    return h2out(((Http2Request*)req)->getParameter(index), dest);
+}
+
+} // extern "C"

--- a/src/uws_sys/libuwsockets_h2.cpp
+++ b/src/uws_sys/libuwsockets_h2.cpp
@@ -22,9 +22,10 @@ using uWS::Http2Request;
 using uWS::Http2Response;
 using uWS::Http2ResponseData;
 
-/* Unified-build: libuwsockets_h3.cpp defines h2sv()/h2out() at file scope
- * in the same TU. Keep ours in an anonymous namespace so they don't
- * collide. */
+/* Unified-build: libuwsockets_h3.cpp defines equivalent string-view
+ * helpers (sv()/ffi_sv()) at file scope in the same TU. The h2 prefix
+ * already disambiguates; the anonymous namespace is belt-and-suspenders
+ * for that collision class. */
 namespace {
 inline std::string_view h2sv(const char* p, size_t n) { return p ? std::string_view { p, n } : std::string_view {}; }
 inline size_t h2out(std::string_view v, const char** dest)

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -1,0 +1,591 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { bunEnv, bunExe, tls } from "harness";
+import { once } from "node:events";
+import nodetls from "node:tls";
+
+// Bun.serve({ h2: true }) attaches to the HTTP/1 TLS listener via ALPN:
+// the server offers "h2,http/1.1" and adopts sockets that negotiate "h2"
+// into the HTTP/2 child context. Every fetch here forces protocol: "h2"
+// so a silent fallback to HTTP/1.1 surfaces as a protocol mismatch (the
+// response's Via-like assertion on the server side checks req.url,
+// headers, and body framing work end-to-end over the H2 path).
+//
+// Uses Bun's own HTTP/2 fetch client so both sides exercise lshpack.
+
+const fetchH2 = (port: number, path: string, init: RequestInit = {}) =>
+  fetch(`https://127.0.0.1:${port}${path}`, {
+    ...init,
+    // @ts-expect-error protocol is a Bun extension
+    protocol: "h2",
+    tls: { rejectUnauthorized: false },
+  } as RequestInit);
+
+const fixture = `
+import { serve } from "bun";
+
+const big = Buffer.alloc(256 * 1024, "abcdefghijklmnop");
+const deferred = Promise.withResolvers();
+
+const server = serve({
+  port: 0,
+  tls: ${JSON.stringify(tls)},
+  h2: true,
+  routes: {
+    "/api/:id": req => new Response("id=" + req.params.id, {
+      headers: { "x-route": "api" },
+    }),
+    "/static": new Response("from-static-route", {
+      headers: { "content-type": "text/plain", etag: '"v1"' },
+    }),
+  },
+  async fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === "/ip") {
+      return Response.json(server.requestIP(req));
+    }
+    if (url.pathname === "/hello") {
+      return new Response("hello over h2", {
+        headers: { "x-proto": "h2", "content-type": "text/plain" },
+      });
+    }
+    if (url.pathname === "/echo") {
+      const body = await req.text();
+      return new Response(body, {
+        status: 201,
+        headers: {
+          "x-method": req.method,
+          "x-echo": req.headers.get("x-echo") ?? "",
+          "x-host": req.headers.get("host") ?? "",
+          "x-len": String(body.length),
+        },
+      });
+    }
+    if (url.pathname === "/big") {
+      return new Response(big, { headers: { "content-type": "application/octet-stream" } });
+    }
+    if (url.pathname === "/headers") {
+      return Response.json(Object.fromEntries(req.headers));
+    }
+    if (url.pathname === "/hold") {
+      await req.text();
+      await new Promise(() => {});
+    }
+    if (url.pathname === "/deferred") {
+      await deferred.promise;
+      return new Response("late");
+    }
+    if (url.pathname === "/stream") {
+      return new Response(new ReadableStream({
+        async start(ctrl) {
+          for (let i = 0; i < 4; i++) {
+            ctrl.enqueue(new TextEncoder().encode("chunk" + i + ";"));
+            await Bun.sleep(1);
+          }
+          ctrl.close();
+        },
+      }));
+    }
+    return new Response("not found", { status: 404 });
+  },
+});
+console.log(server.port);
+for await (const line of console) {
+  if (line === "graceful") { server.stop(false); console.log("ack"); continue; }
+  if (line === "abrupt")   { server.stop(true);  console.log("ack"); continue; }
+  if (line === "release")  { deferred.resolve(); console.log("ack"); continue; }
+  if (line === "stop")     { server.stop(true);  break; }
+}
+`;
+
+async function withServer(body: (port: number, send: (cmd: string) => Promise<void>) => Promise<void>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const reader = proc.stdout.getReader();
+  let buf = "";
+  const readLine = async (): Promise<string> => {
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing a line");
+      buf += new TextDecoder().decode(value);
+    }
+    const nl = buf.indexOf("\n");
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    return line;
+  };
+  const port = parseInt(await readLine(), 10);
+  if (!Number.isFinite(port)) throw new Error("bad port");
+  // Send a control command and wait for the server's "ack" so the
+  // caller knows the effect (GOAWAY written, deferred resolved, …)
+  // has happened before it proceeds.
+  const send = async (cmd: string) => {
+    proc.stdin.write(cmd + "\n");
+    proc.stdin.flush();
+    const ack = await readLine();
+    if (ack !== "ack") throw new Error("expected ack, got " + JSON.stringify(ack));
+  };
+  let bodyErr: unknown;
+  try {
+    await body(port, send);
+  } catch (e) {
+    bodyErr = e;
+  }
+  reader.releaseLock();
+  proc.stdin.write("stop\n");
+  proc.stdin.end();
+  const exitCode = await proc.exited;
+  // Surface the fetch error first (it's the symptom the test cares
+  // about); the server's exit code is the root cause and stderr is
+  // already inherited so the crash is visible either way.
+  if (bodyErr) throw bodyErr;
+  expect(exitCode).toBe(0);
+}
+
+describe("Bun.serve h2: true", () => {
+  test("simple GET over ALPN h2", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/hello");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-proto")).toBe("h2");
+      expect(res.headers.get("content-type")).toBe("text/plain");
+      expect(await res.text()).toBe("hello over h2");
+    });
+  });
+
+  test("POST body + response headers echoed", async () => {
+    await withServer(async port => {
+      const payload = Buffer.alloc(9000, "Z").toString();
+      const res = await fetchH2(port, "/echo", {
+        method: "POST",
+        headers: { "x-echo": "roundtrip", "content-type": "text/plain" },
+        body: payload,
+      });
+      expect(res.status).toBe(201);
+      expect(res.headers.get("x-method")).toBe("POST");
+      expect(res.headers.get("x-echo")).toBe("roundtrip");
+      // :authority → host synthesis on the server side
+      expect(res.headers.get("x-host")).toContain("127.0.0.1");
+      expect(res.headers.get("x-len")).toBe(String(payload.length));
+      expect(await res.text()).toBe(payload);
+    });
+  });
+
+  test("request headers decode via HPACK and reach the handler", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/headers", {
+        headers: {
+          "x-a": "1",
+          "x-b": "two",
+          "accept": "application/json",
+        },
+      });
+      expect(res.status).toBe(200);
+      const got = (await res.json()) as Record<string, string>;
+      expect(got["x-a"]).toBe("1");
+      expect(got["x-b"]).toBe("two");
+      expect(got["accept"]).toBe("application/json");
+      expect(got["host"]).toContain("127.0.0.1");
+    });
+  });
+
+  test("user routes and static routes are mirrored onto the H2 router", async () => {
+    await withServer(async port => {
+      const r1 = await fetchH2(port, "/api/bun");
+      expect(r1.headers.get("x-route")).toBe("api");
+      expect(await r1.text()).toBe("id=bun");
+
+      const r2 = await fetchH2(port, "/static");
+      expect(r2.status).toBe(200);
+      expect(r2.headers.get("etag")).toBe('"v1"');
+      expect(await r2.text()).toBe("from-static-route");
+    });
+  });
+
+  test("multi-frame response body (>16KiB) with flow control", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/big");
+      expect(res.status).toBe(200);
+      const buf = new Uint8Array(await res.arrayBuffer());
+      expect(buf.length).toBe(256 * 1024);
+      // verify content integrity — 16-byte repeating pattern
+      const want = createHash("sha1")
+        .update(Buffer.alloc(256 * 1024, "abcdefghijklmnop"))
+        .digest("hex");
+      const got = createHash("sha1").update(buf).digest("hex");
+      expect(got).toBe(want);
+    });
+  });
+
+  test("streamed ReadableStream response arrives intact", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/stream");
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("chunk0;chunk1;chunk2;chunk3;");
+    });
+  });
+
+  test("multiple requests multiplex on one TLS connection", async () => {
+    await withServer(async port => {
+      // Bun's H2 fetch client pools connections per origin; firing these
+      // concurrently exercises multiplexing + HPACK dynamic-table reuse.
+      const results = await Promise.all(
+        Array.from({ length: 8 }, (_, i) => fetchH2(port, "/api/" + i).then(r => r.text())),
+      );
+      expect(results).toEqual(Array.from({ length: 8 }, (_, i) => "id=" + i));
+    });
+  });
+
+  test("server.requestIP(req) returns the peer's textual address", async () => {
+    await withServer(async port => {
+      const res = await fetchH2(port, "/ip");
+      expect(res.status).toBe(200);
+      const info = (await res.json()) as { address: string; port: number; family: string };
+      // Loopback over either stack; what matters is a well-formed text
+      // address (not raw in_addr bytes) and a real ephemeral port.
+      expect(["127.0.0.1", "::1", "::ffff:127.0.0.1"]).toContain(info.address);
+      expect(info.family === "IPv4" || info.family === "IPv6").toBe(true);
+      expect(info.port).toBeGreaterThan(0);
+    });
+  });
+
+  test("HTTP/1.1 still works on the same listener when h2 is enabled", async () => {
+    await withServer(async port => {
+      // Force http/1.1 so the assertion stays meaningful once fetch's
+      // default starts offering h2: proves the ALPN cb falls through to
+      // http/1.1 and the H1 parser on the same TLS port still works.
+      const res = await fetch(`https://127.0.0.1:${port}/hello`, {
+        // @ts-expect-error protocol/tls are Bun extensions
+        protocol: "http1.1",
+        tls: { rejectUnauthorized: false },
+      } as RequestInit);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello over h2");
+    });
+  });
+
+  // Raw TLS+H2 client for wire-level / lifecycle assertions. Speaks just
+  // enough HPACK (static-table literals) to issue a single request and
+  // parses inbound frames into {type, flags, sid, payload}. `pong()`
+  // writes a PING and resolves on the ACK — a deterministic barrier
+  // proving the server processed everything written before it.
+  type RawFrame = { type: number; flags: number; sid: number; payload: Buffer };
+  async function rawH2(port: number) {
+    const frame = (type: number, flags: number, sid: number, payload: Buffer = Buffer.alloc(0)) => {
+      const hdr = Buffer.alloc(9);
+      hdr.writeUIntBE(payload.length, 0, 3);
+      hdr[3] = type;
+      hdr[4] = flags;
+      hdr.writeUInt32BE(sid, 5);
+      return Buffer.concat([hdr, payload]);
+    };
+    const request = (sid: number, method: "GET" | "POST", path: string, endStream: boolean) => {
+      const authority = `127.0.0.1:${port}`;
+      const hpack = Buffer.concat([
+        Buffer.from([method === "GET" ? 0x82 : 0x83, 0x87]), // :method idx, :scheme https idx7
+        Buffer.from([0x44, path.length]), // :path literal, name idx 4
+        Buffer.from(path),
+        Buffer.from([0x41, authority.length]), // :authority literal, name idx 1
+        Buffer.from(authority),
+      ]);
+      sock.write(frame(0x01, 0x04 | (endStream ? 0x01 : 0), sid, hpack));
+    };
+    const sock = nodetls.connect({ host: "127.0.0.1", port, ALPNProtocols: ["h2"], rejectUnauthorized: false });
+    await once(sock, "secureConnect");
+    expect(sock.alpnProtocol).toBe("h2");
+    sock.write(Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"));
+    sock.write(frame(0x04, 0, 0)); // empty client SETTINGS
+
+    const frames: RawFrame[] = [];
+    const waiters: { pred: (f: RawFrame) => boolean; resolve: (f: RawFrame) => void }[] = [];
+    let rx = Buffer.alloc(0);
+    let off = 0;
+    sock.on("data", chunk => {
+      rx = Buffer.concat([rx, chunk]);
+      while (off + 9 <= rx.length) {
+        const len = rx.readUIntBE(off, 3);
+        if (off + 9 + len > rx.length) break;
+        const f: RawFrame = {
+          type: rx[off + 3],
+          flags: rx[off + 4],
+          sid: rx.readUInt32BE(off + 5) & 0x7fffffff,
+          payload: Buffer.from(rx.subarray(off + 9, off + 9 + len)),
+        };
+        frames.push(f);
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i].pred(f)) waiters.splice(i, 1)[0].resolve(f);
+        }
+        off += 9 + len;
+      }
+    });
+    const waitFor = (pred: (f: RawFrame) => boolean): Promise<RawFrame> => {
+      const hit = frames.find(pred);
+      if (hit) return Promise.resolve(hit);
+      return new Promise(resolve => waiters.push({ pred, resolve }));
+    };
+    const pong = async () => {
+      sock.write(frame(0x06, 0, 0, Buffer.alloc(8)));
+      await waitFor(f => f.type === 0x06 && !!(f.flags & 0x01));
+    };
+    return { sock, frame, request, frames, waitFor, pong };
+  }
+
+  test("request terminated by a trailer section delivers body to the handler", async () => {
+    // RFC 9113 §8.1: HEADERS → DATA (no END_STREAM) → HEADERS(trailers,
+    // END_STREAM). gRPC clients, Node http2 with the trailers option,
+    // and `curl --trailer` all terminate this way. The server must
+    // dispatch last=true to the body callback from the trailers
+    // branch, not only from DATA(END_STREAM), or `await req.text()`
+    // never resolves.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      h2.request(1, "POST", "/echo", false);
+      h2.sock.write(h2.frame(0x00, 0x00, 1, Buffer.from("trailed-body"))); // DATA, no END_STREAM
+      // Trailer HEADERS carrying END_STREAM. HPACK literal-without-
+      // indexing (0x00 prefix): name len, name, value len, value.
+      const trailer = Buffer.concat([
+        Buffer.from([0x00, "x-trailer".length]),
+        Buffer.from("x-trailer"),
+        Buffer.from(["t".length]),
+        Buffer.from("t"),
+      ]);
+      h2.sock.write(h2.frame(0x01, 0x04 | 0x01, 1, trailer)); // HEADERS, END_HEADERS|END_STREAM
+
+      // /echo returns the body it read; getting a DATA(END_STREAM)
+      // back proves req.text() resolved with what we sent.
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("trailed-body");
+      h2.sock.destroy();
+    });
+  });
+
+  test("SETTINGS_INITIAL_WINDOW_SIZE delta that overflows a stream window → GOAWAY(FLOW_CONTROL_ERROR)", async () => {
+    // RFC 9113 §6.9.2: a change to SETTINGS_INITIAL_WINDOW_SIZE that
+    // causes any flow-control window to exceed 2³¹-1 MUST be treated
+    // as a connection FLOW_CONTROL_ERROR. Without the int64 widening
+    // guard the int32 add hits UB (UBSan trap on ASAN builds).
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // 1. INITIAL_WINDOW_SIZE = 0 so new streams start at 0.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0)));
+      // 2. Open stream 1 on /hold (handler parks; stream stays open).
+      h2.request(1, "POST", "/hold", false);
+      // 3. WINDOW_UPDATE stream 1 by 2³¹-1 → sendWindow = INT32_MAX.
+      const inc = Buffer.alloc(4);
+      inc.writeUInt32BE(0x7fffffff, 0);
+      h2.sock.write(h2.frame(0x08, 0, 1, inc));
+      // 4. INITIAL_WINDOW_SIZE = 2³¹-1 → delta = 2³¹-1, would overflow.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0x7fffffff)));
+
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(3); // FLOW_CONTROL_ERROR
+      h2.sock.on("error", () => {}); // RST after GOAWAY is expected
+      h2.sock.destroy();
+    });
+  });
+
+  test("raising SETTINGS_INITIAL_WINDOW_SIZE drains backpressured streams", async () => {
+    // RFC 9113 §6.9.2: a change to INITIAL_WINDOW_SIZE adjusts every
+    // open stream's send window — equivalent to a per-stream
+    // WINDOW_UPDATE. Clients that BDP-autotune (nghttp2, Chrome) open
+    // windows this way. handleSettings must drain after applying the
+    // delta, like handleWindowUpdate does, or a stream parked on
+    // flow-control backpressure never resumes.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // INITIAL_WINDOW_SIZE=0 so stream 1 starts with sendWindow=0;
+      // open the connection window so only the per-stream window
+      // blocks the response body.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 0)));
+      const connInc = Buffer.alloc(4);
+      connInc.writeUInt32BE(1 << 20, 0);
+      h2.sock.write(h2.frame(0x08, 0, 0, connInc)); // WINDOW_UPDATE stream 0
+      h2.request(1, "GET", "/hello", true);
+      // Response HEADERS proves the handler ran; the body is parked
+      // in backpressure because sendWindow=0.
+      await h2.waitFor(f => f.type === 0x01 && f.sid === 1);
+      await h2.pong();
+      expect(h2.frames.some(f => f.type === 0x00 && f.sid === 1 && f.payload.length > 0)).toBe(false);
+
+      // Raise the per-stream window via SETTINGS — not WINDOW_UPDATE.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(4, 65535)));
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("hello over h2");
+      h2.sock.destroy();
+    });
+  });
+
+  test("DATA after END_STREAM is rejected with RST_STREAM(STREAM_CLOSED)", async () => {
+    // RFC 9113 §5.1: DATA in half-closed(remote) MUST be a STREAM_CLOSED
+    // stream error. The server's async handler keeps the stream open
+    // (server side hasn't responded yet), so without this guard a
+    // malicious client could re-invoke the body callback after the
+    // handler already finalised it on the first END_STREAM.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      // /hold reads the body then blocks forever so the stream stays in
+      // the server's map (half-closed remote, open local) when the
+      // violating DATA arrives.
+      h2.request(1, "POST", "/hold", false);
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("hello"))); // DATA, END_STREAM
+      await h2.pong();
+      // No spurious RST(NO_ERROR) on a cleanly-ended body.
+      expect(h2.frames.filter(f => f.type === 0x03 && f.sid === 1)).toEqual([]);
+
+      // Violate §5.1: DATA on a half-closed(remote) stream.
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("evil")));
+      const rst = await h2.waitFor(f => f.type === 0x03 && f.sid === 1);
+      expect(rst.payload.readUInt32BE(0)).toBe(5); // STREAM_CLOSED
+      h2.sock.destroy();
+    });
+  });
+
+  test("server.stop(true) force-closes live H2 connections", async () => {
+    // H2 sockets are adopted out of the H1 context into a child context
+    // via us_socket_context_adopt_socket, so closing the H1 context
+    // alone (TemplatedApp::close) would miss them. The abrupt path must
+    // walk h2ChildContext the same way it walks webSocketContexts[].
+    await withServer(async (port, send) => {
+      const h2 = await rawH2(port);
+      h2.request(1, "POST", "/hold", false);
+      h2.sock.write(h2.frame(0x00, 0x01, 1, Buffer.from("x")));
+      await h2.pong(); // server has the stream open, handler is parked
+      h2.sock.on("error", () => {}); // RST is expected
+
+      const closed = once(h2.sock, "close");
+      await send("abrupt");
+      // Without the h2ChildContext walk the socket would sit open until
+      // the 10s idle timeout; the test's default 5s timeout makes that
+      // an observable failure.
+      await closed;
+    });
+  });
+
+  test("graceful stop: in-flight H2 response completes and connection FINs", async () => {
+    // After server.stop() sends GOAWAY, an async handler's response
+    // completes via cork() outside any uSockets event — there is no
+    // on_data/on_writable epilogue to run sweep(), so cork() must
+    // shutdown the write side itself once the last stream drains,
+    // otherwise the connection idles open until the 10s timeout.
+    await withServer(async (port, send) => {
+      const h2 = await rawH2(port);
+      h2.request(1, "GET", "/deferred", true);
+      await h2.pong(); // handler is awaiting `deferred`
+
+      await send("graceful");
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(0); // NO_ERROR
+
+      const ended = once(h2.sock, "end"); // server FIN
+      await send("release");
+      // Response completes over the still-open connection. The server
+      // may split body + END_STREAM across two DATA frames, so wait
+      // for the terminator and concatenate all stream-1 DATA payloads.
+      await h2.waitFor(f => f.type === 0x00 && f.sid === 1 && !!(f.flags & 0x01));
+      const body = Buffer.concat(h2.frames.filter(f => f.type === 0x00 && f.sid === 1).map(f => f.payload));
+      expect(body.toString()).toBe("late");
+      // … and the server shuts its write side promptly (no 10s idle wait).
+      await ended;
+      h2.sock.destroy();
+    });
+  });
+
+  test("ALPN offers h2 on per-SNI SSL_CTX (tls.serverName)", async () => {
+    // With tls.serverName set, addServerName() creates a fresh per-SNI
+    // SSL_CTX. BoringSSL's sni_cb swaps ssl->ctx to it *before*
+    // ssl_negotiate_alpn reads alpn_select_cb, so the ALPN callback
+    // must be installed on that per-SNI ctx too — otherwise an SNI-
+    // routed connection silently falls back to http/1.1 and h2: true
+    // is a no-op. H3 already does this (us_quic_prepare_ssl_ctx on
+    // each SNI entry).
+    const sniFixture = `
+      import { serve } from "bun";
+      const server = serve({
+        port: 0,
+        tls: { ...${JSON.stringify(tls)}, serverName: "localhost" },
+        h2: true,
+        fetch: () => new Response("sni-ok"),
+      });
+      console.log(server.port);
+      for await (const line of console) if (line === "stop") { server.stop(true); break; }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", sniFixture],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    let buf = "";
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing port");
+      buf += new TextDecoder().decode(value);
+    }
+    reader.releaseLock();
+    const port = parseInt(buf.trim(), 10);
+
+    // Connect with SNI "localhost" so sni_cb swaps to the per-SNI ctx.
+    const sock = nodetls.connect({
+      host: "127.0.0.1",
+      port,
+      servername: "localhost",
+      ALPNProtocols: ["h2", "http/1.1"],
+      rejectUnauthorized: false,
+    });
+    await once(sock, "secureConnect");
+    expect(sock.alpnProtocol).toBe("h2");
+    sock.destroy();
+
+    proc.stdin.write("stop\n");
+    proc.stdin.end();
+    expect(await proc.exited).toBe(0);
+  });
+
+  test("h2: true without tls throws", () => {
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        // @ts-expect-error h2 is new
+        h2: true,
+        fetch: () => new Response("x"),
+      }),
+    ).toThrow(/HTTP\/2 requires 'tls'/);
+  });
+
+  test("h2: true with h1: false throws", () => {
+    // Without h3 the generic "Cannot disable h1 without enabling h3"
+    // fires first; with h3 we reach the h2-specific guard.
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        tls,
+        // @ts-expect-error h2 is new
+        h2: true,
+        h3: true,
+        h1: false,
+        fetch: () => new Response("x"),
+      }),
+    ).toThrow(/h2 requires h1/);
+  });
+});

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -4,7 +4,7 @@ import { bunEnv, bunExe, tls } from "harness";
 import { once } from "node:events";
 import nodetls from "node:tls";
 
-// Bun.serve({ h2: true }) attaches to the HTTP/1 TLS listener via ALPN:
+// Bun.serve({ http2: true }) attaches to the HTTP/1 TLS listener via ALPN:
 // the server offers "h2,http/1.1" and adopts sockets that negotiate "h2"
 // into the HTTP/2 child context. Every fetch here forces protocol: "h2"
 // so a silent fallback to HTTP/1.1 surfaces as a protocol mismatch (the
@@ -30,7 +30,7 @@ const deferred = Promise.withResolvers();
 const server = serve({
   port: 0,
   tls: ${JSON.stringify(tls)},
-  h2: true,
+  http2: true,
   routes: {
     "/api/:id": req => new Response("id=" + req.params.id, {
       headers: { "x-route": "api" },
@@ -147,7 +147,7 @@ async function withServer(body: (port: number, send: (cmd: string) => Promise<vo
   expect(exitCode).toBe(0);
 }
 
-describe("Bun.serve h2: true", () => {
+describe("Bun.serve http2: true", () => {
   test("simple GET over ALPN h2", async () => {
     await withServer(async port => {
       const res = await fetchH2(port, "/hello");
@@ -580,7 +580,7 @@ describe("Bun.serve h2: true", () => {
     // SSL_CTX. BoringSSL's sni_cb swaps ssl->ctx to it *before*
     // ssl_negotiate_alpn reads alpn_select_cb, so the ALPN callback
     // must be installed on that per-SNI ctx too — otherwise an SNI-
-    // routed connection silently falls back to http/1.1 and h2: true
+    // routed connection silently falls back to http/1.1 and http2: true
     // is a no-op. H3 already does this (us_quic_prepare_ssl_ctx on
     // each SNI entry).
     const sniFixture = `
@@ -588,7 +588,7 @@ describe("Bun.serve h2: true", () => {
       const server = serve({
         port: 0,
         tls: { ...${JSON.stringify(tls)}, serverName: "localhost" },
-        h2: true,
+        http2: true,
         fetch: () => new Response("sni-ok"),
       });
       console.log(server.port);
@@ -628,30 +628,30 @@ describe("Bun.serve h2: true", () => {
     expect(await proc.exited).toBe(0);
   });
 
-  test("h2: true without tls throws", () => {
+  test("http2: true without tls throws", () => {
     expect(() =>
       Bun.serve({
         port: 0,
-        // @ts-expect-error h2 is new
-        h2: true,
+        // @ts-expect-error http2 is new
+        http2: true,
         fetch: () => new Response("x"),
       }),
     ).toThrow(/HTTP\/2 requires 'tls'/);
   });
 
-  test("h2: true with h1: false throws", () => {
-    // Without h3 the generic "Cannot disable h1 without enabling h3"
-    // fires first; with h3 we reach the h2-specific guard.
+  test("http2: true with http1: false throws", () => {
+    // Without http3 the generic "Cannot disable http1 without enabling
+    // http3" fires first; with http3 we reach the http2-specific guard.
     expect(() =>
       Bun.serve({
         port: 0,
         tls,
-        // @ts-expect-error h2 is new
-        h2: true,
-        h3: true,
-        h1: false,
+        // @ts-expect-error http2 is new
+        http2: true,
+        http3: true,
+        http1: false,
         fetch: () => new Response("x"),
       }),
-    ).toThrow(/h2 requires h1/);
+    ).toThrow(/http2 requires http1/);
   });
 });

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -632,7 +632,6 @@ describe("Bun.serve http2: true", () => {
     expect(() =>
       Bun.serve({
         port: 0,
-        // @ts-expect-error http2 is new
         http2: true,
         fetch: () => new Response("x"),
       }),
@@ -646,7 +645,6 @@ describe("Bun.serve http2: true", () => {
       Bun.serve({
         port: 0,
         tls,
-        // @ts-expect-error http2 is new
         http2: true,
         http3: true,
         http1: false,

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -421,6 +421,47 @@ describe("Bun.serve h2: true", () => {
     });
   });
 
+  test("RST_STREAM / WINDOW_UPDATE on an idle stream → GOAWAY(PROTOCOL_ERROR)", async () => {
+    // RFC 9113 §5.1 (idle): "Receiving any frame other than HEADERS or
+    // PRIORITY on a stream in this state MUST be treated as a connection
+    // error of type PROTOCOL_ERROR." §6.4 repeats it for RST_STREAM.
+    // The *closed* case is distinct: §5.1 explicitly permits late
+    // RST_STREAM/WINDOW_UPDATE there as a race allowance.
+    const u32 = (v: number) => {
+      const b = Buffer.alloc(4);
+      b.writeUInt32BE(v, 0);
+      return b;
+    };
+    for (const [label, type, payload] of [
+      ["RST_STREAM", 0x03, u32(0)], // error code = 0
+      ["WINDOW_UPDATE", 0x08, u32(1)], // non-zero increment
+      ["WINDOW_UPDATE inc=0", 0x08, u32(0)], // §6.9 stream error — but on idle → connection error
+    ] as const) {
+      await withServer(async port => {
+        const h2 = await rawH2(port);
+        // Open and complete stream 1 so lastStreamId=1; then target stream 3 (idle).
+        h2.request(1, "GET", "/hello", true);
+        await h2.waitFor(f => f.sid === 1 && f.type === 0x00 && (f.flags & 0x1) !== 0);
+        const seen = h2.frames.length;
+        // Late frame on closed stream 1 → §5.1 MUST ignore. No GOAWAY, and
+        // no RST back on stream 1 either (would itself break §5.1's
+        // "MUST NOT send frames other than PRIORITY on a closed stream").
+        h2.sock.write(h2.frame(type, 0, 1, payload));
+        await h2.pong();
+        expect(
+          h2.frames.slice(seen).some(f => f.type === 0x07 || (f.type === 0x03 && f.sid === 1)),
+          `${label} on closed stream 1`,
+        ).toBe(false);
+        // Same frame on idle stream 3 → connection error.
+        h2.sock.write(h2.frame(type, 0, 3, payload));
+        const goaway = await h2.waitFor(f => f.type === 0x07);
+        expect(goaway.payload.readUInt32BE(4), `${label} on idle stream 3`).toBe(1);
+        h2.sock.on("error", () => {});
+        h2.sock.destroy();
+      });
+    }
+  });
+
   test("raising SETTINGS_INITIAL_WINDOW_SIZE drains backpressured streams", async () => {
     // RFC 9113 §6.9.2: a change to INITIAL_WINDOW_SIZE adjusts every
     // open stream's send window — equivalent to a per-stream

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -396,6 +396,31 @@ describe("Bun.serve h2: true", () => {
     });
   });
 
+  test("SETTINGS_ENABLE_PUSH value other than 0/1 → GOAWAY(PROTOCOL_ERROR)", async () => {
+    // RFC 9113 §6.5.2: "Any value other than 0 or 1 MUST be treated as a
+    // connection error of type PROTOCOL_ERROR." ENABLE_PUSH is a *defined*
+    // setting with a value constraint — it's not in the "unknown settings
+    // MUST be ignored" bucket even though the server never pushes.
+    await withServer(async port => {
+      const h2 = await rawH2(port);
+      const setting = (id: number, v: number) => {
+        const b = Buffer.alloc(6);
+        b.writeUInt16BE(id, 0);
+        b.writeUInt32BE(v, 2);
+        return b;
+      };
+      // ENABLE_PUSH = 0 is valid → ACK'd.
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(2, 0)));
+      await h2.pong();
+      // ENABLE_PUSH = 2 is invalid → GOAWAY(PROTOCOL_ERROR).
+      h2.sock.write(h2.frame(0x04, 0, 0, setting(2, 2)));
+      const goaway = await h2.waitFor(f => f.type === 0x07);
+      expect(goaway.payload.readUInt32BE(4)).toBe(1); // PROTOCOL_ERROR
+      h2.sock.on("error", () => {});
+      h2.sock.destroy();
+    });
+  });
+
   test("raising SETTINGS_INITIAL_WINDOW_SIZE drains backpressured streams", async () => {
     // RFC 9113 §6.9.2: a change to INITIAL_WINDOW_SIZE adjusts every
     // open stream's send window — equivalent to a per-stream


### PR DESCRIPTION
`Bun.serve({ http2: true, tls: ... })` now offers `h2,http/1.1` via ALPN on the existing TLS listener. Connections that negotiate `h2` are adopted from the HTTP/1 socket group into an HTTP/2 group; everything else continues to speak HTTP/1.1 on the same port.

```ts
Bun.serve({
  port: 0,
  tls: { cert, key },
  http2: true,
  fetch: req => new Response("hello"),
});
```

## How it's wired

The interface mirrors what `http3: true` already does, so Zig's `AnyResponse`/`AnyRequest` `inline else` dispatch works unchanged and `server.zig` doesn't need protocol-specific branches beyond construction.

**uWebSockets** (`packages/bun-uws/src/Http2*.h`)
- `H2App` / `Http2Context` / `Http2Response` / `Http2Request` mirror `Http3*`.
- `Http2Context` is a heap struct with an embedded `us_socket_group_t` + static `h2VTable`, same shape as `HttpContext<SSL>` post-#29932. `H2App::create()` installs an ALPN select cb on the parent SSLApp's root `sslCtx` and each per-SNI `domainCtx` (`addServerName` propagates it to new ones — `sni_cb` swaps `ssl->ctx` before BoringSSL reads `alpn_select_cb`, so every ctx needs a copy).
- `HttpContext<true>::onData` checks ALPN at the top of each read; on `h2` it destructs the H1 per-socket state, `us_socket_adopt`s the socket into the H2 group (kind `.dynamic` → `h2VTable`), and dispatches the initial bytes (preface + client SETTINGS). The `SSL*` stays on the socket so TLS decryption continues transparently.
- Per-connection state (lshpack enc/dec, stream map, flow-control windows, frame-parse accumulator) lives in the adopted socket's ext. `Http2Response` is heap-allocated per stream.
- Frame parser handles DATA / HEADERS / CONTINUATION / SETTINGS / WINDOW_UPDATE / PING / RST_STREAM / GOAWAY / PRIORITY per RFC 9113. HPACK via `lshpack` (same library the fetch client uses).
- Stream teardown is deferred to the connection's next event (matching how H3 defers to lsquic's `process_conns()`), so Zig callers can touch the response handle after `end()`/`tryEnd()` returns.

**C ABI** (`src/uws_sys/libuwsockets_h2.cpp`): `uws_h2_*` mirrors `uws_h3_*` 1:1.

**Zig** (`src/uws_sys/h2.zig`): mirrors `h3.zig`. `AnyResponse`/`AnyRequest`/`ResponseKind`/`UWSResponseKind` gain `.H2`/`.h2` arms. `RequestContext`'s transport parameter becomes an enum `{h1,h2,h3}`; the shared stream-multiplexed branches (body terminated by END_STREAM, connection-specific headers stripped, onAborted post-completion) are keyed on `transport != .h1` so H2 and H3 share them.

**server.zig** wires `h2_app` alongside `h3_app`: created against the parent SSLApp (no separate `listen()`), routes mirrored in `setRoutes`, GOAWAY on graceful `stop`, force-close on abrupt stop via `TemplatedApp::close()` walking the H2 group like it walks WS groups, freed in `deinit`.

## Rebases

**onto #29932** (`us_socket_context_t` → embedded `us_socket_group_t` + static vtable + kind-byte dispatch):
- `Http2Context` went from a reinterpret_cast over `us_socket_context_t` to a real heap struct with `group{}` + `data` members and static `onOpen`/`onData`/… handlers in `h2VTable` — direct mirror of `HttpContext<SSL>`'s new shape.
- Adoption: `us_socket_context_adopt_socket` → `us_socket_adopt(s, &h2ctx->group, US_SOCKET_KIND_DYNAMIC, …)`. `dynamic` routes through `group->vtable`; the SSL* carried over on `s->ssl` keeps TLS decryption working.
- Per-socket calls dropped the leading `ssl` arg (`us_socket_is_closed(s)`, `us_socket_ext(s)`, …).
- ALPN/SNI: the SNI tree moved from the SSL socket context to the listen socket, and per-SNI `SSL_CTX` is now created inside `TemplatedApp::addServerName`; the `installH2Alpn` call moved there.
- `TemplatedApp::close()`: `us_socket_context_close(h2ChildContext)` → `us_socket_group_close_all(&h2ctx->group)`.

**onto the `src/` restructure**: `src/deps/libuwsockets_h2.cpp` → `src/uws_sys/libuwsockets_h2.cpp`, `src/deps/uws/h2.zig` → `src/uws_sys/h2.zig`, `src/bun.js/api/server/` → `src/runtime/server/`, etc. No logic changes.

**onto #30583** (`h3`/`h1` → `http3`/`http1`): the option key and `ServerConfig` struct field are now `http2` to match; internal transport tags (`.h1`/`.h2`/`.h3`) and ALPN wire strings stay as-is per #30583's convention.

All HTTP/2 protocol logic (framing, HPACK, flow control, stream lifecycle, JS-reentrancy hardening) carried over unchanged.

## Verification

`test/js/bun/http/serve-http2.test.ts` exercises Bun's own HTTP/2 fetch client (`protocol: "h2"`) and a raw-TLS wire-level client against `Bun.serve({ http2: true })`:
- simple GET over ALPN h2
- POST with 9 KB body echoed back (request DATA framing + `:authority` → `host` synthesis)
- request headers decoded via HPACK reach the handler
- user routes and static routes are mirrored onto the H2 router
- 256 KB response body (multi-frame + flow control)
- streamed `ReadableStream` response
- 8 concurrent requests multiplexed on one TLS connection
- `server.requestIP(req)` returns a textual address
- HTTP/1.1 still works on the same listener (ALPN fallback)
- request terminated by a trailer section (gRPC-style) delivers body
- §6.9.2 window-delta overflow → `GOAWAY(FLOW_CONTROL_ERROR)`
- §6.5.2 `SETTINGS_ENABLE_PUSH` value ≠ 0/1 → `GOAWAY(PROTOCOL_ERROR)`
- §5.1/§6.4 RST_STREAM / WINDOW_UPDATE on idle stream → `GOAWAY(PROTOCOL_ERROR)`; on closed stream → ignored
- raised `SETTINGS_INITIAL_WINDOW_SIZE` drains backpressured streams
- DATA after END_STREAM → `RST_STREAM(STREAM_CLOSED)`
- `server.stop(true)` force-closes live H2 connections
- graceful stop: in-flight response completes and the connection FINs
- ALPN offers h2 on per-SNI `SSL_CTX` (`tls.serverName`)
- `http2: true` without `tls` / with `http1: false` throws
