### PR TITLE
Upgrade WebKit to 39862040be27

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "6ef83cb658722ff1f33f4a4c9335fb094bed4c6b";
+export const WEBKIT_VERSION = "39862040be27e0b6e1d103aaa5dc6796f21a581f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to oven-sh/WebKit@181881a5aadc — see oven-sh/WebKit#210.

Syncs with upstream WebKit `6cc6aff95e13` (226 commits, 48 in JSC/WTF/bmalloc) and includes the BBQCallee keepalive fix from oven-sh/WebKit#209.

**Highlights:**
- Wasm RTT canonicalization refactor (supersedes the #63906 cherry-pick)
- DFG/FTL: word-at-a-time 8-bit string equality, bit-rotate idiom in B3, IntegerRangeOptimizations improvements, NewTypedArray zero-fill unroll
- Module loader: star-export graph walked once, resolution cache only for star/indirect
- DateCache slow-init workaround for recent ICU
- libpas: upstream now carries `pas_process_is_shutting_down()` TLS guard

**No `JSType.h` changes** — `JSType.zig` unchanged.

**Header reshuffling** (`5cdc5c93d15b`) moved several inline definitions into `*InlinesLight.h` headers and added `JSDOMBindingFacade.h`. Local build of Bun against this WebKit compiled clean; if CI surfaces missing-include errors in `src/bun.js/bindings/webcore/`, compare against `Source/WebCore/bindings/scripts/test/JS/*.cpp` for the new include set.

Supersedes oven-sh/WebKit#209.