### PR TITLE
node:vm: allocate prepareStackTrace call sites in the vm realm

### DIFF
--- a/src/jsc/bindings/BunGlobalScope.cpp
+++ b/src/jsc/bindings/BunGlobalScope.cpp
@@ -8,6 +8,8 @@
 #include "JavaScriptCore/LazyClassStructure.h"
 #include "JavaScriptCore/LazyClassStructureInlines.h"
 #include "BunClientData.h"
+#include "CallSite.h"
+#include "CallSitePrototype.h"
 
 namespace Bun {
 
@@ -31,6 +33,15 @@ void GlobalScope::finishCreation(JSC::VM& vm)
             RELEASE_ASSERT(offset == 1);
             init.set(structure);
         });
+
+    m_callSiteStructure.initLater(
+        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
+            auto& vm = init.vm;
+            auto* globalObject = init.owner;
+            auto* prototype = Zig::CallSitePrototype::create(vm, Zig::CallSitePrototype::createStructure(vm, globalObject, globalObject->objectPrototype()), globalObject);
+            auto* structure = Zig::CallSite::createStructure(vm, globalObject, prototype);
+            init.set(structure);
+        });
 }
 
 DEFINE_VISIT_CHILDREN(GlobalScope);
@@ -43,6 +54,7 @@ void GlobalScope::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 
     thisObject->m_encodeIntoObjectStructure.visit(visitor);
+    thisObject->m_callSiteStructure.visit(visitor);
 }
 
 const JSC::ClassInfo GlobalScope::s_info = { "GlobalScope"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(GlobalScope) };

--- a/src/jsc/bindings/BunGlobalScope.h
+++ b/src/jsc/bindings/BunGlobalScope.h
@@ -28,6 +28,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     JSC::Structure* encodeIntoObjectStructure() const { return m_encodeIntoObjectStructure.getInitializedOnMainThread(this); }
+    JSC::Structure* callSiteStructure() const { return m_callSiteStructure.getInitializedOnMainThread(this); }
 
     /**
      * WARNING: You must update visitChildrenImpl() if you add a new field.
@@ -40,6 +41,11 @@ public:
      * those callbacks will eventually never be called anymore. But it'll work the first time!
      */
     LazyProperty<JSGlobalObject, Structure> m_encodeIntoObjectStructure;
+    // CallSite structure lives here (rather than Zig::GlobalObject) so that
+    // node:vm realms get their own per-realm prototype chain for the
+    // `sites` array entries passed to Error.prepareStackTrace. Otherwise the
+    // host-realm Object/Function constructors leak into the vm sandbox.
+    LazyProperty<JSGlobalObject, Structure> m_callSiteStructure;
 };
 
 } // namespace Bun

--- a/src/jsc/bindings/BunGlobalScope.h
+++ b/src/jsc/bindings/BunGlobalScope.h
@@ -41,10 +41,6 @@ public:
      * those callbacks will eventually never be called anymore. But it'll work the first time!
      */
     LazyProperty<JSGlobalObject, Structure> m_encodeIntoObjectStructure;
-    // CallSite structure lives here (rather than Zig::GlobalObject) so that
-    // node:vm realms get their own per-realm prototype chain for the
-    // `sites` array entries passed to Error.prepareStackTrace. Otherwise the
-    // host-realm Object/Function constructors leak into the vm sandbox.
     LazyProperty<JSGlobalObject, Structure> m_callSiteStructure;
 };
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -509,7 +509,11 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
         }
     }
 
-    JSArray* callSitesArray = JSC::constructArray(globalObject, globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), callSites);
+    // Allocate the sites array in the lexical (error's) realm. When running
+    // inside node:vm, lexicalGlobalObject is the vm's NodeVMGlobalObject, not
+    // the host Zig::GlobalObject — using the host here would leak host-realm
+    // Array/Function into the sandbox via sites.constructor.
+    JSArray* callSitesArray = JSC::constructArray(lexicalGlobalObject, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), callSites);
     RETURN_IF_EXCEPTION(scope, {});
 
     RELEASE_AND_RETURN(scope, formatStackTraceToJSValue(vm, globalObject, lexicalGlobalObject, errorObject, callSitesArray, prepareStackTrace));
@@ -833,8 +837,13 @@ void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool encounteredStrictFrame = false;
 
-    // TODO: is it safe to use CallSite structure from a different JSGlobalObject? This case would happen within a node:vm
-    JSC::Structure* callSiteStructure = globalObject->callSiteStructure();
+    // Use the lexical (error's) realm for the CallSite structure so that
+    // inside node:vm the prototype chain terminates at the vm's
+    // Object.prototype, not the host's. Both Zig::GlobalObject and
+    // NodeVMGlobalObject derive from Bun::GlobalScope, which owns the
+    // per-realm CallSite structure.
+    auto* lexicalScope = dynamicDowncast<Bun::GlobalScope>(lexicalGlobalObject);
+    JSC::Structure* callSiteStructure = lexicalScope ? lexicalScope->callSiteStructure() : globalObject->callSiteStructure();
     size_t framesCount = stackTrace.size();
 
     for (size_t i = 0; i < framesCount; i++) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -437,7 +437,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     MarkedArgumentBuffer callSites;
 
     // Create the call sites (one per frame)
-    Zig::createCallSitesFromFrames(globalObject, lexicalGlobalObject, stackTrace, callSites);
+    Zig::createCallSitesFromFrames(lexicalGlobalObject, stackTrace, callSites);
     RETURN_IF_EXCEPTION(scope, {});
 
     // We need to sourcemap it if it's a GlobalObject.
@@ -509,10 +509,6 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
         }
     }
 
-    // Allocate the sites array in the lexical (error's) realm. When running
-    // inside node:vm, lexicalGlobalObject is the vm's NodeVMGlobalObject, not
-    // the host Zig::GlobalObject — using the host here would leak host-realm
-    // Array/Function into the sandbox via sites.constructor.
     JSArray* callSitesArray = JSC::constructArray(lexicalGlobalObject, lexicalGlobalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous), callSites);
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -826,24 +822,19 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
 
 namespace Zig {
 
-void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, MarkedArgumentBuffer& callSites)
+void createCallSitesFromFrames(JSC::JSGlobalObject* lexicalGlobalObject, JSCStackTrace& stackTrace, MarkedArgumentBuffer& callSites)
 {
     /* From v8's "Stack Trace API" (https://github.com/v8/v8/wiki/Stack-Trace-API):
      * "To maintain restrictions imposed on strict mode functions, frames that have a
      * strict mode function and all frames below (its caller etc.) are not allow to access
      * their receiver and function objects. For those frames, getFunction() and getThis()
      * will return undefined."." */
-    auto& vm = JSC::getVM(globalObject);
+    auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool encounteredStrictFrame = false;
 
-    // Use the lexical (error's) realm for the CallSite structure so that
-    // inside node:vm the prototype chain terminates at the vm's
-    // Object.prototype, not the host's. Both Zig::GlobalObject and
-    // NodeVMGlobalObject derive from Bun::GlobalScope, which owns the
-    // per-realm CallSite structure.
-    auto* lexicalScope = dynamicDowncast<Bun::GlobalScope>(lexicalGlobalObject);
-    JSC::Structure* callSiteStructure = lexicalScope ? lexicalScope->callSiteStructure() : globalObject->callSiteStructure();
+    // Per-realm structure: inside node:vm the CallSite prototype chain must end at the vm's Object.prototype.
+    JSC::Structure* callSiteStructure = uncheckedDowncast<Bun::GlobalScope>(lexicalGlobalObject)->callSiteStructure();
     size_t framesCount = stackTrace.size();
 
     for (size_t i = 0; i < framesCount; i++) {

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -89,7 +89,6 @@ namespace Zig {
 
 // GlobalObject member function for creating CallSite objects
 void createCallSitesFromFrames(
-    Zig::GlobalObject* globalObject,
     JSC::JSGlobalObject* lexicalGlobalObject,
     Zig::JSCStackTrace& stackTrace,
     JSC::MarkedArgumentBuffer& callSites);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -73,8 +73,6 @@
 #include "NodeV8.h"
 #include "ProcessIdentifier.h"
 #include "GlobalEventScope.h"
-#include "CallSite.h"
-#include "CallSitePrototype.h"
 #include "FormatStackTraceForJS.h"
 #include "JSCommonJSModule.h"
 #include "JSCommonJSExtensions.h"
@@ -2185,12 +2183,6 @@ void GlobalObject::finishCreation(VM& vm)
              init.setPrototype(prototype);
              init.setStructure(structure);
              init.setConstructor(constructor);
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_callSiteStructure), [](LazyClassStructure::Initializer& init) {
-             auto* prototype = CallSitePrototype::create(init.vm, CallSitePrototype::createStructure(init.vm, init.global, init.global->objectPrototype()), init.global);
-             auto* structure = CallSite::createStructure(init.vm, init.global, prototype);
-             init.setPrototype(prototype);
-             init.setStructure(structure);
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSStringDecoderClassStructure), [](LazyClassStructure::Initializer& init) {
              auto* prototype = JSStringDecoderPrototype::create(

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -260,8 +260,6 @@ public:
     // moduleLoader()->registryEntry(key) / moduleMap() / removeEntry(key) /
     // clearAll() instead.
 
-    JSC::Structure* callSiteStructure() const { return m_callSiteStructure.getInitializedOnMainThread(this); }
-
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
     JSC::JSFunction* utilInspectFunction() const { return m_utilInspectFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* utilInspectStylizeColorFunction() const { return m_utilInspectStylizeColorFunction.getInitializedOnMainThread(this); }
@@ -577,7 +575,6 @@ public:
     V(public, LazyClassStructure, m_JSNodeSqliteLimitsClassStructure)                                        \
     V(public, LazyClassStructure, m_JSNodeSqliteTagStoreClassStructure)                                      \
     V(private, LazyClassStructure, m_NapiClassStructure)                                                     \
-    V(private, LazyClassStructure, m_callSiteStructure)                                                      \
     V(public, LazyClassStructure, m_JSBufferClassStructure)                                                  \
     V(public, LazyClassStructure, m_NodeVMScriptClassStructure)                                              \
     V(public, LazyClassStructure, m_NodeVMSourceTextModuleClassStructure)                                    \

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1974,3 +1974,69 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+test("Error.prepareStackTrace sites array uses the vm realm", () => {
+  // The array and CallSite objects passed to a user-installed
+  // Error.prepareStackTrace must be allocated in the vm's realm, not the
+  // host realm. Otherwise `sites.constructor.constructor` is the host
+  // Function constructor and can be used to escape the sandbox.
+  const context = createContext({});
+  const result = runInContext(
+    `
+    let captured;
+    Error.prepareStackTrace = (err, sites) => {
+      captured = sites;
+      return "";
+    };
+    new Error().stack;
+
+    let escaped;
+    try {
+      escaped = captured.constructor.constructor("return typeof process")();
+    } catch {
+      escaped = "undefined";
+    }
+
+    const site = captured[0];
+    ({
+      sitesCtorIsVmArray: captured.constructor === Array,
+      sitesProtoIsVmArrayProto: Object.getPrototypeOf(captured) === Array.prototype,
+      callSiteProtoProtoIsVmObjectProto:
+        Object.getPrototypeOf(Object.getPrototypeOf(site)) === Object.prototype,
+      callSiteCtorIsVmObject: site.constructor === Object,
+      escapedProcessType: escaped,
+      getLineNumberWorks: typeof site.getLineNumber() === "number",
+    });
+    `,
+    context,
+  );
+
+  expect(result).toEqual({
+    sitesCtorIsVmArray: true,
+    sitesProtoIsVmArrayProto: true,
+    callSiteProtoProtoIsVmObjectProto: true,
+    callSiteCtorIsVmObject: true,
+    escapedProcessType: "undefined",
+    getLineNumberWorks: true,
+  });
+});
+
+test("Error.prepareStackTrace sites do not leak host Array into vm", () => {
+  const context = createContext({});
+  const sites = runInContext(
+    `
+    let captured;
+    Error.prepareStackTrace = (err, sites) => {
+      captured = sites;
+      return "";
+    };
+    new Error().stack;
+    captured;
+    `,
+    context,
+  );
+  // From the host's perspective the array must not be a host Array instance.
+  expect(sites.constructor === Array).toBe(false);
+  expect(Object.getPrototypeOf(sites) === Array.prototype).toBe(false);
+  expect(Object.getPrototypeOf(Object.getPrototypeOf(sites[0])) === Object.prototype).toBe(false);
+});


### PR DESCRIPTION
### Problem
- Inside a `node:vm` context, a user-installed `Error.prepareStackTrace(err, sites)` received a `sites` array and `CallSite` objects allocated in the host realm, so `sites.constructor.constructor("return process")()` returned the host `process` from inside the sandbox.
- `computeErrorInfoWithPrepareStackTrace` built the array with the host `globalObject` (`src/jsc/bindings/FormatStackTraceForJS.cpp`, `constructArray` call), and `createCallSitesFromFrames` took the `CallSite` structure from the host `Zig::GlobalObject` (same file, the spot previously marked with a TODO asking whether this was safe under `node:vm`).
- Node.js hands the callback vm-realm objects; Bun did not.

### Fix
- Move `m_callSiteStructure` (and its lazy initializer and GC visit) from `Zig::GlobalObject` to `Bun::GlobalScope`, the base class shared by `Zig::GlobalObject` and `NodeVMGlobalObject`, so each realm owns a `CallSite` structure whose prototype chain ends at that realm's `Object.prototype`.
- `computeErrorInfoWithPrepareStackTrace` builds the `sites` array from `lexicalGlobalObject` (the error's realm) instead of the host global.
- `createCallSitesFromFrames` downcasts the lexical global to `Bun::GlobalScope` and uses its structure; the host `globalObject` parameter is removed because nothing in the function needs it. Every global Bun creates (`Zig::GlobalObject`, `EvalGlobalObject`, ShadowRealm globals, `NodeVMGlobalObject`) derives from `Bun::GlobalScope`, so the downcast is unconditional and asserted in debug builds.
- Verified:
  - `test/js/node/vm/vm.test.ts` gains two tests: one runs inside the vm and checks `sites.constructor === Array`, the `CallSite` prototype chain, and that the Function-constructor escape yields `undefined`; the other reads the array from the host and checks it is not a host `Array`. Both fail on main and pass with this change.
  - `test/js/node/vm/vm.test.ts`, `test/js/node/v8/capture-stack-trace.test.js`, `test/regression/issue/fix-bindings-stack-trace.test.ts`, `test/regression/issue/prepare-stack-trace-crash.test.ts`: 264 pass, 0 fail on the debug build.
  - A debug-build probe set `Error.prepareStackTrace` in the main realm, a `node:vm` context, a `ShadowRealm`, and a `Worker`, and read a vm error's `.stack` from the host; no assertion fired and the vm cases returned vm-realm arrays.

### Background
- A realm is one global object plus its own set of intrinsics (`Object.prototype`, `Array`, `Function`, ...). `node:vm` contexts are separate realms; a sandbox escape is any path that hands the sandbox an object whose prototype chain reaches a host-realm intrinsic, since `obj.constructor.constructor` is then the host `Function` and can evaluate code with host globals in scope.
- A JSC `Structure` describes an object's shape and prototype. Allocating an object with a structure created for realm A puts it on realm A's prototype chain regardless of where the allocation happens, which is why the structure itself has to be per realm.
- `LazyProperty` is JSC's on-first-use holder for a GC-managed value owned by a global object; it must be visited in the owner's `visitChildren`, which `Bun::GlobalScope::visitChildrenImpl` now does for this field.
- `Bun::GlobalScope` is the thin `JSGlobalObject` subclass that both the main/worker global (`Zig::GlobalObject`) and the `node:vm` global (`NodeVMGlobalObject`) extend; it is the natural home for anything that must exist once per realm.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 21 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->