### PR TITLE
dns: reject oversized hostnames before copying to stack buffer

### DIFF
--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -231,9 +231,11 @@ const LibUVBackend = struct {
         port_buf[port_len] = 0;
         const portZ = port_buf[0..port_len :0];
         var hostname: bun.PathBuffer = undefined;
-        _ = strings.copy(hostname[0..], query.name);
-        hostname[query.name.len] = 0;
-        const host = hostname[0..query.name.len :0];
+        // Reserve the last byte for the NUL terminator so the index below can never
+        // exceed the buffer even if the upstream length guard in `doLookup` is bypassed.
+        const copied = strings.copy(hostname[0 .. hostname.len - 1], query.name);
+        hostname[copied.len] = 0;
+        const host = hostname[0..copied.len :0];
 
         request.backend.libc.uv.data = request;
         const promise = request.head.promise.value();
@@ -763,10 +765,13 @@ pub const GetAddrInfoRequest = struct {
                     port_buf[port_len] = 0;
                     const portZ = port_buf[0..port_len :0];
                     var hostname: bun.PathBuffer = undefined;
-                    _ = strings.copy(hostname[0..], query.name);
-                    hostname[query.name.len] = 0;
+                    // Reserve the last byte for the NUL terminator so the index below
+                    // can never exceed the buffer even if the upstream length guard in
+                    // `doLookup` is bypassed.
+                    const copied = strings.copy(hostname[0 .. hostname.len - 1], query.name);
+                    hostname[copied.len] = 0;
                     var addrinfo: ?*std.c.addrinfo = null;
-                    const host = hostname[0..query.name.len :0];
+                    const host = hostname[0..copied.len :0];
                     const debug_timer = bun.Output.DebugTimer.start();
                     const err = std.c.getaddrinfo(
                         host.ptr,
@@ -2866,6 +2871,17 @@ pub const Resolver = struct {
     }
 
     pub fn doLookup(this: *Resolver, name: []const u8, port: u16, options: GetAddrInfo.Options, globalThis: *jsc.JSGlobalObject) bun.JSError!jsc.JSValue {
+        // The system backends copy the hostname into a fixed `bun.PathBuffer` on the
+        // stack before null-terminating it. Reject anything that cannot fit so we never
+        // index past that buffer. RFC 1035 caps hostnames at 253 octets and NI_MAXHOST
+        // is 1025, so this never rejects a name that could have resolved.
+        if (name.len >= bun.MAX_PATH_BYTES) {
+            var promise = jsc.JSPromise.Strong.init(globalThis);
+            const promise_value = promise.value();
+            c_ares.Error.ENOTFOUND.toDeferred("getaddrinfo", name, &promise).rejectLater(globalThis);
+            return promise_value;
+        }
+
         var opts = options;
         var backend = opts.backend;
         const normalized = normalizeDNSName(name, &backend);

--- a/src/bun.js/api/bun/dns.zig
+++ b/src/bun.js/api/bun/dns.zig
@@ -239,15 +239,30 @@ const LibUVBackend = struct {
 
         request.backend.libc.uv.data = request;
         const promise = request.head.promise.value();
-        if (libuv.uv_getaddrinfo(
+        const rc = libuv.uv_getaddrinfo(
             this.vm.uvLoop(),
             &request.backend.libc.uv,
             &onRawLibUVComplete,
             host.ptr,
             portZ.ptr,
             if (hints) |*hint| hint else null,
-        ).errEnum()) |_| {
-            @panic("TODO: handle error");
+        );
+        if (rc.int() < 0) {
+            // uv_getaddrinfo can fail synchronously before it queues any work
+            // (e.g. UV_EINVAL from the 256-byte IDNA buffer for long hostnames,
+            // or UV_ENOMEM). Route the error through the same path the async
+            // completion would have taken so the pending-cache slot is released
+            // and the promise is rejected with a DNSException.
+            if (request.resolver_for_caching) |resolver| {
+                if (request.cache.pending_cache) {
+                    resolver.drainPendingHostNative(request.cache.pos_in_pending, request.head.globalThis, rc.int(), .{ .addrinfo = null });
+                    return promise;
+                }
+            }
+            var head = request.head;
+            head.processGetAddrInfoNative(rc.int(), null);
+            head.globalThis.allocator().destroy(request);
+            return promise;
         }
         return promise;
     }

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -114,10 +114,12 @@ describe("dns", () => {
   });
 
   // Hostnames longer than the fixed stack buffer used by the libc/system
-  // backends (bun.PathBuffer) previously overflowed when writing the NUL
-  // terminator. They must reject cleanly on every backend.
+  // backends (bun.PathBuffer, which is MAX_PATH_BYTES: 1024 on macOS, 4096 on
+  // Linux, ~98302 on Windows) previously overflowed when writing the NUL
+  // terminator. They must reject cleanly on every backend. 100 000 bytes
+  // exceeds the buffer on every platform so the doLookup guard is what fires.
   test.each(backends)("lookup() with oversized hostname rejects [backend: %s]", async backend => {
-    const long = Buffer.alloc(5000, "a").toString();
+    const long = Buffer.alloc(100_000, "a").toString();
     // @ts-expect-error
     await expect(dns.lookup(long, { backend })).rejects.toMatchObject({
       name: "DNSException",
@@ -137,7 +139,7 @@ describe("dns", () => {
         bunExe(),
         "-e",
         `
-          const long = Buffer.alloc(5000, "a").toString() + ".local";
+          const long = Buffer.alloc(100_000, "a").toString() + ".local";
           const settled = await Promise.allSettled([
             Bun.dns.lookup(long, { backend: "system" }),
             Bun.dns.lookup(long, { backend: "libc" }),

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -1,6 +1,6 @@
 import { SystemError, dns } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, isWindows, withoutAggressiveGC } from "harness";
 import { isIP, isIPv4, isIPv6 } from "node:net";
 
 const backends = ["system", "libc", "c-ares"];
@@ -111,6 +111,55 @@ describe("dns", () => {
         name: "DNSException",
       });
     });
+  });
+
+  // Hostnames longer than the fixed stack buffer used by the libc/system
+  // backends (bun.PathBuffer) previously overflowed when writing the NUL
+  // terminator. They must reject cleanly on every backend.
+  test.each(backends)("lookup() with oversized hostname rejects [backend: %s]", async backend => {
+    const long = Buffer.alloc(5000, "a").toString();
+    // @ts-expect-error
+    await expect(dns.lookup(long, { backend })).rejects.toMatchObject({
+      name: "DNSException",
+      code: "DNS_ENOTFOUND",
+      syscall: "getaddrinfo",
+    });
+  });
+
+  test("lookup() with oversized .local hostname rejects via system backend in subprocess", async () => {
+    // A `.local` suffix forces the c-ares backend to fall through to the
+    // system resolver, which is the path that wrote past its stack buffer.
+    // Run in a subprocess so the panic that the unfixed debug build raises on
+    // the worker thread shows up as a non-zero exit instead of aborting the
+    // whole test file.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const long = Buffer.alloc(5000, "a").toString() + ".local";
+          const settled = await Promise.allSettled([
+            Bun.dns.lookup(long, { backend: "system" }),
+            Bun.dns.lookup(long, { backend: "libc" }),
+            Bun.dns.lookup(long),
+          ]);
+          for (const result of settled) {
+            if (result.status !== "rejected") throw new Error("expected rejection");
+            if (result.reason?.code !== "DNS_ENOTFOUND") {
+              throw new Error("expected DNS_ENOTFOUND, got " + result.reason?.code);
+            }
+          }
+          console.log("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
   });
 
   test("lookup with non-object second argument should not crash", async () => {


### PR DESCRIPTION
## What

`Bun.dns.lookup` / `dns.promises.lookup` with a hostname ≥ `MAX_PATH_BYTES` wrote past a fixed stack buffer in the libc/system `getaddrinfo` backends. On Windows, a synchronous `uv_getaddrinfo` error (hit by any hostname ≥ 256 bytes) aborted the process via `@panic("TODO: handle error")`.

## Repro

```js
await Bun.dns.lookup('a'.repeat(100_000), { backend: 'libc' });
// or any '.local' / '.localhost' suffix, which forces the system backend
```

Debug build:
```
panic: index out of bounds: index 100000, len 4096
bun.js.api.bun.dns.GetAddrInfoRequest.Backend.run
src/bun.js/api/bun/dns.zig:767:29
```

ReleaseFast elides the bounds check, so the NUL write and the `[:0]` slice that follow it extend past the worker-thread stack buffer.

## Cause

Both the POSIX libc worker (`GetAddrInfoRequest.Backend.libc.run`) and the Windows libuv path (`LibUVBackend.lookup`) do:

```zig
var hostname: bun.PathBuffer = undefined;
_ = strings.copy(hostname[0..], query.name);
hostname[query.name.len] = 0;                 // unclamped index
const host = hostname[0..query.name.len :0];  // unclamped slice
```

`strings.copy` clamps the memcpy to `hostname.len`, but the terminator index and the sentinel slice use the *unclamped* `query.name.len`. `MAX_PATH_BYTES` is 1024 on macOS, 4096 on Linux, and ~98302 on Windows.

Separately, `LibUVBackend.lookup` handled a non-zero synchronous return from `uv_getaddrinfo` with `@panic("TODO: handle error")`. libuv's `uv__idna_toascii` encodes into a fixed 256-byte buffer and returns `UV_EINVAL` synchronously for anything longer — so on Windows a ≥256-byte hostname aborted the process before this PR's guard even mattered.

## Fix

- `Resolver.doLookup` (the shared entry point for every backend) now rejects with `DNS_ENOTFOUND` via the same `toDeferred().rejectLater()` path the other DNS failures use when `name.len >= bun.MAX_PATH_BYTES`. RFC 1035 caps hostnames at 253 octets and `NI_MAXHOST` is 1025, so this never rejects a name that could have resolved.
- Both copy sites now derive the terminator index and the sentinel slice from the clamped `strings.copy` result (`hostname[0 .. hostname.len - 1]`), so they stay in bounds even if the upstream guard is ever bypassed.
- `LibUVBackend.lookup`'s synchronous-error `@panic` is replaced with the same `drainPendingHostNative` / `processGetAddrInfoNative` path the async completion takes: the pending-cache slot is released, the request is destroyed, and the promise is rejected with a `DNSException` (Windows `initEAI` maps `UV_EINVAL` → `ENOTFOUND`).

## Verification

- `bun run zig:check-all` — all targets (Linux/macOS/Windows × debug/release) compile.
- New tests in `test/js/bun/dns/resolve-dns.test.ts` use a 100 000-byte hostname so the `doLookup` guard fires on every platform:
  - `lookup() with oversized hostname rejects [backend: %s]` for `system` / `libc` / `c-ares` — asserts `{ code: "DNS_ENOTFOUND", syscall: "getaddrinfo" }`.
  - Subprocess test that appends `.local` to force the system-backend fall-through and asserts a clean exit with three rejections.
- **Gate:** with `src/` at base, `bun bd test resolve-dns.test.ts -t oversized` panics `index out of bounds: index 100000, len 4096` at `dns.zig:767` on the worker thread; with the fix, all 4 pass. Full file: 75 pass / 0 fail. `node-dns.test.js`: 66 pass / 0 fail.
