### PR TITLE
dns: add regression test for LibInfo pending-cache release on getaddrinfo_async_start error

### DIFF
--- a/src/bun_core/env_var.zig
+++ b/src/bun_core/env_var.zig
@@ -207,6 +207,12 @@ pub const feature_flag = struct {
     pub const BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS = newFeatureFlag("BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", .{});
     pub const BUN_INSTRUMENTS = newFeatureFlag("BUN_INSTRUMENTS", .{});
     pub const BUN_INTERNAL_BUNX_INSTALL = newFeatureFlag("BUN_INTERNAL_BUNX_INSTALL", .{});
+    /// Testing hook for `Bun.dns.lookup` on macOS: force `LibInfo.lookup`'s
+    /// call to `getaddrinfo_async_start` to be treated as having failed
+    /// synchronously so the pending-cache error path runs. The real failure
+    /// is only observable under mach-port exhaustion. See the UAF fixed in
+    /// https://github.com/oven-sh/bun/pull/30005.
+    pub const BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR = newFeatureFlag("BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR", .{});
     pub const BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN", .{});
     pub const BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT", .{});
     pub const BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF = newFeatureFlag("BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF", .{});

--- a/src/runtime/dns_jsc/dns.zig
+++ b/src/runtime/dns_jsc/dns.zig
@@ -87,8 +87,11 @@ const LibInfo = struct {
         const errno: i32 = if (bun.feature_flag.BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR.get())
             // Testing hook: exercise the synchronous error path below without
             // needing mach-port exhaustion. The real getaddrinfo_async_start is
-            // skipped so no mach port is allocated.
-            @intFromEnum(std.c.E.PERM)
+            // skipped so no mach port is allocated. Any nonzero value works;
+            // the reject path calls bun.sys.getErrno(rc) which on darwin only
+            // inspects thread errno when rc == -1, so the specific value here
+            // is not surfaced in the error message.
+            1
         else
             getaddrinfo_async_start_(
                 &request.backend.libinfo.machport,

--- a/src/runtime/dns_jsc/dns.zig
+++ b/src/runtime/dns_jsc/dns.zig
@@ -84,14 +84,20 @@ const LibInfo = struct {
         const promise_value = request.head.promise.value();
 
         const hints = query.options.toLibC();
-        const errno = getaddrinfo_async_start_(
-            &request.backend.libinfo.machport,
-            name_z.ptr,
-            null,
-            if (hints != null) &hints.? else null,
-            GetAddrInfoRequest.getAddrInfoAsyncCallback,
-            request,
-        );
+        const errno: i32 = if (bun.feature_flag.BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR.get())
+            // Testing hook: exercise the synchronous error path below without
+            // needing mach-port exhaustion. The real getaddrinfo_async_start is
+            // skipped so no mach port is allocated.
+            @intFromEnum(std.c.E.PERM)
+        else
+            getaddrinfo_async_start_(
+                &request.backend.libinfo.machport,
+                name_z.ptr,
+                null,
+                if (hints != null) &hints.? else null,
+                GetAddrInfoRequest.getAddrInfoAsyncCallback,
+                request,
+            );
 
         if (errno != 0) {
             request.head.promise.rejectTask(globalThis, globalThis.createErrorInstance("getaddrinfo_async_start error: {s}", .{@tagName(bun.sys.getErrno(errno))})) catch {}; // TODO: properly propagate exception upwards

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -188,7 +188,8 @@ describe("dns", () => {
       // Two lookups with the same hostname+options so they hash to the same
       // pending-cache slot. If the first failure orphans the slot, the second
       // lookup is classified .inflight and PendingCacheKey.append dereferences
-      // the freed GetAddrInfoRequest -> heap-use-after-free under ASAN.
+      // the freed GetAddrInfoRequest -> heap-use-after-free under ASAN (or a
+      // never-resolving promise in release builds).
       for (let i = 0; i < 2; i++) {
         try {
           await dns.lookup("example.com", opts);
@@ -196,23 +197,6 @@ describe("dns", () => {
         } catch (e) {
           console.log("rejected:" + e.message);
         }
-      }
-      // The HiveArray has 32 slots; with the old used.set() no-op, 32 distinct
-      // failures permanently fill it. Verify a 33rd distinct host still hits
-      // the error path rather than falling through to .disabled.
-      for (let i = 0; i < 33; i++) {
-        try {
-          await dns.lookup("host-" + i + ".invalid", opts);
-          console.log("resolved");
-        } catch (e) {
-          // ok
-        }
-      }
-      try {
-        await dns.lookup("example.com", opts);
-        console.log("post:resolved");
-      } catch (e) {
-        console.log("post:rejected:" + e.message);
       }
     `;
     await using proc = Bun.spawn({
@@ -231,7 +215,6 @@ describe("dns", () => {
       stdout: [
         expect.stringContaining("rejected:getaddrinfo_async_start error"),
         expect.stringContaining("rejected:getaddrinfo_async_start error"),
-        expect.stringContaining("post:rejected:getaddrinfo_async_start error"),
       ],
     });
     expect(exitCode).toBe(0);

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -1,6 +1,6 @@
 import { SystemError, dns } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isMacOS, isWindows, withoutAggressiveGC } from "harness";
 import { isIP, isIPv4, isIPv6 } from "node:net";
 
 const backends = ["system", "libc", "c-ares"];
@@ -171,6 +171,70 @@ describe("dns", () => {
     expect(result).toBeArray();
     expect(result.length).toBeGreaterThan(0);
     expect(isIP(result[0].address)).toBeGreaterThan(0);
+  });
+
+  // LibInfo.lookup (macOS `backend: "system"`) acquires a slot in the 32-entry
+  // pending_host_cache_native HiveArray, then calls getaddrinfo_async_start. If
+  // that call fails synchronously the slot must be released via used.unset so a
+  // later lookup for the same hostname doesn't see .inflight and append onto the
+  // freed request (use-after-free). https://github.com/oven-sh/bun/pull/30005
+  //
+  // getaddrinfo_async_start only fails under mach-port exhaustion, so the error
+  // branch is forced via BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR.
+  test.skipIf(!isMacOS)("LibInfo.lookup releases pending-cache slot on getaddrinfo_async_start error", async () => {
+    const script = /* js */ `
+      const { dns } = require("bun");
+      const opts = { backend: "system" };
+      // Two lookups with the same hostname+options so they hash to the same
+      // pending-cache slot. If the first failure orphans the slot, the second
+      // lookup is classified .inflight and PendingCacheKey.append dereferences
+      // the freed GetAddrInfoRequest -> heap-use-after-free under ASAN.
+      for (let i = 0; i < 2; i++) {
+        try {
+          await dns.lookup("example.com", opts);
+          console.log("resolved");
+        } catch (e) {
+          console.log("rejected:" + e.message);
+        }
+      }
+      // The HiveArray has 32 slots; with the old used.set() no-op, 32 distinct
+      // failures permanently fill it. Verify a 33rd distinct host still hits
+      // the error path rather than falling through to .disabled.
+      for (let i = 0; i < 33; i++) {
+        try {
+          await dns.lookup("host-" + i + ".invalid", opts);
+          console.log("resolved");
+        } catch (e) {
+          // ok
+        }
+      }
+      try {
+        await dns.lookup("example.com", opts);
+        console.log("post:resolved");
+      } catch (e) {
+        console.log("post:rejected:" + e.message);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stderr, stdout: stdout.trim().split("\n") }).toEqual({
+      stderr: "",
+      stdout: [
+        expect.stringContaining("rejected:getaddrinfo_async_start error"),
+        expect.stringContaining("rejected:getaddrinfo_async_start error"),
+        expect.stringContaining("post:rejected:getaddrinfo_async_start error"),
+      ],
+    });
+    expect(exitCode).toBe(0);
   });
 
   describe("setServers", () => {


### PR DESCRIPTION
Follow-up to #30005, which fixed a use-after-free in `LibInfo.lookup`'s synchronous error path but shipped without a test because `getaddrinfo_async_start` only fails under mach-port exhaustion and isn't CI-reproducible.

## Bug (fixed in #30005)

On macOS, `Bun.dns.lookup(name, { backend: "system" })` acquires a slot in the 32-entry `pending_host_cache_native` HiveArray via `HiveArray.get` (which **sets** the `used` bit) and stores the `GetAddrInfoRequest*` in `buffer[pos].lookup`. When `getaddrinfo_async_start` returned nonzero, the old error path called `used.set(pos)` — a no-op — then freed the request. The slot stayed marked used with `.lookup` pointing at freed memory, so the next lookup for the same hostname was classified `.inflight` and `PendingCacheKey.append` dereferenced `this.lookup.tail` on the dangling pointer.

## Changes

- `src/env_var.zig`: new `BUN_INTERNAL_DNS_FORCE_LIBINFO_START_ERROR` feature flag (test-only, `BUN_INTERNAL_*` prefix following `BUN_INTERNAL_SUPPRESS_CRASH_*` precedent).
- `src/bun.js/api/bun/dns.zig`: when the flag is set, `LibInfo.lookup` skips the real `getaddrinfo_async_start` call and takes the `errno != 0` branch. No behaviour change otherwise.
- `test/js/bun/dns/resolve-dns.test.ts`: new `test.skipIf(!isMacOS)` case that spawns a subprocess with the flag set and does two `dns.lookup("example.com", { backend: "system" })` calls. With the pre-#30005 code the second call is classified `.inflight` and `PendingCacheKey.append` dereferences a freed request — heap-use-after-free under ASAN, or a never-resolving promise in release builds.

## Verification

- `bun run zig:check-all` — 61/61 steps, all targets including `{x86_64,aarch64}-macos`.
- `bun bd test test/js/bun/dns/resolve-dns.test.ts` on Linux — 71 pass, 1 skip (the new macOS-only test), 0 fail.

The new test is macOS-only because `LibInfo.lookup` is compiled only for macOS; actual pass/fail will come from the macOS CI lanes.
