### PR TITLE
subprocess: release start() ref in PipeReader.onReaderError

### DIFF
--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -937,6 +937,48 @@ pub fn getGlobalThis(this: *Subprocess) ?*jsc.JSGlobalObject {
 
 const IPClog = Output.scoped(.IPC, .visible);
 
+pub const TestingAPIs = struct {
+    /// Inject a synthetic read error into a subprocess's stdout/stderr
+    /// PipeReader, as if the underlying read() syscall (Posix) or libuv read
+    /// callback (Windows) had failed with EBADF. Used by tests to exercise
+    /// the onReaderError cleanup path, which is otherwise very hard to
+    /// trigger deterministically — on Windows in particular, peer death on
+    /// a named pipe maps to UV_EOF rather than an error.
+    ///
+    /// Returns true if an error was injected, false if the given stdio is
+    /// not (or no longer) a buffered pipe reader.
+    pub fn injectStdioReadError(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        const arguments = callframe.arguments_old(2).slice();
+        if (arguments.len < 2) {
+            return globalThis.throw("injectStdioReadError(subprocess, 'stdout'|'stderr')", .{});
+        }
+        const subprocess = Subprocess.fromJS(arguments[0]) orelse {
+            return globalThis.throw("first argument must be a Subprocess", .{});
+        };
+        const kind_str = try arguments[1].toBunString(globalThis);
+        defer kind_str.deref();
+
+        const out: *Readable = if (kind_str.eqlComptime("stdout"))
+            &subprocess.stdout
+        else if (kind_str.eqlComptime("stderr"))
+            &subprocess.stderr
+        else
+            return globalThis.throw("second argument must be 'stdout' or 'stderr'", .{});
+
+        if (out.* != .pipe) return .false;
+        const pipe = out.pipe;
+
+        // Mirror what the real error path does (onStreamRead on Windows,
+        // read() on Posix) so the teardown exercised is identical.
+        const fake_err = bun.sys.Error.fromCode(.BADF, .read);
+        if (comptime Environment.isWindows) {
+            _ = pipe.reader.stopReading();
+        }
+        pipe.reader.onError(fake_err);
+        return .true;
+    }
+};
+
 pub const StdioResult = if (Environment.isWindows) bun.spawn.WindowsSpawnResult.StdioResult else ?bun.FD;
 pub const Writable = @import("./subprocess/Writable.zig").Writable;
 

--- a/src/bun.js/api/bun/subprocess.zig
+++ b/src/bun.js/api/bun/subprocess.zig
@@ -948,14 +948,11 @@ pub const TestingAPIs = struct {
     /// Returns true if an error was injected, false if the given stdio is
     /// not (or no longer) a buffered pipe reader.
     pub fn injectStdioReadError(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
-        const arguments = callframe.arguments_old(2).slice();
-        if (arguments.len < 2) {
-            return globalThis.throw("injectStdioReadError(subprocess, 'stdout'|'stderr')", .{});
-        }
-        const subprocess = Subprocess.fromJS(arguments[0]) orelse {
+        const subprocess_value, const kind_value = callframe.argumentsAsArray(2);
+        const subprocess = Subprocess.fromJS(subprocess_value) orelse {
             return globalThis.throw("first argument must be a Subprocess", .{});
         };
-        const kind_str = try arguments[1].toBunString(globalThis);
+        const kind_str = try kind_value.toBunString(globalThis);
         defer kind_str.deref();
 
         const out: *Readable = if (kind_str.eqlComptime("stdout"))

--- a/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
+++ b/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
@@ -78,8 +78,8 @@ pub fn start(this: *PipeReader, process: *Subprocess, event_loop: *jsc.EventLoop
         .result => {
             if (comptime Environment.isPosix) {
                 if (this.state == .err) {
-                    // onReaderError already ran and tore everything down;
-                    // the handle is closed and the poll is gone.
+                    // onReaderError already ran; the guard deref on return
+                    // will drop the last ref and deinit() closes the handle.
                     return .success;
                 }
                 const poll = this.reader.handle.poll;

--- a/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
+++ b/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
@@ -63,12 +63,25 @@ pub fn start(this: *PipeReader, process: *Subprocess, event_loop: *jsc.EventLoop
         return this.reader.startWithCurrentPipe();
     }
 
+    // PosixBufferedReader.start() always returns .result, but if poll
+    // registration fails it synchronously invokes onReaderError() first,
+    // which drops both the Readable.pipe ref (via onCloseIO) and the ref we
+    // just took above. Hold one more ref so `this` survives long enough to
+    // check state after start() returns.
+    this.ref();
+    defer this.deref();
+
     switch (this.reader.start(this.stdio_result.?, true)) {
         .err => |err| {
             return .{ .err = err };
         },
         .result => {
             if (comptime Environment.isPosix) {
+                if (this.state == .err) {
+                    // onReaderError already ran and tore everything down;
+                    // the handle is closed and the poll is gone.
+                    return .success;
+                }
                 const poll = this.reader.handle.poll;
                 poll.flags.insert(.socket);
                 this.reader.flags.socket = true;

--- a/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
+++ b/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
@@ -171,8 +171,11 @@ pub fn onReaderError(this: *PipeReader, err: bun.sys.Error) void {
         bun.default_allocator.free(this.state.done);
     }
     this.state = .{ .err = err };
-    if (this.process) |process|
+    if (this.process) |process| {
+        this.process = null;
         process.onCloseIO(this.kind(process));
+        this.deref();
+    }
 }
 
 pub fn close(this: *PipeReader) void {
@@ -199,7 +202,7 @@ pub fn loop(this: *PipeReader) *bun.Async.Loop {
 
 fn deinit(this: *PipeReader) void {
     if (comptime Environment.isPosix) {
-        bun.assert(this.reader.isDone());
+        bun.assert(this.reader.isDone() or this.state == .err);
     }
 
     if (comptime Environment.isWindows) {

--- a/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
+++ b/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
@@ -219,7 +219,14 @@ fn deinit(this: *PipeReader) void {
     }
 
     if (comptime Environment.isWindows) {
-        bun.assert(this.reader.source == null or this.reader.source.?.isClosed() or this.state == .err);
+        // WindowsBufferedReader.onError() never closes the source, and
+        // WindowsBufferedReader.deinit() nulls this.source before calling
+        // closeImpl so it never actually closes either. Close it here on
+        // the error path so the uv.Pipe handle doesn't leak.
+        if (this.state == .err and this.reader.source != null and !this.reader.source.?.isClosed()) {
+            this.reader.closeImpl(false);
+        }
+        bun.assert(this.reader.source == null or this.reader.source.?.isClosed());
     }
 
     if (this.state == .done) {

--- a/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
+++ b/src/bun.js/api/bun/subprocess/SubprocessPipeReader.zig
@@ -206,7 +206,7 @@ fn deinit(this: *PipeReader) void {
     }
 
     if (comptime Environment.isWindows) {
-        bun.assert(this.reader.source == null or this.reader.source.?.isClosed());
+        bun.assert(this.reader.source == null or this.reader.source.?.isClosed() or this.state == .err);
     }
 
     if (this.state == .done) {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -980,13 +980,11 @@ pub const WindowsBufferedReader = struct {
         MaxBuf.removeFromPipereader(&this.maxbuf);
         this.buffer().deinit();
         const source = this.source orelse return;
+        this.source = null;
         if (!source.isClosed()) {
-            // closeImpl reads this.source, closes the handle, and nulls it.
-            // Do not null this.source beforehand or closeImpl becomes a no-op
-            // and the handle leaks.
+            // closeImpl will take care of freeing the source
             this.closeImpl(false);
         }
-        this.source = null;
     }
 
     pub fn setRawMode(this: *WindowsBufferedReader, value: bool) bun.sys.Maybe(void) {

--- a/src/io/PipeReader.zig
+++ b/src/io/PipeReader.zig
@@ -980,11 +980,13 @@ pub const WindowsBufferedReader = struct {
         MaxBuf.removeFromPipereader(&this.maxbuf);
         this.buffer().deinit();
         const source = this.source orelse return;
-        this.source = null;
         if (!source.isClosed()) {
-            // closeImpl will take care of freeing the source
+            // closeImpl reads this.source, closes the handle, and nulls it.
+            // Do not null this.source beforehand or closeImpl becomes a no-op
+            // and the handle leaks.
             this.closeImpl(false);
         }
+        this.source = null;
     }
 
     pub fn setRawMode(this: *WindowsBufferedReader, value: bool) bun.sys.Maybe(void) {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -64,6 +64,13 @@ export const shellInternals = {
   builtinDisabled: $newZigFunction("shell.zig", "TestingAPIs.disabledOnThisPlatform", 1),
 };
 
+export const subprocessInternals = {
+  injectStdioReadError: $newZigFunction("subprocess.zig", "TestingAPIs.injectStdioReadError", 2) as (
+    subprocess: import("bun").Subprocess,
+    kind: "stdout" | "stderr",
+  ) => boolean,
+};
+
 export const iniInternals = {
   parse: $newZigFunction("ini.zig", "IniTestingAPIs.parse", 1),
   // loadNpmrc: (

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -127,9 +127,7 @@ process.exit(0);
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const stderrLines = stderr
-    .split("\n")
-    .filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+  const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
   expect(stderrLines).toEqual([]);
   expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
   expect(exitCode).toBe(0);

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, libcPathForDlopen, tempDir } from "harness";
+
+// PipeReader.onReaderError() was missing the this.deref() that balances the
+// this.ref() from start(), so when a read on a subprocess stdout/stderr pipe
+// failed with a real error (not EOF/EAGAIN), the PipeReader struct, its
+// buffered data, its poll registration and the pipe fd were all leaked. The
+// leaked poll's keep-alive ref also prevented the event loop from exiting.
+//
+// Triggering a real read error on an AF_UNIX socketpair from JS is hard; the
+// only reliable way is to dup() the parent's read-end fd (so the underlying
+// file description stays alive in the epoll interest list), then dup2() a
+// write-only fd onto the original fd number. When the child writes, epoll
+// still fires for the original file description but read() on the swapped fd
+// returns EBADF, which reaches SubprocessPipeReader.onReaderError. This
+// relies on Linux epoll semantics so the test is Linux-only, but the leak
+// itself is cross-platform.
+test.skipIf(!isLinux)("PipeReader is freed when a subprocess stdout read fails", async () => {
+  using dir = tempDir("spawn-pipe-read-error-leak", {
+    "fixture.js": `
+const { dlopen, FFIType } = require("bun:ffi");
+const { readdirSync, readlinkSync, openSync, closeSync, writeFileSync, rmSync } = require("fs");
+const { execFileSync } = require("child_process");
+const { join } = require("path");
+
+const libc = dlopen(process.env.LIBC_PATH, {
+  dup: { args: [FFIType.i32], returns: FFIType.i32 },
+  dup2: { args: [FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+});
+
+function snapshotFds() {
+  const out = new Map();
+  for (const name of readdirSync("/proc/self/fd")) {
+    const fd = Number(name);
+    if (!Number.isInteger(fd)) continue;
+    try {
+      out.set(fd, readlinkSync("/proc/self/fd/" + fd));
+    } catch {
+      // fd closed between readdir and readlink (e.g. readdir's own dir fd)
+    }
+  }
+  return out;
+}
+
+const fifo = join(process.cwd(), "sync-fifo");
+
+async function once() {
+  try { rmSync(fifo); } catch {}
+  execFileSync("mkfifo", [fifo]);
+
+  const before = snapshotFds();
+
+  // cat blocks opening the fifo until the parent opens it for writing, then
+  // copies whatever the parent writes to stdout.
+  const proc = Bun.spawn({
+    cmd: ["cat", fifo],
+    stdin: "ignore",
+    stdout: "pipe", // PipeReader - never access proc.stdout from JS
+    stderr: "inherit",
+  });
+
+  // Only stdout is piped, so exactly one new socket fd exists: the parent's
+  // read end of the stdout socketpair.
+  const after = snapshotFds();
+  let stdoutFd = -1;
+  for (const [fd, link] of after) {
+    if (link.startsWith("socket:") && before.get(fd) !== link) {
+      stdoutFd = fd;
+    }
+  }
+  if (stdoutFd < 0) {
+    proc.kill();
+    await proc.exited;
+    throw new Error("could not locate stdout socket fd");
+  }
+
+  // Keep the file description alive so the epoll interest-list entry survives
+  // the dup2() below; epoll tracks file descriptions, not fd numbers.
+  const dupFd = libc.symbols.dup(stdoutFd);
+  if (dupFd < 0) throw new Error("dup() failed");
+
+  // Swap the stdout fd number to point at a write-only file so the next
+  // read() on it fails with EBADF.
+  const wo = openSync("/dev/null", "w");
+  if (libc.symbols.dup2(wo, stdoutFd) < 0) throw new Error("dup2() failed");
+  closeSync(wo);
+
+  // Unblock the child so it writes to stdout; epoll fires on the original
+  // file description and the reader's read() on stdoutFd returns EBADF.
+  writeFileSync(fifo, "x");
+
+  await proc.exited;
+
+  // Drop our extra reference to the original file description so its epoll
+  // entry goes away.
+  closeSync(dupFd);
+
+  await Bun.sleep(0);
+  Bun.gc(true);
+
+  const final = snapshotFds();
+  let leaked = 0;
+  for (const [fd, link] of final) {
+    if (before.get(fd) !== link) leaked++;
+  }
+  return leaked;
+}
+
+let total = 0;
+for (let i = 0; i < 10; i++) total += await once();
+try { rmSync(fifo); } catch {}
+console.log(JSON.stringify({ leaked: total }));
+// Without the fix the leaked polls keep the event loop alive forever; exit
+// explicitly so the parent test can assert on the leak count instead of
+// just timing out.
+process.exit(0);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: { ...bunEnv, LIBC_PATH: libcPathForDlopen() },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -159,8 +159,9 @@ test("PipeReader is freed when a subprocess stdout read fails (injected)", async
     "fixture.js": `
 const { subprocessInternals } = require("bun:internal-for-testing");
 
+// timeout.exe refuses to run with redirected stdin; ping works regardless.
 const sleeper = process.platform === "win32"
-  ? ["cmd.exe", "/c", "timeout /t 120 /nobreak >nul"]
+  ? ["cmd.exe", "/c", "ping -n 120 127.0.0.1 >nul"]
   : ["sleep", "120"];
 
 let injected = 0;

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -15,9 +15,11 @@ import { bunEnv, bunExe, isLinux, libcPathForDlopen, tempDir } from "harness";
 // returns EBADF, which reaches SubprocessPipeReader.onReaderError. This
 // relies on Linux epoll semantics so the test is Linux-only, but the leak
 // itself is cross-platform.
-test.skipIf(!isLinux)("PipeReader is freed when a subprocess stdout read fails", async () => {
-  using dir = tempDir("spawn-pipe-read-error-leak", {
-    "fixture.js": `
+test.skipIf(!isLinux)(
+  "PipeReader is freed when a subprocess stdout read fails",
+  async () => {
+    using dir = tempDir("spawn-pipe-read-error-leak", {
+      "fixture.js": `
 const { dlopen, FFIType } = require("bun:ffi");
 const { readdirSync, readlinkSync, openSync, closeSync, writeFileSync, rmSync } = require("fs");
 const { execFileSync } = require("child_process");
@@ -123,20 +125,22 @@ console.log(JSON.stringify({ leaked: total }));
 // just timing out.
 process.exit(0);
 `,
-  });
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "fixture.js"],
-    env: { ...bunEnv, LIBC_PATH: libcPathForDlopen() },
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: { ...bunEnv, LIBC_PATH: libcPathForDlopen() },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
-  expect(stderrLines).toEqual([]);
-  expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
-  expect(exitCode).toBe(0);
-}, 30_000);
+    const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+    expect(stderrLines).toEqual([]);
+    expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -139,4 +139,4 @@ process.exit(0);
   expect(stderrLines).toEqual([]);
   expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
   expect(exitCode).toBe(0);
-});
+}, 30_000);

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -160,8 +160,9 @@ test("PipeReader is freed when a subprocess stdout read fails (injected)", async
 const { subprocessInternals } = require("bun:internal-for-testing");
 
 // timeout.exe refuses to run with redirected stdin; ping works regardless.
+// Spawn ping directly (not via cmd.exe) so proc.kill() actually reaches it.
 const sleeper = process.platform === "win32"
-  ? ["cmd.exe", "/c", "ping -n 120 127.0.0.1 >nul"]
+  ? ["ping", "-n", "120", "127.0.0.1"]
   : ["sleep", "120"];
 
 let injected = 0;

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -154,11 +154,9 @@ process.exit(0);
 // Without the fix, the leaked poll keep-alive refs (Posix) / uv.Pipe handles
 // (Windows) prevent the event loop from exiting after the loop completes, so
 // the fixture hangs and the spawn timeout kills it.
-test(
-  "PipeReader is freed when a subprocess stdout read fails (injected)",
-  async () => {
-    using dir = tempDir("spawn-pipe-read-error-leak-inject", {
-      "fixture.js": `
+test("PipeReader is freed when a subprocess stdout read fails (injected)", async () => {
+  using dir = tempDir("spawn-pipe-read-error-leak-inject", {
+    "fixture.js": `
 const { subprocessInternals } = require("bun:internal-for-testing");
 
 const sleeper = process.platform === "win32"
@@ -188,27 +186,25 @@ console.log(JSON.stringify({ injected }));
 // (Posix) / open uv.Pipe handles (Windows) keep it alive and the parent's
 // spawn timeout fires.
 `,
-    });
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      // Without the fix the fixture never exits; bound it so the assertion
-      // below shows a clear failure instead of the test itself timing out.
-      timeout: isWindows ? 25_000 : 15_000,
-    });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Without the fix the fixture never exits; bound it so the assertion
+    // below shows a clear failure instead of the test itself timing out.
+    timeout: isWindows ? 25_000 : 15_000,
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
-    expect(stderrLines).toEqual([]);
-    expect(stdout.trim()).toBe(JSON.stringify({ injected: 10 }));
-    // SIGKILL from the spawn timeout is the failure signal here.
-    expect(proc.signalCode).toBeNull();
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+  const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+  expect(stderrLines).toEqual([]);
+  expect(stdout.trim()).toBe(JSON.stringify({ injected: 10 }));
+  // SIGKILL from the spawn timeout is the failure signal here.
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, libcPathForDlopen, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, libcPathForDlopen, tempDir } from "harness";
 
 // PipeReader.onReaderError() was missing the this.deref() that balances the
 // this.ref() from start(), so when a read on a subprocess stdout/stderr pipe
@@ -143,4 +143,72 @@ process.exit(0);
     expect(exitCode).toBe(0);
   },
   30_000,
+);
+
+// Cross-platform version that uses an internal-for-testing hook to inject a
+// synthetic EBADF directly into the reader, instead of relying on Linux epoll
+// semantics. On Windows, normal subprocess termination maps to UV_EOF (not an
+// error), and the uv.Pipe HANDLE isn't JS-accessible, so there's no way to
+// trigger a real read error from JS — hence the hook.
+//
+// Without the fix, the leaked poll keep-alive refs (Posix) / uv.Pipe handles
+// (Windows) prevent the event loop from exiting after the loop completes, so
+// the fixture hangs and the spawn timeout kills it.
+test(
+  "PipeReader is freed when a subprocess stdout read fails (injected)",
+  async () => {
+    using dir = tempDir("spawn-pipe-read-error-leak-inject", {
+      "fixture.js": `
+const { subprocessInternals } = require("bun:internal-for-testing");
+
+const sleeper = process.platform === "win32"
+  ? ["cmd.exe", "/c", "timeout /t 120 /nobreak >nul"]
+  : ["sleep", "120"];
+
+let injected = 0;
+for (let i = 0; i < 10; i++) {
+  const proc = Bun.spawn({
+    cmd: sleeper,
+    stdin: "ignore",
+    stdout: "pipe", // PipeReader - never access proc.stdout from JS
+    stderr: "ignore",
+  });
+
+  // Inject EBADF into the stdout PipeReader as if read()/uv_read_cb had
+  // failed. This tears down the PipeReader via onReaderError.
+  if (subprocessInternals.injectStdioReadError(proc, "stdout")) injected++;
+
+  proc.kill();
+  await proc.exited;
+}
+Bun.gc(true);
+console.log(JSON.stringify({ injected }));
+// No explicit process.exit(): if the fix works, the event loop exits on its
+// own once the script finishes. Without the fix, the leaked keep-alive refs
+// (Posix) / open uv.Pipe handles (Windows) keep it alive and the parent's
+// spawn timeout fires.
+`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      // Without the fix the fixture never exits; bound it so the assertion
+      // below shows a clear failure instead of the test itself timing out.
+      timeout: isWindows ? 25_000 : 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+    expect(stderrLines).toEqual([]);
+    expect(stdout.trim()).toBe(JSON.stringify({ injected: 10 }));
+    // SIGKILL from the spawn timeout is the failure signal here.
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  },
+  60_000,
 );

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -127,7 +127,10 @@ process.exit(0);
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
+  const stderrLines = stderr
+    .split("\n")
+    .filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+  expect(stderrLines).toEqual([]);
   expect(stdout.trim()).toBe(JSON.stringify({ leaked: 0 }));
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-read-error-leak.test.ts
@@ -95,13 +95,21 @@ async function once() {
   // entry goes away.
   closeSync(dupFd);
 
-  await Bun.sleep(0);
   Bun.gc(true);
 
-  const final = snapshotFds();
+  // The fd close goes through bun.Async.Closer which schedules close() on
+  // a jsc.WorkPool thread; Bun.sleep(0) doesn't synchronize with that. Poll
+  // a few times so a briefly-starved close thread doesn't flag a false
+  // positive (same pattern as spawn-stdin-pipe-fd-leak.test.ts).
   let leaked = 0;
-  for (const [fd, link] of final) {
-    if (before.get(fd) !== link) leaked++;
+  for (let i = 0; i < 20; i++) {
+    const final = snapshotFds();
+    leaked = 0;
+    for (const [fd, link] of final) {
+      if (before.get(fd) !== link) leaked++;
+    }
+    if (leaked === 0) break;
+    await Bun.sleep(20);
   }
   return leaked;
 }


### PR DESCRIPTION
## What

`PipeReader.start()` takes a ref that `onReaderDone()` releases after `onCloseIO`, but `onReaderError()` only called `onCloseIO` and never released it. Whenever a subprocess stdout/stderr read failed with a real error (not EOF/EAGAIN — e.g. `EBADF`, `EIO` on a revoked tty), the `PipeReader` struct, its buffered bytes, its `FilePoll` and the pipe fd all leaked. The leaked poll's keep-alive ref also prevented the event loop from ever exiting.

Refcount trace:
- `create()` → ref=1 (owned by `Readable.pipe`)
- `start()` → `this.ref()` → ref=2 (owned by the in-flight read)
- success: `onReaderDone` → `onCloseIO` (`pipe.deref()`, ref=1) → `this.deref()` → ref=0 → `deinit`
- **error**: `onReaderError` → `onCloseIO` (`pipe.deref()`, ref=1) → *(nothing)* → ref stays at 1 forever; `onCloseIO` converted the `Readable` to `.ignore` so nothing else ever touches the pipe again

## Fix

Mirror `onReaderDone` in the error path: clear `this.process`, call `onCloseIO`, then `this.deref()`. Also relax the `deinit()` assertion to allow `state == .err`, matching the shell's `PipeReader` in `src/shell/subproc.zig` which already handles this correctly (the underlying `PosixBufferedReader.onError` doesn't set `is_done` before invoking the vtable).

## Test

There's no JS-visible hook to inject a read error on an `AF_UNIX` socketpair, so the test forces one on Linux by:

1. Spawning `cat <fifo>` with `stdout: "pipe"` (never touching `proc.stdout`, so ownership stays with `SubprocessPipeReader`)
2. Diffing `/proc/self/fd` to find the stdout socketpair read-end fd `N`
3. `dup(N)` → `M` so the underlying file description stays alive in the epoll interest list (epoll tracks file descriptions, not fd numbers)
4. `dup2(write-only /dev/null, N)` so `N` now points at a write-only file
5. Writing to the fifo so `cat` writes to stdout → epoll fires for the original file description → the reader's `read(N)` returns `EBADF` → `onReaderError`

Bun registers the poll with `EPOLLONESHOT`, so the disarmed entry never fires again after the error and there's no UAF when `deinit` frees the poll.

## Verification

```
# without fix
Expected: "{\"leaked\":0}"
Received: "{\"leaked\":10}"

# with fix
(pass) PipeReader is freed when a subprocess stdout read fails
```