### PR TITLE
fix: pump event loop for async plugin onLoad in require()

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -67,6 +67,7 @@ public:
 };
 
 extern "C" BunLoaderType Bun__getDefaultLoader(JSC::JSGlobalObject*, BunString* specifier);
+extern "C" void Bun__VirtualMachine__waitForPromise(void* bunVM, JSC::JSPromise* promise);
 
 static JSC::JSPromise* rejectedInternalPromise(JSC::JSGlobalObject* globalObject, JSC::JSValue value)
 {
@@ -660,6 +661,53 @@ JSValue fetchCommonJSModule(
 
     bool wasModuleMock = false;
 
+    // Handles the promise returned by handleVirtualModuleResult. When the
+    // plugin's onLoad callback was an `async` function the promise may still
+    // be Pending here; require() is synchronous, so pump the event loop
+    // until it settles rather than erroring out. If the wait completes with
+    // a fulfilled promise we extract the JSSourceCode it carries (produced
+    // by jsFunctionOnLoadObjectResultResolve in the async case, or placed
+    // directly on the promise by handleVirtualModuleResult in the sync case)
+    // and hand it to the module loader via provideFetch.
+    const auto handleVirtualModulePromise = [&](JSPromise* promise, bool wasMock) -> JSValue {
+        if (promise->status() == JSPromise::Status::Pending) {
+            // We're about to consume any rejection via `throwException` below,
+            // so mark the promise handled up front. Otherwise a rejection
+            // during `waitForPromise` would also be reported as an unhandled
+            // rejection by the event-loop tick that settles it.
+            promise->markAsHandled();
+            Bun__VirtualMachine__waitForPromise(bunVM, promise);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+        switch (promise->status()) {
+        case JSPromise::Status::Rejected: {
+            promise->markAsHandled();
+            JSC::throwException(globalObject, scope, promise->result());
+            return {};
+        }
+        case JSPromise::Status::Pending: {
+            // Only reachable if the wait bailed out (e.g. termination).
+            JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
+            return {};
+        }
+        case JSPromise::Status::Fulfilled: {
+            if (!wasMock) {
+                auto* jsSourceCode = uncheckedDowncast<JSSourceCode>(promise->result());
+                JSC::VM::SynchronousModuleQueue queue;
+                queue.prev = vm.m_synchronousModuleQueue;
+                vm.m_synchronousModuleQueue = &queue;
+                globalObject->moduleLoader()->provideFetch(globalObject, JSC::Identifier::fromString(vm, specifierWtfString), JSC::ScriptFetchParameters::Type::JavaScript, jsSourceCode);
+                if (!scope.exception()) JSC::JSModuleLoader::drainSynchronousModuleQueue(globalObject);
+                vm.m_synchronousModuleQueue = queue.prev;
+                if (scope.exception()) return {};
+            }
+            return jsNumber(-1);
+        }
+        }
+        ASSERT_NOT_REACHED();
+        return {};
+    };
+
     // When "bun test" is enabled, allow users to override builtin modules
     // This is important for being able to trivially mock things like the filesystem.
     if (isBunTest) {
@@ -674,34 +722,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, target);
             }
             JSPromise* promise = uncheckedDowncast<JSPromise>(promiseOrCommonJSModule);
-            switch (promise->status()) {
-            case JSPromise::Status::Rejected: {
-                promise->markAsHandled();
-                JSC::throwException(globalObject, scope, promise->result());
-                RELEASE_AND_RETURN(scope, JSValue {});
-            }
-            case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
-                RELEASE_AND_RETURN(scope, JSValue {});
-            }
-            case JSPromise::Status::Fulfilled: {
-                if (!res->success) {
-                    throwException(scope, res->result.err, globalObject);
-                    RELEASE_AND_RETURN(scope, {});
-                }
-                if (!wasModuleMock) {
-                    auto* jsSourceCode = uncheckedDowncast<JSSourceCode>(promise->result());
-                    JSC::VM::SynchronousModuleQueue queue;
-                    queue.prev = vm.m_synchronousModuleQueue;
-                    vm.m_synchronousModuleQueue = &queue;
-                    globalObject->moduleLoader()->provideFetch(globalObject, JSC::Identifier::fromString(vm, specifierWtfString), JSC::ScriptFetchParameters::Type::JavaScript, jsSourceCode);
-                    if (!scope.exception()) JSC::JSModuleLoader::drainSynchronousModuleQueue(globalObject);
-                    vm.m_synchronousModuleQueue = queue.prev;
-                    RETURN_IF_EXCEPTION(scope, {});
-                }
-                RELEASE_AND_RETURN(scope, jsNumber(-1));
-            }
-            }
+            RELEASE_AND_RETURN(scope, handleVirtualModulePromise(promise, wasModuleMock));
         }
     }
 
@@ -729,34 +750,7 @@ JSValue fetchCommonJSModule(
                 RELEASE_AND_RETURN(scope, target);
             }
             JSPromise* promise = uncheckedDowncast<JSPromise>(promiseOrCommonJSModule);
-            switch (promise->status()) {
-            case JSPromise::Status::Rejected: {
-                promise->markAsHandled();
-                JSC::throwException(globalObject, scope, promise->result());
-                RELEASE_AND_RETURN(scope, JSValue {});
-            }
-            case JSPromise::Status::Pending: {
-                JSC::throwTypeError(globalObject, scope, makeString("require() async module \""_s, specifierWtfString, "\" is unsupported. use \"await import()\" instead."_s));
-                RELEASE_AND_RETURN(scope, JSValue {});
-            }
-            case JSPromise::Status::Fulfilled: {
-                if (!res->success) {
-                    throwException(scope, res->result.err, globalObject);
-                    RELEASE_AND_RETURN(scope, {});
-                }
-                if (!wasModuleMock) {
-                    auto* jsSourceCode = uncheckedDowncast<JSSourceCode>(promise->result());
-                    JSC::VM::SynchronousModuleQueue queue;
-                    queue.prev = vm.m_synchronousModuleQueue;
-                    vm.m_synchronousModuleQueue = &queue;
-                    globalObject->moduleLoader()->provideFetch(globalObject, JSC::Identifier::fromString(vm, specifierWtfString), JSC::ScriptFetchParameters::Type::JavaScript, jsSourceCode);
-                    if (!scope.exception()) JSC::JSModuleLoader::drainSynchronousModuleQueue(globalObject);
-                    vm.m_synchronousModuleQueue = queue.prev;
-                    RETURN_IF_EXCEPTION(scope, {});
-                }
-                RELEASE_AND_RETURN(scope, jsNumber(-1));
-            }
-            }
+            RELEASE_AND_RETURN(scope, handleVirtualModulePromise(promise, wasModuleMock));
         }
     }
 

--- a/src/jsc/virtual_machine_exports.zig
+++ b/src/jsc/virtual_machine_exports.zig
@@ -17,6 +17,13 @@ pub export fn Bun__drainMicrotasks() void {
     jsc.VirtualMachine.get().eventLoop().tick();
 }
 
+/// Pump the event loop until the given promise is settled.
+/// Used from C++ when a synchronous call (e.g. `require()`) needs to wait
+/// on an async plugin result. Caller must check for termination exception.
+pub export fn Bun__VirtualMachine__waitForPromise(vm: *jsc.VirtualMachine, promise: *jsc.JSPromise) void {
+    vm.waitForPromise(.{ .normal = promise });
+}
+
 export fn Bun__readOriginTimer(vm: *jsc.VirtualMachine) u64 {
     // Check if performance.now() is overridden (for fake timers)
     if (vm.overridden_performance_now) |overridden| {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -227,8 +227,11 @@ describe("require", () => {
 });
 
 describe("module", () => {
-  it("throws with require()", () => {
-    expect(() => require("my-virtual-module-async")).toThrow();
+  it("async module works with require() by pumping the event loop", () => {
+    // @ts-expect-error
+    const { hello } = require("my-virtual-module-async");
+    expect(hello).toBe("world");
+    delete require.cache["my-virtual-module-async"];
   });
 
   it("async module works with async import", async () => {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -227,17 +227,20 @@ describe("require", () => {
 });
 
 describe("module", () => {
-  it("async module works with require() by pumping the event loop", () => {
-    // @ts-expect-error
-    const { hello } = require("my-virtual-module-async");
-    expect(hello).toBe("world");
-    delete require.cache["my-virtual-module-async"];
-  });
-
+  // Keep the `await import()` case first so it runs against a fresh registry —
+  // a regression in the import path shouldn't be masked by the registry entry
+  // the require() test below leaves behind.
   it("async module works with async import", async () => {
     // @ts-expect-error
     const { hello } = await import("my-virtual-module-async");
 
+    expect(hello).toBe("world");
+    delete require.cache["my-virtual-module-async"];
+  });
+
+  it("async module works with require() by pumping the event loop", () => {
+    // @ts-expect-error
+    const { hello } = require("my-virtual-module-async");
     expect(hello).toBe("world");
     delete require.cache["my-virtual-module-async"];
   });

--- a/test/regression/issue/30014.test.ts
+++ b/test/regression/issue/30014.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/30014
+// An async plugin onLoad returning a pending promise caused require() to
+// throw "require() async module ... is unsupported" even when the resolved
+// module itself has no top-level await. The fix pumps the event loop to
+// await the plugin promise before declaring the module async.
+
+test("require() with async plugin onLoad for .ts", async () => {
+  using dir = tempDir("issue-30014-async-onload", {
+    "preload.ts": `
+      import { plugin } from "bun";
+
+      plugin({
+        name: "ts-pass-through",
+        setup(build) {
+          build.onLoad({ filter: /\\.ts$/ }, async ({ path }) => ({
+            contents: await Bun.file(path).text(),
+            loader: "ts",
+          }));
+        },
+      });
+    `,
+    "entry.ts": `
+      import { createRequire } from "module";
+
+      const require = createRequire(import.meta.url);
+      const mod = require("./repro.ts");
+      console.log("typeof f:", typeof mod.f);
+      console.log("greet:", mod.greet("world"));
+    `,
+    "repro.ts": `
+      export async function f() {}
+      export function greet(who: string) { return "Hello, " + who; }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.ts", "./entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("require() async module");
+  expect(stdout).toContain("typeof f: function");
+  expect(stdout).toContain("greet: Hello, world");
+  expect(exitCode).toBe(0);
+});
+
+test("require() with async plugin that rejects surfaces the rejection", async () => {
+  // The plugin only targets `.target.ts`, not `.ts`, so it doesn't reject
+  // the entry file itself.
+  using dir = tempDir("issue-30014-async-onload-reject", {
+    "preload.ts": `
+      import { plugin } from "bun";
+
+      plugin({
+        name: "async-reject-plugin",
+        setup(build) {
+          build.onLoad({ filter: /\\.target\\.ts$/ }, async ({ path }) => {
+            await 1;
+            throw new Error("intentional plugin failure");
+          });
+        },
+      });
+    `,
+    "entry.ts": `
+      import { createRequire } from "module";
+      const require = createRequire(import.meta.url);
+      try {
+        require("./repro.target.ts");
+        console.log("ERROR: should have thrown");
+        process.exit(1);
+      } catch (e: any) {
+        console.log("caught:", e.message);
+      }
+    `,
+    "repro.target.ts": `export const x = 1;`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.ts", "./entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("caught: intentional plugin failure");
+  expect(stderr).not.toContain("unhandled");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Issue

Fixes #30014.

When a Bun plugin registers an `async` `onLoad` for an extension that is later loaded via `require()` (commonly through `createRequire`), Bun threw:

```
TypeError: require() async module "/path/to/file.ts" is unsupported. use "await import()" instead.
```

even when the loaded module itself had no top-level `await` — the plugin was just `async`.

## Reproduction

```ts
// preload.ts
import { plugin } from 'bun';
plugin({
  setup(build) {
    build.onLoad({ filter: /\.ts$/ }, async ({ path }) => ({
      contents: await Bun.file(path).text(),
      loader: 'ts',
    }));
  },
});

// entry.ts
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
console.log(typeof require('./repro.ts').f); // threw before

// repro.ts
export async function f() {}
```

```
bun --preload ./preload.ts ./entry.ts
```

## Root cause

`fetchCommonJSModule` in `src/bun.js/bindings/ModuleLoader.cpp` calls `handleVirtualModuleResult`, which for an async `onLoad` callback wraps the plugin's promise in a `PendingVirtualModuleResult` whose internal promise is still `Pending` by the time the caller inspects it. The `Pending` branch threw unconditionally.

The dynamic `import()` path awaits the same promise through JSC's module loader microtasks, which is why `await import(...)` worked.

## Fix

Before erroring on `Pending`, pump the event loop until the promise settles (via a new `Bun__VirtualMachine__waitForPromise` C++ → Zig shim that calls `EventLoop.waitForPromise`). After the wait:

- `Fulfilled`: extract the `JSSourceCode` the resolve-handler produced and hand it to the module loader via `provideFetch` + `drainSynchronousModuleQueue` — the same tail the synchronous-plugin path already uses.
- `Rejected`: throw the rejection from `require()`, so user `try { require(...) } catch` works.
- Still `Pending`: only reachable on termination; keep the original error.

`markAsHandled()` is called on the internal promise before waiting so a plugin rejection settling during the wait isn't ALSO reported as an unhandled rejection by the tick's `handleRejectedPromises`.

The two `Pending | Rejected | Fulfilled` switches in `fetchCommonJSModule` were identical and are now collapsed into a local lambda, `handleVirtualModulePromise`.

## Tests

- `test/regression/issue/30014.test.ts` — reproduces the issue (async onLoad + createRequire), plus a companion test that an async plugin rejection is surfaced through `require()` (and not additionally reported as unhandled).
- `test/js/bun/plugin/plugins.test.ts` — the existing `module > throws with require()` test codified the bug; renamed to `async module works with require() by pumping the event loop` and updated to assert the new behavior. `my-virtual-module-async` now works via `require` as well as via `await import`.

## Verification

```
$ bun bd test test/regression/issue/30014.test.ts test/js/bun/plugin/plugins.test.ts
...
 31 pass
  0 fail
```

Gate check (stash src → test fails, pop → test passes) confirmed both new regression tests and the renamed plugins test exercise the fix.