### PR TITLE
sql(mysql): pin ArrayBuffer backing store while binding BLOB parameters

### DIFF
--- a/src/sql/mysql/MySQLQuery.zig
+++ b/src/sql/mysql/MySQLQuery.zig
@@ -12,7 +12,7 @@ const MySQLQuery = @This();
     _padding: u3 = 0,
 },
 
-fn bind(this: *MySQLQuery, execute: *PreparedStatement.Execute, globalObject: *JSGlobalObject, binding_value: JSValue, columns_value: JSValue) AnyMySQLError.Error!void {
+fn bind(this: *MySQLQuery, execute: *PreparedStatement.Execute, globalObject: *JSGlobalObject, binding_value: JSValue, columns_value: JSValue, roots: *bun.jsc.MarkedArgumentBuffer) AnyMySQLError.Error!void {
     var iter = try QueryBindingIterator.init(binding_value, columns_value, globalObject);
 
     var i: u32 = 0;
@@ -37,6 +37,7 @@ fn bind(this: *MySQLQuery, execute: *PreparedStatement.Execute, globalObject: *J
             globalObject,
             param.type,
             param.flags.UNSIGNED,
+            roots,
         );
         i += 1;
     }
@@ -60,6 +61,40 @@ fn bindAndExecute(this: *MySQLQuery, writer: anytype, statement: *MySQLStatement
     if (statement.signature.fields.len != statement.params.len) {
         return error.WrongNumberOfParametersProvided;
     }
+
+    // BLOB parameters borrow ArrayBuffer/Blob bytes rather than copying.
+    // Converting later parameters can run user JS (index getters, toJSON,
+    // toString coercion) which could drop the last reference to an earlier
+    // buffer and force GC. Root every borrowed JSValue in a stack-scoped
+    // MarkedArgumentBuffer so the wrapper (and its RefPtr<ArrayBuffer>)
+    // survives until execute.deinit() has unpinned and released the borrow.
+    const Ctx = struct {
+        this: *MySQLQuery,
+        writer: @TypeOf(writer),
+        statement: *MySQLStatement,
+        globalObject: *JSGlobalObject,
+        binding_value: JSValue,
+        columns_value: JSValue,
+        result: AnyMySQLError.Error!void,
+
+        pub fn run(ctx: *@This(), roots: *bun.jsc.MarkedArgumentBuffer) callconv(.c) void {
+            ctx.result = bindAndExecuteImpl(ctx.this, ctx.writer, ctx.statement, ctx.globalObject, ctx.binding_value, ctx.columns_value, roots);
+        }
+    };
+    var ctx: Ctx = .{
+        .this = this,
+        .writer = writer,
+        .statement = statement,
+        .globalObject = globalObject,
+        .binding_value = binding_value,
+        .columns_value = columns_value,
+        .result = {},
+    };
+    bun.jsc.MarkedArgumentBuffer.run(Ctx, &ctx, &Ctx.run);
+    return ctx.result;
+}
+
+fn bindAndExecuteImpl(this: *MySQLQuery, writer: anytype, statement: *MySQLStatement, globalObject: *JSGlobalObject, binding_value: JSValue, columns_value: JSValue, roots: *bun.jsc.MarkedArgumentBuffer) AnyMySQLError.Error!void {
     var execute = PreparedStatement.Execute{
         .statement_id = statement.statement_id,
         .param_types = statement.signature.fields,
@@ -70,7 +105,7 @@ fn bindAndExecute(this: *MySQLQuery, writer: anytype, statement: *MySQLStatement
     // Bind before touching the writer so a bind failure (user-triggerable via JS
     // getters / param-count mismatch) doesn't leave a partial packet header in
     // the connection's write buffer.
-    try this.bind(&execute, globalObject, binding_value, columns_value);
+    try this.bind(&execute, globalObject, binding_value, columns_value, roots);
     var packet = try writer.start(0);
     try execute.write(writer);
     try packet.end();

--- a/src/sql/mysql/MySQLTypes.zig
+++ b/src/sql/mysql/MySQLTypes.zig
@@ -390,15 +390,42 @@ pub const Value = union(enum) {
 
     string: JSC.ZigString.Slice,
     string_data: Data,
-    bytes: JSC.ZigString.Slice,
+    bytes: Bytes,
     bytes_data: Data,
     date: DateTime,
     time: Time,
     // decimal: Decimal,
 
+    /// BLOB parameter bytes. `MySQLQuery.bind()` fills every `Value` before
+    /// `execute.write()` reads any of them, and converting later parameters
+    /// can run user JS (array index getters, toJSON, toString coercion). That
+    /// JS could `transfer()`/detach an earlier ArrayBuffer, or drop the last
+    /// JS reference to it and force GC, while we still hold a borrowed slice
+    /// into it. Pinning the backing `ArrayBuffer` makes it non-detachable for
+    /// the duration (`transfer()` then hands the user a copy), and the
+    /// caller's stack-scoped `MarkedArgumentBuffer` roots the wrapper so GC
+    /// can't sweep the cell whose `RefPtr<ArrayBuffer>` keeps the storage
+    /// alive — `params` is on the malloc heap and isn't scanned. `deinit()`
+    /// unpins.
+    pub const Bytes = struct {
+        slice: JSC.ZigString.Slice = .empty,
+        /// JS ArrayBuffer/view to `unpinArrayBuffer` in `deinit()`. `.zero`
+        /// when the slice is owned (FastTypedArray dupe), borrowed from a
+        /// Blob store (nothing to unpin), or empty. GC rooting of this value
+        /// is the caller's responsibility via the `MarkedArgumentBuffer`
+        /// passed to `fromJS`.
+        pinned: JSC.JSValue = .zero,
+
+        pub fn deinit(this: *Bytes) void {
+            if (this.pinned != .zero) JSC__JSValue__unpinArrayBuffer(this.pinned);
+            this.slice.deinit();
+        }
+    };
+
     pub fn deinit(this: *Value, _: std.mem.Allocator) void {
         switch (this.*) {
-            inline .string, .bytes => |*slice| slice.deinit(),
+            .string => |*slice| slice.deinit(),
+            .bytes => |*b| b.deinit(),
             inline .string_data, .bytes_data => |*data| data.deinit(),
             // .decimal => |*decimal| decimal.deinit(allocator),
             else => {},
@@ -428,13 +455,14 @@ pub const Value = union(enum) {
             },
             // .decimal => |dec| return try dec.toBinary(field_type),
             .string_data, .bytes_data => |data| return data,
-            .string, .bytes => |slice| return if (slice.len > 0) Data{ .temporary = slice.slice() } else Data{ .empty = {} },
+            .string => |slice| return if (slice.len > 0) Data{ .temporary = slice.slice() } else Data{ .empty = {} },
+            .bytes => |b| return if (b.slice.len > 0) Data{ .temporary = b.slice.slice() } else Data{ .empty = {} },
         }
 
         return try Data.create(buffer[0..stream.pos], bun.default_allocator);
     }
 
-    pub fn fromJS(value: JSC.JSValue, globalObject: *JSC.JSGlobalObject, field_type: FieldType, unsigned: bool) AnyMySQLError.Error!Value {
+    pub fn fromJS(value: JSC.JSValue, globalObject: *JSC.JSGlobalObject, field_type: FieldType, unsigned: bool, roots: *JSC.MarkedArgumentBuffer) AnyMySQLError.Error!Value {
         if (value.isEmptyOrUndefinedOrNull()) {
             return Value{ .null = {} };
         }
@@ -464,15 +492,43 @@ pub const Value = union(enum) {
             .MYSQL_TYPE_TIME => Value{ .time = try Time.fromJS(value, globalObject) },
             .MYSQL_TYPE_DATE, .MYSQL_TYPE_TIMESTAMP, .MYSQL_TYPE_DATETIME => Value{ .date = try DateTime.fromJS(value, globalObject) },
             .MYSQL_TYPE_TINY_BLOB, .MYSQL_TYPE_MEDIUM_BLOB, .MYSQL_TYPE_LONG_BLOB, .MYSQL_TYPE_BLOB => {
-                if (value.asArrayBuffer(globalObject)) |array_buffer| {
-                    return Value{ .bytes = JSC.ZigString.Slice.fromUTF8NeverFree(array_buffer.slice()) };
+                if (value.jsType().isArrayBufferLike()) {
+                    // Later parameters in the same bind loop may run user
+                    // JS (toString/toJSON/getters) that can transfer() or
+                    // detach this buffer before execute.write() reads it.
+                    // Pin the backing ArrayBuffer so it stays non-detachable
+                    // until Value.deinit() unpins it; borrowing the slice is
+                    // then safe without a copy. See `Value.Bytes`.
+                    var ptr: [*]const u8 = undefined;
+                    var len: usize = 0;
+                    return switch (JSC__JSValue__borrowBytesForOffThread(value, &ptr, &len)) {
+                        // detached / null
+                        0 => Value{ .bytes = .{} },
+                        // FastTypedArray — tiny, GC-movable vector; dupe.
+                        1 => Value{ .bytes = .{ .slice = try JSC.ZigString.Slice.initDupe(bun.default_allocator, ptr[0..len]) } },
+                        // Oversize/Wasteful/DataView/JSArrayBuffer — pinned
+                        // by the helper. Root the wrapper so GC can't
+                        // collect it (and free the backing store despite
+                        // the pin) if user JS drops the last reference from
+                        // a later parameter.
+                        2 => blk: {
+                            roots.append(value);
+                            break :blk Value{ .bytes = .{ .slice = JSC.ZigString.Slice.fromUTF8NeverFree(ptr[0..len]), .pinned = value } };
+                        },
+                        else => unreachable,
+                    };
                 }
 
                 if (value.as(JSC.WebCore.Blob)) |blob| {
                     if (blob.needsToReadFile()) {
                         return globalObject.throwInvalidArguments("File blobs are not supported", .{});
                     }
-                    return Value{ .bytes = JSC.ZigString.Slice.fromUTF8NeverFree(blob.sharedView()) };
+                    // Blob byte stores are immutable from JS (no detach),
+                    // but user JS running for a later parameter could drop
+                    // the last reference and force GC. Root the wrapper so
+                    // the store survives until execute.write() has read it.
+                    roots.append(value);
+                    return Value{ .bytes = .{ .slice = JSC.ZigString.Slice.fromUTF8NeverFree(blob.sharedView()) } };
                 }
 
                 if (value.isString()) {
@@ -865,6 +921,11 @@ pub const int2 = u16;
 pub const int3 = u24;
 pub const int4 = u32;
 pub const int8 = u64;
+
+extern fn JSC__JSValue__unpinArrayBuffer(v: JSC.JSValue) void;
+/// 0 = detached/null, 1 = FastTypedArray (GC-movable — caller should dupe;
+/// no unpin needed), 2 = pinned ArrayBuffer (caller must `unpinArrayBuffer`).
+extern fn JSC__JSValue__borrowBytesForOffThread(v: JSC.JSValue, out_ptr: *[*]const u8, out_len: *usize) i32;
 
 const AnyMySQLError = @import("./protocol/AnyMySQLError.zig");
 const std = @import("std");

--- a/test/js/sql/sql-mysql-bind-blob-borrow.fixture.ts
+++ b/test/js/sql/sql-mysql-bind-blob-borrow.fixture.ts
@@ -1,0 +1,93 @@
+// Reproducer for a borrowed-bytes bug in MySQL BLOB parameter binding.
+//
+// Value.fromJS for BLOB params borrowed the ArrayBuffer backing store
+// without protecting it. The bind loop in MySQLQuery.bind() then continues
+// to later parameters, which can run user JS (array index getters, toJSON,
+// toString coercion) that transfers or detaches the earlier buffer.
+// execute.write() then reads bytes that no longer belong to the original
+// buffer.
+//
+// For a non-resizable ArrayBuffer, `buf.transfer()` with no arguments is
+// zero-copy in JSC — the new buffer takes ownership of the *same* backing
+// pointer. Overwriting the new buffer therefore mutates the bytes the
+// borrowed slice still points at, and those mutated bytes are what go on
+// the wire. With the fix the backing ArrayBuffer is pinned for the
+// duration of bind+execute, so `transfer()` hands the user a copy instead
+// of detaching and the original bytes reach the server.
+
+import { SQL, randomUUIDv7 } from "bun";
+
+const url = process.env.MYSQL_URL;
+if (!url) throw new Error("MYSQL_URL is required");
+
+const tls = process.env.CA_PATH ? { ca: Bun.file(process.env.CA_PATH) } : undefined;
+const sql = new SQL({ url, tls, max: 1 });
+
+try {
+  const tbl = "blob_borrow_" + randomUUIDv7("hex").replaceAll("-", "");
+  await sql.unsafe(`CREATE TEMPORARY TABLE ${tbl} (id INT, data BLOB, name VARCHAR(255))`).simple();
+
+  // Prime the prepared-statement cache with signature [LONG, BLOB, STRING]
+  // so the next call with the same signature goes straight to
+  // bindAndExecute (statement already .prepared).
+  await sql.unsafe(`INSERT INTO ${tbl} (id, data, name) VALUES (?, ?, ?)`, [0, new Uint8Array(4).fill(0xaa), "prime"]);
+  // Marker so the harness can distinguish "couldn't connect" from
+  // "connected then crashed" when no MySQL is available.
+  console.log("CONNECTED");
+
+  const buf = new ArrayBuffer(64);
+  const ta = new Uint8Array(buf);
+  for (let i = 0; i < ta.length; i++) ta[i] = i;
+  const originalHex = Buffer.from(ta).toString("hex");
+
+  const values: unknown[] = [1, ta, "placeholder"];
+  let calls = 0;
+  Object.defineProperty(values, "2", {
+    enumerable: true,
+    configurable: true,
+    get() {
+      calls++;
+      // The array is iterated once by Signature.generate (type inference
+      // only — no user JS on the values themselves) and again by bind().
+      // By the 2nd access the BLOB param has already been converted to a
+      // Value, so this is the first point at which mutating `buf` can race
+      // with the borrowed slice.
+      if (calls >= 2 && buf.byteLength > 0) {
+        // Zero-copy transfer: the new buffer owns the same backing pointer.
+        // Overwriting it mutates what the borrowed slice still points at.
+        const moved = buf.transfer();
+        new Uint8Array(moved).fill(0xff);
+      }
+      return "evil";
+    },
+  });
+
+  await sql.unsafe(`INSERT INTO ${tbl} (id, data, name) VALUES (?, ?, ?)`, values);
+
+  // The backing ArrayBuffer is pinned for the duration of bind+execute,
+  // which makes `buf.transfer()` inside the getter return a copy instead
+  // of detaching. Once the query has resolved the pin must be released —
+  // verify `buf` is detachable again.
+  let detachableAfter = true;
+  if (buf.byteLength > 0) {
+    buf.transfer();
+    detachableAfter = buf.byteLength === 0;
+  }
+
+  const [row] = await sql.unsafe(`SELECT data, name FROM ${tbl} WHERE id = 1`);
+  const gotHex = Buffer.from(row.data).toString("hex");
+
+  console.log(
+    JSON.stringify({
+      calls,
+      detached: buf.byteLength === 0,
+      detachableAfter,
+      originalHex,
+      gotHex,
+      name: row.name,
+      match: gotHex === originalHex,
+    }),
+  );
+} finally {
+  await sql.close();
+}

--- a/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
+++ b/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, describeWithContainer, isDockerEnabled } from "harness";
+import path from "path";
+
+// Regression: Value.fromJS for MySQL BLOB parameters borrowed the
+// ArrayBuffer backing store without protecting it. A later parameter in
+// the same bind loop can run user JS (array index getter here) that
+// transfer()s the earlier buffer before execute.write() reads it, so the
+// wire bytes come from memory the caller no longer owns.
+//
+// For a non-resizable ArrayBuffer, `buf.transfer()` with no arguments is
+// zero-copy in JSC — the new buffer takes ownership of the same backing
+// pointer. The fixture overwrites the transferred buffer with 0xff; without
+// the fix MySQL would store 64 bytes of 0xff instead of 0..63. The fix pins
+// the ArrayBuffer for the duration of bind+execute so transfer() hands the
+// user a copy instead of detaching.
+
+const fixture = path.join(import.meta.dir, "sql-mysql-bind-blob-borrow.fixture.ts");
+
+async function runFixture(url: string, caPath = "") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    env: { ...bunEnv, MYSQL_URL: url, CA_PATH: caPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function expectedHex() {
+  let hex = "";
+  for (let i = 0; i < 64; i++) hex += i.toString(16).padStart(2, "0");
+  return hex;
+}
+
+function assertFixtureOutput(stdout: string, stderr: string, exitCode: number) {
+  const filteredStderr = stderr
+    .split(/\r?\n/)
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
+  const lines = stdout.trim().split(/\r?\n/);
+  expect(lines[0]).toBe("CONNECTED");
+  const payload = JSON.parse(lines[1] ?? "null");
+  expect(payload).toEqual({
+    calls: expect.any(Number),
+    // With the ArrayBuffer pinned for the duration of bind+execute,
+    // `buf.transfer()` inside the getter returns a copy and leaves the
+    // original attached. Once the query resolves the pin is released and
+    // `buf` becomes detachable again.
+    detached: true,
+    detachableAfter: true,
+    originalHex: expectedHex(),
+    gotHex: expectedHex(),
+    name: "evil",
+    match: true,
+  });
+  // The getter must have fired during bind (after Signature.generate),
+  // otherwise the test isn't exercising the race.
+  expect(payload.calls).toBeGreaterThanOrEqual(2);
+  expect(exitCode).toBe(0);
+}
+
+// Spawning the debug bun subprocess + MySQL round-trip can exceed the 5s
+// default on a cold cache under ASAN.
+const TEST_TIMEOUT = 30_000;
+
+if (isDockerEnabled()) {
+  describeWithContainer("mysql", { image: "mysql_plain" }, container => {
+    test(
+      "BLOB param backing store is pinned across the bind loop",
+      async () => {
+        await container.ready;
+        const url = `mysql://root@${container.host}:${container.port}/bun_sql_test`;
+        const { stdout, stderr, exitCode } = await runFixture(url);
+        assertFixtureOutput(stdout, stderr, exitCode);
+      },
+      TEST_TIMEOUT,
+    );
+  });
+} else {
+  // No docker daemon (e.g. local/sandboxed environments). If a MySQL server
+  // is reachable at MYSQL_URL or the conventional local address, exercise
+  // the fixture there so the regression is still covered.
+  const url = process.env.MYSQL_URL || "mysql://bun@127.0.0.1:3306/bun_sql_test";
+
+  describe("mysql (local)", () => {
+    test(
+      "BLOB param backing store is pinned across the bind loop",
+      async () => {
+        const { stdout, stderr, exitCode } = await runFixture(url);
+        // The fixture prints "CONNECTED" after the priming query succeeds. If
+        // it never got that far, there's no MySQL to talk to in this
+        // environment; the docker-gated branch above provides the CI coverage.
+        if (!stdout.startsWith("CONNECTED")) {
+          if (process.env.MYSQL_URL) {
+            throw new Error(
+              `sql-mysql-bind-blob-borrow: MYSQL_URL was provided but fixture never reached CONNECTED\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+            );
+          }
+          console.warn("sql-mysql-bind-blob-borrow: no MySQL reachable at " + url + "; skipping assertions");
+          return;
+        }
+        assertFixtureOutput(stdout, stderr, exitCode);
+      },
+      TEST_TIMEOUT,
+    );
+  });
+}


### PR DESCRIPTION
## Repro

```ts
const buf = new ArrayBuffer(64);
const ta = new Uint8Array(buf);
for (let i = 0; i < ta.length; i++) ta[i] = i;

const values = [1, ta, "placeholder"];
let calls = 0;
Object.defineProperty(values, "2", {
  get() {
    if (++calls >= 2 && buf.byteLength > 0) {
      // zero-copy transfer: same backing pointer
      new Uint8Array(buf.transfer()).fill(0xff);
    }
    return "evil";
  },
});

await sql.unsafe(`INSERT INTO t (id, data, name) VALUES (?, ?, ?)`, values);
// stored `data`: 64 × 0xff  — should be 0x00..0x3f
```

## Cause

`Value.fromJS` for `MYSQL_TYPE_*BLOB` returned `ZigString.Slice.fromUTF8NeverFree(array_buffer.slice())`, borrowing the backing store without protecting it.

`MySQLQuery.bind()` collects every parameter into a `[]Value` first and only then calls `execute.write()`. Converting later parameters can run user JS — array index getters via `QueryBindingIterator.next()`, `toJSON` via `jsonStringifyFast`, `toString` via `bun.String.fromJS` — and that JS can `transfer()`/detach an earlier buffer, or drop the last JS reference to it and force GC. `execute.write()` then reads bytes the caller no longer owns.

For a non-resizable `ArrayBuffer`, `buf.transfer()` with no arguments is zero-copy in JSC: the new buffer takes ownership of the **same** backing pointer, so overwriting the new buffer mutates exactly what the borrowed slice still points at. With a resizing `transferToFixedLength(n)` the old backing store is freed outright.

(The Postgres path doesn't have this window: `PostgresRequest.writeBind` writes each parameter to the wire inside the loop before touching the next one.)

## Fix

`bindAndExecute` now runs inside a stack-scoped `MarkedArgumentBuffer` (same pattern as `udp_socket.zig` `sendMany`) that `Value.fromJS` appends borrowed buffer/Blob wrappers to, and the backing `ArrayBuffer` is pinned via `JSC__JSValue__borrowBytesForOffThread` (the same helper `Bun.Image` uses):

- **Oversize/Wasteful/DataView/JSArrayBuffer** → `ArrayBuffer::pin()` makes it non-detachable — `transfer()` hands the user a **copy** and leaves the original backing store intact. The wrapper is appended to the `MarkedArgumentBuffer` so GC can't sweep the cell whose `RefPtr<ArrayBuffer>` keeps the storage alive (`params` lives on the malloc heap and isn't scanned).
- **FastTypedArray** (≤ ~1 KB, GC-movable vector) → bytes are duped. Pinning would force `slowDownAndWasteMemory()` which copies anyway.
- **Blob** → plain borrow (immutable store, no detach); wrapper appended to the `MarkedArgumentBuffer` so the store survives GC.

`Value.bytes` now carries the `JSValue` to unpin alongside the slice:

```zig
pub const Bytes = struct {
    slice: JSC.ZigString.Slice = .empty,
    pinned: JSC.JSValue = .zero,
};
```

`Value.deinit()` — already run via `Execute.deinit()` after `execute.write()`, inside the `MarkedArgumentBuffer` scope — calls `JSC__JSValue__unpinArrayBuffer(pinned)` and frees the dupe via `slice.deinit()`.

## Verification

`test/js/sql/sql-mysql-bind-blob-borrow.test.ts` primes the prepared-statement cache so the second call goes straight to `bindAndExecute`, then binds `[id, Uint8Array(buf), <getter>]` where the getter `transfer()`s `buf` and fills the result with `0xff` during the bind loop. It also asserts `buf` is detachable again **after** the query resolves (pin released).

Fail-before (`src/` reverted, test kept):

```
  {
    "detachableAfter": true,
    "detached": true,
-   "gotHex": "000102…3f",
-   "match": true,
+   "gotHex": "ffffff…ff",
+   "match": false,
    "originalHex": "000102…3f",
  }
(fail) mysql (local) > BLOB param backing store is pinned across the bind loop
```

Pass-after: `gotHex == originalHex`, `match: true`, `detachableAfter: true` (pin released), 5 expect() calls.
