### PR TITLE
Fix use-after-free in HTMLRewriter when text handler throws during end()

### DIFF
--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -573,7 +573,7 @@ pub const HTMLRewriter = struct {
         ) ?JSValue {
             bun.handleOom(sink.bytes.growBy(bytes.len));
             const global = sink.global;
-            var response = sink.response;
+            const response = sink.response;
 
             sink.rewriter.?.write(bytes) catch {
                 if (is_async) {
@@ -585,8 +585,6 @@ pub const HTMLRewriter = struct {
             };
 
             sink.rewriter.?.end() catch {
-                if (!is_async) response.finalize();
-                sink.response = undefined;
                 if (is_async) {
                     response.getBodyValue().toErrorInstance(.{ .Message = createLOLHTMLStringError() }, global) catch {}; // TODO: properly propagate exception upwards
                     return null;

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -84,6 +84,21 @@ describe("HTMLRewriter", () => {
     }
   });
 
+  it("error thrown from document text handler during end() does not use-after-free", () => {
+    for (let i = 0; i < 100; i++) {
+      expect(() =>
+        new HTMLRewriter()
+          .onDocument({
+            text(chunk) {
+              if (chunk.lastInTextNode) throw new Error("fail in end");
+            },
+          })
+          .transform(new ArrayBuffer(64)),
+      ).toThrow();
+      Bun.gc(true);
+    }
+  });
+
   it("HTMLRewriter: async replacement", async () => {
     await gcTick();
     const res = new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -94,7 +94,7 @@ describe("HTMLRewriter", () => {
             },
           })
           .transform(new ArrayBuffer(64)),
-      ).toThrow();
+      ).toThrow("fail in end");
       Bun.gc(true);
     }
   });


### PR DESCRIPTION
Fuzzer found a use-after-poison crash with fingerprint `Address:use-after-poison:bun-debug+0x827701e`.

### What

When a document text handler throws during the final text chunk (emitted from lol-html's `end()`), `BufferOutputSink.runOutputSink` would call `response.finalize()`, which destroys the `Response` struct via `bun.destroy`. However, the JS `Response` wrapper is still held by `sink.response_value` (a `Strong`), and its wrapped pointer still points at the freed struct. When GC later finalizes that JS wrapper, it calls `Response.finalize` on freed memory.

```
#0 JSRef.deinit src/bun.js/bindings/JSRef.zig:188
#1 JSRef.finalize src/bun.js/bindings/JSRef.zig:200
#2 Response.finalize src/bun.js/webcore/Response.zig:474
#3 ResponseClass__finalize codegen/ZigGeneratedClasses.zig
#4 WebCore::JSResponse::~JSResponse()
```

The `Response` is owned by its JS wrapper and will be cleaned up when the sink drops its strong reference in `deinit()`, so the manual `finalize()` call (and the `sink.response = undefined`) are removed.

### Repro

```js
for (let i = 0; i < 100; i++) {
  try {
    new HTMLRewriter()
      .onDocument({
        text(chunk) {
          if (chunk.lastInTextNode) throw new Error("fail in end");
        },
      })
      .transform(new ArrayBuffer(64));
  } catch {}
  Bun.gc(true);
}
```

The fuzzer originally hit this via `new HTMLRewriter().onDocument(Bun.stdout).transform(new SharedArrayBuffer(1004))` — `Bun.stdout` has a `.text` method, which gets registered as the text handler and returns a Promise, routing through `waitForPromise` during the rewrite.