### PR TITLE
s3(list): size encode buffer to input*3 instead of panicking on overflow

### DIFF
--- a/src/s3/client.zig
+++ b/src/s3/client.zig
@@ -115,16 +115,16 @@ pub fn listObjects(
     bun.handleOom(search_params.appendSlice(bun.default_allocator, "?"));
 
     if (listOptions.continuation_token) |continuation_token| {
-        var buff: [1024]u8 = undefined;
-        const encoded = S3Credentials.encodeURIComponent(continuation_token, &buff, true) catch |err|
-            std.debug.panic("unexpected error from S3Credentials.encodeURIComponent: {}", .{err});
+        const buff = bun.handleOom(bun.default_allocator.alloc(u8, continuation_token.len * 3));
+        defer bun.default_allocator.free(buff);
+        const encoded = S3Credentials.encodeURIComponent(continuation_token, buff, true) catch unreachable;
         bun.handleOom(search_params.appendFmt(bun.default_allocator, "continuation-token={s}", .{encoded}));
     }
 
     if (listOptions.delimiter) |delimiter| {
-        var buff: [1024]u8 = undefined;
-        const encoded = S3Credentials.encodeURIComponent(delimiter, &buff, true) catch |err|
-            std.debug.panic("unexpected error from S3Credentials.encodeURIComponent: {}", .{err});
+        const buff = bun.handleOom(bun.default_allocator.alloc(u8, delimiter.len * 3));
+        defer bun.default_allocator.free(buff);
+        const encoded = S3Credentials.encodeURIComponent(delimiter, buff, true) catch unreachable;
 
         if (listOptions.continuation_token != null) {
             bun.handleOom(search_params.appendFmt(bun.default_allocator, "&delimiter={s}", .{encoded}));
@@ -160,16 +160,16 @@ pub fn listObjects(
     }
 
     if (listOptions.prefix) |prefix| {
-        var buff: [1024]u8 = undefined;
-        const encoded = S3Credentials.encodeURIComponent(prefix, &buff, true) catch |err|
-            std.debug.panic("unexpected error from S3Credentials.encodeURIComponent: {}", .{err});
+        const buff = bun.handleOom(bun.default_allocator.alloc(u8, prefix.len * 3));
+        defer bun.default_allocator.free(buff);
+        const encoded = S3Credentials.encodeURIComponent(prefix, buff, true) catch unreachable;
         bun.handleOom(search_params.appendFmt(bun.default_allocator, "&prefix={s}", .{encoded}));
     }
 
     if (listOptions.start_after) |start_after| {
-        var buff: [1024]u8 = undefined;
-        const encoded = S3Credentials.encodeURIComponent(start_after, &buff, true) catch |err|
-            std.debug.panic("unexpected error from S3Credentials.encodeURIComponent: {}", .{err});
+        const buff = bun.handleOom(bun.default_allocator.alloc(u8, start_after.len * 3));
+        defer bun.default_allocator.free(buff);
+        const encoded = S3Credentials.encodeURIComponent(start_after, buff, true) catch unreachable;
         bun.handleOom(search_params.appendFmt(bun.default_allocator, "&start-after={s}", .{encoded}));
     }
 

--- a/test/js/bun/s3/s3-list-encode-overflow.test.ts
+++ b/test/js/bun/s3/s3-list-encode-overflow.test.ts
@@ -1,0 +1,14 @@
+import { S3Client } from "bun";
+import { describe, expect, it } from "bun:test";
+
+describe("S3Client.list() option encoding", () => {
+  it.each(["prefix", "delimiter", "continuationToken", "startAfter"])(
+    "should not panic when %s is longer than 1024 bytes when encoded",
+    async key => {
+      // S3 keys may be up to 1024 bytes; percent-encoding can triple that.
+      // Previously a fixed 1024-byte stack buffer caused `std.debug.panic` on overflow.
+      const value = Buffer.alloc(1024, " ").toString();
+      await expect(new S3Client().list({ [key]: value })).rejects.toThrow();
+    },
+  );
+});

--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -1073,6 +1073,15 @@ describe.concurrent("S3 - List Objects", () => {
       expect(error.code).toBe("ERR_S3_MISSING_CREDENTIALS");
     }
   });
+
+  it.each(["prefix", "delimiter", "continuationToken", "startAfter"])(
+    "should not panic when %s is longer than 1024 bytes when encoded",
+    async key => {
+      // S3 keys may be up to 1024 bytes; percent-encoding can triple that.
+      const value = Buffer.alloc(1024, " ").toString();
+      await expect(new S3Client().list({ [key]: value })).rejects.toThrow();
+    },
+  );
 });
 
 const optionsFromEnv: S3Options = {

--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -1073,15 +1073,6 @@ describe.concurrent("S3 - List Objects", () => {
       expect(error.code).toBe("ERR_S3_MISSING_CREDENTIALS");
     }
   });
-
-  it.each(["prefix", "delimiter", "continuationToken", "startAfter"])(
-    "should not panic when %s is longer than 1024 bytes when encoded",
-    async key => {
-      // S3 keys may be up to 1024 bytes; percent-encoding can triple that.
-      const value = Buffer.alloc(1024, " ").toString();
-      await expect(new S3Client().list({ [key]: value })).rejects.toThrow();
-    },
-  );
 });
 
 const optionsFromEnv: S3Options = {


### PR DESCRIPTION
`S3Client.list()` URL-encodes `prefix`, `delimiter`, `continuationToken`, and `startAfter` into a fixed 1024-byte stack buffer. When the encoded output exceeds 1024 bytes, `encodeURIComponent` returns `error.BufferTooSmall` and the caller hits `std.debug.panic`:

```js
Bun.s3.list({ prefix: " ".repeat(342) }); // 342 spaces -> "%20" * 342 = 1026 bytes
// panic(main thread): unexpected error from S3Credentials.encodeURIComponent: error.BufferTooSmall
```

S3 object keys can be up to 1024 bytes, and percent-encoding can triple that, so this is reachable with legitimate inputs — not just adversarial ones.

Allocate a buffer of `input.len * 3` for each field instead. Every input byte produces at most three output bytes (`%XX`), so the encode can no longer fail; `catch unreachable` documents that invariant. The buffer is freed immediately after the encoded slice is copied into the growing `search_params` list.

Found by Fuzzilli (fingerprint `982993eb865047a1`).