### PR TITLE
Fix use-after-free in Bun.Transpiler async transform() parse errors

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -490,6 +490,14 @@ pub const TransformTask = struct {
 
         var arena = MimallocArena.init();
         defer arena.deinit();
+        defer {
+            if (this.log.msgs.items.len > 0) {
+                var new_log = logger.Log.init(bun.default_allocator);
+                new_log.level = this.log.level;
+                bun.handleOom(this.log.appendToWithRecycled(&new_log, true));
+                this.log = new_log;
+            }
+        }
 
         const allocator = arena.allocator();
         var ast_memory_allocator = bun.handleOom(allocator.create(JSAst.ASTMemoryAllocator));

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("async transform() parse errors do not read freed arena memory", async () => {
+  const script = `
+    const t = new Bun.Transpiler();
+    const promises = [];
+    for (let i = 0; i < 200; i++) {
+      promises.push(t.transform("@@", "js"));
+    }
+    const results = await Promise.allSettled(promises);
+    for (const r of results) {
+      if (r.status !== "rejected") throw new Error("expected rejection");
+      if (!String(r.reason).includes("@")) throw new Error("expected message, got: " + String(r.reason));
+    }
+    console.log("ok", results.length);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      MIMALLOC_PURGE_DELAY: "0",
+      MIMALLOC_PAGE_RECLAIM_ON_FREE: "0",
+      UV_THREADPOOL_SIZE: "2",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok 200");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Bun.Transpiler.prototype.transform()` (the async variant) could read freed memory when reporting parse errors, producing garbage error messages in release builds and an ASAN crash in debug builds.

## Why

`TransformTask.run()` runs on a thread-pool thread and creates a `MimallocArena` for parsing. The parser and lexer allocate their error message text (via `log.addErrorFmt` etc.) using that arena as the allocator. The arena is torn down at the end of `run()`.

`TransformTask.then()` runs afterwards on the JS thread and calls `this.log.toJS()`, which clones each message — reading `msg.data.text`. At this point the text still points into the destroyed arena, so the read is a use-after-free.

Setting `this.log.msgs.allocator = bun.default_allocator` only covers the `msgs` ArrayList backing storage, not the per-message text payload.

## Fix

Before the arena is destroyed, deep-copy any accumulated log messages into `bun.default_allocator` using the existing `appendToWithRecycled(..., true)` path, which rebuilds each message (text, location, notes) via a `StringBuilder`.

## Testing

The new test runs 200 concurrent async `transform()` calls that all fail to parse, with `MIMALLOC_PURGE_DELAY=0` so freed arena pages are purged immediately rather than being reused verbatim from the abandoned-page pool. Before this change, the error messages come back as garbage bytes (or ASAN aborts with use-after-poison). After, every rejection carries the expected `Expected identifier but found "@"` message.

Found by Fuzzilli.