### PR TITLE
shell: reject oversized cd/.cwd() paths with ENAMETOOLONG

### DIFF
--- a/src/shell/builtin/cd.zig
+++ b/src/shell/builtin/cd.zig
@@ -87,6 +87,16 @@ fn handleChangeCwdErr(this: *Cd, err: Syscall.Error, new_cwd_: []const u8) Yield
 
             return this.writeStderrNonBlocking("not a directory: {s}\n", .{new_cwd_});
         },
+        @as(usize, @intFromEnum(Syscall.E.NAMETOOLONG)) => {
+            if (this.bltn().stderr.needsIO() == null) {
+                const buf = this.bltn().fmtErrorArena(.cd, "file name too long\n", .{});
+                _ = this.bltn().writeNoIO(.stderr, buf);
+                this.state = .done;
+                return this.bltn().done(1);
+            }
+
+            return this.writeStderrNonBlocking("file name too long\n", .{});
+        },
         else => return .failed,
     }
 }

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -606,17 +606,23 @@ pub const Interpreter = struct {
                 @compileError("Bad type for new_cwd " ++ @typeName(@TypeOf(new_cwd_)));
             }
             const is_sentinel = @TypeOf(new_cwd_) == [:0]const u8;
+            const is_abs = ResolvePath.Platform.auto.isAbsolute(new_cwd_);
 
-            // The path (absolute or joined) is copied into the 4096-byte threadlocal
-            // `ResolvePath.join_buf` below. Without this check, an attacker-controlled
-            // path longer than the buffer overflows adjacent TLS in ReleaseFast (where
-            // slice bounds are elided) and segfaults.
-            if (new_cwd_.len >= ResolvePath.join_buf.len) {
+            // Both branches below write into the 4096-byte threadlocal
+            // `ResolvePath.join_buf` with no bounds check: the absolute branch
+            // `@memcpy`s `new_cwd_` directly, and the relative branch normalizes
+            // `cwd + "/" + new_cwd_` into it via `joinZ`. In ReleaseFast (where
+            // slice bounds are elided) an oversized input overflows adjacent TLS
+            // and segfaults. Normalization never grows the path, so bounding the
+            // un-normalized length is sufficient (and matches POSIX `chdir`, which
+            // returns ENAMETOOLONG on argument length, not canonicalized length).
+            const required_len = if (is_abs) new_cwd_.len else this.cwd().len + 1 + new_cwd_.len;
+            if (required_len >= ResolvePath.join_buf.len) {
                 return Maybe(void).initErr(Syscall.Error.fromCode(.NAMETOOLONG, .chdir));
             }
 
             const new_cwd: [:0]const u8 = brk: {
-                if (ResolvePath.Platform.auto.isAbsolute(new_cwd_)) {
+                if (is_abs) {
                     if (is_sentinel) {
                         @memcpy(ResolvePath.join_buf[0..new_cwd_.len], new_cwd_[0..new_cwd_.len]);
                         ResolvePath.join_buf[new_cwd_.len] = 0;

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -607,6 +607,14 @@ pub const Interpreter = struct {
             }
             const is_sentinel = @TypeOf(new_cwd_) == [:0]const u8;
 
+            // The path (absolute or joined) is copied into the 4096-byte threadlocal
+            // `ResolvePath.join_buf` below. Without this check, an attacker-controlled
+            // path longer than the buffer overflows adjacent TLS in ReleaseFast (where
+            // slice bounds are elided) and segfaults.
+            if (new_cwd_.len >= ResolvePath.join_buf.len) {
+                return Maybe(void).initErr(Syscall.Error.fromCode(.NAMETOOLONG, .chdir));
+            }
+
             const new_cwd: [:0]const u8 = brk: {
                 if (ResolvePath.Platform.auto.isAbsolute(new_cwd_)) {
                     if (is_sentinel) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -786,6 +786,52 @@ booga"
       const { stdout } = await $`cd ${temp_dir} && pwd && cd - && pwd`;
       expect(stdout.toString()).toEqual(`${temp_dir}\n${process.cwd().replaceAll("\\", "/")}\n`);
     });
+
+    // Overflowing the 4096-byte threadlocal join_buf used by changeCwdImpl would
+    // corrupt adjacent TLS (ReleaseFast) or trip bounds checks (debug). These must
+    // now return ENAMETOOLONG instead. Spawned in a subprocess so a regression
+    // crashes the child, not the test runner.
+    test("cd rejects path longer than buffer with ENAMETOOLONG", async () => {
+      const script = `
+        import { $ } from "bun";
+        const big = "/" + Buffer.alloc(1 << 20, "a").toString();
+        const { stderr, exitCode } = await $\`cd \${big}\`.nothrow().quiet();
+        console.log(JSON.stringify({ exitCode, stderr: stderr.toString() }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ exitCode: 1, stderr: "cd: file name too long\n" }));
+      expect(exitCode).toBe(0);
+    });
+
+    test(".cwd() rejects path longer than buffer with ENAMETOOLONG", async () => {
+      const script = `
+        import { $ } from "bun";
+        const big = "/" + Buffer.alloc(1 << 20, "a").toString();
+        try {
+          await $\`echo hi\`.cwd(big);
+          console.log("no-throw");
+        } catch (e) {
+          console.log(e.code ?? e.message);
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("ENAMETOOLONG");
+      expect(exitCode).toBe(0);
+    });
   });
 
   test("which", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -810,6 +810,28 @@ booga"
       expect(exitCode).toBe(0);
     });
 
+    test("cd rejects relative path that would overflow join buffer", async () => {
+      // cwd + "/" + rel must exceed join_buf.len (4096) even though rel alone might not;
+      // the relative branch normalizes into the same buffer via joinZ with no bounds check.
+      // Uses a 1MB relative path so a regression faults rather than silently corrupting TLS.
+      const script = `
+        import { $ } from "bun";
+        const rel = Buffer.alloc(1 << 20, "a/").toString();
+        const { stderr, exitCode } = await $\`cd \${rel}\`.nothrow().quiet();
+        console.log(JSON.stringify({ exitCode, stderr: stderr.toString() }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(JSON.stringify({ exitCode: 1, stderr: "cd: file name too long\n" }));
+      expect(exitCode).toBe(0);
+    });
+
     test(".cwd() rejects path longer than buffer with ENAMETOOLONG", async () => {
       const script = `
         import { $ } from "bun";


### PR DESCRIPTION
## What

`changeCwdImpl` in `src/shell/interpreter.zig` copies the user-supplied path into the 4096-byte threadlocal `ResolvePath.join_buf` with no length check:
- **absolute** paths are `@memcpy`'d directly into the buffer;
- **relative** paths are joined with `cwd` and normalized into the same buffer via `ResolvePath.joinZ` → `normalizeStringGenericTZ` (resolve_path.zig:915), also without a bounds check.

In ReleaseFast (where Zig slice bounds are elided) an oversized input overflows adjacent thread-local storage; ~1MB segfaults release bun.

## Repro

```js
await Bun.$`cd ${"/" + "a".repeat(1 << 20)}`;         // SIGSEGV on 1.3.14 (absolute)
await Bun.$`cd ${"a/".repeat(1 << 19)}`;               // SIGSEGV / hang on 1.3.14 (relative)
await Bun.$`echo hi`.cwd("/" + "a".repeat(1 << 20));  // SIGSEGV on 1.3.14 (.cwd())
```

## Fix

- `changeCwdImpl`: compute `required_len = is_abs ? new_cwd_.len : cwd.len + 1 + new_cwd_.len` and return `ENAMETOOLONG` (`.chdir`) when `required_len >= ResolvePath.join_buf.len`, before any copy. Normalization never grows the path, so bounding the un-normalized joined length is sufficient (and matches POSIX `chdir` ENAMETOOLONG semantics). Checked against the actual buffer length rather than `bun.MAX_PATH_BYTES` so Windows (where `MAX_PATH_BYTES` ≫ 4096) is covered too.
- `cd` builtin: handle `ENAMETOOLONG` with `cd: file name too long` and exit 1 (matching the existing `ENOTDIR`/`ENOENT` arms), instead of falling through to `.failed`. The path is deliberately omitted from the message so we don't echo a megabyte of attacker bytes to stderr.

## Verification

Three subprocess-isolated tests in `test/js/bun/shell/bunshell.test.ts` (absolute `cd`, relative `cd`, `.cwd()`):

- `USE_SYSTEM_BUN=1 bun test ... -t "rejects"` → 3 fail (child segfaults, empty stdout)
- `bun bd test ... -t "rejects"` → 3 pass

Relates to #26990 (which fixes the `else => .failed` hang for kernel-returned errnos but does not guard the buffer overflow).
