### PR TITLE
fix(transpiler): persist printer.ctx on error path in transformSync

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -1032,19 +1032,20 @@ pub fn transformSync(
         break :brk writer;
     };
 
-    defer {
-        this.buffer_writer = buffer_writer;
-    }
-
     buffer_writer.reset();
     var printer = JSPrinter.BufferPrinter.init(buffer_writer);
+    // BufferPrinter.init copies buffer_writer by value into printer.ctx, and
+    // the underlying MutableString may reallocate while printing. Always
+    // persist printer.ctx (not the stale local snapshot) so that an error
+    // return from print() can't leave this.buffer_writer holding a freed
+    // pointer for the next transformSync call to reuse.
+    defer this.buffer_writer = printer.ctx;
+
     _ = this.transpiler.print(parse_result, @TypeOf(&printer), &printer, .esm_ascii) catch |err| {
         return globalThis.throwError(err, "Failed to print code");
     };
 
-    // TODO: benchmark if pooling this way is faster or moving is faster
-    buffer_writer = printer.ctx;
-    var out = jsc.ZigString.init(buffer_writer.written);
+    var out = jsc.ZigString.init(printer.ctx.written);
     out.setOutputEncoding();
 
     return out.toJS(globalThis);

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+// transformSync caches its print buffer on the Transpiler instance and reuses
+// it across calls. The printer holds a by-value copy of that BufferWriter, so
+// when printing grows the buffer past its capacity the old allocation is
+// freed and only the printer's copy sees the new pointer. The cached
+// BufferWriter must be refreshed from printer.ctx on every return path;
+// previously the error path skipped that step, leaving a freed pointer in the
+// cache for the next call. These tests drive the reuse path hard with output
+// that forces reallocations so ASAN trips if the cached pointer ever goes
+// stale.
+describe("Transpiler transformSync buffer reuse", () => {
+  test("pooled print buffer survives repeated growth and shrink", () => {
+    const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+    // First call sizes the cached buffer to the input length (1 byte), so the
+    // next large call is guaranteed to reallocate inside the printer.
+    expect(transpiler.transformSync(";")).toBe("");
+
+    const filler = Buffer.alloc(64 * 1024, "a").toString();
+    const big = transpiler.transformSync(`export const s: string = "${filler}";`);
+    expect(big).toBe(`export const s = "${filler}";\n`);
+
+    // Shrink back down and grow again several times to churn the pooled
+    // buffer. Each iteration reads through whatever pointer was cached by the
+    // previous call.
+    for (let i = 0; i < 8; i++) {
+      expect(transpiler.transformSync("const n: number = 1;")).toBe("const n = 1;\n");
+      const grown = transpiler.transformSync(`export const s: string = "${filler}${filler}${i}";`);
+      expect(grown).toBe(`export const s = "${filler}${filler}${i}";\n`);
+    }
+  });
+
+  test("output is correct after many reallocating transformSync calls", () => {
+    const transpiler = new Bun.Transpiler({ loader: "ts" });
+
+    // Prime the cache with a tiny buffer.
+    transpiler.transformSync(";");
+
+    // Monotonically growing output so every call reallocates past the
+    // previous capacity. Verify the tail of each result so a stale buffer
+    // (truncated or garbage bytes) would fail the assertion, not just crash.
+    let body = "";
+    for (let i = 0; i < 128; i++) {
+      body += `export const v${i}: number = ${i};\n`;
+      const out = transpiler.transformSync(body);
+      expect(out.endsWith(`export const v${i} = ${i};\n`)).toBe(true);
+    }
+  });
+});

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -22,10 +22,8 @@ describe("Transpiler transformSync buffer reuse", () => {
   // silent there. Gated to the debug build specifically: the reserved-arena
   // size below is tuned against its memory footprint, and it is what the
   // fail-before gate runs. Windows mimalloc reserve semantics differ.
-  test.skipIf(!isDebug || isWindows)(
-    "does not cache a freed print buffer after transformSync throws",
-    async () => {
-      const fixture = /* js */ `
+  test.skipIf(!isDebug || isWindows)("does not cache a freed print buffer after transformSync throws", async () => {
+    const fixture = /* js */ `
         const t = new Bun.Transpiler({ loader: "js" });
         // Prime the cached BufferWriter with a ~500KB allocation so the first
         // growth during the huge print below moves it (freeing this pointer).
@@ -46,36 +44,35 @@ describe("Transpiler transformSync buffer reuse", () => {
         const out = t.transformSync("const ok = 1;");
         process.stdout.write(out === "const ok = 1;\\n" ? "RECOVERED_OK\\n" : "BAD:" + JSON.stringify(out) + "\\n");
       `;
-      using dir = tempDir("transpiler-buffer-writer", { "repro.js": fixture });
+    using dir = tempDir("transpiler-buffer-writer", { "repro.js": fixture });
 
-      // 128MiB sits comfortably inside the 64–160MiB window where parse
-      // succeeds but the print buffer growth past ~20–30MiB exhausts the
-      // reserved arena on current debug/ASAN builds.
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "repro.js"],
-        cwd: String(dir),
-        env: {
-          ...bunEnv,
-          MIMALLOC_RESERVE_OS_MEMORY: "128M",
-          MIMALLOC_DISALLOW_OS_ALLOC: "1",
-          MIMALLOC_SHOW_ERRORS: "0",
-          MIMALLOC_MAX_ERRORS: "0",
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // 128MiB sits comfortably inside the 64–160MiB window where parse
+    // succeeds but the print buffer growth past ~20–30MiB exhausts the
+    // reserved arena on current debug/ASAN builds.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "repro.js"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        MIMALLOC_RESERVE_OS_MEMORY: "128M",
+        MIMALLOC_DISALLOW_OS_ALLOC: "1",
+        MIMALLOC_SHOW_ERRORS: "0",
+        MIMALLOC_MAX_ERRORS: "0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // Fail loudly if the allocator never returned OOM mid-print; otherwise
-      // this test would silently stop covering the regression when mimalloc
-      // tuning shifts. Adjust MIMALLOC_RESERVE_OS_MEMORY / the statement count
-      // above if this fires.
-      expect(stdout).not.toContain("NO_OOM");
-      expect(stderr).not.toContain("AddressSanitizer");
-      expect(stdout.trim()).toBe("RECOVERED_OK");
-      expect(exitCode).toBe(0);
-    },
-  );
+    // Fail loudly if the allocator never returned OOM mid-print; otherwise
+    // this test would silently stop covering the regression when mimalloc
+    // tuning shifts. Adjust MIMALLOC_RESERVE_OS_MEMORY / the statement count
+    // above if this fires.
+    expect(stdout).not.toContain("NO_OOM");
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout.trim()).toBe("RECOVERED_OK");
+    expect(exitCode).toBe(0);
+  });
 
   test("pooled print buffer survives repeated growth and shrink", () => {
     const transpiler = new Bun.Transpiler({ loader: "ts" });

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -30,7 +30,7 @@ describe("Transpiler transformSync buffer reuse", () => {
         // Prime the cached BufferWriter with a ~500KB allocation so the first
         // growth during the huge print below moves it (freeing this pointer).
         t.transformSync(";");
-        const chunk = "a".repeat(500 * 1024);
+        const chunk = Buffer.alloc(500 * 1024, "a").toString();
         t.transformSync('var m = "' + chunk + '";');
         // Many statements: each string literal is one writeAll, so the buffer
         // grows in ~500KB steps and getError() is checked after every statement
@@ -75,7 +75,6 @@ describe("Transpiler transformSync buffer reuse", () => {
       expect(stdout.trim()).toBe("RECOVERED_OK");
       expect(exitCode).toBe(0);
     },
-    30_000,
   );
 
   test("pooled print buffer survives repeated growth and shrink", () => {

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 
 // transformSync caches its print buffer on the Transpiler instance and reuses
 // it across calls. BufferPrinter.init copies that BufferWriter *by value* into
@@ -19,10 +19,10 @@ describe("Transpiler transformSync buffer reuse", () => {
   //
   // Requires an ASAN-instrumented mimalloc (MI_TRACK_ASAN) to observe the UAF;
   // release builds keep freed large segments mapped so the stale write is
-  // silent there. Windows mimalloc reserve semantics differ enough that we
-  // skip it.
-  const hasASAN = isDebug || isASAN;
-  test.skipIf(!hasASAN || isWindows)(
+  // silent there. Gated to the debug build specifically: the reserved-arena
+  // size below is tuned against its memory footprint, and it is what the
+  // fail-before gate runs. Windows mimalloc reserve semantics differ.
+  test.skipIf(!isDebug || isWindows)(
     "does not cache a freed print buffer after transformSync throws",
     async () => {
       const fixture = /* js */ `
@@ -66,16 +66,14 @@ describe("Transpiler transformSync buffer reuse", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      if (stdout.includes("NO_OOM")) {
-        // Could not drive the allocator to fail mid-print (e.g. mimalloc tuning
-        // changed). The bug is not exercised, but the buffer-reuse path below
-        // still is.
-        console.warn("transformSync OOM repro: allocator did not fail mid-print; skipping UAF assertion");
-      } else {
-        expect(stderr).not.toContain("AddressSanitizer");
-        expect(stdout.trim()).toBe("RECOVERED_OK");
-        expect(exitCode).toBe(0);
-      }
+      // Fail loudly if the allocator never returned OOM mid-print; otherwise
+      // this test would silently stop covering the regression when mimalloc
+      // tuning shifts. Adjust MIMALLOC_RESERVE_OS_MEMORY / the statement count
+      // above if this fires.
+      expect(stdout).not.toContain("NO_OOM");
+      expect(stderr).not.toContain("AddressSanitizer");
+      expect(stdout.trim()).toBe("RECOVERED_OK");
+      expect(exitCode).toBe(0);
     },
     30_000,
   );
@@ -108,13 +106,14 @@ describe("Transpiler transformSync buffer reuse", () => {
     transpiler.transformSync(";");
 
     // Monotonically growing output so every call reallocates past the
-    // previous capacity. Verify the tail of each result so a stale buffer
-    // (truncated or garbage bytes) would fail the assertion, not just crash.
+    // previous capacity. Compare the full output each time so any prefix
+    // corruption from a stale buffer shows up, not just the tail.
     let body = "";
+    let expected = "";
     for (let i = 0; i < 128; i++) {
       body += `export const v${i}: number = ${i};\n`;
-      const out = transpiler.transformSync(body);
-      expect(out.endsWith(`export const v${i} = ${i};\n`)).toBe(true);
+      expected += `export const v${i} = ${i};\n`;
+      expect(transpiler.transformSync(body)).toBe(expected);
     }
   });
 });

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -1,15 +1,89 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
 
 // transformSync caches its print buffer on the Transpiler instance and reuses
-// it across calls. The printer holds a by-value copy of that BufferWriter, so
-// when printing grows the buffer past its capacity the old allocation is
-// freed and only the printer's copy sees the new pointer. The cached
-// BufferWriter must be refreshed from printer.ctx on every return path;
-// previously the error path skipped that step, leaving a freed pointer in the
-// cache for the next call. These tests drive the reuse path hard with output
-// that forces reallocations so ASAN trips if the cached pointer ever goes
-// stale.
+// it across calls. BufferPrinter.init copies that BufferWriter *by value* into
+// printer.ctx, so when printing grows the underlying MutableString past its
+// capacity the old allocation is freed and only printer.ctx sees the new
+// pointer. The cached BufferWriter must be refreshed from printer.ctx on every
+// return path. Previously the error path returned before that sync happened,
+// so the defer stored the stale snapshot (freed pointer) into
+// this.buffer_writer for the next call to write through.
 describe("Transpiler transformSync buffer reuse", () => {
+  // The only way transpiler.print() can fail on this path is allocator OOM, so
+  // we pin mimalloc to a fixed reserved arena and disallow further OS
+  // allocations. After the print buffer reallocates at least once, a later
+  // growth returns NULL and transformSync throws. Without the fix, the next
+  // transformSync writes through the freed cached pointer — ASAN catches it as
+  // a SEGV on write inside BufferWriter.writeAll → MutableString.append.
+  //
+  // Requires an ASAN-instrumented mimalloc (MI_TRACK_ASAN) to observe the UAF;
+  // release builds keep freed large segments mapped so the stale write is
+  // silent there. Windows mimalloc reserve semantics differ enough that we
+  // skip it.
+  const hasASAN = isDebug || isASAN;
+  test.skipIf(!hasASAN || isWindows)(
+    "does not cache a freed print buffer after transformSync throws",
+    async () => {
+      const fixture = /* js */ `
+        const t = new Bun.Transpiler({ loader: "js" });
+        // Prime the cached BufferWriter with a ~500KB allocation so the first
+        // growth during the huge print below moves it (freeing this pointer).
+        t.transformSync(";");
+        const chunk = "a".repeat(500 * 1024);
+        t.transformSync('var m = "' + chunk + '";');
+        // Many statements: each string literal is one writeAll, so the buffer
+        // grows in ~500KB steps and getError() is checked after every statement
+        // (the first OOM is reported without millions of retry writes).
+        let huge = "";
+        for (let i = 0; i < 80; i++) huge += 'var h' + i + ' = "' + chunk + '";\\n';
+        let threw = false;
+        try { t.transformSync(huge); } catch { threw = true; }
+        if (!threw) { process.stdout.write("NO_OOM\\n"); process.exit(0); }
+        // With the fix, the cached BufferWriter is printer.ctx (the live buffer
+        // at the point of OOM). Without the fix, it is the freed ~500KB pointer
+        // and this write trips ASAN.
+        const out = t.transformSync("const ok = 1;");
+        process.stdout.write(out === "const ok = 1;\\n" ? "RECOVERED_OK\\n" : "BAD:" + JSON.stringify(out) + "\\n");
+      `;
+      using dir = tempDir("transpiler-buffer-writer", { "repro.js": fixture });
+
+      // 128MiB sits comfortably inside the 64–160MiB window where parse
+      // succeeds but the print buffer growth past ~20–30MiB exhausts the
+      // reserved arena on current debug/ASAN builds.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repro.js"],
+        cwd: String(dir),
+        env: {
+          ...bunEnv,
+          MIMALLOC_RESERVE_OS_MEMORY: "128M",
+          MIMALLOC_DISALLOW_OS_ALLOC: "1",
+          MIMALLOC_SHOW_ERRORS: "0",
+          MIMALLOC_MAX_ERRORS: "0",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      if (stdout.includes("NO_OOM")) {
+        // Could not drive the allocator to fail mid-print (e.g. mimalloc tuning
+        // changed). The bug is not exercised, but the buffer-reuse path below
+        // still is.
+        console.warn("transformSync OOM repro: allocator did not fail mid-print; skipping UAF assertion");
+      } else {
+        expect(stderr).not.toContain("AddressSanitizer");
+        expect(stdout.trim()).toBe("RECOVERED_OK");
+        expect(exitCode).toBe(0);
+      }
+    },
+    30_000,
+  );
+
   test("pooled print buffer survives repeated growth and shrink", () => {
     const transpiler = new Bun.Transpiler({ loader: "ts" });
 

--- a/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
+++ b/test/js/bun/transpiler/transpiler-buffer-writer-reuse.test.ts
@@ -64,11 +64,7 @@ describe("Transpiler transformSync buffer reuse", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       if (stdout.includes("NO_OOM")) {
         // Could not drive the allocator to fail mid-print (e.g. mimalloc tuning


### PR DESCRIPTION
## What

`transformSync` caches a `BufferWriter` on the `Transpiler` instance and reuses it across calls. `BufferPrinter.init` takes that writer **by value** (`NewWriter.ctx: ContextType`), so when printing grows the underlying `MutableString` past its capacity the old allocation is freed and only `printer.ctx` sees the new pointer — the local `buffer_writer` snapshot is left pointing at freed memory.

The old code had:

```zig
defer { this.buffer_writer = buffer_writer; }  // saves whatever the local holds
...
var printer = JSPrinter.BufferPrinter.init(buffer_writer);
_ = this.transpiler.print(...) catch |err| {
    return globalThis.throwError(err, ...);     // early return, local never synced
};
buffer_writer = printer.ctx;                    // only reached on success
```

On the error path the defer stored the stale snapshot (freed pointer) back into `this.buffer_writer`. The next `transformSync` call would then `reset()` it and write through the freed allocation.

The buffer is allocated from `arena.backingAllocator()` → `MimallocArena.getThreadLocalDefault()`, the persistent thread-local heap (not the per-call arena), so the stale pointer survives across calls.

## Fix

Move the defer after `printer` is constructed and have it persist `printer.ctx` directly. Both the success and error paths now cache the live buffer.

## How did you verify your code works?

The only way `transpiler.print` can return an error on this path is allocator OOM. The regression test pins mimalloc to a fixed 128MiB reserved arena (`MIMALLOC_RESERVE_OS_MEMORY` + `MIMALLOC_DISALLOW_OS_ALLOC`) and feeds `transformSync` 80×500KB statements so the print buffer reallocates several times before a later growth returns NULL. After the throw, a follow-up `transformSync` writes through the cached pointer.

Without the fix, under ASAN:

```
AddressSanitizer: SEGV on unknown address ... (WRITE)
  #3 string.MutableString.append
  #4 js_printer.BufferWriter.writeAll
  ...
  #13 bun.js.api.JSTranspiler.transformSync  JSTranspiler.zig:1037
```

With the fix, the follow-up call returns the correct output and exits 0.

The test is gated to ASAN-instrumented builds (`isDebug || isASAN`) since release mimalloc keeps freed large segments mapped and the stale write is silent there. Two additional tests churn the pooled buffer through repeated growth/shrink cycles on all builds.
