### PR TITLE
webcore/Blob: clamp untrusted offset in structured-clone deserialize

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -517,7 +517,23 @@ fn _onStructuredCloneDeserialize(
     }
 
     bun.assertf(blob.isHeapAllocated(), "expected blob to be heap-allocated", .{});
-    blob.offset = @as(u52, @intCast(offset));
+
+    // `offset` comes from untrusted bytes. Clamp it so a crafted payload cannot
+    // make sharedView() slice past the end of the backing store (OOB heap read
+    // in ReleaseFast). For bytes stores this also keeps `size` within bounds;
+    // file/s3 stores report `max_size` here and are bounded by the filesystem
+    // read path instead.
+    blob.offset = @as(SizeType, @truncate(offset));
+    if (blob.store) |store| {
+        const store_size = store.size();
+        if (store_size != Blob.max_size) {
+            blob.offset = @min(blob.offset, store_size);
+            blob.size = @min(blob.size, store_size - blob.offset);
+        }
+    } else {
+        blob.offset = 0;
+    }
+
     if (content_type.len > 0) {
         blob.content_type = content_type;
         blob.content_type_allocated = true;
@@ -3599,7 +3615,9 @@ pub fn sharedView(this: *const Blob) []const u8 {
     if (this.size == 0 or this.store == null) return "";
     var slice_ = this.store.?.sharedView();
     if (slice_.len == 0) return "";
-    slice_ = slice_[this.offset..];
+    // Defensive: `offset` may originate from untrusted structured-clone data.
+    // Never index past the store's actual length regardless of caller state.
+    slice_ = slice_[@min(@as(usize, this.offset), slice_.len)..];
 
     return slice_[0..@min(slice_.len, @as(usize, this.size))];
 }

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,5 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -301,45 +302,67 @@ describe("structuredClone with Blob and File", () => {
     // the sender controls. A malicious payload can set it past the end of the
     // serialized byte store; without clamping, reading the resulting Blob
     // (`arrayBuffer()`/`text()`/`bytes()`) slices past the backing allocation
-    // and returns unrelated heap memory.
+    // and returns unrelated heap memory (or segfaults on an unmapped page).
     //
     // These tests assert that out-of-range offsets are clamped to the store
-    // bounds so no out-of-store bytes are ever exposed.
+    // bounds so no out-of-store bytes are ever exposed. The work runs in a
+    // child process so that the pre-fix crash surfaces as an ordinary test
+    // failure instead of killing the test runner.
+
+    // Locate the offset field once. Do it by serializing a sliced blob with a
+    // sentinel offset and comparing against a zero-offset payload; keeps the
+    // test robust against wire-format header changes.
+    const marker = 0xa5;
+    const baseline = new Uint8Array(serialize(new Blob([Buffer.alloc(4, marker)])));
+    const sentinel = new Uint8Array(serialize(new Blob([Buffer.alloc(8, marker)]).slice(4)));
+    let offsetFieldIndex = -1;
+    for (let i = 0; i + 8 <= sentinel.length; i++) {
+      if (
+        sentinel[i] === 4 &&
+        sentinel[i + 1] === 0 &&
+        sentinel[i + 2] === 0 &&
+        sentinel[i + 3] === 0 &&
+        sentinel[i + 4] === 0 &&
+        sentinel[i + 5] === 0 &&
+        sentinel[i + 6] === 0 &&
+        sentinel[i + 7] === 0 &&
+        baseline[i] === 0
+      ) {
+        offsetFieldIndex = i;
+        break;
+      }
+    }
+    if (offsetFieldIndex < 0) throw new Error("could not locate offset field in serialized blob");
 
     function craft(offset: bigint) {
-      // Use a recognizable marker for the store bytes so we can detect
-      // whether any returned byte came from outside the store.
-      const marker = 0xa5;
-      const payload = Buffer.alloc(4, marker);
-      const serialized = new Uint8Array(serialize(new Blob([payload])));
-
-      // Locate the offset field by serializing a sliced blob with a sentinel
-      // offset and diffing; this keeps the test robust against wire-format
-      // header changes.
-      const sentinel = new Uint8Array(serialize(new Blob([Buffer.alloc(8, marker)]).slice(4)));
-      let at = -1;
-      for (let i = 0; i + 8 <= sentinel.length; i++) {
-        if (
-          sentinel[i] === 4 &&
-          sentinel[i + 1] === 0 &&
-          sentinel[i + 2] === 0 &&
-          sentinel[i + 3] === 0 &&
-          sentinel[i + 4] === 0 &&
-          sentinel[i + 5] === 0 &&
-          sentinel[i + 6] === 0 &&
-          sentinel[i + 7] === 0 &&
-          serialized[i] === 0
-        ) {
-          at = i;
-          break;
-        }
-      }
-      if (at < 0) throw new Error("could not locate offset field in serialized blob");
-
+      const serialized = new Uint8Array(serialize(new Blob([Buffer.alloc(4, marker)])));
       const view = new DataView(serialized.buffer, serialized.byteOffset, serialized.byteLength);
-      view.setBigUint64(at, offset, true);
-      return { serialized, marker };
+      view.setBigUint64(offsetFieldIndex, offset, true);
+      return serialized;
     }
+
+    // Child script: receives (offsetFieldIndex, offset) on argv, rebuilds the
+    // crafted payload, deserializes, reads every body-mixin path, and prints a
+    // JSON summary. On a vulnerable build this either prints a non-zero length
+    // (OOB heap bytes) or the process dies before printing anything.
+    const childScript = `
+      const { serialize, deserialize } = require("bun:jsc");
+      const v8 = require("node:v8");
+      const [, atStr, offsetStr] = process.argv;
+      const at = Number(atStr);
+      const offset = BigInt(offsetStr);
+      const serialized = new Uint8Array(serialize(new Blob([Buffer.alloc(4, 0xa5)])));
+      new DataView(serialized.buffer, serialized.byteOffset, serialized.byteLength).setBigUint64(at, offset, true);
+
+      for (const de of [deserialize, buf => v8.deserialize(Buffer.from(buf))]) {
+        const blob = de(serialized);
+        const ab = new Uint8Array(await blob.arrayBuffer());
+        const bytes = await blob.bytes();
+        const text = await blob.text();
+        const all5 = ab.every(b => b === 0xa5);
+        process.stdout.write(JSON.stringify({ len: ab.byteLength, bytesLen: bytes.byteLength, textLen: text.length, all5 }) + "\\n");
+      }
+    `;
 
     test.each([
       ["just past end", 5n],
@@ -350,32 +373,38 @@ describe("structuredClone with Blob and File", () => {
       ["> u52", (1n << 52n) + 123n],
       ["u64 max", (1n << 64n) - 1n],
     ])("offset %s does not expose out-of-store bytes", async (_name, offset) => {
-      const { serialized, marker } = craft(offset);
-      const blob = deserialize(serialized);
-      expect(blob).toBeInstanceOf(Blob);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childScript, String(offsetFieldIndex), String(offset)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      const bytes = new Uint8Array(await blob.arrayBuffer());
-      // Every returned byte must have come from the 4-byte store. With the
-      // crafted offset >= store length, the only in-bounds result is empty.
-      expect(bytes.byteLength).toBe(0);
-      for (const b of bytes) expect(b).toBe(marker);
+      // offset >= store length, so the only in-bounds result is an empty view
+      // from every reader on both deserialize entry points.
+      const expected = { len: 0, bytesLen: 0, textLen: 0, all5: true };
+      expect(
+        stdout
+          .split("\n")
+          .filter(Boolean)
+          .map(l => JSON.parse(l)),
+      ).toEqual([expected, expected]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }, 30_000);
 
-      // Other readers go through the same sharedView() path.
-      expect(await blob.text()).toBe("");
-      expect((await blob.bytes()).byteLength).toBe(0);
-    });
-
-    test("offset equal to store length yields empty view", async () => {
-      const { serialized } = craft(4n);
-      const blob = deserialize(serialized);
-      expect(new Uint8Array(await blob.arrayBuffer()).byteLength).toBe(0);
-    });
-
-    test("node:v8 deserialize is equally bounded", async () => {
-      const { serialized } = craft(1n << 20n);
-      const blob = v8.deserialize(Buffer.from(serialized));
+    test("in-process: offset at store boundary yields empty view", async () => {
+      // offset == store length stays within the allocation on any build, so
+      // this is safe to assert in-process and covers the boundary directly.
+      const blob = deserialize(craft(4n));
       expect(blob).toBeInstanceOf(Blob);
       expect((await blob.arrayBuffer()).byteLength).toBe(0);
+      expect((await blob.bytes()).byteLength).toBe(0);
+      expect(await blob.text()).toBe("");
+
+      const viaV8 = v8.deserialize(Buffer.from(craft(4n)));
+      expect((await viaV8.arrayBuffer()).byteLength).toBe(0);
     });
   });
 });

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { serialize, deserialize } from "bun:jsc";
 
 describe("structuredClone with Blob and File", () => {
   describe("Blob structured clone", () => {
@@ -291,6 +292,92 @@ describe("structuredClone with Blob and File", () => {
 
       const cloned = structuredClone(obj);
       expect(cloned.file).toBeInstanceOf(File);
+    });
+  });
+
+  describe("deserialize of crafted payloads", () => {
+    // The Blob structured-clone wire format carries an `offset` (u64 LE) that
+    // the sender controls. A malicious payload can set it past the end of the
+    // serialized byte store; without clamping, reading the resulting Blob
+    // (`arrayBuffer()`/`text()`/`bytes()`) slices past the backing allocation
+    // and returns unrelated heap memory.
+    //
+    // These tests assert that out-of-range offsets are clamped to the store
+    // bounds so no out-of-store bytes are ever exposed.
+
+    function craft(offset: bigint) {
+      // Use a recognizable marker for the store bytes so we can detect
+      // whether any returned byte came from outside the store.
+      const marker = 0xa5;
+      const payload = Buffer.alloc(4, marker);
+      const serialized = new Uint8Array(serialize(new Blob([payload])));
+
+      // Locate the offset field by serializing a sliced blob with a sentinel
+      // offset and diffing; this keeps the test robust against wire-format
+      // header changes.
+      const sentinel = new Uint8Array(
+        serialize(new Blob([Buffer.alloc(8, marker)]).slice(4)),
+      );
+      let at = -1;
+      for (let i = 0; i + 8 <= sentinel.length; i++) {
+        if (
+          sentinel[i] === 4 &&
+          sentinel[i + 1] === 0 &&
+          sentinel[i + 2] === 0 &&
+          sentinel[i + 3] === 0 &&
+          sentinel[i + 4] === 0 &&
+          sentinel[i + 5] === 0 &&
+          sentinel[i + 6] === 0 &&
+          sentinel[i + 7] === 0 &&
+          serialized[i] === 0
+        ) {
+          at = i;
+          break;
+        }
+      }
+      if (at < 0) throw new Error("could not locate offset field in serialized blob");
+
+      const view = new DataView(serialized.buffer, serialized.byteOffset, serialized.byteLength);
+      view.setBigUint64(at, offset, true);
+      return { serialized, marker };
+    }
+
+    test.each([
+      ["just past end", 5n],
+      ["small", 64n],
+      ["page", 4096n],
+      ["1 MiB", 1024n * 1024n],
+      ["2^40", 1n << 40n],
+      ["> u52", (1n << 52n) + 123n],
+      ["u64 max", (1n << 64n) - 1n],
+    ])("offset %s does not expose out-of-store bytes", async (_name, offset) => {
+      const { serialized, marker } = craft(offset);
+      const blob = deserialize(serialized);
+      expect(blob).toBeInstanceOf(Blob);
+
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      // Every returned byte must have come from the 4-byte store. With the
+      // crafted offset >= store length, the only in-bounds result is empty.
+      expect(bytes.byteLength).toBe(0);
+      for (const b of bytes) expect(b).toBe(marker);
+
+      // Other readers go through the same sharedView() path.
+      expect(await blob.text()).toBe("");
+      expect((await blob.bytes()).byteLength).toBe(0);
+    });
+
+    test("offset equal to store length yields empty view", async () => {
+      const { serialized } = craft(4n);
+      const blob = deserialize(serialized);
+      expect(new Uint8Array(await blob.arrayBuffer()).byteLength).toBe(0);
+    });
+
+    test("node:v8 deserialize is equally bounded", async () => {
+      const v8 = require("node:v8");
+      const { serialized } = craft(1n << 20n);
+      const blob = v8.deserialize(Buffer.from(serialized));
+      expect(blob).toBeInstanceOf(Blob);
+      expect((await blob.arrayBuffer()).byteLength).toBe(0);
     });
   });
 });

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,5 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
+import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
   describe("Blob structured clone", () => {
@@ -371,7 +372,6 @@ describe("structuredClone with Blob and File", () => {
     });
 
     test("node:v8 deserialize is equally bounded", async () => {
-      const v8 = require("node:v8");
       const { serialized } = craft(1n << 20n);
       const blob = v8.deserialize(Buffer.from(serialized));
       expect(blob).toBeInstanceOf(Blob);

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -372,27 +372,31 @@ describe("structuredClone with Blob and File", () => {
       ["2^40", 1n << 40n],
       ["> u52", (1n << 52n) + 123n],
       ["u64 max", (1n << 64n) - 1n],
-    ])("offset %s does not expose out-of-store bytes", async (_name, offset) => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", childScript, String(offsetFieldIndex), String(offset)],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    ])(
+      "offset %s does not expose out-of-store bytes",
+      async (_name, offset) => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", childScript, String(offsetFieldIndex), String(offset)],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      // offset >= store length, so the only in-bounds result is an empty view
-      // from every reader on both deserialize entry points.
-      const expected = { len: 0, bytesLen: 0, textLen: 0, all5: true };
-      expect(
-        stdout
-          .split("\n")
-          .filter(Boolean)
-          .map(l => JSON.parse(l)),
-      ).toEqual([expected, expected]);
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
-    }, 30_000);
+        // offset >= store length, so the only in-bounds result is an empty view
+        // from every reader on both deserialize entry points.
+        const expected = { len: 0, bytesLen: 0, textLen: 0, all5: true };
+        expect(
+          stdout
+            .split("\n")
+            .filter(Boolean)
+            .map(l => JSON.parse(l)),
+        ).toEqual([expected, expected]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+      },
+      30_000,
+    );
 
     test("in-process: offset at store boundary yields empty view", async () => {
       // offset == store length stays within the allocation on any build, so

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,5 +1,5 @@
+import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { serialize, deserialize } from "bun:jsc";
 
 describe("structuredClone with Blob and File", () => {
   describe("Blob structured clone", () => {
@@ -315,9 +315,7 @@ describe("structuredClone with Blob and File", () => {
       // Locate the offset field by serializing a sliced blob with a sentinel
       // offset and diffing; this keeps the test robust against wire-format
       // header changes.
-      const sentinel = new Uint8Array(
-        serialize(new Blob([Buffer.alloc(8, marker)]).slice(4)),
-      );
+      const sentinel = new Uint8Array(serialize(new Blob([Buffer.alloc(8, marker)]).slice(4)));
       let at = -1;
       for (let i = 0; i + 8 <= sentinel.length; i++) {
         if (

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -364,7 +364,7 @@ describe("structuredClone with Blob and File", () => {
       }
     `;
 
-    test.each([
+    test.concurrent.each([
       ["just past end", 5n],
       ["small", 64n],
       ["page", 4096n],

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -372,31 +372,27 @@ describe("structuredClone with Blob and File", () => {
       ["2^40", 1n << 40n],
       ["> u52", (1n << 52n) + 123n],
       ["u64 max", (1n << 64n) - 1n],
-    ])(
-      "offset %s does not expose out-of-store bytes",
-      async (_name, offset) => {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "-e", childScript, String(offsetFieldIndex), String(offset)],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    ])("offset %s does not expose out-of-store bytes", async (_name, offset) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childScript, String(offsetFieldIndex), String(offset)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-        // offset >= store length, so the only in-bounds result is an empty view
-        // from every reader on both deserialize entry points.
-        const expected = { len: 0, bytesLen: 0, textLen: 0, all5: true };
-        expect(
-          stdout
-            .split("\n")
-            .filter(Boolean)
-            .map(l => JSON.parse(l)),
-        ).toEqual([expected, expected]);
-        expect(stderr).toBe("");
-        expect(exitCode).toBe(0);
-      },
-      30_000,
-    );
+      // offset >= store length, so the only in-bounds result is an empty view
+      // from every reader on both deserialize entry points.
+      const expected = { len: 0, bytesLen: 0, textLen: 0, all5: true };
+      expect(
+        stdout
+          .split("\n")
+          .filter(Boolean)
+          .map(l => JSON.parse(l)),
+      ).toEqual([expected, expected]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
 
     test("in-process: offset at store boundary yields empty view", async () => {
       // offset == store length stays within the allocation on any build, so


### PR DESCRIPTION
## Problem

`_onStructuredCloneDeserialize` reads a u64 `offset` from untrusted bytes — reachable via `require('bun:jsc').deserialize`, `require('node:v8').deserialize`, and cross-process IPC advanced serialization — and assigns it directly to `blob.offset` via `@intCast` with no bounds check against the backing store. `sharedView()` then does `slice_[this.offset..]`, which is unchecked in ReleaseFast.

Result: `await blob.arrayBuffer()` / `.text()` / `.bytes()` on a maliciously-crafted deserialized Blob returns an attacker-chosen-offset, up-to-store-length read off the mimalloc heap as a JS ArrayBuffer. Small offsets leak adjacent heap (free-list pointers, neighbouring allocations); large offsets segfault the process.

## Repro

```js
const { serialize, deserialize } = require('bun:jsc');
const u8 = new Uint8Array(serialize(new Blob(['ABCD'])));
// overwrite the u64 offset field in the wire format
new DataView(u8.buffer).setBigUint64(6, 1n << 20n, true);
const leaked = new Uint8Array(await deserialize(u8).arrayBuffer());
// leaked[0..4] is heap memory 1 MiB past the 4-byte store
```

On current release builds this returns heap bytes; with `offset = 1n << 40n` it segfaults.

## Fix

In `_onStructuredCloneDeserialize`, after materialising the store:

- replace `@intCast` with `@truncate` so an `offset > 2^52` isn't UB,
- clamp `blob.offset = @min(offset, store_size)` and `blob.size = @min(size, store_size - offset)` for bytes stores (file/s3 stores report `max_size` and are bounded by the filesystem read path),
- reset `offset = 0` when there's no store.

`sharedView()` also now clamps its slice index to `slice_.len` as a defensive second line, so no future caller can reach an OOB slice regardless of how `offset` was populated.

## Verification

New tests in `test/js/web/structured-clone-blob-file.test.ts` craft payloads with offsets of 5, 64, 4 KiB, 1 MiB, 2^40, >2^52, and u64-max, plus a `node:v8` deserialize case. Each asserts the resulting Blob's readers return **zero** bytes (offset ≥ store length ⇒ nothing in-bounds remains).

- Without fix: release build returns 4 bytes of OOB heap for small offsets, segfaults at 2^40; debug build panics on the slice bound.
- With fix: all 33 tests in the file pass.