### PR TITLE
Clear pending exception before reporting stdio construction failure

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -2582,8 +2582,8 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdioWriteStream, callData, globalObject->globalThis(), args);
     if (auto* exception = scope.exception()) {
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return jsUndefined();
     }
 
@@ -2643,8 +2643,8 @@ static JSValue constructStdin(VM& vm, JSObject* processObject)
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdinStream, callData, globalObject, args);
     if (auto* exception = scope.exception()) {
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         (void)scope.tryClearException();
+        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
         return jsUndefined();
     }
     return result;

--- a/src/bun.js/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/bun.js/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -192,8 +192,9 @@ void JSNodeHTTPServerSocket::onDrain()
         auto* globalObject = defaultGlobalObject(this->globalObject());
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
         us_socket_buffered_js_write(this->socket, this->is_ssl, this->ended, &this->streamBuffer, globalObject, JSValue::encode(JSC::jsUndefined()), JSValue::encode(JSC::jsUndefined()));
-        if (scope.exception()) {
-            globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
+        if (auto* exception = scope.exception()) {
+            (void)scope.tryClearException();
+            globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
             return;
         }
         bufferedSize = this->streamBuffer.bufferedSize();
@@ -244,8 +245,9 @@ void JSNodeHTTPServerSocket::onData(const char* data, int length, bool last)
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
         JSC::JSUint8Array* buffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(data), length));
         auto chunk = JSC::JSValue(buffer);
-        if (scope.exception()) {
-            globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
+        if (auto* exception = scope.exception()) {
+            (void)scope.tryClearException();
+            globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
             return;
         }
         gcProtect(chunk);

--- a/test/js/node/process/process-stdio-stack-overflow-fixture.js
+++ b/test/js/node/process/process-stdio-stack-overflow-fixture.js
@@ -1,0 +1,20 @@
+// Exercise lazy process.stdin / process.stdout / process.stderr creation near
+// the stack limit. The property callbacks that create these streams report the
+// exception if stream construction fails with a stack overflow; that reporting
+// path must not observe the exception as still pending.
+const which = process.argv[2];
+function F(a, ...b) {
+  if (!new.target) throw 0;
+  const C = this.constructor;
+  try {
+    new C(a, F, this, this);
+  } catch {}
+  try {
+    if (which === "stdin") void process.stdin;
+    else if (which === "stdout") void process.stdout;
+    else if (which === "stderr") void process.stderr;
+    else if (which === "openStdin") process.openStdin();
+  } catch {}
+  process.reallyExit(0);
+}
+new F();

--- a/test/js/node/process/process-stdio-stack-overflow-fixture.js
+++ b/test/js/node/process/process-stdio-stack-overflow-fixture.js
@@ -1,7 +1,10 @@
 // Exercise lazy process.stdin / process.stdout / process.stderr creation near
 // the stack limit. The property callbacks that create these streams report the
 // exception if stream construction fails with a stack overflow; that reporting
-// path must not observe the exception as still pending.
+// path must not observe the exception as still pending when it re-enters JS
+// to invoke the uncaughtException listener (Interpreter::executeCallImpl
+// asserts no pending exception on entry).
+process.on("uncaughtException", () => {});
 const which = process.argv[2];
 function F(a, ...b) {
   if (!new.target) throw 0;

--- a/test/js/node/process/process-stdio-stack-overflow.test.ts
+++ b/test/js/node/process/process-stdio-stack-overflow.test.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "path";
+
+test.each(["stdin", "stdout", "stderr", "openStdin"])(
+  "process.%s lazy init near stack limit does not assert",
+  which => {
+    const { stdout, stderr, signalCode } = spawnSync({
+      cmd: [bunExe(), path.join(import.meta.dir, "process-stdio-stack-overflow-fixture.js"), which],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "pipe",
+    });
+    expect(stdout.toString()).not.toContain("ASSERTION FAILED");
+    expect(stderr.toString()).not.toContain("ASSERTION FAILED");
+    expect(signalCode).toBeUndefined();
+  },
+);

--- a/test/js/node/process/process-stdio-stack-overflow.test.ts
+++ b/test/js/node/process/process-stdio-stack-overflow.test.ts
@@ -6,15 +6,13 @@ import path from "path";
 test.each(["stdin", "stdout", "stderr", "openStdin"])(
   "process.%s lazy init near stack limit does not assert",
   which => {
-    const { stdout, stderr, signalCode } = spawnSync({
+    const { stderr, signalCode } = spawnSync({
       cmd: [bunExe(), path.join(import.meta.dir, "process-stdio-stack-overflow-fixture.js"), which],
       env: bunEnv,
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
       stdin: "pipe",
     });
-    expect(stdout.toString()).not.toContain("ASSERTION FAILED");
-    expect(stderr.toString()).not.toContain("ASSERTION FAILED");
-    expect(signalCode).toBeUndefined();
+    expect({ signalCode, stderr: stderr.toString() }).toEqual({ signalCode: undefined, stderr: expect.any(String) });
   },
 );

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -169,7 +169,8 @@ describe.concurrent("process-stdio", () => {
         stderr: "pipe",
         stdin: "pipe",
       });
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).not.toContain("ASSERTION FAILED");
       expect(stderr).not.toContain("ASSERTION FAILED");
       expect(proc.signalCode).toBeNull();
       expect(exitCode).toBe(0);

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,22 +158,4 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
-
-  test.concurrent.each(["stdin", "stdout", "stderr", "openStdin"])(
-    "process.%s lazy init near stack limit does not assert",
-    async which => {
-      await using proc = spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "process-stdio-stack-overflow-fixture.js"), which],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout).not.toContain("ASSERTION FAILED");
-      expect(stderr).not.toContain("ASSERTION FAILED");
-      expect(proc.signalCode).toBeNull();
-      expect(exitCode).toBe(0);
-    },
-  );
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -158,4 +158,21 @@ describe.concurrent("process-stdio", () => {
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
   });
+
+  test.concurrent.each(["stdin", "stdout", "stderr", "openStdin"])(
+    "process.%s lazy init near stack limit does not assert",
+    async which => {
+      await using proc = spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "process-stdio-stack-overflow-fixture.js"), which],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("ASSERTION FAILED");
+      expect(proc.signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
When lazy construction of `process.stdin`/`process.stdout`/`process.stderr` throws (e.g. a stack overflow near the recursion limit), the exception was being passed to `reportUncaughtExceptionAtEventLoop` while still pending on the VM. If anything in the error-reporting path re-enters the interpreter — e.g. invoking a `process.on('uncaughtException')` listener — `Interpreter::executeCallImpl` trips `scope.assertNoException()` on entry.

Found by Fuzzilli (fingerprint `2b08d737dd2d54aa`). Deterministic repro:

```js
process.on("uncaughtException", () => {});
function F(a, ...b) {
  if (!new.target) throw 0;
  try { new this.constructor(a, F, this, this); } catch {}
  try { void process.stdin; } catch {}
  process.reallyExit(0);
}
new F();
```

Clear the exception before reporting it — matching the ordering used elsewhere (e.g. `ZigGlobalObject.cpp:2994`). The `Exception*` stays alive via `VM::m_lastException` after clearing, and there's no GC safepoint between the two lines. Applied the same fix to two identical sites in `JSNodeHTTPServerSocket.cpp`.