### PR TITLE
napi: don't mutate m_pendingNapiModules while range-for iterating it

### DIFF
--- a/src/bun.js/bindings/BunProcess.cpp
+++ b/src/bun.js/bindings/BunProcess.cpp
@@ -584,34 +584,46 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
 #endif
 
     if (callCountAtStart != globalObject->napiModuleRegisterCallCount) {
-        // Module self-registered via static constructor(s)
-        // Save ALL registrations to handle map before executing
+        // Module self-registered via static constructor(s).
+        // Move pending registrations into locals before iterating: an
+        // nm_register_func can itself call napi_module_register(), which
+        // appends to m_pendingNapiModules. Appending to a WTF::Vector while
+        // range-for iterating it reallocates the buffer and leaves the
+        // iterator dangling.
+        auto pendingNapiModules = std::exchange(globalObject->m_pendingNapiModules, {});
+        auto pendingV8Modules = std::exchange(globalObject->m_pendingV8Modules, {});
 
         if (handle) {
             // Save all NAPI module registrations
-            for (auto& mod : globalObject->m_pendingNapiModules) {
+            for (auto& mod : pendingNapiModules) {
                 auto* heapModule = new napi_module(mod);
                 Bun::DLHandleMap::singleton().add(handle, heapModule);
             }
 
             // Save all V8 C++ module registrations
-            for (auto* mod : globalObject->m_pendingV8Modules) {
+            for (auto* mod : pendingV8Modules) {
                 Bun::DLHandleMap::singleton().add(handle, mod);
             }
         }
 
-        // Execute all NAPI modules
-        for (auto& mod : globalObject->m_pendingNapiModules) {
-            // Restore dlopen handle for this module before execution
-            // executePendingNapiModule clears it, so we must set it for each module
-            globalObject->m_pendingNapiModuleDlopenHandle = handle;
-            globalObject->m_pendingNapiModule = mod;
-            Napi::executePendingNapiModule(globalObject);
-            globalObject->m_pendingNapiModule = {};
+        // Execute all NAPI modules. If an nm_register_func registers more
+        // modules re-entrantly, they accumulate back in m_pendingNapiModules;
+        // drain those too once the current batch is done.
+        for (;;) {
+            for (auto& mod : pendingNapiModules) {
+                // Restore dlopen handle for this module before execution
+                // executePendingNapiModule clears it, so we must set it for each module
+                globalObject->m_pendingNapiModuleDlopenHandle = handle;
+                globalObject->m_pendingNapiModule = mod;
+                Napi::executePendingNapiModule(globalObject);
+                globalObject->m_pendingNapiModule = {};
+            }
+            if (globalObject->m_pendingNapiModules.isEmpty())
+                break;
+            pendingNapiModules = std::exchange(globalObject->m_pendingNapiModules, {});
         }
 
-        // Clear all pending registrations
-        globalObject->m_pendingNapiModules.clear();
+        // Clear any re-entrant V8 registrations (not executed here).
         globalObject->m_pendingV8Modules.clear();
 
         JSValue resultValue = globalObject->m_pendingNapiModuleAndExports[0].get();
@@ -647,18 +659,22 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
                 registration);
         }
 
-        // Execute all NAPI modules that were just registered
-        for (auto& mod : globalObject->m_pendingNapiModules) {
-            // Restore dlopen handle for this module before execution
-            // executePendingNapiModule clears it, so we must set it for each module
-            globalObject->m_pendingNapiModuleDlopenHandle = handle;
-            globalObject->m_pendingNapiModule = mod;
-            Napi::executePendingNapiModule(globalObject);
-            globalObject->m_pendingNapiModule = {};
+        // Execute all NAPI modules that were just registered. Move to a
+        // local first and drain so re-entrant napi_module_register() calls
+        // from inside nm_register_func can't invalidate our iterator.
+        while (!globalObject->m_pendingNapiModules.isEmpty()) {
+            auto pendingNapiModules = std::exchange(globalObject->m_pendingNapiModules, {});
+            for (auto& mod : pendingNapiModules) {
+                // Restore dlopen handle for this module before execution
+                // executePendingNapiModule clears it, so we must set it for each module
+                globalObject->m_pendingNapiModuleDlopenHandle = handle;
+                globalObject->m_pendingNapiModule = mod;
+                Napi::executePendingNapiModule(globalObject);
+                globalObject->m_pendingNapiModule = {};
+            }
         }
 
-        // Clear the vectors (no need to save again since already in DLHandleMap)
-        globalObject->m_pendingNapiModules.clear();
+        // Clear the V8 vector (no need to save again since already in DLHandleMap)
         globalObject->m_pendingV8Modules.clear();
 
         JSValue resultValue = globalObject->m_pendingNapiModuleAndExports[0].get();

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -122,6 +122,16 @@
             ],
         },
         {
+            "target_name": "reentrant_register_addon",
+            "sources": ["reentrant_register_addon.cpp"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+            ],
+        },
+        {
             "target_name": "test_cleanup_hook_order",
             "sources": ["test_cleanup_hook_order.c"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/reentrant_register_addon.cpp
+++ b/test/napi/napi-app/reentrant_register_addon.cpp
@@ -1,0 +1,83 @@
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdio.h>
+
+// This addon exercises re-entrant napi_module_register: the init callback
+// of a module registered via a static constructor itself calls
+// napi_module_register() for more modules. Bun iterates the pending-module
+// vector after dlopen returns, and appending to that vector while iterating
+// it used to reallocate the backing buffer and leave the range-for iterator
+// dangling (heap-use-after-free under ASAN).
+
+static napi_value register_cb_a(napi_env env, napi_value exports);
+static napi_value register_cb_b(napi_env env, napi_value exports);
+static napi_value register_cb_reentrant(napi_env env, napi_value exports);
+
+static napi_module mod_a = {
+    1,                              // nm_version
+    0,                              // nm_flags
+    "reentrant_register_addon.cpp", // nm_filename
+    register_cb_a,                  // nm_register_func
+    "reentrant_register_a",         // nm_modname
+    NULL,                           // nm_priv
+    {NULL}                          // reserved
+};
+
+static napi_module mod_b = {
+    1,                              // nm_version
+    0,                              // nm_flags
+    "reentrant_register_addon.cpp", // nm_filename
+    register_cb_b,                  // nm_register_func
+    "reentrant_register_b",         // nm_modname
+    NULL,                           // nm_priv
+    {NULL}                          // reserved
+};
+
+// Enough extra registrations to force the backing WTF::Vector to grow
+// past any initial capacity and reallocate at least once.
+#define N_REENTRANT 64
+static napi_module reentrant_mods[N_REENTRANT];
+static int reentrant_calls = 0;
+
+class call_register {
+public:
+  call_register() {
+    // Register two modules so the outer execute loop iterates more than
+    // once; the second iteration is what touches freed memory if the
+    // vector was reallocated by the re-entrant appends in register_cb_a.
+    napi_module_register(&mod_a);
+    napi_module_register(&mod_b);
+  }
+};
+
+static call_register constructor1;
+
+static napi_value register_cb_a(napi_env env, napi_value exports) {
+  (void)env;
+  printf("register_cb_a\n");
+  for (int i = 0; i < N_REENTRANT; i++) {
+    reentrant_mods[i].nm_version = 1;
+    reentrant_mods[i].nm_flags = 0;
+    reentrant_mods[i].nm_filename = "reentrant_register_addon.cpp";
+    reentrant_mods[i].nm_register_func = register_cb_reentrant;
+    reentrant_mods[i].nm_modname = "reentrant_register_extra";
+    reentrant_mods[i].nm_priv = NULL;
+    napi_module_register(&reentrant_mods[i]);
+  }
+  return exports;
+}
+
+static napi_value register_cb_b(napi_env env, napi_value exports) {
+  (void)env;
+  printf("register_cb_b\n");
+  return exports;
+}
+
+static napi_value register_cb_reentrant(napi_env env, napi_value exports) {
+  (void)env;
+  reentrant_calls++;
+  if (reentrant_calls == N_REENTRANT) {
+    printf("register_cb_reentrant x %d\n", N_REENTRANT);
+  }
+  return exports;
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -21,7 +21,9 @@ describe.concurrent("napi", () => {
       process.exit(1);
     }
     console.timeEnd("Building node-gyp");
-  });
+    // node-gyp rebuild can take a while under a debug/ASAN binary; default
+    // 5s hook timeout kills the install subprocess mid-build.
+  }, 120_000);
 
   describe.each(["esm", "cjs"])("bundle .node files to %s via", format => {
     describe.each(["node", "bun"])("target %s", target => {
@@ -556,6 +558,30 @@ describe.concurrent("napi", () => {
 
   it("runs the napi_module_register callback after dlopen finishes", async () => {
     await checkSameOutput("test_constructor_order", []);
+  });
+
+  it("handles napi_module_register called re-entrantly from nm_register_func", async () => {
+    // The init callback of the first static-constructor-registered module
+    // calls napi_module_register() 64 more times. Before the fix, that
+    // appended to the same WTF::Vector the execute loop was range-for
+    // iterating, reallocating it and leaving a dangling iterator for the
+    // second static-constructor-registered module (heap-use-after-free
+    // under ASAN, garbage nm_register_func pointer otherwise).
+    const addonPath = join(__dirname, "napi-app", "build", "Debug", "reentrant_register_addon.node");
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", `require(${JSON.stringify(addonPath)});`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual([
+      "register_cb_a",
+      "register_cb_b",
+      "register_cb_reentrant x 64",
+    ]);
+    expect(exitCode).toBe(0);
   });
 
   it("behaves as expected when performing operations with an exception pending", async () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -576,7 +576,7 @@ describe.concurrent("napi", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout.split("\n").filter(Boolean)).toEqual([
+    expect(stdout.split(/\r?\n/).filter(Boolean)).toEqual([
       "register_cb_a",
       "register_cb_b",
       "register_cb_reentrant x 64",


### PR DESCRIPTION
## What

`process.dlopen` iterates `globalObject->m_pendingNapiModules` after the shared library's static constructors have run, invoking each module's `nm_register_func`. If that callback itself calls `napi_module_register()` — or triggers a nested `dlopen` whose static constructors do — the append can grow the backing `WTF::Vector` and leave the outer range-for's iterator pointing into freed storage. Re-entrantly registered modules were also silently dropped by the trailing `.clear()`.

## How

`std::exchange` the pending NAPI/V8 vectors into locals before iterating, then drain `m_pendingNapiModules` in a loop so modules registered during an init callback are executed rather than discarded. Applied to both execute paths in `Process_functionDlopen` (fresh static-constructor registrations and the cached-registration replay).

## Test

New `reentrant_register_addon` in `test/napi/napi-app`: two modules are registered from a static constructor; the first one's `nm_register_func` registers 64 more. Before this change the 64 re-entrant registrations are never executed (and the second static-constructor registration is reached via a stale iterator into the reallocated buffer); after, all 66 init callbacks run in order.

Also gives the `beforeAll` in `napi.test.ts` a 120 s timeout — the `bunExe() install` it runs does a full node-gyp rebuild which can exceed the default 5 s hook timeout under a debug/ASAN binary, at which point the test runner SIGTERMs the install and the whole file aborts with `build failed, bailing out!`.