### PR TITLE
Fix refcount leak in BunString__toThreadSafe

### DIFF
--- a/src/bun.js/bindings/BunString.cpp
+++ b/src/bun.js/bindings/BunString.cpp
@@ -211,9 +211,14 @@ BunString fromJS(JSC::JSGlobalObject* globalObject, JSValue value)
 extern "C" [[ZIG_EXPORT(nothrow)]] void BunString__toThreadSafe(BunString* str)
 {
     if (str->tag == BunStringTag::WTFStringImpl) {
-        auto impl = str->impl.wtf->isolatedCopy();
-        if (impl.ptr() != str->impl.wtf) {
+        auto* existing = str->impl.wtf;
+        // StringImpl::isolatedCopy() always returns a freshly-allocated impl,
+        // so when we replace the pointer we must release the ref we were
+        // holding to the original; otherwise every call leaks one ref.
+        auto impl = existing->isolatedCopy();
+        if (impl.ptr() != existing) {
             str->impl.wtf = &impl.leakRef();
+            existing->deref();
         }
     }
 }

--- a/src/bun.js/bindings/InternalForTesting.cpp
+++ b/src/bun.js/bindings/InternalForTesting.cpp
@@ -4,10 +4,15 @@
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSArrayBufferView.h"
+#include "headers-handwritten.h"
+#include <wtf/text/StringImpl.h>
+#include <wtf/text/WTFString.h>
 
 #if ASAN_ENABLED
 #include <sanitizer/lsan_interface.h>
 #endif
+
+extern "C" void BunString__toThreadSafe(BunString* str);
 
 namespace Bun {
 
@@ -40,6 +45,35 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_lsanDoLeakCheck, (JSC::JSGlobalObject * glob
     return JSValue::encode(jsNumber(__lsan_do_recoverable_leak_check()));
 #endif
     return encodedJSUndefined();
+}
+
+// Returns the net refcount change on the *original* StringImpl after a
+// BunString owning one ref to it is passed through BunString__toThreadSafe
+// and then released. A correct implementation must return 0; a positive
+// value means BunString__toThreadSafe leaked a reference to the original
+// StringImpl when it installed the isolated copy.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    // Create a fresh, non-static, non-atom StringImpl with exactly one ref
+    // held by `original`.
+    Ref<WTF::StringImpl> original = WTF::String::fromLatin1("BunString__toThreadSafe leak test").releaseImpl().releaseNonNull();
+
+    const unsigned before = original->refCount();
+
+    // Give the BunString its own ref, mirroring how a Zig-side bun.String
+    // owns one reference to the underlying StringImpl.
+    original->ref();
+    BunString str = { BunStringTag::WTFStringImpl, { .wtf = original.ptr() } };
+
+    BunString__toThreadSafe(&str);
+
+    // Drop whatever the BunString now owns (the isolated copy, or the
+    // original if the implementation ever decides no copy is needed).
+    ASSERT(str.tag == BunStringTag::WTFStringImpl);
+    str.impl.wtf->deref();
+
+    const unsigned after = original->refCount();
+    return JSValue::encode(jsNumber(static_cast<int32_t>(after) - static_cast<int32_t>(before)));
 }
 
 }

--- a/src/bun.js/bindings/InternalForTesting.h
+++ b/src/bun.js/bindings/InternalForTesting.h
@@ -8,5 +8,6 @@ namespace Bun {
 JSC_DECLARE_HOST_FUNCTION(jsFunction_arrayBufferViewHasBuffer);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_hasReifiedStatic);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lsanDoLeakCheck);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 
 }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -235,6 +235,12 @@ export const structuredCloneAdvanced: (
 
 export const lsanDoLeakCheck = $newCppFunction("InternalForTesting.cpp", "jsFunction_lsanDoLeakCheck", 1);
 
+export const BunString_toThreadSafeRefCountDelta: () => number = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_BunString_toThreadSafeRefCountDelta",
+  0,
+);
+
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newZigFunction("event_loop.zig", "getActiveTasks", 0);
 

--- a/src/string.zig
+++ b/src/string.zig
@@ -1056,7 +1056,10 @@ pub const String = extern struct {
         return bun.strings.eqlLong(this.byteSlice(), value, true);
     }
 
-    /// Does not increment the reference count unless the StringImpl is cloned.
+    /// Replace the underlying StringImpl with an isolated copy that is safe to
+    /// hand to another thread. This **transfers** ownership: the reference this
+    /// String held on the previous StringImpl is released, and the String now
+    /// holds exactly one reference to the new (or unchanged) StringImpl.
     pub fn toThreadSafe(this: *String) void {
         jsc.markBinding(@src());
 
@@ -1065,18 +1068,14 @@ pub const String = extern struct {
         }
     }
 
-    /// We don't ref unless the underlying StringImpl is new.
-    ///
-    /// This will ref even if it doesn't change.
+    /// Like `toThreadSafe`, but leaves the result with one extra ref compared
+    /// to before the call (i.e. the caller wants `toThreadSafe` + `ref`).
     pub fn toThreadSafeEnsureRef(this: *String) void {
         jsc.markBinding(@src());
 
         if (this.tag == .WTFStringImpl) {
-            const orig = this.value.WTFStringImpl;
             bun.cpp.BunString__toThreadSafe(this);
-            if (this.value.WTFStringImpl == orig) {
-                orig.ref();
-            }
+            this.value.WTFStringImpl.ref();
         }
     }
 
@@ -1203,11 +1202,12 @@ pub const SliceWithUnderlyingString = struct {
 
     pub fn toThreadSafe(this: *SliceWithUnderlyingString) void {
         if (this.underlying.tag == .WTFStringImpl) {
-            var orig = this.underlying.value.WTFStringImpl;
+            const orig = this.underlying.value.WTFStringImpl;
+            // BunString__toThreadSafe transfers ownership: it derefs the
+            // previous impl and installs a new one. We only need to migrate
+            // the utf8 slice if it was a ref-counted view into the old impl.
             this.underlying.toThreadSafe();
             if (this.underlying.value.WTFStringImpl != orig) {
-                orig.deref();
-
                 if (this.utf8.allocator.get()) |allocator| {
                     if (String.isWTFAllocator(allocator)) {
                         this.utf8.deinit();

--- a/test/js/bun/util/bunstring-tothreadsafe.test.ts
+++ b/test/js/bun/util/bunstring-tothreadsafe.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test";
 import { BunString_toThreadSafeRefCountDelta } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // BunString__toThreadSafe must release the ref it held on the previous

--- a/test/js/bun/util/bunstring-tothreadsafe.test.ts
+++ b/test/js/bun/util/bunstring-tothreadsafe.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { BunString_toThreadSafeRefCountDelta } from "bun:internal-for-testing";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// BunString__toThreadSafe must release the ref it held on the previous
+// StringImpl when it installs the isolated copy. Before the fix this
+// leaked one ref per call because StringImpl::isolatedCopy() always
+// returns a brand-new impl and the old pointer was overwritten without
+// ever being deref'd.
+test("BunString__toThreadSafe does not leak a ref on the original StringImpl", () => {
+  expect(typeof BunString_toThreadSafeRefCountDelta).toBe("function");
+
+  // A correct implementation leaves the original StringImpl's refcount
+  // unchanged once the BunString is released. A positive delta means the
+  // original ref was leaked.
+  for (let i = 0; i < 8; i++) {
+    expect(BunString_toThreadSafeRefCountDelta()).toBe(0);
+  }
+});
+
+// Exercise the real callers (Bun.file / async fs.write) whose Zig-side
+// SliceWithUnderlyingString.toThreadSafe wrappers were updated alongside the
+// C++ fix. With ASAN this would crash on a double-deref if the two sides ever
+// disagree on who owns the old StringImpl.
+test("toThreadSafe callers (Bun.file / fs.write) keep refcounts balanced", async () => {
+  using dir = tempDir("bunstring-tothreadsafe", {
+    "target.txt": "",
+  });
+  const src = `
+    const fs = require("node:fs");
+    const { promisify } = require("node:util");
+    const path = require("node:path");
+    const write = promisify(fs.write);
+
+    const targetPath = path.join(process.env.TEST_DIR, "target.txt");
+
+    // Bun.file(path) routes through SliceWithUnderlyingString.toThreadSafe.
+    for (let i = 0; i < 64; i++) {
+      const p = targetPath + "";
+      const f = Bun.file(p);
+      if (typeof f.name !== "string") throw new Error("bad");
+    }
+
+    // Async fs.write(fd, string) routes the data string through
+    // StringOrBuffer -> SliceWithUnderlyingString.toThreadSafe.
+    const fd = fs.openSync(targetPath, "w");
+    const payload = Buffer.alloc(48, "p").toString();
+    let total = 0;
+    for (let i = 0; i < 64; i++) {
+      const { bytesWritten } = await write(fd, payload);
+      total += bytesWritten;
+    }
+    fs.closeSync(fd);
+
+    console.log(JSON.stringify({ total }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: { ...bunEnv, TEST_DIR: String(dir) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(JSON.stringify({ total: 64 * 48 }));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`WTF::StringImpl::isolatedCopy()` always returns a freshly-allocated impl (both arms call `create` / `createWithoutCopying`, never return `this`), so the `impl.ptr() != str->impl.wtf` check in `BunString__toThreadSafe` is always taken:

```cpp
auto impl = str->impl.wtf->isolatedCopy();
if (impl.ptr() != str->impl.wtf) {
    str->impl.wtf = &impl.leakRef();   // old impl never deref'd
}
```

The previous `StringImpl*` is overwritten without the ref the `BunString` held on it ever being released.

`SliceWithUnderlyingString.toThreadSafe` in `src/string.zig` happened to compensate for this with its own `orig.deref()`, which masked the leak on the `Bun.file` / async `fs.write` paths. But any direct `String.toThreadSafe` caller (e.g. `src/bake/production.zig`) leaked one `StringImpl` per call, and the `== orig` branches in the Zig wrappers (`toThreadSafeEnsureRef`, `SliceWithUnderlyingString.toThreadSafe`) were unreachable dead code, making the intended semantics impossible to reason about.

## Fix

- `BunString__toThreadSafe` now derefs the previous impl before installing the isolated copy, so ownership of the single ref cleanly transfers from the old impl to the new one.
- Removed the now-redundant `orig.deref()` from `SliceWithUnderlyingString.toThreadSafe` (keeping it would double-free under ASAN).
- Updated `toThreadSafeEnsureRef` and doc comments to match the new semantics.

## Verification

Added `BunString_toThreadSafeRefCountDelta()` to `bun:internal-for-testing`. It creates a fresh `StringImpl`, hands one ref to a `BunString`, runs `BunString__toThreadSafe`, releases the result, and returns the net change in the *original* impl's refcount.

- Without the fix: returns **1** (leaked ref)
- With the fix: returns **0**

A second test exercises `Bun.file(path)` and async `fs.write(fd, string)` in a subprocess so ASAN would surface any double-free introduced by changing the Zig compensation alongside the C++ deref.