### PR TITLE
socket: guard flush() with isDetached() to prevent UAF on TLS close

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -1281,6 +1281,15 @@ pub fn NewSocket(comptime ssl: bool) type {
 
         pub fn flush(this: *This, _: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!JSValue {
             jsc.markBinding(@src());
+            // `end()` → `internalFlush` → `markInactive` → `closeAndDetach(.normal)`
+            // detaches `this.socket` and, for TLS, defers the raw close until the
+            // peer's close_notify arrives — leaving `is_active` set so the eventual
+            // `onClose` can run `handlers.markInactive()`. Without this guard a
+            // follow-up `flush()` re-enters `markInactive`, sees the detached
+            // socket as closed, and frees `*Handlers` early; the deferred `onClose`
+            // then derefs freed memory. Every other `internalFlush` caller already
+            // has this check.
+            if (this.socket.isDetached()) return .js_undefined;
             this.internalFlush();
             return .js_undefined;
         }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3,7 +3,7 @@ import { connect, fileURLToPath, SocketHandler, spawn } from "bun";
 import { createSocketPair } from "bun:internal-for-testing";
 import { describe, expect, it, jest } from "bun:test";
 import { closeSync } from "fs";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, getMaxFD, isWindows, tls } from "harness";
+import { bunEnv, bunExe, expectMaxObjectTypeCount, getMaxFD, isWindows, tempDir, tls } from "harness";
 describe.concurrent("socket", () => {
   it("should throw when a socket from a file descriptor has a bad file descriptor", async () => {
     const open = jest.fn();
@@ -831,3 +831,68 @@ it("reading fd of a TLS listener should not crash", () => {
   expect(typeof listener.fd).toBe("number");
   expect(listener.fd).toBeGreaterThanOrEqual(0);
 });
+
+it("TLS client: flush() after end() does not double-teardown before deferred onClose", async () => {
+  // `end()` on a TLS client sends close_notify and defers the raw close until the
+  // peer replies, leaving `is_active` set so the eventual onClose can release the
+  // Handlers. A `flush()` in that window must not re-enter markInactive and free
+  // the Handlers early — when the peer's close_notify then arrives, onClose would
+  // deref freed memory (ASAN heap-use-after-free). Run in a subprocess so an ASAN
+  // abort surfaces as a clean test failure rather than taking down the runner.
+  using dir = tempDir("tls-flush-after-end", {
+    "run.ts": `
+      const tls = JSON.parse(process.env.TLS_JSON!);
+
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls,
+        socket: {
+          open() {},
+          data() {},
+          // reply to the client's close_notify so its deferred onClose fires
+          end(s) { s.end(); },
+          close() {},
+          error() {},
+        },
+      });
+
+      const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+      const { promise: handshook, resolve: onHandshook } = Promise.withResolvers<void>();
+
+      const client = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls,
+        socket: {
+          handshake() { onHandshook(); },
+          data() {},
+          close() { onClosed(); },
+          error() { onClosed(); },
+        },
+      });
+
+      await handshook;
+      client.end("x");
+      // Previously this re-entered markInactive while the TLS raw close was
+      // still deferred, freeing *Handlers before onClose ran.
+      client.flush();
+      client.flush();
+      await closed;
+      console.log("OK");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.ts"],
+    env: { ...bunEnv, TLS_JSON: JSON.stringify(tls) },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 30_000); // debug subprocess startup + ASAN symbolication on failure is slow


### PR DESCRIPTION
## Repro

```js
const client = await Bun.connect({ hostname, port, tls, socket: { ... } });
// after handshake:
client.end("x");
client.flush();   // ← second markInactive frees *Handlers
// peer replies close_notify → onClose derefs freed Handlers
```

ASAN on debug build:

```
==4075==ERROR: AddressSanitizer: use-after-poison on address 0x7aff355e0469
READ of size 1 at 0x7aff355e0469 thread T0
    #0 bun.js.api.bun.socket.NewSocket(true).onClose  src/bun.js/api/bun/socket.zig:661:46
    #1 deps.uws.handlers.PtrHandler(...).onClose      src/deps/uws/handlers.zig:49:61
    ...
    #5 us_internal_ssl_on_close                       packages/bun-usockets/src/crypto/openssl.c:940:29
```

## Cause

`end()` → `internalFlush` → `canEndAfterFlush()` → `markInactive()` → `closeAndDetach(.normal)` detaches `this.socket` and calls `us_socket_close(code=0)`. For TLS with `code==0`, `us_internal_ssl_close` sends close_notify and **defers** the raw close until the peer replies (so the loop stays alive to receive it). `markInactive` returns early without clearing `is_active`, relying on the eventual `onClose` → `markInactive` to run `handlers.markInactive()` and free the client-mode `*Handlers`.

`flush()` was the only `internalFlush()` caller without an `isDetached()` guard. Calling it in that window re-enters `canEndAfterFlush()` (still `is_active && end_after_flush`) → `markInactive()`, which now sees the detached socket as closed and runs the **full** teardown: `handlers.markInactive()` → `active_connections == 0` → `vm.allocator.destroy(handlers)`. When the peer's close_notify later arrives, `onClose` calls `this.getHandlers()` on freed memory.

## Fix

Add the same `isDetached()` early-return to `flush()` that `end()`, `endBuffered()`, `onWritable`, and every other `internalFlush()` caller already have.

## Verification

New test in `test/js/bun/net/socket.test.ts` spawns a TLS client that does `end("x"); flush(); flush();` after handshake and awaits `close`.

- Without fix (`git stash -- src/`): subprocess aborts with the ASAN trace above; test fails.
- With fix: subprocess prints `OK` and exits 0; test passes.