### PR TITLE
node:http: send 500 instead of 200 when handler throws synchronously

### DIFF
--- a/src/runtime/server/server.zig
+++ b/src/runtime/server/server.zig
@@ -2170,7 +2170,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                         if (!node_response.flags.upgraded and node_response.raw_response != null) {
                             const raw_response = node_response.raw_response.?;
                             if (!node_response.flags.request_has_completed and raw_response.state().isResponsePending()) {
-                                if (raw_response.state().isHttpStatusCalled()) {
+                                if (!raw_response.state().isHttpStatusCalled()) {
                                     raw_response.writeStatus("500 Internal Server Error");
                                     raw_response.endWithoutBody(true);
                                 } else {

--- a/test/js/node/http/node-http-sync-throw-500.test.ts
+++ b/test/js/node/http/node-http-sync-throw-500.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When a node:http request handler throws synchronously before any status line
+// has been written, Bun should respond with 500 Internal Server Error rather
+// than defaulting to 200 OK. The cleanup path in server.zig checks whether a
+// status has already been sent via isHttpStatusCalled(); previously the
+// condition was inverted so the 500 branch was unreachable and endStream()
+// wrote a default "HTTP/1.1 200 OK".
+test.concurrent("node:http responds 500 when handler throws synchronously before writing status", async () => {
+  const script = /* js */ `
+    const http = require("node:http");
+    const net = require("node:net");
+    const { once } = require("node:events");
+
+    // Swallow the propagated handler exception so the process stays alive.
+    process.on("uncaughtException", err => {
+      process.stderr.write("uncaughtException:" + err.message + "\\n");
+    });
+
+    const server = http.createServer((req, res) => {
+      throw new Error("boom");
+    });
+
+    server.listen(0, "127.0.0.1", async () => {
+      const port = server.address().port;
+      const socket = net.connect(port, "127.0.0.1");
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n");
+      let raw = "";
+      for await (const chunk of socket) raw += chunk.toString("latin1");
+      const statusLine = raw.slice(0, raw.indexOf("\\r\\n"));
+      process.stdout.write("STATUS_LINE:" + statusLine + "\\n");
+      server.close();
+      process.exit(0);
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("uncaughtException:boom");
+  expect(stdout.trim()).toBe("STATUS_LINE:HTTP/1.1 500 Internal Server Error");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("node:http still terminates the response when handler throws after writeHead", async () => {
+  const script = /* js */ `
+    const http = require("node:http");
+    const net = require("node:net");
+    const { once } = require("node:events");
+
+    process.on("uncaughtException", err => {
+      process.stderr.write("uncaughtException:" + err.message + "\\n");
+    });
+
+    const server = http.createServer((req, res) => {
+      res.writeHead(201, { "x-before-throw": "yes" });
+      res.flushHeaders();
+      throw new Error("boom-after-head");
+    });
+
+    server.listen(0, "127.0.0.1", async () => {
+      const port = server.address().port;
+      const socket = net.connect(port, "127.0.0.1");
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n");
+      let raw = "";
+      for await (const chunk of socket) raw += chunk.toString("latin1");
+      const statusLine = raw.slice(0, raw.indexOf("\\r\\n"));
+      process.stdout.write("STATUS_LINE:" + statusLine + "\\n");
+      process.stdout.write("HAS_HEADER:" + raw.includes("x-before-throw: yes") + "\\n");
+      server.close();
+      process.exit(0);
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("uncaughtException:boom-after-head");
+  // Status was already sent before the throw, so it stays 201, but the
+  // connection must still be terminated (we received a complete response).
+  expect(stdout.trim()).toBe("STATUS_LINE:HTTP/1.1 201 Created\nHAS_HEADER:true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Reproduction

```js
const http = require("node:http");
process.on("uncaughtException", () => {}); // keep process alive
const server = http.createServer((req, res) => {
  throw new Error("boom");
});
server.listen(0, async () => {
  const res = await fetch(`http://127.0.0.1:${server.address().port}/`);
  console.log(res.status); // before: 200, after: 500
});
```

## Root cause

When a `node:http` request handler throws (or its returned promise rejects) before the response has completed, `onNodeHTTPRequestWithUpgradeCtx` in `src/bun.js/api/server.zig` cleans up by writing a status and ending the response. The branch that writes `"500 Internal Server Error"` was guarded by `raw_response.state().isHttpStatusCalled()` — i.e. it only ran when a status line had *already* been written, which makes `writeStatus` a no-op. When no status had been written, control fell into the `else` arm and called `endStream(true)`, which bottoms out in uWS `sendTerminatingChunk()` → `writeStatus(HTTP_200_OK)`.

The condition is simply inverted; the equivalent rejection handler in `NodeHTTPResponse.Bun__NodeHTTPRequest__onReject` uses `!isHttpStatusCalled()` correctly.

## Fix

Invert the condition so that:
- if no status has been sent yet → `writeStatus("500 Internal Server Error")` + `endWithoutBody(true)`
- if a status was already sent → `endStream(true)` to terminate the in-flight chunked response

## Verification

New test `test/js/node/http/node-http-sync-throw-500.test.ts`:

- **before fix** (and with `USE_SYSTEM_BUN=1`):
  ```
  Expected: "STATUS_LINE:HTTP/1.1 500 Internal Server Error"
  Received: "STATUS_LINE:HTTP/1.1 200 OK"
  ```
- **after fix**: both tests pass — the sync-throw case returns 500, and the throw-after-`writeHead(201)` case still preserves the 201 status while cleanly terminating the stream.

The existing `node-http.test.ts` suite passes (the single `request via http proxy` failure is pre-existing ECONNREFUSED flake, reproduces without this change).