### PR TITLE
fix(console): don't iterate WeakMap/WeakSet when formatting

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2757,14 +2757,17 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakMap;
+                const length = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = if (is_weak) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2867,17 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
-                const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                const length = try length_value.coerce(i32, this.globalThis);
+                const is_weak = value.jsType() == .WeakSet;
+                const length = if (is_weak) 0 else length: {
+                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                    break :length try length_value.coerce(i32, this.globalThis);
+                };
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = if (is_weak) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1307,14 +1307,17 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakMap;
+                    const length = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const map_name = if (is_weak) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,8 +1338,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
-                    const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
-                    const length = length_value.toInt32();
+                    const is_weak = value.jsType() == .WeakSet;
+                    const length = if (is_weak) 0 else length: {
+                        const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
+                        break :length length_value.toInt32();
+                    };
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
@@ -1344,7 +1350,7 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const set_name = if (is_weak) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,15 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+it("WeakMap/WeakSet with own size property does not throw", () => {
+  const wm = new WeakMap();
+  wm.size = 2;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  expect(() => expect(wm).toMatchObject([1, 2])).toThrow();
+
+  const ws = new WeakSet();
+  ws.size = 2;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  expect(() => expect(ws).toMatchObject([1, 2])).toThrow();
+});


### PR DESCRIPTION
## What does this PR do?

`WeakMap` and `WeakSet` are not iterable. The console and jest pretty formatters relied on the `"size"` property being absent (coercing to 0) to skip iteration for these types. If a user assigns an own `size` property:

```js
const wm = new WeakMap();
wm.size = 2;
Bun.inspect(wm); // TypeError: Type error
```

the formatter would attempt `forEachInIterable` on a non-iterable value and throw. In `expect().toMatchObject()` this exception was caught on the Zig side via `catch {}` while remaining pending in JSC, later tripping an `ExceptionScope::assertNoExceptionExceptTermination()` assertion in debug builds.

Fix: skip the `"size"` lookup entirely for `WeakMap`/`WeakSet` since we can never iterate their contents anyway, matching the existing `WeakMap {}` / `WeakSet {}` output.

## How did you verify your code works?

Added a regression test in `test/js/bun/util/inspect.test.js` that fails on the release build and passes with this change. Existing inspect and snapshot tests continue to pass.