### PR TITLE
Blob.toJSONWithBytes: free raw_bytes, not the BOM-stripped interior slice

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -3757,7 +3757,11 @@ pub fn toJSON(this: *Blob, global: *JSGlobalObject, comptime lifetime: Lifetime)
 
 pub fn toJSONWithBytes(this: *Blob, global: *JSGlobalObject, raw_bytes: []const u8, comptime lifetime: Lifetime) bun.JSError!JSValue {
     const bom, const buf = strings.BOM.detectAndSplit(raw_bytes);
-    if (buf.len == 0) return global.createSyntaxErrorInstance("Unexpected end of JSON input", .{});
+    if (buf.len == 0) {
+        // If all it contained was the bom, we still need to free the bytes
+        if (lifetime == .temporary) bun.default_allocator.free(raw_bytes);
+        return global.createSyntaxErrorInstance("Unexpected end of JSON input", .{});
+    }
 
     if (bom == .utf16_le) {
         var out = bun.String.cloneUTF16(bun.reinterpretSlice(u16, buf));
@@ -3769,7 +3773,9 @@ pub fn toJSONWithBytes(this: *Blob, global: *JSGlobalObject, raw_bytes: []const 
     // null == unknown
     // false == can't be
     const could_be_all_ascii = this.isAllASCII() orelse this.store.?.is_all_ascii;
-    defer if (comptime lifetime == .temporary) bun.default_allocator.free(@constCast(buf));
+    // When a BOM is present `buf` is an interior slice of `raw_bytes`; we must
+    // free the original allocation, not the offset pointer.
+    defer if (comptime lifetime == .temporary) bun.default_allocator.free(raw_bytes);
 
     if (could_be_all_ascii == null or !could_be_all_ascii.?) {
         var stack_fallback = std.heap.stackFallback(4096, bun.default_allocator);

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -113,4 +113,50 @@ test("Bun.file().arrayBuffer() errors include async stack frames", async () => {
   expect(caught).toBeDefined();
   expect(caught.code).toBe("ENOENT");
   expect(caught.stack).toContain("at async caller");
+});
+
+test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async () => {
+  // When a file starts with EF BB BF, the BOM is stripped before parsing and
+  // the temporary read buffer is freed. Previously the *post-strip* slice was
+  // passed to the allocator, handing mimalloc `raw.ptr + 3` instead of `raw.ptr`.
+  // In debug builds this surfaces as "mimalloc: error: mi_free: invalid
+  // (unaligned) pointer" on stderr; in release it silently corrupts the heap.
+  const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+  const dir = tempDirWithFiles("bun-file-json-bom", {
+    // pure-ASCII body: exercises the direct ZigString path
+    "ascii.json": Buffer.concat([bom, Buffer.from(JSON.stringify({ a: 1, b: "two" }))]),
+    // non-ASCII body: exercises the toUTF16Alloc path
+    "utf8.json": Buffer.concat([bom, Buffer.from(JSON.stringify({ s: "wörld" }))]),
+    // BOM only: exercises the empty-after-strip rejection path
+    "empty.json": Buffer.from(bom),
+    "read.js": `
+      const { join } = require("path");
+      const dir = process.argv[2];
+      const ascii = await Bun.file(join(dir, "ascii.json")).json();
+      const utf8 = await Bun.file(join(dir, "utf8.json")).json();
+      let emptyErr;
+      try {
+        await Bun.file(join(dir, "empty.json")).json();
+      } catch (e) {
+        emptyErr = e.message;
+      }
+      console.log(JSON.stringify({ ascii, utf8, emptyErr }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(dir, "read.js"), dir],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    ascii: { a: 1, b: "two" },
+    utf8: { s: "wörld" },
+    emptyErr: "Unexpected end of JSON input",
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Repro

```js
// file starts with EF BB BF
await Bun.file("data.json").json();
```

Debug build stderr:
```
mimalloc: error: mi_free_size: invalid (unaligned) pointer: 0x...0003
mimalloc: error: mi_free: invalid (unaligned) pointer: 0x...0003
```

Release builds are silent — mimalloc just puts the interior pointer on its free list.

## Root cause

`BOM.detectAndSplit(raw_bytes)` returns `buf = raw_bytes[3..]` when the input starts with a UTF-8 BOM. In `toJSONWithBytes`, the `.utf16_le` branch correctly frees `raw_bytes`, but the fall-through path did:

```zig
defer if (comptime lifetime == .temporary) bun.default_allocator.free(@constCast(buf));
```

handing mimalloc `raw_bytes.ptr + 3` instead of the original allocation. `toStringWithBytes` right above it already handles this correctly.

The `buf.len == 0` early return (file contains only a BOM) also leaked `raw_bytes` in the `.temporary` path; fixed to match `toStringWithBytes`.

## Fix

Free `raw_bytes`, not `buf`. Drop the now-unnecessary `@constCast`.

## Verification

New test in `test/js/bun/util/bun-file.test.ts` spawns a subprocess that reads three BOM-prefixed JSON files (ASCII body, non-ASCII body, BOM-only) via `Bun.file().json()` and asserts stderr is empty and the parsed results are correct.

- Without fix (`bun bd`): test fails — stderr contains two mimalloc "invalid (unaligned) pointer" errors per call, addresses ending in `0x...03`.
- With fix: `bun bd test test/js/bun/util/bun-file.test.ts` — 6/6 pass.