### PR TITLE
fix(dev-server): preserve <link> stylesheet source order

### DIFF
--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -761,11 +761,37 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
             // removing edges.
             const quick_lookup_values_to_care_len = quick_lookup.count();
 
-            // A new import linked list is constructed. A side effect of this
-            // approach is that the order of the imports is reversed on every
-            // save. However, the ordering here doesn't matter.
+            // A new import linked list is constructed via head-insertion in
+            // `processEdgeAttachment` (and the equivalent inline path in
+            // `processChunkImportRecords`). Head-insertion produces a list in
+            // the *reverse* of the source order in which import records were
+            // visited. After processing we reverse the list once so that
+            // forward iteration of `first_import` matches the order the
+            // imports appear in the source file.
+            //
+            // This matters whenever the consumer of `first_import` cares
+            // about source order. The motivating case is HTML files with
+            // multiple `<link rel="stylesheet">` tags: when `traceImports`
+            // walks the imports for `.find_css`, it must visit them in the
+            // same order the author wrote them, otherwise the CSS cascade's
+            // source-order tiebreak resolves backwards and (e.g.) a rule in
+            // a later stylesheet stops winning over an equally-specific rule
+            // in an earlier stylesheet.
             var new_imports: EdgeIndex.Optional = .none;
-            defer g.first_import.items[file_index.get()] = new_imports;
+            defer {
+                // Reverse the head-inserted linked list in place so that
+                // iteration is in source order.
+                var prev: EdgeIndex.Optional = .none;
+                var cursor = new_imports;
+                while (cursor.unwrap()) |cursor_idx| {
+                    const cursor_edge = &g.edges.items[cursor_idx.get()];
+                    const next = cursor_edge.next_import;
+                    cursor_edge.next_import = prev;
+                    prev = cursor;
+                    cursor = next;
+                }
+                g.first_import.items[file_index.get()] = prev;
+            }
 
             // (CSS chunks are not present on the server side)
             if (mode == .normal and side == .server) {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -570,6 +570,57 @@ devTest("css import before create project relative", {
   },
 });
 
+// Regression: multiple <link rel="stylesheet"> tags must be served in the
+// same order they appear in the source HTML. The CSS cascade's source-order
+// tiebreak (CSS Cascade Level 4 § 6.4.6) decides which of two equally
+// specific declarations wins; if the dev server emits the link tags in the
+// wrong order, the cascade resolves backward and the wrong rule wins.
+devTest("multiple stylesheet links preserve source order", {
+  files: {
+    "a.css": `
+      .target { color: red; }
+    `,
+    "b.css": `
+      .target { color: blue; }
+    `,
+    "index.html": emptyHtmlFile({
+      styles: ["a.css", "b.css"],
+      body: `<div class="target">hello</div>`,
+    }),
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    // a.css declares red; b.css declares blue. Both have specificity
+    // (0,1,0) and are unlayered. Source-order tiebreak: b.css wins.
+    await c.style(".target").color.expect.toBe("#00f");
+  },
+});
+
+devTest("multiple stylesheet links preserve source order inside @layer", {
+  files: {
+    "a.css": `
+      @layer test {
+        .target { color: red; }
+      }
+    `,
+    "b.css": `
+      @layer test {
+        .target { color: blue; }
+      }
+    `,
+    "index.html": emptyHtmlFile({
+      styles: ["a.css", "b.css"],
+      body: `<div class="target">hello</div>`,
+    }),
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    // Both rules sit inside the same @layer; source-order tiebreak still
+    // applies, so b.css wins.
+    await c.style(".target").color.expect.toBe("#00f");
+  },
+});
+
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);
   if (!url) {


### PR DESCRIPTION
## What

Fixes a bug in the Bake dev server where multiple `<link rel=\"stylesheet\">` tags on an HTML route are emitted in the **reverse** of their source order. The bug silently breaks the CSS cascade's source-order tiebreak.

## Reproduction

Three files in a fresh directory:

`index.html`:
```html
<!DOCTYPE html>
<html>
  <head>
    <link rel=\"stylesheet\" href=\"a.css\">
    <link rel=\"stylesheet\" href=\"b.css\">
  </head>
  <body>
    <div class=\"target\">should be blue</div>
  </body>
</html>
```

`a.css`:
```css
.target { color: red; }
```

`b.css`:
```css
.target { color: blue; }
```

Per [CSS Cascade L4 § 6.4.6 Order of Appearance](https://www.w3.org/TR/css-cascade-4/#cascade-order), with two equally specific declarations the **later** one wins, so `.target` should be **blue**.

- `bun build ./index.html --outdir=dist` then opening `dist/index.html`: `.target` is blue. Correct.
- `bun ./index.html` (Bake dev server): `.target` is red. Wrong.

Inspecting the dev-server response, the `<link>` tags appear in opposite order to the source HTML. With more stylesheets the order is perfectly inverted: the last `<link>` in the source is served first.

The bug also breaks the equivalent case inside `@layer` — two equally-specific declarations across two stylesheets in the same named layer resolve backward.

## Root cause

`IncrementalGraph(client).processChunkDependencies` builds the per-file import linked list (`first_import`) via head-insertion in `processEdgeAttachment` and the inline path in `processChunkImportRecords`. Forward iteration of `first_import` therefore yields imports in reverse source order.

The existing comment acknowledged the reversal but asserted \"the ordering here doesn't matter.\" It does for `traceImports` with goal `.find_css`: that walk pushes CSS roots into `client_graph.current_css_files` in the order it encounters them, and the dev server then emits one `<link>` per entry directly (`DevServer.zig:1598`). Reversed traversal -> reversed `<link>` order -> reversed cascade.

## Fix

Reverse the head-inserted linked list once at the end of `processChunkDependencies`, before the deferred assignment to `first_import`. Forward iteration now matches source order.

The other consumers of `first_import` are order-independent:
- `processChunkDependencies` itself rebuilds `quick_lookup` (a hash map) from the existing list — order doesn't matter.
- `onFileDeleted`, `disconnectAndDeleteFile` walk to free edges — order doesn't matter.
- The debug assertion that scans `first_import.items` is order-independent.

So the only observable change is that `find_css` (and any future order-sensitive consumer) now sees the correct order.

## Tests

Adds two regression tests in `test/bake/dev/css.test.ts`:

1. `multiple stylesheet links preserve source order` — two unlayered stylesheets, later one should win.
2. `multiple stylesheet links preserve source order inside @layer` — same, but rules wrapped in `@layer test { ... }`.

## Notes

- The standalone bundler (`bun build`) is unaffected; it uses a different code path (`LinkerContext.findImportedFilesInCSSOrder` and friends) that already preserves order.
- I wasn't able to build Bun locally to run the tests on my machine (couldn't get the exact `clang@21` toolchain set up in the time I had), but the change is small and the fix is mechanical (single-pass linked-list reversal). Happy to iterate if the test names/style don't match the project conventions.