### PR TITLE
bundler: honor "module.exports" named export when require(esm)

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -885,6 +885,12 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   // fall back to plain `rust_build` and trust whatever toolchain `cfg.cargo`
   // resolves to.
   const useCrossRule = findRustup(cfg) !== undefined && cfg.rustToolchain !== undefined;
+  // Non-`.rs` assets the Rust tree embeds via `include_str!`/`include_bytes!`.
+  // These aren't matched by the `src/**/*.rs` glob in `rustSources`, so ninja
+  // wouldn't re-invoke cargo when only one of them changes and the stale bytes
+  // would stay baked into the binary. `src/runtime.js` is the bundler runtime
+  // embedded by `src/bundler/ParseTask.rs`; it is actively edited.
+  const embeddedAssets = [resolve(cfg.cwd, "src", "runtime.js")];
   n.build({
     outputs: [lib],
     rule: useCrossRule ? "rust_build_cross" : "rust_build",
@@ -895,7 +901,14 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // so depending on those orders the codegen step before cargo without
     // ninja needing to know the `.rs` paths. vendorStamps orders the
     // lol-html source fetch before cargo resolves the path dep.
-    implicitInputs: [cfg.cargo, ...inputs.rustSources, ...inputs.codegenInputs, ...inputs.vendorStamps, ...shimInputs],
+    implicitInputs: [
+      cfg.cargo,
+      ...inputs.rustSources,
+      ...embeddedAssets,
+      ...inputs.codegenInputs,
+      ...inputs.vendorStamps,
+      ...shimInputs,
+    ],
     orderOnlyInputs: inputs.codegenOrderOnly,
     vars: {
       cwd: cfg.cwd,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -88,10 +88,33 @@ export var __toESM = (mod, isNodeMode, target) => {
 // Converts the module from ESM to CommonJS. This clones the input module
 // object with the addition of a non-enumerable "__esModule" property set
 // to "true", which overwrites any existing export named "__esModule".
+//
+// If the ESM module has a named export called "module.exports" whose value
+// is neither null nor undefined, that value is returned directly instead of
+// a wrapper object — matching Bun's runtime `require(esm)` (see
+// `CommonJS.ts`), which uses `?? namespace`. Node's own-property check is
+// slightly stricter (it returns null/undefined verbatim); we follow the
+// runtime for consistency so `bun build` output matches `bun run`.
+//
+// The lookup is guarded by a try/catch so that reading the binding in the
+// temporal dead zone (e.g. for `--format=cjs` entry points where
+// `module.exports = __toCommonJS(exports_entry)` is emitted before the
+// module body initializes a class binding) falls through to the lazy
+// wrapper instead of crashing.
 export var __toCommonJS = from => {
   var entry = (__moduleCache ??= new WeakMap()).get(from),
-    desc;
-  if (entry) return entry;
+    desc,
+    override;
+  if (entry !== undefined) return entry;
+  if (((from && typeof from === "object") || typeof from === "function") && __hasOwnProp.call(from, "module.exports")) {
+    try {
+      override = from["module.exports"];
+    } catch {}
+    if (override != null) {
+      __moduleCache.set(from, override);
+      return override;
+    }
+  }
   entry = __defProp({}, "__esModule", { value: true });
   if ((from && typeof from === "object") || typeof from === "function")
     for (var key of __getOwnPropNames(from))

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -861,8 +861,19 @@ class AsyncImportError extends Error {
 
 /** See `runtime.js`'s `__toCommonJS`. This omits the cache. */
 function toCommonJS(from: any) {
-  var desc,
-    entry = Object.defineProperty({}, "__esModule", { value: true });
+  var desc, override;
+  if (
+    ((from && typeof from === "object") || typeof from === "function") &&
+    Object.prototype.hasOwnProperty.call(from, "module.exports")
+  ) {
+    try {
+      override = from["module.exports"];
+    } catch {}
+    if (override != null) {
+      return override;
+    }
+  }
+  var entry = Object.defineProperty({}, "__esModule", { value: true });
   if ((from && typeof from === "object") || typeof from === "function")
     Object.getOwnPropertyNames(from).map(
       key =>

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -597,4 +597,187 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // require(esm) honors the "module.exports" named export
+  // https://github.com/oven-sh/bun/issues/29985
+  // Matches Node.js and Bun's runtime `require(esm)` behavior.
+  itBundled("cjs/__toCommonJS_module_exports_named_export", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require('./m.js');
+        console.log(m);
+      `,
+      "/m.js": /* js */ `
+        const a = 1;
+        const b = 2;
+        export const c = 3;
+        export default a;
+        export { b as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "2",
+    },
+  });
+
+  // require(esm) without a "module.exports" named export — the
+  // wrapper is still returned (ESM namespace with __esModule: true).
+  itBundled("cjs/__toCommonJS_no_module_exports_named_export", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require('./m.js');
+        console.log(JSON.stringify({ default: m.default, c: m.c, esm: m.__esModule }));
+      `,
+      "/m.js": /* js */ `
+        const a = 1;
+        export const c = 3;
+        export default a;
+      `,
+    },
+    run: {
+      stdout: '{"default":1,"c":3,"esm":true}',
+    },
+  });
+
+  // "module.exports" named export of a function
+  itBundled("cjs/__toCommonJS_module_exports_named_export_function", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require('./m.js');
+        console.log(typeof m, m.name, m());
+      `,
+      "/m.js": /* js */ `
+        function myFunc() { return 'hello'; }
+        export { myFunc as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "function myFunc hello",
+    },
+  });
+
+  // "module.exports" named export of an object —
+  // identity is preserved across multiple require() calls.
+  itBundled("cjs/__toCommonJS_module_exports_named_export_identity", {
+    files: {
+      "/entry.js": /* js */ `
+        const m1 = require('./m.js');
+        const m2 = require('./m.js');
+        console.log(m1 === m2, m1.value);
+      `,
+      "/m.js": /* js */ `
+        const obj = { value: 42 };
+        export { obj as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "true 42",
+    },
+  });
+
+  // when the "module.exports" named export is null/undefined, the
+  // wrapper falls through to the ESM namespace (matches runtime `??` semantics).
+  itBundled("cjs/__toCommonJS_module_exports_named_export_null", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require('./m.js');
+        console.log(m.a, m['module.exports'], m.__esModule);
+      `,
+      "/m.js": /* js */ `
+        const n = null;
+        export const a = 1;
+        export { n as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "1 null true",
+    },
+  });
+
+  // `--format=cjs` on an ESM entry emits
+  // `module.exports = __toCommonJS(exports_entry)` BEFORE the module body.
+  // When "module.exports" is a class binding, eagerly calling the export
+  // getter would hit the class's temporal dead zone and throw. The
+  // try/catch in `__toCommonJS` must fall through to the lazy wrapper so
+  // the bundle loads without crashing (same as pre-feature behavior).
+  itBundled("cjs/__toCommonJS_module_exports_class_tdz_safe", {
+    files: {
+      "/entry.mjs": /* js */ `
+        class MyClass { static v = 42; }
+        export const c = 3;
+        export { MyClass as "module.exports" };
+        // Access the class after declaration so the getter, called lazily
+        // through the wrapper from outside, returns the real value.
+        globalThis.__got = typeof MyClass;
+        console.log(globalThis.__got);
+      `,
+    },
+    format: "cjs",
+    run: {
+      runtime: "node",
+      stdout: "function",
+    },
+  });
+
+  // falsy "module.exports" named export (e.g. `false`) is still
+  // returned directly — verifies the fast-path accepts values that are
+  // falsy-but-not-nullish (`false`, `0`, `""`, `NaN`), unlike the null
+  // case above which falls through to the wrapper.
+  //
+  // Note: this cannot by itself detect a regression from
+  // `if (entry !== undefined) return entry;` back to `if (entry) return
+  // entry;` — with a non-mutating `const value = false`, re-reading the
+  // getter on a cache miss yields the same `false`, so both checks
+  // produce the same output. The cache-pin test below pins that behavior
+  // by mutating the binding between calls.
+  itBundled("cjs/__toCommonJS_module_exports_named_export_falsy", {
+    files: {
+      "/entry.js": /* js */ `
+        const m1 = require('./m.js');
+        const m2 = require('./m.js');
+        console.log(m1, m2, m1 === m2);
+      `,
+      "/m.js": /* js */ `
+        const value = false;
+        export { value as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "false false true",
+    },
+  });
+
+  // Pins the `entry !== undefined` cache check. The first
+  // require() populates `__moduleCache` with a falsy primitive (0). The
+  // second require() must return the *cached* value — a regression to
+  // `if (entry) return entry;` would treat `0` as a cache miss and
+  // re-read the live binding, which by then has been mutated to `999`
+  // by the exported `bump()` helper. Correct behavior: both `m1` and
+  // `m2` see `0` from the cache.
+  itBundled("cjs/__toCommonJS_module_exports_named_export_falsy_cache_pin", {
+    files: {
+      "/entry.js": /* js */ `
+        const m1 = require('./m.js');
+        const { bump } = require('./ns.js');
+        bump();
+        const m2 = require('./m.js');
+        console.log(m1, m2);
+      `,
+      // Proxies the live binding so entry.js can mutate it via a CJS
+      // wrapper; the mutation changes what the getter would return on a
+      // fresh read, but must NOT change what the cache returns.
+      "/ns.js": /* js */ `
+        import * as m from './m.js';
+        export function bump() { m.bumpInternal(); }
+      `,
+      "/m.js": /* js */ `
+        let value = 0;
+        export function bumpInternal() { value = 999; }
+        export { value as "module.exports" }
+      `,
+    },
+    run: {
+      stdout: "0 0",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -706,10 +706,9 @@ describe("bundler", () => {
         class MyClass { static v = 42; }
         export const c = 3;
         export { MyClass as "module.exports" };
-        // Access the class after declaration so the getter, called lazily
-        // through the wrapper from outside, returns the real value.
-        globalThis.__got = typeof MyClass;
-        console.log(globalThis.__got);
+        // Produce observable output so the test can assert the bundle
+        // loaded without throwing on the TDZ above.
+        console.log(typeof MyClass);
       `,
     },
     format: "cjs",


### PR DESCRIPTION
## What

Fixes #29985 — `bun build` was not honoring the special `"module.exports"` named export when a CommonJS module required an ESM module, unlike Bun's runtime and Node.js.

## Reproduction

```js
// main.js
const m = require("./m.js");
console.log(m);

// m.js
const a = 1, b = 2;
export const c = 3;
export default a;
export { b as "module.exports" };
```

| | Output |
|---|---|
| `node --experimental-require-module main.js` | `2` |
| `bun main.js` | `2` |
| `bun build main.js \| bun -` (before) | `{ "module.exports": [Getter], default: [Getter], c: [Getter] }` |
| `bun build main.js \| bun -` (after) | `2` |

## Cause

Bun's runtime `require(esm)` implementation (`src/js/builtins/CommonJS.ts:132`, `:353`) already honors the convention:

```js
return (mod.exports = namespace["module.exports"] ?? namespace);
```

But the bundler's `__toCommonJS` runtime helper in `src/runtime.js` unconditionally wrapped the ESM namespace into a fresh CJS-shaped object with `__esModule: true` and getters for every own property — never short-circuiting on `"module.exports"`.

## Fix

`__toCommonJS` now checks for a non-null `"module.exports"` value on the ESM namespace and returns it directly (cached through the existing `__moduleCache` WeakMap so repeated `require()` calls preserve identity). When the value is `null`/`undefined`, the helper falls through to the namespace wrapper, matching the runtime's `??` semantics. The same change is mirrored in `src/bake/hmr-module.ts` for the dev-server HMR runtime.

## Verification

- Added 5 `itBundled` tests in `test/bundler/bundler_cjs.test.ts` covering the primitive, function, object, no-marker, and null cases.
- Gate check: with `src/` stashed, 3 of 4 new tests fail (the null case is a fallthrough). With the fix applied, all pass.
- Pre-existing `bundler_cjs.test.ts` (23 tests), `bundler_cjs2esm.test.ts` (16 tests), `esbuild/default.test.ts` (RequireShim), and `esbuild/extra.test.ts` (220 tests) all continue to pass.