### PR TITLE
FileSystemRouter: deep-copy extensions and asset_prefix_path on reload()

### DIFF
--- a/src/runtime/api/filesystem_router.zig
+++ b/src/runtime/api/filesystem_router.zig
@@ -256,10 +256,22 @@ pub const FileSystemRouter = struct {
             return globalThis.throw("Unable to find directory: {s}", .{this.router.config.dir});
         };
 
+        // Deep-copy config strings into the new arena. The previous arena is freed below, so
+        // any slice that still points into it (the inner extension strings, asset_prefix_path)
+        // would dangle on the *next* reload() and be read by loadRoutes. dupe(string, ...) only
+        // copies the outer []string; each inner []const u8 must be duped individually.
+        const extensions = extensions: {
+            const old = this.router.config.extensions;
+            const new = allocator.alloc(string, old.len) catch unreachable;
+            for (old, new) |ext, *out| {
+                out.* = allocator.dupe(u8, ext) catch unreachable;
+            }
+            break :extensions new;
+        };
         var router = Router.init(vm.transpiler.fs, allocator, .{
             .dir = allocator.dupe(u8, this.router.config.dir) catch unreachable,
-            .extensions = allocator.dupe(string, this.router.config.extensions) catch unreachable,
-            .asset_prefix_path = this.router.config.asset_prefix_path,
+            .extensions = extensions,
+            .asset_prefix_path = allocator.dupe(u8, this.router.config.asset_prefix_path) catch unreachable,
         }) catch unreachable;
         router.loadRoutes(&log, root_dir_info, Resolver, &vm.transpiler.resolver, router.config.dir) catch {
             // Build the JS error before freeing the arena: `log` is backed by the arena allocator.

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -368,6 +368,41 @@ it("reload() works", () => {
   expect(router.match("/posts")!.name).toBe("/posts");
 });
 
+it("reload() preserves custom fileExtensions and assetPrefix across multiple reloads", () => {
+  // Regression: reload() shallow-copied the []string of extensions into the new arena but
+  // left the inner []const u8 pointing into the old arena (which is then freed). The second
+  // reload() would scan routes against dangling extension bytes, dropping every route (and
+  // tripping ASAN). asset_prefix_path was not copied at all.
+  const { dir } = make(["index.tsx", "posts/[id].tsx", "posts.tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+    fileExtensions: [".tsx"],
+    assetPrefix: "/_next/static/",
+    origin: "https://nextjs.org",
+  });
+
+  const expected = {
+    "/": `${dir}/index.tsx`,
+    "/posts": `${dir}/posts.tsx`,
+    "/posts/[id]": `${dir}/posts/[id].tsx`,
+  };
+
+  expect(router.routes).toEqual(expected);
+
+  // First reload() happens while the original arena is still live during loadRoutes,
+  // so it appears to work even with the shallow copy. The second and subsequent reloads
+  // read extension strings that were freed by the previous reload.
+  for (let i = 0; i < 5; i++) {
+    router.reload();
+    expect(router.routes).toEqual(expected);
+    const { name, src } = router.match("/posts/hello-world")!;
+    expect(name).toBe("/posts/[id]");
+    expect(src).toBe("https://nextjs.org/_next/static/posts/[id].tsx");
+  }
+});
+
 it("reload() works with new dirs/files", () => {
   const { dir } = make(["posts.tsx"]);
 


### PR DESCRIPTION
## What

`FileSystemRouter.reload()` creates a new arena and carries the existing config forward into it before freeing the old arena:

```zig
var router = Router.init(vm.transpiler.fs, allocator, .{
    .dir = allocator.dupe(u8, this.router.config.dir) catch unreachable,
    .extensions = allocator.dupe(string, this.router.config.extensions) catch unreachable,
    .asset_prefix_path = this.router.config.asset_prefix_path,
}) catch unreachable;
...
this.arena.deinit();
```

`allocator.dupe(string, ...)` (`string` = `[]const u8`) only duplicates the **outer** `[]string` slice — each inner `[]const u8` still points into the previous arena. `asset_prefix_path` isn't copied at all.

The first `reload()` appears to work because `loadRoutes` runs while the old arena is still live. But the config it leaves behind holds dangling inner slices, so the **second** `reload()` reads freed bytes at `router.zig:443` (`strings.eql(extname[1..], _extname)`) for every scanned file — tripping ASAN in debug and silently dropping routes in release.

## Repro

```js
const r = new Bun.FileSystemRouter({
  dir, style: 'nextjs', fileExtensions: ['.tsx'], assetPrefix: '/_next/static/',
});
r.reload();
r.reload();  // ASAN use-after-poison in strings.eql → router.zig:443
```

```
==4118==ERROR: AddressSanitizer: use-after-poison
    #1 string.immutable.eql        src/string/immutable.zig:864
    #2 router.RouteLoader.load     src/router.zig:443
    #4 router.loadRoutes           src/router.zig:484
    #5 FileSystemRouter.reload     src/bun.js/api/filesystem_router.zig:262
```

## Fix

Deep-copy each inner extension string into the new arena with a loop over `allocator.dupe(u8, ext)`, and `dupe(u8, ...)` the `asset_prefix_path` as well, so the config is fully self-contained once the previous arena is freed.

## Verification

- `git stash -- src/ && bun bd test filesystem_router.test.ts -t 'preserves custom fileExtensions'` → **fail** (ASAN use-after-poison at router.zig:443)
- `git stash pop && bun bd test filesystem_router.test.ts -t 'preserves custom fileExtensions'` → **pass**
- All 21 tests in `filesystem_router.test.ts` pass.

Follow-up to #29971.