### PR TITLE
fs.promises.cp: defer AsyncCpTask destruction until all subtasks finish

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -461,9 +461,12 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
         arena: bun.ArenaAllocator,
         tracker: jsc.Debugger.AsyncTaskTracker,
         has_result: std.atomic.Value(bool),
-        /// On each creation of a `AsyncCpSingleFileTask`, this is incremented.
-        /// When each task is finished, decrement.
-        /// The maintask thread starts this at 1 and decrements it at the end, to avoid the promise being resolved while new tasks may be added.
+        /// Number of in-flight references to `this`. Starts at 1 for the main
+        /// directory-scan task; incremented for each `SingleTask` spawned. Every
+        /// holder calls `onSubtaskDone` exactly once when finished (regardless of
+        /// success or error). `runFromJSThread` — which destroys `this` — is only
+        /// enqueued once the count reaches zero, so subtasks still running on the
+        /// thread pool never dereference a freed parent.
         subtask_count: std.atomic.Value(usize),
 
         shelltask: ShellTaskT,
@@ -496,17 +499,18 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
 
             fn workPoolCallback(task: *jsc.WorkPoolTask) void {
                 var this: *ThisSingleTask = @fieldParentPtr("task", task);
+                const parent = this.cp_task;
 
                 // TODO: error strings on node_fs will die
                 var node_fs = NodeFS{};
 
-                const args = this.cp_task.args;
+                const args = parent.args;
                 const result = node_fs._copySingleFileSync(
                     this.src,
                     this.dest,
                     @enumFromInt((if (args.flags.errorOnExist or !args.flags.force) constants.COPYFILE_EXCL else @as(u8, 0))),
                     null,
-                    this.cp_task.args,
+                    parent.args,
                 );
 
                 brk: {
@@ -515,22 +519,18 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
                             if (err.errno == @intFromEnum(E.EXIST) and !args.flags.errorOnExist) {
                                 break :brk;
                             }
-                            this.cp_task.finishConcurrently(result);
-                            this.deinit();
-                            return;
+                            parent.finishConcurrently(result);
                         },
                         .result => {
-                            this.cp_task.onCopy(this.src, this.dest);
+                            parent.onCopy(this.src, this.dest);
                         },
                     }
                 }
 
-                const old_count = this.cp_task.subtask_count.fetchSub(1, .monotonic);
-                if (old_count == 1) {
-                    this.cp_task.finishConcurrently(.success);
-                }
-
                 this.deinit();
+                // Must be the very last use of `parent`: when the count reaches
+                // zero, runFromJSThread is enqueued and may destroy the parent.
+                parent.onSubtaskDone();
             }
 
             pub fn deinit(this: *ThisSingleTask) void {
@@ -631,7 +631,11 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
             ThisAsyncCpTask.cpAsync(&node_fs, this);
         }
 
-        /// May be called from any thread (the subtasks)
+        /// May be called from any thread (the subtasks).
+        /// Records the result (first caller wins). Does NOT schedule destruction —
+        /// `runFromJSThread` is only enqueued from `onSubtaskDone` once every
+        /// in-flight subtask has dropped its reference, so that subtasks still
+        /// running on the thread pool don't dereference a freed parent.
         fn finishConcurrently(this: *ThisAsyncCpTask, result: Maybe(Return.Cp)) void {
             if (this.has_result.cmpxchgStrong(false, true, .monotonic, .monotonic)) |_| {
                 return;
@@ -641,6 +645,22 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
 
             if (this.result == .err) {
                 this.result.err = this.result.err.clone(bun.default_allocator);
+            }
+        }
+
+        /// Called exactly once by the main directory-scan task and once by each
+        /// `SingleTask` when it is done touching `this`. The last caller (count
+        /// drops to zero) enqueues `runFromJSThread`, which resolves the promise
+        /// and destroys `this`.
+        fn onSubtaskDone(this: *ThisAsyncCpTask) void {
+            const old_count = this.subtask_count.fetchSub(1, .acq_rel);
+            bun.assert(old_count > 0);
+            if (old_count != 1) return;
+
+            // All subtasks have finished. If none reported an error, the copy succeeded.
+            if (!this.has_result.load(.monotonic)) {
+                this.has_result.store(true, .monotonic);
+                this.result = .success;
             }
 
             if (this.evtloop == .js) {
@@ -706,6 +726,12 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
             nodefs: *NodeFS,
             this: *ThisAsyncCpTask,
         ) void {
+            // The directory-scan task holds one reference in `subtask_count`
+            // (initialized to 1 in create*). Drop it on return. `runFromJSThread`
+            // (which destroys `this`) is only enqueued once this reference and
+            // every spawned SingleTask's reference have been dropped.
+            defer this.onSubtaskDone();
+
             const args = this.args;
             var src_buf: bun.OSPathBuffer = undefined;
             var dest_buf: bun.OSPathBuffer = undefined;
@@ -781,11 +807,7 @@ pub fn NewAsyncCpTask(comptime is_shell: bool) type {
                 return;
             }
 
-            const success = ThisAsyncCpTask._cpAsyncDirectory(nodefs, args.flags, this, &src_buf, @intCast(src.len), &dest_buf, @intCast(dest.len));
-            const old_count = this.subtask_count.fetchSub(1, .monotonic);
-            if (success and old_count == 1) {
-                this.finishConcurrently(.success);
-            }
+            _ = ThisAsyncCpTask._cpAsyncDirectory(nodefs, args.flags, this, &src_buf, @intCast(src.len), &dest_buf, @intCast(dest.len));
         }
 
         // returns boolean `should_continue`

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -454,9 +454,9 @@ test.skipIf(!isPosix)(
   "fs.promises.cp recursive does not free parent task while subtasks are in flight after an error",
   async () => {
     const files: Record<string, string | object> = {};
-    // Plenty of readable siblings so several SingleTasks are running on the
-    // thread pool when the failing one errors.
-    for (let i = 0; i < 128; i++) files[`src/f${i}.txt`] = "x";
+    // Enough siblings so several SingleTasks are running on the thread pool
+    // when the failing one errors.
+    for (let i = 0; i < 32; i++) files[`src/f${i}.txt`] = "x";
     files["src/000-bad.txt"] = "x";
     // The destination for 000-bad.txt is a directory → copying into it fails.
     files["dst/000-bad.txt"] = { ".keep": "" };
@@ -473,7 +473,7 @@ test.skipIf(!isPosix)(
       const src = path.join(base, "src");
       const dst = path.join(base, "dst");
       (async () => {
-        for (let i = 0; i < 50; i++) {
+        for (let i = 0; i < 20; i++) {
           try {
             await fs.promises.cp(src, dst, { recursive: true });
             console.log("UNEXPECTED-SUCCESS");
@@ -499,5 +499,4 @@ test.skipIf(!isPosix)(
     expect(stdout.trim()).toBe("ok");
     expect(exitCode).toBe(0);
   },
-  60_000,
 );

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isArm64, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isArm64, isPosix, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const impls = [
@@ -437,4 +437,67 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
       expect(exitCode).toBe(0);
     });
   },
+);
+
+// fs.promises.cp recursive: when one SingleTask copy fails while siblings are
+// still in flight on the thread pool, the parent AsyncCpTask must not be
+// destroyed until every subtask has dropped its reference. Before the fix,
+// the failing subtask enqueued runFromJSThread immediately and the JS thread
+// freed the parent while other subtasks were still dereferencing it
+// (heap-use-after-free under ASAN).
+//
+// POSIX-only: uses a pre-existing directory at the destination path of one
+// file so that its SingleTask fails with EISDIR. This works even when running
+// as root. On macOS the pre-existing dst/ makes clonefile() fail with EEXIST
+// and fall through to the per-file SingleTask path being tested.
+test.skipIf(!isPosix)(
+  "fs.promises.cp recursive does not free parent task while subtasks are in flight after an error",
+  async () => {
+    const files: Record<string, string | object> = {};
+    // Plenty of readable siblings so several SingleTasks are running on the
+    // thread pool when the failing one errors.
+    for (let i = 0; i < 128; i++) files[`src/f${i}.txt`] = "x";
+    files["src/000-bad.txt"] = "x";
+    // The destination for 000-bad.txt is a directory → copying into it fails.
+    files["dst/000-bad.txt"] = { ".keep": "" };
+    using dir = tempDir("cp-uaf", files);
+    const base = String(dir);
+
+    // Run the copy in a subprocess: before the fix this is a
+    // heap-use-after-free that ASAN aborts on. The subprocess loops to make
+    // the race reliable. It must reject with EISDIR each iteration and exit 0.
+    const script = `
+      const fs = require("fs");
+      const path = require("path");
+      const base = ${JSON.stringify(base)};
+      const src = path.join(base, "src");
+      const dst = path.join(base, "dst");
+      (async () => {
+        for (let i = 0; i < 50; i++) {
+          try {
+            await fs.promises.cp(src, dst, { recursive: true });
+            console.log("UNEXPECTED-SUCCESS");
+            process.exit(1);
+          } catch (e) {
+            if (e?.code !== "EISDIR") {
+              console.log("UNEXPECTED-ERROR:" + (e?.code ?? e?.message));
+              process.exit(1);
+            }
+          }
+        }
+        console.log("ok");
+      })();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ok");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
 );


### PR DESCRIPTION
## What

Fixes a use-after-free in `fs.promises.cp(src, dest, { recursive: true })` when one file copy fails while sibling `SingleTask`s are still running on the thread pool.

## Repro

Recursive `fs.promises.cp` of a directory where copying one file fails (e.g. its destination path is already a directory → `EISDIR`) while ~100 sibling file copies are in flight. Under ASAN:

```
==4475==ERROR: AddressSanitizer: use-after-poison on address 0x79676fca08b0
WRITE of size 8 at 0x79676fca08b0 thread T22 (Bun Pool 11)
    #0 atomic.Value(usize).fetchSub
    #1 NewAsyncCpTask(false).SingleTask.workPoolCallback src/bun.js/node/node_fs.zig:528
```

## Cause

`finishConcurrently()` used the `has_result` cmpxchg only to ensure the **result** was set once, then immediately enqueued `runFromJSThread` → `deinit()` → `bun.destroy(this)`. It did not wait for `subtask_count` to reach zero, so:

- A `SingleTask` that errored called `finishConcurrently(err)` and returned **without** decrementing `subtask_count`. The JS thread then freed the parent while other `SingleTask`s were still dereferencing `cp_task->args` / `cp_task->subtask_count`.
- `cpAsync` decremented `subtask_count` after `_cpAsyncDirectory` returned an error, by which time `runFromJSThread` could already have freed `this`.

## Fix

- `finishConcurrently(result)` now only records the result (first caller wins).
- New `onSubtaskDone()` decrements `subtask_count` with `.acq_rel` ordering; only the caller that drops it to zero enqueues `runFromJSThread`. If no one recorded a result, it defaults to `.success`.
- `cpAsync` drops its initial reference via `defer this.onSubtaskDone()`, covering every early return (Windows, non-directory, EISDIR, and the recursive path).
- `SingleTask.workPoolCallback` always ends with `this.deinit(); parent.onSubtaskDone();` on both success and error paths.

This matches the pattern already used by `AsyncReaddirRecursiveTask`.

## Verification

New test in `test/js/node/fs/cp.test.ts` creates a source dir with 128 files plus one whose destination is a pre-existing directory, and runs `fs.promises.cp` 50× in a subprocess.

- **Without fix** (`git stash -- src/ && bun bd test`): subprocess aborts with the ASAN `use-after-poison` shown above → test fails.
- **With fix** (`bun bd test`): subprocess rejects with `EISDIR` every iteration, exits 0 → test passes.
- Full `cp.test.ts` suite: 38 pass, 3 skip (Windows-only), 0 fail.
- `zig:check-all` passes on all targets.