### PR TITLE
timers: don't keep event loop alive when .ref() is called on a fired timer

### DIFF
--- a/src/bun.js/api/Timer/TimerObjectInternals.zig
+++ b/src/bun.js/api/Timer/TimerObjectInternals.zig
@@ -331,7 +331,11 @@ pub fn doRef(this: *TimerObjectInternals, _: *jsc.JSGlobalObject, this_value: JS
     // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L256
     // and
     // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L685-L687
-    if (!did_have_js_ref and !this.flags.has_cleared_timer) {
+    // Node only re-enables the keep-alive ref when `!this._destroyed`. Checking
+    // `has_cleared_timer` alone is not sufficient: a one-shot timer that has already fired
+    // has `has_cleared_timer == false` but is still destroyed. Calling `.unref(); .ref()`
+    // on such a timer would otherwise leak an event-loop ref and hang the process.
+    if (!did_have_js_ref and !this.getDestroyed()) {
         this.setEnableKeepingEventLoopAlive(jsc.VirtualMachine.get(), true);
     }
 

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -246,6 +246,54 @@ it("setTimeout -> unref doesn't keep event loop alive forever", () => {
   expect(stdout.toString()).toBe("");
 });
 
+it("setTimeout -> fire -> unref -> ref does not keep the event loop alive", async () => {
+  // After a one-shot timer has fired it is destroyed; calling .unref() then .ref()
+  // must not leak an event-loop ref. Previously this would hang forever.
+  const src = `
+    const t = setTimeout(() => {}, 1);
+    setTimeout(() => {
+      t.unref();
+      t.ref();
+      console.log("destroyed=" + t._destroyed);
+    }, 20);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 4_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("destroyed=true\n");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
+it("setImmediate -> fire -> unref -> ref does not keep the event loop alive", async () => {
+  const src = `
+    const im = setImmediate(() => {});
+    setTimeout(() => {
+      im.unref();
+      im.ref();
+      console.log("destroyed=" + im._destroyed);
+    }, 20);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 4_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("destroyed=true\n");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 it("setTimeout should refresh N times", done => {
   let count = 0;
   let timer = setTimeout(() => {


### PR DESCRIPTION
## What

`timer.ref()` no longer keeps the event loop alive when called on a timer that has already fired.

## Repro

```js
const t = setTimeout(() => {}, 10);
setTimeout(() => {
  t.unref();
  t.ref();
}, 50);
```

Node exits after ~50ms. Bun hung forever. Same for `setImmediate`.

## Cause

`doRef()` in `TimerObjectInternals.zig` only checked `!has_cleared_timer` before re-enabling the event-loop keep-alive ref:

```zig
if (!did_have_js_ref and !this.flags.has_cleared_timer) {
    this.setEnableKeepingEventLoopAlive(vm, true);
}
```

After a one-shot timer fires, its state is `FIRED` but `has_cleared_timer` is still `false` (that flag is only set by `clearTimeout`/`clearImmediate`). So `.unref()` followed by `.ref()` on a fired timer would increment the active-timer count with nothing to ever decrement it.

Node.js gates this on `!this._destroyed` in both [`Timeout.prototype.ref`](https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L256) and [`Immediate.prototype.ref`](https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L685-L687).

## Fix

Use `getDestroyed()` (Bun's `_destroyed` implementation, which also accounts for the `FIRED`/`CANCELLED` state) instead of just `has_cleared_timer`:

```zig
if (!did_have_js_ref and !this.getDestroyed()) {
    this.setEnableKeepingEventLoopAlive(vm, true);
}
```

## Verification

Added tests spawning a subprocess for each of `setTimeout` and `setImmediate` that does `.unref(); .ref()` on a fired timer. Without the fix the subprocess hangs and gets SIGTERM'd by the spawn timeout; with the fix it exits with code 0.