### PR TITLE
event_loop: don't drop ConcurrentTasks when the task FIFO wraps

### DIFF
--- a/src/bun.js/event_loop.zig
+++ b/src/bun.js/event_loop.zig
@@ -327,8 +327,13 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
         this.tasks.head = 0;
     }
 
+    // `ensureUnusedCapacity` guarantees `writableLength() >= count` (total free
+    // space across the ring), but `writableSlice(0)` only returns the contiguous
+    // tail segment — which can be shorter when `head > 0`. Writing via the slice
+    // and breaking on `len == 0` would silently drop the remaining ConcurrentTasks
+    // (and leak their auto_delete wrappers). `writeItemAssumeCapacity` wraps the
+    // tail index correctly, so every popped task is transferred.
     this.tasks.ensureUnusedCapacity(count) catch unreachable;
-    var writable = this.tasks.writableSlice(0);
 
     // Defer destruction of the ConcurrentTask to avoid issues with pointer aliasing
     var to_destroy: ?*ConcurrentTask = null;
@@ -343,16 +348,14 @@ pub fn tickConcurrentWithCount(this: *EventLoop) usize {
             to_destroy = task;
         }
 
-        writable[0] = task.task;
-        writable = writable[1..];
-        this.tasks.count += 1;
-        if (writable.len == 0) break;
+        this.tasks.writeItemAssumeCapacity(task.task);
     }
 
     if (to_destroy) |dest| {
         dest.deinit();
     }
 
+    bun.debugAssert(this.tasks.count - start_count == count);
     return this.tasks.count - start_count;
 }
 

--- a/src/bun.js/event_loop/MiniEventLoop.zig
+++ b/src/bun.js/event_loop/MiniEventLoop.zig
@@ -138,15 +138,16 @@ pub fn tickConcurrentWithCount(this: *MiniEventLoop) usize {
         this.tasks.head = 0;
     }
 
+    // See the matching comment in `EventLoop.tickConcurrentWithCount`:
+    // `writableSlice(0)` is only the contiguous tail and can be shorter than
+    // `count` when `head > 0`, which would drop tasks. `writeItemAssumeCapacity`
+    // handles ring-buffer wraparound correctly.
     this.tasks.ensureUnusedCapacity(count) catch unreachable;
-    var writable = this.tasks.writableSlice(0);
     while (iter.next()) |task| {
-        writable[0] = task;
-        writable = writable[1..];
-        this.tasks.count += 1;
-        if (writable.len == 0) break;
+        this.tasks.writeItemAssumeCapacity(task);
     }
 
+    bun.debugAssert(this.tasks.count - start_count == count);
     return this.tasks.count - start_count;
 }
 

--- a/test/cli/hot/hot-concurrent-fifo-fixture.js
+++ b/test/cli/hot/hot-concurrent-fifo-fixture.js
@@ -1,0 +1,68 @@
+// Fixture for hot-concurrent-fifo.test.ts — run with `bun --hot`.
+//
+// Sets up the event-loop task FIFO so that `tickConcurrentWithCount` is
+// entered with `head > 0` and `count > 0` (reachable via HotReloadTask's
+// early return from `tickQueueWithCount`) while a fresh batch of
+// ConcurrentTasks is waiting. If `tickConcurrentWithCount` only writes into
+// the contiguous tail of the ring buffer, the tail of that batch is silently
+// dropped and the corresponding promises never resolve.
+//
+// `crypto.subtle.digest` with a sub-64-byte message computes synchronously
+// and posts its callback via `ScriptExecutionContext::postTaskTo`, which
+// always routes through `postTaskConcurrently` — so each call pushes exactly
+// one ConcurrentTask to the main thread's queue before returning. That gives
+// us precise, single-threaded control over the batch layout.
+import { writeFileSync, readFileSync } from "node:fs";
+
+globalThis.__run ??= 0;
+globalThis.__run++;
+globalThis.__resolved ??= 0;
+globalThis.__total ??= 0;
+globalThis.__phase_d_fired ??= false;
+
+const small = new Uint8Array(1);
+function fire(n) {
+  for (let i = 0; i < n; i++) {
+    globalThis.__total++;
+    crypto.subtle.digest("SHA-256", small).then(() => {
+      globalThis.__resolved++;
+      // Phase D: while draining phase A (well before the HotReloadTask at
+      // position ~50), synchronously enqueue 50 more ConcurrentTasks. These
+      // are what the tickConcurrent() immediately after the early-return
+      // will pop, with the FIFO at head=51, count=10 in a 64-slot buffer —
+      // writableSlice(0) has length 3, writableLength is 54.
+      if (globalThis.__resolved === 40 && !globalThis.__phase_d_fired) {
+        globalThis.__phase_d_fired = true;
+        fire(50);
+      }
+    });
+  }
+}
+
+if (globalThis.__run === 1) {
+  // Phase A: 50 ConcurrentTasks land before the HotReloadTask.
+  fire(50);
+
+  // Trigger a hot reload. The watcher thread enqueues a HotReloadTask (also a
+  // ConcurrentTask) after phase A in FIFO order.
+  const self = import.meta.path;
+  writeFileSync(self, readFileSync(self, "utf8"));
+  Bun.sleepSync(250);
+
+  // Phase C: 10 ConcurrentTasks after the HotReloadTask so that `count > 0`
+  // when tickQueueWithCount early-returns and `head` is not reset.
+  fire(10);
+
+  // Report once the event loop has settled. The timer itself lives on the
+  // uv/usockets loop, not in the task FIFO, so it can't be dropped by the
+  // bug under test.
+  globalThis.__report ??= setTimeout(() => {
+    const out = {
+      run: globalThis.__run,
+      total: globalThis.__total,
+      resolved: globalThis.__resolved,
+    };
+    console.log(JSON.stringify(out));
+    process.exit(out.resolved === out.total ? 0 : 1);
+  }, 1000);
+}

--- a/test/cli/hot/hot-concurrent-fifo.test.ts
+++ b/test/cli/hot/hot-concurrent-fifo.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { cpSync } from "node:fs";
 import { join } from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // Regression test: EventLoop.tickConcurrentWithCount used `writableSlice(0)`
 // after `ensureUnusedCapacity(count)`. The latter guarantees `writableLength()
@@ -44,7 +44,10 @@ test.skipIf(isWindows)(
         stderr: "pipe",
       });
       [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      const line = stdout.trim().split("\n").findLast(l => l.startsWith("{"));
+      const line = stdout
+        .trim()
+        .split("\n")
+        .findLast(l => l.startsWith("{"));
       expect(line, `no JSON in stdout:\n${stdout}\nstderr:\n${stderr}`).toBeString();
       result = JSON.parse(line!);
       if (result!.run >= 2) break;

--- a/test/cli/hot/hot-concurrent-fifo.test.ts
+++ b/test/cli/hot/hot-concurrent-fifo.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "bun:test";
+import { cpSync } from "node:fs";
+import { join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// Regression test: EventLoop.tickConcurrentWithCount used `writableSlice(0)`
+// after `ensureUnusedCapacity(count)`. The latter guarantees `writableLength()
+// >= count` (total free ring-buffer space), but the former only returns the
+// contiguous tail segment — which is shorter when `head > 0`. The copy loop
+// `break`s when that slice fills, silently dropping the remaining popped
+// ConcurrentTasks (and leaking their auto_delete wrappers).
+//
+// The wrap-vulnerable state (`head > 0 && count > 0` on entry) is reachable
+// via HotReloadTask, which early-returns from tickQueueWithCount before the
+// queue is fully drained. See the fixture for the exact batch layout.
+//
+// Windows: `--hot` uses a different watch backend with enough latency that
+// the HotReloadTask can't reliably be placed between phases A and C.
+test.skipIf(isWindows)(
+  "tickConcurrentWithCount does not drop ConcurrentTasks when the task FIFO wraps after a HotReloadTask early-return",
+  async () => {
+    using dir = tempDir("hot-concurrent-fifo", {
+      // File is rewritten by the fixture itself to trigger the reload; copy
+      // it into the temp dir so we don't mutate the checked-in fixture.
+      "entry.js": "",
+    });
+    cpSync(join(import.meta.dir, "hot-concurrent-fifo-fixture.js"), join(String(dir), "entry.js"));
+
+    // The watcher enqueueing the HotReloadTask between phase A and phase C is
+    // the only timing-dependent step (inotify is normally sub-millisecond and
+    // the fixture sleeps 250ms). If it lands late the fixture still exits 0 on
+    // any build but reports `run: 1`, so retry a couple of times before
+    // treating it as a real miss.
+    let result: { run: number; total: number; resolved: number } | undefined;
+    let stdout = "";
+    let stderr = "";
+    let exitCode: number | null = null;
+    for (let attempt = 0; attempt < 4; attempt++) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--hot", "--no-clear-screen", "entry.js"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const line = stdout.trim().split("\n").findLast(l => l.startsWith("{"));
+      expect(line, `no JSON in stdout:\n${stdout}\nstderr:\n${stderr}`).toBeString();
+      result = JSON.parse(line!);
+      if (result!.run >= 2) break;
+      // Watcher didn't fire in time — restore the fixture and retry.
+      cpSync(join(import.meta.dir, "hot-concurrent-fifo-fixture.js"), join(String(dir), "entry.js"));
+    }
+
+    expect(result!.run, "hot reload never fired; watcher too slow on this platform").toBeGreaterThanOrEqual(2);
+    expect({ resolved: result!.resolved, total: result!.total }).toEqual({
+      resolved: result!.total,
+      total: result!.total,
+    });
+    expect(exitCode, `stderr:\n${stderr}`).toBe(0);
+  },
+);


### PR DESCRIPTION
## What

`EventLoop.tickConcurrentWithCount` (and the `MiniEventLoop` twin) transferred a popped `ConcurrentTask` batch into the `tasks` FIFO by calling `ensureUnusedCapacity(count)` followed by a manual copy into `writableSlice(0)`, breaking when the slice ran out.

`ensureUnusedCapacity` checks **total** free space (`buf.len - count`) and does not realign; `writableSlice(0)` returns only the **contiguous tail** (`buf.len - head - count`). When `head > 0` with items still in the FIFO, the slice can be shorter than the batch and the `break` silently drops the remaining `ConcurrentTask`s — the wrapped `Task` never runs and the `auto_delete` wrapper leaks.

## Reachability

`HotReloadTask` early-returns from `tickQueueWithCount` before the queue is drained (`Task.zig:268-276`), leaving `tasks.count > 0 && tasks.head > 0`. The very next `tickConcurrent()` in the `tick()` loop then enters `tickConcurrentWithCount` in the wrap-vulnerable state.

## Fix

Use `writeItemAssumeCapacity` per task instead of writing into the contiguous slice. It wraps the tail index with `& (buf.len - 1)` so every popped task lands in the ring. Added a `bun.debugAssert` that the written count equals the popped count.

## Test

`test/cli/hot/hot-concurrent-fifo.test.ts` drives `bun --hot` into the exact state:

- `crypto.subtle.digest("SHA-256", <1 byte>)` computes synchronously and posts its callback via `postTaskTo → postTaskConcurrently`, so each call pushes exactly one `ConcurrentTask` **before returning** — no threads, no timing.
- Phase A (50 digests) → `writeFileSync(self)` + sleep (watcher enqueues `HotReloadTask`) → Phase C (10 digests) gives a 61-item batch with the HotReloadTask at position 50.
- From digest #40's `.then()` (mid-drain, before the HotReloadTask), 50 more digests are enqueued.
- After the early-return the FIFO has `head=51, count=10` in a 64-slot buffer; `writableSlice(0)` has length 3, `writableLength()` is 54.

On `main` the test resolves **63/110** promises every run (47 dropped). With this change it resolves **110/110**.

```
# main (and USE_SYSTEM_BUN=1)
  { "resolved": 63, "total": 110 }   ×5 runs

# this branch
  { "resolved": 110, "total": 110 }  ×5 runs
```

Skipped on Windows where `--hot` watch latency makes the HotReloadTask placement between phases A and C unreliable.