### PR TITLE
FileSystemRouter: store Windows abs_path in DirnameStore to fix MatchedRoute UAF

### DIFF
--- a/src/router/router.zig
+++ b/src/router/router.zig
@@ -40,11 +40,11 @@ pub fn init(
 }
 
 pub fn deinit(this: *Router) void {
-    if (comptime Environment.isWindows) {
-        for (this.routes.list.items(.filepath)) |abs_path| {
-            this.allocator.free(abs_path);
-        }
-    }
+    // Route strings (name, public_path, match_name, abs_path) live in the global
+    // DirnameStore on all platforms, so nothing to free here. Previously the Windows
+    // abs_path was arena-owned and freed here, but that allowed a live JS MatchedRoute
+    // to read freed memory after reload()/GC.
+    _ = this;
 }
 
 pub fn getEntryPoints(this: *const Router) []const string {
@@ -532,8 +532,8 @@ pub const Route = struct {
     full_hash: u32,
     param_count: u16,
 
-    // On windows we need to normalize this path to have forward slashes.
-    // To avoid modifying memory we do not own, allocate another buffer
+    // On windows we need to normalize this path to have forward slashes, so we
+    // store a separate DirnameStore-interned copy rather than reusing entry.abs_path.
     abs_path: if (Environment.isWindows) struct {
         path: string,
 
@@ -760,8 +760,11 @@ pub const Route = struct {
             entry.abs_path = PathString.init(abs_path_str);
         }
 
+        // Store the Windows-normalized path in DirnameStore (same as POSIX and the other
+        // route strings above). This must not be arena-backed: a JS `MatchedRoute` borrows
+        // `file_path` and can outlive the router's arena across `reload()` / GC finalize.
         const abs_path = if (comptime Environment.isWindows)
-            bun.handleOom(allocator.dupe(u8, bun.path.platformToPosixBuf(u8, abs_path_str, &route_bufs.get().normalized_abs_path_buf)))
+            FileSystem.DirnameStore.instance.append([]const u8, bun.path.platformToPosixBuf(u8, abs_path_str, &route_bufs.get().normalized_abs_path_buf)) catch unreachable
         else
             PathString.init(abs_path_str);
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -557,9 +557,6 @@ it("MatchedRoute.filePath survives router.reload() (no use-after-free)", async (
     });
     const index = router.match("/");
     const post = router.match("/posts/hello");
-    // Capture the expected value before the old arena is discarded.
-    const expectedIndex = index.filePath;
-    const expectedPost = post.filePath;
 
     // reload() drops the previous arena. The existing MatchedRoute objects must
     // continue to read back the same path, not freed memory.
@@ -567,12 +564,15 @@ it("MatchedRoute.filePath survives router.reload() (no use-after-free)", async (
     router.reload();
     Bun.gc(true);
 
-    for (const [m, expected] of [[index, expectedIndex], [post, expectedPost]]) {
-      if (m.filePath !== expected) throw new Error("filePath changed: " + m.filePath + " vs " + expected);
-      // src also reads file_path internally.
-      if (typeof m.src !== "string" || m.src.length === 0) throw new Error("bad src: " + m.src);
-    }
-    console.log("ok:" + index.filePath + "|" + post.filePath);
+    // MatchedRoute.filePath / .src have cache:true in the generated bindings, so the
+    // first access is what invokes the native getter and reads route.file_path. Do not
+    // touch them before reload() or the cached JSString would mask the freed read.
+    console.log(JSON.stringify({
+      indexFilePath: index.filePath,
+      postFilePath: post.filePath,
+      indexSrc: index.src,
+      postSrc: post.src,
+    }));
   `;
 
   await using proc = Bun.spawn({
@@ -583,7 +583,12 @@ it("MatchedRoute.filePath survives router.reload() (no use-after-free)", async (
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe(`ok:${pagesDir}/index.tsx|${pagesDir}/posts/[id].tsx`);
+  expect(JSON.parse(stdout)).toEqual({
+    indexFilePath: `${pagesDir}/index.tsx`,
+    postFilePath: `${pagesDir}/posts/[id].tsx`,
+    indexSrc: `https://example.com/_next/static/index.tsx`,
+    postSrc: `https://example.com/_next/static/posts/[id].tsx`,
+  });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -536,6 +536,57 @@ it("MatchedRoute.params does not leak", async () => {
   expect(exitCode).toBe(0);
 }, 60_000);
 
+it("MatchedRoute.filePath survives router.reload() (no use-after-free)", async () => {
+  // On Windows, Route.abs_path used to be allocated in the FileSystemRouter's arena.
+  // MatchedRoute borrows file_path without owning it, so reload() (which replaces the
+  // arena) left the live MatchedRoute pointing at freed memory. POSIX was unaffected
+  // because abs_path lives in the global DirnameStore; Windows now does the same.
+  // Run in a subprocess so an ASAN crash doesn't take down the test runner.
+  using dir = tempDir("fsr-match-reload", {
+    "pages/index.tsx": "export default 1;",
+    "pages/posts/[id].tsx": "export default 1;",
+  });
+  const pagesDir = path.join(String(dir), "pages").replaceAll("\\", "/");
+
+  const code = /* ts */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(pagesDir)},
+      style: "nextjs",
+      assetPrefix: "/_next/static/",
+      origin: "https://example.com",
+    });
+    const index = router.match("/");
+    const post = router.match("/posts/hello");
+    // Capture the expected value before the old arena is discarded.
+    const expectedIndex = index.filePath;
+    const expectedPost = post.filePath;
+
+    // reload() drops the previous arena. The existing MatchedRoute objects must
+    // continue to read back the same path, not freed memory.
+    router.reload();
+    router.reload();
+    Bun.gc(true);
+
+    for (const [m, expected] of [[index, expectedIndex], [post, expectedPost]]) {
+      if (m.filePath !== expected) throw new Error("filePath changed: " + m.filePath + " vs " + expected);
+      // src also reads file_path internally.
+      if (typeof m.src !== "string" || m.src.length === 0) throw new Error("bad src: " + m.src);
+    }
+    console.log("ok:" + index.filePath + "|" + post.filePath);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe(`ok:${pagesDir}/index.tsx|${pagesDir}/posts/[id].tsx`);
+  expect(exitCode).toBe(0);
+});
+
 it("throws a clean error for invalid route filenames (no use-after-free)", async () => {
   // The constructor's log is backed by an arena allocator. When route loading
   // produces errors (e.g. a filename like `[foo.tsx` missing its closing bracket),


### PR DESCRIPTION
## Repro (Windows only)

```js
const r = new Bun.FileSystemRouter({ dir: './pages', style: 'nextjs' });
const m = r.match('/foo');
r.reload();            // or: drop `r` and Bun.gc(true)
console.log(m.filePath);   // reads freed arena memory
```

## Cause

On Windows, `Route.parse` normalizes `abs_path` to forward slashes and dupes the result into the **arena allocator** passed from `FileSystemRouter`:

```zig
// router.zig:762
const abs_path = if (comptime Environment.isWindows)
    bun.handleOom(allocator.dupe(u8, bun.path.platformToPosixBuf(...)))  // arena-owned
else
    PathString.init(abs_path_str);  // DirnameStore-owned
```

`matchPageWithAllocator` returns a `Match` whose `.file_path = route.abs_path.slice()`. `MatchedRoute.init` copies that `Match` by value and refs `origin`/`asset_prefix`/`base_dir`, but takes no reference on the router's arena and does not dupe `file_path`.

`reload()` then calls `this.arena.deinit()` (and `Router.deinit()` explicitly frees the Windows paths), freeing the bytes while the JS `MatchedRoute` is still alive. `MatchedRoute.getFilePath` and `getScriptSrc` subsequently read freed memory.

POSIX is unaffected because `abs_path_str` already lives in the global `DirnameStore` (router.zig:757).

## Fix

Store the Windows-normalized path in `FileSystem.DirnameStore.instance` — same as POSIX, and same as `name`/`public_path`/`match_name` in the same function. The per-route string now has process lifetime on both platforms, so a `MatchedRoute` can safely outlive its router's arena. The now-dead free loop in `Router.deinit()` is removed.

## Verification

- `bun run zig:check-all` passes on all targets including `x86_64-windows` / `aarch64-windows`.
- All 21 tests in `test/js/bun/util/filesystem_router.test.ts` pass on the debug build.
- New test `MatchedRoute.filePath survives router.reload()` matches a route, calls `reload()` twice, forces GC, then reads `.filePath` / `.src` from the pre-reload `MatchedRoute` in a subprocess. On Windows without the fix this trips ASAN; on POSIX it documents the expected behavior (already correct there).