### PR TITLE
server: route streaming 413 through endWithoutBody so ctx.resp detaches

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2403,20 +2403,30 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     resp.clearOnData();
                     this.flags.is_waiting_for_request_body = false;
 
-                    if (!resp.hasResponded()) {
-                        resp.writeStatus("413 Payload Too Large");
-                        resp.endWithoutBody(comptime !http3);
-                    }
-
                     var loop = vm.eventLoop();
                     loop.enter();
                     defer loop.exit();
-                    // toErrorInstance handles .Locked itself (rejects the
-                    // promise, deinits the readable, calls onReceiveValue),
-                    // so don't re-resolve a stale copy afterwards.
+                    // Reject the pending body first so endRequestStreaming()
+                    // below (via this.endWithoutBody) doesn't substitute a
+                    // generic ConnectionClosed. toErrorInstance handles
+                    // .Locked itself (rejects the promise, deinits the
+                    // readable, calls onReceiveValue).
                     body.value.toErrorInstance(.{
                         .Message = bun.String.static("Request body exceeded maxRequestBodySize"),
                     }, globalThis) catch {};
+
+                    // Route through the normal end path so this.resp is
+                    // detached and the base ref released. Writing directly on
+                    // the raw uWS response left this.resp pointing at a
+                    // completed (and soon freed) response — uWS markDone()
+                    // clears onAborted so no abort ever fires to release the
+                    // ref, and a later handleResolve()/handleReject() from an
+                    // async handler would dereference the stale pointer.
+                    if (this.resp != null and !resp.hasResponded()) {
+                        this.flags.has_written_status = true;
+                        resp.writeStatus("413 Payload Too Large");
+                    }
+                    this.endWithoutBody(comptime !http3);
                     return;
                 }
 

--- a/test/js/bun/http/serve-413-streaming-late-resolve-fixture.ts
+++ b/test/js/bun/http/serve-413-streaming-late-resolve-fixture.ts
@@ -1,0 +1,131 @@
+import { connect } from "node:net";
+
+// A chunked (no Content-Length) POST that exceeds maxRequestBodySize hits the
+// streaming 413 in onBufferedBodyChunk, not the up-front server.zig check.
+// That path previously wrote the 413 directly on the raw uWS response without
+// detaching ctx.resp or releasing the base ref — uWS markDone() nulls
+// onAborted, so when the socket closed no abort fired. If the fetch handler's
+// Promise then settled, handleResolve()/handleReject() dereferenced the
+// already-freed response (heap-use-after-free under ASAN) and the
+// RequestContext leaked.
+
+async function sendChunkedOverflow(port: number) {
+  const sock = connect(port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.on("connect", resolve);
+    sock.on("error", reject);
+  });
+
+  sock.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n",
+  );
+  const chunk = Buffer.alloc(2048, "A");
+  sock.write(chunk.length.toString(16) + "\r\n");
+  sock.write(chunk);
+  sock.write("\r\n0\r\n\r\n");
+
+  let received = "";
+  const { promise, resolve: done } = Promise.withResolvers<void>();
+  sock.on("data", d => {
+    received += d.toString();
+    if (received.includes("\r\n\r\n")) done();
+  });
+  sock.on("close", () => done());
+  await promise;
+  sock.destroy();
+  return received.split("\r\n")[0];
+}
+
+async function waitForPending(server: ReturnType<typeof Bun.serve>, n: number) {
+  for (let i = 0; i < 100 && server.pendingRequests !== n; i++) {
+    Bun.gc(true);
+    await Bun.sleep(10);
+  }
+  return server.pendingRequests;
+}
+
+// --- resolve path ---
+{
+  let capturedResolve: ((r: Response) => void) | undefined;
+  let bodyErr = "";
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: 1024,
+    fetch(req) {
+      if (req.method !== "POST") return new Response("follow-up");
+      req.text().catch(e => (bodyErr = String(e?.message ?? e)));
+      return new Promise<Response>(resolve => {
+        capturedResolve = resolve;
+      });
+    },
+  });
+
+  const status = await sendChunkedOverflow(Number(server.port));
+  // Let the closed socket's memory be reclaimed before the late resolve so a
+  // stale ctx.resp is a real dangling pointer, not just a done-but-live one.
+  await waitForPending(server, 1);
+  await Bun.sleep(10);
+
+  // handleResolve must observe isAbortedOrEnded() and drop the Response; it
+  // must not cork/write on the freed uWS socket.
+  capturedResolve!(new Response("late"));
+  capturedResolve = undefined;
+  const pending = await waitForPending(server, 0);
+
+  // A follow-up request must still work and must not see the stale "late".
+  const ok = await fetch(server.url, { method: "GET" });
+  const okText = await ok.text();
+
+  console.log(
+    JSON.stringify({
+      case: "resolve",
+      status,
+      bodyErr,
+      pendingAfterResolve: pending,
+      followUp: { status: ok.status, text: okText },
+    }),
+  );
+  server.stop(true);
+}
+
+// --- reject path ---
+{
+  let capturedReject: ((e: unknown) => void) | undefined;
+  const server = Bun.serve({
+    port: 0,
+    idleTimeout: 0,
+    maxRequestBodySize: 1024,
+    fetch(req) {
+      req.text().catch(() => {});
+      return new Promise<Response>((_resolve, reject) => {
+        capturedReject = reject;
+      });
+    },
+    error() {
+      // A late reject after the 413 should be a no-op for this request; the
+      // error handler only renders when it can still respond.
+      return new Response("error-handler", { status: 500 });
+    },
+  });
+
+  const status = await sendChunkedOverflow(Number(server.port));
+  await waitForPending(server, 1);
+  await Bun.sleep(10);
+
+  capturedReject!(new Error("late reject"));
+  capturedReject = undefined;
+  const pending = await waitForPending(server, 0);
+
+  console.log(
+    JSON.stringify({
+      case: "reject",
+      status,
+      pendingAfterReject: pending,
+    }),
+  );
+  server.stop(true);
+}

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -76,6 +76,41 @@ test("resolve() inside abort handler is handled safely", async () => {
   expect(server.pendingRequests).toBe(0);
 });
 
+test("streaming 413 detaches the response so a late resolve/reject is a no-op", async () => {
+  // Run in a subprocess: without the fix this is a heap-use-after-free under
+  // ASAN (render() corks a uWS socket that was freed when the 413 closed the
+  // connection — markDone() cleared onAborted so no abort ever detached
+  // ctx.resp).
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-413-streaming-late-resolve-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const lines = stdout
+    .trim()
+    .split("\n")
+    .map(l => JSON.parse(l));
+  expect(lines).toEqual([
+    {
+      case: "resolve",
+      status: "HTTP/1.1 413 Payload Too Large",
+      bodyErr: "Request body exceeded maxRequestBodySize",
+      pendingAfterResolve: 0,
+      followUp: { status: 200, text: "follow-up" },
+    },
+    {
+      case: "reject",
+      status: "HTTP/1.1 413 Payload Too Large",
+      pendingAfterReject: 0,
+    },
+  ]);
+  expect(exitCode).toBe(0);
+}, 30_000);
+
 test("resolve() after abort does not crash and cleans up", async () => {
   // UAF safety: while the resolve function is reachable, the Promise stays
   // alive, the NativePromiseContext cell stays alive, and the RequestContext


### PR DESCRIPTION
## What

When a chunked (or HTTP/3) request body exceeds `maxRequestBodySize`, `onBufferedBodyChunk` writes the 413 directly on the raw uWS response:

```zig
resp.writeStatus("413 Payload Too Large");
resp.endWithoutBody(comptime !http3);
```

`internalEnd` → `markDone()` nulls `onAborted`, so when the socket closes no abort ever fires to detach `ctx.resp` or release the base ref. `this.resp` is left pointing at a completed response whose socket is about to be freed by `us_internal_free_closed_sockets`.

If the fetch handler returned a pending Promise:

- **resolve**: `handleResolve` → `isAbortedOrEnded()` is false (`this.resp != null`) → `render()` → `runCorkedWithType` corks the freed socket → **heap-use-after-free** (ASAN trace below).
- **reject**: `handleReject` reads `resp.hasResponded()` off freed memory, sees `true`, skips the error handler, and returns without ever releasing the base ref → **RequestContext leaks** (`server.pendingRequests` never returns to 0).

## Fix

Route through `this.endWithoutBody()` (the `RequestContext` wrapper) instead of the raw `resp.endWithoutBody()`. That path does `detachResponse()` (nulls `this.resp`, clears `onData`/`onAborted`/`onTimeout`) and `deref()` (releases the base ref), matching every other end path in this file.

The body promise is rejected with the specific `"Request body exceeded maxRequestBodySize"` error *before* `endWithoutBody()` so `endRequestStreaming()` doesn't overwrite it with a generic `ConnectionClosed`. `has_written_status` is set so any later `renderMissing`/`renderMetadata` knows the status line is already committed.

## Repro

```
==ERROR: AddressSanitizer: heap-use-after-free
  #0 us_socket_group socket.c:77
  #1 uWS::AsyncSocket<false>::getLoopData() AsyncSocket.h:69
  #2 uWS::AsyncSocket<false>::isCorked() AsyncSocket.h:141
  #3 uWS::HttpResponse<false>::cork(...) HttpResponse.h:647
  #4 uws_res_cork libuwsockets.cpp:1740
  #5 ...runCorkedWithType Response.zig:299
  #6 ...doRenderBlob RequestContext.zig:1942
  ...
  #11 ...handleResolve RequestContext.zig:220
  #12 ...onResolve RequestContext.zig:154
freed by:
  #1 us_poll_free epoll_kqueue.c:73
  #2 us_internal_free_closed_sockets loop.c:305
```

## Test

`test/js/bun/http/serve-pending-promise-abort-leak.test.ts` — new case sends a raw `Transfer-Encoding: chunked` POST exceeding `maxRequestBodySize` with a handler that holds its resolve/reject, waits for the socket to be reclaimed, then settles the Promise. Asserts `pendingRequests` returns to 0 for both paths, the body was rejected with the right message, and a follow-up request still works.

Without the fix: ASAN heap-use-after-free on the resolve path; on release builds the reject path shows `pendingAfterReject: 1` (leak).