### PR TITLE
fuzzilli: chain crash signal handlers to JSC/ASAN instead of SIG_DFL

### DIFF
--- a/src/bun.js/bindings/FuzzilliREPRL.cpp
+++ b/src/bun.js/bindings/FuzzilliREPRL.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
+#include <mutex>
 #include <sanitizer/asan_interface.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -55,7 +56,10 @@ static void installFuzzilliSignalHandler(int sig)
     struct sigaction action;
     action.sa_sigaction = fuzzilliSignalHandler;
     sigfillset(&action.sa_mask);
-    action.sa_flags = SA_SIGINFO;
+    // SA_ONSTACK so stack-overflow faults are delivered on the sigaltstack
+    // ASAN/JSC already set up; otherwise the kernel can't push the frame and
+    // the process dies with a bare SIGSEGV before we reach the chain.
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
     sigaction(sig, &action, &fuzzilliOldActions[sig]);
 }
 
@@ -288,10 +292,17 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
     // Install signal handlers to ensure output is flushed before crashes.
     // Chain to the previous handler (JSC's jscSignalHandler → ASAN) so
     // VMTraps/WASM fault handling keeps working and ASAN reports are printed.
-    installFuzzilliSignalHandler(SIGABRT);
-    installFuzzilliSignalHandler(SIGSEGV);
-    installFuzzilliSignalHandler(SIGILL);
-    installFuzzilliSignalHandler(SIGFPE);
+    // Signal dispositions are process-wide; this function runs once per
+    // GlobalObject (main thread, macros, and every Worker), so guard with a
+    // once-flag — re-installing would save ourselves into fuzzilliOldActions
+    // and recurse on the next signal.
+    static std::once_flag installOnce;
+    std::call_once(installOnce, [] {
+        installFuzzilliSignalHandler(SIGABRT);
+        installFuzzilliSignalHandler(SIGSEGV);
+        installFuzzilliSignalHandler(SIGILL);
+        installFuzzilliSignalHandler(SIGFPE);
+    });
 
     globalObject->putDirectNativeFunction(
         vm,

--- a/src/bun.js/bindings/FuzzilliREPRL.cpp
+++ b/src/bun.js/bindings/FuzzilliREPRL.cpp
@@ -19,8 +19,14 @@
 
 extern "C" {
 
-// Signal handler to ensure output is flushed before crash
-static void fuzzilliSignalHandler(int sig)
+// Previous handlers (JSC's jscSignalHandler, which itself chains to ASAN's
+// handler). We flush stdio so Fuzzilli captures buffered output, then forward
+// to the prior handler so JSC's VMTraps/WASM fault handling keeps working and
+// ASAN can print its report. Using signal()+SIG_DFL here used to swallow both,
+// leaving crash reports with just "TERMSIG: 11" and no stack.
+static struct sigaction fuzzilliOldActions[NSIG];
+
+static void fuzzilliSignalHandler(int sig, siginfo_t* info, void* ucontext)
 {
     // Flush all output
     fflush(stdout);
@@ -28,9 +34,29 @@ static void fuzzilliSignalHandler(int sig)
     fsync(STDOUT_FILENO);
     fsync(STDERR_FILENO);
 
-    // Re-raise the signal with default handler
+    struct sigaction& old = fuzzilliOldActions[sig];
+    if (old.sa_flags & SA_SIGINFO) {
+        if (old.sa_sigaction) {
+            old.sa_sigaction(sig, info, ucontext);
+            return;
+        }
+    } else if (old.sa_handler && old.sa_handler != SIG_DFL && old.sa_handler != SIG_IGN) {
+        old.sa_handler(sig);
+        return;
+    }
+
+    // No previous handler: re-raise with default handler.
     signal(sig, SIG_DFL);
     raise(sig);
+}
+
+static void installFuzzilliSignalHandler(int sig)
+{
+    struct sigaction action;
+    action.sa_sigaction = fuzzilliSignalHandler;
+    sigfillset(&action.sa_mask);
+    action.sa_flags = SA_SIGINFO;
+    sigaction(sig, &action, &fuzzilliOldActions[sig]);
 }
 
 // Implementation of the global fuzzilli() function for Bun
@@ -259,12 +285,13 @@ void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject* globalObject)
 {
     JSC::VM& vm = globalObject->vm();
 
-    // Install signal handlers to ensure output is flushed before crashes
-    // This is important for ASAN output to be captured
-    signal(SIGABRT, fuzzilliSignalHandler);
-    signal(SIGSEGV, fuzzilliSignalHandler);
-    signal(SIGILL, fuzzilliSignalHandler);
-    signal(SIGFPE, fuzzilliSignalHandler);
+    // Install signal handlers to ensure output is flushed before crashes.
+    // Chain to the previous handler (JSC's jscSignalHandler → ASAN) so
+    // VMTraps/WASM fault handling keeps working and ASAN reports are printed.
+    installFuzzilliSignalHandler(SIGABRT);
+    installFuzzilliSignalHandler(SIGSEGV);
+    installFuzzilliSignalHandler(SIGILL);
+    installFuzzilliSignalHandler(SIGFPE);
 
     globalObject->putDirectNativeFunction(
         vm,

--- a/test/internal/fuzzilli-signal-chain.test.ts
+++ b/test/internal/fuzzilli-signal-chain.test.ts
@@ -25,29 +25,26 @@ const fastCrashEnv = {
   ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
 };
 
-test.skipIf(!isFuzzilliBuild)(
-  "fuzzilli crash signal handler chains to JSC/ASAN for SIGSEGV",
-  async () => {
-    // FUZZILLI_CRASH type 5 writes to a volatile null pointer. With a working
-    // handler chain the fault reaches jscSignalHandler → ASAN and we get an
-    // "AddressSanitizer: SEGV" report on stderr; with signal()+SIG_DFL the
-    // process dies with stderr containing only the [COV] banner.
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'fuzzilli("FUZZILLI_CRASH", 5);'],
-      env: fastCrashEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler chains to JSC/ASAN for SIGSEGV", async () => {
+  // FUZZILLI_CRASH type 5 writes to a volatile null pointer. With a working
+  // handler chain the fault reaches jscSignalHandler → ASAN and we get an
+  // "AddressSanitizer: SEGV" report on stderr; with signal()+SIG_DFL the
+  // process dies with stderr containing only the [COV] banner.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'fuzzilli("FUZZILLI_CRASH", 5);'],
+    env: fastCrashEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toContain("FUZZILLI_CRASH: 5");
-    expect(stderr).toContain("AddressSanitizer: SEGV");
-    // ASAN aborts after printing; a bare SIGSEGV would surface as signalCode
-    // "SIGSEGV" with nothing useful on stderr.
-    expect(proc.signalCode).not.toBe("SIGSEGV");
-  },
-);
+  expect(stdout).toContain("FUZZILLI_CRASH: 5");
+  expect(stderr).toContain("AddressSanitizer: SEGV");
+  // ASAN aborts after printing; a bare SIGSEGV would surface as signalCode
+  // "SIGSEGV" with nothing useful on stderr.
+  expect(proc.signalCode).not.toBe("SIGSEGV");
+});
 
 test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler still terminates for SIGABRT", async () => {
   // FUZZILLI_CRASH type 0 is std::abort(). No JSC/ASAN handler is registered

--- a/test/internal/fuzzilli-signal-chain.test.ts
+++ b/test/internal/fuzzilli-signal-chain.test.ts
@@ -1,0 +1,69 @@
+// The fuzzilli REPRL setup installs SIGSEGV/SIGILL/SIGFPE/SIGABRT handlers so
+// buffered stdio is flushed before a crash. Those handlers must chain to the
+// previously-installed handler (WTF::jscSignalHandler → ASAN) instead of
+// re-raising with SIG_DFL, otherwise:
+//   • ASAN never prints a report for null derefs / wild accesses, so every
+//     signal-based fuzzer crash shows up as a bare "TERMSIG: 11".
+//   • JSC's signal-based VMTraps and WASM fault handling are broken, turning
+//     intentional JIT trap breakpoints into hard process crashes.
+//
+// Only runs when the binary under test was built with FUZZILLI_ENABLED (the
+// `fuzzilli()` global exists). Normal debug/release builds skip.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+declare const fuzzilli: unknown;
+const isFuzzilliBuild = typeof fuzzilli === "function";
+
+// Skip symbolization so ASAN writes its report and exits immediately instead
+// of shelling out to llvm-symbolizer for every frame (several seconds on the
+// fuzz binary). The presence of "AddressSanitizer: SEGV" is enough to prove
+// the handler chain reached ASAN.
+const fastCrashEnv = {
+  ...bunEnv,
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+};
+
+test.skipIf(!isFuzzilliBuild)(
+  "fuzzilli crash signal handler chains to JSC/ASAN for SIGSEGV",
+  async () => {
+    // FUZZILLI_CRASH type 5 writes to a volatile null pointer. With a working
+    // handler chain the fault reaches jscSignalHandler → ASAN and we get an
+    // "AddressSanitizer: SEGV" report on stderr; with signal()+SIG_DFL the
+    // process dies with stderr containing only the [COV] banner.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'fuzzilli("FUZZILLI_CRASH", 5);'],
+      env: fastCrashEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("FUZZILLI_CRASH: 5");
+    expect(stderr).toContain("AddressSanitizer: SEGV");
+    // ASAN aborts after printing; a bare SIGSEGV would surface as signalCode
+    // "SIGSEGV" with nothing useful on stderr.
+    expect(proc.signalCode).not.toBe("SIGSEGV");
+  },
+);
+
+test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler still terminates for SIGABRT", async () => {
+  // FUZZILLI_CRASH type 0 is std::abort(). No JSC/ASAN handler is registered
+  // for SIGABRT by default, so the chain falls through to SIG_DFL and the
+  // process terminates with SIGABRT — Fuzzilli's crash detection relies on
+  // this.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", 'fuzzilli("FUZZILLI_CRASH", 0);'],
+    env: fastCrashEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("FUZZILLI_CRASH: 0");
+  expect(exitCode).not.toBe(0);
+  expect(proc.signalCode).toBe("SIGABRT");
+});

--- a/test/internal/fuzzilli-signal-chain.test.ts
+++ b/test/internal/fuzzilli-signal-chain.test.ts
@@ -19,10 +19,11 @@ const isFuzzilliBuild = typeof fuzzilli === "function";
 // Skip symbolization so ASAN writes its report and exits immediately instead
 // of shelling out to llvm-symbolizer for every frame (several seconds on the
 // fuzz binary). The presence of "AddressSanitizer: SEGV" is enough to prove
-// the handler chain reached ASAN.
+// the handler chain reached ASAN. allow_user_segv_handler keeps JSC from
+// disabling its own fault handling when it sees ASAN_OPTIONS is set.
 const fastCrashEnv = {
   ...bunEnv,
-  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allow_user_segv_handler=1", "symbolize=0"].filter(Boolean).join(":"),
 };
 
 test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler chains to JSC/ASAN for SIGSEGV", async () => {
@@ -43,6 +44,29 @@ test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler chains to JSC/ASAN 
   expect(stderr).toContain("AddressSanitizer: SEGV");
   // ASAN aborts after printing; a bare SIGSEGV would surface as signalCode
   // "SIGSEGV" with nothing useful on stderr.
+  expect(proc.signalCode).not.toBe("SIGSEGV");
+});
+
+test.skipIf(!isFuzzilliBuild)("fuzzilli crash signal handler survives Worker global creation", async () => {
+  // Bun__REPRL__registerFuzzilliFunctions runs for every GlobalObject (main,
+  // macros, Workers). Without a once-guard the Worker's call re-installs the
+  // handler, saving fuzzilliSignalHandler itself into fuzzilliOldActions and
+  // turning the next SIGSEGV into infinite self-recursion → bare TERMSIG 11.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      'const w = new Worker("data:text/javascript,postMessage(0)"); await new Promise(r => (w.onmessage = r)); w.terminate(); fuzzilli("FUZZILLI_CRASH", 5);',
+    ],
+    env: fastCrashEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("FUZZILLI_CRASH: 5");
+  expect(stderr).toContain("AddressSanitizer: SEGV");
   expect(proc.signalCode).not.toBe("SIGSEGV");
 });
 


### PR DESCRIPTION
## Problem

Fuzzilli hit a flaky SIGSEGV (fingerprint `a488dd11600c00b1`) from:

```js
const t4 = this.require("compile");
t4();
Bun.gc(true);
```

The crash report is just `TERMSIG: 11` with nothing on stderr — no ASAN output, no stack, unreproducible across thousands of direct and REPRL runs.

The reason there's nothing to go on: `Bun__REPRL__registerFuzzilliFunctions()` installs SIGSEGV/SIGILL/SIGFPE/SIGABRT handlers via `signal()` that flush stdio and then `signal(sig, SIG_DFL); raise(sig)`. This runs **after** VM construction — i.e. after `Config::finalize()` has already installed `WTF::jscSignalHandler` for SIGSEGV/SIGBUS — so it overwrites JSC's handler (and, transitively, ASAN's).

That has two effects in the REPRL process:

1. **Every SIGSEGV is reported as a bare TERMSIG 11.** ASAN's `AsanOnDeadlySignal` is never reached, so null derefs / wild reads produce no report. This is why this fingerprint (and #29255's `2519cad1804eace1`) arrive with no stack.

2. **JSC's signal-based VMTraps and WASM fault handling are broken.** `Options::usePollingTraps` defaults to `false`, so `VMTraps::SignalSender` installs trap breakpoints in JIT code that raise SIGSEGV on purpose; `jscSignalHandler` normally catches it, jettisons the CodeBlock, and returns. With the old handler that SIGSEGV kills the process instead. Any **earlier** REPRL iteration that armed VMTraps (e.g. `Worker#terminate()` → `notifyNeedTermination()` → `fireTrap`) can make a **later** iteration die in unrelated JIT code — which matches "flaky, 609 ms, no output, involves `Bun.gc(true)` after auto-install spins the event loop".

## Fix

Save the previous `struct sigaction` with `sigaction()` and forward to it after flushing, falling back to `SIG_DFL + raise` only when there is no previous handler. The chain for SIGSEGV becomes:

```
fuzzilliSignalHandler (flush) → WTF::jscSignalHandler (VMTraps/WASM) → ASAN → SIG_DFL
```

## Verification

Before:
```
$ bun-debug -e 'fuzzilli("FUZZILLI_CRASH", 5)'   # null deref
FUZZILLI_CRASH: 5
Segmentation fault (core dumped)               # nothing else
```

After:
```
FUZZILLI_CRASH: 5
==…==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
    #0 functionFuzzilli …/FuzzilliREPRL.cpp:132:22
    …
    #6 WTF::jscSignalHandler …/WTF/wtf/threads/Signals.cpp:540:13
```

All `FUZZILLI_CRASH` modes (0–7) still terminate the process, so Fuzzilli's crash detection is unchanged. 150 REPRL iterations of the original repro, plus 100 iterations interleaving `new Worker(...).terminate()` (arms VMTraps) with the repro, run clean.

(No regression test: this code is only compiled under `FUZZILLI_ENABLED`, which isn't a CI target.)

If this fingerprint re-fires after this lands it will now come with an ASAN stack.