### PR TITLE
shell: don't skip atoms after cmd subst in tilde-prefixed compound words

### DIFF
--- a/src/shell/states/Expansion.zig
+++ b/src/shell/states/Expansion.zig
@@ -365,7 +365,11 @@ pub fn expandVarAndCmdSubst(this: *Expansion, start_word_idx: u32) ?Yield {
             }
         },
         .compound => |cmp| {
-            const starting_offset: usize = if (this.node.hasTildeExpansion()) brk: {
+            // The tilde is always the first atom of the compound word. Skip it only on the
+            // initial pass (start_word_idx == 0); when we re-enter after a command
+            // substitution completes, `start_word_idx` already points at the next atom to
+            // process and applying the offset again would skip it.
+            const starting_offset: usize = if (start_word_idx == 0 and this.node.hasTildeExpansion()) brk: {
                 this.word_idx += 1;
                 break :brk 1;
             } else 0;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -467,6 +467,21 @@ describe("bunshell", () => {
         .stdout("lmao\nlmao/Documents\n")
         .runAsTest("2");
     });
+
+    describe("with command substitution", async () => {
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo ~/$(echo bin)/subdir`
+        .stdout("/home/user/bin/subdir\n")
+        .runAsTest("atom after cmd subst is preserved");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo ~/$(echo a)/$(echo b)/c`
+        .stdout("/home/user/a/b/c\n")
+        .runAsTest("multiple cmd substs");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo ~$(echo /bin)/sub`
+        .stdout("/home/user/bin/sub\n")
+        .runAsTest("cmd subst immediately after tilde");
+      TestBuilder.command`HOME=/home/user USERPROFILE=/home/user && echo ~/$(echo bin)`
+        .stdout("/home/user/bin\n")
+        .runAsTest("cmd subst as last atom");
+    });
   });
 
   // Ported from GNU bash "quote.tests"


### PR DESCRIPTION
## Problem

```sh
echo ~/$(echo bin)/subdir
```

| | output |
|---|---|
| bash | `/home/user/bin/subdir` |
| bun (before) | `/home/user/bin` |
| bun (after) | `/home/user/bin/subdir` |

The `/subdir` atom was silently dropped.

## Root cause

In `expandVarAndCmdSubst` (`src/shell/states/Expansion.zig`), when the compound word starts with `~`, `starting_offset = 1` and `word_idx += 1` were applied on **every** entry to skip the tilde atom.

When a command substitution is encountered mid-word, the function yields. After the substitution completes, `childDone` increments `word_idx` and control returns to `next()`, which calls `expandVarAndCmdSubst(this.word_idx)` again. Since `hasTildeExpansion()` is a property of the node, it's still true on re-entry — so the offset is applied again and iteration resumes from `cmp.atoms[start_word_idx + 1..]`, skipping the atom immediately after the substitution.

With multiple substitutions (`~/$(echo a)/$(echo b)/c`), an atom is skipped after *each* one: the result was `/home/user/ab` instead of `/home/user/a/b/c`.

## Fix

Only apply the tilde offset on the first entry (`start_word_idx == 0`). The tilde is always at index 0, so on re-entry `start_word_idx` already points past it and no offset is needed.

## Verification

```
bunshell > tilde_expansion > with command substitution > atom after cmd subst is preserved  ✓
bunshell > tilde_expansion > with command substitution > multiple cmd substs                ✓
bunshell > tilde_expansion > with command substitution > cmd subst immediately after tilde  ✓
bunshell > tilde_expansion > with command substitution > cmd subst as last atom             ✓
```

All 13 existing `tilde_expansion` tests continue to pass. New tests fail on current main / system bun.