### PR TITLE
cli: dupe --tsconfig-override path out of joinAbsString's threadlocal buffer

### DIFF
--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -728,7 +728,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     }
 
     opts.tsconfig_override = if (args.option("--tsconfig-override")) |ts|
-        resolve_path.joinAbsString(cwd, &[_]string{ts}, .auto)
+        // joinAbsString returns a slice into a threadlocal buffer that is
+        // reused by later path operations (e.g. fs.abs() in the resolver's
+        // package.json parser), so the result must be copied.
+        try allocator.dupe(u8, resolve_path.joinAbsString(cwd, &[_]string{ts}, .auto))
     else
         null;
 

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { createHash } from "node:crypto";
 import path from "node:path";
+
+// Build a minimal npm tarball containing the given files under `package/`.
+function buildTarball(files: Record<string, string>) {
+  function header(name: string, size: number) {
+    const buf = Buffer.alloc(512, 0);
+    buf.write(name, 0, 100, "utf8");
+    buf.write("0000644\0", 100);
+    buf.write("0000000\0", 108);
+    buf.write("0000000\0", 116);
+    buf.write(size.toString(8).padStart(11, "0") + "\0", 124);
+    buf.write("00000000000\0", 136);
+    buf.fill(" ", 148, 156);
+    buf.write("0", 156);
+    buf.write("ustar\0", 257);
+    buf.write("00", 263);
+    let sum = 0;
+    for (let i = 0; i < 512; i++) sum += buf[i];
+    buf.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+    return buf;
+  }
+  const blocks: Buffer[] = [];
+  for (const [name, body] of Object.entries(files)) {
+    const data = Buffer.from(body);
+    blocks.push(header("package/" + name, data.length), data, Buffer.alloc((512 - (data.length % 512)) % 512, 0));
+  }
+  blocks.push(Buffer.alloc(1024, 0));
+  const tgz = Buffer.from(Bun.gzipSync(Buffer.concat(blocks)));
+  return {
+    tgz,
+    shasum: createHash("sha1").update(tgz).digest("hex"),
+    integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
+  };
+}
 
 describe("bun run --tsconfig-override", () => {
   test("should use custom tsconfig for path resolution", async () => {
@@ -302,4 +336,91 @@ describe("bun run --tsconfig-override", () => {
     }
     expect(exitCode).toBe(0);
   });
+
+  // `--tsconfig-override` stores the resolved absolute path in the resolver
+  // options. That path was previously a slice into joinAbsString's
+  // threadlocal scratch buffer. The first root-level DirInfo read (for `/`)
+  // happens before any overwrite so the common case worked, but auto-install
+  // resolves packages from the global cache via `dirInfoForResolution`, which
+  // calls `dirInfoUncached` with `parent == null` for a directory that *does*
+  // contain a package.json — so the package.json parse (fs.abs) clobbers the
+  // buffer before the subsequent tsconfig_override read, leaving a garbage
+  // path and dropping the override's path mappings for that tree.
+  test("path survives threadlocal buffer reuse when auto-installing", async () => {
+    const pkg = "dummy-pkg-tsconfig-override-buffer";
+    const tarball = buildTarball({
+      "package.json": JSON.stringify({ name: pkg, version: "1.0.0", main: "index.js" }),
+      // This import is resolved from inside the global-cache directory, whose
+      // DirInfo only has the override's path mappings if the override path
+      // survived until the second parent==null read.
+      "index.js": "module.exports.hello = require('@utils/math').value;\n",
+    });
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === `/${pkg}`) {
+          return Response.json({
+            name: pkg,
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: pkg,
+                version: "1.0.0",
+                dist: {
+                  tarball: `${server.url}${pkg}/-/${pkg}-1.0.0.tgz`,
+                  shasum: tarball.shasum,
+                  integrity: tarball.integrity,
+                },
+              },
+            },
+          });
+        }
+        if (url.pathname === `/${pkg}/-/${pkg}-1.0.0.tgz`) {
+          return new Response(tarball.tgz, { headers: { "content-type": "application/octet-stream" } });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const dir = tempDirWithFiles("run-tsconfig-override-buffer-reuse", {
+      "package.json": JSON.stringify({
+        name: "tsconfig-override-buffer-reuse",
+        version: "1.0.0",
+        dependencies: { [pkg]: "1.0.0" },
+      }),
+      "custom-tsconfig.json": JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "@utils/*": ["./src/*"] },
+        },
+      }),
+      "src/math.ts": `export const value = 42;\n`,
+      "index.ts": `
+        import { hello } from "${pkg}";
+        console.log("hello=" + hello);
+      `,
+      "cache/.keep": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--install=force", "--tsconfig-override", "./custom-tsconfig.json", "./index.ts"],
+      env: {
+        ...bunEnv,
+        BUN_CONFIG_REGISTRY: server.url.href,
+        NPM_CONFIG_REGISTRY: server.url.href,
+        BUN_INSTALL_CACHE_DIR: path.join(dir, "cache"),
+      },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find module '@utils/math'");
+    expect(stdout).toContain("hello=42");
+    expect(exitCode).toBe(0);
+  }, 60_000);
 });


### PR DESCRIPTION
## Problem

`Arguments.zig` resolved `--tsconfig-override` to an absolute path via `resolve_path.joinAbsString` and stored the returned slice directly in `opts.tsconfig_override`. `joinAbsString` writes into `parser_join_input_buffer`, a threadlocal scratch buffer whose doc comment explicitly says the result must be copied; the stored slice is read much later in `resolver.dirInfoUncached`.

The first root-level read (for `/`) happens before anything has clobbered the buffer, so the common `bun run` / `bun test` cases happen to work. But any subsequent `dirInfoUncached(parent == null)` call reads garbage:

- `dirInfoForResolution` (auto-install from the global cache) calls `dirInfoUncached` with `parent == null` for a directory that contains a `package.json`. `parsePackageJSON` → `r.fs.abs()` overwrites the buffer *before* `tsconfig_override` is read on line 4241, so the override is parsed from a truncated garbage path and its path mappings are silently dropped for that package tree.
- The same would happen if `/` had a `package.json`, or on Windows when resolving across drive letters, or after `bustDirCache` evicts the root in watch mode.

## Repro

```sh
bun --install=force --tsconfig-override ./custom-tsconfig.json ./index.ts
```
where `custom-tsconfig.json` maps `@utils/*` → `./src/*` and an auto-installed package does `require('@utils/math')`:

```
error: Cannot find module '@utils/math' from '.../cache/dummy-pkg@1.0.0@@localhost@@@1/index.js'
```

Tracing the override read at `resolver.zig:4241` shows the corruption directly — the second read sees `…/cache/dummy-pkg-tsco` (the package.json path truncated to the original override's length).

## Fix

Dupe the result of `joinAbsString` into the CLI allocator, matching the existing pattern for `--cwd` a few lines above.

## Verification

`test/cli/run/tsconfig-override.test.ts` gains a case that serves a package from a local registry, auto-installs it with `--install=force`, and has it `require('@utils/math')` via the override's path mapping.

```
USE_SYSTEM_BUN=1 bun test tsconfig-override.test.ts -t 'threadlocal'  → fail (Cannot find module '@utils/math')
bun bd          test tsconfig-override.test.ts                        → 7 pass
```