### PR TITLE
shell(braces): fix expansion count for sibling nested braces

### DIFF
--- a/src/shell/braces.zig
+++ b/src/shell/braces.zig
@@ -380,32 +380,32 @@ pub const Parser = struct {
 };
 
 pub fn calculateExpandedAmount(tokens: []const Token) u32 {
-    var nested_brace_stack = bun.SmallList(u8, MAX_NESTED_BRACES){};
+    const StackEntry = struct {
+        segment_product: u32 = 1,
+        accumulator: u32 = 0,
+    };
+    var nested_brace_stack = bun.SmallList(StackEntry, MAX_NESTED_BRACES){};
     defer nested_brace_stack.deinit(bun.default_allocator);
     var variant_count: u32 = 0;
-    var prev_comma: bool = false;
 
     for (tokens) |tok| {
-        prev_comma = false;
         switch (tok) {
-            .open => nested_brace_stack.append(bun.default_allocator, 0),
+            .open => nested_brace_stack.append(bun.default_allocator, .{}),
             .comma => {
-                const val = nested_brace_stack.lastMut().?;
-                val.* += 1;
-                prev_comma = true;
+                const top = nested_brace_stack.lastMut().?;
+                top.accumulator +|= top.segment_product;
+                top.segment_product = 1;
             },
             .close => {
-                var variants = nested_brace_stack.pop().?;
-                if (!prev_comma) {
-                    variants += 1;
-                }
+                const entry = nested_brace_stack.pop().?;
+                const total = entry.accumulator +| entry.segment_product;
                 if (nested_brace_stack.len() > 0) {
-                    const top = nested_brace_stack.lastMut().?;
-                    top.* += variants - 1;
+                    const parent = nested_brace_stack.lastMut().?;
+                    parent.segment_product *|= total;
                 } else if (variant_count == 0) {
-                    variant_count = variants;
+                    variant_count = total;
                 } else {
-                    variant_count *= variants;
+                    variant_count *|= total;
                 }
             },
             else => {},

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -27,6 +27,22 @@ describe("$.braces", () => {
     expect(result).toEqual(["echo 123", "echo 456", "echo 789", "echo abc"]);
   });
 
+  test("nested sibling product", () => {
+    expect($.braces(`{{d,e}{g,h}}`)).toEqual(["dg", "dh", "eg", "eh"]);
+  });
+
+  test("nested sibling product with surrounding text", () => {
+    expect($.braces(`pre{{a,b}{c,d}}post`)).toEqual(["preacpost", "preadpost", "prebcpost", "prebdpost"]);
+  });
+
+  test("nested sibling product mixed with variants", () => {
+    expect($.braces(`{a,{b,c}{d,e},f}`)).toEqual(["a", "bd", "be", "cd", "ce", "f"]);
+  });
+
+  test("nested sibling product triple", () => {
+    expect($.braces(`{{a,b}{c,d}{e,f}}`)).toEqual(["ace", "acf", "ade", "adf", "bce", "bcf", "bde", "bdf"]);
+  });
+
   test("very deeply nested", () => {
     const result = $.braces(`{1,{2,{3,{4,{5,{6,{7,{8,{9,{10,{11,{12,{13,{14,{15,{16,{17}}}}}}}}}}}}}}}}}`);
     expect(result).toEqual([


### PR DESCRIPTION
Found by Fuzzilli (fingerprint `11b9aaba259eece1`).

## What

`Bun.$.braces("{{d,e}{g,h}}")` crashed with an index-out-of-bounds panic in `expandNested`.

## Why

`calculateExpandedAmount` pre-computes how many output strings brace expansion will produce so the caller can preallocate. When a nested brace closed, it added `variants - 1` into the parent's running count. That's fine for `{a,{b,c},d}` (the nested brace contributes items *linearly* into the parent's comma list), but wrong for `{{a,b}{c,d}}` — sibling braces within the *same* comma-separated segment multiply, so the result is 4, not 3.

`expandNested` then wrote past the end of the under-sized `out` slice.

## Fix

For each nesting level, track:
- `segment_product`: product of nested brace counts within the current comma-separated segment
- `accumulator`: sum of completed segments

On `,`, fold the segment product into the accumulator and reset it. On `}`, the brace's total is `accumulator + segment_product`, which multiplies into the parent's current segment.

Saturating arithmetic is used to avoid wraparound on pathological inputs.

## Tests

Added regression tests in `test/js/bun/shell/brace.test.ts` covering `{{d,e}{g,h}}`, `pre{{a,b}{c,d}}post`, `{a,{b,c}{d,e},f}`, and `{{a,b}{c,d}{e,f}}` — all of which previously crashed.