### PR TITLE
fix(archive): fall back to raw pathname when UTF-8 conversion fails

### DIFF
--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1166,7 +1166,18 @@ impl FilesContext {
                 continue;
             }
 
-            let pathname = entry_ref.pathname_utf8().as_bytes();
+            // libarchive's archive_entry_pathname_utf8() returns NULL (surfaced
+            // here as an empty ZStr) when the stored name cannot be converted
+            // to UTF-8. Fall back to the raw multibyte pathname so the entry is
+            // still reachable instead of ending up under an empty key.
+            let mut pathname_z = entry_ref.pathname_utf8();
+            if pathname_z.is_empty() {
+                pathname_z = entry_ref.pathname();
+            }
+            if pathname_z.is_empty() {
+                continue;
+            }
+            let pathname = pathname_z.as_bytes();
             // Apply glob pattern filtering (supports both positive and negative patterns)
             if let Some(patterns) = &self.glob_patterns {
                 if !match_glob_patterns(patterns, pathname) {
@@ -1468,7 +1479,14 @@ fn extract_to_disk_filtered(
 
     while archive.read_next_header(&mut entry) == lib::Result::Ok {
         let entry_ref = lib::Entry::opaque_ref(entry);
-        let pathname_z = entry_ref.pathname_utf8();
+        // libarchive's archive_entry_pathname_utf8() returns NULL (surfaced
+        // here as an empty ZStr) when the stored name cannot be converted to
+        // UTF-8. Fall back to the raw multibyte pathname so the entry is still
+        // extracted instead of being silently dropped by is_safe_path("").
+        let mut pathname_z = entry_ref.pathname_utf8();
+        if pathname_z.is_empty() {
+            pathname_z = entry_ref.pathname();
+        }
         let pathname = pathname_z.as_bytes();
 
         // Validate path safety (reject absolute paths, path traversal)

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1752,4 +1752,102 @@ describe("Bun.Archive", () => {
       expect(bytes.length).toBe(uncompressedBytes.length);
     });
   });
+
+  describe("entries with non-UTF-8 pathnames", () => {
+    // libarchive's archive_entry_pathname_utf8() returns NULL when the stored
+    // pathname cannot be converted to UTF-8. Previously the Zig binding passed
+    // that NULL straight to bun.sliceTo and crashed with SIGSEGV at address 0.
+    //
+    // We build the ustar header by hand so we can put raw 0xFF 0xFE bytes
+    // (never valid UTF-8) directly into the 100-byte name field.
+    function rawUstarHeader(nameBytes: Buffer, size: number, typeflag: string, linkBytes?: Buffer): Buffer {
+      const h = Buffer.alloc(512);
+      nameBytes.copy(h, 0);
+      h.write("0000644\0", 100);
+      h.write("0000000\0", 108);
+      h.write("0000000\0", 116);
+      h.write(size.toString(8).padStart(11, "0") + "\0", 124);
+      h.write("00000000000\0", 136);
+      h.write("        ", 148);
+      h.write(typeflag, 156);
+      if (linkBytes) linkBytes.copy(h, 157);
+      h.write("ustar\0", 257);
+      h.write("00", 263);
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += h[i];
+      h.write(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+      return h;
+    }
+
+    // "foo\xff\xfe.txt" — the 0xFF 0xFE sequence is never valid UTF-8.
+    const badName = Buffer.from([0x66, 0x6f, 0x6f, 0xff, 0xfe, 0x2e, 0x74, 0x78, 0x74]);
+    const body = Buffer.from("hello");
+    const bodyPad = Buffer.alloc((512 - (body.length % 512)) % 512);
+
+    test("files() does not crash on entry whose name is not valid UTF-8", async () => {
+      const tar = new Uint8Array(
+        Buffer.concat([
+          rawUstarHeader(badName, body.length, "0"),
+          body,
+          bodyPad,
+          ustarEntry("good.txt", Buffer.from("world")),
+          Buffer.alloc(1024),
+        ]),
+      );
+
+      const archive = new Bun.Archive(tar);
+      const files = await archive.files();
+      expect(files).toBeInstanceOf(Map);
+      expect(files.size).toBe(2);
+      // The well-formed entry must survive regardless of how the bad entry is handled.
+      expect(await files.get("good.txt")!.text()).toBe("world");
+      // The bad entry must be surfaced under the raw bytes libarchive hands
+      // back, not under an empty key (which is what happens when
+      // archive_entry_pathname_utf8() returns NULL and no fallback is applied).
+      const badKey = [...files.keys()].find(k => k !== "good.txt");
+      expect(badKey).toBeDefined();
+      expect(badKey).not.toBe("");
+      expect(badKey).toStartWith("foo");
+      expect(await files.get(badKey!)!.text()).toBe("hello");
+    });
+
+    test("extract() does not crash on entry whose name is not valid UTF-8", async () => {
+      const tar = new Uint8Array(
+        Buffer.concat([
+          rawUstarHeader(badName, body.length, "0"),
+          body,
+          bodyPad,
+          ustarEntry("good.txt", Buffer.from("world")),
+          Buffer.alloc(1024),
+        ]),
+      );
+
+      using dir = tempDir("archive-non-utf8-name", {});
+      const archive = new Bun.Archive(tar);
+      // Passing a glob routes through extractToDiskFiltered (the code path that
+      // previously dereferenced the null pathnameUtf8 result). It also skips
+      // entries whose file cannot be created, which matters on macOS/Windows
+      // where the filesystem rejects non-UTF-8 filenames.
+      const count = await archive.extract(String(dir), { glob: "**" });
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(await Bun.file(join(String(dir), "good.txt")).text()).toBe("world");
+    });
+
+    test("extract() does not crash on symlink entry with non-UTF-8 target", async () => {
+      // typeflag "2" = symlink, linkname field holds the target bytes.
+      const tar = new Uint8Array(
+        Buffer.concat([
+          rawUstarHeader(Buffer.from("link"), 0, "2", badName),
+          ustarEntry("good.txt", Buffer.from("world")),
+          Buffer.alloc(1024),
+        ]),
+      );
+
+      using dir = tempDir("archive-non-utf8-link", {});
+      const archive = new Bun.Archive(tar);
+      const count = await archive.extract(String(dir), { glob: "**" });
+      expect(count).toBeGreaterThanOrEqual(1);
+      expect(await Bun.file(join(String(dir), "good.txt")).text()).toBe("world");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`archive_entry_pathname_utf8()` in libarchive returns `NULL` when the stored name cannot be converted to UTF-8 — for example, a ustar header whose 100-byte name field contains raw `0xFF 0xFE` bytes. The Rust binding surfaces that as `ZStr::EMPTY`, so:

- `Bun.Archive.files()` inserted such entries under key `""` (multiple non-UTF-8 entries collide)
- `Bun.Archive.extract(dir, { glob })` silently dropped them via `is_safe_path("")`

## Fix

In `src/runtime/api/Archive.rs`, when `pathname_utf8()` yields an empty string, fall back to the raw multibyte `pathname()` so the entry is reachable under its stored bytes. The raw pathname still flows through `is_safe_path()` before any filesystem operation, so path-traversal protection is preserved.

## Verification

3 tests in `test/js/bun/archive.test.ts` build a hand-crafted ustar archive with `0xFF 0xFE` in the name/linkname fields:

- Without the fallback, the `files()` test fails: the bad entry's key is `""`
- With the fallback, the bad entry surfaces as `"foo��.txt"` (raw bytes, with `U+FFFD` substituted at JS-string conversion time)
- `bun bd test test/js/bun/archive.test.ts` → **103 pass, 0 fail**

> Note: this PR originally edited the `.zig` porting-reference files, which are no longer compiled after the Rust rewrite (#30412). Those edits were dropped; the fix is now in `Archive.rs` where it belongs.