### PR TITLE
fs: free PathLike on error in Symlink/Link/Rename.fromJS

### DIFF
--- a/src/bun.js/node/node_fs.zig
+++ b/src/bun.js/node/node_fs.zig
@@ -1298,10 +1298,12 @@ pub const Arguments = struct {
             const old_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArgumentTypeValue("oldPath", "string or an instance of Buffer or URL", arguments.next() orelse .js_undefined);
             };
+            errdefer old_path.deinit();
 
             const new_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArgumentTypeValue("newPath", "string or an instance of Buffer or URL", arguments.next() orelse .js_undefined);
             };
+            errdefer new_path.deinit();
 
             return Rename{ .old_path = old_path, .new_path = new_path };
         }
@@ -1811,10 +1813,12 @@ pub const Arguments = struct {
             const old_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArguments("oldPath must be a string or TypedArray", .{});
             };
+            errdefer old_path.deinit();
 
             const new_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArguments("newPath must be a string or TypedArray", .{});
             };
+            errdefer new_path.deinit();
 
             return Link{ .old_path = old_path, .new_path = new_path };
         }
@@ -1854,10 +1858,12 @@ pub const Arguments = struct {
             const old_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArguments("target must be a string or TypedArray", .{});
             };
+            errdefer old_path.deinit();
 
             const new_path = try PathLike.fromJS(ctx, arguments) orelse {
                 return ctx.throwInvalidArguments("path must be a string or TypedArray", .{});
             };
+            errdefer new_path.deinit();
 
             // The type argument is only available on Windows and
             // ignored on other platforms. It can be set to 'dir',


### PR DESCRIPTION
## What

`Arguments.Symlink.fromJS`, `Arguments.Link.fromJS` and `Arguments.Rename.fromJS` in `src/bun.js/node/node_fs.zig` parsed two `PathLike` arguments without an `errdefer`, so when a later argument was rejected the already-parsed `PathLike` values leaked their `encoded_slice` / `slice_with_underlying_string` allocations.

## Repro

```js
const fs = require('fs');
const p = '/tmp/' + Buffer.alloc(800, '💩').toString(); // non-ASCII forces a heap-allocated encoded_slice

for (let i = 0; i < 100_000; i++) {
  try { fs.symlinkSync(p, p, 123); } catch {} // both paths leak when 'type' is rejected
  try { fs.symlinkSync(p, 123);    } catch {} // target leaks when 'path' is rejected
  try { fs.linkSync(p, 123);       } catch {} // oldPath leaks when 'newPath' is rejected
  try { fs.renameSync(p, 123);     } catch {} // oldPath leaks when 'newPath' is rejected
}
```

RSS grows by hundreds of MB.

## Cause

- `Symlink.fromJS`: no `errdefer old_path.deinit()` after the first `PathLike.fromJS`, so the throw when `path` is invalid leaks `target`. No `errdefer new_path.deinit()` either, so the throws for an invalid `type` argument leak both `target` and `path`.
- `Link.fromJS` / `Rename.fromJS`: no `errdefer old_path.deinit()`, so `oldPath` leaks whenever `newPath` is rejected.

`CopyFile.fromJS` and `Cp.fromJS` in the same file already handle this correctly.

## Fix

Add `errdefer <path>.deinit()` after each successful `PathLike.fromJS`, mirroring `CopyFile.fromJS` / `Cp.fromJS`.

## Verification

New `test/js/node/fs/symlink-link-rename-args-leak.test.ts` runs a warmup batch then a measured batch of 10k iterations and checks RSS growth on the second batch:

| | RSS delta (second batch) |
|---|---|
| Without fix (debug ASAN) | ~48 MB → fail |
| Without fix (release / system bun) | ~45 MB → fail |
| With fix (debug ASAN) | ~1 MB → pass |

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/symlink-link-rename-args-leak.test.ts  # fail
bun bd test test/js/node/fs/symlink-link-rename-args-leak.test.ts                # pass
```

Related: #29892 touches other `PathLike` leaks (`fs.watch`/`watchFile` / `fromBunString`); this PR covers `symlink`/`link`/`rename` argument parsing and is independent.