### PR TITLE
HTMLRewriter: detach attribute iterators when element handler returns

### DIFF
--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -1721,16 +1721,26 @@ pub const Element = struct {
         this.deref();
     }
 
+    /// Detach every `AttributeIterator` we handed to JS. Called when the
+    /// underlying attribute buffer is about to become invalid — either
+    /// because the handler is returning, or because `setAttribute` /
+    /// `removeAttribute` is about to mutate the `Vec<Attribute>` the
+    /// iterators borrow from.
+    fn detachAttributeIterators(this: *Element) void {
+        for (this.attribute_iterators.items) |iter| {
+            iter.detach();
+            iter.deref();
+        }
+        this.attribute_iterators.clearRetainingCapacity();
+    }
+
     /// Called by `HandlerCallback` when the handler returns. The underlying
     /// `*LOLHTML.Element` (and the attribute buffer any `AttributeIterator`
     /// borrows from) is only valid during handler execution, so we must null
     /// it out here along with any iterators we handed to JS.
     pub fn invalidate(this: *Element) void {
         this.element = null;
-        for (this.attribute_iterators.items) |iter| {
-            iter.detach();
-            iter.deref();
-        }
+        this.detachAttributeIterators();
         this.attribute_iterators.clearAndFree(bun.default_allocator);
     }
 
@@ -1796,6 +1806,10 @@ pub const Element = struct {
         if (this.element == null)
             return .js_undefined;
 
+        // Mutating the attribute Vec (push → possible realloc) invalidates
+        // the slice::Iter any live AttributeIterator borrows from.
+        this.detachAttributeIterators();
+
         var name_slice = name_.toSlice(bun.default_allocator);
         defer name_slice.deinit();
 
@@ -1809,6 +1823,10 @@ pub const Element = struct {
     pub fn removeAttribute_(this: *Element, callFrame: *jsc.CallFrame, globalObject: *JSGlobalObject, name: ZigString) JSValue {
         if (this.element == null)
             return .js_undefined;
+
+        // Vec::remove shifts trailing elements and shrinks len, leaving any
+        // live slice::Iter's end pointer past the new end.
+        this.detachAttributeIterators();
 
         var name_slice = name.toSlice(bun.default_allocator);
         defer name_slice.deinit();

--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -908,7 +908,14 @@ fn HandlerCallback(
             // The init values are handled by bun.new with .init()
 
             defer {
-                @field(wrapper, field_name) = null;
+                if (comptime @hasDecl(ZigType, "invalidate")) {
+                    // Some wrapper types (Element) hand out sub-objects that
+                    // borrow from the underlying lol-html value and must be
+                    // detached along with the wrapper itself.
+                    wrapper.invalidate();
+                } else {
+                    @field(wrapper, field_name) = null;
+                }
                 wrapper.deref();
             }
 
@@ -1692,6 +1699,11 @@ pub const Element = struct {
 
     ref_count: RefCount,
     element: ?*LOLHTML.Element = null,
+    /// AttributeIterator instances created by `getAttributes()` that borrow
+    /// from `element`. They must be detached in `invalidate()` when the
+    /// handler returns so that JS cannot dereference the freed lol-html
+    /// attribute buffer.
+    attribute_iterators: std.ArrayListUnmanaged(*AttributeIterator) = .{},
 
     pub const js = jsc.Codegen.JSElement;
     pub const toJS = js.toJS;
@@ -1709,8 +1721,21 @@ pub const Element = struct {
         this.deref();
     }
 
-    fn deinit(this: *Element) void {
+    /// Called by `HandlerCallback` when the handler returns. The underlying
+    /// `*LOLHTML.Element` (and the attribute buffer any `AttributeIterator`
+    /// borrows from) is only valid during handler execution, so we must null
+    /// it out here along with any iterators we handed to JS.
+    pub fn invalidate(this: *Element) void {
         this.element = null;
+        for (this.attribute_iterators.items) |iter| {
+            iter.detach();
+            iter.deref();
+        }
+        this.attribute_iterators.clearAndFree(bun.default_allocator);
+    }
+
+    fn deinit(this: *Element) void {
+        this.invalidate();
         bun.destroy(this);
     }
 
@@ -1964,6 +1989,12 @@ pub const Element = struct {
             .ref_count = .init(),
             .iterator = iter,
         });
+        // Track this iterator so we can detach it when the handler returns.
+        // lol-html's attribute iterator borrows from the element's attribute
+        // buffer which is freed after the callback; leaking the iterator to
+        // JS without detaching it would be a use-after-free.
+        attr_iter.ref();
+        bun.handleOom(this.attribute_iterators.append(bun.default_allocator, attr_iter));
         return attr_iter.toJS(globalObject);
     }
 };

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -189,6 +189,41 @@ describe("HTMLRewriter", () => {
     expect(expected.length).toBe(0);
   });
 
+  it("attribute iterator is detached after handler returns", async () => {
+    // The lol-html attribute iterator borrows from the element's attribute
+    // buffer, which is freed when the handler returns. Previously we leaked
+    // the raw iterator pointer to JS, so calling .next() after the transform
+    // read freed memory. Now the iterator is detached and reports done.
+    let leaked;
+    let partiallyConsumed;
+    const inside = [];
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          // A fresh iterator leaked without being touched.
+          leaked = el.attributes;
+          // A second iterator fully consumed inside the handler must still work.
+          for (const pair of el.attributes) inside.push(pair);
+          // A third iterator partially consumed then leaked.
+          partiallyConsumed = el.attributes;
+          partiallyConsumed.next();
+        },
+      })
+      .transform(new Response('<div a="1" b="2" c="3"></div>'))
+      .text();
+
+    expect(inside).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
+
+    expect(leaked.next()).toEqual({ done: true, value: undefined });
+    expect(partiallyConsumed.next()).toEqual({ done: true, value: undefined });
+    // for..of over a detached iterator should simply not iterate.
+    expect([...leaked]).toEqual([]);
+  });
+
   it("handles element specific mutations", async () => {
     // prepend/append
     let res = new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -224,6 +224,38 @@ describe("HTMLRewriter", () => {
     expect([...leaked]).toEqual([]);
   });
 
+  it("attribute iterator is detached when attributes are mutated", async () => {
+    // setAttribute pushes onto the backing Vec<Attribute> (possible realloc);
+    // removeAttribute shifts elements. Either invalidates a live slice::Iter.
+    let afterSet, afterRemove;
+    let fresh = [];
+    await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          const it1 = el.attributes;
+          el.setAttribute("x", "9");
+          afterSet = it1.next();
+
+          const it2 = el.attributes;
+          el.removeAttribute("a");
+          afterRemove = it2.next();
+
+          // An iterator obtained after the mutations still sees the final state.
+          fresh = [...el.attributes];
+        },
+      })
+      .transform(new Response('<div a="1" b="2" c="3"></div>'))
+      .text();
+
+    expect(afterSet).toEqual({ done: true, value: undefined });
+    expect(afterRemove).toEqual({ done: true, value: undefined });
+    expect(fresh).toEqual([
+      ["b", "2"],
+      ["c", "3"],
+      ["x", "9"],
+    ]);
+  });
+
   it("handles element specific mutations", async () => {
     // prepend/append
     let res = new HTMLRewriter()


### PR DESCRIPTION
## Problem

`Element.prototype.attributes` returns an `AttributeIterator` wrapping a raw `lol_html_attributes_iterator_t*`. From [`lol_html.h`](https://github.com/cloudflare/lol-html/blob/main/c-api/include/lol_html.h):

> WARNING: The iterator is valid only during the handler execution and should never be leaked outside of it.

The underlying Rust type is `Box<slice::Iter<Attribute>>`, borrowing from the element's `Vec<Attribute>` which is dropped after the C callback returns. `HandlerCallback` nulled `wrapper.element` on return but never touched the separately-allocated `AttributeIterator.iterator` pointer, so JS could keep calling `.next()` on it and read freed memory.

## Repro

```js
let saved;
await new HTMLRewriter()
  .on("div", { element(el) { saved = el.attributes; } })
  .transform(new Response('<div a="1" b="2" c="3"></div>'))
  .text();
saved.next(); // reads freed Vec<Attribute> — returns {done:false, value:["a","1"]} from stale heap
```

## Fix

`Element` now tracks every `AttributeIterator` it hands out in `getAttributes()` (holding a ref) and detaches them in a new `invalidate()` method that `HandlerCallback` calls when the handler returns. `detach()` frees the lol-html iterator box and nulls the pointer, so subsequent `.next()` calls return `{done: true}` instead of dereferencing a dangling pointer.

## Verification

New test in `test/js/workerd/html-rewriter.test.js` covers:
- iterator saved without being consumed → `{done: true}` after transform
- iterator partially consumed inside handler then saved → `{done: true}` after transform
- iterator fully consumed inside handler → still yields all attributes (unchanged)

Without the fix the test fails with `{done: false, value: ["a","1"]}` (freed-memory read). With the fix it passes, and all 42 existing HTMLRewriter tests still pass.