### PR TITLE
FileSink: release keep-alive ref when a pending write errors or closes

### DIFF
--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -115,6 +115,14 @@ comptime {
 
 pub fn onAttachedProcessExit(this: *FileSink, status: *const bun.spawn.Status) void {
     log("onAttachedProcessExit()", .{});
+
+    // `writer.close()` below re-enters `onClose` which releases the
+    // keep-alive ref, and `stream.cancel`/`runPending` drain microtasks
+    // which may drop the JS wrapper's ref. Hold a local ref so `this`
+    // stays valid for the rest of this function (same pattern as `onWrite`).
+    this.ref();
+    defer this.deref();
+
     this.done = true;
     var readable_stream = this.readable_stream;
     this.readable_stream = .{};

--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -140,10 +140,9 @@ pub fn onAttachedProcessExit(this: *FileSink, status: *const bun.spawn.Status) v
     this.pending.result = .{ .err = .fromCode(.PIPE, .write) };
     this.runPending();
 
-    if (this.must_be_kept_alive_until_eof) {
-        this.must_be_kept_alive_until_eof = false;
-        this.deref();
-    }
+    // `writer.close()` → `onClose` already released this above; kept for
+    // paths where `onClose` isn't reached (e.g. writer already closed).
+    this.clearKeepAliveRef();
 }
 
 fn runPending(this: *FileSink) void {
@@ -222,11 +221,8 @@ pub fn onWrite(this: *FileSink, amount: usize, status: bun.io.WriteStatus) void 
     }
 
     if (status == .end_of_file) {
-        if (this.must_be_kept_alive_until_eof) {
-            this.must_be_kept_alive_until_eof = false;
-            this.deref();
-        }
         this.signal.close(null);
+        this.clearKeepAliveRef();
     }
 }
 

--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -38,6 +38,18 @@ pub const RefCount = bun.ptr.RefCount(FileSink, "ref_count", deinit, .{});
 pub const ref = RefCount.ref;
 pub const deref = RefCount.deref;
 
+/// Count of live native FileSink instances. Incremented at allocation,
+/// decremented in `deinit`. Exposed to tests via `bun:internal-for-testing`
+/// so leak tests can detect native FileSink leaks that are invisible to
+/// `heapStats()` (which only counts JS wrapper objects).
+pub var live_count = std.atomic.Value(i32).init(0);
+
+pub const TestingAPIs = struct {
+    pub fn fileSinkLiveCount(_: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        return .jsNumber(live_count.load(.monotonic));
+    }
+};
+
 pub const IOWriter = bun.io.StreamingWriter(@This(), opaque {
     pub const onClose = FileSink.onClose;
     pub const onWritable = FileSink.onReady;
@@ -218,12 +230,25 @@ pub fn onError(this: *FileSink, err: bun.sys.Error) void {
         if (this.eventLoop().bunVM()) |vm| {
             if (vm.is_inside_deferred_task_queue) {
                 this.runPendingLater();
+                if (comptime Environment.isWindows) this.clearKeepAliveRef();
                 return;
             }
         }
 
         this.runPending();
     }
+
+    // On POSIX, the streaming writer always calls `close()` → `onClose`
+    // after `onError`, so `onClose` releases the keep-alive ref. Releasing
+    // it here could drop the last ref and free `this` before the writer's
+    // subsequent `close()` touches its (embedded) fields.
+    //
+    // On Windows, the pipe error paths call `closeWithoutReporting()` which
+    // skips `onClose`, so release here. This is safe because those paths
+    // always hold another ref (the in-flight write's ref via `defer
+    // parent.deref()` in `onWriteComplete`, or the JS caller's ref when
+    // reached synchronously from `write()`) through `closeWithoutReporting`.
+    if (comptime Environment.isWindows) this.clearKeepAliveRef();
 }
 
 pub fn onReady(this: *FileSink) void {
@@ -243,6 +268,21 @@ pub fn onClose(this: *FileSink) void {
     }
 
     this.signal.close(null);
+
+    // The writer is fully closed; no further callbacks will arrive. Release
+    // the ref taken when a write returned `.pending`. This must be the last
+    // thing we do as it may free `this`.
+    this.clearKeepAliveRef();
+}
+
+/// Release the ref taken in `toResult`/`end`/`endFromJS` when a write
+/// returned `.pending` and we needed to stay alive until it completed.
+/// Idempotent via the flag check. May free `this`.
+fn clearKeepAliveRef(this: *FileSink) void {
+    if (this.must_be_kept_alive_until_eof) {
+        this.must_be_kept_alive_until_eof = false;
+        this.deref();
+    }
 }
 
 pub fn createWithPipe(
@@ -263,6 +303,7 @@ pub fn createWithPipe(
         .event_loop_handle = jsc.EventLoopHandle.init(evtloop),
         .fd = pipe.fd(),
     });
+    _ = live_count.fetchAdd(1, .monotonic);
     this.writer.setPipe(pipe);
     this.writer.setParent(this);
     return this;
@@ -281,6 +322,7 @@ pub fn create(
         .event_loop_handle = jsc.EventLoopHandle.init(evtloop),
         .fd = fd,
     });
+    _ = live_count.fetchAdd(1, .monotonic);
     this.writer.setParent(this);
     return this;
 }
@@ -504,6 +546,7 @@ pub fn init(fd: bun.FD, event_loop_handle: anytype) *FileSink {
         .fd = fd,
         .event_loop_handle = jsc.EventLoopHandle.init(event_loop_handle),
     });
+    _ = live_count.fetchAdd(1, .monotonic);
     this.writer.setParent(this);
 
     return this;
@@ -514,6 +557,7 @@ pub fn construct(this: *FileSink, _: std.mem.Allocator) void {
         .ref_count = .init(),
         .event_loop_handle = jsc.EventLoopHandle.init(jsc.VirtualMachine.get().eventLoop()),
     };
+    _ = live_count.fetchAdd(1, .monotonic);
 }
 
 pub fn write(this: *@This(), data: streams.Result) streams.Result.Writable {
@@ -572,6 +616,7 @@ pub fn end(this: *FileSink, _: ?bun.sys.Error) bun.sys.Maybe(void) {
 }
 
 fn deinit(this: *FileSink) void {
+    _ = live_count.fetchSub(1, .monotonic);
     this.pending.deinit();
     this.writer.deinit();
     this.readable_stream.deinit();

--- a/src/bun.js/webcore/FileSink.zig
+++ b/src/bun.js/webcore/FileSink.zig
@@ -166,6 +166,13 @@ fn runPending(this: *FileSink) void {
 pub fn onWrite(this: *FileSink, amount: usize, status: bun.io.WriteStatus) void {
     log("onWrite({d}, {any})", .{ amount, status });
 
+    // `runPending()` below drains microtasks and may drop the JS wrapper's
+    // ref, and `writer.end()`/`writer.close()` re-enter `onClose` which
+    // releases the keep-alive ref. Hold a local ref so `this` stays valid
+    // for the rest of this function (same pattern as `runPending`/`onAutoFlush`).
+    this.ref();
+    defer this.deref();
+
     this.written += amount;
 
     // TODO: on windows done means ended (no pending data on the buffer) on unix we can still have pending data on the buffer

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -110,15 +110,14 @@ pub fn PosixPipeWriter(
                     }
                 },
                 .wrote => |amt| {
+                    // `.drained`: the buffer was fully written before the
+                    // callback. If the callback buffers more data via
+                    // `write()`, that path already calls `registerPoll()`.
+                    // Don't touch `parent` after the callback returns — the
+                    // `.drained` callback is allowed to close/free the writer
+                    // (e.g. `FileSink.onWrite` → `writer.end()` → `onClose`
+                    // may drop the last ref).
                     onWrite(parent, amt, .drained);
-                    if (@hasDecl(This, "auto_poll")) {
-                        if (!This.auto_poll) return;
-                    }
-                    if (getBuffer(parent).len > 0) {
-                        if (comptime registerPoll) |register| {
-                            register(parent);
-                        }
-                    }
                 },
                 .err => |err| {
                     onError(parent, err);

--- a/src/io/PipeWriter.zig
+++ b/src/io/PipeWriter.zig
@@ -192,8 +192,6 @@ pub fn PosixBufferedWriter(Parent: type, function_table: anytype) type {
             return @sizeOf(@This());
         }
 
-        pub const auto_poll = if (@hasDecl(Parent, "auto_poll")) Parent.auto_poll else true;
-
         pub fn createPoll(this: *@This(), fd: bun.FD) *Async.FilePoll {
             return Async.FilePoll.init(@as(*Parent, @ptrCast(this.parent)).eventLoop(), fd, .{}, PosixWriter, this);
         }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -286,3 +286,7 @@ export const fetchH3Internals = {
     streams: number;
   },
 };
+
+export const fileSinkInternals = {
+  liveCount: $newZigFunction("bun.js/webcore/FileSink.zig", "TestingAPIs.fileSinkLiveCount", 0) as () => number,
+};

--- a/src/shell/IOWriter.zig
+++ b/src/shell/IOWriter.zig
@@ -56,8 +56,6 @@ const CallstackChild = struct {
     completed: bool = false,
 };
 
-pub const auto_poll = false;
-
 pub const WriterImpl = bun.io.BufferedWriter(IOWriter, struct {
     pub const onWrite = IOWriter.onWritePollable;
     pub const onError = IOWriter.onError;

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
+import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
-import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { fileDescriptorLeakChecker, isWindows, tmpdirSync } from "harness";
+import { fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
+import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -217,3 +218,53 @@ if (isWindows) {
     );
   });
 }
+
+// When a write to a pollable fd returns `.pending`, FileSink takes a
+// `must_be_kept_alive_until_eof` ref on itself so it survives until the
+// buffered data is drained. If the write later fails (e.g. EPIPE because the
+// reader closed), neither `onError` nor `onClose` released that ref, so the
+// native FileSink (and its buffers) leaked for the rest of the process even
+// after the JS wrapper was garbage-collected. `heapStats()` only counts JS
+// wrappers, so we check the native live counter directly.
+it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (EPIPE)", async () => {
+  async function once() {
+    const [readFd, writeFd] = createSocketPair();
+    const sink = Bun.file(writeFd).writer();
+
+    // Large enough to overflow the socket send buffer so the write returns
+    // `.pending` and the keep-alive ref is taken.
+    const writePromise = sink.write(Buffer.alloc(4 * 1024 * 1024, 0x61));
+    expect(writePromise).toBeInstanceOf(Promise);
+
+    // Close the reader so the buffered write fails with EPIPE.
+    fs.closeSync(readFd);
+
+    await Promise.resolve(writePromise).catch(() => {});
+    await Promise.resolve(sink.end()).catch(() => {});
+
+    // The writer may have already closed the fd after the error.
+    try {
+      fs.closeSync(writeFd);
+    } catch {}
+  }
+
+  const baseline = fileSinkInternals.liveCount();
+  const iterations = 8;
+
+  for (let i = 0; i < iterations; i++) {
+    await once();
+  }
+
+  // Allow finalizers to run.
+  for (let i = 0; i < 50; i++) {
+    Bun.gc(true);
+    if (fileSinkInternals.liveCount() <= baseline) break;
+    await Bun.sleep(10);
+  }
+
+  // Before the fix, every iteration leaked one native FileSink because the
+  // `must_be_kept_alive_until_eof` ref was never released on error/close.
+  // One straggler whose JS wrapper has not yet been finalized is acceptable;
+  // more than that indicates a native leak.
+  expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
+});


### PR DESCRIPTION
## Problem

When `write()`/`end()`/`endFromJS()` returns `.pending`, `FileSink` takes a self-ref (`must_be_kept_alive_until_eof` → `this.ref()`) so the native instance outlives the in-flight buffered write. The matching `deref()` was only performed in:
- `onWrite()` when `status == .end_of_file`
- `onAttachedProcessExit()`

If the buffered write **fails** (e.g. EPIPE after the reader closes), the writer instead drives:
- **POSIX**: `_onError` → `FileSink.onError` → `close()` → `FileSink.onClose`
- **Windows pipe**: `onWriteComplete` error → `FileSink.onError` → `closeWithoutReporting()` (skips `onClose`)

Neither `onError` nor `onClose` released the keep-alive ref, so the native `FileSink` (plus its outgoing buffer, AutoFlusher registration, and `Strong` refs) leaked for the life of the process — even after the JS wrapper was GC'd and `finalize()` dropped its ref.

## Repro

```js
const [readFd, writeFd] = createSocketPair();
const sink = Bun.file(writeFd).writer();
sink.write(Buffer.alloc(4 * 1024 * 1024));  // overflows send buffer → .pending, ref() taken
fs.closeSync(readFd);                        // next write attempt → EPIPE
await sink.end();                            // onClose fires but never derefs
// sink = null; Bun.gc(true);
// → native FileSink ref_count stuck at 1 forever
```

Before: 8 iterations → 8 live native `FileSink` instances after GC.
After: 0.

## Fix

- `onClose`: release the keep-alive ref as the last step. This is the terminal callback on POSIX (always called after `onError` via `_onError` → `close()`) and on Windows for normal close / `onFsWriteComplete` error. Placed after `signal.close()` since it may free `this`.
- `onError` (Windows only): release the keep-alive ref here too, since the Windows pipe error paths call `closeWithoutReporting()` which **skips** `onClose`. On POSIX this is deliberately **not** done in `onError` — `_onError` calls `this.close()` on the embedded writer *after* `onError` returns, so freeing `this` there would be a UAF. On Windows the error paths always hold one extra ref (the in-flight write's `defer parent.deref()` in `onWriteComplete`, or the JS caller's ref when reached synchronously from `write()`) through `closeWithoutReporting`, so it's safe.

Both sites check `must_be_kept_alive_until_eof` first, so the existing `onWrite(.end_of_file)` / `onAttachedProcessExit` paths that already clear it are unchanged (no double-deref).

## Testing

Added a native live-instance counter (`FileSink.live_count`, incremented at allocation / decremented in `deinit`) exposed as `fileSinkInternals.liveCount()` via `bun:internal-for-testing`, following the same pattern as `fetchH2Internals.liveCounts`. This is needed because `heapStats().objectTypeCounts.FileSink` only counts JS wrappers, which **were** being collected here — it's the native struct behind them that leaked.

The new test in `test/js/bun/util/filesink.test.ts` creates 8 sinks that each buffer a 4 MB write to a socketpair, closes the read side, lets the write fail, and asserts `liveCount()` returns to baseline after GC.

- `bun bd test test/js/bun/util/filesink.test.ts` — 40/40 pass
- `bun bd test test/js/web/fetch/blob-write.test.ts` — pass
- `bun bd test test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts` — pass
- `bun bd test test/js/node/process/process-stdio.test.ts` — pass
- `bun run zig:check-all` — all platforms compile