### PR TITLE
Archive.files(): free collected entries when readData fails mid-stream

### DIFF
--- a/src/bun.js/api/Archive.zig
+++ b/src/bun.js/api/Archive.zig
@@ -770,17 +770,19 @@ const FilesContext = struct {
         fn deinit(self: *Result) void {
             switch (self.*) {
                 .libarchive_err => |s| bun.default_allocator.free(std.mem.span(s)),
-                .success => |*list| {
-                    for (list.items) |e| {
-                        bun.default_allocator.free(e.path);
-                        if (e.data.len > 0) bun.default_allocator.free(e.data);
-                    }
-                    list.deinit(bun.default_allocator);
-                },
+                .success => |*list| freeEntries(list),
                 .err => {},
             }
         }
     };
+
+    fn freeEntries(list: *FileEntryList) void {
+        for (list.items) |e| {
+            bun.default_allocator.free(e.path);
+            if (e.data.len > 0) bun.default_allocator.free(e.data);
+        }
+        list.deinit(bun.default_allocator);
+    }
 
     store: *jsc.WebCore.Blob.Store,
     glob_patterns: ?[]const []const u8,
@@ -803,13 +805,7 @@ const FilesContext = struct {
         }
 
         var entries: FileEntryList = .empty;
-        errdefer {
-            for (entries.items) |e| {
-                bun.default_allocator.free(e.path);
-                if (e.data.len > 0) bun.default_allocator.free(e.data);
-            }
-            entries.deinit(bun.default_allocator);
-        }
+        errdefer freeEntries(&entries);
 
         var entry: *lib.Archive.Entry = undefined;
         while (archive.readNextHeader(&entry) == .ok) {
@@ -832,8 +828,11 @@ const FilesContext = struct {
                 while (total_read < size) {
                     const read = archive.readData(data[total_read..]);
                     if (read < 0) {
-                        // Read error - not an allocation error, must free manually
+                        // Read error - returned as a normal Result (not a Zig error), so the
+                        // errdefer above won't fire. Free the current buffer and all previously
+                        // collected entries manually to avoid leaking them.
                         bun.default_allocator.free(data);
+                        freeEntries(&entries);
                         return if (cloneErrorString(archive)) |err| .{ .libarchive_err = err } else .{ .err = error.ReadError };
                     }
                     if (read == 0) break;

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync, readdirSync, rmSync } from "node:fs";
 import { join } from "path";
 
@@ -612,6 +612,79 @@ describe("Bun.Archive", () => {
         // Throwing is also acceptable for empty/invalid data
       }
     });
+
+    test(
+      "files() does not leak entries when readData fails mid-stream",
+      async () => {
+        // Regression test: a tarball with two valid 64KB entries followed by a third
+        // entry whose header advertises 64KB but whose data is truncated. libarchive
+        // successfully reads the first two entries (allocating path + data for each),
+        // then readData() fails on the third. The already-collected entries must be
+        // freed on that error path; previously they were leaked on every call.
+        //
+        // Each leaked iteration costs ~128KB (2 entries × 64KB data), so 1500
+        // iterations would leak ~190MB. A 64MB threshold comfortably separates
+        // "fixed" (stable RSS) from "leaking".
+        const code = /* ts */ `
+          function ustarHeader(name, size) {
+            const h = Buffer.alloc(512);
+            h.write(name, 0, 100, "utf8");
+            h.write("0000644\\0", 100);
+            h.write("0000000\\0", 108);
+            h.write("0000000\\0", 116);
+            h.write(size.toString(8).padStart(11, "0") + "\\0", 124);
+            h.write("00000000000\\0", 136);
+            h.write("        ", 148);
+            h.write("0", 156);
+            h.write("ustar\\0", 257);
+            h.write("00", 263);
+            let sum = 0;
+            for (let i = 0; i < 512; i++) sum += h[i];
+            h.write(sum.toString(8).padStart(6, "0") + "\\0 ", 148);
+            return h;
+          }
+          function ustarEntry(name, data) {
+            const pad = Buffer.alloc((512 - (data.length % 512)) % 512);
+            return Buffer.concat([ustarHeader(name, data.length), data, pad]);
+          }
+          const payload = Buffer.alloc(64 * 1024, "A");
+          const corrupt = new Uint8Array(Buffer.concat([
+            ustarEntry("file1.txt", payload),
+            ustarEntry("file2.txt", payload),
+            ustarHeader("file3.txt", 64 * 1024),
+            Buffer.alloc(100),
+          ]));
+          const archive = new Bun.Archive(corrupt);
+
+          async function once() {
+            let rejected = false;
+            try { await archive.files(); } catch { rejected = true; }
+            if (!rejected) throw new Error("expected archive.files() to reject for truncated entry");
+          }
+
+          for (let i = 0; i < 100; i++) await once();
+          Bun.gc(true);
+          const before = process.memoryUsage.rss();
+          for (let i = 0; i < 1500; i++) await once();
+          Bun.gc(true);
+          const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+          console.log("RSS growth: " + growthMB.toFixed(1) + " MB");
+          if (growthMB > 64) throw new Error("leaked " + growthMB.toFixed(1) + " MB");
+        `;
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--smol", "-e", code],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout).toContain("RSS growth:");
+        expect(exitCode).toBe(0);
+      },
+      60_000,
+    );
   });
 
   describe("path safety", () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -613,19 +613,17 @@ describe("Bun.Archive", () => {
       }
     });
 
-    test(
-      "files() does not leak entries when readData fails mid-stream",
-      async () => {
-        // Regression test: a tarball with two valid 64KB entries followed by a third
-        // entry whose header advertises 64KB but whose data is truncated. libarchive
-        // successfully reads the first two entries (allocating path + data for each),
-        // then readData() fails on the third. The already-collected entries must be
-        // freed on that error path; previously they were leaked on every call.
-        //
-        // Each leaked iteration costs ~128KB (2 entries × 64KB data), so 1500
-        // iterations would leak ~190MB. A 64MB threshold comfortably separates
-        // "fixed" (stable RSS) from "leaking".
-        const code = /* ts */ `
+    test("files() does not leak entries when readData fails mid-stream", async () => {
+      // Regression test: a tarball with two valid 64KB entries followed by a third
+      // entry whose header advertises 64KB but whose data is truncated. libarchive
+      // successfully reads the first two entries (allocating path + data for each),
+      // then readData() fails on the third. The already-collected entries must be
+      // freed on that error path; previously they were leaked on every call.
+      //
+      // Each leaked iteration costs ~128KB (2 entries × 64KB data), so 1500
+      // iterations would leak ~190MB. A 64MB threshold comfortably separates
+      // "fixed" (stable RSS) from "leaking".
+      const code = /* ts */ `
           function ustarHeader(name, size) {
             const h = Buffer.alloc(512);
             h.write(name, 0, 100, "utf8");
@@ -672,19 +670,17 @@ describe("Bun.Archive", () => {
           if (growthMB > 64) throw new Error("leaked " + growthMB.toFixed(1) + " MB");
         `;
 
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "--smol", "-e", code],
-          env: bunEnv,
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(stdout).toContain("RSS growth:");
-        expect(exitCode).toBe(0);
-      },
-      60_000,
-    );
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("RSS growth:");
+      expect(exitCode).toBe(0);
+    }, 60_000);
   });
 
   describe("path safety", () => {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -680,7 +680,7 @@ describe("Bun.Archive", () => {
       expect(stderr).toBe("");
       expect(stdout).toContain("RSS growth:");
       expect(exitCode).toBe(0);
-    }, 60_000);
+    });
   });
 
   describe("path safety", () => {


### PR DESCRIPTION
## Problem

`Bun.Archive.prototype.files()` leaks memory when `archive_read_data` fails partway through a tarball — e.g. a truncated/corrupted archive where some entries have already been successfully read before the failure.

## Repro

```js
// tar with 2 valid 64KB entries + a 3rd entry whose header
// claims 64KB but whose data is truncated to 100 bytes
const archive = new Bun.Archive(corrupt);
for (let i = 0; i < 1500; i++) {
  try { await archive.files(); } catch {}
}
// RSS grows ~192 MB (1500 × 2 entries × 64KB)
```

## Cause

In `FilesContext.run` (src/bun.js/api/Archive.zig), the local `entries` list accumulates heap-owned `FileEntry` structs (`path` + `data` both allocated with `bun.default_allocator`). It's guarded by an `errdefer` — but that only fires on a Zig error return.

When `archive.readData` returns < 0, the function returns a *normal* `Result` value (`.libarchive_err` / `.err`), which is the **success** arm of the `!Result` error union. The `errdefer` does not run, so every previously-appended entry's `path` and `data` buffers are leaked. The caller only sees the returned `Result` and has no reference to the lost list.

## Fix

Extract a `freeEntries` helper and call it on the `readData`-failure path before returning. The same helper now also backs the `errdefer` and `Result.deinit(.success)`, deduplicating three copies of the same loop.

## Verification

Regression test added to `test/js/bun/archive.test.ts` ("corrupted archives" block) — builds a tar with two valid 64KB entries followed by a truncated entry, calls `files()` 1500× in a subprocess, and asserts RSS growth stays under 64 MB.

| | RSS growth (1500 iter) | test |
|---|---|---|
| `git stash -- src/` + `bun bd test` | 226.5 MB | ❌ fail |
| `USE_SYSTEM_BUN=1 bun test` | 192.0 MB | ❌ fail |
| `bun bd test` (this branch) | < 20 MB | ✅ pass |

Full `test/js/bun/archive.test.ts`: 100 pass, 1 skip (Windows-only), 0 fail.