### PR TITLE
webcore/Body: handle tag change after toReadableStream in bufferLockedBodyValue

### DIFF
--- a/src/runtime/webcore/Body.zig
+++ b/src/runtime/webcore/Body.zig
@@ -1776,6 +1776,15 @@ pub const ValueBufferer = struct {
             // so handle the terminal states here instead of recursing.
             switch (value.*) {
                 .Locked => {
+                    // `toReadableStream` also leaves the value `.Locked` *without*
+                    // populating `locked.readable` when a body-mixin consumer
+                    // (`.text()`/`.json()`/...) already set `promise`/`action` — it
+                    // just hands back a `ReadableStream.used()` sentinel. Recursing
+                    // in that state makes no progress and loops until the stack or
+                    // the allocator gives out, so surface the real error instead.
+                    if (value.Locked.readable.get(sink.global) == null) {
+                        return error.StreamAlreadyUsed;
+                    }
                     readable.protect();
                     return try sink.bufferLockedBodyValue(value, null);
                 },

--- a/src/runtime/webcore/Body.zig
+++ b/src/runtime/webcore/Body.zig
@@ -1769,8 +1769,31 @@ pub const ValueBufferer = struct {
             // someone else is waiting for the stream or waiting for `onStartStreaming`
             const readable = try value.toReadableStream(sink.global);
             readable.ensureStillAlive();
-            readable.protect();
-            return try sink.bufferLockedBodyValue(value, null);
+            // `toReadableStream` may drain via `onStartStreaming` and transition
+            // `value` out of `.Locked` (to `.Null` when the drain returned
+            // `.aborted` or `.empty`). Recursing into `bufferLockedBodyValue` in
+            // that state reads stale `.Locked` union fields and loops forever,
+            // so handle the terminal states here instead of recursing.
+            switch (value.*) {
+                .Locked => {
+                    readable.protect();
+                    return try sink.bufferLockedBodyValue(value, null);
+                },
+                .Null, .Empty => {
+                    return sink.onFinishedBuffering(sink.ctx, "", null, false);
+                },
+                .Error => |err| {
+                    return sink.onFinishedBuffering(sink.ctx, "", err, false);
+                },
+                .Used => {
+                    return error.StreamAlreadyUsed;
+                },
+                .WTFStringImpl, .InternalBlob, .Blob => {
+                    var input = value.useAsAnyBlobAllowNonUTF8String();
+                    defer input.detach();
+                    return sink.onFinishedBuffering(sink.ctx, input.slice(), null, false);
+                },
+            }
         }
         // is safe to wait it buffer
         locked.task = @ptrCast(sink);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tls, tmpdirSync } from "harness";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
 var setTimeoutAsync = (fn, delay) => {
@@ -137,6 +137,56 @@ describe("HTMLRewriter", () => {
       expect(await fetch(url).then(res => res.text())).toBe(`<div>${content}</div>`);
       await gcTick();
     }
+  });
+
+  it("transform(response) does not crash when the fetch signal was aborted before body was accessed", async () => {
+    // When a fetch Response body is still .Locked (headers received, body pending)
+    // and its AbortSignal has already fired, HTMLRewriter.transform calls
+    // toReadableStream which drains via onStartStreaming, gets `.aborted`, and
+    // replaces the body value with .Null. Previously bufferLockedBodyValue would
+    // then recurse into itself reading stale .Locked fields forever.
+    const src = `
+      const { promise: headersSent, resolve: resolveHeadersSent } = Promise.withResolvers();
+      const server = Bun.serve({
+        port: 0,
+        idleTimeout: 0,
+        async fetch() {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller) {
+                controller.write("<");
+                await controller.flush();
+                resolveHeadersSent();
+                await new Promise(() => {});
+              },
+            }),
+            { headers: { "content-type": "text/html" } },
+          );
+        },
+      });
+      const controller = new AbortController();
+      const response = await fetch("http://localhost:" + server.port + "/", { signal: controller.signal });
+      await headersSent;
+      controller.abort();
+      try {
+        const out = new HTMLRewriter().transform(response);
+        await out.text().catch(() => {});
+      } catch {}
+      await server.stop(true);
+      console.log("OK");
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
   });
 
   for (let input of [new Response("<div>hello</div>"), "<div>hello</div>"]) {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -173,7 +173,6 @@ describe("HTMLRewriter", () => {
         const out = new HTMLRewriter().transform(response);
         await out.text().catch(() => {});
       } catch {}
-      await server.stop(true);
       console.log("OK");
       process.exit(0);
     `;
@@ -196,6 +195,7 @@ describe("HTMLRewriter", () => {
     // StreamAlreadyUsed rather than recursing (which previously spun ~1000+ times
     // allocating throwaway streams before giving up with a misleading error).
     const { promise: headersSent, resolve: resolveHeadersSent } = Promise.withResolvers();
+    const { promise: done, resolve: resolveDone } = Promise.withResolvers();
     await using server = Bun.serve({
       port: 0,
       idleTimeout: 0,
@@ -207,7 +207,7 @@ describe("HTMLRewriter", () => {
               controller.write("<");
               await controller.flush();
               resolveHeadersSent();
-              await new Promise(() => {});
+              await done;
             },
           }),
           { headers: { "content-type": "text/html" } },
@@ -220,6 +220,7 @@ describe("HTMLRewriter", () => {
     expect(() => new HTMLRewriter().transform(response)).toThrow(
       expect.objectContaining({ code: "ERR_STREAM_ALREADY_FINISHED" }),
     );
+    resolveDone();
     await server.stop(true);
   });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -189,6 +189,40 @@ describe("HTMLRewriter", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("transform(response) throws StreamAlreadyUsed when a body-mixin consumer is pending", async () => {
+    // When .text()/.json()/etc. has already been called on a pending fetch body,
+    // toReadableStream returns a "used" sentinel without populating locked.readable
+    // or changing the tag. bufferLockedBodyValue must detect this and surface
+    // StreamAlreadyUsed rather than recursing (which previously spun ~1000+ times
+    // allocating throwaway streams before giving up with a misleading error).
+    const { promise: headersSent, resolve: resolveHeadersSent } = Promise.withResolvers();
+    await using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      async fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write("<");
+              await controller.flush();
+              resolveHeadersSent();
+              await new Promise(() => {});
+            },
+          }),
+          { headers: { "content-type": "text/html" } },
+        );
+      },
+    });
+    const response = await fetch(`http://localhost:${server.port}/`);
+    await headersSent;
+    response.text().catch(() => {});
+    expect(() => new HTMLRewriter().transform(response)).toThrow(
+      expect.objectContaining({ code: "ERR_STREAM_ALREADY_FINISHED" }),
+    );
+    await server.stop(true);
+  });
+
   for (let input of [new Response("<div>hello</div>"), "<div>hello</div>"]) {
     it("supports element handlers with input " + input.constructor.name, async () => {
       var rewriter = new HTMLRewriter();

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -217,11 +217,14 @@ describe("HTMLRewriter", () => {
     const response = await fetch(`http://localhost:${server.port}/`);
     await headersSent;
     response.text().catch(() => {});
-    expect(() => new HTMLRewriter().transform(response)).toThrow(
-      expect.objectContaining({ code: "ERR_STREAM_ALREADY_FINISHED" }),
-    );
-    resolveDone();
-    await server.stop(true);
+    try {
+      expect(() => new HTMLRewriter().transform(response)).toThrow(
+        expect.objectContaining({ code: "ERR_STREAM_ALREADY_FINISHED" }),
+      );
+    } finally {
+      resolveDone();
+      await server.stop(true);
+    }
   });
 
   for (let input of [new Response("<div>hello</div>"), "<div>hello</div>"]) {


### PR DESCRIPTION
## Problem

`HTMLRewriter.transform(response)` crashes with a stack overflow (ReleaseFast) or assertion failure (Debug) when:
- `response` came from `fetch()` with an `AbortSignal`
- the signal has already fired
- `response.body` has not been accessed yet

## Repro

```js
const server = Bun.serve({
  port: 0,
  idleTimeout: 0,
  fetch: () => new Response(new ReadableStream({
    type: "direct",
    async pull(c) { c.write("<"); await c.flush(); await new Promise(() => {}); },
  }), { headers: { "content-type": "text/html" } }),
});
const controller = new AbortController();
const response = await fetch(`http://localhost:${server.port}/`, { signal: controller.signal });
controller.abort();
new HTMLRewriter().transform(response); // segfault
```

## Root cause

In `Body.ValueBufferer.bufferLockedBodyValue` (src/bun.js/webcore/Body.zig:1752-1758), when the body is `.Locked` with a pending `.task`, it calls `value.toReadableStream()` and then recurses into itself.

`toReadableStream` invokes the `onStartStreaming` callback which, for an aborted `fetch`, returns `.aborted`. `toReadableStream` then assigns `this.* = .{ .Null = {} }` — but since `.Null` is a void payload, only the union **tag** is overwritten; the `.Locked` payload bytes (including `.task`) are left intact.

The recursive call's entry `assert(value.* == .Locked)` is stripped in ReleaseFast. `&value.Locked` then reads the stale fields; `locked.task != null` is still true, so it calls `toReadableStream` again (now on a `.Null` body, returning `JSValue.null`) and recurses forever → stack overflow.

## Fix

After `toReadableStream()`, re-check the tag. If it's no longer `.Locked`, dispatch the terminal state inline (same handling as `ValueBufferer.run()`) instead of recursing. The `.Locked` path is unchanged.

## Verification

New test in `test/js/workerd/html-rewriter.test.js` spawns a subprocess that reproduces the exact scenario above.

- `USE_SYSTEM_BUN=1 bun test` → subprocess segfaults, test fails
- Debug build without fix → subprocess panics at `assert(value.* == .Locked)`, test fails
- Debug build with fix → subprocess prints `OK`, test passes
- Full `html-rewriter.test.js` suite: 42 pass, 2 todo, 0 fail