### PR TITLE
shell: `[[ -f path ]]` now checks S.ISREG, not just stat() success

### DIFF
--- a/src/shell/states/CondExpr.zig
+++ b/src/shell/states/CondExpr.zig
@@ -119,7 +119,14 @@ pub fn next(this: *CondExpr) Yield {
             .stat_complete => {
                 switch (this.node.op) {
                     .@"-f" => {
-                        return this.parent.childDone(this, if (this.state.stat_complete.stat == .result) 0 else 1);
+                        const st: bun.Stat = switch (this.state.stat_complete.stat) {
+                            .result => |st| st,
+                            .err => {
+                                // It seems that bash always gives exit code 1
+                                return this.parent.childDone(this, 1);
+                            },
+                        };
+                        return this.parent.childDone(this, if (bun.S.ISREG(@intCast(st.mode))) 0 else 1);
                     },
                     .@"-d" => {
                         const st: bun.Stat = switch (this.state.stat_complete.stat) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1914,7 +1914,10 @@ describe("condexprs", () => {
 
   TestBuilder.command`[[ -d mydir ]] && echo yes!`.directory("mydir").stdout("yes!\n").runAsTest("-d");
   TestBuilder.command`[[ -d mumbo.jumbo ]] && echo yes!`.exitCode(1).runAsTest("-d non-existent");
-  TestBuilder.command`[[ -d package.json ]] && echo yes!`.file("package.json", "hi").exitCode(1).runAsTest("-d regular file");
+  TestBuilder.command`[[ -d package.json ]] && echo yes!`
+    .file("package.json", "hi")
+    .exitCode(1)
+    .runAsTest("-d regular file");
 
   TestBuilder.command`[[ -c /dev/null ]] && echo yes!`.stdout("yes!\n").runAsTest("-c");
   TestBuilder.command`[[ -c lol ]] && echo yes!`.exitCode(1).file("lol", "lol").runAsTest("-c not character device");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1909,9 +1909,12 @@ cat redir_out`
 describe("condexprs", () => {
   TestBuilder.command`[[ -f package.json ]] && echo yes!`.file("package.json", "hi").stdout("yes!\n").runAsTest("-f");
   TestBuilder.command`[[ -f mumbo.jumbo ]] && echo yes!`.exitCode(1).runAsTest("-f non-existent");
+  TestBuilder.command`[[ -f mydir ]] && echo yes!`.directory("mydir").exitCode(1).runAsTest("-f directory");
+  TestBuilder.command`[[ -f /dev/null ]] && echo yes!`.exitCode(1).runAsTest("-f character device");
 
   TestBuilder.command`[[ -d mydir ]] && echo yes!`.directory("mydir").stdout("yes!\n").runAsTest("-d");
   TestBuilder.command`[[ -d mumbo.jumbo ]] && echo yes!`.exitCode(1).runAsTest("-d non-existent");
+  TestBuilder.command`[[ -d package.json ]] && echo yes!`.file("package.json", "hi").exitCode(1).runAsTest("-d regular file");
 
   TestBuilder.command`[[ -c /dev/null ]] && echo yes!`.stdout("yes!\n").runAsTest("-c");
   TestBuilder.command`[[ -c lol ]] && echo yes!`.exitCode(1).file("lol", "lol").runAsTest("-c not character device");


### PR DESCRIPTION
## What

`[[ -f path ]]` in Bun Shell was returning true for **any path that exists**, not just regular files. Directories, character devices, sockets, and FIFOs all reported as "regular files".

## Repro

```sh
$ bun -e 'await Bun.$`mkdir -p /tmp/d && [[ -f /tmp/d ]] && echo is-file || echo not-file`'
is-file   # ← wrong, bash prints not-file
```

## Cause

In `src/shell/states/CondExpr.zig`, the `-f` handler only checked whether `stat()` succeeded:

```zig
.@"-f" => {
    return this.parent.childDone(this, if (this.state.stat_complete.stat == .result) 0 else 1);
},
```

The neighboring `-d` and `-c` handlers correctly check `S.ISDIR(st.mode)` / `S.ISCHR(st.mode)`; `-f` was missing the equivalent `S.ISREG` check.

## Fix

Match the pattern used by `-d` / `-c`: extract the stat result and check `bun.S.ISREG(st.mode)`.

## Verification

- New tests `condexprs > -f directory` and `condexprs > -f character device` in `test/js/bun/shell/bunshell.test.ts`
- Both **fail** on system bun and on `bun bd` with the src change stashed
- Both **pass** with the fix applied
- `bun run zig:check-all` passes on all targets
- Also added `condexprs > -d regular file` for symmetric coverage (already worked, just untested)