### PR TITLE
Fix Buffer.copyBytesFrom double-applying byteOffset on TypedArray views

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -990,9 +990,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_copyBytesFromBody(JSC::JS
         RELEASE_AND_RETURN(throwScope, JSValue::encode(createBuffer(lexicalGlobalObject, span.data(), span.size())));
     }
 
-    auto boffset = view->byteOffset();
-    auto blength = view->byteLength();
-    auto span = view->span().subspan(boffset, blength - boffset);
+    auto span = view->span();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(createBuffer(lexicalGlobalObject, span.data(), span.size())));
 }
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3259,3 +3259,41 @@ describe("*Write methods with NaN/invalid offset and length", () => {
     });
   }
 });
+
+describe("Buffer.copyBytesFrom", () => {
+  it("copies the correct bytes from a Uint8Array view with a non-zero byteOffset", () => {
+    const ab = new ArrayBuffer(10);
+    const full = new Uint8Array(ab);
+    for (let i = 0; i < 10; i++) full[i] = i;
+
+    // byteOffset (2) < byteLength (6)
+    const view = new Uint8Array(ab, 2, 6);
+    const buf = Buffer.copyBytesFrom(view);
+    expect([...buf]).toEqual([2, 3, 4, 5, 6, 7]);
+
+    // ensure it's an independent copy
+    full[2] = 0xff;
+    expect(buf[0]).toBe(2);
+  });
+
+  it("handles a view where byteOffset > byteLength without underflowing", () => {
+    const ab = new ArrayBuffer(10);
+    const full = new Uint8Array(ab);
+    for (let i = 0; i < 10; i++) full[i] = i;
+
+    // byteOffset (6) > byteLength (4) -> previously underflowed to ~SIZE_MAX and threw OOM
+    const view = new Uint8Array(ab, 6, 4);
+    const buf = Buffer.copyBytesFrom(view);
+    expect([...buf]).toEqual([6, 7, 8, 9]);
+  });
+
+  it("copies the correct bytes from a multi-byte TypedArray view with a non-zero byteOffset", () => {
+    const ab = new ArrayBuffer(16);
+    const full = new Uint8Array(ab);
+    for (let i = 0; i < 16; i++) full[i] = i;
+
+    const view = new Uint16Array(ab, 8, 4); // bytes 8..15
+    const buf = Buffer.copyBytesFrom(view);
+    expect([...buf]).toEqual([8, 9, 10, 11, 12, 13, 14, 15]);
+  });
+});


### PR DESCRIPTION
## Problem

`Buffer.copyBytesFrom(view)` (no explicit offset/length) produced incorrect results when `view` was a TypedArray with a non-zero `byteOffset` into its backing `ArrayBuffer`.

```js
const ab = new ArrayBuffer(10);
new Uint8Array(ab).set([0,1,2,3,4,5,6,7,8,9]);

// byteOffset > byteLength → size_t underflow → OOM
Buffer.copyBytesFrom(new Uint8Array(ab, 6, 4));
// RangeError: Out of memory   (expected <Buffer 06 07 08 09>)

// byteOffset < byteLength → wrong bytes
Buffer.copyBytesFrom(new Uint8Array(ab, 2, 6));
// <Buffer 04 05 06 07>        (expected <Buffer 02 03 04 05 06 07>)
```

## Cause

In `jsBufferConstructorFunction_copyBytesFromBody` (src/bun.js/bindings/JSBuffer.cpp), the fallback path did:

```cpp
auto boffset = view->byteOffset();
auto blength = view->byteLength();
auto span = view->span().subspan(boffset, blength - boffset);
```

But `JSArrayBufferView::span()` is defined as `{ vector(), byteLength() }`, and `vector()` already points to the view's data (i.e. `byteOffset` is already applied). Calling `.subspan(byteOffset, byteLength - byteOffset)` applied the offset a second time. When `byteOffset > byteLength`, `blength - boffset` underflowed to near `SIZE_MAX`, triggering an out-of-memory allocation.

## Fix

Use `view->span()` directly — it's already exactly the bytes to copy.

## Verification

- Added 3 tests to `test/js/node/buffer.test.js` covering byteOffset < byteLength, byteOffset > byteLength, and a multi-byte element view. All fail on main, pass with this change.
- `test/js/node/test/parallel/test-buffer-from.js` continues to pass.