### PR TITLE
run: keep pre*/post* completions when no sibling script exists

### DIFF
--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1124,8 +1124,14 @@ pub const RunCommand = struct {
                             }
                         }
 
-                        if (strings.startsWith(key, "post") or strings.startsWith(key, "pre")) {
-                            continue :loop;
+                        // npm-style lifecycle hooks: a script named `pre<X>` or `post<X>` runs
+                        // automatically around `<X>`, so there's no reason to list it as a
+                        // completion target. But `prettier`, `prebuild`-with-no-`build`,
+                        // `postgres`, etc. are standalone scripts — keep them.
+                        if (strings.hasPrefixComptime(key, "pre")) {
+                            if (scripts.contains(key["pre".len..])) continue :loop;
+                        } else if (strings.hasPrefixComptime(key, "post")) {
+                            if (scripts.contains(key["post".len..])) continue :loop;
                         }
 
                         const entry_item = results.getOrPutAssumeCapacity(key);

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -103,7 +103,6 @@ describe("bun", () => {
           env: bunEnv,
           cwd: String(dir),
         });
-        expect(exitCode).toBe(0);
         const lines = stdout
           .toString()
           .split("\n")
@@ -122,6 +121,8 @@ describe("bun", () => {
         expect(lines).not.toContain("prebuild");
         expect(lines).not.toContain("postbuild");
         expect(lines).not.toContain("pretest");
+
+        expect(exitCode).toBe(0);
       }
     });
   });

--- a/test/cli/bun.test.ts
+++ b/test/cli/bun.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 
@@ -67,6 +67,62 @@ describe("bun", () => {
       });
       expect(exitCode).toBe(0);
       expect(stdout.toString()).not.toBeEmpty();
+    });
+
+    // https://github.com/oven-sh/bun/issues/30086
+    test("getcompletes keeps scripts whose names start with 'pre'/'post' when no sibling script exists", () => {
+      using dir = tempDir("getcompletes-pre-post", {
+        "package.json": JSON.stringify({
+          name: "test",
+          scripts: {
+            // standalone scripts — nothing named `ttier`, `pare-release`, `gres`, `css`, `view`
+            "prettier": "echo prettier",
+            "prettier:fix": "echo prettier:fix",
+            "prepare-release": "echo prepare-release",
+            "postgres": "echo postgres",
+            "postcss": "echo postcss",
+            "preview": "echo preview",
+            // plain scripts
+            "build": "echo build",
+            "dev": "echo dev",
+            "lint": "echo lint",
+            "lint:fix": "echo lint:fix",
+            "fix": "echo fix",
+            "test": "echo test",
+            // real lifecycle hooks — these SHOULD be hidden (sibling exists)
+            "prebuild": "echo prebuild",
+            "postbuild": "echo postbuild",
+            "pretest": "echo pretest",
+          },
+        }),
+      });
+
+      for (const filter of ["s", "i", "r", "g", "z"]) {
+        const { stdout, exitCode } = spawnSync({
+          cmd: [bunExe(), "getcompletes", filter],
+          env: bunEnv,
+          cwd: String(dir),
+        });
+        expect(exitCode).toBe(0);
+        const lines = stdout
+          .toString()
+          .split("\n")
+          .map(l => l.split("\t")[0]) // "z" filter emits "name\tdescription"
+          .filter(Boolean);
+
+        // standalone pre/post-prefixed scripts must be present
+        expect(lines).toContain("prettier");
+        expect(lines).toContain("prettier:fix");
+        expect(lines).toContain("prepare-release");
+        expect(lines).toContain("postgres");
+        expect(lines).toContain("postcss");
+        expect(lines).toContain("preview");
+
+        // real npm lifecycle hooks (sibling `build`/`test` exists) must still be hidden
+        expect(lines).not.toContain("prebuild");
+        expect(lines).not.toContain("postbuild");
+        expect(lines).not.toContain("pretest");
+      }
     });
   });
   describe("test command line arguments", () => {


### PR DESCRIPTION
## Summary

Fixes #30086.

`bun getcompletes` filtered out every script whose name started with `pre` or `post`, so standalone scripts like `prettier`, `prepare-release`, `postgres`, `postcss`, `preview` never showed up in shell completions (tab-complete for `bun run`, zsh/bash/fish).

## Reproduction

```json
{
  "scripts": {
    "lint": "...", "lint:fix": "...",
    "prettier": "...", "prettier:fix": "...",
    "fix": "...", "dev": "...", "build": "...", "test": "..."
  }
}
```

```console
$ bun getcompletes i
dev
fix
lint
lint:fix
```

`prettier` and `prettier:fix` are missing.

## Cause

`src/cli/run_command.zig` unconditionally skipped any key starting with `pre` or `post`:

```zig
if (strings.startsWith(key, "post") or strings.startsWith(key, "pre")) {
    continue :loop;
}
```

The intent was to hide npm-style lifecycle hooks (`prebuild`, `postinstall`, …) that run automatically around the main script — but the prefix check matched any name, sweeping up user scripts that happen to start with those letters.

## Fix

Only skip `preX` or `postX` when a sibling script named `X` exists in the same `scripts` block — that's the case where npm treats it as a lifecycle hook:

```zig
if (strings.hasPrefixComptime(key, "pre")) {
    if (scripts.contains(key["pre".len..])) continue :loop;
} else if (strings.hasPrefixComptime(key, "post")) {
    if (scripts.contains(key["post".len..])) continue :loop;
}
```

`prebuild` with a `build` sibling: hidden (hook).  
`prebuild` with no `build` sibling: shown (standalone).  
`prettier` (no `ttier` sibling): shown.

## Verification

New test in `test/cli/bun.test.ts`:

- Fails without the fix: `prettier`, `prettier:fix`, `prepare-release`, `postgres`, `postcss`, `preview` are dropped from `getcompletes s|i|r|g|z`.
- Passes with the fix; `prebuild`/`postbuild`/`pretest` (real hooks with `build`/`test` siblings) remain hidden.

Existing `pre`/`post` lifecycle hook tests (`test/cli/run/filter-workspace.test.ts`) still pass — the run path is untouched.