### PR TITLE
fetch: fix Content-Length for sliced file body over sendfile()

### DIFF
--- a/src/runtime/webcore/fetch.zig
+++ b/src/runtime/webcore/fetch.zig
@@ -1199,6 +1199,11 @@ fn fetchImpl(
                     if (bun.isRegularFile(stat.mode)) {
                         http_body.Sendfile.offset = @min(http_body.Sendfile.offset, stat_size);
                         http_body.Sendfile.remain = @min(@max(http_body.Sendfile.remain, http_body.Sendfile.offset), stat_size) -| http_body.Sendfile.offset;
+                        // content_size becomes the Content-Length header; it must match the
+                        // number of bytes we will actually send (remain), not the full file
+                        // size. Otherwise sliced blobs advertise the whole file and the peer
+                        // hangs waiting for bytes that never arrive.
+                        http_body.Sendfile.content_size = http_body.Sendfile.remain;
                     }
                     body.detach();
 

--- a/test/js/bun/http/fetch-file-upload.test.ts
+++ b/test/js/bun/http/fetch-file-upload.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isBroken, isWindows, withoutAggressiveGC } from "harness";
+import { isBroken, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -158,6 +158,60 @@ test.todoIf(isBroken && isWindows)(
   },
   10_000,
 );
+
+test.todoIf(isBroken && isWindows)("sliced file upload with sendfile() sends correct Content-Length", async () => {
+  // File must be >= 32 KB and served over plain HTTP to take the sendfile() path.
+  const fileSize = 64 * 1024;
+  const full = Buffer.alloc(fileSize);
+  for (let i = 0; i < fileSize; i++) full[i] = i & 0xff;
+
+  using dir = tempDir("fetch-sendfile-slice", {
+    "huge.bin": full,
+  });
+  const path = join(String(dir), "huge.bin");
+
+  const { promise: gotHeaders, resolve: resolveHeaders } = Promise.withResolvers<string | null>();
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    maxRequestBodySize: fileSize * 2,
+    async fetch(req) {
+      resolveHeaders(req.headers.get("content-length"));
+      const body = Buffer.from(await req.arrayBuffer());
+      return Response.json({
+        contentLength: req.headers.get("content-length"),
+        bodyLength: body.length,
+        hash: Bun.CryptoHasher.hash("sha256", body, "hex"),
+      });
+    },
+  });
+
+  const start = 1000;
+  const end = 1234;
+  const expected = full.subarray(start, end);
+
+  const resPromise = fetch(server.url, {
+    method: "POST",
+    body: Bun.file(path).slice(start, end),
+  });
+  // Prevent an unhandled rejection if the header assertion below throws
+  // before we get to await resPromise.
+  resPromise.catch(() => {});
+
+  // Check the header first so we get a clean assertion failure (not a hang)
+  // if Content-Length advertises the full file size while only the slice is
+  // sent — the server would otherwise block in req.arrayBuffer() waiting for
+  // bytes that never arrive.
+  expect(await gotHeaders).toBe(String(expected.length));
+
+  const res = await resPromise;
+  expect(res.status).toBe(200);
+  expect(await res.json()).toEqual({
+    contentLength: String(expected.length),
+    bodyLength: expected.length,
+    hash: Bun.CryptoHasher.hash("sha256", expected, "hex"),
+  });
+});
 
 test("missing file throws the expected error", async () => {
   Bun.gc(true);


### PR DESCRIPTION
## Problem

`fetch(url, { method: 'POST', body: Bun.file(path).slice(0, 100) })` over plain HTTP hangs the server.

The sendfile upload path (`src/bun.js/webcore/fetch.zig`) sets `content_size` to the full `stat_size` for regular files, but clamps `remain` to the slice bounds. `content_size` becomes the `Content-Length` header (via `HTTPRequestBody.len()` → `buildRequest`), while only `remain` bytes are actually written by `sendfile()`. The server receives a `Content-Length` for the whole file but a body the size of the slice, and blocks waiting for bytes that never arrive.

## Repro

```js
// file is 64 KB on disk
await fetch(url, { method: 'POST', body: Bun.file(path).slice(1000, 1234) });
// → Content-Length: 65536, body: 234 bytes → server hangs
```

Requires a file ≥ 32 KB over plain HTTP (no proxy, no TLS) to hit the sendfile branch.

## Fix

After clamping `offset`/`remain` for regular files, set `content_size = remain` so the advertised length matches what is sent.

## Verification

New test in `test/js/bun/http/fetch-file-upload.test.ts` posts a 234-byte slice of a 64 KB file and asserts the server sees `Content-Length: 234` and the exact slice bytes.

- System bun: fails with `Expected: "234", Received: "65536"`
- This build: all 7 tests in the file pass