### PR TITLE
resolver: reject overlapping prefix/suffix in tsconfig paths wildcard match

### DIFF
--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -3118,7 +3118,13 @@ pub const Resolver = struct {
                 // prefix length, pick the one with the longest suffix. This second edge
                 // case isn't handled by the TypeScript compiler, but we handle it
                 // because we want the output to always be deterministic
-                if (strings.startsWith(path, prefix) and
+                //
+                // Require `path.len >= prefix.len + suffix.len` so the prefix and
+                // suffix don't overlap in the import path. Without this, a pattern
+                // like "ab*ba" would "match" the path "aba" (startsWith "ab" and
+                // endsWith "ba" both pass) and the slice below would underflow.
+                if (path.len >= prefix.len + suffix.len and
+                    strings.startsWith(path, prefix) and
                     strings.endsWith(path, suffix) and
                     (prefix.len > longest_match_prefix_length or
                         (prefix.len == longest_match_prefix_length and suffix.len > longest_match_suffix_length)))

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -182,3 +182,56 @@ describe.concurrent("long import path overflow", () => {
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
   });
 });
+
+describe.concurrent("tsconfig paths wildcard overlap", () => {
+  // A pattern like "ab*ba" has prefix "ab" and suffix "ba". The import path
+  // "aba" both startsWith "ab" and endsWith "ba", but the two overlap — the
+  // path is shorter than prefix+suffix. matchTSConfigPaths used to accept this
+  // and then compute matched_text = path[2..1], underflowing the slice length.
+  async function run(files: Record<string, string>, entry: string) {
+    using dir = tempDir("tsconfig-paths-overlap", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "node_modules/.keep": "",
+      ...files,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("does not underflow when prefix+suffix overlap in the import path", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "tsconfig.json": `{"compilerOptions": {"baseUrl": ".", "paths": {"ab*ba": ["./src/*.ts"]}}}`,
+        "index.ts": `import "aba";`,
+      },
+      "./index.ts",
+    );
+    // "aba" must NOT match "ab*ba" — it falls through to a normal resolve error.
+    expect(stderr).toContain(`Could not resolve: "aba"`);
+    expect(exitCode).toBe(1);
+  });
+
+  it("still matches when the wildcard captures the empty string", async () => {
+    // "lib" vs "lib*": prefix exactly covers the path, '*' captures "".
+    // This is the `path.len == prefix.len + suffix.len` boundary of the
+    // length check above and must keep working.
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "tsconfig.json": `{"compilerOptions": {"baseUrl": ".", "paths": {"lib*": ["./src/*"]}}}`,
+        "src/index.ts": `export const v = 1;`,
+        "index.ts": `import { v } from "lib"; console.log(v);`,
+      },
+      "./index.ts",
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toContain("var v = 1");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Repro

```jsonc
// tsconfig.json
{"compilerOptions": {"baseUrl": ".", "paths": {"ab*ba": ["./src/*.ts"]}}}
```
```ts
// index.ts
import "aba";
```
```console
$ bun build ./index.ts
panic(main thread): start index 2 is larger than end index 1
Crashed while resolving aba from ... (import-statement)
resolver.resolver.Resolver.matchTSConfigPaths
/src/resolver/resolver.zig:3131:42
```

## Cause

`matchTSConfigPaths` splits the pattern key at `*` into a prefix and suffix, then accepts the import path if `startsWith(path, prefix)` and `endsWith(path, suffix)` both hold. For `"ab*ba"` vs `"aba"`:

- `prefix = "ab"`, `suffix = "ba"`, `path.len = 3`
- `startsWith("aba", "ab")` ✓ and `endsWith("aba", "ba")` ✓

…but the prefix and suffix **overlap** — `prefix.len + suffix.len = 4 > path.len = 3`. The captured wildcard text is then computed as:

```zig
const matched_text = path[longest_match.prefix.len .. path.len - longest_match.suffix.len];
// = path[2 .. 3 - 2] = path[2..1]
```

In debug/ReleaseSafe this panics. In ReleaseFast the slice length wraps to near-`SIZE_MAX`; the subsequent `matched_text.len + suffix.len` wraps back around the buffer-size check and `bun.concat` memmoves ~`SIZE_MAX` bytes into a threadlocal `PathBuffer`.

## Fix

Require `path.len >= prefix.len + suffix.len` before accepting the match. That is also the correct wildcard semantics — the prefix and suffix must occupy disjoint regions of the path for `*` to have captured anything (including the empty string), so `"ab*ba"` does not match `"aba"`. TypeScript's own matcher applies the same check.

## Verification

New tests in `test/js/bun/resolve/resolve-error.test.ts`:

- `"ab*ba"` + `import "aba"` → clean `Could not resolve` error instead of a crash
- `"lib*"` + `import "lib"` → boundary case `path.len == prefix.len + suffix.len` (empty `*` capture) still matches

```
$ git stash push -- src/ && bun bd test resolve-error.test.ts -t "wildcard overlap"
(fail) does not underflow when prefix+suffix overlap ...    # subprocess panics
(pass) still matches when the wildcard captures the empty string

$ git stash pop && bun bd test resolve-error.test.ts
 17 pass, 0 fail
```