### PR TITLE
Fix uninitialized memory leak in Buffer.concat / Bun.concatArrayBuffers via getter-detach TOCTOU

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -22,6 +22,7 @@
 #include <JavaScriptCore/JSONObject.h>
 #include "wtf/SIMDUTF.h"
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/JSObjectInlines.h>
 #include "headers.h"
 #include "BunObject.h"
 #include "WebCoreJSBuiltins.h"
@@ -122,7 +123,6 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Arr
         return {};
     }
 
-    size_t arrayLength = array->length();
     const auto returnEmptyArrayBufferView = [&]() -> EncodedJSValue {
         if (asUint8Array) {
             RELEASE_AND_RETURN(throwScope, JSValue::encode(JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), 0)));
@@ -130,54 +130,53 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Arr
 
         RELEASE_AND_RETURN(throwScope, JSValue::encode(JSC::JSArrayBuffer::create(vm, lexicalGlobalObject->arrayBufferStructure(), JSC::ArrayBuffer::create(static_cast<size_t>(0), 1))));
     };
-    RETURN_IF_EXCEPTION(throwScope, {});
 
-    if (arrayLength < 1) {
-        return returnEmptyArrayBufferView();
-    }
-
-    size_t byteLength = 0;
-    bool any_buffer = false;
-    bool any_typed = false;
-
-    // Use an argument buffer to avoid calling `getIndex` more than once per element.
-    // This is a small optimization
+    // Resolve every element of the input array into a MarkedArgumentBuffer
+    // first so that all user-observable side effects (index getters) run to
+    // completion before we read any byte lengths or allocate the output
+    // buffer. This avoids a TOCTOU where a getter at index N detaches or
+    // resizes the buffer backing index M < N after M's length was measured,
+    // which previously left uninitialized bytes in the output.
     MarkedArgumentBuffer args;
-    args.ensureCapacity(arrayLength);
+    args.ensureCapacity(array->length());
     if (args.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(lexicalGlobalObject, throwScope);
         return {};
     }
 
-    for (size_t i = 0; i < arrayLength; i++) {
-        auto element = array->getIndex(lexicalGlobalObject, i);
-        RETURN_IF_EXCEPTION(throwScope, {});
+    JSC::forEachInArrayLike(lexicalGlobalObject, array, [&](JSValue element) -> bool {
+        args.append(element);
+        return true;
+    });
+    RETURN_IF_EXCEPTION(throwScope, {});
+    if (args.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
+        return {};
+    }
 
+    // All user code is done running. Validate each element and sum their
+    // byte lengths. Nothing between here and the final memcpy loop can call
+    // back into JavaScript, so the lengths we measure now are the lengths we
+    // copy below.
+    size_t byteLength = 0;
+    bool any_buffer = false;
+    bool any_typed = false;
+
+    for (size_t i = 0; i < args.size(); i++) {
+        JSValue element = args.at(i);
         if (auto* typedArray = dynamicDowncast<JSC::JSArrayBufferView>(element)) {
             if (typedArray->isDetached()) [[unlikely]] {
                 return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject, "Cannot validate on a detached buffer"_s);
             }
-            size_t current = typedArray->byteLength();
             any_typed = true;
-            byteLength += current;
-
-            if (current > 0) {
-                args.append(typedArray);
-            }
+            byteLength += typedArray->byteLength();
         } else if (auto* arrayBuffer = dynamicDowncast<JSC::JSArrayBuffer>(element)) {
             auto* impl = arrayBuffer->impl();
-            if (!impl) [[unlikely]] {
+            if (!impl || impl->isDetached()) [[unlikely]] {
                 return Bun::ERR::INVALID_STATE(throwScope, lexicalGlobalObject, "Cannot validate on a detached buffer"_s);
             }
-
-            size_t current = impl->byteLength();
             any_buffer = true;
-
-            if (current > 0) {
-                args.append(arrayBuffer);
-            }
-
-            byteLength += current;
+            byteLength += impl->byteLength();
         } else {
             throwTypeError(lexicalGlobalObject, throwScope, "Expected TypedArray"_s);
             return {};
@@ -199,51 +198,43 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Arr
     auto* head = reinterpret_cast<char*>(buffer->data());
 
     if (!any_buffer) {
-        for (size_t i = 0; i < args.size(); i++) {
-            auto element = args.at(i);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            auto* view = uncheckedDowncast<JSC::JSArrayBufferView>(element);
+        for (size_t i = 0; i < args.size() && remain > 0; i++) {
+            auto* view = uncheckedDowncast<JSC::JSArrayBufferView>(args.at(i));
             size_t length = std::min(remain, view->byteLength());
-            memcpy(head, view->vector(), length);
+            if (length > 0)
+                memcpy(head, view->vector(), length);
             remain -= length;
             head += length;
         }
     } else if (!any_typed) {
-        for (size_t i = 0; i < args.size(); i++) {
-            auto element = args.at(i);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            auto* view = uncheckedDowncast<JSC::JSArrayBuffer>(element);
+        for (size_t i = 0; i < args.size() && remain > 0; i++) {
+            auto* view = uncheckedDowncast<JSC::JSArrayBuffer>(args.at(i));
             size_t length = std::min(remain, view->impl()->byteLength());
-            memcpy(head, view->impl()->data(), length);
+            if (length > 0)
+                memcpy(head, view->impl()->data(), length);
             remain -= length;
             head += length;
         }
     } else {
-        for (size_t i = 0; i < args.size(); i++) {
+        for (size_t i = 0; i < args.size() && remain > 0; i++) {
             auto element = args.at(i);
-            RETURN_IF_EXCEPTION(throwScope, {});
             size_t length = 0;
             if (auto* view = dynamicDowncast<JSC::JSArrayBuffer>(element)) {
                 length = std::min(remain, view->impl()->byteLength());
-                memcpy(head, view->impl()->data(), length);
+                if (length > 0)
+                    memcpy(head, view->impl()->data(), length);
             } else {
                 auto* typedArray = uncheckedDowncast<JSC::JSArrayBufferView>(element);
                 length = std::min(remain, typedArray->byteLength());
-                memcpy(head, typedArray->vector(), length);
+                if (length > 0)
+                    memcpy(head, typedArray->vector(), length);
             }
-
             remain -= length;
             head += length;
         }
     }
 
-    // If any input was detached between the sizing loop and the copy loop
-    // (e.g. via a user-defined getter calling ArrayBuffer.prototype.transfer),
-    // the tail of `buffer` was never written. Zero it so we don't leak
-    // uninitialized heap memory to JavaScript.
-    if (remain > 0) [[unlikely]] {
-        memset(head, 0, remain);
-    }
+    ASSERT(remain == 0);
 
     if (asUint8Array) {
         auto uint8array = JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), WTF::move(buffer), 0, byteLength);

--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -237,6 +237,14 @@ static inline JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Arr
         }
     }
 
+    // If any input was detached between the sizing loop and the copy loop
+    // (e.g. via a user-defined getter calling ArrayBuffer.prototype.transfer),
+    // the tail of `buffer` was never written. Zero it so we don't leak
+    // uninitialized heap memory to JavaScript.
+    if (remain > 0) [[unlikely]] {
+        memset(head, 0, remain);
+    }
+
     if (asUint8Array) {
         auto uint8array = JSC::JSUint8Array::create(lexicalGlobalObject, lexicalGlobalObject->m_typedArrayUint8.get(lexicalGlobalObject), WTF::move(buffer), 0, byteLength);
         RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -930,10 +930,20 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         auto source = bufferView->span();
         size_t length = std::min(output.size(), source.size());
 
-        ASSERT_WITH_MESSAGE(length > 0, "length should be greater than 0. This should be checked before appending to the MarkedArgumentBuffer.");
+        // `length` can be 0 here if a user getter detached this view's
+        // ArrayBuffer after we measured it in the first loop above.
+        if (length > 0) {
+            WTF::memcpySpan(output.first(length), source.first(length));
+            output = output.subspan(length);
+        }
+    }
 
-        WTF::memcpySpan(output.first(length), source.first(length));
-        output = output.subspan(length);
+    // If any input was detached between the sizing loop and the copy loop
+    // (e.g. via a user-defined getter calling ArrayBuffer.prototype.transfer),
+    // the tail of `outBuffer` was never written. Zero it so we don't leak
+    // uninitialized heap memory to JavaScript.
+    if (!output.empty()) [[unlikely]] {
+        memset(output.data(), 0, output.size());
     }
 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(outBuffer));

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -913,7 +913,8 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         return {};
     }
 
-    JSC::JSUint8Array* outBuffer = byteLength <= availableLength
+    const bool outputIsUninitialized = byteLength <= availableLength;
+    JSC::JSUint8Array* outBuffer = outputIsUninitialized
         ?
         // all pages will be copied in, so we can use uninitialized buffer
         createUninitializedBuffer(lexicalGlobalObject, byteLength)
@@ -941,8 +942,9 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     // If any input was detached between the sizing loop and the copy loop
     // (e.g. via a user-defined getter calling ArrayBuffer.prototype.transfer),
     // the tail of `outBuffer` was never written. Zero it so we don't leak
-    // uninitialized heap memory to JavaScript.
-    if (!output.empty()) [[unlikely]] {
+    // uninitialized heap memory to JavaScript. Skip when `allocBuffer` was
+    // used — that path already returned zero-initialized memory.
+    if (outputIsUninitialized && !output.empty()) [[unlikely]] {
         memset(output.data(), 0, output.size());
     }
 

--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -81,6 +81,7 @@
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
+#include <JavaScriptCore/JSObjectInlines.h>
 
 extern "C" bool Bun__Node__ZeroFillBuffers;
 
@@ -839,62 +840,61 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     Bun::V::validateArray(throwScope, lexicalGlobalObject, listValue, "list"_s, jsUndefined());
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    // Note: `validateArray` uses `JSC::isArray()` which returns true for Proxy->Array.
-    // `dynamicDowncast<JSArray>` returns nullptr for Proxy, so we must fall back to
-    // the generic get() path to match Node.js behavior.
-    auto* array = dynamicDowncast<JSC::JSArray>(listValue);
-    uint64_t arrayLength64;
-    if (array) [[likely]] {
-        arrayLength64 = array->length();
-    } else {
-        JSValue lengthValue = listValue.get(lexicalGlobalObject, vm.propertyNames->length);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        arrayLength64 = lengthValue.toLength(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(throwScope, {});
-    }
-    if (arrayLength64 < 1) {
-        RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
-    }
-    if (arrayLength64 > std::numeric_limits<unsigned>::max()) [[unlikely]] {
-        throwOutOfMemoryError(lexicalGlobalObject, throwScope);
-        return {};
-    }
-    unsigned arrayLength = static_cast<unsigned>(arrayLength64);
-
     JSValue totalLengthValue = callFrame->argument(1);
 
-    size_t byteLength = 0;
-
-    // Use an argument buffer to avoid calling `getIndex` more than once per element.
-    // This is a small optimization
+    // Resolve every element of `list` into a MarkedArgumentBuffer first so
+    // that all user-observable side effects (index getters, proxy traps)
+    // run to completion before we read any byte lengths or allocate the
+    // output buffer. This avoids a TOCTOU where a getter at index N detaches
+    // or resizes the buffer backing index M < N after M's length was
+    // measured, which previously left uninitialized bytes in the output.
+    //
+    // Note: `validateArray` uses `JSC::isArray()` which returns true for
+    // Proxy->Array. `forEachInArrayLike` reads `.length` and each index via
+    // `JSObject::getIndex`, which fast-paths dense JSArrays and falls back
+    // to [[Get]] for proxies and sparse arrays.
     MarkedArgumentBuffer args;
-    args.ensureCapacity(arrayLength);
+    if (auto* array = dynamicDowncast<JSC::JSArray>(listValue)) [[likely]] {
+        args.ensureCapacity(array->length());
+        if (args.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(lexicalGlobalObject, throwScope);
+            return {};
+        }
+    }
+
+    JSC::forEachInArrayLike(lexicalGlobalObject, asObject(listValue), [&](JSValue element) -> bool {
+        args.append(element);
+        return true;
+    });
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (args.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(lexicalGlobalObject, throwScope);
         return {};
     }
+    // Node.js: `if (list.length === 0) return new FastBuffer();`
+    // — an empty list returns an empty buffer regardless of totalLength.
+    if (args.isEmpty()) {
+        RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
+    }
 
-    for (unsigned i = 0; i < arrayLength; i++) {
-        JSValue element = array ? array->getIndex(lexicalGlobalObject, i) : listValue.get(lexicalGlobalObject, i);
-        RETURN_IF_EXCEPTION(throwScope, {});
-
+    // All user code is done running. Validate each element and sum their
+    // byte lengths. Nothing between here and the final memcpy loop can call
+    // back into JavaScript, so the lengths we measure now are the lengths we
+    // copy below.
+    size_t availableLength = 0;
+    for (unsigned i = 0; i < args.size(); i++) {
+        JSValue element = args.at(i);
         auto* typedArray = dynamicDowncast<JSC::JSUint8Array>(element);
-        if (!typedArray) {
+        if (!typedArray) [[unlikely]] {
             return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, makeString("list["_s, i, "]"_s), "Buffer or Uint8Array"_s, element);
         }
         if (typedArray->isDetached()) [[unlikely]] {
             return throwVMTypeError(lexicalGlobalObject, throwScope, "ArrayBufferView is detached"_s);
         }
-
-        auto length = typedArray->byteLength();
-
-        if (length > 0)
-            args.append(element);
-
-        byteLength += length;
+        availableLength += typedArray->byteLength();
     }
 
-    size_t availableLength = byteLength;
+    size_t byteLength = availableLength;
     if (!totalLengthValue.isUndefined()) {
         if (!totalLengthValue.isNumber()) [[unlikely]] {
             throwTypeError(lexicalGlobalObject, throwScope, "totalLength must be a valid number"_s);
@@ -913,8 +913,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         return {};
     }
 
-    const bool outputIsUninitialized = byteLength <= availableLength;
-    JSC::JSUint8Array* outBuffer = outputIsUninitialized
+    JSC::JSUint8Array* outBuffer = byteLength <= availableLength
         ?
         // all pages will be copied in, so we can use uninitialized buffer
         createUninitializedBuffer(lexicalGlobalObject, byteLength)
@@ -925,28 +924,17 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     RETURN_IF_EXCEPTION(throwScope, {});
 
     auto output = outBuffer->typedSpan();
-    const size_t arrayLengthI = args.size();
-    for (size_t i = 0; i < arrayLengthI && output.size() > 0; i++) {
-        auto* bufferView = uncheckedDowncast<JSC::JSArrayBufferView>(args.at(i));
+    for (size_t i = 0; i < args.size() && output.size() > 0; i++) {
+        auto* bufferView = uncheckedDowncast<JSC::JSUint8Array>(args.at(i));
         auto source = bufferView->span();
+        if (source.empty())
+            continue;
         size_t length = std::min(output.size(), source.size());
-
-        // `length` can be 0 here if a user getter detached this view's
-        // ArrayBuffer after we measured it in the first loop above.
-        if (length > 0) {
-            WTF::memcpySpan(output.first(length), source.first(length));
-            output = output.subspan(length);
-        }
+        WTF::memcpySpan(output.first(length), source.first(length));
+        output = output.subspan(length);
     }
 
-    // If any input was detached between the sizing loop and the copy loop
-    // (e.g. via a user-defined getter calling ArrayBuffer.prototype.transfer),
-    // the tail of `outBuffer` was never written. Zero it so we don't leak
-    // uninitialized heap memory to JavaScript. Skip when `allocBuffer` was
-    // used — that path already returned zero-initialized memory.
-    if (outputIsUninitialized && !output.empty()) [[unlikely]] {
-        memset(output.data(), 0, output.size());
-    }
+    ASSERT(byteLength > availableLength || output.empty());
 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(outBuffer));
 }

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 
 test("Buffer.concat throws RangeError for too large buffers", () => {
   const bufferToUse = Buffer.allocUnsafe(1024 * 1024 * 64);
@@ -57,4 +57,119 @@ test("Bun.concatArrayBuffers throws OutOfMemoryError", () => {
   }
 
   expect(() => Bun.concatArrayBuffers(buffers)).toThrow(/Failed to allocate/i);
+});
+
+describe("does not leak uninitialized memory when input is detached by a getter during iteration", () => {
+  // These tests exercise a TOCTOU between the sizing pass and the copy pass.
+  // A user-defined getter on the input array detaches a previously-measured
+  // buffer via ArrayBuffer.prototype.transfer(). The output allocation was
+  // sized for the original length, but the copy pass sees a 0-length span for
+  // the detached buffer. The tail of the output must be zeroed, not left as
+  // uninitialized heap.
+
+  const SIZE = 64 * 1024;
+
+  function sprayHeap() {
+    // Prime freed Gigacage pages with a recognizable pattern so that if the
+    // implementation ever regresses to leaking uninitialized memory, the
+    // assertions below observe non-zero bytes rather than happening to pass
+    // on a freshly-zeroed heap.
+    const spray = [];
+    for (let i = 0; i < 64; i++) spray.push(Buffer.alloc(SIZE, 0xcc));
+    spray.length = 0;
+    Bun.gc(true);
+  }
+
+  function makeDetachingArray(first: Uint8Array) {
+    const arr: Uint8Array[] = [first];
+    Object.defineProperty(arr, 1, {
+      enumerable: true,
+      get() {
+        // Detach the element that was already measured at index 0.
+        first.buffer.transfer();
+        return new Uint8Array(0);
+      },
+    });
+    arr.length = 2;
+    return arr;
+  }
+
+  test("Buffer.concat", () => {
+    sprayHeap();
+    const first = new Uint8Array(SIZE);
+    const out = Buffer.concat(makeDetachingArray(first));
+    expect(out.length).toBe(SIZE);
+    expect(out.every(b => b === 0)).toBe(true);
+  });
+
+  test("Buffer.concat preserves bytes copied before the detach", () => {
+    sprayHeap();
+    const head = Buffer.alloc(16, 0xaa);
+    const victim = new Uint8Array(SIZE);
+    const arr: Uint8Array[] = [head, victim];
+    Object.defineProperty(arr, 2, {
+      enumerable: true,
+      get() {
+        victim.buffer.transfer();
+        return new Uint8Array(0);
+      },
+    });
+    arr.length = 3;
+    const out = Buffer.concat(arr);
+    expect(out.length).toBe(16 + SIZE);
+    expect(out.subarray(0, 16).every(b => b === 0xaa)).toBe(true);
+    expect(out.subarray(16).every(b => b === 0)).toBe(true);
+  });
+
+  test("Bun.concatArrayBuffers (TypedArray inputs)", () => {
+    sprayHeap();
+    const first = new Uint8Array(SIZE);
+    const out = new Uint8Array(Bun.concatArrayBuffers(makeDetachingArray(first)));
+    expect(out.length).toBe(SIZE);
+    expect(out.every(b => b === 0)).toBe(true);
+  });
+
+  test("Bun.concatArrayBuffers (ArrayBuffer inputs)", () => {
+    sprayHeap();
+    const first = new ArrayBuffer(SIZE);
+    const arr: ArrayBuffer[] = [first];
+    Object.defineProperty(arr, 1, {
+      enumerable: true,
+      get() {
+        first.transfer();
+        return new ArrayBuffer(0);
+      },
+    });
+    arr.length = 2;
+    const out = new Uint8Array(Bun.concatArrayBuffers(arr));
+    expect(out.length).toBe(SIZE);
+    expect(out.every(b => b === 0)).toBe(true);
+  });
+
+  test("Bun.concatArrayBuffers (mixed inputs)", () => {
+    sprayHeap();
+    const typed = new Uint8Array(SIZE);
+    const ab = new ArrayBuffer(16);
+    const arr: (Uint8Array | ArrayBuffer)[] = [typed, ab];
+    Object.defineProperty(arr, 2, {
+      enumerable: true,
+      get() {
+        typed.buffer.transfer();
+        return new Uint8Array(0);
+      },
+    });
+    arr.length = 3;
+    const out = new Uint8Array(Bun.concatArrayBuffers(arr));
+    expect(out.length).toBe(SIZE + 16);
+    expect(out.every(b => b === 0)).toBe(true);
+  });
+
+  test("Bun.concatArrayBuffers (asUint8Array = true)", () => {
+    sprayHeap();
+    const first = new Uint8Array(SIZE);
+    const out = Bun.concatArrayBuffers(makeDetachingArray(first), undefined, true);
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBe(SIZE);
+    expect(out.every(b => b === 0)).toBe(true);
+  });
 });

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -59,50 +59,49 @@ test("Bun.concatArrayBuffers throws OutOfMemoryError", () => {
   expect(() => Bun.concatArrayBuffers(buffers)).toThrow(/Failed to allocate/i);
 });
 
-describe("does not leak uninitialized memory when input is detached by a getter during iteration", () => {
-  // These tests exercise a TOCTOU between the sizing pass and the copy pass.
-  // A user-defined getter on the input array detaches a previously-measured
-  // buffer via ArrayBuffer.prototype.transfer(). The output allocation was
-  // sized for the original length, but the copy pass sees a 0-length span for
-  // the detached buffer. The tail of the output must be zeroed, not left as
-  // uninitialized heap.
+describe("does not leak uninitialized memory when a getter mutates input buffers during iteration", () => {
+  // These tests exercise a former TOCTOU between the sizing pass and the
+  // copy pass. A user-defined getter on the input array detaches or resizes
+  // a previously-read buffer via ArrayBuffer.prototype.transfer() /
+  // .resize(). All user code (getters) now runs before any byte lengths are
+  // read or the output buffer is allocated, so the detached/resized state is
+  // observed consistently and no uninitialized heap is exposed.
 
   const SIZE = 64 * 1024;
 
   function sprayHeap() {
     // Prime freed Gigacage pages with a recognizable pattern so that if the
     // implementation ever regresses to leaking uninitialized memory, the
-    // assertions below observe non-zero bytes rather than happening to pass
-    // on a freshly-zeroed heap.
+    // zero-content assertions below observe non-zero bytes rather than
+    // happening to pass on a freshly-zeroed heap.
     const spray = [];
     for (let i = 0; i < 64; i++) spray.push(Buffer.alloc(SIZE, 0xcc));
     spray.length = 0;
     Bun.gc(true);
   }
 
-  function makeDetachingArray(first: Uint8Array) {
-    const arr: Uint8Array[] = [first];
+  function makeDetachingArray<T extends { buffer: ArrayBuffer } | ArrayBuffer>(first: T, replacement: T) {
+    const arr: T[] = [first];
     Object.defineProperty(arr, 1, {
       enumerable: true,
       get() {
-        // Detach the element that was already measured at index 0.
-        first.buffer.transfer();
-        return new Uint8Array(0);
+        // Detach the element that was already read at index 0.
+        const ab = first instanceof ArrayBuffer ? first : first.buffer;
+        ab.transfer();
+        return replacement;
       },
     });
     arr.length = 2;
     return arr;
   }
 
-  test("Buffer.concat", () => {
+  test("Buffer.concat throws on buffer detached by later getter", () => {
     sprayHeap();
     const first = new Uint8Array(SIZE);
-    const out = Buffer.concat(makeDetachingArray(first));
-    expect(out.length).toBe(SIZE);
-    expect(out.every(b => b === 0)).toBe(true);
+    expect(() => Buffer.concat(makeDetachingArray(first, new Uint8Array(0)))).toThrow(TypeError);
   });
 
-  test("Buffer.concat preserves bytes copied before the detach", () => {
+  test("Buffer.concat throws on buffer detached by later getter (3 elements)", () => {
     sprayHeap();
     const head = Buffer.alloc(16, 0xaa);
     const victim = new Uint8Array(SIZE);
@@ -115,38 +114,43 @@ describe("does not leak uninitialized memory when input is detached by a getter 
       },
     });
     arr.length = 3;
-    const out = Buffer.concat(arr);
-    expect(out.length).toBe(16 + SIZE);
-    expect(out.subarray(0, 16).every(b => b === 0xaa)).toBe(true);
-    expect(out.subarray(16).every(b => b === 0)).toBe(true);
+    expect(() => Buffer.concat(arr)).toThrow(TypeError);
   });
 
-  test("Bun.concatArrayBuffers (TypedArray inputs)", () => {
+  test("Buffer.concat sizes output using post-getter length when a resizable buffer shrinks", () => {
     sprayHeap();
-    const first = new Uint8Array(SIZE);
-    const out = new Uint8Array(Bun.concatArrayBuffers(makeDetachingArray(first)));
-    expect(out.length).toBe(SIZE);
-    expect(out.every(b => b === 0)).toBe(true);
-  });
-
-  test("Bun.concatArrayBuffers (ArrayBuffer inputs)", () => {
-    sprayHeap();
-    const first = new ArrayBuffer(SIZE);
-    const arr: ArrayBuffer[] = [first];
+    // A shrink doesn't detach, so it must not throw — but the output must
+    // reflect the *final* length, not the pre-getter length, otherwise the
+    // tail would be uninitialized.
+    const ab = new ArrayBuffer(SIZE, { maxByteLength: SIZE });
+    const view = new Uint8Array(ab).fill(0xaa);
+    const arr: Uint8Array[] = [view];
     Object.defineProperty(arr, 1, {
       enumerable: true,
       get() {
-        first.transfer();
-        return new ArrayBuffer(0);
+        ab.resize(16);
+        return new Uint8Array(0);
       },
     });
     arr.length = 2;
-    const out = new Uint8Array(Bun.concatArrayBuffers(arr));
-    expect(out.length).toBe(SIZE);
-    expect(out.every(b => b === 0)).toBe(true);
+    const out = Buffer.concat(arr);
+    expect(out.length).toBe(16);
+    expect(out.every(b => b === 0xaa)).toBe(true);
   });
 
-  test("Bun.concatArrayBuffers (mixed inputs)", () => {
+  test("Bun.concatArrayBuffers throws on TypedArray detached by later getter", () => {
+    sprayHeap();
+    const first = new Uint8Array(SIZE);
+    expect(() => Bun.concatArrayBuffers(makeDetachingArray(first, new Uint8Array(0)))).toThrow();
+  });
+
+  test("Bun.concatArrayBuffers throws on ArrayBuffer detached by later getter", () => {
+    sprayHeap();
+    const first = new ArrayBuffer(SIZE);
+    expect(() => Bun.concatArrayBuffers(makeDetachingArray(first, new ArrayBuffer(0)))).toThrow();
+  });
+
+  test("Bun.concatArrayBuffers throws on mixed inputs with detach", () => {
     sprayHeap();
     const typed = new Uint8Array(SIZE);
     const ab = new ArrayBuffer(16);
@@ -159,17 +163,30 @@ describe("does not leak uninitialized memory when input is detached by a getter 
       },
     });
     arr.length = 3;
-    const out = new Uint8Array(Bun.concatArrayBuffers(arr));
-    expect(out.length).toBe(SIZE + 16);
-    expect(out.every(b => b === 0)).toBe(true);
+    expect(() => Bun.concatArrayBuffers(arr)).toThrow();
   });
 
-  test("Bun.concatArrayBuffers (asUint8Array = true)", () => {
+  test("Bun.concatArrayBuffers (asUint8Array = true) throws on detach", () => {
     sprayHeap();
     const first = new Uint8Array(SIZE);
-    const out = Bun.concatArrayBuffers(makeDetachingArray(first), Infinity, true);
-    expect(out).toBeInstanceOf(Uint8Array);
-    expect(out.length).toBe(SIZE);
-    expect(out.every(b => b === 0)).toBe(true);
+    expect(() => Bun.concatArrayBuffers(makeDetachingArray(first, new Uint8Array(0)), Infinity, true)).toThrow();
+  });
+
+  test("Bun.concatArrayBuffers sizes output using post-getter length when a resizable buffer shrinks", () => {
+    sprayHeap();
+    const ab = new ArrayBuffer(SIZE, { maxByteLength: SIZE });
+    new Uint8Array(ab).fill(0xbb);
+    const arr: ArrayBuffer[] = [ab];
+    Object.defineProperty(arr, 1, {
+      enumerable: true,
+      get() {
+        ab.resize(16);
+        return new ArrayBuffer(0);
+      },
+    });
+    arr.length = 2;
+    const out = new Uint8Array(Bun.concatArrayBuffers(arr));
+    expect(out.length).toBe(16);
+    expect(out.every(b => b === 0xbb)).toBe(true);
   });
 });

--- a/test/js/node/buffer-concat.test.ts
+++ b/test/js/node/buffer-concat.test.ts
@@ -167,7 +167,7 @@ describe("does not leak uninitialized memory when input is detached by a getter 
   test("Bun.concatArrayBuffers (asUint8Array = true)", () => {
     sprayHeap();
     const first = new Uint8Array(SIZE);
-    const out = Bun.concatArrayBuffers(makeDetachingArray(first), undefined, true);
+    const out = Bun.concatArrayBuffers(makeDetachingArray(first), Infinity, true);
     expect(out).toBeInstanceOf(Uint8Array);
     expect(out.length).toBe(SIZE);
     expect(out.every(b => b === 0)).toBe(true);


### PR DESCRIPTION
## What

`Buffer.concat()` and `Bun.concatArrayBuffers()` could return uninitialized heap memory to JavaScript when a user-defined getter on the input array detached or resized one of the input buffers during iteration.

## Reproduction

```js
const big = new Uint8Array(64 * 1024);
const arr = [big];
Object.defineProperty(arr, 1, {
  get() {
    big.buffer.transfer(); // detach element 0 after it was already measured
    return new Uint8Array(0);
  },
});
arr.length = 2;
Buffer.concat(arr); // returned 64KB of stale Gigacage heap contents
```

## Root cause

Both implementations interleaved element resolution with length measurement: each call to `getIndex(i)` (which can invoke a user getter) was immediately followed by reading that element's `byteLength()`. A getter at index `N` could therefore detach or shrink the buffer backing index `N-1` *after* `N-1`'s length had already been summed into the output size. The output was then allocated **uninitialized** at the stale total, and the copy pass — which re-reads `span()` / `byteLength()` — saw 0 bytes for the detached element and left that region unwritten.

## Fix

Resolve every element into a `MarkedArgumentBuffer` first via `JSC::forEachInArrayLike`, so all user-observable side effects (index getters, proxy traps) complete before any length is read. Then, over the collected elements, validate type / detached state and sum byte lengths; then allocate; then copy. Nothing between measurement and copy can call back into JavaScript.

Behavioral consequences:
- A buffer that is detached by a later getter now throws `TypeError` (the same error it would throw if it were detached to begin with).
- A resizable `ArrayBuffer` shrunk by a later getter produces output sized to its *final* length, with no uninitialized tail.

Applied to `jsBufferConstructorFunction_concatBody` in `JSBuffer.cpp` and `flattenArrayOfBuffersIntoArrayBufferOrUint8Array` in `BunObject.cpp`.

## Verification

New tests in `test/js/node/buffer-concat.test.ts` spray the heap with `0xcc` and then exercise detach and resizable-shrink for `Buffer.concat` and for `Bun.concatArrayBuffers` with TypedArray / ArrayBuffer / mixed inputs and the `asUint8Array` variant. All 8 new tests fail on current `bun` (leaked `0xcc` bytes visible in the output) and pass with this change. Existing `test/js/node/test/parallel/test-buffer-concat.js`, `test/js/bun/util/concat.test.js`, and the `Buffer.concat` cases in `test/js/node/buffer.test.js` continue to pass.
