### PR TITLE
socket: set Handlers.mode=.client for Windows named-pipe Bun.connect

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -737,7 +737,14 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
                     }
                     prev.handlers = handlers_ptr;
                     bun.assert(prev.socket.socket == .detached);
-                    bun.assert(prev.connection == null);
+                    // Adopt `connection` (heap-owned for .unix) so the socket's
+                    // deinit frees it; matches the TLS arm above and the
+                    // non-pipe arm below. Previously `.connection = null`
+                    // dropped the duped pipe-path bytes on the floor.
+                    if (prev.connection) |old_connection| {
+                        old_connection.deinit();
+                    }
+                    prev.connection = connection;
                     bun.assert(prev.protos == null);
                     bun.assert(prev.server_name == null);
                     break :blk prev;
@@ -745,7 +752,7 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
                     .ref_count = .init(),
                     .handlers = handlers_ptr,
                     .socket = TCPSocket.Socket.detached,
-                    .connection = null,
+                    .connection = connection,
                     .protos = null,
                     .server_name = null,
                 });

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -561,7 +561,12 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
     }
     const vm = globalObject.bunVM();
 
-    var socket_config = try SocketConfig.fromJS(vm, opts, globalObject, true);
+    // is_server=false: this is the client connect path. Handlers.mode must be
+    // .client so markInactive() takes the allocator.destroy branch — the
+    // .server branch does @fieldParentPtr("handlers", this) to reach a
+    // Listener, but here handlers live in a standalone allocator.create()
+    // block (see below), so that would read past the allocation.
+    var socket_config = try SocketConfig.fromJS(vm, opts, globalObject, false);
     defer socket_config.deinitExcludingHandlers();
 
     const handlers = &socket_config.handlers;
@@ -654,6 +659,7 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
 
             const handlers_ptr = bun.handleOom(handlers.vm.allocator.create(Handlers));
             handlers_ptr.* = handlers.*;
+            handlers_ptr.mode = .client;
 
             var promise = jsc.JSPromise.create(globalObject);
             const promise_value = promise.toJS();

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -949,3 +949,116 @@ it("TLS client: flush() after end() does not double-teardown before deferred onC
   expect(stdout.trim()).toBe("OK");
   expect(exitCode).toBe(0);
 }, 30_000); // debug subprocess startup + ASAN symbolication on failure is slow
+
+// Bun.connect() on a Windows named pipe takes a dedicated early branch in
+// Listener.connectInner that heap-allocates a standalone Handlers block. That
+// block's `.mode` must be `.client` so Handlers.markInactive() destroys it on
+// close; the `.server` path does `@fieldParentPtr("handlers", ...)` expecting
+// a surrounding Listener struct and would read past the standalone
+// allocation (heap-buffer-overflow under ASAN) and leak the block.
+describe.skipIf(!isWindows)("Bun.connect named-pipe client Handlers lifecycle", () => {
+  it("open → close cleans up without reading past the Handlers allocation", async () => {
+    const src = /* js */ `
+      const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-connect-" + Math.random().toString(36).slice(2);
+
+      const closed = Promise.withResolvers();
+      const opened = Promise.withResolvers();
+
+      using server = Bun.listen({
+        unix: pipe,
+        socket: {
+          data() {},
+          open(s) { s.end(); },
+          close() {},
+          error() {},
+        },
+      });
+
+      const client = await Bun.connect({
+        unix: pipe,
+        socket: {
+          data() {},
+          open() { opened.resolve(); },
+          close() { closed.resolve(); },
+          error() {},
+        },
+      });
+
+      await opened.promise;
+      client.end();
+      await closed.promise;
+      server.stop(true);
+
+      Bun.gc(true);
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      stdout: "OK",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  it("failed connect to a non-existent pipe rejects and cleans up", async () => {
+    const src = /* js */ `
+      const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-missing-" + Math.random().toString(36).slice(2);
+
+      let rejected = false;
+      await Bun.connect({
+        unix: pipe,
+        socket: {
+          data() {},
+          open() {},
+          close() {},
+          connectError() {},
+          error() {},
+        },
+      }).catch(() => { rejected = true; });
+
+      if (!rejected) {
+        console.error("expected Bun.connect to reject for a non-existent pipe");
+        process.exit(1);
+      }
+
+      Bun.gc(true);
+      console.log("OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      stdout: "OK",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});


### PR DESCRIPTION
## Repro

Windows only:
```js
await Bun.connect({
  unix: '\\\\.\\pipe\\x',
  socket: { data() {}, open() {}, close() {} },
});
// then close (or fail) the connection
```

On close, `Handlers.markInactive()` hits `active_connections == 0` with `.mode == .server` and does `@fieldParentPtr("handlers", this)` expecting an enclosing `Listener` — but the handlers live in a standalone `allocator.create(Handlers)` block, so reading `listen_socket.listener` falls past the allocation. Under ASAN that's a heap-buffer-overflow; on release it reads garbage and — because the `.client` branch is skipped — leaks the block.

## Cause

`connectInner()` calls `SocketConfig.fromJS(vm, opts, globalObject, true)` at `Listener.zig:564`. The last argument is `is_server`, which feeds `handlers.mode`. It was `false` until 4a06991d3b (#23755) flipped it during a bindings-generator refactor.

The non-pipe path at :797 has always had an explicit `handlers_ptr.mode = .client` after copying into the heap block (it was `handlers_ptr.is_server = false` before #26539), which masked the flip everywhere except the Windows named-pipe early-return at :655–656, which never had one.

`is_server` is only used to set `handlers.mode`; nothing else in `SocketConfig.fromGenerated` / `Handlers.fromGenerated` branches on it.

## Fix

- Restore `is_server=false` at the `connectInner` call site (this is the client connect path).
- Add the same defensive `handlers_ptr.mode = .client` on the named-pipe branch to mirror the non-pipe branch, so the two copies into a standalone `Handlers` block look the same.

Audited the other standalone `allocator.create(Handlers)` sites:
- `socket.zig:1557` — sourced from `Handlers.fromJS(..., false)`, already `.client`.
- `socket.zig:2062` — explicit `.mode = if (is_server) .duplex_server else .client`.

## Verification

`bun run zig:check-all` passes (all targets, including both Windows arches).

New Windows-only tests in `test/js/bun/net/socket.test.ts`:
- Listen on a named pipe, `Bun.connect` to it, close → clean exit.
- `Bun.connect` to a non-existent pipe → rejects, clean exit.

Both are spawned in a subprocess so an ASAN crash surfaces as a non-zero exit instead of killing the test runner. Skipped on non-Windows (the `if (Environment.isWindows)` branch is unreachable there, and the non-pipe path's :797 override already covers it).