### PR TITLE
HTMLRewriter: free element.onEndTag handler after it fires

### DIFF
--- a/src/lolhtml_sys/lol_html.zig
+++ b/src/lolhtml_sys/lol_html.zig
@@ -525,7 +525,7 @@ pub const Element = opaque {
     }
     pub fn getUserData(element: *const Element, comptime Type: type) ?*Type {
         auto_disable();
-        return @as(?*Element, @ptrCast(@alignCast(lol_html_element_user_data_get(element))));
+        return @as(?*Type, @ptrCast(@alignCast(lol_html_element_user_data_get(element))));
     }
     pub fn onEndTag(element: *Element, end_tag_handler: lol_html_end_tag_handler_t, user_data: ?*anyopaque) Error!void {
         auto_disable();

--- a/src/runtime/api/html_rewriter.zig
+++ b/src/runtime/api/html_rewriter.zig
@@ -1520,13 +1520,30 @@ pub const EndTag = struct {
         callback: ?JSValue,
         global: *JSGlobalObject,
 
-        pub const onEndTag = HandlerCallback(
+        /// Unprotects the JS callback and frees this struct.
+        pub fn deinit(this: *Handler) void {
+            if (this.callback) |cb| {
+                cb.unprotect();
+                this.callback = null;
+            }
+            bun.default_allocator.destroy(this);
+        }
+
+        const callbackImpl = HandlerCallback(
             Handler,
             EndTag,
             LOLHTML.EndTag,
             "end_tag",
             "callback",
         );
+
+        /// lol-html's end tag handler is `FnOnce`: it is invoked at most once
+        /// per element and then dropped. Free ourselves after it runs so we
+        /// don't leak the heap struct and the protected JS callback.
+        pub fn onEndTag(this: *Handler, value: *LOLHTML.EndTag) bool {
+            defer this.deinit();
+            return callbackImpl(this, value);
+        }
 
         pub const onEndTagHandler = LOLHTML.DirectiveHandler(LOLHTML.EndTag, Handler, onEndTag);
     };
@@ -1759,6 +1776,16 @@ pub const Element = struct {
             return ZigString.init("Expected a function").withEncoding().toJS(globalObject);
         }
 
+        // `LOLHTML.Element.onEndTag` clears any previously-registered handler
+        // on the lol-html side. The pending `*EndTag.Handler` is stashed in
+        // the underlying element's user_data (shared across all Zig wrappers
+        // created for overlapping selectors), so fetch and drop it here to
+        // avoid leaking the struct and its protected JS callback.
+        if (this.element.?.getUserData(EndTag.Handler)) |prev| {
+            prev.deinit();
+            this.element.?.setUserData(null);
+        }
+
         const end_tag_handler = bun.handleOom(bun.default_allocator.create(EndTag.Handler));
         end_tag_handler.* = .{ .global = globalObject, .callback = function };
 
@@ -1769,6 +1796,10 @@ pub const Element = struct {
         };
 
         function.protect();
+        // Record the pending handler on the underlying element so a later
+        // `onEndTag` call (from this or another matching selector) can free
+        // it before replacing. The handler frees itself after it fires.
+        this.element.?.setUserData(end_tag_handler);
         return callFrame.this();
     }
 

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 
 // Each .on() / .onDocument() call heap-allocates an ElementHandler / DocumentHandler
@@ -79,3 +79,93 @@ test.skipIf(isDebug)(
   },
   15_000,
 );
+
+// element.onEndTag(fn) heap-allocates an EndTag.Handler and JSValueProtect()s
+// the callback, then hands both to lol-html as opaque user_data. lol-html's
+// end-tag handler is FnOnce — it fires at most once and is then dropped —
+// but nothing ever freed the Zig allocation or unprotected the callback.
+// Calling onEndTag() twice on the same element additionally leaked the first
+// allocation because LOLHTML.Element.onEndTag clears the Rust-side handler
+// list without telling us.
+//
+// Detection: protected JSValues are GC roots, so every leaked handler pins
+// one Function in heapStats().protectedObjectTypeCounts. After the fix the
+// protected-Function count returns to its pre-loop baseline; before the fix
+// it grows by exactly one per onEndTag() call.
+describe("element.onEndTag does not leak the handler allocation / protected callback", () => {
+  async function run(setup: string) {
+    const code = /* js */ `
+      const { heapStats } = require("bun:jsc");
+      const protectedFns = () => heapStats().protectedObjectTypeCounts.Function ?? 0;
+
+      ${setup}
+
+      async function pass(n) {
+        for (let i = 0; i < n; i++) {
+          await rw.transform(new Response("<div></div>")).text();
+        }
+        Bun.gc(true);
+        return protectedFns();
+      }
+
+      // Warm up so baseline reflects any steady-state roots.
+      await pass(10);
+      const before = await pass(10);
+      const after = await pass(500);
+
+      process.stdout.write(JSON.stringify({ before, after, delta: after - before }) + "\\n");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(line => !line.startsWith("WARNING: ASAN interferes"))
+      .join("\n")
+      .trim();
+    expect(filteredStderr).toBe("");
+    const { delta } = JSON.parse(stdout.trim());
+
+    // Unfixed: delta == 500 per onEndTag() call per iteration. Fixed: 0.
+    // Allow a little slack for unrelated protected functions.
+    expect(delta).toBeLessThan(10);
+    expect(exitCode).toBe(0);
+  }
+
+  test("single registration", async () => {
+    await run(`
+      const rw = new HTMLRewriter().on("div", {
+        element(el) { el.onEndTag(() => {}); },
+      });
+    `);
+  });
+
+  test("re-registration on the same element", async () => {
+    await run(`
+      const rw = new HTMLRewriter().on("div", {
+        element(el) {
+          el.onEndTag(() => {});
+          el.onEndTag(() => {});
+        },
+      });
+    `);
+  });
+
+  // Each matching selector gets its own Zig Element wrapper around the same
+  // underlying lol-html element; the second wrapper's onEndTag must still be
+  // able to find and free the first wrapper's handler.
+  test("re-registration across overlapping selectors", async () => {
+    await run(`
+      const rw = new HTMLRewriter()
+        .on("div", { element(el) { el.onEndTag(() => {}); } })
+        .on("*",   { element(el) { el.onEndTag(() => {}); } });
+    `);
+  });
+});


### PR DESCRIPTION
## What

`element.onEndTag(fn)` leaked one heap-allocated `EndTag.Handler` struct and one `JSValueProtect()`'d callback per call, forever.

## Repro

```js
const rw = new HTMLRewriter().on("div", { element(el) { el.onEndTag(() => {}); } });
for (let i = 0; i < 1e6; i++) await rw.transform(new Response("<div></div>")).text();
// 1M EndTag.Handler structs + 1M permanently GC-rooted closures that Bun.gc(true) cannot reclaim.
```

## Cause

`onEndTag_` ([html_rewriter.zig](https://github.com/oven-sh/bun/blob/main/src/bun.js/api/html_rewriter.zig)) does:

```zig
const end_tag_handler = bun.default_allocator.create(EndTag.Handler);
end_tag_handler.* = .{ .global = globalObject, .callback = function };
this.element.?.onEndTag(EndTag.Handler.onEndTagHandler, end_tag_handler) catch { ... };
function.protect();
```

The `*EndTag.Handler` is passed to `lol_html_element_add_end_tag_handler` as opaque `user_data`, captured by-value into a Rust `Box<dyn FnOnce>`. lol-html drops the closure after the end tag fires (or when the rewriter is torn down), but dropping a raw pointer is a no-op — nothing ever called `bun.default_allocator.destroy(end_tag_handler)` or `function.unprotect()`.

`LOLHTML.Element.onEndTag` also calls `lol_html_element_clear_end_tag_handlers` first, so re-registering — either from the same element callback or from a second overlapping selector on the same start tag — silently discarded the previous Rust closure while the previous Zig struct + protected JSValue leaked.

## Fix

- lol-html's end-tag handler is `FnOnce`; wrap the callback so the handler `deinit()`s itself (unprotect + destroy) after it runs.
- Stash the pending `*EndTag.Handler` in the underlying `*LOLHTML.Element`'s user_data slot. That slot is shared across every Zig `Element` wrapper created for the same start tag (one per matching selector), so a subsequent `onEndTag` call from any wrapper can find and free the previous allocation before `clear_end_tag_handlers` drops its closure.
- Fixes the return type of `LOLHTML.Element.getUserData` (was `?*Element` instead of `?*Type`; previously unused).

## Verification

New tests in `test/js/workerd/html-rewriter-leak.test.ts` measure `heapStats().protectedObjectTypeCounts.Function` across 500 transforms:

| | before | after |
|---|---|---|
| single `onEndTag` | +500 | 0 |
| double `onEndTag` (same element callback) | +1000 | 0 |
| `onEndTag` from two overlapping selectors | +1000 | 0 |

All existing HTMLRewriter tests pass. `zig:check-all` green on all targets.

Fixes #10159