### PR TITLE
glob: keep Glob alive until WalkTask.then consumes the error

### DIFF
--- a/src/runtime/api/glob.zig
+++ b/src/runtime/api/glob.zig
@@ -161,7 +161,6 @@ pub const WalkTask = struct {
     }
 
     pub fn run(this: *WalkTask) void {
-        defer decrPendingActivityFlag(this.has_pending_activity);
         const result = this.walker.walk() catch |err| {
             this.err = .{ .unknown = err };
             return;
@@ -176,6 +175,10 @@ pub const WalkTask = struct {
 
     pub fn then(this: *WalkTask, promise: *jsc.JSPromise) bun.JSTerminated!void {
         defer this.deinit();
+        // The stored syscall error's path may borrow from `Glob.pattern` (see
+        // GlobWalker.zig's literal-tail statat), so keep the Glob alive via
+        // pending-activity until after `err.toJS()` has consumed it.
+        defer decrPendingActivityFlag(this.has_pending_activity);
 
         if (this.err) |err| {
             try promise.rejectWithAsyncStack(this.global, err.toJS(this.global));

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -23,7 +23,7 @@
 import { Glob, GlobScanOptions } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import fg from "fast-glob";
-import { tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles, tmpdirSync } from "harness";
 import * as fs from "node:fs";
 import * as path from "path";
 import { createTempDirectoryWithBrokenSymlinks, prepareEntries, tempFixturesDir } from "./util";
@@ -852,4 +852,54 @@ test.skipIf(process.platform === "win32")("patterns with many components", () =>
       .join("/") +
     "/*.txt";
   expect([...new Bun.Glob(sandwich).scanSync({ cwd: dir })].length).toBe(1);
+});
+
+// The literal-tail statat optimization returns an error whose `path` is a
+// slice into `Glob.pattern`. The Glob must stay alive (via hasPendingActivity)
+// until `then()` consumes that error on the JS thread — previously
+// pending-activity was dropped on the threadpool in `run()`, so GC could free
+// `Glob.pattern` before `then()` read `err.path`, causing a heap-use-after-free.
+// Skipped on Windows: relies on fstatat ENAMETOOLONG for a >255-byte component.
+test.skipIf(isWindows)("scan: error path borrowing Glob.pattern survives until promise settles", async () => {
+  const cwd = tempDirWithFiles("glob-uaf", { "placeholder.txt": "" });
+  const longName = Buffer.alloc(300, "a").toString();
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const longName = ${JSON.stringify(longName)};
+        const cwd = ${JSON.stringify(cwd)};
+        // No reference to the Glob is kept; the returned async generator
+        // closes over the internal promise only.
+        const iter = new Bun.Glob(longName).scan({ cwd, onlyFiles: false });
+        // Let the threadpool finish walk() so the (buggy) run() would have
+        // dropped pending-activity to 0.
+        Bun.sleepSync(50);
+        // With pending-activity at 0 and no JS refs, this collects the Glob
+        // and frees its pattern buffer before then() runs.
+        Bun.gc(true);
+        let caught;
+        try {
+          for await (const _ of iter) {}
+        } catch (e) {
+          caught = e;
+        }
+        if (!caught) throw new Error("expected ENAMETOOLONG from statat");
+        if (caught.path !== longName) {
+          throw new Error("err.path mismatch: " + JSON.stringify(caught.path));
+        }
+        process.stdout.write("ok " + caught.code);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok ENAMETOOLONG");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
const iter = new Bun.Glob("a".repeat(300)).scan({ cwd, onlyFiles: false });
Bun.sleepSync(50); // let threadpool finish walk()
Bun.gc(true);      // collect the Glob (no JS refs, pending-activity == 0)
for await (const _ of iter) {} // then() reads freed err.path
```

Under ASAN:
```
==ERROR: AddressSanitizer: use-after-poison ... READ of size 300
  #6 sys.Error.toSystemError          src/sys/Error.zig:284
  #7 sys.Error.toJS                   src/sys/Error.zig:324
  #8 glob.WalkTask.Err.toJS           src/bun.js/api/glob.zig:139
  #9 glob.WalkTask.then               src/bun.js/api/glob.zig:181
  #10 ConcurrentPromiseTask.runFromJS
```

## Cause

`GlobWalker` borrows `Glob.pattern` (`/// not owned by this struct`). When the literal-tail statat optimization fails with a non-ENOENT errno, it returns `e.withPath(patternSlice(walker.pattern))` — a slice directly into `Glob.pattern`. That error is stored in `WalkTask.err` by `run()` on the threadpool.

`run()` then did `defer decrPendingActivityFlag(...)`, dropping pending-activity to 0 on the threadpool before `then()` runs on the JS thread. The `scan()` builtin's async generator closes over the internal promise only, not `this`, so once `__scan` returns there are no JS references to the Glob. With pending-activity at 0 the Glob is eligible for GC; `finalize()` frees `Glob.pattern`.

When the event loop later drains the concurrent task and calls `then()`, `err.toJS()` reads `err.path` pointing into freed memory.

## Fix

Move `decrPendingActivityFlag` from `run()` to `then()` (deferred, runs after `err.toJS()` but before `this.deinit()`), so the Glob stays alive via `hasPendingActivity()` until the borrowed error path has been consumed.

## Verification

Test added to `test/js/bun/glob/scan.test.ts` using a 300-byte literal pattern to force `fstatat` → `ENAMETOOLONG` through the literal-tail path, then `sleepSync` + `gc(true)` to race collection against `then()`. Asserts the rejection's `err.path` equals the original pattern.

- Without fix (`bun bd`, ASAN): subprocess aborts with `use-after-poison` at `sys.Error.toSystemError` reading 300 bytes → test fails.
- With fix: `err.path` matches the pattern, test passes.
- All 171 tests in `scan.test.ts` pass.