### PR TITLE
node:zlib: copy dictionary into owned buffer to prevent use-after-free on detach

### DIFF
--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -115,7 +115,7 @@ mod _impl {
         pub fn estimated_size(&self) -> usize {
             // @sizeOf(@cImport(@cInclude("deflate.h")).internal_state) @ cloudflare/zlib @ 92530568d2c128b4432467b76a3b54d93d6350bd
             const INTERNAL_STATE_SIZE: usize = 3309;
-            mem::size_of::<Self>() + INTERNAL_STATE_SIZE + self.stream.get().dictionary.len()
+            mem::size_of::<Self>() + INTERNAL_STATE_SIZE
         }
 
         #[bun_jsc::host_fn(method)]
@@ -367,11 +367,13 @@ impl Context {
         };
         self.err = c::ReturnCode::Ok;
         match self.mode {
-            // SAFETY: FFI — state is an initialized deflate stream; dict_ptr/dict_len borrow a rooted ArrayBuffer.
+            // SAFETY: FFI — state is an initialized deflate stream; dict_ptr/dict_len point into
+            // `self.dictionary` (owned Box), which outlives this call.
             DEFLATE | DEFLATERAW => unsafe {
                 self.err = c::deflateSetDictionary(&raw mut self.state, dict_ptr, dict_len);
             },
-            // SAFETY: FFI — state is an initialized inflate stream; dict_ptr/dict_len borrow a rooted ArrayBuffer.
+            // SAFETY: FFI — state is an initialized inflate stream; dict_ptr/dict_len point into
+            // `self.dictionary` (owned Box), which outlives this call.
             INFLATERAW => unsafe {
                 self.err = c::inflateSetDictionary(&raw mut self.state, dict_ptr, dict_len);
             },
@@ -554,7 +556,8 @@ impl Context {
                 let dict = self.dictionary();
                 (dict.as_ptr(), u32::try_from(dict.len()).expect("int cast"))
             };
-            // SAFETY: FFI — state is an initialized inflate stream; dict is rooted.
+            // SAFETY: FFI — state is an initialized inflate stream; dict_ptr/dict_len point into
+            // `self.dictionary` (owned Box), which outlives this call.
             self.err = unsafe { c::inflateSetDictionary(&raw mut self.state, dict_ptr, dict_len) };
 
             if self.err == c::ReturnCode::Ok {

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -115,7 +115,7 @@ mod _impl {
         pub fn estimated_size(&self) -> usize {
             // @sizeOf(@cImport(@cInclude("deflate.h")).internal_state) @ cloudflare/zlib @ 92530568d2c128b4432467b76a3b54d93d6350bd
             const INTERNAL_STATE_SIZE: usize = 3309;
-            mem::size_of::<Self>() + INTERNAL_STATE_SIZE
+            mem::size_of::<Self>() + INTERNAL_STATE_SIZE + self.stream.get().dictionary.len()
         }
 
         #[bun_jsc::host_fn(method)]
@@ -198,11 +198,6 @@ mod _impl {
                 write_callback.with_async_context_if_needed(global),
             );
 
-            // Keep the dictionary alive by keeping a reference to it in the JS object.
-            if dictionary.is_some() {
-                js::dictionary_set_cached(this_value, global, arguments.ptr[6]);
-            }
-
             self.stream
                 .with_mut(|s| s.init(level, window_bits, mem_level, strategy, dictionary));
 
@@ -264,10 +259,13 @@ pub struct Context {
     pub state: c::z_stream,
     pub err: c::ReturnCode,
     pub flush: c::FlushValue,
-    // Borrows a JS ArrayBuffer kept alive via `js::dictionary_set_cached`
-    // (BACKREF/FFI class) for the lifetime of the JS wrapper, which strictly
-    // outlives this Context — `RawSlice` invariant. Default is `EMPTY`.
-    pub dictionary: bun_ptr::RawSlice<u8>,
+    // Owned copy of the user-supplied dictionary. The user's ArrayBuffer can
+    // be detached after `init()` (e.g. `ArrayBuffer.prototype.transfer()`),
+    // freeing its backing store while inflate still reads the dictionary
+    // lazily from the threadpool on `Z_NEED_DICT` (and on `reset()`), so
+    // borrowing the JS buffer would be a use-after-free. Node.js copies too
+    // (`ZlibContext::dictionary_` is a `std::vector<unsigned char>`).
+    pub dictionary: Box<[u8]>,
     pub gzip_id_bytes_read: u8,
 }
 
@@ -278,7 +276,7 @@ impl Default for Context {
             state: bun_core::ffi::zeroed::<c::z_stream>(),
             err: c::ReturnCode::Ok,
             flush: c::FlushValue::NoFlush,
-            dictionary: bun_ptr::RawSlice::EMPTY,
+            dictionary: Box::default(),
             gzip_id_bytes_read: 0,
         }
     }
@@ -290,7 +288,7 @@ impl Context {
 
     #[inline]
     fn dictionary(&self) -> &[u8] {
-        self.dictionary.slice()
+        &self.dictionary
     }
 
     pub fn init(
@@ -315,10 +313,10 @@ impl Context {
             ZSTD_COMPRESS | ZSTD_DECOMPRESS => unreachable!(),
         };
 
-        // See field comment on `dictionary` — `RawSlice` invariant.
+        // See field comment on `dictionary` — copy into an owned buffer.
         self.dictionary = match dictionary {
-            Some(d) => bun_ptr::RawSlice::new(d),
-            None => bun_ptr::RawSlice::EMPTY,
+            Some(d) => Box::from(d),
+            None => Box::default(),
         };
 
         match self.mode {
@@ -625,6 +623,7 @@ impl Context {
         }
         debug_assert!(status == c::ReturnCode::Ok || status == c::ReturnCode::DataError);
         self.mode = NONE;
+        self.dictionary = Box::default();
     }
 }
 

--- a/test/js/node/zlib/zlib-dictionary-detach.test.ts
+++ b/test/js/node/zlib/zlib-dictionary-detach.test.ts
@@ -1,0 +1,167 @@
+// Regression test: node:zlib stored a raw pointer into the user-supplied
+// dictionary ArrayBuffer and read it lazily from the threadpool
+// (inflateSetDictionary on Z_NEED_DICT, and on reset()). Caching the JS view
+// does not prevent the underlying ArrayBuffer from being detached —
+// ArrayBuffer.prototype.transfer(newLength) with a different length
+// synchronously frees the old backing store, leaving the native handle with
+// a dangling pointer. Under ASAN this is a heap-use-after-free in
+// adler32()/inflateSetDictionary() on the worker thread.
+//
+// The fix copies the dictionary into an owned buffer in Context.init(),
+// matching Node.js (ZlibContext::dictionary_ is a std::vector).
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// Malloc=1 routes JSC ArrayBuffer allocations through system malloc instead
+// of bmalloc/libpas so that ASAN poisons freed ArrayBuffer backing stores.
+// Without it bmalloc keeps the freed region in its own free list and ASAN
+// never sees the UAF. bmalloc's SystemHeap is unimplemented on Windows
+// (RELEASE_BASSERT_NOT_REACHED), so skip it there — Windows CI isn't ASAN
+// anyway, and the test still verifies correctness.
+//
+// detect_leaks=0: Malloc=1 also exposes pre-existing small runtime leaks
+// (parser/transpiler allocations normally hidden behind bmalloc) to
+// LeakSanitizer, which would print them to stderr at exit. We only care
+// about the heap-use-after-free here.
+// symbolize=0: when this test is run against an unfixed build, ASAN aborts
+// and symbolizing the debug binary takes longer than the default test
+// timeout. We only care that the subprocess prints "OK" and exits 0.
+// allow_user_segv_handler=1 suppresses JSC's "ASAN interferes with JSC
+// signal handlers" stderr banner on ASAN builds where bunEnv didn't set it.
+const asanOptions = [bunEnv.ASAN_OPTIONS, "allow_user_segv_handler=1", "symbolize=0", "detect_leaks=0"]
+  .filter(Boolean)
+  .join(":");
+const env = { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }), ASAN_OPTIONS: asanOptions };
+
+const inflateFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const expected = Buffer.alloc(64, "a").toString();
+  const ab = new ArrayBuffer(4096);
+  const dict = Buffer.from(ab);
+  dict.fill("a");
+
+  // Deflate with a dictionary so the stream sets FDICT and inflate() will
+  // return Z_NEED_DICT, which triggers inflateSetDictionary() on the
+  // threadpool with the stored dictionary pointer.
+  const payload = zlib.deflateSync(Buffer.alloc(64, "a"), { dictionary: dict });
+
+  const inf = zlib.createInflate({ dictionary: dict });
+  inf.on("error", err => {
+    console.error("error:", err.message);
+    process.exitCode = 1;
+  });
+  let out = Buffer.alloc(0);
+  inf.on("data", chunk => {
+    out = Buffer.concat([out, chunk]);
+  });
+  inf.on("end", () => {
+    console.log(out.toString() === expected ? "OK" : "WRONG: " + out.toString());
+  });
+
+  // transfer() with a different length allocates a new backing, memcpy's, and
+  // synchronously frees the old backing (Gigacage::free -> system free under
+  // Malloc=1). The native zlib handle still holds a pointer into it.
+  ab.transfer(1);
+
+  inf.write(payload, () => inf.end());
+`;
+
+const resetFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const expected = Buffer.alloc(64, "a").toString();
+  const ab = new ArrayBuffer(4096);
+  const dict = Buffer.from(ab);
+  dict.fill("a");
+
+  const payload = zlib.deflateRawSync(Buffer.alloc(64, "a"), { dictionary: dict });
+
+  // INFLATERAW applies the dictionary synchronously in init(), and reset()
+  // re-applies it via setDictionary() — both read the stored pointer.
+  const inf = zlib.createInflateRaw({ dictionary: dict });
+  inf.on("error", err => {
+    console.error("error:", err.message);
+    process.exitCode = 1;
+  });
+  let out = Buffer.alloc(0);
+  inf.on("data", chunk => {
+    out = Buffer.concat([out, chunk]);
+  });
+  inf.on("end", () => {
+    console.log(out.toString() === expected ? "OK" : "WRONG: " + out.toString());
+  });
+
+  ab.transfer(1);
+
+  // reset() re-applies the dictionary from the stored (now stale) pointer.
+  inf.reset();
+  inf.write(payload, () => inf.end());
+`;
+
+const deflateResetFixture = /* js */ `
+  const zlib = require("zlib");
+
+  const expected = Buffer.alloc(64, "a").toString();
+  const ab = new ArrayBuffer(4096);
+  const dict = Buffer.from(ab);
+  dict.fill("a");
+  const dictCopy = Buffer.from(dict);
+
+  const def = zlib.createDeflate({ dictionary: dict });
+  def.on("error", err => {
+    console.error("error:", err.message);
+    process.exitCode = 1;
+  });
+  let out = Buffer.alloc(0);
+  def.on("data", chunk => {
+    out = Buffer.concat([out, chunk]);
+  });
+  def.on("end", () => {
+    const result = zlib.inflateSync(out, { dictionary: dictCopy }).toString();
+    console.log(result === expected ? "OK" : "WRONG: " + result);
+  });
+
+  ab.transfer(1);
+
+  // reset() calls deflateReset() then deflateSetDictionary() with the stored
+  // pointer on the JS thread.
+  def.reset();
+  def.end(Buffer.alloc(64, "a"));
+`;
+
+async function run(fixture: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.concurrent(
+  "inflate: detaching the dictionary ArrayBuffer after createInflate does not use-after-free",
+  async () => {
+    const { stdout, stderr, exitCode } = await run(inflateFixture);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent("inflateRaw: reset() after detaching the dictionary ArrayBuffer does not use-after-free", async () => {
+  const { stdout, stderr, exitCode } = await run(resetFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("deflate: reset() after detaching the dictionary ArrayBuffer does not use-after-free", async () => {
+  const { stdout, stderr, exitCode } = await run(deflateResetFixture);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`Context.dictionary` borrows the user-supplied dictionary ArrayBuffer's backing store (`bun_ptr::RawSlice<u8>` in `src/runtime/node/zlib/NativeZlib.rs`):

```rust
// Borrows a JS ArrayBuffer kept alive via `js::dictionary_set_cached` ...
pub dictionary: bun_ptr::RawSlice<u8>,
```

and reads it later from the threadpool in `do_work_inflate()` (when `inflate()` returns `Z_NEED_DICT`) and on `reset()` (via `set_dictionary()`).

Caching the JS view object (`js::dictionary_set_cached`) keeps the view alive but does **not** prevent the underlying ArrayBuffer from being detached. `ArrayBuffer.prototype.transfer(newLength)` with a different length reallocates and **synchronously frees** the old backing store (via `Gigacage::free` in `JSC::arrayBufferCopyAndDetach`), leaving the native handle with a dangling pointer.

## Repro

```js
const zlib = require("zlib");
const ab = new ArrayBuffer(4096);
const dict = Buffer.from(ab).fill("a");
const payload = zlib.deflateSync(Buffer.alloc(64, "a"), { dictionary: dict });
const inf = zlib.createInflate({ dictionary: dict });
ab.transfer(1);                           // frees old backing synchronously
inf.write(payload, () => inf.end());      // threadpool reads freed memory
```

Under ASAN with `Malloc=1` (routes JSC ArrayBuffer allocations through system malloc so freed regions are poisoned):

```
==ERROR: AddressSanitizer: heap-use-after-free
READ of size 64 thread (Bun Pool 0)
    #0 adler32
    #1 inflateSetDictionary vendor/zlib/inflate.c
    #2 Context::do_work_inflate src/runtime/node/zlib/NativeZlib.rs
freed by thread T0 here:
    ...
    #N JSC::arrayBufferCopyAndDetach JSArrayBufferPrototype.cpp
```

The same stale pointer is read on `reset()` for DEFLATE/DEFLATERAW/INFLATERAW (via `deflateSetDictionary`/`inflateSetDictionary`), and on the GUNZIP multi-member path which calls `reset()` from the threadpool.

## Fix

Copy the dictionary into an owned `Box<[u8]>` in `Context::init()` and drop it in `close()`, matching Node.js (where `ZlibContext::dictionary_` is a `std::vector<unsigned char>`). The JS-side cached reference is no longer load-bearing and is no longer set. `estimated_size()` now includes the owned copy.

> **Note (rebase onto the Rust rewrite):** this PR originally fixed `NativeZlib.zig`. After #30412 ("Rewrite Bun in Rust") the `.zig` files are porting references only and are not compiled — the shipped implementation `src/runtime/node/zlib/NativeZlib.rs` carries the same borrowed-slice bug. The rebase re-applies the identical fix to the Rust implementation (owned copy, freed on close) and drops the now-dead `.zig`/`zlib.classes.ts` edits. The regression test is unchanged.

## Verification

`test/js/node/zlib/zlib-dictionary-detach.test.ts` spawns subprocesses with `Malloc=1` and exercises:
- async inflate with `Z_NEED_DICT` on the threadpool
- `inflateRaw.reset()` after detach
- `deflate.reset()` after detach (also verifies the compressed output round-trips with a clean copy of the dictionary)

Before fix (`bun bd`, ASAN, at current main): all three subprocesses abort with `AddressSanitizer: heap-use-after-free`.

After fix: all pass. Existing `test-zlib-dictionary.js`, `test-zlib-dictionary-fail.js`, and the zlib test suite (minus two pre-existing brotli/zstd streaming timeouts on debug-ASAN that also fail on main) pass. `cargo clippy -p bun_runtime` and `cargo fmt` are clean.

Related but separate: #28250 (in/out buffers in `write()`, since superseded by the `pendingInput`/`pendingOutput` cached values), #30118 (`writeState` buffer in `init()`).
