### PR TITLE
Fix WebSocket client leak on wss:// through HTTP proxy

### DIFF
--- a/src/http/websocket_client.zig
+++ b/src/http/websocket_client.zig
@@ -144,6 +144,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             this.ref();
             defer this.deref();
 
+            const had_tunnel = this.proxy_tunnel != null;
             this.clearData();
 
             if (comptime ssl) {
@@ -151,6 +152,17 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 this.tcp.close(.normal);
             } else {
                 this.tcp.close(.failure);
+            }
+
+            // In tunnel mode tcp is .detached so close() above is a no-op and
+            // handleClose() never fires. Mirror what handleClose() does for
+            // the non-tunnel path: drop the C++ ref (if still held) via
+            // dispatchAbruptClose so e.g. ws.terminate() — which calls
+            // cancel() then sets m_connectedWebSocketKind = None, bypassing
+            // the destructor's finalize() — does not leak. When reached via
+            // fail(), outgoing_websocket is already null and this is a no-op.
+            if (had_tunnel) {
+                this.dispatchAbruptClose(ErrorCode.ended);
             }
         }
 
@@ -1044,6 +1056,12 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             len: usize,
             op: u8,
         ) callconv(.c) void {
+            // In tunnel mode, SSLWrapper.writeData() can synchronously fire
+            // onClose → ws.fail() → cancel() → clearData() and free `this`
+            // before the catch block in enqueueEncodedBytes/sendBuffer runs.
+            this.ref();
+            defer this.deref();
+
             if (!this.hasTCP() or op > 0xF) {
                 this.dispatchAbruptClose(ErrorCode.ended);
                 return;
@@ -1074,6 +1092,10 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             blob_value: jsc.JSValue,
             op: u8,
         ) callconv(.c) void {
+            // See writeBinaryData() — tunnel.write() can re-enter fail().
+            this.ref();
+            defer this.deref();
+
             if (!this.hasTCP() or op > 0xF) {
                 this.dispatchAbruptClose(ErrorCode.ended);
                 return;
@@ -1116,6 +1138,10 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
             str_: *const jsc.ZigString,
             op: u8,
         ) callconv(.c) void {
+            // See writeBinaryData() — tunnel.write() can re-enter fail().
+            this.ref();
+            defer this.deref();
+
             const str = str_.*;
             if (!this.hasTCP()) {
                 this.dispatchAbruptClose(ErrorCode.ended);
@@ -1180,6 +1206,13 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
         }
 
         pub fn close(this: *WebSocket, code: u16, reason: ?*const jsc.ZigString) callconv(.c) void {
+            // In tunnel mode, SSLWrapper.writeData() (via sendCloseWithBody →
+            // enqueueEncodedBytes → tunnel.write) can synchronously fire
+            // onClose → ws.fail() → cancel() → clearData() and free `this`
+            // before sendCloseWithBody's own clearData/dispatchClose run.
+            this.ref();
+            defer this.deref();
+
             if (!this.hasTCP())
                 return;
             const tcp = this.tcp;
@@ -1374,6 +1407,12 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
         /// Flushes any buffered plaintext data through the tunnel.
         pub fn handleTunnelWritable(this: *WebSocket) void {
             if (this.close_received) return;
+            // sendBuffer → tunnel.write() can re-enter fail() synchronously
+            // (see writeBinaryData). The tunnel ref-guards itself in
+            // onWritable() but not this struct.
+            this.ref();
+            defer this.deref();
+
             const send_buf = this.send_buffer.readableSlice(0);
             if (send_buf.len == 0) return;
             _ = this.sendBuffer(send_buf);

--- a/src/http/websocket_client.zig
+++ b/src/http/websocket_client.zig
@@ -126,11 +126,24 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 tunnel.clearConnectedWebSocket();
                 tunnel.shutdown();
                 tunnel.deref();
+                // Release the I/O-layer ref taken in initWithTunnel() — the
+                // tunnel was this struct's socket-equivalent owner. In the
+                // non-tunnel path this same ref is released by handleClose()
+                // when the adopted uSockets socket fires its close event, but
+                // tunnel mode never adopts a socket so that callback never runs.
+                // Callers that touch `this` after clearData() must hold a local
+                // ref guard (see cancel/finalize).
+                this.deref();
             }
         }
 
         pub fn cancel(this: *WebSocket) callconv(.c) void {
             log("cancel", .{});
+            // clearData() may drop the tunnel's I/O-layer ref; keep `this`
+            // alive until we've finished closing the socket below.
+            this.ref();
+            defer this.deref();
+
             this.clearData();
 
             if (comptime ssl) {
@@ -1302,6 +1315,11 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
         ) callconv(.c) ?*anyopaque {
             const tunnel: *WebSocketProxyTunnel = @ptrCast(@alignCast(tunnel_ptr));
 
+            // ref_count starts at 1: this is the I/O-layer ref, owned by the
+            // tunnel connection (analogous to the adopted-socket ref in init()
+            // that handleClose() releases). It is released in clearData() when
+            // proxy_tunnel is detached. The ws.ref() below adds the C++ ref
+            // paired with m_connectedWebSocket.
             var ws = bun.new(WebSocket, .{
                 .ref_count = .init(),
                 .tcp = .{ .socket = .{ .detached = {} } }, // No direct socket - using tunnel
@@ -1363,6 +1381,12 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
 
         pub fn finalize(this: *WebSocket) callconv(.c) void {
             log("finalize", .{});
+            // clearData() may drop the tunnel's I/O-layer ref and the block
+            // below drops the C++ ref; keep `this` alive until we've finished
+            // the tcp close check.
+            this.ref();
+            defer this.deref();
+
             this.clearData();
 
             // This is only called by outgoing_websocket.

--- a/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
@@ -1,0 +1,145 @@
+// Repro for NewWebSocketClient(false) leak on wss:// through an HTTP CONNECT
+// proxy (tunnel mode). initWithTunnel() starts the struct at ref_count=1 (the
+// I/O-layer ref, analogous to the adopted-socket ref in the non-tunnel path)
+// and then ws.ref() brings it to 2 for C++'s m_connectedWebSocket. Only the
+// C++ ref was ever released (dispatchClose / dispatchAbruptClose / finalize);
+// nothing dropped the I/O ref because tcp is .detached so handleClose() never
+// fires. Every tunnel-mode connection leaked the full WebSocket client struct
+// (send/receive FIFOs + deflate state + poll_ref).
+//
+// The wss:// endpoint and CONNECT proxy run in-process on node:net/tls so
+// everything stays single-threaded — using Bun.serve here races the debug
+// scoped logger's per-scope mutex against the server's own allocations and
+// sporadically deadlocks the fixture.
+//
+// Runs under BUN_DEBUG_alloc=1 so the test can count
+//   new(…NewWebSocketClient(…))   vs   destroy(…NewWebSocketClient(…))
+// emitted by `bun.new`/`bun.destroy` on debug builds.
+import net from "node:net";
+import tls from "node:tls";
+import crypto from "node:crypto";
+import { tls as tlsCerts } from "../../../harness";
+
+// Minimal wss:// endpoint: completes the RFC 6455 handshake, echoes the
+// client's close frame (unmasked) so the clean-close path runs end-to-end,
+// and idles otherwise.
+const wss = tls.createServer({ cert: tlsCerts.cert, key: tlsCerts.key }, sock => {
+  let buf = Buffer.alloc(0);
+  let upgraded = false;
+  sock.on("data", chunk => {
+    buf = Buffer.concat([buf, chunk]);
+    if (!upgraded) {
+      const end = buf.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const head = buf.subarray(0, end).toString("latin1");
+      const m = /Sec-WebSocket-Key:\s*([A-Za-z0-9+/=]+)/i.exec(head);
+      if (!m) {
+        sock.destroy();
+        return;
+      }
+      const accept = crypto
+        .createHash("sha1")
+        .update(m[1] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+        .digest("base64");
+      sock.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Accept: ${accept}\r\n` +
+          "\r\n",
+      );
+      upgraded = true;
+      buf = buf.subarray(end + 4);
+      if (buf.length === 0) return;
+    }
+    // Upgraded: look for a masked client close frame (FIN + opcode 0x8,
+    // mask bit set) and reply with an unmasked server close so the client's
+    // sendCloseWithBody → clearData → dispatchClose path runs.
+    if (buf.length >= 2 && (buf[0] & 0x0f) === 0x8 && buf[1] & 0x80) {
+      const payloadLen = buf[1] & 0x7f;
+      if (buf.length >= 2 + 4 + payloadLen) {
+        const mask = buf.subarray(2, 6);
+        const payload = Buffer.from(buf.subarray(6, 6 + payloadLen));
+        for (let i = 0; i < payload.length; i++) payload[i] ^= mask[i % 4];
+        const reply = Buffer.alloc(2 + payloadLen);
+        reply[0] = 0x88; // FIN + Close
+        reply[1] = payloadLen; // no mask from server
+        payload.copy(reply, 2);
+        sock.write(reply);
+        sock.end();
+      }
+    }
+  });
+  sock.on("error", () => {});
+});
+await new Promise<void>(r => wss.listen(0, "127.0.0.1", () => r()));
+const wssPort = (wss.address() as net.AddressInfo).port;
+
+// HTTP CONNECT proxy — plain bidirectional tunnel. We also track the client
+// sockets so the abrupt-close variant can hard-close them.
+const clientSockets: net.Socket[] = [];
+const proxy = net.createServer(clientSocket => {
+  clientSockets.push(clientSocket);
+  let buf = Buffer.alloc(0);
+  let serverSocket: net.Socket | null = null;
+  clientSocket.on("data", chunk => {
+    if (serverSocket) {
+      serverSocket.write(chunk);
+      return;
+    }
+    buf = Buffer.concat([buf, chunk]);
+    const end = buf.indexOf("\r\n\r\n");
+    if (end === -1) return;
+    const m = /^CONNECT\s+([^:]+):(\d+)\s+HTTP/.exec(buf.toString("latin1"));
+    if (!m) {
+      clientSocket.destroy();
+      return;
+    }
+    const rest = buf.subarray(end + 4);
+    serverSocket = net.createConnection({ host: m[1], port: Number(m[2]) }, () => {
+      clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (rest.length) serverSocket!.write(rest);
+      serverSocket!.on("data", d => clientSocket.write(d));
+    });
+    serverSocket.on("error", () => clientSocket.destroy());
+    serverSocket.on("close", () => clientSocket.destroy());
+    clientSocket.on("close", () => serverSocket?.destroy());
+  });
+  clientSocket.on("error", () => serverSocket?.destroy());
+});
+await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
+const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+async function roundTrip(mode: "clean" | "abrupt") {
+  const ws = new WebSocket(`wss://127.0.0.1:${wssPort}/`, {
+    // @ts-ignore Bun-specific options
+    tls: { rejectUnauthorized: false },
+    proxy: `http://127.0.0.1:${proxyPort}`,
+  });
+  const opened = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<void>();
+  ws.onopen = () => opened.resolve();
+  ws.onclose = () => closed.resolve();
+  ws.onerror = () => {};
+  await opened.promise;
+  if (mode === "clean") {
+    // Client-initiated close → sendCloseWithBody → clearData → dispatchClose.
+    ws.close();
+  } else {
+    // Proxy-socket teardown → HTTPClient.handleClose → tunnel.onClose → ws.fail
+    // → cancel → clearData.
+    for (const s of clientSockets.splice(0)) s.destroy();
+  }
+  await closed.promise;
+}
+
+// Exercise both close paths; either one leaked before the fix.
+for (let i = 0; i < 3; i++) await roundTrip("clean");
+for (let i = 0; i < 3; i++) await roundTrip("abrupt");
+
+// dispatchClose/dispatchAbruptClose fire `onclose` from inside the ref-drop
+// path; yield so the trailing deref/destroy is emitted before we exit.
+await new Promise(r => setImmediate(r));
+await new Promise(r => setImmediate(r));
+
+process.exit(0);

--- a/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
@@ -118,9 +118,18 @@ async function roundTrip(mode: "clean" | "abrupt") {
   });
   const opened = Promise.withResolvers<void>();
   const closed = Promise.withResolvers<void>();
-  ws.onopen = () => opened.resolve();
-  ws.onclose = () => closed.resolve();
-  ws.onerror = () => {};
+  let isOpen = false;
+  ws.onopen = () => {
+    isOpen = true;
+    opened.resolve();
+  };
+  ws.onclose = ev => {
+    if (!isOpen) opened.reject(new Error(`closed before open: ${ev.code} ${ev.reason}`));
+    closed.resolve();
+  };
+  ws.onerror = ev => {
+    if (!isOpen) opened.reject(new Error(`error before open: ${(ev as ErrorEvent).message ?? ev.type}`));
+  };
   await opened.promise;
   if (mode === "clean") {
     // Client-initiated close → sendCloseWithBody → clearData → dispatchClose.

--- a/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-client-leak-fixture.ts
@@ -110,7 +110,7 @@ const proxy = net.createServer(clientSocket => {
 await new Promise<void>(r => proxy.listen(0, "127.0.0.1", () => r()));
 const proxyPort = (proxy.address() as net.AddressInfo).port;
 
-async function roundTrip(mode: "clean" | "abrupt") {
+async function roundTrip(mode: "clean" | "terminate" | "abrupt") {
   const ws = new WebSocket(`wss://127.0.0.1:${wssPort}/`, {
     // @ts-ignore Bun-specific options
     tls: { rejectUnauthorized: false },
@@ -134,16 +134,29 @@ async function roundTrip(mode: "clean" | "abrupt") {
   if (mode === "clean") {
     // Client-initiated close → sendCloseWithBody → clearData → dispatchClose.
     ws.close();
+    await closed.promise;
+  } else if (mode === "terminate") {
+    // C++ WebSocket::terminate() → cancel() → clearData. terminate() then
+    // sets m_connectedWebSocketKind = None so the destructor's finalize()
+    // never runs — cancel() must drop the C++ ref itself. On the unfixed
+    // path onclose never fired, so don't block on it here; the alloc-log
+    // new/destroy count still proves the leak.
+    // @ts-ignore Bun-specific method
+    ws.terminate();
+    // Tear down the proxy side so the upgrade client's socket ref drops too.
+    for (const s of clientSockets.splice(0)) s.destroy();
+    closed.promise.catch(() => {});
   } else {
     // Proxy-socket teardown → HTTPClient.handleClose → tunnel.onClose → ws.fail
     // → cancel → clearData.
     for (const s of clientSockets.splice(0)) s.destroy();
+    await closed.promise;
   }
-  await closed.promise;
 }
 
-// Exercise both close paths; either one leaked before the fix.
+// Exercise all three close paths; each leaked before the fix.
 for (let i = 0; i < 3; i++) await roundTrip("clean");
+for (let i = 0; i < 3; i++) await roundTrip("terminate");
 for (let i = 0; i < 3; i++) await roundTrip("abrupt");
 
 // dispatchClose/dispatchAbruptClose fire `onclose` from inside the ref-drop

--- a/test/js/web/websocket/websocket-proxy-tunnel-client-leak.test.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-client-leak.test.ts
@@ -37,9 +37,11 @@ test.skipIf(!isDebug)(
     // `bun.new`/`bun.destroy` log via Output.scoped(.alloc) in debug builds:
     //   [alloc] new(http.websocket_client.NewWebSocketClient(false)) = …
     //   [alloc] destroy(http.websocket_client.NewWebSocketClient(false)) = …
+    // Tunnel mode always uses the non-TLS client (TLS is handled by the
+    // tunnel itself), so match the (false) variant explicitly.
     const lines = (stdout + stderr)
       .split("\n")
-      .filter(l => l.startsWith("[alloc] ") && l.includes("NewWebSocketClient"));
+      .filter(l => l.startsWith("[alloc] ") && l.includes("NewWebSocketClient(false)"));
     const created = lines.filter(l => l.startsWith("[alloc] new(")).length;
     const destroyed = lines.filter(l => l.startsWith("[alloc] destroy(")).length;
 

--- a/test/js/web/websocket/websocket-proxy-tunnel-client-leak.test.ts
+++ b/test/js/web/websocket/websocket-proxy-tunnel-client-leak.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import path from "node:path";
+
+// initWithTunnel() creates the WebSocket client with ref_count=1 (I/O-layer
+// ref, analogous to the adopted-socket ref that handleClose() releases in the
+// non-tunnel path) and then ws.ref() → 2 for C++'s m_connectedWebSocket. The
+// C++ ref is released by dispatchClose/dispatchAbruptClose/finalize, but
+// nothing released the I/O ref because tcp is .detached in tunnel mode so
+// handleClose() never fires. Every wss://-through-HTTP-proxy connection leaked
+// the entire NewWebSocketClient(false) struct.
+//
+// The assertion counts `[alloc] new(…NewWebSocketClient(…))` vs
+// `[alloc] destroy(…NewWebSocketClient(…))` in the alloc debug scope, which
+// is only emitted by debug builds.
+test.skipIf(!isDebug)(
+  "wss:// through HTTP proxy does not leak NewWebSocketClient",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "websocket-proxy-tunnel-client-leak-fixture.ts")],
+      env: {
+        ...bunEnv,
+        BUN_DEBUG_alloc: "1",
+        // NO_PROXY in CI environments short-circuits the explicit `proxy:` option
+        // for 127.0.0.1, so the fixture would bypass tunnel mode entirely.
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // `bun.new`/`bun.destroy` log via Output.scoped(.alloc) in debug builds:
+    //   [alloc] new(http.websocket_client.NewWebSocketClient(false)) = …
+    //   [alloc] destroy(http.websocket_client.NewWebSocketClient(false)) = …
+    const lines = (stdout + stderr)
+      .split("\n")
+      .filter(l => l.startsWith("[alloc] ") && l.includes("NewWebSocketClient"));
+    const created = lines.filter(l => l.startsWith("[alloc] new(")).length;
+    const destroyed = lines.filter(l => l.startsWith("[alloc] destroy(")).length;
+
+    // Must have exercised the tunnel path — guards against NO_PROXY or a
+    // fixture regression silently skipping the scenario.
+    expect(created).toBeGreaterThan(0);
+    expect({ created, destroyed }).toEqual({ created, destroyed: created });
+    if (exitCode !== 0) console.error(stderr);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);


### PR DESCRIPTION
## What

Fixes a per-connection memory leak of `NewWebSocketClient(false)` when connecting to `wss://` through an HTTP CONNECT proxy (tunnel mode).

## Why

`initWithTunnel()` creates the struct at `ref_count=1` and then `ws.ref()` → 2.

In the non-tunnel `init()` path, the initial ref is owned by the adopted uSockets socket and released in `handleClose()` when the socket's close event fires. In tunnel mode, `tcp` is `.detached` and no socket is ever adopted, so `handleClose()` never runs — nothing releases the initial ref.

The second ref (for C++ `m_connectedWebSocket`) *is* released by `dispatchClose` / `dispatchAbruptClose` / `finalize`, so ref_count ends at 1 and the struct (send/receive FIFOs + deflate state + poll_ref) leaks forever — one per connection.

## How

- Release the I/O-layer ref inside `clearData()`'s `proxy_tunnel` block (the single choke-point where the tunnel is detached — tunnel mode's equivalent of the socket close).
- Add `ref()/defer deref()` guards to `cancel()` and `finalize()` — the two `clearData()` callers that touch `this` afterward — so the synchronous deref can't free the struct out from under them. `handleData()` already guards itself; `HTTPClient.cancel()` in the upgrade client uses the same pattern.
- Document the ownership split in `initWithTunnel()`.

## Verification

New test `websocket-proxy-tunnel-client-leak.test.ts` runs a fixture under `BUN_DEBUG_alloc=1` and counts `[alloc] new(…NewWebSocketClient…)` vs `[alloc] destroy(…NewWebSocketClient…)` across 6 round-trips (3 client-initiated `ws.close()`, 3 proxy-socket teardowns):

- **Before:** `{ created: 6, destroyed: 0 }` → fail
- **After:** `{ created: 6, destroyed: 6 }` → pass

Existing proxy/tunnel tests (`websocket-proxy-tunnel-upgrade-leak`, `websocket-proxy-close-reentrancy`, `test-ws-bidir-proxy`, `websocket-proxy` wss-through-proxy cases) continue to pass.