### PR TITLE
Fix use-after-free in Bun.Transpiler.transform() error path

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -491,6 +491,15 @@ pub const TransformTask = struct {
         var arena = MimallocArena.init();
         defer arena.deinit();
 
+        // Log messages produced during parsing/printing borrow text allocated
+        // from `arena`. Clone them into `bun.default_allocator` before the
+        // arena is destroyed so `then()` can safely read them on the JS thread.
+        defer {
+            for (this.log.msgs.items) |*msg| {
+                msg.* = bun.handleOom(msg.clone(bun.default_allocator));
+            }
+        }
+
         const allocator = arena.allocator();
         var ast_memory_allocator = bun.handleOom(allocator.create(JSAst.ASTMemoryAllocator));
         var ast_scope = ast_memory_allocator.enter(allocator);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3626,6 +3626,26 @@ it("Bun.Transpiler.transform stack overflows", async () => {
   expect(async () => await transpiler.transform(code)).toThrow(`Maximum call stack size exceeded`);
 });
 
+it("Bun.Transpiler.transform rejects with a readable parse error after allocation churn", async () => {
+  // The error message text produced by the parser used to be allocated in a
+  // per-task arena that was destroyed before the promise was rejected on the
+  // JS thread, leaving a dangling pointer. Force page reuse between the
+  // worker thread finishing and the promise settling.
+  const transpiler = new Bun.Transpiler();
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const pending = transpiler.transform("const x = 1 ++ 2 ++ 3;").then(
+      () => {
+        throw new Error("should have rejected");
+      },
+      err => err,
+    );
+    for (let i = 0; i < 10000; i++) Buffer.alloc(64);
+    Bun.gc(true);
+    const err = await pending;
+    expect(err.message).toBe('Expected ";" but found "2"');
+  }
+});
+
 describe("arrow function parsing after const declaration (scope mismatch bug)", () => {
   const transpiler = new Bun.Transpiler({ loader: "tsx" });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in the async `Bun.Transpiler().transform()` error path found by Fuzzilli (fingerprint `Address:use-after-poison:bun-debug+0x827621e`).

`TransformTask.run()` executes the parser on a worker thread using a `MimallocArena` that is destroyed at the end of `run()`. When parsing fails, the lexer/parser format their error messages with `allocPrint` using that arena allocator, and the resulting `Msg.data.text` slices are appended (shallowly, via `appendToMaybeRecycled`) into `this.log`.

Later, `then()` runs on the JS thread and calls `this.log.toJS()`, which clones each message. At that point the arena is already gone, so `Data.clone`'s `allocator.dupe(u8, this.text)` reads freed memory. Whether this crashes depends on whether the arena's pages have been handed back out and re-poisoned, which is why it was flaky.

The fix: before tearing down the arena, deep-clone any accumulated log messages into `bun.default_allocator` so they outlive the worker thread.

## How did you verify your code works?

Repro (crashed ~8/30 runs under ASAN before, 0/50 after):

```js
const t = new Bun.Transpiler();
const p = t.transform("const x = 1 ++ 2 ++ 3;").catch(e => e);
for (let i = 0; i < 10000; i++) Buffer.alloc(64);
Bun.gc(true);
await p;
```

Added a regression test in `test/bundler/transpiler/transpiler.test.js` that asserts the rejection message is intact after allocation churn. It crashes the unfixed debug build at the same `logger.Data.clone → Allocator.dupe` frame the fuzzer hit and passes with the fix.