### PR TITLE
websocket(proxy): don't alias body buffer after split CONNECT reply

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.zig
@@ -674,10 +674,25 @@ pub fn NewHTTPUpgradeClient(comptime ssl: bool) type {
             // Proxy tunnel established
             log("Proxy tunnel established", .{});
 
+            const remain_src = body[@as(usize, @intCast(response.bytes_read))..];
+
+            // When the CONNECT reply was split across reads, `body` is
+            // `this.body.items` and `remain_src` points into `this.body`'s
+            // backing allocation. The ws:// branch below re-enters
+            // `handleData`, which on a ShortRead of the upstream 101 response
+            // would `appendSlice` that slice back into `this.body` — an
+            // overlapping `@memcpy` (UB; "@memcpy arguments alias" panic in
+            // safe builds). Copy it out before clearing so downstream
+            // consumers see stable, non-aliased bytes.
+            var remain_owned: []u8 = &.{};
+            defer if (remain_owned.len > 0) bun.default_allocator.free(remain_owned);
+            const remain_buf: []const u8 = if (remain_src.len > 0 and this.body.items.len > 0) brk: {
+                remain_owned = bun.handleOom(bun.default_allocator.dupe(u8, remain_src));
+                break :brk remain_owned;
+            } else remain_src;
+
             // Clear the body buffer for WebSocket handshake
             this.body.clearRetainingCapacity();
-
-            const remain_buf = body[@as(usize, @intCast(response.bytes_read))..];
 
             // Safely unwrap proxy state - it must exist if we're in proxy_handshake state
             const p = if (this.proxy) |*proxy| proxy else {

--- a/test/js/web/websocket/websocket-proxy-split-connect-fixture.ts
+++ b/test/js/web/websocket/websocket-proxy-split-connect-fixture.ts
@@ -1,0 +1,120 @@
+// Repro for aliased @memcpy in WebSocketUpgradeClient.handleProxyResponse.
+//
+// When the proxy CONNECT reply is split across TCP reads, the upgrade client
+// buffers into `this.body`, so `body = this.body.items`. After parsing the
+// 200 it does `this.body.clearRetainingCapacity()` then takes
+// `remain_buf = body[bytes_read..]` — a slice into `this.body`'s retained
+// capacity — and re-enters `handleData(socket, remain_buf)`. On a ShortRead
+// of the upstream 101 response, `handleData` calls
+// `this.body.appendSlice(remain_buf)`: source and destination overlap in the
+// same allocation, which panics with "@memcpy arguments alias" in safe
+// builds (UB in release).
+//
+// This fixture plays both the CONNECT proxy and the upstream WebSocket server
+// on a single raw TCP socket so it can control exactly how the bytes are
+// chunked across reads.
+import net from "node:net";
+import crypto from "node:crypto";
+
+function computeAccept(key: string): string {
+  return crypto
+    .createHash("sha1")
+    .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+    .digest("base64");
+}
+
+const connectResponse = "HTTP/1.1 200 OK\r\n\r\n"; // 19 bytes
+// Partial 101 — enough headers to make PicoHTTP return ShortRead (no terminating
+// CRLF CRLF), and longer than the CONNECT response so the @memcpy dest[0..n]
+// overlaps src[19..19+n] in the same buffer.
+const partial101 =
+  "HTTP/1.1 101 Switching Protocols\r\n" + //
+  "Upgrade: websocket\r\n" +
+  "Connection: Upgrade\r\n";
+
+let results: string[] = [];
+
+const proxy = net.createServer(socket => {
+  socket.setNoDelay(true);
+  let phase: "connect" | "upgrade" | "done" = "connect";
+  let buf = "";
+
+  socket.on("data", chunk => {
+    buf += chunk.toString("latin1");
+
+    if (phase === "connect") {
+      if (buf.indexOf("\r\n\r\n") === -1) return;
+      buf = "";
+      phase = "upgrade";
+
+      // First chunk: partial CONNECT response → forces the client to buffer
+      // into `this.body` (ShortRead in handleProxyResponse).
+      socket.write(connectResponse.slice(0, 10));
+      // Second chunk: rest of CONNECT response + partial 101 → client parses
+      // the 200, computes remain_buf pointing into `this.body`'s storage,
+      // clears the body, sends the WS upgrade request, then re-enters
+      // handleData with the aliased remain_buf.
+      setTimeout(() => {
+        socket.write(connectResponse.slice(10) + partial101);
+      }, 20);
+      return;
+    }
+
+    if (phase === "upgrade") {
+      // Client sends the WebSocket upgrade request; wait for full headers.
+      if (buf.indexOf("\r\n\r\n") === -1) return;
+      const m = /Sec-WebSocket-Key:\s*([^\r\n]+)/i.exec(buf);
+      if (!m) {
+        socket.destroy();
+        return;
+      }
+      const accept = computeAccept(m[1].trim());
+      phase = "done";
+      buf = "";
+
+      // Finish the 101 response (the first three header lines were already
+      // sent as `partial101` trailing the CONNECT 200). After the client
+      // buffers the aliased bytes on ShortRead, this completes the parse.
+      socket.write("Sec-WebSocket-Accept: " + accept + "\r\n\r\n");
+
+      // Send a text frame "hello" so the client's onmessage fires.
+      socket.write(Uint8Array.from([0x81, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f]));
+      return;
+    }
+  });
+
+  socket.on("error", () => {});
+});
+
+await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
+const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+// Run several rounds to make the split-read land reliably even if the kernel
+// occasionally coalesces the two writes.
+for (let i = 0; i < 10; i++) {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+  // Target host/port are irrelevant — the "proxy" never dials upstream.
+  const ws = new WebSocket(`ws://127.0.0.1:1/`, {
+    // @ts-ignore Bun-specific option
+    proxy: `http://127.0.0.1:${proxyPort}`,
+  });
+  ws.onmessage = ev => resolve(String(ev.data));
+  ws.onerror = ev => reject(new Error("WebSocket error: " + (ev as any).message));
+  ws.onclose = ev => {
+    if (!ev.wasClean && ws.readyState !== WebSocket.OPEN) {
+      reject(new Error("closed before open: code=" + ev.code + " reason=" + ev.reason));
+    }
+  };
+  results.push(await promise);
+  ws.close();
+}
+
+proxy.close();
+
+if (results.every(r => r === "hello")) {
+  console.log("OK");
+  process.exit(0);
+} else {
+  console.error("unexpected results", results);
+  process.exit(1);
+}

--- a/test/js/web/websocket/websocket-proxy-split-connect.test.ts
+++ b/test/js/web/websocket/websocket-proxy-split-connect.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// When a proxy CONNECT 200 response is split across TCP reads and arrives
+// with trailing upstream bytes (the start of the 101 Switching Protocols
+// reply), handleProxyResponse computed `remain_buf` as a slice into
+// `this.body`'s retained capacity, cleared the ArrayList, then re-entered
+// handleData which appendSlice'd that aliased slice back into `this.body`
+// — "@memcpy arguments alias" panic in safe builds, UB in release.
+test("ws:// through proxy: split CONNECT reply with trailing bytes does not alias body buffer", async () => {
+  // Clear proxy env vars so `Bun__isNoProxy` doesn't bypass the explicit
+  // proxy option (CI containers set NO_PROXY=127.0.0.1 which would make the
+  // client dial the fake target directly and fail to connect).
+  const env = { ...bunEnv };
+  for (const k of ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]) delete env[k];
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "websocket-proxy-split-connect-fixture.ts")],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout).toBe("OK\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`WebSocketUpgradeClient.handleProxyResponse` aliases its own `body` ArrayList when the proxy CONNECT response is split across TCP reads **and** has trailing upstream bytes.

Flow (ws:// through HTTP proxy):
1. First chunk of `HTTP/1.1 200 …` arrives → ShortRead → buffered into `this.body`.
2. Second chunk arrives → appended, so `body = this.body.items`. CONNECT 200 parses OK.
3. `this.body.clearRetainingCapacity()` sets `items.len = 0` but keeps the backing buffer.
4. `remain_buf = body[response.bytes_read..]` — a slice **into** `this.body`'s retained capacity.
5. Re-enters `handleData(socket, remain_buf)`; `this.body.items.len == 0` so `body = data = remain_buf`.
6. Partial 101 → `error.ShortRead` → `this.body.appendSlice(bun.default_allocator, data)` where `data` aliases `this.body`'s own allocation.
7. `@memcpy` dest `this.body.items.ptr[0..n]` and src `this.body.items.ptr[bytes_read..][0..n]` overlap → UB in release, `@memcpy arguments alias` panic in safe builds.

## Fix

Compute the trailing slice **before** `clearRetainingCapacity()`, and if it points into `this.body` (i.e. we buffered), `dupe()` it to a fresh allocation that's freed on scope exit. The wss:// branch (`startProxyTLSHandshake`) was already safe since `SSLWrapper.startWithPayload` → `BIO_write` copies the bytes synchronously, but it now sees the copy too so there's no surviving reference into the cleared buffer.

## Repro / test

`test/js/web/websocket/websocket-proxy-split-connect.test.ts` runs a fixture that plays both proxy and upstream on one raw TCP socket: it sends the CONNECT 200 in two writes, the second carrying a **partial** 101 Switching Protocols (no terminating `\r\n\r\n`). On unfixed debug builds the subprocess panics:

```
[websocketupgradeclient] handleProxyResponse
[websocketupgradeclient] handleProxyResponse
[websocketupgradeclient] Proxy tunnel established
[websocketupgradeclient] onData
panic(main thread): @memcpy arguments alias
```

With the fix the WebSocket opens, receives the echoed frame, and the fixture prints `OK`.