### PR TITLE
Bun.spawn: initialize extra stdio[N>=3] to .ignore when undefined

### DIFF
--- a/src/bun.js/api/bun/js_bun_spawn_bindings.zig
+++ b/src/bun.js/api/bun/js_bun_spawn_bindings.zig
@@ -305,7 +305,9 @@ pub fn spawnMaybeSync(
                         i += 1;
 
                         while (try stdio_iter.next()) |value| : (i += 1) {
-                            var new_item: Stdio = undefined;
+                            // extract() leaves `out_stdio` untouched when `value` is undefined, so this
+                            // must be initialized to a sane default instead of `undefined`.
+                            var new_item: Stdio = .{ .ignore = {} };
                             try new_item.extract(globalThis, i, value, is_sync);
 
                             const opt = switch (new_item.asSpawnOption(i)) {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -867,6 +867,34 @@ describe("close handling", () => {
       } catch {}
     }
   });
+
+  for (const [label, makeStdio] of [
+    ["undefined", () => ["ignore", "pipe", "inherit", undefined, undefined]],
+    // eslint-disable-next-line no-sparse-arrays
+    ["a hole", () => ["ignore", "pipe", "inherit", , "ignore"]],
+  ] as const) {
+    it(`stdio[N>=3] = ${label} is treated as ignore`, async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
+        env: bunEnv,
+        stdio: makeStdio() as any,
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("ok");
+      expect(proc.stdio).toEqual([null, null, null, null, null]);
+      expect(exitCode).toBe(0);
+    });
+
+    it(`spawnSync stdio[N>=3] = ${label} is treated as ignore`, () => {
+      const { stdout, exitCode } = spawnSync({
+        cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
+        env: bunEnv,
+        stdio: makeStdio() as any,
+      });
+      expect(stdout.toString()).toBe("ok");
+      expect(exitCode).toBe(0);
+    });
+  }
 });
 
 it("dispose keyword works", async () => {


### PR DESCRIPTION
## What

`Bun.spawn({ cmd: [...], stdio: ['ignore', 'ignore', 'ignore', undefined] })` (or a sparse array with a hole at index ≥ 3) read an uninitialized `Stdio` union.

## Why

In `js_bun_spawn_bindings.zig`, extra stdio entries past index 2 are collected into a local:

```zig
var new_item: Stdio = undefined;
try new_item.extract(globalThis, i, value, is_sync);
const opt = switch (new_item.asSpawnOption(i)) { ... };
```

`Stdio.extract()` returns early without writing to `out_stdio` when `value.isUndefined()`. For `stdio[0..2]` that's fine — those slots are pre-initialized to `.ignore`/`.pipe`/`.inherit`. But for `stdio[N>=3]`, `new_item` stays `undefined`, and the very next line switches on its tag inside `asSpawnOption()`.

In debug builds the 0xAA poison lands on a tag that creates pipe pairs, so `proc.stdio[3..]` exposes garbage fd numbers instead of `null`:

```js
// before
Bun.spawn({cmd:['echo'], stdio:['ignore','ignore','ignore', undefined, undefined, undefined]}).stdio
// → [ null, null, null, 12, 14, 16 ]
```

In release builds the tag is arbitrary garbage — could land on `.blob` / `.path` / `.capture` and deref a garbage pointer, or on `.fd` and dup2 a garbage fd into the child.

## Fix

Initialize `new_item` to `.{ .ignore = {} }`. Matches how `null` is handled in `extract()`, and leaves the `stdio[0..2]` defaults-on-undefined semantics intact.

## Verification

Added tests in `test/js/bun/spawn/spawn.test.ts` covering both explicit `undefined` and sparse-array holes at index ≥ 3, for `Bun.spawn` and `Bun.spawnSync`. The async tests fail on main (`proc.stdio` contains garbage fds) and pass with this change.