### PR TITLE
fs.cp: preserve symlink target instead of linking back to source path

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6370,6 +6370,43 @@ pub const NodeFS = struct {
         return result;
     }
 
+    /// Recreate the symlink at `src` as a symlink at `dest`.
+    ///
+    /// Used by `_copySingleFileSync` when `open(src, O_NOFOLLOW)` fails with
+    /// ELOOP/EMLINK. The previous implementation called `symlink(src, dest)`,
+    /// which created a link whose *target string* was the path of the source
+    /// symlink instead of the target that the source symlink pointed at, so
+    /// every copied link pointed back into the source tree.
+    ///
+    /// The native fast path only runs when `verbatimSymlinks` is not set (the
+    /// JS fallback handles that option), so we match Node's default here:
+    /// `readlink(src)`, then resolve a relative target against `dirname(src)`.
+    fn _cpSymlink(this: *NodeFS, src: [:0]const u8, dest: [:0]const u8) Maybe(Return.CopyFile) {
+        var target_buf: bun.PathBuffer = undefined;
+        const link_target = switch (Syscall.readlink(src, &target_buf)) {
+            .result => |result| result,
+            .err => |err| {
+                @memcpy(this.sync_error_buf[0..src.len], src);
+                return .{ .err = err.withPath(this.sync_error_buf[0..src.len]) };
+            },
+        };
+
+        if (std.fs.path.isAbsolute(link_target)) {
+            return Syscall.symlink(link_target, dest);
+        }
+
+        var cwd_buf: bun.PathBuffer = undefined;
+        var resolved_buf: bun.PathBuffer = undefined;
+        const src_dir = bun.path.dirname(src, .posix);
+        const cwd = bun.getcwd(&cwd_buf) catch {
+            // If we can't resolve cwd, preserve the link target as-is rather
+            // than pointing the copied link back at the source path.
+            return Syscall.symlink(link_target, dest);
+        };
+        const resolved = bun.path.joinAbsStringBufZ(cwd, &resolved_buf, &.{ src_dir, link_target }, .posix);
+        return Syscall.symlink(resolved, dest);
+    }
+
     /// This is `copyFile`, but it copies symlinks as-is
     pub fn _copySingleFileSync(
         this: *NodeFS,
@@ -6510,7 +6547,7 @@ pub const NodeFS = struct {
                     if (err.getErrno() == .LOOP) {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return Syscall.symlink(src, dest);
+                        return this._cpSymlink(src, dest);
                     }
 
                     return .{ .err = err };
@@ -6657,9 +6694,11 @@ pub const NodeFS = struct {
             const src_fd = switch (Syscall.open(src, bun.O.RDONLY | bun.O.NOFOLLOW, 0o644)) {
                 .result => |result| result,
                 .err => |err| {
-                    // ELOOP from O_NOFOLLOW on a symlink → recreate the link.
-                    if (err.getErrno() == .LOOP) {
-                        return Syscall.symlink(src, dest);
+                    // O_NOFOLLOW on a symlink → recreate the link. FreeBSD's
+                    // open(2) returns EMLINK for this case, though POSIX
+                    // specifies ELOOP; accept either.
+                    if (err.getErrno() == .MLINK or err.getErrno() == .LOOP) {
+                        return this._cpSymlink(src, dest);
                     }
                     return .{ .err = err };
                 },

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -6403,8 +6403,24 @@ pub const NodeFS = struct {
             // than pointing the copied link back at the source path.
             return Syscall.symlink(link_target, dest);
         };
-        const resolved = bun.path.joinAbsStringBufZ(cwd, &resolved_buf, &.{ src_dir, link_target }, .posix);
-        return Syscall.symlink(resolved, dest);
+        // link_target is user-controlled and can approach PATH_MAX on its own,
+        // so prepending src_dir may exceed resolved_buf. Use the bounds-checked
+        // join and surface ENAMETOOLONG instead of corrupting the stack.
+        const resolved = bun.path.joinAbsStringBufChecked(
+            cwd,
+            resolved_buf[0 .. resolved_buf.len - 1],
+            &.{ src_dir, link_target },
+            .posix,
+        ) orelse {
+            @memcpy(this.sync_error_buf[0..src.len], src);
+            return .{ .err = .{
+                .errno = @intFromEnum(E.NAMETOOLONG),
+                .syscall = .symlink,
+                .path = this.sync_error_buf[0..src.len],
+            } };
+        };
+        resolved_buf[resolved.len] = 0;
+        return Syscall.symlink(resolved_buf[0..resolved.len :0], dest);
     }
 
     /// This is `copyFile`, but it copies symlinks as-is

--- a/test/js/node/fs/cp-symlink-target.test.ts
+++ b/test/js/node/fs/cp-symlink-target.test.ts
@@ -18,6 +18,12 @@ import os from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
 
+// On Windows the copied link's target comes from GetFinalPathNameByHandleW,
+// which returns the filesystem's canonical case (e.g. C:\Windows\Temp), while
+// paths built from os.tmpdir() carry the environment's case (e.g.
+// C:\Windows\TEMP). They name the same file, so compare case-insensitively.
+const normPath = process.platform === "win32" ? (p: string) => p.toLowerCase() : (p: string) => p;
+
 function makeFixture() {
   const base = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "cp-symlink-"));
   const origTarget = path.join(base, "target.txt");
@@ -48,13 +54,13 @@ function check(base: string, origTarget: string, srcAbs: string, srcRel: string)
     // symlink. With the bug, readlink(copiedLink) returned srcLink.
     const copiedTarget = fs.readlinkSync(copiedLink);
     assert.notStrictEqual(
-      copiedTarget,
-      srcLink,
+      normPath(copiedTarget),
+      normPath(srcLink),
       `copied ${which} target must not be the source symlink path (got ${copiedTarget})`,
     );
     assert.strictEqual(
-      fs.realpathSync(copiedLink),
-      fs.realpathSync(origTarget),
+      normPath(fs.realpathSync(copiedLink)),
+      normPath(fs.realpathSync(origTarget)),
       `copied ${which} must resolve to the original target`,
     );
   }

--- a/test/js/node/fs/cp-symlink-target.test.ts
+++ b/test/js/node/fs/cp-symlink-target.test.ts
@@ -1,0 +1,96 @@
+/**
+ * This test runs under `bun test` and (via node:test/node:assert) under
+ * `node --experimental-strip-types --test`.
+ *
+ * On Linux/FreeBSD, Bun's native fs.cp fallback for symlinks used to call
+ * symlink(src, dest) — creating a link whose *target string* was the path of
+ * the source symlink instead of what the source symlink pointed at. Every
+ * copied link therefore pointed back into the source tree, and removing the
+ * source left them dangling. The fix reads the source link's target with
+ * readlink() first and, since the native fast path only runs when
+ * verbatimSymlinks is not set, resolves a relative target against dirname(src)
+ * like Node does.
+ */
+import assert from "node:assert";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+function makeFixture() {
+  const base = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "cp-symlink-"));
+  const origTarget = path.join(base, "target.txt");
+  fs.writeFileSync(origTarget, "hello");
+  fs.mkdirSync(path.join(base, "from"));
+  fs.writeFileSync(path.join(base, "from", "keep"), "");
+
+  // Absolute target — exercises the isAbsolute fast path.
+  const srcAbs = path.join(base, "from", "abs_link");
+  fs.symlinkSync(origTarget, srcAbs);
+
+  // Relative target — exercises the dirname(src) resolve path.
+  const srcRel = path.join(base, "from", "rel_link");
+  fs.symlinkSync(path.join("..", "target.txt"), srcRel);
+
+  return { base, origTarget, srcAbs, srcRel };
+}
+
+function check(base: string, origTarget: string, srcAbs: string, srcRel: string) {
+  for (const [which, srcLink] of [
+    ["abs_link", srcAbs],
+    ["rel_link", srcRel],
+  ] as const) {
+    const copiedLink = path.join(base, "to", which);
+    assert.ok(
+      fs.lstatSync(copiedLink).isSymbolicLink(),
+      `copied ${which} should be a symlink`,
+    );
+
+    // The copied link's target string must not be the path of the source
+    // symlink. With the bug, readlink(copiedLink) returned srcLink.
+    const copiedTarget = fs.readlinkSync(copiedLink);
+    assert.notStrictEqual(
+      copiedTarget,
+      srcLink,
+      `copied ${which} target must not be the source symlink path (got ${copiedTarget})`,
+    );
+    assert.strictEqual(
+      fs.realpathSync(copiedLink),
+      fs.realpathSync(origTarget),
+      `copied ${which} must resolve to the original target`,
+    );
+  }
+
+  // Deleting the source tree must not break the absolute link, since its
+  // target lives outside the source tree. With the bug, the copied link
+  // pointed at from/abs_link and would dangle once from/ was removed.
+  fs.rmSync(path.join(base, "from"), { recursive: true, force: true });
+  assert.strictEqual(
+    fs.readFileSync(path.join(base, "to", "abs_link"), "utf8"),
+    "hello",
+    "copied abs_link must remain valid after the source tree is removed",
+  );
+}
+
+describe("fs.cp preserves symlink targets instead of linking back to the source path", () => {
+  test("fs.cpSync", () => {
+    const { base, origTarget, srcAbs, srcRel } = makeFixture();
+    try {
+      fs.cpSync(path.join(base, "from"), path.join(base, "to"), { recursive: true });
+      check(base, origTarget, srcAbs, srcRel);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("fs.promises.cp", async () => {
+    const { base, origTarget, srcAbs, srcRel } = makeFixture();
+    try {
+      await fsp.cp(path.join(base, "from"), path.join(base, "to"), { recursive: true });
+      check(base, origTarget, srcAbs, srcRel);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/js/node/fs/cp-symlink-target.test.ts
+++ b/test/js/node/fs/cp-symlink-target.test.ts
@@ -42,10 +42,7 @@ function check(base: string, origTarget: string, srcAbs: string, srcRel: string)
     ["rel_link", srcRel],
   ] as const) {
     const copiedLink = path.join(base, "to", which);
-    assert.ok(
-      fs.lstatSync(copiedLink).isSymbolicLink(),
-      `copied ${which} should be a symlink`,
-    );
+    assert.ok(fs.lstatSync(copiedLink).isSymbolicLink(), `copied ${which} should be a symlink`);
 
     // The copied link's target string must not be the path of the source
     // symlink. With the bug, readlink(copiedLink) returned srcLink.

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -227,26 +227,36 @@ for (const [name, copy] of impls) {
         "from/keep": "",
       });
 
-      const srcLink = join(basename, "from", "link");
       const origTarget = join(basename, "target.txt");
-      fs.symlinkSync(origTarget, srcLink);
+
+      // Absolute target — exercises the isAbsolute fast path.
+      const srcAbs = join(basename, "from", "abs_link");
+      fs.symlinkSync(origTarget, srcAbs);
+
+      // Relative target — exercises the dirname(src) resolve path.
+      const srcRel = join(basename, "from", "rel_link");
+      fs.symlinkSync(join("..", "target.txt"), srcRel);
 
       await copy(basename + "/from", basename + "/to", { recursive: true });
 
-      const copiedLink = join(basename, "to", "link");
-      expect(fs.lstatSync(copiedLink).isSymbolicLink()).toBe(true);
+      for (const [which, srcLink] of [
+        ["abs_link", srcAbs],
+        ["rel_link", srcRel],
+      ] as const) {
+        const copiedLink = join(basename, "to", which);
+        expect(fs.lstatSync(copiedLink).isSymbolicLink()).toBe(true);
 
-      // The copied link's target string must not be the path of the source
-      // symlink. With the bug, readlink(copiedLink) returned srcLink.
-      const copiedTarget = fs.readlinkSync(copiedLink);
-      expect(copiedTarget).not.toBe(srcLink);
-      expect(fs.realpathSync(copiedLink)).toBe(fs.realpathSync(origTarget));
+        // The copied link's target string must not be the path of the source
+        // symlink. With the bug, readlink(copiedLink) returned srcLink.
+        expect(fs.readlinkSync(copiedLink)).not.toBe(srcLink);
+        expect(fs.realpathSync(copiedLink)).toBe(fs.realpathSync(origTarget));
+      }
 
-      // Deleting the source tree must not break the copied link, since the
-      // link target lives outside the source tree. With the bug, the copied
-      // link pointed at from/link and would dangle once from/ was removed.
+      // Deleting the source tree must not break the absolute link, since its
+      // target lives outside the source tree. With the bug, the copied link
+      // pointed at from/abs_link and would dangle once from/ was removed.
       fs.rmSync(join(basename, "from"), { recursive: true, force: true });
-      expect(fs.readFileSync(copiedLink, "utf8")).toBe("hello");
+      expect(fs.readFileSync(join(basename, "to", "abs_link"), "utf8")).toBe("hello");
     });
 
     test("filter - works", async () => {

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -218,6 +218,37 @@ for (const [name, copy] of impls) {
       expect(fs.readdirSync(basename + "/result/dir_symlink")).toEqual(["c.txt"]);
     });
 
+    test("symlinks - copied link target is the original target, not the source link path", async () => {
+      // Previously the ELOOP fallback on Linux/FreeBSD called symlink(src, dest),
+      // so the copied link's target string was the path of the *source* symlink
+      // and every copied link pointed back into the source tree.
+      const basename = tempDirWithFiles("cp", {
+        "target.txt": "hello",
+        "from/keep": "",
+      });
+
+      const srcLink = join(basename, "from", "link");
+      const origTarget = join(basename, "target.txt");
+      fs.symlinkSync(origTarget, srcLink);
+
+      await copy(basename + "/from", basename + "/to", { recursive: true });
+
+      const copiedLink = join(basename, "to", "link");
+      expect(fs.lstatSync(copiedLink).isSymbolicLink()).toBe(true);
+
+      // The copied link's target string must not be the path of the source
+      // symlink. With the bug, readlink(copiedLink) returned srcLink.
+      const copiedTarget = fs.readlinkSync(copiedLink);
+      expect(copiedTarget).not.toBe(srcLink);
+      expect(fs.realpathSync(copiedLink)).toBe(fs.realpathSync(origTarget));
+
+      // Deleting the source tree must not break the copied link, since the
+      // link target lives outside the source tree. With the bug, the copied
+      // link pointed at from/link and would dangle once from/ was removed.
+      fs.rmSync(join(basename, "from"), { recursive: true, force: true });
+      expect(fs.readFileSync(copiedLink, "utf8")).toBe("hello");
+    });
+
     test("filter - works", async () => {
       const basename = tempDirWithFiles("cp", {
         "from/a.txt": "a",


### PR DESCRIPTION
## What

`fs.cp` / `fs.cpSync` on Linux and FreeBSD copied every symlink as a link whose target was the *path of the source symlink* rather than what that symlink pointed at. Deleting the source directory left every copied link dangling.

## Repro

```js
import fs from 'fs';
import { join } from 'path';

fs.mkdirSync('from', { recursive: true });
fs.writeFileSync('target.txt', 'hello');
fs.symlinkSync(join(process.cwd(), 'target.txt'), 'from/link');

fs.cpSync('from', 'to', { recursive: true });

console.log(fs.readlinkSync('to/link'));
// Bun (before): "<cwd>/from/link"   ← points back at the source symlink
// Node:         "<cwd>/target.txt"  ← points at the original target
```

## Cause

`_copySingleFileSync` (src/bun.js/node/node_fs.zig) opens the source with `O_NOFOLLOW`. When the source is a symlink, that fails with `ELOOP` and the fallback did:

```zig
return Syscall.symlink(src, dest);
```

`symlink(target, linkpath)` takes the *target string* first, so this created `dest` with a target of `src` — the source symlink's path — instead of what the source symlink pointed at.

## Fix

Added `_cpSymlink(src, dest)`, called from both the Linux and FreeBSD branches:

1. `readlink(src)` to get the source link's target
2. If the target is relative, resolve it against `dirname(src)` (matching Node's default / non-`verbatimSymlinks` behaviour — the native path is only taken when that option is unset)
3. `symlink(target, dest)`

Also accept `EMLINK` in the FreeBSD branch since FreeBSD's `open(2)` returns that (not `ELOOP`) for `O_NOFOLLOW` on a symlink.

## Verification

New test in `test/js/node/fs/cp.test.ts` (`symlinks - copied link target is the original target, not the source link path`) for both `cpSync` and `fs.promises.cp`:

- asserts `readlinkSync(copied) !== srcLinkPath`
- asserts the copied link resolves to the original target
- deletes the source tree and asserts the copied link still reads

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/cp.test.ts -t 'copied link target'  → 2 fail
bun bd test test/js/node/fs/cp.test.ts -t 'copied link target'                → 2 pass
bun bd test test/js/node/fs/cp.test.ts                                         → 39 pass / 2 skip
bun run zig:check-all                                                          → all targets OK
```

Touches the same lines as #28998 (which adds a parent-dir retry around this symlink call) — whichever lands second will need a trivial rebase.