### PR TITLE
Bun.write: stream pending Response/Request bodies to disk

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -1240,7 +1240,7 @@ pub fn writeFileWithSourceDestination(ctx: *jsc.JSGlobalObject, source_blob: *Bl
             source_blob,
             @truncate(s3.options.partSize),
         ), ctx)) |stream| {
-            return destination_blob.pipeReadableStreamToBlob(ctx, stream, options.extra_options);
+            return destination_blob.pipeReadableStreamToBlob(ctx, stream, options.extra_options, options.mkdirp_if_not_exists orelse true);
         } else {
             return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(ctx, ctx.createErrorInstance("Failed to stream bytes from s3 bucket", .{}));
         }
@@ -1543,49 +1543,88 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                     return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err_ref.toJS(globalThis));
                 },
                 .Locked => {
+                    // Stream the pending body to disk instead of buffering it.
+                    //
+                    // Previously this branch registered a callback via
+                    // Locked.onReceiveValue and waited for the entire body to be
+                    // buffered in memory before writing, which both wasted memory
+                    // and hung forever once the Response was GC'd (the
+                    // FetchResponse weak-finalizer doesn't know about
+                    // onReceiveValue and drops the body — #13237, #21455).
+                    //
+                    // Three sub-cases for how we get a ReadableStream:
+                    //   1. One already exists (`new Response(stream)`, or `.body`
+                    //      was accessed). Response moves it into a JS write
+                    //      barrier (see Response.checkBodyStreamRef), so check
+                    //      via getBodyReadableStream first, then Locked.readable.
+                    //   2. The producer supports streaming (`onStartStreaming` is
+                    //      set — fetch responses, server request bodies). Calling
+                    //      toReadableStream while Locked.task is still the
+                    //      producer wires the stream up so chunks flow.
+                    //   3. The producer only calls resolve() once the full
+                    //      payload is ready (HTMLRewriter). Creating a stream
+                    //      here would leave it forever empty since resolve()
+                    //      just closes it; fall back to waiting on
+                    //      onReceiveValue for these.
+                    const readable: jsc.WebCore.ReadableStream = readable: {
+                        if (response.getBodyReadableStream(globalThis)) |r| break :readable r;
+                        if (bodyValue.Locked.readable.get(globalThis)) |r| break :readable r;
+                        if (bodyValue.Locked.onStartStreaming != null) {
+                            _ = try bodyValue.toReadableStream(globalThis);
+                            if (bodyValue.* == .Locked) {
+                                if (bodyValue.Locked.readable.get(globalThis)) |r| break :readable r;
+                            }
+                            // toReadableStream transitioned to .Null (.empty/.aborted)
+                            break :brk bodyValue.use();
+                        }
+                        // Case 3: non-streamable producer. Wait for resolve().
+                        var task = bun.new(WriteFileWaitFromLockedValueTask, .{
+                            .globalThis = globalThis,
+                            .file_blob = destination_blob,
+                            .promise = jsc.JSPromise.Strong.init(globalThis),
+                            .mkdirp_if_not_exists = options.mkdirp_if_not_exists orelse true,
+                        });
+                        bodyValue.Locked.task = task;
+                        bodyValue.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
+                        return task.promise.value();
+                    };
+
+                    if (readable.isDisturbed(globalThis)) {
+                        destination_blob.detach();
+                        return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                    }
+
                     if (destination_blob.isS3()) {
                         const s3 = &destination_blob.store.?.data.s3;
                         var aws_options = try s3.getCredentialsWithOptions(options.extra_options, globalThis);
                         defer aws_options.deinit();
-                        _ = try bodyValue.toReadableStream(globalThis);
-
-                        if (response.getBodyReadableStream(globalThis) orelse bodyValue.Locked.readable.get(globalThis)) |readable| {
-                            if (readable.isDisturbed(globalThis)) {
-                                destination_blob.detach();
-                                return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
-                            }
-                            const proxy = globalThis.bunVM().transpiler.env.getHttpProxy(true, null, null);
-                            const proxy_url = if (proxy) |p| p.href else null;
-
-                            return S3.uploadStream(
-                                (if (options.extra_options != null) aws_options.credentials.dupe() else s3.getCredentials()),
-                                s3.path(),
-                                readable,
-                                globalThis,
-                                aws_options.options,
-                                aws_options.acl,
-                                aws_options.storage_class,
-                                destination_blob.contentTypeOrMimeType(),
-                                aws_options.content_disposition,
-                                aws_options.content_encoding,
-                                proxy_url,
-                                aws_options.request_payer,
-                                null,
-                                undefined,
-                            );
-                        }
-                        destination_blob.detach();
-                        return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        const proxy = globalThis.bunVM().transpiler.env.getHttpProxy(true, null, null);
+                        const proxy_url = if (proxy) |p| p.href else null;
+                        return S3.uploadStream(
+                            (if (options.extra_options != null) aws_options.credentials.dupe() else s3.getCredentials()),
+                            s3.path(),
+                            readable,
+                            globalThis,
+                            aws_options.options,
+                            aws_options.acl,
+                            aws_options.storage_class,
+                            destination_blob.contentTypeOrMimeType(),
+                            aws_options.content_disposition,
+                            aws_options.content_encoding,
+                            proxy_url,
+                            aws_options.request_payer,
+                            null,
+                            undefined,
+                        );
                     }
-                    var task = bun.new(WriteFileWaitFromLockedValueTask, .{
-                        .globalThis = globalThis,
-                        .file_blob = destination_blob,
-                        .promise = jsc.JSPromise.Strong.init(globalThis),
-                        .mkdirp_if_not_exists = options.mkdirp_if_not_exists orelse true,
-                    });
-                    bodyValue.Locked.task = task;
-                    bodyValue.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
-                    return task.promise.value();
+
+                    defer destination_blob.detach();
+                    return destination_blob.pipeReadableStreamToBlob(
+                        globalThis,
+                        readable,
+                        options.extra_options,
+                        options.mkdirp_if_not_exists orelse true,
+                    );
                 },
             }
         }
@@ -1607,50 +1646,65 @@ pub fn writeFileInternal(globalThis: *jsc.JSGlobalObject, path_or_blob_: *PathOr
                     _ = bodyValue.use();
                     return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err_ref.toJS(globalThis));
                 },
-                .Locked => |locked| {
+                .Locked => {
+                    // See the matching comment in the Response branch above.
+                    const readable: jsc.WebCore.ReadableStream = readable: {
+                        if (request.getBodyReadableStream(globalThis)) |r| break :readable r;
+                        if (bodyValue.Locked.readable.get(globalThis)) |r| break :readable r;
+                        if (bodyValue.Locked.onStartStreaming != null) {
+                            _ = try bodyValue.toReadableStream(globalThis);
+                            if (bodyValue.* == .Locked) {
+                                if (bodyValue.Locked.readable.get(globalThis)) |r| break :readable r;
+                            }
+                            break :brk bodyValue.use();
+                        }
+                        var task = bun.new(WriteFileWaitFromLockedValueTask, .{
+                            .globalThis = globalThis,
+                            .file_blob = destination_blob,
+                            .promise = jsc.JSPromise.Strong.init(globalThis),
+                            .mkdirp_if_not_exists = options.mkdirp_if_not_exists orelse true,
+                        });
+                        bodyValue.Locked.task = task;
+                        bodyValue.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
+                        return task.promise.value();
+                    };
+
+                    if (readable.isDisturbed(globalThis)) {
+                        destination_blob.detach();
+                        return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                    }
+
                     if (destination_blob.isS3()) {
                         const s3 = &destination_blob.store.?.data.s3;
                         var aws_options = try s3.getCredentialsWithOptions(options.extra_options, globalThis);
                         defer aws_options.deinit();
-                        _ = try bodyValue.toReadableStream(globalThis);
-                        if (request.getBodyReadableStream(globalThis) orelse locked.readable.get(globalThis)) |readable| {
-                            if (readable.isDisturbed(globalThis)) {
-                                destination_blob.detach();
-                                return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
-                            }
-                            const proxy = globalThis.bunVM().transpiler.env.getHttpProxy(true, null, null);
-                            const proxy_url = if (proxy) |p| p.href else null;
-                            return S3.uploadStream(
-                                (if (options.extra_options != null) aws_options.credentials.dupe() else s3.getCredentials()),
-                                s3.path(),
-                                readable,
-                                globalThis,
-                                aws_options.options,
-                                aws_options.acl,
-                                aws_options.storage_class,
-                                destination_blob.contentTypeOrMimeType(),
-                                aws_options.content_disposition,
-                                aws_options.content_encoding,
-                                proxy_url,
-                                aws_options.request_payer,
-                                null,
-                                undefined,
-                            );
-                        }
-                        destination_blob.detach();
-                        return globalThis.throwInvalidArguments("ReadableStream has already been used", .{});
+                        const proxy = globalThis.bunVM().transpiler.env.getHttpProxy(true, null, null);
+                        const proxy_url = if (proxy) |p| p.href else null;
+                        return S3.uploadStream(
+                            (if (options.extra_options != null) aws_options.credentials.dupe() else s3.getCredentials()),
+                            s3.path(),
+                            readable,
+                            globalThis,
+                            aws_options.options,
+                            aws_options.acl,
+                            aws_options.storage_class,
+                            destination_blob.contentTypeOrMimeType(),
+                            aws_options.content_disposition,
+                            aws_options.content_encoding,
+                            proxy_url,
+                            aws_options.request_payer,
+                            null,
+                            undefined,
+                        );
                     }
-                    var task = bun.new(WriteFileWaitFromLockedValueTask, .{
-                        .globalThis = globalThis,
-                        .file_blob = destination_blob,
-                        .promise = jsc.JSPromise.Strong.init(globalThis),
-                        .mkdirp_if_not_exists = options.mkdirp_if_not_exists orelse true,
-                    });
 
-                    bodyValue.Locked.task = task;
-                    bodyValue.Locked.onReceiveValue = WriteFileWaitFromLockedValueTask.thenWrap;
-
-                    return task.promise.value();
+                    defer destination_blob.detach();
+                    return destination_blob.pipeReadableStreamToBlob(
+                        globalThis,
+                        readable,
+                        options.extra_options,
+                        options.mkdirp_if_not_exists orelse true,
+                    );
                 },
             }
         }
@@ -2557,14 +2611,14 @@ pub fn onFileStreamResolveRequestStream(globalThis: *jsc.JSGlobalObject, callfra
     if (strong.get(globalThis)) |stream| {
         stream.done(globalThis);
     }
-    try this.promise.resolve(globalThis, jsc.JSValue.jsNumber(0));
+    try this.promise.resolve(globalThis, .jsNumberFromUint64(this.sink.written));
     return .js_undefined;
 }
 
 pub fn onFileStreamRejectRequestStream(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const args = callframe.arguments_old(2);
     var this = args.ptr[args.len - 1].asPromisePtr(FileStreamWrapper);
-    defer this.sink.deref();
+    defer this.deinit();
     const err = args.ptr[0];
 
     var strong = this.readable_stream_ref;
@@ -2585,7 +2639,7 @@ comptime {
     @export(&jsonRejectRequestStream, .{ .name = "Bun__FileStreamWrapper__onRejectRequestStream" });
 }
 
-pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, readable_stream: jsc.WebCore.ReadableStream, extra_options: ?JSValue) bun.JSError!jsc.JSValue {
+pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, readable_stream: jsc.WebCore.ReadableStream, extra_options: ?JSValue, mkdirp_if_not_exists: bool) bun.JSError!jsc.JSValue {
     var store = this.store orelse {
         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, globalThis.createErrorInstance("Blob is detached", .{}));
     };
@@ -2629,19 +2683,33 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             const fd: bun.FD = if (pathlike == .fd) pathlike.fd else brk: {
                 var file_path: bun.PathBuffer = undefined;
                 const path = pathlike.path.sliceZ(&file_path);
-                switch (bun.sys.open(
-                    path,
-                    bun.O.WRONLY | bun.O.CREAT | bun.O.NONBLOCK,
-                    write_permissions,
-                )) {
-                    .result => |result| {
-                        break :brk result;
+                const open_flags = bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC | bun.O.NONBLOCK;
+                const raw_fd = switch (bun.sys.open(path, open_flags, write_permissions)) {
+                    .result => |result| result,
+                    .err => |first_err| retry: {
+                        if (mkdirp_if_not_exists and first_err.getErrno() == .NOENT) {
+                            if (std.fs.path.dirname(path)) |dirname| {
+                                var node_fs: jsc.Node.fs.NodeFS = .{};
+                                if (node_fs.mkdirRecursive(.{
+                                    .path = .{ .string = bun.PathString.init(dirname) },
+                                    .recursive = true,
+                                    .always_return_none = true,
+                                }) == .result) {
+                                    if (bun.sys.open(path, open_flags, write_permissions).unwrap()) |result| {
+                                        break :retry result;
+                                    } else |_| {}
+                                }
+                            }
+                        }
+                        return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try first_err.withPath(path).toJS(globalThis));
                     },
+                };
+                break :brk switch (raw_fd.makeLibUVOwnedForSyscall(.open, .close_on_fail)) {
+                    .result => |uv_fd| uv_fd,
                     .err => |err| {
                         return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try err.withPath(path).toJS(globalThis));
                     },
-                }
-                unreachable;
+                };
             };
 
             const is_stdout_or_stderr = brk: {
@@ -2707,13 +2775,26 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
         const stream_start: jsc.WebCore.streams.Start = .{
             .FileSink = .{
                 .input_path = input_path,
+                .truncate = true,
             },
         };
 
         switch (sink.start(stream_start)) {
-            .err => |err| {
+            .err => |first_err| retry: {
+                if (mkdirp_if_not_exists and input_path == .path and first_err.getErrno() == .NOENT) {
+                    if (std.fs.path.dirname(input_path.path.slice())) |dirname| {
+                        var node_fs: jsc.Node.fs.NodeFS = .{};
+                        if (node_fs.mkdirRecursive(.{
+                            .path = .{ .string = bun.PathString.init(dirname) },
+                            .recursive = true,
+                            .always_return_none = true,
+                        }) == .result) {
+                            if (sink.start(stream_start) == .result) break :retry;
+                        }
+                    }
+                }
                 sink.deref();
-                return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try err.toJS(globalThis));
+                return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, try first_err.toJS(globalThis));
             },
             else => {},
         }
@@ -2737,8 +2818,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
 
     assignment_result.ensureStillAlive();
 
-    // assert that it was updated
-    bun.assert(!signal.isDead());
+    // signal may still be dead if assignToStream completed synchronously (the
+    // stream was already fully buffered and readMany() returned done:true), in
+    // which case $startDirectStream is never called. The data was already
+    // flushed via sink.end(), so there is nothing to set up.
 
     if (assignment_result.toError()) |err| {
         file_sink.deref();
@@ -2769,9 +2852,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
                     return promise_value;
                 },
                 .fulfilled => {
+                    const written = file_sink.written;
                     file_sink.deref();
                     readable_stream.done(globalThis);
-                    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+                    return jsc.JSPromise.resolvedPromiseValue(globalThis, .jsNumberFromUint64(written));
                 },
                 .rejected => {
                     file_sink.deref();
@@ -2789,9 +2873,10 @@ pub fn pipeReadableStreamToBlob(this: *Blob, globalThis: *jsc.JSGlobalObject, re
             return jsc.JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, assignment_result);
         }
     }
+    const written = file_sink.written;
     file_sink.deref();
 
-    return jsc.JSPromise.resolvedPromiseValue(globalThis, jsc.JSValue.jsNumber(0));
+    return jsc.JSPromise.resolvedPromiseValue(globalThis, .jsNumberFromUint64(written));
 }
 
 pub fn getWriter(

--- a/src/runtime/webcore/FileSink.zig
+++ b/src/runtime/webcore/FileSink.zig
@@ -61,14 +61,14 @@ pub const Poll = IOWriter;
 pub const Options = struct {
     chunk_size: Blob.SizeType = 1024,
     input_path: webcore.PathOrFileDescriptor,
-    truncate: bool = true,
+    truncate: bool = false,
     close: bool = false,
     mode: bun.Mode = 0o664,
 
     pub fn flags(this: *const Options) i32 {
-        _ = this;
-
-        return bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        var f: i32 = bun.O.NONBLOCK | bun.O.CLOEXEC | bun.O.CREAT | bun.O.WRONLY;
+        if (this.truncate) f |= bun.O.TRUNC;
+        return f;
     }
 };
 

--- a/src/runtime/webcore/blob/write_file.zig
+++ b/src/runtime/webcore/blob/write_file.zig
@@ -743,9 +743,6 @@ const bloblog = bun.Output.scoped(.WriteFile, .hidden);
 
 const std = @import("std");
 
-const ZigString = jsc.ZigString;
-const Body = jsc.WebCore.Body;
-
 const bun = @import("bun");
 const Environment = bun.Environment;
 const invalid_fd = bun.invalid_fd;
@@ -756,6 +753,8 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSPromise = jsc.JSPromise;
 const SystemError = jsc.SystemError;
+const ZigString = jsc.ZigString;
+const Body = jsc.WebCore.Body;
 
 const Blob = jsc.WebCore.Blob;
 const ClosingState = Blob.ClosingState;

--- a/src/runtime/webcore/blob/write_file.zig
+++ b/src/runtime/webcore/blob/write_file.zig
@@ -666,6 +666,12 @@ pub const WriteFilePromise = struct {
     }
 };
 
+/// Used by `Bun.write` for `.Locked` Response/Request bodies whose producer
+/// does not support streaming (e.g. HTMLRewriter's BufferOutputSink) and only
+/// knows how to call `Body.Value.resolve()` once the full payload is ready.
+/// Streamable producers (fetch responses, server request bodies, user
+/// ReadableStreams) take the `pipeReadableStreamToBlob` path instead and never
+/// reach this.
 pub const WriteFileWaitFromLockedValueTask = struct {
     file_blob: Blob,
     globalThis: *JSGlobalObject,
@@ -737,6 +743,9 @@ const bloblog = bun.Output.scoped(.WriteFile, .hidden);
 
 const std = @import("std");
 
+const ZigString = jsc.ZigString;
+const Body = jsc.WebCore.Body;
+
 const bun = @import("bun");
 const Environment = bun.Environment;
 const invalid_fd = bun.invalid_fd;
@@ -747,8 +756,6 @@ const jsc = bun.jsc;
 const JSGlobalObject = jsc.JSGlobalObject;
 const JSPromise = jsc.JSPromise;
 const SystemError = jsc.SystemError;
-const ZigString = jsc.ZigString;
-const Body = jsc.WebCore.Body;
 
 const Blob = jsc.WebCore.Blob;
 const ClosingState = Blob.ClosingState;

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -288,6 +288,121 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await gcTick();
   });
 
+  describe("streams pending Response/Request body to disk", () => {
+    // https://github.com/oven-sh/bun/issues/13237
+    // https://github.com/oven-sh/bun/issues/21455
+    // Previously these buffered the entire body in memory before writing,
+    // and hung forever if the JS Response object was GC'd while the body
+    // was still arriving.
+    it("fetch Response (body still arriving, Response GC'd)", async () => {
+      using dir = tempDir("bun-write-fetch-stream", {});
+      const TOTAL = 100 * 64 * 1024;
+      await using server = Bun.serve({
+        port: 0,
+        async fetch() {
+          let i = 0;
+          return new Response(
+            new ReadableStream({
+              type: "bytes",
+              async pull(c) {
+                if (i++ === 0) await Bun.sleep(20); // headers flush before body
+                if (i > 100) return c.close();
+                c.enqueue(new Uint8Array(64 * 1024).fill(65));
+                await Bun.sleep(2);
+              },
+            }),
+          );
+        },
+      });
+
+      const out = join(String(dir), "out.bin");
+      // The Response is unreferenced after this expression; force GC
+      // while the body is still in flight.
+      const p = Bun.write(out, await fetch(server.url));
+      Bun.gc(true);
+      await Bun.sleep(10);
+      Bun.gc(true);
+
+      expect(await p).toBe(TOTAL);
+      expect((await Bun.file(out).stat()).size).toBe(TOTAL);
+    });
+
+    it("new Response(ReadableStream)", async () => {
+      using dir = tempDir("bun-write-response-stream", {});
+      const out = join(String(dir), "out.txt");
+      const wrote = await Bun.write(
+        out,
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("hello "));
+              c.enqueue(new TextEncoder().encode("world"));
+              c.close();
+            },
+          }),
+        ),
+      );
+      expect(wrote).toBe(11);
+      expect(await Bun.file(out).text()).toBe("hello world");
+    });
+
+    it("new Request(url, { body: ReadableStream })", async () => {
+      using dir = tempDir("bun-write-request-stream", {});
+      const out = join(String(dir), "out.txt");
+      const wrote = await Bun.write(
+        out,
+        new Request("http://example.com", {
+          method: "POST",
+          body: new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("from a request body"));
+              c.close();
+            },
+          }),
+        }),
+      );
+      expect(wrote).toBe(19);
+      expect(await Bun.file(out).text()).toBe("from a request body");
+    });
+
+    it("truncates the destination", async () => {
+      using dir = tempDir("bun-write-stream-trunc", {});
+      const out = join(String(dir), "out.txt");
+      await Bun.write(out, Buffer.alloc(1000, "0").toString());
+      const wrote = await Bun.write(
+        out,
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("short"));
+              c.close();
+            },
+          }),
+        ),
+      );
+      expect(wrote).toBe(5);
+      expect(await Bun.file(out).text()).toBe("short");
+    });
+
+    it("creates parent directory (createPath default true)", async () => {
+      using dir = tempDir("bun-write-stream-mkdirp", {});
+      const out = join(String(dir), "a", "b", "c", "out.txt");
+      const wrote = await Bun.write(
+        out,
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(new TextEncoder().encode("nested"));
+              c.close();
+            },
+          }),
+        ),
+      );
+      expect(wrote).toBe(6);
+      expect(await Bun.file(out).text()).toBe("nested");
+    });
+  });
+
   it("Response -> Bun.file -> Response -> text", async () => {
     await gcTick();
     const file = path.join(import.meta.dir, "fetch.js.txt");


### PR DESCRIPTION
## What does this PR do?

`await Bun.write(path, await fetch(url))` now streams the response body to disk chunk-by-chunk instead of buffering the whole thing in memory first. Same for `new Response(stream)`, `new Request(url, {body: stream})`, and incoming server request bodies.

This fixes the long-standing hang where the above would stall forever on large downloads. Root cause: the `.Locked` body branch registered an `onReceiveValue` callback and waited for the producer to buffer the whole body, but

- for fetch responses, if the JS `Response` is GC'd before the body finishes (any large download where the Response is a temp value), `Bun__FetchResponse_finalize` doesn't know about `onReceiveValue` and drops the body — the callback never fires;
- for `new Response(stream)` / `new Request(url, {body: stream})`, nothing ever calls `resolve()` so the callback never fires.

Now the `.Locked` branch obtains a `ReadableStream` and pumps it through `pipeReadableStreamToBlob` → `FileSink`, the same path S3 destinations already used:

1. A stream already exists on the body — use it.
2. Producer supports streaming (`onStartStreaming` set — fetch, server req body) — `toReadableStream` while `Locked.task` is still the producer, then pump. For fetch this also sets `FetchTasklet.readable_stream_ref`, so the weak-finalizer leaves the body alone after GC.
3. Producer only calls `resolve()` (HTMLRewriter) — fall back to `WriteFileWaitFromLockedValueTask` as before.

`pipeReadableStreamToBlob` is hardened: `mkdirp` retry on `ENOENT`, `O_TRUNC` on open, Windows `makeLibUVOwnedForSyscall`, return `file_sink.written` instead of `0`, drop the `!signal.isDead()` assert that fires on synchronously-completed streams, fix the reject-handler leak.

`FileSink.Options.flags()` now honors the previously-dead `truncate` field (default flipped to `false` so other callers are unchanged).

Fixes #13237
Fixes #21455
Fixes #26395

Supersedes #28112, #28988, #26397.

## How did you verify your code works?

5 new tests in `test/js/bun/io/bun-write.test.js` under `"streams pending Response/Request body to disk"` — all 5 hang on v1.3.13, all 5 pass on this branch:

- fetch Response with body still arriving + forced `Bun.gc(true)`
- `new Response(ReadableStream)`
- `new Request(url, { body: ReadableStream })`
- truncates an existing larger file
- creates parent directory (mkdirp)

Also: `test/js/workerd/html-rewriter.test.js` 41/41, `bun run zig:check-all` clean on all platforms, and the original #13237 server-side repro `Bun.write(out, new Response(req.body))` works.