### PR TITLE
TextDecoder.decode: read options.stream before capturing input bytes

### DIFF
--- a/src/bun.js/webcore/TextDecoder.zig
+++ b/src/bun.js/webcore/TextDecoder.zig
@@ -158,6 +158,21 @@ pub fn decodeUTF16(
 pub fn decode(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!JSValue {
     const arguments = callframe.arguments_old(2).slice();
 
+    // Evaluate options.stream before reading the input bytes. Reading `stream`
+    // can invoke a user-defined getter that detaches/transfers the input's
+    // ArrayBuffer; capturing the byte pointer before that getter runs leaves
+    // `decodeSlice` reading through a stale pointer into memory that may have
+    // been freed or reused. Node.js reads options first as well.
+    const stream = stream: {
+        if (arguments.len > 1 and arguments[1].isObject()) {
+            if (try arguments[1].fastGet(globalThis, .stream)) |stream_value| {
+                break :stream stream_value.toBoolean();
+            }
+        }
+
+        break :stream false;
+    };
+
     const input_slice = input_slice: {
         if (arguments.len == 0 or arguments[0].isUndefined()) {
             break :input_slice "";
@@ -168,16 +183,6 @@ pub fn decode(this: *TextDecoder, globalThis: *jsc.JSGlobalObject, callframe: *j
         }
 
         return globalThis.throwInvalidArguments("TextDecoder.decode expects an ArrayBuffer or TypedArray", .{});
-    };
-
-    const stream = stream: {
-        if (arguments.len > 1 and arguments[1].isObject()) {
-            if (try arguments[1].fastGet(globalThis, .stream)) |stream_value| {
-                break :stream stream_value.toBoolean();
-            }
-        }
-
-        break :stream false;
     };
 
     return switch (!stream) {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -580,6 +580,48 @@ it("should not crash with a getter that throws", () => {
   ).toThrowErrorMatchingInlineSnapshot(`"stream get error"`);
 });
 
+it("reads the input after the options.stream getter runs", () => {
+  // The Encoding spec processes options before pushing a copy of the input to
+  // the I/O queue, and Node.js matches that: a `stream` getter that detaches
+  // the input buffer causes decode() to see an empty input. Previously Bun
+  // cached the byte pointer before evaluating the getter and then read through
+  // it afterwards — a stale pointer into memory that no longer belongs to the
+  // input buffer.
+  const buf = new Uint8Array(300);
+  for (let i = 0; i < buf.length; i += 3) {
+    buf[i] = 0xe2;
+    buf[i + 1] = 0x82;
+    buf[i + 2] = 0xac;
+  }
+  let ran = 0;
+  const result = new TextDecoder().decode(buf, {
+    get stream() {
+      ran++;
+      const transferred = buf.buffer.transfer();
+      // Overwrite the transferred backing store so that if decode() still
+      // reads through the old pointer it cannot coincidentally produce "".
+      new Uint8Array(transferred).fill(0x41);
+      return false;
+    },
+  });
+  expect(ran).toBe(1);
+  expect(buf.byteLength).toBe(0);
+  expect(result).toBe("");
+});
+
+it("sees writes made by the options.stream getter", () => {
+  // Conversely, mutations the getter makes to a still-attached buffer must be
+  // visible to the decoder — the bytes are read after the getter runs.
+  const buf = new Uint8Array(4).fill(0x41); // "AAAA"
+  const result = new TextDecoder().decode(buf, {
+    get stream() {
+      buf.set([0x42, 0x42, 0x42, 0x42]); // "BBBB"
+      return false;
+    },
+  });
+  expect(result).toBe("BBBB");
+});
+
 it.each(["utf-16le", "utf-16be"])("TextDecoder(%s).decode() should not leak the output buffer", encoding => {
   const unit = encoding === "utf-16le" ? [0x61, 0x00] : [0x00, 0x61];
   const CODE_UNITS = 16 * 1024;

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -206,8 +206,7 @@ describe("TextDecoder", () => {
           expect(decoded).toBe(text);
         }
       });
-    }, // 100k iterations under ASAN instrumentation takes ~13s.
-    30_000);
+    }, 30_000); // 100k iterations under ASAN instrumentation takes ~13s.
   });
 
   it("should decode unicode text with multiple consecutive emoji", () => {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -198,20 +198,16 @@ describe("TextDecoder", () => {
       });
     }
 
-    it(
-      "DOMJIT call",
-      () => {
-        const array = new Uint8Array(bytes.buffer);
-        withoutAggressiveGC(() => {
-          for (let i = 0; i < 100_000; i++) {
-            const decoded = decoder.decode(array);
-            expect(decoded).toBe(text);
-          }
-        });
-      },
-      // 100k iterations under ASAN instrumentation takes ~13s.
-      30_000,
-    );
+    it("DOMJIT call", () => {
+      const array = new Uint8Array(bytes.buffer);
+      withoutAggressiveGC(() => {
+        for (let i = 0; i < 100_000; i++) {
+          const decoded = decoder.decode(array);
+          expect(decoded).toBe(text);
+        }
+      });
+    }, // 100k iterations under ASAN instrumentation takes ~13s.
+    30_000);
   });
 
   it("should decode unicode text with multiple consecutive emoji", () => {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -198,15 +198,20 @@ describe("TextDecoder", () => {
       });
     }
 
-    it("DOMJIT call", () => {
-      const array = new Uint8Array(bytes.buffer);
-      withoutAggressiveGC(() => {
-        for (let i = 0; i < 100_000; i++) {
-          const decoded = decoder.decode(array);
-          expect(decoded).toBe(text);
-        }
-      });
-    });
+    it(
+      "DOMJIT call",
+      () => {
+        const array = new Uint8Array(bytes.buffer);
+        withoutAggressiveGC(() => {
+          for (let i = 0; i < 100_000; i++) {
+            const decoded = decoder.decode(array);
+            expect(decoded).toBe(text);
+          }
+        });
+      },
+      // 100k iterations under ASAN instrumentation takes ~13s.
+      30_000,
+    );
   });
 
   it("should decode unicode text with multiple consecutive emoji", () => {


### PR DESCRIPTION
## What

`TextDecoder.prototype.decode(input, options)` captured a raw pointer into `input`'s backing store **before** evaluating `options.stream`, then handed that pointer to `decodeSlice` **after** the getter ran. `fastGet` on `options.stream` can invoke a user-defined accessor, which can `transfer()` / `resize()` / `postMessage`-transfer the input's ArrayBuffer.

After that getter returns, the cached slice no longer points into memory owned by the input buffer — it aliases whatever the transferred backing store now contains, or (after GC / reallocation) freed or reused heap memory. `decodeSlice` then reads it and hands it to simdutf's two-pass length+convert.

## Repro

```js
const buf = new Uint8Array(300);
for (let i = 0; i < buf.length; i += 3) { buf[i] = 0xe2; buf[i+1] = 0x82; buf[i+2] = 0xac; }
const result = new TextDecoder().decode(buf, {
  get stream() {
    const t = buf.buffer.transfer();
    new Uint8Array(t).fill(0x41);
    return false;
  },
});
```

| | result |
|---|---|
| Node.js | `""` (buffer detached → length 0) |
| Bun before | `"€€€…"` or `"AAA…"` or something else, depending on what lands in the freed memory |
| Bun after | `""` |

With larger buffers plus `Bun.gc(true)` and a reallocation inside the getter, the result is fully non-deterministic (3 MB input alternates between 1 M and 3 M output chars across iterations) — the decoder is reading through a dangling pointer.

## Fix

Evaluate `options.stream` first, **then** call `asArrayBuffer()` and take the byte slice. Once the getter has run there is no further user JS on the path into `decodeSlice`, so the slice stays valid. `asArrayBuffer().slice()` on a now-detached buffer returns an empty slice, so a getter that detaches the input yields `""` — the same as Node and the Encoding spec (which reads `options["stream"]` in step 2 and copies the input in step 3).

## Relation to the crash report

The reported stack is a null-deref inside `mi_malloc` during `toUTF16AllocMaybeBuffered` ← `TextDecoder.decodeSlice` — i.e. mimalloc's metadata was already corrupt when the next allocation ran. Reading freed/reused memory via the stale input pointer is one of the few ways this code path can trample heap that it doesn't own. I wasn't able to reproduce the exact fault (the reported commit hash isn't in the repo), so I can't claim this is the sole cause, but it is a real memory-safety bug in the exact frames shown and the fix is independently correct.

#29088 covers the related but separate SharedArrayBuffer-mutated-by-Worker race in the same converter; this change is orthogonal.

## Tests

- `reads the input after the options.stream getter runs` — getter detaches → `""` (fails on current main with stale-pointer output)
- `sees writes made by the options.stream getter` — getter mutates a still-attached buffer → mutation visible (positive check that we didn't snapshot too early)

Full `text-decoder.test.js` / `text-decoder-wpt.test.ts` / `text-decoder-stream.test.ts` pass; the pre-existing `DOMJIT call` debug-build timeout is unchanged on main.