### PR TITLE
Fix type confusion in JSBundlerPlugin sync-exception fallback

### DIFF
--- a/src/bun.js/bindings/JSBundlerPlugin.cpp
+++ b/src/bun.js/bindings/JSBundlerPlugin.cpp
@@ -540,11 +540,12 @@ extern "C" void JSBundlerPlugin__matchOnLoad(Bun::JSBundlerPlugin* plugin, const
         auto exception = scope.exception();
         (void)scope.tryClearException();
         if (!plugin->plugin.tombstoned) {
+            // which = 1 (Load). Zig's JSBundlerPlugin__addError casts ctx based on this value.
             plugin->plugin.addError(
                 context,
-                plugin->plugin.config,
+                plugin,
                 JSC::JSValue::encode(exception),
-                JSValue::encode(jsNumber(0)));
+                JSValue::encode(jsNumber(1)));
         }
     }
 }
@@ -583,11 +584,12 @@ extern "C" void JSBundlerPlugin__matchOnResolve(Bun::JSBundlerPlugin* plugin, co
         auto exception = JSValue(scope.exception());
         (void)scope.tryClearException();
         if (!plugin->plugin.tombstoned) {
-            JSBundlerPlugin__addError(
+            // which = 0 (Resolve). Zig's JSBundlerPlugin__addError casts ctx based on this value.
+            plugin->plugin.addError(
                 context,
                 plugin,
                 JSC::JSValue::encode(exception),
-                JSValue::encode(jsNumber(1)));
+                JSValue::encode(jsNumber(0)));
         }
         return;
     }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
 import path, { join } from "path";
 import { buildNoThrow } from "./buildNoThrow";
 
@@ -1178,3 +1178,85 @@ test.skipIf(!isDebug && !isASAN)(
   },
   120_000,
 );
+
+// Regression: the C++ synchronous-exception fallback in JSBundlerPlugin__matchOnLoad /
+// JSBundlerPlugin__matchOnResolve passed the wrong `which` value to JSBundlerPlugin__addError,
+// so Zig would reinterpret a *Load as a *Resolve (and vice versa) and read garbage / crash.
+// The builtin calls the public `.then` on the pending IIFE promise, so we can force a
+// synchronous throw there to reach that fallback deterministically.
+describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin throws synchronously", hook => {
+  test.concurrent("addError receives the correct context type", async () => {
+    const fixture = /* js */ `
+      const originalThen = Promise.prototype.then;
+      let armed = false;
+      Promise.prototype.then = function (...args) {
+        if (armed) {
+          armed = false;
+          Promise.prototype.then = originalThen;
+          throw new Error("synchronous throw from ${hook} builtin");
+        }
+        return originalThen.apply(this, args);
+      };
+
+      const result = await Bun.build({
+        entrypoints: [Bun.fileURLToPath(new URL("./entry.ts", import.meta.url))],
+        throw: false,
+        plugins: [
+          {
+            name: "sync-throw",
+            setup(build) {
+              build.${hook}(
+                { filter: ${hook === "onLoad" ? "/entry\\.ts$/" : "/^sync-throw:thing$/"} },
+                () => {
+                  armed = true;
+                  // Pending promise: the outer async IIFE in the builtin suspends on it,
+                  // so the builtin falls through to the public .then() call which throws
+                  // synchronously and surfaces to the C++ TOP_EXCEPTION_SCOPE fallback.
+                  return new Promise(() => {});
+                },
+              );
+              ${hook === "onResolve" ? 'build.onLoad({ filter: /.*/, namespace: "sync-throw" }, () => ({ contents: "", loader: "js" }));' : ""}
+            },
+          },
+        ],
+      });
+
+      Promise.prototype.then = originalThen;
+      console.log(JSON.stringify({
+        success: result.success,
+        logs: result.logs.map(l => String(l.message ?? l)),
+      }));
+    `;
+
+    using dir = tempDir(`bun-build-plugin-sync-throw-${hook}`, {
+      "entry.ts": hook === "onLoad" ? `export const x = 1;` : `import "sync-throw:thing"; export const x = 1;`,
+      "build.ts": fixture,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", join(String(dir), "build.ts")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // On the buggy build this reinterprets the Load/Resolve struct, which under ASAN
+    // typically aborts the process; on release it may hang or print garbage.
+    expect({
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      exitCode: 0,
+      signalCode: null,
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.success).toBe(false);
+    expect(parsed.logs.join("\n")).toContain(`synchronous throw from ${hook} builtin`);
+  });
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, tempDir, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDirWithFiles, tempDirWithFilesAnon } from "harness";
 import path, { join } from "path";
 import { buildNoThrow } from "./buildNoThrow";
 
@@ -1178,85 +1178,3 @@ test.skipIf(!isDebug && !isASAN)(
   },
   120_000,
 );
-
-// Regression: the C++ synchronous-exception fallback in JSBundlerPlugin__matchOnLoad /
-// JSBundlerPlugin__matchOnResolve passed the wrong `which` value to JSBundlerPlugin__addError,
-// so Zig would reinterpret a *Load as a *Resolve (and vice versa) and read garbage / crash.
-// The builtin calls the public `.then` on the pending IIFE promise, so we can force a
-// synchronous throw there to reach that fallback deterministically.
-describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin throws synchronously", hook => {
-  test.concurrent("addError receives the correct context type", async () => {
-    const fixture = /* js */ `
-      const originalThen = Promise.prototype.then;
-      let armed = false;
-      Promise.prototype.then = function (...args) {
-        if (armed) {
-          armed = false;
-          Promise.prototype.then = originalThen;
-          throw new Error("synchronous throw from ${hook} builtin");
-        }
-        return originalThen.apply(this, args);
-      };
-
-      const result = await Bun.build({
-        entrypoints: [Bun.fileURLToPath(new URL("./entry.ts", import.meta.url))],
-        throw: false,
-        plugins: [
-          {
-            name: "sync-throw",
-            setup(build) {
-              build.${hook}(
-                { filter: ${hook === "onLoad" ? "/entry\\.ts$/" : "/^sync-throw:thing$/"} },
-                () => {
-                  armed = true;
-                  // Pending promise: the outer async IIFE in the builtin suspends on it,
-                  // so the builtin falls through to the public .then() call which throws
-                  // synchronously and surfaces to the C++ TOP_EXCEPTION_SCOPE fallback.
-                  return new Promise(() => {});
-                },
-              );
-              ${hook === "onResolve" ? 'build.onLoad({ filter: /.*/, namespace: "sync-throw" }, () => ({ contents: "", loader: "js" }));' : ""}
-            },
-          },
-        ],
-      });
-
-      Promise.prototype.then = originalThen;
-      console.log(JSON.stringify({
-        success: result.success,
-        logs: result.logs.map(l => String(l.message ?? l)),
-      }));
-    `;
-
-    using dir = tempDir(`bun-build-plugin-sync-throw-${hook}`, {
-      "entry.ts": hook === "onLoad" ? `export const x = 1;` : `import "sync-throw:thing"; export const x = 1;`,
-      "build.ts": fixture,
-    });
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", join(String(dir), "build.ts")],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 30_000,
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // On the buggy build this reinterprets the Load/Resolve struct, which under ASAN
-    // typically aborts the process; on release it may hang or print garbage.
-    expect({
-      stderr: stderr.trim(),
-      exitCode,
-      signalCode: proc.signalCode ?? null,
-    }).toMatchObject({
-      exitCode: 0,
-      signalCode: null,
-    });
-
-    const parsed = JSON.parse(stdout.trim());
-    expect(parsed.success).toBe(false);
-    expect(parsed.logs.join("\n")).toContain(`synchronous throw from ${hook} builtin`);
-  });
-});

--- a/test/bundler/plugin-sync-exception-fallback.test.ts
+++ b/test/bundler/plugin-sync-exception-fallback.test.ts
@@ -69,12 +69,15 @@ describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin thr
       stderr: "pipe",
       // If the build hangs (the onResolve bug), kill it so the assertion below reports
       // a useful diff instead of the test runner timing out.
-      timeout: 30_000,
+      timeout: 10_000,
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    // Receiver includes stdout/stderr so the diff on failure shows the crash output
+    // (UBSan/SIGSEGV under the old code) instead of a bare "expected 0, got 1".
     expect({
+      stdout: stdout.trim(),
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
@@ -86,5 +89,5 @@ describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin thr
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.success).toBe(false);
     expect(parsed.logs.join("\n")).toContain(`synchronous throw from ${hook} builtin`);
-  }, 60_000);
+  });
 });

--- a/test/bundler/plugin-sync-exception-fallback.test.ts
+++ b/test/bundler/plugin-sync-exception-fallback.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// Regression: the C++ synchronous-exception fallback in JSBundlerPlugin__matchOnLoad /
+// JSBundlerPlugin__matchOnResolve passed the wrong `which` value to JSBundlerPlugin__addError,
+// so Zig would reinterpret a *Load as a *Resolve (and vice versa). matchOnLoad additionally
+// passed plugin.config instead of the JSBundlerPlugin* as the plugin argument, so
+// plugin.globalObject() in Zig dereferenced the wrong pointer.
+//
+// The builtin calls the public `.then` on its pending async-IIFE promise, so we can force a
+// synchronous throw there to reach that fallback deterministically. Before the fix:
+// onLoad crashes (null deref in JSGlobalObject under ASAN, SIGSEGV on release) and
+// onResolve hangs (wrong completion handler leaves the resolve counter un-decremented).
+describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin throws synchronously", hook => {
+  test("addError receives the correct context type", async () => {
+    const fixture = /* js */ `
+      const originalThen = Promise.prototype.then;
+      let armed = false;
+      Promise.prototype.then = function (...args) {
+        if (armed) {
+          armed = false;
+          Promise.prototype.then = originalThen;
+          throw new Error("synchronous throw from ${hook} builtin");
+        }
+        return originalThen.apply(this, args);
+      };
+
+      const result = await Bun.build({
+        entrypoints: [Bun.fileURLToPath(new URL("./entry.ts", import.meta.url))],
+        throw: false,
+        plugins: [
+          {
+            name: "sync-throw",
+            setup(build) {
+              build.${hook}(
+                { filter: ${hook === "onLoad" ? "/entry\\.ts$/" : "/^sync-throw:thing$/"} },
+                () => {
+                  armed = true;
+                  // Pending promise: the outer async IIFE in the builtin suspends on it,
+                  // so the builtin falls through to the public .then() call which throws
+                  // synchronously and surfaces to the C++ TOP_EXCEPTION_SCOPE fallback.
+                  return new Promise(() => {});
+                },
+              );
+              ${hook === "onResolve" ? 'build.onLoad({ filter: /.*/, namespace: "sync-throw" }, () => ({ contents: "", loader: "js" }));' : ""}
+            },
+          },
+        ],
+      });
+
+      Promise.prototype.then = originalThen;
+      console.log(JSON.stringify({
+        success: result.success,
+        logs: result.logs.map(l => String(l.message ?? l)),
+      }));
+    `;
+
+    using dir = tempDir(`plugin-sync-exception-${hook}`, {
+      "entry.ts": hook === "onLoad" ? `export const x = 1;` : `import "sync-throw:thing"; export const x = 1;`,
+      "build.ts": fixture,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", join(String(dir), "build.ts")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      // If the build hangs (the onResolve bug), kill it so the assertion below reports
+      // a useful diff instead of the test runner timing out.
+      timeout: 30_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toMatchObject({
+      exitCode: 0,
+      signalCode: null,
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.success).toBe(false);
+    expect(parsed.logs.join("\n")).toContain(`synchronous throw from ${hook} builtin`);
+  }, 60_000);
+});

--- a/test/bundler/plugin-sync-exception-fallback.test.ts
+++ b/test/bundler/plugin-sync-exception-fallback.test.ts
@@ -13,7 +13,7 @@ import { join } from "path";
 // onLoad crashes (null deref in JSGlobalObject under ASAN, SIGSEGV on release) and
 // onResolve hangs (wrong completion handler leaves the resolve counter un-decremented).
 describe.each(["onLoad", "onResolve"] as const)("Bun.build plugin %s builtin throws synchronously", hook => {
-  test("addError receives the correct context type", async () => {
+  test.concurrent("addError receives the correct context type", async () => {
     const fixture = /* js */ `
       const originalThen = Promise.prototype.then;
       let armed = false;


### PR DESCRIPTION
## What

The C++ synchronous-exception fallback in `JSBundlerPlugin__matchOnLoad` / `JSBundlerPlugin__matchOnResolve` passed the wrong `which` discriminator to `JSBundlerPlugin__addError`, causing Zig to reinterpret a `*Load` as a `*Resolve` (and vice versa).

The same source fix was independently identified in #29486 — this PR additionally adds a deterministic regression test for the fallback path.

## Root cause

Zig's `JSBundlerPlugin__addError` casts its `ctx` pointer based on the `which` value:

```zig
switch (which.to(i32)) {
    0 => { const resolve: *JSBundler.Resolve = bun.cast(*Resolve, ctx); ... },
    1 => { const load: *Load = bun.cast(*Load, ctx); ... },
    ...
}
```

The JS builtin (`BundlerPlugin.ts`) passes these correctly: `runOnResolvePlugins` → `addError(..., 0)`, `runOnLoadPlugins` → `addError(..., 1)`.

When the builtin itself throws synchronously (e.g. a stack overflow or termination exception that escapes the async IIFE, or a tampered `Promise.prototype.then`), the C++ `DECLARE_TOP_EXCEPTION_SCOPE` fallback kicks in. That fallback had the values swapped:

- `matchOnLoad` (ctx is `*Load`) passed `jsNumber(0)` → Zig cast to `*Resolve`
- `matchOnResolve` (ctx is `*Resolve`) passed `jsNumber(1)` → Zig cast to `*Load`

`matchOnLoad` additionally passed `plugin->plugin.config` (the BundleV2 completion task) as the second argument, where Zig expects the `JSBundlerPlugin*` so it can call `plugin.globalObject()`. Both the JS host function `jsBundlerPluginFunction_addError` and the `matchOnResolve` fallback already pass the `JSBundlerPlugin*` there.

## Fix

`src/bun.js/bindings/JSBundlerPlugin.cpp`:
- `matchOnLoad` fallback: `jsNumber(0)` → `jsNumber(1)`, second arg `plugin->plugin.config` → `plugin`
- `matchOnResolve` fallback: `jsNumber(1)` → `jsNumber(0)`, route through `plugin->plugin.addError` for consistency with the other callsite

## Verification

Added a test in `test/bundler/bun-build-api.test.ts` that deterministically reaches the C++ fallback: the plugin callback arms a one-shot throwing `Promise.prototype.then` and returns a pending promise, so the builtin's post-IIFE public `.then` call throws synchronously and surfaces to `DECLARE_TOP_EXCEPTION_SCOPE`.

Before the fix (`bun bd`, src/ stashed):
- `onLoad`: UBSan `member call on null pointer of type 'JSC::JSGlobalObject'` (release bun: SIGSEGV at `0x38`)
- `onResolve`: build hangs — the resolve counter is never decremented because Zig dispatched to `onLoadAsync` instead

After the fix: both report the error via `result.logs` and the build completes with `success: false`.

`bundler_plugin.test.ts` and `plugin-error-nested-throw.test.ts` continue to pass.
