### PR TITLE
Fix out-of-bounds write in toUTF16Alloc sentinel branch

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -253,6 +253,18 @@ export const sysErrorNameFromLibuv: (errno: number) => string | undefined = $new
   1,
 );
 
+export const stringsInternals = {
+  /**
+   * Calls `bun.strings.toUTF16AllocForReal(allocator, bytes, false, true)` and
+   * returns the resulting UTF-16 data as a JS string. The `sentinel = true`
+   * path is otherwise only reachable from Windows `bun build --compile`
+   * metadata, so this binding lets us exercise it on all platforms.
+   */
+  toUTF16AllocSentinel: $newZigFunction("string/immutable/unicode.zig", "TestingAPIs.toUTF16AllocSentinel", 1) as (
+    bytes: Uint8Array,
+  ) => string,
+};
+
 export const fetchH2Internals = {
   liveCounts: $newZigFunction("http/H2Client.zig", "TestingAPIs.liveCounts", 0) as () => {
     sessions: number;

--- a/src/string/immutable/unicode.zig
+++ b/src/string/immutable/unicode.zig
@@ -1178,8 +1178,9 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
         }
 
         if (comptime sentinel) {
-            output.items[output.items.len] = 0;
-            return output.items[0 .. output.items.len + 1 :0];
+            try output.ensureUnusedCapacity(1);
+            output.appendAssumeCapacity(0);
+            return output.items[0 .. output.items.len - 1 :0];
         }
 
         return output.items;
@@ -1187,6 +1188,35 @@ pub fn toUTF16Alloc(allocator: std.mem.Allocator, bytes: []const u8, comptime fa
 
     return null;
 }
+
+pub const TestingAPIs = struct {
+    /// Used in JS tests, see `internal-for-testing.ts`.
+    /// Exercises the `sentinel = true` path of `toUTF16AllocForReal`, which is
+    /// otherwise only reachable from Windows-only code (`bun build --compile`
+    /// metadata in `src/windows.zig`).
+    pub fn toUTF16AllocSentinel(globalThis: *bun.jsc.JSGlobalObject, callframe: *bun.jsc.CallFrame) bun.JSError!bun.jsc.JSValue {
+        const arguments = callframe.arguments();
+        if (arguments.len < 1) {
+            return globalThis.throw("toUTF16AllocSentinel: expected 1 argument", .{});
+        }
+        const array_buffer = arguments[0].asArrayBuffer(globalThis) orelse {
+            return globalThis.throw("toUTF16AllocSentinel: expected a Uint8Array", .{});
+        };
+        const bytes = array_buffer.byteSlice();
+
+        const allocator = bun.default_allocator;
+        const result = strings.toUTF16AllocForReal(allocator, bytes, false, true) catch |err| {
+            return globalThis.throwError(err, "toUTF16AllocForReal failed");
+        };
+        defer allocator.free(result);
+
+        bun.assert(result.ptr[result.len] == 0);
+
+        var out = bun.String.cloneUTF16(result);
+        defer out.deref();
+        return out.toJS(globalThis);
+    }
+};
 
 // this one does the thing it's named after
 pub fn toUTF16AllocForReal(allocator: std.mem.Allocator, bytes: []const u8, comptime fail_if_invalid: bool, comptime sentinel: bool) !if (sentinel) [:0]u16 else []u16 {

--- a/test/js/bun/util/toUTF16Alloc.test.ts
+++ b/test/js/bun/util/toUTF16Alloc.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
 import { stringsInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
 
 // `bun.strings.toUTF16AllocForReal(..., sentinel = true)` is only called from
 // Windows-specific code (`bun build --compile` metadata in `src/windows.zig`),

--- a/test/js/bun/util/toUTF16Alloc.test.ts
+++ b/test/js/bun/util/toUTF16Alloc.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { stringsInternals } from "bun:internal-for-testing";
+
+// `bun.strings.toUTF16AllocForReal(..., sentinel = true)` is only called from
+// Windows-specific code (`bun build --compile` metadata in `src/windows.zig`),
+// so we exercise it directly via an internal binding here.
+//
+// Previously, the manual-conversion fallback (taken when simdutf rejects the
+// input as invalid UTF-8) wrote the null sentinel with
+// `output.items[output.items.len] = 0`, which indexes one past the slice
+// length: always a bounds-check panic in safe builds, and a heap write past
+// the allocation in release builds whenever the ArrayList's capacity equals
+// its length.
+
+const { toUTF16AllocSentinel } = stringsInternals;
+
+describe("bun.strings.toUTF16AllocForReal(sentinel=true)", () => {
+  test("pure ASCII", () => {
+    expect(toUTF16AllocSentinel(Buffer.from("abc"))).toBe("abc");
+  });
+
+  test("valid UTF-8 with non-ASCII (simdutf fast path)", () => {
+    expect(toUTF16AllocSentinel(Buffer.from("café", "utf8"))).toBe("café");
+    expect(toUTF16AllocSentinel(Buffer.from("アプリケーション", "utf8"))).toBe("アプリケーション");
+  });
+
+  test("lone continuation byte", () => {
+    expect(toUTF16AllocSentinel(new Uint8Array([0x80]))).toBe("\uFFFD");
+  });
+
+  test("ASCII prefix then invalid byte (capacity == len at sentinel)", () => {
+    // firstNonASCII = 3; simdutf allocates out_length+1 then fails at 0x80;
+    // the fallback ArrayList ends up with items.len == capacity after
+    // appending U+FFFD, so writing the sentinel must grow the allocation.
+    expect(toUTF16AllocSentinel(new Uint8Array([0x61, 0x62, 0x63, 0x80]))).toBe("abc\uFFFD");
+  });
+
+  test("multiple invalid sequences ending in non-ASCII", () => {
+    expect(toUTF16AllocSentinel(new Uint8Array([0x80, 0x61, 0x80, 0x62, 0x80]))).toBe("\uFFFDa\uFFFDb\uFFFD");
+  });
+
+  test("invalid sequence followed by trailing ASCII", () => {
+    expect(toUTF16AllocSentinel(new Uint8Array([0x80, 0x61, 0x62, 0x63]))).toBe("\uFFFDabc");
+  });
+});


### PR DESCRIPTION
## What

`toUTF16Alloc` with `sentinel = true` writes the null terminator out of bounds when the manual UTF-8 → UTF-16 fallback is taken (i.e. when simdutf rejects the input as invalid UTF-8).

```zig
output.items[output.items.len] = 0;
return output.items[0 .. output.items.len + 1 :0];
```

- `output.items[output.items.len]` indexes one past the slice length — a guaranteed `index out of bounds` panic in safe builds, and a heap write one `u16` past the mimalloc allocation in release builds whenever the ArrayList's capacity equals its length (which happens when the input ends in a non-ASCII byte so the trailing `ensureTotalCapacityPrecise` that normally reserves the sentinel slot is skipped).
- The returned slice `[0 .. len + 1 :0]` is also off by one: it has length `len + 1` and asserts the sentinel at index `len + 1`, but the zero was written at index `len`. All other sentinel-returning paths in this function return length `len`.

## Trigger

The only callers with `sentinel = true` are in `src/windows.zig` — Windows `bun build --compile` metadata (`--windows-title`, `--windows-publisher`, `--windows-version`, `--windows-description`, `--windows-copyright`). Valid UTF-8 returns early via simdutf, so reaching the broken branch requires a metadata value containing invalid UTF-8 (e.g. a WTF-8 encoded lone surrogate, or a stray continuation byte).

## Fix

Reserve one slot, append the terminator, and slice with the sentinel:

```zig
try output.ensureUnusedCapacity(1);
output.appendAssumeCapacity(0);
return output.items[0 .. output.items.len - 1 :0];
```

## Verification

Since the real-world trigger is Windows-only, a `bun:internal-for-testing` binding (`stringsInternals.toUTF16AllocSentinel`) was added to exercise `toUTF16AllocForReal(..., sentinel = true)` directly on all platforms.

With the old code, the "lone continuation byte" test panics on the debug build:

```
panic(main thread): index out of bounds: index 1, len 1
string.immutable.unicode.toUTF16Alloc
/workspace/bun/src/string/immutable/unicode.zig:1181:25
```

With the fix, all 6 tests in `test/js/bun/util/toUTF16Alloc.test.ts` pass. `zig:check-all` passes on all targets including Windows.