### PR TITLE
Fix use-after-free in `Bun.Transpiler` async `transform()` parse errors

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -491,6 +491,16 @@ pub const TransformTask = struct {
         var arena = MimallocArena.init();
         defer arena.deinit();
 
+        // Error messages added by the parser/lexer may contain text allocated
+        // in the arena. Deep-clone them into default_allocator before the arena
+        // is freed so they remain valid when then() reads them on the JS thread.
+        defer if (this.log.msgs.items.len > 0) {
+            var new_log = logger.Log.init(bun.default_allocator);
+            new_log.level = this.log.level;
+            bun.handleOom(this.log.appendToWithRecycled(&new_log, true));
+            this.log = new_log;
+        };
+
         const allocator = arena.allocator();
         var ast_memory_allocator = bun.handleOom(allocator.create(JSAst.ASTMemoryAllocator));
         var ast_scope = ast_memory_allocator.enter(allocator);

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+
+test("async transform() with parse errors does not read freed arena memory", async () => {
+  const transpiler = new Bun.Transpiler();
+
+  // Parse errors are allocated in a per-task arena that is freed when the
+  // worker thread finishes. Before the fix, the error text was read from
+  // that freed arena on the JS thread when rejecting the promise.
+  const results = await Promise.allSettled(
+    Array.from({ length: 64 }, () => transpiler.transform("const x = ;;;")),
+  );
+
+  for (const result of results) {
+    expect(result.status).toBe("rejected");
+    const reason = (result as PromiseRejectedResult).reason;
+    expect(reason.message).toBe("Unexpected ;");
+    expect(reason.position?.line).toBe(1);
+    expect(reason.position?.lineText).toBe("const x = ;;;");
+  }
+});

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -6,9 +6,7 @@ test("async transform() with parse errors does not read freed arena memory", asy
   // Parse errors are allocated in a per-task arena that is freed when the
   // worker thread finishes. Before the fix, the error text was read from
   // that freed arena on the JS thread when rejecting the promise.
-  const results = await Promise.allSettled(
-    Array.from({ length: 64 }, () => transpiler.transform("const x = ;;;")),
-  );
+  const results = await Promise.allSettled(Array.from({ length: 64 }, () => transpiler.transform("const x = ;;;")));
 
   for (const result of results) {
     expect(result.status).toBe("rejected");


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free when `new Bun.Transpiler().transform(code)` (the async variant) is called with input that produces parse errors.

### Root cause

`TransformTask.run()` executes on a worker thread and creates a `MimallocArena` for parsing, which is freed via `defer arena.deinit()` when `run()` returns. The transpiler allocator is set to this arena, so when the lexer/parser add error messages (e.g. via `addRangeError` → `std.fmt.allocPrint(self.allocator, ...)`), the message text lives in the arena.

The `Log.msgs` ArrayList itself is backed by `bun.default_allocator`, so it survives — but its entries point into the now-freed arena. When `then()` runs on the JS thread and calls `this.log.toJS()` → `Msg.clone()` → `allocator.dupe(u8, text)`, it reads freed memory.

In release builds this manifests as garbage error messages (e.g. `""` or arbitrary bytes instead of `"Unexpected ;"`). In ASAN builds it's a `use-after-poison`.

### Fix

Before the arena is freed, deep-clone any log messages into `bun.default_allocator` via `appendToWithRecycled` so the text remains valid for `then()`.

## How did you verify your code works?

- Added a regression test that fails on `main` (error message comes back as garbage) and passes with this fix.
- Ran 30 iterations of the minimized repro under ASAN with no crashes.
- Existing `transpiler.test.js` and `transpiler-tsconfig-uaf.test.ts` pass.