### PR TITLE
Guard MessagePortChannelRegistry::m_openChannels with a Lock

### DIFF
--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
@@ -184,10 +184,4 @@ std::optional<MessageWithMessagePorts> MessagePortChannelRegistry::tryTakeMessag
     return channel->tryTakeMessageForPort(port);
 }
 
-MessagePortChannel* MessagePortChannelRegistry::existingChannelContainingPort(const MessagePortIdentifier& port)
-{
-    Locker locker { m_openChannelsLock };
-    return m_openChannels.get(port);
-}
-
 } // namespace WebCore

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.cpp
@@ -30,10 +30,14 @@
 
 // #include "Logging.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/Locker.h>
 #include <wtf/MainThread.h>
 
-// ASSERT(isMainThread()) is used alot here, and I think it may be required, but i'm not 100% sure.
-// we totally are calling these off the main thread in many cases in Bun, so ........
+// Upstream WebKit asserts isMainThread() throughout this file. Bun shares a single
+// process-global registry across the main thread and every Worker thread, so those
+// asserts are removed and every m_openChannels access is guarded by m_openChannelsLock
+// instead. The lock is always released before calling into MessagePortChannel because
+// ~MessagePortChannel() re-enters messagePortChannelDestroyed().
 
 namespace WebCore {
 
@@ -49,14 +53,15 @@ MessagePortChannelRegistry::~MessagePortChannelRegistry()
 void MessagePortChannelRegistry::didCreateMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
 {
     // LOG(MessagePorts, "Registry: Creating MessagePortChannel %p linking %s and %s", this, port1.logString().utf8().data(), port2.logString().utf8().data());
-    // ASSERT(isMainThread());
 
+    // No direct m_openChannels access here; MessagePortChannel's constructor calls
+    // messagePortChannelCreated() which takes the lock.
     MessagePortChannel::create(*this, port1, port2);
 }
 
 void MessagePortChannelRegistry::messagePortChannelCreated(MessagePortChannel& channel)
 {
-    // ASSERT(isMainThread());
+    Locker locker { m_openChannelsLock };
 
     auto result = m_openChannels.add(channel.port1(), channel);
     ASSERT_UNUSED(result, result.isNewEntry);
@@ -67,7 +72,7 @@ void MessagePortChannelRegistry::messagePortChannelCreated(MessagePortChannel& c
 
 void MessagePortChannelRegistry::messagePortChannelDestroyed(MessagePortChannel& channel)
 {
-    // ASSERT(isMainThread());
+    Locker locker { m_openChannelsLock };
 
     ASSERT(m_openChannels.get(channel.port1()) == &channel);
     ASSERT(m_openChannels.get(channel.port2()) == &channel);
@@ -80,10 +85,12 @@ void MessagePortChannelRegistry::messagePortChannelDestroyed(MessagePortChannel&
 
 void MessagePortChannelRegistry::didEntangleLocalToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote, ProcessIdentifier process)
 {
-    // ASSERT(isMainThread());
-
     // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(local);
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(local);
+    }
     if (!channel)
         return;
 
@@ -94,20 +101,25 @@ void MessagePortChannelRegistry::didEntangleLocalToRemote(const MessagePortIdent
 
 void MessagePortChannelRegistry::didDisentangleMessagePort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
     // The channel might be gone if the remote side was closed.
-    if (RefPtr channel = m_openChannels.get(port))
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(port);
+    }
+    if (channel)
         channel->disentanglePort(port);
 }
 
 void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: MessagePort %s closed in registry", port.logString().utf8().data());
 
-    RefPtr channel = m_openChannels.get(port);
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(port);
+    }
     if (!channel)
         return;
 
@@ -124,12 +136,14 @@ void MessagePortChannelRegistry::didCloseMessagePort(const MessagePortIdentifier
 
 bool MessagePortChannelRegistry::didPostMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& remoteTarget)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: Posting message to MessagePort %s in registry", remoteTarget.logString().utf8().data());
 
     // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(remoteTarget);
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(remoteTarget);
+    }
     if (!channel) {
         // LOG(MessagePorts, "Registry: Could not find MessagePortChannel for port %s; It was probably closed. Message will be dropped.", remoteTarget.logString().utf8().data());
         return false;
@@ -140,10 +154,12 @@ bool MessagePortChannelRegistry::didPostMessageToRemote(MessageWithMessagePorts&
 
 void MessagePortChannelRegistry::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& callback)
 {
-    // ASSERT(isMainThread());
-
     // The channel might be gone if the remote side was closed.
-    RefPtr channel = m_openChannels.get(port);
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(port);
+    }
     if (!channel) {
         callback({}, [] {});
         return;
@@ -154,12 +170,14 @@ void MessagePortChannelRegistry::takeAllMessagesForPort(const MessagePortIdentif
 
 std::optional<MessageWithMessagePorts> MessagePortChannelRegistry::tryTakeMessageForPort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
     // LOG(MessagePorts, "Registry: Trying to take a message for MessagePort %s", port.logString().utf8().data());
 
     // The channel might be gone if the remote side was closed.
-    auto* channel = m_openChannels.get(port);
+    RefPtr<MessagePortChannel> channel;
+    {
+        Locker locker { m_openChannelsLock };
+        channel = m_openChannels.get(port);
+    }
     if (!channel)
         return std::nullopt;
 
@@ -168,8 +186,7 @@ std::optional<MessageWithMessagePorts> MessagePortChannelRegistry::tryTakeMessag
 
 MessagePortChannel* MessagePortChannelRegistry::existingChannelContainingPort(const MessagePortIdentifier& port)
 {
-    // ASSERT(isMainThread());
-
+    Locker locker { m_openChannelsLock };
     return m_openChannels.get(port);
 }
 

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
@@ -52,8 +52,6 @@ public:
     WEBCORE_EXPORT void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
     WEBCORE_EXPORT std::optional<MessageWithMessagePorts> tryTakeMessageForPort(const MessagePortIdentifier&);
 
-    WEBCORE_EXPORT MessagePortChannel* existingChannelContainingPort(const MessagePortIdentifier&);
-
     WEBCORE_EXPORT void messagePortChannelCreated(MessagePortChannel&);
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 

--- a/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
+++ b/src/bun.js/bindings/webcore/MessagePortChannelRegistry.h
@@ -31,6 +31,7 @@
 #include "ProcessIdentifier.h"
 #include <wtf/HashMap.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Lock.h>
 
 namespace WebCore {
 
@@ -57,7 +58,11 @@ public:
     WEBCORE_EXPORT void messagePortChannelDestroyed(MessagePortChannel&);
 
 private:
-    UncheckedKeyHashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels;
+    // Upstream WebKit only ever touches this registry on the main thread. Bun runs each
+    // Worker on its own thread and shares a single process-global registry, so concurrent
+    // access to this map is possible and must be guarded.
+    Lock m_openChannelsLock;
+    UncheckedKeyHashMap<MessagePortIdentifier, WeakRef<MessagePortChannel>> m_openChannels WTF_GUARDED_BY_LOCK(m_openChannelsLock);
 };
 
 } // namespace WebCore

--- a/test/js/web/workers/message-channel-registry-race.test.ts
+++ b/test/js/web/workers/message-channel-registry-race.test.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// MessagePortChannelRegistry is a process-global singleton shared by the main
+// thread and every Worker thread. Its m_openChannels HashMap had no lock, so
+// when two threads call new MessageChannel() concurrently (each doing two
+// HashMap add()s, which rehashes the table as it grows), one thread reads
+// freed backing storage and ASAN reports heap-use-after-free.
+test("MessagePortChannelRegistry m_openChannels is guarded against concurrent access", async () => {
+  using dir = tempDir("message-channel-registry-race", {
+    "main.ts": `
+      const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+
+      await new Promise<void>(resolve => {
+        worker.onmessage = e => {
+          if (e.data === "ready") resolve();
+        };
+      });
+
+      // Hammer m_openChannels.add() from the main thread while the worker
+      // does the same from its thread. The array keeps the channels alive
+      // so the map only grows (maximising rehashes).
+      const keepAlive: MessageChannel[] = [];
+      for (let round = 0; round < 40; round++) {
+        for (let i = 0; i < 500; i++) {
+          keepAlive.push(new MessageChannel());
+        }
+        await new Promise<void>(r => setTimeout(r, 0));
+      }
+
+      worker.postMessage("stop");
+      const workerCount = await new Promise<number>(resolve => {
+        worker.onmessage = e => resolve(e.data);
+      });
+      await worker.terminate();
+
+      console.log(JSON.stringify({ main: keepAlive.length, worker: workerCount }));
+    `,
+    "worker.ts": `
+      declare var self: Worker;
+      let stop = false;
+      const keepAlive: MessageChannel[] = [];
+
+      self.onmessage = e => {
+        if (e.data === "stop") {
+          stop = true;
+          postMessage(keepAlive.length);
+        }
+      };
+
+      postMessage("ready");
+
+      const spin = () => {
+        for (let i = 0; i < 500 && !stop; i++) {
+          keepAlive.push(new MessageChannel());
+        }
+        if (!stop) setTimeout(spin, 0);
+      };
+      spin();
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result).toEqual({ main: 20000, worker: expect.any(Number) });
+  expect(result.worker).toBeGreaterThan(0);
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/web/workers/message-channel-registry-race.test.ts
+++ b/test/js/web/workers/message-channel-registry-race.test.ts
@@ -21,11 +21,12 @@ test("MessagePortChannelRegistry m_openChannels is guarded against concurrent ac
       // does the same from its thread. The array keeps the channels alive
       // so the map only grows (maximising rehashes).
       const keepAlive: MessageChannel[] = [];
-      for (let round = 0; round < 40; round++) {
-        for (let i = 0; i < 500; i++) {
+      for (let round = 0; round < 10; round++) {
+        for (let i = 0; i < 400; i++) {
           keepAlive.push(new MessageChannel());
         }
-        await new Promise<void>(r => setTimeout(r, 0));
+        // Yield so the worker thread interleaves with us.
+        await Bun.sleep(0);
       }
 
       worker.postMessage("stop");
@@ -50,13 +51,14 @@ test("MessagePortChannelRegistry m_openChannels is guarded against concurrent ac
 
       postMessage("ready");
 
-      const spin = () => {
-        for (let i = 0; i < 500 && !stop; i++) {
-          keepAlive.push(new MessageChannel());
+      (async () => {
+        while (!stop) {
+          for (let i = 0; i < 400 && !stop; i++) {
+            keepAlive.push(new MessageChannel());
+          }
+          await Bun.sleep(0);
         }
-        if (!stop) setTimeout(spin, 0);
-      };
-      spin();
+      })();
     `,
   });
 
@@ -72,7 +74,7 @@ test("MessagePortChannelRegistry m_openChannels is guarded against concurrent ac
 
   expect(stderr).toBe("");
   const result = JSON.parse(stdout.trim());
-  expect(result).toEqual({ main: 20000, worker: expect.any(Number) });
+  expect(result).toEqual({ main: 4000, worker: expect.any(Number) });
   expect(result.worker).toBeGreaterThan(0);
   expect(exitCode).toBe(0);
-}, 60_000);
+}, 30_000);

--- a/test/js/web/workers/message-channel-registry-race.test.ts
+++ b/test/js/web/workers/message-channel-registry-race.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // MessagePortChannelRegistry is a process-global singleton shared by the main


### PR DESCRIPTION
## Problem

`MessagePortChannelProviderImpl` is a process-wide singleton (`BunWorkerGlobalScope.cpp` returns `MessagePortChannelProviderImpl::singleton()` for every global). Its `m_registry.m_openChannels` is an `UncheckedKeyHashMap` with no synchronization.

Upstream WebKit guards this with `ASSERT(isMainThread())` at every entry point, but Bun runs each Worker on its own thread and had commented all those asserts out. When one thread calls `new MessageChannel()` (→ `m_openChannels.add()`, which rehashes the table as it grows) while another thread does `port.postMessage()` or `new MessageChannel()` (→ `m_openChannels.get()` / `add()`), the reader dereferences freed backing storage.

## Repro

Under ASAN, with no fix applied:

```
ASSERTION FAILED: m_ptr
wtf/Ref.h(182) : T &WTF::Ref<WTF::DefaultWeakPtrImpl>::leakRef()
AddressSanitizer: SEGV on unknown address 0x758911091110
==2863==The signal is caused by a READ memory access.
```

Triggered by a Worker and the main thread both creating `MessageChannel`s in a tight loop — see the new `message-channel-registry-race.test.ts`.

## Fix

Add `Lock m_openChannelsLock` to `MessagePortChannelRegistry` and take it around every `m_openChannels` access, matching how `MessagePort.cpp` already guards its own process-global `allMessagePorts()` map with `allMessagePortsLock`.

The lock is released before calling into `MessagePortChannel` methods because `~MessagePortChannel()` calls back into `messagePortChannelDestroyed()` — holding the lock across e.g. `closePort()`/`disentanglePort()` (which can drop the last ref) would self-deadlock.

## Verification

```
# Without fix (src/ stashed)
bun bd test test/js/web/workers/message-channel-registry-race.test.ts
  (fail) ... AddressSanitizer: SEGV ... [2074ms]

# With fix
bun bd test test/js/web/workers/message-channel-registry-race.test.ts
  (pass) ... [6707ms]

# Existing MessageChannel tests still pass
bun bd test test/js/web/workers/message-channel.test.ts
  12 pass, 0 fail
```

## Related

- #29442 is a more comprehensive fix that additionally makes `MessagePortChannel` use `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr` and restructures `takeAllMessagesForPort`. This PR is the minimal fix for the registry map race specifically; happy to close in favor of #29442 if that lands.
- Supersedes #29832 (recursive-lock variant).
- See also #25806.
- Likely related to crash reports #16186, #22471, #29458 (many workers spawned → concurrent channel creation). #25805 has a related but distinct race inside `MessagePortChannel::m_pendingMessages` that this PR does not address.
