### PR TITLE
fix(napi): reject napi_create_external_{arraybuffer,buffer} with pending exception; use armable destructor

### DIFF
--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2100,25 +2100,32 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
+    // Match Node.js: reject while a napi exception is pending before
+    // adopting external_data, so the caller cleanly retains ownership.
+    // Checking after JSArrayBuffer::create would orphan a GC cell that
+    // still points at external_data with a disarmed destructor.
+    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
 
     // Uses NapiExternalBufferDestructor instead of createSharedTask so that
-    // finalize_cb is only invoked if JSArrayBuffer::create succeeds. Per the
-    // Node-API contract, the caller retains ownership of external_data when
-    // this function fails, so calling finalize_cb on the failure path would
-    // cause a double-free.
+    // finalize_cb is only invoked once JSArrayBuffer::create has succeeded.
+    // Per the Node-API contract, the caller retains ownership of
+    // external_data when this function fails, so calling finalize_cb on a
+    // failure path would cause a double-free. JSArrayBuffer::create(vm, ...)
+    // currently asserts on OOM rather than throwing, so there is no
+    // reachable failure between createFromBytes and arm() today; the
+    // pattern is kept for parity with napi_create_external_buffer and to
+    // guard any future early return added in between.
     Ref<NapiExternalBufferDestructor> destructor = adoptRef(*new NapiExternalBufferDestructor(WTF::Ref<NapiEnv>(*env), finalize_cb, finalize_hint));
     // Get pointer before using WTF::move
     auto* destructorPtr = destructor.ptr();
     auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, WTF::move(destructor));
 
     auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), WTF::move(arrayBuffer));
-    NAPI_RETURN_IF_EXCEPTION(env);
-
-    // Arm only after successful creation: if create threw, the destructor
-    // runs disarmed and skips finalize_cb (caller retains ownership).
+    // Arm only after successful creation so that if a future change makes
+    // create() throw, the destructor runs disarmed and skips finalize_cb.
     destructorPtr->arm();
 
     *result = toNapi(buffer, globalObject);

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2055,6 +2055,13 @@ extern "C" napi_status napi_create_external_buffer(napi_env env, size_t length,
 {
     NAPI_PREAMBLE(env);
     NAPI_CHECK_ARG(env, result);
+    // Match Node.js: reject while a napi exception is pending before
+    // adopting data. NAPI_RETURN_IF_EXCEPTION below also consults
+    // hasPendingException(), so without this early return a stashed
+    // napi_throw* exception would pass the preamble, let createFromBytes
+    // adopt data, then bail after JSUint8Array::create succeeded but
+    // before arm(), orphaning a GC cell with a disarmed destructor.
+    NAPI_RETURN_EARLY_IF_FALSE(env, !env->hasPendingException(), napi_pending_exception);
 
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);

--- a/src/bun.js/bindings/napi.cpp
+++ b/src/bun.js/bindings/napi.cpp
@@ -2018,8 +2018,9 @@ extern "C" napi_status napi_create_buffer(napi_env env, size_t length,
 }
 
 // SharedTask subclass with an armed flag so that the destructor can be
-// armed only after JSUint8Array::create succeeds.  If creation throws,
-// the destructor runs disarmed and skips finalize_cb.
+// armed only after the wrapping JS object (JSUint8Array / JSArrayBuffer)
+// is successfully created. If creation throws, the destructor runs
+// disarmed and skips finalize_cb so the caller retains ownership.
 class NapiExternalBufferDestructor final : public SharedTask<void(void*)> {
 public:
     NapiExternalBufferDestructor(WTF::Ref<NapiEnv>&& env, napi_finalize cb, void* hint)
@@ -2103,12 +2104,22 @@ extern "C" napi_status napi_create_external_arraybuffer(napi_env env, void* exte
     Zig::GlobalObject* globalObject = toJS(env);
     JSC::VM& vm = JSC::getVM(globalObject);
 
-    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, createSharedTask<void(void*)>([env = WTF::Ref<NapiEnv>(*env), finalize_hint, finalize_cb](void* p) {
-        NAPI_LOG("external ArrayBuffer finalizer");
-        env->doFinalizer(finalize_cb, p, finalize_hint);
-    }));
+    // Uses NapiExternalBufferDestructor instead of createSharedTask so that
+    // finalize_cb is only invoked if JSArrayBuffer::create succeeds. Per the
+    // Node-API contract, the caller retains ownership of external_data when
+    // this function fails, so calling finalize_cb on the failure path would
+    // cause a double-free.
+    Ref<NapiExternalBufferDestructor> destructor = adoptRef(*new NapiExternalBufferDestructor(WTF::Ref<NapiEnv>(*env), finalize_cb, finalize_hint));
+    // Get pointer before using WTF::move
+    auto* destructorPtr = destructor.ptr();
+    auto arrayBuffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(external_data), byte_length }, WTF::move(destructor));
 
     auto* buffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Default), WTF::move(arrayBuffer));
+    NAPI_RETURN_IF_EXCEPTION(env);
+
+    // Arm only after successful creation: if create threw, the destructor
+    // runs disarmed and skips finalize_cb (caller retains ownership).
+    destructorPtr->arm();
 
     *result = toNapi(buffer, globalObject);
     NAPI_RETURN_SUCCESS(env);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2095,6 +2095,70 @@ static napi_value test_external_arraybuffer_with_pending_exception(
   return ok(env);
 }
 
+// Same as above, for napi_create_external_buffer: the post-create
+// NAPI_RETURN_IF_EXCEPTION check in that function also consults
+// hasPendingException(), so a stashed napi_throw* exception must be
+// rejected up front rather than after createFromBytes has adopted data.
+static int external_buffer_finalize_count = 0;
+
+static napi_value test_external_buffer_with_pending_exception(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  external_buffer_finalize_count = 0;
+
+  const size_t data_size = 8;
+  uint8_t *ext_data = (uint8_t *)malloc(data_size);
+  memset(ext_data, 0x5A, data_size);
+
+  NODE_API_CALL(env,
+                napi_throw_error(env, nullptr, "stashed before create"));
+
+  napi_value buffer = nullptr;
+  napi_status status = napi_create_external_buffer(
+      env, data_size, ext_data,
+      +[](napi_env, void *data, void *) {
+        external_buffer_finalize_count++;
+        free(data);
+      },
+      nullptr, &buffer);
+
+  napi_value exc;
+  napi_get_and_clear_last_exception(env, &exc);
+
+  printf("napi_create_external_buffer with pending exception: status=%d\n",
+         (int)status);
+
+  if (status == napi_ok) {
+    if (external_buffer_finalize_count != 0) {
+      printf("FAIL: finalizer ran before Buffer was collected\n");
+      return ok(env);
+    }
+    void *buf_data;
+    size_t buf_len;
+    NODE_API_CALL(env,
+                  napi_get_buffer_info(env, buffer, &buf_data, &buf_len));
+    if (buf_data == ext_data && buf_len == data_size) {
+      printf("PASS: ownership transferred on napi_ok with pending "
+             "exception\n");
+    } else {
+      printf("FAIL: napi_ok but buffer does not wrap caller data\n");
+    }
+  } else {
+    if (external_buffer_finalize_count == 0) {
+      printf("PASS: caller retains ownership on failure with pending "
+             "exception\n");
+    } else {
+      printf("FAIL: finalizer ran %d time(s) even though the call "
+             "failed\n",
+             external_buffer_finalize_count);
+    }
+    free(ext_data);
+  }
+
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -2324,6 +2388,8 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);
   REGISTER_FUNCTION(env, exports,
                     test_external_arraybuffer_with_pending_exception);
+  REGISTER_FUNCTION(env, exports,
+                    test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2023,6 +2023,78 @@ test_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// Regression test: napi_create_external_arraybuffer while a napi exception
+// is pending (via napi_throw_error). Whatever status is returned, the
+// function must not adopt external_data and then leave the destructor
+// disarmed (which would leak the caller's buffer forever or leave a
+// dangling pointer in an orphaned JSArrayBuffer if the caller frees on
+// failure per the Node-API contract).
+static napi_value test_external_arraybuffer_with_pending_exception(
+    const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  external_arraybuffer_finalize_count = 0;
+
+  const size_t data_size = 8;
+  uint8_t *ext_data = (uint8_t *)malloc(data_size);
+  memset(ext_data, 0x5A, data_size);
+
+  // Stash a napi-level pending exception (no VM exception is raised yet).
+  NODE_API_CALL(env,
+                napi_throw_error(env, nullptr, "stashed before create"));
+
+  napi_value arraybuffer = nullptr;
+  napi_status status = napi_create_external_arraybuffer(
+      env, ext_data, data_size,
+      +[](napi_env, void *data, void *) {
+        external_arraybuffer_finalize_count++;
+        free(data);
+      },
+      nullptr, &arraybuffer);
+
+  // Clear the pending exception so the rest of the test can run cleanly.
+  napi_value exc;
+  napi_get_and_clear_last_exception(env, &exc);
+
+  printf("napi_create_external_arraybuffer with pending exception: "
+         "status=%d\n",
+         (int)status);
+
+  if (status == napi_ok) {
+    // Ownership transferred: the ArrayBuffer must wrap our pointer and the
+    // finalizer must eventually free ext_data. It must not have fired yet.
+    if (external_arraybuffer_finalize_count != 0) {
+      printf("FAIL: finalizer ran before ArrayBuffer was collected\n");
+      return ok(env);
+    }
+    void *ab_data;
+    size_t ab_len;
+    NODE_API_CALL(env, napi_get_arraybuffer_info(env, arraybuffer, &ab_data,
+                                                 &ab_len));
+    if (ab_data == ext_data && ab_len == data_size) {
+      printf("PASS: ownership transferred on napi_ok with pending "
+             "exception\n");
+    } else {
+      printf("FAIL: napi_ok but arraybuffer does not wrap caller data\n");
+    }
+  } else {
+    // Caller retains ownership on failure. The finalizer must not have
+    // run (that would be the double-free the armable destructor guards
+    // against).
+    if (external_arraybuffer_finalize_count == 0) {
+      printf("PASS: caller retains ownership on failure with pending "
+             "exception\n");
+    } else {
+      printf("FAIL: finalizer ran %d time(s) even though the call "
+             "failed\n",
+             external_arraybuffer_finalize_count);
+    }
+    free(ext_data);
+  }
+
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -2250,6 +2322,8 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, napi_get_typeof);
   REGISTER_FUNCTION(env, exports, test_external_buffer_data_lifetime);
   REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);
+  REGISTER_FUNCTION(env, exports,
+                    test_external_arraybuffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1927,6 +1927,102 @@ static napi_value test_external_buffer_data_lifetime(const Napi::CallbackInfo &i
   return ok(env);
 }
 
+// Regression test: napi_create_external_arraybuffer uses the armable
+// NapiExternalBufferDestructor so that if the wrapping JSArrayBuffer fails
+// to be created, finalize_cb is not invoked (per the Node-API contract the
+// caller retains ownership on failure). The JSArrayBuffer::create(vm, ...)
+// path cannot currently fail without crashing, so the failure branch is not
+// directly reachable from a test; this covers the success path to guard
+// against the refactor breaking finalize_cb delivery (forgetting arm()) or
+// firing it prematurely.
+static int external_arraybuffer_finalize_count = 0;
+
+static napi_value
+test_external_arraybuffer_finalizer(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  external_arraybuffer_finalize_count = 0;
+
+  const size_t data_size = 16;
+  uint8_t *ext_data = (uint8_t *)malloc(data_size);
+  for (size_t i = 0; i < data_size; i++)
+    ext_data[i] = (uint8_t)(0xA0 + i);
+
+  napi_value arraybuffer;
+  NODE_API_CALL(
+      env, napi_create_external_arraybuffer(
+               env, ext_data, data_size,
+               +[](napi_env, void *data, void *) {
+                 external_arraybuffer_finalize_count++;
+                 free(data);
+               },
+               nullptr, &arraybuffer));
+
+  // The finalizer must not have run yet: the ArrayBuffer is still live.
+  if (external_arraybuffer_finalize_count != 0) {
+    printf("FAIL: napi_create_external_arraybuffer finalizer ran before "
+           "ArrayBuffer was collected\n");
+    return ok(env);
+  }
+
+  // Verify the backing store is the caller's pointer and the bytes match.
+  void *ab_data;
+  size_t ab_len;
+  NODE_API_CALL(
+      env, napi_get_arraybuffer_info(env, arraybuffer, &ab_data, &ab_len));
+
+  bool bytes_ok = ab_len == data_size;
+  for (size_t i = 0; bytes_ok && i < data_size; i++)
+    bytes_ok = ((uint8_t *)ab_data)[i] == (uint8_t)(0xA0 + i);
+
+  if (ab_data == ext_data && bytes_ok) {
+    printf("PASS: napi_create_external_arraybuffer wraps caller data "
+           "without copying\n");
+  } else {
+    printf("FAIL: napi_create_external_arraybuffer data mismatch\n");
+  }
+
+  // Pin the ArrayBuffer across several GC cycles and verify the finalizer
+  // does not fire while it is reachable.
+  napi_ref ab_ref;
+  NODE_API_CALL(env, napi_create_reference(env, arraybuffer, 1, &ab_ref));
+
+  run_gc(info);
+  run_gc(info);
+  run_gc(info);
+
+  if (external_arraybuffer_finalize_count == 0) {
+    printf("PASS: napi_create_external_arraybuffer finalizer not called "
+           "while ArrayBuffer is alive\n");
+  } else {
+    printf("FAIL: napi_create_external_arraybuffer finalizer called %d "
+           "time(s) while ArrayBuffer is alive\n",
+           external_arraybuffer_finalize_count);
+  }
+
+  // The data must still be intact.
+  napi_value ab_value;
+  NODE_API_CALL(env, napi_get_reference_value(env, ab_ref, &ab_value));
+  NODE_API_CALL(env,
+                napi_get_arraybuffer_info(env, ab_value, &ab_data, &ab_len));
+  bytes_ok = ab_len == data_size;
+  for (size_t i = 0; bytes_ok && i < data_size; i++)
+    bytes_ok = ((uint8_t *)ab_data)[i] == (uint8_t)(0xA0 + i);
+  if (bytes_ok) {
+    printf("PASS: napi_create_external_arraybuffer data intact after GC\n");
+  } else {
+    printf("FAIL: napi_create_external_arraybuffer data corrupted after "
+           "GC\n");
+  }
+
+  NODE_API_CALL(env, napi_delete_reference(env, ab_ref));
+
+  // Do not assert on post-release finalizer timing: both V8 and JSC may
+  // defer it past the synchronous GC calls above. Any double-invocation or
+  // use-after-free will be caught by ASAN when the process tears down.
+  return ok(env);
+}
+
 // Regression test: PROPERTY_NAME_FROM_UTF8 must copy string data.
 // Previously it used StringImpl::createWithoutCopying for ASCII strings,
 // which could leave dangling pointers in JSC's atom string table.
@@ -2153,6 +2249,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_empty_buffer_info);
   REGISTER_FUNCTION(env, exports, napi_get_typeof);
   REGISTER_FUNCTION(env, exports, test_external_buffer_data_lifetime);
+  REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -290,6 +290,13 @@ describe.concurrent("napi", () => {
       expect(result).toContain("PASS: napi_is_detached_arraybuffer returns true for empty buffer's arraybuffer");
       expect(result).not.toContain("FAIL");
     });
+
+    it("rejects with napi_pending_exception before adopting data when an exception is pending", async () => {
+      const result = await checkSameOutput("test_external_buffer_with_pending_exception", []);
+      expect(result).toContain("status=10");
+      expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
+      expect(result).not.toContain("FAIL");
+    });
   });
 
   describe("napi_create_external_arraybuffer", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -292,6 +292,18 @@ describe.concurrent("napi", () => {
     });
   });
 
+  describe("napi_create_external_arraybuffer", () => {
+    it("wraps caller data and does not fire finalize_cb while the ArrayBuffer is alive", async () => {
+      const result = await checkSameOutput("test_external_arraybuffer_finalizer", []);
+      expect(result).toContain("PASS: napi_create_external_arraybuffer wraps caller data without copying");
+      expect(result).toContain(
+        "PASS: napi_create_external_arraybuffer finalizer not called while ArrayBuffer is alive",
+      );
+      expect(result).toContain("PASS: napi_create_external_arraybuffer data intact after GC");
+      expect(result).not.toContain("FAIL");
+    });
+  });
+
   describe("napi_async_work", () => {
     it("null checks execute callbacks", async () => {
       const output = await checkSameOutput("test_napi_async_work_execute_null_check", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -302,6 +302,13 @@ describe.concurrent("napi", () => {
       expect(result).toContain("PASS: napi_create_external_arraybuffer data intact after GC");
       expect(result).not.toContain("FAIL");
     });
+
+    it("rejects with napi_pending_exception before adopting external_data when an exception is pending", async () => {
+      const result = await checkSameOutput("test_external_arraybuffer_with_pending_exception", []);
+      expect(result).toContain("status=10");
+      expect(result).toContain("PASS: caller retains ownership on failure with pending exception");
+      expect(result).not.toContain("FAIL");
+    });
   });
 
   describe("napi_async_work", () => {


### PR DESCRIPTION
## What

`napi_create_external_arraybuffer` and `napi_create_external_buffer` now both:

1. Return `napi_pending_exception` **before** adopting the caller's data when a napi exception is already pending (via `napi_throw*`), matching Node.js. Previously `napi_create_external_arraybuffer` returned `napi_ok` here, and `napi_create_external_buffer` returned `napi_pending_exception` only *after* the data had been adopted into an orphaned GC cell with a permanently-disarmed destructor.
2. Use the armable `NapiExternalBufferDestructor` so `finalize_cb` is only invoked once the wrapping JS object is successfully created. (`napi_create_external_buffer` already did; `napi_create_external_arraybuffer` now matches.)

## Why

Previously `napi_create_external_arraybuffer` installed `finalize_cb` via an unconditional `createSharedTask` **before** `JSC::JSArrayBuffer::create`. If creating the JS wrapper ever failed, the local `Ref<ArrayBuffer>` would be destroyed during unwinding and run `finalize_cb` even though the napi call returned an error. Per the Node-API contract, the caller retains ownership of `external_data` on failure and will free it — so calling `finalize_cb` on the failure path is a double-free.

`napi_create_external_buffer` already used `NapiExternalBufferDestructor::arm()` (added in #26450 because `JSUint8Array::create(globalObject, …)` can throw `RangeError`). This change applies the same pattern to the arraybuffer variant.

The pending-exception check must happen **before** `ArrayBuffer::createFromBytes`. Bun's `NAPI_PREAMBLE` gates only on the VM throw scope, while `NAPI_RETURN_IF_EXCEPTION` (used after `JSUint8Array::create` in `napi_create_external_buffer`) also consults `env->hasPendingException()` — so a stashed `napi_throw*` exception would pass the preamble, let `createFromBytes` adopt the data, then bail after the JS cell is created but before `arm()` / `*result`, orphaning a GC cell holding the caller's pointer with a destructor that will never fire.

`JSArrayBuffer::create(vm, …)` cannot throw (`allocateCell` with `AllocationFailureMode::Assert` crashes on OOM), so no post-create exception check is used in `napi_create_external_arraybuffer`; the armable pattern there is defensive parity.

## Tests

- `test_external_arraybuffer_with_pending_exception` / `test_external_buffer_with_pending_exception` — stash a napi exception via `napi_throw_error`, call the function, verify `napi_pending_exception` is returned, `finalize_cb` did **not** fire, and the caller frees. Compared against Node.js via `checkSameOutput`. The arraybuffer variant **fails on main** (Bun returns `napi_ok`, Node returns `napi_pending_exception`) and passes with this fix.
- `test_external_arraybuffer_finalizer` — success path: data is wrapped without copying, `finalize_cb` does not fire while the `ArrayBuffer` is reachable across GC cycles, data remains intact. Guards against the armable refactor breaking finalize delivery.
