### PR TITLE
shell(IOReader): drain readers instead of iterating a snapshot of the list

### DIFF
--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -50,9 +50,7 @@ struct State {
     evtloop: EventLoopHandle,
     #[cfg(windows)]
     is_reading: bool,
-    /// Re-entrancy guard for `drain_readers()`. `start()` can be reached from
-    /// inside a drain (via the Yield trampoline) and must not recurse; the
-    /// outer drain loop will pick up any reader appended in the meantime.
+    /// Set while `drain_readers` runs; a nested call returns and the outer loop handles new entries.
     draining: bool,
     /// Weak self-ref so `keepalive()` can bump the strong count from `&self`
     /// without unsafe Arc-pointer reconstruction. Set via `Arc::new_cyclic` in
@@ -233,15 +231,7 @@ impl IOReader {
             if s.is_reading {
                 return Yield::suspended();
             }
-            // A reader's done-handler can start a new command that calls
-            // `add_reader`+`start()` on this same IOReader after the pipe has
-            // reached EOF. On Windows the underlying BufferedReader has
-            // already nulled its `source` by then, so `start_with_current_pipe`
-            // would unwrap a `None`. There is nothing left to read; drain the
-            // newly-registered reader(s) now so they don't hang.
-            // `drain_readers()` is re-entrancy-guarded so calling it from
-            // inside an existing drain (via the Yield trampoline) is a no-op —
-            // the outer loop handles the new entry.
+            // Already at EOF (the source is gone): just notify whoever registered late.
             if self.reader().is_done() {
                 self.drain_readers();
                 return Yield::suspended();
@@ -339,19 +329,7 @@ impl IOReader {
         self.drain_readers();
     }
 
-    /// Notify every registered reader that this IOReader is finished,
-    /// including readers appended while draining.
-    ///
-    /// `run_yield` drives the Yield trampoline which can (a) call
-    /// `add_reader()` on this same IOReader — iterating a snapshot would miss
-    /// those, and leaving already-notified entries in `readers` would let
-    /// `add_reader`'s `contains()` dedup match a freed-then-reused `NodeId` —
-    /// and (b) drop the last external Arc. Pop each reader out via
-    /// `swap_remove(0)` before dispatching so neither hazard applies.
-    ///
-    /// Re-entrant calls (reached via `start()` from inside the trampoline)
-    /// are no-ops; the outermost loop owns the drain and will pick up
-    /// anything appended in the meantime. Keeps `Yield::run` nesting bounded.
+    /// Pops before dispatching: a callback may `add_reader` (must be notified too) or free this entry's node.
     fn drain_readers(&self) {
         let s = self.state();
         if s.draining {
@@ -361,9 +339,6 @@ impl IOReader {
         let interp = s.interp;
         while !self.state().readers.is_empty() {
             let r = self.state().readers.swap_remove(0);
-            // `SystemError` isn't `Clone` yet, so we keep the source
-            // `sys::Error` (which IS `Clone`) and re-derive a fresh
-            // `SystemError` per callee.
             let ee = self
                 .state()
                 .raw_err

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -227,8 +227,7 @@ impl IOReader {
         }
         #[cfg(windows)]
         {
-            let s = self.state();
-            if s.is_reading {
+            if self.state().is_reading {
                 return Yield::suspended();
             }
             // Already at EOF (the source is gone): just notify whoever registered late.
@@ -236,7 +235,7 @@ impl IOReader {
                 self.drain_readers();
                 return Yield::suspended();
             }
-            s.is_reading = true;
+            self.state().is_reading = true;
             if let Err(e) = self.reader().start_with_current_pipe() {
                 self.on_reader_error(&e);
                 return Yield::failed();
@@ -314,8 +313,7 @@ impl IOReader {
         // alive across the loop.
         let _keepalive = self.keepalive();
         self.set_reading(false);
-        let s = self.state();
-        s.raw_err = Some(err.clone());
+        self.state().raw_err = Some(err.clone());
         self.drain_readers();
     }
 

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -50,6 +50,10 @@ struct State {
     evtloop: EventLoopHandle,
     #[cfg(windows)]
     is_reading: bool,
+    /// Re-entrancy guard for `drain_readers()`. `start()` can be reached from
+    /// inside a drain (via the Yield trampoline) and must not recurse; the
+    /// outer drain loop will pick up any reader appended in the meantime.
+    draining: bool,
     /// Weak self-ref so `keepalive()` can bump the strong count from `&self`
     /// without unsafe Arc-pointer reconstruction. Set via `Arc::new_cyclic` in
     /// `init()` (the sole constructor).
@@ -141,6 +145,7 @@ impl IOReader {
                 evtloop,
                 #[cfg(windows)]
                 is_reading: false,
+                draining: false,
                 self_weak: std::sync::Weak::clone(w),
                 read_guards: Vec::new(),
                 interp: None,
@@ -228,6 +233,19 @@ impl IOReader {
             if s.is_reading {
                 return Yield::suspended();
             }
+            // A reader's done-handler can start a new command that calls
+            // `add_reader`+`start()` on this same IOReader after the pipe has
+            // reached EOF. On Windows the underlying BufferedReader has
+            // already nulled its `source` by then, so `start_with_current_pipe`
+            // would unwrap a `None`. There is nothing left to read; drain the
+            // newly-registered reader(s) now so they don't hang.
+            // `drain_readers()` is re-entrancy-guarded so calling it from
+            // inside an existing drain (via the Yield trampoline) is a no-op —
+            // the outer loop handles the new entry.
+            if self.reader().is_done() {
+                self.drain_readers();
+                return Yield::suspended();
+            }
             s.is_reading = true;
             if let Err(e) = self.reader().start_with_current_pipe() {
                 self.on_reader_error(&e);
@@ -308,15 +326,7 @@ impl IOReader {
         self.set_reading(false);
         let s = self.state();
         s.raw_err = Some(err.clone());
-        // NOTE: reshaped for borrowck — copy out before dispatching.
-        let readers: Vec<ChildPtr> = s.readers.clone();
-        let interp = s.interp;
-        for r in readers {
-            // Re-derive a fresh SystemError per callee (see
-            // IOWriter.on_error note).
-            let ee = err.to_shell_system_error();
-            self.run_yield(dispatch_reader_done(r, Some(ee), interp));
-        }
+        self.drain_readers();
     }
 
     fn on_reader_done_cb(&self) {
@@ -326,17 +336,42 @@ impl IOReader {
         // Hold a strong ref across the body.
         let _keepalive = self.keepalive();
         self.set_reading(false);
+        self.drain_readers();
+    }
+
+    /// Notify every registered reader that this IOReader is finished,
+    /// including readers appended while draining.
+    ///
+    /// `run_yield` drives the Yield trampoline which can (a) call
+    /// `add_reader()` on this same IOReader — iterating a snapshot would miss
+    /// those, and leaving already-notified entries in `readers` would let
+    /// `add_reader`'s `contains()` dedup match a freed-then-reused `NodeId` —
+    /// and (b) drop the last external Arc. Pop each reader out via
+    /// `swap_remove(0)` before dispatching so neither hazard applies.
+    ///
+    /// Re-entrant calls (reached via `start()` from inside the trampoline)
+    /// are no-ops; the outermost loop owns the drain and will pick up
+    /// anything appended in the meantime. Keeps `Yield::run` nesting bounded.
+    fn drain_readers(&self) {
         let s = self.state();
-        let readers: Vec<ChildPtr> = s.readers.clone();
+        if s.draining {
+            return;
+        }
+        s.draining = true;
         let interp = s.interp;
-        // `SystemError` isn't `Clone` yet, so we keep the source `sys::Error`
-        // (which IS `Clone`) and re-derive a fresh `SystemError` per callee —
-        // same approach as `on_reader_error`.
-        let raw_err = s.raw_err.clone();
-        for r in readers {
-            let ee = raw_err.as_ref().map(|e| e.to_shell_system_error());
+        while !self.state().readers.is_empty() {
+            let r = self.state().readers.swap_remove(0);
+            // `SystemError` isn't `Clone` yet, so we keep the source
+            // `sys::Error` (which IS `Clone`) and re-derive a fresh
+            // `SystemError` per callee.
+            let ee = self
+                .state()
+                .raw_err
+                .as_ref()
+                .map(|e| e.to_shell_system_error());
             self.run_yield(dispatch_reader_done(r, ee, interp));
         }
+        self.state().draining = false;
     }
 
     fn run_yield(&self, y: Yield) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1502,6 +1502,16 @@ describe("deno_task", () => {
         .stdout("0\n")
         .runAsTest("long pipeline");
 
+      // Every `cat` here shares the subshell's stdin *IOReader. When EOF fires, each
+      // reader's done-handler starts the next `cat` via the Yield trampoline, which calls
+      // addReader()+start() on the same already-done IOReader. drainReaders() must pop
+      // each entry before dispatching (so the SmolList can mutate safely and addReader's
+      // dedup never matches a freed pointer) and start() must drain late-registered
+      // readers rather than restarting the finished pipe.
+      TestBuilder.command`echo hi | (cat && cat && cat && cat && cat && cat && cat && cat && cat && cat && cat && cat)`
+        .stdout("hi\n")
+        .runAsTest("many readers on shared stdin IOReader");
+
       // Test pipeline stack consistency with complex nesting
       TestBuilder.command`echo outer | (echo inner1 | echo inner2 | (echo deep1 | echo deep2) | echo inner3) | echo final | BUN_TEST_VAR=1 ${BUN} -e 'process.stdin.pipe(process.stdout)'`
         .stdout("final\n")

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1502,12 +1502,12 @@ describe("deno_task", () => {
         .stdout("0\n")
         .runAsTest("long pipeline");
 
-      // Every `cat` here shares the subshell's stdin *IOReader. When EOF fires, each
+      // Every `cat` here shares the subshell's stdin Arc<IOReader>. When EOF fires, each
       // reader's done-handler starts the next `cat` via the Yield trampoline, which calls
-      // addReader()+start() on the same already-done IOReader. drainReaders() must pop
-      // each entry before dispatching (so the SmolList can mutate safely and addReader's
-      // dedup never matches a freed pointer) and start() must drain late-registered
-      // readers rather than restarting the finished pipe.
+      // add_reader()+start() on the same already-done IOReader. drain_readers() must pop
+      // each entry before dispatching (so the readers Vec can mutate safely and add_reader's
+      // dedup never matches a freed-then-reused NodeId) and start() must drain
+      // late-registered readers rather than restarting the finished pipe.
       TestBuilder.command`echo hi | (cat && cat && cat && cat && cat && cat && cat && cat && cat && cat && cat && cat)`
         .stdout("hi\n")
         .runAsTest("many readers on shared stdin IOReader");


### PR DESCRIPTION
## What

`IOReader.on_reader_done_cb` and `on_reader_error` iterated a clone of `readers` while the loop body runs the Yield trampoline. The trampoline drives shell state machines that can call `add_reader()` on the **same** `IOReader` (the root stdin reader is shared across every command that inherits stdin). Two problems:

- readers appended mid-loop are never notified, because the snapshot was taken before they existed
- already-notified entries stay in the list, so `add_reader`'s `contains()` dedup can match a freed-then-reused `NodeId` and silently skip registering the next reader

Both loops are replaced by `drain_readers()`, which pops each entry via `swap_remove(0)` *before* dispatching, so neither hazard applies and readers appended mid-drain are still picked up. A `draining` re-entrancy flag makes nested calls (reached from inside the trampoline) no-ops so the outermost loop owns the drain and `Yield::run` nesting stays bounded.

## Windows

The new test exposed a separate pre-existing Windows crash: the `BufferedReader` nulls its `source` before invoking `on_reader_done_cb`, so when a reader's done-handler starts the next `cat` and calls `start()` from inside that callback, `start_with_current_pipe()` unwraps a `None` source and panics. `echo | (cat && cat)` had never been tested, so this never fired.

`start()` on Windows now checks `reader().is_done()` and drains the late-registered reader(s) instead of restarting the finished pipe. Because of the re-entrancy guard, this covers both call sites: reached from *inside* a drain (sync stdout write) it's a no-op and the outer loop handles the new reader; reached *after* the drain returned (async stdout, `on_io_writer_chunk` fires later) it starts a fresh drain. Without the fresh-drain path the test hung for 90s on Windows 11 aarch64 in CI.

## Test

Added `echo hi | (cat && cat && … ×12)` to the pipeline-stack tests in `bunshell.test.ts`. Every `cat` shares the subshell's stdin `IOReader`; each done-handler appends the next reader and calls `start()` on the already-done reader. Crashes on Windows without this change; passes with it on all three Windows lanes plus debian-asan.

## Rebase note

Earlier revisions of this PR changed both `src/runtime/shell/IOReader.zig` and `src/runtime/shell/IOReader.rs`. The Zig shell source has since been deleted from main (the Zig→Rust port completed), so the `.zig` half of the change was dropped during the rebase and the PR now touches only `IOReader.rs` and the test. The `.rs` logic is unchanged from what reviewers already looked at.