### PR TITLE
[publish images] bootstrap: rebake CI images to refresh prefetched deps

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -27,11 +27,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
    software-properties-common apt-transport-https \
    ca-certificates gnupg lsb-release unzip xz-utils \
    libxml2-dev ruby ruby-dev bison gawk perl make golang ccache qemu-user-static \
-   && add-apt-repository ppa:ubuntu-toolchain-r/test \
-   && apt-get update \
-   && apt-get install -y gcc-13 g++-13 libgcc-13-dev libstdc++-13-dev \
-       libasan6 libubsan1 libatomic1 libtsan0 liblsan0 \
-       libgfortran5 libc6-dev \
+   libc6-dev \
+   # gcc-13 on focal: Launchpad ppa:ubuntu-toolchain-r/test times out / 503s
+   # often enough to break image builds, so install from a mirrored snapshot
+   # of the PPA's .debs instead. See oven-sh/WebKit release gcc-13-focal-debs.
+   && mkdir /tmp/gcc13 \
+   && wget -qO- "https://github.com/oven-sh/WebKit/releases/download/gcc-13-focal-debs/gcc-13-focal-${TARGETARCH}.tar.gz" \
+      | tar -xz -C /tmp/gcc13 \
+   && apt-get install -y --no-install-recommends /tmp/gcc13/*.deb \
+   && rm -rf /tmp/gcc13 \
    && wget https://apt.llvm.org/llvm.sh \
    && chmod +x llvm.sh \
    && ./llvm.sh ${LLVM_VERSION} all \

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,4 +1,4 @@
-# Version: 19
+# Version: 20
 # A script that installs the dependencies needed to build and test Bun on Windows.
 # Supports both x64 and ARM64 using Scoop for package management.
 # Used by Azure [build images] pipeline.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1191,23 +1191,18 @@ install_gcc() {
 		return
 	fi
 
-	# Taken from WebKit's Dockerfile.
-	# https://github.com/oven-sh/WebKit/blob/816a3c02e0f8b53f8eec06b5ed911192589b51e2/Dockerfile
-
-	execute_sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-	execute_sudo apt update -y
-	execute_sudo apt install -y \
-		"gcc-$gcc_version" \
-		"g++-$gcc_version" \
-		"libgcc-$gcc_version-dev" \
-		"libstdc++-$gcc_version-dev" \
-		libasan6 \
-		libubsan1 \
-		libatomic1 \
-		libtsan0 \
-		liblsan0 \
-		libgfortran5 \
-		libc6-dev
+	# gcc-13 on focal: Launchpad ppa:ubuntu-toolchain-r/test times out / 503s
+	# often enough to break image builds, so install from a mirrored snapshot
+	# of the PPA's .debs instead. See oven-sh/WebKit release gcc-13-focal-debs.
+	case "$arch" in
+	x64) gcc_deb_arch="amd64" ;;
+	aarch64) gcc_deb_arch="arm64" ;;
+	esac
+	gcc_deb_url="https://github.com/oven-sh/WebKit/releases/download/gcc-13-focal-debs/gcc-13-focal-$gcc_deb_arch.tar.gz"
+	gcc_deb_dir="$(create_tmp_directory)"
+	fetch "$gcc_deb_url" | execute tar -xz -C "$gcc_deb_dir"
+	execute_sudo apt-get install -y --no-install-recommends "$gcc_deb_dir"/*.deb libc6-dev
+	execute rm -rf "$gcc_deb_dir"
 
 	execute_sudo update-alternatives \
 		--install /usr/bin/gcc gcc "/usr/bin/gcc-$gcc_version" 130 \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 34
+# Version: 35
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.


### PR DESCRIPTION
Bumps `bootstrap.sh` v34→35 and `bootstrap.ps1` v19→20 to force a fresh image build.

**Why:** GitHub release-tarball downloads intermittently 503 (~1/10000 runs). Since #29568 the build images bake a dep prefetch cache, so a rebake means runtime CI reads from the image cache instead of hitting github.com — fewer flakes.

No script content changes; version bump only.

- HEAD commit carries `[build images]` so BuildKite builds the new images on this PR.
- `[publish images]` is in the PR title for the squash-merge commit.