### PR TITLE
Lock cellLock() around JSCommonJSModule::m_children mutation and visitChildren

### DIFF
--- a/src/bun.js/bindings/JSCommonJSModule.cpp
+++ b/src/bun.js/bindings/JSCommonJSModule.cpp
@@ -267,6 +267,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule, (JSGlobalObject * lex
             // referrer.children.indexOf(moduleObject) === -1 && referrer.children.push(moduleObject)
             returnValue = referrer->m_childrenValue.get();
         } else {
+            WTF::Locker locker { referrer->cellLock() };
             referrer->m_children.append(WriteBarrier<Unknown>());
             referrer->m_children.last().set(vm, referrer, moduleObject);
         }
@@ -532,7 +533,10 @@ JSC_DEFINE_CUSTOM_SETTER(setterChildren,
     JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
     if (!thisObject)
         return false;
-    thisObject->m_children.clear();
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        thisObject->m_children.clear();
+    }
     thisObject->m_childrenValue.set(globalObject->vm(), thisObject, JSValue::decode(value));
     return true;
 }
@@ -576,7 +580,10 @@ JSC_DEFINE_CUSTOM_GETTER(getterChildren, (JSC::JSGlobalObject * globalObject, JS
         RETURN_IF_EXCEPTION(throwScope, {});
         mod->m_childrenValue.set(globalObject->vm(), mod, array);
 
-        mod->m_children.clear();
+        {
+            WTF::Locker locker { mod->cellLock() };
+            mod->m_children.clear();
+        }
 
         return JSValue::encode(array);
     }
@@ -1168,7 +1175,10 @@ void JSCommonJSModule::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.appendHidden(thisObject->m_overriddenParent);
     visitor.appendHidden(thisObject->m_overriddenCompile);
     visitor.appendHidden(thisObject->m_childrenValue);
-    visitor.appendValues(thisObject->m_children.begin(), thisObject->m_children.size());
+    {
+        WTF::Locker locker { thisObject->cellLock() };
+        visitor.appendValues(thisObject->m_children.begin(), thisObject->m_children.size());
+    }
 }
 
 DEFINE_VISIT_CHILDREN(JSCommonJSModule);

--- a/test/js/node/module/module-children-concurrent-gc.test.ts
+++ b/test/js/node/module/module-children-concurrent-gc.test.ts
@@ -1,0 +1,78 @@
+// JSCommonJSModule::m_children is a WTF::Vector<WriteBarrier<Unknown>> that
+// the mutator appends to on every require() (jsFunctionEvaluateCommonJSModule)
+// while visitChildrenImpl iterates it on the concurrent GC marker thread.
+// Both sides must hold cellLock() so Vector growth cannot free the backing
+// buffer while the marker still holds a stale begin() pointer.
+//
+// require() of an already-cached module still calls
+// $evaluateCommonJSModule(existing, this), which appends to the referrer's
+// m_children, so a tight loop of `require("./c.cjs")` against a cached child
+// drives thousands of appends (and ~a dozen reallocations) while
+// collectContinuously keeps the concurrent marker repeatedly visiting the
+// same module via require.cache.
+//
+// This race is not reliably observable as a crash in the default build
+// because the prebuilt debug WebKit uses bmalloc (USE_SYSTEM_MALLOC=0), so
+// the freed Vector buffer is neither ASAN-poisoned nor scribbled and the
+// marker just re-reads still-valid JSCell pointers. The test is kept as a
+// regression guard for the locking — it exercises every m_children mutation
+// site (append, setter clear, getter clear) under concurrent GC and asserts
+// the program still runs to completion with correct output.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// collectContinuously is very slow on Windows in CI and the code path is
+// identical across platforms; skip there (same rationale as issue 29519).
+test.skipIf(isWindows)(
+  "JSCommonJSModule m_children mutation under concurrent GC",
+  async () => {
+    const files: Record<string, string> = {
+      "c.cjs": `module.exports = 1;\n`,
+      "p.cjs": `
+        // ~12 reallocations of this module's m_children backing buffer.
+        for (let i = 0; i < 4000; i++) require("./c.cjs");
+        // setterChildren: locks, clears the native Vector, stores the JS value.
+        module.children = module.children;
+        module.exports = module.children.length;
+      `,
+      "entry.cjs": `
+        require("./c.cjs");
+        const pPath = require.resolve("./p.cjs");
+        let n = 0;
+        for (let iter = 0; iter < 4; iter++) {
+          // Fresh JSCommonJSModule (and fresh empty m_children) each time.
+          delete require.cache[pPath];
+          n = require("./p.cjs");
+        }
+        // getterChildren: materializes the JSArray then locks and clears.
+        if (module.children.length < 2) throw new Error("children missing");
+        console.log("ok " + n);
+      `,
+    };
+
+    using dir = tempDir("cjs-children-concurrent-gc", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.cjs"],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Assert output before exit code so a failure shows the actual crash
+    // text. Debug/ASAN builds print a harmless "WARNING: ASAN interferes
+    // with JSC signal handlers" banner on stderr, so only surface stderr
+    // when the process failed.
+    expect(stdout.trim()).toBe("ok 1");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## Race

`JSCommonJSModule::m_children` is a `WTF::Vector<WriteBarrier<Unknown>>`. The mutator appends to it on every CommonJS `require()` (in `jsFunctionEvaluateCommonJSModule`) and clears it in the `module.children` getter/setter, while `visitChildrenImpl` iterates it on the concurrent GC marker thread via `visitor.appendValues(m_children.begin(), m_children.size())`.

None of these sites took a lock. When the Vector grows past capacity, `WTF::Vector::append` frees the old backing buffer; `clear()` → `shrinkCapacity(0)` does the same. If the marker has already loaded the old `begin()` it then iterates freed memory.

## Fix

Hold `cellLock()` at all four sites:

- the `append()` in `jsFunctionEvaluateCommonJSModule`
- the `clear()` in `setterChildren`
- the `clear()` in `getterChildren`
- the `appendValues()` in `visitChildrenImpl`

This is the same pattern already used in Bun's `NapiHandleScopeImpl` (whose `m_storage` is the same shape) and in JSC's own `AbstractModuleRecord::visitChildrenImpl` / `SparseArrayValueMap` / `JSModuleNamespaceObject` etc. The lock scopes are kept tight so no allocation happens while held.

## Verification

- `bun bd test test/js/node/module/module-children-concurrent-gc.test.ts` — new stress test that loops thousands of cached `require()` calls (each appending to `m_children` and forcing repeated reallocations) plus the getter/setter `clear()` paths, all under `BUN_JSC_collectContinuously=1`. Passes in ~10s.
- `bun bd test test/js/node/module/node-module-module.test.js` — 28/28 existing module tests pass, including both `children` fixtures.

Note: the race does not manifest as a deterministic crash in the default debug build because the prebuilt debug WebKit is built with `USE_SYSTEM_MALLOC=0`, so the freed Vector buffer is returned to bmalloc (not ASAN-poisoned, not scribbled) and the marker just re-reads still-valid `JSCell*`s. The test is retained as a regression guard that exercises every `m_children` mutation site under concurrent GC.