### PR TITLE
fix(Bun.serve): HEAD response Transfer-Encoding/Content-Length freed before write

### DIFF
--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1372,7 +1372,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (response.getFetchHeaders()) |headers| {
                 // first respect the headers
                 if (comptime !http3) if (headers.fastGet(.TransferEncoding)) |transfer_encoding| {
-                    const transfer_encoding_str = transfer_encoding.toSlice(server.allocator);
+                    // fastGet() borrows the header map's StringImpl; renderMetadata() ->
+                    // doWriteHeaders() calls fastRemove(.TransferEncoding) and derefs the
+                    // FetchHeaders, freeing that StringImpl before we write it. Clone so
+                    // the bytes outlive renderMetadata().
+                    const transfer_encoding_str = bun.handleOom(transfer_encoding.toSliceClone(server.allocator));
                     defer transfer_encoding_str.deinit();
                     this.renderMetadata();
                     resp.writeHeader("transfer-encoding", transfer_encoding_str.slice());
@@ -1381,11 +1385,13 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     return;
                 };
                 if (headers.fastGet(.ContentLength)) |content_length| {
+                    // Parse before renderMetadata(): doWriteHeaders() will fastRemove(.ContentLength)
+                    // and deref the FetchHeaders, freeing the borrowed StringImpl.
                     const content_length_str = content_length.toSlice(server.allocator);
-                    defer content_length_str.deinit();
-                    this.renderMetadata();
-
                     const len = std.fmt.parseInt(usize, content_length_str.slice(), 10) catch 0;
+                    content_length_str.deinit();
+
+                    this.renderMetadata();
                     resp.writeHeaderInt("content-length", len);
                     this.endWithoutBody(this.shouldCloseConnection());
                     return;

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerWebSocket, Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, rejectUnauthorizedScope, tempDirWithFiles, tls } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, rejectUnauthorizedScope, tempDirWithFiles, tls } from "harness";
 import path from "path";
 
 describe.concurrent("Server", () => {
@@ -1091,6 +1091,94 @@ describe("HEAD requests #15355", () => {
       const response = await fetch(server.url, { method: "HEAD" });
       expect(response.status).toBe(404);
       expect(response.headers.get("transfer-encoding")).toBe("chunked");
+    });
+
+    // fastGet(.TransferEncoding/.ContentLength) returns a ZigString borrowing
+    // the header map entry's WTF::StringImpl; renderMetadata() -> doWriteHeaders()
+    // then calls fastRemove() on those names and derefs the FetchHeaders,
+    // destroying the StringImpl before the borrowed bytes are written to the
+    // socket (Transfer-Encoding) or parsed (Content-Length).
+    //
+    // Passing duplicate header entries makes FetchHeaders combine them via
+    // makeString(), producing a fresh StringImpl owned solely by the map so the
+    // remove actually frees it. `Malloc=1` routes bmalloc through the system
+    // allocator so ASAN-enabled builds observe the use-after-free; release
+    // builds fall through and validate the header values round-trip.
+    test("transfer-encoding / content-length whose StringImpl is held only by the header map", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            import { connect } from "node:net";
+            using server = Bun.serve({
+              port: 0,
+              fetch(req) {
+                if (req.url.endsWith("/te")) {
+                  return new Response("hello", {
+                    headers: [
+                      ["Transfer-Encoding", "gzip"],
+                      ["Transfer-Encoding", "chunked"],
+                    ],
+                  });
+                }
+                return new Response("hello", {
+                  headers: [
+                    ["Content-Length", "1"],
+                    ["Content-Length", "2"],
+                  ],
+                });
+              },
+            });
+            function rawHead(path) {
+              return new Promise((resolve, reject) => {
+                let data = "";
+                const sock = connect(server.port, "127.0.0.1", () => {
+                  sock.write("HEAD " + path + " HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+                });
+                sock.on("data", d => (data += d.toString("latin1")));
+                sock.on("end", () => resolve(data));
+                sock.on("error", reject);
+              });
+            }
+            const te = await rawHead("/te");
+            const cl = await rawHead("/cl");
+            console.log(JSON.stringify({
+              te: /transfer-encoding:\\s*(.+)\\r\\n/i.exec(te)?.[1],
+              cl: /content-length:\\s*(.+)\\r\\n/i.exec(cl)?.[1],
+            }));
+          `,
+        ],
+        env: {
+          ...bunEnv,
+          // Route bmalloc through the system heap so ASAN observes StringImpl
+          // allocations in sanitizer builds. On Windows bmalloc's SystemHeap is
+          // unimplemented and would RELEASE_BASSERT, so leave bmalloc in place
+          // there — Windows has no ASAN lane anyway.
+          ...(isWindows
+            ? {}
+            : {
+                Malloc: "1",
+                // symbolize=0 so a pre-fix ASAN abort exits promptly instead of
+                // spending seconds in llvm-symbolizer; detect_leaks=0 because
+                // routing WTF allocations through system malloc makes
+                // process-lifetime WebKit singletons visible to LSan at exit.
+                ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
+              }),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // "1, 2" is not a valid integer so Content-Length parses as 0; what we
+      // care about is that parsing it does not read freed memory.
+      expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({
+        stdout: JSON.stringify({ te: "gzip, chunked", cl: "0" }),
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
     });
 
     test("status only with body", async () => {


### PR DESCRIPTION
## Repro

```js
Bun.serve({
  port: 0,
  fetch: () =>
    new Response("hello", {
      headers: [
        ["Transfer-Encoding", "gzip"],
        ["Transfer-Encoding", "chunked"],
      ],
    }),
});
// HEAD / → ASAN heap-use-after-free in uWS::HttpResponse::writeHeader
```

The duplicate entries make `FetchHeaders` combine them via `makeString()`, producing a `StringImpl` held only by the header map — the minimal condition for the free to actually happen.

StringImpl is allocated via bmalloc which ASAN doesn't instrument by default; with `Malloc=1` (bmalloc → system heap) the debug build reports:

```
AddressSanitizer: heap-use-after-free
READ of size 13
  #2 uWS::HttpResponse<false>::writeHeader
  #5 doRenderHeadResponse  RequestContext.zig:1378
freed by:
  #23 HTTPHeaderMap::remove
  #28 doWriteHeaders       RequestContext.zig:2303
  #29 renderMetadata       RequestContext.zig:2209
  #30 doRenderHeadResponse RequestContext.zig:1377
```

## Cause

`doRenderHeadResponse()` calls `headers.fastGet(.TransferEncoding)`, which returns a `ZigString` that **borrows** the header map entry's `StringImpl` bytes (no ref taken). For an ASCII value, `toSlice()` also borrows rather than copying. It then calls `this.renderMetadata()`, whose `doWriteHeaders()` does `headers.fastRemove(.TransferEncoding)` (and `renderMetadata` also `swapInitHeaders()` + `deref()`s the whole `FetchHeaders`). When the map held the only reference to the `StringImpl`, it's destroyed right there — and the very next line `resp.writeHeader("transfer-encoding", transfer_encoding_str.slice())` writes the freed bytes to the socket.

The adjacent `Content-Length` branch has the same bug: `std.fmt.parseInt()` runs on the borrowed slice *after* `renderMetadata()` has already `fastRemove(.ContentLength)`'d it.

## Fix

- **Transfer-Encoding**: use `toSliceClone()` instead of `toSlice()` so the value is owned and survives `renderMetadata()`.
- **Content-Length**: parse the integer *before* `renderMetadata()` (and drop the slice immediately), so the borrowed bytes are never touched after the header entry is removed. No extra allocation needed since only the parsed `usize` is used afterwards.

## Verification

New test in `test/js/bun/http/bun-server.test.ts` (inside the existing `HEAD requests #15355` block) spawns a subprocess with `Malloc=1` (non-Windows), serves HEAD responses whose Transfer-Encoding / Content-Length values are `makeString()`-combined (sole-owner StringImpl), and asserts the raw wire output.

```
git stash push -- src/   → test fails with "AddressSanitizer: heap-use-after-free" in stderr
git stash pop            → test passes
```

All other tests in the `HEAD requests #15355` describe block continue to pass.