### PR TITLE
Detect circular references when inspecting JSX elements

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,38 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+
+  const el2 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "span",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el2.props.foo = el2;
+  expect(Bun.inspect(el2)).toBe("<span foo=[Circular] />");
+
+  const el3 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "p",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el3.props.children = el3;
+  expect(Bun.inspect(el3)).toBe("<p>\n  [Circular]\n</p>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
`Bun.inspect()` crashes with a segfault when formatting a React element that contains a circular reference back to itself via `key`, a prop value, or `children`.

The `.JSX` format tag was not included in `canHaveCircularReferences()`, so the formatter recursed into the element without the stack-safety check or the visited-object map that normally prints `[Circular]`.

### Repro
```js
const el = {
  $$typeof: Symbol.for("react.element"),
  type: "div",
  key: null,
  ref: null,
  props: {},
};
el.key = el;
Bun.inspect(el); // segfault
```

### After
```
<div key=[Circular] />
```

Found by Fuzzilli (fingerprint `bb8715595a137556`).