### PR TITLE
sqlite: fix off-by-one database handle bounds checks

### DIFF
--- a/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/bun.js/bindings/sqlite/JSSQLStatement.cpp
@@ -1364,7 +1364,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     }
 
     int32_t handle = callFrame->argument(0).toInt32(lexicalGlobalObject);
-    if (databases().size() < handle) {
+    if (handle < 0 || handle >= databases().size()) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
         return {};
     }
@@ -1513,7 +1513,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementIsInTransactionFunction, (JSC::JSGlobalOb
 
     int32_t handle = dbNumber.toInt32(lexicalGlobalObject);
 
-    if (handle < 0 || handle > databases().size()) {
+    if (handle < 0 || handle >= databases().size()) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Invalid database handle"_s));
         return {};
     }
@@ -1552,7 +1552,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
     }
 
     int32_t handle = dbNumber.toInt32(lexicalGlobalObject);
-    if (handle < 0 || handle > databases().size()) {
+    if (handle < 0 || handle >= databases().size()) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Invalid database handle"_s));
         return {};
     }

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1494,3 +1494,53 @@ it("#13082", async () => {
 
   await Promise.allSettled(runs);
 });
+
+// The internal SQL.run / SQL.prepare / SQL.isInTransaction helpers used to
+// perform an off-by-one bounds check on the database handle (`>` instead of
+// `>=`), so a handle equal to databases().size() skipped the early-return and
+// indexed past the end of the WTF::Vector, crashing the process instead of
+// throwing a catchable error.
+it("internal SQL helpers reject out-of-range database handles", async () => {
+  const src = `
+    const { SQL } = require("bun:internal-for-testing");
+    const ctor = SQL[0];
+    const tuple = SQL[1];
+
+    // No databases have been opened, so databases().size() === 0 and handle 0
+    // is out of range. Each call must throw "Invalid database handle" rather
+    // than fall through to databases()[0] and crash.
+    const results = [];
+    for (const [name, fn] of [
+      ["isInTransaction", () => ctor.isInTransaction(0)],
+      ["prepare", () => ctor.prepare(0, "SELECT 1", undefined, 0, 0)],
+      ["run", () => ctor.run(0, 0, tuple, "SELECT 1")],
+    ]) {
+      try {
+        fn();
+        results.push(name + ": no throw");
+      } catch (e) {
+        results.push(name + ": " + e.message);
+      }
+    }
+    console.log(JSON.stringify(results));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify([
+      "isInTransaction: Invalid database handle",
+      "prepare: Invalid database handle",
+      "run: Invalid database handle",
+    ]),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
## Problem

Three internal `bun:sqlite` host functions validate the JS-supplied database handle with an off-by-one comparison, so a handle equal to `databases().size()` passes the check and indexes one past the end of the `WTF::Vector`:

- `jsSQLStatementExecuteFunction` (`SQL.run`): `if (databases().size() < handle)`
- `jsSQLStatementIsInTransactionFunction` (`SQL.isInTransaction`): `if (handle < 0 || handle > databases().size())`
- `jsSQLStatementPrepareStatementFunction` (`SQL.prepare`): `if (handle < 0 || handle > databases().size())`

`WTF::Vector::operator[]` uses the default `CrashOnOverflow` handler, so the out-of-range access hard-crashes the process (`SIGABRT`) rather than throwing a catchable JS error. The other five call sites in the file already use the correct `>=` form.

## Repro

With no databases open (`databases().size() == 0`), calling the internal constructor's `isInTransaction(0)` / `prepare(0, …)` / `run(0, …)` aborts:

```
$ bun -e 'const { SQL } = require("bun:internal-for-testing"); SQL[0].isInTransaction(0)'
Aborted (core dumped)   # exit 134
```

The public `bun:sqlite` wrapper keeps the handle behind a `#private` field so this is not reachable from the documented API, but the native bounds check should still be correct.

## Fix

Change all three to `handle < 0 || handle >= databases().size()` to match the existing correct call sites.

## Verification

New test in `test/js/bun/sqlite/sqlite.test.js` spawns a subprocess that calls each helper with an out-of-range handle and asserts all three throw `"Invalid database handle"` instead of crashing.

- Without fix: subprocess aborts (exit 134), test fails
- With fix: test passes
- Rest of `sqlite.test.js` passes