### PR TITLE
fix: run all VSCode tests from workspace root

### DIFF
--- a/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
+++ b/packages/bun-vscode/src/features/tests/__tests__/bun-test-controller.test.ts
@@ -593,6 +593,18 @@ describe("BunTestController - Test Discovery and Management", () => {
       expect(config.bunCommand).toBe("bun");
     });
   });
+
+  describe("getTestTargetArgs", () => {
+    test("should use the workspace root when running all discovered tests", () => {
+      const args = internal.getTestTargetArgs(new Set(["/test/workspace/a.test.ts", "/test/workspace/b.test.ts"]), true);
+      expect(args).toEqual(["."]);
+    });
+
+    test("should use explicit files for targeted test runs", () => {
+      const args = internal.getTestTargetArgs(new Set(["/test/workspace/a.test.ts", "/test/workspace/b.test.ts"]), false);
+      expect(args).toEqual(["/test/workspace/a.test.ts", "/test/workspace/b.test.ts"]);
+    });
+  });
 });
 
 describe("BunTestController - Test Item Management", () => {

--- a/packages/bun-vscode/src/features/tests/bun-test-controller.ts
+++ b/packages/bun-vscode/src/features/tests/bun-test-controller.ts
@@ -291,6 +291,10 @@ export class BunTestController implements vscode.Disposable {
     return { bunCommand, testArgs };
   }
 
+  private getTestTargetArgs(files: Set<string>, useWorkspaceRoot: boolean): string[] {
+    return useWorkspaceRoot ? ["."] : [...files];
+  }
+
   private async discoverTests(
     testItem?: vscode.TestItem | false,
     filePath?: string,
@@ -698,15 +702,17 @@ export class BunTestController implements vscode.Disposable {
 
     const { bunCommand, testArgs } = this.getBunExecutionConfig();
 
-    let args = [...testArgs, ...allFiles];
+    const useWorkspaceRoot = !isIndividualTestRun && tests.length === this.testController.items.size;
+    const targetArgs = this.getTestTargetArgs(allFiles, useWorkspaceRoot);
+    let args = [...testArgs, ...targetArgs];
     let printedArgs = `\x1b[34;1m>\x1b[0m \x1b[34;1m${bunCommand} ${testArgs.join(" ")}\x1b[2m`;
 
-    for (const file of allFiles) {
-      const f = path.relative(this.workspaceFolder.uri.fsPath, file) || file;
+    for (const target of targetArgs) {
+      const f = target === "." ? target : path.relative(this.workspaceFolder.uri.fsPath, target) || target;
       if (f.includes(" ")) {
-        printedArgs += ` ".${path.sep}${f}"`;
+        printedArgs += ` "${f === "." ? f : `.${path.sep}${f}`}"`;
       } else {
-        printedArgs += ` .${path.sep}${f}`;
+        printedArgs += f === "." ? " ." : ` .${path.sep}${f}`;
       }
     }
 
@@ -1481,6 +1487,7 @@ export class BunTestController implements vscode.Disposable {
       isTestFile: this.isTestFile.bind(this),
       customFilePattern: this.customFilePattern.bind(this),
       getBunExecutionConfig: this.getBunExecutionConfig.bind(this),
+      getTestTargetArgs: this.getTestTargetArgs.bind(this),
 
       findTestByPath: this.findTestByPath.bind(this),
       findTestByName: this.findTestByName.bind(this),


### PR DESCRIPTION
## Summary
Fixes #25797

When the VSCode extension runs the entire discovered test suite, it currently appends every discovered test file to `bun test`. That can behave differently from `bun test .`, including not loading root-level `bunfig.toml` preloads as reported in this issue.

This changes whole-workspace test runs to pass `.` as the test target, while keeping explicit file arguments for targeted file/test runs.

## Changes
- Add a small helper for choosing test target arguments.
- Use `bun test .` for full discovered-suite runs from the VSCode test explorer.
- Preserve explicit file arguments for targeted/non-full runs.
- Add unit coverage for both target selection paths.

## Testing
- `cd packages/bun-vscode && bun test src/features/tests/__tests__/bun-test-controller.test.ts`
