### PR TITLE
fix(transpiler): fold `import.meta?.main` through the optional chain

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1434,7 +1434,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
 
-        if e_.optional_chain.is_none() {
+        // `import.meta` is never nullish, so `import.meta?.x` is equivalent to
+        // `import.meta.x`; the optional chain is a no-op and the rewrite is safe.
+        let target_is_always_object = matches!(e_.target.data, Data::EImportMeta(..));
+
+        if e_.optional_chain.is_none() || target_is_always_object {
             if let Some(_expr) = p.maybe_rewrite_property_access(
                 expr.loc,
                 e_.target,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -844,6 +844,28 @@ describe("bundler", () => {
     },
     run: { stdout: new Array(7).fill("true").join("\n") },
   });
+  // https://github.com/oven-sh/bun/issues/30084
+  itBundled("compile/ImportMetaMainOptionalChain", {
+    compile: true,
+    backend: "cli",
+    files: {
+      "/entry.ts": /* js */ `
+        import { isModuleMain } from './sub/mod';
+        // Use toString on an arrow so we can observe what the transpiler folded.
+        // With --compile, optional chain now folds to 'true' for the entry and
+        // 'false' for any other module.
+        console.log((() => import.meta?.main).toString().includes('true'));
+        console.log((() => !import.meta?.main).toString().includes('false'));
+        console.log((() => import.meta?.main).toString().includes('import.meta'));
+        console.log(isModuleMain);
+      `,
+      "/sub/mod.ts": /* js */ `
+        // Non-entry module: import.meta?.main must fold to false here.
+        export const isModuleMain = (() => import.meta?.main).toString().includes('false');
+      `,
+    },
+    run: { stdout: "true\ntrue\nfalse\ntrue" },
+  });
   itBundled("compile/SourceMap", {
     target: "bun",
     compile: true,


### PR DESCRIPTION
Fixes #30084.

## Reproduction

```ts
// entry.ts
if (import.meta?.main) console.log("ok");
else throw `import.meta.main is false? ${import.meta?.main}`;
```

```console
> bun build --compile --target=bun-windows-x64 entry.ts --outfile out.exe
> .\out.exe
error: import.meta.main is false? false
```

## Root cause

`bun build --compile` already constant-folds `import.meta.main` to `true`/`false` for every module at build time. But the `e_dot` visitor skipped that rewrite whenever an optional chain was set (`x?.y`), a reasonable default because `x?.y` short-circuits when `x` is nullish.

`import.meta` is never nullish, so the optional chain on `import.meta?.main` is a no-op. Bailing out of the rewrite left the runtime builtin in the compiled binary, which compares `import.meta.path === Bun.main`. On Windows standalone executables those two disagree on path separator:

- `Bun.main` is the graph entry name `B:/~BUN/root/entry.ts` (forward slashes). It has to stay that way: the CommonJS `requireMap` is keyed by the same specifier, and `require.main` / `process.mainModule` both look up with `requireMap.get(Bun.main)`.
- `import.meta.path` is produced via WebKit's `URL::fileSystemPath()`, which on Windows converts every `/` in the URL path to `\` (`vendor/WebKit/Source/WTF/wtf/URL.cpp:239`). Result: `"B:\\~BUN\\root\\entry.ts"`.

So `===` always returned `false` and `import.meta?.main` was always falsy in Windows `--compile`d binaries. Linux/macOS were not affected because their standalone base path is `/$bunfs/` and `fileSystemPath()` doesn't touch separators off Windows.

## Fix

In the `e_dot` visitor (`src/js_parser/visit/visit_expr.rs`), allow `maybe_rewrite_property_access` to run through the optional chain when the target is `EImportMeta`. Since `import.meta` is guaranteed non-null, the short-circuit never fires and eliding it is a pure semantic no-op. `import.meta?.main` now folds to `true` in the entry module and `false` elsewhere at build time, exactly like `import.meta.main` already did.

The runtime builtin and the standalone-graph separator choice are untouched. No other APIs change.

## Verification

`compile/ImportMetaMainOptionalChain` in `test/bundler/bundler_compile.test.ts` captures `(() => import.meta?.main).toString()` in both the entry and a non-entry module and asserts the fold left the literal `true` / `false`. Fail-before / pass-after confirmed locally:
- without the fix: `false\nfalse\ntrue\nfalse`
- with the fix: `true\ntrue\nfalse\ntrue`
