### PR TITLE
Fix out-of-bounds read in hex_table when decoding byte 0xFF

### DIFF
--- a/src/string/immutable.zig
+++ b/src/string/immutable.zig
@@ -1365,8 +1365,8 @@ pub fn indexOfNotChar(slice: []const u8, char: u8) ?u32 {
 }
 
 const invalid_char: u8 = 0xff;
-const hex_table: [255]u8 = brk: {
-    var values: [255]u8 = [_]u8{invalid_char} ** 255;
+const hex_table: [256]u8 = brk: {
+    var values: [256]u8 = [_]u8{invalid_char} ** 256;
     values['0'] = 0;
     values['1'] = 1;
     values['2'] = 2;

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -832,6 +832,19 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(Buffer.from("Abx", "hex")).toEqual(Buffer.from("Ab", "hex"));
       });
 
+      it("hex input containing byte 0xFF is treated as invalid", () => {
+        // hex_table is indexed by the full u8 range; 0xFF must not read out of bounds.
+        // latin1 (8-bit) string path
+        expect(Buffer.from("\xff\xff", "hex")).toEqual(Buffer.alloc(0));
+        expect(Buffer.from("ab\xff\xffcd", "hex")).toEqual(Buffer.from([0xab]));
+        // 16-bit string path (U+0100 forces two-byte storage, U+00FF still <= 0xFF)
+        expect(Buffer.from("ab\xff\xff\u0100", "hex")).toEqual(Buffer.from([0xab]));
+
+        const buf = Buffer.alloc(4);
+        expect(buf.write("ab\xff\xffcd", "hex")).toBe(1);
+        expect(buf).toEqual(Buffer.from([0xab, 0, 0, 0]));
+      });
+
       it("single base64 char encodes as 0", () => {
         expect(Buffer.from("A", "base64").length).toBe(0);
       });


### PR DESCRIPTION
## Repro

```js
Buffer.from("\xff\xff", "hex")
```

Debug build:
```
panic(main thread): index out of bounds: index 255, len 255
string.immutable._decodeHexToBytes
/workspace/bun/src/string/immutable.zig:1416:28
```

## Cause

`hex_table` in `src/string/immutable.zig` was declared `[255]u8` (valid indices 0..254) but `_decodeHexToBytes` indexes it with `@as(u8, @truncate(...))`, which can produce any value 0..255. When the input contains byte `0xFF` — reachable from JS via a Latin1-backed string like `"\xff"`, or a 16-bit string containing U+00FF — index 255 reads one past the end of the array. In debug builds this is a Zig bounds-check panic; in release builds it's an out-of-bounds read of .rodata.

## Fix

Declare the table as `[256]u8` so every `u8` is a valid index. Entry 255 is `invalid_char` like every other non-hex byte, so decoding truncates at `0xFF` exactly as Node does.

## Verification

Added a test to `test/js/node/buffer.test.js` covering:
- `Buffer.from("\xff\xff", "hex")` → empty buffer (Latin1 / 8-bit path)
- `Buffer.from("ab\xff\xffcd", "hex")` → `[0xab]` (truncate at first invalid)
- `Buffer.from("ab\xff\xff\u0100", "hex")` → `[0xab]` (16-bit string path)
- `buf.write("ab\xff\xffcd", "hex")` → writes 1 byte

All assertions match Node.js. Without the fix the test panics on the first line; with the fix all 459 tests in `buffer.test.js` pass.