### PR TITLE
sql(mysql): reject short auth nonce instead of OOB-reading it

### DIFF
--- a/src/sql/mysql/protocol/Auth.zig
+++ b/src/sql/mysql/protocol/Auth.zig
@@ -11,6 +11,12 @@ pub const mysql_native_password = struct {
         if (password.len == 0) {
             return result;
         }
+        // A malicious or broken server can send an AuthSwitchRequest with a
+        // short plugin_data; without this check the slicing below reads past
+        // the end of the buffer.
+        if (nonce.len < 20) {
+            return error.MissingAuthData;
+        }
 
         // Stage 1: SHA1(password)
         bun.sha.SHA1.hash(password, &stage1, jsc.VirtualMachine.get().rareData().boringEngine());
@@ -102,6 +108,11 @@ pub const caching_sha2_password = struct {
         // RSA encrypted value of XOR(password, seed) using server public key (RSA_PKCS1_OAEP_PADDING).
 
         pub fn writeInternal(this: *const EncryptedPassword, comptime Context: type, writer: NewWriter(Context)) !void {
+            // The XOR below does `nonce[i % nonce.len]`; an empty nonce from a
+            // malicious server's AuthSwitchRequest would be a divide-by-zero.
+            if (this.nonce.len == 0) {
+                return error.MissingAuthData;
+            }
             // 1024 is overkill but lets cover all cases
             var password_buf: [1024]u8 = undefined;
             var needs_to_free_password = false;

--- a/src/sql/mysql/protocol/Auth.zig
+++ b/src/sql/mysql/protocol/Auth.zig
@@ -113,6 +113,12 @@ pub const caching_sha2_password = struct {
             if (this.nonce.len == 0) {
                 return error.MissingAuthData;
             }
+            // `&this.public_key[0]` below would index past a zero-length
+            // slice if the server answered the public-key request with an
+            // empty payload.
+            if (this.public_key.len == 0) {
+                return error.InvalidPublicKey;
+            }
             // 1024 is overkill but lets cover all cases
             var password_buf: [1024]u8 = undefined;
             var needs_to_free_password = false;

--- a/test/js/sql/sql-mysql-auth-short-nonce.test.ts
+++ b/test/js/sql/sql-mysql-auth-short-nonce.test.ts
@@ -1,0 +1,125 @@
+// Regression: mysql_native_password.scramble() sliced nonce[0..8] and
+// nonce[8..20] with no length check. A malicious server can send an
+// AuthSwitchRequest whose plugin_data is shorter than 20 bytes, which flows
+// straight into scramble() as the nonce — OOB read (panic under safety
+// checks, silent heap over-read in release). With the fix the client rejects
+// with ERR_MYSQL_MISSING_AUTH_DATA before touching the buffer.
+//
+// Uses a minimal mock MySQL server so it can run without Docker.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { once } from "events";
+import net from "net";
+
+function u16le(n: number) {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number) {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number) {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer) {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+
+// Server capability flags (subset sufficient for the auth-switch path).
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+// Advertise caching_sha2_password in the initial handshake so the client
+// has to follow the AuthSwitchRequest path to reach
+// mysql_native_password.scramble() with the server-controlled plugin_data.
+function handshakeV10() {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62); // includes trailing NUL as part of 13 bytes
+  authData2[12] = 0;
+  const payload = Buffer.concat([
+    Buffer.from([10]), // protocol version
+    Buffer.from("mock-5.7.0\0"), // server version NUL-terminated
+    u32le(1), // connection id
+    authData1, // auth-plugin-data-part-1 (8)
+    Buffer.from([0]), // filler
+    u16le(SERVER_CAPS & 0xffff), // capability flags lower
+    Buffer.from([0x2d]), // character set (utf8mb4_general_ci)
+    u16le(0x0002), // status flags (SERVER_STATUS_AUTOCOMMIT)
+    u16le((SERVER_CAPS >>> 16) & 0xffff), // capability flags upper
+    Buffer.from([21]), // length of auth-plugin-data
+    Buffer.alloc(10, 0), // reserved
+    authData2, // auth-plugin-data-part-2 (13 bytes)
+    Buffer.from("caching_sha2_password\0"),
+  ]);
+  return packet(0, payload);
+}
+
+// AuthSwitchRequest: 0xfe, plugin_name NUL-terminated, plugin_data (rest of
+// packet). Send only 4 bytes of plugin_data — well under the 20 bytes
+// scramble() slices.
+function authSwitchShortNonce(seq: number) {
+  return packet(
+    seq,
+    Buffer.concat([Buffer.from([0xfe]), Buffer.from("mysql_native_password\0"), Buffer.alloc(4, 0x63)]),
+  );
+}
+
+test("MySQL: AuthSwitchRequest with a short mysql_native_password nonce is rejected, not OOB-read", async () => {
+  let sawAuthSwitchResponse = false;
+
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let sentAuthSwitch = false;
+    socket.write(handshakeV10());
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        buffered = buffered.subarray(4 + len);
+        if (!sentAuthSwitch) {
+          // Reply to HandshakeResponse41 with the short-nonce AuthSwitch.
+          sentAuthSwitch = true;
+          socket.write(authSwitchShortNonce(seq + 1));
+        } else {
+          // Pre-fix release builds OOB-read garbage into the scramble and
+          // still send an AuthSwitchResponse; reaching here means the
+          // length check did not fire. Close so the client does not hang.
+          sawAuthSwitchResponse = true;
+          socket.end();
+        }
+      }
+    });
+    socket.on("error", () => {});
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  try {
+    // Non-empty password so scramble() proceeds past the empty-password early return.
+    await using sql = new SQL({ url: `mysql://root:pw@127.0.0.1:${port}/db`, max: 1 });
+    const err = await sql`select 1`.then(
+      () => ({ code: "UNEXPECTED_SUCCESS" }),
+      e => ({ code: e?.code ?? String(e) }),
+    );
+
+    expect({ err, sawAuthSwitchResponse }).toEqual({
+      err: { code: "ERR_MYSQL_MISSING_AUTH_DATA" },
+      sawAuthSwitchResponse: false,
+    });
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});


### PR DESCRIPTION
## Problem

`mysql_native_password.scramble()` slices `nonce[0..8]` and `nonce[8..20]` with no length check. The initial HandshakeV10 path always supplies ≥21 bytes, but the **AuthSwitchRequest** path forwards server-controlled `plugin_data` of arbitrary length straight into `scramble()` as the nonce. A malicious server sending fewer than 20 bytes triggers an out-of-bounds read — a panic under debug/safety checks, a silent heap over-read in release.

## Repro

Mock server that answers HandshakeResponse41 with an `AuthSwitchRequest` for `mysql_native_password` whose `plugin_data` is 4 bytes. Without the fix:

```
panic(main thread): index out of bounds: index 8, len 4
sql.mysql.protocol.Auth.mysql_native_password.scramble
/workspace/bun/src/sql/mysql/protocol/Auth.zig:24:26
sql.mysql.AuthMethod.AuthMethod.scramble
sql.mysql.MySQLConnection.sendAuthSwitchResponse
sql.mysql.MySQLConnection.handleAuth
```

In release the OOB-read produces a garbage scramble that still gets sent to the server (observable in the test as `sawAuthSwitchResponse: true`).

## Fix

In `src/sql/mysql/protocol/Auth.zig`, reject server-controlled short buffers before indexing into them:

- `mysql_native_password.scramble`: return `error.MissingAuthData` when `nonce.len < 20`, before slicing. Surfaces to JS as `ERR_MYSQL_MISSING_AUTH_DATA` and the connection fails cleanly.
- `caching_sha2_password.EncryptedPassword.writeInternal`:
  - `nonce.len == 0` → `error.MissingAuthData`. The XOR loop does `nonce[i % nonce.len]`, which is a divide-by-zero when an AuthSwitch to `caching_sha2_password` carries an empty `plugin_data` into `#auth_data` before the public-key flow.
  - `public_key.len == 0` → `error.InvalidPublicKey`. `&this.public_key[0]` would index past a zero-length slice when the server answers the public-key request with an empty payload.

## Verification

`test/js/sql/sql-mysql-auth-short-nonce.test.ts` drives a mock server through the auth-switch path with a 4-byte nonce and asserts `{ code: 'ERR_MYSQL_MISSING_AUTH_DATA', sawAuthSwitchResponse: false }`.

- `bun bd test` with fix → pass
- `bun bd test` without fix → panic `index out of bounds: index 8, len 4` at `Auth.zig:24`
- `USE_SYSTEM_BUN=1 bun test` → fail (`ERR_MYSQL_CONNECTION_CLOSED`, `sawAuthSwitchResponse: true`)
