### PR TITLE
server(ServePlugins): read dev_server before switching union variant

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -468,6 +468,7 @@ const ServePlugins = struct {
 
         const error_js, const plugin_js = callframe.argumentsAsArray(2);
         const plugins = plugin_js.asPromisePtr(ServePlugins);
+        defer plugins.deref();
         handleOnReject(plugins, globalThis, error_js);
 
         return .js_undefined;

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -445,6 +445,7 @@ const ServePlugins = struct {
         bun.assert(this.state == .pending);
         const pending = &this.state.pending;
         const plugin = pending.plugin;
+        const dev_server = pending.dev_server;
         var html_bundle_routes = pending.html_bundle_routes;
         pending.html_bundle_routes = .empty;
         defer html_bundle_routes.deinit(bun.default_allocator);
@@ -457,7 +458,7 @@ const ServePlugins = struct {
             bun.handleOom(route.onPluginsResolved(plugin));
             route.deref();
         }
-        if (pending.dev_server) |server| {
+        if (dev_server) |server| {
             bun.handleOom(server.onPluginsResolved(plugin));
         }
     }
@@ -475,6 +476,7 @@ const ServePlugins = struct {
     pub fn handleOnReject(this: *ServePlugins, global: *jsc.JSGlobalObject, err: JSValue) void {
         bun.assert(this.state == .pending);
         const pending = &this.state.pending;
+        const dev_server = pending.dev_server;
         var html_bundle_routes = pending.html_bundle_routes;
         pending.html_bundle_routes = .empty;
         defer html_bundle_routes.deinit(bun.default_allocator);
@@ -487,7 +489,7 @@ const ServePlugins = struct {
             bun.handleOom(route.onPluginsRejected());
             route.deref();
         }
-        if (pending.dev_server) |server| {
+        if (dev_server) |server| {
             bun.handleOom(server.onPluginsRejected());
         }
 

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -93,13 +93,13 @@ test("DevServer is notified when [serve.static] plugin setup resolves", async ()
           await Promise.resolve();
           build.onLoad({ filter: /entry\\.ts$/ }, () => ({
             loader: "ts",
-            contents: "console.log('from-plugin');",
+            contents: "console.log('PLUGIN_MARKER');",
           }));
         },
       };
     `,
     "index.html": indexHtml,
-    "entry.ts": `console.log("not-from-plugin");`,
+    "entry.ts": `console.log("ORIGINAL_MARKER");`,
     "server.ts": `
       import html from "./index.html";
       const server = Bun.serve({
@@ -115,7 +115,10 @@ test("DevServer is notified when [serve.static] plugin setup resolves", async ()
         ? await fetch(new URL(m[1], server.url), { signal: AbortSignal.timeout(10_000) }).then(r => r.text())
         : "";
       await server.stop(true);
-      console.log(JSON.stringify({ status: res.status, fromPlugin: js.includes("from-plugin") }));
+      console.log(JSON.stringify({
+        status: res.status,
+        fromPlugin: js.includes("PLUGIN_MARKER") && !js.includes("ORIGINAL_MARKER"),
+      }));
     `,
   });
 

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -1,0 +1,136 @@
+// ServePlugins.handleOnResolve / handleOnReject take `pending = &this.state.pending`,
+// then reassign `this.state` to a different union variant, and must still be able to
+// notify the DevServer afterwards. That only works if `dev_server` is read out of the
+// pending payload *before* the reassignment. When it isn't, the optional reads back as
+// null (or garbage, depending on build mode) and the DevServer is never told that
+// plugin loading finished, so the request it deferred to `next_bundle` waits forever.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const indexHtml = /* html */ `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body><script type="module" src="./entry.ts"></script></body></html>`;
+
+// DevServer waits on `[serve.static]` plugins and the plugin promise rejects.
+// Exercises ServePlugins.handleOnReject with pending.dev_server set — the request that
+// was deferred while plugins were pending must be released once the DevServer is told
+// the load failed.
+test("DevServer is notified when [serve.static] plugin setup rejects", async () => {
+  using dir = tempDir("serve-plugins-devserver-reject", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "plugin.ts": `
+      export default {
+        name: "boom-plugin",
+        async setup() {
+          // Make the load observably async so ServePlugins sits in .pending with
+          // dev_server stored before handleOnReject runs.
+          await Promise.resolve();
+          throw new Error("plugin setup failed on purpose");
+        },
+      };
+    `,
+    "index.html": indexHtml,
+    "entry.ts": `console.log("unused");`,
+    "server.ts": `
+      import html from "./index.html";
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        routes: { "/": html },
+        fetch() { return new Response("fallback"); },
+      });
+      // First request while plugin_state == .unknown:
+      //   DevServer.ensureRouteIsBundled -> getOrLoadPlugins(.{ .dev_server = dev })
+      //   -> ServePlugins .pending (dev_server stored) -> request deferred to next_bundle.
+      // Plugin promise rejects -> handleOnReject must call dev.onPluginsRejected(),
+      // which releases the deferred request. If the DevServer is never notified the
+      // request hangs indefinitely; the AbortSignal below turns that hang into a
+      // concrete failure.
+      let result: string;
+      try {
+        const res = await fetch(server.url, { signal: AbortSignal.timeout(10_000) });
+        result = String(res.status);
+      } catch (e) {
+        result = (e as Error).name;
+      }
+      await server.stop(true);
+      console.log(JSON.stringify({ result }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // handleOnReject always prints the plugin error regardless of the bug; this just
+  // confirms we actually reached the reject path.
+  expect(stderr).toContain("plugin setup failed on purpose");
+
+  const line = stdout.split("\n").find(l => l.startsWith("{"));
+  expect(line).toBeDefined();
+  const { result } = JSON.parse(line!);
+  // With the DevServer notified, the deferred request is released promptly. If it
+  // isn't, the fetch sits until the 10s abort fires and we see "TimeoutError" here.
+  expect(result).not.toBe("TimeoutError");
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+// DevServer waits on `[serve.static]` plugins and the plugin promise resolves.
+// Exercises ServePlugins.handleOnResolve with pending.dev_server set — the DevServer
+// must be handed the resolved plugin so its bundle actually goes through it.
+test("DevServer is notified when [serve.static] plugin setup resolves", async () => {
+  using dir = tempDir("serve-plugins-devserver-resolve", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "plugin.ts": `
+      export default {
+        name: "marker-plugin",
+        async setup(build) {
+          await Promise.resolve();
+          build.onLoad({ filter: /entry\\.ts$/ }, () => ({
+            loader: "ts",
+            contents: "console.log('from-plugin');",
+          }));
+        },
+      };
+    `,
+    "index.html": indexHtml,
+    "entry.ts": `console.log("not-from-plugin");`,
+    "server.ts": `
+      import html from "./index.html";
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        routes: { "/": html },
+        fetch() { return new Response("fallback"); },
+      });
+      const res = await fetch(server.url, { signal: AbortSignal.timeout(10_000) });
+      const body = await res.text();
+      const m = body.match(/src="([^"]+)"/);
+      const js = m
+        ? await fetch(new URL(m[1], server.url), { signal: AbortSignal.timeout(10_000) }).then(r => r.text())
+        : "";
+      await server.stop(true);
+      console.log(JSON.stringify({ status: res.status, fromPlugin: js.includes("from-plugin") }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const line = stdout.split("\n").find(l => l.startsWith("{"));
+  expect(line).toBeDefined();
+  const out = JSON.parse(line!);
+  expect(out).toEqual({ status: 200, fromPlugin: true });
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -15,7 +15,7 @@ const indexHtml = /* html */ `<!DOCTYPE html>
 // Exercises ServePlugins.handleOnReject with pending.dev_server set — the request that
 // was deferred while plugins were pending must be released once the DevServer is told
 // the load failed.
-test("DevServer is notified when [serve.static] plugin setup rejects", async () => {
+test.concurrent("DevServer is notified when [serve.static] plugin setup rejects", async () => {
   using dir = tempDir("serve-plugins-devserver-reject", {
     "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
     "plugin.ts": `
@@ -78,12 +78,12 @@ test("DevServer is notified when [serve.static] plugin setup rejects", async () 
   // isn't, the fetch sits until the 10s abort fires and we see "TimeoutError" here.
   expect(result).not.toBe("TimeoutError");
   expect(exitCode).toBe(0);
-}, 30_000);
+});
 
 // DevServer waits on `[serve.static]` plugins and the plugin promise resolves.
 // Exercises ServePlugins.handleOnResolve with pending.dev_server set — the DevServer
 // must be handed the resolved plugin so its bundle actually goes through it.
-test("DevServer is notified when [serve.static] plugin setup resolves", async () => {
+test.concurrent("DevServer is notified when [serve.static] plugin setup resolves", async () => {
   using dir = tempDir("serve-plugins-devserver-resolve", {
     "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
     "plugin.ts": `
@@ -136,4 +136,4 @@ test("DevServer is notified when [serve.static] plugin setup resolves", async ()
   const out = JSON.parse(line!);
   expect(out).toEqual({ status: 200, fromPlugin: true });
   expect(exitCode).toBe(0);
-}, 30_000);
+});


### PR DESCRIPTION
## What

`ServePlugins.handleOnResolve` / `handleOnReject` take a pointer into the active `.pending` union payload:

```zig
const pending = &this.state.pending;
...
this.state = .err;                   // <- active variant switched
...
if (pending.dev_server) |server| {   // <- read through stale .pending pointer
```

After `this.state` is reassigned, `pending` points at inactive payload and the read is UB.

## Observable bug

For `handleOnReject` this is a **live hang in release builds today**, not just latent UB. Assigning the zero-payload `.err` variant zeroes the whole union payload area, so the stale `pending.dev_server` read comes back as `null`, the optional unwrap is skipped, and `dev.onPluginsRejected()` is never called. The DevServer stays in `.pending` and the request it deferred to `next_bundle` waits forever.

Repro: `bunfig.toml` with a `[serve.static]` plugin whose `setup()` throws, `Bun.serve` with an HTML route + `development: true`, then `fetch(server.url)` → never returns.

For `handleOnResolve` the `.loaded` assignment only writes its 8-byte pointer + tag and happens to leave `dev_server`'s bytes untouched with current Zig, so it works by accident — but it's the same stale-pointer read and will break the moment codegen or struct layout changes.

## Fix

Hoist `dev_server` into a local before the union reassignment in both functions — exactly what the surrounding code already does for `plugin` and `html_bundle_routes`.

## Verification

New `test/bake/serve-plugins-dev-server.test.ts`:
- **reject path** — plugin `setup()` throws; asserts the deferred request is released (not left hanging). Fails on main / system bun with `TimeoutError`, passes with this fix.
- **resolve path** — plugin loads successfully; asserts the DevServer bundle actually went through the plugin's `onLoad`.

```
# main / USE_SYSTEM_BUN=1
(fail) DevServer is notified when [serve.static] plugin setup rejects   — TimeoutError
(pass) DevServer is notified when [serve.static] plugin setup resolves

# this branch
(pass) DevServer is notified when [serve.static] plugin setup rejects [1139ms]
(pass) DevServer is notified when [serve.static] plugin setup resolves [1713ms]
```

`test/bake/deinitialization.test.ts` (9/9) still passes.
