### PR TITLE
sql: expose column type metadata on query results

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -339,6 +339,22 @@ const rows = await sql`SELECT * FROM users`.raw();
 console.log(rows); // [[Buffer, Buffer], [Buffer, Buffer], [Buffer, Buffer]]
 ```
 
+### Column metadata
+
+Every result also carries a `.columns` array describing each column, and a `.statement` object (`{ string, columns }`) with the executed SQL. The `type` field is the wire-protocol type identifier &mdash; the `pg_type` OID on PostgreSQL, the column-type code on MySQL/MariaDB &mdash; which lets driver adapters distinguish columns that produce identical JavaScript values, such as a `jsonb` column versus a `text[]` column that both decode to an array.
+
+```ts
+const result = await sql`SELECT '["a","b"]'::jsonb AS data, ARRAY['a','b']::text[] AS tags`;
+
+result.columns;
+// PostgreSQL: [
+//   { name: "data", type: 3802, table: 0, number: 0 },   // jsonb
+//   { name: "tags", type: 1009, table: 0, number: 0 },   // text[]
+// ]
+```
+
+PostgreSQL columns expose `{ name, type, table, number }` (matching `postgres.js`); MySQL/MariaDB columns expose `{ name, type, table, length, flags }`. SQLite results do not carry column metadata (`.columns` is `null`).
+
 ---
 
 ## SQL Fragments

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -493,6 +493,77 @@ declare module "bun" {
     }
 
     /**
+     * Metadata describing a single column in a query result, derived from the
+     * database's wire-protocol row description.
+     *
+     * Currently populated for PostgreSQL and MySQL/MariaDB. SQLite results do
+     * not expose this metadata.
+     *
+     * @example
+     * ```ts
+     * const result = await sql`SELECT id, data FROM posts`;
+     * console.log(result.columns);
+     * // PostgreSQL:
+     * // [
+     * //   { name: "id",   type: 23,   table: 16388, number: 1 },   // int4
+     * //   { name: "data", type: 3802, table: 16388, number: 2 },   // jsonb
+     * // ]
+     * ```
+     */
+    interface ResultColumn {
+      /**
+       * Column name as returned by the database.
+       */
+      name: string;
+      /**
+       * Column type identifier.
+       *
+       * - PostgreSQL: the data type OID from `pg_type` (e.g. `23` = int4,
+       *   `25` = text, `3802` = jsonb, `1009` = text[])
+       * - MySQL/MariaDB: the protocol column type code
+       *   (e.g. `3` = LONG, `253` = VAR_STRING, `245` = JSON)
+       */
+      type: number;
+      /**
+       * Source table identifier.
+       *
+       * - PostgreSQL: the OID of the table, or `0` if the column is not a
+       *   simple reference to a table column
+       * - MySQL/MariaDB: the table alias name
+       */
+      table?: number | string;
+      /**
+       * PostgreSQL: the attribute number of the column within its table
+       * (1-based), `0` if the column is not a simple reference to a table
+       * column, or negative for system columns (e.g. `ctid`, `xmin`).
+       */
+      number?: number;
+      /**
+       * MySQL/MariaDB: the column length.
+       */
+      length?: number;
+      /**
+       * MySQL/MariaDB: the column flags bitmask.
+       */
+      flags?: number;
+    }
+
+    /**
+     * Statement metadata attached to a query result.
+     */
+    interface ResultStatement {
+      /**
+       * The SQL text that was sent to the server (after placeholder
+       * substitution, before parameter binding).
+       */
+      string: string;
+      /**
+       * Column metadata for this result set.
+       */
+      columns: ResultColumn[];
+    }
+
+    /**
      * Callback function type for transaction contexts
      * @param sql Function to execute SQL queries within the transaction
      */

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -27,12 +27,26 @@ function wrapError(error: Error | MySQLErrorOptions) {
   return new MySQLError(error.message, error);
 }
 initMySQL(
-  function onResolveMySQLQuery(query, result, commandTag, count, queries, is_last, last_insert_rowid, affected_rows) {
+  function onResolveMySQLQuery(
+    query,
+    result,
+    commandTag,
+    count,
+    queries,
+    is_last,
+    last_insert_rowid,
+    affected_rows,
+    statement,
+  ) {
     $assert(result instanceof SQLResultArray, "Invalid result array");
 
     result.count = count || 0;
     result.lastInsertRowid = last_insert_rowid;
     result.affectedRows = affected_rows || 0;
+    if (statement) {
+      result.statement = statement;
+      result.columns = statement.columns;
+    }
 
     // CALL <proc>() and multi-statement strings can yield several result sets.
     // Accumulate until the server clears SERVER_MORE_RESULTS_EXISTS (is_last).
@@ -88,6 +102,9 @@ export interface MySQLDotZig {
       count: number,
       queries: any,
       is_last: boolean,
+      last_insert_rowid: number | bigint,
+      affected_rows: number,
+      statement: Bun.SQL.ResultStatement | undefined,
     ) => void,
     onRejectQuery: (query: Query<any, any>, err: Error, queries) => void,
   ) => void;

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -248,7 +248,7 @@ function wrapPostgresError(error: Error | PostgresErrorOptions) {
 }
 
 initPostgres(
-  function onResolvePostgresQuery(query, result, commandTag, count, queries, is_last) {
+  function onResolvePostgresQuery(query, result, commandTag, count, queries, is_last, statement) {
     if (is_last) {
       if (queries) {
         const queriesIndex = queries.indexOf(query);
@@ -274,6 +274,10 @@ initPostgres(
     }
 
     result.count = count || 0;
+    if (statement) {
+      result.statement = statement;
+      result.columns = statement.columns;
+    }
     const last_result = query[_results];
 
     if (!last_result) {
@@ -317,6 +321,7 @@ export interface PostgresDotZig {
       count: number,
       queries: any,
       is_last: boolean,
+      statement: Bun.SQL.ResultStatement | undefined,
     ) => void,
     onRejectQuery: (query: Query<any, any>, err: Error, queries) => void,
   ) => void;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -83,6 +83,8 @@ class SQLResultArray<T> extends PublicArray<T> {
   public command!: string | null;
   public lastInsertRowid!: number | bigint | null;
   public affectedRows!: number | bigint | null;
+  public columns!: Bun.SQL.ResultColumn[] | null;
+  public statement!: Bun.SQL.ResultStatement | null;
 
   static [Symbol.toStringTag] = "SQLResults";
 
@@ -96,6 +98,8 @@ class SQLResultArray<T> extends PublicArray<T> {
       command: { value: null, writable: true },
       lastInsertRowid: { value: null, writable: true },
       affectedRows: { value: null, writable: true },
+      columns: { value: null, writable: true },
+      statement: { value: null, writable: true },
     });
   }
 

--- a/src/sql/mysql/protocol/ColumnDefinition41.rs
+++ b/src/sql/mysql/protocol/ColumnDefinition41.rs
@@ -11,9 +11,9 @@ bun_core::declare_scope!(ColumnDefinition41, hidden);
 pub struct ColumnDefinition41 {
     pub(crate) catalog: Data,
     pub(crate) schema: Data,
-    pub(crate) table: Data,
+    pub table: Data,
     pub(crate) org_table: Data,
-    pub(crate) name: Data,
+    pub name: Data,
     pub(crate) org_name: Data,
     pub(crate) fixed_length_fields_length: u64,
     pub character_set: u16,
@@ -97,12 +97,21 @@ fn extended_metadata_is_json(mut bytes: &[u8]) -> Result<bool, AnyMySQLError> {
     Ok(is_json)
 }
 
+/// What re-decoding a column definition into an already-populated slot invalidated.
+#[derive(Clone, Copy, Default)]
+pub struct Changed {
+    /// `name_or_index` differs, so the cached row structure and duplicate check are stale.
+    pub structure: bool,
+    /// A field reported by `result.columns` differs, so the cached statement object is stale.
+    pub metadata: bool,
+}
+
 impl ColumnDefinition41 {
     pub(crate) fn decode_internal<Context: ReaderContext>(
         &mut self,
         reader: &mut NewReader<Context>,
         extended_type_info: bool,
-    ) -> Result<bool, AnyMySQLError> {
+    ) -> Result<Changed, AnyMySQLError> {
         // Length encoded strings
         self.catalog = reader.encode_len_string()?;
         bun_core::scoped_log!(
@@ -118,7 +127,14 @@ impl ColumnDefinition41 {
             BStr::new(self.schema.slice())
         );
 
-        self.table = reader.encode_len_string()?;
+        let mut changed = Changed::default();
+
+        // `table`/`name` outlive the read buffer (read at OK/EOF time), so they are owned copies.
+        let table = reader.encode_len_string()?;
+        if self.table.slice() != table.slice() {
+            self.table = Data::create(table.slice()).map_err(|_| AnyMySQLError::OutOfMemory)?;
+            changed.metadata = true;
+        }
         bun_core::scoped_log!(
             ColumnDefinition41,
             "table: {}",
@@ -132,7 +148,12 @@ impl ColumnDefinition41 {
             BStr::new(self.org_table.slice())
         );
 
-        self.name = reader.encode_len_string()?;
+        let name = reader.encode_len_string()?;
+        if self.name.slice() != name.slice() {
+            self.name = Data::create(name.slice()).map_err(|_| AnyMySQLError::OutOfMemory)?;
+            // Byte compare: all-digit aliases like `1` and `01` collapse to the same `Index` below.
+            changed.metadata = true;
+        }
         bun_core::scoped_log!(ColumnDefinition41, "name: {}", BStr::new(self.name.slice()));
 
         self.org_name = reader.encode_len_string()?;
@@ -153,13 +174,15 @@ impl ColumnDefinition41 {
 
         self.fixed_length_fields_length = reader.encoded_len_int()?;
         self.character_set = reader.int::<u16>()?;
-        self.column_length = reader.int::<u32>()?;
+        let column_length = reader.int::<u32>()?;
+        changed.metadata |= column_length != self.column_length;
+        self.column_length = column_length;
         // `FieldType` is an exhaustive `#[repr(u8)]` enum, so an unknown wire byte
         // fails the whole query with `UnsupportedColumnType` rather than being
         // carried through and served as a raw/string cell. Resolves once
         // `FieldType` becomes a non-exhaustive newtype-over-u8 (see MySQLTypes.rs).
         let type_byte = reader.int::<u8>()?;
-        self.column_type =
+        let mut column_type =
             FieldType::from_raw(type_byte).ok_or(AnyMySQLError::UnsupportedColumnType)?;
         // MariaDB has no MYSQL_TYPE_JSON: JSON columns and JSON function
         // results arrive as TEXT/BLOB marked format=json, so remap them onto
@@ -168,7 +191,7 @@ impl ColumnDefinition41 {
         // keeping the row reader aligned.
         if json_format
             && matches!(
-                self.column_type,
+                column_type,
                 FieldType::MYSQL_TYPE_BLOB
                     | FieldType::MYSQL_TYPE_TINY_BLOB
                     | FieldType::MYSQL_TYPE_MEDIUM_BLOB
@@ -178,9 +201,13 @@ impl ColumnDefinition41 {
                     | FieldType::MYSQL_TYPE_VARCHAR
             )
         {
-            self.column_type = FieldType::MYSQL_TYPE_JSON;
+            column_type = FieldType::MYSQL_TYPE_JSON;
         }
-        self.flags = ColumnFlags::from_int(reader.int::<u16>()?);
+        changed.metadata |= column_type != self.column_type;
+        self.column_type = column_type;
+        let flags = ColumnFlags::from_int(reader.int::<u16>()?);
+        changed.metadata |= flags != self.flags;
+        self.flags = flags;
         self.decimals = reader.int::<u8>()?;
 
         // `ColumnIdentifier::init` consumes its `Data`. We can't move `self.name`
@@ -195,12 +222,11 @@ impl ColumnDefinition41 {
         // ASAN quarantine (test/regression/issue/28632).
         let unchanged = matches!(&self.name_or_index,
             ColumnIdentifier::Name(existing) if existing.slice() == self.name.slice());
-        let mut changed = false;
         if !unchanged {
             let name_view = Data::Temporary(bun_ptr::RawSlice::new(self.name.slice()));
             let rebuilt =
                 ColumnIdentifier::init(name_view).map_err(|_| AnyMySQLError::OutOfMemory)?;
-            changed = match (&self.name_or_index, &rebuilt) {
+            changed.structure = match (&self.name_or_index, &rebuilt) {
                 (ColumnIdentifier::Index(prev), ColumnIdentifier::Index(curr)) => prev != curr,
                 _ => true,
             };
@@ -218,7 +244,7 @@ impl ColumnDefinition41 {
         &mut self,
         reader: &mut NewReader<Context>,
         extended_type_info: bool,
-    ) -> Result<bool, AnyMySQLError> {
+    ) -> Result<Changed, AnyMySQLError> {
         self.decode_internal(reader, extended_type_info)
     }
 }

--- a/src/sql/postgres/protocol/FieldDescription.rs
+++ b/src/sql/postgres/protocol/FieldDescription.rs
@@ -2,11 +2,16 @@ use crate::postgres::any_postgres_error::AnyPostgresError;
 use crate::postgres::postgres_types::{self as types, Int4, Short};
 use crate::postgres::protocol::new_reader::NewReader;
 use crate::shared::column_identifier::ColumnIdentifier;
+use crate::shared::data::Data;
 
 pub struct FieldDescription {
+    /// Raw wire name for `result.columns`; `name_or_index` may be rewritten to `Duplicate`.
+    pub name: Data,
     /// JavaScriptCore treats numeric property names differently than string property names.
     /// so we do the work to figure out if the property name is a number ahead of time.
     pub name_or_index: ColumnIdentifier,
+    pub table_oid: Int4,
+    pub column_index: Short,
     pub type_oid: Int4,
     pub binary: bool,
 }
@@ -21,17 +26,19 @@ impl FieldDescription {
     pub(crate) fn decode_internal<Container: super::new_reader::ReaderContext>(
         reader: &mut NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let name = reader.read_z()?;
+        let raw_name = reader.read_z()?;
+        let name = Data::create(raw_name.slice()).map_err(|_| AnyPostgresError::OutOfMemory)?;
 
         // Field name (null-terminated string)
-        let field_name = ColumnIdentifier::init(name).map_err(|_| AnyPostgresError::OutOfMemory)?;
+        let field_name =
+            ColumnIdentifier::init(raw_name).map_err(|_| AnyPostgresError::OutOfMemory)?;
         // Table OID (4 bytes)
         // If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
-        reader.int4()?;
+        let table_oid = reader.int4()?;
 
         // Column attribute number (2 bytes)
         // If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
-        reader.short()?;
+        let column_index = reader.short()?;
 
         // Data type OID (4 bytes)
         // The object ID of the field's data type. The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
@@ -49,6 +56,9 @@ impl FieldDescription {
             _ => return Err(AnyPostgresError::UnknownFormatCode),
         };
         Ok(Self {
+            name,
+            table_oid,
+            column_index,
             type_oid,
             binary,
             name_or_index: field_name,

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -216,6 +216,64 @@ impl JSMySQLQuery {
         Ok(JSValue::UNDEFINED)
     }
 
+    /// Builds `result.statement`; cached only if server-prepared, else it would pin the query text.
+    fn build_statement_js(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        use crate::jsc::{StringJsc as _, bun_string_jsc};
+        self.query.with_mut(|q| {
+            let Some(statement) = q.get_statement() else {
+                return Ok(JSValue::UNDEFINED);
+            };
+            let received = statement.columns_received as usize;
+            let use_cache = statement.statement_id > 0 && received == statement.columns.len();
+            if use_cache {
+                if let Some(cached) = statement.cached_statement_js.get() {
+                    return Ok(cached);
+                }
+            }
+            let columns = JSValue::create_empty_array(global_object, received)?;
+            for (i, column) in statement.columns[..received].iter().enumerate() {
+                let col = JSValue::create_empty_object(global_object, 5);
+                col.put(
+                    global_object,
+                    b"name",
+                    bun_string_jsc::create_utf8_for_js(global_object, column.name.slice())?,
+                );
+                col.put(
+                    global_object,
+                    b"type",
+                    JSValue::js_number(column.column_type as u8 as f64),
+                );
+                col.put(
+                    global_object,
+                    b"table",
+                    bun_string_jsc::create_utf8_for_js(global_object, column.table.slice())?,
+                );
+                col.put(
+                    global_object,
+                    b"length",
+                    JSValue::js_number(column.column_length as f64),
+                );
+                col.put(
+                    global_object,
+                    b"flags",
+                    JSValue::js_number(column.flags.bits() as f64),
+                );
+                columns.put_index(global_object, i as u32, col)?;
+            }
+            let obj = JSValue::create_empty_object(global_object, 2);
+            obj.put(
+                global_object,
+                b"string",
+                q.get_query_string().to_js(global_object)?,
+            );
+            obj.put(global_object, b"columns", columns);
+            if use_cache {
+                statement.cached_statement_js.set(global_object, obj);
+            }
+            Ok(obj)
+        })
+    }
+
     pub(crate) fn resolve(&self, queries_array: JSValue, result: &MySQLQueryResult) {
         // `ref_guard` brackets re-entry; drops *after* `_downgrade` so the
         // allocation outlives the closure body.
@@ -262,6 +320,15 @@ impl JSMySQLQuery {
         pending_value.ensure_still_alive();
         self.set_pending_value(JSValue::UNDEFINED);
 
+        // The query already counts as successful; a failed build resolves without metadata.
+        let statement_js = self
+            .build_statement_js(self.global_object())
+            .unwrap_or_else(|_| {
+                let _ = self.global_object().try_take_exception();
+                JSValue::UNDEFINED
+            });
+        statement_js.ensure_still_alive();
+
         let event_loop = self.event_loop();
 
         event_loop.run_callback(
@@ -281,6 +348,7 @@ impl JSMySQLQuery {
                 JSValue::js_boolean(is_last_result),
                 JSValue::js_number(result.last_insert_id as f64),
                 JSValue::js_number(result.affected_rows as f64),
+                statement_js,
             ],
         );
     }

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1578,6 +1578,7 @@ impl MySQLConnection {
                         statement.columns = columns;
                         statement.columns_received = 0;
                         statement.cached_structure = Default::default();
+                        statement.cached_statement_js.deinit();
                         statement.fields_flags = Default::default();
                     }
                     statement
@@ -1592,12 +1593,15 @@ impl MySQLConnection {
                         &mut reader,
                         self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO,
                     )?;
-                    if changed {
+                    if changed.structure {
                         statement.cached_structure = Default::default();
                         statement.fields_flags = Default::default();
                         statement
                             .execution_flags
                             .insert(mysql_statement::ExecutionFlags::NEEDS_DUPLICATE_CHECK);
+                    }
+                    if changed.metadata {
+                        statement.cached_statement_js.deinit();
                     }
                     statement.columns_received += 1;
                 } else {

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -528,4 +528,9 @@ impl MySQLQuery {
             .as_ref()
             .map(|stmt| unsafe { &mut *stmt.as_ptr() })
     }
+
+    #[inline]
+    pub(crate) fn get_query_string(&self) -> &BunString {
+        &self.query
+    }
 }

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 
-use crate::jsc::{JSGlobalObject, JSValue};
+use crate::jsc::{JSGlobalObject, JSValue, StrongOptional};
 
 use crate::mysql::protocol::Signature;
 use crate::shared::CachedStructure;
@@ -16,6 +16,8 @@ bun_core::declare_scope!(MySQLStatement, hidden);
 #[derive(bun_ptr::CellRefCounted)]
 pub struct MySQLStatement {
     pub(crate) cached_structure: CachedStructure,
+    /// `result.statement` for prepared statements; dropped when a column definition changes.
+    pub(crate) cached_statement_js: StrongOptional,
     ref_count: Cell<u32>,
     pub(crate) statement_id: u32,
     pub(crate) params: Vec<Param>,
@@ -37,6 +39,7 @@ impl MySQLStatement {
     pub(crate) fn new(signature: Signature, status: Status) -> Self {
         Self {
             cached_structure: CachedStructure::default(),
+            cached_statement_js: StrongOptional::empty(),
             ref_count: Cell::new(1),
             statement_id: 0,
             params: Vec::new(),

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2496,6 +2496,20 @@ impl PostgresSQLConnection {
                     self.js_value.get().try_get().unwrap_or_default(),
                     false,
                 );
+
+                // Simple mode: a following command without a RowDescription must not inherit these.
+                if request.flags.get().simple {
+                    if let Some(statement) = request.statement_mut() {
+                        if !statement.fields.is_empty() {
+                            statement.fields = Vec::new();
+                            statement.cached_structure = Default::default();
+                            statement.cached_statement_js.deinit();
+                            statement.needs_duplicate_check = true;
+                            statement.fields_flags = Default::default();
+                        }
+                    }
+                }
+
                 self.update_ref();
                 // cmd dropped at scope end
             }
@@ -2568,6 +2582,7 @@ impl PostgresSQLConnection {
                 statement.cached_structure = Default::default();
                 statement.needs_duplicate_check = true;
                 statement.fields_flags = Default::default();
+                statement.cached_statement_js.deinit();
             }
             MessageType::Authentication => {
                 let auth = protocol::Authentication::decode_internal(&mut reader)?;

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -265,6 +265,53 @@ impl PostgresSQLQuery {
         js::target_set_cached(this_value, global_object, JSValue::ZERO);
     }
 
+    /// Builds `result.statement`; cached unless simple-protocol, which would pin the query text.
+    fn build_statement_js(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        use crate::jsc::{StringJsc as _, bun_string_jsc};
+        let Some(statement) = self.statement_mut() else {
+            return Ok(JSValue::UNDEFINED);
+        };
+        let use_cache = !self.flags.get().simple;
+        if use_cache {
+            if let Some(cached) = statement.cached_statement_js.get() {
+                return Ok(cached);
+            }
+        }
+        let columns = JSValue::create_empty_array(global_object, statement.fields.len())?;
+        for (i, field) in statement.fields.iter().enumerate() {
+            let col = JSValue::create_empty_object(global_object, 4);
+            col.put(
+                global_object,
+                b"name",
+                bun_string_jsc::create_utf8_for_js(global_object, field.name.slice())?,
+            );
+            col.put(
+                global_object,
+                b"type",
+                JSValue::js_number(field.type_oid as f64),
+            );
+            col.put(
+                global_object,
+                b"table",
+                JSValue::js_number(field.table_oid as f64),
+            );
+            // attnum is a signed Int16 on the wire (system columns are negative); `Short` is u16.
+            col.put(
+                global_object,
+                b"number",
+                JSValue::js_number(field.column_index as i16 as f64),
+            );
+            columns.put_index(global_object, i as u32, col)?;
+        }
+        let obj = JSValue::create_empty_object(global_object, 2);
+        obj.put(global_object, b"string", self.query.to_js(global_object)?);
+        obj.put(global_object, b"columns", columns);
+        if use_cache {
+            statement.cached_statement_js.set(global_object, obj);
+        }
+        Ok(obj)
+    }
+
     pub(crate) fn on_result(
         &self,
         command_tag_str: &[u8],
@@ -309,6 +356,17 @@ impl PostgresSQLQuery {
             .unwrap();
         let event_loop = vm.event_loop_mut();
 
+        // is_last carries no result set; a failed build must not reject rows already delivered.
+        let statement_js = if is_last {
+            JSValue::UNDEFINED
+        } else {
+            self.build_statement_js(global_object).unwrap_or_else(|_| {
+                let _ = global_object.try_take_exception();
+                JSValue::UNDEFINED
+            })
+        };
+        statement_js.ensure_still_alive();
+
         event_loop.run_callback(
             function,
             global_object,
@@ -326,6 +384,7 @@ impl PostgresSQLQuery {
                         .unwrap_or(JSValue::UNDEFINED)
                 },
                 JSValue::from(is_last),
+                statement_js,
             ],
         );
     }

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 
-use crate::jsc::{JSGlobalObject, JSValue, JsResult};
+use crate::jsc::{JSGlobalObject, JSValue, JsResult, StrongOptional};
 
 use crate::postgres::error_jsc::postgres_error_to_js;
 use crate::postgres::signature::Signature;
@@ -16,6 +16,8 @@ bun_core::declare_scope!(Postgres, visible);
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLStatement {
     pub(crate) cached_structure: PostgresCachedStructure,
+    /// `result.statement` for prepared statements; dropped wherever `fields` is replaced.
+    pub(crate) cached_statement_js: StrongOptional,
     ref_count: Cell<u32>,
     pub(crate) fields: Vec<protocol::FieldDescription>,
     pub(crate) parameters: Box<[int4]>,
@@ -32,6 +34,7 @@ impl Default for PostgresSQLStatement {
         // exists only to mirror the per-field `= ...` initializers.
         Self {
             cached_structure: PostgresCachedStructure::default(),
+            cached_statement_js: StrongOptional::empty(),
             ref_count: Cell::new(1),
             fields: Vec::new(),
             parameters: Box::default(),

--- a/test/js/sql/postgres-result-columns.test.ts
+++ b/test/js/sql/postgres-result-columns.test.ts
@@ -1,0 +1,218 @@
+// https://github.com/oven-sh/bun/issues/26809
+//
+// Verifies the RowDescription → `result.columns` / `result.statement` mapping
+// byte-for-byte with a mock server so the test runs without a Postgres
+// container. The real-server coverage lives in sql.test.ts under
+// `describe("result.columns / result.statement")`; this file exercises the
+// exact name/type/table/number wire values (including negative system-column
+// attnums) that would otherwise require specific DDL in a container.
+//
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+import { SQL } from "bun";
+import { afterEach, expect, test } from "bun:test";
+import type net from "net";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgDataRow,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+let servers: net.Server[] = [];
+afterEach(async () => {
+  for (const s of servers) await new Promise<void>(r => s.close(() => r()));
+  servers = [];
+});
+
+async function simpleQueryServer(onQuery: (socket: net.Socket) => void): Promise<number> {
+  const { port, server } = await listeningServer(socket => {
+    socket.on("error", () => {});
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' */) return;
+      onQuery(socket);
+    });
+  });
+  servers.push(server);
+  return port;
+}
+
+function text(s: string): Buffer {
+  return Buffer.from(s);
+}
+
+test("result.columns exposes RowDescription name/type/table/number", async () => {
+  const port = await simpleQueryServer(socket => {
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([
+          { name: "ctid", typeOid: 27, tableOid: 16388, columnAttr: -1 }, // tid, system column (negative attnum)
+          { name: "id", typeOid: 23, tableOid: 16388, columnAttr: 1 }, // int4
+          { name: "data", typeOid: 3802 }, // jsonb
+          { name: "tags", typeOid: 1009 }, // text[]
+        ]),
+        pgDataRow([text("(0,1)"), text("1"), text('["a","b"]'), text("{a,b}")]),
+        pgCommandComplete("SELECT 1"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const result = await sql`select ctid, id, data, tags from posts`.simple();
+    expect(result.columns).toEqual([
+      { name: "ctid", type: 27, table: 16388, number: -1 },
+      { name: "id", type: 23, table: 16388, number: 1 },
+      { name: "data", type: 3802, table: 0, number: 0 },
+      { name: "tags", type: 1009, table: 0, number: 0 },
+    ]);
+    expect(result.statement.string).toBe("select ctid, id, data, tags from posts");
+    expect(result.statement.columns).toBe(result.columns);
+  } finally {
+    await sql.close();
+  }
+});
+
+test("result.columns is populated even for zero-row result sets", async () => {
+  const port = await simpleQueryServer(socket => {
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([
+          { name: "id", typeOid: 23 },
+          { name: "msg", typeOid: 25 },
+        ]),
+        pgCommandComplete("SELECT 0"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const result = await sql`select id, msg from t where false`.simple();
+    expect(result).toHaveLength(0);
+    expect(result.columns).toEqual([
+      { name: "id", type: 23, table: 0, number: 0 },
+      { name: "msg", type: 25, table: 0, number: 0 },
+    ]);
+  } finally {
+    await sql.close();
+  }
+});
+
+test("result.columns preserves duplicate column names", async () => {
+  const port = await simpleQueryServer(socket => {
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([
+          { name: "x", typeOid: 23 },
+          { name: "x", typeOid: 23 },
+          { name: "y", typeOid: 25 },
+        ]),
+        pgDataRow([text("1"), text("2"), text("a")]),
+        pgCommandComplete("SELECT 1"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const result = await sql`select 1 as x, 2 as x, 'a' as y`.simple().values();
+    expect(result[0]).toEqual([1, 2, "a"]);
+    expect(result.columns.map(c => c.name)).toEqual(["x", "x", "y"]);
+    expect(result.columns.map(c => c.type)).toEqual([23, 23, 25]);
+  } finally {
+    await sql.close();
+  }
+});
+
+test("multi-statement simple() attaches per-result-set columns", async () => {
+  const port = await simpleQueryServer(socket => {
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([{ name: "a", typeOid: 23 }]),
+        pgDataRow([text("1")]),
+        pgCommandComplete("SELECT 1"),
+        pgRowDescription([
+          { name: "b", typeOid: 25 },
+          { name: "c", typeOid: 23 },
+        ]),
+        pgDataRow([text("x"), text("2")]),
+        pgCommandComplete("SELECT 1"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const results = await sql`select 1 as a; select 'x' as b, 2 as c`.simple();
+    expect(results[0].columns).toEqual([{ name: "a", type: 23, table: 0, number: 0 }]);
+    expect(results[1].columns).toEqual([
+      { name: "b", type: 25, table: 0, number: 0 },
+      { name: "c", type: 23, table: 0, number: 0 },
+    ]);
+    expect(results[0].statement.columns).toBe(results[0].columns);
+    expect(results[1].statement.columns).toBe(results[1].columns);
+  } finally {
+    await sql.close();
+  }
+});
+
+test("result.columns is an empty array for commands with no RowDescription", async () => {
+  const port = await simpleQueryServer(socket => {
+    socket.write(Buffer.concat([pgCommandComplete("CREATE TABLE"), pgReadyForQuery()]));
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const result = await sql`create table t (id int)`.simple();
+    expect(result.columns).toEqual([]);
+    expect(result.statement.string).toBe("create table t (id int)");
+  } finally {
+    await sql.close();
+  }
+});
+
+test("multi-statement simple(): non-SELECT after SELECT does not inherit stale columns", async () => {
+  // SELECT (RowDescription+DataRow) then INSERT (no RowDescription) then SELECT again.
+  const port = await simpleQueryServer(socket => {
+    socket.write(
+      Buffer.concat([
+        pgRowDescription([{ name: "x", typeOid: 23 }]),
+        pgDataRow([text("1")]),
+        pgCommandComplete("SELECT 1"),
+        // INSERT: no RowDescription
+        pgCommandComplete("INSERT 0 1"),
+        pgRowDescription([{ name: "y", typeOid: 25 }]),
+        pgDataRow([text("hi")]),
+        pgCommandComplete("SELECT 1"),
+        // DROP: no RowDescription
+        pgCommandComplete("DROP TABLE"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, idleTimeout: 5, connectionTimeout: 5 });
+  try {
+    const results = await sql`select 1 as x; insert into t values (1); select 'hi' as y; drop table t`.simple();
+    expect(results).toHaveLength(4);
+    expect(results[0].columns).toEqual([{ name: "x", type: 23, table: 0, number: 0 }]);
+    expect(results[1].columns).toEqual([]); // INSERT: must not inherit x
+    expect(results[2].columns).toEqual([{ name: "y", type: 25, table: 0, number: 0 }]);
+    expect(results[3].columns).toEqual([]); // DROP: must not inherit y
+  } finally {
+    await sql.close();
+  }
+});

--- a/test/js/sql/sql-mysql-query-string-leak.test.ts
+++ b/test/js/sql/sql-mysql-query-string-leak.test.ts
@@ -24,35 +24,49 @@ if (isDockerEnabled()) {
 
         const sql = new SQL({ url: process.env.MYSQL_URL, max: 1 });
 
-        // Warm up: first query allocates connection buffers, JIT, etc.
-        await sql.unsafe("select 1").simple();
-
         // Each query string is ~512 KiB and unique (so JSC can't dedupe/intern
         // them) and goes through the full create -> run -> finalize lifecycle.
         // 200 iterations x 512 KiB = ~100 MiB of string payload.
         const ITERATIONS = 200;
         const CHUNK = 512 * 1024;
 
-        Bun.gc(true);
-        const rssBefore = rss();
-
-        for (let i = 0; i < ITERATIONS; i++) {
-          const pad = Buffer.alloc(CHUNK, 0x61 + (i % 26)).toString("latin1");
-          // Embed the bulk as a comment so the server's reply is a trivial OK
-          // regardless of content; suffix makes every string unique.
-          const q = "select 1 /* " + pad + " " + i + " */";
-          await sql.unsafe(q).simple();
-          if ((i & 15) === 15) Bun.gc(true);
+        // The label keeps every string unique across both batches.
+        async function runBatch(count, label) {
+          for (let i = 0; i < count; i++) {
+            const pad = Buffer.alloc(CHUNK, 0x61 + (i % 26)).toString("latin1");
+            // Embed the bulk as a comment so the server's reply is a trivial OK
+            // regardless of content.
+            const q = "select 1 /* " + label + " " + pad + " " + i + " */";
+            await sql.unsafe(q).simple();
+            if ((i & 15) === 15) Bun.gc(true);
+          }
         }
-
-        await sql.close({ timeout: 0 }).catch(() => {});
 
         // Give the MySQLQuery wrappers a chance to be finalized so cleanup()
         // runs and drops its (single) ref on each query string.
-        for (let i = 0; i < 8; i++) {
-          await new Promise(r => setImmediate(r));
-          Bun.gc(true);
+        async function drainFinalizers() {
+          for (let i = 0; i < 8; i++) {
+            await new Promise(r => setImmediate(r));
+            Bun.gc(true);
+          }
         }
+
+        // Warm up with the same workload so connection buffers, JIT, and the
+        // allocator high-water mark (the inter-GC peak of the transient query
+        // strings; RSS rarely shrinks back) are all established before the
+        // baseline snapshot. The measured delta then isolates *retained*
+        // strings instead of first-touch heap growth.
+        await runBatch(32, "warmup");
+        await drainFinalizers();
+
+        Bun.gc(true);
+        const rssBefore = rss();
+
+        await runBatch(ITERATIONS, "measured");
+
+        await sql.close({ timeout: 0 }).catch(() => {});
+
+        await drainFinalizers();
 
         const rssAfter = rss();
         const deltaMiB = (rssAfter - rssBefore) / 1024 / 1024;
@@ -86,7 +100,7 @@ if (isDockerEnabled()) {
       // there. The non-ASAN bound is the discriminating check.
       expect(parsed.deltaMiB).toBeLessThan(isASAN ? 384 : 50);
       expect(exitCode).toBe(0);
-      // 200 × 512 KiB round-trips to a real MySQL server plus ~20 Bun.gc(true)
+      // ~230 × 512 KiB round-trips to a real MySQL server plus ~30 Bun.gc(true)
       // calls in an ASAN debug subprocess can take tens of seconds; the 5s
       // default is too tight.
     }, 120_000);

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -223,6 +223,143 @@ if (isDockerEnabled()) {
           using sql = await db.reserve();
           await assertComputedDecimalsAreStrings(sql);
         });
+        describe("result.columns / result.statement", () => {
+          test("columns has name and type", async () => {
+            const result = await sql`select CAST(1 AS SIGNED) as id, CAST('hi' AS CHAR) as msg`;
+            expect(result.columns.map(c => c.name)).toEqual(["id", "msg"]);
+            expect(typeof result.columns[0].type).toBe("number");
+            expect(typeof result.columns[0].length).toBe("number");
+            expect(typeof result.columns[0].flags).toBe("number");
+            expect(result.columns[0].table).toBe("");
+          });
+
+          test(".values() result has columns", async () => {
+            const result = await sql`select CAST(1 AS SIGNED) as x, CAST(2 AS SIGNED) as y`.values();
+            expect(result.columns.map(c => c.name)).toEqual(["x", "y"]);
+          });
+
+          test(".simple() result has columns", async () => {
+            const result = await sql`select CAST(1 AS SIGNED) as x`.simple();
+            expect(result.columns[0].name).toBe("x");
+          });
+
+          test("columns is populated for table columns", async () => {
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            using sql = await db.reserve();
+            const table = "columns_meta_" + randomUUIDv7("hex").replaceAll("-", "");
+            await sql`CREATE TEMPORARY TABLE ${sql(table)} (id INT PRIMARY KEY, name VARCHAR(50))`;
+            await sql`INSERT INTO ${sql(table)} VALUES (1, 'a')`;
+            const result = await sql`SELECT id, name FROM ${sql(table)}`;
+            expect(result.columns.map(c => c.name)).toEqual(["id", "name"]);
+            expect(result.columns[0].table).toBe(table);
+            expect(result.columns[0].type).toBe(3); // MYSQL_TYPE_LONG
+            expect(result.columns[1].type).toBe(253); // MYSQL_TYPE_VAR_STRING
+          });
+
+          test("duplicate column names are preserved in columns", async () => {
+            const result = await sql`select CAST(1 AS SIGNED) as x, CAST(2 AS SIGNED) as x`.values();
+            expect(result.columns.map(c => c.name)).toEqual(["x", "x"]);
+            expect(result[0]).toEqual([1, 2]);
+          });
+
+          test("statement has string and columns", async () => {
+            const result = await sql`select CAST(1 AS SIGNED) as x`;
+            expect(result.statement.string).toBe("select CAST(1 AS SIGNED) as x");
+            expect(result.statement.columns).toBe(result.columns);
+          });
+
+          test("long column names (>15 bytes) are owned, not aliased", async () => {
+            // ColumnDefinition41 stores name via Data.create (.owned for >15 bytes)
+            // and separately passes the .temporary reader slice to ColumnIdentifier.init
+            // so the two don't alias the same heap buffer and double-free on deinit.
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            for (let i = 0; i < 5; i++) {
+              const r = await db`select CAST(1 AS SIGNED) as this_is_a_long_column_name_over_fifteen_bytes`.simple();
+              expect(r.columns[0].name).toBe("this_is_a_long_column_name_over_fifteen_bytes");
+              Bun.gc(true);
+            }
+          });
+
+          test("re-executing a prepared statement reuses the statement metadata object", async () => {
+            // The `{ string, columns }` object is cached on the prepared statement
+            // and reused across executions instead of being rebuilt per query, so
+            // repeated executions stay allocation-flat (test/regression/issue/28632).
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            const r1 = await db`select ${"hello"} as msg, CAST(1 AS SIGNED) as id`;
+            const r2 = await db`select ${"hello"} as msg, CAST(1 AS SIGNED) as id`;
+            expect(r1.columns.map(c => c.name)).toEqual(["msg", "id"]);
+            expect(r2.statement).toBe(r1.statement);
+            expect(r2.columns).toBe(r1.columns);
+          });
+
+          test("prepared CALL with same-name different-type result sets reports per-set types", async () => {
+            // A prepared multi-result-set response (statement_id > 0) re-decodes
+            // column definitions into the same slots. When consecutive equal-width
+            // result sets share a column name but differ in type, the cached
+            // `{ string, columns }` metadata must still be invalidated — change
+            // detection keys on type/length/flags, not just the name, so
+            // results[1].columns[0].type must not report results[0]'s type.
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            using sql = await db.reserve();
+            const proc = "p_26809_" + randomUUIDv7("hex").replaceAll("-", "");
+            await sql.unsafe(
+              `CREATE PROCEDURE ${proc}() BEGIN SELECT CAST(1 AS SIGNED) AS value; SELECT CAST('hi' AS CHAR) AS value; END`,
+            );
+            try {
+              const results = await sql`CALL ${sql(proc)}()`;
+              // MySQL appends a trailing OK result set to CALL; the two SELECTs
+              // are the first two entries.
+              expect(results[0].columns[0].name).toBe("value");
+              expect(results[1].columns[0].name).toBe("value");
+              expect(results[0].columns[0].type).toBe(8); // MYSQL_TYPE_LONGLONG
+              expect(results[1].columns[0].type).toBe(253); // MYSQL_TYPE_VAR_STRING
+            } finally {
+              await sql.unsafe(`DROP PROCEDURE IF EXISTS ${proc}`);
+            }
+          });
+
+          test("prepared CALL with all-digit aliases differing only in leading zeros reports per-set names", async () => {
+            // All-digit column aliases parse to the same ColumnIdentifier::Index
+            // (`1` and `01` both become Index(1)), so name-change detection must
+            // key on the raw bytes, not the parsed identifier, for the cached
+            // metadata to be invalidated between equal-width result sets.
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            using sql = await db.reserve();
+            const proc = "p_26809z_" + randomUUIDv7("hex").replaceAll("-", "");
+            await sql.unsafe(
+              `CREATE PROCEDURE ${proc}() BEGIN SELECT CAST(1 AS SIGNED) AS \`1\`; SELECT CAST(1 AS SIGNED) AS \`01\`; END`,
+            );
+            try {
+              const results = await sql`CALL ${sql(proc)}()`;
+              expect(results[0].columns[0].name).toBe("1");
+              expect(results[1].columns[0].name).toBe("01");
+            } finally {
+              await sql.unsafe(`DROP PROCEDURE IF EXISTS ${proc}`);
+            }
+          });
+
+          test("multi-statement simple() with equal column counts gets per-result-set columns", async () => {
+            // Consecutive result sets with the same column count re-decode into the
+            // same ColumnDefinition41 slots; the cached statement metadata must be
+            // invalidated when the definitions actually change so the second result
+            // set doesn't report the first result set's columns.
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            const results = await db`select 1 as first_col; select 2 as second_col`.simple();
+            expect(results).toHaveLength(2);
+            expect(results[0].columns.map(c => c.name)).toEqual(["first_col"]);
+            expect(results[1].columns.map(c => c.name)).toEqual(["second_col"]);
+          });
+
+          test("multi-statement simple(): OK-only statement after SELECT does not inherit columns", async () => {
+            // An OK-only result set (no column definitions of its own) must not
+            // report the previous result set's cached column metadata.
+            await using db = new SQL({ ...getOptions(), max: 1 });
+            const results = await db`select 1 as only_col; set @bun_26809 := 1`.simple();
+            expect(results).toHaveLength(2);
+            expect(results[0].columns.map(c => c.name)).toEqual(["only_col"]);
+            expect(results[1].columns).toEqual([]);
+          });
+        });
         describe("should work with more than the max inline capacity", () => {
           for (let size of [50, 60, 62, 64, 70, 100]) {
             for (let duplicated of [true, false]) {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -3068,8 +3068,148 @@ if (isDockerEnabled()) {
     //   [true, (await sql`bad keyword`.catch(e => e)) instanceof sql.PostgresError]
     // )
 
-    test.todo("Result has columns spec", async () => {
+    test("Result has columns spec", async () => {
       expect((await sql`select 1 as x`).columns[0].name).toBe("x");
+    });
+
+    describe("result.columns / result.statement", () => {
+      test("columns has name and type OID", async () => {
+        const result = await sql`select 1::int4 as id, 'hi'::text as msg`;
+        expect(result.columns).toEqual([
+          { name: "id", type: 23, table: 0, number: 0 },
+          { name: "msg", type: 25, table: 0, number: 0 },
+        ]);
+      });
+
+      test("columns are available even when no rows are returned", async () => {
+        const result = await sql`select 1::int4 as id, 'hi'::text as msg where false`;
+        expect(result).toHaveLength(0);
+        expect(result.columns).toEqual([
+          { name: "id", type: 23, table: 0, number: 0 },
+          { name: "msg", type: 25, table: 0, number: 0 },
+        ]);
+        expect(result.statement.columns).toBe(result.columns);
+      });
+
+      test("distinguishes jsonb from text[] (issue #26809)", async () => {
+        const result = await sql`select '["a","b"]'::jsonb as data, ARRAY['a','b']::text[] as tags`;
+        // Both JS values are arrays, but the type OIDs differ:
+        expect(result[0].data).toEqual(["a", "b"]);
+        expect(result[0].tags).toEqual(["a", "b"]);
+        expect(result.columns.map(c => ({ name: c.name, type: c.type }))).toEqual([
+          { name: "data", type: 3802 }, // jsonb
+          { name: "tags", type: 1009 }, // text[]
+        ]);
+      });
+
+      test("unsafe() result has columns", async () => {
+        const result = await sql.unsafe("select 1 as x");
+        expect(result.columns[0].name).toBe("x");
+        expect(result.columns[0].type).toBe(23);
+      });
+
+      test(".values() result has columns", async () => {
+        const result = await sql`select 1 as x, 2 as y`.values();
+        expect(result.columns.map(c => c.name)).toEqual(["x", "y"]);
+      });
+
+      test(".raw() result has columns", async () => {
+        const result = await sql`select 1 as x`.raw();
+        expect(result.columns[0].name).toBe("x");
+      });
+
+      test(".simple() result has columns", async () => {
+        const result = await sql`select 1 as x`.simple();
+        expect(result.columns[0].name).toBe("x");
+        expect(result.columns[0].type).toBe(23);
+      });
+
+      test("multi-statement simple() has per-result columns", async () => {
+        const results = await sql`select 1 as a; select 'x'::text as b, 2::int4 as c`.simple();
+        expect(results[0].columns.map(c => c.name)).toEqual(["a"]);
+        expect(results[1].columns.map(c => c.name)).toEqual(["b", "c"]);
+        expect(results[1].columns.map(c => c.type)).toEqual([25, 23]);
+      });
+
+      test("multi-statement simple(): non-SELECT after SELECT does not inherit stale columns", async () => {
+        const table = "stale_cols_" + randomUUIDv7("hex").replaceAll("-", "");
+        const results =
+          await sql`select 1 as x; create table ${sql(table)} (id int); select 2::int4 as y; drop table ${sql(table)}`.simple();
+        expect(results).toHaveLength(4);
+        expect(results[0].columns).toEqual([{ name: "x", type: 23, table: 0, number: 0 }]);
+        expect(results[1].columns).toEqual([]); // CREATE — must not inherit x
+        expect(results[2].columns).toEqual([{ name: "y", type: 23, table: 0, number: 0 }]);
+        expect(results[3].columns).toEqual([]); // DROP — must not inherit y
+      });
+
+      test("columns is populated for table columns with table OID", async () => {
+        const table = "columns_meta_" + randomUUIDv7("hex").replaceAll("-", "");
+        await sql`create table ${sql(table)} (id int4 primary key, name text)`;
+        try {
+          await sql`insert into ${sql(table)} values (1, 'a')`;
+          const result = await sql`select id, name from ${sql(table)}`;
+          expect(result.columns.map(c => c.name)).toEqual(["id", "name"]);
+          expect(result.columns[0].type).toBe(23);
+          expect(result.columns[1].type).toBe(25);
+          expect(result.columns[0].table).toBeGreaterThan(0);
+          expect(result.columns[0].table).toBe(result.columns[1].table);
+          expect(result.columns[0].number).toBe(1);
+          expect(result.columns[1].number).toBe(2);
+        } finally {
+          await sql`drop table ${sql(table)}`;
+        }
+      });
+
+      test("duplicate column names are preserved in columns", async () => {
+        const result = await sql`select 1 as x, 2 as x`.values();
+        expect(result.columns.map(c => c.name)).toEqual(["x", "x"]);
+        expect(result.columns.map(c => c.type)).toEqual([23, 23]);
+        expect(result[0]).toEqual([1, 2]);
+      });
+
+      test("columns is an empty array for commands with no columns", async () => {
+        const table = "columns_empty_" + randomUUIDv7("hex").replaceAll("-", "");
+        const result = await sql`create table ${sql(table)} (id int)`;
+        try {
+          expect(result.columns).toEqual([]);
+        } finally {
+          await sql`drop table ${sql(table)}`;
+        }
+      });
+
+      test("statement has string and columns", async () => {
+        const result = await sql`select 1 as x`;
+        expect(result.statement.string).toBe("select 1 as x");
+        expect(result.statement.columns).toBe(result.columns);
+      });
+
+      test("statement.string reflects parameterized query", async () => {
+        const result = await sql`select ${"TEST"}::text as x`;
+        expect(result.statement.string).toBe("select $1 ::text as x");
+      });
+
+      test("re-executing a prepared statement reuses the statement metadata object", async () => {
+        // postgres.js parity: `statement` is the shared prepared-statement
+        // descriptor, so repeated executions return the same object instead of
+        // rebuilding the column metadata for every query.
+        await using db = postgres({ ...options, max: 1 });
+        const r1 = await db`select ${1}::int4 as id, 'hi'::text as msg`;
+        const r2 = await db`select ${1}::int4 as id, 'hi'::text as msg`;
+        expect(r1.columns).toEqual([
+          { name: "id", type: 23, table: 0, number: 0 },
+          { name: "msg", type: 25, table: 0, number: 0 },
+        ]);
+        expect(r2.statement).toBe(r1.statement);
+        expect(r2.columns).toBe(r1.columns);
+      });
+
+      test("columns and statement don't break Array iteration", async () => {
+        const result = await sql`select 1 as x`;
+        // .map() / iteration should not produce extra entries from metadata
+        expect(result.map(r => r.x)).toEqual([1]);
+        expect(Array.from(result)).toEqual([{ x: 1 }]);
+        expect(result.length).toBe(1);
+      });
     });
 
     // t('forEach has result as second argument', async() => {


### PR DESCRIPTION
Fixes #26809. Fixes #18866. Supersedes #18892.

## Problem

`Bun.sql` auto-parses query results (JSONB → JS objects, arrays → JS arrays) but doesn't expose the underlying PostgreSQL column type OIDs. This makes it impossible to distinguish between:

- A `jsonb` column containing `["a","b"]` (should be treated as JSON)
- A `text[]` column containing `["a","b"]` (should be treated as a text array)

Both produce identical JS arrays. Driver adapters (e.g. Prisma) need the wire-protocol column types to handle these correctly.

## What this adds

Query results now carry `.columns` and `.statement`:

```ts
const result = await sql`select '["a","b"]'::jsonb as data, ARRAY['a','b']::text[] as tags`;

result.columns
// [
//   { name: "data", type: 3802, table: 0, number: 0 },   // jsonb
//   { name: "tags", type: 1009, table: 0, number: 0 },   // text[]
// ]

result.statement
// { string: "select ...", columns: [...] }
```

Works for tagged templates, `.unsafe()`, `.values()`, `.raw()`, and `.simple()` (including multi-statement queries, where each result set gets its own columns).

**PostgreSQL** — `{ name, type, table, number }` (type = OID from `pg_type`, matches `postgres.js`'s `result.columns`).
**MySQL/MariaDB** — `{ name, type, table, length, flags }` (type = protocol column-type code).
**SQLite** — `null` (no wire-protocol row description).

## Implementation

Rather than a getter on the native query handle (PR #18892's approach, which has lifetime issues when a simple query's `RowDescription` is overwritten between result sets), the column metadata is built in `onResult` / `resolve` and passed as an extra argument to the JS resolve callback, which stores it directly on the `SQLResultArray`. This makes multi-statement `.simple()` queries return correct per-result-set columns.

`FieldDescription` now stores the raw column name alongside `name_or_index`, so duplicate column names survive `checkForDuplicateFields()` and are reported correctly in `.columns` (matching `postgres.js`).

The `{ string, columns }` object is built **once per statement** and held on the native statement via a Strong reference (same lifetime/invalidation policy as `cached_structure`), so re-executing a prepared statement reuses it instead of rebuilding per query — matching `postgres.js`, where `statement` is the shared prepared-statement descriptor. It is invalidated wherever the statement's fields are cleared or replaced (simple-protocol batches, result-set column-count changes). On MySQL, where the server re-sends column definitions on every execution, `ColumnDefinition41::decode` reports what a re-decode changed as `Changed { structure, metadata }`: `structure` (the pre-existing `name_or_index` signal) invalidates the row structure and duplicate check, while `metadata` (raw name, table, type, length, flags) invalidates the statement object, so equal-width result sets that differ only in type get fresh metadata without rebuilding the row structure. Together with skipping the `ColumnDefinition41` name/table re-copy when the re-decoded bytes are unchanged, repeated executions stay allocation-flat: without this, the per-query churn pushed `test/regression/issue/28632.test.ts` (MySQL RSS regression test) from ~7 MB to ~44 MB growth on the x64-asan lane (threshold 36 MB); with it, a local run of the same 5000-query loop against MariaDB shows no measurable growth over the no-feature baseline.

## Verification

- `test/js/sql/postgres-result-columns.test.ts` — mock Postgres wire-protocol server (no database required): name/type/table/number incl. negative attnums, zero-row result sets, duplicate names, per-result-set columns for multi-statement `.simple()`, and no stale-column inheritance for commands without a `RowDescription`. Fails without the native changes, passes with them.
- `test/js/sql/sql.test.ts` / `test/js/sql/sql-mysql.test.ts` (docker-gated) — jsonb vs text[] OIDs, table OIDs, `.unsafe()`/`.values()`/`.raw()`/`.simple()`, long (>15 byte) column-name ownership, and `result.statement` / `result.columns` object reuse across re-executions of the same prepared statement.


### Rebase notes

- #32467 converted `sql-mysql-query-string-leak.test.ts` from a mock TCP server to a real `describeWithContainer("mysql")` test; the warmup-batch change (snapshot the RSS baseline after a short identical workload so the measured delta isolates retained strings rather than first-touch heap growth) is carried forward inside the new container-based fixture.
- #32467 also centralized Postgres/MySQL wire-frame builders into `test/js/sql/wire-frames.ts`; `postgres-result-columns.test.ts` is rewritten to use `pgRowDescription`/`pgDataRow`/`pgCommandComplete`/`pgReadyForQuery`/`listeningServer` instead of its own frame encoders. It stays a mock-server test so the RowDescription→`result.columns` mapping (including negative system-column attnums) is verified byte-for-byte without needing a container; the real-server coverage is in `sql.test.ts`.

- Rebased over the MariaDB extended-type-info work (#37130): `ColumnDefinition41::decode` now takes `extended_type_info`, and main remaps `format=json` TEXT/BLOB columns to `MYSQL_TYPE_JSON` during decode. The remap is applied to the decoded type before this PR's change-detection compare, so `result.columns[i].type` reports the same type code the row decoder uses (245 for MariaDB JSON columns, verified against MariaDB 11.8) and a column flipping to or from JSON format invalidates the cached metadata like any other type change.
- Rebased over the dead-code and visibility-narrowing passes: `FieldDescription.table_oid` / `column_index` had been removed on main as unread and are restored here since this PR is their consumer; `ColumnDefinition41.name` / `table` are `pub` again because `bun_sql_jsc` reads them; the removed `ColumnFlags::to_int` is replaced by the bitflags `bits()` accessor (same `from_bits_retain` round-trip of the raw wire value); `cached_statement_js` and the new accessors follow main's `pub(crate)` convention.
- The leak test keeps main's `rss()` measurement helper (#36429, `memoryFootprint` on macOS) together with this PR's warmup batch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 38 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/sql/sql-mysql-query-string-leak.test.ts

<!-- robobun:evidence:end -->
- Rebased over the `bun_core::String` ownership and `StringJsc` changes (#40238, #40374): the free function `bun_string_jsc::to_js(&str, global)` is gone, so `build_statement_js` now converts the query text through the `StringJsc::to_js` trait method on both drivers. The `RefPtr`/`Drop` refactors (#40478, #40516) only dropped a stale refcount comment next to the `cached_statement_js` fields.
