### PR TITLE
Buffer.from(hex/base64): free staging allocation when decoded length is 0

### DIFF
--- a/src/bun.js/bindings/JSBuffer.cpp
+++ b/src/bun.js/bindings/JSBuffer.cpp
@@ -364,6 +364,13 @@ JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalO
 
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, WTF::move(buffer), 0, length);
     } else {
+        // Ownership of ptr was transferred to us. Even though the resulting Buffer is empty,
+        // the caller may have handed over a live allocation (e.g. FFI toBuffer with a
+        // finalizer, or sqlite3_serialize returning a non-null pointer with length 0), so
+        // honor the deallocator instead of silently leaking it.
+        if (bytesDeallocator) {
+            bytesDeallocator(ptr, ctx);
+        }
         uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
     }
 

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -585,6 +585,13 @@ pub const JSValue = enum(i64) {
     pub fn createBuffer(globalObject: *JSGlobalObject, slice: []u8) JSValue {
         jsc.markBinding(@src());
         @setRuntimeSafety(false);
+        if (slice.len == 0) {
+            // A zero-length slice's ptr field is not guaranteed to be a valid
+            // mimalloc allocation (it may be the 0xAA... sentinel from an empty
+            // slice literal). Callers that over-allocated and decoded zero bytes
+            // must free their allocation before calling this.
+            return JSBuffer__bufferFromPointerAndLengthAndDeinit(globalObject, slice.ptr, 0, null, null);
+        }
         return JSBuffer__bufferFromPointerAndLengthAndDeinit(globalObject, slice.ptr, slice.len, null, jsc.array_buffer.MarkedArrayBuffer_deallocator);
     }
 

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -508,7 +508,10 @@ pub fn constructFromU16(input: [*]const u16, len: usize, allocator: std.mem.Allo
         },
 
         .hex => {
-            var to = allocator.alloc(u8, len * 2) catch return &[_]u8{};
+            if (len < 2)
+                return &[_]u8{};
+
+            var to = allocator.alloc(u8, len / 2) catch return &[_]u8{};
             const wrote = strings.decodeHexToBytesTruncate(to, u16, input[0..len]);
             if (wrote == 0) {
                 allocator.free(to);

--- a/src/bun.js/webcore/encoding.zig
+++ b/src/bun.js/webcore/encoding.zig
@@ -459,7 +459,15 @@ pub fn constructFromU8(input: [*]const u8, len: usize, allocator: std.mem.Alloca
                 return &[_]u8{};
 
             var to = allocator.alloc(u8, len / 2) catch return &[_]u8{};
-            return to[0..strings.decodeHexToBytesTruncate(to, u8, input[0..len])];
+            const wrote = strings.decodeHexToBytesTruncate(to, u8, input[0..len]);
+            if (wrote == 0) {
+                // No valid hex pairs were decoded (e.g. Buffer.from("zz", "hex")). The
+                // allocation is unreachable once we return a zero-length slice, so free
+                // it here instead of leaking it.
+                allocator.free(to);
+                return &[_]u8{};
+            }
+            return to[0..wrote];
         },
 
         .base64, .base64url => {
@@ -470,6 +478,10 @@ pub fn constructFromU8(input: [*]const u8, len: usize, allocator: std.mem.Alloca
             const to = allocator.alloc(u8, outlen) catch return &[_]u8{};
 
             const wrote = bun.base64.decode(to[0..outlen], slice).count;
+            if (wrote == 0) {
+                allocator.free(to);
+                return &[_]u8{};
+            }
             return to[0..wrote];
         },
     }
@@ -497,7 +509,12 @@ pub fn constructFromU16(input: [*]const u16, len: usize, allocator: std.mem.Allo
 
         .hex => {
             var to = allocator.alloc(u8, len * 2) catch return &[_]u8{};
-            return to[0..strings.decodeHexToBytesTruncate(to, u16, input[0..len])];
+            const wrote = strings.decodeHexToBytesTruncate(to, u16, input[0..len]);
+            if (wrote == 0) {
+                allocator.free(to);
+                return &[_]u8{};
+            }
+            return to[0..wrote];
         },
 
         .base64, .base64url => {

--- a/test/js/node/buffer-from-encoding-leak.test.ts
+++ b/test/js/node/buffer-from-encoding-leak.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+// JSBuffer__bufferFromPointerAndLengthAndDeinit used to skip the deallocator entirely
+// when the resulting length was 0. Buffer.from(<string with no valid hex>, "hex") would
+// allocate len/2 bytes, decode zero bytes, and hand a zero-length slice back to C++ —
+// which then dropped the allocation on the floor.
+
+describe("Buffer.from(string, encoding) does not leak when decoded length is 0", () => {
+  test("hex with no valid hex digits returns an empty Buffer", () => {
+    expect(Buffer.from("zz", "hex")).toEqual(Buffer.alloc(0));
+    expect(Buffer.from("z", "hex")).toEqual(Buffer.alloc(0));
+    expect(Buffer.from("   ", "base64")).toEqual(Buffer.alloc(0));
+  });
+
+  test("hex with no valid hex digits does not leak the staging allocation", () => {
+    // 8192 input chars -> 4096-byte staging allocation which is leaked per call
+    // without the fix.
+    const str = Buffer.alloc(8192, "z").toString();
+    const iterations = 50_000;
+
+    // warm up so any one-time allocations (JIT tiers, caches) don't count
+    for (let i = 0; i < 1000; i++) Buffer.from(str, "hex");
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+
+    for (let i = 0; i < iterations; i++) Buffer.from(str, "hex");
+    Bun.gc(true);
+    const after = process.memoryUsage.rss();
+
+    const growthMB = (after - before) / 1024 / 1024;
+    // Without the fix this grows by ~200 MB (50k * 4096 bytes). With the fix,
+    // growth is noise.
+    expect(growthMB).toBeLessThan(40);
+  });
+});


### PR DESCRIPTION
## Repro

```js
// Each call allocates 4096 bytes, decodes zero valid hex pairs, and leaks the buffer.
const str = Buffer.alloc(8192, 'z').toString();
for (let i = 0; i < 50_000; i++) Buffer.from(str, 'hex');
// RSS grows by ~200 MB
```

The minimal trigger is `Buffer.from('zz', 'hex')` — allocates 1 byte, decodes nothing, leaks 1 byte.

## Cause

`JSBuffer__bufferFromPointerAndLengthAndDeinit` (src/bun.js/bindings/JSBuffer.cpp:358) only registers the deallocator when `length > 0`:

```cpp
if (length > 0) [[likely]] {
    auto buffer = ArrayBuffer::createFromBytes(..., [=](void* p) { bytesDeallocator(p, ctx); });
    ...
} else {
    uint8Array = JSC::JSUint8Array::create(lexicalGlobalObject, subclassStructure, 0);
}
```

The hex/base64 decode paths in `constructFromU8`/`constructFromU16` allocate `len/2` bytes up front, then return `to[0..wrote]`. When the input has no valid hex digits (`'zz'`), `wrote == 0`, so a zero-length slice whose `.ptr` still points at the live allocation is handed to `JSValue.createBuffer` → C++ sees `length == 0` and drops the deallocator → leak.

The same contract break affects `ffi.toBuffer(ptr, 0, finalizer)` (user's finalizer is never called) and `sqlite3_serialize` when it returns a non-null pointer with length 0.

## Fix

- **JSBuffer.cpp**: call `bytesDeallocator(ptr, ctx)` in the `length == 0` branch when the deallocator is non-null, so ownership is honored for FFI / SQLite callers.
- **encoding.zig** `constructFromU8`/`constructFromU16`: free the staging buffer when hex/base64 decode writes zero bytes, instead of returning a zero-length view into it. This is where the `Buffer.from('zz','hex')` leak actually lives.
- **JSValue.zig** `createBuffer`: when `slice.len == 0`, pass a null deallocator. A Zig empty-slice literal's `.ptr` is the 0xAA… undefined sentinel, not a mimalloc pointer — passing it to `mi_free` after the C++ change would be UB (hit by e.g. `Buffer.from('z','hex')` or `Buffer.from('   ','base64')`). Callers that over-allocated and ended up with zero bytes are responsible for freeing before calling this (encoding.zig now does).

## Verification

New `test/js/node/buffer-from-encoding-leak.test.ts`:

| | 50k × `Buffer.from('z'×8192,'hex')` RSS growth |
|---|---|
| before | 201–255 MB |
| after | < 40 MB (noise) |

- `bun bd test test/js/node/buffer.test.js` — 459/459 pass
- Edge cases verified not to crash: `Buffer.from('z','hex')`, `Buffer.from('   ','base64')`, `Buffer.from('','hex')`, partial-valid `Buffer.from('abzz','hex')` → `'ab'`