### PR TITLE
usockets(win): defer READABLE re-arm past on_open so .end() mid-handshake doesn't hang

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -774,7 +774,7 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
          * WANT_READ — that costs one harmless on_writable tick and then the
          * regular loop.c writable-disarm clears it. */
         if (!us_socket_is_closed(s)) {
-            us_poll_change_force(&s->p, s->group->loop,
+            us_poll_change(&s->p, s->group->loop,
                 LIBUS_SOCKET_READABLE | (s->flags.last_write_failed ? LIBUS_SOCKET_WRITABLE : 0));
         }
 #endif

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -729,9 +729,7 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
             // It's expected that close is called by the caller
         }
     } else {
-#ifndef _WIN32
         us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
-#endif
         bsd_socket_nodelay(us_poll_fd(&s->p), 1);
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET);
         us_socket_timeout(s, 0);
@@ -756,32 +754,6 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
         } else {
             us_dispatch_open(s, 1, 0, 0);
         }
-
-#ifdef _WIN32
-        /* Windows (libuv): re-arm for READABLE *after* on_open. uv_poll_start
-         * submits a fresh AFD poll request; if user code closes the socket
-         * inside on_open (e.g. `.end()` from a TLS socket's `open` handler,
-         * which fires pre-handshake when a `handshake` handler is also
-         * present), the resulting uv_poll_stop + uv_close runs in the same
-         * poll_cb frame as the just-submitted request and the handle never
-         * finishes closing — the process hangs. POSIX has no such re-entrancy
-         * (epoll_ctl(MOD) / kqueue mask change), so the early re-arm above is
-         * kept to leave the hot path bit-identical there.
-         *
-         * last_write_failed: a partial write inside on_open (or the SSL BIO)
-         * already armed WRITABLE via us_poll_change in us_socket{,_raw}_write;
-         * preserve it. For TLS, ssl_update_handshake also sets this on
-         * WANT_READ — that costs one harmless on_writable tick and then the
-         * regular loop.c writable-disarm clears it.
-         *
-         * is_paused: socket.pause() inside on_open already cleared READABLE and
-         * set the flag — re-arming here would silently un-pause. Skipping
-         * leaves the connect-WRITABLE armed for one tick; loop.c disarms it. */
-        if (!us_socket_is_closed(s) && !s->flags.is_paused) {
-            us_poll_change(&s->p, s->group->loop,
-                LIBUS_SOCKET_READABLE | (s->flags.last_write_failed ? LIBUS_SOCKET_WRITABLE : 0));
-        }
-#endif
     }
 }
 

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -772,8 +772,12 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
          * already armed WRITABLE via us_poll_change in us_socket{,_raw}_write;
          * preserve it. For TLS, ssl_update_handshake also sets this on
          * WANT_READ — that costs one harmless on_writable tick and then the
-         * regular loop.c writable-disarm clears it. */
-        if (!us_socket_is_closed(s)) {
+         * regular loop.c writable-disarm clears it.
+         *
+         * is_paused: socket.pause() inside on_open already cleared READABLE and
+         * set the flag — re-arming here would silently un-pause. Skipping
+         * leaves the connect-WRITABLE armed for one tick; loop.c disarms it. */
+        if (!us_socket_is_closed(s) && !s->flags.is_paused) {
             us_poll_change(&s->p, s->group->loop,
                 LIBUS_SOCKET_READABLE | (s->flags.last_write_failed ? LIBUS_SOCKET_WRITABLE : 0));
         }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -729,7 +729,9 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
             // It's expected that close is called by the caller
         }
     } else {
+#ifndef _WIN32
         us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
+#endif
         bsd_socket_nodelay(us_poll_fd(&s->p), 1);
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET);
         us_socket_timeout(s, 0);
@@ -754,6 +756,28 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
         } else {
             us_dispatch_open(s, 1, 0, 0);
         }
+
+#ifdef _WIN32
+        /* Windows (libuv): re-arm for READABLE *after* on_open. uv_poll_start
+         * submits a fresh AFD poll request; if user code closes the socket
+         * inside on_open (e.g. `.end()` from a TLS socket's `open` handler,
+         * which fires pre-handshake when a `handshake` handler is also
+         * present), the resulting uv_poll_stop + uv_close runs in the same
+         * poll_cb frame as the just-submitted request and the handle never
+         * finishes closing — the process hangs. POSIX has no such re-entrancy
+         * (epoll_ctl(MOD) / kqueue mask change), so the early re-arm above is
+         * kept to leave the hot path bit-identical there.
+         *
+         * last_write_failed: a partial write inside on_open (or the SSL BIO)
+         * already armed WRITABLE via us_poll_change in us_socket{,_raw}_write;
+         * preserve it. For TLS, ssl_update_handshake also sets this on
+         * WANT_READ — that costs one harmless on_writable tick and then the
+         * regular loop.c writable-disarm clears it. */
+        if (!us_socket_is_closed(s)) {
+            us_poll_change_force(&s->p, s->group->loop,
+                LIBUS_SOCKET_READABLE | (s->flags.last_write_failed ? LIBUS_SOCKET_WRITABLE : 0));
+        }
+#endif
     }
 }
 

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -44,8 +44,10 @@ static void close_cb_free(uv_handle_t *h) { free(h->data); }
 
 /* This one is different for polls, since we need two frees here */
 static void close_cb_free_poll(uv_handle_t *h) {
-  /* It is only in case we called us_poll_stop then quickly us_poll_free that we
-   * enter this. Most of the time, actual freeing is done by us_poll_free. */
+  /* h->data is the owning us_poll_t (the embedding us_socket_t allocation).
+   * us_poll_free arms this; freeing here (after uv_close completes) is the
+   * only path — the synchronous-free branch was removed when uv_close moved
+   * out of us_poll_stop. */
   if (h->data) {
     free(h->data);
     free(h);
@@ -76,18 +78,23 @@ void us_poll_free(struct us_poll_t *p, struct us_loop_t *loop) {
     free(p);
     return;
   }
-  /* The idea here is like so; in us_poll_stop we call uv_close after setting
-   * data of uv-poll to 0. This means that in close_cb_free we call free on 0
-   * with does nothing, since us_poll_stop should not really free the poll.
-   * HOWEVER, if we then call us_poll_free while still closing the uv-poll, we
-   * simply change back the data to point to our structure so that we actually
-   * do free it like we should. */
+  /* uv_close lives here (not in us_poll_stop) so it runs from check_cb via
+   * us_internal_free_closed_sockets — i.e. *outside* poll_cb. us_poll_stop is
+   * reachable re-entrantly inside the handle's own poll_cb (connect-WRITABLE →
+   * us_internal_socket_after_open → us_poll_change/uv_poll_start(READABLE) →
+   * on_open → JS end() → us_internal_socket_close_raw → us_poll_stop), and
+   * uv_close-ing a uv_poll_t whose AFD poll request was submitted in the same
+   * frame leaves the handle wedged (close_cb never fires; observed as a
+   * full-process hang on Windows for `Bun.connect` TLS sockets ended from
+   * `open`). Deferring to here keeps every us_poll_stop caller's semantics
+   * (they all park on closed_head/closed_udp_head and reach this), just one
+   * loop tick later. */
+  p->uv_p->data = p;
   if (uv_is_closing((uv_handle_t *)p->uv_p)) {
-    p->uv_p->data = p;
-  } else {
-    free(p->uv_p);
-    free(p);
+    /* Shouldn't happen anymore, but tolerate a caller that already closed. */
+    return;
   }
+  uv_close((uv_handle_t *)p->uv_p, close_cb_free_poll);
 }
 
 void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
@@ -118,13 +125,8 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
 void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {
   if(!p->uv_p) return;
   uv_poll_stop(p->uv_p);
-
-  /* We normally only want to close the poll here, not free it. But if we stop
-   * it, then quickly "free" it with us_poll_free, we postpone the actual
-   * freeing to close_cb_free_poll whenever it triggers. That's why we set data
-   * to null here, so that us_poll_free can reset it if needed */
-  p->uv_p->data = 0;
-  uv_close((uv_handle_t *)p->uv_p, close_cb_free_poll);
+  /* uv_close deferred to us_poll_free — see comment there for why closing
+   * here (inside poll_cb) wedged the handle on Windows. */
 }
 
 int us_poll_events(struct us_poll_t *p) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -21,8 +21,8 @@
 
 #ifdef LIBUS_USE_LIBUV
 
-/* uv_poll_t->data always (except for most times after calling us_poll_stop)
- * points to the us_poll_t */
+/* uv_poll_t->data points to the owning us_poll_t for the handle's whole
+ * lifetime (set in us_create_poll, cleared only by close_cb_free_poll). */
 static void poll_cb(uv_poll_t *p, int status, int events) {
   us_internal_dispatch_ready_poll((struct us_poll_t *)p->data, status < 0 && status != UV_EOF, status == UV_EOF,
                                   events);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -836,8 +836,8 @@ it("reading fd of a TLS listener should not crash", () => {
 // fires on TCP-connect (pre-handshake) when a `handshake` handler is also
 // present — left a uv_poll_t with a freshly-submitted AFD request racing
 // uv_close in the same poll_cb frame. The handle never finished closing →
-// loop ref'd → process hung. The fix defers the READABLE re-arm until after
-// on_open returns (and skips it if on_open closed the socket).
+// process hung. The fix moves uv_close from us_poll_stop to us_poll_free,
+// which runs from check_cb (outside poll_cb).
 it("TLS .end() inside open (mid-handshake) fires close and doesn't hang", async () => {
   using server = Bun.listen({
     hostname: "127.0.0.1",

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -831,3 +831,51 @@ it("reading fd of a TLS listener should not crash", () => {
   expect(typeof listener.fd).toBe("number");
   expect(listener.fd).toBeGreaterThanOrEqual(0);
 });
+
+// Regression: on Windows (libuv), `.end()` from `open` on a TLS socket — which
+// fires on TCP-connect (pre-handshake) when a `handshake` handler is also
+// present — left a uv_poll_t with a freshly-submitted AFD request racing
+// uv_close in the same poll_cb frame. The handle never finished closing →
+// loop ref'd → process hung. The fix defers the READABLE re-arm until after
+// on_open returns (and skips it if on_open closed the socket).
+it("TLS .end() inside open (mid-handshake) fires close and doesn't hang", async () => {
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    tls,
+    socket: { data() {}, open() {}, close() {}, error() {} },
+  });
+
+  const events: string[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    tls: { rejectUnauthorized: false },
+    socket: {
+      open(s) {
+        events.push("open");
+        s.end();
+      },
+      // Presence of `handshake` is what makes `open` fire pre-handshake.
+      handshake(_s, ok, err) {
+        events.push(`handshake:${ok}:${err?.code ?? "-"}`);
+      },
+      close() {
+        events.push("close");
+        resolve();
+      },
+      data() {},
+      error(_s, e) {
+        reject(e);
+      },
+      connectError(_s, e) {
+        reject(e);
+      },
+    },
+  });
+  await promise;
+
+  // Closing mid-handshake surfaces ECONNRESET to `handshake` before `close`.
+  expect(events).toEqual(["open", "handshake:false:ECONNRESET", "close"]);
+});


### PR DESCRIPTION
`.end()` on a `Bun.connect` TLS socket from inside its `open` handler (which fires pre-handshake when a `handshake` handler is present) hung the process on Windows. Surfaced by #30024's new test.

## Root cause

`us_poll_stop` (libuv backend) called `uv_close` on the `uv_poll_t` immediately. When `open` runs inside the connect-WRITABLE `poll_cb`, the sequence is `uv_poll_start(READABLE)` (from `us_poll_change` at `context.c:732`) → JS `open` → `end()` → `us_internal_socket_close_raw` → `us_poll_stop` → `uv_close`, all in the same `poll_cb` frame. `uv_close` on a handle whose AFD poll request was just submitted in that frame wedges the handle (close_cb never fires). POSIX has no analogue (epoll_ctl(DEL)/kqueue mask change).

## Fix

Move `uv_close` from `us_poll_stop` to `us_poll_free`. Every `us_poll_stop` caller parks the socket on `closed_head`/`closed_udp_head`; `us_internal_free_closed_sockets` drains those from `check_cb` (a `uv_check_t` handler — runs after I/O callbacks, outside `poll_cb`). `uv_close` from there completes normally on the next tick. `us_internal_socket_after_open` stays bit-identical to POSIX.

Regression test in `socket.test.ts`.