### PR TITLE
bake: validate bundlerOptions values are objects before property access

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -209,14 +209,22 @@ impl UserOptions {
         }
 
         if let Some(js_options) = get_optional_value(config, global, b"bundlerOptions")? {
+            if !js_options.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'{}.bundlerOptions' must be an object",
+                    API_NAME
+                )));
+            }
             if let Some(server_options) = get_optional_value(js_options, global, b"server")? {
-                bundler_options.server = BuildConfigSubset::from_js(global, server_options)?;
+                bundler_options.server =
+                    BuildConfigSubset::from_js(global, "server", server_options)?;
             }
             if let Some(client_options) = get_optional_value(js_options, global, b"client")? {
-                bundler_options.client = BuildConfigSubset::from_js(global, client_options)?;
+                bundler_options.client =
+                    BuildConfigSubset::from_js(global, "client", client_options)?;
             }
             if let Some(ssr_options) = get_optional_value(js_options, global, b"ssr")? {
-                bundler_options.ssr = BuildConfigSubset::from_js(global, ssr_options)?;
+                bundler_options.ssr = BuildConfigSubset::from_js(global, "ssr", ssr_options)?;
             }
         }
 
@@ -407,8 +415,19 @@ pub struct BuildConfigSubset {
 }
 
 impl BuildConfigSubset {
-    pub fn from_js(global: &JSGlobalObject, js_options: JSValue) -> JsResult<BuildConfigSubset> {
+    pub fn from_js(
+        global: &JSGlobalObject,
+        name: &str,
+        js_options: JSValue,
+    ) -> JsResult<BuildConfigSubset> {
         let mut options = BuildConfigSubset::default();
+
+        if !js_options.is_object() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "'{}.bundlerOptions.{}' must be an object",
+                API_NAME, name
+            )));
+        }
 
         'brk: {
             let Some(val) = get_optional_value(js_options, global, b"sourcemap")? else {
@@ -431,11 +450,18 @@ impl BuildConfigSubset {
             let Some(minify_options) = get_optional_value(js_options, global, b"minify")? else {
                 break 'brk;
             };
-            if minify_options.is_boolean() && minify_options.as_boolean() {
+            if minify_options.is_boolean() {
                 options.minify_syntax = Some(minify_options.as_boolean());
                 options.minify_identifiers = Some(minify_options.as_boolean());
                 options.minify_whitespace = Some(minify_options.as_boolean());
                 break 'brk;
+            }
+
+            if !minify_options.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'{}.bundlerOptions.{}.minify' must be a boolean or an object",
+                    API_NAME, name
+                )));
             }
 
             if let Some(value) = get_boolean_loose(minify_options, global, b"whitespace")? {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  test("non-object bundlerOptions throws instead of crashing", () => {
+    for (const value of [42, "string", true, 123n, Symbol("x")]) {
+      expect(() => {
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: value },
+        });
+      }).toThrow("'app.bundlerOptions' must be an object");
+    }
+  });
+
+  test("non-object server/client/ssr throws instead of crashing", () => {
+    for (const key of ["server", "client", "ssr"] as const) {
+      for (const value of [42, "string", true, 123n, Symbol("x")]) {
+        expect(() => {
+          Bun.serve({
+            // @ts-expect-error
+            app: { bundlerOptions: { [key]: value } },
+          });
+        }).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+      }
+    }
+  });
+
+  test("non-boolean, non-object minify throws instead of crashing", () => {
+    for (const value of [42, "string", 123n, Symbol("x")]) {
+      expect(() => {
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { server: { minify: value } } },
+        });
+      }).toThrow("'app.bundlerOptions.server.minify' must be a boolean or an object");
+    }
+  });
+
+  test("boolean minify does not crash", () => {
+    for (const value of [true, false]) {
+      expect(() => {
+        Bun.serve({
+          // @ts-expect-error
+          app: { bundlerOptions: { server: { minify: value } } },
+        });
+      }).toThrow("'app' is missing 'framework'");
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash found by Fuzzilli (fingerprint `db2bbf0400b9a805`).

`Bun.serve({ app: { bundlerOptions: ... } })` hit `bun.debugAssert(target.isObject())` in `JSValue.get()` when:
- `bundlerOptions` itself was a primitive
- `bundlerOptions.server` / `.client` / `.ssr` was a primitive
- `bundlerOptions.<side>.minify` was neither a boolean nor an object (including `minify: false`, which fell past the `is_boolean() && as_boolean()` guard and then called `get_boolean_loose` on a non-object)

Repro:
```js
Bun.serve({ app: { bundlerOptions: { server: 42 } } });
```

Now each of these throws a descriptive `TypeError` instead, matching how `Bun.build` handles `minify`.

## How did you verify your code works?

- Added `test/bake/bundler-options-validation.test.ts` covering all three paths plus `minify: true/false`.
- `bun bd test test/bake/bundler-options-validation.test.ts` → 4 pass.