### PR TITLE
no-orphans(macOS): replace ENOTSUP'd NOTE_TRACK with NOTE_FORK + p_puniqueid scan

### DIFF
--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -2464,10 +2464,10 @@ pub const sync = struct {
 
         // no-orphans: replace the blind `poll()`/`wait4()` with a wait loop
         // that also watches our parent (and on macOS, the script's whole
-        // spawn tree via the NOTE_TRACK kq above). Linux/macOS only — other POSIX
-        // (FreeBSD) falls through to the original `poll()`+`wait4()` below so
-        // buffered stdio still drains; the `defer` above still does the
-        // pgroup kill there.
+        // spawn tree via the NOTE_FORK kq + p_puniqueid scan above).
+        // Linux/macOS only — other POSIX (FreeBSD) falls through to the
+        // original `poll()`+`wait4()` below so buffered stdio still drains;
+        // the `defer` above still does the pgroup kill there.
         //
         // Do NOT return from here — Linux backs `.buffer` stdio with memfds
         // that are read *after* the wait, so falling through to the memfd block
@@ -2636,7 +2636,10 @@ pub const sync = struct {
             // that would drop output or deadlock on a full pipe. ESRCH on the
             // child PROC entry is impossible (our own unreaped child —
             // `filt_procattach` finds zombies), so any errno here is a real
-            // registration failure.
+            // registration failure. `begin()` has already seeded m_tracked
+            // with `child`; prune it so the caller's `reapChild()` doesn't
+            // leave a freed pid for `killTracked()` to SIGSTOP.
+            Bun__noOrphans_onExit(child);
             return null;
         }
         if (ppid > 1 and std.c.getppid() != ppid)

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -2688,6 +2688,12 @@ pub const sync = struct {
                         else {
                             child_status = Status.from(child, &r);
                             child_exited = true;
+                            // wait4 just freed `child`'s pid; if NOTE_EXIT for
+                            // it isn't in this batch we'd return with the root
+                            // still in m_tracked and `killTracked()` would
+                            // SIGSTOP a (potentially recycled) freed pid.
+                            // Idempotent with the NOTE_EXIT handler above.
+                            Bun__noOrphans_onExit(child);
                         }
                     }
                 } else if (ev.filter == std.c.EVFILT.READ) {

--- a/src/bun.js/api/bun/process.zig
+++ b/src/bun.js/api/bun/process.zig
@@ -2206,22 +2206,8 @@ pub const sync = struct {
     // macOS p_puniqueid descendant tracker — see NoOrphansTracker.cpp.
     extern "c" fn Bun__noOrphans_begin(kq: c_int, root: std.c.pid_t) void;
     extern "c" fn Bun__noOrphans_releaseKq() void;
-    extern "c" fn Bun__noOrphans_onChild(pid: std.c.pid_t) void;
+    extern "c" fn Bun__noOrphans_onFork() void;
     extern "c" fn Bun__noOrphans_onExit(pid: std.c.pid_t) void;
-    extern "c" fn Bun__noOrphans_onTrackErr(pid: std.c.pid_t) void;
-
-    /// `EVFILT_PROC` `fflags` not in `std.c.NOTE` (sys/event.h).
-    const NOTE = struct {
-        /// xnu auto-registers the same `NOTE_TRACK|NOTE_EXIT` knote on every
-        /// child inside `fork1()` before the child is schedulable; recursive.
-        /// `udata` is inherited from the parent knote.
-        pub const TRACK: u32 = 0x00000001;
-        /// Kernel couldn't allocate the child's knote (ENOMEM); fires on the
-        /// *parent's* event.
-        pub const TRACKERR: u32 = 0x00000002;
-        /// Fires once on the auto-created child knote; `data` = parent pid.
-        pub const CHILD: u32 = 0x00000004;
-    };
 
     /// TTY job-control bridge for `--no-orphans` `bun run`. We put the script
     /// in its own pgroup so `kill(-pgid)` reaches every descendant on cleanup,
@@ -2355,49 +2341,29 @@ pub const sync = struct {
             _ = std.posix.prctl(.SET_CHILD_SUBREAPER, .{0}) catch {};
         };
 
-        // macOS no_orphans: create kq and arm NOTE_TRACK on *ourselves*
-        // BEFORE spawn so xnu auto-attaches the same NOTE_TRACK|NOTE_EXIT
-        // knote to the script inside `fork1()` before it's schedulable —
-        // zero seed window, recursive. Non-SETEXEC `posix_spawn` goes through
-        // `fork1()`. We `EV_DELETE` the self-knote right after spawn so
-        // unrelated bun-side forks (none today in spawnSync, but
-        // belt-and-braces) aren't tracked; descendant knotes are independent
-        // and survive the delete. Passed into `waitMacKqueue` as its kq;
-        // closed by the defer immediately below so spawn-failure early
-        // returns don't leak the fd.
+        // macOS no_orphans: kqueue passed to `waitMacKqueue` for ppid/child
+        // NOTE_EXIT and per-descendant NOTE_FORK. NOTE_TRACK (auto-attach to
+        // forks) has been ENOTSUP since macOS 10.5 — see sys/event.h:356 — so
+        // we cannot get atomic in-kernel descendant tracking. Instead the
+        // wait loop reacts to NOTE_FORK by running a `p_puniqueid` scan
+        // (`NoOrphansTracker::scan()`) to discover and re-arm new
+        // descendants. `p_puniqueid` is the *spawning* parent's per-boot
+        // uniqueid — immutable across reparenting — so the scan finds
+        // setsid+double-fork escapees as long as each intermediate's uniqueid
+        // was recorded before it died. The `begin()` call below seeds the
+        // scan root after spawn.
         var no_orphans_kq: bun.FD = bun.invalid_fd;
-        if (comptime Environment.isMac) if (no_orphans) blk: {
-            const kq = std.posix.kqueue() catch break :blk;
-            no_orphans_kq = bun.FD.fromNative(kq);
-            var ch = [_]std.c.Kevent{.{
-                .ident = @intCast(std.c.getpid()),
-                .filter = std.c.EVFILT.PROC,
-                .flags = std.c.EV.ADD | std.c.EV.CLEAR,
-                // EXIT so the knote has something to fire on; TRACK is the
-                // point. NOTE_TRACK = 0x1, NOTE_TRACKERR = 0x2, NOTE_CHILD =
-                // 0x4 (sys/event.h; not in std.c.NOTE).
-                .fflags = NOTE.TRACK | std.c.NOTE.EXIT,
-                .data = 0,
-                .udata = 0,
-            }};
-            var ts = std.c.timespec{ .sec = 0, .nsec = 0 };
-            // eventlist must be a non-null `[*]Kevent`; nevents=0 ⇒ not written.
-            // ENOMEM here means no auto-knote on the script ⇒ waitMacKqueue
-            // would have nothing to fire NOTE_EXIT and (non-TTY, .inherit
-            // stdio) block forever. Same policy as `kqueue()` above and the
-            // EV_RECEIPT loop in waitMacKqueue: invalidate so the caller
-            // falls through to the plain `poll()`+`wait4()` loop.
-            if (std.c.kevent(kq, &ch, 1, &ch, 0, &ts) < 0) {
-                no_orphans_kq.close();
-                no_orphans_kq = bun.invalid_fd;
-            }
+        if (comptime Environment.isMac) if (no_orphans) {
+            if (std.posix.kqueue()) |kq| {
+                no_orphans_kq = bun.FD.fromNative(kq);
+            } else |_| {}
         };
-        // LIFO: this runs LAST — after killSyncScriptTree() (which drains
+        // LIFO: this runs LAST — after killSyncScriptTree() (which scans via
         // m_kq) and releaseKq().
         defer if (comptime Environment.isMac) if (no_orphans_kq != bun.invalid_fd)
             no_orphans_kq.close();
         // LIFO: runs after killSyncScriptTree() (which needs m_kq live for
-        // its NOTE_CHILD drain), before the close above.
+        // its NOTE_FORK-drain rescan), before the close above.
         defer if (comptime Environment.isMac) if (no_orphans_kq != bun.invalid_fd)
             Bun__noOrphans_releaseKq();
 
@@ -2424,23 +2390,12 @@ pub const sync = struct {
             // bridged by `JobControl.onChildStopped` in the wait loop. No-op on
             // non-TTY stdin (the supervisor / CI case this feature targets).
             jc.give(process.pid);
-            if (comptime Environment.isMac) if (no_orphans_kq != bun.invalid_fd) {
-                // Drop the self-knote; the script's auto-created knote (and
-                // its whole subtree) stays. `begin()` records the script's
-                // uniqueid for kill-time identity verification and stashes kq
-                // for killTracked()'s drain + the TRACKERR fallback re-arm.
-                var ch = [_]std.c.Kevent{.{
-                    .ident = @intCast(std.c.getpid()),
-                    .filter = std.c.EVFILT.PROC,
-                    .flags = std.c.EV.DELETE,
-                    .fflags = 0,
-                    .data = 0,
-                    .udata = 0,
-                }};
-                var ts = std.c.timespec{ .sec = 0, .nsec = 0 };
-                _ = std.c.kevent(no_orphans_kq.native(), &ch, 1, &ch, 0, &ts);
+            // `begin()` records the script's `p_uniqueid` as the scan root
+            // and stashes kq so `scan()` can EV_ADD NOTE_FORK|NOTE_EXIT on
+            // each discovered descendant. waitMacKqueue registers the
+            // script's own knote.
+            if (comptime Environment.isMac) if (no_orphans_kq != bun.invalid_fd)
                 Bun__noOrphans_begin(no_orphans_kq.native(), process.pid);
-            };
         }
         defer if (no_orphans) {
             jc.restore();
@@ -2582,10 +2537,12 @@ pub const sync = struct {
     /// blocking `wait4()` so that:
     ///   - we notice our parent dying and run cleanup before PDEATHSIG / never
     ///     (macOS) — `Global.exit(129)` → `kill(-pgid)` + deep walk
-    ///   - macOS: kernel-side `NOTE_TRACK` (armed on `getpid()` *before*
-    ///     spawn — see `spawnPosix`) auto-attaches to every descendant
-    ///     inside `fork1()`, so `setsid()`+double-fork escapees are tracked
-    ///     atomically and killed via `Bun__noOrphans_killTracked()`
+    ///   - macOS: `NOTE_FORK` on the script (and recursively on each
+    ///     discovered descendant) triggers a `p_puniqueid` scan
+    ///     (`NoOrphansTracker::scan()`) so `setsid()`+double-fork escapees
+    ///     are tracked and killed via `Bun__noOrphans_killTracked()`.
+    ///     `NOTE_TRACK` would have made this atomic, but it has been
+    ///     ENOTSUP since macOS 10.5.
     ///   - Linux: subreaper (armed in `spawnPosix`) makes those reparent to us,
     ///     so the procfs walk finds them; this loop just needs to run
     ///     cleanup *before* our own SIGKILL-PDEATHSIG fires
@@ -2613,9 +2570,8 @@ pub const sync = struct {
         // defers (pgroup-kill, killTracked() — empty set) still run.
         if (kq_fd == bun.invalid_fd) return null;
 
-        // udata tag for the ppid PROC filter — the only PROC knote we EV_ADD
-        // here. Auto-created NOTE_TRACK descendant knotes inherit udata=0
-        // from the self-knote spawnPosix armed before spawn. EVFILT_READ
+        // udata tag for the ppid PROC filter. Descendant PROC knotes
+        // (`child` here, plus any `scan()` adds) use udata=0; EVFILT_READ
         // udata 0/1 are a separate filter, so the dispatch checks `filter`
         // before `udata`.
         const TAG_PPID: usize = 2;
@@ -2637,18 +2593,14 @@ pub const sync = struct {
         }.f;
         if (ppid > 1)
             add(&changes, @intCast(ppid), std.c.EVFILT.PROC, std.c.NOTE.EXIT, TAG_PPID);
-        // Belt-and-braces: EV_ADD PROC on `child` with the SAME fflags as the
-        // auto-knote xnu creates inside `fork1()`. Idempotent if that knote
-        // exists (EV_ADD on an existing ident+filter updates sfflags — same
-        // value here — and preserves pending `kn_fflags`, so a queued
-        // NOTE_CHILD survives); creates it if the auto-attach was skipped —
-        // NOTE_TRACKERR on the self-knote fires *there* and we `EV_DELETE` it
-        // in `spawnPosix` before ever draining, so the failure is invisible.
-        // Without this the non-TTY `.inherit`-stdio path has no knote on
-        // `child` and `kevent(timeout=null)` below blocks forever (observed
-        // as a whole-file timeout on darwin-14-x64 in CI). Using the same
-        // NOTE_TRACK keeps descendant auto-tracking intact.
-        add(&changes, @intCast(child), std.c.EVFILT.PROC, NOTE.TRACK | std.c.NOTE.EXIT, 0);
+        // NOTE_FORK so the wait loop wakes to scan whenever the script (or
+        // any registered descendant) forks. NOTE_TRACK would have let xnu
+        // auto-attach to the new child atomically, but it returns ENOTSUP on
+        // every macOS since 10.5 — which previously made *this* registration
+        // fail, the receipt loop below `return null`, and the caller fall
+        // through to a plain `wait4()` that watches neither ppid nor
+        // descendants (the `runDied=false` failure on darwin in CI).
+        add(&changes, @intCast(child), std.c.EVFILT.PROC, std.c.NOTE.FORK | std.c.NOTE.EXIT, 0);
         // TTY job-control: EVFILT_PROC has no "stopped" note, so wake on
         // SIGCHLD and `wait4(WUNTRACED|WNOHANG)` to catch Ctrl-Z. Only when
         // stdin is a TTY — non-TTY callers never see stops, matching plain
@@ -2689,6 +2641,11 @@ pub const sync = struct {
         }
         if (ppid > 1 and std.c.getppid() != ppid)
             bun.Global.exit(bun.ParentDeathWatchdog.exit_code);
+        // Initial scan: `child` may have forked between `posix_spawn`
+        // returning (in spawnPosix) and the NOTE_FORK registration above
+        // taking effect; that fork produced no event. `begin()` already
+        // seeded `m_seen` with `child`'s uniqueid, so this picks them up.
+        Bun__noOrphans_onFork();
 
         var events: [16]std.c.Kevent = undefined;
         var child_exited = false;
@@ -2698,22 +2655,20 @@ pub const sync = struct {
                 .err => |err| return .{ .err = err },
                 .result => |c| c,
             };
+            var saw_fork = false;
             for (events[0..got]) |ev| {
                 if (ev.filter == std.c.EVFILT.PROC) {
-                    // ppid is the only PROC knote with udata != 0; every
-                    // auto-created descendant knote inherits udata 0 from the
-                    // self-knote spawnPosix armed before spawn.
+                    // ppid is the only PROC knote with udata != 0; descendant
+                    // knotes (`child` above + any `scan()` added) use udata 0.
                     if (ev.udata == TAG_PPID) {
                         if (ev.fflags & std.c.NOTE.EXIT != 0)
                             bun.Global.exit(bun.ParentDeathWatchdog.exit_code);
                         continue;
                     }
-                    // NOTE_CHILD and NOTE_EXIT can share one event (forked
-                    // and died between kevent calls) — handle both, no else.
-                    if (ev.fflags & NOTE.CHILD != 0)
-                        Bun__noOrphans_onChild(@intCast(ev.ident));
-                    if (ev.fflags & NOTE.TRACKERR != 0)
-                        Bun__noOrphans_onTrackErr(@intCast(ev.ident));
+                    // NOTE_FORK and NOTE_EXIT can share one event (forked and
+                    // died between kevent calls) — handle both, no else.
+                    if (ev.fflags & std.c.NOTE.FORK != 0)
+                        saw_fork = true;
                     if (ev.fflags & std.c.NOTE.EXIT != 0) {
                         // Drop from the live set (root included — `begin()`
                         // seeded it into `m_tracked`, and `reapChild()` is
@@ -2740,6 +2695,17 @@ pub const sync = struct {
                     if (drainFd(&out_fds_to_wait_for[i], &out_fds[i], &out[i])) |err| return .{ .err = err };
                 }
             }
+            // After the batch so a single scan covers every NOTE_FORK in it.
+            // `scan()` walks `proc_listallpids` for any pid whose
+            // `p_puniqueid` (immutable spawning-parent uniqueid) is in our
+            // seen set, adds it to m_tracked, and EV_ADDs NOTE_FORK|NOTE_EXIT
+            // on it (udata 0) so its own forks wake this loop. Race: a
+            // fast-exit intermediate (fork+setsid+fork+exit) can die before
+            // this scan records its uniqueid, leaving its child's
+            // `p_puniqueid` unlinkable. NOTE_TRACK closed that atomically;
+            // without it the freeze-then-rescan loop in `killTracked()` is
+            // the best-effort backstop.
+            if (saw_fork) Bun__noOrphans_onFork();
             if (child_exited) {
                 // Intentionally don't wait for pipe EOF (unlike the `poll()`
                 // path): a grandchild holding the write end is exactly what

--- a/src/bun.js/bindings/NoOrphansTracker.cpp
+++ b/src/bun.js/bindings/NoOrphansTracker.cpp
@@ -84,7 +84,6 @@ public:
         m_seen.clear();
         m_tracked.clear();
         m_kq = kq;
-        m_root = root;
         ProcUniqIdentifierInfo r;
         if (ProcUniqIdentifierInfo::read(root, r)) {
             m_seen.add(r.p_uniqueid);
@@ -253,7 +252,6 @@ private:
     // fork-heavy script (e.g. `make -j`) isn't reallocating every NOTE_FORK.
     WTF::Vector<pid_t> m_pids;
     int m_kq = -1; // borrowed; owned by Zig's spawnPosix
-    pid_t m_root = 0;
 };
 
 } // namespace Bun

--- a/src/bun.js/bindings/NoOrphansTracker.cpp
+++ b/src/bun.js/bindings/NoOrphansTracker.cpp
@@ -5,26 +5,26 @@
 // `kill(-pgid)` nor a libproc child walk can reach it. macOS has no
 // PR_SET_CHILD_SUBREAPER.
 //
-// Solution: `EVFILT_PROC` + `NOTE_TRACK`. xnu auto-registers the same
-// `NOTE_TRACK|NOTE_EXIT` knote on every child *inside `fork1()`* before the
-// child is schedulable, recursively (kern_fork.c:592 → `kqueue_kern_proc`
-// `KNOTE_TRACK`). Each new pid produces a `NOTE_CHILD` event (`data` = parent
-// pid). Non-SETEXEC `posix_spawn` goes through `fork1()`, so arming
-// `NOTE_TRACK` on `getpid()` *before* `posix_spawn` means the script's knote
-// is created atomically with the script — zero seed window. We `EV_DELETE`
-// the self-knote right after spawn so unrelated bun-side forks aren't
-// tracked; the descendant knotes are independent and survive.
+// Solution: `EVFILT_PROC` `NOTE_FORK` + a `p_puniqueid` spawn-graph scan.
+// `p_puniqueid` (exposed via the private-but-ABI-stable
+// `proc_pidinfo(PROC_PIDUNIQIDENTIFIERINFO)`) is the *spawning* parent's
+// per-boot unique id — set inside `fork1()`, immutable across reparenting,
+// never recycled. Seeding `m_seen` with the script's `p_uniqueid` and
+// fixed-point-scanning `proc_listallpids` for any pid whose `p_puniqueid` is
+// in `m_seen` reconstructs the descendant set even after intermediates have
+// died and the daemon has reparented to launchd.
 //
-// We record `(pid, p_uniqueid)` for every `NOTE_CHILD`. At kill time identity
-// is verified by `p_uniqueid` (per-boot monotone, never recycled — exposed via
-// the private-but-ABI-stable `proc_pidinfo(PROC_PIDUNIQIDENTIFIERINFO)`),
-// which is strictly safer than the ppid recheck used elsewhere.
+// `NOTE_FORK` on each tracked pid wakes the wait loop to re-scan whenever
+// something forks. The scan registers `NOTE_FORK|NOTE_EXIT` on every newly
+// discovered pid so the chain continues.
 //
-// `NOTE_TRACKERR` fires on the parent's event if xnu couldn't allocate the
-// child's knote (kern_fork.c:601, ENOMEM). We fall back to a single
-// proc_listallpids fixed-point sweep over `m_seen` (the immutable
-// `p_puniqueid` spawn graph) and manually re-arm `NOTE_TRACK` on anything
-// found so its subtree rejoins the auto-tracked set. Best-effort; cold path.
+// xnu had `NOTE_TRACK` (auto-attach the same knote to every fork inside
+// `fork1()`, atomically) which would have closed the fast-exit race, but it
+// has been ENOTSUP since 10.5 (sys/event.h: "NOTE_TRACK, NOTE_TRACKERR, and
+// NOTE_CHILD are no longer supported as of 10.5"). The remaining race — an
+// intermediate that forks-and-exits before the scan triggered by its own
+// birth records its uniqueid — is narrowed by the freeze-then-rescan loop in
+// `killTracked()` but cannot be fully closed from userspace.
 //
 // All state is process-global; spawnSync is single-threaded by design (see
 // Bun__currentSyncPID), so no locking.
@@ -74,16 +74,17 @@ public:
         return instance;
     }
 
-    // Called once per spawnSync, after the kqueue's self-NOTE_TRACK is armed
-    // and the script has been spawned. Seeds with the *script's* uniqueid (not
-    // the current process's — we don't want to track or kill unrelated
-    // siblings) and stashes kq for the killTracked() drain and any TRACKERR
-    // fallback re-arms. The script's knote was kernel-created inside fork1().
+    // Called once per spawnSync after the script is spawned. Seeds the scan
+    // root with the *script's* uniqueid (not ours — we don't track or kill
+    // unrelated siblings) and stashes kq so `scan()` can EV_ADD on each
+    // discovered descendant. The script's own knote is registered by the
+    // wait loop's EV_RECEIPT batch.
     void begin(int kq, pid_t root)
     {
         m_seen.clear();
         m_tracked.clear();
         m_kq = kq;
+        m_root = root;
         ProcUniqIdentifierInfo r;
         if (ProcUniqIdentifierInfo::read(root, r)) {
             m_seen.add(r.p_uniqueid);
@@ -92,27 +93,13 @@ public:
     }
 
     // Detach from the borrowed kqueue before its owner closes it, so the
-    // drain in killTracked() / re-arm in fallbackScan() don't kevent() on a
-    // closed (or worse, reused) fd.
+    // EV_ADD in `scan()` and the drain in `killTracked()` don't kevent() on
+    // a closed (or worse, reused) fd.
     void releaseKq() { m_kq = -1; }
 
-    // NOTE_CHILD: kernel auto-attached NOTE_TRACK to `pid` inside fork1();
-    // record its uniqueid for kill-time identity verification. ESRCH (already
-    // gone) is fine — its own children's knotes were attached in-kernel, so
-    // the chain continues; we just won't have this link's uid in m_seen,
-    // which only matters for the TRACKERR fallback.
-    void onChild(pid_t pid)
-    {
-        ProcUniqIdentifierInfo u;
-        if (!ProcUniqIdentifierInfo::read(pid, u)) return;
-        // m_tracked may already have it via a TRACKERR fallback that ran
-        // before this NOTE_CHILD drained — m_seen dedups.
-        if (!m_seen.add(u.p_uniqueid).isNewEntry) return;
-        m_tracked.append({ pid, u.p_uniqueid });
-    }
-
     // A tracked pid sent NOTE_EXIT. Drop it from the live list so we don't
-    // try to signal a recycled pid later. Its uniqueid stays in `seen`.
+    // try to signal a recycled pid later. Its uniqueid stays in `m_seen` so
+    // the scan can still chain through it.
     void onExit(pid_t pid)
     {
         for (size_t i = 0; i < m_tracked.size(); ++i) {
@@ -123,38 +110,80 @@ public:
         }
     }
 
-    // NOTE_TRACKERR on `pid`: xnu couldn't allocate its child's knote
-    // (ENOMEM). The child — and its whole subtree — are now untracked. Do a
-    // bounded p_puniqueid fixed-point sweep over m_seen and manually re-arm
-    // NOTE_TRACK on anything found so it rejoins the auto-tracked set.
-    // Best-effort under memory pressure; cold path.
-    void onTrackErr(pid_t)
+    // Fixed-point sweep over the live process table for any pid whose
+    // `p_puniqueid` is in `m_seen`. For each new one: record it, and EV_ADD
+    // `NOTE_FORK|NOTE_EXIT` (udata 0) so its own forks wake the wait loop.
+    // Called on every NOTE_FORK from the wait loop and from `killTracked()`.
+    //
+    // Fast-path: `proc_listchildpids` on each tracked pid first. One syscall
+    // per tracked pid, returns only direct children — usually catches the
+    // new fork before the intermediate can exit. The full `proc_listallpids`
+    // sweep follows for anything that already reparented (its `p_puniqueid`
+    // is unchanged, so it's still linkable as long as the parent's uniqueid
+    // is in `m_seen`).
+    void scan()
     {
-        fallbackScan();
+        if (m_seen.isEmpty()) return;
+
+        // Fast path: direct children of currently-tracked pids. This is the
+        // race-narrowing step — proc_listchildpids is one cheap syscall per
+        // tracked pid, so it usually runs before a fast-exit intermediate
+        // can fork+exit and break the `p_puniqueid` chain.
+        {
+            pid_t kids[256];
+            // m_tracked may grow while iterating; index past the original end.
+            for (size_t i = 0; i < m_tracked.size(); ++i) {
+                int n = proc_listchildpids(m_tracked[i].pid, kids, sizeof kids);
+                for (int k = 0; k < n; ++k) addIfNew(kids[k]);
+            }
+        }
+
+        // Full sweep: catches anything that already reparented to launchd.
+        int cap = proc_listallpids(nullptr, 0);
+        if (cap <= 0) return;
+        const size_t want = static_cast<size_t>(cap) + 64;
+        if (m_pids.size() < want) m_pids.grow(want);
+
+        bool grew;
+        do {
+            grew = false;
+            int n = proc_listallpids(m_pids.mutableSpan().data(),
+                static_cast<int>(m_pids.size() * sizeof(pid_t)));
+            if (n <= 0) return;
+            for (int i = 0; i < n; ++i)
+                if (addIfNew(m_pids[static_cast<size_t>(i)])) grew = true;
+        } while (grew);
     }
 
-    // SIGKILL every tracked descendant. Freeze, drain the kq for any
-    // NOTE_CHILD that raced the SIGSTOPs, freeze the new ones, repeat until
-    // closed. Then verify each p_uniqueid still matches what we recorded
-    // (uniqueids never recycle, unlike pids) — mismatch ⇒ pid was reused
-    // between record and STOP; SIGCONT and skip.
+    // SIGKILL every tracked descendant. Freeze, drain any queued NOTE_FORK
+    // and rescan, freeze the new ones, repeat until closed. Then verify each
+    // `p_uniqueid` still matches what we recorded (uniqueids never recycle,
+    // unlike pids) — mismatch ⇒ pid was reused between record and STOP;
+    // SIGCONT and skip.
     void killTracked()
     {
         size_t frozen = 0;
+        // m_tracked[0] is the script root while it's alive; the wait loop
+        // calls `onExit(root)` before we get here on the normal path, so the
+        // first SIGSTOP target is a real descendant. On the parent-died /
+        // Global.exit path the root may still be at [0] — STOPping it is
+        // fine, it's about to be SIGKILLed.
         do {
             for (; frozen < m_tracked.size(); ++frozen)
                 kill(m_tracked[frozen].pid, SIGSTOP);
-            // Drain any NOTE_CHILD that landed between the last drain and the
-            // SIGSTOPs we just sent. Once a drain adds nothing, every tracked
-            // pid is stopped and cannot fork — set is closed.
-            if (m_kq < 0) break;
-            struct kevent ev[32];
-            struct timespec zero { 0, 0 };
-            int n;
-            while ((n = kevent(m_kq, nullptr, 0, ev, 32, &zero)) > 0)
-                for (int i = 0; i < n; ++i)
-                    if (ev[i].filter == EVFILT_PROC && (ev[i].fflags & NOTE_CHILD))
-                        onChild((pid_t)ev[i].ident);
+            // Drain queued NOTE_FORKs (descendant forked between the wait
+            // loop's last kevent and our SIGSTOPs) and rescan. A frozen
+            // process cannot fork, so once a pass adds nothing the set is
+            // closed. Unconditional first rescan: a fork may have raced the
+            // wait loop's kevent without leaving a queued NOTE_FORK on a pid
+            // we'd already drained.
+            if (m_kq >= 0) {
+                struct kevent ev[32];
+                struct timespec zero { 0, 0 };
+                while (kevent(m_kq, nullptr, 0, ev, 32, &zero) > 0) {
+                }
+            }
+            scan();
         } while (frozen < m_tracked.size());
 
         for (auto& t : m_tracked) {
@@ -173,55 +202,40 @@ public:
 private:
     NoOrphansTracker() = default;
 
-    // p_puniqueid fixed-point sweep over the live process table — only used
-    // on NOTE_TRACKERR (kernel ENOMEM). For any pid discovered, manually
-    // EV_ADD NOTE_TRACK|NOTE_EXIT (udata 0) so its subtree rejoins the
-    // auto-tracked set. Local pid buffer; this is a cold path.
-    void fallbackScan()
+    // Record `pid` if its spawning-parent uniqueid is in `m_seen` and we
+    // haven't seen it before. Registers NOTE_FORK|NOTE_EXIT so its forks
+    // wake the wait loop. Returns true iff `m_seen` grew.
+    bool addIfNew(pid_t pid)
     {
-        if (m_seen.isEmpty()) return;
+        if (pid <= 1 || pid == getpid()) return false;
+        ProcUniqIdentifierInfo u;
+        if (!ProcUniqIdentifierInfo::read(pid, u)) return false;
+        if (!m_seen.contains(u.p_puniqueid)) return false;
+        if (!m_seen.add(u.p_uniqueid).isNewEntry) return false;
 
-        int cap = proc_listallpids(nullptr, 0);
-        if (cap <= 0) return;
-        WTF::Vector<pid_t> pids;
-        pids.grow(static_cast<size_t>(cap) + 64);
+        m_tracked.append({ pid, u.p_uniqueid });
 
-        bool grew;
-        do {
-            grew = false;
-            int n = proc_listallpids(pids.mutableSpan().data(),
-                static_cast<int>(pids.size() * sizeof(pid_t)));
-            if (n <= 0) return;
-
-            for (int i = 0; i < n; ++i) {
-                pid_t pid = pids[static_cast<size_t>(i)];
-                if (pid <= 1 || pid == getpid()) continue;
-
-                ProcUniqIdentifierInfo u;
-                if (!ProcUniqIdentifierInfo::read(pid, u)) continue;
-                if (!m_seen.contains(u.p_puniqueid)) continue;
-                if (!m_seen.add(u.p_uniqueid).isNewEntry) continue;
-
-                m_tracked.append({ pid, u.p_uniqueid });
-                grew = true;
-
-                // Re-arm NOTE_TRACK so this pid's future forks rejoin the
-                // kernel-tracked set. Best-effort — ESRCH (died already) is
-                // fine, ENOMEM means we'll see another TRACKERR later.
-                if (m_kq >= 0) {
-                    struct kevent ch = {
-                        .ident = static_cast<uintptr_t>(pid),
-                        .filter = EVFILT_PROC,
-                        .flags = EV_ADD | EV_CLEAR,
-                        .fflags = NOTE_TRACK | NOTE_EXIT,
-                        .data = 0,
-                        .udata = nullptr,
-                    };
-                    struct timespec zero = { 0, 0 };
-                    kevent(m_kq, &ch, 1, nullptr, 0, &zero);
-                }
-            }
-        } while (grew);
+        // EV_ADD on the wait loop's kq so this pid's forks/exit wake it.
+        // udata 0 — same as the script root's knote — so the wait loop's
+        // dispatch treats it as a descendant event. ESRCH (already gone) is
+        // fine: its uniqueid is in m_seen so its children remain linkable,
+        // and `killTracked()`'s identity check will skip the dead pid.
+        // `m_kq < 0` after `releaseKq()` (we're inside `killTracked()`'s
+        // post-release rescan via `killSyncScriptTree`); the EV_ADD is moot
+        // there since nothing will drain it.
+        if (m_kq >= 0) {
+            struct kevent ch = {
+                .ident = static_cast<uintptr_t>(pid),
+                .filter = EVFILT_PROC,
+                .flags = EV_ADD | EV_CLEAR,
+                .fflags = NOTE_FORK | NOTE_EXIT,
+                .data = 0,
+                .udata = nullptr,
+            };
+            struct timespec zero = { 0, 0 };
+            kevent(m_kq, &ch, 1, nullptr, 0, &zero);
+        }
+        return true;
     }
 
     struct Tracked {
@@ -230,29 +244,31 @@ private:
     };
 
     // Uniqueids ever observed in our subtree. Never shrinks — dead
-    // intermediates must stay so the TRACKERR fallback can chain through.
+    // intermediates must stay so the scan can chain through them.
     WTF::HashSet<uint64_t> m_seen;
     // Live (pid, uniqueid) pairs we'll SIGKILL at cleanup. Pruned on NOTE_EXIT.
     WTF::Vector<Tracked> m_tracked;
+    // Scratch buffer for proc_listallpids; persisted across scans so a
+    // fork-heavy script (e.g. `make -j`) isn't reallocating every NOTE_FORK.
+    WTF::Vector<pid_t> m_pids;
     int m_kq = -1; // borrowed; owned by Zig's spawnPosix
+    pid_t m_root = 0;
 };
 
 } // namespace Bun
 
 extern "C" void Bun__noOrphans_begin(int kq, pid_t root) { Bun::NoOrphansTracker::get().begin(kq, root); }
 extern "C" void Bun__noOrphans_releaseKq() { Bun::NoOrphansTracker::get().releaseKq(); }
-extern "C" void Bun__noOrphans_onChild(pid_t pid) { Bun::NoOrphansTracker::get().onChild(pid); }
+extern "C" void Bun__noOrphans_onFork() { Bun::NoOrphansTracker::get().scan(); }
 extern "C" void Bun__noOrphans_onExit(pid_t pid) { Bun::NoOrphansTracker::get().onExit(pid); }
-extern "C" void Bun__noOrphans_onTrackErr(pid_t pid) { Bun::NoOrphansTracker::get().onTrackErr(pid); }
 extern "C" void Bun__noOrphans_killTracked() { Bun::NoOrphansTracker::get().killTracked(); }
 
 #else // !OS(DARWIN)
 
 extern "C" void Bun__noOrphans_begin(int, int) {}
 extern "C" void Bun__noOrphans_releaseKq() {}
-extern "C" void Bun__noOrphans_onChild(int) {}
+extern "C" void Bun__noOrphans_onFork() {}
 extern "C" void Bun__noOrphans_onExit(int) {}
-extern "C" void Bun__noOrphans_onTrackErr(int) {}
 extern "C" void Bun__noOrphans_killTracked() {}
 
 #endif

--- a/src/bun.js/bindings/NoOrphansTracker.cpp
+++ b/src/bun.js/bindings/NoOrphansTracker.cpp
@@ -127,7 +127,13 @@ public:
         // Fast path: direct children of currently-tracked pids. This is the
         // race-narrowing step — proc_listchildpids is one cheap syscall per
         // tracked pid, so it usually runs before a fast-exit intermediate
-        // can fork+exit and break the `p_puniqueid` chain.
+        // can fork+exit and break the `p_puniqueid` chain. Fixed-size buffer
+        // is intentional: a query-then-allocate round-trip would double the
+        // syscalls and widen the very race this exists to narrow; >256 direct
+        // children of a single tracked pid is pathological, and any overflow
+        // is caught by the full `proc_listallpids` sweep immediately below
+        // (`p_puniqueid` survives reparenting, so nothing is lost — only the
+        // latency advantage for the 257th+ child).
         {
             pid_t kids[256];
             // m_tracked may grow while iterating; index past the original end.

--- a/src/bun.js/bindings/NoOrphansTracker.cpp
+++ b/src/bun.js/bindings/NoOrphansTracker.cpp
@@ -134,7 +134,8 @@ public:
             // m_tracked may grow while iterating; index past the original end.
             for (size_t i = 0; i < m_tracked.size(); ++i) {
                 int n = proc_listchildpids(m_tracked[i].pid, kids, sizeof kids);
-                for (int k = 0; k < n; ++k) addIfNew(kids[k]);
+                for (int k = 0; k < n; ++k)
+                    addIfNew(kids[k]);
             }
         }
 


### PR DESCRIPTION
## What

Fixes `test/cli/run/no-orphans.test.ts` timing out / failing on every darwin CI runner (14 x64, 14 aarch64, 26 aarch64).

## Why

`NOTE_TRACK` has been unsupported since macOS 10.5. xnu's `filt_procattach` hard-rejects it with `ENOTSUP`:

```c
// bsd/kern/kern_event.c:1105
if ((kn->kn_sfflags & (NOTE_TRACK | NOTE_TRACKERR | NOTE_CHILD)) != 0) {
    knote_set_error(kn, ENOTSUP);
    return 0;
}
```

The `NOTE_TRACK`-on-self registration in `spawnPosix` therefore failed on every macOS, which invalidated the kqueue, so `waitMacKqueue` returned `null` and `bun run --no-orphans <script>` fell through to a plain `wait4()` that watched neither its parent nor its descendants.

The event-loop paths (`BUN_FEATURE_FLAG_NO_ORPHANS=1 bun foo.js`, `bun run --filter`) were unaffected since they use `installOnEventLoop` instead of `waitMacKqueue`, which is why most of the suite passed.

## How

Replace `NOTE_TRACK` with `NOTE_FORK` on the script (and recursively on each discovered descendant). A fork wakes the wait loop, which runs a `p_puniqueid` fixed-point scan (`NoOrphansTracker::scan()`) to find new descendants and arm `NOTE_FORK|NOTE_EXIT` on them. `p_puniqueid` is the *spawning* parent's per-boot uniqueid — set in `fork1()`, immutable across reparenting, never recycled — so setsid+double-fork escapees stay linkable as long as each intermediate's uniqueid was recorded before it died. `killTracked()` does a freeze-then-rescan loop and verifies `p_uniqueid` before `SIGKILL` so recycled pids are skipped.

The remaining race (an intermediate that fork+exits before the scan triggered by its own birth records its uniqueid) is narrowed by a fast-path `proc_listchildpids` per tracked pid before the full sweep, but cannot be fully closed from userspace without `NOTE_TRACK` or subreaper.

Also fixes a `WTF::Vector::grow()` debug assert (`grow()` can only grow) when a later scan sees fewer system pids than an earlier one.