### PR TITLE
socket: clear DuplexUpgradeContext.tls in pre-open onError before handleConnectError

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1849,10 +1849,23 @@ pub const DuplexUpgradeContext = struct {
                 tls.handleError(err_value);
             }
         } else {
-            if (this.tls) |tls| {
-                tls.handleConnectError(@intFromEnum(bun.sys.SystemErrno.ECONNREFUSED)) catch {};
-            }
+            this.failConnect(@intFromEnum(bun.sys.SystemErrno.ECONNREFUSED));
         }
+    }
+
+    /// Report a pre-open connection failure to the wrapped TLSSocket and
+    /// stop forwarding duplex events to it.
+    ///
+    /// `handleConnectError` detaches the socket and drops the ref taken in
+    /// `jsUpgradeDuplexToTLS` via its `needs_deref` path, then `markInactive`
+    /// frees the heap-allocated `Handlers`. Any later duplex event forwarded
+    /// to the TLSSocket (`onClose`, `onData`, ...) would read through a
+    /// dangling `tls.handlers` pointer, so clear `this.tls` first to make
+    /// those forwards no-ops.
+    fn failConnect(this: *DuplexUpgradeContext, errno: c_int) void {
+        const tls = this.tls orelse return;
+        this.tls = null;
+        tls.handleConnectError(errno) catch {};
     }
 
     fn onTimeout(this: *DuplexUpgradeContext) void {
@@ -1894,20 +1907,7 @@ pub const DuplexUpgradeContext = struct {
                 else {};
                 started catch |err| switch (err) {
                     error.OutOfMemory => bun.outOfMemory(),
-                    else => {
-                        const errno = @intFromEnum(bun.sys.SystemErrno.ECONNREFUSED);
-                        if (this.tls) |tls| {
-                            // `handleConnectError` consumes our +1 (its
-                            // `needs_deref` path) and detaches. Calling
-                            // `tls.onClose` afterwards (as main did)
-                            // double-derefs; null `this.tls` so the eventual
-                            // `deinit` doesn't make it a triple. Pre-existing
-                            // on main, latent until the leak fix made `deinit`
-                            // reachable.
-                            this.tls = null;
-                            tls.handleConnectError(errno) catch {};
-                        }
-                    },
+                    else => this.failConnect(@intFromEnum(bun.sys.SystemErrno.ECONNREFUSED)),
                 };
                 if (this.ssl_config) |*cfg| {
                     cfg.deinit();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -143,6 +143,53 @@ it("should be able to grab the JSStreamSocket constructor", () => {
   //@ts-ignore
   expect(socket._handle._parentWrap.constructor).toBeFunction();
 });
+
+// DuplexUpgradeContext.onError's pre-open branch (is_open == false) routes
+// through handleConnectError, whose markInactive() destroys the heap-allocated
+// Handlers. Without clearing `this.tls`, the StartTLS task that runs on the
+// next tick still forwards onOpen/onClose into the TLSSocket and dereferences
+// the dangling `handlers` pointer (ASAN: use-after-poison in
+// NewSocket.isServer ← onOpen ← SSLWrapper.start ← startTLSWithCTX ←
+// DuplexUpgradeContext.runEvent). Run in a child so the ASAN abort can't take
+// the test runner down with it.
+it("tls.connect over a Duplex drops forwarded events after a pre-open connect error", async () => {
+  const src = `
+    const { PassThrough } = require("stream");
+    const tls = require("tls");
+
+    const duplex = new PassThrough({ objectMode: true });
+    const socket = tls.connect({ socket: duplex, rejectUnauthorized: false });
+    socket.on("error", err => {
+      process.stdout.write("error:" + (err.code || "unknown") + "\\n");
+    });
+    socket.on("close", () => {
+      process.stdout.write("close\\n");
+    });
+    // Synchronously push a non-buffer chunk before the enqueued StartTLS task
+    // runs: UpgradedDuplex.onReceivedData rejects it with ERR_STREAM_WRAP and
+    // routes through DuplexUpgradeContext.onError while is_open is still
+    // false, which tears down the TLSSocket's Handlers via handleConnectError.
+    duplex.push({ not: "a buffer" });
+    // After StartTLS has run (and must have seen this.tls == null), close the
+    // underlying duplex so DuplexUpgradeContext.onClose / deinit also observe
+    // the cleared pointer.
+    setImmediate(() => duplex.destroy());
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: {
+      ...bunEnv,
+      // If a regression reintroduces the UAF, skip llvm-symbolizer so the
+      // child aborts promptly instead of stalling past the test timeout.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect({ stdout, exitCode }).toEqual({ stdout: "error:ECONNREFUSED\nclose\n", exitCode: 0 });
+});
 for (const { name, connect } of tests) {
   describe(name, () => {
     it("should work with alpnProtocols", done => {


### PR DESCRIPTION
## Repro

```js
const { PassThrough } = require("stream");
const tls = require("tls");

const duplex = new PassThrough({ objectMode: true });
const socket = tls.connect({ socket: duplex, rejectUnauthorized: false });
socket.on("error", e => console.log(e.code));

// Non-buffer chunk before the StartTLS task runs:
// UpgradedDuplex.onReceivedData -> ERR_STREAM_WRAP -> DuplexUpgradeContext.onError
// with is_open == false.
duplex.push({ not: "a buffer" });
setImmediate(() => duplex.destroy());
```

Under the debug/ASAN build:

```
AddressSanitizer: use-after-poison
  NewSocket(true).isServer          socket.zig:454
  NewSocket(true).onOpen            socket.zig:458
  DuplexUpgradeContext.onOpen       socket.zig:1811
  UpgradedDuplex.onOpen             UpgradedDuplex.zig:64
  SSLWrapper.start                  ssl_wrapper.zig:123
  UpgradedDuplex.startTLSWithCTX    UpgradedDuplex.zig:372
  DuplexUpgradeContext.runEvent     socket.zig:1891
```

## Cause

`DuplexUpgradeContext.onError`'s pre-open branch (`is_open == false`) calls `handleConnectError`, which detaches the socket, drops the ref taken in `jsUpgradeDuplexToTLS` (`needs_deref`), and runs `markInactive()`; `Handlers.markInactive()` for `.client` / `.duplex_server` does `vm.allocator.destroy(handlers)`.

`onError` did not clear `this.tls`, so the StartTLS task on the next tick still forwarded `onOpen` into the TLSSocket, where `onOpen` → `isServer()` reads `handlers.mode` through the freed allocation. A later forwarded `onClose` / `deinit` hits the same pointer.

(#29932 fixed the analogous case in `runEvent`'s StartTLS-error branch but left `onError` as-is.)

## Fix

Extract `DuplexUpgradeContext.failConnect(errno)` that nulls `this.tls` before delegating to `handleConnectError`, and route both the pre-open `onError` branch and `runEvent`'s StartTLS-error branch through it. Later duplex events see `this.tls == null` and skip the forward. The `runEvent` hunk is a behaviourally-identical dedup of what #29932 already inlined.

## Verification

New test in `test/js/node/tls/node-tls-connect.test.ts` spawns a child that pushes a non-buffer chunk into an `objectMode` PassThrough wrapped by `tls.connect({ socket: duplex })`, asserts the `error` event carries `ECONNREFUSED`, `close` follows, and the child exits 0 with empty stderr.

- Without the fix (`bun bd`, ASAN): child aborts with `use-after-poison` in `NewSocket(true).isServer`; test fails on the stderr assertion.
- With the fix: child prints `error:ECONNREFUSED` / `close` and exits 0.

Full `node-tls-connect.test.ts` suite (including the "using duplex proxy" describe) passes.
