### PR TITLE
Fix crash in `Bun.inspect` when Proxy prototype trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,46 @@ const fixture = [
         },
       },
     ),
+  () => {
+    class Foo {
+      get bar() {
+        throw new Error("bar throws");
+      }
+    }
+    const obj = new Foo();
+    Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
+    return obj;
+  },
+  () => {
+    const obj = { x: 1 };
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { y: 2 },
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf throws");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
+  () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        { y: 2 },
+        {
+          get() {
+            throw new Error("get throws");
+          },
+        },
+      ),
+    );
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` that crashed the process when inspecting / `console.log`-ing an object whose prototype chain contains a Proxy with a throwing trap.

### Repro

```js
class Foo {
  get bar() { throw new Error("bar throws"); }
}
const obj = new Foo();
Object.setPrototypeOf(obj, new Proxy(Object.getPrototypeOf(obj), {}));
console.log(obj); // crashes
```

or

```js
const obj = { x: 1 };
Object.setPrototypeOf(obj, new Proxy({ y: 2 }, {
  getPrototypeOf() { throw new Error("nope"); },
}));
console.log(obj); // crashes
```

### Root cause

Two related issues in the slow-path prototype walk of `forEachPropertyImpl`:

1. When `getPropertySlot` with `InternalMethodType::Get` goes through a Proxy and a getter on the target throws, `getPropertySlot` returns `false`. The code then did `continue` **before** the `CLEAR_IF_EXCEPTION` call, leaking the exception into subsequent iterations.
2. `iterating = iterating->getPrototype(globalObject).getObject()` calls `.getObject()` unconditionally on the result. If `getPrototype` throws (either directly via a Proxy `getPrototypeOf` trap, or because an exception was already pending from (1)), it returns an empty `JSValue`, and `.getObject()` on an empty `JSValue` calls a method on a null `JSCell*`.

The fast path directly above already handled both of these cases; this brings the slow path to parity.

### How did you verify your code works?

- Original fuzzer repro no longer crashes.
- Added regression cases to the "crash testing" fixture list in `test/js/bun/util/inspect.test.js`.
- `bun bd test test/js/bun/util/inspect.test.js` — 75 pass, 0 fail.

Found by Fuzzilli (fingerprint `3b2a3201fb5f71c3`).