### PR TITLE
sql(postgres): validate server-provided len in binary int4[]/float4[] parsing

### DIFF
--- a/src/sql/postgres/DataCell.zig
+++ b/src/sql/postgres/DataCell.zig
@@ -496,6 +496,26 @@ pub fn fromBytes(binary: bool, bigint: bool, oid: types.Tag, bytes: []const u8, 
                     };
                 }
 
+                // dimensions == 1 here. The 1-D binary array header is 20 bytes:
+                // ndim(4) + flags(4) + elemtype(4) + len(4) + lbound(4), followed by
+                // `len` elements each prefixed by a 4-byte length. `len` is
+                // server-controlled, so validate it against bytes.len before
+                // slice() iterates to avoid reading/writing past the buffer.
+                if (bytes.len < 20) {
+                    return error.InvalidBinaryData;
+                }
+                const array_len: i32 = @byteSwap(@as(i32, @bitCast(bytes[12..16].*)));
+                if (array_len < 0) {
+                    return error.InvalidBinaryData;
+                }
+                // slice() consumes 2 * @sizeOf(element) bytes per element (the
+                // 4-byte length prefix + the 4-byte value for int4/float4).
+                const element_stride: usize = @sizeOf(try tag.byteArrayType()) * 2;
+                const max_elements = (bytes.len - 20) / element_stride;
+                if (@as(usize, @intCast(array_len)) > max_elements) {
+                    return error.InvalidBinaryData;
+                }
+
                 const elements = (try tag.pgArrayType()).init(bytes).slice();
 
                 return SQLDataCell{

--- a/src/sql/postgres/types/Tag.zig
+++ b/src/sql/postgres/types/Tag.zig
@@ -206,7 +206,9 @@ pub const Tag = enum(short) {
             first_value: T,
 
             pub fn slice(this: *@This()) []T {
-                if (this.len == 0) return &.{};
+                // `len` is server-controlled; callers must validate it against
+                // the backing buffer length before calling this.
+                if (this.len <= 0) return &.{};
 
                 var head = @as([*]T, @ptrCast(&this.first_value));
                 var current = head;

--- a/test/js/sql/postgres-binary-array-bounds.test.ts
+++ b/test/js/sql/postgres-binary-array-bounds.test.ts
@@ -52,8 +52,20 @@ function dataRowRaw(cols: Buffer[]): Buffer {
 }
 
 // Binary int4[] header: ndim, flags, elemtype, [len, lbound] per dim, then elements.
-function binaryArrayHeader(opts: { ndim: number; flags: number; elemtype: number; len: number; lbound: number }): Buffer {
-  return Buffer.concat([int32(opts.ndim), int32(opts.flags), int32(opts.elemtype), int32(opts.len), int32(opts.lbound)]);
+function binaryArrayHeader(opts: {
+  ndim: number;
+  flags: number;
+  elemtype: number;
+  len: number;
+  lbound: number;
+}): Buffer {
+  return Buffer.concat([
+    int32(opts.ndim),
+    int32(opts.flags),
+    int32(opts.elemtype),
+    int32(opts.len),
+    int32(opts.lbound),
+  ]);
 }
 
 const authenticationOk = pkt("R", int32(0));

--- a/test/js/sql/postgres-binary-array-bounds.test.ts
+++ b/test/js/sql/postgres-binary-array-bounds.test.ts
@@ -121,80 +121,50 @@ const FLOAT4_ARRAY = 1021;
 const INT4 = 23;
 const FLOAT4 = 700;
 
-test("binary int4[] with len exceeding column bytes is rejected", async () => {
-  // 20-byte header claims 65536 elements but provides none.
-  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 });
-  expect(col.length).toBe(20);
-  let err: any;
-  try {
-    await runMockQuery(col, INT4_ARRAY);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeDefined();
-  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
-});
+const malformed: { name: string; oid: number; col: Buffer }[] = [
+  {
+    // 20-byte header claims 65536 elements but provides none.
+    name: "int4[] with len exceeding column bytes",
+    oid: INT4_ARRAY,
+    col: binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 }),
+  },
+  {
+    // Header claims 65536 elements but only 1 element worth of bytes follows.
+    name: "int4[] with len exceeding column bytes (partial data)",
+    oid: INT4_ARRAY,
+    col: Buffer.concat([
+      binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 }),
+      int32(4),
+      int32(42),
+    ]),
+  },
+  {
+    name: "int4[] with negative len",
+    oid: INT4_ARRAY,
+    col: binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: -1, lbound: 1 }),
+  },
+  {
+    // Only 16 bytes: ndim, flags, elemtype, len — missing lbound.
+    name: "int4[] with ndim=1 but truncated header",
+    oid: INT4_ARRAY,
+    col: Buffer.concat([int32(1), int32(0), int32(INT4), int32(1)]),
+  },
+  {
+    name: "int4[] with len = INT32_MAX",
+    oid: INT4_ARRAY,
+    col: binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 0x7fffffff, lbound: 1 }),
+  },
+  {
+    name: "float4[] with len exceeding column bytes",
+    oid: FLOAT4_ARRAY,
+    col: binaryArrayHeader({ ndim: 1, flags: 0, elemtype: FLOAT4, len: 1 << 20, lbound: 1 }),
+  },
+];
 
-test("binary int4[] with len exceeding column bytes (with partial data) is rejected", async () => {
-  // Header claims 65536 elements but only 1 element worth of bytes follows.
-  const col = Buffer.concat([
-    binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 }),
-    int32(4), // element length prefix
-    int32(42), // element value
-  ]);
+test.each(malformed)("binary $name is rejected", async ({ oid, col }) => {
   let err: any;
   try {
-    await runMockQuery(col, INT4_ARRAY);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeDefined();
-  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
-});
-
-test("binary int4[] with negative len is rejected", async () => {
-  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: -1, lbound: 1 });
-  let err: any;
-  try {
-    await runMockQuery(col, INT4_ARRAY);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeDefined();
-  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
-});
-
-test("binary int4[] with ndim=1 but truncated header is rejected", async () => {
-  // Only 16 bytes: ndim, flags, elemtype, len — missing lbound.
-  const col = Buffer.concat([int32(1), int32(0), int32(INT4), int32(1)]);
-  expect(col.length).toBe(16);
-  let err: any;
-  try {
-    await runMockQuery(col, INT4_ARRAY);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeDefined();
-  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
-});
-
-test("binary float4[] with len exceeding column bytes is rejected", async () => {
-  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: FLOAT4, len: 1 << 20, lbound: 1 });
-  let err: any;
-  try {
-    await runMockQuery(col, FLOAT4_ARRAY);
-  } catch (e) {
-    err = e;
-  }
-  expect(err).toBeDefined();
-  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
-});
-
-test("binary int4[] with len = INT32_MAX is rejected", async () => {
-  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 0x7fffffff, lbound: 1 });
-  let err: any;
-  try {
-    await runMockQuery(col, INT4_ARRAY);
+    await runMockQuery(col, oid);
   } catch (e) {
     err = e;
   }

--- a/test/js/sql/postgres-binary-array-bounds.test.ts
+++ b/test/js/sql/postgres-binary-array-bounds.test.ts
@@ -1,0 +1,205 @@
+// A malicious or buggy Postgres server can send a binary-format int4[]/float4[]
+// DataRow whose header `len` field exceeds the actual column byte length.
+// The binary array parser must validate `len` against the column's byte length
+// before iterating; otherwise slice() reads and writes past the read buffer.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import net from "net";
+
+function pkt(type: string, body: Buffer): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0);
+  header.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([header, body]);
+}
+
+function int16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeInt16BE(n, 0);
+  return b;
+}
+
+function int32(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeInt32BE(n, 0);
+  return b;
+}
+
+function cstr(s: string): Buffer {
+  return Buffer.concat([Buffer.from(s), Buffer.from([0])]);
+}
+
+function rowDescription(cols: { name: string; oid: number; format: number }[]): Buffer {
+  const fields = Buffer.concat(
+    cols.map(c =>
+      Buffer.concat([
+        cstr(c.name),
+        int32(0), // table oid
+        int16(0), // column attr number
+        int32(c.oid), // type oid
+        int16(-1), // type size
+        int32(-1), // type modifier
+        int16(c.format), // format: 0=text, 1=binary
+      ]),
+    ),
+  );
+  return pkt("T", Buffer.concat([int16(cols.length), fields]));
+}
+
+function dataRowRaw(cols: Buffer[]): Buffer {
+  const body = Buffer.concat(cols.map(c => Buffer.concat([int32(c.length), c])));
+  return pkt("D", Buffer.concat([int16(cols.length), body]));
+}
+
+// Binary int4[] header: ndim, flags, elemtype, [len, lbound] per dim, then elements.
+function binaryArrayHeader(opts: { ndim: number; flags: number; elemtype: number; len: number; lbound: number }): Buffer {
+  return Buffer.concat([int32(opts.ndim), int32(opts.flags), int32(opts.elemtype), int32(opts.len), int32(opts.lbound)]);
+}
+
+const authenticationOk = pkt("R", int32(0));
+const readyForQuery = pkt("Z", Buffer.from("I"));
+const commandComplete = (tag: string) => pkt("C", cstr(tag));
+
+async function runMockQuery(columnBytes: Buffer, typeOid: number): Promise<unknown> {
+  const server = net.createServer(socket => {
+    let startup = true;
+    socket.on("data", data => {
+      if (startup) {
+        startup = false;
+        socket.write(Buffer.concat([authenticationOk, readyForQuery]));
+        return;
+      }
+      if (data[0] !== 0x51 /* 'Q' */) return;
+      // Column name length is chosen so the column payload lands on a
+      // 4-byte boundary within the response buffer; this lets the
+      // unpatched parser reach slice() (the actual overflow) instead of
+      // tripping the debug-only @alignCast in init() first.
+      socket.write(
+        Buffer.concat([
+          rowDescription([{ name: "arr", oid: typeOid, format: 1 /* binary */ }]),
+          dataRowRaw([columnBytes]),
+          commandComplete("SELECT 1"),
+          readyForQuery,
+        ]),
+      );
+    });
+    socket.on("error", () => {});
+  });
+
+  await new Promise<void>(r => server.listen(0, "127.0.0.1", () => r()));
+  const port = (server.address() as net.AddressInfo).port;
+
+  const sql = new SQL({
+    url: `postgres://u@127.0.0.1:${port}/db`,
+    max: 1,
+    idleTimeout: 5,
+    connectionTimeout: 5,
+  });
+
+  try {
+    return await sql`select x`.simple();
+  } finally {
+    await sql.close().catch(() => {});
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+const INT4_ARRAY = 1007;
+const FLOAT4_ARRAY = 1021;
+const INT4 = 23;
+const FLOAT4 = 700;
+
+test("binary int4[] with len exceeding column bytes is rejected", async () => {
+  // 20-byte header claims 65536 elements but provides none.
+  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 });
+  expect(col.length).toBe(20);
+  let err: any;
+  try {
+    await runMockQuery(col, INT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("binary int4[] with len exceeding column bytes (with partial data) is rejected", async () => {
+  // Header claims 65536 elements but only 1 element worth of bytes follows.
+  const col = Buffer.concat([
+    binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 65536, lbound: 1 }),
+    int32(4), // element length prefix
+    int32(42), // element value
+  ]);
+  let err: any;
+  try {
+    await runMockQuery(col, INT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("binary int4[] with negative len is rejected", async () => {
+  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: -1, lbound: 1 });
+  let err: any;
+  try {
+    await runMockQuery(col, INT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("binary int4[] with ndim=1 but truncated header is rejected", async () => {
+  // Only 16 bytes: ndim, flags, elemtype, len — missing lbound.
+  const col = Buffer.concat([int32(1), int32(0), int32(INT4), int32(1)]);
+  expect(col.length).toBe(16);
+  let err: any;
+  try {
+    await runMockQuery(col, INT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("binary float4[] with len exceeding column bytes is rejected", async () => {
+  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: FLOAT4, len: 1 << 20, lbound: 1 });
+  let err: any;
+  try {
+    await runMockQuery(col, FLOAT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("binary int4[] with len = INT32_MAX is rejected", async () => {
+  const col = binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 0x7fffffff, lbound: 1 });
+  let err: any;
+  try {
+    await runMockQuery(col, INT4_ARRAY);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err?.code ?? err?.message).toMatch(/ERR_POSTGRES_INVALID_BINARY_DATA|InvalidBinaryData/);
+});
+
+test("well-formed binary int4[] still parses", async () => {
+  const col = Buffer.concat([
+    binaryArrayHeader({ ndim: 1, flags: 0, elemtype: INT4, len: 3, lbound: 1 }),
+    int32(4),
+    int32(1),
+    int32(4),
+    int32(2),
+    int32(4),
+    int32(3),
+  ]);
+  const result: any = await runMockQuery(col, INT4_ARRAY);
+  expect(result[0].arr).toEqual(new Int32Array([1, 2, 3]));
+});


### PR DESCRIPTION
## What

Bounds-check the server-provided `len` field when parsing binary-format `int4[]` / `float4[]` DataRow columns.

## Why

`DataCell.fromBytes` only checked `bytes.len < 12` before calling `PostgresBinarySingleDimensionArray.init(bytes).slice()`. `slice()` then iterated `this.len` (a server-controlled signed `i32`) times, reading **and writing** `head[i]` with no check that `20 + len * 8 <= bytes.len`. A malicious or buggy server sending a 20-byte column with `len = 65536` causes reads/writes past the connection's receive buffer. In ReleaseFast this is a heap write primitive; under ASAN it's a heap-buffer-overflow.

## How

Before calling `init()`/`slice()`:
- require `bytes.len >= 20` (the full 1-D header: ndim + flags + elemtype + len + lbound)
- require `len >= 0`
- require `len <= (bytes.len - 20) / (2 * @sizeOf(T))` (each element is a 4-byte length prefix + a 4-byte value)

Malformed input now returns `ERR_POSTGRES_INVALID_BINARY_DATA`. Also changed `slice()`'s early-return from `len == 0` to `len <= 0` as defense-in-depth.

## Verification

`test/js/sql/postgres-binary-array-bounds.test.ts` spins up a mock Postgres server that sends a binary `int4[]` column with `len` far exceeding the column bytes.

Without the fix (`git stash push -- src/ && bun bd test ...`):
```
==5186==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b03f0921840
READ of size 4 at 0x7b03f0921840 thread T0
    #0 ... sql.postgres.types.Tag.Tag.PostgresBinarySingleDimensionArray(i32).slice ... Tag.zig:218:40
0x7b03f0921840 is located 0 bytes after 524352-byte region
```

With the fix: all 7 tests pass (6 malformed-input cases + 1 well-formed round-trip).