### PR TITLE
napi: stub link slots for post-compile .node injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "bun_sys",
  "bun_threading",
  "bun_url",
+ "bun_wyhash",
  "bun_zlib",
  "bun_zstd",
  "const_format",

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -136,6 +136,25 @@ impl MachoFile {
         None
     }
 
+    /// Borrow the on-disk bytes of a section previously returned by
+    /// `find_section`. Returns `None` if the location (which came from
+    /// untrusted load commands) does not fit inside the file.
+    pub fn section_bytes(&self, loc: SectionLocation) -> Option<&[u8]> {
+        let start = usize::try_from(loc.file_offset).ok()?;
+        let len = usize::try_from(loc.size).ok()?;
+        self.data.get(start..start.checked_add(len)?)
+    }
+
+    /// Mutable counterpart of `section_bytes`, for in-place patching of
+    /// fixed-size tables (no load-command offsets change). Callers must
+    /// re-`find_section` after any `write_section*` call since the backing
+    /// buffer may have been reallocated and later sections shifted.
+    pub fn section_bytes_mut(&mut self, loc: SectionLocation) -> Option<&mut [u8]> {
+        let start = usize::try_from(loc.file_offset).ok()?;
+        let len = usize::try_from(loc.size).ok()?;
+        self.data.get_mut(start..start.checked_add(len)?)
+    }
+
     pub fn write_section(&mut self, data: &[u8]) -> Result<(), MachoError> {
         self.write_section_with_header(data, data.len() as u64)
     }

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -42,6 +42,12 @@ pub struct MachoFile {
     pub(crate) section: macho::section_64,
 }
 
+#[derive(Debug, Copy, Clone)]
+pub struct SectionLocation {
+    pub file_offset: u64,
+    pub size: u64,
+}
+
 /// Expands to one `shift_one` call per named field.
 macro_rules! shift_fields {
     ($shifter:expr, $value:expr, $($field:ident),+ $(,)?) => {{
@@ -88,7 +94,63 @@ impl MachoFile {
         }))
     }
 
+    /// Locate a `(segname, sectname)` pair and return its file offset and
+    /// on-disk size. Unlike `write_section`, this does not assume the
+    /// `__BUN,__bun` layout and does not mutate anything — it's the hook for
+    /// external patchers (e.g. the NAPI link slot table lives in
+    /// `__DATA,__bun_napi_lnk` and is overwritten in place).
+    pub fn find_section(&self, segname: &[u8], sectname: &[u8]) -> Option<SectionLocation> {
+        let base_addr = self.data.as_ptr() as usize;
+        let mut iter = self.iterator();
+        while let Some(entry) = iter.next() {
+            if entry.hdr.cmd != macho::LC::SEGMENT_64 {
+                continue;
+            }
+            let command = entry
+                .cast::<macho::segment_command_64>()
+                .expect("unreachable");
+            if command.seg_name() != segname || command.nsects == 0 {
+                continue;
+            }
+            let section_offset = entry.data.as_ptr() as usize - base_addr;
+            let sections_base = section_offset + size_of::<macho::segment_command_64>();
+            let sect_sz = size_of::<macho::section_64>();
+            let nsects = command.nsects as usize;
+            let table_end = nsects
+                .checked_mul(sect_sz)
+                .and_then(|s| s.checked_add(size_of::<macho::segment_command_64>()))?;
+            if table_end > entry.data.len() {
+                return None;
+            }
+            for i in 0..nsects {
+                let sect_off = sections_base + i * sect_sz;
+                let sect: macho::section_64 = read_struct(&self.data[sect_off..][..sect_sz]);
+                if sect.sect_name() == sectname {
+                    return Some(SectionLocation {
+                        file_offset: sect.offset as u64,
+                        size: sect.size,
+                    });
+                }
+            }
+        }
+        None
+    }
+
     pub fn write_section(&mut self, data: &[u8]) -> Result<(), MachoError> {
+        self.write_section_with_header(data, data.len() as u64)
+    }
+
+    /// Same as `write_section` but the `u64` size header written at the
+    /// section's first 8 bytes is `header_value` instead of `data.len()`. The
+    /// NAPI link-slot appender uses this to keep the header pointing at the
+    /// module-graph payload length (so `StandaloneModuleGraph.fromExecutable`
+    /// still finds its trailer) while tucking addon images past it in the
+    /// same section.
+    pub fn write_section_with_header(
+        &mut self,
+        data: &[u8],
+        header_value: u64,
+    ) -> Result<(), MachoError> {
         let blob_alignment: u64 = 16 * 1024;
         const PAGE_SIZE: u64 = 1 << 12;
         const HASH_SIZE: usize = 32; // SHA256 = 32 bytes
@@ -263,8 +325,7 @@ impl MachoFile {
         }
 
         // Now we copy the u64 size header (8 bytes for alignment)
-        self.data[original_fileoff as usize..][..8]
-            .copy_from_slice(&(data.len() as u64).to_le_bytes());
+        self.data[original_fileoff as usize..][..8].copy_from_slice(&header_value.to_le_bytes());
 
         // Now we copy the data itself
         self.data[original_fileoff as usize + 8..][..data.len()].copy_from_slice(data);

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -94,11 +94,6 @@ impl MachoFile {
         }))
     }
 
-    /// Locate a `(segname, sectname)` pair and return its file offset and
-    /// on-disk size. Unlike `write_section`, this does not assume the
-    /// `__BUN,__bun` layout and does not mutate anything — it's the hook for
-    /// external patchers (e.g. the NAPI link slot table lives in
-    /// `__DATA,__bun_napi_lnk` and is overwritten in place).
     pub fn find_section(&self, segname: &[u8], sectname: &[u8]) -> Option<SectionLocation> {
         let base_addr = self.data.as_ptr() as usize;
         let mut iter = self.iterator();
@@ -136,19 +131,14 @@ impl MachoFile {
         None
     }
 
-    /// Borrow the on-disk bytes of a section previously returned by
-    /// `find_section`. Returns `None` if the location (which came from
-    /// untrusted load commands) does not fit inside the file.
+    /// `None` if the (untrusted) location does not fit inside the file.
     pub fn section_bytes(&self, loc: SectionLocation) -> Option<&[u8]> {
         let start = usize::try_from(loc.file_offset).ok()?;
         let len = usize::try_from(loc.size).ok()?;
         self.data.get(start..start.checked_add(len)?)
     }
 
-    /// Mutable counterpart of `section_bytes`, for in-place patching of
-    /// fixed-size tables (no load-command offsets change). Callers must
-    /// re-`find_section` after any `write_section*` call since the backing
-    /// buffer may have been reallocated and later sections shifted.
+    /// A `SectionLocation` is stale after any `write_section*` call.
     pub fn section_bytes_mut(&mut self, loc: SectionLocation) -> Option<&mut [u8]> {
         let start = usize::try_from(loc.file_offset).ok()?;
         let len = usize::try_from(loc.size).ok()?;
@@ -159,12 +149,9 @@ impl MachoFile {
         self.write_section_with_header(data, data.len() as u64)
     }
 
-    /// Same as `write_section` but the `u64` size header written at the
-    /// section's first 8 bytes is `header_value` instead of `data.len()`. The
-    /// NAPI link-slot appender uses this to keep the header pointing at the
-    /// module-graph payload length (so `StandaloneModuleGraph.fromExecutable`
-    /// still finds its trailer) while tucking addon images past it in the
-    /// same section.
+    /// `header_value` is what the runtime reads back as the payload length;
+    /// it may be shorter than `data` when trailing bytes (linked addons) are
+    /// not part of the module graph.
     pub fn write_section_with_header(
         &mut self,
         data: &[u8],

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -364,6 +364,10 @@ JSC_DEFINE_CUSTOM_SETTER(Process_defaultSetter, (JSC::JSGlobalObject * globalObj
 }
 
 extern "C" BunString Bun__resolveEmbeddedNodeFile(const BunString*);
+extern "C" bool Bun__tryLoadNapiLinkSlot(const char* path, size_t len, void** out_handle, bool* out_is_ns_module);
+#if OS(DARWIN)
+extern "C" void* Bun__darwinLookupSymbolInModule(void* module, const char* name);
+#endif
 #if OS(WINDOWS)
 extern "C" HMODULE Bun__LoadLibraryBunString(BunString*);
 #endif
@@ -508,13 +512,33 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
 #define StandaloneModuleGraph__base_path "/$bunfs/"_s
 #endif
     [[maybe_unused]] bool fromEmbedded = false;
+    // NAPI link-slot addons are loaded from memory rather than via a
+    // filesystem path. On macOS the handle is an `NSModule` (from
+    // `NSLinkModule`), which needs `NSLookupSymbolInModule` in place of
+    // `dlsym`; on Linux it's an ordinary `dlopen()` handle sourced from a
+    // memfd. `slotHandle` short-circuits the path-based `dlopen()` below.
+    void* slotHandle = nullptr;
+    bool slotIsNSModule = false;
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
-        BunString bunStr = Bun::toString(filename);
-        BunString resolved = Bun__resolveEmbeddedNodeFile(&bunStr);
-        if (!resolved.isDead()) {
-            filename = resolved.transferToWTFString();
-            // The extracted file is content-hashed and shared across dlopens
-            // and restarts (#29587), so it is never deleted here.
+        auto pathUtf8 = filename.utf8();
+        if (!Bun__tryLoadNapiLinkSlot(pathUtf8.data(), pathUtf8.length(), &slotHandle, &slotIsNSModule)) {
+            // Not a link slot — fall through to the module-graph extractor
+            // for bundler-embedded addons.
+            BunString bunStr = Bun::toString(filename);
+            BunString resolved = Bun__resolveEmbeddedNodeFile(&bunStr);
+            if (!resolved.isDead()) {
+                filename = resolved.transferToWTFString();
+                // The extracted file is content-hashed and shared across dlopens
+                // and restarts (#29587), so it is never deleted here.
+                fromEmbedded = true;
+            }
+        } else if (!slotHandle) {
+            // Path matched a slot but the in-memory load failed (e.g. the
+            // embedded image isn't a valid Mach-O bundle). Surface that as a
+            // dlopen error rather than trying to find it on disk.
+            return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
+                makeString("failed to load linked native addon '"_s, filename, "' from embedded image"_s));
+        } else {
             fromEmbedded = true;
         }
     }
@@ -543,30 +567,40 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     Bun__process_dlopen_count++;
 
 #if OS(WINDOWS)
-    BunString filename_str = Bun::toString(filename);
-    HMODULE handle = Bun__LoadLibraryBunString(&filename_str);
-#else
-#if OS(LINUX)
-    // A glibc-linked addon loaded into a musl process segfaults inside the
-    // loader (gcompat provides the soname but not the ABI). Inspect the ELF
-    // DT_NEEDED list first so the user sees a catchable error instead of a
-    // crash report. Skipped for addons embedded via `bun build --compile`.
-    // See https://github.com/oven-sh/bun/issues/15753.
-    if (!fromEmbedded) {
-        char soname[64] = { 0 };
-        if (Bun__addonNeedsGlibcOnMusl(utf8.data(), utf8.length(), soname, sizeof(soname))) [[unlikely]] {
-            WTF::StringBuilder msg;
-            msg.append(filename);
-            msg.append(" is linked against glibc (DT_NEEDED "_s);
-            msg.append(WTF::StringView::fromLatin1(soname));
-            msg.append("), but this Bun build uses musl. glibc-targeted native addons cannot be loaded on Alpine/musl even with gcompat. Use a glibc-based image (e.g. oven/bun:debian) or install a musl build of this addon."_s);
-            return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED, msg.toString());
-        }
+    HMODULE handle;
+    if (slotHandle) {
+        handle = reinterpret_cast<HMODULE>(slotHandle);
+    } else {
+        BunString filename_str = Bun::toString(filename);
+        handle = Bun__LoadLibraryBunString(&filename_str);
     }
+#else
+    void* handle;
+    if (slotHandle) {
+        handle = slotHandle;
+    } else {
+#if OS(LINUX)
+        // A glibc-linked addon loaded into a musl process segfaults inside the
+        // loader (gcompat provides the soname but not the ABI). Inspect the ELF
+        // DT_NEEDED list first so the user sees a catchable error instead of a
+        // crash report. Skipped for addons embedded via `bun build --compile`.
+        // See https://github.com/oven-sh/bun/issues/15753.
+        if (!fromEmbedded) {
+            char soname[64] = { 0 };
+            if (Bun__addonNeedsGlibcOnMusl(utf8.data(), utf8.length(), soname, sizeof(soname))) [[unlikely]] {
+                WTF::StringBuilder msg;
+                msg.append(filename);
+                msg.append(" is linked against glibc (DT_NEEDED "_s);
+                msg.append(WTF::StringView::fromLatin1(soname));
+                msg.append("), but this Bun build uses musl. glibc-targeted native addons cannot be loaded on Alpine/musl even with gcompat. Use a glibc-based image (e.g. oven/bun:debian) or install a musl build of this addon."_s);
+                return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED, msg.toString());
+            }
+        }
 #endif
-    CrashHandler__setDlOpenAction(utf8.data());
-    void* handle = dlopen(utf8.data(), RTLD_LAZY);
-    CrashHandler__setDlOpenAction(nullptr);
+        CrashHandler__setDlOpenAction(utf8.data());
+        handle = dlopen(utf8.data(), RTLD_LAZY);
+        CrashHandler__setDlOpenAction(nullptr);
+    }
 #endif
 
     globalObject->m_pendingNapiModuleDlopenHandle = handle;
@@ -720,26 +754,39 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
         return JSValue::encode(jsUndefined());
     }
 
-#if OS(WINDOWS)
-#define dlsym GetProcAddress
+    // Symbol lookup that routes NSModule handles (from in-memory NAPI link
+    // slots on macOS) through `NSLookupSymbolInModule` instead of `dlsym`.
+    // Every other handle — including Linux memfd-backed link slots — is a
+    // plain dlopen/LoadLibrary handle.
+    const auto lookupSymbol = [&](const char* name) -> void* {
+#if OS(DARWIN)
+        if (slotIsNSModule) return Bun__darwinLookupSymbolInModule(handle, name);
 #endif
+        (void)slotIsNSModule;
+#if OS(WINDOWS)
+        return reinterpret_cast<void*>(GetProcAddress(handle, name));
+#else
+        return dlsym(handle, name);
+#endif
+    };
 
     // TODO(@190n) look for node_register_module_vXYZ according to BuildOptions.reported_nodejs_version
     // and the table at https://github.com/nodejs/node/blob/main/doc/abi_version_registry.json
-    auto napi_register_module_v1 = reinterpret_cast<napi_value (*)(napi_env, napi_value)>(dlsym(handle, "napi_register_module_v1"));
+    auto napi_register_module_v1 = reinterpret_cast<napi_value (*)(napi_env, napi_value)>(lookupSymbol("napi_register_module_v1"));
 
-    auto node_api_module_get_api_version_v1 = reinterpret_cast<int32_t (*)()>(dlsym(handle, "node_api_module_get_api_version_v1"));
-
-#if OS(WINDOWS)
-#undef dlsym
-#endif
+    auto node_api_module_get_api_version_v1 = reinterpret_cast<int32_t (*)()>(lookupSymbol("node_api_module_get_api_version_v1"));
 
     if (!napi_register_module_v1) {
+        // Link-slot handles are memoised per process and native addons
+        // can't be unloaded, so leave those in place; closing them would
+        // also strand the cached entry in loaded_handles[].
+        if (!slotHandle) {
 #if OS(WINDOWS)
-        FreeLibrary(handle);
+            FreeLibrary(handle);
 #else
-        dlclose(handle);
+            dlclose(handle);
 #endif
+        }
 
         if (!scope.exception()) [[likely]] {
             JSC::throwTypeError(globalObject, scope, "symbol 'napi_register_module_v1' not found in native module. Is this a Node API (napi) module?"_s);
@@ -780,13 +827,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     JSC::JSValue resultValue = encoded == 0 ? exports : JSValue::decode(encoded);
 
     if (auto resultObject = resultValue.getObject()) {
-#if OS(DARWIN) || OS(LINUX) || OS(FREEBSD)
         // If this is a native bundler plugin we want to store the handle from dlopen
         // as we are going to call `dlsym()` on it later to get the plugin implementation.
-        const char** pointer_to_plugin_name = (const char**)dlsym(handle, "BUN_PLUGIN_NAME");
-#elif OS(WINDOWS)
-        const char** pointer_to_plugin_name = (const char**)GetProcAddress(handle, "BUN_PLUGIN_NAME");
-#endif
+        const char** pointer_to_plugin_name = reinterpret_cast<const char**>(lookupSymbol("BUN_PLUGIN_NAME"));
         if (pointer_to_plugin_name) {
             // TODO: think about the finalizer here
             // currently we do not dealloc napi modules so we don't have to worry about it right now

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -512,18 +512,13 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
 #define StandaloneModuleGraph__base_path "/$bunfs/"_s
 #endif
     [[maybe_unused]] bool fromEmbedded = false;
-    // NAPI link-slot addons are loaded from memory rather than via a
-    // filesystem path. On macOS the handle is an `NSModule` (from
-    // `NSLinkModule`), which needs `NSLookupSymbolInModule` in place of
-    // `dlsym`; on Linux it's an ordinary `dlopen()` handle sourced from a
-    // memfd. `slotHandle` short-circuits the path-based `dlopen()` below.
+    // Set when the addon came from a link slot (see napi_link.rs); it is
+    // already loaded, so the dlopen() below is skipped.
     void* slotHandle = nullptr;
     bool slotIsNSModule = false;
     if (filename.startsWith(StandaloneModuleGraph__base_path)) {
         auto pathUtf8 = filename.utf8();
         if (!Bun__tryLoadNapiLinkSlot(pathUtf8.data(), pathUtf8.length(), &slotHandle, &slotIsNSModule)) {
-            // Not a link slot — fall through to the module-graph extractor
-            // for bundler-embedded addons.
             BunString bunStr = Bun::toString(filename);
             BunString resolved = Bun__resolveEmbeddedNodeFile(&bunStr);
             if (!resolved.isDead()) {
@@ -533,9 +528,6 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
                 fromEmbedded = true;
             }
         } else if (!slotHandle) {
-            // Path matched a slot but the in-memory load failed (e.g. the
-            // embedded image isn't a valid Mach-O bundle). Surface that as a
-            // dlopen error rather than trying to find it on disk.
             return throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
                 makeString("failed to load linked native addon '"_s, filename, "' from embedded image"_s));
         } else {
@@ -754,10 +746,6 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
         return JSValue::encode(jsUndefined());
     }
 
-    // Symbol lookup that routes NSModule handles (from in-memory NAPI link
-    // slots on macOS) through `NSLookupSymbolInModule` instead of `dlsym`.
-    // Every other handle — including Linux memfd-backed link slots — is a
-    // plain dlopen/LoadLibrary handle.
     const auto lookupSymbol = [&](const char* name) -> void* {
 #if OS(DARWIN)
         if (slotIsNSModule) return Bun__darwinLookupSymbolInModule(handle, name);
@@ -777,9 +765,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     auto node_api_module_get_api_version_v1 = reinterpret_cast<int32_t (*)()>(lookupSymbol("node_api_module_get_api_version_v1"));
 
     if (!napi_register_module_v1) {
-        // Link-slot handles are memoised per process and native addons
-        // can't be unloaded, so leave those in place; closing them would
-        // also strand the cached entry in loaded_handles[].
+        // Slot handles are cached in napi_link.rs and must stay valid.
         if (!slotHandle) {
 #if OS(WINDOWS)
             FreeLibrary(handle);

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1165,31 +1165,21 @@ extern "C" void Bun__signpost_emit(os_log_t log, os_signpost_type_t type, os_sig
 
 #endif // OS(DARWIN) signpost code
 
-// -----------------------------------------------------------------------------
-// NAPI link slots: a fixed table of stub native-addon loaders that can be
-// filled in *after* `bun build --compile` without rebundling. Each slot points
-// at a `.node` image appended into the __BUN,__bun / .bun section (after the
-// standalone module graph payload). At runtime `process.dlopen` on a
-// `/$bunfs/...` path checks this table first; on Linux the slice is handed to
-// dlopen() via memfd (/proc/self/fd), and on other platforms it's written once
-// to a content-hashed cache path so repeated launches don't re-extract.
-//
-// The table lives in its own section so an external linker tool can locate it
-// by name (or by scanning for the per-slot magic) and stamp offset/length/
-// hash/path in place — no need to understand the module-graph serialization.
-// 256 bytes per slot keeps the math trivial for such tools.
+// NAPI link slots. Layout is ABI shared with src/standalone_graph/napi_link.rs
+// (which documents the scheme) and with external patch tools; the table gets
+// its own section so those tools can find it by name.
 #define BUN_NAPI_LINK_SLOT_COUNT 8
 #define BUN_NAPI_LINK_SLOT_MAGIC 0x006B6E696C6E7562ULL // "bunlink\0" LE
 
 extern "C" {
 struct BunNapiLinkSlot {
-    uint64_t magic; // BUN_NAPI_LINK_SLOT_MAGIC | slot_index — sanity check + locatable signature
-    uint64_t offset; // byte offset from the start of the .bun section (i.e. from the u64 size header) to the embedded .node image; 0 = unused
-    uint64_t length; // byte length of the embedded .node image
-    uint64_t hash; // content hash of the image (for cache keying on platforms without memfd)
-    char path[224]; // NUL-terminated virtual path ("/$bunfs/..." or "B:/~BUN/...") this slot answers to
+    uint64_t magic; // BUN_NAPI_LINK_SLOT_MAGIC | (index << 56)
+    uint64_t offset; // from the start of the .bun section; 0 = unused
+    uint64_t length;
+    uint64_t hash;
+    char path[224]; // NUL-terminated /$bunfs/ path
 };
-static_assert(sizeof(BunNapiLinkSlot) == 256, "BunNapiLinkSlot must be 256 bytes so external patchers can index the table");
+static_assert(sizeof(BunNapiLinkSlot) == 256);
 }
 
 #define BUN_NAPI_LINK_SLOT_INIT(i) { BUN_NAPI_LINK_SLOT_MAGIC | ((uint64_t)(i) << 56), 0, 0, 0, { 0 } }
@@ -1216,12 +1206,9 @@ extern "C" uint32_t Bun__getNapiLinkSlotCount()
     return BUN_NAPI_LINK_SLOT_COUNT;
 }
 
-// Base pointer that slot offsets are measured from. On Mach-O and ELF this is
-// the address of the BUN_COMPILED symbol (start of the __BUN,__bun / .bun
-// section, where the u64 size header lives). On Windows it is the start of the
-// .bun PE section, looked up at runtime. Declared per-platform below.
+// Start of the .bun section (what BunNapiLinkSlot::offset is relative to);
+// defined per platform below.
 extern "C" const uint8_t* Bun__getNapiLinkSectionBase();
-// -----------------------------------------------------------------------------
 
 #if OS(DARWIN) || defined(__linux__) || defined(__FreeBSD__)
 
@@ -1258,16 +1245,10 @@ extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
     return reinterpret_cast<const uint8_t*>(&BUN_COMPILED);
 }
 
-// In-memory Mach-O bundle loader for NAPI link slots. `dyld` has no API to
-// `dlopen()` a dylib from an offset inside another file, so we hand it the
-// embedded bytes via the (deprecated-but-still-exported) NSObjectFileImage
-// path. On modern dyld this routes through dyld's own private temp-file
-// shim so code-signing still works on arm64, but from bun's side it's a
-// pure pointer+length call — we never create a `.node` on disk ourselves.
-//
-// The returned `NSModule` is used as the "handle" in place of a `dlopen()`
-// result; `Process_functionDlopen` switches symbol lookup to
-// `NSLookupSymbolInModule` when the handle came from here.
+// dlopen() cannot load an image from a byte range, so link slots go through
+// the deprecated NSObjectFileImage API. The result is an NSModule, not a
+// dlopen handle; Process_functionDlopen uses Bun__darwinLookupSymbolInModule
+// on it instead of dlsym.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #include <mach-o/dyld.h>
@@ -1277,15 +1258,12 @@ extern "C" void* Bun__darwinLoadMachOFromMemory(const uint8_t* bytes, size_t len
 {
     if (len < sizeof(mach_header_64)) return nullptr;
 
-    // dyld may patch the image (e.g. slide fixups) and takes ownership of the
-    // buffer on success, so give it a private writable copy.
+    // NSCreateObjectFileImageFromMemory takes ownership of a writable buffer.
     void* copy = ::malloc(len);
     if (!copy) return nullptr;
     ::memcpy(copy, bytes, len);
 
-    // `NSCreateObjectFileImageFromMemory` only accepts `MH_BUNDLE`. node-gyp
-    // builds `.node` addons as bundles already, but if someone hands us an
-    // `MH_DYLIB` the load-command layout is identical, so flip the filetype.
+    // It also only accepts MH_BUNDLE; an MH_DYLIB has the same layout.
     auto* mh = reinterpret_cast<mach_header_64*>(copy);
     if (mh->magic == MH_MAGIC_64 && mh->filetype == MH_DYLIB) {
         mh->filetype = MH_BUNDLE;
@@ -1296,24 +1274,17 @@ extern "C" void* Bun__darwinLoadMachOFromMemory(const uint8_t* bytes, size_t len
         ::free(copy);
         return nullptr;
     }
-    // `NSLINKMODULE_OPTION_PRIVATE` keeps the addon's symbols out of the
-    // global namespace (mirrors `RTLD_LOCAL`, which is what `process.dlopen`
-    // gets from `RTLD_LAZY` by default). `RETURN_ON_ERROR` stops dyld from
-    // aborting the process on an unresolved import.
+    // PRIVATE == RTLD_LOCAL; RETURN_ON_ERROR keeps an unresolved import from aborting the process.
     NSModule module = NSLinkModule(image, name,
         NSLINKMODULE_OPTION_PRIVATE | NSLINKMODULE_OPTION_RETURN_ON_ERROR | NSLINKMODULE_OPTION_BINDNOW);
-    NSDestroyObjectFileImage(image);
-    // On success dyld has either taken ownership of `copy` or duplicated it;
-    // on failure the `NSDestroyObjectFileImage` above released it. Either way
-    // we must not free it here.
+    NSDestroyObjectFileImage(image); // releases `copy` on failure; dyld owns it on success
     return reinterpret_cast<void*>(module);
 }
 
 extern "C" void* Bun__darwinLookupSymbolInModule(void* module, const char* name)
 {
     if (!module) return nullptr;
-    // Mach-O exports carry a leading underscore that `dlsym` strips for you;
-    // `NSLookupSymbolInModule` does not.
+    // Unlike dlsym, NSLookupSymbolInModule wants the raw Mach-O name with its leading underscore.
     char prefixed[256];
     int n = ::snprintf(prefixed, sizeof(prefixed), "_%s", name);
     if (n <= 0 || static_cast<size_t>(n) >= sizeof(prefixed)) return nullptr;
@@ -1333,9 +1304,7 @@ extern "C" uint64_t* Bun__getStandaloneModuleGraphELFVaddr()
 
 extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
 {
-    // On ELF BUN_COMPILED.size holds the vaddr of the appended payload, not
-    // the payload itself, so slot offsets are measured from that vaddr (which
-    // is where the u64 length + module-graph data live).
+    // On ELF, BUN_COMPILED.size is the vaddr of the relocated .bun payload (see elf.rs).
     uint64_t vaddr = BUN_COMPILED.size;
     if (vaddr == 0) return nullptr;
     return reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(vaddr));
@@ -1397,8 +1366,6 @@ extern "C" uint8_t* Bun__getStandaloneModuleGraphPEData()
 extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
 {
     if (!initializePESection()) return nullptr;
-    // Slot offsets are measured from the start of the section (the u64 size
-    // header), matching Mach-O.
     return reinterpret_cast<const uint8_t*>(pe_section_size);
 }
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1165,6 +1165,64 @@ extern "C" void Bun__signpost_emit(os_log_t log, os_signpost_type_t type, os_sig
 
 #endif // OS(DARWIN) signpost code
 
+// -----------------------------------------------------------------------------
+// NAPI link slots: a fixed table of stub native-addon loaders that can be
+// filled in *after* `bun build --compile` without rebundling. Each slot points
+// at a `.node` image appended into the __BUN,__bun / .bun section (after the
+// standalone module graph payload). At runtime `process.dlopen` on a
+// `/$bunfs/...` path checks this table first; on Linux the slice is handed to
+// dlopen() via memfd (/proc/self/fd), and on other platforms it's written once
+// to a content-hashed cache path so repeated launches don't re-extract.
+//
+// The table lives in its own section so an external linker tool can locate it
+// by name (or by scanning for the per-slot magic) and stamp offset/length/
+// hash/path in place — no need to understand the module-graph serialization.
+// 256 bytes per slot keeps the math trivial for such tools.
+#define BUN_NAPI_LINK_SLOT_COUNT 8
+#define BUN_NAPI_LINK_SLOT_MAGIC 0x006B6E696C6E7562ULL // "bunlink\0" LE
+
+extern "C" {
+struct BunNapiLinkSlot {
+    uint64_t magic; // BUN_NAPI_LINK_SLOT_MAGIC | slot_index — sanity check + locatable signature
+    uint64_t offset; // byte offset from the start of the .bun section (i.e. from the u64 size header) to the embedded .node image; 0 = unused
+    uint64_t length; // byte length of the embedded .node image
+    uint64_t hash; // content hash of the image (for cache keying on platforms without memfd)
+    char path[224]; // NUL-terminated virtual path ("/$bunfs/..." or "B:/~BUN/...") this slot answers to
+};
+static_assert(sizeof(BunNapiLinkSlot) == 256, "BunNapiLinkSlot must be 256 bytes so external patchers can index the table");
+}
+
+#define BUN_NAPI_LINK_SLOT_INIT(i) { BUN_NAPI_LINK_SLOT_MAGIC | ((uint64_t)(i) << 56), 0, 0, 0, { 0 } }
+#define BUN_NAPI_LINK_SLOTS_INIT                                                                                      \
+    { BUN_NAPI_LINK_SLOT_INIT(0), BUN_NAPI_LINK_SLOT_INIT(1), BUN_NAPI_LINK_SLOT_INIT(2), BUN_NAPI_LINK_SLOT_INIT(3), \
+        BUN_NAPI_LINK_SLOT_INIT(4), BUN_NAPI_LINK_SLOT_INIT(5), BUN_NAPI_LINK_SLOT_INIT(6), BUN_NAPI_LINK_SLOT_INIT(7) }
+
+#if OS(DARWIN)
+extern "C" __attribute__((section("__DATA,__bun_napi_lnk"), used, aligned(16))) BunNapiLinkSlot BUN_NAPI_LINK_SLOTS[BUN_NAPI_LINK_SLOT_COUNT] = BUN_NAPI_LINK_SLOTS_INIT;
+#elif defined(_WIN32)
+#pragma section(".bnapi", read, write)
+extern "C" __declspec(allocate(".bnapi")) BunNapiLinkSlot BUN_NAPI_LINK_SLOTS[BUN_NAPI_LINK_SLOT_COUNT] = BUN_NAPI_LINK_SLOTS_INIT;
+#else
+extern "C" __attribute__((section(".bun_napi_link"), used, aligned(16))) BunNapiLinkSlot BUN_NAPI_LINK_SLOTS[BUN_NAPI_LINK_SLOT_COUNT] = BUN_NAPI_LINK_SLOTS_INIT;
+#endif
+
+extern "C" BunNapiLinkSlot* Bun__getNapiLinkSlots()
+{
+    return &BUN_NAPI_LINK_SLOTS[0];
+}
+
+extern "C" uint32_t Bun__getNapiLinkSlotCount()
+{
+    return BUN_NAPI_LINK_SLOT_COUNT;
+}
+
+// Base pointer that slot offsets are measured from. On Mach-O and ELF this is
+// the address of the BUN_COMPILED symbol (start of the __BUN,__bun / .bun
+// section, where the u64 size header lives). On Windows it is the start of the
+// .bun PE section, looked up at runtime. Declared per-platform below.
+extern "C" const uint8_t* Bun__getNapiLinkSectionBase();
+// -----------------------------------------------------------------------------
+
 #if OS(DARWIN) || defined(__linux__) || defined(__FreeBSD__)
 
 #if OS(DARWIN)
@@ -1195,6 +1253,75 @@ extern "C" uint64_t* Bun__getStandaloneModuleGraphMachoLength()
     return &BUN_COMPILED.size;
 }
 
+extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
+{
+    return reinterpret_cast<const uint8_t*>(&BUN_COMPILED);
+}
+
+// In-memory Mach-O bundle loader for NAPI link slots. `dyld` has no API to
+// `dlopen()` a dylib from an offset inside another file, so we hand it the
+// embedded bytes via the (deprecated-but-still-exported) NSObjectFileImage
+// path. On modern dyld this routes through dyld's own private temp-file
+// shim so code-signing still works on arm64, but from bun's side it's a
+// pure pointer+length call — we never create a `.node` on disk ourselves.
+//
+// The returned `NSModule` is used as the "handle" in place of a `dlopen()`
+// result; `Process_functionDlopen` switches symbol lookup to
+// `NSLookupSymbolInModule` when the handle came from here.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+
+extern "C" void* Bun__darwinLoadMachOFromMemory(const uint8_t* bytes, size_t len, const char* name)
+{
+    if (len < sizeof(mach_header_64)) return nullptr;
+
+    // dyld may patch the image (e.g. slide fixups) and takes ownership of the
+    // buffer on success, so give it a private writable copy.
+    void* copy = ::malloc(len);
+    if (!copy) return nullptr;
+    ::memcpy(copy, bytes, len);
+
+    // `NSCreateObjectFileImageFromMemory` only accepts `MH_BUNDLE`. node-gyp
+    // builds `.node` addons as bundles already, but if someone hands us an
+    // `MH_DYLIB` the load-command layout is identical, so flip the filetype.
+    auto* mh = reinterpret_cast<mach_header_64*>(copy);
+    if (mh->magic == MH_MAGIC_64 && mh->filetype == MH_DYLIB) {
+        mh->filetype = MH_BUNDLE;
+    }
+
+    NSObjectFileImage image = nullptr;
+    if (NSCreateObjectFileImageFromMemory(copy, len, &image) != NSObjectFileImageSuccess) {
+        ::free(copy);
+        return nullptr;
+    }
+    // `NSLINKMODULE_OPTION_PRIVATE` keeps the addon's symbols out of the
+    // global namespace (mirrors `RTLD_LOCAL`, which is what `process.dlopen`
+    // gets from `RTLD_LAZY` by default). `RETURN_ON_ERROR` stops dyld from
+    // aborting the process on an unresolved import.
+    NSModule module = NSLinkModule(image, name,
+        NSLINKMODULE_OPTION_PRIVATE | NSLINKMODULE_OPTION_RETURN_ON_ERROR | NSLINKMODULE_OPTION_BINDNOW);
+    NSDestroyObjectFileImage(image);
+    // On success dyld has either taken ownership of `copy` or duplicated it;
+    // on failure the `NSDestroyObjectFileImage` above released it. Either way
+    // we must not free it here.
+    return reinterpret_cast<void*>(module);
+}
+
+extern "C" void* Bun__darwinLookupSymbolInModule(void* module, const char* name)
+{
+    if (!module) return nullptr;
+    // Mach-O exports carry a leading underscore that `dlsym` strips for you;
+    // `NSLookupSymbolInModule` does not.
+    char prefixed[256];
+    int n = ::snprintf(prefixed, sizeof(prefixed), "_%s", name);
+    if (n <= 0 || static_cast<size_t>(n) >= sizeof(prefixed)) return nullptr;
+    NSSymbol sym = NSLookupSymbolInModule(reinterpret_cast<NSModule>(module), prefixed);
+    return sym ? NSAddressOfSymbol(sym) : nullptr;
+}
+#pragma clang diagnostic pop
+
 #else // __linux__ / __FreeBSD__ — both ELF, same .bun section approach
 
 extern "C" BlobHeader __attribute__((section(".bun"), aligned(BLOB_HEADER_ALIGNMENT), used)) BUN_COMPILED = { 0 };
@@ -1202,6 +1329,16 @@ extern "C" BlobHeader __attribute__((section(".bun"), aligned(BLOB_HEADER_ALIGNM
 extern "C" uint64_t* Bun__getStandaloneModuleGraphELFVaddr()
 {
     return &BUN_COMPILED.size;
+}
+
+extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
+{
+    // On ELF BUN_COMPILED.size holds the vaddr of the appended payload, not
+    // the payload itself, so slot offsets are measured from that vaddr (which
+    // is where the u64 length + module-graph data live).
+    uint64_t vaddr = BUN_COMPILED.size;
+    if (vaddr == 0) return nullptr;
+    return reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(vaddr));
 }
 
 #endif // OS(DARWIN) / __linux__
@@ -1255,6 +1392,14 @@ extern "C" uint8_t* Bun__getStandaloneModuleGraphPEData()
 {
     if (!initializePESection()) return nullptr;
     return pe_section_data;
+}
+
+extern "C" const uint8_t* Bun__getNapiLinkSectionBase()
+{
+    if (!initializePESection()) return nullptr;
+    // Slot offsets are measured from the start of the section (the u64 size
+    // header), matching Mach-O.
+    return reinterpret_cast<const uint8_t*>(pe_section_size);
 }
 
 #endif

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -100,8 +100,16 @@ fn napi_link_slots(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
             b"path",
             bun_core::String::clone_utf8(slot.path_slice()).to_js(global)?,
         );
-        obj.put(global, b"offset", JSValue::js_number_from_uint64(slot.offset));
-        obj.put(global, b"length", JSValue::js_number_from_uint64(slot.length));
+        obj.put(
+            global,
+            b"offset",
+            JSValue::js_number_from_uint64(slot.offset),
+        );
+        obj.put(
+            global,
+            b"length",
+            JSValue::js_number_from_uint64(slot.length),
+        );
         // Hex of the hash's little-endian bytes, matching a byte-wise dump of
         // the on-disk slot.
         let mut hex = [0u8; 16];

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -148,16 +148,14 @@ fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         Ok(b) => b,
         Err(e) => return Err(e.with_path(&exe_path).throw(global)),
     };
-    let addon_bytes =
-        match bun_sys::File::openat(Fd::cwd(), &addon_path, bun_sys::O::RDONLY, 0)
-            .and_then(|f| f.read_to_end())
-        {
-            Ok(b) => b,
-            Err(e) => return Err(e.with_path(&addon_path).throw(global)),
-        };
-
-    let out_bytes = match napi_link::link_into_macho(&exe_bytes, &addon_bytes, &virtual_path)
+    let addon_bytes = match bun_sys::File::openat(Fd::cwd(), &addon_path, bun_sys::O::RDONLY, 0)
+        .and_then(|f| f.read_to_end())
     {
+        Ok(b) => b,
+        Err(e) => return Err(e.with_path(&addon_path).throw(global)),
+    };
+
+    let out_bytes = match napi_link::link_into_macho(&exe_bytes, &addon_bytes, &virtual_path) {
         Ok(b) => b,
         Err(LinkError::UnsupportedExecutableFormat) => {
             return Err(global.throw(format_args!(

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -137,10 +137,10 @@ fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         )));
     }
     let [exe_arg, addon_arg, vpath_arg, out_arg] = frame.arguments_as_array::<4>();
-    let exe_path = exe_arg.to_slice_or_null(global)?;
-    let addon_path = addon_arg.to_slice_or_null(global)?;
-    let virtual_path = vpath_arg.to_slice_or_null(global)?;
-    let out_path = out_arg.to_slice_or_null(global)?;
+    let exe_path = exe_arg.to_slice(global)?;
+    let addon_path = addon_arg.to_slice(global)?;
+    let virtual_path = vpath_arg.to_slice(global)?;
+    let out_path = out_arg.to_slice(global)?;
 
     let exe_bytes = match bun_sys::File::openat(Fd::cwd(), exe_path.slice(), bun_sys::O::RDONLY, 0)
         .and_then(|f| f.read_to_end())

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -137,26 +137,26 @@ fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         )));
     }
     let [exe_arg, addon_arg, vpath_arg, out_arg] = frame.arguments_as_array::<4>();
-    let exe_path = exe_arg.to_slice(global)?;
-    let addon_path = addon_arg.to_slice(global)?;
-    let virtual_path = vpath_arg.to_slice(global)?;
-    let out_path = out_arg.to_slice(global)?;
+    let exe_path = exe_arg.to_utf8(global)?;
+    let addon_path = addon_arg.to_utf8(global)?;
+    let virtual_path = vpath_arg.to_utf8(global)?;
+    let out_path = out_arg.to_utf8(global)?;
 
-    let exe_bytes = match bun_sys::File::openat(Fd::cwd(), exe_path.slice(), bun_sys::O::RDONLY, 0)
+    let exe_bytes = match bun_sys::File::openat(Fd::cwd(), &exe_path, bun_sys::O::RDONLY, 0)
         .and_then(|f| f.read_to_end())
     {
         Ok(b) => b,
-        Err(e) => return Err(e.with_path(exe_path.slice()).throw(global)),
+        Err(e) => return Err(e.with_path(&exe_path).throw(global)),
     };
     let addon_bytes =
-        match bun_sys::File::openat(Fd::cwd(), addon_path.slice(), bun_sys::O::RDONLY, 0)
+        match bun_sys::File::openat(Fd::cwd(), &addon_path, bun_sys::O::RDONLY, 0)
             .and_then(|f| f.read_to_end())
         {
             Ok(b) => b,
-            Err(e) => return Err(e.with_path(addon_path.slice()).throw(global)),
+            Err(e) => return Err(e.with_path(&addon_path).throw(global)),
         };
 
-    let out_bytes = match napi_link::link_into_macho(&exe_bytes, &addon_bytes, virtual_path.slice())
+    let out_bytes = match napi_link::link_into_macho(&exe_bytes, &addon_bytes, &virtual_path)
     {
         Ok(b) => b,
         Err(LinkError::UnsupportedExecutableFormat) => {
@@ -189,15 +189,15 @@ fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
 
     let out_file = match bun_sys::File::openat(
         Fd::cwd(),
-        out_path.slice(),
+        &out_path,
         bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
         0o755,
     ) {
         Ok(f) => f,
-        Err(e) => return Err(e.with_path(out_path.slice()).throw(global)),
+        Err(e) => return Err(e.with_path(&out_path).throw(global)),
     };
     if let Err(e) = out_file.write_all(&out_bytes) {
-        return Err(e.with_path(out_path.slice()).throw(global));
+        return Err(e.with_path(&out_path).throw(global));
     }
 
     Ok(JSValue::UNDEFINED)

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -1,5 +1,6 @@
-use bun_core::EncodedSlice;
+use bun_core::{EncodedSlice, Fd};
 use bun_jsc::EncodedSliceJsc as _;
+use bun_jsc::StringJsc as _;
 use bun_jsc::virtual_machine::GCLevel;
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSType, JSValue, JsResult};
 
@@ -13,6 +14,8 @@ pub(crate) fn create(global: &JSGlobalObject) -> JSValue {
             ("arrayBufferToString", __jsc_host_array_buffer_to_string, 1),
             ("mimallocDump", __jsc_host_dump_mimalloc, 1),
             ("memoryFootprint", __jsc_host_memory_footprint, 1),
+            ("napiLinkSlots", __jsc_host_napi_link_slots, 1),
+            ("linkNapiModule", __jsc_host_link_napi_module, 4),
         ],
     )
 }
@@ -74,6 +77,130 @@ fn memory_footprint(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JS
         return Ok(JSValue::UNDEFINED);
     }
     Ok(JSValue::js_number(bytes as f64))
+}
+
+/// Return the NAPI link-slot table as an array of
+/// `{ index, used, path, offset, length, hash }` so tests (and curious
+/// users) can see which stub loaders are populated in the current
+/// executable. This inspects the running binary's own table, not a file.
+#[bun_jsc::host_fn]
+fn napi_link_slots(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    let slots = bun_standalone_graph::napi_link::slots();
+    let arr = JSValue::create_empty_array(global, slots.len())?;
+    for (i, slot) in slots.iter().enumerate() {
+        let obj = JSValue::create_empty_object(global, 6);
+        obj.put(
+            global,
+            b"index",
+            JSValue::js_number_from_uint64(slot.index() as u64),
+        );
+        obj.put(global, b"used", JSValue::js_boolean(slot.is_used()));
+        obj.put(
+            global,
+            b"path",
+            bun_core::String::clone_utf8(slot.path_slice()).to_js(global)?,
+        );
+        obj.put(global, b"offset", JSValue::js_number_from_uint64(slot.offset));
+        obj.put(global, b"length", JSValue::js_number_from_uint64(slot.length));
+        // Hex of the hash's little-endian bytes, matching a byte-wise dump of
+        // the on-disk slot.
+        let mut hex = [0u8; 16];
+        for (j, b) in slot.hash.to_le_bytes().iter().enumerate() {
+            const DIGITS: &[u8; 16] = b"0123456789abcdef";
+            hex[j * 2] = DIGITS[(b >> 4) as usize];
+            hex[j * 2 + 1] = DIGITS[(b & 0xf) as usize];
+        }
+        obj.put(
+            global,
+            b"hash",
+            bun_core::String::clone_utf8(&hex).to_js(global)?,
+        );
+        arr.put_index(global, i as u32, obj)?;
+    }
+    Ok(arr)
+}
+
+/// `Bun.unsafe.linkNapiModule(exePath, addonPath, virtualPath, outPath)`
+/// Post-process a `bun build --compile` executable: append the Mach-O
+/// `.node` image at `addonPath` into the `__BUN,__bun` section and stamp the
+/// first free stub slot so that `process.dlopen(virtualPath)` inside the
+/// resulting binary resolves to it. Writes the result to `outPath` (which
+/// may equal `exePath`). Mach-O only for now.
+#[bun_jsc::host_fn]
+fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    use bun_jsc::SysErrorJsc as _;
+    use bun_standalone_graph::napi_link::{self, LinkError, Slot};
+
+    if frame.arguments_count() < 4 {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "linkNapiModule(exePath, addonPath, virtualPath, outPath) requires 4 arguments"
+        )));
+    }
+    let [exe_arg, addon_arg, vpath_arg, out_arg] = frame.arguments_as_array::<4>();
+    let exe_path = exe_arg.to_slice_or_null(global)?;
+    let addon_path = addon_arg.to_slice_or_null(global)?;
+    let virtual_path = vpath_arg.to_slice_or_null(global)?;
+    let out_path = out_arg.to_slice_or_null(global)?;
+
+    let exe_bytes = match bun_sys::File::openat(Fd::cwd(), exe_path.slice(), bun_sys::O::RDONLY, 0)
+        .and_then(|f| f.read_to_end())
+    {
+        Ok(b) => b,
+        Err(e) => return Err(e.with_path(exe_path.slice()).throw(global)),
+    };
+    let addon_bytes =
+        match bun_sys::File::openat(Fd::cwd(), addon_path.slice(), bun_sys::O::RDONLY, 0)
+            .and_then(|f| f.read_to_end())
+        {
+            Ok(b) => b,
+            Err(e) => return Err(e.with_path(addon_path.slice()).throw(global)),
+        };
+
+    let out_bytes = match napi_link::link_into_macho(&exe_bytes, &addon_bytes, virtual_path.slice())
+    {
+        Ok(b) => b,
+        Err(LinkError::UnsupportedExecutableFormat) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: executable is not a Mach-O file (only macOS targets are supported for now)"
+            )));
+        }
+        Err(LinkError::NotStandaloneExecutable) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: executable was not produced by `bun build --compile`"
+            )));
+        }
+        Err(LinkError::NoFreeSlot) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: all {} NAPI link slots are in use",
+                Slot::COUNT
+            )));
+        }
+        Err(LinkError::PathTooLong) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: virtual path must be < 224 bytes"
+            )));
+        }
+        Err(LinkError::SlotTableMissing) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: executable has no NAPI link slot table (was it built with an older bun?)"
+            )));
+        }
+    };
+
+    let out_file = match bun_sys::File::openat(
+        Fd::cwd(),
+        out_path.slice(),
+        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,
+        0o755,
+    ) {
+        Ok(f) => f,
+        Err(e) => return Err(e.with_path(out_path.slice()).throw(global)),
+    };
+    if let Err(e) = out_file.write_all(&out_bytes) {
+        return Err(e.with_path(out_path.slice()).throw(global));
+    }
+
+    Ok(JSValue::UNDEFINED)
 }
 
 #[bun_jsc::host_fn]

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -79,10 +79,8 @@ fn memory_footprint(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JS
     Ok(JSValue::js_number(bytes as f64))
 }
 
-/// Return the NAPI link-slot table as an array of
-/// `{ index, used, path, offset, length, hash }` so tests (and curious
-/// users) can see which stub loaders are populated in the current
-/// executable. This inspects the running binary's own table, not a file.
+/// `Bun.unsafe.napiLinkSlots()`: the running binary's link-slot table as
+/// `{ index, used, path, offset, length, hash }[]`.
 #[bun_jsc::host_fn]
 fn napi_link_slots(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     let slots = bun_standalone_graph::napi_link::slots();
@@ -110,8 +108,6 @@ fn napi_link_slots(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
             b"length",
             JSValue::js_number_from_uint64(slot.length),
         );
-        // Hex of the hash's little-endian bytes, matching a byte-wise dump of
-        // the on-disk slot.
         let mut hex = [0u8; 16];
         for (j, b) in slot.hash.to_le_bytes().iter().enumerate() {
             const DIGITS: &[u8; 16] = b"0123456789abcdef";
@@ -128,12 +124,8 @@ fn napi_link_slots(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
     Ok(arr)
 }
 
-/// `Bun.unsafe.linkNapiModule(exePath, addonPath, virtualPath, outPath)`
-/// Post-process a `bun build --compile` executable: append the Mach-O
-/// `.node` image at `addonPath` into the `__BUN,__bun` section and stamp the
-/// first free stub slot so that `process.dlopen(virtualPath)` inside the
-/// resulting binary resolves to it. Writes the result to `outPath` (which
-/// may equal `exePath`). Mach-O only for now.
+/// `Bun.unsafe.linkNapiModule(exePath, addonPath, virtualPath, outPath)`;
+/// see `napi_link::link_into_macho`.
 #[bun_jsc::host_fn]
 fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     use bun_jsc::SysErrorJsc as _;

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -167,6 +167,11 @@ fn link_napi_module(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                 "linkNapiModule: executable was not produced by `bun build --compile`"
             )));
         }
+        Err(LinkError::ExecutableTooLarge) => {
+            return Err(global.throw(format_args!(
+                "linkNapiModule: linked executable would exceed 4 GiB, the Mach-O file offset limit"
+            )));
+        }
         Err(LinkError::NoFreeSlot) => {
             return Err(global.throw(format_args!(
                 "linkNapiModule: all {} NAPI link slots are in use",

--- a/src/standalone_graph/Cargo.toml
+++ b/src/standalone_graph/Cargo.toml
@@ -35,6 +35,7 @@ bun_perf.workspace = true
 bun_resolver.workspace = true
 bun_sourcemap.workspace = true
 bun_sys.workspace = true
+bun_wyhash.workspace = true
 bun_threading.workspace = true
 bun_url.workspace = true
 bun_zlib.workspace = true

--- a/src/standalone_graph/lib.rs
+++ b/src/standalone_graph/lib.rs
@@ -7,6 +7,8 @@ pub use error::{Error, Result};
 #[path = "StandaloneModuleGraph.rs"]
 pub mod StandaloneModuleGraph;
 
+pub mod napi_link;
+
 // Re-export the flat surface most downstream callers use.
 pub use StandaloneModuleGraph::{
     BASE_PATH, BASE_PUBLIC_PATH, File, StandaloneModuleGraph as Graph, is_bun_standalone_file_path,

--- a/src/standalone_graph/napi_link.rs
+++ b/src/standalone_graph/napi_link.rs
@@ -339,8 +339,7 @@ pub fn link_into_macho(
     let picked = (0..n_slots)
         .find(|i| {
             let off = table_off + i * size_of::<Slot>();
-            let magic =
-                u64::from_le_bytes(macho.data[off..off + 8].try_into().unwrap());
+            let magic = u64::from_le_bytes(macho.data[off..off + 8].try_into().unwrap());
             let offset = u64::from_le_bytes(macho.data[off + 8..off + 16].try_into().unwrap());
             let length = u64::from_le_bytes(macho.data[off + 16..off + 24].try_into().unwrap());
             (magic & 0x00FF_FFFF_FFFF_FFFF) == Slot::MAGIC_BASE && offset == 0 && length == 0
@@ -358,7 +357,8 @@ pub fn link_into_macho(
     let hash = bun_wyhash::hash(addon_bytes);
     macho.data[dest_off..dest_off + 8].copy_from_slice(&magic.to_le_bytes());
     macho.data[dest_off + 8..dest_off + 16].copy_from_slice(&offset.to_le_bytes());
-    macho.data[dest_off + 16..dest_off + 24].copy_from_slice(&(addon_bytes.len() as u64).to_le_bytes());
+    macho.data[dest_off + 16..dest_off + 24]
+        .copy_from_slice(&(addon_bytes.len() as u64).to_le_bytes());
     macho.data[dest_off + 24..dest_off + 32].copy_from_slice(&hash.to_le_bytes());
     macho.data[dest_off + 32..dest_off + 256].copy_from_slice(&path_buf);
 

--- a/src/standalone_graph/napi_link.rs
+++ b/src/standalone_graph/napi_link.rs
@@ -1,0 +1,370 @@
+//! Stub native-addon loaders for standalone (`bun build --compile`) executables.
+//!
+//! The bun binary carries a small fixed table of "link slots" in its own
+//! section (`__DATA,__bun_napi_lnk` on Mach-O, `.bun_napi_link` on ELF,
+//! `.bnapi` on PE; defined in `c-bindings.cpp`). Each slot is 256 bytes:
+//! `{ magic, offset, length, hash, path[224] }`. A post-build linker can
+//! binary-patch a slot in place and append the `.node` image into the
+//! `__BUN,__bun` / `.bun` section *after* the standalone module graph
+//! payload, without re-running the bundler.
+//!
+//! At runtime, when `process.dlopen` sees a `/$bunfs/...` path, it consults
+//! this table before falling back to the per-launch tmpfile extraction used
+//! for bundler-embedded addons. A matching slot is loaded entirely from
+//! memory: on macOS via `NSCreateObjectFileImageFromMemory` + `NSLinkModule`
+//! (bun never writes a `.node` to disk), on Linux via
+//! `memfd_create(MFD_EXEC)` + `dlopen("/proc/self/fd/N")`. Other platforms
+//! return no handle; they also have no post-link patcher yet, so their slots
+//! can never be populated.
+
+use core::ffi::c_void;
+use core::mem::size_of;
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+use bun_exe_format::macho::{MachoError, MachoFile};
+
+/// Mirrors `BunNapiLinkSlot` in `c-bindings.cpp`. Keep both at 256 bytes.
+#[repr(C)]
+pub struct Slot {
+    pub magic: u64,
+    pub offset: u64,
+    pub length: u64,
+    pub hash: u64,
+    pub path: [u8; 224],
+}
+
+const _: () = assert!(
+    size_of::<Slot>() == 256,
+    "BunNapiLinkSlot must be 256 bytes so external patchers can index the table"
+);
+
+impl Slot {
+    pub const COUNT: usize = 8;
+    /// `"bunlink\0"` little-endian — the low 7 bytes are the signature, the
+    /// high byte carries the slot index so patchers can locate slot N by
+    /// scanning for `62 75 6E 6C 69 6E 6B NN`.
+    pub const MAGIC_BASE: u64 = 0x006B_6E69_6C6E_7562;
+
+    pub fn is_used(&self) -> bool {
+        self.offset != 0 && self.length != 0
+    }
+
+    pub fn index(&self) -> u32 {
+        (self.magic >> 56) as u32
+    }
+
+    pub fn path_slice(&self) -> &[u8] {
+        bun_core::slice_to_nul(&self.path)
+    }
+
+    pub fn is_valid(&self) -> bool {
+        (self.magic & 0x00FF_FFFF_FFFF_FFFF) == Self::MAGIC_BASE
+    }
+}
+
+unsafe extern "C" {
+    fn Bun__getNapiLinkSlots() -> *const Slot;
+    safe fn Bun__getNapiLinkSlotCount() -> u32;
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+    fn Bun__getNapiLinkSectionBase() -> *const u8;
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn Bun__darwinLoadMachOFromMemory(
+        bytes: *const u8,
+        len: usize,
+        name: *const core::ffi::c_char,
+    ) -> *mut c_void;
+}
+
+pub fn slots() -> &'static [Slot] {
+    let count = Bun__getNapiLinkSlotCount() as usize;
+    // SAFETY: the table is a static array of `count` slots in the binary's
+    // own data section; it lives for the process lifetime.
+    unsafe { core::slice::from_raw_parts(Bun__getNapiLinkSlots(), count) }
+}
+
+/// Find the slot whose virtual path matches `input_path` exactly.
+pub fn find_slot(input_path: &[u8]) -> Option<&'static Slot> {
+    slots()
+        .iter()
+        .find(|s| s.is_valid() && s.is_used() && s.path_slice() == input_path)
+}
+
+/// Return the embedded `.node` bytes for `slot` as a slice pointing directly
+/// into the mapped `__BUN,__bun` / `.bun` section. The memory lives for the
+/// lifetime of the process.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
+fn slot_bytes(slot: &Slot) -> Option<&'static [u8]> {
+    // SAFETY: base points at the start of the mapped standalone section; the
+    // patcher wrote `offset`/`length` to describe a range inside it.
+    unsafe {
+        let base = Bun__getNapiLinkSectionBase();
+        if base.is_null() {
+            return None;
+        }
+        Some(core::slice::from_raw_parts(
+            base.add(slot.offset as usize),
+            slot.length as usize,
+        ))
+    }
+}
+
+/// Cache of already-loaded slots so repeated `require()` of the same virtual
+/// path returns the same module instance (via the `DLHandleMap` replay path
+/// in `Process_functionDlopen`). Entries are written once and never freed —
+/// native addons cannot be unloaded.
+static LOADED_HANDLES: [AtomicPtr<c_void>; Slot::COUNT] =
+    [const { AtomicPtr::new(core::ptr::null_mut()) }; Slot::COUNT];
+
+/// Load the addon image stored in `slot` and return an opaque handle usable
+/// by `process.dlopen` (an `NSModule` on macOS, a `dlopen()` handle on
+/// Linux). Sets `is_ns_module` on macOS so the caller knows to use
+/// `NSLookupSymbolInModule` instead of `dlsym()`.
+fn load_slot_from_memory(slot: &Slot, is_ns_module: &mut bool) -> *mut c_void {
+    *is_ns_module = false;
+    let idx = slot.index() as usize;
+    if idx < LOADED_HANDLES.len() {
+        let cached = LOADED_HANDLES[idx].load(Ordering::Acquire);
+        if !cached.is_null() {
+            *is_ns_module = cfg!(target_os = "macos");
+            return cached;
+        }
+    }
+
+    let handle = load_slot_for_platform(slot, is_ns_module);
+
+    if !handle.is_null() && idx < LOADED_HANDLES.len() {
+        LOADED_HANDLES[idx].store(handle, Ordering::Release);
+    }
+    handle
+}
+
+#[cfg(target_os = "macos")]
+fn load_slot_for_platform(slot: &Slot, is_ns_module: &mut bool) -> *mut c_void {
+    let Some(bytes) = slot_bytes(slot) else {
+        return core::ptr::null_mut();
+    };
+    // dyld uses this as the image's install name; keep it stable per slot so
+    // stack traces and `NSNameOfModule` are recognisable.
+    let mut name = [0u8; 32];
+    use std::io::Write as _;
+    let mut c = std::io::Cursor::new(&mut name[..]);
+    let _ = write!(c, "bun:napi-slot-{}\0", slot.index());
+    *is_ns_module = true;
+    // SAFETY: `bytes` is a live slice into the mapped section; `name` is
+    // NUL-terminated above.
+    unsafe { Bun__darwinLoadMachOFromMemory(bytes.as_ptr(), bytes.len(), name.as_ptr().cast()) }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn load_slot_for_platform(slot: &Slot, _is_ns_module: &mut bool) -> *mut c_void {
+    use bun_core::ZStr;
+    use bun_sys::FdExt as _;
+
+    if !bun_sys::can_use_memfd() {
+        return core::ptr::null_mut();
+    }
+    let Some(bytes) = slot_bytes(slot) else {
+        return core::ptr::null_mut();
+    };
+    let Ok(fd) = bun_sys::memfd_create(c"bun-napi-link", bun_sys::MemfdFlags::Executable) else {
+        return core::ptr::null_mut();
+    };
+    // Pre-size so dlopen sees the full extent immediately.
+    let _ = bun_sys::ftruncate(fd, bytes.len() as i64);
+    let mut remain = bytes;
+    while !remain.is_empty() {
+        match bun_sys::write(fd, remain) {
+            Ok(0) | Err(_) => {
+                fd.close();
+                return core::ptr::null_mut();
+            }
+            Ok(n) => remain = &remain[n..],
+        }
+    }
+    // Leave the fd open so /proc/self/fd/N remains valid for dlopen and for
+    // the lifetime of the loaded module.
+    let mut path = [0u8; 48];
+    use std::io::Write as _;
+    let mut c = std::io::Cursor::new(&mut path[..]);
+    let _ = write!(c, "/proc/self/fd/{}", fd.0);
+    let len = c.position() as usize;
+    // `path` was zero-initialized, so `path[len] == 0`.
+    let zpath = ZStr::from_buf(&path, len);
+    bun_sys::dlopen(zpath, bun_sys::RTLD::LAZY).unwrap_or(core::ptr::null_mut())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
+fn load_slot_for_platform(_slot: &Slot, _is_ns_module: &mut bool) -> *mut c_void {
+    // No in-memory loader here, and no post-link patcher can populate slots
+    // for this executable format yet either. `Process_functionDlopen`
+    // reports ERR_DLOPEN_FAILED for the (currently unreachable) case of a
+    // populated slot.
+    core::ptr::null_mut()
+}
+
+/// Called from `Process_functionDlopen` when the target starts with the
+/// `/$bunfs/` prefix. If the path matches a populated slot, loads it from
+/// memory and writes the resulting handle into `out_handle`. Returns true
+/// whether or not the load succeeded — a true return with
+/// `*out_handle == null` means "this path is a link slot but loading
+/// failed", so the caller surfaces a dlopen error instead of falling through
+/// to the module-graph tmpfile extractor (which wouldn't find it either).
+///
+/// # Safety
+/// `path_ptr[..path_len]` must be readable; `out_handle` and
+/// `out_is_ns_module` must be valid for writes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__tryLoadNapiLinkSlot(
+    path_ptr: *const u8,
+    path_len: usize,
+    out_handle: *mut *mut c_void,
+    out_is_ns_module: *mut bool,
+) -> bool {
+    // SAFETY: caller (BunProcess.cpp) passes the UTF-8 bytes of the dlopen
+    // target and valid out-pointers.
+    unsafe {
+        *out_handle = core::ptr::null_mut();
+        *out_is_ns_module = false;
+        let path = core::slice::from_raw_parts(path_ptr, path_len);
+        let Some(slot) = find_slot(path) else {
+            return false;
+        };
+        let mut is_ns_module = false;
+        *out_handle = load_slot_from_memory(slot, &mut is_ns_module);
+        *out_is_ns_module = is_ns_module;
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Linker side: rewrite a standalone executable to carry an extra `.node`
+// addon in one of the free slots. We locate the fixed slot table section,
+// stamp a slot, append the addon bytes into the `__BUN,__bun` section (after
+// the existing module-graph payload so `fromExecutable`'s trailer check
+// still lands on the `"\n---- Bun! ----\n"` sentinel), and re-sign.
+//
+// Only Mach-O is wired up for now; ELF and PE need their own
+// section-finders and payload-appenders which can reuse the same slot
+// layout.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum LinkError {
+    UnsupportedExecutableFormat,
+    NotStandaloneExecutable,
+    NoFreeSlot,
+    PathTooLong,
+    SlotTableMissing,
+}
+
+const MH_MAGIC_64: u32 = 0xfeedfacf;
+
+/// Append `addon_bytes` (a complete Mach-O `.node` image) to the standalone
+/// executable `exe_bytes` and register it under `virtual_path` in the first
+/// free link slot. Returns a freshly-allocated, re-signed Mach-O image.
+pub fn link_into_macho(
+    exe_bytes: &[u8],
+    addon_bytes: &[u8],
+    virtual_path: &[u8],
+) -> Result<Vec<u8>, LinkError> {
+    if exe_bytes.len() < 4 || u32::from_le_bytes(exe_bytes[0..4].try_into().unwrap()) != MH_MAGIC_64
+    {
+        return Err(LinkError::UnsupportedExecutableFormat);
+    }
+    if virtual_path.is_empty() || virtual_path.len() >= 224 {
+        return Err(LinkError::PathTooLong);
+    }
+
+    let mut macho = MachoFile::init(exe_bytes, addon_bytes.len() + (16 * 1024))
+        .map_err(|_| LinkError::UnsupportedExecutableFormat)?;
+
+    // The existing `__BUN,__bun` section starts with a u64 length header
+    // followed by the serialised module graph (ending in the trailer). We
+    // preserve that header value so `StandaloneModuleGraph.fromExecutable`
+    // keeps finding the trailer, and append the addon image after it.
+    let bun_section = macho
+        .find_section(b"__BUN", b"__bun")
+        .ok_or(LinkError::NotStandaloneExecutable)?;
+    if bun_section.size < size_of::<u64>() as u64 {
+        return Err(LinkError::NotStandaloneExecutable);
+    }
+
+    let existing = &macho.data[bun_section.file_offset as usize..][..bun_section.size as usize];
+    let graph_len = u64::from_le_bytes(existing[0..8].try_into().unwrap());
+    if graph_len == 0 {
+        return Err(LinkError::NotStandaloneExecutable);
+    }
+    // Current payload (without the u64 header) is `graph ++ prior napi
+    // images`. The section's filesize may be padded past the last byte we
+    // care about, but those padding bytes are zero; copying them is harmless
+    // and keeps previously-linked addons intact.
+    let prior_payload = &existing[size_of::<u64>()..];
+
+    // Pad so the addon image starts on a 16 KiB boundary within the section —
+    // matches the section alignment and gives the loader a page-aligned
+    // source.
+    let alignment: usize = 16 * 1024;
+    let addon_off_in_payload = prior_payload.len().next_multiple_of(alignment);
+    let mut new_payload = Vec::with_capacity(addon_off_in_payload + addon_bytes.len());
+    new_payload.extend_from_slice(prior_payload);
+    new_payload.resize(addon_off_in_payload, 0);
+    new_payload.extend_from_slice(addon_bytes);
+
+    // Rewrite the section. The header must keep pointing at the module graph
+    // length, not the combined length.
+    macho
+        .write_section_with_header(&new_payload, graph_len)
+        .map_err(|e| match e {
+            MachoError::InvalidObject => LinkError::NotStandaloneExecutable,
+            _ => LinkError::UnsupportedExecutableFormat,
+        })?;
+
+    // Stamp the first free slot. The slot table is fixed-size inside
+    // `__DATA,__bun_napi_lnk` so this is a straight overwrite that doesn't
+    // shift any load commands — but it must happen *after*
+    // `write_section_with_header` has finished shuffling bytes around, or
+    // we'd be editing stale memory. `__DATA` sits before `__BUN` in the
+    // file, so its offset is unaffected by the shift.
+    let slot_section = macho
+        .find_section(b"__DATA", b"__bun_napi_lnk")
+        .ok_or(LinkError::SlotTableMissing)?;
+    if slot_section.size < size_of::<Slot>() as u64 {
+        return Err(LinkError::SlotTableMissing);
+    }
+    let n_slots = (slot_section.size as usize) / size_of::<Slot>();
+    let table_off = slot_section.file_offset as usize;
+    let picked = (0..n_slots)
+        .find(|i| {
+            let off = table_off + i * size_of::<Slot>();
+            let magic =
+                u64::from_le_bytes(macho.data[off..off + 8].try_into().unwrap());
+            let offset = u64::from_le_bytes(macho.data[off + 8..off + 16].try_into().unwrap());
+            let length = u64::from_le_bytes(macho.data[off + 16..off + 24].try_into().unwrap());
+            (magic & 0x00FF_FFFF_FFFF_FFFF) == Slot::MAGIC_BASE && offset == 0 && length == 0
+        })
+        .ok_or(LinkError::NoFreeSlot)?;
+
+    // Slot offsets are measured from the start of the section (the u64
+    // header), so account for the 8-byte header `write_section_with_header`
+    // places before `new_payload`.
+    let mut path_buf = [0u8; 224];
+    path_buf[..virtual_path.len()].copy_from_slice(virtual_path);
+    let dest_off = table_off + picked * size_of::<Slot>();
+    let magic = Slot::MAGIC_BASE | ((picked as u64) << 56);
+    let offset = size_of::<u64>() as u64 + addon_off_in_payload as u64;
+    let hash = bun_wyhash::hash(addon_bytes);
+    macho.data[dest_off..dest_off + 8].copy_from_slice(&magic.to_le_bytes());
+    macho.data[dest_off + 8..dest_off + 16].copy_from_slice(&offset.to_le_bytes());
+    macho.data[dest_off + 16..dest_off + 24].copy_from_slice(&(addon_bytes.len() as u64).to_le_bytes());
+    macho.data[dest_off + 24..dest_off + 32].copy_from_slice(&hash.to_le_bytes());
+    macho.data[dest_off + 32..dest_off + 256].copy_from_slice(&path_buf);
+
+    let mut out: Vec<u8> = Vec::new();
+    macho
+        .build_and_sign(&mut out)
+        .map_err(|_| LinkError::UnsupportedExecutableFormat)?;
+    Ok(out)
+}

--- a/src/standalone_graph/napi_link.rs
+++ b/src/standalone_graph/napi_link.rs
@@ -292,7 +292,9 @@ pub fn link_into_macho(
         return Err(LinkError::NotStandaloneExecutable);
     }
 
-    let existing = &macho.data[bun_section.file_offset as usize..][..bun_section.size as usize];
+    let existing = macho
+        .section_bytes(bun_section)
+        .ok_or(LinkError::NotStandaloneExecutable)?;
     let graph_len = u64::from_le_bytes(existing[0..8].try_into().unwrap());
     if graph_len == 0 {
         return Err(LinkError::NotStandaloneExecutable);
@@ -334,14 +336,15 @@ pub fn link_into_macho(
     if slot_section.size < size_of::<Slot>() as u64 {
         return Err(LinkError::SlotTableMissing);
     }
-    let n_slots = (slot_section.size as usize) / size_of::<Slot>();
-    let table_off = slot_section.file_offset as usize;
-    let picked = (0..n_slots)
-        .find(|i| {
-            let off = table_off + i * size_of::<Slot>();
-            let magic = u64::from_le_bytes(macho.data[off..off + 8].try_into().unwrap());
-            let offset = u64::from_le_bytes(macho.data[off + 8..off + 16].try_into().unwrap());
-            let length = u64::from_le_bytes(macho.data[off + 16..off + 24].try_into().unwrap());
+    let table = macho
+        .section_bytes_mut(slot_section)
+        .ok_or(LinkError::SlotTableMissing)?;
+    let picked = table
+        .chunks_exact(size_of::<Slot>())
+        .position(|raw| {
+            let magic = u64::from_le_bytes(raw[0..8].try_into().unwrap());
+            let offset = u64::from_le_bytes(raw[8..16].try_into().unwrap());
+            let length = u64::from_le_bytes(raw[16..24].try_into().unwrap());
             (magic & 0x00FF_FFFF_FFFF_FFFF) == Slot::MAGIC_BASE && offset == 0 && length == 0
         })
         .ok_or(LinkError::NoFreeSlot)?;
@@ -349,18 +352,16 @@ pub fn link_into_macho(
     // Slot offsets are measured from the start of the section (the u64
     // header), so account for the 8-byte header `write_section_with_header`
     // places before `new_payload`.
-    let mut path_buf = [0u8; 224];
-    path_buf[..virtual_path.len()].copy_from_slice(virtual_path);
-    let dest_off = table_off + picked * size_of::<Slot>();
     let magic = Slot::MAGIC_BASE | ((picked as u64) << 56);
     let offset = size_of::<u64>() as u64 + addon_off_in_payload as u64;
     let hash = bun_wyhash::hash(addon_bytes);
-    macho.data[dest_off..dest_off + 8].copy_from_slice(&magic.to_le_bytes());
-    macho.data[dest_off + 8..dest_off + 16].copy_from_slice(&offset.to_le_bytes());
-    macho.data[dest_off + 16..dest_off + 24]
-        .copy_from_slice(&(addon_bytes.len() as u64).to_le_bytes());
-    macho.data[dest_off + 24..dest_off + 32].copy_from_slice(&hash.to_le_bytes());
-    macho.data[dest_off + 32..dest_off + 256].copy_from_slice(&path_buf);
+    let dest = &mut table[picked * size_of::<Slot>()..][..size_of::<Slot>()];
+    dest[0..8].copy_from_slice(&magic.to_le_bytes());
+    dest[8..16].copy_from_slice(&offset.to_le_bytes());
+    dest[16..24].copy_from_slice(&(addon_bytes.len() as u64).to_le_bytes());
+    dest[24..32].copy_from_slice(&hash.to_le_bytes());
+    dest[32..].fill(0);
+    dest[32..][..virtual_path.len()].copy_from_slice(virtual_path);
 
     let mut out: Vec<u8> = Vec::new();
     macho

--- a/src/standalone_graph/napi_link.rs
+++ b/src/standalone_graph/napi_link.rs
@@ -1,21 +1,11 @@
-//! Stub native-addon loaders for standalone (`bun build --compile`) executables.
-//!
-//! The bun binary carries a small fixed table of "link slots" in its own
-//! section (`__DATA,__bun_napi_lnk` on Mach-O, `.bun_napi_link` on ELF,
-//! `.bnapi` on PE; defined in `c-bindings.cpp`). Each slot is 256 bytes:
-//! `{ magic, offset, length, hash, path[224] }`. A post-build linker can
-//! binary-patch a slot in place and append the `.node` image into the
-//! `__BUN,__bun` / `.bun` section *after* the standalone module graph
-//! payload, without re-running the bundler.
-//!
-//! At runtime, when `process.dlopen` sees a `/$bunfs/...` path, it consults
-//! this table before falling back to the per-launch tmpfile extraction used
-//! for bundler-embedded addons. A matching slot is loaded entirely from
-//! memory: on macOS via `NSCreateObjectFileImageFromMemory` + `NSLinkModule`
-//! (bun never writes a `.node` to disk), on Linux via
-//! `memfd_create(MFD_EXEC)` + `dlopen("/proc/self/fd/N")`. Other platforms
-//! return no handle; they also have no post-link patcher yet, so their slots
-//! can never be populated.
+//! NAPI link slots: a fixed table of stub addon loaders baked into the bun
+//! binary (`BUN_NAPI_LINK_SLOTS` in `c-bindings.cpp`), so a `.node` can be
+//! appended to a `bun build --compile` executable after the fact without
+//! rebundling. The addon image is stored in the `__BUN,__bun` / `.bun`
+//! section past the module-graph payload; the slot records its offset and the
+//! `/$bunfs/` path `process.dlopen` will ask for. Matching slots are loaded
+//! from memory (`NSLinkModule` on macOS, memfd on Linux), never extracted to
+//! disk. Only the Mach-O patcher exists so far.
 
 use core::ffi::c_void;
 use core::mem::size_of;
@@ -23,26 +13,23 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 
 use bun_exe_format::macho::{MachoError, MachoFile};
 
-/// Mirrors `BunNapiLinkSlot` in `c-bindings.cpp`. Keep both at 256 bytes.
+/// Mirrors `BunNapiLinkSlot` in `c-bindings.cpp`.
 #[repr(C)]
 pub struct Slot {
+    /// `MAGIC_BASE | (index << 56)`.
     pub magic: u64,
+    /// From the start of the `.bun` section (its u64 size header); 0 = unused.
     pub offset: u64,
     pub length: u64,
     pub hash: u64,
     pub path: [u8; 224],
 }
 
-const _: () = assert!(
-    size_of::<Slot>() == 256,
-    "BunNapiLinkSlot must be 256 bytes so external patchers can index the table"
-);
+const _: () = assert!(size_of::<Slot>() == 256);
 
 impl Slot {
     pub const COUNT: usize = 8;
-    /// `"bunlink\0"` little-endian — the low 7 bytes are the signature, the
-    /// high byte carries the slot index so patchers can locate slot N by
-    /// scanning for `62 75 6E 6C 69 6E 6B NN`.
+    /// `"bunlink\0"` as a little-endian u64; the high byte holds the index.
     pub const MAGIC_BASE: u64 = 0x006B_6E69_6C6E_7562;
 
     pub fn is_used(&self) -> bool {
@@ -80,25 +67,20 @@ unsafe extern "C" {
 
 pub fn slots() -> &'static [Slot] {
     let count = Bun__getNapiLinkSlotCount() as usize;
-    // SAFETY: the table is a static array of `count` slots in the binary's
-    // own data section; it lives for the process lifetime.
+    // SAFETY: static table in the binary's own data section.
     unsafe { core::slice::from_raw_parts(Bun__getNapiLinkSlots(), count) }
 }
 
-/// Find the slot whose virtual path matches `input_path` exactly.
 pub fn find_slot(input_path: &[u8]) -> Option<&'static Slot> {
     slots()
         .iter()
         .find(|s| s.is_valid() && s.is_used() && s.path_slice() == input_path)
 }
 
-/// Return the embedded `.node` bytes for `slot` as a slice pointing directly
-/// into the mapped `__BUN,__bun` / `.bun` section. The memory lives for the
-/// lifetime of the process.
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
 fn slot_bytes(slot: &Slot) -> Option<&'static [u8]> {
-    // SAFETY: base points at the start of the mapped standalone section; the
-    // patcher wrote `offset`/`length` to describe a range inside it.
+    // SAFETY: `offset`/`length` were written by the patcher to lie inside the
+    // mapped `.bun` section, which lives as long as the process.
     unsafe {
         let base = Bun__getNapiLinkSectionBase();
         if base.is_null() {
@@ -111,17 +93,12 @@ fn slot_bytes(slot: &Slot) -> Option<&'static [u8]> {
     }
 }
 
-/// Cache of already-loaded slots so repeated `require()` of the same virtual
-/// path returns the same module instance (via the `DLHandleMap` replay path
-/// in `Process_functionDlopen`). Entries are written once and never freed —
-/// native addons cannot be unloaded.
+/// Per-slot handle cache; native addons are never unloaded, so a second
+/// `require()` must hand `Process_functionDlopen` the same handle for its
+/// `DLHandleMap` replay.
 static LOADED_HANDLES: [AtomicPtr<c_void>; Slot::COUNT] =
     [const { AtomicPtr::new(core::ptr::null_mut()) }; Slot::COUNT];
 
-/// Load the addon image stored in `slot` and return an opaque handle usable
-/// by `process.dlopen` (an `NSModule` on macOS, a `dlopen()` handle on
-/// Linux). Sets `is_ns_module` on macOS so the caller knows to use
-/// `NSLookupSymbolInModule` instead of `dlsym()`.
 fn load_slot_from_memory(slot: &Slot, is_ns_module: &mut bool) -> *mut c_void {
     *is_ns_module = false;
     let idx = slot.index() as usize;
@@ -146,15 +123,12 @@ fn load_slot_for_platform(slot: &Slot, is_ns_module: &mut bool) -> *mut c_void {
     let Some(bytes) = slot_bytes(slot) else {
         return core::ptr::null_mut();
     };
-    // dyld uses this as the image's install name; keep it stable per slot so
-    // stack traces and `NSNameOfModule` are recognisable.
     let mut name = [0u8; 32];
     use std::io::Write as _;
     let mut c = std::io::Cursor::new(&mut name[..]);
     let _ = write!(c, "bun:napi-slot-{}\0", slot.index());
     *is_ns_module = true;
-    // SAFETY: `bytes` is a live slice into the mapped section; `name` is
-    // NUL-terminated above.
+    // SAFETY: `bytes` is a live slice; `name` is NUL-terminated.
     unsafe { Bun__darwinLoadMachOFromMemory(bytes.as_ptr(), bytes.len(), name.as_ptr().cast()) }
 }
 
@@ -172,7 +146,6 @@ fn load_slot_for_platform(slot: &Slot, _is_ns_module: &mut bool) -> *mut c_void 
     let Ok(fd) = bun_sys::memfd_create(c"bun-napi-link", bun_sys::MemfdFlags::Executable) else {
         return core::ptr::null_mut();
     };
-    // Pre-size so dlopen sees the full extent immediately.
     let _ = bun_sys::ftruncate(fd, bytes.len() as i64);
     let mut remain = bytes;
     while !remain.is_empty() {
@@ -184,38 +157,30 @@ fn load_slot_for_platform(slot: &Slot, _is_ns_module: &mut bool) -> *mut c_void 
             Ok(n) => remain = &remain[n..],
         }
     }
-    // Leave the fd open so /proc/self/fd/N remains valid for dlopen and for
-    // the lifetime of the loaded module.
+    // `fd` is intentionally kept open: `/proc/self/fd/N` must stay valid for
+    // as long as the module is mapped.
     let mut path = [0u8; 48];
     use std::io::Write as _;
     let mut c = std::io::Cursor::new(&mut path[..]);
     let _ = write!(c, "/proc/self/fd/{}", fd.0);
     let len = c.position() as usize;
-    // `path` was zero-initialized, so `path[len] == 0`.
     let zpath = ZStr::from_buf(&path, len);
     bun_sys::dlopen(zpath, bun_sys::RTLD::LAZY).unwrap_or(core::ptr::null_mut())
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
 fn load_slot_for_platform(_slot: &Slot, _is_ns_module: &mut bool) -> *mut c_void {
-    // No in-memory loader here, and no post-link patcher can populate slots
-    // for this executable format yet either. `Process_functionDlopen`
-    // reports ERR_DLOPEN_FAILED for the (currently unreachable) case of a
-    // populated slot.
     core::ptr::null_mut()
 }
 
-/// Called from `Process_functionDlopen` when the target starts with the
-/// `/$bunfs/` prefix. If the path matches a populated slot, loads it from
-/// memory and writes the resulting handle into `out_handle`. Returns true
-/// whether or not the load succeeded — a true return with
-/// `*out_handle == null` means "this path is a link slot but loading
-/// failed", so the caller surfaces a dlopen error instead of falling through
-/// to the module-graph tmpfile extractor (which wouldn't find it either).
+/// Returns whether `path` names a link slot. On `true`, `*out_handle` is the
+/// loaded module or null if loading failed; the caller must not fall back to
+/// the module-graph extractor in either case. `*out_is_ns_module` means the
+/// handle is an `NSModule` (use `NSLookupSymbolInModule`, not `dlsym`).
 ///
 /// # Safety
-/// `path_ptr[..path_len]` must be readable; `out_handle` and
-/// `out_is_ns_module` must be valid for writes.
+/// `path_ptr[..path_len]` must be readable; the out-pointers must be valid
+/// for writes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Bun__tryLoadNapiLinkSlot(
     path_ptr: *const u8,
@@ -223,8 +188,7 @@ pub unsafe extern "C" fn Bun__tryLoadNapiLinkSlot(
     out_handle: *mut *mut c_void,
     out_is_ns_module: *mut bool,
 ) -> bool {
-    // SAFETY: caller (BunProcess.cpp) passes the UTF-8 bytes of the dlopen
-    // target and valid out-pointers.
+    // SAFETY: per the function contract, upheld by BunProcess.cpp.
     unsafe {
         *out_handle = core::ptr::null_mut();
         *out_is_ns_module = false;
@@ -239,18 +203,6 @@ pub unsafe extern "C" fn Bun__tryLoadNapiLinkSlot(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Linker side: rewrite a standalone executable to carry an extra `.node`
-// addon in one of the free slots. We locate the fixed slot table section,
-// stamp a slot, append the addon bytes into the `__BUN,__bun` section (after
-// the existing module-graph payload so `fromExecutable`'s trailer check
-// still lands on the `"\n---- Bun! ----\n"` sentinel), and re-sign.
-//
-// Only Mach-O is wired up for now; ELF and PE need their own
-// section-finders and payload-appenders which can reuse the same slot
-// layout.
-// ---------------------------------------------------------------------------
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LinkError {
     UnsupportedExecutableFormat,
@@ -262,9 +214,9 @@ pub enum LinkError {
 
 const MH_MAGIC_64: u32 = 0xfeedfacf;
 
-/// Append `addon_bytes` (a complete Mach-O `.node` image) to the standalone
-/// executable `exe_bytes` and register it under `virtual_path` in the first
-/// free link slot. Returns a freshly-allocated, re-signed Mach-O image.
+/// Append `addon_bytes` to the `__BUN,__bun` section of a compiled Mach-O
+/// executable, stamp the first free slot with its location and
+/// `virtual_path`, and return the re-signed image.
 pub fn link_into_macho(
     exe_bytes: &[u8],
     addon_bytes: &[u8],
@@ -281,10 +233,6 @@ pub fn link_into_macho(
     let mut macho = MachoFile::init(exe_bytes, addon_bytes.len() + (16 * 1024))
         .map_err(|_| LinkError::UnsupportedExecutableFormat)?;
 
-    // The existing `__BUN,__bun` section starts with a u64 length header
-    // followed by the serialised module graph (ending in the trailer). We
-    // preserve that header value so `StandaloneModuleGraph.fromExecutable`
-    // keeps finding the trailer, and append the addon image after it.
     let bun_section = macho
         .find_section(b"__BUN", b"__bun")
         .ok_or(LinkError::NotStandaloneExecutable)?;
@@ -299,24 +247,18 @@ pub fn link_into_macho(
     if graph_len == 0 {
         return Err(LinkError::NotStandaloneExecutable);
     }
-    // Current payload (without the u64 header) is `graph ++ prior napi
-    // images`. The section's filesize may be padded past the last byte we
-    // care about, but those padding bytes are zero; copying them is harmless
-    // and keeps previously-linked addons intact.
+    // Everything after the size header (module graph plus any previously
+    // linked addons) is carried over verbatim; the new image is appended on a
+    // 16 KiB boundary.
     let prior_payload = &existing[size_of::<u64>()..];
-
-    // Pad so the addon image starts on a 16 KiB boundary within the section —
-    // matches the section alignment and gives the loader a page-aligned
-    // source.
-    let alignment: usize = 16 * 1024;
-    let addon_off_in_payload = prior_payload.len().next_multiple_of(alignment);
+    let addon_off_in_payload = prior_payload.len().next_multiple_of(16 * 1024);
     let mut new_payload = Vec::with_capacity(addon_off_in_payload + addon_bytes.len());
     new_payload.extend_from_slice(prior_payload);
     new_payload.resize(addon_off_in_payload, 0);
     new_payload.extend_from_slice(addon_bytes);
 
-    // Rewrite the section. The header must keep pointing at the module graph
-    // length, not the combined length.
+    // The size header must still describe only the module graph, or the
+    // runtime's trailer check lands on the addon bytes instead.
     macho
         .write_section_with_header(&new_payload, graph_len)
         .map_err(|e| match e {
@@ -324,20 +266,13 @@ pub fn link_into_macho(
             _ => LinkError::UnsupportedExecutableFormat,
         })?;
 
-    // Stamp the first free slot. The slot table is fixed-size inside
-    // `__DATA,__bun_napi_lnk` so this is a straight overwrite that doesn't
-    // shift any load commands — but it must happen *after*
-    // `write_section_with_header` has finished shuffling bytes around, or
-    // we'd be editing stale memory. `__DATA` sits before `__BUN` in the
-    // file, so its offset is unaffected by the shift.
+    // Locate the table only after the section rewrite above has moved things.
     let slot_section = macho
         .find_section(b"__DATA", b"__bun_napi_lnk")
         .ok_or(LinkError::SlotTableMissing)?;
-    if slot_section.size < size_of::<Slot>() as u64 {
-        return Err(LinkError::SlotTableMissing);
-    }
     let table = macho
         .section_bytes_mut(slot_section)
+        .filter(|t| t.len() >= size_of::<Slot>())
         .ok_or(LinkError::SlotTableMissing)?;
     let picked = table
         .chunks_exact(size_of::<Slot>())
@@ -349,9 +284,6 @@ pub fn link_into_macho(
         })
         .ok_or(LinkError::NoFreeSlot)?;
 
-    // Slot offsets are measured from the start of the section (the u64
-    // header), so account for the 8-byte header `write_section_with_header`
-    // places before `new_payload`.
     let magic = Slot::MAGIC_BASE | ((picked as u64) << 56);
     let offset = size_of::<u64>() as u64 + addon_off_in_payload as u64;
     let hash = bun_wyhash::hash(addon_bytes);

--- a/src/standalone_graph/napi_link.rs
+++ b/src/standalone_graph/napi_link.rs
@@ -207,6 +207,7 @@ pub unsafe extern "C" fn Bun__tryLoadNapiLinkSlot(
 pub enum LinkError {
     UnsupportedExecutableFormat,
     NotStandaloneExecutable,
+    ExecutableTooLarge,
     NoFreeSlot,
     PathTooLong,
     SlotTableMissing,
@@ -263,6 +264,7 @@ pub fn link_into_macho(
         .write_section_with_header(&new_payload, graph_len)
         .map_err(|e| match e {
             MachoError::InvalidObject => LinkError::NotStandaloneExecutable,
+            MachoError::ExecutableTooLarge => LinkError::ExecutableTooLarge,
             _ => LinkError::UnsupportedExecutableFormat,
         })?;
 

--- a/test/napi/napi-link-slots.test.ts
+++ b/test/napi/napi-link-slots.test.ts
@@ -1,0 +1,127 @@
+// Stub NAPI link slots: a fixed table baked into the bun binary that lets a
+// `.node` addon be appended to a `bun build --compile` executable *after* the
+// fact, without re-running the bundler. Each slot is 256 bytes
+// ({magic,offset,length,hash,path}) and lives in its own section so an
+// external patcher can find it by name and stamp it in place.
+
+import { spawnSync } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
+import { join } from "path";
+
+const unsafe = Bun.unsafe as any;
+
+test("Bun.unsafe.napiLinkSlots() exposes the stub loader table", () => {
+  expect(typeof unsafe.napiLinkSlots).toBe("function");
+  const slots = unsafe.napiLinkSlots();
+  expect(Array.isArray(slots)).toBe(true);
+  expect(slots.length).toBe(8);
+  for (let i = 0; i < slots.length; i++) {
+    // The running bun binary has never been post-processed, so every slot
+    // should be unused but carry its slot index in the magic.
+    expect(slots[i].index).toBe(i);
+    expect(slots[i].used).toBe(false);
+    expect(slots[i].offset).toBe(0);
+    expect(slots[i].length).toBe(0);
+    expect(slots[i].path).toBe("");
+  }
+});
+
+test("Bun.unsafe.linkNapiModule() validates its inputs", () => {
+  expect(typeof unsafe.linkNapiModule).toBe("function");
+  expect(() => unsafe.linkNapiModule()).toThrow();
+
+  using dir = tempDir("napi-link-validate", {});
+  const base = String(dir);
+  // Valid 64-bit ELF header — enough to fail the Mach-O magic check
+  // deterministically regardless of host.
+  writeFileSync(join(base, "notmacho.bin"), Buffer.from([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+  writeFileSync(join(base, "addon.bin"), Buffer.from([0xcf, 0xfa, 0xed, 0xfe]));
+  expect(() =>
+    unsafe.linkNapiModule(
+      join(base, "notmacho.bin"),
+      join(base, "addon.bin"),
+      "/$bunfs/addon.node",
+      join(base, "out.bin"),
+    ),
+  ).toThrow(/Mach-O/);
+});
+
+// Full round-trip: compile → link → run. Only exercisable on macOS for now
+// because the post-link patcher is implemented against Mach-O; the runtime
+// loader side is cross-platform.
+describe.skipIf(!isMacOS)("linkNapiModule round-trip", () => {
+  let addonPath: string;
+
+  beforeAll(() => {
+    // Reuse the existing napi-app build so we don't need our own toolchain.
+    const build = spawnSync({
+      cmd: [bunExe(), "install"],
+      cwd: join(import.meta.dirname, "napi-app"),
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    if (!build.success) throw new Error("napi-app build failed");
+    addonPath = join(import.meta.dirname, "napi-app/build/Debug/second_addon.node");
+    expect(existsSync(addonPath)).toBe(true);
+  }, 180_000);
+
+  test("appended addon is visible in the slot table and loadable via process.dlopen", async () => {
+    using dir = tempDir("napi-link-roundtrip", {
+      // The virtual path is not known to the bundler — it only exists
+      // after `linkNapiModule` stamps a slot. `process.dlopen` is used so
+      // the bundler does not try to resolve it.
+      "app.js": `
+        const slots = (Bun.unsafe).napiLinkSlots();
+        const used = slots.filter(s => s.used);
+        console.log("slots", used.length, used[0]?.path ?? "");
+        const m = { exports: {} };
+        process.dlopen(m, "/$bunfs/linked.node");
+        console.log("loaded", typeof m.exports.try_unwrap);
+      `,
+    });
+    const cwd = String(dir);
+
+    // 1. Compile the standalone executable with an empty slot table.
+    const compile = spawnSync({
+      cmd: [bunExe(), "build", "--compile", "app.js", "--outfile", "app"],
+      cwd,
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(compile.stderr.toString()).not.toContain("error");
+    expect(compile.success).toBe(true);
+
+    // Before linking, dlopen of the unknown /$bunfs path should fail.
+    {
+      const r = spawnSync({ cmd: [join(cwd, "app")], cwd, env: bunEnv, stderr: "pipe", stdout: "pipe" });
+      expect(r.stdout.toString()).toContain("slots 0");
+      expect(r.exitCode).not.toBe(0);
+    }
+
+    // 2. Link the addon in post-hoc — no rebundle.
+    unsafe.linkNapiModule(join(cwd, "app"), addonPath, "/$bunfs/linked.node", join(cwd, "app-linked"));
+    chmodSync(join(cwd, "app-linked"), 0o755);
+
+    // 3. Run the linked executable. The slot should now report used, and
+    //    the addon's `try_unwrap` export should be reachable. The loader is
+    //    in-memory on macOS (NSCreateObjectFileImageFromMemory) so no
+    //    cache dir is needed.
+    const r = spawnSync({
+      cmd: [join(cwd, "app-linked")],
+      cwd,
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const out = r.stdout.toString();
+    const err = r.stderr.toString();
+    expect(err).toBe("");
+    expect(out).toContain("slots 1 /$bunfs/linked.node");
+    expect(out).toContain("loaded function");
+    expect(r.exitCode).toBe(0);
+  }, 60_000);
+});


### PR DESCRIPTION
Prototype for appending a `.node` addon to a `bun build --compile` executable **after** it's been built, without re-running the bundler. The addon bytes ride inside the existing `__BUN,__bun` section and are loaded from memory at runtime: bun never writes a `.node` to disk.

> **Note:** originally implemented in Zig; rewritten in Rust (`src/standalone_graph/napi_link.rs`) after the Zig-to-Rust migration landed on main. The C++ side (`c-bindings.cpp`, `BunProcess.cpp`) and the test carried over; `MachoFile::find_section` / `write_section_with_header` / `section_bytes[_mut]` were added to the Rust `bun_exe_format` crate, and the `Bun.unsafe` host functions use the `#[bun_jsc::host_fn]` API. The FreeBSD cache-file fallback from the Zig version was dropped (no ELF patcher exists, so slots can never be populated there). Later rebases merged two upstream changes to the same `dlopen` block: the glibc-on-musl check (#15753) is skipped for slot-loaded addons, which have no on-disk path, and the post-`dlopen` tmpfile deletion removed by #29587 is gone from the slot branch as well, so bundler-embedded addons keep #29587's content-hashed shared file.

### What

- **Slot table baked into bun.** A fixed `BunNapiLinkSlot[8]` array (256 B each: `{magic, offset, length, hash, path[224]}`) lives in its own section (`__DATA,__bun_napi_lnk` on Mach-O, `.bun_napi_link` on ELF, `.bnapi` on PE) so an external patcher can find it by section name, or by scanning for the per-slot `"bunlink\0"` magic, and stamp offset/length/hash/path in place without understanding the module-graph serialization.
- **In-memory stub loader.** `process.dlopen("/\$bunfs/...")` consults the slot table before the existing per-launch tmpfile extraction. A hit is loaded from memory:
  - **macOS**: `NSCreateObjectFileImageFromMemory` then `NSLinkModule`. `MH_DYLIB` inputs are flipped to `MH_BUNDLE` (identical load-command layout) since the API only accepts bundles. `Process_functionDlopen` routes symbol lookup through `NSLookupSymbolInModule` instead of `dlsym` when the handle came from here; static-constructor `napi_module_register` still fires during `NSLinkModule` so that path is unchanged.
  - **Linux**: `memfd_create(MFD_EXEC)`, write the slice, `dlopen("/proc/self/fd/N")`. The fd is kept for the process lifetime.
  - **Windows/FreeBSD**: no loader yet; also no patcher for PE/ELF, so slots cannot be populated there today.
  - Handles are memoised per slot; repeated `require()` returns the same module instance via the existing `DLHandleMap`.
- **Mach-O post-link patcher.** `Bun.unsafe.linkNapiModule(exePath, addonPath, virtualPath, outPath)` parses the compiled Mach-O, appends the `.node` image into `__BUN,__bun` *after* the module-graph payload (the u64 size header keeps pointing at the graph length so `StandaloneModuleGraph::from_executable`'s trailer check still lands), stamps the first free slot with `{offset = 8 + aligned(graph_len), length, hash, path}`, and re-signs. `MachoFile` gains `find_section()` and `write_section_with_header()`.
- **Inspection.** `Bun.unsafe.napiLinkSlots()` dumps the running binary's table.

### Example

```ts
// After: bun build --compile app.ts --outfile app
Bun.unsafe.linkNapiModule("./app", "./addon.node", "/$bunfs/linked.node", "./app-linked");

// Inside app.ts:
const m = { exports: {} };
process.dlopen(m, "/$bunfs/linked.node");  // resolves via slot 0, loaded from memory
```

### Verification

- `test/napi/napi-link-slots.test.ts`
  - all platforms: 8 empty slots exposed, `linkNapiModule` rejects non-Mach-O input
  - macOS: full `compile -> linkNapiModule -> run` round-trip using `second_addon.node`; checks the slot shows up as used and `process.dlopen` reaches `napi_register_module_v1`
- `readelf -S` on a compiled binary shows `.bun_napi_link` adjacent to `.bun`; the binary reports 8 unused slots
- `bun run rust:check-all` clean on all targets

### Not done yet

- ELF/PE post-link patchers (runtime slot table and sections exist everywhere; only the Mach-O writer is implemented)
- Auto-populating slots from `bun build --compile` itself (so bundler-embedded `.node` files would also get the in-memory path instead of per-launch tmpfiles)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/napi-link-slots.test.ts

<!-- robobun:evidence:end -->
