### PR TITLE
shell(cd): handle remaining errno cases in handleChangeCwdErr instead of hanging

### DIFF
--- a/src/shell/builtin/cd.zig
+++ b/src/shell/builtin/cd.zig
@@ -97,7 +97,17 @@ fn handleChangeCwdErr(this: *Cd, err: Syscall.Error, new_cwd_: []const u8) Yield
 
             return this.writeStderrNonBlocking("file name too long\n", .{});
         },
-        else => return .failed,
+        else => {
+            const errmsg = err.msg() orelse err.name();
+            if (this.bltn().stderr.needsIO() == null) {
+                const buf = this.bltn().fmtErrorArena(.cd, "{s}: {s}\n", .{ errmsg, new_cwd_ });
+                _ = this.bltn().writeNoIO(.stderr, buf);
+                this.state = .done;
+                return this.bltn().done(1);
+            }
+
+            return this.writeStderrNonBlocking("{s}: {s}\n", .{ errmsg, new_cwd_ });
+        },
     }
 }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,6 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { chmodSync, mkdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, runWithErrorPromise, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -868,6 +869,23 @@ booga"
       expect(stderr).toBe("");
       expect(stdout.trim()).toBe("ENAMETOOLONG");
       expect(exitCode).toBe(0);
+    });
+
+    // handleChangeCwdErr's `else` arm previously returned `.failed` without writing
+    // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
+    // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
+    test.if(isPosix)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
+      const dir = tempDirWithFiles("cd-eacces", { "placeholder.txt": "" });
+      const noaccess = join(dir, "noaccess");
+      mkdirSync(noaccess);
+      chmodSync(noaccess, 0o000);
+      try {
+        const { stderr, exitCode } = await $`cd ${noaccess}`.quiet().nothrow();
+        expect(stderr.toString()).toBe(`cd: Permission denied: ${noaccess}\n`);
+        expect(exitCode).toBe(1);
+      } finally {
+        chmodSync(noaccess, 0o755);
+      }
     });
   });
 


### PR DESCRIPTION
## What

`handleChangeCwdErr`'s `else` arm returned `.failed` without writing to stderr or calling `done()`, so any errno other than `NOTDIR`/`NOENT`/`NAMETOOLONG` (e.g. `EACCES`, `ELOOP`, `EIO`) left `await Bun.$\`cd ...\`` unresolved forever.

#30063 fixed the `NAMETOOLONG` overflow path but kept `else => return .failed` for everything else.

## Fix

Write `cd: <strerror>: <path>` via `err.msg() orelse err.name()` and call `done(1)`, matching the existing arms.

## Test

POSIX-only EACCES test (chmod 000 dir): hangs on 1.3.x, now exits 1 with `cd: Permission denied: <path>`.

Supersedes #26990.