### PR TITLE
chore: use standard oxlint disable comment format

### DIFF
--- a/src/js/internal/sql/errors.ts
+++ b/src/js/internal/sql/errors.ts
@@ -25,7 +25,7 @@ export interface PostgresErrorOptions {
   routine?: string | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript/no-unsafe-declaration-merging
 interface PostgresError {
   detail?: string | undefined;
   hint?: string | undefined;
@@ -79,7 +79,7 @@ export interface SQLiteErrorOptions {
   byteOffset?: number | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript/no-unsafe-declaration-merging
 interface SQLiteError {
   byteOffset?: number | undefined;
 }
@@ -106,7 +106,7 @@ export interface MySQLErrorOptions {
   sqlState?: string | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript/no-unsafe-declaration-merging
 interface MySQLError {
   errno?: number | undefined;
   sqlState?: string | undefined;


### PR DESCRIPTION
### What does this PR do?

In the next version of oxlint, we enforce that the disable comment is `plugin-name/rule-name`. These three lines that I have changed don't followin this convention and cause lint failures.

### How did you verify your code works?

I ran oxlint on the codebase.