### PR TITLE
socket: null handlers after client markInactive frees them

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -444,13 +444,22 @@ pub fn NewSocket(comptime ssl: bool) type {
                     return;
                 }
                 const handlers = this.getHandlers();
+                // Non-`.server` `Handlers` are heap-allocated per-socket and
+                // `Handlers.markInactive` frees that allocation once
+                // `active_connections` hits zero. Capture the mode first and
+                // null our pointer after so JS-facing accessors (`.listener`,
+                // `setServername` → `isServer`) and the reconnection path in
+                // `Listener.connect` don't dereference freed memory on a
+                // closed socket.
+                const listener_owned = handlers.mode == .server;
                 handlers.markInactive();
+                if (!listener_owned) this.handlers = null;
                 this.poll_ref.unref(vm);
             }
         }
 
         pub fn isServer(this: *const This) bool {
-            const handlers = this.getHandlers();
+            const handlers = this.handlers orelse return false;
             return handlers.mode.isServer();
         }
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -821,6 +821,59 @@ it("should throw on empty unix path from truthy non-string value", () => {
   expect(() => Bun.connect({ unix: [] as any, socket })).toThrow("SocketOptions.unix must be a string");
 });
 
+it("reading .listener on a closed client socket does not use-after-free handlers", async () => {
+  // Client-mode Handlers is heap-allocated per-connect and freed in
+  // markInactive once the socket closes. `socket.listener` read
+  // `handlers.mode` through the dangling pointer before the isDetached()
+  // check. Run in a subprocess so the ASAN abort is observable as a
+  // non-zero exit instead of killing the test runner.
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { promise: closed, resolve: onClosed } = Promise.withResolvers();
+        using server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          socket: {
+            open(s) { s.end(); },
+            data() {},
+          },
+        });
+        const client = await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          socket: {
+            data() {},
+            close() { onClosed(); },
+          },
+        });
+        await closed;
+        server.stop(true);
+        // The close callback resolves while native onClose is still on the
+        // stack; markInactive (which frees the client Handlers) runs in the
+        // deferred unwind after scope.exit() drains this microtask. Hop one
+        // event-loop turn so the free has actually happened.
+        await new Promise(r => setImmediate(r));
+        console.log("listener:" + client.listener);
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      // llvm-symbolizer on the debug binary takes several seconds; the raw
+      // ASAN report line + exit code are enough to flag the regression.
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:symbolize=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("listener:undefined\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("reading fd of a TLS listener should not crash", () => {
   using listener = Bun.listen({
     hostname: "localhost",


### PR DESCRIPTION
## Repro

```js
const server = Bun.listen({ hostname: '127.0.0.1', port: 0, socket: { open(s){s.end()}, data(){} } });
const client = await Bun.connect({ hostname: '127.0.0.1', port: server.port, socket: { data(){}, close(){} } });
// ... after close fires and the native onClose unwinds:
client.listener; // ← reads handlers.mode through freed pointer
```

ASAN on debug build:

```
==4232==ERROR: AddressSanitizer: use-after-poison on address 0x79f744320469
READ of size 1 at 0x79f744320469 thread T0
    #0 bun.js.api.bun.socket.NewSocket(false).getListener  src/bun.js/api/bun/socket.zig:760:25
    #1 TCPSocketPrototype__listenerGetterWrap              ZigGeneratedClasses.cpp:66452:34
```

## Cause

Client-mode `Handlers` are heap-allocated per `Bun.connect` (Listener.zig:795). When the socket closes, the socket's `markInactive` calls `handlers.markInactive()`, which — for non-`.server` modes — drops `active_connections` to zero, `deinit`s and `destroy`s the allocation. `this.handlers` is never cleared, so it's left pointing at freed memory.

The `.listener` getter then does:

```zig
const handlers = this.handlers orelse return .js_undefined; // non-null, dangling
if (handlers.mode != .server or this.socket.isDetached()) { // ← UAF read
```

Same in `setServername` → `isServer()` → `getHandlers().mode`.

The reconnection path in `Listener.connect` (line 813-816) also checks `if (prev.handlers) |h| { h.deinit(); destroy(h); }` — a double-free when the previous connection's `markInactive` already freed it.

## Fix

In the socket's `markInactive`, capture `handlers.mode == .server` before calling `handlers.markInactive()`, then null `this.handlers` for non-listener-owned modes. `isServer()` now returns `false` on null instead of panicking via `getHandlers()`.

`.server`-mode handlers are embedded in the Listener struct (not freed here), so those pointers stay intact.

## Verification

New test in `test/js/bun/net/socket.test.ts` spawns a client, waits for close + one `setImmediate` hop (so the deferred `markInactive` has run), then reads `.listener`.

- Without fix (`git stash -- src/`): subprocess aborts with the ASAN trace above; test fails on `expect(stdout).toBe("listener:undefined\\n")`.
- With fix: subprocess prints `listener:undefined` and exits 0; test passes.