### PR TITLE
Seal memfd-backed Blob stores against shrinking

### DIFF
--- a/src/bun_alloc/LinuxMemFdAllocator.zig
+++ b/src/bun_alloc/LinuxMemFdAllocator.zig
@@ -170,6 +170,15 @@ pub fn create(bytes: []const u8) bun.sys.Maybe(bun.webcore.Blob.Store.Bytes) {
         }
     }
 
+    // Seal the memfd against shrinking. The backing store is mmap'd
+    // MAP_SHARED; if userspace later ftruncate()s this fd (e.g. via
+    // Bun.file(fd).write() after guessing the descriptor number), writes
+    // to the now-unbacked pages — including std.mem.Allocator.free's
+    // `@memset(ptr, undefined)` in safe builds — would SIGBUS. Ignore
+    // errors: older kernels that reached here via the retry path may
+    // not have MFD_ALLOW_SEALING set, and the store still works.
+    _ = bun.sys.fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK);
+
     var linux_memfd_allocator = Self.new(.{
         .fd = fd,
         .ref_count = .init(),
@@ -190,6 +199,9 @@ pub fn create(bytes: []const u8) bun.sys.Maybe(bun.webcore.Blob.Store.Bytes) {
 pub fn isInstance(allocator_: std.mem.Allocator) bool {
     return allocator_.vtable == AllocatorInterface.VTable;
 }
+
+const F_ADD_SEALS: i32 = 1033;
+const F_SEAL_SHRINK = 0x0002;
 
 const bun = @import("bun");
 const std = @import("std");

--- a/src/bun_alloc/LinuxMemFdAllocator.zig
+++ b/src/bun_alloc/LinuxMemFdAllocator.zig
@@ -175,8 +175,8 @@ pub fn create(bytes: []const u8) bun.sys.Maybe(bun.webcore.Blob.Store.Bytes) {
     // Bun.file(fd).write() after guessing the descriptor number), writes
     // to the now-unbacked pages — including std.mem.Allocator.free's
     // `@memset(ptr, undefined)` in safe builds — would SIGBUS. Ignore
-    // errors: older kernels that reached here via the retry path may
-    // not have MFD_ALLOW_SEALING set, and the store still works.
+    // errors: the store still works unsealed and a sandbox could
+    // conceivably filter F_ADD_SEALS.
     _ = bun.sys.fcntl(fd, F_ADD_SEALS, F_SEAL_SHRINK);
 
     var linux_memfd_allocator = Self.new(.{

--- a/src/runtime/webcore/blob/Store.zig
+++ b/src/runtime/webcore/blob/Store.zig
@@ -541,11 +541,30 @@ pub const Bytes = struct {
     pub fn deinit(this: *Bytes) void {
         bun.default_allocator.free(this.stored_name.slice());
         if (this.ptr) |ptr| {
-            this.allocator.free(ptr[0..this.cap]);
+            if (isMmapBacked(this.allocator)) {
+                // Skip std.mem.Allocator.free's `@memset(ptr, undefined)`:
+                // writing to a MAP_SHARED region that may have been
+                // truncated from under us (or simply dirtying hundreds
+                // of MB of tmpfs pages right before munmap) is both
+                // unsafe and pointless.
+                this.allocator.rawFree(ptr[0..this.cap], .@"1", @returnAddress());
+            } else {
+                this.allocator.free(ptr[0..this.cap]);
+            }
         }
         this.ptr = null;
         this.len = 0;
         this.cap = 0;
+    }
+
+    fn isMmapBacked(alloc: std.mem.Allocator) bool {
+        if (comptime bun.Environment.isLinux) {
+            if (bun.linux.MemFdAllocator.isInstance(alloc)) return true;
+        }
+        if (comptime bun.Environment.isPosix) {
+            if (alloc.vtable == Blob.MmapFreeInterface.vtable) return true;
+        }
+        return false;
     }
 
     pub fn asArrayList(this: Bytes) std.ArrayListUnmanaged(u8) {

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -3309,8 +3309,11 @@ pub const MemfdFlags = enum(u32) {
     cross_process = MFD_NOEXEC_SEAL,
 
     pub fn olderKernelFlag(this: MemfdFlags) u32 {
+        // MFD_EXEC / MFD_NOEXEC_SEAL require Linux 6.3; MFD_ALLOW_SEALING has
+        // existed since memfd_create itself (3.17) and is still wanted so
+        // callers can F_ADD_SEALS after populating the file.
         return switch (this) {
-            .non_executable, .executable => MFD_CLOEXEC,
+            .non_executable, .executable => MFD_CLOEXEC | MFD_ALLOW_SEALING,
             .cross_process => 0,
         };
     }

--- a/test/js/web/fetch/blob-memfd-seal.test.ts
+++ b/test/js/web/fetch/blob-memfd-seal.test.ts
@@ -6,7 +6,19 @@ import { bunEnv, bunExe } from "harness";
 // (e.g. a user passes the descriptor number to Bun.file(fd).write() or
 // fs.ftruncateSync), the finalizer's safety memset would touch unbacked
 // pages during GC and SIGBUS the process.
-describe.skipIf(process.platform !== "linux")("Blob memfd backing", () => {
+describe.concurrent.skipIf(process.platform !== "linux")("Blob memfd backing", () => {
+  const findMemfd = `
+    function findMemfd() {
+      for (const name of fs.readdirSync("/proc/self/fd")) {
+        const fd = Number(name);
+        if (!Number.isInteger(fd) || fd < 3) continue;
+        try {
+          if (fs.readlinkSync("/proc/self/fd/" + fd).includes("memfd")) return fd;
+        } catch {}
+      }
+    }
+  `;
+
   test("is sealed against shrinking", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -14,22 +26,21 @@ describe.skipIf(process.platform !== "linux")("Blob memfd backing", () => {
         "-e",
         `
           const fs = require("node:fs");
+          ${findMemfd}
           // > 8 MiB so the memfd path is taken.
           let blob = new Blob([new Uint8Array(16 * 1024 * 1024)]);
           if (blob.size !== 16 * 1024 * 1024) process.exit(2);
 
-          for (let fd = 3; fd < 64; fd++) {
-            try {
-              if (fs.readlinkSync(\`/proc/self/fd/\${fd}\`).includes("memfd")) {
-                try {
-                  fs.ftruncateSync(fd, 0);
-                  console.error("ftruncate unexpectedly succeeded on memfd", fd);
-                  process.exit(3);
-                } catch {}
-                break;
-              }
-            } catch {}
+          const fd = findMemfd();
+          if (fd === undefined) {
+            console.error("no memfd-backed Blob found; seal not exercised");
+            process.exit(4);
           }
+          try {
+            fs.ftruncateSync(fd, 0);
+            console.error("ftruncate unexpectedly succeeded on memfd", fd);
+            process.exit(3);
+          } catch {}
 
           blob = null;
           Bun.gc(true);
@@ -53,17 +64,12 @@ describe.skipIf(process.platform !== "linux")("Blob memfd backing", () => {
         "-e",
         `
           const fs = require("node:fs");
+          ${findMemfd}
           let held = [];
           let fd;
           for (let i = 0; i < 4; i++) {
             held.push(new Blob([new Uint8Array(16 * 1024 * 1024)]));
-            if (fd === undefined) {
-              for (let f = 3; f < 64; f++) {
-                try {
-                  if (fs.readlinkSync(\`/proc/self/fd/\${f}\`).includes("memfd")) { fd = f; break; }
-                } catch {}
-              }
-            }
+            fd ??= findMemfd();
           }
 
           if (fd !== undefined) {

--- a/test/js/web/fetch/blob-memfd-seal.test.ts
+++ b/test/js/web/fetch/blob-memfd-seal.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // On Linux, large Blob payloads are backed by a memfd that is mmap'd

--- a/test/js/web/fetch/blob-memfd-seal.test.ts
+++ b/test/js/web/fetch/blob-memfd-seal.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// On Linux, large Blob payloads are backed by a memfd that is mmap'd
+// MAP_SHARED. If that memfd's size is reduced from under the mapping
+// (e.g. a user passes the descriptor number to Bun.file(fd).write() or
+// fs.ftruncateSync), the finalizer's safety memset would touch unbacked
+// pages during GC and SIGBUS the process.
+describe.skipIf(process.platform !== "linux")("Blob memfd backing", () => {
+  test("is sealed against shrinking", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          // > 8 MiB so the memfd path is taken.
+          let blob = new Blob([new Uint8Array(16 * 1024 * 1024)]);
+          if (blob.size !== 16 * 1024 * 1024) process.exit(2);
+
+          for (let fd = 3; fd < 64; fd++) {
+            try {
+              if (fs.readlinkSync(\`/proc/self/fd/\${fd}\`).includes("memfd")) {
+                try {
+                  fs.ftruncateSync(fd, 0);
+                  console.error("ftruncate unexpectedly succeeded on memfd", fd);
+                  process.exit(3);
+                } catch {}
+                break;
+              }
+            } catch {}
+          }
+
+          blob = null;
+          Bun.gc(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
+
+  test("finalizer survives writes to the backing fd", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          let held = [];
+          let fd;
+          for (let i = 0; i < 4; i++) {
+            held.push(new Blob([new Uint8Array(16 * 1024 * 1024)]));
+            if (fd === undefined) {
+              for (let f = 3; f < 64; f++) {
+                try {
+                  if (fs.readlinkSync(\`/proc/self/fd/\${f}\`).includes("memfd")) { fd = f; break; }
+                } catch {}
+              }
+            }
+          }
+
+          if (fd !== undefined) {
+            // Previously truncated the memfd, then SIGBUS'd in the finalizer.
+            await Bun.file(fd).write(Bun.file(fd)).catch(() => {});
+          }
+
+          held = null;
+          Bun.gc(true);
+          Bun.gc(true);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
On Linux, large Blob payloads (≥ 8 MiB) are stored in a memfd that is mmap'd `MAP_SHARED`. The memfd's descriptor is an ordinary process fd, so userspace can reach it via `Bun.file(fd).write()` or `fs.ftruncateSync()` and shrink the backing file out from under the mapping. Any subsequent write to the now-unbacked pages — including `std.mem.Allocator.free`'s `@memset(ptr, undefined)` that runs in safe builds right before `munmap` — raises `SIGBUS` during GC finalization.

Fuzzilli found this by creating several `new Blob(new SharedArrayBuffer(256 MiB))` (each backed by a memfd) and then calling `Bun.file(14).write(Bun.file(14))`, which happened to hit one of the memfd descriptors and truncated it mid-copy. The next `Bun.gc(true)` crashed the finalizer.

Two defensive changes:
- Seal the memfd with `F_SEAL_SHRINK` once it's populated so it can never be truncated. The memfd is already created with `MFD_ALLOW_SEALING`; errors are ignored for kernels that reached the fallback flags.
- In `Store.Bytes.deinit`, call `rawFree` directly for mmap-backed allocators (`MemFdAllocator` / `MmapFreeInterface`) instead of routing through `Allocator.free`. Dirtying an entire `MAP_SHARED` region with 0xAA just before unmapping is both unnecessary and the proximate cause of the crash when sealing isn't available.

Added a Linux regression test that asserts the backing memfd rejects `ftruncate` and that writing file-to-itself on the memfd fd no longer SIGBUSes the finalizer.

Fingerprint: `Address:BUS:libc.so.6+0x173614`