### PR TITLE
fs: deref Dirent.path in readdirSync recursive error cleanup

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -5007,7 +5007,7 @@ pub const NodeFS = struct {
                     for (entries.items) |*result| {
                         switch (ExpectedType) {
                             bun.jsc.Node.Dirent => {
-                                result.name.deref();
+                                result.deref();
                             },
                             Buffer => {
                                 result.destroy();

--- a/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
+++ b/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
@@ -1,0 +1,81 @@
+// When readdirSync({ recursive: true, withFileTypes: true }) fails partway through
+// (e.g. a subdirectory can't be opened), the already-collected Dirent entries must
+// be fully released. Each Dirent owns a ref to both .name and .path; previously
+// only .name was dereferenced on the sync error path, leaking the .path string.
+//
+// This fixture builds a wide, shallow tree under a long path, with a
+// self-referential symlink two levels deep. The recursive walker is
+// breadth-first, so every depth-1 directory is fully scanned (allocating
+// distinct Dirent.path strings) before the depth-2 symlink is opened and fails
+// with ELOOP. It repeats the failing readdirSync many times and asserts RSS
+// growth between a warmed-up baseline and the end of the run stays bounded.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const seg = (ch, n = 220) => Buffer.alloc(n, ch).toString();
+
+const base = fs.mkdtempSync(path.join(os.tmpdir(), "readdir-err-leak-"));
+const root = path.join(base, seg("r"));
+fs.mkdirSync(root);
+
+for (let i = 0; i < 4; i++) fs.writeFileSync(path.join(root, "f" + i), "x");
+
+// Eight subdirectories with long names. Each one visited before the error
+// contributes a distinct ~500-byte Dirent.path string.
+const subdirs = [];
+for (let i = 0; i < 8; i++) {
+  const d = path.join(root, seg(String.fromCharCode(97 + i)));
+  fs.mkdirSync(d);
+  for (let j = 0; j < 2; j++) fs.writeFileSync(path.join(d, "f" + j), "x");
+  subdirs.push(d);
+}
+
+// Self-referential symlink at depth 2. Opened last (BFS), yields ELOOP, which
+// is not in the silently-skipped set (NOENT/NOTDIR/PERM) and so propagates as
+// an error after all the Dirents above have been collected.
+const loop = path.join(subdirs[0], "zzloop");
+fs.symlinkSync("zzloop", loop);
+
+// Sanity: confirm the error path actually fires.
+let threw = false;
+try {
+  fs.readdirSync(root, { recursive: true, withFileTypes: true });
+} catch {
+  threw = true;
+}
+if (!threw) throw new Error("expected readdirSync to throw (symlink loop not triggering error path)");
+
+// Warmup: saturate allocator working set / ASAN quarantine so the baseline
+// measurement is taken after steady state is reached.
+for (let i = 0; i < 10000; i++) {
+  try {
+    fs.readdirSync(root, { recursive: true, withFileTypes: true });
+  } catch {}
+}
+Bun.gc(true);
+const before = process.memoryUsage.rss();
+
+for (let i = 0; i < 20000; i++) {
+  try {
+    fs.readdirSync(root, { recursive: true, withFileTypes: true });
+  } catch {}
+}
+Bun.gc(true);
+const after = process.memoryUsage.rss();
+
+const deltaMB = Math.round((after - before) / 1024 / 1024);
+console.log("RSS delta", deltaMB, "MB");
+
+try {
+  fs.rmSync(base, { recursive: true, force: true });
+} catch {}
+
+// With the leak, each failing call retains ~9 path strings (~5 KB). 20k
+// iterations is ~100+ MB of unreclaimable growth on top of the warmed-up
+// baseline (observed: ~124-130 MB). Without the leak the delta is allocator /
+// ASAN-quarantine noise (observed: ~26 MB in debug+ASAN, ~0 in release).
+if (deltaMB > 64) {
+  throw new Error("Dirent.path leak: RSS grew " + deltaMB + " MB over 20000 failing readdirSync calls");
+}

--- a/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
+++ b/test/js/node/fs/readdirSync-recursive-error-leak.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+import path from "path";
+
+// Windows: self-referential symlinks behave differently and the recursive
+// walker takes a different open path there; this leak is posix-specific.
+test.skipIf(isWindows)(
+  "readdirSync({recursive:true, withFileTypes:true}) error path does not leak Dirent.path",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "readdirSync-recursive-error-leak-fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("RSS delta");
+    expect(exitCode).toBe(0);
+  },
+  90_000,
+);


### PR DESCRIPTION
## What

When `fs.readdirSync(dir, { recursive: true, withFileTypes: true })` fails partway through (e.g. a subdirectory returns `ELOOP`/`EACCES` on open), the error-path cleanup in `readdirInner` was only calling `result.name.deref()` on each collected `Dirent`, leaking the ref on `Dirent.path` that was taken via `dirent_path_prev.ref()` in `readdirWithEntriesRecursiveSync`.

The async recursive path (`AsyncReaddirRecursiveTask.performWork`) and the non-recursive path (`readdirWithEntries`) already call `Dirent.deref()` which releases both `name` and `path`. This brings the sync-recursive error path in line.

## Repro

```js
const fs = require('fs');
// dir contains a self-referential symlink at depth 2, so the BFS walker
// collects a bunch of Dirents before hitting ELOOP and unwinding.
for (let i = 0; i < 30000; i++) {
  try { fs.readdirSync(dir, { recursive: true, withFileTypes: true }); } catch {}
}
// RSS grows linearly with iteration count
```

## Verification

The new test builds a wide tree under a long path with a symlink loop at depth 2, warms up to saturate ASAN quarantine, then runs 20k failing `readdirSync` calls and asserts RSS growth stays under 64 MB.

| build | RSS delta (20k iters after 10k warmup) |
|---|---|
| before fix (debug+ASAN) | ~130 MB |
| before fix (release) | ~124 MB |
| after fix (debug+ASAN) | ~26 MB |
