### PR TITLE
Fix uninitialized loader/define slots when JSPropertyIterator skips empty keys

### DIFF
--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -971,9 +971,16 @@ pub const JSBundler = struct {
                     written += 1;
                 }
 
+                // Shrink to the dense length so `Config.deinit` frees exactly what was
+                // allocated. Slicing alone would leak both backing arrays when
+                // `written == 0` (Zig's `Allocator.free` early-returns on zero-length
+                // slices) and otherwise passes a mismatched length to the allocator.
+                loader_names = try allocator.realloc(loader_names, written);
+                loader_values = try allocator.realloc(loader_values, written);
+
                 this.loaders = api.LoaderMap{
-                    .extensions = loader_names[0..written],
-                    .loaders = loader_values[0..written],
+                    .extensions = loader_names,
+                    .loaders = loader_values,
                 };
             }
 

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -949,23 +949,31 @@ pub const JSBundler = struct {
                 var loader_values = try allocator.alloc(api.Loader, loader_iter.len);
                 errdefer allocator.free(loader_values);
 
+                // `loader_iter.i` is the property position, not a dense index of yielded
+                // entries. With `skip_empty_name = true` (or a skipped property getter),
+                // writing at `loader_iter.i` would leave earlier slots uninitialized and
+                // later freed as garbage. Track a dense counter instead.
+                var written: usize = 0;
+                errdefer for (loader_names[0..written]) |name| bun.default_allocator.free(name);
+
                 while (try loader_iter.next()) |prop| {
                     if (!prop.hasPrefixComptime(".") or prop.length() < 2) {
                         return globalThis.throwInvalidArguments("loader property names must be file extensions, such as '.txt'", .{});
                     }
 
-                    loader_values[loader_iter.i] = try loader_iter.value.toEnumFromMap(
+                    loader_values[written] = try loader_iter.value.toEnumFromMap(
                         globalThis,
                         "loader",
                         api.Loader,
                         options.Loader.api_names,
                     );
-                    loader_names[loader_iter.i] = try prop.toOwnedSlice(bun.default_allocator);
+                    loader_names[written] = try prop.toOwnedSlice(bun.default_allocator);
+                    written += 1;
                 }
 
                 this.loaders = api.LoaderMap{
-                    .extensions = loader_names,
-                    .loaders = loader_values,
+                    .extensions = loader_names[0..written],
+                    .loaders = loader_values[0..written],
                 };
             }
 

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -944,43 +944,39 @@ pub const JSBundler = struct {
                 }).init(globalThis, loaders);
                 defer loader_iter.deinit();
 
-                var loader_names = try allocator.alloc(string, loader_iter.len);
-                errdefer allocator.free(loader_names);
-                var loader_values = try allocator.alloc(api.Loader, loader_iter.len);
-                errdefer allocator.free(loader_values);
-
                 // `loader_iter.i` is the property position, not a dense index of yielded
                 // entries. With `skip_empty_name = true` (or a skipped property getter),
                 // writing at `loader_iter.i` would leave earlier slots uninitialized and
-                // later freed as garbage. Track a dense counter instead.
-                var written: usize = 0;
-                errdefer for (loader_names[0..written]) |name| bun.default_allocator.free(name);
+                // later freed as garbage. Use ArrayLists so the stored slice is always
+                // exactly what was appended.
+                var loader_names: std.ArrayListUnmanaged(string) = .{};
+                errdefer {
+                    for (loader_names.items) |name| bun.default_allocator.free(name);
+                    loader_names.deinit(allocator);
+                }
+                var loader_values: std.ArrayListUnmanaged(api.Loader) = .{};
+                errdefer loader_values.deinit(allocator);
+
+                try loader_names.ensureTotalCapacityPrecise(allocator, loader_iter.len);
+                try loader_values.ensureTotalCapacityPrecise(allocator, loader_iter.len);
 
                 while (try loader_iter.next()) |prop| {
                     if (!prop.hasPrefixComptime(".") or prop.length() < 2) {
                         return globalThis.throwInvalidArguments("loader property names must be file extensions, such as '.txt'", .{});
                     }
 
-                    loader_values[written] = try loader_iter.value.toEnumFromMap(
+                    loader_values.appendAssumeCapacity(try loader_iter.value.toEnumFromMap(
                         globalThis,
                         "loader",
                         api.Loader,
                         options.Loader.api_names,
-                    );
-                    loader_names[written] = try prop.toOwnedSlice(bun.default_allocator);
-                    written += 1;
+                    ));
+                    loader_names.appendAssumeCapacity(try prop.toOwnedSlice(bun.default_allocator));
                 }
 
-                // Shrink to the dense length so `Config.deinit` frees exactly what was
-                // allocated. Slicing alone would leak both backing arrays when
-                // `written == 0` (Zig's `Allocator.free` early-returns on zero-length
-                // slices) and otherwise passes a mismatched length to the allocator.
-                loader_names = try allocator.realloc(loader_names, written);
-                loader_values = try allocator.realloc(loader_values, written);
-
                 this.loaders = api.LoaderMap{
-                    .extensions = loader_names,
-                    .loaders = loader_values,
+                    .extensions = loader_names.items,
+                    .loaders = loader_values.items,
                 };
             }
 

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -76,6 +76,13 @@ pub const Config = struct {
 
                 var values = map_entries[define_iter.len..];
 
+                // `define_iter.i` is the property position, not a dense index of yielded
+                // entries. With `skip_empty_name = true` (or a skipped property getter),
+                // writing at `define_iter.i` would leave earlier slots uninitialized.
+                // Track a dense counter instead. `allocator` is an arena, so slicing to
+                // `[0..written]` is sufficient here (no realloc needed).
+                var written: usize = 0;
+
                 while (try define_iter.next()) |prop| {
                     const property_value = define_iter.value;
                     const value_type = property_value.jsType();
@@ -84,18 +91,19 @@ pub const Config = struct {
                         return globalThis.throwInvalidArguments("define \"{f}\" must be a JSON string", .{prop});
                     }
 
-                    names[define_iter.i] = prop.toOwnedSlice(allocator) catch unreachable;
+                    names[written] = prop.toOwnedSlice(allocator) catch unreachable;
                     var val = jsc.ZigString.init("");
                     try property_value.toZigString(&val, globalThis);
                     if (val.len == 0) {
                         val = jsc.ZigString.init("\"\"");
                     }
-                    values[define_iter.i] = std.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable;
+                    values[written] = std.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable;
+                    written += 1;
                 }
 
                 this.transform.define = api.StringMap{
-                    .keys = names,
-                    .values = values,
+                    .keys = names[0..written],
+                    .values = values[0..written],
                 };
             }
         }

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -70,18 +70,15 @@ pub const Config = struct {
                 }).init(globalThis, define_obj);
                 defer define_iter.deinit();
 
-                // cannot be a temporary because it may be loaded on different threads.
-                var map_entries = allocator.alloc([]u8, define_iter.len * 2) catch unreachable;
-                var names = map_entries[0..define_iter.len];
-
-                var values = map_entries[define_iter.len..];
-
                 // `define_iter.i` is the property position, not a dense index of yielded
                 // entries. With `skip_empty_name = true` (or a skipped property getter),
                 // writing at `define_iter.i` would leave earlier slots uninitialized.
-                // Track a dense counter instead. `allocator` is an arena, so slicing to
-                // `[0..written]` is sufficient here (no realloc needed).
-                var written: usize = 0;
+                // Use ArrayLists so the stored slice is always exactly what was appended.
+                // `allocator` is an arena, so ownership transfers via `.items`.
+                var names: std.ArrayListUnmanaged([]const u8) = .{};
+                var values: std.ArrayListUnmanaged([]const u8) = .{};
+                names.ensureTotalCapacityPrecise(allocator, define_iter.len) catch unreachable;
+                values.ensureTotalCapacityPrecise(allocator, define_iter.len) catch unreachable;
 
                 while (try define_iter.next()) |prop| {
                     const property_value = define_iter.value;
@@ -91,19 +88,18 @@ pub const Config = struct {
                         return globalThis.throwInvalidArguments("define \"{f}\" must be a JSON string", .{prop});
                     }
 
-                    names[written] = prop.toOwnedSlice(allocator) catch unreachable;
+                    names.appendAssumeCapacity(prop.toOwnedSlice(allocator) catch unreachable);
                     var val = jsc.ZigString.init("");
                     try property_value.toZigString(&val, globalThis);
                     if (val.len == 0) {
                         val = jsc.ZigString.init("\"\"");
                     }
-                    values[written] = std.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable;
-                    written += 1;
+                    values.appendAssumeCapacity(std.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable);
                 }
 
                 this.transform.define = api.StringMap{
-                    .keys = names[0..written],
-                    .values = values[0..written],
+                    .keys = names.items,
+                    .values = values.items,
                 };
             }
         }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -357,22 +357,20 @@ describe("Bun.build", () => {
   //   throw new Error("test was not fully written");
   // });
 
-  test.concurrent(
-    "loader map with an empty-string key is ignored without leaving uninitialized slots",
-    async () => {
-      // `JSPropertyIterator` skips empty-name properties, but `loader_names` was being
-      // indexed by the property position instead of a dense counter, leaving garbage in
-      // the skipped slot that was later read/freed. Run in a subprocess so a crash in the
-      // bundler thread surfaces as a test failure instead of taking down the test runner.
-      const dir = tempDirWithFiles("bun-build-loader-empty-key", {
-        "entry.ts": `export const x: number = 42;\n`,
-      });
+  test.concurrent("loader map with an empty-string key is ignored without leaving uninitialized slots", async () => {
+    // `JSPropertyIterator` skips empty-name properties, but `loader_names` was being
+    // indexed by the property position instead of a dense counter, leaving garbage in
+    // the skipped slot that was later read/freed. Run in a subprocess so a crash in the
+    // bundler thread surfaces as a test failure instead of taking down the test runner.
+    const dir = tempDirWithFiles("bun-build-loader-empty-key", {
+      "entry.ts": `export const x: number = 42;\n`,
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
           const result = await Bun.build({
             entrypoints: [${JSON.stringify(join(dir, "entry.ts"))}],
             loader: { "": "js", ".ts": "ts", ".js": "js" },
@@ -380,19 +378,17 @@ describe("Bun.build", () => {
           if (!result.success) throw new AggregateError(result.logs, "build failed");
           console.log(JSON.stringify({ success: result.success, outputs: result.outputs.length }));
         `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout.trim())).toEqual({ success: true, outputs: 1 });
-      expect(exitCode).toBe(0);
-    },
-    30_000,
-  );
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ success: true, outputs: 1 });
+    expect(exitCode).toBe(0);
+  });
 
   test.concurrent("rebuilding busts the directory entries cache", async () => {
     Bun.gc(true);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -357,6 +357,39 @@ describe("Bun.build", () => {
   //   throw new Error("test was not fully written");
   // });
 
+  test.concurrent("loader map with an empty-string key is ignored without leaving uninitialized slots", async () => {
+    // `JSPropertyIterator` skips empty-name properties, but `loader_names` was being
+    // indexed by the property position instead of a dense counter, leaving garbage in
+    // the skipped slot that was later read/freed. Run in a subprocess so a crash in the
+    // bundler thread surfaces as a test failure instead of taking down the test runner.
+    const dir = tempDirWithFiles("bun-build-loader-empty-key", {
+      "entry.ts": `export const x: number = 42;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const result = await Bun.build({
+            entrypoints: [${JSON.stringify(join(dir, "entry.ts"))}],
+            loader: { "": "js", ".ts": "ts", ".js": "js" },
+          });
+          if (!result.success) throw new AggregateError(result.logs, "build failed");
+          console.log(JSON.stringify({ success: result.success, outputs: result.outputs.length }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ success: true, outputs: 1 });
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
   test.concurrent("rebuilding busts the directory entries cache", async () => {
     Bun.gc(true);
     const tmpdir = tempDirWithFiles("rebuild-bust-dirent-cache", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -357,20 +357,22 @@ describe("Bun.build", () => {
   //   throw new Error("test was not fully written");
   // });
 
-  test.concurrent("loader map with an empty-string key is ignored without leaving uninitialized slots", async () => {
-    // `JSPropertyIterator` skips empty-name properties, but `loader_names` was being
-    // indexed by the property position instead of a dense counter, leaving garbage in
-    // the skipped slot that was later read/freed. Run in a subprocess so a crash in the
-    // bundler thread surfaces as a test failure instead of taking down the test runner.
-    const dir = tempDirWithFiles("bun-build-loader-empty-key", {
-      "entry.ts": `export const x: number = 42;\n`,
-    });
+  test.concurrent(
+    "loader map with an empty-string key is ignored without leaving uninitialized slots",
+    async () => {
+      // `JSPropertyIterator` skips empty-name properties, but `loader_names` was being
+      // indexed by the property position instead of a dense counter, leaving garbage in
+      // the skipped slot that was later read/freed. Run in a subprocess so a crash in the
+      // bundler thread surfaces as a test failure instead of taking down the test runner.
+      const dir = tempDirWithFiles("bun-build-loader-empty-key", {
+        "entry.ts": `export const x: number = 42;\n`,
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
           const result = await Bun.build({
             entrypoints: [${JSON.stringify(join(dir, "entry.ts"))}],
             loader: { "": "js", ".ts": "ts", ".js": "js" },
@@ -378,17 +380,19 @@ describe("Bun.build", () => {
           if (!result.success) throw new AggregateError(result.logs, "build failed");
           console.log(JSON.stringify({ success: result.success, outputs: result.outputs.length }));
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toEqual({ success: true, outputs: 1 });
-    expect(exitCode).toBe(0);
-  }, 30_000);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual({ success: true, outputs: 1 });
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 
   test.concurrent("rebuilding busts the directory entries cache", async () => {
     Bun.gc(true);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1302,6 +1302,30 @@ export default <>hi</>
     ).toThrow();
   });
 
+  it("define with an empty-string key is ignored without leaving uninitialized slots", async () => {
+    // `JSPropertyIterator` skips empty-name properties, but `names`/`values` were being
+    // indexed by the property position instead of a dense counter, leaving garbage in the
+    // skipped slot that `stringHashMapFromArrays` then tried to hash. Run in a subprocess
+    // so a crash surfaces as a test failure instead of taking down the test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const t = new Bun.Transpiler({ define: { "": "1", FOO: '"bar"' } });
+          process.stdout.write(t.transformSync("console.log(FOO);", "js"));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe('console.log("bar");');
+    expect(exitCode).toBe(0);
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",


### PR DESCRIPTION
## Repro

```js
await Bun.build({
  entrypoints: ["./entry.ts"],
  loader: { "": "js", ".ts": "ts" },
});
// or
new Bun.Transpiler({ define: { "": "1", FOO: '"bar"' } }).transformSync("FOO");
```

Debug build:

```
==590==ERROR: AddressSanitizer: SEGV on unknown address
  ...
  rdx = 0xaaaaaaaaaaaaaaaa
  #10 options.stringHashMapFromArrays    src/options.zig:46
```

## Cause

`JSPropertyIterator` with `skip_empty_name = true` advances `.i` to the **property position**, not a dense count of yielded entries. Both `JSBundler.Config.fromJS` (`loader`) and `JSTranspiler.Config.fromJS` (`define`) allocated arrays sized to `iter.len` and wrote at `iter.i`:

```zig
var loader_names = try allocator.alloc(string, loader_iter.len); // len = 2
while (try loader_iter.next()) |prop| {
    loader_names[loader_iter.i] = ...; // i = 1 for ".ts" after "" is skipped
}
```

With `{ "": "js", ".ts": "ts" }`, the empty key is skipped by the iterator so `.i == 1` on the only yielded entry, leaving slot 0 uninitialized (0xAA in safe builds). `stringHashMapFromArrays` then hashes that garbage, and in the bundler case `Config.deinit` later frees it.

The same gap exists for any property the iterator skips internally (`value == .zero`, dead name).

## Fix

Replace the raw `alloc` + `iter.i` indexing with `std.ArrayListUnmanaged` + `ensureTotalCapacityPrecise(iter.len)` + `appendAssumeCapacity` in both call sites, then store `.items` directly. The list's `.items` slice reflects exactly what was appended, so skipped entries leave no gaps. On the error path, `errdefer` frees already-appended extension names and the lists.

## Verification

Two subprocess tests (`bun-build-api.test.ts`, `transpiler.test.js`):

- **without fix** (`bun bd`, origin/main src): both fail — child process SEGVs in `stringHashMapFromArrays`
- **with fix**: `Bun.build` succeeds with `{ success: true, outputs: 1 }`; `Transpiler` correctly replaces `FOO` → `"bar"`
