### PR TITLE
server.upgrade: clone Sec-WebSocket-* from request.headers before option getters

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -894,10 +894,38 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
             var sec_websocket_extensions = ZigString.Empty;
 
+            // Owned backing storage for sec_websocket_key/protocol/extensions.
+            //
+            // fastGet on request.headers returns a ZigString that borrows from the header map
+            // entry's StringImpl. Before we use these values we call opts.data / opts.headers
+            // getters, which run arbitrary user JS — that JS can mutate request.headers
+            // (set/delete Sec-WebSocket-*), freeing the StringImpl out from under the borrowed
+            // slice. Clone into owned storage so the bytes stay valid across the getter calls
+            // below and the later resp.upgrade().
+            //
+            // The options.headers path reuses the protocol/extensions slots (and frees the
+            // previous clone first) since fastRemove there would likewise free the backing
+            // StringImpl.
+            var sec_websocket_key_owned = ZigString.Slice.empty;
+            defer sec_websocket_key_owned.deinit();
+            var sec_websocket_protocol_owned = ZigString.Slice.empty;
+            defer sec_websocket_protocol_owned.deinit();
+            var sec_websocket_extensions_owned = ZigString.Slice.empty;
+            defer sec_websocket_extensions_owned.deinit();
+
             if (request.getFetchHeaders()) |head| {
-                sec_websocket_key_str = head.fastGet(.SecWebSocketKey) orelse ZigString.Empty;
-                sec_websocket_protocol = head.fastGet(.SecWebSocketProtocol) orelse ZigString.Empty;
-                sec_websocket_extensions = head.fastGet(.SecWebSocketExtensions) orelse ZigString.Empty;
+                if (head.fastGet(.SecWebSocketKey)) |key| {
+                    sec_websocket_key_owned = bun.handleOom(key.toSliceClone(bun.default_allocator));
+                    sec_websocket_key_str = sec_websocket_key_owned.toZigString();
+                }
+                if (head.fastGet(.SecWebSocketProtocol)) |protocol| {
+                    sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
+                    sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
+                }
+                if (head.fastGet(.SecWebSocketExtensions)) |extensions| {
+                    sec_websocket_extensions_owned = bun.handleOom(extensions.toSliceClone(bun.default_allocator));
+                    sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
+                }
             }
 
             if (upgrader.req) |req| {
@@ -935,15 +963,6 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                     fh.deref();
                 }
             }
-
-            // Owned backing storage for sec_websocket_protocol/extensions when they come
-            // from options.headers. fastGet returns a ZigString that borrows from the header
-            // map entry's StringImpl, which fastRemove then frees — so we must copy the
-            // bytes before removing the entry.
-            var sec_websocket_protocol_owned = ZigString.Slice.empty;
-            defer sec_websocket_protocol_owned.deinit();
-            var sec_websocket_extensions_owned = ZigString.Slice.empty;
-            defer sec_websocket_extensions_owned.deinit();
 
             var fetch_headers_to_use: ?*WebCore.FetchHeaders = null;
 
@@ -991,6 +1010,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketProtocol)) |protocol| {
                             // Clone before fastRemove frees the backing StringImpl.
+                            sec_websocket_protocol_owned.deinit();
                             sec_websocket_protocol_owned = bun.handleOom(protocol.toSliceClone(bun.default_allocator));
                             sec_websocket_protocol = sec_websocket_protocol_owned.toZigString();
                             // Remove from headers so it's not written twice (once here and once by upgrade())
@@ -999,6 +1019,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
 
                         if (fetch_headers_to_use.?.fastGet(.SecWebSocketExtensions)) |extensions| {
                             // Clone before fastRemove frees the backing StringImpl.
+                            sec_websocket_extensions_owned.deinit();
                             sec_websocket_extensions_owned = bun.handleOom(extensions.toSliceClone(bun.default_allocator));
                             sec_websocket_extensions = sec_websocket_extensions_owned.toZigString();
                             // Remove from headers so it's not written twice (once here and once by upgrade())

--- a/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
+++ b/test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts
@@ -1,11 +1,104 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 
 // server.upgrade(req, opts) reads opts.data / opts.headers via property
 // access, which can invoke user getters. A getter that calls
 // server.upgrade(req) again on the same request used to perform a second
 // upgrade on a uws response that had already been converted into a
 // WebSocket, double-deref'ing the RequestContext in the process.
+
+// server.upgrade() reads Sec-WebSocket-Key/Protocol/Extensions from
+// req.headers via FetchHeaders::fastGet, which returns a ZigString that
+// BORROWS from the header map entry's StringImpl. It then invokes the
+// opts.data / opts.headers getters (arbitrary user JS) before using those
+// borrowed slices in the actual upgrade. A getter that mutates req.headers
+// frees the backing StringImpl, and the subsequent resp.upgrade() read
+// freed memory.
+//
+// WTF::StringImpl is allocated via bmalloc, which is not ASAN-instrumented by
+// default. On Linux, `Malloc=1` makes bmalloc route through the system allocator
+// so ASAN observes the free and flags the use-after-free in
+// uWS::HttpResponse::upgrade(). We only do this on Linux: on Windows the
+// bmalloc system-heap path crashes (SIGILL on aarch64), and with WTF allocations
+// going through system malloc LeakSanitizer starts reporting pre-existing
+// process-lifetime WebKit singletons, so we also disable LSan for the subprocess.
+// On non-Linux platforms the test still verifies the upgrade completes
+// successfully — regressions are caught by the Linux ASAN lane.
+test("server.upgrade() clones Sec-WebSocket-* from request.headers before running option getters", async () => {
+  using dir = tempDir("ws-upgrade-header-uaf", {
+    "index.ts": `
+      const server = Bun.serve({
+        port: 0,
+        fetch(req, server) {
+          // Materialize the JS FetchHeaders so server.upgrade() reads the
+          // Sec-WebSocket-* values from it (the borrowed-StringImpl path)
+          // rather than from the raw uWS request buffer.
+          req.headers.get("sec-websocket-key");
+
+          const ok = server.upgrade(req, {
+            get data() {
+              // Drop the sole ref on the StringImpl that sec_websocket_key /
+              // protocol / extensions were borrowed from. Without the fix,
+              // the subsequent resp.upgrade() reads these freed bytes.
+              req.headers.set("sec-websocket-key", "overwritten-overwritten-overwritten");
+              req.headers.set("sec-websocket-protocol", "overwritten-overwritten-overwritten");
+              req.headers.set("sec-websocket-extensions", "overwritten-overwritten-overwritten");
+              return undefined;
+            },
+          });
+          if (!ok) return new Response("no upgrade", { status: 500 });
+        },
+        websocket: {
+          open(ws) {
+            ws.send("hello");
+          },
+          message() {},
+          close() {},
+        },
+      });
+
+      const ws = new WebSocket(server.url.href.replace("http", "ws"), "chat");
+      const got = await new Promise<string>((resolve, reject) => {
+        ws.onmessage = e => {
+          resolve(String(e.data));
+          ws.close();
+        };
+        ws.onerror = () => reject(new Error("ws error"));
+        ws.onclose = e => {
+          if (e.code !== 1000 && e.code !== 1005) reject(new Error("ws closed: " + e.code + " " + e.reason));
+        };
+      });
+      console.log("got=" + got);
+      server.stop(true);
+      process.exit(0);
+    `,
+  });
+
+  const env: Record<string, string | undefined> = { ...bunEnv };
+  if (isLinux) {
+    // Route bmalloc through the system heap so ASAN sees StringImpl frees.
+    env.Malloc = "1";
+    // Skip symbolization so an ASAN abort (the pre-fix behaviour) exits
+    // promptly; disable LSan because routing WTF allocations through system
+    // malloc makes pre-existing process-lifetime WebKit singletons visible
+    // to LeakSanitizer at exit.
+    env.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":");
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("got=hello");
+  expect(exitCode).toBe(0);
+});
 
 for (const via of ["data", "headers"] as const) {
   test(`server.upgrade() is safe against re-entrant upgrade from options.${via} getter`, async () => {


### PR DESCRIPTION
## Problem

`server.upgrade(req, opts)` reads `Sec-WebSocket-Key` / `Sec-WebSocket-Protocol` / `Sec-WebSocket-Extensions` from `request.getFetchHeaders()` via `FetchHeaders.fastGet`, which returns a `ZigString` that **borrows** directly from the header map entry's `StringImpl` (`bindings.cpp` `WebCore__FetchHeaders__fastGet_` → `Zig::toZigString(StringView)`, no ref taken).

It then invokes the `opts.data` / `opts.headers` getters — arbitrary user JS — and only afterwards passes those borrowed slices to `resp.upgrade()`.

A getter that mutates `req.headers` (e.g. `req.headers.set('sec-websocket-key', ...)`) drops the sole ref on the original `StringImpl` (`HTTPHeaderMap::set` does a `RefPtr` assignment), freeing it. `resp.upgrade()` then reads freed memory for the key/protocol/extensions.

```js
Bun.serve({
  fetch(req, server) {
    req.headers; // materialize FetchHeaders
    server.upgrade(req, {
      get data() {
        req.headers.set('sec-websocket-key', 'x'); // frees the borrowed StringImpl
        return undefined;
      },
    });
  },
  websocket: { message() {} },
});
```

The re-entrancy guard after the getters only checks `isAbortedOrEnded() / didUpgradeWebSocket()`, not header mutation. The `opts.headers` path was already defensively cloning with `toSliceClone` (because `fastRemove` there frees the backing); the `request.headers` path was missed.

## Fix

Clone `sec_websocket_key` / `protocol` / `extensions` into owned `ZigString.Slice` storage immediately after reading them from `request.getFetchHeaders()`, so the bytes stay valid across the option getters and `resp.upgrade()`. The `opts.headers` override path reuses the same owned slots (freeing the previous clone first).

## Verification

New test in `test/js/bun/websocket/websocket-server-upgrade-reentrant.test.ts` spawns a subprocess with `Malloc=1` (routes bmalloc → system heap so ASAN observes `StringImpl` frees) and has an `opts.data` getter overwrite all three `Sec-WebSocket-*` headers.

**Before** (src/ stashed, `bun bd test`):
```
==ERROR: AddressSanitizer: heap-use-after-free
  #3 uWS::HttpResponse<false>::upgrade ... HttpResponse.h:269
  #6 server.zig:1076 (resp.upgrade call)
(fail) server.upgrade() clones Sec-WebSocket-* from request.headers before running option getters
```

**After**: all three tests in the file pass.

Also fails on `USE_SYSTEM_BUN=1` (release, no ASAN) — with `Malloc=1` the system allocator reuses the freed slot and the WebSocket client rejects the handshake (bad `Sec-WebSocket-Accept` / mismatched protocol).