### PR TITLE
crypto/fs: pin ArrayBuffer backing store for off-thread buffer inputs

### DIFF
--- a/src/jsc/JSValue.zig
+++ b/src/jsc/JSValue.zig
@@ -1212,6 +1212,29 @@ pub const JSValue = enum(i64) {
         }
         return null;
     }
+
+    extern fn JSC__JSValue__pinArrayBuffer(this: JSValue) bool;
+    extern fn JSC__JSValue__unpinArrayBuffer(this: JSValue) void;
+
+    /// Pin the backing `ArrayBuffer` of a `JSArrayBuffer` / `JSArrayBufferView`
+    /// so that `transfer()` / detach copies the contents instead of freeing
+    /// the backing store while a native caller holds a pointer into it.
+    ///
+    /// This calls `possiblySharedBuffer()` under the hood, which promotes a
+    /// `FastTypedArray` (small, GC-movable inline storage) to stable heap
+    /// storage — so any slice captured *before* pinning may be stale; re-read
+    /// via `asArrayBuffer` after pinning. No-op on `SharedArrayBuffer`.
+    ///
+    /// Returns `false` if `this` has no backing ArrayBuffer. Pair every `true`
+    /// return with exactly one `unpinArrayBuffer` call.
+    pub fn pinArrayBuffer(this: JSValue) bool {
+        return JSC__JSValue__pinArrayBuffer(this);
+    }
+
+    pub fn unpinArrayBuffer(this: JSValue) void {
+        JSC__JSValue__unpinArrayBuffer(this);
+    }
+
     extern fn JSC__JSValue__fromInt64NoTruncate(globalObject: *JSGlobalObject, i: i64) JSValue;
     /// This always returns a JS BigInt
     pub fn fromInt64NoTruncate(globalObject: *JSGlobalObject, i: i64) JSValue {

--- a/src/jsc/array_buffer.zig
+++ b/src/jsc/array_buffer.zig
@@ -195,6 +195,19 @@ pub const ArrayBuffer = extern struct {
         return value.asArrayBuffer(ctx).?;
     }
 
+    extern "c" fn Bun__ArrayBuffer__pinAndRefresh(out: *ArrayBuffer) bool;
+
+    /// Pin the backing store of `this.value` so `transfer()` / detach copies
+    /// instead of freeing it while a native caller holds a slice. Pinning
+    /// promotes a `FastTypedArray` to stable heap storage, which repoints
+    /// the vector — `ptr` / `len` / `byte_len` are updated here to reflect
+    /// the post-pin storage. Returns `false` if there is no backing
+    /// ArrayBuffer (e.g. already detached). Pair every `true` return with
+    /// exactly one `this.value.unpinArrayBuffer()`.
+    pub fn pinAndRefresh(this: *ArrayBuffer) bool {
+        return Bun__ArrayBuffer__pinAndRefresh(this);
+    }
+
     extern "c" fn JSArrayBuffer__fromDefaultAllocator(*jsc.JSGlobalObject, ptr: [*]u8, len: usize) jsc.JSValue;
     pub fn toJSFromDefaultAllocator(globalThis: *jsc.JSGlobalObject, bytes: []u8) jsc.JSValue {
         return JSArrayBuffer__fromDefaultAllocator(globalThis, bytes.ptr, bytes.len);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3333,6 +3333,37 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
         buf->unpin();
 }
 
+// Pin `out->value`'s backing ArrayBuffer and refresh `out->ptr`/`byte_len`
+// from the view afterwards. Pinning promotes a FastTypedArray to stable
+// heap storage (possiblySharedBuffer() → slowDownAndWasteMemory()), which
+// repoints vector(), so any slice captured before the pin is stale. This
+// lets Zig callers that cached a Bun__ArrayBuffer (e.g. StringOrBuffer /
+// PathLike in their `.buffer` state) pin + re-read without needing a
+// JSGlobalObject on hand. Returns false if there is no backing ArrayBuffer.
+CPP_DECL bool Bun__ArrayBuffer__pinAndRefresh(Bun__ArrayBuffer* out)
+{
+    auto value = JSC::JSValue::decode(out->_value);
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
+        auto* buf = view->possiblySharedBuffer();
+        if (!buf) return false;
+        buf->pin();
+        out->ptr = static_cast<char*>(view->vector());
+        out->len = view->length();
+        out->byte_len = view->byteLength();
+        return true;
+    }
+    if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
+        auto* buf = jb->impl();
+        if (!buf) return false;
+        buf->pin();
+        out->ptr = static_cast<char*>(buf->data());
+        out->len = buf->byteLength();
+        out->byte_len = buf->byteLength();
+        return true;
+    }
+    return false;
+}
+
 // Borrow `v`'s byte storage for off-thread reading. Splits out only the
 // `FastTypedArray` case from `pinArrayBuffer`, because that's the one mode
 // where `possiblySharedBuffer()` actually COPIES data

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3308,9 +3308,11 @@ bool JSC__JSValue__asArrayBuffer(
 }
 
 // Pin/unpin the backing ArrayBuffer of a JSArrayBuffer or JSArrayBufferView so
-// transfer()/detach() throw while a native borrower holds a slice into it.
-// `pin` is a no-op on SharedArrayBuffer (already non-detachable). Returns
-// false if `value` has no ArrayBuffer impl.
+// a concurrent transfer()/detach copies the contents out instead of freeing
+// the backing store while a native borrower holds a slice into it
+// (ArrayBuffer::transferTo → !isDetachable() → m_contents.copyTo — the source
+// stays attached). `pin` is a no-op on SharedArrayBuffer (already
+// non-detachable). Returns false if `value` has no ArrayBuffer impl.
 static JSC::ArrayBuffer* arrayBufferImpl(JSC::JSValue value)
 {
     if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value))

--- a/src/runtime/node/node_crypto_binding.zig
+++ b/src/runtime/node/node_crypto_binding.zig
@@ -188,21 +188,26 @@ fn CryptoJob(comptime Ctx: type) type {
 
 const random = struct {
     const JobCtx = struct {
+        /// The user-supplied destination (randomFill) or `.zero` when we
+        /// create the result ourselves (randomBytes).
         value: JSValue,
         /// Bun-owned scratch buffer filled on the threadpool. We do *not* hold
         /// a raw pointer into the JS ArrayBuffer backing store here because
         /// user code can synchronously detach it (e.g. `buf.buffer.transfer()`)
         /// while the task is queued/running, which would free that storage and
         /// turn the threadpool write into a use-after-free. Instead we fill
-        /// this buffer off-thread and copy it into the JS view back on the
-        /// main thread in `runFromJS`.
+        /// this buffer off-thread and either (randomFill) copy it into the JS
+        /// view back on the main thread, or (randomBytes) hand it off to a
+        /// fresh JS Buffer via `createBuffer`, which takes ownership.
         bytes: []u8,
         offset: u32,
 
         result: void = {},
 
         fn init(this: *JobCtx, _: *JSGlobalObject) JSError!void {
-            this.value.protect();
+            if (this.value != .zero) {
+                this.value.protect();
+            }
         }
 
         fn runTask(this: *JobCtx, _: void) void {
@@ -210,6 +215,17 @@ const random = struct {
         }
 
         fn runFromJS(this: *JobCtx, global: *JSGlobalObject, callback: JSValue) void {
+            const vm = global.bunVM();
+            if (this.value == .zero) {
+                // randomBytes: wrap the scratch buffer directly — no memcpy,
+                // no second allocation. `createBuffer` takes ownership via
+                // the mimalloc deallocator, so clear `bytes` before `deinit`
+                // runs to avoid a double-free.
+                const buf = JSValue.createBuffer(global, this.bytes);
+                this.bytes = &.{};
+                vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, buf });
+                return;
+            }
             if (this.value.asArrayBuffer(global)) |buf| {
                 const dest = buf.slice();
                 // If the buffer was detached or shrunk while the task ran,
@@ -219,13 +235,14 @@ const random = struct {
                     @memcpy(dest[this.offset..][0..this.bytes.len], this.bytes);
                 }
             }
-            const vm = global.bunVM();
             vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, this.value });
         }
 
         fn deinit(this: *JobCtx) void {
             bun.default_allocator.free(this.bytes);
-            this.value.unprotect();
+            if (this.value != .zero) {
+                this.value.unprotect();
+            }
         }
     };
 
@@ -341,20 +358,17 @@ const random = struct {
 
         const size = try assertSize(global, size_value, 1, 0, max_possible_length + 1);
 
-        if (!callback.isUndefined()) {
-            _ = try validators.validateFunction(global, "callback", callback);
-        }
-
-        const result, const bytes = try jsc.ArrayBuffer.alloc(global, .ArrayBuffer, size);
-
         if (callback.isUndefined()) {
             // sync
+            const result, const bytes = try jsc.ArrayBuffer.alloc(global, .ArrayBuffer, size);
             bun.csprng(bytes);
             return result;
         }
 
+        _ = try validators.validateFunction(global, "callback", callback);
+
         const ctx: JobCtx = .{
-            .value = result,
+            .value = .zero,
             .bytes = bun.handleOom(bun.default_allocator.alloc(u8, size)),
             .offset = 0,
         };

--- a/src/runtime/node/node_crypto_binding.zig
+++ b/src/runtime/node/node_crypto_binding.zig
@@ -188,61 +188,37 @@ fn CryptoJob(comptime Ctx: type) type {
 
 const random = struct {
     const JobCtx = struct {
-        /// The user-supplied destination (randomFill) or `.zero` when we
-        /// create the result ourselves (randomBytes).
         value: JSValue,
-        /// Bun-owned scratch buffer filled on the threadpool. We do *not* hold
-        /// a raw pointer into the JS ArrayBuffer backing store here because
-        /// user code can synchronously detach it (e.g. `buf.buffer.transfer()`)
-        /// while the task is queued/running, which would free that storage and
-        /// turn the threadpool write into a use-after-free. Instead we fill
-        /// this buffer off-thread and either (randomFill) copy it into the JS
-        /// view back on the main thread, or (randomBytes) hand it off to a
-        /// fresh JS Buffer via `createBuffer`, which takes ownership.
-        bytes: []u8,
+        /// Slice into `value`'s ArrayBuffer backing store. The backing store
+        /// is pinned by the caller (see `JSValue.pinArrayBuffer`), so user
+        /// code calling `buf.buffer.transfer()` while the task is queued or
+        /// running copies the contents out instead of freeing them — the
+        /// threadpool can safely write through this pointer. Captured
+        /// *after* pinning because the pin promotes a `FastTypedArray` to
+        /// stable heap storage, which repoints the view's vector.
+        bytes: [*]u8,
         offset: u32,
+        length: usize,
+        pinned: bool,
 
         result: void = {},
 
         fn init(this: *JobCtx, _: *JSGlobalObject) JSError!void {
-            if (this.value != .zero) {
-                this.value.protect();
-            }
+            this.value.protect();
         }
 
         fn runTask(this: *JobCtx, _: void) void {
-            bun.csprng(this.bytes);
+            bun.csprng(this.bytes[this.offset..][0..this.length]);
         }
 
         fn runFromJS(this: *JobCtx, global: *JSGlobalObject, callback: JSValue) void {
             const vm = global.bunVM();
-            if (this.value == .zero) {
-                // randomBytes: wrap the scratch buffer directly — no memcpy,
-                // no second allocation. `createBuffer` takes ownership via
-                // the mimalloc deallocator, so clear `bytes` before `deinit`
-                // runs to avoid a double-free.
-                const buf = JSValue.createBuffer(global, this.bytes);
-                this.bytes = &.{};
-                vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, buf });
-                return;
-            }
-            if (this.value.asArrayBuffer(global)) |buf| {
-                const dest = buf.slice();
-                // If the buffer was detached or shrunk while the task ran,
-                // `dest` will no longer cover the requested range; in that
-                // case there is nothing to copy into.
-                if (this.bytes.len + @as(usize, this.offset) <= dest.len) {
-                    @memcpy(dest[this.offset..][0..this.bytes.len], this.bytes);
-                }
-            }
             vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, this.value });
         }
 
         fn deinit(this: *JobCtx) void {
-            bun.default_allocator.free(this.bytes);
-            if (this.value != .zero) {
-                this.value.unprotect();
-            }
+            if (this.pinned) this.value.unpinArrayBuffer();
+            this.value.unprotect();
         }
     };
 
@@ -358,19 +334,28 @@ const random = struct {
 
         const size = try assertSize(global, size_value, 1, 0, max_possible_length + 1);
 
+        if (!callback.isUndefined()) {
+            _ = try validators.validateFunction(global, "callback", callback);
+        }
+
+        const result, const bytes = try jsc.ArrayBuffer.alloc(global, .ArrayBuffer, size);
+
         if (callback.isUndefined()) {
             // sync
-            const result, const bytes = try jsc.ArrayBuffer.alloc(global, .ArrayBuffer, size);
             bun.csprng(bytes);
             return result;
         }
 
-        _ = try validators.validateFunction(global, "callback", callback);
-
+        // `result` is freshly allocated and not yet exposed to user JS, so a
+        // detach can't race us here; pin anyway so `JobCtx` has uniform
+        // unpin-in-deinit semantics. `ArrayBuffer.alloc` produces a proper
+        // heap-backed buffer, so `bytes` is already the stable slice.
         const ctx: JobCtx = .{
-            .value = .zero,
-            .bytes = bun.handleOom(bun.default_allocator.alloc(u8, size)),
+            .value = result,
+            .bytes = bytes.ptr,
             .offset = 0,
+            .length = size,
+            .pinned = result.pinArrayBuffer(),
         };
         try Job.initAndSchedule(global, callback, &ctx);
 
@@ -444,10 +429,22 @@ const random = struct {
             return .js_undefined;
         }
 
+        // Pin the backing store so a concurrent `buf.buffer.transfer()` copies
+        // instead of freeing it while the threadpool is writing. Pinning may
+        // promote a FastTypedArray to stable heap storage, so re-read the
+        // slice afterwards. `JobCtx.deinit` unpins.
+        const pinned = buf_value.pinArrayBuffer();
+        const stable = buf_value.asArrayBuffer(global) orelse {
+            if (pinned) buf_value.unpinArrayBuffer();
+            return global.throwInvalidArgumentTypeValue("buf", "ArrayBuffer or ArrayBufferView", buf_value);
+        };
+
         const ctx: JobCtx = .{
             .value = buf_value,
-            .bytes = bun.handleOom(bun.default_allocator.alloc(u8, size)),
+            .bytes = stable.slice().ptr,
             .offset = offset,
+            .length = size,
+            .pinned = pinned,
         };
         try Job.initAndSchedule(global, callback, &ctx);
 

--- a/src/runtime/node/node_crypto_binding.zig
+++ b/src/runtime/node/node_crypto_binding.zig
@@ -347,15 +347,22 @@ const random = struct {
         }
 
         // `result` is freshly allocated and not yet exposed to user JS, so a
-        // detach can't race us here; pin anyway so `JobCtx` has uniform
-        // unpin-in-deinit semantics. `ArrayBuffer.alloc` produces a proper
-        // heap-backed buffer, so `bytes` is already the stable slice.
+        // detach can't race us here; pin anyway so the worker's pointer
+        // survives a GC that could relocate a FastTypedArray's inline
+        // storage, and so `JobCtx` has uniform unpin-in-deinit semantics.
+        // `ArrayBuffer.alloc` → `JSUint8Array::createUninitialized` yields a
+        // FastTypedArray for `size ≤ fastSizeLimit`, and pinning promotes
+        // that to stable heap storage (repointing the vector), so re-read
+        // the slice *after* pinning — `bytes` above is stale for small
+        // sizes once the pin runs.
+        const pinned = result.pinArrayBuffer();
+        const stable = result.asArrayBuffer(global).?;
         const ctx: JobCtx = .{
             .value = result,
-            .bytes = bytes.ptr,
+            .bytes = stable.slice().ptr,
             .offset = 0,
             .length = size,
-            .pinned = result.pinArrayBuffer(),
+            .pinned = pinned,
         };
         try Job.initAndSchedule(global, callback, &ctx);
 

--- a/src/runtime/node/node_crypto_binding.zig
+++ b/src/runtime/node/node_crypto_binding.zig
@@ -189,9 +189,15 @@ fn CryptoJob(comptime Ctx: type) type {
 const random = struct {
     const JobCtx = struct {
         value: JSValue,
-        bytes: [*]u8,
+        /// Bun-owned scratch buffer filled on the threadpool. We do *not* hold
+        /// a raw pointer into the JS ArrayBuffer backing store here because
+        /// user code can synchronously detach it (e.g. `buf.buffer.transfer()`)
+        /// while the task is queued/running, which would free that storage and
+        /// turn the threadpool write into a use-after-free. Instead we fill
+        /// this buffer off-thread and copy it into the JS view back on the
+        /// main thread in `runFromJS`.
+        bytes: []u8,
         offset: u32,
-        length: usize,
 
         result: void = {},
 
@@ -200,15 +206,25 @@ const random = struct {
         }
 
         fn runTask(this: *JobCtx, _: void) void {
-            bun.csprng(this.bytes[this.offset..][0..this.length]);
+            bun.csprng(this.bytes);
         }
 
         fn runFromJS(this: *JobCtx, global: *JSGlobalObject, callback: JSValue) void {
+            if (this.value.asArrayBuffer(global)) |buf| {
+                const dest = buf.slice();
+                // If the buffer was detached or shrunk while the task ran,
+                // `dest` will no longer cover the requested range; in that
+                // case there is nothing to copy into.
+                if (this.bytes.len + @as(usize, this.offset) <= dest.len) {
+                    @memcpy(dest[this.offset..][0..this.bytes.len], this.bytes);
+                }
+            }
             const vm = global.bunVM();
             vm.eventLoop().runCallback(callback, global, .js_undefined, &.{ .null, this.value });
         }
 
         fn deinit(this: *JobCtx) void {
+            bun.default_allocator.free(this.bytes);
             this.value.unprotect();
         }
     };
@@ -339,9 +355,8 @@ const random = struct {
 
         const ctx: JobCtx = .{
             .value = result,
-            .bytes = bytes.ptr,
+            .bytes = bun.handleOom(bun.default_allocator.alloc(u8, size)),
             .offset = 0,
-            .length = size,
         };
         try Job.initAndSchedule(global, callback, &ctx);
 
@@ -417,9 +432,8 @@ const random = struct {
 
         const ctx: JobCtx = .{
             .value = buf_value,
-            .bytes = buf.slice().ptr,
+            .bytes = bun.handleOom(bun.default_allocator.alloc(u8, size)),
             .offset = offset,
-            .length = size,
         };
         try Job.initAndSchedule(global, callback, &ctx);
 

--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -2461,22 +2461,6 @@ pub const Arguments = struct {
         }
 
         pub fn toThreadSafe(self: *@This()) void {
-            if (self.buffer == .buffer) {
-                // `writeInner`/`pwriteInner` (and the libuv path) only ever
-                // consume `buffer.slice()[offset..][0..length]`, so dupe just
-                // that range rather than letting the generic
-                // `StringOrBuffer.toThreadSafe` copy the whole view. This
-                // keeps the detach-safety guarantee while avoiding an
-                // O(view.byteLength) copy per chunked write.
-                const full = self.buffer.buffer.slice();
-                const off: usize = @min(self.offset, full.len);
-                const len: usize = @min(self.length, full.len - off);
-                const owned = bun.handleOom(bun.default_allocator.dupe(u8, full[off..][0..len]));
-                self.buffer = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
-                self.offset = 0;
-                self.length = owned.len;
-                return;
-            }
             self.buffer.toThreadSafe();
         }
 

--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -714,7 +714,10 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
                 this.result.err.deinit();
             }
             if (comptime !is_shell) this.ref.unref(this.evtloop);
-            this.args.deinit();
+            // `createWithShellTask`/`createMini` call `toThreadSafe()` on
+            // `src`/`dest`, which for `.buffer` paths pins + protects the
+            // backing ArrayBuffer; pair with `deinitAndUnprotect` here.
+            this.args.deinitAndUnprotect();
             this.promise.deinit();
             this.arena.deinit();
             bun.destroy(this);
@@ -1284,7 +1287,11 @@ pub const AsyncReaddirRecursiveTask = struct {
         }
 
         this.ref.unref(this.globalObject.bunVM());
-        this.args.deinit();
+        // `create` calls `args.toThreadSafe()`, which for a `.buffer` path
+        // pins + protects the backing ArrayBuffer; pair with
+        // `deinitAndUnprotect` here (this runs on the JS thread, not from
+        // a GC finalizer, so unpinning is safe).
+        this.args.deinitAndUnprotect();
         bun.default_allocator.free(this.root_path.slice());
         this.clearResultList();
         this.promise.deinit();
@@ -3088,6 +3095,13 @@ pub const Arguments = struct {
             if (this.flags.deinit_paths) {
                 this.src.deinit();
                 this.dest.deinit();
+            }
+        }
+
+        pub fn deinitAndUnprotect(this: *const Cp) void {
+            if (this.flags.deinit_paths) {
+                this.src.deinitAndUnprotect();
+                this.dest.deinitAndUnprotect();
             }
         }
 

--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -2461,6 +2461,22 @@ pub const Arguments = struct {
         }
 
         pub fn toThreadSafe(self: *@This()) void {
+            if (self.buffer == .buffer) {
+                // `writeInner`/`pwriteInner` (and the libuv path) only ever
+                // consume `buffer.slice()[offset..][0..length]`, so dupe just
+                // that range rather than letting the generic
+                // `StringOrBuffer.toThreadSafe` copy the whole view. This
+                // keeps the detach-safety guarantee while avoiding an
+                // O(view.byteLength) copy per chunked write.
+                const full = self.buffer.buffer.slice();
+                const off: usize = @min(self.offset, full.len);
+                const len: usize = @min(self.length, full.len - off);
+                const owned = bun.handleOom(bun.default_allocator.dupe(u8, full[off..][0..len]));
+                self.buffer = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
+                self.offset = 0;
+                self.length = owned.len;
+                return;
+            }
             self.buffer.toThreadSafe();
         }
 

--- a/src/runtime/node/types.zig
+++ b/src/runtime/node/types.zig
@@ -158,14 +158,22 @@ pub const StringOrBuffer = union(enum) {
             .threadsafe_string => {},
             .encoded_slice => {},
             .buffer => {
-                // `protect()`ing the JS value keeps the wrapper alive for GC
-                // but does not pin the ArrayBuffer backing store – user code
-                // can detach it (e.g. `buffer.transfer()`), freeing the bytes
-                // while the threadpool is still reading them. Copy the bytes
-                // into Bun-owned memory instead so the off-thread reader has
-                // a stable view.
-                const owned = bun.handleOom(bun.default_allocator.dupe(u8, this.buffer.slice()));
-                this.* = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
+                // `protect()` alone keeps the JS wrapper alive for GC but does
+                // not stop user code from detaching the ArrayBuffer (e.g.
+                // `buffer.transfer()`), which would free the backing store
+                // while the threadpool still holds a pointer into it. Pin the
+                // backing store so a concurrent detach copies instead of
+                // frees. Pinning may promote a FastTypedArray to stable heap
+                // storage, so `pinAndRefresh` also re-reads `ptr`/`byte_len`.
+                // `deinitAndUnprotect` unpins.
+                if (!this.buffer.buffer.pinAndRefresh()) {
+                    // No backing ArrayBuffer (already detached) — nothing to
+                    // pin and the slice is empty. Drop to an owned empty
+                    // slice so `deinitAndUnprotect` doesn't try to unpin.
+                    this.* = .{ .encoded_slice = jsc.ZigString.Slice.empty };
+                    return;
+                }
+                this.buffer.buffer.value.protect();
             },
         }
     }
@@ -232,6 +240,7 @@ pub const StringOrBuffer = union(enum) {
                 str.deinit();
             },
             .buffer => |buffer| {
+                buffer.buffer.value.unpinArrayBuffer();
                 buffer.buffer.value.unprotect();
             },
             .encoded_slice => |*encoded| {
@@ -281,19 +290,22 @@ pub const StringOrBuffer = union(enum) {
             .BigUint64Array,
             .DataView,
             => {
-                const buffer = Buffer.fromArrayBuffer(global, value);
+                var buffer = Buffer.fromArrayBuffer(global, value);
 
                 if (is_async) {
-                    // Copy the bytes into Bun-owned memory. Holding a raw
-                    // pointer into the ArrayBuffer and merely `protect()`ing
-                    // the JS value is not enough: user code can detach the
-                    // buffer (e.g. `buffer.transfer()`), which frees the
-                    // backing store while the threadpool still holds the
-                    // pointer.
-                    const bytes = buffer.slice();
-                    const owned = bun.handleOom(allocator.dupe(u8, bytes));
-                    defer global.vm().reportExtraMemory(owned.len);
-                    return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
+                    // `protect()` alone doesn't stop user code from
+                    // detaching the ArrayBuffer (e.g. `buffer.transfer()`),
+                    // which would free the backing store while the
+                    // threadpool still holds a pointer into it. Pin the
+                    // backing store so a concurrent detach copies instead of
+                    // frees. Pinning may promote a FastTypedArray to stable
+                    // heap storage, so `pinAndRefresh` also re-reads the
+                    // slice. `deinitAndUnprotect` unpins.
+                    if (!buffer.buffer.pinAndRefresh()) {
+                        // Already detached — nothing to pin or read.
+                        return .{ .encoded_slice = jsc.ZigString.Slice.empty };
+                    }
+                    buffer.buffer.value.protect();
                 }
 
                 return .{ .buffer = buffer };
@@ -312,15 +324,15 @@ pub const StringOrBuffer = union(enum) {
 
     pub fn fromJSWithEncodingMaybeAsync(global: *jsc.JSGlobalObject, allocator: std.mem.Allocator, value: jsc.JSValue, encoding: Encoding, is_async: bool, allow_string_object: bool) bun.JSError!?StringOrBuffer {
         if (value.isCell() and value.jsType().isArrayBufferLike()) {
-            const buffer = Buffer.fromArrayBuffer(global, value);
+            var buffer = Buffer.fromArrayBuffer(global, value);
             if (is_async) {
-                // See fromJSMaybeAsync: copy so a concurrent detach/transfer
+                // See fromJSMaybeAsync: pin so a concurrent detach/transfer
                 // of the ArrayBuffer can't free the bytes out from under the
                 // threadpool reader.
-                const bytes = buffer.slice();
-                const owned = bun.handleOom(allocator.dupe(u8, bytes));
-                defer global.vm().reportExtraMemory(owned.len);
-                return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
+                if (!buffer.buffer.pinAndRefresh()) {
+                    return .{ .encoded_slice = jsc.ZigString.Slice.empty };
+                }
+                buffer.buffer.value.protect();
             }
             return .{ .buffer = buffer };
         }
@@ -584,12 +596,14 @@ pub const PathLike = union(enum) {
                 this.* = .{ .threadsafe_string = slice_with_underlying_string };
             },
             .buffer => {
-                // See StringOrBuffer.toThreadSafe: `protect()` doesn't stop
-                // user code from detaching the ArrayBuffer and freeing the
-                // backing store while the threadpool still holds a pointer
-                // into it. Copy into Bun-owned memory instead.
-                const owned = bun.handleOom(bun.default_allocator.dupe(u8, this.buffer.slice()));
-                this.* = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
+                // See StringOrBuffer.toThreadSafe: pin the backing store so
+                // a concurrent detach/transfer copies instead of freeing it
+                // while the threadpool still holds a pointer into it.
+                if (!this.buffer.buffer.pinAndRefresh()) {
+                    this.* = .{ .encoded_slice = jsc.ZigString.Slice.empty };
+                    return;
+                }
+                this.buffer.buffer.value.protect();
             },
             else => {},
         }
@@ -601,6 +615,7 @@ pub const PathLike = union(enum) {
                 val.deinit();
             },
             .buffer => |val| {
+                val.buffer.value.unpinArrayBuffer();
                 val.buffer.value.unprotect();
             },
             else => {},

--- a/src/runtime/node/types.zig
+++ b/src/runtime/node/types.zig
@@ -584,7 +584,12 @@ pub const PathLike = union(enum) {
                 this.* = .{ .threadsafe_string = slice_with_underlying_string };
             },
             .buffer => {
-                this.buffer.buffer.value.protect();
+                // See StringOrBuffer.toThreadSafe: `protect()` doesn't stop
+                // user code from detaching the ArrayBuffer and freeing the
+                // backing store while the threadpool still holds a pointer
+                // into it. Copy into Bun-owned memory instead.
+                const owned = bun.handleOom(bun.default_allocator.dupe(u8, this.buffer.slice()));
+                this.* = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
             },
             else => {},
         }

--- a/src/runtime/node/types.zig
+++ b/src/runtime/node/types.zig
@@ -609,6 +609,22 @@ pub const PathLike = union(enum) {
         }
     }
 
+    /// Like `toThreadSafe`, but for long-lived ownership where cleanup may
+    /// run from a GC finalizer (e.g. `Blob.Store`). A `.buffer` path is
+    /// borrowed from a JS ArrayBuffer; `toThreadSafe` pins + protects it,
+    /// but the matching unpin/unprotect can't safely run during sweeping.
+    /// Instead, copy the (short) path bytes into an owned `.encoded_slice`
+    /// so `deinit()` alone releases everything. Other variants go through
+    /// `toThreadSafe` unchanged — their `deinit()` already handles cleanup.
+    pub fn toOwnedThreadSafe(this: *PathLike) void {
+        if (this.* == .buffer) {
+            const owned = bun.handleOom(bun.default_allocator.dupe(u8, this.buffer.slice()));
+            this.* = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
+            return;
+        }
+        this.toThreadSafe();
+    }
+
     pub fn deinitAndUnprotect(this: *const PathLike) void {
         switch (this.*) {
             inline .encoded_slice, .threadsafe_string, .slice_with_underlying_string => |*val| {
@@ -967,6 +983,13 @@ pub const PathOrFileDescriptor = union(Tag) {
     pub fn toThreadSafe(this: *PathOrFileDescriptor) void {
         if (this.* == .path) {
             this.path.toThreadSafe();
+        }
+    }
+
+    /// See `PathLike.toOwnedThreadSafe`.
+    pub fn toOwnedThreadSafe(this: *PathOrFileDescriptor) void {
+        if (this.* == .path) {
+            this.path.toOwnedThreadSafe();
         }
     }
 

--- a/src/runtime/node/types.zig
+++ b/src/runtime/node/types.zig
@@ -158,7 +158,14 @@ pub const StringOrBuffer = union(enum) {
             .threadsafe_string => {},
             .encoded_slice => {},
             .buffer => {
-                this.buffer.buffer.value.protect();
+                // `protect()`ing the JS value keeps the wrapper alive for GC
+                // but does not pin the ArrayBuffer backing store – user code
+                // can detach it (e.g. `buffer.transfer()`), freeing the bytes
+                // while the threadpool is still reading them. Copy the bytes
+                // into Bun-owned memory instead so the off-thread reader has
+                // a stable view.
+                const owned = bun.handleOom(bun.default_allocator.dupe(u8, this.buffer.slice()));
+                this.* = .{ .encoded_slice = jsc.ZigString.Slice.init(bun.default_allocator, owned) };
             },
         }
     }
@@ -277,7 +284,16 @@ pub const StringOrBuffer = union(enum) {
                 const buffer = Buffer.fromArrayBuffer(global, value);
 
                 if (is_async) {
-                    buffer.buffer.value.protect();
+                    // Copy the bytes into Bun-owned memory. Holding a raw
+                    // pointer into the ArrayBuffer and merely `protect()`ing
+                    // the JS value is not enough: user code can detach the
+                    // buffer (e.g. `buffer.transfer()`), which frees the
+                    // backing store while the threadpool still holds the
+                    // pointer.
+                    const bytes = buffer.slice();
+                    const owned = bun.handleOom(allocator.dupe(u8, bytes));
+                    defer global.vm().reportExtraMemory(owned.len);
+                    return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
                 }
 
                 return .{ .buffer = buffer };
@@ -298,7 +314,13 @@ pub const StringOrBuffer = union(enum) {
         if (value.isCell() and value.jsType().isArrayBufferLike()) {
             const buffer = Buffer.fromArrayBuffer(global, value);
             if (is_async) {
-                buffer.buffer.value.protect();
+                // See fromJSMaybeAsync: copy so a concurrent detach/transfer
+                // of the ArrayBuffer can't free the bytes out from under the
+                // threadpool reader.
+                const bytes = buffer.slice();
+                const owned = bun.handleOom(allocator.dupe(u8, bytes));
+                defer global.vm().reportExtraMemory(owned.len);
+                return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
             }
             return .{ .buffer = buffer };
         }

--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2152,7 +2152,11 @@ pub fn findOrCreateFileFromPath(path_or_fd: *jsc.Node.PathOrFileDescriptor, glob
                     }
                 }
 
-                path_or_fd.toThreadSafe();
+                // The Store takes long-lived ownership and is released
+                // from a GC finalizer, which can't safely unpin/unprotect
+                // a borrowed `.buffer` path — so copy buffer paths into an
+                // owned `.encoded_slice` instead of pinning them.
+                path_or_fd.toOwnedThreadSafe();
                 const copy = path_or_fd.*;
                 path_or_fd.* = .{ .path = .{ .string = bun.PathString.empty } };
                 break :brk copy;

--- a/src/runtime/webcore/blob/Store.zig
+++ b/src/runtime/webcore/blob/Store.zig
@@ -67,8 +67,9 @@ pub fn external(ptr: ?*anyopaque, _: ?*anyopaque, _: usize) callconv(.c) void {
 }
 pub fn initS3WithReferencedCredentials(pathlike: node.PathLike, mime_type: ?MimeType, credentials: *bun.S3.S3Credentials, allocator: std.mem.Allocator) !*Store {
     var path = pathlike;
-    // this actually protects/refs the pathlike
-    path.toThreadSafe();
+    // The Store is released from a GC finalizer, which can't safely
+    // unpin/unprotect a borrowed `.buffer` path; copy it instead.
+    path.toOwnedThreadSafe();
 
     const store = Blob.Store.new(.{
         .data = .{
@@ -96,8 +97,9 @@ pub fn initS3WithReferencedCredentials(pathlike: node.PathLike, mime_type: ?Mime
 
 pub fn initS3(pathlike: node.PathLike, mime_type: ?MimeType, credentials: bun.S3.S3Credentials, allocator: std.mem.Allocator) !*Store {
     var path = pathlike;
-    // this actually protects/refs the pathlike
-    path.toThreadSafe();
+    // The Store is released from a GC finalizer, which can't safely
+    // unpin/unprotect a borrowed `.buffer` path; copy it instead.
+    path.toOwnedThreadSafe();
 
     const store = Blob.Store.new(.{
         .data = .{

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -188,3 +188,106 @@ describe("randomFill default size with multi-byte typed arrays", () => {
     expect(tailFilled).toBe(true);
   });
 });
+
+describe.concurrent("async crypto does not touch a detached ArrayBuffer backing store", () => {
+  // Before the fix, the async variants captured a raw pointer into the
+  // ArrayBuffer backing store and only `protect()`ed the JS wrapper. Calling
+  // `buffer.transfer()` with a different length frees that storage
+  // synchronously, so the worker thread would read from / write to freed
+  // gigacage memory. These tests spawn a fresh process so that the observed
+  // heap reuse isn't perturbed by the test runner itself.
+
+  it("randomFill does not write through a freed backing store", async () => {
+    const src = `
+      const crypto = require("crypto");
+      const iterations = 8;
+      const size = 1 << 16;
+      const zero = Buffer.alloc(size);
+      const keep = [];
+      let pending = iterations;
+      let corrupted = 0;
+      const nonzero = b => Buffer.compare(Buffer.from(b.buffer, b.byteOffset, b.byteLength), zero) !== 0;
+      for (let i = 0; i < iterations; i++) {
+        const old = new Uint8Array(size);
+        crypto.randomFill(old, () => {
+          if (--pending === 0) {
+            // re-check after the callbacks fire in case the write raced us
+            for (const b of keep) if (nonzero(b)) corrupted++;
+            process.stdout.write(String(corrupted));
+          }
+        });
+        // detach + free the backing store before the worker runs
+        old.buffer.transfer(0);
+        // and hand the same-size allocation back out as an all-zero buffer
+        const fresh = new Uint8Array(size);
+        keep.push(fresh);
+        if (nonzero(fresh)) corrupted++;
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("0");
+    expect(exitCode).toBe(0);
+  });
+
+  it("scrypt copies ArrayBuffer inputs before going off-thread", async () => {
+    const src = `
+      const crypto = require("crypto");
+      const size = 1 << 16;
+      const password = new Uint8Array(size).fill(0x41);
+      const salt = new Uint8Array(16).fill(0x42);
+      const expected = crypto.scryptSync(password, salt, 32).toString("hex");
+      crypto.scrypt(password, salt, 32, (err, key) => {
+        if (err) throw err;
+        process.stdout.write(key.toString("hex") === expected ? "ok" : "mismatch:" + key.toString("hex"));
+      });
+      // free the password backing store and fill the reused storage with junk
+      password.buffer.transfer(0);
+      const junk = [];
+      for (let i = 0; i < 50; i++) junk.push(new Uint8Array(size).fill(0x43));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+
+  it("pbkdf2 copies ArrayBuffer inputs before going off-thread", async () => {
+    const src = `
+      const crypto = require("crypto");
+      const size = 1 << 16;
+      const password = new Uint8Array(size).fill(0x41);
+      const salt = new Uint8Array(16).fill(0x42);
+      const expected = crypto.pbkdf2Sync(password, salt, 1000, 32, "sha256").toString("hex");
+      crypto.pbkdf2(password, salt, 1000, 32, "sha256", (err, key) => {
+        if (err) throw err;
+        process.stdout.write(key.toString("hex") === expected ? "ok" : "mismatch:" + key.toString("hex"));
+      });
+      password.buffer.transfer(0);
+      const junk = [];
+      for (let i = 0; i < 50; i++) junk.push(new Uint8Array(size).fill(0x43));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -194,8 +194,10 @@ describe.concurrent("async crypto does not touch a detached ArrayBuffer backing 
   // ArrayBuffer backing store and only `protect()`ed the JS wrapper. Calling
   // `buffer.transfer()` with a different length frees that storage
   // synchronously, so the worker thread would read from / write to freed
-  // gigacage memory. These tests spawn a fresh process so that the observed
-  // heap reuse isn't perturbed by the test runner itself.
+  // gigacage memory. The fix pins the backing ArrayBuffer for the duration
+  // of the off-thread work so a concurrent transfer() copies the bytes out
+  // instead of detaching. These tests spawn a fresh process so that the
+  // observed heap reuse isn't perturbed by the test runner itself.
 
   it("randomFill does not write through a freed backing store", async () => {
     const src = `
@@ -236,7 +238,7 @@ describe.concurrent("async crypto does not touch a detached ArrayBuffer backing 
     expect(exitCode).toBe(0);
   });
 
-  it("scrypt copies ArrayBuffer inputs before going off-thread", async () => {
+  it("scrypt pins ArrayBuffer inputs while off-thread", async () => {
     const src = `
       const crypto = require("crypto");
       const size = 1 << 16;
@@ -264,7 +266,7 @@ describe.concurrent("async crypto does not touch a detached ArrayBuffer backing 
     expect(exitCode).toBe(0);
   });
 
-  it("pbkdf2 copies ArrayBuffer inputs before going off-thread", async () => {
+  it("pbkdf2 pins ArrayBuffer inputs while off-thread", async () => {
     const src = `
       const crypto = require("crypto");
       const size = 1 << 16;

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -57,6 +57,25 @@ describe("randomBytes", () => {
 
     await promise;
   });
+
+  it("async fills the returned buffer (small sizes)", async () => {
+    // Small sizes exercise the FastTypedArray path inside
+    // ArrayBuffer.alloc — make sure the bytes the callback receives were
+    // actually written by the worker and aren't a stale uninitialized copy
+    // left behind by a pin-time promotion.
+    for (const size of [16, 32, 64]) {
+      let allZero = true;
+      for (let i = 0; i < 8 && allZero; i++) {
+        const buf = await new Promise<Buffer>((resolve, reject) =>
+          randomBytes(size, (err, b) => (err ? reject(err) : resolve(b))),
+        );
+        expect(buf).toBeInstanceOf(Buffer);
+        expect(buf.length).toBe(size);
+        if (buf.some(x => x !== 0)) allZero = false;
+      }
+      expect(allZero).toBe(false);
+    }
+  });
 });
 
 describe("randomFill bounds checking", () => {


### PR DESCRIPTION
## Problem

`crypto.randomFill(buf, cb)` captures `buf.slice().ptr` and only `protect()`s the wrapper JSValue before scheduling the fill on the threadpool. `protect()` roots the cell but does **not** pin the ArrayBuffer's backing store — calling `buf.buffer.transfer(n)` with a different length synchronously frees the old storage, after which the worker writes csprng output through a dangling pointer into whatever gigacage hands out next.

`StringOrBuffer` / `PathLike` have the same bug in their async paths (`fromJSMaybeAsync`, `fromJSWithEncodingMaybeAsync`, `toThreadSafe`), so `crypto.scrypt` / `crypto.pbkdf2` would read password/salt from freed memory after a detach, and `fs.write`/`fs.writeFile`, `Bun.zstd.*`, and `Transpiler.transform` could read stale input bytes.

## Repro

```js
const crypto = require("crypto");
const old = new Uint8Array(1 << 16);
crypto.randomFill(old, () => {});
old.buffer.transfer(0);               // frees backing store
const fresh = new Uint8Array(1 << 16); // likely reuses same gigacage slot
// fresh is now non-zero: the threadpool wrote random bytes into it
```

ASAN doesn't flag this because JSC ArrayBuffer storage lives in Gigacage, but the corruption of an unrelated zero-initialized array is directly observable (8/8 iterations in the test below). Node.js segfaults on the same pattern.

## Fix

Pin the backing `ArrayBuffer` while the threadpool holds a pointer into it. While `m_pinCount > 0`, JSC's `transfer()` / detach **copies** the contents to the new buffer instead of freeing the original backing store (`ArrayBuffer::transferTo` → `!isDetachable()` → `m_contents.copyTo`), so the native pointer stays valid — zero extra allocation, zero memcpy.

- **`JSValue.pinArrayBuffer` / `unpinArrayBuffer`**: centralized Zig wrappers for the existing `JSC__JSValue__{pin,unpin}ArrayBuffer` helpers.
- **`ArrayBuffer.pinAndRefresh`** (new C++ helper `Bun__ArrayBuffer__pinAndRefresh`): pins and re-reads `ptr`/`byte_len` afterwards, since pinning promotes a `FastTypedArray` to stable heap storage (`possiblySharedBuffer()` → `slowDownAndWasteMemory()`) which repoints the view's vector. Lets `toThreadSafe()` callers refresh their cached slice without a `JSGlobalObject` on hand.
- **`random.JobCtx`**: `randomFill` pins the user's buffer and re-reads the stable slice before scheduling; `randomBytes` pins its freshly-allocated result for uniform `deinit` semantics. The worker writes directly into the pinned storage; `deinit` unpins.
- **`StringOrBuffer` / `PathLike`** `.buffer` async paths: `pinAndRefresh` + `protect` instead of the previous `protect`-only; `deinitAndUnprotect` unpins. Falls back to an empty `encoded_slice` if the buffer is already detached (nothing to pin, avoids underflowing the pin count on cleanup).

## Verification

New tests in `test/js/node/crypto/crypto-random.test.ts` spawn subprocesses that schedule the async op, `transfer(0)` the input, then reallocate same-sized buffers:

Before fix:
```
(fail) randomFill does not write through a freed backing store — Received: "8" (corrupted buffers)
(fail) scrypt pins ArrayBuffer inputs while off-thread — Received: "mismatch:75bcd131…"
(fail) pbkdf2 pins ArrayBuffer inputs while off-thread — Received: "mismatch:00a7b78a…"
```

After fix: all 18 pass on both ASAN and release. While pinned, `buf.buffer.transfer(0)` returns a new empty buffer but leaves the original un-detached (`buf.buffer.detached === false`, `buf.byteLength` unchanged); after the callback fires and the pin is released, a subsequent `transfer()` detaches normally.

Existing `crypto.test.ts` (369), `pbkdf2.test.ts` (25), `test-crypto-random.js`, `test-crypto-scrypt.js`, `test-crypto-pbkdf2.js`, `test-fs-buffer.js`, `test-fs-write-buffer.js` all pass.
