### PR TITLE
fs: close Windows handle in cp reparse-point branch

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6782,6 +6782,7 @@ pub const NodeFS = struct {
                     .err => |err| return .{ .err = err },
                     .result => |src_fd| src_fd,
                 };
+                defer handle.close();
                 const wbuf = bun.os_path_buffer_pool.get();
                 defer bun.os_path_buffer_pool.put(wbuf);
                 const len = bun.windows.GetFinalPathNameByHandleW(handle.cast(), wbuf, wbuf.len, 0);

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isArm64, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const impls = [
@@ -322,6 +322,47 @@ test("cp with missing callback throws", () => {
     // @ts-expect-error
     fs.cp("a", "b" as any);
   }).toThrow(/"cb"/);
+});
+
+// On Windows, _copySingleFileSync's reparse-point branch opens a handle to the
+// source symlink to resolve its target via GetFinalPathNameByHandleW. Previously
+// that handle was never closed, leaking one OS handle per symlink copied. Over a
+// large tree (e.g. node_modules with junctions) this eventually exhausts the
+// process handle table. bun:ffi (TinyCC) is unavailable on Windows arm64.
+test.skipIf(!isWindows || isArm64)("cpSync over symlinks does not leak Windows handles", () => {
+  const { dlopen } = require("bun:ffi");
+  const k32 = dlopen("kernel32.dll", {
+    GetCurrentProcess: { args: [], returns: "ptr" },
+    GetProcessHandleCount: { args: ["ptr", "ptr"], returns: "i32" },
+  });
+  const out = new Uint32Array(1);
+  const handleCount = () => {
+    if (k32.symbols.GetProcessHandleCount(k32.symbols.GetCurrentProcess(), out) === 0) {
+      throw new Error("GetProcessHandleCount failed");
+    }
+    return out[0];
+  };
+
+  const N = 64;
+  const basename = tempDirWithFiles("cp-symlink-leak", {
+    "from/target.txt": "hello",
+  });
+  for (let i = 0; i < N; i++) {
+    fs.symlinkSync(join(basename, "from", "target.txt"), join(basename, "from", `link${i}.txt`));
+  }
+
+  // Warm up once so any lazy init (thread pool, path buffers, etc.) doesn't
+  // count against the measured delta.
+  fs.cpSync(join(basename, "from"), join(basename, "warmup"), { recursive: true });
+
+  const before = handleCount();
+  fs.cpSync(join(basename, "from"), join(basename, "result"), { recursive: true });
+  const after = handleCount();
+
+  // Without the fix every symlink leaks a handle, so `after - before` is >= N.
+  // With the fix the delta is ~0; allow generous slack for unrelated background
+  // activity while still catching a per-symlink leak.
+  expect(after - before).toBeLessThan(N / 2);
 });
 
 // On Windows the OS path buffer is 32768 wide chars, which is impractical to exceed


### PR DESCRIPTION
## Problem

On Windows, `fs.cp`/`fs.cpSync` leaks one OS handle for every symlink or junction in the source tree. Copying a large tree (e.g. `node_modules` with pnpm-style junctions) steadily grows the process handle table until operations start failing.

## Cause

`_copySingleFileSync` in `src/bun.js/node/node_fs.zig` handles the `FILE_ATTRIBUTE_REPARSE_POINT` case by opening the source with `bun.sys.openatWindows` so it can call `GetFinalPathNameByHandleW` to resolve the link target — but the handle was never closed on any of the three return paths (`GetFinalPathNameByHandleW` failure, `CreateSymbolicLinkW` failure, success):

```zig
const handle = switch (bun.sys.openatWindows(bun.invalid_fd, src, bun.O.RDONLY, 0)) {
    .err => |err| return .{ .err = err },
    .result => |src_fd| src_fd,
};
// <-- no defer handle.close()
const wbuf = bun.os_path_buffer_pool.get();
defer bun.os_path_buffer_pool.put(wbuf);
const len = bun.windows.GetFinalPathNameByHandleW(handle.cast(), wbuf, wbuf.len, 0);
```

## Fix

Add `defer handle.close();` immediately after the successful open.

## Test

`test/js/node/fs/cp.test.ts` gains a Windows-only test that:
1. creates a directory with 64 file symlinks,
2. does a warmup `cpSync` to get lazy init out of the way,
3. reads `GetProcessHandleCount` (via `bun:ffi` → `kernel32.dll`),
4. `cpSync`'s the tree again,
5. asserts the handle-count delta is well under 64.

Without the fix the delta is ≥ 64 (one per symlink); with it the delta is ~0. Skipped on non-Windows and on Windows arm64 (no `bun:ffi`).

## Verification

- `bun run zig:check-all` — all 61 platform builds succeed
- `bun bd test test/js/node/fs/cp.test.ts` on Linux — 37 pass, 3 skip (Windows-only), 0 fail
- Windows CI will exercise the new test