### PR TITLE
crypto: fix f32 precision loss and unit mismatch in randomFill bounds checks

### DIFF
--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -408,7 +408,7 @@ const random = struct {
             try assertSize(global, size_value, element_size, offset, buf.byte_len);
 
         if (size == 0) {
-            _ = try callback.call(global, .js_undefined, &.{ .null, JSValue.jsNumber(0) });
+            _ = try callback.call(global, .js_undefined, &.{ .null, buf_value });
             return .js_undefined;
         }
 

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -393,7 +393,10 @@ const random = struct {
         } else if (size_value.isCallable()) {
             callback = size_value;
             offset = try assertOffset(global, offset_value, element_size, buf.byte_len);
-            size_value = JSValue.jsNumber(buf.len - offset);
+            // `offset` is a byte offset (already scaled by element_size) but `buf.len`
+            // is an element count, so `buf.len - offset` would mix units and can
+            // underflow. Defer to the `buf.byte_len - offset` default below instead.
+            size_value = .js_undefined;
         } else {
             _ = try validators.validateFunction(global, "callback", callback);
             offset = try assertOffset(global, offset_value, element_size, buf.byte_len);

--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -293,7 +293,7 @@ const random = struct {
         if (!offset_value.isNumber()) {
             return global.throwInvalidArgumentTypeValue("offset", "number", offset_value);
         }
-        const offset = offset_value.asNumber() * @as(f32, @floatFromInt(element_size));
+        const offset = offset_value.asNumber() * @as(f64, @floatFromInt(element_size));
 
         const max_length = @min(length, max_possible_length);
         if (std.math.isNan(offset) or offset > @as(f64, @floatFromInt(max_length)) or offset < 0) {
@@ -304,14 +304,14 @@ const random = struct {
     }
     fn assertSize(global: *JSGlobalObject, size_value: JSValue, element_size: u8, offset: u32, length: usize) JSError!u32 {
         var size = try validators.validateNumber(global, size_value, "size", null, null);
-        size *= @as(f32, @floatFromInt(element_size));
+        size *= @as(f64, @floatFromInt(element_size));
 
         if (std.math.isNan(size) or size > max_possible_length or size < 0) {
             return global.throwRangeError(size, .{ .field_name = "size", .min = 0, .max = max_possible_length });
         }
 
-        if (size + @as(f32, @floatFromInt(offset)) > @as(f64, @floatFromInt(length))) {
-            return global.throwRangeError(size + @as(f32, @floatFromInt(offset)), .{ .field_name = "size + offset", .max = @intCast(length) });
+        if (size + @as(f64, @floatFromInt(offset)) > @as(f64, @floatFromInt(length))) {
+            return global.throwRangeError(size + @as(f64, @floatFromInt(offset)), .{ .field_name = "size + offset", .max = @intCast(length) });
         }
 
         return @intFromFloat(size);

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
+import { bunEnv, bunExe } from "harness";
 
 describe("randomInt args validation", () => {
   it("default min is 0 so max should be greater than 0", () => {
@@ -63,13 +64,33 @@ describe("randomFill bounds checking", () => {
   // bounds check in assertSize cast the u32 offset to f32 before adding, so an offset
   // of 16777217 rounded down to 16777216 and `size + offset > length` passed when the
   // true sum exceeded the buffer length, leading to a heap write past the end.
-  it("randomFillSync rejects size + offset > length when offset exceeds 2**24", () => {
-    const length = 2 ** 24 + 2; // 16777218
-    const offset = 2 ** 24 + 1; // 16777217 -> rounds to 16777216 as f32
-    const size = 2; // offset + size = 16777219 > 16777218
-    expect(() => randomFillSync(new ArrayBuffer(length), offset, size)).toThrow(
-      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
-    );
+  //
+  // Without the fix this path writes out of bounds: debug panics on the slice bounds
+  // check and release writes past the allocation. Run in a subprocess so the test
+  // runner survives and records a clean failure either way.
+  it("randomFillSync rejects size + offset > length when offset exceeds 2**24", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { randomFillSync } = require("crypto");
+         const length = 2 ** 24 + 2; // 16777218
+         const offset = 2 ** 24 + 1; // 16777217 -> rounds to 16777216 as f32
+         const size = 2;             // offset + size = 16777219 > 16777218
+         try {
+           randomFillSync(new ArrayBuffer(length), offset, size);
+           console.log("NO_THROW");
+         } catch (e) {
+           console.log(e.code);
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("ERR_OUT_OF_RANGE");
+    expect(exitCode).toBe(0);
   });
 
   it("randomFillSync still accepts size + offset == length at the f32 precision boundary", () => {
@@ -80,14 +101,28 @@ describe("randomFill bounds checking", () => {
     expect(() => randomFillSync(buf, offset, size)).not.toThrow();
   });
 
-  it("randomFill (async) rejects size + offset > length when offset exceeds 2**24", () => {
-    const length = 2 ** 24 + 2;
-    const offset = 2 ** 24 + 1;
-    const size = 2;
-    // Validation errors are thrown synchronously even for the async API.
-    expect(() => randomFill(new ArrayBuffer(length), offset, size, () => {})).toThrow(
-      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
-    );
+  it("randomFill (async) rejects size + offset > length when offset exceeds 2**24", async () => {
+    // Validation errors are thrown synchronously even for the async API. Without the
+    // fix the check passes and the threadpool writes past the end of the buffer, so
+    // run in a subprocess.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { randomFill } = require("crypto");
+         try {
+           randomFill(new ArrayBuffer(2 ** 24 + 2), 2 ** 24 + 1, 2, () => {});
+           console.log("NO_THROW");
+         } catch (e) {
+           console.log(e.code);
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("ERR_OUT_OF_RANGE");
   });
 
   it("randomFill (async) still accepts size + offset == length at the f32 precision boundary", async () => {
@@ -107,13 +142,26 @@ describe("randomFill default size with multi-byte typed arrays", () => {
   // already been scaled to a byte offset by assertOffset. For element_size > 1 this
   // either underflowed (panic in debug) or under-filled the buffer.
   it("randomFill(Float64Array, offset, cb) does not underflow when byte offset > element count", async () => {
-    const buf = new Float64Array(10); // 80 bytes, 10 elements
-    const { promise, resolve } = Promise.withResolvers<Error | null>();
-    // offset 2 elements = 16 bytes; previously computed size as 10 - 16 -> underflow
-    randomFill(buf, 2, err => resolve(err));
-    expect(await promise).toBeNull();
-    expect(buf[0]).toBe(0);
-    expect(buf[1]).toBe(0);
+    // Without the fix this underflows usize and panics in debug, so run in a subprocess.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { randomFill } = require("crypto");
+         // 80 bytes, 10 elements; offset 2 elements = 16 bytes.
+         // Previously computed default size as 10 - 16 -> usize underflow.
+         randomFill(new Float64Array(10), 2, (err, buf) => {
+           if (err) return console.log("ERR:" + err.code);
+           console.log("OK", buf[0], buf[1]);
+         });`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("OK 0 0");
+    expect(exitCode).toBe(0);
   });
 
   it("randomFill passes the buffer (not 0) to the callback when size is 0", async () => {

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -89,4 +89,14 @@ describe("randomFill bounds checking", () => {
       expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
     );
   });
+
+  it("randomFill (async) still accepts size + offset == length at the f32 precision boundary", async () => {
+    const length = 2 ** 24 + 2;
+    const offset = 2 ** 24 + 1;
+    const size = 1;
+    const buf = new Uint8Array(length);
+    const { promise, resolve } = Promise.withResolvers<Error | null>();
+    randomFill(buf, offset, size, err => resolve(err));
+    expect(await promise).toBeNull();
+  });
 });

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { randomBytes, randomInt } from "crypto";
+import { randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
 
 describe("randomInt args validation", () => {
   it("default min is 0 so max should be greater than 0", () => {
@@ -55,5 +55,38 @@ describe("randomBytes", () => {
     });
 
     await promise;
+  });
+});
+
+describe("randomFill bounds checking", () => {
+  // f32 can only represent integers exactly up to 2**24 (16777216). Previously the
+  // bounds check in assertSize cast the u32 offset to f32 before adding, so an offset
+  // of 16777217 rounded down to 16777216 and `size + offset > length` passed when the
+  // true sum exceeded the buffer length, leading to a heap write past the end.
+  it("randomFillSync rejects size + offset > length when offset exceeds 2**24", () => {
+    const length = 2 ** 24 + 2; // 16777218
+    const offset = 2 ** 24 + 1; // 16777217 -> rounds to 16777216 as f32
+    const size = 2; // offset + size = 16777219 > 16777218
+    expect(() => randomFillSync(new ArrayBuffer(length), offset, size)).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
+  });
+
+  it("randomFillSync still accepts size + offset == length at the f32 precision boundary", () => {
+    const length = 2 ** 24 + 2;
+    const offset = 2 ** 24 + 1;
+    const size = 1; // offset + size = 16777218 == length, should be fine
+    const buf = new Uint8Array(length);
+    expect(() => randomFillSync(buf, offset, size)).not.toThrow();
+  });
+
+  it("randomFill (async) rejects size + offset > length when offset exceeds 2**24", () => {
+    const length = 2 ** 24 + 2;
+    const offset = 2 ** 24 + 1;
+    const size = 2;
+    // Validation errors are thrown synchronously even for the async API.
+    expect(() => randomFill(new ArrayBuffer(length), offset, size, () => {})).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
   });
 });

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -100,3 +100,34 @@ describe("randomFill bounds checking", () => {
     expect(await promise).toBeNull();
   });
 });
+
+describe("randomFill default size with multi-byte typed arrays", () => {
+  // In the 3-arg form `randomFill(buf, offset, cb)`, the default size was computed
+  // as `buf.len - offset` where `buf.len` is the element count but `offset` had
+  // already been scaled to a byte offset by assertOffset. For element_size > 1 this
+  // either underflowed (panic in debug) or under-filled the buffer.
+  it("randomFill(Float64Array, offset, cb) does not underflow when byte offset > element count", async () => {
+    const buf = new Float64Array(10); // 80 bytes, 10 elements
+    const { promise, resolve } = Promise.withResolvers<Error | null>();
+    // offset 2 elements = 16 bytes; previously computed size as 10 - 16 -> underflow
+    randomFill(buf, 2, err => resolve(err));
+    expect(await promise).toBeNull();
+    expect(buf[0]).toBe(0);
+    expect(buf[1]).toBe(0);
+  });
+
+  it("randomFill(Float64Array, offset, cb) fills to the end of the buffer", async () => {
+    // Run several times since each byte has a 1/256 chance of being 0 anyway.
+    let tailFilled = false;
+    for (let i = 0; i < 8 && !tailFilled; i++) {
+      const buf = new Float64Array(100); // 800 bytes
+      const { promise, resolve } = Promise.withResolvers<Error | null>();
+      randomFill(buf, 1, err => resolve(err));
+      expect(await promise).toBeNull();
+      // Previously only bytes 8..744 were filled; bytes 744..800 stayed zero.
+      const bytes = new Uint8Array(buf.buffer);
+      if (bytes.subarray(744, 800).some(b => b !== 0)) tailFilled = true;
+    }
+    expect(tailFilled).toBe(true);
+  });
+});

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -116,6 +116,15 @@ describe("randomFill default size with multi-byte typed arrays", () => {
     expect(buf[1]).toBe(0);
   });
 
+  it("randomFill passes the buffer (not 0) to the callback when size is 0", async () => {
+    const buf = new Uint8Array(0);
+    const { promise, resolve } = Promise.withResolvers<[Error | null, unknown]>();
+    randomFill(buf, (err, b) => resolve([err, b]));
+    const [err, b] = await promise;
+    expect(err).toBeNull();
+    expect(b).toBe(buf);
+  });
+
   it("randomFill(Float64Array, offset, cb) fills to the end of the buffer", async () => {
     // Run several times since each byte has a 1/256 chance of being 0 anyway.
     let tailFilled = false;


### PR DESCRIPTION
## What does this PR do?

Fixes two bounds-checking bugs in `crypto.randomFill` / `crypto.randomFillSync`:

1. **Heap overflow via f32 precision loss** in the `size + offset > length` check
2. **Unit mismatch** in the 3-arg `randomFill(buf, offset, cb)` default-size computation causing integer underflow or silent under-fill for multi-byte typed arrays

## Reproduction

```js
// (1) writes 1 byte past the end of the allocation instead of throwing
require('crypto').randomFillSync(new ArrayBuffer(16777218), 16777217, 2);

// (2a) panics in debug / throws spurious ERR_OUT_OF_RANGE in release
require('crypto').randomFill(new Float64Array(10), 2, () => {});

// (2b) leaves bytes 744..800 un-randomized
require('crypto').randomFill(new Float64Array(100), 1, () => {});
```

Node.js throws `ERR_OUT_OF_RANGE` for (1) and fills the full tail for (2).

## Root cause

**(1)** In `assertSize`, the `u32` `offset` was cast to `f32` before being added to the `f64` `size`:

```zig
if (size + @as(f32, @floatFromInt(offset)) > @as(f64, @floatFromInt(length))) {
```

`f32` only represents integers exactly up to 2²⁴ = 16777216. An offset of 16777217 rounds down to 16777216, so with `length = 16777218` and `size = 2` the check evaluates `2 + 16777216 > 16777218` → `false`, when the true sum `16777219` exceeds `length`. The bogus offset/size are then used to slice the buffer (sync) or handed to the threadpool as a raw `[*]u8` span (async), producing an OOB write.

**(2)** In `randomFill`'s 3-arg branch, the default size was computed as `buf.len - offset` where `buf.len` is the **element** count but `offset` had already been scaled to a **byte** offset by `assertOffset`. For `Float64Array(10)` with offset 2, that's `10 - 16` → usize underflow.

## Fix

- Change all four `f32` casts in `assertOffset` / `assertSize` to `f64` (exact for all integers up to 2⁵³, well beyond `max_possible_length`).
- In the 3-arg branch, set `size_value = .js_undefined` to fall through to the existing `buf.byte_len - offset` default, keeping both operands in byte units.

## Verification

- `bun bd test test/js/node/crypto/crypto-random.test.ts` — 14 pass, 0 fail
- `test/js/node/test/parallel/test-crypto-random.js` — passes
- `test/js/node/test/parallel/test-crypto-randomfillsync-regression.js` — passes
- Without the fix, the new tests panic in debug (Zig bounds check / integer overflow) and fail in release.
