### PR TITLE
webcore(FileReader): undo onStart() ref + close fd when reader.start() fails

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -71,6 +71,16 @@ export const subprocessInternals = {
   ) => boolean,
 };
 
+export const fileReaderInternals = {
+  /**
+   * Make the next lazy `Bun.file(...).stream()` start behave as if the
+   * underlying `reader.start()` call failed with EBADF. On POSIX the real
+   * `PosixBufferedReader.start()` can never return an error, so this is the
+   * only way to exercise the start-failure cleanup path outside of Windows.
+   */
+  failNextReaderStart: $newZigFunction("FileReader.zig", "TestingAPIs.failNextReaderStart", 0) as () => void,
+};
+
 export const iniInternals = {
   parse: $newZigFunction("ini.zig", "IniTestingAPIs.parse", 1),
   // loadNpmrc: (

--- a/src/runtime/webcore/FileReader.zig
+++ b/src/runtime/webcore/FileReader.zig
@@ -244,10 +244,15 @@ pub fn onStart(this: *FileReader) streams.Start {
                 // and waiting_for_onReaderDone above so finalize() can
                 // bring the ref_count to 0, and close the fd we opened in
                 // openFileBlob() if the reader didn't take ownership of it
-                // (on Windows, Source.open() can fail before wrapping the fd).
+                // (on Windows, Source.open() can fail before wrapping the
+                // fd; if it succeeded the reader owns it and reader.deinit()
+                // closes it). Check getFd() == invalid rather than != this.fd
+                // because on Windows pipe/tty sources return a .system-kind
+                // FD while this.fd is .uv-kind — same kernel object, but
+                // bit-inequal.
                 this.waiting_for_onReaderDone = false;
                 _ = this.parent().decrementCount();
-                if (this.fd != bun.invalid_fd and this.reader.getFd() != this.fd) {
+                if (this.fd != bun.invalid_fd and this.reader.getFd() == bun.invalid_fd) {
                     this.fd.close();
                 }
                 this.fd = bun.invalid_fd;

--- a/src/runtime/webcore/FileReader.zig
+++ b/src/runtime/webcore/FileReader.zig
@@ -222,20 +222,37 @@ pub fn onStart(this: *FileReader) streams.Start {
     if (was_lazy) {
         _ = this.parent().incrementCount();
         this.waiting_for_onReaderDone = true;
-        if (this.start_offset) |offset| {
-            switch (this.reader.startFileOffset(this.fd, pollable, offset)) {
-                .result => {},
-                .err => |e| {
-                    return .{ .err = e };
-                },
+
+        const start_result: bun.sys.Maybe(void) = brk: {
+            if (TestingAPIs.fail_next_reader_start) {
+                // Test-only: simulate the Windows `Source.open` failure path
+                // (PosixBufferedReader.start() can never return `.err`).
+                TestingAPIs.fail_next_reader_start = false;
+                break :brk .{ .err = .fromCode(.BADF, .open) };
             }
-        } else {
-            switch (this.reader.start(this.fd, pollable)) {
-                .result => {},
-                .err => |e| {
-                    return .{ .err = e };
-                },
+            if (this.start_offset) |offset| {
+                break :brk this.reader.startFileOffset(this.fd, pollable, offset);
             }
+            break :brk this.reader.start(this.fd, pollable);
+        };
+
+        switch (start_result) {
+            .result => {},
+            .err => |e| {
+                // reader.start() failed before registering any I/O, so
+                // onReaderDone will never fire. Undo the incrementCount()
+                // and waiting_for_onReaderDone above so finalize() can
+                // bring the ref_count to 0, and close the fd we opened in
+                // openFileBlob() if the reader didn't take ownership of it
+                // (on Windows, Source.open() can fail before wrapping the fd).
+                this.waiting_for_onReaderDone = false;
+                _ = this.parent().decrementCount();
+                if (this.fd != bun.invalid_fd and this.reader.getFd() != this.fd) {
+                    this.fd.close();
+                }
+                this.fd = bun.invalid_fd;
+                return .{ .err = e };
+            },
         }
     } else if (comptime Environment.isPosix) {
         if (this.reader.flags.pollable and !this.reader.isDone()) {
@@ -655,6 +672,21 @@ pub fn memoryCost(this: *const FileReader) usize {
     // ReadableStreamSource covers @sizeOf(FileReader)
     return this.reader.memoryCost() + this.buffered.capacity;
 }
+
+pub const TestingAPIs = struct {
+    /// One-shot flag: when true, the next `onStart()` in the `was_lazy`
+    /// branch returns an error as if `reader.start()` failed, without
+    /// actually calling it. This lets tests exercise the start-failure
+    /// cleanup path on POSIX, where `PosixBufferedReader.start()` never
+    /// returns `.err` — the real failure is Windows-only, when libuv's
+    /// `Source.open()` rejects the fd (e.g. `uv_pipe_open` failure).
+    var fail_next_reader_start: bool = false;
+
+    pub fn failNextReaderStart(_: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        fail_next_reader_start = true;
+        return .js_undefined;
+    }
+};
 
 pub const Source = ReadableStream.NewSource(
     @This(),

--- a/test/js/web/streams/file-reader-start-error.test.ts
+++ b/test/js/web/streams/file-reader-start-error.test.ts
@@ -79,13 +79,14 @@ test("FileReader releases its ref and fd when reader.start() fails", async () =>
       exitCode: 0,
     });
   }
+  expect(stderr).toBe("");
   const result = JSON.parse(stdout.trim());
 
   if (isLinux) {
     // Without the fix each iteration leaks the fd that openFileBlob()
-    // opened, so `leaked` would be ~iterations. A small amount of slack
-    // tolerates unrelated background fds (e.g. epoll, procfs dir handle).
-    expect(result.leaked).toBeLessThan(result.iterations / 2);
+    // opened, so `leaked` would equal `iterations` (50). A small constant
+    // slack tolerates unrelated background fds (e.g. procfs dir handle).
+    expect(result.leaked).toBeLessThanOrEqual(5);
   }
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/streams/file-reader-start-error.test.ts
+++ b/test/js/web/streams/file-reader-start-error.test.ts
@@ -1,0 +1,91 @@
+// On Windows, WindowsBufferedReader.start() can return `.err` when libuv's
+// Source.open() rejects the fd (e.g. uv_pipe_open failure). Before the fix,
+// FileReader.onStart() had already called incrementCount() and set
+// waiting_for_onReaderDone=true, but the early `return .{ .err = e }` left
+// both in place. Since start() failed before any I/O was registered,
+// onReaderDone never fires, so the extra ref and the fd opened by
+// openFileBlob() leak permanently (GC finalize drops ref_count to 1, never 0).
+//
+// PosixBufferedReader.start() can never return `.err`, so the test uses a
+// bun:internal-for-testing hook to force the same branch on every platform.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+
+const fixture = /* js */ `
+const { fileReaderInternals } = require("bun:internal-for-testing");
+const { writeFileSync, readdirSync } = require("fs");
+const { join } = require("path");
+
+const tmpfile = join(process.cwd(), "payload.bin");
+writeFileSync(tmpfile, "hello world");
+
+${
+  isLinux
+    ? `const countOpenFds = () => readdirSync("/proc/self/fd").length;`
+    : `const countOpenFds = () => 0; // fd counting not available on this platform`
+}
+
+async function once() {
+  fileReaderInternals.failNextReaderStart();
+  let threw = false;
+  try {
+    const stream = Bun.file(tmpfile).stream();
+    const reader = stream.getReader();
+    await reader.read();
+  } catch (e) {
+    threw = true;
+  }
+  if (!threw) throw new Error("expected stream start to fail");
+}
+
+// Warm up any lazy one-time allocations and fds.
+for (let i = 0; i < 5; i++) await once();
+Bun.gc(true);
+await Bun.sleep(0);
+Bun.gc(true);
+
+const before = countOpenFds();
+
+const iterations = 50;
+for (let i = 0; i < iterations; i++) await once();
+Bun.gc(true);
+await Bun.sleep(0);
+Bun.gc(true);
+
+const after = countOpenFds();
+console.log(JSON.stringify({ before, after, leaked: after - before, iterations }));
+`;
+
+test("FileReader releases its ref and fd when reader.start() fails", async () => {
+  using dir = tempDir("file-reader-start-error", {
+    "fixture.js": fixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (!/^\{.*\}$/.test(stdout.trim())) {
+    // Surface what the child actually printed so the failure is actionable.
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(/^\{.*\}$/),
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+  const result = JSON.parse(stdout.trim());
+
+  if (isLinux) {
+    // Without the fix each iteration leaks the fd that openFileBlob()
+    // opened, so `leaked` would be ~iterations. A small amount of slack
+    // tolerates unrelated background fds (e.g. epoll, procfs dir handle).
+    expect(result.leaked).toBeLessThan(result.iterations / 2);
+  }
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

In the `was_lazy` branch of `FileReader.onStart()`, the parent `Source` refcount is incremented and `waiting_for_onReaderDone = true` is set *before* calling `reader.start()` / `reader.startFileOffset()`. On Windows, `WindowsBufferedReader.start()` returns `.err` when `Source.open(loop, fd)` fails (e.g. `uv_pipe_open` failure, or `uv_guess_handle` returning a type we don't handle and `GetLastError` is nonzero).

The early `return .{ .err = e }` left the increment and flag in place. Because start failed before any I/O was registered, `onReaderDone` never fires; and because `reader.source` is still `null`, `reader.close()` → `closeImpl()` is a no-op and never calls `done()`. After the JS wrapper is GC'd, `finalize()` drops the refcount from 2→1, it never reaches 0, so `FileReader.deinit` never runs — the `FileReader.Source` struct and the fd opened by `openFileBlob()` both leak permanently.

Refcount trace:
- `onStart()` → `parent().incrementCount()` (1→2), `waiting_for_onReaderDone = true`
- `reader.start()` → `.err` → `return .{ .err = e }` *(nothing undone)*
- JS `finalize()` → `decrementCount()` (2→1) → stays at 1 forever

## Fix

In the `.err` branch:
- clear `waiting_for_onReaderDone` and call `decrementCount()` so the JS `finalize()` can bring it to 0
- close `this.fd` if the reader didn't take ownership of it (`reader.getFd() != this.fd` — covers the `Source.open` failure where `reader.source` is still null; if `startReading()` failed after `Source.open` succeeded the reader owns it and `reader.deinit()` closes it)

## Test

`PosixBufferedReader.start()` can never return `.err` (it always returns `.result`; poll registration errors surface via `onReaderError` instead), so there's no JS-visible way to hit this branch on Linux/macOS. A test-only `fileReaderInternals.failNextReaderStart()` hook (via `bun:internal-for-testing`) makes the next `onStart()` take the `.err` branch without calling `reader.start()`, simulating the Windows `Source.open` failure on every platform.

The test loops 50 times setting the flag, creating `Bun.file(tmpfile).stream().getReader().read()`, catching the error, then GC; and diffs `/proc/self/fd` before/after.

## Verification

```
# without the cleanup (hook present, fix reverted)
error: expect(received).toBeLessThan(expected)
Expected: < 25
Received: 50

# with the fix
(pass) FileReader releases its ref and fd when reader.start() fails
```

## Related

- #30116 fixes the sibling leak in `onReaderError` (read failure *after* start succeeds). This PR fixes the path where start itself fails *before* any I/O. They touch the same file but different functions; no overlap.
- #29440 bundles the `onReaderError` change plus several Windows `BufferedReader`/`Source` fixes. It also does not touch the `onStart()` `.err` return path.