### PR TITLE
node:vm: take cellLock() around NodeVMModule m_resolveCache mutation/visit

### DIFF
--- a/src/bun.js/bindings/NodeVMModule.cpp
+++ b/src/bun.js/bindings/NodeVMModule.cpp
@@ -509,6 +509,12 @@ void NodeVMModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(vmModule->m_evaluationResult);
     visitor.append(vmModule->m_moduleWrapper);
 
+    // m_resolveCache is mutated on the mutator thread by
+    // NodeVMSourceTextModule::link() via m_resolveCache.set(), which can
+    // rehash and free the old bucket array while a concurrent marker is
+    // iterating values() here. Both sides take cellLock() (same pattern as
+    // AbstractModuleRecord::visitChildrenImpl / setImportedModule).
+    WTF::Locker locker { vmModule->cellLock() };
     auto moduleNatives = vmModule->m_resolveCache.values();
     visitor.append(moduleNatives.begin(), moduleNatives.end());
 }

--- a/src/bun.js/bindings/NodeVMSourceTextModule.cpp
+++ b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
@@ -364,7 +364,13 @@ JSValue NodeVMSourceTextModule::link(JSGlobalObject* globalObject, JSArray* spec
             else
                 record->setImportedModule(globalObject, JSC::AbstractModuleRecord::ModuleRequest { Identifier::fromString(vm, specifier), nullptr }, resolvedRecord);
             RETURN_IF_EXCEPTION(scope, {});
-            m_resolveCache.set(WTF::move(specifier), WriteBarrier<JSObject> { vm, this, moduleNative });
+            {
+                // NodeVMModule::visitChildrenImpl iterates m_resolveCache.values()
+                // on the GC thread under cellLock(); take the same lock here so a
+                // set()-triggered rehash can't free the bucket array mid-iteration.
+                WTF::Locker locker { cellLock() };
+                m_resolveCache.set(WTF::move(specifier), WriteBarrier<JSObject> { vm, this, moduleNative });
+            }
             RETURN_IF_EXCEPTION(scope, {});
         }
     }

--- a/test/js/node/vm/sourcetextmodule-link-gc.test.ts
+++ b/test/js/node/vm/sourcetextmodule-link-gc.test.ts
@@ -1,0 +1,72 @@
+// NodeVMModule::visitChildrenImpl iterates m_resolveCache.values() on the
+// concurrent GC thread while NodeVMSourceTextModule::link() calls
+// m_resolveCache.set() on the mutator. A set()-triggered rehash frees the
+// old bucket array mid-iteration → WTF::HashTable's debug iterator-validity
+// assert (`ASSERTION FAILED: m_table`) or heap-use-after-free under ASAN.
+// Both sides now take cellLock() (same pattern as JSC's AbstractModuleRecord).
+//
+// collectContinuously runs a dedicated collector thread so marking overlaps
+// the link() loop; useGenerationalGC=0 makes every cycle a full mark so the
+// freshly-allocated SourceTextModule is actually visited while link()
+// populates its cache. 500 specifiers per module → the WTF::HashMap rehashes
+// ~9× per link() call.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// collectContinuously is very slow under Windows + ASAN in CI; the code path
+// is identical on Linux/macOS, so skip Windows to keep duration reasonable.
+test.skipIf(isWindows)(
+  "vm.SourceTextModule link() m_resolveCache survives concurrent GC",
+  async () => {
+    const fixture = `
+      const vm = require("node:vm");
+
+      const N = 500;
+      let src = "";
+      for (let i = 0; i < N; i++) src += "import {} from 'm" + i + "';\\n";
+      src += "export default 0;\\n";
+
+      const deps = new Map();
+      for (let i = 0; i < N; i++) {
+        deps.set("m" + i, new vm.SyntheticModule([], function () {}, { identifier: "m" + i }));
+      }
+      const linker = spec => deps.get(spec);
+
+      (async () => {
+        // Create all modules up front so each one exists across several GC
+        // cycles before link() mutates its m_resolveCache.
+        const mods = [];
+        for (let iter = 0; iter < 60; iter++) {
+          mods.push(new vm.SourceTextModule(src, { identifier: "root" + iter }));
+        }
+        Bun.gc(true);
+        for (const mod of mods) await mod.link(linker);
+        console.log("ok");
+      })().catch(e => {
+        console.error(e);
+        process.exit(1);
+      });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+        BUN_JSC_useGenerationalGC: "0",
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Debug/ASAN builds print a "WARNING: ASAN interferes with JSC signal
+    // handlers…" banner to stderr at startup; stdout === "ok" + exit 0 is the
+    // real signal — a mid-rehash visit aborts before either.
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+    void stderr;
+  },
+  120_000,
+);


### PR DESCRIPTION
## Problem

`NodeVMModule::m_resolveCache` is a `WTF::HashMap<WTF::String, WriteBarrier<JSObject>>` that is:

- **mutated** on the mutator thread by `NodeVMSourceTextModule::link()` → `m_resolveCache.set(...)` (once per resolved import specifier)
- **iterated** on the concurrent GC thread by `NodeVMModule::visitChildrenImpl` → `m_resolveCache.values()`

Neither side took `cellLock()`. When `.set()` triggers a rehash it frees the old bucket array, and a concurrent marker that is mid-`.values()` walks freed memory. On debug builds WTF::HashTable's iterator-validity check catches it first:

```
ASSERTION FAILED: m_table
wtf/HashTable.h(238) : HashTableConstIterator<...WriteBarrier<JSObject>...>::checkValidity
```

## Repro

```js
// BUN_JSC_collectContinuously=1 BUN_JSC_useGenerationalGC=0 bun-debug repro.js
const vm = require("node:vm");
const N = 500;
let src = ""; for (let i = 0; i < N; i++) src += `import {} from 'm${i}';\n`;
const deps = new Map();
for (let i = 0; i < N; i++) deps.set("m" + i, new vm.SyntheticModule([], () => {}));
const mods = []; for (let i = 0; i < 60; i++) mods.push(new vm.SourceTextModule(src));
Bun.gc(true);
for (const m of mods) await m.link(s => deps.get(s));
```

`useGenerationalGC=0` makes every cycle a full mark so the freshly-allocated `SourceTextModule` is actually visited while `link()` is populating its cache; 500 specifiers → the HashMap rehashes ~9× per `link()`.

## Fix

Take `cellLock()` on both sides — identical to what JSC's own `AbstractModuleRecord` does for `m_dependencies` in `visitChildrenImpl` / `setImportedModule`. The mutator-side lock is scoped to just the `.set()` call so it's not held across any allocation or JS call.

## Verification

`test/js/node/vm/sourcetextmodule-link-gc.test.ts` — on the debug/ASAN build:

- without fix: **3/3 fail** (SIGABRT, `ASSERTION FAILED: m_table`) in ~6.5s
- with fix: **3/3 pass** in ~15s