### PR TITLE
Copy ArrayBuffer bytes for async StringOrBuffer consumers

### DIFF
--- a/src/bun.js/node/types.zig
+++ b/src/bun.js/node/types.zig
@@ -277,7 +277,16 @@ pub const StringOrBuffer = union(enum) {
                 const buffer = Buffer.fromArrayBuffer(global, value);
 
                 if (is_async) {
-                    buffer.buffer.value.protect();
+                    // The backing store of an ArrayBuffer can be detached
+                    // (e.g. via `transfer()`) or mutated by JS after this call
+                    // returns while the async work is still running on another
+                    // thread. `protect()` only prevents GC, not detachment, so
+                    // we must copy the bytes into memory we own. This matches
+                    // how Blob and String inputs are handled for async use.
+                    const bytes = buffer.slice();
+                    const owned = try allocator.dupe(u8, bytes);
+                    global.vm().reportExtraMemory(owned.len);
+                    return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
                 }
 
                 return .{ .buffer = buffer };
@@ -298,7 +307,12 @@ pub const StringOrBuffer = union(enum) {
         if (value.isCell() and value.jsType().isArrayBufferLike()) {
             const buffer = Buffer.fromArrayBuffer(global, value);
             if (is_async) {
-                buffer.buffer.value.protect();
+                // See fromJSMaybeAsync: copy so JS-side detach/mutation cannot
+                // race with the off-thread consumer.
+                const bytes = buffer.slice();
+                const owned = try allocator.dupe(u8, bytes);
+                global.vm().reportExtraMemory(owned.len);
+                return .{ .encoded_slice = jsc.ZigString.Slice.init(allocator, owned) };
             }
             return .{ .buffer = buffer };
         }

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -582,4 +582,48 @@ describe("bundler files option", () => {
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
   });
+
+  test("Uint8Array file contents are snapshotted (mutation after Bun.build does not affect build)", async () => {
+    const source = `export const MARKER = "typed-array-file-contents-are-copied";\nconsole.log(MARKER);\n`;
+    const buf = new TextEncoder().encode(source);
+
+    const promise = Bun.build({
+      entrypoints: ["/entry.js"],
+      files: { "/entry.js": buf },
+      throw: false,
+    });
+
+    // The bundler reads this file on a worker thread after Bun.build() has
+    // returned. If it kept a pointer into the live ArrayBuffer instead of
+    // copying, overwriting the bytes here would make the worker read garbage.
+    buf.fill("(".charCodeAt(0));
+
+    const result = await promise;
+    expect(result.logs.map(String)).toEqual([]);
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+    expect(output).toContain("typed-array-file-contents-are-copied");
+  });
+
+  test("ArrayBuffer file contents survive transfer() during build", async () => {
+    const source = `export const MARKER = "detached-arraybuffer-file-contents-survive";\nconsole.log(MARKER);\n`;
+    const buf = new TextEncoder().encode(source);
+
+    const promise = Bun.build({
+      entrypoints: ["/entry.js"],
+      files: { "/entry.js": buf },
+      throw: false,
+    });
+
+    // Detaching the backing store frees memory that a borrowed pointer would
+    // still reference (use-after-free on the bundler worker thread).
+    const transferred = buf.buffer.transfer();
+    new Uint8Array(transferred).fill("(".charCodeAt(0));
+
+    const result = await promise;
+    expect(result.logs.map(String)).toEqual([]);
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+    expect(output).toContain("detached-arraybuffer-file-contents-survive");
+  });
 });


### PR DESCRIPTION
## Problem

`Bun.build({ files: { '/a.js': buf } })` hands the `files` map to a bundler worker thread. When `buf` is a TypedArray/ArrayBuffer, `StringOrBuffer.fromJSMaybeAsync` (called via `FileMap.fromJS` with `is_async=true`) only `protect()`s the JSValue and caches the raw `ptr`/`byte_len`. `protect()` prevents GC but not `ArrayBuffer.prototype.transfer()` or plain mutation, so the worker can read a detached or overwritten backing store.

### Repro

```js
const buf = new TextEncoder().encode('console.log("MARKER");');
const p = Bun.build({ entrypoints: ['/a.js'], files: { '/a.js': buf } });
buf.fill('('.charCodeAt(0));       // bundler worker now reads '(((...'
await p;                            // → BuildMessage: Unexpected end of file
```

Same code path is used by `Bun.Transpiler.transform`, `Bun.zstdCompress`/`zstdDecompress`, `crypto.pbkdf2` and `crypto.scrypt`.

## Fix

When `is_async=true`, copy the ArrayBuffer bytes into an owned `.encoded_slice` instead of returning `.buffer`. This matches how the Blob path in `BlobOrStringOrBuffer.fromJSMaybeFileMaybeAsync` and the String path already behave. All affected callers only use `.slice()` + `.deinitAndUnprotect()`, both of which handle `.encoded_slice` correctly.

## Verification

```
# without fix
(fail) Uint8Array file contents are snapshotted ... → BuildMessage: Unexpected end of file

# with fix
(pass) Uint8Array file contents are snapshotted (mutation after Bun.build does not affect build)
(pass) ArrayBuffer file contents survive transfer() during build
```

Full `bundler_files.test.ts` (25 pass), `pbkdf2.test.ts` (25 pass), `zstd.test.ts` (75 pass), `transpiler-tsconfig-uaf.test.ts` (3 pass) all green.