### PR TITLE
Fix stack overflow when inspecting circular JSX elements

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,34 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("JSX circular references", () => {
+  it("does not crash when key is a circular reference", () => {
+    const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {}, key: null };
+    el.key = el;
+    expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+  });
+
+  it("does not crash when a prop is a circular reference", () => {
+    const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {}, key: null };
+    el.props.foo = el;
+    expect(Bun.inspect(el)).toBe("<div foo=[Circular] />");
+  });
+
+  it("does not crash when children is a circular reference", () => {
+    const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {}, key: null };
+    el.props.children = el;
+    expect(Bun.inspect(el)).toBe("<div>\n  [Circular]\n</div>");
+  });
+
+  it("does not mark repeated non-circular children as circular", () => {
+    const child = { $$typeof: Symbol.for("react.element"), type: "span", props: {}, key: null };
+    const parent = {
+      $$typeof: Symbol.for("react.element"),
+      type: "div",
+      props: { children: [child, child] },
+      key: null,
+    };
+    expect(Bun.inspect(parent)).toBe("<div>\n  <span />\n  <span />\n</div>");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`Bun.inspect()` / `console.log()` on a React element whose `key`, `props`, or `children` reference the element itself would recurse unboundedly and crash with a stack overflow (SIGSEGV).

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", props: {}, key: null };
el.key = el;
Bun.inspect(el); // SIGSEGV
```

The `.JSX` formatter tag was missing from `canHaveCircularReferences()`, so the visited-set `[Circular]` short-circuit and the `stack_check.isSafeToRecurse()` guard were skipped for JSX elements.

## How did you verify your code works?

Added regression tests covering circular `key`, circular `props`, circular `children`, and repeated (non-circular) children to ensure those still print normally.

Found by Fuzzilli, fingerprint `bb8715595a137556`.