### PR TITLE
shell(cat): release IOReader in Cat.deinit

### DIFF
--- a/src/runtime/shell/builtin/cat.zig
+++ b/src/runtime/shell/builtin/cat.zig
@@ -19,7 +19,10 @@ state: union(enum) {
         in_done: bool = false,
 
         pub fn deinit(this: *@This()) void {
-            if (this.reader) |r| r.deref();
+            if (this.reader) |r| {
+                r.deref();
+                this.reader = null;
+            }
         }
     },
     waiting_write_err,
@@ -245,7 +248,22 @@ pub fn onIOReaderDone(this: *Cat, err: ?jsc.SystemError) Yield {
     return .suspended;
 }
 
-pub fn deinit(_: *Cat) void {}
+pub fn deinit(this: *Cat) void {
+    // The normal completion paths (next(), onIOWriterChunk, onIOReaderDone) call
+    // exec_filepath_args.deinit() before bltn().done(), which then cascades back into
+    // this function via Cmd.deinit → Builtin.deinit. At that point `state` is still
+    // .exec_filepath_args but the reader has already been released; the inner deinit
+    // nulls `reader` so calling it again here is a no-op. This call exists so that if
+    // the parent tears down the Cmd while cat is suspended with a live IOReader (e.g.
+    // a future cancel/teardown path), the reader and its fd are not leaked.
+    switch (this.state) {
+        .exec_filepath_args => |*exec| {
+            if (exec.reader) |r| r.removeReader(this);
+            exec.deinit();
+        },
+        else => {},
+    }
+}
 
 pub inline fn bltn(this: *Cat) *Builtin {
     const impl: *Builtin.Impl = @alignCast(@fieldParentPtr("cat", this));

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,0 +1,121 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isPosix, isWindows, tempDir } from "harness";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { createTestBuilder } from "../test_builder";
+
+const TestBuilder = createTestBuilder(import.meta.path);
+
+$.env(bunEnv);
+$.nothrow();
+
+describe("cat", () => {
+  TestBuilder.command`cat ${import.meta.path}`
+    .quiet()
+    .stdout(async out => expect(out).toEqual(await Bun.file(import.meta.path).text()))
+    .exitCode(0)
+    .runAsTest("single file");
+
+  TestBuilder.command`cat ${import.meta.path} ${import.meta.path}`
+    .quiet()
+    .stdout(async out => {
+      const self = await Bun.file(import.meta.path).text();
+      expect(out).toEqual(self + self);
+    })
+    .exitCode(0)
+    .runAsTest("multiple files");
+
+  TestBuilder.command`cat /definitely/does/not/exist/anywhere`
+    .quiet()
+    .stderr(s => expect(s).toContain("cat:"))
+    .exitCode(1)
+    .runAsTest("nonexistent file");
+
+  TestBuilder.command`echo hello | cat`.quiet().stdout("hello\n").exitCode(0).runAsTest("stdin");
+
+  // These exercise Cat.deinit with state == .exec_filepath_args after normal completion.
+  // Cat owns a refcounted *IOReader while reading each file; the inner
+  // exec_filepath_args.deinit() releases it before bltn().done() cascades back into
+  // Cat.deinit. Cat.deinit must be safe to run at that point (reader already released,
+  // pointer nulled) without double-freeing, and must release the reader if a teardown
+  // path ever reaches it while the reader is still live.
+  describe("does not leak the file IOReader or its fd", () => {
+    function fdCount(): number {
+      return readdirSync(process.platform === "linux" ? "/proc/self/fd" : "/dev/fd").length;
+    }
+
+    test.skipIf(isWindows)("plain file (completes, then deinit)", async () => {
+      using dir = tempDir("cat-fd", {
+        "a.txt": Buffer.alloc(64 * 1024, "A").toString(),
+      });
+      const file = join(String(dir), "a.txt");
+
+      // Prime.
+      await $`cat ${file}`.quiet();
+      Bun.gc(true);
+      const baseline = fdCount();
+
+      for (let i = 0; i < 100; i++) {
+        const { exitCode } = await $`cat ${file}`.quiet();
+        expect(exitCode).toBe(0);
+      }
+      Bun.gc(true);
+
+      // IOReader.asyncDeinit hops through the event loop; let any queued closes drain.
+      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
+        await Bun.sleep(0);
+        Bun.gc(true);
+      }
+
+      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
+    });
+
+    test.skipIf(isWindows)("multiple files including a nonexistent one", async () => {
+      using dir = tempDir("cat-fd-multi", {
+        "a.txt": Buffer.alloc(32 * 1024, "A").toString(),
+      });
+      const file = join(String(dir), "a.txt");
+
+      await $`cat ${file} ${file}`.quiet();
+      Bun.gc(true);
+      const baseline = fdCount();
+
+      for (let i = 0; i < 100; i++) {
+        const { exitCode } = await $`cat ${file} /does/not/exist ${file}`.quiet();
+        expect(exitCode).toBe(1);
+      }
+      Bun.gc(true);
+
+      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
+        await Bun.sleep(0);
+        Bun.gc(true);
+      }
+
+      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
+    });
+
+    test.skipIf(!isPosix)("downstream closes early (EPIPE on stdout)", async () => {
+      using dir = tempDir("cat-fd-pipe", {
+        "big.txt": Buffer.alloc(512 * 1024, "A").toString(),
+      });
+      const file = join(String(dir), "big.txt");
+
+      await $`cat ${file} | head -c 1`.quiet();
+      Bun.gc(true);
+      const baseline = fdCount();
+
+      for (let i = 0; i < 30; i++) {
+        await $`cat ${file} | head -c 1`.quiet();
+      }
+      Bun.gc(true);
+
+      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
+        await Bun.sleep(0);
+        Bun.gc(true);
+      }
+
+      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
+    });
+  });
+});

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,121 +1,185 @@
 import { $ } from "bun";
+import { shellInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isPosix, isWindows, tempDir } from "harness";
-import { readdirSync } from "node:fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createTestBuilder } from "../test_builder";
 
 const TestBuilder = createTestBuilder(import.meta.path);
+const { builtinDisabled } = shellInternals;
+
+const self = readFileSync(import.meta.path, "utf8");
 
 $.env(bunEnv);
 $.nothrow();
 
-describe("cat", () => {
+// The `cat` builtin is disabled on posix by default (falls back to /bin/cat).
+// On Windows the builtin is always used; elsewhere it requires
+// BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1. The TestBuilder-based checks below
+// run in-process so they only exercise the Zig code on Windows.
+describe.if(!builtinDisabled("cat"))("cat builtin (in-process)", () => {
   TestBuilder.command`cat ${import.meta.path}`
     .quiet()
-    .stdout(async out => expect(out).toEqual(await Bun.file(import.meta.path).text()))
+    .stdout(out => expect(out).toEqual(self))
     .exitCode(0)
     .runAsTest("single file");
 
   TestBuilder.command`cat ${import.meta.path} ${import.meta.path}`
     .quiet()
-    .stdout(async out => {
-      const self = await Bun.file(import.meta.path).text();
-      expect(out).toEqual(self + self);
-    })
+    .stdout(out => expect(out).toEqual(self + self))
     .exitCode(0)
     .runAsTest("multiple files");
 
-  TestBuilder.command`cat /definitely/does/not/exist/anywhere`
+  TestBuilder.command`cat ./definitely-does-not-exist-anywhere`
     .quiet()
     .stderr(s => expect(s).toContain("cat:"))
     .exitCode(1)
     .runAsTest("nonexistent file");
 
   TestBuilder.command`echo hello | cat`.quiet().stdout("hello\n").exitCode(0).runAsTest("stdin");
+});
 
-  // These exercise Cat.deinit with state == .exec_filepath_args after normal completion.
-  // Cat owns a refcounted *IOReader while reading each file; the inner
-  // exec_filepath_args.deinit() releases it before bltn().done() cascades back into
-  // Cat.deinit. Cat.deinit must be safe to run at that point (reader already released,
-  // pointer nulled) without double-freeing, and must release the reader if a teardown
-  // path ever reaches it while the reader is still live.
-  describe("does not leak the file IOReader or its fd", () => {
+// These exercise Cat.deinit with state == .exec_filepath_args. Cat owns a refcounted
+// *IOReader for each file argument (created via IOReader.init in next()); the inner
+// exec_filepath_args.deinit() releases it before bltn().done() cascades back into
+// Cat.deinit. Cat.deinit must be safe to run at that point (reader already released,
+// pointer nulled) without double-freeing, and must release the reader if a teardown
+// path ever reaches it while still live.
+//
+// Run in a subprocess with BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 so the Zig builtin
+// is used on posix instead of /bin/cat; the subprocess counts its own fds. On posix
+// the builtin's IOReader currently errors on regular files (epoll rejects them with
+// EPERM), so the read fails — but the IOReader is still created with the file fd and
+// must be released via exec_filepath_args.deinit() / Cat.deinit without leaking.
+describe("cat builtin does not leak the file IOReader or its fd", () => {
+  const env = {
+    ...bunEnv,
+    BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1",
+  };
+
+  async function run(fixture: Record<string, string>, script: string) {
+    using dir = tempDir("cat-builtin-leak", {
+      ...fixture,
+      "check.ts": script,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "check.ts")],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const fdCounter = /* ts */ `
+    import { readdirSync } from "node:fs";
     function fdCount(): number {
+      if (process.platform === "win32") return 0;
       return readdirSync(process.platform === "linux" ? "/proc/self/fd" : "/dev/fd").length;
     }
+  `;
 
-    test.skipIf(isWindows)("plain file (completes, then deinit)", async () => {
-      using dir = tempDir("cat-fd", {
-        "a.txt": Buffer.alloc(64 * 1024, "A").toString(),
-      });
-      const file = join(String(dir), "a.txt");
+  test("single file arg", { timeout: 30_000 }, async () => {
+    // On Linux the builtin's read of a regular file currently fails (epoll rejects
+    // regular files with EPERM) so cat exits 1; on macOS/Windows it succeeds. Either
+    // way the IOReader holding the file fd must be released.
+    const { stdout, stderr, exitCode } = await run(
+      { "a.txt": "A".repeat(64 * 1024) },
+      /* ts */ `
+        ${fdCounter}
+        import { $ } from "bun";
+        $.nothrow();
 
-      // Prime.
-      await $`cat ${file}`.quiet();
-      Bun.gc(true);
-      const baseline = fdCount();
-
-      for (let i = 0; i < 100; i++) {
-        const { exitCode } = await $`cat ${file}`.quiet();
-        expect(exitCode).toBe(0);
-      }
-      Bun.gc(true);
-
-      // IOReader.asyncDeinit hops through the event loop; let any queued closes drain.
-      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
-        await Bun.sleep(0);
+        await $\`cat a.txt\`.quiet(); // prime
         Bun.gc(true);
-      }
+        const baseline = fdCount();
 
-      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
-    });
-
-    test.skipIf(isWindows)("multiple files including a nonexistent one", async () => {
-      using dir = tempDir("cat-fd-multi", {
-        "a.txt": Buffer.alloc(32 * 1024, "A").toString(),
-      });
-      const file = join(String(dir), "a.txt");
-
-      await $`cat ${file} ${file}`.quiet();
-      Bun.gc(true);
-      const baseline = fdCount();
-
-      for (let i = 0; i < 100; i++) {
-        const { exitCode } = await $`cat ${file} /does/not/exist ${file}`.quiet();
-        expect(exitCode).toBe(1);
-      }
-      Bun.gc(true);
-
-      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
-        await Bun.sleep(0);
+        for (let i = 0; i < 100; i++) {
+          await $\`cat a.txt\`.quiet();
+        }
         Bun.gc(true);
-      }
+        for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
+          await Bun.sleep(0);
+          Bun.gc(true);
+        }
 
-      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
-    });
+        const after = fdCount();
+        if (process.platform !== "win32" && after - baseline > 5) {
+          console.error("fd leak:", after - baseline);
+          process.exit(1);
+        }
+        console.log("ok", baseline, after);
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toContain("ok");
+    expect(exitCode).toBe(0);
+  });
 
-    test.skipIf(!isPosix)("downstream closes early (EPIPE on stdout)", async () => {
-      using dir = tempDir("cat-fd-pipe", {
-        "big.txt": Buffer.alloc(512 * 1024, "A").toString(),
-      });
-      const file = join(String(dir), "big.txt");
+  test("multiple file args including a nonexistent one", { timeout: 30_000 }, async () => {
+    const { stdout, stderr, exitCode } = await run(
+      { "a.txt": "A".repeat(32 * 1024) },
+      /* ts */ `
+        ${fdCounter}
+        import { $ } from "bun";
+        $.nothrow();
 
-      await $`cat ${file} | head -c 1`.quiet();
-      Bun.gc(true);
-      const baseline = fdCount();
-
-      for (let i = 0; i < 30; i++) {
-        await $`cat ${file} | head -c 1`.quiet();
-      }
-      Bun.gc(true);
-
-      for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
-        await Bun.sleep(0);
+        await $\`cat a.txt a.txt\`.quiet(); // prime
         Bun.gc(true);
-      }
+        const baseline = fdCount();
 
-      expect(fdCount()).toBeLessThanOrEqual(baseline + 5);
-    });
+        for (let i = 0; i < 100; i++) {
+          const { exitCode } = await $\`cat a.txt ./does-not-exist a.txt\`.quiet();
+          if (exitCode !== 1) {
+            console.error("expected exit 1, got", exitCode);
+            process.exit(1);
+          }
+        }
+        Bun.gc(true);
+        for (let i = 0; i < 10 && fdCount() > baseline + 5; i++) {
+          await Bun.sleep(0);
+          Bun.gc(true);
+        }
+
+        const after = fdCount();
+        if (process.platform !== "win32" && after - baseline > 5) {
+          console.error("fd leak:", after - baseline);
+          process.exit(1);
+        }
+        console.log("ok", baseline, after);
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toContain("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  // Exercises the chunk-write → onIOWriterChunk → exec.deinit() → done() → Cat.deinit
+  // path on Windows where the builtin can actually read a regular file.
+  test.skipIf(!isWindows)("reads file and writes to pipe (Windows)", { timeout: 30_000 }, async () => {
+    const { stderr, exitCode } = await run(
+      { "a.txt": "A".repeat(64 * 1024) },
+      /* ts */ `
+        import { $ } from "bun";
+        $.nothrow();
+        for (let i = 0; i < 50; i++) {
+          const { exitCode, stdout } = await $\`cat a.txt | cat\`.quiet();
+          if (exitCode !== 0) {
+            console.error("unexpected exit code", exitCode);
+            process.exit(1);
+          }
+          if (stdout.length !== 64 * 1024) {
+            console.error("unexpected stdout length", stdout.length);
+            process.exit(1);
+          }
+        }
+        console.log("ok");
+      `,
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -82,12 +82,12 @@ describe("cat builtin does not leak the file IOReader or its fd", () => {
     }
   `;
 
-  test("single file arg", { timeout: 30_000 }, async () => {
+  test("single file arg", async () => {
     // On Linux the builtin's read of a regular file currently fails (epoll rejects
     // regular files with EPERM) so cat exits 1; on macOS/Windows it succeeds. Either
     // way the IOReader holding the file fd must be released.
     const { stdout, stderr, exitCode } = await run(
-      { "a.txt": "A".repeat(64 * 1024) },
+      { "a.txt": Buffer.alloc(64 * 1024, "A").toString() },
       /* ts */ `
         ${fdCounter}
         import { $ } from "bun";
@@ -119,9 +119,9 @@ describe("cat builtin does not leak the file IOReader or its fd", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("multiple file args including a nonexistent one", { timeout: 30_000 }, async () => {
+  test("multiple file args including a nonexistent one", async () => {
     const { stdout, stderr, exitCode } = await run(
-      { "a.txt": "A".repeat(32 * 1024) },
+      { "a.txt": Buffer.alloc(32 * 1024, "A").toString() },
       /* ts */ `
         ${fdCounter}
         import { $ } from "bun";
@@ -159,9 +159,9 @@ describe("cat builtin does not leak the file IOReader or its fd", () => {
 
   // Exercises the chunk-write → onIOWriterChunk → exec.deinit() → done() → Cat.deinit
   // path on Windows where the builtin can actually read a regular file.
-  test.skipIf(!isWindows)("reads file and writes to pipe (Windows)", { timeout: 30_000 }, async () => {
+  test.skipIf(!isWindows)("reads file and writes to pipe (Windows)", async () => {
     const { stderr, exitCode } = await run(
-      { "a.txt": "A".repeat(64 * 1024) },
+      { "a.txt": Buffer.alloc(64 * 1024, "A").toString() },
       /* ts */ `
         import { $ } from "bun";
         $.nothrow();


### PR DESCRIPTION
## What

`Cat.deinit` (`src/shell/builtin/cat.zig`) was empty. The `exec_filepath_args` state variant owns a refcounted `*IOReader` (created via `IOReader.init` in `next()` for each file argument and holding the file's fd). If the parent `Cmd` is ever torn down while cat is suspended in that state, the reader — and its open file descriptor — would leak.

Fix has two parts:

1. **Make `exec_filepath_args.deinit()` idempotent** — null `reader` after `deref()`. Previously it deref'd but left the pointer dangling.
2. **Make `Cat.deinit` release the reader** — when `state == .exec_filepath_args`, remove cat from the reader's child list and call the inner `deinit()`.

Part (1) is required for part (2) to be safe: on the normal completion path, `exec_filepath_args.deinit()` runs *before* `bltn().done()`, which cascades through `Cmd.deinit → Builtin.deinit → Cat.deinit` while `state` is still `.exec_filepath_args`. Without the null, the non-empty `Cat.deinit` would deref a dangling pointer. Verified: removing just the `this.reader = null` line panics in the refcount debug assertion on the first `cat file` invocation.

## Why no runtime repro on main

I traced every caller of `Cmd.deinit` / `Builtin.deinit` (Pipeline/Stmt/Binary/Async `childDone`, `Pipeline.deinit`, `Stmt.deinit`, `Binary.deinit`). In today's code, every reachable path to `Cat.deinit` goes through `bltn().done()` *after* the reader has already been released:

- `cat file` (completes) → `next()` → `exec.deinit()` → `done()` → `Cat.deinit`
- `cat file | head -c 1` → EPIPE on stdout → `onIOWriterChunk(err)` → `removeReader` + `exec.deinit()` → `done()` → `Cat.deinit`
- `cat file /nonexistent` → open fails → previous reader already deref'd+nulled at top of `next()`

The force-teardown branches (`Pipeline.deinit`'s loop over `.cmd` entries, `Stmt.deinit`'s `currently_executing.deinit()`) are not reachable with a started builtin today, and there's no JS cancel/abort API. So this is a correctness fix for the empty-finalize pattern flagged by static analysis, not a live leak.

## Tests

New `test/js/bun/shell/commands/cat.test.ts`. Because `.cat` is in `Builtin.Kind.DISABLED_ON_POSIX`, in-process `Bun.$` on Linux/macOS spawns `/bin/cat`, not the Zig builtin — and `process.env.X = "1"` in JS doesn't reach `std.c.getenv`, so the feature flag can't be flipped in-process. The fd-leak tests therefore spawn a subprocess with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` in its env:

- **posix**: 100× `cat file` / `cat file ./does-not-exist file` with the builtin enabled. On Linux the builtin's `IOReader.start()` fails on regular files (epoll rejects them with `EPERM`), so cat exits 1 — but the `IOReader` holding the file fd is still created and must be released via `exec_filepath_args.deinit()` on the `onIOReaderDone(errno)` path, which then reaches `Cat.deinit` with `state == .exec_filepath_args`. The subprocess counts its own `/proc/self/fd` entries and fails if they grow.
- **Windows** (builtin always active, reads regular files successfully): 50× `cat file | cat` to exercise the full `onIOWriterChunk → exec.deinit() → done() → Cat.deinit` path, plus the in-process `TestBuilder` checks.

The `cat bigfile | head -c 1` EPIPE scenario is not tested with the builtin on posix: the read errors before any chunk is queued, and the existing `onIOReaderDone` error branch hangs there when `stdout.needsIO() != null` (pre-existing, out of scope here).
