### PR TITLE
path: bounds-check joinZBuf and return error.NameTooLong on overflow

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4660,7 +4660,7 @@ pub const NodeFS = struct {
 
                     const path_parts = [_]string{ root_basename, basename };
                     return .{
-                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto)),
+                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto) catch basename),
                     };
                 }
                 return .{
@@ -4692,7 +4692,7 @@ pub const NodeFS = struct {
                 if (comptime !is_root) {
                     const path_parts = [_]string{ root_basename, basename };
                     return .{
-                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto)),
+                        .err = err.withPath(bun.path.joinZBuf(buf, &path_parts, .auto) catch basename),
                     };
                 }
 
@@ -4710,7 +4710,9 @@ pub const NodeFS = struct {
                 }
 
                 const path_parts = [_]string{ basename, utf8_name };
-                break :brk bun.path.joinZBuf(buf, &path_parts, .auto);
+                break :brk bun.path.joinZBuf(buf, &path_parts, .auto) catch return .{
+                    .err = bun.sys.Error.fromCode(.NAMETOOLONG, .scandir).withPath(basename),
+                };
             };
 
             // Track effective kind - may be resolved from .unknown via stat
@@ -4878,7 +4880,9 @@ pub const NodeFS = struct {
                     }
 
                     const path_parts = [_]string{ basename, utf8_name };
-                    break :brk bun.path.joinZBuf(buf, &path_parts, .auto);
+                    break :brk bun.path.joinZBuf(buf, &path_parts, .auto) catch return .{
+                        .err = bun.sys.Error.fromCode(.NAMETOOLONG, .scandir).withPath(basename),
+                    };
                 };
 
                 // Track effective kind - may be resolved from .unknown via stat

--- a/src/glob/GlobWalker.zig
+++ b/src/glob/GlobWalker.zig
@@ -106,7 +106,8 @@ pub fn statatWindows(fd: bun.FD, path: [:0]const u8) Maybe(bun.Stat) {
         dir[0..dir.len],
         path,
     };
-    const statpath = ResolvePath.joinZBuf(&buf, parts, .auto);
+    const statpath = ResolvePath.joinZBuf(&buf, parts, .auto) catch
+        return .{ .err = Syscall.Error.fromCode(.NAMETOOLONG, .stat).withPath(path) };
     return Syscall.stat(statpath);
 }
 
@@ -1553,10 +1554,17 @@ pub fn GlobWalker_(
                 return try stdJoin(this.arena.allocator(), subdir_parts);
             }
 
-            const out = try this.arena.allocator().dupe(u8, bunJoin(subdir_parts, .auto));
-            if (comptime sentinel) return out[0 .. out.len - 1 :0];
+            if (comptime !sentinel) {
+                return try this.arena.allocator().dupe(u8, bunJoin(subdir_parts, .auto));
+            }
 
-            return out;
+            // Allocate a buffer large enough that joinZBuf can't return
+            // error.NameTooLong; the result is already arena-owned.
+            var upper: usize = 2;
+            for (subdir_parts) |part| upper += part.len + 1;
+            const out = try this.arena.allocator().alloc(u8, upper);
+            const joined = ResolvePath.joinZBuf(out, subdir_parts, .auto) catch unreachable;
+            return joined;
         }
 
         inline fn startsWithDot(filepath: []const u8) bool {

--- a/src/install/PackageInstall.zig
+++ b/src/install/PackageInstall.zig
@@ -112,7 +112,7 @@ pub const PackageInstall = struct {
         const patch_tag_path = bun.path.joinZ(&[_][]const u8{
             this.destination_dir_subpath,
             bunhashtag,
-        }, .posix);
+        }, .posix) catch return false;
 
         var destination_dir = this.node_modules.openDir(root_node_modules_dir) catch return false;
         defer {

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -58,7 +58,8 @@ pub const PackageInstaller = struct {
         noinline fn directoryExistsAtWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
             var path_buf: bun.PathBuffer = undefined;
             const parts: [2][]const u8 = .{ this.path.items, file_path };
-            return bun.sys.directoryExistsAt(.fromStdDir(root_node_modules_dir), bun.path.joinZBuf(&path_buf, &parts, .auto)).unwrapOr(false);
+            const joined = bun.path.joinZBuf(&path_buf, &parts, .auto) catch return false;
+            return bun.sys.directoryExistsAt(.fromStdDir(root_node_modules_dir), joined).unwrapOr(false);
         }
 
         pub fn directoryExistsAt(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bool {
@@ -75,7 +76,9 @@ pub const PackageInstaller = struct {
         noinline fn openFileWithoutOpeningDirectories(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8) bun.sys.Maybe(bun.sys.File) {
             var path_buf: bun.PathBuffer = undefined;
             const parts: [2][]const u8 = .{ this.path.items, file_path };
-            return bun.sys.File.openat(.fromStdDir(root_node_modules_dir), bun.path.joinZBuf(&path_buf, &parts, .auto), bun.O.RDONLY, 0);
+            const joined = bun.path.joinZBuf(&path_buf, &parts, .auto) catch
+                return .{ .err = .fromCode(.NAMETOOLONG, .open) };
+            return bun.sys.File.openat(.fromStdDir(root_node_modules_dir), joined, bun.O.RDONLY, 0);
         }
 
         pub fn readFile(this: *const NodeModulesFolder, root_node_modules_dir: std.fs.Dir, file_path: [:0]const u8, allocator: std.mem.Allocator) !bun.sys.File.ReadToEndResult {

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -87,7 +87,10 @@ pub fn doPatchCommit(
     const _cache_dir: std.fs.Dir, const _cache_dir_subpath: stringZ, const _changes_dir: []const u8, const _pkg: Package = switch (arg_kind) {
         .path => result: {
             const package_json_source: *const logger.Source = &brk: {
-                const package_json_path = bun.path.joinZ(&[_][]const u8{ argument, "package.json" }, .auto);
+                const package_json_path = bun.path.joinZ(&[_][]const u8{ argument, "package.json" }, .auto) catch {
+                    Output.errGeneric("path to package.json under {f} is too long", .{bun.fmt.quote(argument)});
+                    Global.crash();
+                };
 
                 switch (bun.sys.File.toSource(package_json_path, manager.allocator, .{})) {
                     .result => |s| break :brk s,
@@ -165,7 +168,10 @@ pub fn doPatchCommit(
             const changes_dir = bun.path.joinZBuf(pathbuf[0..], &[_][]const u8{
                 node_modules.relative_path,
                 name,
-            }, .auto);
+            }, .auto) catch {
+                Output.errGeneric("path to package \"{s}\" is too long", .{name});
+                Global.crash();
+            };
             const pkg = lockfile.packages.get(pkg_id);
 
             const cache_result = manager.computeCacheDirAndSubpath(
@@ -429,7 +435,10 @@ pub fn doPatchCommit(
             patch_filename,
         },
         .posix,
-    );
+    ) catch {
+        Output.errGeneric("patch file path is too long: {s}/{s}", .{ manager.options.patch_features.commit.patches_dir, patch_filename });
+        Global.crash();
+    };
 
     var nodefs = bun.jsc.Node.fs.NodeFS{};
     const args = bun.jsc.Node.fs.Arguments.Mkdir{
@@ -454,7 +463,9 @@ pub fn doPatchCommit(
 
     const patch_key = bun.handleOom(std.fmt.allocPrint(manager.allocator, "{s}", .{resolution_label}));
     const patchfile_path = bun.handleOom(manager.allocator.dupe(u8, path_in_patches_dir));
-    _ = bun.sys.unlink(bun.path.joinZ(&[_][]const u8{ changes_dir, ".bun-patch-tag" }, .auto));
+    if (bun.path.joinZ(&[_][]const u8{ changes_dir, ".bun-patch-tag" }, .auto)) |patch_tag| {
+        _ = bun.sys.unlink(patch_tag);
+    } else |_| {}
 
     return .{
         .patch_key = patch_key,
@@ -572,7 +583,10 @@ pub fn preparePatch(manager: *PackageManager) !void {
             var lockfile = manager.lockfile;
 
             const package_json_source: *const logger.Source = &src: {
-                const package_json_path = bun.path.joinZ(&[_][]const u8{ argument, "package.json" }, .auto);
+                const package_json_path = bun.path.joinZ(&[_][]const u8{ argument, "package.json" }, .auto) catch {
+                    Output.errGeneric("path to package.json under {f} is too long", .{bun.fmt.quote(argument)});
+                    Global.crash();
+                };
 
                 switch (bun.sys.File.toSource(package_json_path, manager.allocator, .{})) {
                     .result => |s| break :src s,

--- a/src/install/extract_tarball.zig
+++ b/src/install/extract_tarball.zig
@@ -503,9 +503,19 @@ pub fn moveToCacheDirectory(
         else => this.package_manager.lockfile.trusted_dependencies != null and
             this.package_manager.lockfile.trusted_dependencies.?.contains(@truncate(Semver.String.Builder.stringHash(name))),
     }) {
+        const package_json_rel_path = bun.path.joinZBuf(&json_path_buf, &[_]string{ folder_name, "package.json" }, .auto) catch |err| {
+            log.addErrorFmt(
+                null,
+                logger.Loc.Empty,
+                bun.default_allocator,
+                "\"package.json\" path for \"{s}\" is too long: {s}",
+                .{ name, @errorName(err) },
+            ) catch unreachable;
+            return error.InstallFailed;
+        };
         const json_file, json_buf = bun.sys.File.readFileFrom(
             bun.FD.fromStdDir(cache_dir),
-            bun.path.joinZBuf(&json_path_buf, &[_]string{ folder_name, "package.json" }, .auto),
+            package_json_rel_path,
             bun.default_allocator,
         ).unwrap() catch |err| {
             if (this.resolution.tag == .github and err == error.ENOENT) {

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -239,7 +239,14 @@ pub const PatchTask = struct {
         const absolute_patchfile_path = bun.path.joinZBuf(&absolute_patchfile_path_buf, &[_][]const u8{
             dir,
             patchfile_path,
-        }, .auto);
+        }, .auto) catch {
+            return try log.addErrorFmtOpts(
+                this.manager.allocator,
+                "patch file path is too long: {s}/{s}",
+                .{ dir, patchfile_path },
+                .{},
+            );
+        };
         // TODO: can the patch file be anything other than utf-8?
 
         const patchfile_txt = switch (bun.sys.File.readFrom(
@@ -382,7 +389,14 @@ pub const PatchTask = struct {
                 // tempdir_name,
             },
             .auto,
-        );
+        ) catch {
+            return try log.addErrorFmtOpts(
+                this.manager.allocator,
+                "temporary directory path is too long: {s}",
+                .{tempdir_name},
+                .{},
+            );
+        };
 
         if (bun.sys.renameatConcurrently(
             .fromStdDir(system_tmpdir),
@@ -414,7 +428,16 @@ pub const PatchTask = struct {
                 patchfile_path,
             },
             .auto,
-        );
+        ) catch {
+            log.addErrorFmt(
+                null,
+                Loc.Empty,
+                this.manager.allocator,
+                "patch file path is too long: {s}/{s}",
+                .{ dir, patchfile_path },
+            ) catch unreachable;
+            return null;
+        };
 
         const stat: bun.Stat = switch (bun.sys.stat(absolute_patchfile_path)) {
             .err => |e| {

--- a/src/patch.zig
+++ b/src/patch.zig
@@ -76,7 +76,7 @@ pub const PatchFile = struct {
                         const path_to_make = bun.path.joinZ(&[_][]const u8{
                             abs_patch_dir,
                             todir,
-                        }, .auto);
+                        }, .auto) catch return bun.sys.Error.fromCode(.NAMETOOLONG, .mkdir).withoutPath();
                         var nodefs = bun.api.node.fs.NodeFS{};
                         if (nodefs.mkdirRecursive(.{
                             .path = .{ .string = bun.PathString.init(path_to_make) },
@@ -179,7 +179,8 @@ pub const PatchFile = struct {
                             .err => |e| return e.withoutPath(),
                         };
                         var buf: bun.PathBuffer = undefined;
-                        const joined_absfilepath = bun.path.joinZBuf(&buf, &[_][]const u8{ absfilepath, filepath }, .auto);
+                        const joined_absfilepath = bun.path.joinZBuf(&buf, &[_][]const u8{ absfilepath, filepath }, .auto) catch
+                            return bun.sys.Error.fromCode(.NAMETOOLONG, .open).withoutPath();
                         const fd = switch (bun.sys.open(joined_absfilepath, bun.O.RDWR, 0)) {
                             .err => |e| return e.withoutPath(),
                             .result => |f| f,
@@ -219,7 +220,8 @@ pub const PatchFile = struct {
         else
             bun.sys.stat(
                 switch (state.patchDirAbsPath(patch_dir)) {
-                    .result => |p| bun.path.joinZ(&[_][]const u8{ p, file_path }, .auto),
+                    .result => |p| bun.path.joinZ(&[_][]const u8{ p, file_path }, .auto) catch
+                        return .{ .err = bun.sys.Error.fromCode(.NAMETOOLONG, .stat).withPath(file_path) },
                     .err => |e| return .{ .err = e },
                 },
             )) {

--- a/src/repl.zig
+++ b/src/repl.zig
@@ -186,7 +186,7 @@ const History = struct {
         if (home_path.len == 0) return;
 
         var path_buf: bun.PathBuffer = undefined;
-        const path = bun.path.joinZBuf(&path_buf, &[_][]const u8{ home_path, HISTORY_FILENAME }, .auto);
+        const path = bun.path.joinZBuf(&path_buf, &[_][]const u8{ home_path, HISTORY_FILENAME }, .auto) catch return;
         self.file_path = try self.allocator.dupe(u8, path);
 
         const content = switch (bun.sys.File.readFrom(bun.FD.cwd(), path, self.allocator)) {

--- a/src/resolver/resolve_path.zig
+++ b/src/resolver/resolve_path.zig
@@ -1218,16 +1218,40 @@ pub threadlocal var join_buf: [4096]u8 = undefined;
 pub fn join(_parts: anytype, comptime platform: Platform) []const u8 {
     return joinStringBuf(&join_buf, _parts, platform);
 }
-pub fn joinZ(_parts: anytype, comptime platform: Platform) [:0]const u8 {
+pub fn joinZ(_parts: anytype, comptime platform: Platform) error{NameTooLong}![:0]const u8 {
     return joinZBuf(&join_buf, _parts, platform);
 }
 
-pub fn joinZBuf(buf: []u8, _parts: anytype, comptime platform: Platform) [:0]const u8 {
-    const joined = joinStringBuf(buf[0 .. buf.len - 1], _parts, platform);
-    assert(bun.isSliceInBuffer(joined, buf));
-    const start_offset = @intFromPtr(joined.ptr) - @intFromPtr(buf.ptr);
-    buf[joined.len + start_offset] = 0;
-    return buf[start_offset..][0..joined.len :0];
+/// Join path `_parts` into `buf` as a null-terminated string. Returns
+/// `error.NameTooLong` if the *normalized* result (plus null terminator) does
+/// not fit in `buf`. `..` segments are accounted for: a path whose
+/// unnormalized length exceeds `buf.len` but normalizes down will succeed.
+pub fn joinZBuf(buf: []u8, _parts: anytype, comptime platform: Platform) error{NameTooLong}![:0]const u8 {
+    // Upper-bound the unnormalized joined length. Normalization never grows
+    // the string beyond this (it only collapses `.`/`..`/separators), so this
+    // bounds the output too.
+    var upper: usize = 2; // covers null terminator + minimum "." output
+    for (_parts) |part| upper += part.len + 1;
+
+    // Fast path: the upper bound fits in buf, so joinStringBuf cannot overflow it.
+    if (upper <= buf.len) {
+        const joined = joinStringBuf(buf[0 .. buf.len - 1], _parts, platform);
+        assert(bun.isSliceInBuffer(joined, buf));
+        const start_offset = @intFromPtr(joined.ptr) - @intFromPtr(buf.ptr);
+        buf[joined.len + start_offset] = 0;
+        return buf[start_offset..][0..joined.len :0];
+    }
+
+    // Slow path: parts may overflow buf as-is, but normalization may shrink
+    // them enough to fit. Join into a heap scratch, then check the normalized
+    // length against buf.
+    const scratch = bun.handleOom(bun.default_allocator.alloc(u8, upper));
+    defer bun.default_allocator.free(scratch);
+    const joined = joinStringBuf(scratch, _parts, platform);
+    if (joined.len + 1 > buf.len) return error.NameTooLong;
+    bun.copy(u8, buf, joined);
+    buf[joined.len] = 0;
+    return buf[0..joined.len :0];
 }
 pub fn joinStringBuf(buf: []u8, parts: anytype, comptime platform: Platform) []const u8 {
     return joinStringBufT(u8, buf, parts, platform);

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -448,7 +448,8 @@ pub const ShellCpTask = struct {
                 this.cwd_path[0..],
                 this.src[0..],
             };
-            break :brk ResolvePath.joinZ(parts, .auto);
+            break :brk ResolvePath.joinZ(parts, .auto) catch
+                return bun.shell.ShellErr.newSys(Syscall.Error.fromCode(.NAMETOOLONG, .copyfile).withPath(this.src));
         };
         var tgt: [:0]const u8 = brk: {
             if (ResolvePath.Platform.auto.isAbsolute(this.tgt)) break :brk this.tgt;
@@ -456,7 +457,8 @@ pub const ShellCpTask = struct {
                 this.cwd_path[0..],
                 this.tgt[0..],
             };
-            break :brk ResolvePath.joinZBuf(buf2[0..bun.MAX_PATH_BYTES], parts, .auto);
+            break :brk ResolvePath.joinZBuf(buf2[0..bun.MAX_PATH_BYTES], parts, .auto) catch
+                return bun.shell.ShellErr.newSys(Syscall.Error.fromCode(.NAMETOOLONG, .copyfile).withPath(this.tgt));
         };
 
         // Cases:
@@ -514,7 +516,8 @@ pub const ShellCpTask = struct {
                     tgt[0..tgt.len],
                     basename,
                 };
-                tgt = ResolvePath.joinZBuf(buf3[0..bun.MAX_PATH_BYTES], parts, .auto);
+                tgt = ResolvePath.joinZBuf(buf3[0..bun.MAX_PATH_BYTES], parts, .auto) catch
+                    return bun.shell.ShellErr.newSys(Syscall.Error.fromCode(.NAMETOOLONG, .copyfile).withPath(this.tgt));
             } else if (this.operands == 2) {
                 // source_dir -> new_target_dir
             } else {
@@ -532,7 +535,8 @@ pub const ShellCpTask = struct {
                 tgt[0..tgt.len],
                 basename,
             };
-            tgt = ResolvePath.joinZBuf(buf3[0..bun.MAX_PATH_BYTES], parts, .auto);
+            tgt = ResolvePath.joinZBuf(buf3[0..bun.MAX_PATH_BYTES], parts, .auto) catch
+                return bun.shell.ShellErr.newSys(Syscall.Error.fromCode(.NAMETOOLONG, .copyfile).withPath(this.tgt));
             copying_many = true;
         }
 

--- a/src/shell/builtin/mkdir.zig
+++ b/src/shell/builtin/mkdir.zig
@@ -231,7 +231,16 @@ pub const ShellMkdirTask = struct {
     fn runFromThreadPool(task: *jsc.WorkPoolTask) void {
         var this: *ShellMkdirTask = @fieldParentPtr("task", task);
         debug("{f} runFromThreadPool", .{this});
+        this.runFromThreadPoolImpl();
 
+        if (this.event_loop == .js) {
+            this.event_loop.js.enqueueTaskConcurrent(this.concurrent_task.js.from(this, .manual_deinit));
+        } else {
+            this.event_loop.mini.enqueueTaskConcurrent(this.concurrent_task.mini.from(this, "runFromMainThreadMini"));
+        }
+    }
+
+    fn runFromThreadPoolImpl(this: *ShellMkdirTask) void {
         // We have to give an absolute path to our mkdir
         // implementation for it to work with cwd
         const filepath: [:0]const u8 = brk: {
@@ -240,7 +249,10 @@ pub const ShellMkdirTask = struct {
                 this.cwd_path[0..],
                 this.filepath[0..],
             };
-            break :brk ResolvePath.joinZ(parts, .auto);
+            break :brk ResolvePath.joinZ(parts, .auto) catch {
+                this.err = bun.sys.Error.fromCode(.NAMETOOLONG, .mkdir).withPath(this.filepath).toShellSystemError();
+                return;
+            };
         };
 
         var node_fs = jsc.Node.fs.NodeFS{};
@@ -279,12 +291,6 @@ pub const ShellMkdirTask = struct {
                     std.mem.doNotOptimizeAway(&node_fs);
                 },
             }
-        }
-
-        if (this.event_loop == .js) {
-            this.event_loop.js.enqueueTaskConcurrent(this.concurrent_task.js.from(this, .manual_deinit));
-        } else {
-            this.event_loop.mini.enqueueTaskConcurrent(this.concurrent_task.mini.from(this, "runFromMainThreadMini"));
         }
     }
 

--- a/src/shell/builtin/mv.zig
+++ b/src/shell/builtin/mv.zig
@@ -122,7 +122,11 @@ pub const ShellMvBatchedTask = struct {
                 const target_path = ResolvePath.joinZ(&[_][]const u8{
                     this.target,
                     ResolvePath.basename(src),
-                }, .auto);
+                }, .auto) catch {
+                    this.err = e.withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, this.target)));
+                    this.err_path_owned = true;
+                    return false;
+                };
 
                 this.err = e.withPath(bun.handleOom(bun.default_allocator.dupeZ(u8, target_path[0..])));
                 this.err_path_owned = true;

--- a/src/shell/builtin/rm.zig
+++ b/src/shell/builtin/rm.zig
@@ -807,10 +807,12 @@ pub const ShellRmTask = struct {
         }
     }
 
-    pub fn bufJoin(this: *ShellRmTask, buf: *bun.PathBuffer, parts: []const []const u8, _: Syscall.Tag) Maybe([:0]const u8) {
-        if (this.join_style == .posix) {
-            return .{ .result = ResolvePath.joinZBuf(buf, parts, .posix) };
-        } else return .{ .result = ResolvePath.joinZBuf(buf, parts, .windows) };
+    pub fn bufJoin(this: *ShellRmTask, buf: *bun.PathBuffer, parts: []const []const u8, syscall: Syscall.Tag) Maybe([:0]const u8) {
+        const joined = if (this.join_style == .posix)
+            ResolvePath.joinZBuf(buf, parts, .posix)
+        else
+            ResolvePath.joinZBuf(buf, parts, .windows);
+        return .{ .result = joined catch return .{ .err = .fromCode(.NAMETOOLONG, syscall) } };
     }
 
     pub fn removeEntry(this: *ShellRmTask, dir_task: *DirTask, is_absolute: bool) Maybe(void) {

--- a/src/shell/builtin/touch.zig
+++ b/src/shell/builtin/touch.zig
@@ -219,7 +219,16 @@ pub const ShellTouchTask = struct {
     fn runFromThreadPool(task: *jsc.WorkPoolTask) void {
         var this: *ShellTouchTask = @fieldParentPtr("task", task);
         debug("{f} runFromThreadPool", .{this});
+        this.runFromThreadPoolImpl();
 
+        if (this.event_loop == .js) {
+            this.event_loop.js.enqueueTaskConcurrent(this.concurrent_task.js.from(this, .manual_deinit));
+        } else {
+            this.event_loop.mini.enqueueTaskConcurrent(this.concurrent_task.mini.from(this, "runFromMainThreadMini"));
+        }
+    }
+
+    fn runFromThreadPoolImpl(this: *ShellTouchTask) void {
         // We have to give an absolute path
         const filepath: [:0]const u8 = brk: {
             if (ResolvePath.Platform.auto.isAbsolute(this.filepath)) break :brk this.filepath;
@@ -227,7 +236,10 @@ pub const ShellTouchTask = struct {
                 this.cwd_path[0..],
                 this.filepath[0..],
             };
-            break :brk ResolvePath.joinZ(parts, .auto);
+            break :brk ResolvePath.joinZ(parts, .auto) catch {
+                this.err = Syscall.Error.fromCode(.NAMETOOLONG, .open).withPath(this.filepath).toShellSystemError();
+                return;
+            };
         };
 
         var node_fs = jsc.Node.fs.NodeFS{};
@@ -257,12 +269,6 @@ pub const ShellTouchTask = struct {
                 }
             }
             this.err = err.withPath(filepath).toShellSystemError();
-        }
-
-        if (this.event_loop == .js) {
-            this.event_loop.js.enqueueTaskConcurrent(this.concurrent_task.js.from(this, .manual_deinit));
-        } else {
-            this.event_loop.mini.enqueueTaskConcurrent(this.concurrent_task.mini.from(this, "runFromMainThreadMini"));
         }
     }
 };

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -623,7 +623,8 @@ pub const Interpreter = struct {
                 const cwd_str = ResolvePath.joinZ(&[_][]const u8{
                     existing_cwd,
                     new_cwd_,
-                }, .auto);
+                }, .auto) catch
+                    return .{ .err = .fromCode(.NAMETOOLONG, .chdir) };
 
                 // remove trailing separator
                 if (bun.Environment.isWindows) {
@@ -1840,7 +1841,8 @@ pub const ShellSyscall = struct {
             dirpath[0..dirpath.len],
             to[0..to.len],
         };
-        const joined = ResolvePath.joinZBuf(buf, parts, .auto);
+        const joined = ResolvePath.joinZBuf(buf, parts, .auto) catch
+            return .{ .err = Syscall.Error.fromCode(.NAMETOOLONG, .open).withPath(to) };
         return .{ .result = joined };
     }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -788,6 +788,32 @@ booga"
     });
   });
 
+  describe.each(["touch", "mkdir"])("%s", builtin => {
+    test("very long relative path errors with ENAMETOOLONG instead of overflowing path buffer", async () => {
+      // joinZ uses a 4096-byte threadlocal buffer; this is large enough to
+      // overflow it (and the surrounding stack) without the bounds check.
+      // Spawn a subprocess so a crash on regression shows up as a failed
+      // assertion rather than killing the test runner.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const longPath = Buffer.alloc(100000, "a").toString();
+           const { exitCode, stderr } = await Bun.$\`${builtin} \${longPath}\`.quiet().nothrow();
+           console.log(JSON.stringify({ exitCode, stderr: stderr.toString().slice(0, 30) }));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(
+        JSON.stringify({ exitCode: 1, stderr: `${builtin}: File name too long: aaa`.slice(0, 30) }),
+      );
+      expect(exitCode).toBe(0);
+    });
+  });
+
   test("which", async () => {
     const bogus = "akdfjlsdjflks";
     const { stdout } = await $`which ${BUN} ${bogus}`;


### PR DESCRIPTION
## What does this PR do?

`bun.path.joinZBuf` (and `joinZ`, which wraps it with a 4096-byte threadlocal buffer) previously wrote the normalized result into the caller's buffer with no length check. User-controlled paths long enough to exceed the buffer would overflow it.

The new signature is `error{NameTooLong}![:0]const u8`:
- **Fast path**: when the upper-bound joined length fits in `buf`, behave exactly as before (zero allocation).
- **Slow path**: heap-normalize first and check the *normalized* length against `buf`, so paths whose `..` segments collapse under the limit still succeed (matching `joinAbsStringBufChecked`'s contract).

All call sites are updated to handle the error. Most map it to an `ENAMETOOLONG` `bun.sys.Error` or fall through to the surrounding code's existing error path; `GlobWalker.join` sidesteps it by sizing its arena buffer to the upper bound so the call cannot fail. Shell `touch`/`mkdir` gain a small `runFromThreadPoolImpl` split so the early-error path still enqueues the completion task.

## How did you verify your code works?

- `bun run zig:check-all` passes on all platforms.
- New regression test in `test/js/bun/shell/bunshell.test.ts` drives 100k-byte relative paths through shell `touch` and `mkdir`; before this change the `joinZ` buffer overflow aborts the subprocess (exit 134 on the released bun).
- Ran `bun bd test` against `test/js/bun/shell/commands/{cp,rm,mv}.test.ts`, `test/js/node/fs/fs.test.ts -t readdir`, and `test/cli/install/bun-patch.test.ts` — all green.