### PR TITLE
css: fix stale clips pointer and self-compare in BackgroundHandler

### DIFF
--- a/src/css/properties/background.zig
+++ b/src/css/properties/background.zig
@@ -690,7 +690,7 @@ pub const BackgroundHandler = struct {
                 }
                 var clips_vp = VendorPrefix{ .none = true };
                 if (this.clips) |*clips_and_vp| {
-                    if (clips_vp != clips_and_vp.*[1] and !clips_and_vp.*[0].eql(&clips_and_vp[0])) {
+                    if (clips_vp != clips_and_vp.*[1] and !clips.eql(&clips_and_vp.*[0])) {
                         this.flush(allocator, dest, context);
                     } else {
                         bun.bits.insert(VendorPrefix, &clips_vp, clips_and_vp.*[1]);

--- a/src/css/properties/background.zig
+++ b/src/css/properties/background.zig
@@ -660,8 +660,10 @@ pub const BackgroundHandler = struct {
                     var clips: *SmallList(BackgroundClip, 1) = &clips_and_vp.*[0];
                     const vp: *VendorPrefix = &clips_and_vp.*[1];
                     if (vendor_prefix != vp.* and !val.eql(clips)) {
+                        // `flush()` takes ownership of `this.clips` via `bun.take` and
+                        // frees it, so `clips` (which aliases the payload of `this.clips`)
+                        // is a stale pointer once `flush()` returns. Do not touch it.
                         this.flush(allocator, dest, context);
-                        clips.deinit(allocator);
                         this.clips = .{ val.deepClone(allocator), vendor_prefix };
                     } else {
                         if (!val.eql(clips)) {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2825,6 +2825,40 @@ describe("css tests", () => {
     `,
     );
 
+    // A prefixed background-clip followed by a background shorthand
+    // whose implied clip values differ must flush the prefixed clip
+    // first rather than merging its vendor prefix into the shorthand's
+    // (different) clip values.
+    cssTest(
+      `
+      .foo {
+        -webkit-background-clip: text;
+        background: green content-box;
+      }
+    `,
+      indoc`
+      .foo {
+        -webkit-background-clip: text;
+        background: green content-box content-box;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-background-clip: text, text;
+        background: none, green none;
+      }
+    `,
+      indoc`
+      .foo {
+        -webkit-background-clip: text, text;
+        background: none, green;
+      }
+    `,
+    );
+
     cssTest(
       `
       .foo {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -2786,6 +2786,45 @@ describe("css tests", () => {
     `,
     );
 
+    // Multi-layer variants of the above: with >1 background layer the
+    // SmallList(BackgroundClip, 1) spills to the heap. The
+    // `-webkit-background-clip` that follows the shorthand has both a
+    // different vendor prefix and a different value, which forces a
+    // flush() while a pointer into the previous `clips` payload is still
+    // live. flush() takes ownership of that payload, so the caller must
+    // not touch it afterwards.
+    cssTest(
+      `
+      .foo {
+        background: none, green none;
+        -webkit-background-clip: text, text;
+      }
+    `,
+      indoc`
+      .foo {
+        background: none, green;
+        -webkit-background-clip: text, text;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        background: none, green none;
+        -webkit-background-clip: text, text;
+        background-clip: content-box, content-box;
+      }
+    `,
+      indoc`
+      .foo {
+        background: none, green;
+        -webkit-background-clip: text, text;
+        background-clip: content-box, content-box;
+      }
+    `,
+    );
+
     cssTest(
       `
       .foo {


### PR DESCRIPTION
Two related fixes in `BackgroundHandler.handleProperty` (`src/css/properties/background.zig`).

## 1. Stale pointer / double-free in `.@"background-clip"` arm

`clips` aliases the payload of `this.clips`:

```zig
if (this.clips) |*clips_and_vp| {
    var clips: *SmallList(BackgroundClip, 1) = &clips_and_vp.*[0];
    ...
    if (vendor_prefix != vp.* and !val.eql(clips)) {
        this.flush(allocator, dest, context);
        clips.deinit(allocator);   // <-- stale
```

`flush()` does `bun.take(&this.clips)` — moving the value out and setting the field to `null` — and frees the heap buffer via its `defer` block. When control returns, `clips` still points at the optional's stale payload bytes, which still hold the old (now-freed) heap pointer, so `clips.deinit(allocator)` re-freed the same buffer. Only a real heap buffer with ≥2 background layers (inline storage for a single layer made `deinit` a no-op, which is why the existing single-layer tests didn't surface it).

**Fix:** drop the redundant `deinit`; `flush()` already owns and cleans up `this.clips`.

## 2. Self-compare typo in `.background` arm

The sibling flush guard for the `background` shorthand compared the stored clips list to itself:

```zig
if (clips_vp != clips_and_vp.*[1] and !clips_and_vp.*[0].eql(&clips_and_vp[0])) {
```

Zig auto-derefs single-item pointers when indexed, so `clips_and_vp[0]` ≡ `clips_and_vp.*[0]`; the negation was always false and the flush branch was dead. The lightningcss source compares against the newly-built `clips` local (`*cur_clips != clips`).

This was observable: `-webkit-background-clip: text; background: green content-box;` previously emitted `-webkit-background-clip: content-box` — the `text` value was dropped and the prefix reapplied to the shorthand's clip. After the fix the prefixed declaration is flushed first, matching lightningcss.

## Tests

Added multi-layer `background:` ↔ prefixed `background-clip` cases to `test/js/bun/css/css.test.ts` covering both paths.

```
bun bd test test/js/bun/css/css.test.ts
 1032 pass
 67 skip
 0 fail
```

The self-compare tests fail without the fix (wrong output) and pass with it.
