### PR TITLE
net(BlockList): fix UAF/SIGFPE when structured-clone is deserialized more than once

### DIFF
--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -220,7 +220,11 @@ pub fn onStructuredCloneDeserialize(globalThis: *jsc.JSGlobalObject, ptr: *[*]u8
 
     const this: *@This() = @ptrFromInt(int);
     // A single SerializedScriptValue can be deserialized multiple times
-    // (e.g. BroadcastChannel fan-out), so each wrapper must own its own ref.
+    // (e.g. BroadcastChannel fan-out), so each wrapper must own its own ref
+    // instead of adopting the one taken in serialize. The serialize ref is
+    // what keeps the backing alive while the pointer sits in the byte buffer;
+    // SerializedScriptValue has no destroy hook for Bun-native tags, so that
+    // ref is retained until a buffer-level deref exists (preferable to UAF).
     this.ref();
     return this.toJS(globalThis);
 }

--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -25,7 +25,7 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callFrame: *jsc.CallFrame) b
 
 /// May be called from any thread.
 pub fn estimatedSize(this: *@This()) usize {
-    return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / this.ref_count.get();
+    return (@sizeOf(@This()) + this.estimated_size.load(.seq_cst)) / @max(this.ref_count.get(), 1);
 }
 
 pub fn finalize(this: *@This()) void {

--- a/src/bun.js/node/net/BlockList.zig
+++ b/src/bun.js/node/net/BlockList.zig
@@ -219,6 +219,9 @@ pub fn onStructuredCloneDeserialize(globalThis: *jsc.JSGlobalObject, ptr: *[*]u8
     ptr.* = ptr.* + buffer_stream.pos;
 
     const this: *@This() = @ptrFromInt(int);
+    // A single SerializedScriptValue can be deserialized multiple times
+    // (e.g. BroadcastChannel fan-out), so each wrapper must own its own ref.
+    this.ref();
     return this.toJS(globalThis);
 }
 

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -20,18 +20,19 @@ test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
         const recvA = new BroadcastChannel("blocklist-gc");
         const recvB = new BroadcastChannel("blocklist-gc");
 
-        const received = [];
-        recvA.onmessage = e => received.push(e.data);
-        recvB.onmessage = e => received.push(e.data);
-
         let bl = new BlockList();
         bl.addAddress("127.0.0.1");
-        sender.postMessage(bl);
 
-        for (let i = 0; i < 100 && received.length < 2; i++) {
-          await new Promise(r => setTimeout(r, 10));
-        }
-        if (received.length !== 2) throw new Error("expected 2 messages, got " + received.length);
+        const received = [];
+        const { promise, resolve } = Promise.withResolvers();
+        const onmessage = e => {
+          received.push(e.data);
+          if (received.length === 2) resolve();
+        };
+        recvA.onmessage = onmessage;
+        recvB.onmessage = onmessage;
+        sender.postMessage(bl);
+        await promise;
 
         // Keep one clone reachable, drop the original and the other clone so
         // their finalizers run and deref the shared backing.
@@ -60,4 +61,4 @@ test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
   expect(stderr).not.toContain("AddressSanitizer");
   expect(stdout.trim()).toBe("ok");
   expect(exited).toBe(0);
-}, 30_000);
+});

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -28,7 +28,9 @@ test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
         bl.addAddress("127.0.0.1");
         sender.postMessage(bl);
 
-        await new Promise(r => setTimeout(r, 10));
+        for (let i = 0; i < 100 && received.length < 2; i++) {
+          await new Promise(r => setTimeout(r, 10));
+        }
         if (received.length !== 2) throw new Error("expected 2 messages, got " + received.length);
 
         // Keep one clone reachable, drop the original and the other clone so

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
-import { bunExe, bunEnv } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // BlockList.estimatedSize divided by ref_count which can be observed as 0
 // from the concurrent GC thread while another JS wrapper for the same

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -58,7 +58,7 @@ test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
   });
 
   const [stdout, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("AddressSanitizer");
+  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");
   expect(exited).toBe(0);
 });

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -1,25 +1,51 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// BlockList.estimatedSize divided by ref_count which can be observed as 0
-// from the concurrent GC thread while another JS wrapper for the same
-// BlockList is being finalized, raising SIGFPE.
-test("BlockList survives GC with multiple wrappers sharing one backing", async () => {
+// BlockList structured-clone serialize writes the native pointer and takes a
+// single ref. When the same SerializedScriptValue is deserialized more than
+// once (BroadcastChannel fans one message out to every subscriber), each
+// deserialize created a JS wrapper whose finalizer derefs, so wrappers > refs
+// and the backing was freed while a live wrapper still pointed at it. The
+// next GC's visitChildren -> estimatedSize then read freed memory, hitting
+// ASAN use-after-poison or SIGFPE (ref_count divisor read back as 0).
+test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
         const { BlockList } = require("node:net");
-        for (let j = 0; j < 100; j++) {
-          let bl = new BlockList();
-          bl.addAddress("127.0.0.1");
-          let clones = [];
-          for (let i = 0; i < 8; i++) clones.push(structuredClone(bl));
-          bl = null;
-          clones = null;
-          Bun.gc(true);
-        }
+
+        const sender = new BroadcastChannel("blocklist-gc");
+        const recvA = new BroadcastChannel("blocklist-gc");
+        const recvB = new BroadcastChannel("blocklist-gc");
+
+        const received = [];
+        recvA.onmessage = e => received.push(e.data);
+        recvB.onmessage = e => received.push(e.data);
+
+        let bl = new BlockList();
+        bl.addAddress("127.0.0.1");
+        sender.postMessage(bl);
+
+        await new Promise(r => setTimeout(r, 10));
+        if (received.length !== 2) throw new Error("expected 2 messages, got " + received.length);
+
+        // Keep one clone reachable, drop the original and the other clone so
+        // their finalizers run and deref the shared backing.
+        let kept = received[1];
+        bl = null;
+        received.length = 0;
+        Bun.gc(true);
+        Bun.gc(true);
+
+        // Must not be a dangling pointer: visitChildren/estimatedSize runs here.
+        Bun.gc(true);
+        if (kept.rules.length !== 1) throw new Error("clone lost its rules");
+
+        sender.close();
+        recvA.close();
+        recvB.close();
         console.log("ok");
       `,
     ],
@@ -28,7 +54,8 @@ test("BlockList survives GC with multiple wrappers sharing one backing", async (
     stderr: "pipe",
   });
 
-  const [stdout, exited] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("AddressSanitizer");
   expect(stdout.trim()).toBe("ok");
   expect(exited).toBe(0);
-});
+}, 30_000);

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -58,7 +58,11 @@ test("BlockList survives GC after BroadcastChannel fan-out clone", async () => {
   });
 
   const [stdout, stderr, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  const cleanedStderr = stderr
+    .split("\n")
+    .filter(line => line && !line.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(cleanedStderr).toBe("");
   expect(stdout.trim()).toBe("ok");
   expect(exited).toBe(0);
 });

--- a/test/js/node/net/blocklist-gc.test.ts
+++ b/test/js/node/net/blocklist-gc.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv } from "harness";
+
+// BlockList.estimatedSize divided by ref_count which can be observed as 0
+// from the concurrent GC thread while another JS wrapper for the same
+// BlockList is being finalized, raising SIGFPE.
+test("BlockList survives GC with multiple wrappers sharing one backing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { BlockList } = require("node:net");
+        for (let j = 0; j < 100; j++) {
+          let bl = new BlockList();
+          bl.addAddress("127.0.0.1");
+          let clones = [];
+          for (let i = 0; i < 8; i++) clones.push(structuredClone(bl));
+          bl = null;
+          clones = null;
+          Bun.gc(true);
+        }
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, exited] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("ok");
+  expect(exited).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

`BlockList.onStructuredCloneSerialize` writes the native pointer into the serialized bytes and takes one ref to keep the backing alive. `onStructuredCloneDeserialize` reads the pointer back and creates a new JS wrapper, whose finalizer will `deref()`.

That is only balanced when serialize and deserialize are 1:1. `BroadcastChannel` shares a single `SerializedScriptValue` with every subscriber, so one `postMessage` produces N deserialize calls and N wrappers against one serialize ref. Once two of those wrappers are finalized the backing is freed while other wrappers still point at it. The next GC `visitChildren` → `BlockList.estimatedSize` reads the freed struct, which ASAN reports as use-after-poison and release builds see as SIGFPE (the `ref_count` slot was written to 0 by the final `deref` before `bun.destroy`, and `estimatedSize` divides by it).

Fix by having each deserialize take its own ref so every wrapper is independently balanced. Also clamp the `estimatedSize` divisor to `@max(ref_count, 1)` as defense in depth since it runs on the concurrent GC thread.

Fuzzer fingerprint: `b8fa7c24b78655ee` (flaky TERMSIG 8 during `Bun.gc(true)` in the REPRL loop after a prior iteration left a dangling `BlockList` wrapper).

## How did you verify your code works?

Added `test/js/node/net/blocklist-gc.test.ts` which posts a `BlockList` through a `BroadcastChannel` with two receivers, drops the original plus one received clone, forces GC, and then uses the surviving clone.

Without the fix:
- ASAN debug: `AddressSanitizer: use-after-poison` in `BlockList.estimatedSize` via `JSBlockList::visitChildrenImpl`
- Release: `panic(main thread): Floating point error`

With the fix the subprocess prints `ok` and exits 0. Existing `test-blocklist.js` and `test-blocklist-clone.js` still pass.