### PR TITLE
Fix use-after-free in FileSystemRouter.reload() with custom fileExtensions

### DIFF
--- a/src/bun.js/api/filesystem_router.zig
+++ b/src/bun.js/api/filesystem_router.zig
@@ -256,8 +256,19 @@ pub const FileSystemRouter = struct {
 
         var router = Router.init(vm.transpiler.fs, allocator, .{
             .dir = allocator.dupe(u8, this.router.config.dir) catch unreachable,
-            .extensions = allocator.dupe(string, this.router.config.extensions) catch unreachable,
-            .asset_prefix_path = this.router.config.asset_prefix_path,
+            // Deep-copy each extension string into the new arena. A shallow `dupe(string, ...)`
+            // only copies the outer slice; the inner `[]const u8` would still point into the
+            // previous arena, which is freed below — causing a use-after-free on the *next*
+            // reload() when RouteLoader compares file extensions.
+            .extensions = brk: {
+                const old = this.router.config.extensions;
+                const new = allocator.alloc(string, old.len) catch unreachable;
+                for (old, new) |ext, *out| {
+                    out.* = allocator.dupe(u8, ext) catch unreachable;
+                }
+                break :brk new;
+            },
+            .asset_prefix_path = allocator.dupe(u8, this.router.config.asset_prefix_path) catch unreachable,
         }) catch unreachable;
         router.loadRoutes(&log, root_dir_info, Resolver, &vm.transpiler.resolver, router.config.dir) catch {
             // Build the JS error before freeing the arena: `log` is backed by the arena allocator.

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -368,6 +368,46 @@ it("reload() works", () => {
   expect(router.match("/posts")!.name).toBe("/posts");
 });
 
+it("reload() preserves custom fileExtensions across multiple reloads (no use-after-free)", async () => {
+  // reload() rebuilds the router in a fresh arena and frees the old one. The extension
+  // strings must be deep-copied into the new arena; a shallow copy of the outer slice
+  // leaves the inner bytes pointing into the freed arena, so the *second* reload() reads
+  // freed memory when RouteLoader compares file extensions. Run in a subprocess so an
+  // ASAN crash doesn't take down the test runner.
+  using dir = tempDir("fsr-reload-ext", {
+    "pages/index.tsx": "export default 1;",
+    "pages/posts.jsx": "export default 1;",
+    "pages/skip.md": "nope",
+  });
+
+  const code = /* ts */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(path.join(String(dir), "pages"))},
+      style: "nextjs",
+      fileExtensions: [".tsx", ".jsx"],
+    });
+    for (let i = 0; i < 4; i++) {
+      router.reload();
+      const routes = Object.keys(router.routes).sort();
+      if (routes.length !== 2 || routes[0] !== "/" || routes[1] !== "/posts") {
+        throw new Error("reload " + i + ": wrong routes " + JSON.stringify(routes));
+      }
+    }
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+}, 30_000);
+
 it("reload() works with new dirs/files", () => {
   const { dir } = make(["posts.tsx"]);
 


### PR DESCRIPTION
## Repro

```js
const r = new Bun.FileSystemRouter({
  dir: './pages',
  style: 'nextjs',
  fileExtensions: ['.tsx', '.jsx'],
});
r.reload();
r.reload();  // ASAN: use-after-poison in strings.eql at router.zig:443
```

## Cause

`reload()` creates a fresh arena, copies the router config into it, then frees the old arena. The `extensions` array was copied with `allocator.dupe(string, this.router.config.extensions)`, which only duplicates the **outer** `[]string` — each inner `[]const u8` still points into the old arena.

After the first `reload()` frees the old arena, the inner extension bytes dangle. The second `reload()` then calls `RouteLoader.load`, which iterates `config.extensions` and does `strings.eql(extname[1..], _extname)` against freed memory.

`asset_prefix_path` had the same lifetime bug (it wasn't copied at all).

## Fix

Deep-copy each extension string into the new arena, and `dupe` `asset_prefix_path` as well.

## Verification

Without fix (ASAN debug build):
```
==3666==ERROR: AddressSanitizer: use-after-poison on address 0x7a51199e0431
    #1 string.immutable.eql src/string/immutable.zig:864
    #2 router.RouteLoader.load src/router.zig:443
    #5 bun.js.api.filesystem_router.FileSystemRouter.reload src/bun.js/api/filesystem_router.zig:262
```

With fix: all 21 tests in `test/js/bun/util/filesystem_router.test.ts` pass.