### PR TITLE
webcore/Blob: free StringJoiner slices when FormData serialization fails

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -600,6 +600,15 @@ pub fn fromDOMFormData(
 
     form_data.forEach(FormDataContext, &context, FormDataContext.onEntry);
     if (context.failed) {
+        // The joiner's Node structs are owned by the arena (freed by the
+        // `defer arena.deinit()` above), but each node's data carries its own
+        // owner allocator — `bun.default_allocator` for non-ASCII name/value
+        // slices and the NodeFS readFile result buffer for file entries that
+        // succeeded before the failing one. Those owners are only invoked from
+        // `StringJoiner.done` (success path) or `StringJoiner.deinit`, so we
+        // must call deinit() here or every heap-owned slice already pushed is
+        // leaked.
+        context.joiner.deinit();
         return Blob.initEmpty(globalThis);
     }
 

--- a/test/js/web/html/FormData-file-error-leak-fixture.ts
+++ b/test/js/web/html/FormData-file-error-leak-fixture.ts
@@ -1,0 +1,68 @@
+// Fixture for FormData → multipart body memory leak on readFile failure.
+//
+// Blob.fromDOMFormData() walks the FormData entries and pushes heap-owned
+// slices into a StringJoiner. If a later entry is a Bun.file() whose read
+// fails, the pre-fix failure path returned Blob.initEmpty() WITHOUT calling
+// joiner.deinit(), leaking every readFile buffer (and any non-ASCII string
+// dup) already pushed for prior entries.
+//
+// This fixture appends one real on-disk file (so its contents are pushed to
+// the joiner via readFile) followed by a Bun.file() pointing at a
+// nonexistent path, then serializes the FormData via `new Response(fd)`.
+// Without the fix, each iteration leaks ~FILE_SIZE bytes.
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeFileSync, unlinkSync } from "node:fs";
+
+const iterations = parseInt(process.env.ITERATIONS || "100", 10);
+const warmup = parseInt(process.env.WARMUP || "10", 10);
+const fileSize = parseInt(process.env.FILE_SIZE || String(256 * 1024), 10);
+
+const realPath = join(tmpdir(), `formdata-leak-real-${process.pid}.bin`);
+const missingPath = join(tmpdir(), `formdata-leak-missing-${process.pid}.bin`);
+writeFileSync(realPath, Buffer.alloc(fileSize, "a"));
+process.on("exit", () => {
+  try {
+    unlinkSync(realPath);
+  } catch {}
+});
+
+function iterate() {
+  const fd = new FormData();
+  // Entry 1: real file — its contents are read into a heap buffer and
+  // pushed to the joiner before the failing entry.
+  fd.append("good", Bun.file(realPath));
+  // Entry 2: missing file — readFile fails, context.failed = true, and the
+  // pre-fix code leaked entry 1's buffer on the early return.
+  fd.append("bad", Bun.file(missingPath));
+  try {
+    new Response(fd);
+    throw new Error("expected Response constructor to throw");
+  } catch (e) {
+    if (!(e instanceof Error) || !("code" in e) || (e as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw e;
+    }
+  }
+}
+
+for (let i = 0; i < warmup; i++) iterate();
+Bun.gc(true);
+const baselineRss = process.memoryUsage.rss();
+
+for (let i = 0; i < iterations; i++) iterate();
+Bun.gc(true);
+const finalRss = process.memoryUsage.rss();
+
+const growthMB = (finalRss - baselineRss) / (1024 * 1024);
+const leakedPerIterMB = fileSize / (1024 * 1024);
+
+console.log(
+  JSON.stringify({
+    baselineRss,
+    finalRss,
+    growthMB: Math.round(growthMB * 100) / 100,
+    iterations,
+    expectedLeakMB: Math.round(leakedPerIterMB * iterations * 100) / 100,
+  }),
+);

--- a/test/js/web/html/FormData-file-error-leak-fixture.ts
+++ b/test/js/web/html/FormData-file-error-leak-fixture.ts
@@ -9,24 +9,20 @@
 // This fixture appends one real on-disk file (so its contents are pushed to
 // the joiner via readFile) followed by a Bun.file() pointing at a
 // nonexistent path, then serializes the FormData via `new Response(fd)`.
-// Without the fix, each iteration leaks ~FILE_SIZE bytes.
-
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { writeFileSync, unlinkSync } from "node:fs";
+// Without the fix, each iteration leaks ~<file size> bytes.
+//
+// The scratch file is created and cleaned up by the parent test via
+// `using tempDir(...)` so cleanup is guaranteed even if this process is
+// killed by signal.
 
 const iterations = parseInt(process.env.ITERATIONS || "100", 10);
 const warmup = parseInt(process.env.WARMUP || "10", 10);
-const fileSize = parseInt(process.env.FILE_SIZE || String(256 * 1024), 10);
+const realPath = process.env.REAL_PATH;
+const missingPath = process.env.MISSING_PATH;
 
-const realPath = join(tmpdir(), `formdata-leak-real-${process.pid}.bin`);
-const missingPath = join(tmpdir(), `formdata-leak-missing-${process.pid}.bin`);
-writeFileSync(realPath, Buffer.alloc(fileSize, "a"));
-process.on("exit", () => {
-  try {
-    unlinkSync(realPath);
-  } catch {}
-});
+if (!realPath || !missingPath) {
+  throw new Error("REAL_PATH and MISSING_PATH env vars required");
+}
 
 function iterate() {
   const fd = new FormData();
@@ -55,7 +51,6 @@ Bun.gc(true);
 const finalRss = process.memoryUsage.rss();
 
 const growthMB = (finalRss - baselineRss) / (1024 * 1024);
-const leakedPerIterMB = fileSize / (1024 * 1024);
 
 console.log(
   JSON.stringify({
@@ -63,6 +58,5 @@ console.log(
     finalRss,
     growthMB: Math.round(growthMB * 100) / 100,
     iterations,
-    expectedLeakMB: Math.round(leakedPerIterMB * iterations * 100) / 100,
   }),
 );

--- a/test/js/web/html/FormData-file-error-leak.test.ts
+++ b/test/js/web/html/FormData-file-error-leak.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// Blob.fromDOMFormData pushes each FormData entry's bytes — including the
+// full NodeFS.readFile result for Bun.file() entries — into a StringJoiner.
+// If a subsequent entry's read fails (e.g. ENOENT), the failure path used to
+// return an empty Blob without calling joiner.deinit(). The arena defer only
+// frees the joiner's Node structs; each node's data slice has its own owner
+// allocator (bun.default_allocator / the readFile buffer) that is only freed
+// by StringJoiner.done() or StringJoiner.deinit(), so every file buffer read
+// for earlier entries was leaked.
+test("FormData serialization does not leak prior file buffers when a later file read fails", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", join(import.meta.dir, "FormData-file-error-leak-fixture.ts")],
+    env: {
+      ...bunEnv,
+      ITERATIONS: "100",
+      WARMUP: "10",
+      FILE_SIZE: String(256 * 1024),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+
+  const result = JSON.parse(stdout.trim());
+  console.log(
+    `FormData file-error leak: ${result.iterations} iterations, growth ${result.growthMB} MB (pre-fix ~${result.expectedLeakMB} MB)`,
+  );
+
+  // Without the fix: ~25 MB growth (256 KiB × 100). With the fix: ~0.
+  // Threshold is well under half the expected leak to leave headroom for
+  // unrelated allocator noise while still catching the regression.
+  expect(result.growthMB).toBeLessThan(10);
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/web/html/FormData-file-error-leak.test.ts
+++ b/test/js/web/html/FormData-file-error-leak.test.ts
@@ -49,4 +49,4 @@ test("FormData serialization does not leak prior file buffers when a later file 
   // unrelated allocator noise while still catching the regression.
   expect(result.growthMB).toBeLessThan(10);
   expect(exitCode).toBe(0);
-}, 60_000);
+});

--- a/test/js/web/html/FormData-file-error-leak.test.ts
+++ b/test/js/web/html/FormData-file-error-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 // Blob.fromDOMFormData pushes each FormData entry's bytes — including the
@@ -11,13 +11,24 @@ import { join } from "node:path";
 // by StringJoiner.done() or StringJoiner.deinit(), so every file buffer read
 // for earlier entries was leaked.
 test("FormData serialization does not leak prior file buffers when a later file read fails", async () => {
+  const fileSize = 256 * 1024;
+  const iterations = 100;
+
+  // Own the scratch file in the parent so cleanup is guaranteed via `using`
+  // even if the child is SIGTERMed on test timeout (process.on("exit") in the
+  // child wouldn't run in that case).
+  using dir = tempDir("formdata-file-error-leak", {
+    "real.bin": Buffer.alloc(fileSize, "a"),
+  });
+
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--smol", join(import.meta.dir, "FormData-file-error-leak-fixture.ts")],
     env: {
       ...bunEnv,
-      ITERATIONS: "100",
+      REAL_PATH: join(String(dir), "real.bin"),
+      MISSING_PATH: join(String(dir), "missing.bin"),
+      ITERATIONS: String(iterations),
       WARMUP: "10",
-      FILE_SIZE: String(256 * 1024),
     },
     stdout: "pipe",
     stderr: "pipe",
@@ -28,8 +39,9 @@ test("FormData serialization does not leak prior file buffers when a later file 
   if (exitCode !== 0) console.error(stderr);
 
   const result = JSON.parse(stdout.trim());
+  const expectedLeakMB = (fileSize * iterations) / (1024 * 1024);
   console.log(
-    `FormData file-error leak: ${result.iterations} iterations, growth ${result.growthMB} MB (pre-fix ~${result.expectedLeakMB} MB)`,
+    `FormData file-error leak: ${result.iterations} iterations, growth ${result.growthMB} MB (pre-fix ~${expectedLeakMB} MB)`,
   );
 
   // Without the fix: ~25 MB growth (256 KiB × 100). With the fix: ~0.

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -514,6 +515,40 @@ describe("FormData", () => {
       const formData = new FormData();
       formData.append("foo", Bun.file("missing"));
       expect(() => new Response(formData)).toThrow();
+    });
+
+    it("does not leak prior file buffers when a later file read fails", async () => {
+      // Blob.fromDOMFormData pushes each entry's bytes (including full
+      // readFile results for Bun.file entries) into a StringJoiner. If a
+      // subsequent entry's read fails, the failure path used to return an
+      // empty Blob without calling joiner.deinit(), leaking every heap-owned
+      // slice already pushed (file contents + any non-ASCII name/value dups).
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", join(import.meta.dir, "FormData-file-error-leak-fixture.ts")],
+        env: {
+          ...bunEnv,
+          ITERATIONS: "100",
+          WARMUP: "10",
+          FILE_SIZE: String(256 * 1024),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      if (exitCode !== 0) console.error(stderr);
+
+      const result = JSON.parse(stdout.trim());
+      console.log(
+        `FormData file-error leak: ${result.iterations} iterations, growth ${result.growthMB} MB (pre-fix ~${result.expectedLeakMB} MB)`,
+      );
+
+      // Without the fix: ~25 MB growth (256 KiB × 100). With the fix: ~0.
+      // Threshold is well under half the expected leak to leave headroom for
+      // unrelated allocator noise while still catching the regression.
+      expect(result.growthMB).toBeLessThan(10);
+      expect(exitCode).toBe(0);
     });
   });
 

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -515,40 +514,6 @@ describe("FormData", () => {
       const formData = new FormData();
       formData.append("foo", Bun.file("missing"));
       expect(() => new Response(formData)).toThrow();
-    });
-
-    it("does not leak prior file buffers when a later file read fails", async () => {
-      // Blob.fromDOMFormData pushes each entry's bytes (including full
-      // readFile results for Bun.file entries) into a StringJoiner. If a
-      // subsequent entry's read fails, the failure path used to return an
-      // empty Blob without calling joiner.deinit(), leaking every heap-owned
-      // slice already pushed (file contents + any non-ASCII name/value dups).
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "--smol", join(import.meta.dir, "FormData-file-error-leak-fixture.ts")],
-        env: {
-          ...bunEnv,
-          ITERATIONS: "100",
-          WARMUP: "10",
-          FILE_SIZE: String(256 * 1024),
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      if (exitCode !== 0) console.error(stderr);
-
-      const result = JSON.parse(stdout.trim());
-      console.log(
-        `FormData file-error leak: ${result.iterations} iterations, growth ${result.growthMB} MB (pre-fix ~${result.expectedLeakMB} MB)`,
-      );
-
-      // Without the fix: ~25 MB growth (256 KiB × 100). With the fix: ~0.
-      // Threshold is well under half the expected leak to leave headroom for
-      // unrelated allocator noise while still catching the regression.
-      expect(result.growthMB).toBeLessThan(10);
-      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Problem

`Blob.fromDOMFormData` (used by `new Response(formData)` / `new Request({body: formData})`) walks each FormData entry via `FormDataContext.onEntry` and pushes heap-owned slices into a `StringJoiner`:

- non-ASCII name/filename/value strings duped into `bun.default_allocator` (Blob.zig:220/226/231)
- for `Bun.file()` entries, the entire `NodeFS.readFile` result buffer (Blob.zig:271)

When a later entry's `readFile` fails (e.g. `ENOENT`), the `.err` branch sets `context.failed = true` and throws. Back in `fromDOMFormData`, the failure path did:

```zig
if (context.failed) {
    return Blob.initEmpty(globalThis);
}
```

The `defer arena.deinit()` frees the joiner's Node structs (arena-allocated), but each node's data slice has its own `NullableAllocator` owner that is only invoked from `StringJoiner.done()` (success path) or `StringJoiner.deinit()`. Neither ran on failure, so every readFile buffer already pushed for earlier entries was leaked.

## Repro

```js
// real.bin is 256 KiB
while (true) {
  const fd = new FormData();
  fd.append("a", Bun.file("real.bin"));       // pushed to joiner
  fd.append("b", Bun.file("/no/such/path"));  // readFile fails
  try { new Response(fd); } catch {}
}
// RSS grows by ~256 KiB per iteration
```

## Fix

Call `context.joiner.deinit()` before the early return.

## Verification

New `test/js/web/html/FormData-file-error-leak.test.ts` spawns a `--smol` subprocess that appends a 256 KiB real file (created by the parent via `tempDir` from harness) followed by a missing file and serializes via `new Response(fd)` 100× after warmup, then measures RSS growth.

| | RSS growth (100 × 256 KiB) |
|---|---|
| before | ~25–30 MB |
| after | ~0–3 MB |

Gate: with `src/` stashed the test fails (30 MB under ASAN, 26 MB release); with the fix it passes (2–3 MB under ASAN, ~0 release). No ASAN errors.
