### PR TITLE
Bump WebKit (ICU data filter −7.46 MB, CRASH_WITH_INFO strings −550 KB)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "6ef83cb658722ff1f33f4a4c9335fb094bed4c6b";
+export const WEBKIT_VERSION = "autobuild-preview-pr-211-719922d0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Picks up oven-sh/WebKit#211 (`719922d0ed0d`):

| Change | Savings |
|---|--:|
| Filter unreachable ICU data (`.cnv`/`translit/`/`rbnf/`/`*.spp`/`*.cfu`/`cnvalias.icu`/`unames.icu`) — Bun has zero `ucnv_`/`utrans_`/`usprep_`/`uspoof_` consumers; `TextCodecICU` was already removed | **−7,462,064** (`libicudata.a` 30.73 MB → 23.27 MB) |
| `CRASH_WITH_INFO`: skip `__FILE__`/`__PRETTY_FUNCTION__` on platforms where `WTFCrashWithInfo` ignores them | ~−550 KB |
| Dockerfile: fall back to `archive.ubuntu.com` when Azure apt mirror is unreachable | (CI reliability) |

Currently pointing at the PR-preview release tag so CI can validate end-to-end. **Before merging:** once oven-sh/WebKit#211 lands on `main`, update `WEBKIT_VERSION` to the `autobuild-<merge-sha>` tag.

Companion to #30098 (bun-side −2 MB).