### PR TITLE
Fix heap overflows in normalizePathWindows

### DIFF
--- a/src/sys.zig
+++ b/src/sys.zig
@@ -987,8 +987,28 @@ pub fn normalizePathWindows(
     if (comptime T != u8 and T != u16) {
         @compileError("normalizePathWindows only supports u8 and u16 character types");
     }
+
+    const name_too_long: Maybe([:0]const u16) = .{
+        .err = .{
+            .errno = @intFromEnum(E.NAMETOOLONG),
+            .syscall = .open,
+        },
+    };
+    // normalizeStringGenericTZ writes into `buf` with .add_nt_prefix = true and
+    // .zero_terminate = true but performs no bounds checking of its own. The NT
+    // prefix adds up to 6 u16 ("\\" -> "\??\UNC\") plus a NUL. Reserve enough
+    // headroom wherever we feed it a path that could approach `buf.len`.
+    const nt_prefix_headroom = 8;
+
     const wbuf = if (T != u16) bun.w_path_buffer_pool.get();
     defer if (T != u16) bun.w_path_buffer_pool.put(wbuf);
+    // convertUTF8toUTF16InBuffer forwards only `output.ptr` to simdutf, which
+    // performs no output bounds checking. UTF-16 output length is always <=
+    // UTF-8 input byte length, so bounding `path_.len` by `wbuf.len` is
+    // sufficient to keep the conversion in-bounds.
+    if (T != u16 and path_.len > wbuf.len) {
+        return name_too_long;
+    }
     var path = if (T == u16) path_ else bun.strings.convertUTF8toUTF16InBuffer(wbuf, path_);
 
     if (std.fs.path.isAbsoluteWindowsWTF16(path)) {
@@ -1006,6 +1026,9 @@ pub fn normalizePathWindows(
                 // Preserve the device path, instead of resolving '.' as a relative
                 // path. This prevents simplifying the path '\\.\pipe' into '\pipe'
                 if (path[2] == '.') {
+                    if (path.len >= buf.len) {
+                        return name_too_long;
+                    }
                     buf[0..4].* = .{ '\\', '\\', '.', '\\' };
                     const rest = path[4..];
                     @memcpy(buf[4..][0..rest.len], rest);
@@ -1020,18 +1043,16 @@ pub fn normalizePathWindows(
             }
         }
 
+        if (path.len > buf.len -| nt_prefix_headroom) {
+            return name_too_long;
+        }
         const norm = bun.path.normalizeStringGenericTZ(u16, path, buf, .{ .add_nt_prefix = opts.add_nt_prefix, .zero_terminate = true });
         return .{ .result = norm };
     }
 
     if (bun.strings.indexOfAnyT(T, path_, &.{ '\\', '/', '.' }) == null) {
         if (path.len >= buf.len) {
-            return .{
-                .err = .{
-                    .errno = @intFromEnum(E.NAMETOOLONG),
-                    .syscall = .open,
-                },
-            };
+            return name_too_long;
         }
 
         // Skip the system call to get the final path name if it doesn't have any of the above characters.
@@ -1061,19 +1082,8 @@ pub fn normalizePathWindows(
     const buf1 = bun.w_path_buffer_pool.get();
     defer bun.w_path_buffer_pool.put(buf1);
     const joined_len = base_path.len + 1 + path.len;
-    // normalizeStringGenericTZ below writes into `buf` (same size as `buf1`)
-    // with .add_nt_prefix = true and .zero_terminate = true but performs no
-    // bounds checking. GetFinalPathNameByHandle strips the long-path prefix,
-    // so normalization re-adds up to 6 u16 ("\\" -> "\??\UNC\") plus a NUL.
-    // Reserve that headroom in addition to fitting the join in `buf1`.
-    const nt_prefix_headroom = 8;
     if (joined_len > buf1.len -| nt_prefix_headroom) {
-        return .{
-            .err = .{
-                .errno = @intFromEnum(E.NAMETOOLONG),
-                .syscall = .open,
-            },
-        };
+        return name_too_long;
     }
     @memcpy(buf1[0..base_path.len], base_path);
     buf1[base_path.len] = '\\';

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1060,10 +1060,19 @@ pub fn normalizePathWindows(
 
     const buf1 = bun.w_path_buffer_pool.get();
     defer bun.w_path_buffer_pool.put(buf1);
+    const joined_len = base_path.len + 1 + path.len;
+    if (joined_len > buf1.len) {
+        return .{
+            .err = .{
+                .errno = @intFromEnum(E.NAMETOOLONG),
+                .syscall = .open,
+            },
+        };
+    }
     @memcpy(buf1[0..base_path.len], base_path);
     buf1[base_path.len] = '\\';
-    @memcpy(buf1[base_path.len + 1 .. base_path.len + 1 + path.len], path);
-    const norm = bun.path.normalizeStringGenericTZ(u16, buf1[0 .. base_path.len + 1 + path.len], buf, .{ .add_nt_prefix = true, .zero_terminate = true });
+    @memcpy(buf1[base_path.len + 1 .. joined_len], path);
+    const norm = bun.path.normalizeStringGenericTZ(u16, buf1[0..joined_len], buf, .{ .add_nt_prefix = true, .zero_terminate = true });
     return .{
         .result = norm,
     };

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1044,7 +1044,7 @@ pub fn normalizePathWindows(
             }
         }
 
-        if (path.len > buf.len -| nt_prefix_headroom) {
+        if (path.len > buf.len -| (if (opts.add_nt_prefix) nt_prefix_headroom else 1)) {
             return name_too_long;
         }
         const norm = bun.path.normalizeStringGenericTZ(u16, path, buf, .{ .add_nt_prefix = opts.add_nt_prefix, .zero_terminate = true });

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1047,7 +1047,10 @@ pub fn normalizePathWindows(
             }
         }
 
-        if (path.len > buf.len -| (if (opts.add_nt_prefix) nt_prefix_headroom else 1)) {
+        // With .add_nt_prefix = false, normalizeStringGenericTZ can still grow
+        // the input by one u16 (it appends a trailing '\' after a bare UNC
+        // volume name) plus the NUL terminator.
+        if (path.len > buf.len -| (if (opts.add_nt_prefix) nt_prefix_headroom else 2)) {
             return name_too_long;
         }
         const norm = bun.path.normalizeStringGenericTZ(u16, path, buf, .{ .add_nt_prefix = opts.add_nt_prefix, .zero_terminate = true });

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1013,7 +1013,10 @@ pub fn normalizePathWindows(
     var path = if (T == u16) path_ else bun.strings.convertUTF8toUTF16InBuffer(wbuf, path_);
 
     if (std.fs.path.isAbsoluteWindowsWTF16(path)) {
-        if (path_.len >= 4) {
+        // `path_.len` guards the `path_[path_.len - 4 ..]` slice below; `path.len`
+        // guards `path[1]`/`path[3]`. For T == u8 these can differ when the input
+        // contains multi-byte UTF-8 (e.g. "\\\\é" is 4 bytes but 3 u16).
+        if (path_.len >= 4 and path.len >= 4) {
             if ((bun.strings.eqlComptimeT(T, path_[path_.len - "\\nul".len ..], "\\nul") or
                 bun.strings.eqlComptimeT(T, path_[path_.len - "\\NUL".len ..], "\\NUL")))
             {

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1025,10 +1025,10 @@ pub fn normalizePathWindows(
     }
 
     if (bun.strings.indexOfAnyT(T, path_, &.{ '\\', '/', '.' }) == null) {
-        if (buf.len < path.len) {
+        if (path.len >= buf.len) {
             return .{
                 .err = .{
-                    .errno = @intFromEnum(E.NOMEM),
+                    .errno = @intFromEnum(E.NAMETOOLONG),
                     .syscall = .open,
                 },
             };
@@ -1061,7 +1061,13 @@ pub fn normalizePathWindows(
     const buf1 = bun.w_path_buffer_pool.get();
     defer bun.w_path_buffer_pool.put(buf1);
     const joined_len = base_path.len + 1 + path.len;
-    if (joined_len > buf1.len) {
+    // normalizeStringGenericTZ below writes into `buf` (same size as `buf1`)
+    // with .add_nt_prefix = true and .zero_terminate = true but performs no
+    // bounds checking. GetFinalPathNameByHandle strips the long-path prefix,
+    // so normalization re-adds up to 6 u16 ("\\" -> "\??\UNC\") plus a NUL.
+    // Reserve that headroom in addition to fitting the join in `buf1`.
+    const nt_prefix_headroom = 8;
+    if (joined_len > buf1.len -| nt_prefix_headroom) {
         return .{
             .err = .{
                 .errno = @intFromEnum(E.NAMETOOLONG),

--- a/src/sys.zig
+++ b/src/sys.zig
@@ -1004,9 +1004,10 @@ pub fn normalizePathWindows(
     defer if (T != u16) bun.w_path_buffer_pool.put(wbuf);
     // convertUTF8toUTF16InBuffer forwards only `output.ptr` to simdutf, which
     // performs no output bounds checking. UTF-16 output length is always <=
-    // UTF-8 input byte length, so bounding `path_.len` by `wbuf.len` is
-    // sufficient to keep the conversion in-bounds.
-    if (T != u16 and path_.len > wbuf.len) {
+    // UTF-8 input byte length, so `path_.len` is a cheap upper bound; when it
+    // exceeds `wbuf.len`, compute the exact post-conversion length to avoid
+    // over-rejecting multi-byte inputs whose UTF-16 representation fits.
+    if (T != u16 and path_.len > wbuf.len and bun.simdutf.length.utf16.from.utf8(path_) > wbuf.len) {
         return name_too_long;
     }
     var path = if (T == u16) path_ else bun.strings.convertUTF8toUTF16InBuffer(wbuf, path_);

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -54,14 +54,13 @@ describe.if(isPosix)("path length validation with multi-byte characters", () => 
 });
 
 // On Windows, PATH_MAX_WIDE is 32767 u16 code units. normalizePathWindows
-// joins the dirfd's resolved path with the relative input path into a pooled
-// [32767]u16 buffer. A relative path that fits in a WPathBuffer on its own but
-// overflows once the cwd is prepended must return ENAMETOOLONG rather than
-// writing past the buffer.
-describe.if(isWindows)("path length validation when joining cwd + relative path on Windows", () => {
+// copies the input and/or the joined cwd + input into pooled [32767]u16
+// buffers at several points. Each copy site must return ENAMETOOLONG rather
+// than writing past the buffer when the input would not fit.
+describe.if(isWindows)("path length validation in normalizePathWindows", () => {
   // 32765 ASCII chars → 32765 u16 after UTF-8→UTF-16 conversion (fits in the
   // 32767-u16 conversion buffer). Even a minimal cwd like "C:\" (3 chars)
-  // brings the joined length to 3 + 1 + 32765 = 32769 > 32767.
+  // brings the joined length past 32767.
   const longRelative = "./" + Buffer.alloc(32763, "a").toString();
 
   it("rejects overly long relative paths in readdirSync", () => {
@@ -73,11 +72,33 @@ describe.if(isWindows)("path length validation when joining cwd + relative path 
   });
 
   // A relative path containing no '\\', '/', or '.' takes the early-return
-  // branch in normalizePathWindows that copies the path directly into `buf`
-  // and appends a NUL. When path.len == buf.len the NUL write lands one past
-  // the end of the buffer; this must be rejected with ENAMETOOLONG instead.
-  it("rejects a PATH_MAX_WIDE-length separator-free relative path in readdirSync", () => {
+  // branch that copies the path directly into `buf` and appends a NUL. When
+  // path.len == buf.len the NUL write would land one past the end.
+  it("rejects a PATH_MAX_WIDE-length separator-free relative path", () => {
     const noSep = Buffer.alloc(32767, "a").toString();
     expect(() => fs.readdirSync(noSep)).toThrow("ENAMETOOLONG");
+  });
+
+  // The UTF-8→UTF-16 conversion at the top of normalizePathWindows forwards
+  // only the output pointer to simdutf, which performs no bounds checking.
+  // Upstream path validation caps at MAX_PATH_BYTES (~98302 on Windows), not
+  // PATH_MAX_WIDE, so inputs in (32767, 98302] bytes reach the conversion.
+  it("rejects relative paths longer than the UTF-16 conversion buffer", () => {
+    const tooLong = Buffer.alloc(40000, "a").toString();
+    expect(() => fs.readdirSync(tooLong)).toThrow("ENAMETOOLONG");
+  });
+
+  // Absolute drive-letter paths are normalized into `buf` with an NT object
+  // prefix (\??\ or \??\UNC\) and NUL terminator added by
+  // normalizeStringGenericTZ, which does not bounds-check.
+  it("rejects overly long absolute drive-letter paths", () => {
+    const absLong = "C:\\" + Buffer.alloc(32762, "a").toString();
+    expect(() => fs.readdirSync(absLong)).toThrow("ENAMETOOLONG");
+  });
+
+  // Device paths (\\.\...) are copied verbatim into `buf` with a trailing NUL.
+  it("rejects overly long device paths", () => {
+    const devLong = "\\\\.\\" + Buffer.alloc(32763, "a").toString();
+    expect(() => fs.readdirSync(devLong)).toThrow("ENAMETOOLONG");
   });
 });

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isPosix } from "harness";
+import { isPosix, isWindows } from "harness";
 import fs from "node:fs";
 
 // On POSIX systems, MAX_PATH_BYTES is 4096.
@@ -50,5 +50,25 @@ describe.if(isPosix)("path length validation with multi-byte characters", () => 
     // 1500 emoji = 3000 UTF-16 code units but 6000 UTF-8 bytes > 4096
     const emojiPath = "\u{1F600}".repeat(1500);
     expect(() => fs.statSync(emojiPath)).toThrow("ENAMETOOLONG");
+  });
+});
+
+// On Windows, PATH_MAX_WIDE is 32767 u16 code units. normalizePathWindows
+// joins the dirfd's resolved path with the relative input path into a pooled
+// [32767]u16 buffer. A relative path that fits in a WPathBuffer on its own but
+// overflows once the cwd is prepended must return ENAMETOOLONG rather than
+// writing past the buffer.
+describe.if(isWindows)("path length validation when joining cwd + relative path on Windows", () => {
+  // 32765 ASCII chars → 32765 u16 after UTF-8→UTF-16 conversion (fits in the
+  // 32767-u16 conversion buffer). Even a minimal cwd like "C:\" (3 chars)
+  // brings the joined length to 3 + 1 + 32765 = 32769 > 32767.
+  const longRelative = "./" + Buffer.alloc(32763, "a").toString();
+
+  it("rejects overly long relative paths in readdirSync", () => {
+    expect(() => fs.readdirSync(longRelative)).toThrow("ENAMETOOLONG");
+  });
+
+  it("rejects overly long relative paths in writeFileSync", () => {
+    expect(() => fs.writeFileSync(longRelative, "")).toThrow("ENAMETOOLONG");
   });
 });

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -90,9 +90,12 @@ describe.if(isWindows)("path length validation in normalizePathWindows", () => {
 
   // Absolute drive-letter paths are normalized into `buf` with an NT object
   // prefix (\??\ or \??\UNC\) and NUL terminator added by
-  // normalizeStringGenericTZ, which does not bounds-check.
+  // normalizeStringGenericTZ, which does not bounds-check. node:fs prepends
+  // a \\?\ long-path prefix before reaching normalizePathWindows, so size
+  // the input so that prefixed length (+4) still fits the 32767-u16
+  // conversion buffer and the headroom guard is what rejects it.
   it("rejects overly long absolute drive-letter paths", () => {
-    const absLong = "C:\\" + Buffer.alloc(32762, "a").toString();
+    const absLong = "C:\\" + Buffer.alloc(32757, "a").toString();
     expect(() => fs.readdirSync(absLong)).toThrow("ENAMETOOLONG");
   });
 

--- a/test/js/node/fs/fs-path-length.test.ts
+++ b/test/js/node/fs/fs-path-length.test.ts
@@ -71,4 +71,13 @@ describe.if(isWindows)("path length validation when joining cwd + relative path 
   it("rejects overly long relative paths in writeFileSync", () => {
     expect(() => fs.writeFileSync(longRelative, "")).toThrow("ENAMETOOLONG");
   });
+
+  // A relative path containing no '\\', '/', or '.' takes the early-return
+  // branch in normalizePathWindows that copies the path directly into `buf`
+  // and appends a NUL. When path.len == buf.len the NUL write lands one past
+  // the end of the buffer; this must be rejected with ENAMETOOLONG instead.
+  it("rejects a PATH_MAX_WIDE-length separator-free relative path in readdirSync", () => {
+    const noSep = Buffer.alloc(32767, "a").toString();
+    expect(() => fs.readdirSync(noSep)).toThrow("ENAMETOOLONG");
+  });
 });


### PR DESCRIPTION
## Problem

`normalizePathWindows` in `src/sys.zig` writes into pooled `[32767]u16` buffers at several points without bounds-checking the input length. The originally reported case was the dirfd-join branch, but the same pattern exists at every write site in the function:

1. **UTF-8→UTF-16 conversion** (T == u8): `convertUTF8toUTF16InBuffer` forwards only `output.ptr` to simdutf, which performs no output bounds checking. Upstream path validation caps at `MAX_PATH_BYTES` (~98302 bytes on Windows), not `PATH_MAX_WIDE` (32767), so an ASCII input in (32767, 98302] bytes writes past the conversion buffer before any downstream check runs.
2. **Device-path (`\\.\`) early-return**: copies the path verbatim into `buf` and writes a NUL at `buf[path.len]` with no length check.
3. **Absolute-path normalization**: calls `normalizeStringGenericTZ` into `buf` with `.add_nt_prefix=true` and `.zero_terminate=true`; that function performs no bounds checking, and the NT prefix adds up to 6 u16 (`\\` → `\??\UNC\`) plus a NUL.
4. **Separator-free early-return**: `if (buf.len < path.len)` permitted `path.len == buf.len`, after which `buf[path.len] = 0` wrote one past the end.
5. **Relative-path dirfd join**: concatenates `base_path + '\' + path` into a pooled `[32767]u16` buffer with no bounds check, then normalizes into `buf` (same NT-prefix headroom issue as 3).

## Repro

On Windows, via `fs.readdirSync` / `fs.writeFileSync` (which route through `openDirAtWindowsA` / `openFileAtWindowsT` → `normalizePathWindows`):

```js
const fs = require('node:fs');
fs.readdirSync('./' + 'a'.repeat(32763));      // (5) dirfd join
fs.readdirSync('a'.repeat(32767));             // (4) separator-free NUL off-by-one
fs.readdirSync('a'.repeat(40000));             // (1) simdutf conversion overflow
fs.readdirSync('C:\\' + 'a'.repeat(32762));    // (3) absolute normalize overflow
fs.readdirSync('\\\\.\\' + 'a'.repeat(32763)); // (2) device-path NUL off-by-one
```

Without this fix: out-of-bounds panic in debug/safe builds, heap corruption in release.

## Fix

Return `ENAMETOOLONG` before each write site when the input (or input + NT-prefix headroom + NUL) would not fit in the destination `WPathBuffer`. The NT-prefix headroom (8 u16) and the error value are hoisted as function-level constants to avoid duplication.

## Test

Added Windows-gated cases in `test/js/node/fs/fs-path-length.test.ts` covering each overflow site via `fs.readdirSync` / `fs.writeFileSync`.

Verified `zig:check-all` passes on all targets including both Windows arches.
