### PR TITLE
BroadcastChannel: don't hold cross-thread strong refs in registry post()

### DIFF
--- a/src/bun.js/bindings/webcore/BunBroadcastChannelRegistry.cpp
+++ b/src/bun.js/bindings/webcore/BunBroadcastChannelRegistry.cpp
@@ -36,13 +36,21 @@ void BunBroadcastChannelRegistry::unsubscribe(const String& name, BroadcastChann
 
 void BunBroadcastChannelRegistry::post(const String& name, BroadcastChannel& source, Ref<SerializedScriptValue>&& message)
 {
-    // Resolve subscribers to strong refs under the lock, then fan out
-    // without holding it — postTaskTo takes the contexts-map lock and we
-    // don't want to nest. Collecting straight into strong refs (rather
-    // than copying the Subscriber vector and its ThreadSafeWeakPtrs) keeps
-    // this to one CAS per target; inline capacity covers the common small
-    // subscriber count without a heap allocation.
-    Vector<std::pair<ScriptExecutionContextIdentifier, Ref<BroadcastChannel>>, 4> targets;
+    // Snapshot subscribers under the lock as (ctxId, weak) pairs, then fan
+    // out without holding it — postTaskTo takes the contexts-map lock and we
+    // don't want to nest.
+    //
+    // We deliberately do NOT take strong Refs on this thread.
+    // BroadcastChannel owns thread-affine state (EventTarget's
+    // EventListenerMap, the m_name String, ContextDestructionObserver
+    // registration), so if a foreign-thread Ref turns out to be the last one
+    // — which happens when a Worker is terminated while we're mid-post —
+    // ~BroadcastChannel runs here and EventListenerMap::clear() asserts on
+    // the thread mismatch. Instead, bump the queued-message count via the raw
+    // identity pointer: unsubscribe() takes this same lock, so any channel
+    // still in the list cannot be past close() in its destructor and the
+    // pointer is valid for the duration of the locked section.
+    Vector<std::pair<ScriptExecutionContextIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>, 4> targets;
     {
         Locker locker { m_lock };
         auto it = m_subscribers.find(name);
@@ -55,25 +63,28 @@ void BunBroadcastChannelRegistry::post(const String& name, BroadcastChannel& sou
         for (auto& sub : it->value) {
             if (sub.identity == &source)
                 continue;
-            if (RefPtr channel = sub.channel.get())
-                targets.append({ sub.ctxId, channel.releaseNonNull() });
+            sub.identity->m_state.fetch_add(BroadcastChannel::QueuedOne, std::memory_order_acq_rel);
+            targets.append({ sub.ctxId, sub.channel });
         }
     }
 
     // One task per (message, subscriber), queued in subscription order.
     // Same-context subscribers share a task queue, so this preserves the
-    // spec-mandated (message-major, creation-minor) delivery order.
-    for (auto& [ctxId, channel] : targets) {
-        // Keep the channel alive for GC until the task runs.
-        channel->m_state.fetch_add(BroadcastChannel::QueuedOne, std::memory_order_acq_rel);
-        bool posted = ScriptExecutionContext::postTaskTo(ctxId, [channel = channel.copyRef(), message = message.copyRef()](ScriptExecutionContext&) mutable {
-            channel->dispatchMessage(WTF::move(message));
+    // spec-mandated (message-major, creation-minor) delivery order. The task
+    // upgrades the weak ref on the channel's own context thread, so the
+    // resulting strong ref is created and dropped where ~BroadcastChannel is
+    // allowed to run.
+    for (auto& [ctxId, weak] : targets) {
+        ScriptExecutionContext::postTaskTo(ctxId, [weak = WTF::move(weak), message = message.copyRef()](ScriptExecutionContext&) mutable {
+            if (RefPtr channel = weak.get())
+                channel->dispatchMessage(WTF::move(message));
         });
-        if (!posted) {
-            // Context is already gone; balance the count so a subsequent
-            // close() doesn't leave the channel looking busy forever.
-            channel->m_state.fetch_sub(BroadcastChannel::QueuedOne, std::memory_order_acq_rel);
-        }
+        // If postTaskTo returned false the context has been removed from the
+        // map; ~ScriptExecutionContext will fire contextDestroyed() which
+        // sets Closed, after which hasPendingActivity() ignores the queued
+        // count, so the unbalanced fetch_add above is harmless. If the
+        // channel is already gone (refcount hit zero while we held the lock),
+        // the weak upgrade fails and the message is dropped.
     }
 }
 


### PR DESCRIPTION
## Symptom

`broadcast-channel-worker-gc.test.ts` → "repeated worker create/terminate stress" core-dumps on alpine-aarch64 (1/20 shards, build 49676):

```
#4  EventListenerMap::releaseAssertOrSetThreadUID   ← RELEASE_ASSERT
#5  EventListenerMap::clear
#7  EventTarget::~EventTarget
#10 ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<BroadcastChannel>::deref
#12 Ref<BroadcastChannel>::~Ref
#13 std::pair<unsigned, Ref<BroadcastChannel>>::~pair
#15 Vector<pair<...>, 4>::~Vector
#16 BunBroadcastChannelRegistry::post           (line 78, end of scope)
#17 BroadcastChannel::postMessage
```

## Mechanism

```
main thread                              worker thread
───────────                              ─────────────
bc.postMessage()
  registry.post():
    lock; for each sub:
      Ref r = sub.weak.get()  ──────┐
      targets.append({ctx, r})      │    worker.terminate()
    unlock                          │      JS wrapper swept
                                    │      └─ BroadcastChannel deref (n→1)
    for (...) postTaskTo(ctx, ...)  │
                                    │
  ~Vector targets                   │
    ~pair → ~Ref → deref (1→0) ◄────┘
      ~BroadcastChannel  ← on MAIN thread
        ~EventTarget
          EventListenerMap::clear()
            releaseAssertOrSetThreadUID()  ← m_threadUID == worker, current == main
```

`BroadcastChannel` is `ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<..., DestructionThread::Any>`, but it owns thread-affine state (`EventListenerMap`, `m_name` String, `ContextDestructionObserver`). #29937 introduced the `Ref<BroadcastChannel>` snapshot in `post()`; before that, the registry bounced through the main thread and never held foreign-thread strong refs. musl mutex timing + aarch64 weak ordering widen the window between the worker dropping its ref and `post()` releasing the snapshot — same shape as the PathWatcher `deinit_claimed` race.

The same crash also fires when `postTaskTo` returns false (context gone): the lambda's captured `channel.copyRef()` is destroyed on the posting thread.

## Fix

Snapshot `(ctxId, ThreadSafeWeakPtr)` instead of strong refs. Bump `m_state`'s queued count via the raw `sub.identity` pointer **under the registry lock** — safe because `unsubscribe()` (the only path off the list) takes the same lock, so any channel still in the list cannot be past `close()` in its destructor. The cross-thread task upgrades the weak ref on the **target** thread, so the resulting strong ref is created and dropped where `~BroadcastChannel` is allowed to run.

When `postTaskTo` fails the context is gone; `contextDestroyed()` sets `Closed` and `hasPendingActivity()` ignores the queued count thereafter, so the unbalanced `fetch_add` is harmless.

## Tests

- `broadcast-channel-worker-gc.test.ts` 20× local: 20/20 pass (3 pass / 0 fail each)
- Full `test/js/web/broadcastchannel/`: 14 pass / 0 fail
- `test/js/web/workers/`: 245 pass / 5 fail — same 5 timeouts on main without this change (pre-existing, unrelated)

Neither #29895 (MessagePortPipe drain) nor #29920 (MessagePort jsRef leak) touch this path.