### PR TITLE
fix(Bun.concatArrayBuffers): zero uninitialized tail when getter detaches earlier buffer

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -237,6 +237,14 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Arr
         }
     }
 
+    // A getter invoked by getIndex() during the first pass can detach or shrink
+    // an earlier buffer. The copy loop re-reads byteLength(), so it may copy fewer
+    // bytes than we allocated with tryCreateUninitialized(). Zero the tail so we
+    // never return uninitialized heap memory to JS.
+    if (remain > 0) [[unlikely]] {
+        memset(head, 0, remain);
+    }
+
     if (asUint8Array) {
         auto uint8array = JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), WTF::move(buffer), 0, byteLength);
         RETURN_IF_EXCEPTION(throwScope, {});

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 test("Buffer.concat throws RangeError for too large buffers", () => {
   const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
@@ -57,4 +57,142 @@ test("Bun.concatArrayBuffers throws OutOfMemoryError", () => {
   }
 
   expect(() => Bun.concatArrayBuffers(buffers)).toThrow(/Failed to allocate/i);
+});
+
+describe("Bun.concatArrayBuffers does not leak uninitialized heap when a getter detaches an earlier buffer", () => {
+  const BIG = 4096;
+  const SMALL = 16;
+  const TOTAL = BIG + SMALL;
+
+  function dirtyHeap() {
+    // Prime the primitive gigacage with non-zero blocks of the exact size
+    // tryCreateUninitialized() will request, so that if the tail is left
+    // uninitialized we observe it.
+    let churn: Uint8Array[] | null = [];
+    for (let i = 0; i < 256; i++) {
+      churn.push(new Uint8Array(TOTAL).fill(0xcc));
+    }
+    churn = null;
+    Bun.gc(true);
+  }
+
+  function detach(buf: ArrayBuffer) {
+    structuredClone(buf, { transfer: [buf] });
+  }
+
+  function check(makeBig: () => ArrayBufferView | ArrayBuffer, makeSmall: () => ArrayBufferView | ArrayBuffer) {
+    dirtyHeap();
+    const expectedSmall = new Uint8Array(SMALL).fill(0x42);
+    const expectedTail = new Uint8Array(BIG); // zeros
+
+    for (let attempt = 0; attempt < 32; attempt++) {
+      const big = makeBig();
+      const small = makeSmall();
+      const bigBuffer = big instanceof ArrayBuffer ? big : big.buffer;
+
+      const arr: any[] = [big];
+      Object.defineProperty(arr, 1, {
+        get() {
+          // big's byteLength has already been summed; neuter it now.
+          detach(bigBuffer as ArrayBuffer);
+          return small;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+      arr.length = 2;
+
+      const out = new Uint8Array(Bun.concatArrayBuffers(arr));
+      expect(out.length).toBe(TOTAL);
+      // big is detached (byteLength 0) by the time the copy loop runs, so
+      // small's 16 bytes land at offset 0 and the remaining 4096 bytes must
+      // be zeroed rather than whatever was previously in that allocation.
+      expect(out.subarray(0, SMALL)).toEqual(expectedSmall);
+      expect(out.subarray(SMALL)).toEqual(expectedTail);
+    }
+  }
+
+  test("typed array path", () => {
+    check(
+      () => new Uint8Array(BIG).fill(0x41),
+      () => new Uint8Array(SMALL).fill(0x42),
+    );
+  });
+
+  test("ArrayBuffer path", () => {
+    check(
+      () => {
+        const b = new ArrayBuffer(BIG);
+        new Uint8Array(b).fill(0x41);
+        return b;
+      },
+      () => {
+        const b = new ArrayBuffer(SMALL);
+        new Uint8Array(b).fill(0x42);
+        return b;
+      },
+    );
+  });
+
+  test("mixed ArrayBuffer + typed array path", () => {
+    check(
+      () => {
+        const b = new ArrayBuffer(BIG);
+        new Uint8Array(b).fill(0x41);
+        return b;
+      },
+      () => new Uint8Array(SMALL).fill(0x42),
+    );
+  });
+
+  test("resizable ArrayBuffer shrunk by getter", () => {
+    dirtyHeap();
+    const expectedTail = new Uint8Array(BIG); // zeros
+
+    for (let attempt = 0; attempt < 32; attempt++) {
+      const big = new ArrayBuffer(BIG, { maxByteLength: BIG });
+      new Uint8Array(big).fill(0x41);
+      const small = new Uint8Array(SMALL).fill(0x42);
+
+      const arr: any[] = [big];
+      Object.defineProperty(arr, 1, {
+        get() {
+          big.resize(0);
+          return small;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+      arr.length = 2;
+
+      const out = new Uint8Array(Bun.concatArrayBuffers(arr));
+      expect(out.length).toBe(TOTAL);
+      expect(out.subarray(0, SMALL)).toEqual(new Uint8Array(SMALL).fill(0x42));
+      expect(out.subarray(SMALL)).toEqual(expectedTail);
+    }
+  });
+
+  test("asUint8Array=true return path", () => {
+    dirtyHeap();
+    for (let attempt = 0; attempt < 32; attempt++) {
+      const big = new Uint8Array(BIG).fill(0x41);
+      const small = new Uint8Array(SMALL).fill(0x42);
+
+      const arr: any[] = [big];
+      Object.defineProperty(arr, 1, {
+        get() {
+          detach(big.buffer as ArrayBuffer);
+          return small;
+        },
+        enumerable: true,
+        configurable: true,
+      });
+      arr.length = 2;
+
+      const out = Bun.concatArrayBuffers(arr, Infinity, true);
+      expect(out).toBeInstanceOf(Uint8Array);
+      expect(out.length).toBe(TOTAL);
+      expect(out.subarray(SMALL)).toEqual(new Uint8Array(BIG));
+    }
+  });
 });


### PR DESCRIPTION
## What

`Bun.concatArrayBuffers()` leaks uninitialized primitive-gigacage heap memory to JS when a later array index getter detaches (or resizes smaller) an earlier buffer.

## Repro

```js
const big = new Uint8Array(4096).fill(0x41);
const small = new Uint8Array(16).fill(0x42);

const arr = [big];
Object.defineProperty(arr, 1, {
  get() {
    // big's byteLength was already summed into the output size;
    // neuter it before the copy loop re-reads it
    structuredClone(big.buffer, { transfer: [big.buffer] });
    return small;
  },
});
arr.length = 2;

const out = new Uint8Array(Bun.concatArrayBuffers(arr));
// out.length === 4112, but only 16 bytes were copied.
// out[16..4112) is whatever was previously in that heap block.
```

With the heap primed with `0xcc`-filled buffers of the same size, 52/64 attempts returned non-zero tail bytes on the baked bun.

## Cause

`flattenArrayOfBuffersIntoArrayBufferOrUint8Array` in `src/bun.js/bindings/BunObject.cpp`:

1. First pass: `getIndex()` runs user getters, sums `byteLength` from each element, appends the JS buffer objects to a `MarkedArgumentBuffer`.
2. Allocates output with `ArrayBuffer::tryCreateUninitialized(byteLength, 1)`.
3. Copy loop: re-reads `view->byteLength()` from the *live* objects. If a getter in step 1 detached/shrunk an earlier buffer, its `byteLength()` is now smaller, so fewer bytes are copied than were allocated.
4. Returns with `remain > 0` bytes of uninitialized output.

This function is also called internally by `ReadableStream` consumers.

## Fix

Zero the `remain` bytes after the copy loop. The common path (`remain == 0`) is unaffected.

## Tests

Added 5 tests in `test/js/node/buffer-concat.test.ts` covering:
- typed-array-only copy path
- `ArrayBuffer`-only copy path
- mixed copy path
- resizable `ArrayBuffer` shrunk by getter
- `asUint8Array=true` return path

Each primes the heap with `0xcc` at the target allocation size so uninitialized memory shows up reliably. All 5 fail on main, pass with this fix.