### PR TITLE
fs: return ENAMETOOLONG from recursive cp when path exceeds OSPathBuffer

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -867,9 +867,24 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
                 },
                 .result => |ent| ent,
             }) |current| : (entry = iterator.next()) {
+                const cname = current.name.slice();
+
+                // The accumulated path for deep directory trees can exceed the fixed
+                // OSPathBuffer. Bail out with ENAMETOOLONG instead of writing past the
+                // end of the buffer and corrupting the stack.
+                if (src_dir_len + 1 + cname.len >= src_buf.len or
+                    dest_dir_len + 1 + cname.len >= dest_buf.len)
+                {
+                    this.finishConcurrently(.{ .err = .{
+                        .errno = @intFromEnum(E.NAMETOOLONG),
+                        .syscall = .copyfile,
+                        .path = nodefs.osPathIntoSyncErrorBuf(src_buf[0..src_dir_len]),
+                    } });
+                    return false;
+                }
+
                 switch (current.kind) {
                     .directory => {
-                        const cname = current.name.slice();
                         @memcpy(src_buf[src_dir_len + 1 .. src_dir_len + 1 + cname.len], cname);
                         src_buf[src_dir_len] = std.fs.path.sep;
                         src_buf[src_dir_len + 1 + cname.len] = 0;
@@ -891,8 +906,6 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
                     },
                     else => {
                         _ = this.subtask_count.fetchAdd(1, .monotonic);
-
-                        const cname = current.name.slice();
 
                         // Allocate a path buffer for the path data
                         var path_buf = bun.default_allocator.alloc(
@@ -6264,6 +6277,19 @@ pub const NodeFS = struct {
             .result => |ent| ent,
         }) |current| : (entry = iterator.next()) {
             const name_slice = current.name.slice();
+
+            // The accumulated path for deep directory trees can exceed the fixed
+            // OSPathBuffer. Bail out with ENAMETOOLONG instead of writing past the
+            // end of the buffer and corrupting the stack.
+            if (src_dir_len + 1 + name_slice.len >= src_buf.len or
+                dest_dir_len + 1 + name_slice.len >= dest_buf.len)
+            {
+                return .{ .err = .{
+                    .errno = @intFromEnum(E.NAMETOOLONG),
+                    .syscall = .copyfile,
+                    .path = this.osPathIntoSyncErrorBuf(src_buf[0..src_dir_len]),
+                } };
+            }
 
             @memcpy(src_buf[src_dir_len + 1 .. src_dir_len + 1 + name_slice.len], name_slice);
             src_buf[src_dir_len] = std.fs.path.sep;

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -335,6 +335,10 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
       const src = join(base, "s");
       const dst = join(base, "d");
       fs.mkdirSync(src);
+      // Pre-create dst so macOS clonefile() fails with EEXIST and falls through to the
+      // manual iteration path that contains the bounds check; otherwise clonefile clones
+      // the whole tree at the vnode level without ever building interior path strings.
+      fs.mkdirSync(dst);
 
       // Build a directory tree whose full path exceeds MAX_PATH_BYTES by creating each
       // level with a short relative path from a shell; the kernel never sees the whole

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
 import { join } from "path";
 
 const impls = [
@@ -323,3 +323,69 @@ test("cp with missing callback throws", () => {
     fs.cp("a", "b" as any);
   }).toThrow(/"cb"/);
 });
+
+// On Windows the OS path buffer is 32768 wide chars, which is impractical to exceed
+// with on-disk directories, so this test targets POSIX where MAX_PATH_BYTES is small
+// enough to reach via relative mkdir + chdir.
+describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
+  "fs.%s recursive returns ENAMETOOLONG instead of overflowing path buffer",
+  which => {
+    test(which, async () => {
+      const base = tmpdirSync();
+      const src = join(base, "s");
+      const dst = join(base, "d");
+      fs.mkdirSync(src);
+
+      // Build a directory tree whose full path exceeds MAX_PATH_BYTES by creating each
+      // level with a short relative path from a shell; the kernel never sees the whole
+      // path so it never rejects it. We do this in /bin/sh rather than via process.chdir
+      // so the test process's cwd is unaffected.
+      const seg = Buffer.alloc(200, "a").toString();
+      await using mktree = Bun.spawn({
+        cmd: [
+          "/bin/sh",
+          "-c",
+          `cd "$1" && i=0 && while [ $i -lt 64 ]; do mkdir "$2" && cd "$2" || exit 0; i=$((i+1)); done`,
+          "sh",
+          src,
+          seg,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await mktree.exited;
+
+      // Run the cp in a subprocess: before the fix this corrupts the stack and segfaults.
+      const script = `
+        const fs = require("fs");
+        const src = ${JSON.stringify(src)};
+        const dst = ${JSON.stringify(dst)};
+        const done = e => {
+          if (e && e.code === "ENAMETOOLONG") {
+            console.log("ENAMETOOLONG");
+          } else if (e) {
+            console.log("ERR:" + (e.code || e.message));
+          } else {
+            console.log("OK");
+          }
+        };
+        if (${JSON.stringify(which)} === "cpSync") {
+          try { fs.cpSync(src, dst, { recursive: true }); done(); } catch (e) { done(e); }
+        } else {
+          fs.promises.cp(src, dst, { recursive: true }).then(() => done(), done);
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ENAMETOOLONG");
+      expect(exitCode).toBe(0);
+    });
+  },
+);

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -335,30 +335,35 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
       const src = join(base, "s");
       const dst = join(base, "d");
       fs.mkdirSync(src);
-      // Pre-create dst so macOS clonefile() fails with EEXIST and falls through to the
-      // manual iteration path that contains the bounds check; otherwise clonefile clones
-      // the whole tree at the vnode level without ever building interior path strings.
       fs.mkdirSync(dst);
 
       // Build a directory tree whose full path exceeds MAX_PATH_BYTES by creating each
       // level with a short relative path from a shell; the kernel never sees the whole
       // path so it never rejects it. We do this in /bin/sh rather than via process.chdir
       // so the test process's cwd is unaffected.
+      //
+      // The same tree is mirrored under dst so that on macOS — where both cpSyncInner and
+      // _cpAsyncDirectory retry clonefile() at every recursion level — clonefile hits
+      // EEXIST at every level and falls through to the manual iteration path containing
+      // the bounds check (clonefile would otherwise clone the whole subtree at the vnode
+      // level without ever building interior path strings).
       const seg = Buffer.alloc(200, "a").toString();
-      await using mktree = Bun.spawn({
-        cmd: [
-          "/bin/sh",
-          "-c",
-          `cd "$1" && i=0 && while [ $i -lt 64 ]; do mkdir "$2" && cd "$2" || exit 0; i=$((i+1)); done`,
-          "sh",
-          src,
-          seg,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      await mktree.exited;
+      for (const root of [src, dst]) {
+        await using mktree = Bun.spawn({
+          cmd: [
+            "/bin/sh",
+            "-c",
+            `cd "$1" && i=0 && while [ $i -lt 64 ]; do mkdir "$2" && cd "$2" || exit 0; i=$((i+1)); done`,
+            "sh",
+            root,
+            seg,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        await mktree.exited;
+      }
 
       // Run the cp in a subprocess: before the fix this corrupts the stack and segfaults.
       const script = `

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const impls = [
@@ -331,11 +331,10 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
   "fs.%s recursive returns ENAMETOOLONG instead of overflowing path buffer",
   which => {
     test(which, async () => {
-      const base = tmpdirSync();
+      using dir = tempDir("cp-enametoolong", { s: {}, d: {} });
+      const base = String(dir);
       const src = join(base, "s");
       const dst = join(base, "d");
-      fs.mkdirSync(src);
-      fs.mkdirSync(dst);
 
       // Build a directory tree whose full path exceeds MAX_PATH_BYTES by creating each
       // level with a short relative path from a shell; the kernel never sees the whole


### PR DESCRIPTION
## Reproduction

```js
const fs = require("fs");
// src/ contains ~21 nested dirs with 200-char names each (created via
// relative mkdir + chdir so the kernel never sees the full path).
await fs.promises.cp(src, dst, { recursive: true });
```

Before:

```
panic: Segmentation fault at address 0x0
```

`fs.cpSync` on the same tree silently corrupts the adjacent stack buffer and fails with a spurious `ENOENT`.

## Cause

`_cpAsyncDirectory` and `cpSyncInner` in `src/bun.js/node/node_fs.zig` append the current directory entry to a fixed-size `OSPathBuffer` at `src_dir_len + 1` on each recursion level:

```zig
@memcpy(src_buf[src_dir_len + 1 .. src_dir_len + 1 + cname.len], cname);
src_buf[src_dir_len] = std.fs.path.sep;
src_buf[src_dir_len + 1 + cname.len] = 0;
```

`src_dir_len` grows by `1 + cname.len` per level with no bounds check against `src_buf.len`. When the accumulated path exceeds `MAX_PATH_BYTES` the `@memcpy` writes past the stack-allocated buffer.

## Fix

Check `src_dir_len + 1 + cname.len >= src_buf.len` (and the same for `dest_buf`) before writing and return `ENAMETOOLONG`, matching Node's `fs.promises.cp` behavior.

## Verification

New tests in `test/js/node/fs/cp.test.ts` build a tree whose full path exceeds `MAX_PATH_BYTES` via `/bin/sh` relative `mkdir`/`cd`, then run `fs.cp` and `fs.cpSync` in a subprocess:

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/cp.test.ts -t ENAMETOOLONG
  → 0 pass / 2 fail  (async: segfault; sync: ERR:ENOENT)

bun bd test test/js/node/fs/cp.test.ts -t ENAMETOOLONG
  → 2 pass / 0 fail

bun bd test test/js/node/fs/cp.test.ts
  → 37 pass / 2 skip / 0 fail
```