### PR TITLE
sql(mysql): drain request queue into local before rejecting in clean()

### DIFF
--- a/src/sql/mysql/MySQLRequestQueue.zig
+++ b/src/sql/mysql/MySQLRequestQueue.zig
@@ -178,10 +178,20 @@ pub inline fn current(this: *const @This()) ?*JSMySQLQuery {
 }
 
 pub fn clean(this: *@This(), reason: ?JSValue, queries_array: JSValue) void {
-    while (this.current()) |request| {
+    // reject()/rejectWithJSValue() run JS which can synchronously call .close()
+    // (or otherwise fail the connection) and re-enter clean(). Swap the queue
+    // into a local first so the re-entrant call sees an empty queue instead of
+    // deref()'ing + discard()'ing the same requests out from under us.
+    var requests = this.#requests;
+    this.#requests = Queue.init(bun.default_allocator);
+    this.#pipelined_requests = 0;
+    this.#nonpipelinable_requests = 0;
+    this.#waiting_to_prepare = false;
+    defer requests.deinit();
+
+    while (requests.readItem()) |request| {
+        defer request.deref();
         if (request.isCompleted()) {
-            request.deref();
-            this.#requests.discard(1);
             continue;
         }
         if (reason) |r| {
@@ -189,13 +199,7 @@ pub fn clean(this: *@This(), reason: ?JSValue, queries_array: JSValue) void {
         } else {
             request.reject(queries_array, error.ConnectionClosed);
         }
-        this.#requests.discard(1);
-        request.deref();
-        continue;
     }
-    this.#pipelined_requests = 0;
-    this.#nonpipelinable_requests = 0;
-    this.#waiting_to_prepare = false;
 }
 
 pub fn deinit(this: *@This()) void {

--- a/test/js/sql/sql-mysql-clean-reentry.test.ts
+++ b/test/js/sql/sql-mysql-clean-reentry.test.ts
@@ -67,26 +67,29 @@ test.skipIf(!isDebug && !isASAN)(
 
       const sql = new SQL({ url: \`mysql://root@127.0.0.1:\${port}/db\`, max: 1 });
 
-      // Obtain the native MySQLConnection by shadowing the first query handle's
+      // Obtain the native MySQLConnection (and observe when every query has
+      // actually been enqueued natively) by shadowing each query handle's
       // .run(connection, query) with an own-property before the pool invokes it.
       let nativeConnection;
-      const q0 = sql\`select 0\`;
-      q0.values(); // force lazy creation of the native MySQLQuery handle
-      const handleSym = Object.getOwnPropertySymbols(q0).find(s => s.description === "handle");
-      const handle = q0[handleSym];
-      const protoRun = Object.getPrototypeOf(handle).run;
-      Object.defineProperty(handle, "run", {
-        configurable: true,
-        writable: true,
-        value(connection, query) {
-          nativeConnection = connection;
-          return protoRun.call(this, connection, query);
-        },
-      });
+      let runCount = 0;
+      let protoRun;
+      const queries = [sql\`select 0\`, sql\`select 1\`, sql\`select 2\`, sql\`select 3\`, sql\`select 4\`];
+      for (const q of queries) {
+        q.values(); // force lazy creation of the native MySQLQuery handle
+        const handleSym = Object.getOwnPropertySymbols(q).find(s => s.description === "handle");
+        const handle = q[handleSym];
+        protoRun ??= Object.getPrototypeOf(handle).run;
+        Object.defineProperty(handle, "run", {
+          configurable: true,
+          writable: true,
+          value(connection, query) {
+            nativeConnection = connection;
+            runCount++;
+            return protoRun.call(this, connection, query);
+          },
+        });
+      }
 
-      // Queue several more queries on the same (max: 1) connection so the native
-      // request queue has multiple entries when clean() runs.
-      const queries = [q0, sql\`select 1\`, sql\`select 2\`, sql\`select 3\`, sql\`select 4\`];
       const settled = queries.map(q =>
         q.catch(err => {
           // Re-enter clean() synchronously: this runs in the microtask drain that
@@ -96,11 +99,9 @@ test.skipIf(!isDebug && !isASAN)(
         })
       );
 
-      // Wait until the pool has actually handed the native connection to q0
+      // Wait until the pool has handed the native connection to every query
       // (requires real event-loop ticks, not just microtasks).
-      while (nativeConnection == null) await new Promise(r => setImmediate(r));
-      // Let the remaining queries flow into the native queue.
-      for (let i = 0; i < 10; i++) await new Promise(r => setImmediate(r));
+      while (runCount < queries.length) await new Promise(r => setImmediate(r));
 
       // Replace the pool's JS onclose handler with a no-op so it does not
       // pre-emptively reject the queries before native clean() runs. That leaves
@@ -127,7 +128,13 @@ test.skipIf(!isDebug && !isASAN)(
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "fixture.js"],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // A crash here writes a multi-GB core dump that outlives the default
+        // test timeout; the stderr panic trace is the useful signal.
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1",
+        BUN_ENABLE_CRASH_REPORTING: "0",
+      },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
@@ -148,5 +155,4 @@ test.skipIf(!isDebug && !isASAN)(
     ]);
     expect(exitCode).toBe(0);
   },
-  30_000,
 );

--- a/test/js/sql/sql-mysql-clean-reentry.test.ts
+++ b/test/js/sql/sql-mysql-clean-reentry.test.ts
@@ -1,0 +1,152 @@
+// MySQLRequestQueue.clean() iterated the live queue while running reject
+// callbacks. rejectWithJSValue() runs JS via event_loop.runCallback(), whose
+// exit() drains microtasks when the outer entered_event_loop_count is 0.
+// User code reachable from that drain can call MySQLConnection.close(),
+// which re-enters clean(). The inner call deref()'d + discard()'d the same
+// requests out from under the outer loop; when the outer loop resumed it
+// called LinearFifo.discard(1) on an empty fifo (debug assert -> panic) and
+// deref() on an already-deref'd request (release -> double free / UAF).
+//
+// Uses a minimal mock MySQL server so it can run without Docker.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
+
+// The failure mode is a debug assert in LinearFifo.discard() (and a UAF under
+// ASAN); in release builds the underflow is UB and may not crash, so only run
+// where it is observable.
+test.skipIf(!isDebug && !isASAN)(
+  "MySQL: clean() is safe when reject callback re-enters via connection.close()",
+  async () => {
+    using dir = tempDir("mysql-clean-reentry", {
+      "fixture.js": /* js */ `
+      const net = require("net");
+      const { SQL } = require("bun");
+
+      function u16le(n) { return Buffer.from([n & 0xff, (n >> 8) & 0xff]); }
+      function u24le(n) { return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]); }
+      function u32le(n) { return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]); }
+      function packet(seq, payload) { return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]); }
+
+      const SERVER_CAPS = (1 << 9) | (1 << 15) | (1 << 19) | (1 << 21) | (1 << 24);
+      function handshakeV10() {
+        const authData1 = Buffer.alloc(8, 0x61);
+        const authData2 = Buffer.alloc(13, 0x62);
+        authData2[12] = 0;
+        return packet(0, Buffer.concat([
+          Buffer.from([10]), Buffer.from("mock-5.7.0\\0"), u32le(1), authData1,
+          Buffer.from([0]), u16le(SERVER_CAPS & 0xffff), Buffer.from([0x2d]),
+          u16le(0x0002), u16le((SERVER_CAPS >>> 16) & 0xffff), Buffer.from([21]),
+          Buffer.alloc(10, 0), authData2, Buffer.from("mysql_native_password\\0"),
+        ]));
+      }
+      function okPacket(seq) { return packet(seq, Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])); }
+
+      let socketRef;
+      const server = net.createServer(socket => {
+        socketRef = socket;
+        let buffered = Buffer.alloc(0), authed = false;
+        socket.write(handshakeV10());
+        socket.on("data", chunk => {
+          buffered = Buffer.concat([buffered, chunk]);
+          while (buffered.length >= 4) {
+            const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+            if (buffered.length < 4 + len) break;
+            const seq = buffered[3];
+            buffered = buffered.subarray(4 + len);
+            if (!authed) { authed = true; socket.write(okPacket(seq + 1)); }
+            // Never respond to queries -> they stay in the native request queue.
+          }
+        });
+        socket.on("error", () => {});
+      });
+
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const { port } = server.address();
+
+      const sql = new SQL({ url: \`mysql://root@127.0.0.1:\${port}/db\`, max: 1 });
+
+      // Obtain the native MySQLConnection by shadowing the first query handle's
+      // .run(connection, query) with an own-property before the pool invokes it.
+      let nativeConnection;
+      const q0 = sql\`select 0\`;
+      q0.values(); // force lazy creation of the native MySQLQuery handle
+      const handleSym = Object.getOwnPropertySymbols(q0).find(s => s.description === "handle");
+      const handle = q0[handleSym];
+      const protoRun = Object.getPrototypeOf(handle).run;
+      Object.defineProperty(handle, "run", {
+        configurable: true,
+        writable: true,
+        value(connection, query) {
+          nativeConnection = connection;
+          return protoRun.call(this, connection, query);
+        },
+      });
+
+      // Queue several more queries on the same (max: 1) connection so the native
+      // request queue has multiple entries when clean() runs.
+      const queries = [q0, sql\`select 1\`, sql\`select 2\`, sql\`select 3\`, sql\`select 4\`];
+      const settled = queries.map(q =>
+        q.catch(err => {
+          // Re-enter clean() synchronously: this runs in the microtask drain that
+          // follows each rejectWithJSValue() call inside the outer clean().
+          try { nativeConnection?.close(); } catch {}
+          return err?.code ?? String(err);
+        })
+      );
+
+      // Wait until the pool has actually handed the native connection to q0
+      // (requires real event-loop ticks, not just microtasks).
+      while (nativeConnection == null) await new Promise(r => setImmediate(r));
+      // Let the remaining queries flow into the native queue.
+      for (let i = 0; i < 10; i++) await new Promise(r => setImmediate(r));
+
+      // Replace the pool's JS onclose handler with a no-op so it does not
+      // pre-emptively reject the queries before native clean() runs. That leaves
+      // failWithJSValue's deferred clean() to do the rejecting at elc==0, where
+      // runCallback.exit() drains microtasks between requests and lets the
+      // .catch() handlers above re-enter clean().
+      nativeConnection.onclose = () => {};
+
+      // Drop the socket -> onClose -> failWithJSValue -> defer cleanQueueAndClose
+      // -> MySQLRequestQueue.clean() with all 5 requests still pending.
+      socketRef.destroy();
+
+      const codes = await Promise.all(settled);
+
+      // Yield to the event loop so the native clean() stack frame that invoked
+      // our .catch() handlers resumes and finishes (this is where the old code
+      // would discard(1) on the now-empty fifo and panic).
+      await new Promise(r => setImmediate(r));
+
+      console.log("ok", JSON.stringify(codes));
+      process.exit(0);
+    `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toStartWith("ok ");
+    // Every pending query must have been rejected exactly once.
+    const codes = JSON.parse(stdout.slice(3));
+    expect(codes).toEqual([
+      "ERR_MYSQL_CONNECTION_CLOSED",
+      "ERR_MYSQL_CONNECTION_CLOSED",
+      "ERR_MYSQL_CONNECTION_CLOSED",
+      "ERR_MYSQL_CONNECTION_CLOSED",
+      "ERR_MYSQL_CONNECTION_CLOSED",
+    ]);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
## What

`MySQLRequestQueue.clean()` iterated the live fifo while running per-request reject callbacks. A reject callback that synchronously re-entered `clean()` (via `MySQLConnection.close()`) would `deref()`/`discard()` the same requests out from under the outer loop; when the outer loop resumed it called `LinearFifo.discard(1)` on an empty fifo (debug `unreachable`) and `deref()` on an already-freed request (release UAF).

## Why it can re-enter

`rejectWithJSValue()` runs JS via `event_loop.runCallback()`, whose `exit()` drains microtasks when the outer `entered_event_loop_count == 0`. That is exactly the context `failWithJSValue`'s deferred `cleanQueueAndClose` runs in — the preceding `runCallback(on_close)` has fully unwound by the time the `defer` fires. A query `.catch()` that calls `nativeConnection.close()` during that drain lands back in `doClose` → `cleanQueueAndClose` → `clean()` while the outer frame is still mid-loop.

## Reproduction

Mock MySQL server (handshake + auth OK, never responds to queries), 5 pending queries on one connection, native `onclose` stubbed so the JS pool doesn't pre-reject, then the server drops the socket. Each query's `.catch()` calls `nativeConnection.close()`.

Before:

```
panic(main thread): reached unreachable code
linear_fifo.LinearFifo(*JSMySQLQuery,.Dynamic).discard  (src/linear_fifo.zig:175)
sql.mysql.MySQLRequestQueue.clean                       (src/sql/mysql/MySQLRequestQueue.zig:192)
sql.mysql.MySQLConnection.cleanQueueAndClose
sql.mysql.js.JSMySQLConnection.failWithJSValue
sql.mysql.js.JSMySQLConnection.SocketHandler(false).onClose
```

After: all 5 queries reject once with `ERR_MYSQL_CONNECTION_CLOSED`, clean exit.

## Fix

Swap `#requests` into a local and reset the live fifo/counters *before* running any callbacks, then drain the local via `readItem()`. Re-entrant `clean()` now sees an empty queue and is a no-op. This matches the pattern already used by `valkey.rejectAllPendingCommands()` and `MySQLConnection.cleanup()` for the same fifo.

## Test

`test/js/sql/sql-mysql-clean-reentry.test.ts` — subprocess with a mock MySQL server, no Docker required. Gated to debug/ASAN builds since the failure mode (fifo-underflow assert / UAF) is not observable in release.