### PR TITLE
socket: balance ref on synchronous doConnect failure for reused sockets

### DIFF
--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -851,7 +851,12 @@ pub fn connectInner(globalObject: *jsc.JSGlobalObject, prev_maybe_tcp: ?*TCPSock
             socket.flags.allow_half_open = socket_config.allowHalfOpen;
             socket.doConnect(connection) catch {
                 socket.handleConnectError(@intFromEnum(if (port == null) bun.sys.SystemErrno.ENOENT else bun.sys.SystemErrno.ECONNREFUSED)) catch {};
-                if (maybe_previous == null) socket.deref();
+                // Balance the unconditional `socket.ref()` above. `handleConnectError`
+                // only derefs when the socket was attached (`needs_deref`), which is
+                // never true on this synchronous-failure path — the socket is still
+                // `.detached`. This applies to reused (`prev`) sockets as well; the
+                // guard that skipped them leaked one ref per failed reconnect.
+                socket.deref();
                 return promise_value;
             };
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -674,6 +674,7 @@ it.skipIf(isWindows)(
     // string.
     const script = `
       const net = require("node:net");
+      const { heapStats } = require("bun:jsc");
       const path = "/tmp/bun-test-nonexistent-" + process.pid + ".sock";
 
       function once() {
@@ -691,22 +692,25 @@ it.skipIf(isWindows)(
           await Promise.all(batch);
         }
         Bun.gc(true);
-        await Bun.sleep(10);
+        await Bun.sleep(20);
         Bun.gc(true);
       }
 
-      // Sample RSS after equal-sized work units. A real per-iteration leak
-      // grows linearly with the sample index; allocator/GC noise plateaus.
-      const samples = [];
-      for (let i = 0; i < 8; i++) {
-        await run(2500);
-        samples.push(process.memoryUsage.rss());
+      // Count live mimalloc pages across all size bins. Each leaked
+      // TCPSocket struct is ~300-400 bytes; 8k of them fill ~25 pages
+      // (release) / ~160 pages (debug+ASAN). Unlike RSS this is the
+      // allocator's own bookkeeping, so it's independent of OS page
+      // reclamation and JSC heap oscillation — same result on every
+      // platform, every run.
+      function pageCount() {
+        return heapStats().mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
       }
-      // Discard first two as warmup; compare the last sample against the
-      // first steady-state sample.
-      const base = samples[2];
-      const last = samples[samples.length - 1];
-      console.log(JSON.stringify({ samples, delta: last - base }));
+
+      await run(2000);
+      const before = pageCount();
+      await run(8000);
+      const after = pageCount();
+      console.log(JSON.stringify({ before, after, delta: after - before }));
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
@@ -716,12 +720,11 @@ it.skipIf(isWindows)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    const { delta, samples } = JSON.parse(stdout.trim().split("\n").pop()!);
-    // 12.5k post-warmup iterations leak ~4 MB on release / ~15 MB on
-    // debug+ASAN when the ref is not balanced. With the fix, delta is
-    // allocator noise (±1 MB).
-    expect(delta, `RSS samples (bytes): ${JSON.stringify(samples)}`).toBeLessThan(3 * 1024 * 1024);
+    const { before, after, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
+    // Without the balancing deref: +25 pages (release) / +163 pages
+    // (debug+ASAN). With it: 0 ± 2. The threshold sits well clear of both.
+    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(10);
     expect(exitCode).toBe(0);
   },
-  120_000,
+  60_000,
 );

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -656,3 +656,72 @@ it.if(isWindows)(
   },
   20_000,
 );
+
+// On Windows, unix paths route through the named-pipe codepath which reports
+// failure asynchronously; this test targets the synchronous-failure branch in
+// Listener.connectInner.
+it.skipIf(isWindows)(
+  "should not leak when connect({path}) fails synchronously on a reused handle",
+  async () => {
+    // node:net creates a detached native socket (`_handle`) and passes it as
+    // `prev` to connectInner. connectInner unconditionally `socket.ref()`s
+    // before `doConnect`. A nonexistent unix path makes `doConnect` throw
+    // synchronously while the socket is still `.detached`, so
+    // `handleConnectError`'s own deref (gated on `!isDetached()`) does not
+    // fire — the ref taken here must be released by the caller for reused
+    // sockets too, not only freshly-allocated ones. Without that, every
+    // failed reconnect leaks one native TCPSocket struct + its connection
+    // string.
+    const script = `
+      const net = require("node:net");
+      const path = "/tmp/bun-test-nonexistent-" + process.pid + ".sock";
+
+      function once() {
+        return new Promise(resolve => {
+          const s = new net.Socket();
+          s.on("error", () => {});
+          s.on("close", resolve);
+          s.connect({ path });
+        });
+      }
+      async function run(n) {
+        for (let i = 0; i < n; i += 100) {
+          const batch = [];
+          for (let j = 0; j < 100; j++) batch.push(once());
+          await Promise.all(batch);
+        }
+        Bun.gc(true);
+        await Bun.sleep(10);
+        Bun.gc(true);
+      }
+
+      // Sample RSS after equal-sized work units. A real per-iteration leak
+      // grows linearly with the sample index; allocator/GC noise plateaus.
+      const samples = [];
+      for (let i = 0; i < 8; i++) {
+        await run(2500);
+        samples.push(process.memoryUsage.rss());
+      }
+      // Discard first two as warmup; compare the last sample against the
+      // first steady-state sample.
+      const base = samples[2];
+      const last = samples[samples.length - 1];
+      console.log(JSON.stringify({ samples, delta: last - base }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { delta, samples } = JSON.parse(stdout.trim().split("\n").pop()!);
+    // 12.5k post-warmup iterations leak ~4 MB on release / ~15 MB on
+    // debug+ASAN when the ref is not balanced. With the fix, delta is
+    // allocator noise (±1 MB).
+    expect(delta, `RSS samples (bytes): ${JSON.stringify(samples)}`).toBeLessThan(3 * 1024 * 1024);
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);


### PR DESCRIPTION
## Repro

```js
const net = require('node:net');
for (let i = 0; i < 50_000; i++) {
  await new Promise(r => {
    const s = new net.Socket();
    s.on('error', () => {}).on('close', r);
    s.connect({ path: '/nonexistent.sock' }); // ENOENT, synchronous
  });
}
// RSS grows ~17 MB (release) / ~60 MB (debug+ASAN)
```

## Cause

`Listener.connectInner` unconditionally `socket.ref()`s before calling `doConnect`, for both freshly-allocated sockets and reused ones passed as `prev` (the node:net path — `_handle` is a detached native socket from `newDetachedSocket`).

When `doConnect` fails synchronously (ENOENT unix path, bad fd, EMFILE), the socket never leaves `.detached`, so `handleConnectError`'s `needs_deref = !this.socket.isDetached()` is `false` and its own deref does not fire. The caller is responsible for balancing the ref — but the existing line only did so when `maybe_previous == null`:

```zig
if (maybe_previous == null) socket.deref();
```

That guard was added in #23936 to fix the `Bun.connect({fd: badFd})` leak (fresh-socket case) but left the reused-socket case unbalanced: one native `TCPSocket` struct + its `connection` string leak per failed reconnect.

## Fix

Drop the guard. The `ref()` at :849 is unconditional, so the balancing `deref()` on sync failure must be too.

## Verification

New test in `test/js/node/net/node-net.test.ts` does 20k failed unix connects in a subprocess and samples RSS after equal-sized work units. A real leak grows linearly; noise plateaus.

| | RSS growth over 12.5k post-warmup iterations |
|---|---|
| before (debug+ASAN) | ~14 MB |
| before (release) | ~6 MB |
| after (debug+ASAN) | ±1 MB |

Threshold 3 MB. The original #23936 test (`Bun.connect` with bad fd) and `socket-retention.test.ts` still pass.