### PR TITLE
bun:test: root the .each() table array in the JS wrapper

### DIFF
--- a/src/bun.js/test/ScopeFunctions.zig
+++ b/src/bun.js/test/ScopeFunctions.zig
@@ -1,7 +1,9 @@
 const Mode = enum { describe, @"test" };
 mode: Mode,
 cfg: bun_test.BaseScopeCfg,
-/// typically `.zero`. not Strong.Optional because codegen adds it to the visit function.
+/// typically `.zero`. not Strong.Optional because codegen visits the C++ `m_each`
+/// WriteBarrier on the JS wrapper (see `values: ["each"]` in jest.classes.ts). This
+/// field is kept in sync with that slot via `js.eachSetCached` in `createUnbound`.
 each: jsc.JSValue,
 
 pub const strings = struct {
@@ -456,6 +458,10 @@ pub fn createUnbound(globalThis: *JSGlobalObject, mode: Mode, each: jsc.JSValue,
 
     const value = scope_functions.toJS(globalThis);
     value.ensureStillAlive();
+    // Write into the C++ m_each WriteBarrier so GC visits it. The Zig `each` field
+    // lives in unmanaged memory that JSC never scans; without this the array can be
+    // collected between `.each(arr)` and the trailing `("name", cb)` call.
+    if (each != .zero) js.eachSetCached(value, globalThis, each);
     return value;
 }
 

--- a/test/js/bun/test/jest-each-gc-root.test.ts
+++ b/test/js/bun/test/jest-each-gc-root.test.ts
@@ -1,0 +1,115 @@
+// test.each(arr) / describe.each(arr) create a ScopeFunctions whose Zig struct
+// stores `arr` as a raw jsc.JSValue. The codegen for `values: ["each"]` in
+// jest.classes.ts emits a C++ `m_each` WriteBarrier that visitChildren walks,
+// but the Zig side never called `eachSetCached` to populate it — so the only
+// reference to `arr` lived in unmanaged memory the GC never scans. If GC ran
+// between `.each(arr)` and the trailing `("name", cb)` call, the array could
+// be collected and `callAsFunction` would iterate a freed cell.
+//
+// useZombieMode scribbles 0xbadbeef0 over swept cells so the dangling access
+// manifests as a hard crash / wrong-type error instead of a heisenbug.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+const fixture = `
+import { test, describe, expect } from "bun:test";
+
+const seen: unknown[][] = [];
+
+function gcHard() {
+  // Overwrite any stale stack slots that conservative scanning might pick up,
+  // then force a synchronous full collection.
+  for (let i = 0; i < 64; i++) new Array(128).fill({});
+  Bun.gc(true);
+  for (let i = 0; i < 64; i++) new Array(128).fill({});
+  Bun.gc(true);
+}
+
+// Build the .each() callees in nested frames so the table arrays are not kept
+// alive by the top-level stack after these IIFEs return.
+const testEach = (() => (() =>
+  test.each([
+    ["alpha", 1],
+    ["beta", 2],
+    ["gamma", 3],
+  ])
+)())();
+
+const describeEach = (() => (() =>
+  describe.each([["delta"], ["epsilon"]])
+)())();
+
+// .skipIf(false) routes through genericIf -> createBound, propagating the
+// array JSValue into a fresh ScopeFunctions; cover that path too.
+const chainedEach = (() => (() =>
+  test.each([["zeta", 10], ["eta", 20]]).skipIf(false)
+)())();
+
+gcHard();
+
+testEach("test.each %s", (name, num) => {
+  expect(typeof name).toBe("string");
+  expect(typeof num).toBe("number");
+  seen.push([name, num]);
+});
+
+gcHard();
+
+describeEach("describe.each %s", name => {
+  test("inner", () => {
+    expect(typeof name).toBe("string");
+    seen.push([name]);
+  });
+});
+
+gcHard();
+
+chainedEach("chained.each %s", (name, num) => {
+  expect(typeof name).toBe("string");
+  expect(typeof num).toBe("number");
+  seen.push([name, num]);
+});
+
+test("all .each() table rows survived GC", () => {
+  expect(seen).toEqual([
+    ["alpha", 1],
+    ["beta", 2],
+    ["gamma", 3],
+    ["delta"],
+    ["epsilon"],
+    ["zeta", 10],
+    ["eta", 20],
+  ]);
+});
+`;
+
+test("test.each/describe.each table array is a GC root", async () => {
+  using dir = tempDir("jest-each-gc-root", {
+    "each-gc.test.ts": fixture,
+  });
+
+  // useZombieMode scribbles dead cells so a collected array is never silently
+  // "still valid"; collectContinuously keeps the marker racing the mutator.
+  // Windows + collectContinuously is prohibitively slow in CI and the code
+  // path is platform-agnostic, so rely on zombie mode + explicit Bun.gc there.
+  const gcEnv: Record<string, string | undefined> = {
+    ...bunEnv,
+    BUN_JSC_useZombieMode: "1",
+  };
+  if (!isWindows) gcEnv.BUN_JSC_collectContinuously = "1";
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "each-gc.test.ts"],
+    env: gcEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("8 pass");
+  expect(stderr).toContain("0 fail");
+  expect(stdout + stderr).not.toContain("Expected array");
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
### What

`test.each(arr)` / `describe.each(arr)` could iterate a freed cell if GC ran between the `.each(arr)` call and the trailing `("name", cb)` invocation.

### Repro

```ts
const eachFn = (() => test.each([["alpha", 1], ["beta", 2], ["gamma", 3]]))();
Bun.gc(true);
eachFn("test %s", (name, num) => { /* name is garbage */ });
```

Run with `BUN_JSC_useZombieMode=1` (scribbles `0xbadbeef0` over swept cells) and the 3-row table's cell gets reused by another allocation — `callAsFunction` then either throws `Expected array, got …` or iterates the wrong array, passing recycled objects to the callback instead of the original rows.

### Root cause

`jest.classes.ts` declares `values: ["each"]` for `ScopeFunctions`, which makes codegen emit a C++ `WriteBarrier<Unknown> m_each` on the JS wrapper plus `visitor.append(thisObject->m_each)` in `visitChildren`. But `createUnbound` only wrote the array into the Zig struct field `each: jsc.JSValue` — it never called `js.eachSetCached` to populate the C++ slot. The comment *"not Strong.Optional because codegen adds it to the visit function"* described a sync the code never performed: `m_each` stayed empty, so GC visited nothing, and the only reference lived in unmanaged Zig memory JSC never scans.

### Fix

Call `js.eachSetCached(value, globalThis, each)` in `createUnbound` right after `toJS()`. `createBound`, `genericIf` and `genericExtend` all funnel through `createUnbound`, so this single write covers every path that propagates the table (including `.skipIf(…)` chaining).

### Verification

New `test/js/bun/test/jest-each-gc-root.test.ts` spawns `bun test` on a fixture that stores `.each()` results across `Bun.gc(true)` + heap churn under `BUN_JSC_useZombieMode=1` / `BUN_JSC_collectContinuously=1`, covering `test.each`, `describe.each` and `.each(…).skipIf(false)`:

- **without fix** (src stashed, `bun bd`): `error: Expected array, got [native code]` → 0 pass / 1 fail
- **with fix**: 8 pass / 0 fail
- `USE_SYSTEM_BUN=1`: fails (callback receives `{}` ×128 instead of 3 string rows)
- existing `jest-each.test.ts`, `describe.test.ts`, `bun_test.test.ts` all still pass