### PR TITLE
Fix stack overflow in Bun.inspect for circular JSX elements

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2089,6 +2089,7 @@ pub mod formatter {
                     | Tag::Error
                     | Tag::Class
                     | Tag::Event
+                    | Tag::JSX
             )
         }
     }

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -514,7 +514,7 @@ impl Tag {
 
     #[inline]
     pub const fn can_have_circular_references(self) -> bool {
-        matches!(self, Tag::Array | Tag::Object | Tag::Map | Tag::Set)
+        matches!(self, Tag::Array | Tag::Object | Tag::Map | Tag::Set | Tag::JSX)
     }
 }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -314,6 +314,34 @@ it("jsx with fragment", () => {
   const output = `<>foo bar</>`;
 
   expect(input).toBe(output);
+});
+
+it("jsx with circular references does not stack overflow", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const sym = Symbol.for("react.element");
+        const a = { $$typeof: sym, type: "div", key: null, props: {} };
+        a.key = a;
+        console.log(Bun.inspect(a));
+        const b = { $$typeof: sym, type: "div", key: null, props: {} };
+        b.props.children = b;
+        console.log(Bun.inspect(b));
+        const c = { $$typeof: sym, type: "div", key: null, props: {} };
+        c.props.foo = c;
+        console.log(Bun.inspect(c));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("<div key=[Circular] />\n" + "<div>\n  [Circular]\n</div>\n" + "<div foo=[Circular] />\n");
+  expect(exitCode).toBe(0);
 });
 
 it("inspect", () => {


### PR DESCRIPTION
Inspecting a React element whose `key`, `props`, or `children` referenced the element itself crashed with a stack overflow.

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, props: {} };
el.key = el;
Bun.inspect(el); // segfault
```

The `JSX` tag was not included in `can_have_circular_references()`, so the visited-map and stack checks in `print_as` were skipped for JSX elements. Circular JSX elements now print `[Circular]` like other circular values.

Found by Fuzzilli (fingerprint `bb8715595a137556`).

### What does this PR do?

Adds `Tag::JSX` to `can_have_circular_references()` in `src/jsc/ConsoleObject.rs` and `src/runtime/test_runner/pretty_format.rs`.

### How did you verify your code works?

Regression test in `test/js/bun/util/inspect.test.js` spawns a subprocess that inspects three circular JSX shapes (via `key`, `props.children`, and an arbitrary prop) and asserts `[Circular]` output with exit code 0. Without the fix, the subprocess segfaults (exit 139) and the test fails.