### PR TITLE
Fix null deref in Bun.inspect when Proxy prototype traps throw

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5285,10 +5285,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5360,7 +5361,13 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            if (scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                break;
+            }
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -453,6 +453,44 @@ const fixture = [
     ),
 ];
 
+describe("Proxy prototype with throwing traps", () => {
+  it("getPrototypeOf trap that throws", () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("nope");
+          },
+        },
+      ),
+    );
+    expect(Bun.inspect(obj)).toBe("{}");
+  });
+
+  it("get trap that throws", () => {
+    const obj = {};
+    const proto = {};
+    Object.defineProperty(proto, "x", {
+      get() {
+        throw new Error("getter throw");
+      },
+      enumerable: true,
+    });
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(proto, {
+        get(t, k, r) {
+          return Reflect.get(t, k, r);
+        },
+      }),
+    );
+    expect(Bun.inspect(obj)).toBe("{}");
+  });
+});
+
 describe("crash testing", () => {
   for (let input of fixture) {
     it(`inspecting "${input.toString().slice(0, 20).replaceAll("\n", "\\n")}" doesn't crash`, async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `Bun.inspect` / `console.log` when formatting an object whose prototype chain contains a Proxy with throwing traps.

In `JSC__JSValue__forEachPropertyImpl`, the slow-path prototype walk had two issues:

1. `getPropertySlot` can throw via a Proxy `get` trap and return `false`. The early `continue` skipped `CLEAR_IF_EXCEPTION`, leaving the exception pending for subsequent operations.
2. `getPrototype(globalObject)` can throw via a Proxy `getPrototypeOf` trap and return an empty `JSValue`. Calling `.getObject()` on an empty value dereferences a null `JSCell`.

Both now clear the exception and stop walking the chain gracefully.

## Repro

```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, {
  getPrototypeOf() { throw new Error("nope"); }
}));
console.log(obj); // segfault before, prints "{}" after
```

## How did you verify your code works?

- Added regression tests in `test/js/bun/util/inspect.test.js` covering both throwing `getPrototypeOf` and throwing `get` traps in the prototype chain.
- Verified tests segfault on `main` and pass with this fix.
- Full `inspect.test.js` suite passes (74 tests).

Found by fuzzer (fingerprint `8d8ced8f16c8c4dd`).