### PR TITLE
tls: native weak SSL_CTX cache + WeakGCMap SecureContext dedup

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -115,6 +115,7 @@ long us_ssl_ctx_live_count(void) {
  * the same via std::call_once.) */
 static int us_ctx_ex_idx = -1;
 static int us_sni_ex_idx = -1;
+static int us_ctx_cache_ex_idx = -1;
 static int us_ssl_reneg_state_idx = -1;
 static int us_ssl_listener_ex_idx = -1;
 #ifdef _WIN32
@@ -144,9 +145,16 @@ static void us_ssl_reneg_state_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
   us_free(ptr);
 }
 
+/* Defined in Zig (`SSLContextCache.zig`): tombstones the cache entry on
+ * SSL_CTX refcount→0 so the per-VM weak SSL_CTX cache learns the pointer is
+ * dead without holding a ref of its own. */
+extern void bun_ssl_ctx_cache_on_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                      int index, long argl, void *argp);
+
 static void us_ex_idx_init(void) {
   us_ctx_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, us_ctx_ex_free);
   us_sni_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+  us_ctx_cache_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, bun_ssl_ctx_cache_on_free);
   us_ssl_reneg_state_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_reneg_state_free);
   us_ssl_listener_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
 }
@@ -170,6 +178,11 @@ static inline void us_ex_idx_ensure(void) {
 static inline int us_ssl_ctx_ex_idx(void) {
   us_ex_idx_ensure();
   return us_ctx_ex_idx;
+}
+
+int us_ssl_ctx_cache_ex_idx(void) {
+  us_ex_idx_ensure();
+  return us_ctx_cache_ex_idx;
 }
 
 static inline void us_reneg_policy(SSL *ssl, uint32_t *limit, uint32_t *window) {
@@ -1247,7 +1260,10 @@ int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
   SSL_CTX_set_ex_data(ctx, us_sni_ex_idx, user);
 
   if (sni_add(ls->sni, hostname_pattern, node)) {
+    /* Duplicate hostname — propagate so App.h's `if (result != 0)` rollback
+     * (which frees the per-domain HttpRouter it just built) actually fires. */
     sni_node_destructor(node);
+    return 1;
   }
   return 0;
 }

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -130,7 +130,6 @@ extern struct us_socket_t *us_dispatch_connect_error(us_socket_r s, int code);
 extern struct us_connecting_socket_t *us_dispatch_connecting_error(struct us_connecting_socket_t *c, int code);
 extern void us_dispatch_handshake(us_socket_r s, int success, struct us_bun_verify_error_t err);
 extern struct us_socket_t *us_dispatch_ssl_raw_tap(us_socket_r s, char *data, int length);
-extern int us_dispatch_is_low_prio(us_socket_r s);
 
 extern int Bun__addrinfo_get(struct us_loop_t* loop, const char* host, uint16_t port,  struct addrinfo_request** ptr);
 extern int Bun__addrinfo_set(struct addrinfo_request* ptr, struct us_connecting_socket_t* socket);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -259,7 +259,6 @@ struct us_socket_vtable_t {
     struct us_socket_t *(*on_connect_error)(us_socket_r, int code);
     struct us_connecting_socket_t *(*on_connecting_error)(struct us_connecting_socket_t *, int code);
     void (*on_handshake)(us_socket_r, int success, struct us_bun_verify_error_t, void *custom_data);
-    int (*is_low_prio)(us_socket_r);
 };
 
 /* Mutable list-head + sweep state. Zero-initialise then us_socket_group_init().

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -501,7 +501,11 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                  * SSL handshakes are CPU intensive, so we limit the number of handshakes per loop iteration, and move the rest
                  * to the low-priority queue */
                 struct us_socket_flags* flags = &s->flags;
-                if (s->ssl ? us_internal_ssl_is_low_prio(s) : us_dispatch_is_low_prio(s)) {
+                /* Only the SSL handshake gate ever returns low-prio. The
+                 * non-SSL arm dispatched a full vtable lookup just to read
+                 * NULL — no Zig handler defines isLowPrio and every C++ vtable
+                 * sets is_low_prio = nullptr — so it's been dropped. */
+                if (s->ssl && us_internal_ssl_is_low_prio(s)) {
                     if (flags->low_prio_state == 2) {
                         flags->low_prio_state = 0; /* Socket has been delayed and now it's time to process incoming data for one iteration */
                     } else if (loop->data.low_prio_budget > 0) {

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -578,7 +578,6 @@ private:
         /* on_connect_error */nullptr,
         /* on_connecting_error */ nullptr,
         /* on_handshake */    SSL ? &onHandshake : nullptr,
-        /* is_low_prio */     nullptr,
     };
 
 public:

--- a/packages/bun-uws/src/WebSocketContext.h
+++ b/packages/bun-uws/src/WebSocketContext.h
@@ -439,7 +439,6 @@ private:
         /* on_connect_error */nullptr,
         /* on_connecting_error */ nullptr,
         /* on_handshake */    nullptr,
-        /* is_low_prio */     nullptr,
     };
 
     void free() {

--- a/src/bun.js/api.zig
+++ b/src/bun.js/api.zig
@@ -25,6 +25,7 @@ pub const TLSSocket = @import("./api/bun/socket.zig").TLSSocket;
 pub const SocketHandlers = @import("./api/bun/socket.zig").Handlers;
 pub const NewSocket = @import("./api/bun/socket.zig").NewSocket;
 pub const SecureContext = @import("./api/bun/SecureContext.zig");
+pub const SSLContextCache = @import("./api/bun/SSLContextCache.zig");
 
 pub const Subprocess = @import("./api/bun/subprocess.zig");
 pub const cron = @import("./api/cron.zig");

--- a/src/bun.js/api/SecureContext.classes.ts
+++ b/src/bun.js/api/SecureContext.classes.ts
@@ -7,7 +7,12 @@ export default [
     finalize: true,
     memoryCost: true,
     configurable: false,
-    klass: {},
+    klass: {
+      // `tls.createSecureContext()` entry — WeakGCMap-memoised by config
+      // digest so identical configs return the same JS cell. Replaces the
+      // old SHA-256/WeakRef cache that lived in `tls.ts`.
+      intern: { fn: "intern", length: 1 },
+    },
     // No prototype surface — node:tls hands out the SecureContext object
     // itself as `.context`. We deliberately do NOT expose the underlying
     // SSL_CTX* to JS: a Number would lose precision above 2^53, and Node's

--- a/src/bun.js/api/bun/SSLContextCache.zig
+++ b/src/bun.js/api/bun/SSLContextCache.zig
@@ -64,14 +64,20 @@ pub fn getOrCreateOpts(
         }
         // Tombstoned — rebuild and reuse the slot.
         const ctx = opts.createSSLContext(err) orelse return null;
+        // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
+        // it did, the entry would never tombstone and `entry.ctx` would dangle
+        // after the CTX is freed. Don't cache it; caller still owns the ref.
+        if (BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry) != 1) return ctx;
         entry.ctx = ctx;
-        _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry);
         return ctx;
     }
 
     const ctx = opts.createSSLContext(err) orelse return null;
     const entry = bun.new(Entry, .{ .ctx = ctx, .owner = self });
-    _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry);
+    if (BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry) != 1) {
+        bun.destroy(entry);
+        return ctx;
+    }
     bun.handleOom(self.map.put(bun.default_allocator, d, entry));
 
     self.ops_since_compact += 1;

--- a/src/bun.js/api/bun/SSLContextCache.zig
+++ b/src/bun.js/api/bun/SSLContextCache.zig
@@ -21,11 +21,24 @@
 
 const SSLContextCache = @This();
 
-map: std.AutoArrayHashMapUnmanaged(Digest, *Entry) = .empty,
+map: std.ArrayHashMapUnmanaged(Digest, *Entry, DigestContext, false) = .empty,
 mutex: bun.Mutex = .{},
 ops_since_compact: u32 = 0,
 
 pub const Digest = [32]u8;
+
+/// SHA-256 output is uniformly distributed, so the first 4 bytes are a perfect
+/// bucket hash — no need to re-Wyhash 32 bytes (what AutoContext would do).
+/// `eql` still compares the full digest. `store_hash = false` since recompute
+/// is a single load.
+const DigestContext = struct {
+    pub fn hash(_: @This(), k: Digest) u32 {
+        return std.mem.readInt(u32, k[0..4], .little);
+    }
+    pub fn eql(_: @This(), a: Digest, b: Digest, _: usize) bool {
+        return bun.strings.eqlLong(&a, &b, false);
+    }
+};
 
 pub const Entry = struct {
     /// Nulled by `bun_ssl_ctx_cache_on_free` when BoringSSL drops the last
@@ -41,7 +54,8 @@ pub fn getOrCreate(
     config: *const SSLConfig,
     err: *uws.create_bun_socket_error_t,
 ) ?*BoringSSL.SSL_CTX {
-    return self.getOrCreateOpts(config.asUSockets(), err);
+    const opts = config.asUSockets();
+    return self.getOrCreateDigest(opts, opts.digest(), err);
 }
 
 /// Variant for callers that already projected to `BunSocketContextOptions`
@@ -51,8 +65,18 @@ pub fn getOrCreateOpts(
     opts: uws.SocketContext.BunSocketContextOptions,
     err: *uws.create_bun_socket_error_t,
 ) ?*BoringSSL.SSL_CTX {
-    const d = opts.digest();
+    return self.getOrCreateDigest(opts, opts.digest(), err);
+}
 
+/// Core entry — `d` already computed by caller. `SecureContext.intern()`
+/// threads its WeakGCMap key through here so the SHA-256 runs once total
+/// instead of three times on a miss.
+pub fn getOrCreateDigest(
+    self: *SSLContextCache,
+    opts: uws.SocketContext.BunSocketContextOptions,
+    d: Digest,
+    err: *uws.create_bun_socket_error_t,
+) ?*BoringSSL.SSL_CTX {
     self.mutex.lock();
     defer self.mutex.unlock();
 

--- a/src/bun.js/api/bun/SSLContextCache.zig
+++ b/src/bun.js/api/bun/SSLContextCache.zig
@@ -77,17 +77,37 @@ pub fn getOrCreateDigest(
     d: Digest,
     err: *uws.create_bun_socket_error_t,
 ) ?*BoringSSL.SSL_CTX {
+    {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+        if (self.map.get(d)) |entry| {
+            if (entry.ctx) |ctx| {
+                _ = BoringSSL.SSL_CTX_up_ref(ctx);
+                return ctx;
+            }
+        }
+    }
+
+    // Miss (or tombstoned): build outside the lock. `createSSLContext` does
+    // file I/O / cert parsing and on Windows the system-CA load — none of
+    // which has a reason to serialize, and holding a non-reentrant SRWLock
+    // across an SSL_CTX_free that *did* tombstone would self-deadlock.
+    const ctx = opts.createSSLContext(err) orelse return null;
+
     self.mutex.lock();
     defer self.mutex.unlock();
 
-    if (self.map.getPtr(d)) |slot| {
-        const entry = slot.*;
-        if (entry.ctx) |ctx| {
-            _ = BoringSSL.SSL_CTX_up_ref(ctx);
-            return ctx;
+    // Re-check: another caller may have inserted while we were building.
+    // Prefer the already-cached one and drop ours so callers converge.
+    const gop = bun.handleOom(self.map.getOrPut(bun.default_allocator, d));
+    if (gop.found_existing) {
+        const entry = gop.value_ptr.*;
+        if (entry.ctx) |existing| {
+            _ = BoringSSL.SSL_CTX_up_ref(existing);
+            BoringSSL.SSL_CTX_free(ctx);
+            return existing;
         }
-        // Tombstoned — rebuild and reuse the slot.
-        const ctx = opts.createSSLContext(err) orelse return null;
+        // Tombstone — adopt the rebuilt CTX into the existing slot.
         // SSL_CTX_set_ex_data only fails on OOM (Bun crashes anyway), but if
         // it did, the entry would never tombstone and `entry.ctx` would dangle
         // after the CTX is freed. Don't cache it; caller still owns the ref.
@@ -96,13 +116,13 @@ pub fn getOrCreateDigest(
         return ctx;
     }
 
-    const ctx = opts.createSSLContext(err) orelse return null;
     const entry = bun.new(Entry, .{ .ctx = ctx, .owner = self });
+    gop.value_ptr.* = entry;
     if (BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry) != 1) {
+        _ = self.map.swapRemove(d);
         bun.destroy(entry);
         return ctx;
     }
-    bun.handleOom(self.map.put(bun.default_allocator, d, entry));
 
     self.ops_since_compact += 1;
     if (self.ops_since_compact > 16) {

--- a/src/bun.js/api/bun/SSLContextCache.zig
+++ b/src/bun.js/api/bun/SSLContextCache.zig
@@ -1,0 +1,154 @@
+//! Process/VM-scoped weak cache of `SSL_CTX*` keyed by config digest.
+//!
+//! The map holds **zero** refs on the cached `SSL_CTX*`. An `SSL_CTX` ex_data
+//! slot stores a back-pointer to the heap `Entry`; BoringSSL's `CRYPTO_EX_free`
+//! callback (registered once in `openssl.c`'s `us_ex_idx_init`) tombstones the
+//! entry (`entry.ctx = null`) when the real refcount hits 0. The next
+//! `getOrCreate` for that digest sees the tombstone and rebuilds.
+//!
+//! Race-freedom relies on the per-VM instance only being touched from the JS
+//! thread: every consumer's `SSL_CTX_free` (socket close, `owned_ssl_ctx`
+//! deinit, `SecureContext.finalize`) runs there — JSC sweeps destructible
+//! objects on the mutator, not heap-helper, thread. The mutex makes the
+//! tombstone-write / `getOrCreate`-load+`up_ref` ordering explicit and
+//! protects against any future caller that does free off-thread; the lock is
+//! uncontended in practice.
+//!
+//! This subsumes the per-consumer `createSSLContext` calls (Postgres, MySQL,
+//! Valkey, `Bun.connect`, `upgradeTLS`, WebSocket client) and the JS-side
+//! `tls.ts` SHA-256/WeakRef memo: every path that turns an `SSLConfig` into an
+//! `SSL_CTX*` goes through here, so one config = one CTX per process.
+
+const SSLContextCache = @This();
+
+map: std.AutoArrayHashMapUnmanaged(Digest, *Entry) = .empty,
+mutex: bun.Mutex = .{},
+ops_since_compact: u32 = 0,
+
+pub const Digest = [32]u8;
+
+pub const Entry = struct {
+    /// Nulled by `bun_ssl_ctx_cache_on_free` when BoringSSL drops the last
+    /// ref. Tombstoned entries are reclaimed on the next `getOrCreate` for the
+    /// same digest, or by the periodic compact.
+    ctx: ?*BoringSSL.SSL_CTX,
+    owner: *SSLContextCache,
+};
+
+/// Returns +1 ref; caller must `SSL_CTX_free`. The map itself holds no ref.
+pub fn getOrCreate(
+    self: *SSLContextCache,
+    config: *const SSLConfig,
+    err: *uws.create_bun_socket_error_t,
+) ?*BoringSSL.SSL_CTX {
+    return self.getOrCreateOpts(config.asUSockets(), err);
+}
+
+/// Variant for callers that already projected to `BunSocketContextOptions`
+/// (e.g. via `asUSocketsForClientVerification()`).
+pub fn getOrCreateOpts(
+    self: *SSLContextCache,
+    opts: uws.SocketContext.BunSocketContextOptions,
+    err: *uws.create_bun_socket_error_t,
+) ?*BoringSSL.SSL_CTX {
+    const d = opts.digest();
+
+    self.mutex.lock();
+    defer self.mutex.unlock();
+
+    if (self.map.getPtr(d)) |slot| {
+        const entry = slot.*;
+        if (entry.ctx) |ctx| {
+            _ = BoringSSL.SSL_CTX_up_ref(ctx);
+            return ctx;
+        }
+        // Tombstoned — rebuild and reuse the slot.
+        const ctx = opts.createSSLContext(err) orelse return null;
+        entry.ctx = ctx;
+        _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry);
+        return ctx;
+    }
+
+    const ctx = opts.createSSLContext(err) orelse return null;
+    const entry = bun.new(Entry, .{ .ctx = ctx, .owner = self });
+    _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), entry);
+    bun.handleOom(self.map.put(bun.default_allocator, d, entry));
+
+    self.ops_since_compact += 1;
+    if (self.ops_since_compact > 16) {
+        self.ops_since_compact = 0;
+        self.compactLocked();
+    }
+    return ctx;
+}
+
+/// `CRYPTO_EX_free` for the cache slot. `ptr` is the `*Entry` we stashed via
+/// `SSL_CTX_set_ex_data` (null for CTXs that never went through the cache —
+/// e.g. `HTTPThread`'s, or build-fail paths). Runs synchronously inside
+/// whichever `SSL_CTX_free` took the refcount to zero, on that caller's
+/// thread; for the per-VM cache that's always the JS thread.
+export fn bun_ssl_ctx_cache_on_free(
+    parent: ?*anyopaque,
+    ptr: ?*anyopaque,
+    ad: [*c]BoringSSL.CRYPTO_EX_DATA,
+    index: c_int,
+    argl: c_long,
+    argp: ?*anyopaque,
+) callconv(.c) void {
+    _ = parent;
+    _ = ad;
+    _ = index;
+    _ = argl;
+    _ = argp;
+    const entry: *Entry = @ptrCast(@alignCast(ptr orelse return));
+    entry.owner.mutex.lock();
+    defer entry.owner.mutex.unlock();
+    entry.ctx = null;
+}
+
+/// Reclaim tombstoned entries. Locked variant — callers hold `self.mutex`.
+fn compactLocked(self: *SSLContextCache) void {
+    var i: usize = 0;
+    while (i < self.map.count()) {
+        const entry = self.map.values()[i];
+        if (entry.ctx == null) {
+            bun.destroy(entry);
+            self.map.swapRemoveAt(i);
+        } else i += 1;
+    }
+}
+
+/// VM teardown. Clears each live entry's ex_data so the eventual
+/// `SSL_CTX_free` (from sockets/SecureContexts that outlive RareData) doesn't
+/// dereference the freed `Entry`/map. Map itself holds no refs, so no
+/// `SSL_CTX_free` here.
+pub fn deinit(self: *SSLContextCache) void {
+    self.mutex.lock();
+    defer self.mutex.unlock();
+    for (self.map.values()) |entry| {
+        if (entry.ctx) |ctx| {
+            _ = BoringSSL.SSL_CTX_set_ex_data(ctx, c.us_ssl_ctx_cache_ex_idx(), null);
+        }
+        bun.destroy(entry);
+    }
+    self.map.deinit(bun.default_allocator);
+}
+
+pub const c = struct {
+    /// Registered alongside the other usockets ex_data slots in
+    /// `us_ex_idx_init` (pthread_once-guarded).
+    pub extern fn us_ssl_ctx_cache_ex_idx() c_int;
+};
+
+comptime {
+    // Force into the link even though nothing in Zig calls it — `openssl.c`
+    // references it as the `CRYPTO_EX_free` for `us_ctx_cache_ex_idx`.
+    _ = &bun_ssl_ctx_cache_on_free;
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const uws = bun.uws;
+const jsc = bun.jsc;
+const BoringSSL = bun.BoringSSL.c;
+const SSLConfig = jsc.API.ServerConfig.SSLConfig;

--- a/src/bun.js/api/bun/SSLContextCache.zig
+++ b/src/bun.js/api/bun/SSLContextCache.zig
@@ -147,8 +147,9 @@ comptime {
 }
 
 const std = @import("std");
+
 const bun = @import("bun");
-const uws = bun.uws;
 const jsc = bun.jsc;
+const uws = bun.uws;
 const BoringSSL = bun.BoringSSL.c;
 const SSLConfig = jsc.API.ServerConfig.SSLConfig;

--- a/src/bun.js/api/bun/SecureContext.zig
+++ b/src/bun.js/api/bun/SecureContext.zig
@@ -134,6 +134,7 @@ const cpp = struct {
 };
 
 const std = @import("std");
+
 const bun = @import("bun");
 const jsc = bun.jsc;
 const uws = bun.uws;

--- a/src/bun.js/api/bun/SecureContext.zig
+++ b/src/bun.js/api/bun/SecureContext.zig
@@ -96,6 +96,10 @@ pub fn intern(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSErro
     }
 
     const sc = try create(global, &config);
+    // intern() and create() both derive the digest via asUSockets().digest();
+    // if those paths ever drift, identical configs would silently stop
+    // interning. Debug-assert they agree.
+    bun.assert(bun.strings.eqlLong(&sc.digest, &d, false));
     const value = sc.toJS(global);
     cpp.Bun__SecureContextCache__set(global, key, value);
     return value;

--- a/src/bun.js/api/bun/SecureContext.zig
+++ b/src/bun.js/api/bun/SecureContext.zig
@@ -48,8 +48,12 @@ pub fn constructor(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
 /// `us_ssl_ctx_from_options` so that override has roots to validate against.
 pub fn create(global: *jsc.JSGlobalObject, config: *const SSLConfig) bun.JSError!*SecureContext {
     const ctx_opts = config.asUSockets();
+    return createWithDigest(global, ctx_opts, ctx_opts.digest());
+}
+
+fn createWithDigest(global: *jsc.JSGlobalObject, ctx_opts: uws.SocketContext.BunSocketContextOptions, d: [32]u8) bun.JSError!*SecureContext {
     var err: uws.create_bun_socket_error_t = .none;
-    const ctx = global.bunVM().rareData().sslCtxCache().getOrCreateOpts(ctx_opts, &err) orelse {
+    const ctx = global.bunVM().rareData().sslCtxCache().getOrCreateDigest(ctx_opts, d, &err) orelse {
         // `err` is only set for the input-validation paths (bad PEM, missing
         // file, …). When BoringSSL itself fails (e.g. unsupported curve) the
         // enum is still `.none`; surface the library error stack instead of
@@ -63,7 +67,7 @@ pub fn create(global: *jsc.JSGlobalObject, config: *const SSLConfig) bun.JSError
     };
     return bun.new(SecureContext, .{
         .ctx = ctx,
-        .digest = ctx_opts.digest(),
+        .digest = d,
         .extra_memory = ctx_opts.approxCertBytes() + ssl_ctx_base_cost,
     });
 }
@@ -81,7 +85,8 @@ pub fn intern(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSErro
     var config = (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
     defer config.deinit();
 
-    const d = config.ctxDigest();
+    const ctx_opts = config.asUSockets();
+    const d = ctx_opts.digest();
     const key = std.mem.readInt(u64, d[0..8], .little);
 
     const cached = cpp.Bun__SecureContextCache__get(global, key);
@@ -95,11 +100,7 @@ pub fn intern(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSErro
         }
     }
 
-    const sc = try create(global, &config);
-    // intern() and create() both derive the digest via asUSockets().digest();
-    // if those paths ever drift, identical configs would silently stop
-    // interning. Debug-assert they agree.
-    bun.assert(bun.strings.eqlLong(&sc.digest, &d, false));
+    const sc = try createWithDigest(global, ctx_opts, d);
     const value = sc.toJS(global);
     cpp.Bun__SecureContextCache__set(global, key, value);
     return value;

--- a/src/bun.js/api/bun/SecureContext.zig
+++ b/src/bun.js/api/bun/SecureContext.zig
@@ -6,9 +6,12 @@
 //! refcount is the only refcount and a socket safely outlives a GC'd
 //! SecureContext.
 //!
-//! `tls.ts` memoises `createSecureContext()` by config hash, so the common
-//! "one config, thousands of connections" pattern allocates one of these and
-//! one `SSL_CTX` total instead of one per connection.
+//! `intern()` memoises by config digest at two levels: a `WeakGCMap` on the
+//! global (same digest → same `JSSecureContext` while alive) and the per-VM
+//! native `SSLContextCache` (same digest → same `SSL_CTX*` regardless of which
+//! consumer asked). The "one config, thousands of connections" pattern
+//! allocates one of these and one `SSL_CTX` total — `tls.ts` no longer hashes
+//! in JS.
 const SecureContext = @This();
 
 pub const js = jsc.Codegen.JSSecureContext;
@@ -17,6 +20,10 @@ pub const fromJS = js.fromJS;
 pub const fromJSDirect = js.fromJSDirect;
 
 ctx: *BoringSSL.SSL_CTX,
+/// `BunSocketContextOptions.digest()` — exactly the fields that reach
+/// `us_ssl_ctx_from_options`. Stored so an `intern()` WeakGCMap hit (keyed by
+/// the low 64 bits) can do a full content-equality check before reusing.
+digest: [32]u8,
 /// Approximate cert/key/CA byte length plus the BoringSSL `SSL_CTX` floor
 /// (~50 KB), so the GC can account for the off-heap allocation.
 extra_memory: usize,
@@ -42,7 +49,7 @@ pub fn constructor(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.J
 pub fn create(global: *jsc.JSGlobalObject, config: *const SSLConfig) bun.JSError!*SecureContext {
     const ctx_opts = config.asUSockets();
     var err: uws.create_bun_socket_error_t = .none;
-    const ctx = ctx_opts.createSSLContext(&err) orelse {
+    const ctx = global.bunVM().rareData().sslCtxCache().getOrCreateOpts(ctx_opts, &err) orelse {
         // `err` is only set for the input-validation paths (bad PEM, missing
         // file, …). When BoringSSL itself fails (e.g. unsupported curve) the
         // enum is still `.none`; surface the library error stack instead of
@@ -56,8 +63,42 @@ pub fn create(global: *jsc.JSGlobalObject, config: *const SSLConfig) bun.JSError
     };
     return bun.new(SecureContext, .{
         .ctx = ctx,
+        .digest = ctx_opts.digest(),
         .extra_memory = ctx_opts.approxCertBytes() + ssl_ctx_base_cost,
     });
+}
+
+/// `tls.createSecureContext(opts)` entry point. WeakGCMap-memoised by config
+/// digest so identical configs return the same `JSSecureContext` cell while
+/// it's alive; falls through to `create()` (which itself hits the native
+/// `SSLContextCache`) on miss. Returning the same cell is what makes
+/// `secureContext === createSecureContext(opts)` hold and lets `Listener.zig`
+/// pointer-compare without a JS-side WeakRef map.
+pub fn intern(global: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+    const args = callframe.arguments();
+    const opts = if (args.len > 0) args[0] else .js_undefined;
+
+    var config = (try SSLConfig.fromJS(global.bunVM(), global, opts)) orelse SSLConfig.zero;
+    defer config.deinit();
+
+    const d = config.ctxDigest();
+    const key = std.mem.readInt(u64, d[0..8], .little);
+
+    const cached = cpp.Bun__SecureContextCache__get(global, key);
+    if (cached != .zero) {
+        if (fromJS(cached)) |existing| {
+            // 64-bit key collision is ~2⁻⁶⁴ but a false hit hands the wrong
+            // cert to a connection. Full-digest compare is 32 bytes; cheap.
+            if (bun.strings.eqlLong(&existing.digest, &d, false)) {
+                return cached;
+            }
+        }
+    }
+
+    const sc = try create(global, &config);
+    const value = sc.toJS(global);
+    cpp.Bun__SecureContextCache__set(global, key, value);
+    return value;
 }
 
 /// `SSL_CTX_up_ref` and return — for callers that want to outlive this
@@ -87,6 +128,12 @@ const ssl_ctx_base_cost: usize = 50 * 1024;
 
 pub const c = uws.SocketContext.c;
 
+const cpp = struct {
+    pub extern fn Bun__SecureContextCache__get(*jsc.JSGlobalObject, u64) jsc.JSValue;
+    pub extern fn Bun__SecureContextCache__set(*jsc.JSGlobalObject, u64, jsc.JSValue) void;
+};
+
+const std = @import("std");
 const bun = @import("bun");
 const jsc = bun.jsc;
 const uws = bun.uws;

--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1532,7 +1532,10 @@ pub fn NewSocket(comptime ssl: bool) type {
                 }
                 const cfg = &(ssl_opts orelse return globalObject.throw("Expected \"tls\" option", .{}));
                 var create_err: uws.create_bun_socket_error_t = .none;
-                owned_ctx = cfg.asUSockets().createSSLContext(&create_err) orelse {
+                // Per-VM weak cache: `tls:true` and `{servername}`-only hit
+                // the same CTX as `Bun.connect`; an inline CA dedupes across
+                // every upgradeTLS that names it.
+                owned_ctx = jsc.VirtualMachine.get().rareData().sslCtxCache().getOrCreate(cfg, &create_err) orelse {
                     // us_ssl_ctx_from_options only sets *err for the CA/cipher
                     // cases; bad cert/key/DH return NULL with err==.none and the
                     // detail is on the BoringSSL error queue.

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -391,7 +391,7 @@ pub fn addServerName(this: *Listener, global: *jsc.JSGlobalObject, hostname: JSV
         var cfg = ssl_config;
         defer cfg.deinit();
         var create_err: uws.create_bun_socket_error_t = .none;
-        break :brk cfg.asUSockets().createSSLContext(&create_err) orelse {
+        break :brk jsc.VirtualMachine.get().rareData().sslCtxCache().getOrCreate(&cfg, &create_err) orelse {
             if (create_err != .none) return global.throwValue(create_err.toJS(global));
             return global.throwValue(bun.BoringSSL.ERR_toJS(global, BoringSSL.ERR_get_error()));
         };
@@ -775,23 +775,16 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
     // `socket.owned_ssl_ctx` to the per-VM connect group.
     if (ssl_enabled and owned_ssl_ctx == null) {
         if (ssl) |ssl_cfg| {
-            // `Bun.connect({tls: true})` and other no-cert/no-CA configs are
-            // the common case for clients (default trust store, default
-            // ciphers). Building a fresh SSL_CTX for those is ~70 ms of cert
-            // parsing and ex-data registration on debug+ASAN — measurable
-            // first-connect latency and exactly the per-connection cost this
-            // PR exists to remove. Reuse the per-VM default; only fall through
-            // to a fresh build when the config actually customises something.
-            if (!ssl_cfg.requires_custom_request_ctx) {
-                const shared = vm.rareData().defaultClientSslCtx();
-                _ = BoringSSL.SSL_CTX_up_ref(shared);
-                owned_ssl_ctx = shared;
-            } else {
-                var create_err: uws.create_bun_socket_error_t = .none;
-                owned_ssl_ctx = ssl_cfg.asUSockets().createSSLContext(&create_err) orelse {
-                    return globalObject.throwValue(create_err.toJS(globalObject));
-                };
-            }
+            // Per-VM weak `SSLContextCache`: identical configs (including the
+            // common `tls:true` / `{servername}`-only / `{ALPNProtocols}`-only
+            // cases — those fields aren't in the digest because they're
+            // applied per-SSL, not per-CTX) share one `SSL_CTX*`. The
+            // `requires_custom_request_ctx` gate is gone; the cache makes the
+            // default-vs-custom distinction by content.
+            var create_err: uws.create_bun_socket_error_t = .none;
+            owned_ssl_ctx = vm.rareData().sslCtxCache().getOrCreate(ssl_cfg, &create_err) orelse {
+                return globalObject.throwValue(create_err.toJS(globalObject));
+            };
         }
     }
     // (errdefer for owned_ssl_ctx already armed at the earlier lookup site;

--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -111,23 +111,6 @@ pub fn asUSockets(this: *const SSLConfig) uws.SocketContext.BunSocketContextOpti
     return ctx_opts;
 }
 
-/// SHA-256 over exactly the fields that reach `us_ssl_ctx_from_options`. Two
-/// configs with the same digest build a byte-identical `SSL_CTX*`, so the
-/// native `SSLContextCache` can hand the same pointer to both. We hash the
-/// `BunSocketContextOptions` projection (not `SSLConfig` itself) so per-SSL
-/// fields that never touch the CTX — `server_name`, `protos` (ALPN) — are
-/// excluded by construction: `Bun.connect({tls:{servername:'x'}})` and
-/// `{tls:true}` digest identically and share the default client CTX.
-///
-/// `secure_options` and `client_renegotiation_{limit,window}` are read from
-/// `BunSocketContextOptions` by the C builder (the latter packed into a CTX
-/// ex_data slot), so they're hashed even though `asUSockets()` currently
-/// leaves them at struct defaults — keeps the digest future-proof if that
-/// gap is closed.
-pub fn ctxDigest(this: *const SSLConfig) [32]u8 {
-    return this.asUSockets().digest();
-}
-
 /// Returns socket options for client-side TLS with manual verification.
 /// Sets request_cert=1 (to receive server cert) and reject_unauthorized=0
 /// (to handle verification manually in handshake callback).

--- a/src/bun.js/api/server/SSLConfig.zig
+++ b/src/bun.js/api/server/SSLConfig.zig
@@ -111,6 +111,23 @@ pub fn asUSockets(this: *const SSLConfig) uws.SocketContext.BunSocketContextOpti
     return ctx_opts;
 }
 
+/// SHA-256 over exactly the fields that reach `us_ssl_ctx_from_options`. Two
+/// configs with the same digest build a byte-identical `SSL_CTX*`, so the
+/// native `SSLContextCache` can hand the same pointer to both. We hash the
+/// `BunSocketContextOptions` projection (not `SSLConfig` itself) so per-SSL
+/// fields that never touch the CTX — `server_name`, `protos` (ALPN) — are
+/// excluded by construction: `Bun.connect({tls:{servername:'x'}})` and
+/// `{tls:true}` digest identically and share the default client CTX.
+///
+/// `secure_options` and `client_renegotiation_{limit,window}` are read from
+/// `BunSocketContextOptions` by the C builder (the latter packed into a CTX
+/// ex_data slot), so they're hashed even though `asUSockets()` currently
+/// leaves them at struct defaults — keeps the digest future-proof if that
+/// gap is closed.
+pub fn ctxDigest(this: *const SSLConfig) [32]u8 {
+    return this.asUSockets().digest();
+}
+
 /// Returns socket options for client-side TLS with manual verification.
 /// Sets request_cert=1 (to receive server cert) and reject_unauthorized=0
 /// (to handle verification manually in handshake callback).

--- a/src/bun.js/bindings/BunSecureContextCache.cpp
+++ b/src/bun.js/bindings/BunSecureContextCache.cpp
@@ -1,0 +1,26 @@
+#include "root.h"
+#include "BunSecureContextCache.h"
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/WeakGCMapInlines.h>
+
+using namespace JSC;
+
+// Called from Zig (`SecureContext.intern`). Returns the cached JSSecureContext
+// for `key` (low 64 bits of the config digest) or jsEmpty() if none / GC'd.
+// The full 32-byte digest lives on the Zig SecureContext, so the caller does
+// a content-equality check on hit to handle the (~2⁻⁶⁴) key-collision case.
+extern "C" JSC::EncodedJSValue Bun__SecureContextCache__get(Zig::GlobalObject* global, uint64_t key)
+{
+    auto& slot = global->m_secureContextCache;
+    if (!slot) return JSValue::encode(JSValue());
+    JSObject* obj = slot->get(key);
+    return JSValue::encode(obj ? JSValue(obj) : JSValue());
+}
+
+extern "C" void Bun__SecureContextCache__set(Zig::GlobalObject* global, uint64_t key, JSC::EncodedJSValue value)
+{
+    auto& slot = global->m_secureContextCache;
+    if (!slot) slot = makeUnique<Bun::SecureContextCache>(global->vm());
+    JSObject* obj = JSValue::decode(value).getObject();
+    if (obj) slot->set(key, obj);
+}

--- a/src/bun.js/bindings/BunSecureContextCache.h
+++ b/src/bun.js/bindings/BunSecureContextCache.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Thin wrapper around `WeakGCMap<uint64_t, JSObject>` so ZigGlobalObject.h
+// can hold a `std::unique_ptr<SecureContextCache>` without pulling in
+// WeakGCMap.h (this header is included from one .cpp file only).
+//
+// Backs the JS-side dedup of `tls.createSecureContext()`: same config digest
+// → same `JSSecureContext` cell while it's alive. The native `SSL_CTX*` cache
+// (Zig `SSLContextCache`) is independent — BoringSSL's refcount is the single
+// source of truth, so the two never need to coordinate.
+
+#include "root.h"
+#include <JavaScriptCore/WeakGCMap.h>
+
+namespace Bun {
+
+class SecureContextCache {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SecureContextCache);
+public:
+    explicit SecureContextCache(JSC::VM& vm)
+        : m_map(vm)
+    {
+    }
+
+    JSC::JSObject* get(uint64_t key) { return m_map.get(key); }
+    void set(uint64_t key, JSC::JSObject* value) { m_map.set(key, JSC::Weak<JSC::JSObject>(value)); }
+
+private:
+    JSC::WeakGCMap<uint64_t, JSC::JSObject, WTF::IntHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>> m_map;
+};
+
+} // namespace Bun

--- a/src/bun.js/bindings/BunSecureContextCache.h
+++ b/src/bun.js/bindings/BunSecureContextCache.h
@@ -16,6 +16,7 @@ namespace Bun {
 
 class SecureContextCache {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(SecureContextCache);
+
 public:
     explicit SecureContextCache(JSC::VM& vm)
         : m_map(vm)

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -66,6 +66,7 @@
 #include "GeneratedBunObject.h"
 #include "BunPlugin.h"
 #include "BunProcess.h"
+#include "BunSecureContextCache.h"
 #include "ProcessIdentifier.h"
 #include "BunWorkerGlobalScope.h"
 #include "CallSite.h"

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -36,6 +36,7 @@ class InternalModuleRegistry;
 class NapiHandleScopeImpl;
 class JSNextTickQueue;
 class Process;
+class SecureContextCache;
 } // namespace Bun
 
 namespace v8 {
@@ -770,6 +771,11 @@ public:
     bool hasOverriddenModuleWrapper = false;
     // De-optimization once `require("module").runMain` is written to
     bool hasOverriddenModuleRunMain = false;
+
+    // WeakGCMap<uint64_t, JSObject> — JS-level dedup of SecureContext by
+    // config digest. WeakGCMap self-registers with the heap, so no
+    // visitChildren wiring needed (and it must NOT keep its values alive).
+    std::unique_ptr<Bun::SecureContextCache> m_secureContextCache;
 
     WTF::Vector<WTF::Ref<NapiEnv>> m_napiEnvs;
     Ref<NapiEnv> makeNapiEnv(const napi_module&);

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -730,14 +730,14 @@ pub fn wsClientGroup(rare: *RareData, vm: *jsc.VirtualMachine, comptime ssl: boo
     return rare.lazyGroup(vm, if (ssl) "ws_client_tls_group" else "ws_client_group");
 }
 
-/// Shared `SSL_CTX*` for client connects that didn't supply a custom CA
-/// (`Valkey({tls: true})`, `new WebSocket("wss://…")`). The old code allocated
-/// a fresh `us_socket_context_t` per such case and cached the pointer; now
-/// the SSL_CTX is the only thing worth caching.
 pub fn sslCtxCache(rare: *RareData) *api.SSLContextCache {
     return &rare.ssl_ctx_cache;
 }
 
+/// Shared `SSL_CTX*` for client connects that didn't supply a custom CA
+/// (`Valkey({tls: true})`, `new WebSocket("wss://…")`). The old code allocated
+/// a fresh `us_socket_context_t` per such case and cached the pointer; now
+/// the SSL_CTX is the only thing worth caching.
 pub fn defaultClientSslCtx(rare: *RareData) *uws.SslCtx {
     if (rare.default_client_ssl_ctx == null) {
         var err: uws.create_bun_socket_error_t = .none;

--- a/src/bun.js/rare_data.zig
+++ b/src/bun.js/rare_data.zig
@@ -47,9 +47,14 @@ ws_upgrade_group: uws.SocketGroup = .{},
 ws_upgrade_tls_group: uws.SocketGroup = .{},
 ws_client_group: uws.SocketGroup = .{},
 ws_client_tls_group: uws.SocketGroup = .{},
-/// Default `SSL_CTX*` for the WS client / Valkey TLS path when no custom CA
-/// is supplied. Built once on first use; replaces the `valkey_context.tls` /
-/// shared C++ WS context.
+/// Weak digest→`SSL_CTX*` cache. Every JS-thread consumer that turns an
+/// `SSLConfig` into an `SSL_CTX*` goes through here so identical configs
+/// share one CTX (Postgres pool, Valkey, `Bun.connect`, `tls.connect`, …).
+ssl_ctx_cache: api.SSLContextCache = .{},
+
+/// `ssl_ctx_cache.getOrCreate(&.{})` — i.e. the default-trust-store client
+/// CTX. Cached separately so the hot `tls:true` / `wss://` path skips even the
+/// SHA-256 + map lookup. Ref owned here.
 default_client_ssl_ctx: ?*uws.SslCtx = null,
 
 mime_types: ?bun.http.MimeType.Map = null,
@@ -729,20 +734,22 @@ pub fn wsClientGroup(rare: *RareData, vm: *jsc.VirtualMachine, comptime ssl: boo
 /// (`Valkey({tls: true})`, `new WebSocket("wss://…")`). The old code allocated
 /// a fresh `us_socket_context_t` per such case and cached the pointer; now
 /// the SSL_CTX is the only thing worth caching.
+pub fn sslCtxCache(rare: *RareData) *api.SSLContextCache {
+    return &rare.ssl_ctx_cache;
+}
+
 pub fn defaultClientSslCtx(rare: *RareData) *uws.SslCtx {
     if (rare.default_client_ssl_ctx == null) {
         var err: uws.create_bun_socket_error_t = .none;
         // Mode-neutral CTX (VERIFY_NONE). `us_internal_ssl_attach` overrides
         // each client SSL to VERIFY_PEER + the shared bundled-root store, so
         // `new WebSocket("wss://…")` (which shares this CTX and defaults to
-        // rejectUnauthorized:true) verifies real servers. The store is built
-        // once via `std::call_once` and only up_ref'd thereafter — the
-        // ~150-cert cost is paid on the first TLS connect of the process, not
-        // per-connect. (An earlier attempt set VERIFY_PEER on the CTX to skip
-        // that cold load for `Bun.connect({tls:true})`; wrong: it left wss://
-        // with no roots and `rejectUnauthorized` failed every public host.
-        // The cold-load is a one-time debug-build cost; correctness wins.)
-        rare.default_client_ssl_ctx = (uws.SocketContext.BunSocketContextOptions{}).createSSLContext(&err) orelse bun.Output.panic(
+        // rejectUnauthorized:true) verifies real servers. Route through the
+        // weak cache so a `tls.connect()` with default options later resolves
+        // to the same CTX rather than building a second one with the same
+        // digest. The +1 ref returned here is held for the VM's lifetime, so
+        // the entry never tombstones.
+        rare.default_client_ssl_ctx = rare.ssl_ctx_cache.getOrCreateOpts(.{}, &err) orelse bun.Output.panic(
             "default client SSL_CTX init failed: {s}",
             .{err.message() orelse "unknown"},
         );
@@ -857,6 +864,11 @@ pub fn deinit(this: *RareData) void {
     this.valkey_context.deinit();
 
     if (this.default_client_ssl_ctx) |s| bun.BoringSSL.c.SSL_CTX_free(s);
+    // After the default-ctx free so the tombstone callback still finds a live
+    // map; deinit then clears every remaining entry's ex_data so any later
+    // SSL_CTX_free (from sockets that survive RareData) doesn't deref freed
+    // Entries.
+    this.ssl_ctx_cache.deinit();
     // closeAllSocketGroups() must have already run (before JSC teardown) so
     // these are empty; deinit() asserts that in debug.
     inline for (socket_group_fields) |f| @field(this, f).deinit();

--- a/src/bun.js/webview/ChromeBackend.cpp
+++ b/src/bun.js/webview/ChromeBackend.cpp
@@ -277,7 +277,6 @@ static constexpr us_socket_vtable_t s_cdpVTable = {
     .on_connect_error = nullptr,
     .on_connecting_error = nullptr,
     .on_handshake = nullptr,
-    .is_low_prio = nullptr,
 };
 
 bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDataDir,

--- a/src/bun.js/webview/WebKitBackend.cpp
+++ b/src/bun.js/webview/WebKitBackend.cpp
@@ -112,7 +112,6 @@ static constexpr us_socket_vtable_t s_hostVTable = {
     .on_connect_error = nullptr,
     .on_connecting_error = nullptr,
     .on_handshake = nullptr,
-    .is_low_prio = nullptr,
 };
 
 // us_socket_ref/unref are no-ops on kqueue, and us_poll_start_rc doesn't

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -109,6 +109,7 @@ pub const c = struct {
 };
 
 const std = @import("std");
+
 const bun = @import("bun");
 const uws = bun.uws;
 const BoringSSL = bun.BoringSSL.c;

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -46,13 +46,20 @@ pub const BunSocketContextOptions = extern struct {
         var h = bun.sha.Hashers.SHA256.init();
         const feedZ = struct {
             fn f(hp: *bun.sha.Hashers.SHA256, s: [*c]const u8) void {
+                // Presence byte so null ≠ "" — both would otherwise feed only
+                // the trailing 0. In practice "" usually fails createSSLContext
+                // and never caches, but injectivity is cheap to guarantee.
+                hp.update(&.{@intFromBool(s != null)});
                 if (s) |p| hp.update(bun.sliceTo(p, 0));
                 hp.update(&.{0}); // terminator so {a:"xy"} ≠ {a:"x",b:"y"}
             }
         }.f;
         const feedArr = struct {
             fn f(hp: *bun.sha.Hashers.SHA256, arr: ?[*]const ?[*:0]const u8, n: u32) void {
+                hp.update(&.{@intFromBool(arr != null)});
+                hp.update(std.mem.asBytes(&n));
                 if (arr) |a| for (a[0..n]) |s| {
+                    hp.update(&.{@intFromBool(s != null)});
                     if (s) |p| hp.update(bun.sliceTo(p, 0));
                     hp.update(&.{0});
                 };

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -66,11 +66,35 @@ pub const BunSocketContextOptions = extern struct {
                 hp.update(&.{0});
             }
         }.f;
-        feedZ(&h, self.key_file_name);
-        feedZ(&h, self.cert_file_name);
+        // File-backed fields: feed path + (mtime, size) so an in-place cert
+        // rotation produces a fresh digest. stat() is ~1µs and only runs when
+        // the file form is used (Bun-specific; node:tls always passes inline
+        // bytes). On stat failure we feed zeros — `createSSLContext` will fail
+        // on the same path and the entry never reaches the cache.
+        const feedPath = struct {
+            fn f(hp: *bun.sha.Hashers.SHA256, s: [*c]const u8) void {
+                hp.update(&.{@intFromBool(s != null)});
+                if (s) |p| {
+                    const path = std.mem.span(@as([*:0]const u8, @ptrCast(p)));
+                    hp.update(path);
+                    var meta: [3]i64 = @splat(0);
+                    if (path.len > 0) switch (bun.sys.stat(path)) {
+                        .result => |st| {
+                            const mt = st.mtime();
+                            meta = .{ @intCast(mt.sec), @intCast(mt.nsec), @intCast(st.size) };
+                        },
+                        .err => {},
+                    };
+                    hp.update(std.mem.asBytes(&meta));
+                }
+                hp.update(&.{0});
+            }
+        }.f;
+        feedPath(&h, self.key_file_name);
+        feedPath(&h, self.cert_file_name);
         feedZ(&h, self.passphrase);
-        feedZ(&h, self.dh_params_file_name);
-        feedZ(&h, self.ca_file_name);
+        feedPath(&h, self.dh_params_file_name);
+        feedPath(&h, self.ca_file_name);
         feedZ(&h, self.ssl_ciphers);
         h.update(std.mem.asBytes(&self.ssl_prefer_low_memory_usage));
         feedArr(&h, self.key, self.key_count);

--- a/src/deps/uws/SocketContext.zig
+++ b/src/deps/uws/SocketContext.zig
@@ -38,6 +38,47 @@ pub const BunSocketContextOptions = extern struct {
         return c.us_ssl_ctx_from_options(options, err);
     }
 
+    /// SHA-256 over every field this struct carries, dereferencing string
+    /// pointers so the digest is content-addressed (not pointer-addressed).
+    /// Two option structs that build the same `SSL_CTX*` produce the same
+    /// digest. Used as the key for `SSLContextCache`.
+    pub fn digest(self: BunSocketContextOptions) [32]u8 {
+        var h = bun.sha.Hashers.SHA256.init();
+        const feedZ = struct {
+            fn f(hp: *bun.sha.Hashers.SHA256, s: [*c]const u8) void {
+                if (s) |p| hp.update(bun.sliceTo(p, 0));
+                hp.update(&.{0}); // terminator so {a:"xy"} ≠ {a:"x",b:"y"}
+            }
+        }.f;
+        const feedArr = struct {
+            fn f(hp: *bun.sha.Hashers.SHA256, arr: ?[*]const ?[*:0]const u8, n: u32) void {
+                if (arr) |a| for (a[0..n]) |s| {
+                    if (s) |p| hp.update(bun.sliceTo(p, 0));
+                    hp.update(&.{0});
+                };
+                hp.update(&.{0});
+            }
+        }.f;
+        feedZ(&h, self.key_file_name);
+        feedZ(&h, self.cert_file_name);
+        feedZ(&h, self.passphrase);
+        feedZ(&h, self.dh_params_file_name);
+        feedZ(&h, self.ca_file_name);
+        feedZ(&h, self.ssl_ciphers);
+        h.update(std.mem.asBytes(&self.ssl_prefer_low_memory_usage));
+        feedArr(&h, self.key, self.key_count);
+        feedArr(&h, self.cert, self.cert_count);
+        feedArr(&h, self.ca, self.ca_count);
+        h.update(std.mem.asBytes(&self.secure_options));
+        h.update(std.mem.asBytes(&self.reject_unauthorized));
+        h.update(std.mem.asBytes(&self.request_cert));
+        h.update(std.mem.asBytes(&self.client_renegotiation_limit));
+        h.update(std.mem.asBytes(&self.client_renegotiation_window));
+        var out: [32]u8 = undefined;
+        h.final(&out);
+        return out;
+    }
+
     /// Best-effort byte count of cert/key/CA material — fed into
     /// `SecureContext.memoryCost` so the GC sees the off-heap allocation.
     pub fn approxCertBytes(self: BunSocketContextOptions) usize {
@@ -60,6 +101,7 @@ pub const c = struct {
     pub extern fn us_ssl_ctx_live_count() c_long;
 };
 
+const std = @import("std");
 const bun = @import("bun");
 const uws = bun.uws;
 const BoringSSL = bun.BoringSSL.c;

--- a/src/deps/uws/SocketGroup.zig
+++ b/src/deps/uws/SocketGroup.zig
@@ -42,7 +42,6 @@ pub const SocketGroup = extern struct {
         on_connect_error: ?*const fn (*us_socket_t, c_int) callconv(.c) ?*us_socket_t = null,
         on_connecting_error: ?*const fn (*ConnectingSocket, c_int) callconv(.c) ?*ConnectingSocket = null,
         on_handshake: ?*const fn (*us_socket_t, c_int, uws.us_bun_verify_error_t, ?*anyopaque) callconv(.c) void = null,
-        is_low_prio: ?*const fn (*us_socket_t) callconv(.c) c_int = null,
     };
 
     comptime {
@@ -50,7 +49,7 @@ pub const SocketGroup = extern struct {
         // 9 ptrs + u32 + u16 + 3×u8, padded to 8-byte alignment.
         if (@sizeOf(SocketGroup) != 9 * @sizeOf(*anyopaque) + 16)
             @compileError("SocketGroup layout drifted from us_socket_group_t");
-        if (@sizeOf(VTable) != 12 * @sizeOf(*anyopaque))
+        if (@sizeOf(VTable) != 11 * @sizeOf(*anyopaque))
             @compileError("VTable layout drifted from us_socket_vtable_t");
     }
 

--- a/src/deps/uws/dispatch.zig
+++ b/src/deps/uws/dispatch.zig
@@ -20,7 +20,6 @@ comptime {
     _ = us_dispatch_connect_error;
     _ = us_dispatch_connecting_error;
     _ = us_dispatch_handshake;
-    _ = us_dispatch_is_low_prio;
     _ = us_dispatch_ssl_raw_tap;
 }
 
@@ -116,9 +115,6 @@ export fn us_dispatch_connecting_error(c: *ConnectingSocket, code: c_int) ?*Conn
 }
 export fn us_dispatch_handshake(s: *us_socket_t, ok: c_int, err: uws.us_bun_verify_error_t) void {
     if (vt(s).on_handshake) |f| f(s, ok, err, null);
-}
-export fn us_dispatch_is_low_prio(s: *us_socket_t) c_int {
-    return if (vt(s).is_low_prio) |f| f(s) else 0;
 }
 
 /// Ciphertext tap for `socket.upgradeTLS()` — fires on the `[raw, _]` half of

--- a/src/deps/uws/vtable.zig
+++ b/src/deps/uws/vtable.zig
@@ -24,7 +24,6 @@
 //!   pub fn onConnectError(ext, *us_socket_t, code: i32) void
 //!   pub fn onConnectingError(*ConnectingSocket, code: i32) void
 //!   pub fn onHandshake(ext, *us_socket_t, ok: bool, err: us_bun_verify_error_t) void
-//!   pub fn isLowPrio(ext, *us_socket_t) bool
 
 /// Produce a `*const VTable` for `H`. The result is a comptime address into
 /// `.rodata`; safe to store in any number of `SocketGroup`s.
@@ -43,7 +42,6 @@ pub fn make(comptime H: type) *const VTable {
             .on_connect_error = if (@hasDecl(H, "onConnectError")) T.on_connect_error else null,
             .on_connecting_error = if (@hasDecl(H, "onConnectingError")) T.on_connecting_error else null,
             .on_handshake = if (@hasDecl(H, "onHandshake")) T.on_handshake else null,
-            .is_low_prio = if (@hasDecl(H, "isLowPrio")) T.is_low_prio else null,
         };
     }).vt;
 }
@@ -108,10 +106,6 @@ pub fn Trampolines(comptime H: type) type {
         }
         pub fn on_handshake(s: *us_socket_t, ok: c_int, err: uws.us_bun_verify_error_t, _: ?*anyopaque) callconv(.c) void {
             call(s, H.onHandshake, .{ ok != 0, err });
-        }
-        pub fn is_low_prio(s: *us_socket_t) callconv(.c) c_int {
-            if (comptime has_ext) return @intFromBool(H.isLowPrio(s.ext(@typeInfo(E).pointer.child), s));
-            return @intFromBool(H.isLowPrio(s));
         }
     };
 }

--- a/src/http/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http/websocket_client/WebSocketUpgradeClient.zig
@@ -280,7 +280,10 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             const secure_ptr: ?*uws.SslCtx = if (comptime ssl) brk: {
                 if (ssl_config) |config| if (config.requires_custom_request_ctx) {
                     var err: uws.create_bun_socket_error_t = .none;
-                    const ctx = config.asUSocketsForClientVerification().createSSLContext(&err) orelse {
+                    // Per-VM weak cache: every `new WebSocket(wss://, {tls:{ca}})`
+                    // with the same CA shares one CTX with each other and with
+                    // any `Bun.connect`/Postgres/etc. that named it.
+                    const ctx = vm.rareData().sslCtxCache().getOrCreateOpts(config.asUSocketsForClientVerification(), &err) orelse {
                         // Do NOT fall through to the default trust store — the
                         // user passed an explicit CA/cert and BoringSSL
                         // rejected it. Swapping in system roots would let the

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -423,7 +423,7 @@ var InternalSecureContext = class SecureContext {
   context;
   servername;
 
-  constructor(options, native?) {
+  constructor(options) {
     if (options) {
       if (options.cert) throwOnInvalidTLSArray("options.cert", options.cert);
       if (options.key) throwOnInvalidTLSArray("options.key", options.key);
@@ -454,7 +454,7 @@ var InternalSecureContext = class SecureContext {
     // The native handle (SSL_CTX wrapper) is what's memoised — not this JS
     // object — so per-call fields like `servername` come from THIS call's
     // options while the expensive SSL_CTX is shared.
-    this.context = native ?? newNativeSecureContext(options);
+    this.context = newNativeSecureContext(options);
     this.servername = options?.servername;
   }
 };

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -8,10 +8,6 @@ const { throwOnInvalidTLSArray } = require("internal/tls");
 const { validateString } = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
-// Captured at load so a tampered global `Bun.CryptoHasher` can't change
-// secureContextCacheKey()'s hashing — same reason the cache Map ops are
-// $-prefixed.
-const { CryptoHasher } = Bun;
 
 const getBundledRootCertificates = $newCppFunction("NodeTLS.cpp", "getBundledRootCertificates", 1);
 const getExtraCACertificates = $newCppFunction("NodeTLS.cpp", "getExtraCACertificates", 1);
@@ -399,9 +395,11 @@ function checkServerIdentity(hostname, cert) {
   }
 }
 
-// Native SSL_CTX wrapper. The constructor parses cert/key/CA/ciphers once;
-// every connect/upgrade that names this object SSL_CTX_up_ref()s it instead of
-// rebuilding ~50 KB of BoringSSL state per connection.
+// Native SSL_CTX wrapper. `intern()` is WeakGCMap-memoised by config digest
+// (the native `SSLContextCache` underneath is shared with every Zig consumer
+// — Postgres, Valkey, `Bun.connect`, …), so identical options return the same
+// native handle and the same `SSL_CTX*`. Replaces the SHA-256/WeakRef cache
+// that used to live in this file.
 const NativeSecureContext = $zig("SecureContext.zig", "js.getConstructor");
 
 // Node treats any falsy key/cert/ca as "not provided" (test-tls-options-
@@ -418,7 +416,7 @@ function newNativeSecureContext(options) {
       ca: options.ca || null,
     };
   }
-  return new NativeSecureContext(options);
+  return NativeSecureContext.intern(options);
 }
 
 var InternalSecureContext = class SecureContext {
@@ -465,125 +463,12 @@ function SecureContext(options): void {
   return new InternalSecureContext(options) as never;
 }
 
-// ── Memoised createSecureContext ────────────────────────────────────────────
-// pg/mysql2/ioredis call tls.connect() per connection with the same options
-// object (or shallow-equal copies). Without memoisation each call rebuilt an
-// SSL_CTX (cert parse + CA load + cipher init). We key on the few fields that
-// actually feed us_ssl_ctx_from_options and hand back a WeakRef'd shared
-// SecureContext so it can still be collected if the config falls out of use.
-const secureContextCache: Map<string, WeakRef<any>> = new Map();
-let secureContextCacheTrim = 0;
-
-function secureContextCacheKey(o) {
-  // A false hit would hand one config's SSL_CTX to another (wrong CA / client
-  // cert), so the key must be collision-free over the full input. We feed every
-  // field into SHA-256 with explicit type+length tags so neither truncation nor
-  // delimiter bytes inside values can alias two configs. A false miss is fine
-  // (just one extra SSL_CTX), so unhashable shapes return null → uncached.
-  const sha = new CryptoHasher("sha256");
-  let unhashable = false;
-  const tag = (t, s) => sha.update(t + s.length + ":").update(s);
-  const feed = v => {
-    if (v == null) sha.update("n");
-    else if (typeof v === "string") tag("s", v);
-    // boolean/number/bigint — String(v) is content-exact for primitives; the
-    // typeof prefix keeps `true` distinct from `"true"` and `1` from `"1"`.
-    else if (typeof v !== "object") tag("p", typeof v + ":" + v);
-    else if ($isJSArray(v)) {
-      sha.update("a" + v.length + "[");
-      for (const e of v) feed(e);
-      sha.update("]");
-    } else if ($isTypedArrayView(v)) tag("b", v);
-    else if (v instanceof ArrayBuffer || v instanceof SharedArrayBuffer)
-      // Hash the actual bytes — `String(ab)` is content-independent.
-      tag("b", new Uint8Array(v));
-    // Blob / BunFile / `{pem, passphrase}` and any other object the bindgen
-    // union accepts: we can't hash these synchronously and content-exactly
-    // (Blob bytes are async; identity isn't stable across calls). String(v)
-    // would collapse them all to "[object Blob]" and produce a *false hit*, so
-    // bail to uncached instead.
-    else unhashable = true;
-  };
-  feed(o.key);
-  feed(o.cert);
-  feed(o.ca);
-  feed(o.passphrase);
-  feed(o.ciphers);
-  feed(o.secureOptions);
-  // rejectUnauthorized/requestCert: these still shape SSL_CTX_set_verify in
-  // build_raw when ca/requestCert are present (FAIL_IF_NO_PEER_CERT bit), and
-  // a SecureContext is mode-neutral so we can't assume client-only use where
-  // the per-SSL override would mask the difference. A false miss is cheap; a
-  // false hit hands a server a CTX with the wrong CertificateRequest policy.
-  feed(o.rejectUnauthorized);
-  feed(o.requestCert);
-  // The remaining knobs that feed `us_ssl_ctx_from_options`. Anything that
-  // changes what BoringSSL bakes into the SSL_CTX must be in the key, or two
-  // configs that differ only in (e.g.) minVersion would share one SSL_CTX.
-  feed(o.dhparam);
-  feed(o.secureProtocol);
-  feed(o.minVersion);
-  feed(o.maxVersion);
-  feed(o.honorCipherOrder);
-  feed(o.ecdhCurve);
-  feed(o.sigalgs);
-  feed(o.ALPNProtocols);
-  // Bun-extension fields that `SSLConfig.fromJS` also reads. These aren't in
-  // Node's vocabulary so it's tempting to omit them, but a `tls.connect()`
-  // wrapper that passes `caFile` (not `ca`) would otherwise collide with the
-  // empty-config CTX and silently skip its trust store. (False miss for the
-  // path-variant case is fine; false hit is a security bug.)
-  feed(o.keyFile);
-  feed(o.certFile);
-  feed(o.caFile);
-  feed(o.dhParamsFile);
-  feed(o.lowMemoryMode);
-  feed(o.clientRenegotiationLimit);
-  feed(o.clientRenegotiationWindow);
-  if (unhashable) return null;
-  return sha.digest("base64");
-}
-
 function createSecureContext(options) {
   if (options instanceof InternalSecureContext) return options;
-  // Normalise the no-options call so it hits the cache (the empty config is
-  // exactly the case worth memoising — every `tls.connect(port, host)` lands
-  // here and should share one SSL_CTX).
-  if (options == null) options = {};
-  // Uncacheable shapes — pfx/engine/sessionIdContext/privateKey* bypass
-  // us_ssl_ctx_from_options or are validation-only (must hit the constructor
-  // to throw, not return a cached entry built from a different call).
-  // Presence-checked: `sessionIdContext: ""` or `pfx: emptyBuffer` are still
-  // meaningful inputs that must not fall through to a cache built without them.
-  if (
-    "pfx" in options ||
-    "sessionIdContext" in options ||
-    "clientCertEngine" in options ||
-    "privateKeyEngine" in options ||
-    "privateKeyIdentifier" in options
-  ) {
-    return new SecureContext(options);
-  }
-  const key = secureContextCacheKey(options);
-  if (key === null) return new SecureContext(options);
-  // Cache the NATIVE handle (SSL_CTX), not the wrapper. The wrapper carries
-  // `servername` (per-connection, omitted from the key); reusing it would let
-  // the second caller inherit the first caller's servername.
-  // $-intrinsic Map ops: this is a builtin, so user-tamperable Map.prototype
-  // must not be on the lookup/mutation path.
-  const hit = secureContextCache.$get(key)?.deref();
-  if (hit) return new InternalSecureContext(options, hit);
-  const native = newNativeSecureContext(options);
-  secureContextCache.$set(key, new WeakRef(native));
-  // Opportunistic dead-WeakRef sweep so the map can't grow unbounded across
-  // many distinct configs (one CA per tenant, etc.).
-  if (++secureContextCacheTrim > 64) {
-    secureContextCacheTrim = 0;
-    secureContextCache.$forEach((ref, k) => {
-      if (!ref.deref()) secureContextCache.$delete(k);
-    });
-  }
-  return new InternalSecureContext(options, native);
+  // The native handle (SSL_CTX) is memoised inside `NativeSecureContext.intern`
+  // by the per-VM `SSLContextCache`, so no JS-side hashing here. The JS wrapper
+  // is built fresh because it carries the per-call `servername`.
+  return new InternalSecureContext(options);
 }
 
 // Translate some fields from the handle's C-friendly format into more idiomatic

--- a/src/sql/mysql/js/JSMySQLConnection.zig
+++ b/src/sql/mysql/js/JSMySQLConnection.zig
@@ -364,11 +364,21 @@ pub fn createInstance(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFra
         // We always request the cert so we can verify it and also we manually
         // abort the connection if the hostname doesn't match. Built here so
         // CA/cert errors throw synchronously, applied later by upgradeToTLS.
+        // Goes through the per-VM weak `SSLContextCache` so every pooled
+        // connection / reconnect shares one `SSL_CTX*` per distinct config.
         var err: uws.create_bun_socket_error_t = .none;
-        secure = tls_config.asUSocketsForClientVerification().createSSLContext(&err) orelse {
+        secure = vm.rareData().sslCtxCache().getOrCreateOpts(tls_config.asUSocketsForClientVerification(), &err) orelse {
             tls_config.deinit();
             return globalObject.throwValue(err.toJS(globalObject));
         };
+    }
+    // Covers `try arguments[7/8].toBunString()` and the null-byte rejection
+    // below. Ownership passes to `MySQLConnection.init` once `bun.new`
+    // succeeds — we null the locals at that point so the connect-fail path
+    // (which `deref()`s the connection) doesn't double-free.
+    errdefer {
+        if (secure) |s| bun.BoringSSL.c.SSL_CTX_free(s);
+        tls_config.deinit();
     }
 
     var username: []const u8 = "";
@@ -416,8 +426,7 @@ pub fn createInstance(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFra
     inline for (.{ .{ username, "username" }, .{ password, "password" }, .{ database, "database" }, .{ path, "path" } }) |entry| {
         if (entry[0].len > 0 and std.mem.indexOfScalar(u8, entry[0], 0) != null) {
             bun.default_allocator.free(options_buf);
-            tls_config.deinit();
-            if (secure) |s| bun.BoringSSL.c.SSL_CTX_free(s);
+            // tls_config / secure released by the errdefer above.
             return globalObject.throwInvalidArguments(entry[1] ++ " must not contain null bytes", .{});
         }
     }
@@ -448,6 +457,10 @@ pub fn createInstance(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFra
             ssl_mode,
         ),
     });
+    // Ownership transferred into `ptr.#connection`; disarm the errdefer so the
+    // connect-fail `ptr.deref()` is the sole cleanup path from here on.
+    secure = null;
+    tls_config = .{};
 
     {
         const hostname = hostname_str.toUTF8(bun.default_allocator);

--- a/src/sql/postgres/PostgresSQLConnection.zig
+++ b/src/sql/postgres/PostgresSQLConnection.zig
@@ -626,12 +626,22 @@ pub fn call(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
 
         // We always request the cert so we can verify it and also we manually
         // abort the connection if the hostname doesn't match. Built here (not
-        // at STARTTLS time) so cert/CA errors throw synchronously.
+        // at STARTTLS time) so cert/CA errors throw synchronously. Goes
+        // through the per-VM weak `SSLContextCache` so every connection in the
+        // pool — and every reconnect — shares one `SSL_CTX*` per distinct
+        // config instead of building a fresh one per `PostgresSQLConnection`.
         var err: uws.create_bun_socket_error_t = .none;
-        secure = tls_config.asUSocketsForClientVerification().createSSLContext(&err) orelse {
+        secure = vm.rareData().sslCtxCache().getOrCreateOpts(tls_config.asUSocketsForClientVerification(), &err) orelse {
             tls_config.deinit();
             return globalObject.throwValue(err.toJS(globalObject));
         };
+    }
+    // Covers `try arguments[7/8].toBunString()` and the null-byte rejection
+    // below. Ownership passes into `ptr.*` once allocated — locals are nulled
+    // there so the connect-fail path's `ptr.deinit()` is the sole cleanup.
+    errdefer {
+        if (secure) |s| bun.BoringSSL.c.SSL_CTX_free(s);
+        tls_config.deinit();
     }
 
     var username: []const u8 = "";
@@ -680,8 +690,7 @@ pub fn call(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
     inline for (.{ .{ username, "username" }, .{ password, "password" }, .{ database, "database" }, .{ path, "path" } }) |entry| {
         if (entry[0].len > 0 and std.mem.indexOfScalar(u8, entry[0], 0) != null) {
             bun.default_allocator.free(options_buf);
-            tls_config.deinit();
-            if (secure) |s| bun.BoringSSL.c.SSL_CTX_free(s);
+            // tls_config / secure released by the errdefer above.
             return globalObject.throwInvalidArguments(entry[1] ++ " must not contain null bytes", .{});
         }
     }
@@ -718,6 +727,9 @@ pub fn call(globalObject: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JS
             .use_unnamed_prepared_statements = use_unnamed_prepared_statements,
         },
     };
+    // Ownership transferred into `ptr`; disarm the errdefer.
+    secure = null;
+    tls_config = .{};
 
     {
         const hostname = hostname_str.toUTF8(bun.default_allocator);

--- a/src/valkey/js_valkey.zig
+++ b/src/valkey/js_valkey.zig
@@ -1123,7 +1123,10 @@ pub const JSValkeyClient = struct {
                 // old `_socket_ctx` cache existed to preserve.
                 if (this._secure == null) {
                     var err: uws.create_bun_socket_error_t = .none;
-                    this._secure = custom.asUSockets().createSSLContext(&err) orelse {
+                    // Per-VM weak cache: a `duplicate()`'d client (or any
+                    // other client with the same config) hits the same
+                    // `SSL_CTX*` instead of rebuilding.
+                    this._secure = vm.rareData().sslCtxCache().getOrCreate(custom, &err) orelse {
                         this.client.flags.enable_auto_reconnect = false;
                         try this.clientFail("Failed to create TLS context", protocol.RedisError.ConnectionClosed);
                         try this.client.onValkeyClose();

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -8,7 +8,9 @@ import tls from "node:tls";
 import { once } from "node:events";
 // @ts-expect-error - debug-only export
 import { sslCtxLiveCount } from "bun:internal-for-testing";
-import { tls as tlsCerts } from "harness";
+import { tls as tlsCerts, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 async function withServer(fn: (port: number) => Promise<void>) {
   const server = tls.createServer({ ...tlsCerts, rejectUnauthorized: false }, s => s.end());
@@ -156,4 +158,34 @@ test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
     });
     await promise;
   }
+});
+
+test("file-backed config: in-place rotation invalidates cache (mtime+size in digest)", async () => {
+  using dir = tempDir("ssl-ctx-rotate", {
+    "ca.pem": tlsCerts.cert,
+  });
+  const caFile = join(String(dir), "ca.pem");
+
+  await withServer(async port => {
+    const before = sslCtxLiveCount();
+    const connectOnce = async () => {
+      const s = tls.connect({ port, caFile, rejectUnauthorized: false } as any);
+      await once(s, "secureConnect");
+      s.destroy();
+      await once(s, "close");
+    };
+
+    await connectOnce();
+    await connectOnce();
+    const afterTwoSamePath = sslCtxLiveCount();
+    // Second connect with identical (path, mtime, size) hits cache.
+    expect(afterTwoSamePath).toBe(before + 1);
+
+    // Rotate in place — same path, different content. Rewriting bumps mtime
+    // and (here) size; either alone changes the digest.
+    writeFileSync(caFile, tlsCerts.cert + "\n");
+    await connectOnce();
+    // New (mtime, size) → fresh digest → fresh CTX.
+    expect(sslCtxLiveCount()).toBe(afterTwoSamePath + 1);
+  });
 });

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -51,13 +51,17 @@ test("Bun.connect with servername-only tls reuses one SSL_CTX", async () => {
       port,
       tls: { servername: "localhost", rejectUnauthorized: false },
       socket: {
-        open(s) {
+        // With a `handshake` handler present, `open` fires on TCP-connect
+        // (pre-handshake). Calling `s.end()` there leaves the libuv-backed
+        // Windows socket in a state where `close` never fires. End after
+        // the handshake completes instead.
+        open() {},
+        handshake(s) {
           s.end();
         },
         close() {
           resolve();
         },
-        handshake() {},
         data() {},
         error(_s, e) {
           reject(e);
@@ -140,13 +144,17 @@ test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
       port,
       tls: tlsOpts,
       socket: {
-        open(s) {
+        // With a `handshake` handler present, `open` fires on TCP-connect
+        // (pre-handshake). Calling `s.end()` there leaves the libuv-backed
+        // Windows socket in a state where `close` never fires. End after
+        // the handshake completes instead.
+        open() {},
+        handshake(s) {
           s.end();
         },
         close() {
           resolve();
         },
-        handshake() {},
         data() {},
         error(_s, e) {
           reject(e);

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -1,0 +1,156 @@
+// Native weak `SSLContextCache`: every JS-thread consumer that turns an SSL
+// config into an `SSL_CTX*` should hit the same per-VM cache, so identical
+// configs (including `{servername}`-only and inline-CA configs) allocate one
+// CTX, not one per connection. The cache holds zero refs — when the last
+// real owner drops, BoringSSL's ex_data free callback tombstones the entry.
+import { test, expect } from "bun:test";
+import tls from "node:tls";
+import { once } from "node:events";
+// @ts-expect-error - debug-only export
+import { sslCtxLiveCount } from "bun:internal-for-testing";
+import { tls as tlsCerts } from "harness";
+
+async function withServer(fn: (port: number) => Promise<void>) {
+  const server = tls.createServer({ ...tlsCerts, rejectUnauthorized: false }, s => s.end());
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("net").AddressInfo;
+  try {
+    await fn(port);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+}
+
+// Before the native cache, `Bun.connect({tls:{servername}})` set
+// `requires_custom_request_ctx` and built a fresh SSL_CTX per call even though
+// SNI is per-SSL not per-CTX. The digest now excludes servername, so 50 of
+// these share the default client CTX.
+test("Bun.connect with servername-only tls reuses one SSL_CTX", async () => {
+  await withServer(async port => {
+    // Warm: server CTX + the digest-{} client CTX.
+    await connectOnce(port);
+    Bun.gc(true);
+    const before = sslCtxLiveCount();
+
+    for (let i = 0; i < 50; i++) await connectOnce(port);
+    await new Promise<void>(r => setImmediate(() => queueMicrotask(r)));
+    Bun.gc(true);
+
+    // Old behaviour: Δ ≈ 50. Now: Δ ≤ 2.
+    expect(sslCtxLiveCount() - before).toBeLessThanOrEqual(2);
+  });
+
+  async function connectOnce(port: number) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const sock = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      tls: { servername: "localhost", rejectUnauthorized: false },
+      socket: {
+        open(s) {
+          s.end();
+        },
+        close() {
+          resolve();
+        },
+        handshake() {},
+        data() {},
+        error(_s, e) {
+          reject(e);
+        },
+        connectError(_s, e) {
+          reject(e);
+        },
+      },
+    });
+    await promise;
+  }
+});
+
+// `tls.createSecureContext()` is now WeakGCMap-memoised by digest in native
+// code (replacing the SHA-256/WeakRef Map that lived in tls.ts), so the same
+// options return the same native handle.
+test("createSecureContext returns the same native handle for identical configs", () => {
+  const opts = { ca: tlsCerts.cert, rejectUnauthorized: false };
+  const a = tls.createSecureContext(opts);
+  const b = tls.createSecureContext({ ...opts });
+  // The JS wrapper carries per-call `servername`, so wrappers differ; the
+  // SSL_CTX-owning `.context` is the deduped native cell.
+  expect(a.context).toBe(b.context);
+  // Different config → different handle.
+  const c = tls.createSecureContext({ rejectUnauthorized: false });
+  expect(c.context).not.toBe(a.context);
+});
+
+// Weak-cache reclaim: once every owner drops its ref and GC sweeps the
+// SecureContext, BoringSSL's free callback tombstones the entry and the live
+// count returns to baseline.
+test("SSL_CTX is freed once no owners remain (weak cache, not strong)", async () => {
+  // Drain anything previous tests left for the sweeper so `before` is stable.
+  Bun.gc(true);
+  await new Promise<void>(r => setImmediate(r));
+  Bun.gc(true);
+  const before = sslCtxLiveCount();
+
+  // Build a CTX with a unique digest (custom cipher) so nothing else holds it.
+  let sc: any = tls.createSecureContext({ ciphers: "ECDHE-RSA-AES128-GCM-SHA256" });
+  expect(sc.context).toBeTruthy();
+  // While `sc` is live the CTX must be live — proves the cache doesn't
+  // *prevent* allocation either.
+  expect(sslCtxLiveCount()).toBe(before + 1);
+  sc = undefined;
+
+  // Weak<> handles are reclaimed on full GC; SecureContext.finalize then
+  // SSL_CTX_free()s, which fires the ex_data tombstone. A strong cache would
+  // pin the count at before+1.
+  Bun.gc(true);
+  await new Promise<void>(r => setImmediate(r));
+  Bun.gc(true);
+  expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
+});
+
+// Same-CA inline configs across `Bun.connect` and `tls.connect` should resolve
+// to one CTX — the cache is keyed by digest, not by which API asked.
+test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
+  await withServer(async port => {
+    const tlsOpts = { ca: tlsCerts.cert, rejectUnauthorized: false };
+    // Warm.
+    await connectOnce(port, tlsOpts);
+    Bun.gc(true);
+    const before = sslCtxLiveCount();
+
+    for (let i = 0; i < 30; i++) await connectOnce(port, tlsOpts);
+    await new Promise<void>(r => setImmediate(() => queueMicrotask(r)));
+    Bun.gc(true);
+
+    expect(sslCtxLiveCount() - before).toBeLessThanOrEqual(2);
+  });
+
+  async function connectOnce(port: number, tlsOpts: object) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      tls: tlsOpts,
+      socket: {
+        open(s) {
+          s.end();
+        },
+        close() {
+          resolve();
+        },
+        handshake() {},
+        data() {},
+        error(_s, e) {
+          reject(e);
+        },
+        connectError(_s, e) {
+          reject(e);
+        },
+      },
+    });
+    await promise;
+  }
+});

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -104,10 +104,13 @@ test("SSL_CTX is freed once no owners remain (weak cache, not strong)", async ()
 
   // Weak<> handles are reclaimed on full GC; SecureContext.finalize then
   // SSL_CTX_free()s, which fires the ex_data tombstone. A strong cache would
-  // pin the count at before+1.
-  Bun.gc(true);
-  await new Promise<void>(r => setImmediate(r));
-  Bun.gc(true);
+  // pin the count at before+1. JSC's conservative stack scan and finalizer
+  // scheduling don't guarantee N passes is enough — await the condition.
+  for (let i = 0; i < 50; i++) {
+    Bun.gc(true);
+    await new Promise<void>(r => setImmediate(r));
+    if (sslCtxLiveCount() <= before) break;
+  }
   expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
 });
 

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -120,8 +120,10 @@ test("SSL_CTX is freed once no owners remain (weak cache, not strong)", async ()
   expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
 });
 
-// Same-CA inline configs across `Bun.connect` and `tls.connect` should resolve
-// to one CTX — the cache is keyed by digest, not by which API asked.
+// Same-CA inline configs across repeated `Bun.connect` calls resolve to one
+// CTX — the cache is keyed by digest. (Not shared with `new WebSocket`, which
+// projects via `asUSocketsForClientVerification()` → different `request_cert`
+// → different digest by design.)
 test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
   await withServer(async port => {
     const tlsOpts = { ca: tlsCerts.cert, rejectUnauthorized: false };
@@ -175,25 +177,33 @@ test("file-backed config: in-place rotation invalidates cache (mtime+size in dig
   const caFile = join(String(dir), "ca.pem");
 
   await withServer(async port => {
-    const before = sslCtxLiveCount();
+    // Pin the wrapped SecureContext so GC between connects can't drop the
+    // count and turn the strict equalities below into flakes — `.context` is
+    // populated from the Symbol-keyed slot via `createSecureContext`.
+    const pin: unknown[] = [];
     const connectOnce = async () => {
-      const s = tls.connect({ port, caFile, rejectUnauthorized: false } as any);
+      const sc = tls.createSecureContext({ caFile, rejectUnauthorized: false } as any);
+      pin.push(sc);
+      const s = tls.connect({ port, secureContext: sc });
       await once(s, "secureConnect");
       s.destroy();
       await once(s, "close");
     };
 
+    // Warm: first connect may also lazy-init unrelated CTXs (default client,
+    // root store) — measure deltas after the first one.
     await connectOnce();
+    const after1 = sslCtxLiveCount();
     await connectOnce();
-    const afterTwoSamePath = sslCtxLiveCount();
     // Second connect with identical (path, mtime, size) hits cache.
-    expect(afterTwoSamePath).toBe(before + 1);
+    expect(sslCtxLiveCount()).toBe(after1);
 
     // Rotate in place — same path, different content. Rewriting bumps mtime
     // and (here) size; either alone changes the digest.
     writeFileSync(caFile, tlsCerts.cert + "\n");
     await connectOnce();
     // New (mtime, size) → fresh digest → fresh CTX.
-    expect(sslCtxLiveCount()).toBe(afterTwoSamePath + 1);
+    expect(sslCtxLiveCount()).toBe(after1 + 1);
+    pin.length = 0;
   });
 });


### PR DESCRIPTION
Follow-up to #29932. Moves the SSL_CTX dedup from JS (`tls.ts` SHA-256/WeakRef memo) into a native per-VM weak cache that **all** TLS consumers share, so Postgres/MySQL/Valkey/`Bun.connect`/`upgradeTLS`/WebSocket-client now reuse `SSL_CTX` the same way `node:tls` does.

## Design

**`SSLContextCache`** (`src/bun.js/api/bun/SSLContextCache.zig`) — `[32]u8 → *Entry` map on `RareData`, mutex-guarded, **holds zero refs**. A `CRYPTO_EX_free` callback registered via `SSL_CTX_get_ex_new_index` tombstones the entry when BoringSSL's refcount hits 0, so the cache is a pure index: entries live exactly as long as some socket/`SecureContext` holds the CTX. No LRU, no cap, no sweep policy.

**Digest** is SHA-256 over `BunSocketContextOptions` — i.e., exactly the fields `us_ssl_ctx_from_options` reads. Excludes `server_name`/`ALPNProtocols` (per-`SSL*`, not per-CTX), so `Bun.connect({tls:{servername:'x'}})` now hashes identical to `tls:true` and shares the default CTX. Includes `client_renegotiation_{limit,window}` (those go into CTX ex_data). SHA-256 chosen over BLAKE2b: BoringSSL's SHA-256 has SHA-NI/ARMv8-crypto asm, its BLAKE2b is scalar C — benched ~1.9× faster at 4 KB.

**`WeakGCMap<uint64_t, JSSecureContext>`** on `ZigGlobalObject` so `tls.createSecureContext(opts)` returns the same JS wrapper for the same config. The two maps don't coordinate — BoringSSL's refcount is the single source of truth.

**`tls.ts` JS memo deleted** (~110 lines).

## Consumers swapped

`Bun.connect` (gate deleted), `upgradeTLS`, `new WebSocket()` custom-tls, `Bun.SQL` Postgres/MySQL, Valkey custom-tls, `addServerName`. `HTTPThread` left on its own LRU (off-JS-thread; could swap to a second `SSLContextCache` instance later — the tombstone callback is per-Entry so two instances coexist cleanly).

## Independent fixes in this PR

- `loop.c:503` — non-SSL `is_low_prio` arm was provably-dead (no handler defines it); collapsed to `s->ssl && us_internal_ssl_is_low_prio(s)`, vtable slot deleted end-to-end.
- `JSMySQLConnection.zig` / `PostgresSQLConnection.zig` — `errdefer` for SSL_CTX leak when `path` coercion throws after `createSSLContext`.
- `openssl.c` `us_listen_socket_add_server_name` — `return 1` on `sni_add` duplicate so App.h's rollback actually fires.

## Expected measurable wins

- `Bun.SQL` Postgres/MySQL pool with `sslmode=require`: N connections → 1 `SSL_CTX` (was N). ~50 KB × (N−1) RSS, plus (N−1) × cert-parse on pool init.
- `Bun.connect({tls:{servername}})`: now hits cached default CTX instead of rebuilding (servername no longer forces fresh).
- `tls.createSecureContext()`: native digest replaces JS `JSON.stringify`+SHA-256; returns `===` same object.
- `Bun.serve` plain-HTTP per-event: one fewer vtable lookup per readable event (`is_low_prio` removal).

## Tests

`test/js/node/tls/ssl-ctx-cache.test.ts` (new, 4 tests), `tls-connect-socket-churn.test.ts` 3/3, full `test/js/node/tls/` 117/0, `zig:check-all` clean.