### PR TITLE
Fix use-after-free in module resolve query string with non-ASCII specifiers

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1855,7 +1855,7 @@ pub fn resolve(
     global: *JSGlobalObject,
     specifier: bun.String,
     source: bun.String,
-    query_string: ?*ZigString,
+    query_string: ?*bun.String,
     is_esm: bool,
 ) !void {
     try resolveMaybeNeedsTrailingSlash(res, global, specifier, source, query_string, is_esm, true, false);
@@ -1874,7 +1874,7 @@ pub fn resolveMaybeNeedsTrailingSlash(
     global: *JSGlobalObject,
     specifier: bun.String,
     source: bun.String,
-    query_string: ?*ZigString,
+    query_string: ?*bun.String,
     is_esm: bool,
     comptime is_a_file_path: bool,
     is_user_require_resolve: bool,
@@ -2001,7 +2001,13 @@ pub fn resolveMaybeNeedsTrailingSlash(
     };
 
     if (query_string) |query| {
-        query.* = ZigString.init(result.query_string);
+        // `result.query_string` is a slice into `specifier_utf8`, which is freed by
+        // `defer specifier_utf8.deinit()` before callers (C++ or Zig) read the out-param.
+        // Clone into an owned bun.String so it survives this function returning.
+        query.* = if (result.query_string.len > 0)
+            bun.String.cloneUTF8(result.query_string)
+        else
+            bun.String.empty;
     }
 
     res.* = ErrorableString.ok(bun.String.init(result.path));

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -822,7 +822,8 @@ fn doResolve(globalThis: *jsc.JSGlobalObject, arguments: []const JSValue) bun.JS
 
 fn doResolveWithArgs(ctx: *jsc.JSGlobalObject, specifier: bun.String, from: bun.String, is_esm: bool, comptime is_file_path: bool, is_user_require_resolve: bool) bun.JSError!jsc.JSValue {
     var errorable: ErrorableString = undefined;
-    var query_string = ZigString.Empty;
+    var query_string = bun.String.empty;
+    defer query_string.deref();
 
     const specifier_decoded = if (specifier.hasPrefixComptime("file://"))
         bun.jsc.URL.pathFromFileURL(specifier)
@@ -845,7 +846,7 @@ fn doResolveWithArgs(ctx: *jsc.JSGlobalObject, specifier: bun.String, from: bun.
         return ctx.throwValue(errorable.result.err.value);
     }
 
-    if (query_string.len > 0) {
+    if (!query_string.isEmpty()) {
         var stack = std.heap.stackFallback(1024, ctx.allocator());
         const allocator = stack.get();
         var arraylist = std.array_list.Managed(u8).initCapacity(allocator, 1024) catch unreachable;

--- a/src/bun.js/bindings/JSGlobalObject.zig
+++ b/src/bun.js/bindings/JSGlobalObject.zig
@@ -896,7 +896,7 @@ pub const JSGlobalObject = opaque {
         return Zig__GlobalObject__resetModuleRegistryMap(global, map);
     }
 
-    pub fn resolve(res: *ErrorableString, global: *JSGlobalObject, specifier: *bun.String, source: *bun.String, query: *ZigString) callconv(.c) void {
+    pub fn resolve(res: *ErrorableString, global: *JSGlobalObject, specifier: *bun.String, source: *bun.String, query: *bun.String) callconv(.c) void {
         jsc.markBinding(@src());
         return jsc.VirtualMachine.resolve(res, global, specifier.*, source.*, query, true) catch {
             bun.debugAssert(res.success == false);

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3323,14 +3323,16 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         }
     }
 
-    ZigString queryString = { 0, 0 };
+    BunString queryString = { BunStringTag::Empty, nullptr };
     Zig__GlobalObject__resolve(&res, globalObject, &keyZ, &referrerZ, &queryString);
     keyZ.deref();
     referrerZ.deref();
 
     if (res.success) {
-        if (queryString.len > 0) {
-            return JSC::Identifier::fromString(globalObject->vm(), makeString(res.result.value.toWTFString(BunString::ZeroCopy), Zig::toString(queryString)));
+        if (!queryString.isEmpty()) {
+            auto result = JSC::Identifier::fromString(globalObject->vm(), makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+            queryString.deref();
+            return result;
         }
 
         return Identifier::fromString(globalObject->vm(), res.result.value.toWTFString(BunString::ZeroCopy));
@@ -3395,7 +3397,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             moduleNameZ = Bun::toStringRef(moduleName);
         }
 
-        ZigString queryString = { 0, 0 };
+        BunString queryString = { BunStringTag::Empty, nullptr };
         String sourceOriginStringHolder;
 
         if (sourceURL.isEmpty()) {
@@ -3426,10 +3428,11 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
         }
 
-        if (queryString.len == 0) {
+        if (queryString.isEmpty()) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolved.result.value.toWTFString());
         } else {
-            resolvedIdentifier = JSC::Identifier::fromString(vm, makeString(resolved.result.value.toWTFString(BunString::ZeroCopy), Zig::toString(queryString)));
+            resolvedIdentifier = JSC::Identifier::fromString(vm, makeString(resolved.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+            queryString.deref();
         }
 
         moduleNameZ.deref();

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -442,7 +442,7 @@ ZIG_DECL void Zig__GlobalObject__fetch(ErrorableResolvedSource* arg0, JSC::JSGlo
 ZIG_DECL void Zig__GlobalObject__onCrash();
 ZIG_DECL JSC::EncodedJSValue Zig__GlobalObject__promiseRejectionTracker(JSC::JSGlobalObject* arg0, JSC::JSPromise* arg1, uint32_t JSPromiseRejectionOperation2);
 ZIG_DECL JSC::EncodedJSValue Zig__GlobalObject__reportUncaughtException(JSC::JSGlobalObject* arg0, JSC::Exception* arg1);
-ZIG_DECL void Zig__GlobalObject__resolve(ErrorableString* arg0, JSC::JSGlobalObject* arg1, BunString* arg2, BunString* arg3, ZigString* arg4);
+ZIG_DECL void Zig__GlobalObject__resolve(ErrorableString* arg0, JSC::JSGlobalObject* arg1, BunString* arg2, BunString* arg3, BunString* arg4);
 
 #endif
 

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
 const resolvedURL = Bun.pathToFileURL(resolvedPath).href;
@@ -42,3 +43,64 @@ for (let order of [
     );
   });
 }
+
+// When the specifier contains non-ASCII characters (so toUTF8() must allocate a
+// fresh buffer on the Zig side), the query string returned to C++ must not point
+// into that freed buffer. With ASAN this is a heap-use-after-free; without it the
+// resolved key comes back corrupted.
+test("query string with non-ASCII specifier (dynamic import)", async () => {
+  using dir = tempDir("import-query-nonascii", {
+    "target.js": `console.log(JSON.stringify(import.meta.url));`,
+    "entry.js": `await import("./target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const url = JSON.parse(stdout.trim());
+  expect(decodeURIComponent(url)).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
+  expect(exitCode).toBe(0);
+});
+
+test("query string with non-ASCII specifier (static import)", async () => {
+  using dir = tempDir("import-query-nonascii-static", {
+    "target.js": `console.log(JSON.stringify(import.meta.url));`,
+    "entry.js": `import "./target.js?v=caf\u00e9-\u65e5\u672c\u8a9e";`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const url = JSON.parse(stdout.trim());
+  expect(decodeURIComponent(url)).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
+  using dir = tempDir("resolve-query-nonascii", {
+    "target.js": ``,
+    "entry.js": `console.log(JSON.stringify(Bun.resolveSync("./target.js?v=caf\u00e9-\u65e5\u672c\u8a9e", import.meta.dir)));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const resolved = JSON.parse(stdout.trim());
+  expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

`Zig__GlobalObject__resolve` writes its `queryString` out-parameter as a `ZigString` that points into the temporary buffer from `specifier.toUTF8()`. That buffer is freed by `defer specifier_utf8.deinit()` in `resolveMaybeNeedsTrailingSlash` before the C++ caller reads it.

For any import specifier that contains a `?` **and** a non-ASCII character — e.g. `import("./target.js?v=café")` or `import("./target.js?v=日本語")` — `toUTF8()` must allocate a fresh buffer (16-bit or non-ASCII Latin-1 input), so the returned `queryString` slice dangles and `makeString(..., Zig::toString(queryString))` reads freed memory.

Under ASAN:
```
AddressSanitizer: use-after-poison on address 0x7b93854d014b
READ of size 18 at 0x7b93854d014b thread T0
```
(18 bytes = UTF-8 length of `?v=café-日本語`)

## Cause

`VirtualMachine.resolveMaybeNeedsTrailingSlash` (src/bun.js/VirtualMachine.zig):
```zig
const specifier_utf8 = specifier.toUTF8(bun.default_allocator);
defer specifier_utf8.deinit();
// ... _resolve() slices out "?..." from specifier_utf8 into result.query_string ...
if (query_string) |query| {
    query.* = ZigString.init(result.query_string); // dangling after return
}
```

This affected:
- `GlobalObject::moduleLoaderResolve` (static imports)
- `GlobalObject::moduleLoaderImportModule` (dynamic `import()`)
- `Bun.resolveSync` / `Bun.resolve` via `doResolveWithArgs`

## Fix

Change the `query_string` out-parameter from `ZigString*` (borrowed slice) to `BunString*` (owned, ref-counted). The Zig side now `bun.String.cloneUTF8()`s the query slice so it outlives the temporary UTF-8 buffer; callers `deref()` it after use.

## Verification

```
# without fix (git stash src/):
bun bd test test/js/bun/resolve/import-query.test.ts -t non-ASCII
  → 3 fail, AddressSanitizer: use-after-poison

# with fix:
bun bd test test/js/bun/resolve/import-query.test.ts
  → 11 pass
```