### PR TITLE
AsyncModule: clone specifier/source_url so SourceProvider owns them

### DIFF
--- a/src/bun.js/AsyncModule.zig
+++ b/src/bun.js/AsyncModule.zig
@@ -703,7 +703,9 @@ pub const AsyncModule = struct {
         }
 
         if (jsc_vm.isWatcherEnabled()) {
-            var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.init(specifier), path.text, null, false);
+            // specifier and path.text borrow this.string_buf; clone so the
+            // SourceProvider owns them after deinit() frees string_buf.
+            var resolved_source = jsc_vm.refCountedResolvedSource(printer.ctx.written, bun.String.cloneUTF8(specifier), path.text, null, false);
 
             if (parse_result.input_fd) |fd_| {
                 if (std.fs.path.isAbsolute(path.text) and !strings.contains(path.text, "node_modules")) {
@@ -724,11 +726,16 @@ pub const AsyncModule = struct {
             return resolved_source;
         }
 
+        // specifier and path.text are slices into this.string_buf which is
+        // freed in deinit() right after Bun__onFulfillAsyncModule returns.
+        // Zig::SourceProvider::create wraps source_url with
+        // StringImpl::createWithoutCopying when given a ZigString, so the
+        // SourceProvider must own these strings (clone into WTFStringImpl).
         return ResolvedSource{
             .allocator = null,
             .source_code = bun.String.cloneLatin1(printer.ctx.getWritten()),
-            .specifier = String.init(specifier),
-            .source_url = String.init(path.text),
+            .specifier = bun.String.cloneUTF8(specifier),
+            .source_url = bun.String.cloneUTF8(path.text),
             .is_commonjs_module = parse_result.ast.has_commonjs_export_names or parse_result.ast.exports_kind == .cjs,
         };
     }


### PR DESCRIPTION
## Problem

`AsyncModule.resumeLoadingModule` builds a `ResolvedSource` with

```zig
.specifier = String.init(specifier),
.source_url = String.init(path.text),
```

Both `specifier` and `path.text` are slices into `this.string_buf` (allocated in `AsyncModule.init`). `Zig::SourceProvider::create` then calls `resolvedSource.source_url.toWTFString(BunString::ZeroCopy)` which, for a non-UTF8-tagged `ZigString`, reaches `Zig::toString` → `WTF::StringImpl::createWithoutCopying` over those bytes and stores the result as the provider's `sourceURL` (and copies the whole `ResolvedSource` into `m_resolvedSource`).

After `Bun__onFulfillAsyncModule` returns, `onDone()` calls `this.deinit()` which frees `string_buf`. The `SourceProvider`'s `m_sourceURL` now points at freed memory; any later read (error stack trace, source map lookup, `sourceURL()`) is a use-after-free.

## Fix

Use `bun.String.cloneUTF8(...)` so the strings are owned `WTFStringImpl`s that outlive `string_buf`. This matches what `ModuleLoader.zig` already does via `input_specifier.createIfDifferent(path.text)`.

Both return sites in `resumeLoadingModule` (watcher and non-watcher) are covered.

## Why no regression test

`resumeLoadingModule` is gated on `parse_result.pending_imports.len > 0` in `ModuleLoader.zig`, but nothing in the tree ever appends to `pending_imports` — the only `result.pending_imports.append()` was commented out in 57a06745a4 (#4468, Sep 2023) and deleted in 483302d09d (#17883, Mar 2025). Runtime auto-install today blocks the resolver synchronously and never enqueues an `AsyncModule`.

So this function is currently unreachable from user input and a black-box test can't exercise it. The change is defensive: it removes a latent UAF so that re-enabling the async-install path doesn't reintroduce it. `bun run zig:check` passes; no behavior change on any reachable path.