### PR TITLE
install(UpdateRequest): heap-allocate spec normalizer temp buffer

### DIFF
--- a/src/install/PackageManager/UpdateRequest.zig
+++ b/src/install/PackageManager/UpdateRequest.zig
@@ -125,10 +125,14 @@ fn parseWithError(
     outer: for (positionals) |positional| {
         var input: []u8 = bun.handleOom(bun.default_allocator.dupe(u8, std.mem.trim(u8, positional, " \n\r\t")));
         {
-            var temp: [2048]u8 = undefined;
-            const len = std.mem.replace(u8, input, "\\\\", "/", &temp);
-            bun.path.platformToPosixInPlace(u8, &temp);
+            // Replacing "\\\\" (2 bytes) with "/" (1 byte) never grows the string, so a
+            // buffer of `input.len` bytes is always sufficient. Previously this was a
+            // fixed `[2048]u8` stack array which overflowed for longer positionals.
+            const temp = bun.handleOom(bun.default_allocator.alloc(u8, input.len));
+            defer bun.default_allocator.free(temp);
+            const len = std.mem.replace(u8, input, "\\\\", "/", temp);
             const input2 = temp[0 .. input.len - len];
+            bun.path.platformToPosixInPlace(u8, input2);
             @memcpy(input[0..input2.len], input2);
             input.len = input2.len;
         }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -362,6 +362,40 @@ it.each(["fileblah://"])("should reject invalid path without segfault: %s", asyn
   );
 });
 
+it("should reject positionals longer than 2048 bytes without stack overflow", async () => {
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "bar",
+      version: "0.0.2",
+    }),
+  );
+  // Previously the spec normalizer wrote the full positional into a 2048-byte
+  // stack buffer with no bounds check, smashing the stack in ReleaseFast and
+  // tripping ASAN in debug builds.
+  const dep = Buffer.alloc(8000, "a").toString();
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "add", dep],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).toContain(`error: unrecognised dependency format: ${dep}`);
+
+  const out = await stdout.text();
+  expect(out).toEqual(expect.stringContaining("bun add v1."));
+  expect(await exited).toBe(1);
+  expect(await file(join(package_dir, "package.json")).text()).toEqual(
+    JSON.stringify({
+      name: "bar",
+      version: "0.0.2",
+    }),
+  );
+});
+
 it("should handle semver-like names", async () => {
   const urls: string[] = [];
   setHandler(async request => {


### PR DESCRIPTION
## Reproduction

```console
$ bun add $(python3 -c 'print("a"*8000)')
bun add v1.3.14
error: unrecognised dependency format: ============================================================
…
panic(main thread): Segmentation fault at address 0x0
```

Any positional > 2048 bytes passed to `bun add`/`remove`/`link`/`unlink` (and `bunx`, which goes through the same parser) segfaults release builds on Linux/macOS x86_64.

## Cause

`UpdateRequest.parseWithError` normalizes each positional by running `std.mem.replace(u8, input, "\\\\", "/", &temp)` into a fixed `var temp: [2048]u8` on the stack. `std.mem.replace` copies the entire input into the output buffer with no capacity check — the output slice length is trusted. ReleaseFast disables slice safety and `stack_protector` is off on x86 (build.zig), so the overflow silently smashes the stack frame. The `positional` slice variable gets corrupted and the subsequent `Output.errGeneric("… {s}", .{positional})` dereferences garbage → SIGSEGV.

In debug builds the same input hits Zig's bounds check:
```
panic(main thread): index out of bounds: index 2048, len 2048
mem.replace  /vendor/zig/lib/std/mem.zig:3829
install.PackageManager.UpdateRequest.parseWithError  UpdateRequest.zig:129
```

## Fix

Heap-allocate `temp` sized to `input.len`. The `"\\\\"` → `"/"` replacement is 2→1 bytes and can only shrink, so `input.len` is always sufficient. Also scope `platformToPosixInPlace` to the initialized portion of the buffer instead of the whole array.

## Verification

Added to `test/cli/install/bun-add.test.ts` (next to the existing "should reject invalid path without segfault" case):

```
USE_SYSTEM_BUN=1 bun test … -t 'longer than 2048'  → FAIL (segfault)
bun bd test …  (without src fix)                   → FAIL (index out of bounds panic)
bun bd test …  (with fix)                           → PASS
```

After the fix the 8000-byte positional is gracefully rejected with `error: unrecognised dependency format: aaa…` and exit code 1.