### PR TITLE
install: consider OR'd alternatives in find_best_version fast path

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1799,7 +1799,7 @@ impl PackageManifest {
         let left = group.head.head.range.left;
         let mut newest_filtered: Option<Semver::Version> = None;
 
-        if left.op == Semver::range::Op::Eql {
+        if group.is_exact() {
             let result = self.find_by_version(left.version);
             if let Some(r) = result {
                 if Self::is_package_version_too_recent(r.package, min_age_ms) {
@@ -1869,7 +1869,7 @@ impl PackageManifest {
     ) -> Option<FindResult<'_>> {
         let left = group.head.head.range.left;
         // Fast path: exact version
-        if left.op == Semver::range::Op::Eql {
+        if group.is_exact() {
             return self.find_by_version(left.version);
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2503,6 +2503,111 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should consider OR'd alternatives when first comparator is an exact version", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "1.0.0": { as: "0.0.3" },
+          "2.5.0": { as: "0.0.5" },
+          latest: "2.5.0",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            baz: "1.0.0 || ^2.0.0",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        expect.stringContaining("+ baz@2.5.0"),
+        "",
+        "1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.5.tgz`]);
+      expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+        name: "baz",
+        version: "0.0.5",
+        bin: {
+          "baz-exec": "index.js",
+        },
+      });
+      await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
+  it("should resolve OR'd alternative when the exact version does not exist", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "2.5.0": { as: "0.0.5" },
+          latest: "2.5.0",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            baz: "1.0.0 || ^2.0.0",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        expect.stringContaining("+ baz@2.5.0"),
+        "",
+        "1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.5.tgz`]);
+      expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
+        name: "baz",
+        version: "0.0.5",
+        bin: {
+          "baz-exec": "index.js",
+        },
+      });
+      await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
   it("should prefer latest-tagged dependency", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];


### PR DESCRIPTION
## What

`PackageManifest::find_best_version` and `find_best_version_with_filter` have an exact-version fast path that checked only `group.head.head.range.left.op == Op::Eql` before calling `find_by_version(left.version)`. This ignored:
- `head.next` — OR'd alternatives (`||`)
- `head.head.next` — AND'd comparators
- `range.right` — the right side of a range

## Repro

```json
{ "dependencies": { "foo": "1.0.0 || ^2.0.0" } }
```

- If the registry has both `1.0.0` and `2.5.0` with `latest: 2.5.0` → bun installs **`1.0.0`** instead of `2.5.0` (the `^2.0.0` branch is silently ignored).
- If the registry has only `2.5.0` (e.g. `1.0.0` was unpublished) → bun fails with **`No version matching "1.0.0 || ^2.0.0" found`** even though `2.5.0` satisfies `^2.0.0`.

## Fix

Gate the fast path on `group.is_exact()`, which already checks all three conditions (`src/semver/SemverQuery.rs`).

## Verification

Two new tests in `test/cli/install/bun-install.test.ts`:

Without fix:
```
(fail) should consider OR'd alternatives when first comparator is an exact version
  + baz@1.0.0 (v2.5.0 available)   ← wrong version
(fail) should resolve OR'd alternative when the exact version does not exist
  error: No version matching "1.0.0 || ^2.0.0" found for specifier "baz"
```

With fix: both install `baz@2.5.0` ✓

---

*Rebase note:* This PR originally targeted `src/install/npm.zig`. After the Zig→Rust port landed on main, the same bug was present verbatim in `src/install/npm.rs` at the equivalent locations; the fix was re-applied there. The `setDefaultTimeout` hoist from the original PR was already on main, so it's no longer part of this diff.
