### PR TITLE
fetch(s3): fix wrong offset when packing proxy into url_proxy_buffer

### DIFF
--- a/src/runtime/webcore/fetch.zig
+++ b/src/runtime/webcore/fetch.zig
@@ -1368,9 +1368,7 @@ fn fetchImpl(
             // proxy and url are in the same buffer lets replace it
             const old_buffer = url_proxy_buffer;
             defer allocator.free(old_buffer);
-            var buffer = bun.handleOom(allocator.alloc(u8, result.url.len + proxy_.href.len));
-            bun.copy(u8, buffer[0..result.url.len], result.url);
-            bun.copy(u8, buffer[proxy_.href.len..], proxy_.href);
+            const buffer = bun.handleOom(std.fmt.allocPrint(allocator, "{s}{s}", .{ result.url, proxy_.href }));
             url_proxy_buffer = buffer;
 
             url = ZigURL.parse(url_proxy_buffer[0..result.url.len]);

--- a/test/js/bun/s3/s3-fetch-proxy.test.ts
+++ b/test/js/bun/s3/s3-fetch-proxy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+
+// fetch("s3://...", { proxy }) rebuilds url_proxy_buffer after signing the
+// request. A wrong offset when copying the proxy href into that buffer left
+// the proxy region pointing past the allocation (proxy longer than the signed
+// URL → heap overflow) or at bytes that were never written (proxy shorter →
+// uninitialized read). Either way the request could not reach the configured
+// proxy.
+
+async function createProxy() {
+  const log: string[] = [];
+  const server = net.createServer(client => {
+    client.once("data", data => {
+      const request = data.toString("latin1");
+      const newline = request.indexOf("\r\n");
+      const [method, target] = request.slice(0, newline).split(" ");
+      log.push(`${method} ${target}`);
+
+      const url = new URL(target);
+      const upstream = net.connect(Number(url.port), url.hostname, () => {
+        upstream.write(`${method} ${url.pathname}${url.search} HTTP/1.1\r\n`);
+        upstream.write(data.subarray(newline + 2));
+        upstream.pipe(client);
+        client.pipe(upstream);
+      });
+      upstream.on("error", () => client.destroy());
+    });
+    client.on("error", () => {});
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+  return { server, port, log };
+}
+
+// The fetch runs in a subprocess so that (a) the heap-overflow case reports as
+// a normal test failure instead of aborting the runner, and (b) NO_PROXY from
+// the surrounding environment cannot suppress the explicit proxy for 127.0.0.1.
+async function fetchS3ViaProxy(proxyUrl: string, endpointPort: number) {
+  const script = `
+    const res = await fetch("s3://bucket/key", {
+      proxy: ${JSON.stringify(proxyUrl)},
+      s3: {
+        endpoint: "http://127.0.0.1:${endpointPort}",
+        accessKeyId: "test",
+        secretAccessKey: "test",
+      },
+    });
+    process.stdout.write(await res.text());
+  `;
+  await using child = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      NO_PROXY: "",
+      no_proxy: "",
+      HTTP_PROXY: "",
+      http_proxy: "",
+      HTTPS_PROXY: "",
+      https_proxy: "",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("fetch s3:// through an HTTP proxy", () => {
+  for (const [label, proxyPath] of [
+    // Proxy href is shorter than the signed "http://127.0.0.1:PORT/bucket/key"
+    // URL: the broken offset meant the bytes parsed as the proxy were never
+    // written, so the HTTP thread tried to connect to garbage.
+    ["shorter than the signed URL", ""],
+    // Proxy href is longer than the signed URL: the broken offset produced a
+    // destination slice shorter than the source and copied past the allocation.
+    ["longer than the signed URL", "/" + Buffer.alloc(512, "p").toString()],
+  ] as const) {
+    test(`proxy URL ${label}`, async () => {
+      let sawBucketKey = false;
+      await using endpoint = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          if (new URL(req.url).pathname === "/bucket/key") sawBucketKey = true;
+          return new Response("hello from s3", { headers: { "Content-Type": "text/plain" } });
+        },
+      });
+
+      const proxy = await createProxy();
+      try {
+        const proxyUrl = `http://127.0.0.1:${proxy.port}${proxyPath}`;
+        const { stdout, stderr, exitCode } = await fetchS3ViaProxy(proxyUrl, endpoint.port);
+
+        expect(stderr).toBe("");
+        expect(stdout).toBe("hello from s3");
+        expect(exitCode).toBe(0);
+        expect(sawBucketKey).toBe(true);
+        expect(proxy.log).toEqual([`GET http://127.0.0.1:${endpoint.port}/bucket/key`]);
+      } finally {
+        proxy.server.close();
+      }
+    }, 30_000);
+  }
+});

--- a/test/js/bun/s3/s3-fetch-proxy.test.ts
+++ b/test/js/bun/s3/s3-fetch-proxy.test.ts
@@ -75,7 +75,7 @@ async function fetchS3ViaProxy(proxyUrl: string, endpointPort: number) {
   return { stdout, stderr, exitCode };
 }
 
-describe("fetch s3:// through an HTTP proxy", () => {
+describe.concurrent("fetch s3:// through an HTTP proxy", () => {
   for (const [label, proxyPath] of [
     // Proxy href is shorter than the signed "http://127.0.0.1:PORT/bucket/key"
     // URL: the broken offset meant the bytes parsed as the proxy were never

--- a/test/js/bun/s3/s3-fetch-proxy.test.ts
+++ b/test/js/bun/s3/s3-fetch-proxy.test.ts
@@ -13,21 +13,27 @@ import net from "node:net";
 async function createProxy() {
   const log: string[] = [];
   const server = net.createServer(client => {
-    client.once("data", data => {
-      const request = data.toString("latin1");
-      const newline = request.indexOf("\r\n");
-      const [method, target] = request.slice(0, newline).split(" ");
+    let head = Buffer.alloc(0);
+    const onData = (chunk: Buffer) => {
+      head = Buffer.concat([head, chunk]);
+      const newline = head.indexOf("\r\n");
+      if (newline === -1) return;
+      client.removeListener("data", onData);
+
+      const [method, target] = head.toString("latin1", 0, newline).split(" ");
       log.push(`${method} ${target}`);
 
       const url = new URL(target);
+      const rest = head.subarray(newline + 2);
       const upstream = net.connect(Number(url.port), url.hostname, () => {
         upstream.write(`${method} ${url.pathname}${url.search} HTTP/1.1\r\n`);
-        upstream.write(data.subarray(newline + 2));
+        upstream.write(rest);
         upstream.pipe(client);
         client.pipe(upstream);
       });
       upstream.on("error", () => client.destroy());
-    });
+    };
+    client.on("data", onData);
     client.on("error", () => {});
   });
   server.listen(0, "127.0.0.1");


### PR DESCRIPTION
## Problem

`fetch("s3://bucket/key", { proxy })` rebuilds `url_proxy_buffer` after signing the request so that both the signed URL and the proxy href live in the same allocation. The second copy used the wrong offset:

```zig
var buffer = bun.handleOom(allocator.alloc(u8, result.url.len + proxy_.href.len));
bun.copy(u8, buffer[0..result.url.len], result.url);
bun.copy(u8, buffer[proxy_.href.len..], proxy_.href);   // <— should be result.url.len
```

`bun.copy` → `memmove` writes `src.len` bytes regardless of the dest slice length, so:

- **proxy shorter than the signed URL** (the common case): the `[result.url.len..]` region that is then parsed as the proxy is never written. The HTTP thread connects to whatever happens to be in that heap, and the tail of the signed URL is overwritten by the proxy href.
- **proxy longer than the signed URL**: the dest slice is shorter than the source and `memmove` writes past the allocation — debug assert / heap-buffer-overflow.

## Repro

```js
// any proxy string triggers it once the path reaches the post-sign rebuild
await fetch("s3://bucket/key", {
  proxy: "http://127.0.0.1:8080",
  s3: { endpoint, accessKeyId, secretAccessKey },
});
```

Debug build with a proxy URL longer than the signed endpoint URL:

```
panic(main thread): reached unreachable code
bun.memmove  src/bun.zig:3384
bun.copy     src/bun.zig:453
fetchImpl    src/bun.js/webcore/fetch.zig:1373
```

## Fix

Replace the manual `alloc` + two `bun.copy` calls with `std.fmt.allocPrint("{s}{s}", .{ result.url, proxy_.href })`, which is what the non-S3 proxy path in the same function already uses and can't get the offset wrong.

## Verification

New `test/js/bun/s3/s3-fetch-proxy.test.ts` stands up a local HTTP forward proxy and a local S3 endpoint, runs `fetch("s3://bucket/key", { proxy, s3: {...} })` in a subprocess (with `NO_PROXY` cleared so the explicit proxy isn't bypassed), and asserts the proxy receives `GET http://127.0.0.1:<endpoint>/bucket/key` and the body round-trips. Two cases:

- proxy href shorter than the signed URL
- proxy href longer than the signed URL

On the unfixed build:

- shorter → `ConnectionRefused`, request line shows the corrupted `.../http://127` path
- longer → `panic(main thread): reached unreachable code` in `bun.memmove`

Both pass on this branch.