### PR TITLE
bun:ffi: destroy FFICallbackFunctionWrapper when JSCallback compilation fails

### DIFF
--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -1608,6 +1608,12 @@ pub const FFI = struct {
             var source_code = std.array_list.Managed(u8).init(this.allocator);
             var source_code_writer = source_code.writer();
             const ffi_wrapper = Bun__createFFICallbackFunction(js_context, js_function);
+            // The wrapper holds JSC::Strong references to the callback and global object.
+            // If we fail to compile for any reason, ownership never transfers to
+            // `step.compiled` and we must destroy it here to avoid leaking those roots.
+            defer if (this.step != .compiled) {
+                FFICallbackFunctionWrapper_destroy(ffi_wrapper);
+            };
             try this.printCallbackSourceCode(js_context, ffi_wrapper, &source_code_writer);
 
             if (comptime Environment.isDebug and Environment.isPosix) {

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -861,7 +861,10 @@ pub const FFI = struct {
         func.base_name = "";
         js_callback.ensureStillAlive();
 
-        func.compileCallback(globalThis, js_callback, func.threadsafe) catch return ZigString.init("Out of memory").toErrorInstance(globalThis);
+        func.compileCallback(globalThis, js_callback, func.threadsafe) catch {
+            func.deinit(globalThis);
+            return ZigString.init("Out of memory").toErrorInstance(globalThis);
+        };
         switch (func.step) {
             .failed => |err| {
                 const message = ZigString.init(err.msg).toErrorInstance(globalThis);

--- a/test/js/bun/ffi/jscallback-compile-failure-leak.test.ts
+++ b/test/js/bun/ffi/jscallback-compile-failure-leak.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isArm64, isWindows } from "harness";
+
+// TinyCC (and all of bun:ffi) is disabled on Windows ARM64
+const isFFIUnavailable = isWindows && isArm64;
+
+// compileCallback() allocates an FFICallbackFunctionWrapper (which holds
+// JSC::Strong refs to the callback function and the global object) before
+// attempting to compile the generated C stub. If compilation fails for any
+// reason, the wrapper used to be leaked because it was only stored on the
+// Function when step == .compiled — permanently rooting the user's callback.
+//
+// This test triggers a known failure path (using "buffer" as a callback arg
+// generates C that TinyCC rejects) and asserts the callback function becomes
+// collectible afterwards.
+test.skipIf(isFFIUnavailable)("JSCallback does not leak the callback function when compilation fails", async () => {
+  const script = /* js */ `
+    const { JSCallback } = require("bun:ffi");
+
+    let collected = 0;
+    const registry = new FinalizationRegistry(() => {
+      collected++;
+    });
+
+    const ITERS = 64;
+
+    function attempt() {
+      const fn = function leakCandidate() {};
+      registry.register(fn, undefined);
+      let result;
+      try {
+        result = new JSCallback(fn, { args: ["buffer"], returns: "void" });
+      } catch {}
+      // Either it threw, or it returned with an unusable (undefined) ptr.
+      // Regardless of how the failure surfaces, the callback must not be
+      // held alive by a leaked Strong handle.
+      if (result && typeof result.ptr === "number") {
+        // Compilation unexpectedly succeeded; release it so the function can
+        // still be collected and this test doesn't report a false positive.
+        result.close();
+      }
+    }
+
+    for (let i = 0; i < ITERS; i++) attempt();
+
+    for (let i = 0; i < 30 && collected < ITERS; i++) {
+      Bun.gc(true);
+      await Bun.sleep(5);
+    }
+
+    console.log(JSON.stringify({ collected, iters: ITERS }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { collected, iters } = JSON.parse(stdout.trim());
+  // Before the fix, every single callback leaked (collected === 0). The fix
+  // releases the wrapper on failure so the functions become collectible. GC
+  // is not fully deterministic across platforms, so only require a majority.
+  expect(collected).toBeGreaterThan(iters / 2);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Function.compileCallback()` in `src/bun.js/api/ffi.zig` allocates an `FFICallbackFunctionWrapper` via `Bun__createFFICallbackFunction()` before attempting to compile the generated C stub with TinyCC. The wrapper is a heap-allocated C++ object holding two `JSC::Strong` handles (the user's callback function and the global object).

The wrapper is only stored on `Function.step.compiled.ffi_callback_function_wrapper` in the **success** branch at the very end of the function. `Function.deinit()` only calls `FFICallbackFunctionWrapper_destroy` when `step == .compiled`.

Every failure path between allocation and that final assignment leaks the wrapper:
- `printCallbackSourceCode` / `source_code.append` returning an error
- `TCC.State.init` failing (`error.TCCMissing`)
- `addSymbol("Bun__thisFFIModuleNapiEnv", …)` failing
- `compileString` failing (invalid generated C)
- `addSymbol("FFI_Callback_call", …)` failing
- `relocate` failing
- `getSymbol("my_callback_function")` returning null
- `handleTCCError` flipping `step` to `.failed`

Each failed `new JSCallback(fn, …)` permanently roots `fn` and the global object in the GC heap.

## Repro

```js
const { JSCallback } = require("bun:ffi");
let collected = 0;
const registry = new FinalizationRegistry(() => collected++);
for (let i = 0; i < 64; i++) {
  const fn = () => {};
  registry.register(fn);
  try { new JSCallback(fn, { args: ["buffer"], returns: "void" }); } catch {}
}
for (let i = 0; i < 30; i++) { Bun.gc(true); await Bun.sleep(5); }
console.log(collected); // 0 before, 64 after
```

Using `"buffer"` as a callback argument generates `arguments[0] = 0.asZigRepr;` which TinyCC rejects, so `step` ends up `.failed` and the wrapper is orphaned.

## Fix

Add a `defer` immediately after allocating the wrapper that destroys it whenever `step != .compiled` at scope exit. This covers both error-returning paths (`try`) and the `this.fail(); return;` paths, while leaving the success path untouched (ownership transfers to `step.compiled`, which `deinit` later frees on `close()`).

## Verification

`test/js/bun/ffi/jscallback-compile-failure-leak.test.ts` registers 64 callback functions with a `FinalizationRegistry`, feeds each to a `JSCallback` constructor that fails TCC compilation, then forces GC.

| | collected / 64 |
|---|---|
| before | 0 |
| after | 64 |

Existing `test/js/bun/ffi/*` tests pass.