### PR TITLE
install.sh: verify SHA-256 of downloaded archive

### DIFF
--- a/src/cli/install.sh
+++ b/src/cli/install.sh
@@ -146,8 +146,66 @@ if [[ ! -d $bin_dir ]]; then
         error "Failed to create install directory \"$bin_dir\""
 fi
 
+info "Downloading bun from \"$bun_uri\""
 curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
     error "Failed to download bun from \"$bun_uri\""
+
+verify_download() {
+    if [[ ${BUN_INSTALL_SKIP_VERIFY:-} = 1 ]]; then
+        info 'Skipping checksum verification (BUN_INSTALL_SKIP_VERIFY=1)'
+        return 0
+    fi
+
+    local sha_cmd
+    if command -v sha256sum >/dev/null; then
+        sha_cmd='sha256sum'
+    elif command -v shasum >/dev/null; then
+        sha_cmd='shasum -a 256'
+    else
+        error 'sha256sum or shasum is required to verify the download (set BUN_INSTALL_SKIP_VERIFY=1 to skip)'
+    fi
+
+    local sums_uri="${bun_uri%/*}/SHASUMS256.txt"
+    local sums_path="$bin_dir/SHASUMS256.txt"
+
+    curl --fail --silent --show-error --location --output "$sums_path" "$sums_uri" ||
+        error "Failed to download checksums from \"$sums_uri\" (set BUN_INSTALL_SKIP_VERIFY=1 to skip)"
+
+    # If gpg is available and the bun release key is already in the user's
+    # keyring, also verify the PGP signature on the manifest. The key is not
+    # fetched on the fly: doing so would create a trust-on-first-use window
+    # that an attacker controlling the channel could exploit.
+    local bun_release_key='F3DCC08A8572C0749B3E18888EAB4D40A7B22B59'
+    if command -v gpg >/dev/null && gpg --list-keys "$bun_release_key" >/dev/null 2>&1; then
+        local sig_uri="${bun_uri%/*}/SHASUMS256.txt.asc"
+        local sig_path="$bin_dir/SHASUMS256.txt.asc"
+        curl --fail --silent --show-error --location --output "$sig_path" "$sig_uri" ||
+            error "Failed to download signature from \"$sig_uri\""
+        gpg --verify "$sig_path" "$sums_path" ||
+            error 'PGP signature verification failed for SHASUMS256.txt'
+        info "Verified PGP signature on SHASUMS256.txt"
+        rm -f "$sig_path"
+    fi
+
+    local zip_name="bun-$target.zip"
+    local expected
+    expected=$(awk -v name="$zip_name" '$2 == name { print $1; exit }' "$sums_path")
+    if [[ -z $expected ]]; then
+        error "No checksum entry for \"$zip_name\" in SHASUMS256.txt"
+    fi
+
+    local actual
+    actual=$($sha_cmd "$exe.zip" | awk '{ print $1 }')
+    if [[ $expected != "$actual" ]]; then
+        rm -f "$exe.zip"
+        error "Checksum mismatch for \"$zip_name\" (expected $expected, got $actual)"
+    fi
+
+    info "Verified SHA-256 of \"$zip_name\""
+    rm -f "$sums_path"
+}
+
+verify_download
 
 unzip -oqd "$bin_dir" "$exe.zip" ||
     error 'Failed to extract bun'


### PR DESCRIPTION
### What does this PR do?

Make `src/cli/install.sh` verify the SHA-256 of the downloaded zip against the published `SHASUMS256.txt` manifest before extracting and executing it. Optionally also verify the PGP signature on that manifest if the user has the bun release key in their keyring.

Closes the supply-chain gap noted in #1732.

This catches release accidents and mirror substitution. It does **not** defend against compromise of the release token unless the user has the bun release key in their keyring. A separate PR could close that gap by bundling the fingerprint.

### How did you verify your code works?

Verified end-to-end on Linux against `bun-v1.3.13`:

    Downloading bun from "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip"
    ######################################################################## 100.0%
    Verified SHA-256 of "bun-linux-x64.zip"
    bun was installed successfully to ...

shellcheck (with the pre-existing `SC2145` warnings in the colour
helpers excluded) is clean on the new code. `bash -n` passes.