### PR TITLE
spawn: kill child on POSIX when poller is still .detached

### DIFF
--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -550,7 +550,17 @@ pub const Process = struct {
     pub fn kill(this: *Process, signal: u8) Maybe(void) {
         if (comptime Environment.isPosix) {
             switch (this.poller) {
-                .waiter_thread, .fd => {
+                .waiter_thread, .fd, .detached => {
+                    // `.detached` is the initial state after `initPosix` (before `watch()` sets up
+                    // `.fd` / `.waiter_thread`), as well as the state after `close()` / reaping. In
+                    // the initial case we still have a live pid that must be killable — e.g. an
+                    // already-aborted AbortSignal in `spawnSync` fires before `watchOrReap()`.
+                    // Guard against the post-reap case via `hasExited()` so we never signal a pid
+                    // that may have been recycled by the OS.
+                    if (this.poller == .detached and this.hasExited()) {
+                        return .{ .result = {} };
+                    }
+
                     const err = std.c.kill(this.pid, signal);
                     if (err != 0) {
                         const errno_ = bun.sys.getErrno(err);
@@ -560,7 +570,6 @@ pub const Process = struct {
                             return .{ .err = bun.sys.Error.fromCode(errno_, .kill) };
                     }
                 },
-                else => {},
             }
         } else if (comptime Environment.isWindows) {
             switch (this.poller) {

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -21,8 +21,6 @@ test("spawn AbortSignal works after spawning", async () => {
 });
 
 test("spawn AbortSignal works if already aborted", async () => {
-  const controller = new AbortController();
-  const { signal } = controller;
   const start = performance.now();
   const subprocess = Bun.spawn({
     cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
@@ -30,10 +28,8 @@ test("spawn AbortSignal works if already aborted", async () => {
     stdout: "inherit",
     stderr: "inherit",
     stdin: "inherit",
-    signal,
+    signal: AbortSignal.abort(),
   });
-  await Bun.sleep(1);
-  controller.abort();
   expect(await subprocess.exited).not.toBe(0);
   const end = performance.now();
   expect(end - start).toBeLessThan(100);

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -67,3 +67,39 @@ test("spawnSync AbortSignal works as timeout", async () => {
   const end = performance.now();
   expect(end - start).toBeLessThan(100);
 });
+
+test("spawnSync with already-aborted AbortSignal kills the process", () => {
+  // On POSIX, Process.kill() previously no-op'd when the poller was still in its
+  // initial `.detached` state. Because the abort listener fires synchronously before
+  // watchOrReap() upgrades the poller, an already-aborted signal left the child
+  // running and spawnSync blocked until the child exited on its own.
+  const subprocess = Bun.spawnSync({
+    cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
+    env: bunEnv,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    signal: AbortSignal.abort(),
+  });
+
+  expect(subprocess.success).toBeFalse();
+  expect(subprocess.exitedDueToTimeout).toBeUndefined();
+  if (process.platform !== "win32") {
+    expect(subprocess.signalCode).toBe("SIGTERM");
+  }
+});
+
+test("spawnSync with already-aborted AbortSignal kills the process (piped stdio)", () => {
+  // Same as above but with default (piped) stdio to cover the non-inherit path.
+  const subprocess = Bun.spawnSync({
+    cmd: [bunExe(), "--eval", "await Bun.sleep(100000)"],
+    env: bunEnv,
+    signal: AbortSignal.abort(),
+  });
+
+  expect(subprocess.success).toBeFalse();
+  expect(subprocess.exitedDueToTimeout).toBeUndefined();
+  if (process.platform !== "win32") {
+    expect(subprocess.signalCode).toBe("SIGTERM");
+  }
+});


### PR DESCRIPTION
## Problem

`Bun.spawnSync({ cmd: ['sleep', '1000'], signal: AbortSignal.abort() })` hangs for ~1000 seconds on POSIX instead of killing the child immediately.

## Cause

`Process.initPosix()` initializes `poller = .detached`. In the `spawnSync` path, the abort listener is attached (js_bun_spawn_bindings.zig:954) *before* `watchOrReap()` (line 978) upgrades the poller to `.fd` / `.waiter_thread`. When the `AbortSignal` is already aborted, the listener fires synchronously → `tryKill` → `Process.kill()`, which on POSIX only handled `.waiter_thread` / `.fd` and fell through `else => {}` for `.detached`. The kill becomes a no-op, the child keeps running, and the sync wait loop blocks until the child exits naturally.

The async `Bun.spawn` path is unaffected because `watch()` runs before the abort listener is attached. Windows is unaffected because the `.uv` poller is set during spawn itself.

## Fix

Handle `.detached` in `Process.kill()` on POSIX by calling `std.c.kill(this.pid, signal)`, guarded by `hasExited()` so we never signal a pid that has been reaped and potentially recycled by the OS. The switch is now exhaustive over `PollerPosix`.

## Verification

```
# before (system bun): hangs, killed by 5s test timeout
(fail) spawnSync with already-aborted AbortSignal kills the process [5006.18ms]
(fail) spawnSync with already-aborted AbortSignal kills the process (piped stdio) [5005.94ms]

# after (bun bd): passes immediately
(pass) spawnSync with already-aborted AbortSignal kills the process [5.66ms]
(pass) spawnSync with already-aborted AbortSignal kills the process (piped stdio) [6.30ms]
```

Also verified `spawn-signal.test.ts`, `spawnSync.test.ts`, `spawn-kill-signal.test.ts`, `spawnsync-isolated-event-loop.test.ts` all pass, and `zig:check-all` succeeds on all platforms.