### PR TITLE
ipc(advanced): avoid u32 overflow in header_length + message_len bounds check

### DIFF
--- a/src/bun.js/ipc.zig
+++ b/src/bun.js/ipc.zig
@@ -110,12 +110,17 @@ const advanced = struct {
                 };
             },
             .SerializedMessage, .SerializedInternalMessage => |tag| {
-                if (data.len < (header_length + message_len)) {
+                // `header_length + message_len` would be evaluated as u32; a peer-controlled
+                // `message_len >= 0xFFFFFFFB` wraps the sum to a small value and defeats the
+                // bounds check. Compare against the remaining bytes instead — `data.len >=
+                // header_length` is already established above, so the subtraction cannot
+                // underflow.
+                if (data.len - header_length < message_len) {
                     log("Not enough bytes to decode IPC message body of len {d}, have {d} bytes", .{ message_len, data.len });
                     return IPCDecodeError.NotEnoughBytes;
                 }
 
-                const message = data[header_length .. header_length + message_len];
+                const message = data[header_length..][0..message_len];
                 const deserialized = try JSValue.deserialize(message, global);
 
                 return .{

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -57,28 +57,37 @@ describe("ipc mode advanced", () => {
     // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child
     // sending length 0xFFFFFFFB makes the sum wrap to 0, the guard passes, and the receiver
     // slices `data[5..0]` (length ~SIZE_MAX) straight into the deserializer.
-    let receivedMessage: unknown;
-    await using child = spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        // type = SerializedMessage (0x02), length = 0xFFFFFFFB (little-endian).
-        // header_length (5) + 0xFFFFFFFB wraps to 0 in u32.
-        `require("fs").writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]))`,
-      ],
+    //
+    // Run the receiver in its own subprocess so a crash is observed as a failing
+    // assertion here rather than taking out the test runner.
+    // prettier-ignore
+    const parent = `
+      const child = Bun.spawn({
+        cmd: [
+          process.execPath, "-e",
+          // type = SerializedMessage (0x02), length = 0xFFFFFFFB (little-endian).
+          // header_length (5) + 0xFFFFFFFB wraps to 0 in u32.
+          'require("fs").writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]))',
+        ],
+        stdio: ["ignore", "inherit", "inherit"],
+        serialization: "advanced",
+        ipc(msg) { console.error("UNEXPECTED_IPC_MESSAGE", msg); },
+      });
+      await child.exited;
+      console.log("PARENT_OK");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parent],
       env: bunEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-      serialization: "advanced",
-      ipc(msg) {
-        receivedMessage = msg;
-      },
+      stdout: "pipe",
+      stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(stdout).toBe("");
-    expect(receivedMessage).toBeUndefined();
+    expect(stdout.trim()).toBe("PARENT_OK");
+    expect(stderr).not.toContain("UNEXPECTED_IPC_MESSAGE");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick } from "harness";
+import { bunEnv, bunExe, gcTick, tempDir } from "harness";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -48,5 +48,42 @@ describe.each(["advanced", "json"])("ipc mode %s", mode => {
     });
     child.exited.then(code => reject(new Error(`exited ${code} before message`)));
     expect(await promise).toBe("hello");
+  });
+});
+
+describe("ipc mode advanced", () => {
+  it("a message_len that overflows header_length + message_len does not crash the receiver", async () => {
+    // The advanced IPC framing is [u8 type][u32-le length][payload]. Decoding previously
+    // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child
+    // sending length 0xFFFFFFFB makes the sum wrap to 0, the guard passes, and the receiver
+    // slices `data[5..0]` (length ~SIZE_MAX) straight into the deserializer.
+    using dir = tempDir("ipc-advanced-overflow", {
+      "child.js": `
+        const fs = require("fs");
+        // type = SerializedMessage (0x02), length = 0xFFFFFFFB (little-endian).
+        // header_length (5) + 0xFFFFFFFB wraps to 0 in u32.
+        fs.writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]));
+        process.exit(0);
+      `,
+    });
+
+    let receivedMessage: unknown;
+    await using child = spawn({
+      cmd: [bunExe(), "child.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdio: ["ignore", "pipe", "pipe"],
+      serialization: "advanced",
+      ipc(msg) {
+        receivedMessage = msg;
+      },
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(receivedMessage).toBeUndefined();
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, gcTick, tempDir } from "harness";
+import { bunEnv, bunExe, gcTick } from "harness";
 import path from "path";
 
 describe.each(["advanced", "json"])("ipc mode %s", mode => {
@@ -57,21 +57,16 @@ describe("ipc mode advanced", () => {
     // checked `data.len < header_length + message_len`, which is u32 arithmetic: a child
     // sending length 0xFFFFFFFB makes the sum wrap to 0, the guard passes, and the receiver
     // slices `data[5..0]` (length ~SIZE_MAX) straight into the deserializer.
-    using dir = tempDir("ipc-advanced-overflow", {
-      "child.js": `
-        const fs = require("fs");
-        // type = SerializedMessage (0x02), length = 0xFFFFFFFB (little-endian).
-        // header_length (5) + 0xFFFFFFFB wraps to 0 in u32.
-        fs.writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]));
-        process.exit(0);
-      `,
-    });
-
     let receivedMessage: unknown;
     await using child = spawn({
-      cmd: [bunExe(), "child.js"],
+      cmd: [
+        bunExe(),
+        "-e",
+        // type = SerializedMessage (0x02), length = 0xFFFFFFFB (little-endian).
+        // header_length (5) + 0xFFFFFFFB wraps to 0 in u32.
+        `require("fs").writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]))`,
+      ],
       env: bunEnv,
-      cwd: String(dir),
       stdio: ["ignore", "pipe", "pipe"],
       serialization: "advanced",
       ipc(msg) {


### PR DESCRIPTION
## Repro

A child spawned with `serialization: "advanced"` writes the raw bytes `\x02\xFB\xFF\xFF\xFF` to the IPC fd:

```js
// child.js
require("fs").writeSync(3, Buffer.from([0x02, 0xfb, 0xff, 0xff, 0xff]));
```

That's a `SerializedMessage` header with `message_len = 0xFFFFFFFB`.

## Cause

`advanced.decodeIPCMessage` guarded the body with:

```zig
if (data.len < (header_length + message_len)) return NotEnoughBytes;
```

`header_length` is the comptime int `5` and `message_len` is a peer-controlled `u32`, so the addition is performed as `u32`. `5 + 0xFFFFFFFB` wraps to `0`; the guard passes with only 5 bytes in hand; and `data[header_length .. header_length + message_len]` becomes `data[5..0]`, which in unchecked builds yields a slice of length ~`SIZE_MAX` that is handed straight to the `SerializedScriptValue` deserializer. In Debug/ReleaseSafe it panics on the overflow.

## Fix

Rewrite the guard as `data.len - header_length < message_len` — the function already returns `NotEnoughBytes` when `data.len < header_length`, so the subtraction cannot underflow — and slice with `data[header_length..][0..message_len]` so the overflowing sum is never computed.

## Verification

```
git stash push -- src/ && bun bd test test/js/bun/spawn/spawn.ipc.test.ts -t overflows
  → panic(main thread): integer overflow @ src/bun.js/ipc.zig:113

git stash pop && bun bd test test/js/bun/spawn/spawn.ipc.test.ts
  → 7 pass, 0 fail
```

Note: the released Linux x64 binary happens not to crash today because LLVM's `nuw` on the add lets it widen the comparison to `usize`, but that is undefined behaviour being optimised one particular way and does not hold across targets or compiler versions.