### PR TITLE
timers: release heap ref when setTimeout is cleared or refreshed inside its own callback

### DIFF
--- a/src/bun.js/api/Timer/TimerObjectInternals.zig
+++ b/src/bun.js/api/Timer/TimerObjectInternals.zig
@@ -234,8 +234,22 @@ pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMac
                     }
                 }
 
-                if (this.eventLoopTimer().state == .FIRED) {
-                    break :is_timer_done true;
+                switch (this.eventLoopTimer().state) {
+                    .FIRED => {
+                        break :is_timer_done true;
+                    },
+                    .ACTIVE => {
+                        // The developer called timer.refresh() synchronously in the callback.
+                        // Balance out the ref count.
+                        // the transition from "FIRED" -> "ACTIVE" caused it to increment.
+                        this.deref();
+                    },
+                    else => {
+                        // The developer called clearTimeout() synchronously in the callback.
+                        // cancel() saw state == .FIRED and skipped its deref, so release the
+                        // heap ref here.
+                        break :is_timer_done true;
+                    },
                 }
             }
 

--- a/src/bun.js/api/Timer/TimerObjectInternals.zig
+++ b/src/bun.js/api/Timer/TimerObjectInternals.zig
@@ -228,8 +228,10 @@ pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMac
                 if (kind == .setTimeout and !repeat.isNull()) {
                     if (idle_timeout.getNumber()) |num| {
                         if (num != -1) {
+                            // reschedule() inside convertToInterval will see state == .FIRED
+                            // and add a ref; fall through to the switch below so the .ACTIVE
+                            // arm can balance it.
                             this.convertToInterval(globalThis, this_object, repeat);
-                            break :is_timer_done false;
                         }
                     }
                 }
@@ -239,9 +241,10 @@ pub fn fire(this: *TimerObjectInternals, _: *const timespec, vm: *jsc.VirtualMac
                         break :is_timer_done true;
                     },
                     .ACTIVE => {
-                        // The developer called timer.refresh() synchronously in the callback.
-                        // Balance out the ref count.
-                        // the transition from "FIRED" -> "ACTIVE" caused it to increment.
+                        // The developer called timer.refresh() synchronously in the callback,
+                        // or the timer was converted to an interval via t._repeat. Balance out
+                        // the ref count: the transition from "FIRED" -> "ACTIVE" via
+                        // reschedule() caused it to increment.
                         this.deref();
                     },
                     else => {

--- a/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
+++ b/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
@@ -1,12 +1,12 @@
-// Regression: calling clearTimeout(t) or t.refresh() inside t's own setTimeout callback
-// leaked the native TimeoutObject. In fire(), state is set to .FIRED before the callback
-// runs, so cancel() skipped its deref (it only derefs when state was .ACTIVE), and the
-// post-callback cleanup only released the heap ref when state was still .FIRED — the
-// .CANCELLED and .ACTIVE transitions inside the callback fell through without a deref.
+// Regression: calling clearTimeout(t), t.refresh(), or setting t._repeat inside t's own
+// setTimeout callback leaked the native TimeoutObject. In fire(), state is set to .FIRED
+// before the callback runs; any transition away from .FIRED during the callback
+// (cancel() -> .CANCELLED, or reschedule() -> .ACTIVE via refresh/convertToInterval) left
+// the heap ref unreleased because the post-callback cleanup only checked for .FIRED.
 
 const mode = process.argv[2];
-if (mode !== "clear" && mode !== "refresh") {
-  throw new Error("usage: <clear|refresh>");
+if (mode !== "clear" && mode !== "refresh" && mode !== "repeat") {
+  throw new Error("usage: <clear|refresh|repeat>");
 }
 
 const BATCH = 2_000;
@@ -25,13 +25,25 @@ async function runBatch() {
         clearTimeout(t);
         if (--remaining === 0) resolve();
       }, 0);
-    } else {
+    } else if (mode === "refresh") {
       let fired = false;
       const t = setTimeout(() => {
         if (!fired) {
           fired = true;
           t.refresh();
         } else {
+          if (--remaining === 0) resolve();
+        }
+      }, 0);
+    } else {
+      // "repeat": convert the timeout to an interval via t._repeat inside the callback
+      let fired = false;
+      const t = setTimeout(() => {
+        if (!fired) {
+          fired = true;
+          t._repeat = 1;
+        } else {
+          clearInterval(t);
           if (--remaining === 0) resolve();
         }
       }, 0);

--- a/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
+++ b/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
@@ -1,0 +1,69 @@
+// Regression: calling clearTimeout(t) or t.refresh() inside t's own setTimeout callback
+// leaked the native TimeoutObject. In fire(), state is set to .FIRED before the callback
+// runs, so cancel() skipped its deref (it only derefs when state was .ACTIVE), and the
+// post-callback cleanup only released the heap ref when state was still .FIRED — the
+// .CANCELLED and .ACTIVE transitions inside the callback fell through without a deref.
+
+const mode = process.argv[2];
+if (mode !== "clear" && mode !== "refresh") {
+  throw new Error("usage: <clear|refresh>");
+}
+
+const BATCH = 2_000;
+
+function gc() {
+  if (typeof Bun !== "undefined") Bun.gc(true);
+  else if (typeof globalThis.gc !== "undefined") globalThis.gc();
+}
+
+async function runBatch() {
+  let remaining = BATCH;
+  const { promise, resolve } = Promise.withResolvers();
+  for (let i = 0; i < BATCH; i++) {
+    if (mode === "clear") {
+      const t = setTimeout(() => {
+        clearTimeout(t);
+        if (--remaining === 0) resolve();
+      }, 0);
+    } else {
+      let fired = false;
+      const t = setTimeout(() => {
+        if (!fired) {
+          fired = true;
+          t.refresh();
+        } else {
+          if (--remaining === 0) resolve();
+        }
+      }, 0);
+    }
+  }
+  await promise;
+  gc();
+}
+
+// warmup
+for (let i = 0; i < 15; i++) await runBatch();
+gc();
+const initial = process.memoryUsage.rss();
+
+for (let i = 0; i < 100; i++) await runBatch();
+gc();
+const final = process.memoryUsage.rss();
+const deltaMB = (final - initial) / 1024 / 1024;
+console.log("mode:", mode);
+console.log("initial RSS:", (initial / 1024 / 1024) | 0, "MB");
+console.log("final RSS:", (final / 1024 / 1024) | 0, "MB");
+console.log("delta:", deltaMB.toFixed(1), "MB");
+
+if (globalThis.Bun) {
+  const heapStats = require("bun:jsc").heapStats();
+  if (heapStats.protectedObjectTypeCounts.Timeout) {
+    throw new Error("Expected 0 protected Timeout but received " + heapStats.protectedObjectTypeCounts.Timeout);
+  }
+}
+
+// Before the fix, 100 * 2_000 leaked TimeoutObjects (~100 bytes each) ≈ 20 MB.
+// After the fix the delta is ~0 MB (noise).
+if (deltaMB > 10) {
+  throw new Error("Memory leak detected: RSS grew by " + deltaMB.toFixed(1) + " MB");
+}

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -376,7 +376,11 @@ for (const mode of ["clear", "refresh"]) {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(filteredStderr).toBe("");
     expect(stdout).toContain("delta:");
     expect(exitCode).toBe(0);
   }, 90_000);

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -367,6 +367,25 @@ it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () =>
   expect([path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"]).toRun();
 });
 
+for (const mode of ["clear", "refresh"]) {
+  it(
+    `setTimeout doesn't leak when ${mode} is called inside its own callback`,
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-clear-in-callback-leak-fixture.js"), mode],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("delta:");
+      expect(exitCode).toBe(0);
+    },
+    90_000,
+  );
+}
+
 it("setTimeout does not leak a pending exception when emitting a timeout warning throws", async () => {
   // The out-of-range timeout warning queues a process.nextTick, which reads process._exiting.
   // If that read throws, the exception must not be left pending on the VM when setTimeout

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -367,7 +367,7 @@ it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () =>
   expect([path.join(import.meta.dir, "timers-fixture-unref.js"), "setTimeout"]).toRun();
 });
 
-for (const mode of ["clear", "refresh"]) {
+for (const mode of ["clear", "refresh", "repeat"]) {
   it(`setTimeout doesn't leak when ${mode} is called inside its own callback`, async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-clear-in-callback-leak-fixture.js"), mode],

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -368,22 +368,18 @@ it("setTimeout canceling with unref, close, _idleTimeout, and _onTimeout", () =>
 });
 
 for (const mode of ["clear", "refresh"]) {
-  it(
-    `setTimeout doesn't leak when ${mode} is called inside its own callback`,
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-clear-in-callback-leak-fixture.js"), mode],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toContain("delta:");
-      expect(exitCode).toBe(0);
-    },
-    90_000,
-  );
+  it(`setTimeout doesn't leak when ${mode} is called inside its own callback`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "setTimeout-clear-in-callback-leak-fixture.js"), mode],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("delta:");
+    expect(exitCode).toBe(0);
+  }, 90_000);
 }
 
 it("setTimeout does not leak a pending exception when emitting a timeout warning throws", async () => {


### PR DESCRIPTION
## What

Fix native memory leaks in `setTimeout` when `clearTimeout(t)`, `t.refresh()`, or `t._repeat = N` is called synchronously inside `t`'s own callback.

## Repro

```js
for (let i = 0; i < 100_000; i++) {
  const t = setTimeout(() => clearTimeout(t), 0);
}
// each native TimeoutObject (~100 bytes) is leaked
```

On current main, 500k timers leak ~48MB of RSS; the native `TimeoutObject` struct is never freed.

## Cause

In `TimerObjectInternals.fire()`:
1. `state` is set to `.FIRED` *before* invoking the user callback.
2. The +1 heap ref that `reschedule()` established (`this.ref()`) is meant to be released after the callback via the `is_timer_done -> this.deref()` path.

If the callback transitions state away from `.FIRED`, the heap ref was never released:

- **`clearTimeout(t)`** → `cancel()` sees `state == .FIRED` (not `.ACTIVE`), so `was_active` is false and it skips `deref()`. It sets `state = .CANCELLED`. The post-callback check was `if (state == .FIRED) is_timer_done = true` — `.CANCELLED` fell through to `is_timer_done = false`.
- **`t.refresh()`** → `reschedule()` sees `state == .FIRED` (not `.ACTIVE`), adds a ref, transitions to `.ACTIVE`. The post-callback check sees `state != .FIRED`, falls through without balancing.
- **`t._repeat = N`** → `convertToInterval()` → `reschedule()` — same `.FIRED → .ACTIVE` +1 as refresh, but then `break :is_timer_done false` skipped the post-callback check entirely.

Refcount: create=1 → reschedule ref=2 → scope ref=3 → callback doesn't balance → scope deref=2 → JS finalize=1 → never reaches 0.

`setInterval` already handled `.ACTIVE` and `.CANCELLED` correctly with an explicit `switch` on the post-callback state.

## Fix

Mirror the `setInterval` switch structure in the `setTimeout` post-callback arm:
- `.FIRED` → `is_timer_done = true` (unchanged)
- `.ACTIVE` → `this.deref()` to balance the extra ref from `reschedule()` called during `.FIRED` (timer stays in heap, keepalive untouched)
- `else` (`.CANCELLED`) → `is_timer_done = true` to release the heap ref

Remove the early `break` after `convertToInterval()` so it falls through to the `.ACTIVE` arm.

## Verification

New fixture `setTimeout-clear-in-callback-leak-fixture.js` runs 100 batches of 2,000 self-clearing / self-refreshing / self-repeating timers and checks RSS growth stays <10MB.

| | `clear` | `refresh` | `repeat` |
|---|---|---|---|
| before (release) | +20 MB (fail) | +18 MB (fail) | +20 MB (fail) |
| before (debug+ASAN) | +98 MB (fail) | +98 MB (fail) | — |
| after | ~0 MB (pass) | ~0 MB (pass) | ~0 MB (pass) |

All 58 `test/js/node/test/parallel/test-timers*.js` tests (including `test-timers-timeout-to-interval.js`) and all existing `setTimeout.test.js` refresh tests continue to pass.
