### PR TITLE
server: unprotect discarded websocket handlers on reload

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -1114,7 +1114,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                     ws.globalObject = globalThis;
                     this.config.websocket = ws.*;
-                } // we don't remove it
+                } else {
+                    // We don't replace the existing websocket config here, but
+                    // the new one was already protected in WebSocketServerContext.onCreate.
+                    // Unprotect the discarded handlers so they don't leak.
+                    ws.unprotect();
+                }
             }
 
             // These get re-applied when we set the static routes again.

--- a/test/js/bun/websocket/websocket-server-reload-leak.test.ts
+++ b/test/js/bun/websocket/websocket-server-reload-leak.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// server.reload({ websocket: { close() {} } }) — i.e. a websocket config
+// without `open` or `message` — is silently discarded by onReloadFromZig.
+// WebSocketServerContext.onCreate has already JSC::gcProtect'd every handler
+// by that point, so discarding without a matching unprotect permanently
+// roots the callbacks (and anything their closures capture).
+test("server.reload() with websocket config lacking open/message does not leak protected handlers", async () => {
+  const script = /* js */ `
+    const { heapStats } = require("bun:jsc");
+
+    const server = Bun.serve({
+      port: 0,
+      fetch() { return new Response("ok"); },
+      websocket: { open() {}, message() {} },
+    });
+
+    const protectedFns = () => heapStats().protectedObjectTypeCounts.Function ?? 0;
+
+    const before = protectedFns();
+
+    const ITERS = 200;
+    for (let i = 0; i < ITERS; i++) {
+      // Only close/drain/ping/pong — no open/message. onReloadFromZig drops
+      // this config; previously the protect() from onCreate was never undone.
+      server.reload({
+        fetch() { return new Response("ok"); },
+        websocket: {
+          close() { void i; },
+          drain() { void i; },
+          ping() { void i; },
+          pong() { void i; },
+        },
+      });
+    }
+
+    Bun.gc(true);
+    const after = protectedFns();
+
+    server.stop(true);
+
+    // A handful of newly-protected functions is fine (e.g. the last reload's
+    // fetch handler). Leaking four handlers per iteration would put the delta
+    // near ITERS * 4 = 800.
+    console.log(JSON.stringify({ before, after, iters: ITERS }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const { before, after, iters } = JSON.parse(stdout.trim());
+  // With the leak, `after - before` is ~iters * 4 (one per close/drain/ping/pong).
+  // Without it, the delta should be a small constant independent of `iters`.
+  expect(after - before).toBeLessThan(iters);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`server.reload({ websocket: { close() {} } })` — i.e. a websocket config with neither `open` nor `message` — leaks protected `Function` objects on every call.

## Why

`WebSocketServerContext.onCreate` unconditionally calls `server.protect()`, which `JSC::gcProtect`s all seven handler callbacks. `Handler.fromJS` accepts a config with only `close`/`drain`/`ping`/`pong`/`error`.

In `onReloadFromZig`, the new websocket config is only committed when `ws.handler.onMessage != .zero or ws.handler.onOpen != .zero`. Otherwise the whole config is silently dropped with no matching `unprotect()`, permanently rooting the discarded handlers (and whatever their closures capture).

## Repro

```js
const server = Bun.serve({
  port: 0,
  fetch() { return new Response(); },
  websocket: { open() {}, message() {} },
});
for (let i = 0; i < 200; i++) {
  server.reload({
    fetch() { return new Response(); },
    websocket: { close() {}, drain() {}, ping() {}, pong() {} },
  });
}
// heapStats().protectedObjectTypeCounts.Function grows by ~800
```

## Fix

Add an `else` branch in `onReloadFromZig` that calls `ws.unprotect()` when the new websocket config is discarded.

## Verification

New test `test/js/bun/websocket/websocket-server-reload-leak.test.ts` measures `heapStats().protectedObjectTypeCounts.Function` before and after 200 reloads.

- Before fix: delta = 800 (4 handlers × 200 iterations) → **fails**
- After fix: delta = 0 → **passes**