### PR TITLE
FileSystemRouter: free arena struct and self in finalize

### DIFF
--- a/src/runtime/api/filesystem_router.zig
+++ b/src/runtime/api/filesystem_router.zig
@@ -409,6 +409,8 @@ pub const FileSystemRouter = struct {
 
         this.router.deinit();
         this.arena.deinit();
+        bun.default_allocator.destroy(this.arena);
+        bun.default_allocator.destroy(this);
     }
 };
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -569,3 +569,43 @@ it("throws a clean error for invalid route filenames (no use-after-free)", async
   expect(stdout.trim()).toBe("caught:Route is missing a closing bracket]");
   expect(exitCode).toBe(0);
 });
+
+it("FileSystemRouter finalize does not leak", async () => {
+  // FileSystemRouter.finalize previously called arena.deinit() but never freed the
+  // heap-allocated ArenaAllocator struct or the FileSystemRouter struct itself,
+  // leaking both on every GC'd instance.
+  using dir = tempDir("fsr-finalize-leak", {
+    "pages/index.tsx": "export default 1;",
+  });
+
+  const code = /* ts */ `
+    const pages = ${JSON.stringify(path.join(String(dir), "pages"))};
+
+    function churn(n) {
+      for (let i = 0; i < n; i++) {
+        new Bun.FileSystemRouter({ dir: pages, style: "nextjs", fileExtensions: [".tsx"] });
+      }
+      Bun.gc(true);
+    }
+
+    // warm up (directory cache, JIT, allocator pools)
+    churn(2000);
+    const before = process.memoryUsage.rss();
+
+    churn(50000);
+    const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+    console.error("RSS growth: " + growthMB.toFixed(2) + "MB");
+    if (growthMB > 20) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("leaked");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -574,8 +574,12 @@ it("FileSystemRouter finalize does not leak", async () => {
   // FileSystemRouter.finalize previously called arena.deinit() but never freed the
   // heap-allocated ArenaAllocator struct or the FileSystemRouter struct itself,
   // leaking both on every GC'd instance.
+  //
+  // Use an empty pages dir so Route.parse is never called — that path appends to
+  // the global DirnameStore (separate, pre-existing behavior) which would add
+  // noise to the RSS measurement.
   using dir = tempDir("fsr-finalize-leak", {
-    "pages/index.tsx": "export default 1;",
+    "pages/.keep": "",
   });
 
   const code = /* ts */ `
@@ -583,19 +587,19 @@ it("FileSystemRouter finalize does not leak", async () => {
 
     function churn(n) {
       for (let i = 0; i < n; i++) {
-        new Bun.FileSystemRouter({ dir: pages, style: "nextjs", fileExtensions: [".tsx"] });
+        new Bun.FileSystemRouter({ dir: pages, style: "nextjs" });
       }
       Bun.gc(true);
     }
 
     // warm up (directory cache, JIT, allocator pools)
-    churn(2000);
+    churn(5000);
     const before = process.memoryUsage.rss();
 
-    churn(50000);
+    churn(80000);
     const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
     console.error("RSS growth: " + growthMB.toFixed(2) + "MB");
-    if (growthMB > 20) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+    if (growthMB > 16) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
   `;
 
   await using proc = Bun.spawn({


### PR DESCRIPTION
## What

`FileSystemRouter.finalize` called `this.arena.deinit()` but never freed the heap-allocated `ArenaAllocator` struct or the `FileSystemRouter` struct itself — both were allocated via `globalThis.allocator().create(...)` in the constructor. Every successfully-constructed router that got GC'd leaked `@sizeOf(FileSystemRouter) + @sizeOf(ArenaAllocator)`.

The constructor's error paths already do this correctly:
```zig
arena.deinit();
globalThis.allocator().destroy(arena);
```
as does `reload()` when swapping arenas, and the sibling `MatchedRoute.deinit` which ends with `bun.default_allocator.destroy(this)`. Only the success-path `finalize` was missing the `destroy` calls.

## Repro

```js
for (let i = 0; i < 50_000; i++) {
  new Bun.FileSystemRouter({ dir: './pages', style: 'nextjs' });
}
Bun.gc(true);
// RSS grows ~28-35MB
```

## Fix

Add `bun.default_allocator.destroy(this.arena)` and `bun.default_allocator.destroy(this)` at the end of `finalize` (`globalThis.allocator()` is `bunVM().allocator` which is `bun.default_allocator`).

## Verification

- Without fix: new test fails with `leaked 35.05MB` over 50k iterations
- With fix: test passes, RSS stable
- All 19 existing `filesystem_router.test.ts` tests pass