### PR TITLE
MarkedArrayBuffer.destroy: don't free the struct itself

### DIFF
--- a/src/bun.js/jsc/array_buffer.zig
+++ b/src/bun.js/jsc/array_buffer.zig
@@ -587,20 +587,15 @@ pub const MarkedArrayBuffer = struct {
         return this.buffer.byteSlice();
     }
 
+    /// Releases the owned byte buffer if this `MarkedArrayBuffer` was created with an
+    /// allocator (e.g. via `fromString`/`fromBytes`). Does not free the struct itself;
+    /// `MarkedArrayBuffer` is passed and stored by value, so callers own its storage.
     pub fn destroy(this: *MarkedArrayBuffer) void {
         const content = this.*;
         if (this.allocator) |allocator| {
             this.allocator = null;
             allocator.free(content.buffer.slice());
-            allocator.destroy(this);
         }
-    }
-
-    pub fn init(allocator: std.mem.Allocator, size: u32, typed_array_type: jsc.JSValue.JSType) !*MarkedArrayBuffer {
-        const bytes = try allocator.alloc(u8, size);
-        const container = try allocator.create(MarkedArrayBuffer);
-        container.* = MarkedArrayBuffer.fromBytes(bytes, allocator, typed_array_type);
-        return container;
     }
 
     pub fn toNodeBuffer(this: *const MarkedArrayBuffer, ctx: *jsc.JSGlobalObject) jsc.JSValue {

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4562,7 +4562,11 @@ pub const NodeFS = struct {
                             item.deref();
                         },
                         Buffer => {
-                            item.destroy();
+                            // The MarkedArrayBuffer struct is stored by-value in `entries.items`,
+                            // so only free the owned byte slice. `item.destroy()` would attempt
+                            // `allocator.destroy(item)` on an interior ArrayList pointer, corrupting
+                            // the heap (and for index 0, double-freeing `entries.items.ptr`).
+                            bun.default_allocator.free(item.buffer.byteSlice());
                         },
                         bun.String => {
                             item.deref();
@@ -5010,7 +5014,11 @@ pub const NodeFS = struct {
                                 result.name.deref();
                             },
                             Buffer => {
-                                result.destroy();
+                                // The MarkedArrayBuffer struct is stored by-value in `entries.items`,
+                                // so only free the owned byte slice. `result.destroy()` would attempt
+                                // `allocator.destroy(result)` on an interior ArrayList pointer, corrupting
+                                // the heap (and for index 0, double-freeing `entries.items.ptr`).
+                                bun.default_allocator.free(result.buffer.byteSlice());
                             },
                             bun.String => {
                                 result.deref();

--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -4562,11 +4562,7 @@ pub const NodeFS = struct {
                             item.deref();
                         },
                         Buffer => {
-                            // The MarkedArrayBuffer struct is stored by-value in `entries.items`,
-                            // so only free the owned byte slice. `item.destroy()` would attempt
-                            // `allocator.destroy(item)` on an interior ArrayList pointer, corrupting
-                            // the heap (and for index 0, double-freeing `entries.items.ptr`).
-                            bun.default_allocator.free(item.buffer.byteSlice());
+                            item.destroy();
                         },
                         bun.String => {
                             item.deref();
@@ -5011,14 +5007,10 @@ pub const NodeFS = struct {
                     for (entries.items) |*result| {
                         switch (ExpectedType) {
                             bun.jsc.Node.Dirent => {
-                                result.name.deref();
+                                result.deref();
                             },
                             Buffer => {
-                                // The MarkedArrayBuffer struct is stored by-value in `entries.items`,
-                                // so only free the owned byte slice. `result.destroy()` would attempt
-                                // `allocator.destroy(result)` on an interior ArrayList pointer, corrupting
-                                // the heap (and for index 0, double-freeing `entries.items.ptr`).
-                                bun.default_allocator.free(result.buffer.byteSlice());
+                                result.destroy();
                             },
                             bun.String => {
                                 result.deref();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1178,6 +1178,58 @@ it("readdirSync throws when given a file path with trailing slash", () => {
   }
 });
 
+// The error cleanup path previously called MarkedArrayBuffer.destroy() on
+// structs stored by-value inside the entries ArrayList, which passed interior
+// ArrayList pointers to the allocator (freeing entries.items.ptr for index 0 and
+// then freeing it again in entries.deinit()). A self-referential symlink makes
+// the recursive walk fail with ELOOP after entries have been collected, exercising
+// that cleanup path.
+it.skipIf(isWindows)(
+  "readdirSync({encoding: 'buffer', recursive: true}) frees entries safely when a subdir fails to open",
+  async () => {
+    using dir = tempDir("readdir-buffer-error", {
+      "a.txt": "a",
+      "b.txt": "b",
+      "c.txt": "c",
+    });
+    fs.symlinkSync("loop", join(String(dir), "loop"));
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          let code;
+          for (let i = 0; i < 2; i++) {
+            try {
+              fs.readdirSync(${JSON.stringify(String(dir))}, { encoding: "buffer", recursive: true });
+              throw new Error("expected readdirSync to throw");
+            } catch (e) {
+              code = e.code;
+            }
+          }
+          console.log(code);
+        `,
+      ],
+      // Disable symbolization so an ASAN abort exits promptly instead of spending
+      // seconds in llvm-symbolizer against the large debug binary.
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allow_user_segv_handler=1", "symbolize=0", "abort_on_error=1"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ELOOP", exitCode: 0 });
+  },
+);
+
 describe("readSync", () => {
   const firstFourBytes = new Uint32Array(new TextEncoder().encode("File").buffer)[0];
 


### PR DESCRIPTION
## Problem

`MarkedArrayBuffer.destroy()` did two things:
```zig
allocator.free(content.buffer.slice()); // free the bytes
allocator.destroy(this);                 // free *this
```

Every constructor that is actually used (`fromString`, `fromBytes`, `fromJS`, `fromTypedArray`, `fromArrayBuffer`) returns `MarkedArrayBuffer` **by value**, so `this` is never an individually heap-allocated struct — it's a stack local, an embedded field, or an ArrayList slot. The `allocator.destroy(this)` call passes that interior pointer to mimalloc.

In the readdir Buffer error-cleanup path (`readdirWithEntries` / `readdirInner`), entries are appended by value via `Buffer.fromString()`:
- `allocator.destroy(&entries.items[0])` frees `entries.items.ptr`
- the next loop iteration reads `this.*` from poisoned memory
- `entries.deinit()` frees the same pointer again

## Repro

```js
const fs = require('fs');
// dir contains regular files + a self-referential symlink 'loop -> loop'
fs.readdirSync(dir, { encoding: 'buffer', recursive: true });
```

The recursive walk collects Buffer entries for the root, then fails with `ELOOP` opening the symlink (not in the swallowed `NOENT/NOTDIR/PERM` set), and enters the cleanup loop. Under ASAN:

```
==3593==ERROR: AddressSanitizer: use-after-poison on address 0x737ec6e50040
READ of size 64 at 0x737ec6e50040 thread T0
    #1 MarkedArrayBuffer.destroy          array_buffer.zig:591
    #2 NodeFS.readdirInner                node_fs.zig:5013
    #3 NodeFS.readdir                     node_fs.zig:4518
```

## Fix

- Drop `allocator.destroy(this)` from `MarkedArrayBuffer.destroy()`. The struct is passed/stored by value; callers own its storage.
- Remove the unused `MarkedArrayBuffer.init()` (the only function that heap-allocated the struct, zero callers) so there's no pairing that would leak.
- The readdir call sites keep calling `.destroy()`, which still checks `this.allocator` before freeing bytes — JS-owned buffers remain untouched.

Also fixed the adjacent `Dirent` arm of the recursive-sync error cleanup: `result.name.deref()` → `result.deref()` so `Dirent.path` is released too (matching the non-recursive and async cleanup sites).

## Verification

New test in `test/js/node/fs/fs.test.ts` creates a temp dir with files + a self-referential symlink, spawns a subprocess that calls `readdirSync({encoding:'buffer', recursive:true})`, and asserts it throws `ELOOP` and exits 0.

```
# without fix
(fail) readdirSync({encoding: 'buffer', recursive: true}) frees entries safely ...
  { exitCode: 134, stdout: "" }  # SIGABRT from ASAN

# with fix
(pass) readdirSync({encoding: 'buffer', recursive: true}) frees entries safely ... [1.5s]
  { exitCode: 0, stdout: "ELOOP" }
```

`zig:check-all` passes on all targets.
