### PR TITLE
WebKit: fix wasm BBQCallee UAF in updateCallsitesToCallUs (astro-post.test.js Windows segfault)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "6ef83cb658722ff1f33f4a4c9335fb094bed4c6b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-209-2c2ff0bb";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
> [!NOTE]
> **Blocked on oven-sh/WebKit#209.** `WEBKIT_VERSION` currently points at that PR's preview-build tag; the WebKit "Preview Build" workflow for forks needs a maintainer to approve the run before the prebuilt exists. Once oven-sh/WebKit#209 is merged, this PR should be updated to the post-merge commit SHA.

## Symptom

`test/js/third_party/astro/astro-post.test.js` has been intermittently segfaulting on the Windows Server 2019 runners (`x64` and `x64-baseline`) across unrelated PRs — e.g. #30025 / [build 49587](https://buildkite.com/bun/bun/builds/49587#019de128-5988-4ce0-b68c-bf8fe112351d), also builds 49639, 49750, 49858. Always `panic: Segmentation fault at address 0x…` ~1.6–1.8 s into the test, on a non-main thread.

## Symbolicated stack

Pulled the `bun-windows-x64-baseline-profile.pdb` for commit `0e27799` from the BuildKite artifacts and fed the `bun.report` offsets + PE image base `0x140000000` to `llvm-symbolizer`:

```
JSC::Wasm::CalleeGroup::updateCallsitesToCallUs   WasmCalleeGroup.cpp:408  ← MacroAssembler::repatchNearCall
JSC::Wasm::CalleeGroup::installOptimizedCallee    WasmCalleeGroup.cpp:310
JSC::Wasm::BBQPlan::work (or OMGPlan::work)
JSC::Wasm::Worklist::Thread::work                 WasmWorklist.cpp:118
WTF::AutomaticThread / WTF::Thread::entryPoint
WTF::wtfThreadEntryPoint
thread_start → KERNEL32 → ntdll
```

All four crash instances from four different commits have this exact shape; fault addresses are inside the JIT region.

## Root cause

`CalleeGroup::updateCallsitesToCallUs` (runs on a wasm compiler thread with `m_lock` held) iterates every caller of the function being tiered up. For each caller with a `BBQCallee`:

```cpp
RefPtr<BBQCallee> bbqCallee;
{
    Locker locker { tuple->m_bbqCalleeLock };
    bbqCallee = tuple->m_bbqCallee.get();
}
if (bbqCallee)
    collectCallsites(bbqCallee.get());   // copies raw CodeLocationNearCall addresses into `callsites`
// bbqCallee goes out of scope here       ← ref dropped
```

then, *after* the switchOn loop and `resetInstructionCacheOnAllThreads()`:

```cpp
for (auto& callsite : callsites)
    MacroAssembler::repatchNearCall(callsite.callLocation, callsite.target);   // line 408
```

A caller's `BBQCallee` can already be weak here — when that caller's own `OMGPlan::work` finished earlier, it called `releaseBBQCallee()` → `convertToWeak()` → `reportToVMsForDestruction()`. After the local `RefPtr` is released the only remaining refs live in each VM's `Heap::m_wasmCalleesPendingDestruction` set.

If a GC on the mutator runs in the window between `collectCallsites()` and the `repatchNearCall()` loop, `ConservativeRoots::~ConservativeRoots()` drops every pending callee not found on a scanned stack. Wasm compiler threads are **not** stopped by `stopThePeriphery()` (the existing comment at `WasmCalleeGroup.cpp:328` says exactly that) and their stacks are not part of `MachineThreads`' scan set, so the callee hits refcount 0 and is destroyed.

`~JITCallee` → `~Entrypoint` → `~Compilation` → `~MacroAssemblerCodeRef` → `~ExecutableMemoryHandle`. On Windows (`ENABLE_LIBPAS_JIT_HEAP` is Darwin/Linux-only, so `ExecutableMemoryHandle` is a `MetaAllocatorHandle`), `MetaAllocator::decrementPageOccupancy` → `FixedVMPoolExecutableAllocator::notifyPageIsFree` → `PageReservation::decommit` → **`VirtualFree(MEM_DECOMMIT)`** on every page whose occupancy reaches zero, synchronously inside the destructor. The next `repatchNearCall` store into one of those pages is an access violation.

On Darwin/Linux the libpas JIT heap is configured with `pas_may_not_mmap`, so freed JIT pages stay mapped RWX; the same use-after-free is a *silent* stale write into dead or reallocated JIT code and never faults. (Worth a follow-up upstream — this is a real correctness bug there too, just invisible.)

## Why this test, why these machines

Astro → Vite → Rollup loads `@rollup/wasm-node`'s `bindings_wasm_bg.wasm` — a few thousand mutually-calling functions, so BBQ→OMG tier-ups happen in rapid succession and many retired-but-not-yet-freed `BBQCallee`s are around while other functions are still in `updateCallsitesToCallUs`. The Win2019 runners are the slowest in the fleet (`CPU lacks AVX support`), widening the collect→repatch window, and Windows is the only target where the freed page actually decommits.

## Fix (in oven-sh/WebKit#209)

Mirror the existing `Vector<Ref<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees` (which protects the other weakly-held callee type in the same function, for the same documented reason, ten lines below) with a `keepAliveBBQCallees` vector, and `append(bbqCallee.releaseNonNull())` instead of letting the `RefPtr` die at lambda exit. The callee's machine code then stays committed through the `repatchNearCall` loop; if this is the last ref, destruction happens on the wasm compiler thread after the writes, which is the behaviour `keepAliveOSREntryCallees` already has.

```diff
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+    Vector<Ref<BBQCallee>, 4> keepAliveBBQCallees;
+#endif
     Vector<Ref<OMGOSREntryCallee>, 4> keepAliveOSREntryCallees;
 ...
         if (bbqCallee) {
             collectCallsites(bbqCallee.get());
             ASSERT(!bbqCallee->osrEntryCallee() || m_osrEntryCallees.find(callerIndex) != m_osrEntryCallees.end());
+            keepAliveBBQCallees.append(bbqCallee.releaseNonNull());
         }
```

## Verification

The bug is a race between a background compiler thread and GC that only hard-faults on Windows; I have not been able to reproduce it off-CI. The fix is the exact pattern the same function already applies to `OMGOSREntryCallee` one block down, and the existing `astro-post.test.js` exercises this path on every Windows CI run.

This is the same code in current upstream WebKit `main`, so the bug should also be reported there.