### PR TITLE
Buffer.write: Node-compatible errors when toString() detaches or shrinks the buffer

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -428,6 +428,12 @@ static JSC::EncodedJSValue writeToBuffer(JSC::JSGlobalObject* lexicalGlobalObjec
         return {};
     }
 
+    size_t byteLength = castedThis->byteLength();
+    if (offset >= byteLength) [[unlikely]]
+        return JSC::JSValue::encode(JSC::jsNumber(0));
+    if (length > byteLength - offset) [[unlikely]]
+        length = byteLength - offset;
+
     size_t written = 0;
 
     // Per Node docs, `'ascii'` on write is equivalent to `'latin1'` —
@@ -2575,16 +2581,14 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
         RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, WebCore::BufferEncodingType::utf8));
     }
     if (lengthValue.isUndefined() && offsetValue.isString()) {
+        Bun::V::validateString(scope, lexicalGlobalObject, stringValue, "string"_s);
+        RETURN_IF_EXCEPTION(scope, {});
         encodingValue = offsetValue;
 
         auto* str = stringValue.toString(lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, {});
         auto encoding = parseEncoding(scope, lexicalGlobalObject, encodingValue, false);
         RETURN_IF_EXCEPTION(scope, {});
-        if (castedThis->isDetached()) [[unlikely]] {
-            throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
-            return {};
-        }
         offset = 0;
         length = castedThis->byteLength();
         RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));
@@ -2619,15 +2623,19 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     auto encoding = parseEncoding(scope, lexicalGlobalObject, encodingValue, false);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwTypeError(lexicalGlobalObject, scope, "ArrayBufferView is detached"_s);
-        return {};
+    size_t byteLength = castedThis->byteLength();
+    if (offset > byteLength) [[unlikely]]
+        return Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, lexicalGlobalObject, "offset"_s);
+    if (length > byteLength - offset) [[unlikely]] {
+        switch (encoding) {
+        case WebCore::BufferEncodingType::utf8:
+        case WebCore::BufferEncodingType::latin1:
+        case WebCore::BufferEncodingType::ascii:
+            return Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, lexicalGlobalObject, "length"_s);
+        default:
+            length = byteLength - offset;
+        }
     }
-    size_t currentByteLength = castedThis->byteLength();
-    if (offset >= currentByteLength)
-        RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(0)));
-    size_t currentRemaining = currentByteLength - offset;
-    if (length > currentRemaining) length = currentRemaining;
 
     RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));
 }

--- a/test/js/node/buffer-write-detach.test.ts
+++ b/test/js/node/buffer-write-detach.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Buffer#write when a user toString() (on the encoding argument, or on a
+// non-string value argument) detaches or resizes the backing ArrayBuffer
+// after offset/length were validated. Node re-validates inside the
+// per-encoding native writer and throws ERR_BUFFER_OUT_OF_BOUNDS, or rejects
+// a non-string value with ERR_INVALID_ARG_TYPE before its toString runs; Bun
+// matches both. Expected values below were produced by Node v24.
+//
+// Each case runs in a fresh subprocess via `bun -e` so a build that still
+// crashes here takes down the child (visible in stderr / exitCode) rather
+// than the test runner.
+
+// stderr lines emitted by the runtime itself that don't indicate failure.
+// Under bun bd, ASAN prints a WARNING on startup; anything else on stderr
+// (Bun crash banner, DEADLYSIGNAL dump, thrown exception text) is a real
+// failure.
+const BENIGN_STDERR = /^WARNING: ASAN interferes with JSC signal handlers;[^\n]*\n$/;
+
+async function runPoc(script: string): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderr = BENIGN_STDERR.test(rawStderr) ? "" : rawStderr;
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("Buffer.write with detach / resize via encoding toString", () => {
+  test("write throws ERR_BUFFER_OUT_OF_BOUNDS(offset) when buffer is detached via encoding toString (crash repro)", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const ab = new ArrayBuffer(16);
+      const buf = Buffer.from(ab);
+      try {
+        buf.write("x", 5, 10, { toString() { structuredClone(ab, { transfer: [ab] }); return "utf8"; } });
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, byteLength: buf.byteLength }));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ threw: true, code: "ERR_BUFFER_OUT_OF_BOUNDS", byteLength: 0 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write throws ERR_BUFFER_OUT_OF_BOUNDS(length) when buffer is detached via encoding toString with offset=0", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const ab = new ArrayBuffer(16);
+      const buf = Buffer.from(ab);
+      try {
+        buf.write("x", 0, 10, { toString() { ab.transfer(0); return "utf8"; } });
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, msg: e.message }));
+      }
+    `);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out).toEqual({ threw: true, code: "ERR_BUFFER_OUT_OF_BOUNDS", msg: '"length" is outside of buffer bounds' });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write throws ERR_BUFFER_OUT_OF_BOUNDS(offset) when buffer is resized smaller than offset via encoding toString", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+      const buf = Buffer.from(ab);
+      try {
+        buf.write("xxxxxxxxxxxx", 5, 10, { toString() { ab.resize(3); return "utf8"; } });
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, msg: e.message, byteLength: buf.byteLength }));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      threw: true,
+      code: "ERR_BUFFER_OUT_OF_BOUNDS",
+      msg: '"offset" is outside of buffer bounds',
+      byteLength: 3,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write throws ERR_BUFFER_OUT_OF_BOUNDS(length) when buffer is resized smaller than offset+length via encoding toString", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+      const buf = Buffer.from(ab);
+      try {
+        buf.write("xxxxxxxxxxxx", 2, 10, { toString() { ab.resize(8); return "utf8"; } });
+        console.log(JSON.stringify({ threw: false }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, msg: e.message, byteLength: buf.byteLength }));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      threw: true,
+      code: "ERR_BUFFER_OUT_OF_BOUNDS",
+      msg: '"length" is outside of buffer bounds',
+      byteLength: 8,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write succeeds when encoding toString resizes but offset/length still fit", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+      const buf = Buffer.from(ab);
+      const n = buf.write("abc", 2, 3, { toString() { ab.resize(8); return "utf8"; } });
+      console.log(JSON.stringify({ n, byteLength: buf.byteLength, b2: buf[2], b3: buf[3], b4: buf[4] }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ n: 3, byteLength: 8, b2: 0x61, b3: 0x62, b4: 0x63 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write still works correctly with a non-detaching encoding toString", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const buf = Buffer.alloc(16);
+      const n = buf.write("hello", 0, 5, { toString() { return "utf8"; } });
+      console.log(JSON.stringify({ n, str: buf.toString("utf8", 0, 5) }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ n: 5, str: "hello" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write with plain string encoding keeps working", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const buf = Buffer.alloc(16);
+      const n = buf.write("hello", 2, 5, "utf8");
+      console.log(JSON.stringify({ n, str: buf.toString("utf8", 2, 7) }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ n: 5, str: "hello" });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// Sibling branch: `buf.write(value, encoding)` — the 2-arg "string + primitive
+// encoding" form. Here the second argument is already a primitive string, so
+// parseEncoding can't fire user JS; but the *first* argument skipped
+// validateString, so a detaching toString on an object value would crash the
+// process. Node's internal/buffer.js rejects non-string `value` up front via
+// validateString; Bun now matches. See issue #30417.
+describe.concurrent("Buffer.write(value, encoding) validates string argument", () => {
+  test("write(obj-with-detaching-toString, 'utf8') throws ERR_INVALID_ARG_TYPE (crash repro)", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const buf = Buffer.alloc(1024, 0xab);
+      let called = false;
+      try {
+        buf.write(
+          { toString() { called = true; buf.buffer.transfer(0); return "hello"; } },
+          "utf8",
+        );
+        console.log(JSON.stringify({ threw: false, called }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, called }));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ threw: true, code: "ERR_INVALID_ARG_TYPE", called: false });
+    expect(exitCode).toBe(0);
+  });
+
+  test("write(obj-with-detaching-toString) with no encoding also throws ERR_INVALID_ARG_TYPE", async () => {
+    // Sibling branch (offsetValue undefined) already had validateString;
+    // this just pins the two paths as behaviorally identical.
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const buf = Buffer.alloc(1024, 0xab);
+      let called = false;
+      try {
+        buf.write({ toString() { called = true; buf.buffer.transfer(0); return "hello"; } });
+        console.log(JSON.stringify({ threw: false, called }));
+      } catch (e) {
+        console.log(JSON.stringify({ threw: true, code: e.code, called }));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ threw: true, code: "ERR_INVALID_ARG_TYPE", called: false });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// Writing into a buffer that was detached before the call. Node returns 0 from
+// every form (byteLength is 0, so the native writer has nothing to do); Bun's
+// encoding-taking forms used to throw a bare TypeError while the encoding-less
+// forms returned 0.
+describe.concurrent("Buffer.write on an already-detached buffer returns 0 (Node-compat)", () => {
+  test("all four argument forms return 0", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      function detached() { const ab = new ArrayBuffer(16); const b = Buffer.from(ab); ab.transfer(0); return b; }
+      const out = {};
+      out.noArgs = detached().write("x");
+      out.encodingOnly = detached().write("x", "utf8");
+      out.offsetOnly = detached().write("x", 0);
+      out.full = detached().write("x", 0, 0, "utf8");
+      console.log(JSON.stringify(out));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ noArgs: 0, encodingOnly: 0, offsetOnly: 0, full: 0 });
+    expect(exitCode).toBe(0);
+  });
+});
+
+// Node dispatches utf8/latin1/ascii through a JS wrapper that throws on an
+// over-long length, but hex/base64/base64url/ucs2/utf16le go straight to the
+// native binding, which clamps. An out-of-range offset throws for every
+// encoding. Bun's hexWrite/base64Write/ucs2Write already clamp; .write() with
+// one of those encodings must agree with them.
+describe.concurrent("Buffer.write length re-check follows Node's per-encoding split", () => {
+  test("over-long length after resize: utf8/latin1/ascii throw, the raw-binding encodings clamp", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const strs = { hex: "aabbccddeeff", base64: "aGVsbG8gd29ybGQ=", base64url: "aGVsbG8gd29ybGQ" };
+      const out = {};
+      for (const enc of ["utf8", "latin1", "ascii", "hex", "base64", "base64url", "ucs2", "utf16le"]) {
+        const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+        const buf = Buffer.from(ab);
+        try {
+          out[enc] = buf.write(strs[enc] ?? "hello world!", 2, 10, { toString() { ab.resize(8); return enc; } });
+        } catch (e) {
+          out[enc] = e.code;
+        }
+      }
+      console.log(JSON.stringify(out));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      utf8: "ERR_BUFFER_OUT_OF_BOUNDS",
+      latin1: "ERR_BUFFER_OUT_OF_BOUNDS",
+      ascii: "ERR_BUFFER_OUT_OF_BOUNDS",
+      hex: 6,
+      base64: 6,
+      base64url: 6,
+      ucs2: 6,
+      utf16le: 6,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("offset beyond the resized buffer throws for every encoding", async () => {
+    const { stdout, stderr, exitCode } = await runPoc(`
+      const strs = { hex: "aabb", base64: "aGk=", base64url: "aGk" };
+      const out = {};
+      for (const enc of ["utf8", "hex", "base64", "ucs2"]) {
+        const ab = new ArrayBuffer(16, { maxByteLength: 32 });
+        const buf = Buffer.from(ab);
+        try {
+          out[enc] = buf.write(strs[enc] ?? "hi", 10, 2, { toString() { ab.resize(4); return enc; } });
+        } catch (e) {
+          out[enc] = e.code;
+        }
+      }
+      console.log(JSON.stringify(out));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      utf8: "ERR_BUFFER_OUT_OF_BOUNDS",
+      hex: "ERR_BUFFER_OUT_OF_BOUNDS",
+      base64: "ERR_BUFFER_OUT_OF_BOUNDS",
+      ucs2: "ERR_BUFFER_OUT_OF_BOUNDS",
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `Buffer.prototype.write` validates `offset` and `length`, then calls `toString()` on an object encoding. That user code can detach or shrink the ArrayBuffer. Main then throws a bare `TypeError("ArrayBufferView is detached")` or clamps silently (`jsBufferPrototypeFunction_writeBody`, `src/jsc/bindings/JSBuffer.cpp`). Node throws `ERR_BUFFER_OUT_OF_BOUNDS`.
- `buf.write(value, encoding)` coerces a non-string `value` with `toString()`. Node throws `ERR_INVALID_ARG_TYPE` and never calls it.
- `buf.write(123, 0, "bogus")` throws `ERR_INVALID_ARG_TYPE`, not Node's `ERR_UNKNOWN_ENCODING`. `buf.write("x", "")` throws `ERR_UNKNOWN_ENCODING`. Node writes utf8 and returns 1.

### Fix
- Every form that takes an encoding shares one tail that resolves it first, as Node's `write()` does. A falsy encoding (`""` included) means utf8.
- Then utf8/latin1/ascii check the current bounds and reject a non-string value. The other encodings reject the value, throw for `offset`, and clamp `length`.
- The two `isDetached()` `TypeError`s are gone. `writeToBuffer` clamps to the current `byteLength()` before it computes `vector() + offset`, so a detached buffer returns `0`, as in Node.
- Verified: `test/js/node/buffer-write-detach.test.ts` (13 tests, 9 fail on main), a new block in `test/js/node/buffer.test.js` (5 tests, 4 fail on main), Node's `test-buffer-write.js`. Self-reviewed: 4 concerns raised, 3 addressed. The fourth is kept on purpose (see Notes).

### Background
- A Buffer is a `Uint8Array` over an ArrayBuffer. `transfer()` and `structuredClone(..., {transfer})` detach it: `byteLength()` becomes 0 and `vector()` becomes null. `resize()` can shrink a resizable ArrayBuffer.
- `parseEncoding` converts the encoding argument with `toString()`. For an object, that is user code.
- In Node, `utf8Write`, `latin1Write` and `asciiWrite` are JS wrappers that check the bounds before the native writer runs. The other encodings call the native writer directly.

<details><summary>Notes</summary>

**Observable on main, with Node v26.3.0 in parentheses.**
- `buf.write('x', 5, 10, {toString(){ detach(); return 'utf8' }})` throws a `TypeError` with no `code` (`ERR_BUFFER_OUT_OF_BOUNDS`).
- The same call with `resize(3)` returns `0` (`ERR_BUFFER_OUT_OF_BOUNDS`).
- `buf.write({toString(){ detach(); return 'x' }}, 'utf8')` calls the object's `toString`, then throws a `TypeError` (`ERR_INVALID_ARG_TYPE`, `toString` never called).
- `detachedBuf.write('x', 'utf8')` and `detachedBuf.write('x', 0, 0, 'utf8')` throw a `TypeError` (`0`). The forms without an encoding already return `0`.
- `buf.write(123, 0, "bogus")` and `buf.write(123, 0, 1, "bogus")` throw `ERR_INVALID_ARG_TYPE` (`ERR_UNKNOWN_ENCODING`).
- `buf.write(123, 0, 1, { toString() { calls++; return "hex" } })` never calls the encoding's `toString` (Node calls it, then throws `ERR_INVALID_ARG_TYPE`).
- `buf.write("x", "")` and `buf.write(123, "")` throw `ERR_UNKNOWN_ENCODING` (`1` and `ERR_INVALID_ARG_TYPE`). The offset forms already read `""` as utf8.

**Node reference.** `write()` in `lib/buffer.js` validates `offset` and `length`, then runs `getEncodingOps(encoding)`, which throws `ERR_UNKNOWN_ENCODING`. `utf8Write`, `latin1Write` and `asciiWrite` are JS wrappers that throw `ERR_BUFFER_OUT_OF_BOUNDS` for `offset` and `length`, then call the native writer ([`lib/internal/buffer.js`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/buffer.js#L962-L990)). hex, base64, base64url and ucs2 call the native `StringWrite` directly ([`src/node_buffer.cc`](https://github.com/nodejs/node/blob/v26.3.0/src/node_buffer.cc#L737-L772)). Both native writers start with `THROW_AND_RETURN_IF_NOT_STRING`. `StringWrite` then throws for `offset` and clamps `length`. In Bun, `writeToBuffer` does that clamp, so the tail of `writeBody` does not repeat it.

**Differential probes.** I ran these under Node v26.3.0 and under the debug (ASAN) build of the last commit. Each output line holds the error code or the return value, the bytes of the buffer, and a log of the `toString` calls.
- 301,740 calls over every argument form, string and non-string values, known and unknown encoding names, non-string encodings, and invalid offsets and lengths.
- 242,489 calls where the encoding's `toString()` detaches, shrinks, grows or re-enters `write`, on fixed and length-tracking views, SharedArrayBuffer and `WebAssembly.Memory`. After each call the script dumps the backing store, so a write past the new end would show. None does.
- The outputs are identical, apart from one difference in call counts that is older than this PR: for an unknown object encoding, Node calls `toString()` a second time for the error message.
- No ASAN report.

**Interaction with #43368.** Both PRs edit the `buf.write(value, encoding)` branch and conflict there. #43368 adds an empty-string check inside that branch. This PR removes the body of the branch: it sets the encoding, offset 0 and the full length, then falls through to the shared tail. The tail already reads a falsy encoding as utf8 and resolves the encoding before the value check. The PR that merges second keeps this PR's version of the branch. The `write()` tests that #43368 adds hold on this branch: I ran their calls under the debug build and under Node v26.3.0, and the outputs are identical.

**Not changed here.** All of these are older than this PR.
- `buf.utf8Write(123)`, `hexWrite(123)` and the other per-encoding methods coerce a non-string value. Node throws `ERR_INVALID_ARG_TYPE`.
- The message of `ERR_INVALID_ARG_TYPE` from `write()` differs from Node's `argument must be a string`. Bun builds it from the value, which can call a `constructor.name` getter or a Proxy trap.
- `parseEncoding` coerces an object encoding with `toString()`. Node uses `encoding += ''`, which tries `valueOf()` first.
- A receiver that is not a Buffer throws `ERR_INVALID_THIS`. Node throws a plain `TypeError`.

**Self-review.** Four concerns came up. Three are addressed: the order of the bounds check and the value check now follows Node for each encoding, a clamp in the tail that `writeToBuffer` repeats is gone, and a test failure now names the value that failed. The fourth is kept on purpose: `validates offset and length before the encoding` in `buffer.test.js` passes on main. It pins that the encoding is not resolved ahead of those checks.

**Tests.** With the debug build: `test/js/node/buffer.test.js` (684 pass, 1 skip), `test/js/node/buffer-write-detach.test.ts` (13 pass), `buffer-copy-fill-detach.test.ts` (23 pass), `buffer-indexOf-detach.test.ts` (13 pass). These files in `test/js/node/test/parallel/` exit 0: `test-buffer-write.js`, `test-buffer-write-fast.js`, `test-buffer-alloc.js`, `test-buffer-fill.js`, `test-buffer-from.js`, `test-buffer-new.js`, `test-buffer-tostring.js`, `test-buffer-bytelength.js`, `test-buffer-indexof.js`, `test-buffer-includes.js`. The new tests are clean under `BUN_JSC_validateExceptionChecks=1`. The new `buffer.test.js` block also passes under Node v26.3.0 with a small `expect` shim.

**History.** This PR first fixed segfaults on these paths (issue #30417). #31129 then landed guards on main (a bare `TypeError` and a clamp), so the crashes are gone on main. The branch was rebuilt on top of that. What remains is the Node-compatible error behavior, the `writeToBuffer` floor, and the tests.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 14 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/buffer.test.js

<!-- robobun:evidence:end -->


