### PR TITLE
Fix crash in Bun.Transpiler when loader is a UTF-16 string

### DIFF
--- a/src/options.zig
+++ b/src/options.zig
@@ -808,7 +808,10 @@ pub const Loader = enum(u8) {
         try loader.toZigString(&zig_str, global);
         if (zig_str.len == 0) return null;
 
-        return fromString(zig_str.slice()) orelse {
+        const slice = zig_str.toSlice(bun.default_allocator);
+        defer slice.deinit();
+
+        return fromString(slice.slice()) orelse {
             return global.throwInvalidArguments("invalid loader - must be js, jsx, tsx, ts, css, file, toml, yaml, wasm, bunsh, json, or md", .{});
         };
     }

--- a/test/js/bun/transpiler/transpiler-utf16-loader.test.ts
+++ b/test/js/bun/transpiler/transpiler-utf16-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.Transpiler with a UTF-16 loader string", () => {
+  // Previously, passing a string with non-Latin-1 characters as the loader
+  // argument would hit a debug assertion because the code called .slice()
+  // on a ZigString that may be backed by UTF-16 storage.
+  const utf16 = "тsx";
+
+  test("scan", () => {
+    const t = new Bun.Transpiler();
+    expect(() => t.scan("", utf16)).toThrow(TypeError);
+  });
+
+  test("scanImports", () => {
+    const t = new Bun.Transpiler();
+    expect(() => t.scanImports("", utf16)).toThrow(TypeError);
+  });
+
+  test("transformSync", () => {
+    const t = new Bun.Transpiler();
+    expect(() => t.transformSync("", utf16)).toThrow(TypeError);
+  });
+
+  test("transform", () => {
+    const t = new Bun.Transpiler();
+    expect(() => t.transform("", utf16)).toThrow(TypeError);
+  });
+
+  test("constructor", () => {
+    expect(() => new Bun.Transpiler({ loader: utf16 as any })).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash in `Bun.Transpiler` when the `loader` argument contains non-Latin-1 characters.

`Loader.fromJS` called `ZigString.slice()` on the loader string, which panics in debug builds when the underlying string is stored as UTF-16. Switched to `ZigString.toSlice()` which transparently handles both Latin-1 and UTF-16 encodings.

This affected all entrypoints that accept a loader string:
- `new Bun.Transpiler({ loader })`
- `transpiler.scan(code, loader)`
- `transpiler.scanImports(code, loader)`
- `transpiler.transform(code, loader)`
- `transpiler.transformSync(code, loader)`

## Repro

```js
new Bun.Transpiler().scan("", "тs");
```

Before:
```
panic(main thread): ZigString.slice() called on a UTF-16 string.
```

After:
```
TypeError: invalid loader - must be js, jsx, tsx, ts, css, file, toml, yaml, wasm, bunsh, json, or md
```

Found by Fuzzilli. Fingerprint: `2cc91e4d05188e2a`