### PR TITLE
strings: fix out-of-bounds read in CodepointIterator.next() on truncated UTF-8

### DIFF
--- a/src/string/immutable/unicode.zig
+++ b/src/string/immutable/unicode.zig
@@ -108,7 +108,24 @@ pub fn NewCodePointIterator(comptime CodePointType_: type, comptime zeroValue: c
                 switch (cp_len) {
                     0 => return false,
                     1 => it.bytes[pos],
-                    else => decodeWTF8RuneTMultibyte(it.bytes[pos..].ptr[0..4], cp_len, CodePointType, error_char),
+                    else => blk: {
+                        // Copy into a zero-padded stack buffer so we never read past
+                        // the end of `it.bytes` when a multi-byte lead appears near
+                        // EOF without enough continuation bytes. The zero padding is
+                        // rejected by decodeWTF8RuneTMultibyte (0x00 is not a valid
+                        // continuation byte), so truncated sequences become U+FFFD.
+                        const remaining = it.bytes[pos..];
+                        const cp_bytes: [4]u8 = switch (@min(remaining.len, 4)) {
+                            inline 1, 2, 3, 4 => |n| .{
+                                remaining[0],
+                                if (comptime n > 1) remaining[1] else 0,
+                                if (comptime n > 2) remaining[2] else 0,
+                                if (comptime n > 3) remaining[3] else 0,
+                            },
+                            else => unreachable,
+                        };
+                        break :blk decodeWTF8RuneTMultibyte(&cp_bytes, cp_len, CodePointType, error_char);
+                    },
                 },
             );
 
@@ -134,7 +151,7 @@ pub fn NewCodePointIterator(comptime CodePointType_: type, comptime zeroValue: c
             it.next_width = cp_len;
             it.i = @min(next_, bytes.len);
 
-            const slice = bytes[prev..][0..cp_len];
+            const slice = bytes[prev..][0..@min(@as(usize, cp_len), bytes.len - prev)];
             it.width = @as(u3_fast, @intCast(slice.len));
             return slice;
         }

--- a/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
@@ -1,15 +1,15 @@
 // Place source bytes immediately before an unmapped guard page so that an
 // out-of-bounds read past the end of the input faults deterministically,
 // independent of allocator layout or ASAN.
-import { existsSync } from "node:fs";
 import { dlopen, ptr, toArrayBuffer } from "bun:ffi";
 
 const isDarwin = process.platform === "darwin";
-const libcPath = isDarwin
-  ? "/usr/lib/libSystem.B.dylib"
-  : existsSync("/usr/lib/libc.so")
-    ? "/usr/lib/libc.so" // musl
-    : "libc.so.6"; // glibc
+// The test passes libcPathForDlopen() from the harness (which distinguishes
+// glibc from musl via process.report). Probing /usr/lib/libc.so is unreliable
+// because on non-multiarch glibc distros that path is an ld linker script,
+// not an ELF, and dlopen() would reject it.
+const libcPath = process.env.BUN_TEST_LIBC_PATH!;
+if (!libcPath) throw new Error("BUN_TEST_LIBC_PATH not set");
 const MAP_ANON = isDarwin ? 0x1000 : 0x20;
 const MAP_PRIVATE = 0x02;
 const PROT_READ = 1;

--- a/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
@@ -27,7 +27,10 @@ if (PAGE <= 0) throw new Error("getpagesize() failed");
 
 const base = libc.symbols.mmap(null, PAGE * 2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0n);
 const baseNum = Number(base);
-if (baseNum <= 0 || baseNum === -1) throw new Error("mmap failed");
+// MAP_FAILED = (void*)-1 marshals through bun:ffi's `ptr` return as
+// (double)(uintptr_t)-1 ≈ 1.8e19, which is not a safe integer; valid
+// user-space addresses always are.
+if (base === null || !Number.isSafeInteger(baseNum)) throw new Error("mmap failed");
 if (libc.symbols.mprotect(baseNum + PAGE, PAGE, PROT_NONE) !== 0) throw new Error("mprotect failed");
 
 function atGuard(bytes: number[]): Uint8Array {

--- a/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
@@ -1,0 +1,74 @@
+// Place source bytes immediately before an unmapped guard page so that an
+// out-of-bounds read past the end of the input faults deterministically,
+// independent of allocator layout or ASAN.
+import { dlopen, ptr, toArrayBuffer } from "bun:ffi";
+
+const libcPath =
+  process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6";
+const MAP_ANON = process.platform === "darwin" ? 0x1000 : 0x20;
+const MAP_PRIVATE = 0x02;
+const PROT_READ = 1;
+const PROT_WRITE = 2;
+const PROT_NONE = 0;
+const _SC_PAGESIZE = process.platform === "darwin" ? 29 : 30;
+
+const libc = dlopen(libcPath, {
+  sysconf: { args: ["i32"], returns: "i64" },
+  mmap: { args: ["ptr", "usize", "i32", "i32", "i32", "i64"], returns: "ptr" },
+  mprotect: { args: ["ptr", "usize", "i32"], returns: "i32" },
+});
+
+const PAGE = Number(libc.symbols.sysconf(_SC_PAGESIZE));
+if (PAGE <= 0) throw new Error("sysconf(_SC_PAGESIZE) failed");
+
+const base = libc.symbols.mmap(
+  null,
+  PAGE * 2,
+  PROT_READ | PROT_WRITE,
+  MAP_PRIVATE | MAP_ANON,
+  -1,
+  0n,
+);
+const baseNum = typeof base === "bigint" ? Number(base) : Number(base);
+if (baseNum <= 0 || baseNum === -1) throw new Error("mmap failed");
+if (libc.symbols.mprotect(baseNum + PAGE, PAGE, PROT_NONE) !== 0)
+  throw new Error("mprotect failed");
+
+function atGuard(bytes: number[]): Uint8Array {
+  const ab = toArrayBuffer(baseNum, 0, PAGE);
+  new Uint8Array(ab).fill(0x20);
+  const off = PAGE - bytes.length;
+  new Uint8Array(ab).set(bytes, off);
+  return new Uint8Array(ab, off, bytes.length);
+}
+
+const tp = new Bun.Transpiler({ loader: "js" });
+
+// Each case ends in a truncated multi-byte UTF-8 lead with no continuation
+// bytes. Before the fix, CodepointIterator.next() read past the end of the
+// buffer into the PROT_NONE page and crashed with SIGSEGV. After the fix,
+// the truncated sequence is treated as U+FFFD and transformSync either
+// returns or throws a normal parse error.
+const cases: Array<[string, number[]]> = [
+  ["1@ + 4-byte lead", [0x31, 0x40, 0xf0]],
+  ["1@ + 3-byte lead", [0x31, 0x40, 0xe0]],
+  ["1@ + 2-byte lead", [0x31, 0x40, 0xc2]],
+  ["4-byte lead + 1 continuation", [0x31, 0x40, 0xf0, 0x90]],
+  ["4-byte lead + 2 continuations", [0x31, 0x40, 0xf0, 0x90, 0x80]],
+  [
+    "sourceMappingURL pragma + 4-byte lead",
+    [...Buffer.from("//# sourceMappingURL=a"), 0xf0],
+  ],
+];
+
+for (const [name, bytes] of cases) {
+  const src = atGuard(bytes);
+  try {
+    tp.transformSync(src);
+    console.log(`ok: ${name} (addr=0x${ptr(src).toString(16)})`);
+  } catch (e) {
+    console.log(`ok: ${name} (threw: ${(e as Error).name})`);
+  }
+}
+
+console.log("DONE");

--- a/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8-fixture.ts
@@ -1,38 +1,34 @@
 // Place source bytes immediately before an unmapped guard page so that an
 // out-of-bounds read past the end of the input faults deterministically,
 // independent of allocator layout or ASAN.
+import { existsSync } from "node:fs";
 import { dlopen, ptr, toArrayBuffer } from "bun:ffi";
 
-const libcPath =
-  process.platform === "darwin" ? "/usr/lib/libSystem.B.dylib" : "libc.so.6";
-const MAP_ANON = process.platform === "darwin" ? 0x1000 : 0x20;
+const isDarwin = process.platform === "darwin";
+const libcPath = isDarwin
+  ? "/usr/lib/libSystem.B.dylib"
+  : existsSync("/usr/lib/libc.so")
+    ? "/usr/lib/libc.so" // musl
+    : "libc.so.6"; // glibc
+const MAP_ANON = isDarwin ? 0x1000 : 0x20;
 const MAP_PRIVATE = 0x02;
 const PROT_READ = 1;
 const PROT_WRITE = 2;
 const PROT_NONE = 0;
-const _SC_PAGESIZE = process.platform === "darwin" ? 29 : 30;
 
 const libc = dlopen(libcPath, {
-  sysconf: { args: ["i32"], returns: "i64" },
+  getpagesize: { args: [], returns: "i32" },
   mmap: { args: ["ptr", "usize", "i32", "i32", "i32", "i64"], returns: "ptr" },
   mprotect: { args: ["ptr", "usize", "i32"], returns: "i32" },
 });
 
-const PAGE = Number(libc.symbols.sysconf(_SC_PAGESIZE));
-if (PAGE <= 0) throw new Error("sysconf(_SC_PAGESIZE) failed");
+const PAGE = libc.symbols.getpagesize();
+if (PAGE <= 0) throw new Error("getpagesize() failed");
 
-const base = libc.symbols.mmap(
-  null,
-  PAGE * 2,
-  PROT_READ | PROT_WRITE,
-  MAP_PRIVATE | MAP_ANON,
-  -1,
-  0n,
-);
-const baseNum = typeof base === "bigint" ? Number(base) : Number(base);
+const base = libc.symbols.mmap(null, PAGE * 2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0n);
+const baseNum = Number(base);
 if (baseNum <= 0 || baseNum === -1) throw new Error("mmap failed");
-if (libc.symbols.mprotect(baseNum + PAGE, PAGE, PROT_NONE) !== 0)
-  throw new Error("mprotect failed");
+if (libc.symbols.mprotect(baseNum + PAGE, PAGE, PROT_NONE) !== 0) throw new Error("mprotect failed");
 
 function atGuard(bytes: number[]): Uint8Array {
   const ab = toArrayBuffer(baseNum, 0, PAGE);
@@ -55,10 +51,7 @@ const cases: Array<[string, number[]]> = [
   ["1@ + 2-byte lead", [0x31, 0x40, 0xc2]],
   ["4-byte lead + 1 continuation", [0x31, 0x40, 0xf0, 0x90]],
   ["4-byte lead + 2 continuations", [0x31, 0x40, 0xf0, 0x90, 0x80]],
-  [
-    "sourceMappingURL pragma + 4-byte lead",
-    [...Buffer.from("//# sourceMappingURL=a"), 0xf0],
-  ],
+  ["sourceMappingURL pragma + 4-byte lead", [...Buffer.from("//# sourceMappingURL=a"), 0xf0]],
 ];
 
 for (const [name, bytes] of cases) {

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+import path from "node:path";
+
+// The fixture uses mmap/mprotect via bun:ffi to place source bytes immediately
+// before a PROT_NONE guard page, so any read past the end of the input faults
+// deterministically. That requires POSIX mmap/mprotect.
+describe.skipIf(!isPosix)(
+  "Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer",
+  () => {
+    test("does not read past the end of the input buffer", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          path.join(import.meta.dir, "transpiler-truncated-utf8-fixture.ts"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      // On failure the subprocess segfaults before printing DONE and exits
+      // with a non-zero code / SIGSEGV signal.
+      expect({
+        stdout: stdout.trim().split("\n"),
+        stderr,
+        exitCode,
+        signalCode: proc.signalCode,
+      }).toEqual({
+        stdout: [
+          expect.stringContaining("ok: 1@ + 4-byte lead"),
+          expect.stringContaining("ok: 1@ + 3-byte lead"),
+          expect.stringContaining("ok: 1@ + 2-byte lead"),
+          expect.stringContaining("ok: 4-byte lead + 1 continuation"),
+          expect.stringContaining("ok: 4-byte lead + 2 continuations"),
+          expect.stringContaining("ok: sourceMappingURL pragma + 4-byte lead"),
+          "DONE",
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+      // ASAN symbolization of the crash in an unfixed debug build is slow;
+      // give the subprocess enough headroom so the failure surfaces as a
+      // proper assertion diff rather than a timeout.
+    }, 30_000);
+  },
+);

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS } from "harness";
 import path from "node:path";
 
 // The fixture uses mmap/mprotect via bun:ffi to place source bytes immediately
 // before a PROT_NONE guard page, so any read past the end of the input faults
-// deterministically. That requires POSIX mmap/mprotect.
-describe.skipIf(!isPosix)("Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer", () => {
+// deterministically. The fixture only knows the libc path / mmap flags for
+// Linux (glibc + musl) and macOS.
+describe.skipIf(!(isLinux || isMacOS))("Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer", () => {
   test("does not read past the end of the input buffer", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "transpiler-truncated-utf8-fixture.ts")],

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -38,8 +38,5 @@ describe.skipIf(!(isLinux || isMacOS))("Bun.Transpiler.transformSync with trunca
       exitCode: 0,
       signalCode: null,
     });
-    // ASAN symbolization of the crash in an unfixed debug build is slow;
-    // give the subprocess enough headroom so the failure surfaces as a
-    // proper assertion diff rather than a timeout.
-  }, 30_000);
+  });
 });

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -5,50 +5,40 @@ import path from "node:path";
 // The fixture uses mmap/mprotect via bun:ffi to place source bytes immediately
 // before a PROT_NONE guard page, so any read past the end of the input faults
 // deterministically. That requires POSIX mmap/mprotect.
-describe.skipIf(!isPosix)(
-  "Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer",
-  () => {
-    test("does not read past the end of the input buffer", async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          path.join(import.meta.dir, "transpiler-truncated-utf8-fixture.ts"),
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+describe.skipIf(!isPosix)("Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer", () => {
+  test("does not read past the end of the input buffer", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "transpiler-truncated-utf8-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // On failure the subprocess segfaults before printing DONE and exits
-      // with a non-zero code / SIGSEGV signal.
-      expect({
-        stdout: stdout.trim().split("\n"),
-        stderr,
-        exitCode,
-        signalCode: proc.signalCode,
-      }).toEqual({
-        stdout: [
-          expect.stringContaining("ok: 1@ + 4-byte lead"),
-          expect.stringContaining("ok: 1@ + 3-byte lead"),
-          expect.stringContaining("ok: 1@ + 2-byte lead"),
-          expect.stringContaining("ok: 4-byte lead + 1 continuation"),
-          expect.stringContaining("ok: 4-byte lead + 2 continuations"),
-          expect.stringContaining("ok: sourceMappingURL pragma + 4-byte lead"),
-          "DONE",
-        ],
-        stderr: "",
-        exitCode: 0,
-        signalCode: null,
-      });
-      // ASAN symbolization of the crash in an unfixed debug build is slow;
-      // give the subprocess enough headroom so the failure surfaces as a
-      // proper assertion diff rather than a timeout.
-    }, 30_000);
-  },
-);
+    // On failure the subprocess segfaults before printing DONE and exits
+    // with a non-zero code / SIGSEGV signal.
+    expect({
+      stdout: stdout.trim().split("\n"),
+      stderr,
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
+      stdout: [
+        expect.stringContaining("ok: 1@ + 4-byte lead"),
+        expect.stringContaining("ok: 1@ + 3-byte lead"),
+        expect.stringContaining("ok: 1@ + 2-byte lead"),
+        expect.stringContaining("ok: 4-byte lead + 1 continuation"),
+        expect.stringContaining("ok: 4-byte lead + 2 continuations"),
+        expect.stringContaining("ok: sourceMappingURL pragma + 4-byte lead"),
+        "DONE",
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+    // ASAN symbolization of the crash in an unfixed debug build is slow;
+    // give the subprocess enough headroom so the failure surfaces as a
+    // proper assertion diff rather than a timeout.
+  }, 30_000);
+});

--- a/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
+++ b/test/js/bun/transpiler/transpiler-truncated-utf8.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen } from "harness";
 import path from "node:path";
 
 // The fixture uses mmap/mprotect via bun:ffi to place source bytes immediately
 // before a PROT_NONE guard page, so any read past the end of the input faults
-// deterministically. The fixture only knows the libc path / mmap flags for
-// Linux (glibc + musl) and macOS.
+// deterministically. The fixture only knows the mmap flags for Linux (glibc +
+// musl) and macOS; libcPathForDlopen() supplies the right shared-object path.
 describe.skipIf(!(isLinux || isMacOS))("Bun.Transpiler.transformSync with truncated UTF-8 at end of buffer", () => {
   test("does not read past the end of the input buffer", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "transpiler-truncated-utf8-fixture.ts")],
-      env: bunEnv,
+      env: { ...bunEnv, BUN_TEST_LIBC_PATH: libcPathForDlopen() },
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## What

`CodepointIterator.next()` computes the byte-sequence length from the lead byte and then unconditionally reads up to 4 bytes:

```zig
else => decodeWTF8RuneTMultibyte(it.bytes[pos..].ptr[0..4], cp_len, CodePointType, error_char),
```

`.ptr[0..4]` drops the slice bounds, so a multi-byte lead (`0xC2` / `0xE0` / `0xF0`) in the last 1-3 bytes of the input causes `decodeWTF8RuneTMultibyte` to read 1-3 bytes past the end of the buffer.

## Reachable surface

`new Bun.Transpiler().transformSync(Uint8Array)` hands the typed array's backing store to the lexer directly (no copy, no padding). When the parser emits a diagnostic, `logger.Source.initErrorPosition` scans to end-of-line with `CodepointIterator.next()` over `contents[offset..]`. With a truncated lead byte at the very end of the buffer and the buffer ending at a page boundary, this is a SIGSEGV:

```
AddressSanitizer: SEGV on 0x...000
  unicode.zig:1971  decodeWTF8RuneTMultibyte  (p[1])
  unicode.zig:111   CodepointIterator.next
  logger.zig:1533   Source.initErrorPosition
  logger.zig:953    Log.addRangeError
  js_lexer.zig:213  addRangeError
  ...
  JSTranspiler.zig:1005  transformSync
```

Other `CodepointIterator.next()` callers on raw source sub-slices (`decodeEscapeSequences`, `rangeOfIdentifier`, JSX entity decoding, `PragmaArg.scan`) are exposed to the same pattern. The main lexer `step()` is not affected — it already clamps.

## Fix

Copy the available bytes into a zero-padded `[4]u8` on the stack before decoding — the same pattern already used in `string/immutable/visible.zig` and `strings.hasPrefixWithWordBoundary`. `0x00` is not a valid continuation byte, so truncated sequences decode to `error_char` and become U+FFFD with `width = 1`, matching existing invalid-sequence behaviour.

`nextCodepointSlice()` is clamped to the remaining input for the same reason.

## Verification

The test (`test/js/bun/transpiler/transpiler-truncated-utf8.test.ts`) uses `mmap` + `mprotect(PROT_NONE)` via `bun:ffi` to place the source bytes immediately before an unmapped guard page, so the over-read faults deterministically on both release and ASAN builds. It covers 2/3/4-byte leads, partial continuation sequences, and the `//# sourceMappingURL=` pragma scan path.

- **Before fix**: subprocess SIGSEGVs on the first case (`exitCode: 139`, `signalCode: "SIGSEGV"`).
- **After fix**: all six cases throw ordinary parse errors or succeed; subprocess exits 0.

Adjacent transpiler / escape-sequence / unicode tests pass; `zig:check-all` is clean on all targets.