### PR TITLE
fix(inspect): handle Proxy trap exceptions when walking prototype chain

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5254,6 +5254,8 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
                     prototypeCount = 1;
                 }
             }
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
         }
     }
     auto* propertyNames = vm.propertyNames;
@@ -5369,10 +5371,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5447,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,36 @@ const fixture = [
         },
       },
     ),
+  () => {
+    // Proxy in the prototype chain where a getter on the underlying
+    // prototype throws. This used to leave a pending exception that
+    // caused a null dereference when walking to the next prototype.
+    const proto = Object.create(Object.prototype, {
+      foo: { get: () => 1, enumerable: true, configurable: true },
+      bar: {
+        get() {
+          throw new Error("boom");
+        },
+        enumerable: true,
+        configurable: true,
+      },
+      baz: { get: () => 2, enumerable: true, configurable: true },
+    });
+    return Object.create(new Proxy(proto, {}));
+  },
+  () => {
+    // Proxy in the prototype chain whose getPrototypeOf trap throws.
+    const proto = Object.create(Object.prototype, {
+      foo: { get: () => 1, enumerable: true, configurable: true },
+    });
+    return Object.create(
+      new Proxy(proto, {
+        getPrototypeOf() {
+          throw new Error("getPrototypeOf trap");
+        },
+      }),
+    );
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect` / `console.log` formatting) when the object being inspected has a `Proxy` in its prototype chain.

### Root cause

In the slow-path property enumeration loop:

1. `object->getPropertySlot(globalObject, property, slot)` can throw (e.g. a Proxy forwards `[[Get]]` to a native getter that throws). When it throws, JSC returns `false` from `getPropertySlot`.
2. The code did `if (!getPropertySlot(...)) continue;` — skipping the `CLEAR_IF_EXCEPTION` that came *after* the `continue`, so the exception stayed pending.
3. After the property loop, `iterating->getPrototype(globalObject)` is called. With an exception pending (or with a Proxy `getPrototypeOf` trap that throws), this returns an **empty** `JSValue`.
4. `.getObject()` on an empty `JSValue` calls `asCell()->getObject()` on a null pointer.

### Fix

- Clear the exception from `getPropertySlot` *before* the `continue` (matching what `forEachPropertyOrdered` already does).
- Clear exceptions from `getPrototype` and null-check the result before calling `.getObject()`, both in the slow-path iteration and in the initial fast-path prototype lookup.

## How did you verify your code works?

Minimal repro that crashed before and now works:

```js
const proto = Object.create(Object.prototype, {
  foo: { get: () => 1, enumerable: true, configurable: true },
  bar: { get() { throw new Error("boom"); }, enumerable: true, configurable: true },
  baz: { get: () => 2, enumerable: true, configurable: true },
});
const obj = Object.create(new Proxy(proto, {}));
Bun.inspect(obj); // used to SIGABRT (UBSAN null deref), now prints { foo: 1, baz: 2 }
```

Added regression tests to `test/js/bun/util/inspect.test.js` covering both the throwing-getter case and the throwing-`getPrototypeOf` case. Both tests crash the old binary with the same UBSAN report and pass on this branch.

Found by Fuzzilli (fingerprint `6913eddd71ce20aa`).