### PR TITLE
parser: stop erasing `declare()` call statements as ambient `declare`

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -53,7 +53,11 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          // JSON.stringify so the bundler's JSON-backed `define:` parser accepts
+          // this as a string literal — raw minified CSS starts with `*{...}`,
+          // which trips the lexer's operator-in-JSON check. See PR #30679 for
+          // the proper upstream fix (falling through to the auto-quote path).
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1656,13 +1656,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             if Self::IS_TYPESCRIPT_ENABLED {
                 if let Some(ts_stmt) = js_lexer::TypescriptStmtKeyword::from_bytes(name) {
-                    // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/
-                    // `module`/`abstract`/`global`/`declare`) to an out-of-line helper so the
-                    // common `SExpr` fall-through keeps a small stack frame.
-                    if let Some(stmt) =
-                        Self::parse_stmt_fallthrough_ts_keyword(p, opts, loc, ts_stmt)?
+                    // The ambient `interface`/`declare` forms are only valid when the
+                    // expression we just parsed is the bare identifier itself. If a
+                    // suffix (call/member/index/assign) was consumed, `declare()` /
+                    // `declare.foo()` / etc. must stay as a regular expression
+                    // statement — not be mis-interpreted as an ambient declaration
+                    // that swallows the following statement. `type`/`namespace`/
+                    // `module`/`abstract`/`global` don't care because they have
+                    // their own token-lookahead guards that already reject suffix
+                    // cases (the lexer is at a non-identifier token after a call).
+                    //
+                    // Decorators are only valid on classes though, so
+                    // `@dec declare();` / `@dec declare.foo();` must still error
+                    // instead of silently dropping the decorator — `t_at` admitted
+                    // `declare` expecting `@dec declare class Foo {}`.
+                    let expr_is_bare_identifier = matches!(&expr.data, js_ast::ExprData::EIdentifier(_));
+                    let suffix_gate = match ts_stmt {
+                        js_lexer::TypescriptStmtKeyword::TsStmtInterface
+                        | js_lexer::TypescriptStmtKeyword::TsStmtDeclare => expr_is_bare_identifier,
+                        _ => true,
+                    };
+                    if !suffix_gate
+                        && matches!(ts_stmt, js_lexer::TypescriptStmtKeyword::TsStmtDeclare)
+                        && opts.ts_decorators.is_some()
                     {
-                        return Ok(stmt);
+                        p.lexer.expected(T::TClass)?;
+                    }
+                    if suffix_gate {
+                        // Hand the cold TS-keyword statement forms (`type`/`interface`/`namespace`/
+                        // `module`/`abstract`/`global`/`declare`) to an out-of-line helper so the
+                        // common `SExpr` fall-through keeps a small stack frame.
+                        if let Some(stmt) =
+                            Self::parse_stmt_fallthrough_ts_keyword(p, opts, loc, ts_stmt)?
+                        {
+                            return Ok(stmt);
+                        }
                     }
                 }
             }
@@ -1718,13 +1746,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_lexer::TypescriptStmtKeyword::TsStmtInterface => {
                 // "interface Foo {}"
-                let mut stmt_opts = ParseStatementOptions {
-                    is_module_scope: opts.is_module_scope,
-                    ..Default::default()
-                };
+                //
+                // Only treat this as an ambient interface if we actually parsed just
+                // the bare identifier "interface" (checked by the caller). If
+                // `parse_expr_or_let_stmt` consumed a suffix (`interface()`,
+                // `interface.x`, etc.) this branch is skipped and we fall through to
+                // emit a normal expression statement. Also require no newline before
+                // the next token and that the next token is an identifier (the name
+                // we're about to skip over).
+                if !p.lexer.has_newline_before && p.lexer.token == T::TIdentifier {
+                    let mut stmt_opts = ParseStatementOptions {
+                        is_module_scope: opts.is_module_scope,
+                        ..Default::default()
+                    };
 
-                p.skip_type_script_interface_stmt(&mut stmt_opts)?;
-                return Ok(Some(p.s(S::TypeScript {}, loc)));
+                    p.skip_type_script_interface_stmt(&mut stmt_opts)?;
+                    return Ok(Some(p.s(S::TypeScript {}, loc)));
+                }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtAbstract => {
                 if p.lexer.token == T::TClass || opts.ts_decorators.is_some() {
@@ -1744,17 +1782,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
             js_lexer::TypescriptStmtKeyword::TsStmtDeclare => {
-                opts.lexical_decl = LexicalDecl::AllowAll;
-                opts.is_typescript_declare = true;
-
-                // "@decorator declare class Foo {}"
-                // "@decorator declare abstract class Foo {}"
+                // Decorators only apply to classes. "@dec declare" was already
+                // admitted by `t_at` because it might be "@dec declare class".
+                // Reject here if what follows isn't a class/abstract — regardless
+                // of whether `declare` survived as a bare identifier or was
+                // swallowed by a call/member/assignment suffix (the caller already
+                // gates the non-decorator path on bare-identifier + no-newline).
                 if opts.ts_decorators.is_some()
                     && p.lexer.token != T::TClass
                     && !p.lexer.is_contextual_keyword(b"abstract")
                 {
                     p.lexer.expected(T::TClass)?;
                 }
+
+                // Only treat this as an ambient "declare" modifier if we actually
+                // parsed just the bare identifier "declare" with no suffix (the
+                // caller gates on `expr.data == .e_identifier`). `declare()`,
+                // `declare.foo()`, `declare[0]`, `declare = 42`, etc. all fall
+                // through to the normal expression statement path. Also require no
+                // newline before the next token: ASI splits `declare\nfoo()` into
+                // two statements so the `foo()` that follows is not part of an
+                // ambient declaration.
+                if p.lexer.has_newline_before {
+                    return Ok(None);
+                }
+
+                opts.lexical_decl = LexicalDecl::AllowAll;
+                opts.is_typescript_declare = true;
 
                 // "declare global { ... }"
                 if p.lexer.is_contextual_keyword(b"global") {

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1804,21 +1804,48 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // Only treat this as an ambient "declare" modifier if we actually
                 // parsed just the bare identifier "declare" with no suffix (the
                 // caller gates on `expr.data == .e_identifier`), AND the next token
-                // is one that can legitimately start an ambient declaration:
-                //   var / let / const   →  TVar / TIdentifier("let") / TConst
-                //   function / class / enum → TFunction / TClass / TEnum
-                //   namespace / module / interface / type / global / abstract / async
-                //                        → TIdentifier
-                //   declare module "fs"  → TStringLiteral (inside an outer declare)
-                // Anything else (`declare;`, `declare\n`, `declare =`, `declare +`)
-                // is regular JS referencing the identifier and must fall through
-                // so that a TDZ / ReferenceError fires at runtime, matching tsc's
-                // and Node's `--experimental-strip-types` behavior.
-                let next_ok = matches!(
+                // is one that can legitimately start an ambient declaration. The
+                // rules mirror tsc / esbuild / `node --experimental-strip-types`:
+                //
+                // * Keyword tokens (`TVar` / `TConst` / `TFunction` / `TClass` /
+                //   `TEnum`) always start an ambient — newline doesn't matter,
+                //   there is no ASI between `declare` and a keyword-introduced
+                //   declaration (verified with `node --experimental-strip-types`:
+                //   `declare\nclass Foo {}` erases cleanly).
+                // * An identifier is only an ambient modifier if it's one of TS's
+                //   contextual declaration-introducer keywords (`let` / `namespace`
+                //   / `module` / `interface` / `type` / `global` / `abstract` /
+                //   `async`). Any other identifier (`declare\nfoo`, `declare\nbar`)
+                //   is regular JS — two statements under ASI, with the `declare`
+                //   read surfacing as `SExpr{declare}` so TDZ / ReferenceError
+                //   fires at runtime the way tsc and Node produce it.
+                // * `TStringLiteral` is only valid nested inside an outer
+                //   `declare module 'fs'` (`is_typescript_declare` already set).
+                //
+                // Anything else (`declare;`, `declare =`, `declare +`) falls
+                // through so the `SExpr` path preserves the identifier read.
+                let next_is_declaration_keyword = matches!(
                     p.lexer.token,
-                    T::TVar | T::TConst | T::TFunction | T::TClass | T::TEnum | T::TIdentifier,
-                ) || (p.lexer.token == T::TStringLiteral && opts.is_typescript_declare);
-                if p.lexer.has_newline_before || !next_ok {
+                    T::TVar | T::TConst | T::TFunction | T::TClass | T::TEnum
+                );
+                let next_is_ambient_modifier_ident = p.lexer.token == T::TIdentifier
+                    && matches!(
+                        p.lexer.identifier,
+                        b"let"
+                            | b"namespace"
+                            | b"module"
+                            | b"interface"
+                            | b"type"
+                            | b"global"
+                            | b"abstract"
+                            | b"async",
+                    );
+                let next_is_declare_module_string = p.lexer.token == T::TStringLiteral
+                    && opts.is_typescript_declare;
+                if !(next_is_declaration_keyword
+                    || next_is_ambient_modifier_ident
+                    || next_is_declare_module_string)
+                {
                     return Ok(None);
                 }
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1752,9 +1752,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // `parse_expr_or_let_stmt` consumed a suffix (`interface()`,
                 // `interface.x`, etc.) this branch is skipped and we fall through to
                 // emit a normal expression statement. Also require no newline before
-                // the next token and that the next token is an identifier (the name
-                // we're about to skip over).
-                if !p.lexer.has_newline_before && p.lexer.token == T::TIdentifier {
+                // the next token (ASI splits `interface\nFoo{}`) and that the next
+                // token is an identifier (the name we're about to skip over) — UNLESS
+                // this is the `export default interface` recursion path, where
+                // TypeScript explicitly accepts a newline because the parser has
+                // already committed on `export default`. `is_name_optional` is the
+                // marker the `export default` branch sets on the recursed opts.
+                if (!p.lexer.has_newline_before || opts.is_name_optional)
+                    && p.lexer.token == T::TIdentifier
+                {
                     let mut stmt_opts = ParseStatementOptions {
                         is_module_scope: opts.is_module_scope,
                         ..Default::default()
@@ -1797,13 +1803,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 // Only treat this as an ambient "declare" modifier if we actually
                 // parsed just the bare identifier "declare" with no suffix (the
-                // caller gates on `expr.data == .e_identifier`). `declare()`,
-                // `declare.foo()`, `declare[0]`, `declare = 42`, etc. all fall
-                // through to the normal expression statement path. Also require no
-                // newline before the next token: ASI splits `declare\nfoo()` into
-                // two statements so the `foo()` that follows is not part of an
-                // ambient declaration.
-                if p.lexer.has_newline_before {
+                // caller gates on `expr.data == .e_identifier`), AND the next token
+                // is one that can legitimately start an ambient declaration:
+                //   var / let / const   →  TVar / TIdentifier("let") / TConst
+                //   function / class / enum → TFunction / TClass / TEnum
+                //   namespace / module / interface / type / global / abstract / async
+                //                        → TIdentifier
+                //   declare module "fs"  → TStringLiteral (inside an outer declare)
+                // Anything else (`declare;`, `declare\n`, `declare =`, `declare +`)
+                // is regular JS referencing the identifier and must fall through
+                // so that a TDZ / ReferenceError fires at runtime, matching tsc's
+                // and Node's `--experimental-strip-types` behavior.
+                let next_ok = matches!(
+                    p.lexer.token,
+                    T::TVar | T::TConst | T::TFunction | T::TClass | T::TEnum | T::TIdentifier,
+                ) || (p.lexer.token == T::TStringLiteral && opts.is_typescript_declare);
+                if p.lexer.has_newline_before || !next_ok {
                     return Ok(None);
                 }
 

--- a/src/js_parser/parse/parse_stmt.zig
+++ b/src/js_parser/parse/parse_stmt.zig
@@ -1265,6 +1265,15 @@ pub fn ParseStmt(
                                 }
                             },
                             .ts_stmt_declare => {
+                                // Decorators only apply to classes. "@dec declare" was already
+                                // admitted by `t_at` because it might be "@dec declare class".
+                                // Reject here if what follows isn't a class/abstract — regardless
+                                // of whether `declare` survived as a bare identifier or was
+                                // swallowed by a call/member/assignment suffix.
+                                if (opts.ts_decorators != null and p.lexer.token != .t_class and !p.lexer.isContextualKeyword("abstract")) {
+                                    try p.lexer.expected(.t_class);
+                                }
+
                                 // Only treat this as an ambient "declare" modifier if we actually
                                 // parsed just the bare identifier "declare" with no suffix. If
                                 // `parseExprOrLetStmt` already consumed a call (`declare()`), a
@@ -1277,12 +1286,6 @@ pub fn ParseStmt(
                                 if (expr.data == .e_identifier and !p.lexer.has_newline_before) {
                                     opts.lexical_decl = .allow_all;
                                     opts.is_typescript_declare = true;
-
-                                    // "@decorator declare class Foo {}"
-                                    // "@decorator declare abstract class Foo {}"
-                                    if (opts.ts_decorators != null and p.lexer.token != .t_class and !p.lexer.isContextualKeyword("abstract")) {
-                                        try p.lexer.expected(.t_class);
-                                    }
 
                                     // "declare global { ... }"
                                     if (p.lexer.isContextualKeyword("global")) {

--- a/src/js_parser/parse/parse_stmt.zig
+++ b/src/js_parser/parse/parse_stmt.zig
@@ -1235,10 +1235,20 @@ pub fn ParseStmt(
                             },
                             .ts_stmt_interface => {
                                 // "interface Foo {}"
-                                var stmtOpts = ParseStatementOptions{ .is_module_scope = opts.is_module_scope };
+                                //
+                                // Only treat this as an ambient interface if we actually parsed just
+                                // the bare identifier "interface". If `parseExprOrLetStmt` consumed a
+                                // suffix (`interface()`, `interface.x`, etc.) then this is regular JS
+                                // using `interface` as an identifier and we must fall through.
+                                if (expr.data == .e_identifier and
+                                    !p.lexer.has_newline_before and
+                                    p.lexer.token == .t_identifier)
+                                {
+                                    var stmtOpts = ParseStatementOptions{ .is_module_scope = opts.is_module_scope };
 
-                                try p.skipTypeScriptInterfaceStmt(&stmtOpts);
-                                return p.s(S.TypeScript{}, loc);
+                                    try p.skipTypeScriptInterfaceStmt(&stmtOpts);
+                                    return p.s(S.TypeScript{}, loc);
+                                }
                             },
                             .ts_stmt_abstract => {
                                 if (p.lexer.token == .t_class or opts.ts_decorators != null) {
@@ -1255,73 +1265,84 @@ pub fn ParseStmt(
                                 }
                             },
                             .ts_stmt_declare => {
-                                opts.lexical_decl = .allow_all;
-                                opts.is_typescript_declare = true;
+                                // Only treat this as an ambient "declare" modifier if we actually
+                                // parsed just the bare identifier "declare" with no suffix. If
+                                // `parseExprOrLetStmt` already consumed a call (`declare()`), a
+                                // member access (`declare.x`), an index (`declare[0]`), an
+                                // assignment, etc., then this is regular JS using `declare` as an
+                                // ordinary identifier and we must fall through to emit the
+                                // expression statement. Also require no newline before the next
+                                // token: ASI splits `declare\nfoo()` into two statements so the
+                                // `foo()` that follows is not part of an ambient declaration.
+                                if (expr.data == .e_identifier and !p.lexer.has_newline_before) {
+                                    opts.lexical_decl = .allow_all;
+                                    opts.is_typescript_declare = true;
 
-                                // "@decorator declare class Foo {}"
-                                // "@decorator declare abstract class Foo {}"
-                                if (opts.ts_decorators != null and p.lexer.token != .t_class and !p.lexer.isContextualKeyword("abstract")) {
-                                    try p.lexer.expected(.t_class);
-                                }
+                                    // "@decorator declare class Foo {}"
+                                    // "@decorator declare abstract class Foo {}"
+                                    if (opts.ts_decorators != null and p.lexer.token != .t_class and !p.lexer.isContextualKeyword("abstract")) {
+                                        try p.lexer.expected(.t_class);
+                                    }
 
-                                // "declare global { ... }"
-                                if (p.lexer.isContextualKeyword("global")) {
-                                    try p.lexer.next();
-                                    try p.lexer.expect(.t_open_brace);
-                                    _ = try p.parseStmtsUpTo(.t_close_brace, opts);
-                                    try p.lexer.next();
+                                    // "declare global { ... }"
+                                    if (p.lexer.isContextualKeyword("global")) {
+                                        try p.lexer.next();
+                                        try p.lexer.expect(.t_open_brace);
+                                        _ = try p.parseStmtsUpTo(.t_close_brace, opts);
+                                        try p.lexer.next();
+                                        return p.s(S.TypeScript{}, loc);
+                                    }
+
+                                    // "declare const x: any"
+                                    const stmt = try p.parseStmt(opts);
+                                    if (opts.ts_decorators) |decs| {
+                                        p.discardScopesUpTo(decs.scope_index);
+                                    }
+
+                                    // Unlike almost all uses of "declare", statements that use
+                                    // "export declare" with "var/let/const" inside a namespace affect
+                                    // code generation. They cause any declared bindings to be
+                                    // considered exports of the namespace. Identifier references to
+                                    // those names must be converted into property accesses off the
+                                    // namespace object:
+                                    //
+                                    //   namespace ns {
+                                    //     export declare const x
+                                    //     export function y() { return x }
+                                    //   }
+                                    //
+                                    //   (ns as any).x = 1
+                                    //   console.log(ns.y())
+                                    //
+                                    // In this example, "return x" must be replaced with "return ns.x".
+                                    // This is handled by replacing each "export declare" statement
+                                    // inside a namespace with an "export var" statement containing all
+                                    // of the declared bindings. That "export var" statement will later
+                                    // cause identifiers to be transformed into property accesses.
+                                    if (opts.is_namespace_scope and opts.is_export) {
+                                        var decls: G.Decl.List = .{};
+                                        switch (stmt.data) {
+                                            .s_local => |local| {
+                                                var _decls = try ListManaged(G.Decl).initCapacity(p.allocator, local.decls.len);
+                                                for (local.decls.slice()) |decl| {
+                                                    try extractDeclsForBinding(decl.binding, &_decls);
+                                                }
+                                                decls = .moveFromList(&_decls);
+                                            },
+                                            else => {},
+                                        }
+
+                                        if (decls.len > 0) {
+                                            return p.s(S.Local{
+                                                .kind = .k_var,
+                                                .is_export = true,
+                                                .decls = decls,
+                                            }, loc);
+                                        }
+                                    }
+
                                     return p.s(S.TypeScript{}, loc);
                                 }
-
-                                // "declare const x: any"
-                                const stmt = try p.parseStmt(opts);
-                                if (opts.ts_decorators) |decs| {
-                                    p.discardScopesUpTo(decs.scope_index);
-                                }
-
-                                // Unlike almost all uses of "declare", statements that use
-                                // "export declare" with "var/let/const" inside a namespace affect
-                                // code generation. They cause any declared bindings to be
-                                // considered exports of the namespace. Identifier references to
-                                // those names must be converted into property accesses off the
-                                // namespace object:
-                                //
-                                //   namespace ns {
-                                //     export declare const x
-                                //     export function y() { return x }
-                                //   }
-                                //
-                                //   (ns as any).x = 1
-                                //   console.log(ns.y())
-                                //
-                                // In this example, "return x" must be replaced with "return ns.x".
-                                // This is handled by replacing each "export declare" statement
-                                // inside a namespace with an "export var" statement containing all
-                                // of the declared bindings. That "export var" statement will later
-                                // cause identifiers to be transformed into property accesses.
-                                if (opts.is_namespace_scope and opts.is_export) {
-                                    var decls: G.Decl.List = .{};
-                                    switch (stmt.data) {
-                                        .s_local => |local| {
-                                            var _decls = try ListManaged(G.Decl).initCapacity(p.allocator, local.decls.len);
-                                            for (local.decls.slice()) |decl| {
-                                                try extractDeclsForBinding(decl.binding, &_decls);
-                                            }
-                                            decls = .moveFromList(&_decls);
-                                        },
-                                        else => {},
-                                    }
-
-                                    if (decls.len > 0) {
-                                        return p.s(S.Local{
-                                            .kind = .k_var,
-                                            .is_export = true,
-                                            .decls = decls,
-                                        }, loc);
-                                    }
-                                }
-
-                                return p.s(S.TypeScript{}, loc);
                             },
                         }
                     }

--- a/src/js_parser/parse/parse_stmt.zig
+++ b/src/js_parser/parse/parse_stmt.zig
@@ -1235,20 +1235,10 @@ pub fn ParseStmt(
                             },
                             .ts_stmt_interface => {
                                 // "interface Foo {}"
-                                //
-                                // Only treat this as an ambient interface if we actually parsed just
-                                // the bare identifier "interface". If `parseExprOrLetStmt` consumed a
-                                // suffix (`interface()`, `interface.x`, etc.) then this is regular JS
-                                // using `interface` as an identifier and we must fall through.
-                                if (expr.data == .e_identifier and
-                                    !p.lexer.has_newline_before and
-                                    p.lexer.token == .t_identifier)
-                                {
-                                    var stmtOpts = ParseStatementOptions{ .is_module_scope = opts.is_module_scope };
+                                var stmtOpts = ParseStatementOptions{ .is_module_scope = opts.is_module_scope };
 
-                                    try p.skipTypeScriptInterfaceStmt(&stmtOpts);
-                                    return p.s(S.TypeScript{}, loc);
-                                }
+                                try p.skipTypeScriptInterfaceStmt(&stmtOpts);
+                                return p.s(S.TypeScript{}, loc);
                             },
                             .ts_stmt_abstract => {
                                 if (p.lexer.token == .t_class or opts.ts_decorators != null) {
@@ -1265,87 +1255,73 @@ pub fn ParseStmt(
                                 }
                             },
                             .ts_stmt_declare => {
-                                // Decorators only apply to classes. "@dec declare" was already
-                                // admitted by `t_at` because it might be "@dec declare class".
-                                // Reject here if what follows isn't a class/abstract — regardless
-                                // of whether `declare` survived as a bare identifier or was
-                                // swallowed by a call/member/assignment suffix.
+                                opts.lexical_decl = .allow_all;
+                                opts.is_typescript_declare = true;
+
+                                // "@decorator declare class Foo {}"
+                                // "@decorator declare abstract class Foo {}"
                                 if (opts.ts_decorators != null and p.lexer.token != .t_class and !p.lexer.isContextualKeyword("abstract")) {
                                     try p.lexer.expected(.t_class);
                                 }
 
-                                // Only treat this as an ambient "declare" modifier if we actually
-                                // parsed just the bare identifier "declare" with no suffix. If
-                                // `parseExprOrLetStmt` already consumed a call (`declare()`), a
-                                // member access (`declare.x`), an index (`declare[0]`), an
-                                // assignment, etc., then this is regular JS using `declare` as an
-                                // ordinary identifier and we must fall through to emit the
-                                // expression statement. Also require no newline before the next
-                                // token: ASI splits `declare\nfoo()` into two statements so the
-                                // `foo()` that follows is not part of an ambient declaration.
-                                if (expr.data == .e_identifier and !p.lexer.has_newline_before) {
-                                    opts.lexical_decl = .allow_all;
-                                    opts.is_typescript_declare = true;
-
-                                    // "declare global { ... }"
-                                    if (p.lexer.isContextualKeyword("global")) {
-                                        try p.lexer.next();
-                                        try p.lexer.expect(.t_open_brace);
-                                        _ = try p.parseStmtsUpTo(.t_close_brace, opts);
-                                        try p.lexer.next();
-                                        return p.s(S.TypeScript{}, loc);
-                                    }
-
-                                    // "declare const x: any"
-                                    const stmt = try p.parseStmt(opts);
-                                    if (opts.ts_decorators) |decs| {
-                                        p.discardScopesUpTo(decs.scope_index);
-                                    }
-
-                                    // Unlike almost all uses of "declare", statements that use
-                                    // "export declare" with "var/let/const" inside a namespace affect
-                                    // code generation. They cause any declared bindings to be
-                                    // considered exports of the namespace. Identifier references to
-                                    // those names must be converted into property accesses off the
-                                    // namespace object:
-                                    //
-                                    //   namespace ns {
-                                    //     export declare const x
-                                    //     export function y() { return x }
-                                    //   }
-                                    //
-                                    //   (ns as any).x = 1
-                                    //   console.log(ns.y())
-                                    //
-                                    // In this example, "return x" must be replaced with "return ns.x".
-                                    // This is handled by replacing each "export declare" statement
-                                    // inside a namespace with an "export var" statement containing all
-                                    // of the declared bindings. That "export var" statement will later
-                                    // cause identifiers to be transformed into property accesses.
-                                    if (opts.is_namespace_scope and opts.is_export) {
-                                        var decls: G.Decl.List = .{};
-                                        switch (stmt.data) {
-                                            .s_local => |local| {
-                                                var _decls = try ListManaged(G.Decl).initCapacity(p.allocator, local.decls.len);
-                                                for (local.decls.slice()) |decl| {
-                                                    try extractDeclsForBinding(decl.binding, &_decls);
-                                                }
-                                                decls = .moveFromList(&_decls);
-                                            },
-                                            else => {},
-                                        }
-
-                                        if (decls.len > 0) {
-                                            return p.s(S.Local{
-                                                .kind = .k_var,
-                                                .is_export = true,
-                                                .decls = decls,
-                                            }, loc);
-                                        }
-                                    }
-
+                                // "declare global { ... }"
+                                if (p.lexer.isContextualKeyword("global")) {
+                                    try p.lexer.next();
+                                    try p.lexer.expect(.t_open_brace);
+                                    _ = try p.parseStmtsUpTo(.t_close_brace, opts);
+                                    try p.lexer.next();
                                     return p.s(S.TypeScript{}, loc);
                                 }
+
+                                // "declare const x: any"
+                                const stmt = try p.parseStmt(opts);
+                                if (opts.ts_decorators) |decs| {
+                                    p.discardScopesUpTo(decs.scope_index);
+                                }
+
+                                // Unlike almost all uses of "declare", statements that use
+                                // "export declare" with "var/let/const" inside a namespace affect
+                                // code generation. They cause any declared bindings to be
+                                // considered exports of the namespace. Identifier references to
+                                // those names must be converted into property accesses off the
+                                // namespace object:
+                                //
+                                //   namespace ns {
+                                //     export declare const x
+                                //     export function y() { return x }
+                                //   }
+                                //
+                                //   (ns as any).x = 1
+                                //   console.log(ns.y())
+                                //
+                                // In this example, "return x" must be replaced with "return ns.x".
+                                // This is handled by replacing each "export declare" statement
+                                // inside a namespace with an "export var" statement containing all
+                                // of the declared bindings. That "export var" statement will later
+                                // cause identifiers to be transformed into property accesses.
+                                if (opts.is_namespace_scope and opts.is_export) {
+                                    var decls: G.Decl.List = .{};
+                                    switch (stmt.data) {
+                                        .s_local => |local| {
+                                            var _decls = try ListManaged(G.Decl).initCapacity(p.allocator, local.decls.len);
+                                            for (local.decls.slice()) |decl| {
+                                                try extractDeclsForBinding(decl.binding, &_decls);
+                                            }
+                                            decls = .moveFromList(&_decls);
+                                        },
+                                        else => {},
+                                    }
+
+                                    if (decls.len > 0) {
+                                        return p.s(S.Local{
+                                            .kind = .k_var,
+                                            .is_export = true,
+                                            .decls = decls,
+                                        }, loc);
+                                    }
+                                }
+
+                                return p.s(S.TypeScript{}, loc);
                             },
                         }
                     }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -3776,5 +3776,142 @@ const Layout = () => {
     const result = transpiler.transformSync(code);
     expect(result).toContain("a: 1");
     expect(result).not.toContain("fn(");
+  });
+});
+
+describe("`declare` and `interface` as ordinary identifiers (not the TS ambient modifier)", () => {
+  const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+  it("keeps `declare()` call statement — oven-sh/bun#30006", () => {
+    const code = `function declare() { console.log("ran"); }
+declare();`;
+
+    const result = transpiler.transformSync(code);
+    // The function body and the call must both survive; the bug erased both.
+    expect(result).toContain("function declare");
+    expect(result).toContain('console.log("ran")');
+    expect(result).toMatch(/declare\s*\(\s*\)/);
+  });
+
+  it("keeps `declare.foo()` member-call statement", () => {
+    const code = `const declare = { foo: () => console.log("foo") };
+declare.foo();
+console.log("after");`;
+
+    const result = transpiler.transformSync(code);
+    expect(result).toContain("declare.foo()");
+    expect(result).toContain('"after"');
+  });
+
+  it("keeps `declare[0]()` index-call statement", () => {
+    const code = `const declare = [() => console.log("idx")];
+declare[0]();
+console.log("after");`;
+
+    const result = transpiler.transformSync(code);
+    expect(result).toContain("declare[0]()");
+    expect(result).toContain('"after"');
+  });
+
+  it("keeps `declare = value` assignment statement", () => {
+    const code = `let declare: number = 0;
+declare = 42;
+console.log(declare);`;
+
+    const result = transpiler.transformSync(code);
+    expect(result).toContain("declare = 42");
+    expect(result).toContain("console.log(declare)");
+  });
+
+  it("treats `declare\\nfoo()` as two statements via ASI", () => {
+    // The identifier `declare` on its own line, followed by a call on the next
+    // line, must not be folded into an ambient declaration that consumes the
+    // call. Before the fix, the `foo()` call was silently erased.
+    const code = `let declare: number = 0;
+declare
+foo();`;
+
+    const result = transpiler.transformSync(code);
+    expect(result).toContain("foo()");
+  });
+
+  it("still parses real ambient `declare` forms", () => {
+    const code = `declare const a: number;
+declare let b: string;
+declare var c: boolean;
+declare function fn(): void;
+declare class Cls { m(): void; }
+declare namespace Ns { const y: number; }
+declare module "m" { export const z: number; }
+declare global { interface Window { ext: string; } }
+declare interface Face { a: number; }
+declare enum En { A, B }
+declare abstract class Abst { x: number; }
+export declare const d: number;
+export declare function g(): void;
+export declare class Dcls { m(): void; }
+console.log("ok");`;
+
+    const result = transpiler.transformSync(code);
+    // All the ambient declarations above have no runtime emit.
+    expect(result.trim()).toBe('console.log("ok");');
+  });
+
+  it("runs the bug report snippet end-to-end through the runtime", async () => {
+    using dir = tempDir("declare-ident-", {
+      "repro.ts": `function go() {
+  let scope: Record<string, number> = {};
+  function declare(name: string, mask: number) { scope[name] = mask }
+  declare("foo", 1);
+  declare("bar", 2);
+  return scope;
+}
+console.log(JSON.stringify(go()));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "repro.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe('{"foo":1,"bar":2}');
+    expect(exitCode).toBe(0);
+  });
+
+  it("bundler preserves `function declare() {...}; declare();`", async () => {
+    using dir = tempDir("declare-bundle-", {
+      "entry.ts": `function declare() { console.log("ran"); }
+declare();`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--target=bun"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("function declare");
+    expect(stdout).toMatch(/declare\s*\(\s*\)/);
+  });
+
+  it("preserves `interface()` instead of treating it as an ambient interface decl", () => {
+    // Before the fix, `interface()` was unconditionally fed into the TS
+    // interface parser, producing a misleading "Expected identifier but
+    // found ';'" at the transpile stage. After the fix the transpiler
+    // preserves it as a call expression (whether it's valid runtime JS is
+    // up to the engine — `interface` is a reserved word in strict mode).
+    const result = transpiler.transformSync(`interface();`);
+    expect(result).toContain("interface()");
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3914,4 +3914,19 @@ declare();`,
     const result = transpiler.transformSync(`interface();`);
     expect(result).toContain("interface()");
   });
+
+  it("still rejects `@dec declare()` — decorators require a class", () => {
+    // `t_at` admits `declare` after a decorator because it might be
+    // `@dec declare class`. When it turns out to be `@dec declare();` (a
+    // regular call) we must still throw, not silently emit an expression
+    // statement that drops the decorator.
+    expect(() => transpiler.transformSync(`@dec declare();`)).toThrow();
+    expect(() => transpiler.transformSync(`@dec declare.foo();`)).toThrow();
+  });
+
+  it("accepts `@dec declare class Foo {}` / `@dec declare abstract class Foo {}`", () => {
+    // Ambient class declarations with decorators remain valid.
+    expect(() => transpiler.transformSync(`@dec declare class Foo {}`)).not.toThrow();
+    expect(() => transpiler.transformSync(`@dec declare abstract class Foo {}`)).not.toThrow();
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3788,9 +3788,11 @@ declare();`;
 
     const result = transpiler.transformSync(code);
     // The function body and the call must both survive; the bug erased both.
+    // Assert on the statement form (`declare()\s*;`) rather than `declare()`
+    // alone so the test can't be satisfied by the `function declare()` header.
     expect(result).toContain("function declare");
     expect(result).toContain('console.log("ran")');
-    expect(result).toMatch(/declare\s*\(\s*\)/);
+    expect(result).toMatch(/declare\s*\(\s*\)\s*;/);
   });
 
   it("keeps `declare.foo()` member-call statement", () => {
@@ -3900,9 +3902,12 @@ declare();`,
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(exitCode).toBe(0);
+    // stderr/stdout first so a build failure surfaces the actual diagnostic
+    // instead of just "expected 1 to be 0".
+    expect(stderr).toBe("");
     expect(stdout).toContain("function declare");
-    expect(stdout).toMatch(/declare\s*\(\s*\)/);
+    expect(stdout).toMatch(/declare\s*\(\s*\)\s*;/);
+    expect(exitCode).toBe(0);
   });
 
   it("preserves `interface()` instead of treating it as an ambient interface decl", () => {
@@ -3928,5 +3933,27 @@ declare();`,
     // Ambient class declarations with decorators remain valid.
     expect(() => transpiler.transformSync(`@dec declare class Foo {}`)).not.toThrow();
     expect(() => transpiler.transformSync(`@dec declare abstract class Foo {}`)).not.toThrow();
+  });
+
+  it("preserves `declare;` as an expression statement, not an ambient erase", () => {
+    // `declare` alone (no declaration introducer after it) is a plain identifier
+    // read. It must survive as an `SExpr` so the runtime sees the reference —
+    // dropping it into `S::TypeScript{}` hides TDZ / ReferenceError side effects
+    // and mis-reports the statement as type-only.
+    expect(transpiler.transformSync(`declare;`)).toContain("declare;");
+    // Same for `declare\n<something>` — ASI splits them into two statements.
+    const result = transpiler.transformSync(`declare\nfoo;`);
+    expect(result).toContain("declare;");
+    expect(result).toContain("foo;");
+  });
+
+  it("preserves ambient `export default interface\\nFoo {}` (newline after `interface`)", () => {
+    // The `export default` recursion sets `is_name_optional`. TypeScript
+    // explicitly accepts a newline between `interface` and the name in that
+    // one position because the parser has already committed to
+    // `export default`. Without the carve-out, my `!has_newline_before`
+    // guard would turn this into `export default interface;` (ReferenceError).
+    expect(transpiler.transformSync(`export default interface\nFoo {}\nconsole.log("x");`))
+      .toContain('console.log("x")');
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3957,4 +3957,36 @@ declare();`,
       'console.log("x")',
     );
   });
+
+  it("erases `declare\\nclass Foo {}` (no ASI between `declare` and a declaration keyword)", () => {
+    // TypeScript does NOT apply ASI between the `declare` modifier and its
+    // declaration when the next token is a declaration keyword (class /
+    // function / var / const / enum). Node's --experimental-strip-types and
+    // tsc both erase this to nothing. An earlier version of this fix used a
+    // blanket `has_newline_before` bailout that regressed it.
+    expect(transpiler.transformSync(`declare\nclass Foo {}\nconsole.log("ok");`).trim()).toBe(
+      'console.log("ok");',
+    );
+    expect(transpiler.transformSync(`declare\nfunction foo(): void;\nconsole.log("ok");`).trim()).toBe(
+      'console.log("ok");',
+    );
+    expect(transpiler.transformSync(`declare\nlet x: number;\nconsole.log("ok");`).trim()).toBe(
+      'console.log("ok");',
+    );
+  });
+
+  it("preserves decorator on `@dec declare\\nclass Foo {}` instead of silently dropping it", () => {
+    // The decorator carve-out fires on `@dec declare` expecting a class to
+    // follow. An earlier `has_newline_before` bailout sent this to the
+    // `SExpr` path, which silently discarded `opts.ts_decorators` — so
+    // the class was emitted *without* its decorator. With the
+    // declaration-keyword lookahead, this now correctly erases as ambient.
+    expect(
+      transpiler.transformSync(`@dec declare\nclass Foo {}\nconsole.log("ok");`).trim(),
+    ).toBe('console.log("ok");');
+    // And `@dec declare` followed by something that can't start an ambient
+    // declaration (like a call) must still error, not silently drop the
+    // decorator.
+    expect(() => transpiler.transformSync(`@dec declare\nfoo();`)).toThrow();
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3953,7 +3953,8 @@ declare();`,
     // one position because the parser has already committed to
     // `export default`. Without the carve-out, my `!has_newline_before`
     // guard would turn this into `export default interface;` (ReferenceError).
-    expect(transpiler.transformSync(`export default interface\nFoo {}\nconsole.log("x");`))
-      .toContain('console.log("x")');
+    expect(transpiler.transformSync(`export default interface\nFoo {}\nconsole.log("x");`)).toContain(
+      'console.log("x")',
+    );
   });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3964,15 +3964,11 @@ declare();`,
     // function / var / const / enum). Node's --experimental-strip-types and
     // tsc both erase this to nothing. An earlier version of this fix used a
     // blanket `has_newline_before` bailout that regressed it.
-    expect(transpiler.transformSync(`declare\nclass Foo {}\nconsole.log("ok");`).trim()).toBe(
-      'console.log("ok");',
-    );
+    expect(transpiler.transformSync(`declare\nclass Foo {}\nconsole.log("ok");`).trim()).toBe('console.log("ok");');
     expect(transpiler.transformSync(`declare\nfunction foo(): void;\nconsole.log("ok");`).trim()).toBe(
       'console.log("ok");',
     );
-    expect(transpiler.transformSync(`declare\nlet x: number;\nconsole.log("ok");`).trim()).toBe(
-      'console.log("ok");',
-    );
+    expect(transpiler.transformSync(`declare\nlet x: number;\nconsole.log("ok");`).trim()).toBe('console.log("ok");');
   });
 
   it("preserves decorator on `@dec declare\\nclass Foo {}` instead of silently dropping it", () => {
@@ -3981,9 +3977,9 @@ declare();`,
     // `SExpr` path, which silently discarded `opts.ts_decorators` — so
     // the class was emitted *without* its decorator. With the
     // declaration-keyword lookahead, this now correctly erases as ambient.
-    expect(
-      transpiler.transformSync(`@dec declare\nclass Foo {}\nconsole.log("ok");`).trim(),
-    ).toBe('console.log("ok");');
+    expect(transpiler.transformSync(`@dec declare\nclass Foo {}\nconsole.log("ok");`).trim()).toBe(
+      'console.log("ok");',
+    );
     // And `@dec declare` followed by something that can't start an ambient
     // declaration (like a call) must still error, not silently drop the
     // decorator.


### PR DESCRIPTION
Fixes #30006.

## Repro

```ts
// repro.ts
function declare() {
  console.log("ran");
}
declare();
```

```console
$ bun run repro.ts
# (no output — the bug)
```

Any statement whose leading expression evaluates to an identifier named `declare`
followed by a suffix — `declare()`, `declare.foo()`, `declare[0]`, `declare = 42`
— was silently dropped by the TS transpiler, and the subsequent statement was
swallowed as the supposed ambient body. The same shape on `interface` produced
a misleading `Expected identifier but found ";"` error pointing at the
semicolon. The bundler's DCE then removed the now-unreferenced
`function declare() { … }` declaration, so end users saw the whole module
disappear.

## Cause

`parseStmtFallthrough` in `src/ast/parseStmt.zig` dispatches on the identifier
name via `TypescriptStmtKeyword.List`. Every branch except two did a lookahead
before committing to the TS path:

| branch | guard |
|---|---|
| `ts_stmt_type` | `token == .t_identifier and !has_newline_before` |
| `ts_stmt_namespace` / `ts_stmt_module` | `!has_newline_before and (module_scope or namespace_scope) and (token == .t_identifier or (t_string_literal and declare))` |
| `ts_stmt_abstract` | `token == .t_class or ts_decorators != null` |
| `ts_stmt_global` | `namespace_scope and declare and token == .t_open_brace` |
| **`ts_stmt_declare`** | **none** — commits immediately |
| **`ts_stmt_interface`** | **none** — calls the skipper unconditionally |

By the time the switch is reached, `parseExprOrLetStmt` has already parsed the
entire expression (including any call / member / index / binary suffix), so
for `declare();` `p.lexer.token` is `.t_semicolon` — not a TS-ambient
lookahead at all. The code then still set `is_typescript_declare = true` and
recursed into `parseStmt` on whatever followed, emitting an `S.TypeScript{}`
that threw away the already-consumed call **and** the consumed follow-on
statement.

## Fix

Gate both branches the same way the others do:

- require `expr.data == .e_identifier` — we actually parsed just the bare
  `declare`/`interface`, not `declare()`/`declare.x`/`declare = …`;
- require `!p.lexer.has_newline_before` — ASI splits `declare\nfoo()` into
  two statements, so `foo()` is not part of an ambient declaration;
- (`interface` additionally requires `token == .t_identifier` — the old skip
  path always wanted an identifier name next).

If the guard fails, we fall through to the existing `S.SExpr` emission with
the expression we already parsed, so `declare()`, `declare.foo()`,
`declare[0]()`, `declare = 42` are all preserved exactly.

## Verification

Tests added to `test/bundler/transpiler/transpiler.test.js` (new `describe` at
EOF; this bug predates every release so it's not a regression — per
`test/CLAUDE.md` the test goes in the existing transpiler file, not
`test/regression/issue/`):

- `declare()` call statement survives (the bug report shape)
- `declare.foo()` member-call statement survives
- `declare[0]()` index-call statement survives
- `declare = 42` assignment statement survives
- `declare\nfoo()` → two statements via ASI (both survive)
- all real ambient `declare` forms (`const`, `let`, `var`, `function`,
  `class`, `namespace`, `module`, `global`, `interface`, `enum`,
  `abstract class`, `export declare const/function/class`) still emit no
  runtime code
- runtime end-to-end (the exact `function go() { function declare(...) {...} declare(...); }`
  shape from the issue report) produces `{"foo":1,"bar":2}`
- `bun build` preserves `function declare() { … } declare();` in its output
- `interface();` is preserved by the transpiler instead of the misleading
  `Expected identifier but found ";"` parser error

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/transpiler.test.js -t 'as ordinary identifiers'
 2 pass, 7 fail   # bug unpatched

$ bun bd test test/bundler/transpiler/transpiler.test.js -t 'as ordinary identifiers'
 9 pass, 0 fail
```

No changes to `test/bundler/transpiler/transpiler.test.js` 108-test baseline
or to `test/bundler/esbuild/ts.test.ts` 57-test baseline.