### PR TITLE
bake(DevServer): clear Dep.specifier in freeDependencyIndex to avoid double-free in deinit

### DIFF
--- a/src/bake/DevServer/DirectoryWatchStore.zig
+++ b/src/bake/DevServer/DirectoryWatchStore.zig
@@ -190,15 +190,10 @@ fn insert(
 /// Caller must detach the dependency from the linked list it is in.
 pub fn freeDependencyIndex(store: *DirectoryWatchStore, alloc: Allocator, index: Dep.Index) !void {
     alloc.free(store.dependencies.items[index.get()].specifier);
-
-    if (Environment.isDebug) {
-        store.dependencies.items[index.get()] = undefined;
-    }
-    // DevServer.deinit and memoryCost iterate `dependencies.items` without
-    // consulting `dependencies_free_list`. Leave an empty slice in free-list
-    // slots so that `alloc.free`/`.len` see a harmless no-op instead of the
-    // already-freed allocation.
-    store.dependencies.items[index.get()].specifier = &.{};
+    // Zero out the slot so that DevServer.deinit and memoryCost, which
+    // iterate `dependencies.items` without consulting the free list, do
+    // not touch the freed allocation or stale borrowed pointers.
+    store.dependencies.items[index.get()] = .empty;
 
     if (index.get() == (store.dependencies.items.len - 1)) {
         store.dependencies.items.len -= 1;
@@ -296,11 +291,16 @@ pub const Dep = struct {
     /// creating an unrelated file should not re-emit another error. Allocated memory
     specifier: []u8,
 
+    pub const empty: Dep = .{
+        .next = .none,
+        .source_file_path = "",
+        .specifier = &.{},
+    };
+
     pub const Index = bun.GenericIndex(u32, Dep);
 };
 
 const bun = @import("bun");
-const Environment = bun.Environment;
 const Watcher = bun.Watcher;
 const assert = bun.assert;
 const bake = bun.bake;

--- a/src/bake/DevServer/DirectoryWatchStore.zig
+++ b/src/bake/DevServer/DirectoryWatchStore.zig
@@ -194,6 +194,11 @@ pub fn freeDependencyIndex(store: *DirectoryWatchStore, alloc: Allocator, index:
     if (Environment.isDebug) {
         store.dependencies.items[index.get()] = undefined;
     }
+    // DevServer.deinit and memoryCost iterate `dependencies.items` without
+    // consulting `dependencies_free_list`. Leave an empty slice in free-list
+    // slots so that `alloc.free`/`.len` see a harmless no-op instead of the
+    // already-freed allocation.
+    store.dependencies.items[index.get()].specifier = &.{};
 
     if (index.get() == (store.dependencies.items.len - 1)) {
         store.dependencies.items.len -= 1;

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -358,6 +358,46 @@ devTest("removing 'use client' from a component with a pending resolution failur
     expect(res).toBeInstanceOf(Response);
   },
 });
+devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    // Import-record order is source order, so trackResolutionFailure is
+    // called for ./sub/a first (dep index 0) and ./sub/b second (dep index 1).
+    "index.ts": `
+      import './sub/a';
+      import './sub/b';
+      export {};
+    `,
+    // sub/ must exist for the directory watch to be opened.
+    "sub/placeholder.ts": `export {};`,
+  },
+  async test(dev) {
+    // Initial bundle: both imports fail and attach deps to the sub/ watch.
+    await dev.fetch("/");
+
+    {
+      await using _ = await dev.batchChanges({ errors: null });
+      // Rewrite index.ts so the rebuild has no failing imports and therefore
+      // does not re-track anything (which would consume the free-list slot).
+      await dev.write("index.ts", `export {};`);
+      // Creating sub/a.ts fires the sub/ directory watch. Walking the dep
+      // chain (LIFO: 1 then 0), dep 1 (./sub/b) still fails and is kept;
+      // dep 0 (./sub/a) now resolves, so freeDependencyIndex(0) frees its
+      // specifier and, because 0 != len-1, pushes index 0 onto
+      // dependencies_free_list.
+      await dev.write("sub/a.ts", `export {};`);
+    }
+
+    // The server should still respond.
+    const res = await dev.fetch("/");
+    expect(res).toBeInstanceOf(Response);
+
+    // Test teardown sends graceful-exit, which calls DevServer.deinit.
+    // Before the fix, deinit iterated every dependencies.items slot and
+    // freed .specifier again for the free-list slot at index 0, tripping
+    // AllocationScope's invalid-free panic.
+  },
+});
 devTest("importing html file", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
## Repro

Dev server with a directory watch that has two pending resolution-failure dependencies (`./sub/a` at index 0, `./sub/b` at index 1). Create `sub/a.ts` so dep 0 resolves; because it is not the tail slot, `freeDependencyIndex(0)` pushes index 0 onto `dependencies_free_list`. Shut the server down.

```
==ERROR: AddressSanitizer: negative-size-param: (size=-6148914691236517206)
    #1 mem.Allocator.free
    #2 bake.DevServer.deinit /workspace/bun/src/bake/DevServer.zig:686
    #3 bun.js.api.server.NewServer(.http,.debug).deinitIfWeCan
Address 0xaaaaaaaaaaaaaaaa is a wild pointer
```

## Cause

`DirectoryWatchStore.freeDependencyIndex` frees `dep.specifier` and (in debug) sets the whole slot to `undefined`, then pushes the index onto `dependencies_free_list`. The slot stays in `dependencies.items`.

`DevServer.deinit` iterates every `dependencies.items` slot and calls `alloc.free(watcher.specifier)` without consulting the free list, so free-list slots are freed a second time. In debug builds the `undefined` (0xAA…) slice trips ASAN's negative-size check; in release it is a straight double-free. `memoryCost` has the same blind iteration and would read `.len` from freed memory.

## Fix

After freeing, write an empty slice back into `specifier` so the slot is safe to revisit: `alloc.free(&.{})` is a no-op and `.len == 0`.

## Verification

New test `deinit with a free-list slot in DirectoryWatchStore.dependencies` in `test/bake/dev/bundle.test.ts` arranges the free-list slot and lets the harness's graceful-exit call `deinit`.

- `git stash -- src/ && bun bd test … -t 'deinit with a free-list slot'` → 3/3 **fail** (ASAN abort at DevServer.zig:686)
- with fix → 3/3 **pass**
- adjacent `removing 'use client' from a component with a pending resolution failure` test still passes