### PR TITLE
node:zlib: re-resolve writeState buffer on each write instead of storing raw pointer

### DIFF
--- a/src/runtime/api/zlib.classes.ts
+++ b/src/runtime/api/zlib.classes.ts
@@ -10,7 +10,7 @@ function generate(name: string) {
     estimatedSize: true,
     klass: {},
     JSType: "0b11101110",
-    values: ["writeCallback", "errorCallback", "dictionary", "pendingInput", "pendingOutput"],
+    values: ["writeCallback", "errorCallback", "dictionary", "pendingInput", "pendingOutput", "writeState"],
 
     proto: {
       init: { fn: "init" },

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -24,7 +24,7 @@ bun_output::declare_scope!(zlib, hidden);
 /// Zig: `fn CompressionStream(comptime T: type) type { return struct { ... } }`
 /// This is a mixin: methods all take `this: *T` and access fields on `T`
 /// (write_in_progress, pending_close, pending_reset, closed, stream, this_value,
-/// write_result, task, poll_ref, globalThis) plus `T.js.*` codegen accessors and
+/// task, poll_ref, globalThis) plus `T.js.*` codegen accessors and
 /// `T.ref()/deref()`.
 // PORT NOTE: expressed as a marker struct + trait bound. Field accesses on
 // `T` go through the [`CompressionStreamImpl`] trait below.
@@ -225,22 +225,36 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     /// deref lives in `BackRef::get`, so callers and impls are safe.
     fn global_this(&self) -> &JSGlobalObject;
     fn stream(&self) -> &JsCell<Self::Stream>;
-    fn write_result_ptr(&self) -> Option<*mut u32>;
 
-    /// Write `(avail_out, avail_in)` into the JS-owned 2-element `Uint32Array`
-    /// (`this._writeState`). Single unsafe deref site for the set-once
-    /// `write_result: Cell<Option<NonNull<u32>>>` field so callers stay safe.
+    /// Write `(avail_out, avail_in)` into the JS-owned `Uint32Array`
+    /// (`this._writeState`).
+    ///
+    /// The typed array is cached as a JSValue (see `writeState` in
+    /// zlib.classes.ts) and its backing store is re-resolved on every call
+    /// rather than captured as a raw pointer at `init()` time: a typed array's
+    /// vector can move (FastTypedArray -> WastefulTypedArray when `.buffer` is
+    /// first accessed) or be freed entirely when the buffer is detached via
+    /// `ArrayBuffer.prototype.transfer()` / `postMessage` / `structuredClone`
+    /// transfer. Re-resolving here (plus the length check) turns a detached
+    /// `_writeState` into a safe no-op instead of a write through a stale
+    /// pointer.
     #[inline]
-    fn flush_write_result(&self) {
-        let Some(write_result) = self.write_result_ptr() else {
+    fn flush_write_result(&self, global: &JSGlobalObject, this_value: JSValue) {
+        let Some(write_state) = Self::write_state_get_cached(this_value) else {
             return;
         };
-        // SAFETY: `write_result` points at a 2-element `u32[]` owned by JS
-        // (set in each impl's `init()`); both indices are in-bounds and the
-        // backing buffer is kept alive by `this._writeState` /
-        // `_handle[owner_symbol]`.
-        let (r1, r0) = unsafe { (&mut *write_result.add(1), &mut *write_result) };
-        self.stream().with_mut(|s| s.update_write_result(r1, r0));
+        let Some(mut buf) = write_state.as_array_buffer(global) else {
+            return;
+        };
+        // A detached view reports byte_len 0 (and may carry a poisoned vector
+        // pointer), so bail out before reinterpreting the storage as u32s.
+        if buf.byte_len < 2 * core::mem::size_of::<u32>() {
+            return;
+        }
+        if let [avail_out, avail_in, ..] = buf.as_u32() {
+            self.stream()
+                .with_mut(|s| s.update_write_result(avail_in, avail_out));
+        }
     }
 
     fn poll_ref(&self) -> &JsCell<CountedKeepAlive>;
@@ -282,6 +296,7 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn pending_output_set_cached(this_value: JSValue, global: &JSGlobalObject, value: JSValue);
     fn pending_input_get_cached(this_value: JSValue) -> Option<JSValue>;
     fn pending_output_get_cached(this_value: JSValue) -> Option<JSValue>;
+    fn write_state_get_cached(this_value: JSValue) -> Option<JSValue>;
 }
 
 impl<T: CompressionStreamImpl> CompressionStream<T> {
@@ -546,7 +561,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             return;
         }
 
-        this.flush_write_result();
+        this.flush_write_result(global, this_value);
         this_value.ensure_still_alive();
 
         let write_callback: JSValue = T::write_callback_get_cached(this_value).unwrap();
@@ -697,7 +712,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
 
         this.stream().with_mut(|s| s.do_work());
         if Self::check_error(this, global_this, this_value) {
-            this.flush_write_result();
+            this.flush_write_result(global_this, this_value);
             this.write_in_progress().set(false);
         }
         // SAFETY: matching `ref_()` above. The bracketed `ref_()`/`deref()`
@@ -980,9 +995,9 @@ pub(crate) fn native_zstd(global: &JSGlobalObject) -> JSValue {
 /// comptime duck-typed `CompressionStream(T)` mixin).
 ///
 /// All three `Native{Zlib,Brotli,Zstd}` structs share the exact field layout
-/// (`global_this`, `stream`, `write_result`, `poll_ref`, `this_value`,
-/// `write_in_progress`, `pending_close`, `pending_reset`, `closed`, `task`,
-/// `ref_count`), so the macro can stamp the impls uniformly.
+/// (`global_this`, `stream`, `poll_ref`, `this_value`, `write_in_progress`,
+/// `pending_close`, `pending_reset`, `closed`, `task`, `ref_count`), so the
+/// macro can stamp the impls uniformly.
 ///
 /// `$type_name` is the C++-side class name (matches `.classes.ts`); the macro
 /// emits a `pub mod js { … }` with the cached-property accessors
@@ -1001,7 +1016,7 @@ macro_rules! __impl_compression_stream {
         /// `generate-classes.ts` for the `values:` list in `zlib.classes.ts`.
         #[allow(unused)]
         pub(crate) mod js {
-            ::bun_jsc::codegen_cached_accessors!($type_name; writeCallback, errorCallback, dictionary, pendingInput, pendingOutput);
+            ::bun_jsc::codegen_cached_accessors!($type_name; writeCallback, errorCallback, dictionary, pendingInput, pendingOutput, writeState);
         }
 
         impl $crate::node::node_zlib_binding::CompressionContext for $ctx {
@@ -1019,7 +1034,6 @@ macro_rules! __impl_compression_stream {
 
             #[inline] fn global_this(&self) -> &::bun_jsc::JSGlobalObject { self.global_this.get() }
             #[inline] fn stream(&self) -> &::bun_jsc::JsCell<Self::Stream> { &self.stream }
-            #[inline] fn write_result_ptr(&self) -> Option<*mut u32> { self.write_result.get().map(|p| p.cast::<u32>()) }
             #[inline] fn poll_ref(&self) -> &::bun_jsc::JsCell<$crate::node::node_zlib_binding::CountedKeepAlive> { &self.poll_ref }
             #[inline] fn this_value(&self) -> &::bun_jsc::JsCell<::bun_jsc::StrongOptional> { &self.this_value }
             #[inline] fn task(&self) -> &::bun_jsc::JsCell<::bun_jsc::WorkPoolTask> { &self.task }
@@ -1068,6 +1082,9 @@ macro_rules! __impl_compression_stream {
             }
             #[inline] fn pending_output_get_cached(this_value: ::bun_jsc::JSValue) -> Option<::bun_jsc::JSValue> {
                 js::pending_output_get_cached(this_value)
+            }
+            #[inline] fn write_state_get_cached(this_value: ::bun_jsc::JSValue) -> Option<::bun_jsc::JSValue> {
+                js::write_state_get_cached(this_value)
             }
         }
     };

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -85,9 +85,6 @@ mod _impl {
         // centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
-        /// Points into a JS `Uint32Array` (`this._writeState`). Kept alive because
-        /// the JS object is tied to the native handle as `_handle[owner_symbol]`.
-        pub write_result: Cell<Option<*mut u32>>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         // TODO(port): Strong on m_ctx self-ref → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
@@ -145,7 +142,6 @@ mod _impl {
                 // JSC_BORROW backref — the global outlives this m_ctx payload.
                 global_this: bun_ptr::BackRef::new(global_this),
                 stream: JsCell::new(stream),
-                write_result: Cell::new(None),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -188,11 +184,11 @@ mod _impl {
                     .throw());
             }
 
-            // this does not get gc'd because it is stored in the JS object's
-            // `this._writeState`. and the JS object is tied to the native handle
-            // as `_handle[owner_symbol]`.
-            // `flush_write_result` writes two u32s through this pointer, so the
-            // caller-supplied array must hold at least 2 elements.
+            // Cached on the JS wrapper as `writeState` and re-resolved by
+            // `flush_write_result` on every write completion; storing a raw
+            // pointer here would go stale if the typed array's backing store
+            // moves or is detached. `flush_write_result` writes two u32s, so
+            // the caller-supplied array must hold at least 2 elements.
             let write_result_value = arguments.ptr[1];
             let Some(mut write_result_buf) = write_result_value.as_array_buffer(global_this) else {
                 return Err(global_this.throw_invalid_argument_type_value(
@@ -208,8 +204,7 @@ mod _impl {
                     write_result_value,
                 ));
             }
-            let write_result_slice = write_result_buf.as_u32();
-            if write_result_slice.len() < 2 {
+            if write_result_buf.as_u32().len() < 2 {
                 return Err(global_this
                     .err(
                         ErrorCode::INVALID_ARG_VALUE,
@@ -217,7 +212,6 @@ mod _impl {
                     )
                     .throw());
             }
-            let write_result = write_result_slice.as_mut_ptr();
             let write_callback =
                 validators::validate_function(global_this, "writeCallback", arguments.ptr[2])?;
 
@@ -240,7 +234,7 @@ mod _impl {
                 ));
             }
 
-            self.write_result.set(Some(write_result));
+            js::write_state_set_cached(this_value, global_this, write_result_value);
 
             js::write_callback_set_cached(
                 this_value,

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -44,7 +44,6 @@ mod _impl {
         // centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
-        pub write_result: Cell<Option<*mut u32>>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -97,7 +96,6 @@ mod _impl {
                 // JSC_BORROW backref — the global outlives this m_ctx payload.
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
-                write_result: Cell::new(None),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -141,9 +139,11 @@ mod _impl {
                 validators::validate_int32(global, arguments.ptr[2], "memLevel", None, None)?;
             let strategy =
                 validators::validate_int32(global, arguments.ptr[3], "strategy", None, None)?;
-            // this does not get gc'd because it is stored in the JS object's `this._writeState`. and the JS object is tied to the native handle as `_handle[owner_symbol]`.
-            // `flush_write_result` writes two u32s through this pointer, so the
-            // caller-supplied array must hold at least 2 elements.
+            // Cached on the JS wrapper as `writeState` and re-resolved by
+            // `flush_write_result` on every write completion; storing a raw
+            // pointer here would go stale if the typed array's backing store
+            // moves or is detached. `flush_write_result` writes two u32s, so
+            // the caller-supplied array must hold at least 2 elements.
             let write_result_value = arguments.ptr[4];
             let Some(mut write_result_buf) = write_result_value.as_array_buffer(global) else {
                 return Err(global.throw_invalid_argument_type_value(
@@ -159,8 +159,7 @@ mod _impl {
                     write_result_value,
                 ));
             }
-            let write_result_slice = write_result_buf.as_u32();
-            if write_result_slice.len() < 2 {
+            if write_result_buf.as_u32().len() < 2 {
                 return Err(global
                     .err(
                         bun_jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -168,7 +167,6 @@ mod _impl {
                     )
                     .throw());
             }
-            let write_result = write_result_slice.as_mut_ptr();
             let write_callback =
                 validators::validate_function(global, "writeCallback", arguments.ptr[5])?;
             // Bind the ArrayBuffer view to a local so the borrowed byte_slice() outlives
@@ -191,7 +189,7 @@ mod _impl {
                 Some(dictionary_buf.byte_slice())
             };
 
-            self.write_result.set(Some(write_result));
+            js::write_state_set_cached(this_value, global, write_result_value);
             js::write_callback_set_cached(
                 this_value,
                 global,

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -42,8 +42,6 @@ mod _impl {
         // `BackRef` centralises the single unsafe deref so the trait impl is safe.
         pub global_this: bun_ptr::BackRef<JSGlobalObject>,
         pub stream: JsCell<Context>,
-        // LIFETIMES.tsv: BORROW_PARAM → Option<*mut u32> (points into JS Uint32Array backing store)
-        pub write_result: Cell<Option<*mut u32>>,
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
@@ -101,7 +99,6 @@ mod _impl {
                 // wrapper is owned by that global's heap).
                 global_this: bun_ptr::BackRef::new(global),
                 stream: JsCell::new(stream),
-                write_result: Cell::new(None),
                 poll_ref: JsCell::new(CountedKeepAlive::default()),
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
@@ -160,10 +157,12 @@ mod _impl {
                     write_state_value,
                 ));
             }
-            // `flush_write_result` writes two u32s through this pointer, so the
-            // caller-supplied array must hold at least 2 elements.
-            let write_state_slice = write_state.as_u32();
-            if write_state_slice.len() < 2 {
+            // Cached on the JS wrapper as `writeState` and re-resolved by
+            // `flush_write_result` on every write completion; storing a raw
+            // pointer here would go stale if the typed array's backing store
+            // moves or is detached. `flush_write_result` writes two u32s, so
+            // the caller-supplied array must hold at least 2 elements.
+            if write_state.as_u32().len() < 2 {
                 return Err(global
                     .err(
                         jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -171,7 +170,7 @@ mod _impl {
                     )
                     .throw());
             }
-            self.write_result.set(Some(write_state_slice.as_mut_ptr()));
+            js::write_state_set_cached(this_value, global, write_state_value);
 
             let write_js_callback =
                 validators::validate_function(global, "processCallback", process_callback_value)?;

--- a/test/js/node/zlib/zlib-writestate-detached.test.ts
+++ b/test/js/node/zlib/zlib-writestate-detached.test.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The native zlib/brotli/zstd handles receive a `Uint32Array(2)` "writeState"
+// from JS at init() time and write avail_in/avail_out back into it after every
+// write()/writeSync(). Previously the native side captured a raw `[*]u32` into
+// the typed array's backing store. If the backing ArrayBuffer was later
+// detached (transfer()/postMessage()/structuredClone transfer), the native
+// handle would keep writing through that stale pointer into memory it no
+// longer owns — a use-after-free if the transferred buffer is freed, or silent
+// corruption of whoever now owns that memory.
+//
+// These tests re-init() the handle with a writeState whose backing store is a
+// real heap ArrayBuffer (materialized before init() so the captured vector
+// points into it), transfer ownership of that storage to a separate typed
+// array, fill it with sentinels, and then perform another write. The handle
+// must not scribble over the transferred memory.
+
+const fixture = /* js */ `
+  const zlib = require("zlib");
+
+  const z = zlib.createDeflate();
+  const handle = z._handle;
+
+  // Re-init with our own writeState. Touch .buffer first so the typed array
+  // is backed by a real ArrayBuffer (WastefulTypedArray) before init()
+  // observes it; otherwise a later .buffer access would move the vector on
+  // its own.
+  const state = new Uint32Array(8);
+  void state.buffer;
+  handle.init(15, -1, 8, 0, state, () => {}, undefined);
+
+  const inBuf = Buffer.from("hello");
+  const outBuf = Buffer.alloc(1024);
+  handle.writeSync(zlib.constants.Z_NO_FLUSH, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+  if (state[0] === 0) throw new Error("sanity: writeSync did not update writeState");
+
+  // Detach: the backing store now belongs exclusively to 'stolen'.
+  const stolen = new Uint32Array(state.buffer.transfer());
+  if (state.byteLength !== 0) throw new Error("sanity: buffer not detached");
+  stolen.fill(0xdeadbeef);
+
+  // This write must not touch 'stolen'. If the handle kept a raw pointer to
+  // the original backing store, it writes avail_out/avail_in into stolen[0..1].
+  handle.writeSync(zlib.constants.Z_NO_FLUSH, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+
+  for (let i = 0; i < stolen.length; i++) {
+    if (stolen[i] !== 0xdeadbeef) {
+      console.log("CORRUPTED", i, stolen[i].toString(16));
+      process.exit(1);
+    }
+  }
+  console.log("OK");
+`;
+
+test.concurrent("zlib: writeSync does not write through stale writeState pointer after detach", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+const asyncFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const z = zlib.createDeflate();
+  const handle = z._handle;
+
+  const state = new Uint32Array(8);
+  void state.buffer;
+  let stolen;
+  handle.init(15, -1, 8, 0, state, () => {
+    // Async write completed; native has just run updateWriteResult.
+    for (let i = 0; i < stolen.length; i++) {
+      if (stolen[i] !== 0xdeadbeef) {
+        console.log("CORRUPTED", i, stolen[i].toString(16));
+        process.exit(1);
+      }
+    }
+    console.log("OK");
+    process.exit(0);
+  }, undefined);
+  handle.onerror = () => {};
+
+  stolen = new Uint32Array(state.buffer.transfer());
+  stolen.fill(0xdeadbeef);
+
+  const inBuf = Buffer.from("hello");
+  const outBuf = Buffer.alloc(1024);
+  handle.write(zlib.constants.Z_NO_FLUSH, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+`;
+
+test.concurrent("zlib: async write does not write through stale writeState pointer after detach", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", asyncFixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+const brotliFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const z = zlib.createBrotliCompress();
+  const handle = z._handle;
+
+  const state = new Uint32Array(8);
+  void state.buffer;
+  // Brotli init(params, writeResult, writeCallback)
+  const params = new Uint32Array(0);
+  handle.init(params, state, () => {});
+
+  const inBuf = Buffer.from("hello");
+  const outBuf = Buffer.alloc(1024);
+  handle.writeSync(0, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+  if (state[0] === 0) throw new Error("sanity: writeSync did not update writeState");
+
+  const stolen = new Uint32Array(state.buffer.transfer());
+  stolen.fill(0xdeadbeef);
+
+  handle.writeSync(0, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+
+  for (let i = 0; i < stolen.length; i++) {
+    if (stolen[i] !== 0xdeadbeef) {
+      console.log("CORRUPTED", i, stolen[i].toString(16));
+      process.exit(1);
+    }
+  }
+  console.log("OK");
+`;
+
+test.concurrent("brotli: writeSync does not write through stale writeState pointer after detach", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", brotliFixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+const zstdFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const z = zlib.createZstdCompress();
+  const handle = z._handle;
+
+  const state = new Uint32Array(8);
+  void state.buffer;
+  // Zstd init(initParamsArray, pledgedSrcSize, writeState, processCallback)
+  const params = new Uint32Array(0);
+  handle.init(params, undefined, state, () => {});
+
+  const inBuf = Buffer.from("hello");
+  const outBuf = Buffer.alloc(1024);
+  handle.writeSync(0, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+  if (state[0] === 0) throw new Error("sanity: writeSync did not update writeState");
+
+  const stolen = new Uint32Array(state.buffer.transfer());
+  stolen.fill(0xdeadbeef);
+
+  handle.writeSync(0, inBuf, 0, inBuf.length, outBuf, 0, outBuf.length);
+
+  for (let i = 0; i < stolen.length; i++) {
+    if (stolen[i] !== 0xdeadbeef) {
+      console.log("CORRUPTED", i, stolen[i].toString(16));
+      process.exit(1);
+    }
+  }
+  console.log("OK");
+`;
+
+test.concurrent("zstd: writeSync does not write through stale writeState pointer after detach", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", zstdFixture],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`NativeZlib`/`NativeBrotli`/`NativeZstd` capture a raw `*mut u32` into the `_writeState` `Uint32Array`'s backing store at `init()` time (`write_result: Cell<Option<*mut u32>>`) and write `avail_in`/`avail_out` through it after every `write()`/`writeSync()` (`flush_write_result`).

A typed array's vector is not a stable address:
- Accessing `.buffer` on a small `Uint32Array` migrates it from `FastTypedArray` (inline storage) to `WastefulTypedArray` (new heap allocation) — the vector moves.
- `ArrayBuffer.prototype.transfer()` / `structuredClone(..., { transfer })` / `postMessage` transfer detach the buffer entirely — the storage is now owned by someone else (or freed once they're collected).

After either, the stored pointer is stale and `flush_write_result` writes 8 bytes into memory the handle no longer owns.

## Repro

```js
const zlib = require("zlib");
const z = zlib.createDeflate();
const handle = z._handle;

const state = new Uint32Array(8);
void state.buffer; // pin to WastefulTypedArray before init() captures the vector
handle.init(15, -1, 8, 0, state, () => {}, undefined);

handle.writeSync(0, Buffer.from("hi"), 0, 2, Buffer.alloc(1024), 0, 1024);

const stolen = new Uint32Array(state.buffer.transfer()); // we now own that memory
stolen.fill(0xdeadbeef);

handle.writeSync(0, Buffer.from("hi"), 0, 2, Buffer.alloc(1024), 0, 1024);
console.log(stolen[0].toString(16)); // prints '400' — native scribbled over it
```

## Fix

- Add `writeState` to the codegen `values[]` list in `zlib.classes.ts` so the `Uint32Array` JSValue is cached on the wrapper (GC-visited), and to the `codegen_cached_accessors!` list in the `__impl_compression_stream!` macro.
- Drop the `write_result: Cell<Option<*mut u32>>` field from all three structs; `init()` now stores the JSValue via `write_state_set_cached` (keeping the existing Uint32Array/length validation).
- `flush_write_result` (called from `run_from_js_thread` and `write_sync`, always on the JS thread) re-resolves the cached JSValue → `as_array_buffer` → `as_u32()` and only writes when the buffer still has ≥ 2 elements, so a detached/migrated `_writeState` is a safe no-op instead of a wild write. A `byte_len` guard avoids reinterpreting a detached view's poisoned vector pointer.

(Originally implemented against the Zig bindings; rebased onto the Rust runtime after #30412 — the Rust port carried the same raw-pointer pattern, and the old Zig sources are no longer compiled, so the fix now targets `node_zlib_binding.rs` / `NativeZlib.rs` / `NativeBrotli.rs` / `NativeZstd.rs` only.)

## Verification

New test `test/js/node/zlib/zlib-writestate-detached.test.ts` covers zlib sync, zlib async, brotli sync, and zstd sync. Each transfers the writeState backing store to a sentinel-filled buffer and asserts the native handle does not scribble over it.

Before fix: all 4 fail (`CORRUPTED 0 400` / `3fe` — the handle writes avail_out/avail_in into the transferred buffer). After fix: all 4 pass. The rest of `test/js/node/zlib/` has an identical pass/fail set with and without this change (the only differences are the 4 new tests), and `cargo check --workspace` is clean.

Note: #28250 and the `pendingInput`/`pendingOutput` rooting added in #31221 address the in/out buffers passed to `write()`; this PR addresses the `writeState` buffer passed to `init()` — a separate stale-pointer path.
