### PR TITLE
fix(serve): free HTMLBundle.PendingResponse when client aborts during build

### DIFF
--- a/src/runtime/server/HTMLBundle.zig
+++ b/src/runtime/server/HTMLBundle.zig
@@ -507,14 +507,17 @@ pub const Route = struct {
             bun.debugAssert(this.is_response_pending == true);
             this.is_response_pending = false;
 
-            // Technically, this could be the final ref count, but we don't want to risk it
-            this.route.ref();
-            defer this.route.deref();
-
-            while (std.mem.indexOfScalar(*PendingResponse, this.route.pending_responses.items, this)) |index| {
+            // `this` holds a ref on `route` until deinit(), so it is safe to touch
+            // `this.route.pending_responses` here without an extra guard ref.
+            if (std.mem.indexOfScalar(*PendingResponse, this.route.pending_responses.items, this)) |index| {
                 _ = this.route.pending_responses.orderedRemove(index);
-                this.route.deref();
             }
+
+            // Release the route ref taken when this PendingResponse was queued
+            // and free the allocation. Without this, an aborted request would
+            // leak the PendingResponse: resumePendingResponses() only deinit()s
+            // entries still in the list, and we just removed ourselves.
+            this.deinit();
         }
     };
 };

--- a/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
@@ -38,11 +38,13 @@ function countAlloc(verb: "new" | "destroy"): number {
   return n;
 }
 
-// Poll `cond` once per event-loop turn. Falls through to a hard error after
-// `deadline` iterations so a regressed build fails fast with a clear message
-// instead of hanging until the parent test times out.
-async function until(cond: () => boolean, what: string, deadline = 2_000) {
-  for (let i = 0; i < deadline; i++) {
+// Poll `cond` once per event-loop turn. The wall-clock bound is a safety
+// net so a regressed build fails with a clear message instead of hanging
+// until the parent test times out; on a fixed build every condition is met
+// in well under a second.
+async function until(cond: () => boolean, what: string, deadlineMs = 20_000) {
+  const start = performance.now();
+  while (performance.now() - start < deadlineMs) {
     if (cond()) return;
     await new Promise(r => setImmediate(r));
   }

--- a/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
@@ -4,18 +4,49 @@
 // fires HTTP requests at it, then closes the sockets while the route is
 // still `.building` so HTMLBundle.PendingResponse.onAborted runs.
 //
-// Run under BUN_DEBUG_alloc=1; the parent test counts
-// `[alloc] new(PendingResponse)` vs `[alloc] destroy(PendingResponse)`.
+// Run with BUN_DEBUG_alloc=1 and BUN_DEBUG=<log file>. The fixture polls that
+// file for `[alloc] new(PendingResponse)` / `[alloc] destroy(PendingResponse)`
+// lines so every ordering constraint is a real condition wait, not a
+// tick-count sleep. The parent test reads the same file after exit to do the
+// final balance check.
 //
 // Invoked with cwd = a temp dir containing index.html, app.js, plugin.js
 // and bunfig.toml (`[serve.static] plugins = ["./plugin.js"]`).
 
+import { readFileSync } from "node:fs";
 import { connect } from "node:net";
 import path from "node:path";
 
 declare global {
   var __gateStarted: PromiseWithResolvers<void> | undefined;
   var __gateRelease: PromiseWithResolvers<void> | undefined;
+}
+
+const allocLog = process.env.ALLOC_LOG;
+if (!allocLog) throw new Error("ALLOC_LOG env var is required");
+
+function countAlloc(verb: "new" | "destroy"): number {
+  let text: string;
+  try {
+    text = readFileSync(allocLog!, "utf8");
+  } catch {
+    return 0;
+  }
+  let n = 0;
+  const needle = `[alloc] ${verb}(PendingResponse)`;
+  for (let i = text.indexOf(needle); i !== -1; i = text.indexOf(needle, i + needle.length)) n++;
+  return n;
+}
+
+// Poll `cond` once per event-loop turn. Falls through to a hard error after
+// `deadline` iterations so a regressed build fails fast with a clear message
+// instead of hanging until the parent test times out.
+async function until(cond: () => boolean, what: string, deadline = 2_000) {
+  for (let i = 0; i < deadline; i++) {
+    if (cond()) return;
+    await new Promise(r => setImmediate(r));
+  }
+  throw new Error(`gave up waiting for: ${what}`);
 }
 
 // plugin.js awaits __gateRelease.promise and resolves __gateStarted when
@@ -36,13 +67,6 @@ const server = Bun.serve({
   },
 });
 
-// Yield to the event loop a fixed number of times. Client and server share
-// the same loop, so after a few ticks any locally-written socket data has
-// been delivered to uWS and processed.
-async function spin(ticks = 8) {
-  for (let i = 0; i < ticks; i++) await new Promise(r => setImmediate(r));
-}
-
 // Fire the first request to kick the route from `pending` → `building`
 // (triggers plugin load; plugin.setup() blocks on __gateRelease).
 const first = fetch(`http://127.0.0.1:${server.port}/`)
@@ -55,25 +79,33 @@ await globalThis.__gateStarted!.promise;
 
 // Open raw TCP connections, send an HTTP request on each (queued as a
 // PendingResponse), then close the socket before the build completes.
+// Connect in parallel — debug+ASAN node:net is slow per-socket.
 const ABORTED = 5;
-const sockets: import("node:net").Socket[] = [];
-for (let i = 0; i < ABORTED; i++) {
-  const sock = connect({ port: server.port, host: "127.0.0.1" });
-  await new Promise<void>((resolve, reject) => {
-    sock.once("connect", () => resolve());
-    sock.once("error", reject);
-  });
-  sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n`);
-  sockets.push(sock);
-}
+const sockets: import("node:net").Socket[] = await Promise.all(
+  Array.from({ length: ABORTED }, () => {
+    const sock = connect({ port: server.port, host: "127.0.0.1" });
+    return new Promise<import("node:net").Socket>((resolve, reject) => {
+      sock.once("connect", () => {
+        sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n`);
+        resolve(sock);
+      });
+      sock.once("error", reject);
+    });
+  }),
+);
 
-// Let the server read + route every request before we abort.
-await spin();
+// Wait until every request has been routed and queued (first fetch + the
+// ABORTED raw sockets). Without this the destroy() below could race the
+// server reading the request line.
+await until(() => countAlloc("new") >= ABORTED + 1, `${ABORTED + 1}x new(PendingResponse)`);
 
 for (const sock of sockets) sock.destroy();
 
-// Let onAborted fire for each closed socket.
-await spin();
+// Wait until onAborted has fired (and, with the fix, freed the allocation)
+// for every closed socket *before* releasing the build. If we released the
+// gate first, resumePendingResponses() would clearAborted()+deinit() the
+// still-queued entries itself and the test would pass even without the fix.
+await until(() => countAlloc("destroy") >= ABORTED, `${ABORTED}x destroy(PendingResponse) via onAborted`);
 
 // Release the build so the first (non-aborted) request completes and
 // resumePendingResponses() runs on whatever is left in the list.
@@ -81,7 +113,4 @@ globalThis.__gateRelease!.resolve();
 await first;
 
 await server.stop(true);
-
-// Give the scoped logger a chance to flush.
-await spin(2);
 process.exit(0);

--- a/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak-fixture.ts
@@ -1,0 +1,87 @@
+// Fixture for bun-serve-html-abort-leak.test.ts.
+//
+// Serves an HTML bundle route whose build is held open by a plugin gate,
+// fires HTTP requests at it, then closes the sockets while the route is
+// still `.building` so HTMLBundle.PendingResponse.onAborted runs.
+//
+// Run under BUN_DEBUG_alloc=1; the parent test counts
+// `[alloc] new(PendingResponse)` vs `[alloc] destroy(PendingResponse)`.
+//
+// Invoked with cwd = a temp dir containing index.html, app.js, plugin.js
+// and bunfig.toml (`[serve.static] plugins = ["./plugin.js"]`).
+
+import { connect } from "node:net";
+import path from "node:path";
+
+declare global {
+  var __gateStarted: PromiseWithResolvers<void> | undefined;
+  var __gateRelease: PromiseWithResolvers<void> | undefined;
+}
+
+// plugin.js awaits __gateRelease.promise and resolves __gateStarted when
+// setup() begins, so create them before anything can trigger plugin load.
+globalThis.__gateStarted = Promise.withResolvers();
+globalThis.__gateRelease = Promise.withResolvers();
+
+const html = (await import(path.join(process.cwd(), "index.html"))).default;
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  static: {
+    "/": html,
+  },
+  fetch() {
+    return new Response("not found", { status: 404 });
+  },
+});
+
+// Yield to the event loop a fixed number of times. Client and server share
+// the same loop, so after a few ticks any locally-written socket data has
+// been delivered to uWS and processed.
+async function spin(ticks = 8) {
+  for (let i = 0; i < ticks; i++) await new Promise(r => setImmediate(r));
+}
+
+// Fire the first request to kick the route from `pending` → `building`
+// (triggers plugin load; plugin.setup() blocks on __gateRelease).
+const first = fetch(`http://127.0.0.1:${server.port}/`)
+  .then(r => r.text())
+  .catch(() => {});
+
+// Wait until the plugin's setup() has actually started. From this point the
+// route stays in `.building` until we resolve __gateRelease.
+await globalThis.__gateStarted!.promise;
+
+// Open raw TCP connections, send an HTTP request on each (queued as a
+// PendingResponse), then close the socket before the build completes.
+const ABORTED = 5;
+const sockets: import("node:net").Socket[] = [];
+for (let i = 0; i < ABORTED; i++) {
+  const sock = connect({ port: server.port, host: "127.0.0.1" });
+  await new Promise<void>((resolve, reject) => {
+    sock.once("connect", () => resolve());
+    sock.once("error", reject);
+  });
+  sock.write(`GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n`);
+  sockets.push(sock);
+}
+
+// Let the server read + route every request before we abort.
+await spin();
+
+for (const sock of sockets) sock.destroy();
+
+// Let onAborted fire for each closed socket.
+await spin();
+
+// Release the build so the first (non-aborted) request completes and
+// resumePendingResponses() runs on whatever is left in the list.
+globalThis.__gateRelease!.resolve();
+await first;
+
+await server.stop(true);
+
+// Give the scoped logger a chance to flush.
+await spin(2);
+process.exit(0);

--- a/test/js/bun/http/bun-serve-html-abort-leak.test.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak.test.ts
@@ -1,0 +1,65 @@
+// HTMLBundle.PendingResponse.onAborted removed itself from
+// route.pending_responses and balanced the route ref, but never freed the
+// PendingResponse allocation. resumePendingResponses() only deinit()s
+// entries still in the list, so every aborted-while-building request leaked
+// one PendingResponse struct.
+//
+// The allocation is tiny, so RSS can't isolate it. We instead count
+// `[alloc] new(PendingResponse)` vs `[alloc] destroy(PendingResponse)` in the
+// debug-build allocation log (Output.scoped(.alloc)).
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import path from "node:path";
+
+// BUN_DEBUG_alloc output is only emitted in builds with
+// Environment.allow_assert (debug). Release CI lanes skip this; the gate
+// runs `bun bd` (debug+ASAN) so it is covered.
+test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts during build", async () => {
+  using dir = tempDir("html-bundle-abort-leak", {
+    "index.html": /* html */ `<!DOCTYPE html>
+<html>
+  <head><script type="module" src="./app.js"></script></head>
+  <body><h1>hi</h1></body>
+</html>
+`,
+    "app.js": `console.log("app");\n`,
+    // setup() blocks until the fixture resolves __gateRelease, guaranteeing
+    // the route stays in .building while we abort requests against it.
+    "plugin.js": `export default {
+  name: "gate",
+  async setup() {
+    globalThis.__gateStarted.resolve();
+    await globalThis.__gateRelease.promise;
+  },
+};
+`,
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_DEBUG_alloc: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Output.scoped writes to the raw stdout stream; scan both to be safe.
+  const output = stdout + stderr;
+  const created = [...output.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
+  const destroyed = [...output.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
+
+  // First fetch + ABORTED raw sockets => at least 6 PendingResponses. Guard
+  // against a future refactor silently skipping the building-state queue.
+  expect(created).toBeGreaterThanOrEqual(6);
+  // Every PendingResponse that was created must have been destroyed.
+  expect({ created, destroyed }).toEqual({ created, destroyed: created });
+  if (exitCode !== 0) console.error({ stdout, stderr });
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/bun/http/bun-serve-html-abort-leak.test.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak.test.ts
@@ -9,25 +9,27 @@
 // debug-build allocation log (Output.scoped(.alloc)).
 
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
 // BUN_DEBUG_alloc output is only emitted in builds with
 // Environment.allow_assert (debug). Release CI lanes skip this; the gate
 // runs `bun bd` (debug+ASAN) so it is covered.
-test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts during build", async () => {
-  using dir = tempDir("html-bundle-abort-leak", {
-    "index.html": /* html */ `<!DOCTYPE html>
+test.skipIf(!isDebug)(
+  "HTMLBundle.PendingResponse is freed when client aborts during build",
+  async () => {
+    using dir = tempDir("html-bundle-abort-leak", {
+      "index.html": /* html */ `<!DOCTYPE html>
 <html>
   <head><script type="module" src="./app.js"></script></head>
   <body><h1>hi</h1></body>
 </html>
 `,
-    "app.js": `console.log("app");\n`,
-    // setup() blocks until the fixture resolves __gateRelease, guaranteeing
-    // the route stays in .building while we abort requests against it.
-    "plugin.js": `export default {
+      "app.js": `console.log("app");\n`,
+      // setup() blocks until the fixture resolves __gateRelease, guaranteeing
+      // the route stays in .building while we abort requests against it.
+      "plugin.js": `export default {
   name: "gate",
   async setup() {
     globalThis.__gateStarted.resolve();
@@ -35,40 +37,42 @@ test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts du
   },
 };
 `,
-    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
-  });
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
+    });
 
-  // BUN_DEBUG=<path> redirects all scoped debug output to this file so the
-  // fixture can poll it as a condition and we can read the final tally here.
-  const allocLog = path.join(String(dir), "alloc.log");
+    // BUN_DEBUG=<path> redirects all scoped debug output to this file so the
+    // fixture can poll it as a condition and we can read the final tally here.
+    const allocLog = path.join(String(dir), "alloc.log");
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_DEBUG_alloc: "1",
-      BUN_DEBUG: allocLog,
-      ALLOC_LOG: allocLog,
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DEBUG_alloc: "1",
+        BUN_DEBUG: allocLog,
+        ALLOC_LOG: allocLog,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const log = readFileSync(allocLog, "utf8");
-  const created = [...log.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
-  const destroyed = [...log.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
+    const log = readFileSync(allocLog, "utf8");
+    const created = [...log.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
+    const destroyed = [...log.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
 
-  if (exitCode !== 0) console.error({ stdout, stderr });
-  // First fetch + 5 aborted raw sockets => at least 6 PendingResponses. Guard
-  // against a future refactor silently skipping the building-state queue.
-  expect(created).toBeGreaterThanOrEqual(6);
-  // Every PendingResponse that was created must have been destroyed. Before
-  // the fix the fixture fails inside `until()` waiting for the aborted
-  // allocations to be destroyed (they never are), so exitCode is non-zero
-  // and destroyed == 0.
-  expect({ created, destroyed }).toEqual({ created, destroyed: created });
-  expect(exitCode).toBe(0);
-}, 60_000); // debug+ASAN subprocess + Bun.serve + bundler routinely exceeds the 5s local default
+    if (exitCode !== 0) console.error({ stdout, stderr });
+    // First fetch + 5 aborted raw sockets => at least 6 PendingResponses. Guard
+    // against a future refactor silently skipping the building-state queue.
+    expect(created).toBeGreaterThanOrEqual(6);
+    // Every PendingResponse that was created must have been destroyed. Before
+    // the fix the fixture fails inside `until()` waiting for the aborted
+    // allocations to be destroyed (they never are), so exitCode is non-zero
+    // and destroyed == 0.
+    expect({ created, destroyed }).toEqual({ created, destroyed: created });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+); // debug+ASAN subprocess + Bun.serve + bundler routinely exceeds the 5s local default

--- a/test/js/bun/http/bun-serve-html-abort-leak.test.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak.test.ts
@@ -9,26 +9,25 @@
 // debug-build allocation log (Output.scoped(.alloc)).
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
 // BUN_DEBUG_alloc output is only emitted in builds with
 // Environment.allow_assert (debug). Release CI lanes skip this; the gate
 // runs `bun bd` (debug+ASAN) so it is covered.
-test.skipIf(!isDebug)(
-  "HTMLBundle.PendingResponse is freed when client aborts during build",
-  async () => {
-    using dir = tempDir("html-bundle-abort-leak", {
-      "index.html": /* html */ `<!DOCTYPE html>
+test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts during build", async () => {
+  using dir = tempDir("html-bundle-abort-leak", {
+    "index.html": /* html */ `<!DOCTYPE html>
 <html>
   <head><script type="module" src="./app.js"></script></head>
   <body><h1>hi</h1></body>
 </html>
 `,
-      "app.js": `console.log("app");\n`,
-      // setup() blocks until the fixture resolves __gateRelease, guaranteeing
-      // the route stays in .building while we abort requests against it.
-      "plugin.js": `export default {
+    "app.js": `console.log("app");\n`,
+    // setup() blocks until the fixture resolves __gateRelease, guaranteeing
+    // the route stays in .building while we abort requests against it.
+    "plugin.js": `export default {
   name: "gate",
   async setup() {
     globalThis.__gateStarted.resolve();
@@ -36,34 +35,40 @@ test.skipIf(!isDebug)(
   },
 };
 `,
-      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
-    });
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
+  });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
-      cwd: String(dir),
-      env: {
-        ...bunEnv,
-        BUN_DEBUG_alloc: "1",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  // BUN_DEBUG=<path> redirects all scoped debug output to this file so the
+  // fixture can poll it as a condition and we can read the final tally here.
+  const allocLog = path.join(String(dir), "alloc.log");
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_DEBUG_alloc: "1",
+      BUN_DEBUG: allocLog,
+      ALLOC_LOG: allocLog,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    // Output.scoped writes to the raw stdout stream; scan both to be safe.
-    const output = stdout + stderr;
-    const created = [...output.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
-    const destroyed = [...output.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // First fetch + ABORTED raw sockets => at least 6 PendingResponses. Guard
-    // against a future refactor silently skipping the building-state queue.
-    expect(created).toBeGreaterThanOrEqual(6);
-    // Every PendingResponse that was created must have been destroyed.
-    expect({ created, destroyed }).toEqual({ created, destroyed: created });
-    if (exitCode !== 0) console.error({ stdout, stderr });
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+  const log = readFileSync(allocLog, "utf8");
+  const created = [...log.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
+  const destroyed = [...log.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
+
+  if (exitCode !== 0) console.error({ stdout, stderr });
+  // First fetch + 5 aborted raw sockets => at least 6 PendingResponses. Guard
+  // against a future refactor silently skipping the building-state queue.
+  expect(created).toBeGreaterThanOrEqual(6);
+  // Every PendingResponse that was created must have been destroyed. Before
+  // the fix the fixture fails inside `until()` waiting for the aborted
+  // allocations to be destroyed (they never are), so exitCode is non-zero
+  // and destroyed == 0.
+  expect({ created, destroyed }).toEqual({ created, destroyed: created });
+  expect(exitCode).toBe(0);
+}, 60_000); // debug+ASAN subprocess + Bun.serve + bundler routinely exceeds the 5s local default

--- a/test/js/bun/http/bun-serve-html-abort-leak.test.ts
+++ b/test/js/bun/http/bun-serve-html-abort-leak.test.ts
@@ -15,18 +15,20 @@ import path from "node:path";
 // BUN_DEBUG_alloc output is only emitted in builds with
 // Environment.allow_assert (debug). Release CI lanes skip this; the gate
 // runs `bun bd` (debug+ASAN) so it is covered.
-test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts during build", async () => {
-  using dir = tempDir("html-bundle-abort-leak", {
-    "index.html": /* html */ `<!DOCTYPE html>
+test.skipIf(!isDebug)(
+  "HTMLBundle.PendingResponse is freed when client aborts during build",
+  async () => {
+    using dir = tempDir("html-bundle-abort-leak", {
+      "index.html": /* html */ `<!DOCTYPE html>
 <html>
   <head><script type="module" src="./app.js"></script></head>
   <body><h1>hi</h1></body>
 </html>
 `,
-    "app.js": `console.log("app");\n`,
-    // setup() blocks until the fixture resolves __gateRelease, guaranteeing
-    // the route stays in .building while we abort requests against it.
-    "plugin.js": `export default {
+      "app.js": `console.log("app");\n`,
+      // setup() blocks until the fixture resolves __gateRelease, guaranteeing
+      // the route stays in .building while we abort requests against it.
+      "plugin.js": `export default {
   name: "gate",
   async setup() {
     globalThis.__gateStarted.resolve();
@@ -34,32 +36,34 @@ test.skipIf(!isDebug)("HTMLBundle.PendingResponse is freed when client aborts du
   },
 };
 `,
-    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
-  });
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.js"]\n`,
+    });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
-    cwd: String(dir),
-    env: {
-      ...bunEnv,
-      BUN_DEBUG_alloc: "1",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "bun-serve-html-abort-leak-fixture.ts")],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DEBUG_alloc: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // Output.scoped writes to the raw stdout stream; scan both to be safe.
-  const output = stdout + stderr;
-  const created = [...output.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
-  const destroyed = [...output.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
+    // Output.scoped writes to the raw stdout stream; scan both to be safe.
+    const output = stdout + stderr;
+    const created = [...output.matchAll(/\[alloc\] new\(PendingResponse\)/g)].length;
+    const destroyed = [...output.matchAll(/\[alloc\] destroy\(PendingResponse\)/g)].length;
 
-  // First fetch + ABORTED raw sockets => at least 6 PendingResponses. Guard
-  // against a future refactor silently skipping the building-state queue.
-  expect(created).toBeGreaterThanOrEqual(6);
-  // Every PendingResponse that was created must have been destroyed.
-  expect({ created, destroyed }).toEqual({ created, destroyed: created });
-  if (exitCode !== 0) console.error({ stdout, stderr });
-  expect(exitCode).toBe(0);
-}, 60_000);
+    // First fetch + ABORTED raw sockets => at least 6 PendingResponses. Guard
+    // against a future refactor silently skipping the building-state queue.
+    expect(created).toBeGreaterThanOrEqual(6);
+    // Every PendingResponse that was created must have been destroyed.
+    expect({ created, destroyed }).toEqual({ created, destroyed: created });
+    if (exitCode !== 0) console.error({ stdout, stderr });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## What

`HTMLBundle.Route.PendingResponse.onAborted()` removed itself from `route.pending_responses` and balanced the route ref, but never called `bun.destroy(this)`. Since the only other `deinit()` caller (`resumePendingResponses()`) iterates `pending_responses` — which no longer contains it — the struct leaked.

## Repro

1. `Bun.serve({ static: { "/": html } })` with a `[serve.static]` plugin whose `setup()` stays pending
2. Send an HTTP request to `/` (route enters `.building`, request is queued as a `PendingResponse`)
3. Close the socket before the bundle completes → `onAborted` fires

Before: the `PendingResponse` allocation is never freed.

## Fix

`onAborted()` now removes itself from the list and calls `this.deinit()`, which releases the route ref (previously done inline) and `bun.destroy()`s the allocation. The temporary `route.ref()/deref()` guard pair is no longer needed because `this` already holds a ref on the route until `deinit()` drops it.

```zig
pub fn onAborted(this: *PendingResponse, _: HTTPResponse) void {
    bun.debugAssert(this.is_response_pending == true);
    this.is_response_pending = false;

    if (std.mem.indexOfScalar(*PendingResponse, this.route.pending_responses.items, this)) |index| {
        _ = this.route.pending_responses.orderedRemove(index);
    }

    this.deinit();
}
```

## Verification

New test `test/js/bun/http/bun-serve-html-abort-leak.test.ts` gates a plugin `setup()` so the route stays `.building`, opens 5 raw TCP connections, sends `GET /`, destroys them, then releases the gate. Under `BUN_DEBUG_alloc=1` it counts `[alloc] new(PendingResponse)` vs `[alloc] destroy(PendingResponse)` (same pattern as `tsconfig-extends-leak.test.ts` / `websocket-proxy-tunnel-upgrade-leak.test.ts`).

- Without fix: `{ created: 6, destroyed: 1 }` — the 5 aborted requests leak
- With fix: `{ created: 6, destroyed: 6 }`

Test is `skipIf(!isDebug)` since the `.alloc` scoped logger only emits in debug builds.