### PR TITLE
Move the "command not found" warning from the bottom of the page into…

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -24,6 +24,10 @@ Bun ships as a single, dependency-free executable. You can install it via script
       **Linux users**  The `unzip` package is required to install Bun. Use `sudo apt install unzip` to install the unzip package. Kernel version 5.6 or higher is recommended; Bun runs on kernels as old as 3.10 (RHEL 7) with graceful degradation of newer syscalls. Use `uname -r` to check your kernel version.
       </Note>
 
+    <Warning>
+      If you're seeing a `command not found: bun` error after installation, you may have to manually add the installation directory (`~/.bun/bin`) to your `PATH`.
+    </Warning>
+
   </Tab>
 
   <Tab title="Windows">
@@ -37,6 +41,10 @@ Bun ships as a single, dependency-free executable. You can install it via script
       Bun requires Windows 10 version 1809 or later.
     </Warning>
 
+
+    <Warning>
+      If you're seeing a `command not found: bun` error after installation, you may have to manually add the installation directory (`%USERPROFILE%\.bun\bin`) to your `PATH`.
+    </Warning>
 
     For support and discussion, please join the **#windows** channel on our [Discord](https://bun.com/discord).
 
@@ -58,6 +66,10 @@ Bun ships as a single, dependency-free executable. You can install it via script
     	```
 
     	</CodeGroup>
+
+    <Warning>
+      If you're seeing a `command not found: bun` error after installation, ensure that your package manager's global binary directory is included in your `PATH`.
+    </Warning>
 
     </Tab>
 
@@ -94,10 +106,7 @@ bun --revision
 # Output: 1.x.y+b7982ac13189
 ```
 
-<Warning>
-  If you've installed Bun but are seeing a `command not found` error, you may have to manually add the installation
-  directory (`~/.bun/bin`) to your `PATH`.
-</Warning>
+
 
 <Accordion title="Add Bun to your PATH">
   <Tabs>


### PR DESCRIPTION
… the individual installation tabs.

This change improves visibility and provides platform-specific guidance:
- macOS/Linux: Explicitly mentions ~/.bun/bin.
- Windows: Explicitly mentions %USERPROFILE%\.bun\bin.
- Package Managers: Advises checking the manager's global binary directory.

### What does this PR do?

### How did you verify your code works?
