### PR TITLE
http2: own queued DATA frame across re-entrant onWrite in flushQueue

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -956,8 +956,17 @@ pub const H2FrameParser = struct {
             // dataFrameQueue with an empty one. Holding the frame on the stack
             // means cleanQueue cannot free it out from under us, and we never
             // unwrap null on a queue that was just emptied by re-entry.
+            //
+            // outboundQueueSize is NOT decremented here: sendData() uses
+            // `outboundQueueSize > 0` to decide whether new DATA must queue or
+            // may write straight to the socket. Keeping the count >= 1 across
+            // the two writer.write() calls below forces any re-entrant
+            // sendData() onto the queueFrame path instead of interleaving a
+            // fresh DATA header+payload between this frame's header and its
+            // payload on the wire. The count is settled only once the frame
+            // is fully disposed of (finishFlushedFrame / the reset-drop path);
+            // requeue paths leave it untouched.
             var frame = this.dataFrameQueue.dequeue() orelse return .no_action;
-            client.outboundQueueSize -= 1;
 
             const writer = client.toWriter();
 
@@ -981,8 +990,8 @@ pub const H2FrameParser = struct {
                 log("dataFrame flow control limited {} {} {} {} {} {}", .{ frame_slice.len, this.remoteWindowSize, this.remoteUsedWindowSize, client.remoteWindowSize, client.remoteUsedWindowSize, max_size });
                 // Nothing was written (no JS re-entry possible here), put the
                 // frame back exactly where it was for the next flush attempt.
+                // outboundQueueSize was never decremented for this frame.
                 this.dataFrameQueue.pushFront(frame, client.allocator);
-                client.outboundQueueSize += 1;
                 // we are flow control limited lets return backpressure if is limited in the connection so we short circuit the flush
                 return if (client.remoteWindowSize == client.remoteUsedWindowSize) .backpressure else .no_action;
             }
@@ -1026,13 +1035,14 @@ pub const H2FrameParser = struct {
                 // to do with the remainder AFTER all re-entrant JS has run.
                 frame.offset += @intCast(max_size);
                 if (this.canSendData()) {
-                    // stream still open: keep remainder for next flush
+                    // stream still open: keep remainder for next flush.
+                    // outboundQueueSize was never decremented for this frame.
                     this.dataFrameQueue.pushFront(frame, client.allocator);
-                    client.outboundQueueSize += 1;
                 } else {
                     // stream was reset/closed from inside onWrite; drop the
                     // remainder, matching cleanQueue's accounting.
                     client.queuedDataSize -= frame.slice().len;
+                    client.outboundQueueSize -= 1;
                     if (frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
                     frame.deinit(client.allocator);
                 }
@@ -1078,6 +1088,10 @@ pub const H2FrameParser = struct {
         /// previous defer block but is tolerant of the stream having been reset
         /// from inside the JS onWrite callback.
         fn finishFlushedFrame(this: *Stream, client: *H2FrameParser, frame: *PendingFrame) void {
+            // Only now release this frame's slot in the outbound count; kept
+            // >= 1 across both writer.write() calls so re-entrant sendData()
+            // takes the queueFrame path instead of interleaving on the wire.
+            client.outboundQueueSize -= 1;
             if (frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
             if (this.dataFrameQueue.isEmpty() and frame.end_stream and this.canSendData()) {
                 if (this.waitForTrailers) {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -840,6 +840,23 @@ pub const H2FrameParser = struct {
                 log("PendingQueue.enqueue {}", .{self.len});
             }
 
+            /// Put a frame back at the front of the queue. Used by flushQueue
+            /// when it has dequeued a frame, written only part of it due to
+            /// flow control, and needs to retain the remainder for the next
+            /// flush. Reuses the slot vacated by the immediately-preceding
+            /// dequeue() where possible, otherwise inserts at index 0.
+            pub fn pushFront(self: *PendingQueue, value: PendingFrame, allocator: Allocator) void {
+                if (self.front > 0) {
+                    self.front -= 1;
+                    self.data.items[self.front] = value;
+                    self.len += 1;
+                } else {
+                    bun.handleOom(self.data.insert(allocator, 0, value));
+                    self.len += 1;
+                }
+                log("PendingQueue.pushFront {}", .{self.len});
+            }
+
             pub fn peek(self: *PendingQueue) ?*PendingFrame {
                 if (self.len == 0) {
                     return null;
@@ -927,131 +944,153 @@ pub const H2FrameParser = struct {
             }
         }
         pub fn flushQueue(this: *Stream, client: *H2FrameParser, written: *usize) FlushState {
-            if (this.canSendData()) {
-                // try to flush one frame
-                if (this.dataFrameQueue.peekFront()) |frame| {
-                    const no_backpressure = brk: {
-                        var is_flow_control_limited = false;
-                        defer {
-                            if (!is_flow_control_limited) {
-                                // only call the callback + free the frame if we write to the socket the full frame
-                                var _frame = this.dataFrameQueue.dequeue().?;
-                                client.outboundQueueSize -= 1;
+            if (!this.canSendData()) {
+                // cannot send data
+                return .no_action;
+            }
+            // Take ownership of the front frame before doing any socket write.
+            // With a non-native socket, writer.write() ends up in _write() which
+            // calls the JS onWrite callback synchronously. That callback can call
+            // back into the parser (e.g. rstStream -> endStream -> freeResources
+            // -> cleanQueue), which frees every queued frame.buffer and replaces
+            // dataFrameQueue with an empty one. Holding the frame on the stack
+            // means cleanQueue cannot free it out from under us, and we never
+            // unwrap null on a queue that was just emptied by re-entry.
+            var frame = this.dataFrameQueue.dequeue() orelse return .no_action;
+            client.outboundQueueSize -= 1;
 
-                                if (_frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
-                                if (this.dataFrameQueue.isEmpty()) {
-                                    if (_frame.end_stream) {
-                                        if (this.waitForTrailers) {
-                                            client.dispatch(.onWantTrailers, this.getIdentifier());
-                                        } else {
-                                            const identifier = this.getIdentifier();
-                                            identifier.ensureStillAlive();
-                                            if (this.state == .HALF_CLOSED_REMOTE) {
-                                                this.state = .CLOSED;
-                                            } else {
-                                                this.state = .HALF_CLOSED_LOCAL;
-                                            }
-                                            client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(this.state)));
-                                        }
-                                    }
-                                }
-                                _frame.deinit(client.allocator);
-                            }
-                        }
+            const writer = client.toWriter();
 
-                        const writer = client.toWriter();
+            if (frame.len == 0) {
+                // flush a zero payload frame
+                var dataHeader: FrameHeader = .{
+                    .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
+                    .flags = if (frame.end_stream and !this.waitForTrailers) @intFromEnum(DataFrameFlags.END_STREAM) else 0,
+                    .streamIdentifier = @intCast(this.id),
+                    .length = 0,
+                };
+                // may re-enter JS; `frame` is stack-owned so this is safe.
+                const no_backpressure = dataHeader.write(@TypeOf(writer), writer);
+                this.finishFlushedFrame(client, &frame);
+                return if (no_backpressure) .flushed else .backpressure;
+            }
 
-                        if (frame.len == 0) {
+            const frame_slice = frame.slice();
+            const max_size = @min(@min(frame_slice.len, this.remoteWindowSize -| this.remoteUsedWindowSize, client.remoteWindowSize -| client.remoteUsedWindowSize), MAX_PAYLOAD_SIZE_WITHOUT_FRAME);
+            if (max_size == 0) {
+                log("dataFrame flow control limited {} {} {} {} {} {}", .{ frame_slice.len, this.remoteWindowSize, this.remoteUsedWindowSize, client.remoteWindowSize, client.remoteUsedWindowSize, max_size });
+                // Nothing was written (no JS re-entry possible here), put the
+                // frame back exactly where it was for the next flush attempt.
+                this.dataFrameQueue.pushFront(frame, client.allocator);
+                client.outboundQueueSize += 1;
+                // we are flow control limited lets return backpressure if is limited in the connection so we short circuit the flush
+                return if (client.remoteWindowSize == client.remoteUsedWindowSize) .backpressure else .no_action;
+            }
 
-                            // flush a zero payload frame
-                            var dataHeader: FrameHeader = .{
-                                .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
-                                .flags = if (frame.end_stream and !this.waitForTrailers) @intFromEnum(DataFrameFlags.END_STREAM) else 0,
-                                .streamIdentifier = @intCast(this.id),
-                                .length = 0,
-                            };
-                            break :brk dataHeader.write(@TypeOf(writer), writer);
-                        } else {
-                            const frame_slice = frame.slice();
-                            const max_size = @min(@min(frame_slice.len, this.remoteWindowSize -| this.remoteUsedWindowSize, client.remoteWindowSize -| client.remoteUsedWindowSize), MAX_PAYLOAD_SIZE_WITHOUT_FRAME);
-                            if (max_size == 0) {
-                                is_flow_control_limited = true;
-                                log("dataFrame flow control limited {} {} {} {} {} {}", .{ frame_slice.len, this.remoteWindowSize, this.remoteUsedWindowSize, client.remoteWindowSize, client.remoteUsedWindowSize, max_size });
-                                // we are flow control limited lets return backpressure if is limited in the connection so we short circuit the flush
-                                return if (client.remoteWindowSize == client.remoteUsedWindowSize) .backpressure else .no_action;
-                            }
-                            if (max_size < frame_slice.len) {
-                                is_flow_control_limited = true;
-                                // we need to break the frame into smaller chunks
-                                frame.offset += @intCast(max_size);
-                                const able_to_send = frame_slice[0..max_size];
-                                client.queuedDataSize -= able_to_send.len;
-                                written.* += able_to_send.len;
+            if (max_size < frame_slice.len) {
+                // we need to break the frame into smaller chunks
+                const able_to_send = frame_slice[0..max_size];
+                client.queuedDataSize -= able_to_send.len;
+                written.* += able_to_send.len;
 
-                                const padding = this.getPadding(able_to_send.len, max_size - 1);
-                                const payload_size = able_to_send.len + (if (padding != 0) @as(usize, @intCast(padding)) + 1 else 0);
-                                log("padding: {d} size: {d} max_size: {d} payload_size: {d}", .{ padding, able_to_send.len, max_size, payload_size });
-                                this.remoteUsedWindowSize += payload_size;
-                                client.remoteUsedWindowSize += payload_size;
+                const padding = this.getPadding(able_to_send.len, max_size - 1);
+                const payload_size = able_to_send.len + (if (padding != 0) @as(usize, @intCast(padding)) + 1 else 0);
+                log("padding: {d} size: {d} max_size: {d} payload_size: {d}", .{ padding, able_to_send.len, max_size, payload_size });
+                this.remoteUsedWindowSize += payload_size;
+                client.remoteUsedWindowSize += payload_size;
 
-                                var flags: u8 = 0; // we ignore end_stream for now because we know we have more data to send
-                                if (padding != 0) {
-                                    flags |= @intFromEnum(DataFrameFlags.PADDED);
-                                }
-                                var dataHeader: FrameHeader = .{
-                                    .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
-                                    .flags = flags,
-                                    .streamIdentifier = @intCast(this.id),
-                                    .length = @intCast(payload_size),
-                                };
-                                _ = dataHeader.write(@TypeOf(writer), writer);
-                                if (padding != 0) {
-                                    var buffer = shared_request_buffer[0..];
-                                    bun.memmove(buffer[1..][0..able_to_send.len], able_to_send);
-                                    buffer[0] = padding;
-                                    break :brk (writer.write(buffer[0..payload_size]) catch 0) != 0;
-                                } else {
-                                    break :brk (writer.write(able_to_send) catch 0) != 0;
-                                }
-                            } else {
+                var flags: u8 = 0; // we ignore end_stream for now because we know we have more data to send
+                if (padding != 0) {
+                    flags |= @intFromEnum(DataFrameFlags.PADDED);
+                }
+                var dataHeader: FrameHeader = .{
+                    .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
+                    .flags = flags,
+                    .streamIdentifier = @intCast(this.id),
+                    .length = @intCast(payload_size),
+                };
+                // Copy into the shared buffer BEFORE any write() that can
+                // re-enter JS; after re-entry frame.buffer may have been freed
+                // by cleanQueue if we hadn't taken ownership, and even with
+                // ownership we prefer not to interleave reads across the
+                // callback boundary.
+                const out_bytes: []const u8 = if (padding != 0) blk: {
+                    var buffer = shared_request_buffer[0..];
+                    bun.memmove(buffer[1..][0..able_to_send.len], able_to_send);
+                    buffer[0] = padding;
+                    break :blk buffer[0..payload_size];
+                } else able_to_send;
+                _ = dataHeader.write(@TypeOf(writer), writer);
+                const no_backpressure = (writer.write(out_bytes) catch 0) != 0;
 
-                                // flush with some payload
-                                client.queuedDataSize -= frame_slice.len;
-                                written.* += frame_slice.len;
+                // Record how much of this frame has been sent and decide what
+                // to do with the remainder AFTER all re-entrant JS has run.
+                frame.offset += @intCast(max_size);
+                if (this.canSendData()) {
+                    // stream still open: keep remainder for next flush
+                    this.dataFrameQueue.pushFront(frame, client.allocator);
+                    client.outboundQueueSize += 1;
+                } else {
+                    // stream was reset/closed from inside onWrite; drop the
+                    // remainder, matching cleanQueue's accounting.
+                    client.queuedDataSize -= frame.slice().len;
+                    if (frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
+                    frame.deinit(client.allocator);
+                }
+                return if (no_backpressure) .flushed else .backpressure;
+            }
 
-                                const padding = this.getPadding(frame_slice.len, max_size - 1);
-                                const payload_size = frame_slice.len + (if (padding != 0) @as(usize, @intCast(padding)) + 1 else 0);
-                                log("padding: {d} size: {d} max_size: {d} payload_size: {d}", .{ padding, frame_slice.len, max_size, payload_size });
-                                this.remoteUsedWindowSize += payload_size;
-                                client.remoteUsedWindowSize += payload_size;
-                                var flags: u8 = if (frame.end_stream and !this.waitForTrailers) @intFromEnum(DataFrameFlags.END_STREAM) else 0;
-                                if (padding != 0) {
-                                    flags |= @intFromEnum(DataFrameFlags.PADDED);
-                                }
-                                var dataHeader: FrameHeader = .{
-                                    .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
-                                    .flags = flags,
-                                    .streamIdentifier = @intCast(this.id),
-                                    .length = @intCast(payload_size),
-                                };
-                                _ = dataHeader.write(@TypeOf(writer), writer);
-                                if (padding != 0) {
-                                    var buffer = shared_request_buffer[0..];
-                                    bun.memmove(buffer[1..][0..frame_slice.len], frame_slice);
-                                    buffer[0] = padding;
-                                    break :brk (writer.write(buffer[0..payload_size]) catch 0) != 0;
-                                } else {
-                                    break :brk (writer.write(frame_slice) catch 0) != 0;
-                                }
-                            }
-                        }
-                    };
+            // flush with some payload (entire remaining slice fits)
+            client.queuedDataSize -= frame_slice.len;
+            written.* += frame_slice.len;
 
-                    return if (no_backpressure) .flushed else .backpressure;
+            const padding = this.getPadding(frame_slice.len, max_size - 1);
+            const payload_size = frame_slice.len + (if (padding != 0) @as(usize, @intCast(padding)) + 1 else 0);
+            log("padding: {d} size: {d} max_size: {d} payload_size: {d}", .{ padding, frame_slice.len, max_size, payload_size });
+            this.remoteUsedWindowSize += payload_size;
+            client.remoteUsedWindowSize += payload_size;
+            var flags: u8 = if (frame.end_stream and !this.waitForTrailers) @intFromEnum(DataFrameFlags.END_STREAM) else 0;
+            if (padding != 0) {
+                flags |= @intFromEnum(DataFrameFlags.PADDED);
+            }
+            var dataHeader: FrameHeader = .{
+                .type = @intFromEnum(FrameType.HTTP_FRAME_DATA),
+                .flags = flags,
+                .streamIdentifier = @intCast(this.id),
+                .length = @intCast(payload_size),
+            };
+            const out_bytes: []const u8 = if (padding != 0) blk: {
+                var buffer = shared_request_buffer[0..];
+                bun.memmove(buffer[1..][0..frame_slice.len], frame_slice);
+                buffer[0] = padding;
+                break :blk buffer[0..payload_size];
+            } else frame_slice;
+            _ = dataHeader.write(@TypeOf(writer), writer);
+            const no_backpressure = (writer.write(out_bytes) catch 0) != 0;
+            this.finishFlushedFrame(client, &frame);
+            return if (no_backpressure) .flushed else .backpressure;
+        }
+
+        /// Runs after a frame has been fully written to the socket. Mirrors the
+        /// previous defer block but is tolerant of the stream having been reset
+        /// from inside the JS onWrite callback.
+        fn finishFlushedFrame(this: *Stream, client: *H2FrameParser, frame: *PendingFrame) void {
+            if (frame.callback.get()) |callback_value| client.dispatchWriteCallback(callback_value);
+            if (this.dataFrameQueue.isEmpty() and frame.end_stream and this.canSendData()) {
+                if (this.waitForTrailers) {
+                    client.dispatch(.onWantTrailers, this.getIdentifier());
+                } else {
+                    const identifier = this.getIdentifier();
+                    identifier.ensureStillAlive();
+                    if (this.state == .HALF_CLOSED_REMOTE) {
+                        this.state = .CLOSED;
+                    } else {
+                        this.state = .HALF_CLOSED_LOCAL;
+                    }
+                    client.dispatchWithExtra(.onStreamEnd, identifier, jsc.JSValue.jsNumber(@intFromEnum(this.state)));
                 }
             }
-            // empty or cannot send data
-            return .no_action;
+            frame.deinit(client.allocator);
         }
 
         pub fn queueFrame(this: *Stream, client: *H2FrameParser, bytes: []const u8, callback: jsc.JSValue, end_stream: bool) void {

--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -1009,19 +1009,18 @@ pub const H2FrameParser = struct {
                     .streamIdentifier = @intCast(this.id),
                     .length = @intCast(payload_size),
                 };
-                // Copy into the shared buffer BEFORE any write() that can
-                // re-enter JS; after re-entry frame.buffer may have been freed
-                // by cleanQueue if we hadn't taken ownership, and even with
-                // ownership we prefer not to interleave reads across the
-                // callback boundary.
-                const out_bytes: []const u8 = if (padding != 0) blk: {
+                // May re-enter JS. `able_to_send` points into frame.buffer
+                // which is stack-owned here, so it stays valid across the
+                // callback. `shared_request_buffer` is threadlocal and can be
+                // clobbered by a re-entrant padded request()/sendData(), so
+                // fill it AFTER the header write, immediately before use.
+                _ = dataHeader.write(@TypeOf(writer), writer);
+                const no_backpressure = if (padding != 0) blk: {
                     var buffer = shared_request_buffer[0..];
                     bun.memmove(buffer[1..][0..able_to_send.len], able_to_send);
                     buffer[0] = padding;
-                    break :blk buffer[0..payload_size];
-                } else able_to_send;
-                _ = dataHeader.write(@TypeOf(writer), writer);
-                const no_backpressure = (writer.write(out_bytes) catch 0) != 0;
+                    break :blk (writer.write(buffer[0..payload_size]) catch 0) != 0;
+                } else (writer.write(able_to_send) catch 0) != 0;
 
                 // Record how much of this frame has been sent and decide what
                 // to do with the remainder AFTER all re-entrant JS has run.
@@ -1059,14 +1058,18 @@ pub const H2FrameParser = struct {
                 .streamIdentifier = @intCast(this.id),
                 .length = @intCast(payload_size),
             };
-            const out_bytes: []const u8 = if (padding != 0) blk: {
+            // May re-enter JS. `frame_slice` points into frame.buffer which is
+            // stack-owned here, so it stays valid across the callback.
+            // `shared_request_buffer` is threadlocal and can be clobbered by a
+            // re-entrant padded request()/sendData(), so fill it AFTER the
+            // header write, immediately before use.
+            _ = dataHeader.write(@TypeOf(writer), writer);
+            const no_backpressure = if (padding != 0) blk: {
                 var buffer = shared_request_buffer[0..];
                 bun.memmove(buffer[1..][0..frame_slice.len], frame_slice);
                 buffer[0] = padding;
-                break :blk buffer[0..payload_size];
-            } else frame_slice;
-            _ = dataHeader.write(@TypeOf(writer), writer);
-            const no_backpressure = (writer.write(out_bytes) catch 0) != 0;
+                break :blk (writer.write(buffer[0..payload_size]) catch 0) != 0;
+            } else (writer.write(frame_slice) catch 0) != 0;
             this.finishFlushedFrame(client, &frame);
             return if (no_backpressure) .flushed else .backpressure;
         }

--- a/test/js/node/http2/node-http2-flush-rststream.fixture.js
+++ b/test/js/node/http2/node-http2-flush-rststream.fixture.js
@@ -61,12 +61,22 @@ server.listen(0, "127.0.0.1", () => {
           chunk[3] === 0 /* HTTP_FRAME_DATA */ &&
           (chunk.readUInt32BE(5) & 0x7fffffff) === rstTarget
         ) {
-          fired = true;
           // Re-enter the parser synchronously from inside onWrite: this frees
-          // the queued frame currently being flushed.
+          // the queued frame currently being flushed. Fail fast if the
+          // internal handle is gone or rstStream() rejects the call, so a
+          // broken hook surfaces as a clear error rather than a timeout.
+          const nativeSession = session[kNative];
+          if (!nativeSession || typeof nativeSession.rstStream !== "function") {
+            console.error("missing native http2 session handle");
+            process.exit(1);
+          }
           try {
-            session[kNative]?.rstStream(rstTarget, 8 /* CANCEL */);
-          } catch {}
+            nativeSession.rstStream(rstTarget, 8 /* CANCEL */);
+            fired = true;
+          } catch (err) {
+            console.error("rstStream failed", err);
+            process.exit(1);
+          }
         }
         raw.write(chunk, encoding);
         // Signal completion immediately so the Duplex does not queue chunks

--- a/test/js/node/http2/node-http2-flush-rststream.fixture.js
+++ b/test/js/node/http2/node-http2-flush-rststream.fixture.js
@@ -1,0 +1,141 @@
+"use strict";
+// Reproduces a use-after-free in H2FrameParser.Stream.flushQueue when the
+// parser is using the non-native (JS onWrite) write path.
+//
+// flushQueue used to peekFront() a *PendingFrame and then call
+// dataHeader.write(writer). With a non-native socket that write() reaches
+// _write() -> JS onWrite -> socket.write(), which runs user JS
+// synchronously. If that JS calls rstStream() on the stream being flushed,
+// endStream -> freeResources -> cleanQueue frees every queued frame.buffer
+// and replaces dataFrameQueue with an empty one. flushQueue would then read
+// the freed buffer and finally unwrap null from dequeue().?.
+//
+// Under ASAN this is a heap-use-after-free; without ASAN it's a panic on the
+// null unwrap.
+
+const http2 = require("node:http2");
+const net = require("node:net");
+const { Duplex } = require("node:stream");
+
+const kNative = Symbol.for("::bunhttp2native::");
+
+const server = http2.createServer();
+server.on("stream", stream => {
+  stream.respond({ ":status": 200 });
+  // Drain the body so the server sends WINDOW_UPDATE, which triggers the
+  // client's flushStreamQueue -> Stream.flushQueue path.
+  stream.on("data", () => {});
+  stream.on("end", () => stream.end("ok"));
+  stream.on("error", () => {});
+});
+server.on("error", () => {});
+
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+
+  let armed = false;
+  let fired = false;
+  let rstTarget = 0;
+  let session;
+
+  // Wrap a real TCP socket in a Duplex so socket._handle is undefined and the
+  // H2FrameParser falls back to the JS onWrite path (native_socket == .none).
+  // _write calls its callback synchronously so the Duplex never buffers: by
+  // the time req.write() returns below, every direct-send chunk from
+  // sendData() has already passed through here and `armed` can only observe
+  // writes originating from flushQueue (triggered by WINDOW_UPDATE).
+  function createConnection() {
+    const raw = net.connect({ port, host: "127.0.0.1" });
+    const dup = new Duplex({
+      read() {},
+      write(chunk, encoding, callback) {
+        // Only fire on a DATA frame header for our stream. flushQueue writes
+        // the 9-byte header first (type byte at index 3 is 0 for DATA) and
+        // then writes the payload; firing here puts cleanQueue between the
+        // header write and the payload write that reads frame.buffer.
+        if (
+          armed &&
+          !fired &&
+          rstTarget !== 0 &&
+          chunk.length === 9 &&
+          chunk[3] === 0 /* HTTP_FRAME_DATA */ &&
+          (chunk.readUInt32BE(5) & 0x7fffffff) === rstTarget
+        ) {
+          fired = true;
+          // Re-enter the parser synchronously from inside onWrite: this frees
+          // the queued frame currently being flushed.
+          try {
+            session[kNative]?.rstStream(rstTarget, 8 /* CANCEL */);
+          } catch {}
+        }
+        raw.write(chunk, encoding);
+        // Signal completion immediately so the Duplex does not queue chunks
+        // across the `armed = true` boundary. We do NOT want raw-socket
+        // backpressure here; we want flow-control (window exhaustion) to be
+        // the reason data lands in the parser's per-stream dataFrameQueue.
+        callback();
+      },
+      final(callback) {
+        raw.end();
+        callback();
+      },
+      destroy(err, callback) {
+        raw.destroy(err);
+        callback(err);
+      },
+    });
+    raw.on("data", d => dup.push(d));
+    raw.on("end", () => dup.push(null));
+    raw.on("error", e => dup.destroy(e));
+    raw.on("connect", () => dup.emit("connect"));
+    dup.connecting = true;
+    raw.on("connect", () => {
+      dup.connecting = false;
+    });
+    return dup;
+  }
+
+  const client = http2.connect(`http://127.0.0.1:${port}`, { createConnection });
+  session = client;
+  client.on("error", err => {
+    console.error("client error", err);
+    process.exit(1);
+  });
+
+  client.on("connect", () => {
+    const req = client.request({ ":method": "POST", ":path": "/" }, { endStream: false });
+    rstTarget = req.id;
+    req.on("error", () => {});
+    req.on("response", () => {});
+    req.on("data", () => {});
+    req.on("close", () => finish());
+
+    // Write more than the default initial window (65535) so the tail is
+    // queued by the native frame parser. flushQueue runs for the queued tail
+    // once WINDOW_UPDATE arrives.
+    const payload = Buffer.alloc(128 * 1024, 0x61);
+    req.write(payload);
+    // All direct writes have completed synchronously; the remainder is in the
+    // dataFrameQueue. Arm the trap so the NEXT DATA-frame header write (from
+    // flushQueue after WINDOW_UPDATE) resets the stream from inside onWrite.
+    armed = true;
+  });
+
+  let finished = false;
+  function finish() {
+    if (finished) return;
+    finished = true;
+    if (!fired) {
+      console.error("rstStream was never invoked from inside onWrite");
+      process.exit(1);
+    }
+    try {
+      client.destroy();
+    } catch {}
+    try {
+      server.close();
+    } catch {}
+    console.log("ok");
+    process.exit(0);
+  }
+});

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -8,6 +8,11 @@ import path from "node:path";
 // a rehash. Streams are now heap-allocated and stored by pointer, so *Stream
 // is stable for the lifetime of the H2FrameParser regardless of map growth.
 // These three tests cover the call sites where this was observed under ASAN.
+//
+// Each test spawns an ASAN-debug bun subprocess that stands up both the
+// http2 server and client in-process; on throttled CI the subprocess alone
+// takes 3-5s, so give these more than the default 5s.
+const TIMEOUT = 30_000;
 
 test("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
   await using proc = Bun.spawn({
@@ -18,7 +23,7 @@ test("session.request() from a stream 'timeout' listener during forEachStream do
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
-});
+}, TIMEOUT);
 
 test("http2 client request() does not hold *Stream across user-controlled options getters", async () => {
   const script = /* js */ `
@@ -94,7 +99,7 @@ test("http2 client request() does not hold *Stream across user-controlled option
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "done", exitCode: 0 });
-});
+}, TIMEOUT);
 
 test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
   await using proc = Bun.spawn({
@@ -105,7 +110,7 @@ test("http2 client write callback that opens new streams during flushQueue does 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-});
+}, TIMEOUT);
 
 // With a non-native socket, flushQueue's writer.write() reaches JS onWrite
 // synchronously. If that callback resets the stream being flushed (rstStream
@@ -121,4 +126,4 @@ test("rstStream from inside the non-native onWrite callback during flushQueue do
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-});
+}, TIMEOUT);

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -14,19 +14,25 @@ import path from "node:path";
 // takes 3-5s, so give these more than the default 5s.
 const TIMEOUT = 30_000;
 
-test("session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash.fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
-}, TIMEOUT);
+test(
+  "session.request() from a stream 'timeout' listener during forEachStream does not UAF on hashmap rehash",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", path.join(import.meta.dir, "node-http2-foreach-rehash.fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "OK", exitCode: 0 });
+  },
+  TIMEOUT,
+);
 
-test("http2 client request() does not hold *Stream across user-controlled options getters", async () => {
-  const script = /* js */ `
+test(
+  "http2 client request() does not hold *Stream across user-controlled options getters",
+  async () => {
+    const script = /* js */ `
     const http2 = require("node:http2");
 
     const server = http2.createServer();
@@ -91,39 +97,49 @@ test("http2 client request() does not hold *Stream across user-controlled option
     });
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "done", exitCode: 0 });
-}, TIMEOUT);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "done", exitCode: 0 });
+  },
+  TIMEOUT,
+);
 
-test("http2 client write callback that opens new streams during flushQueue does not UAF", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rehash.fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-}, TIMEOUT);
+test(
+  "http2 client write callback that opens new streams during flushQueue does not UAF",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rehash.fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
+  },
+  TIMEOUT,
+);
 
 // With a non-native socket, flushQueue's writer.write() reaches JS onWrite
 // synchronously. If that callback resets the stream being flushed (rstStream
 // -> cleanQueue), the old code would read freed frame.buffer and then unwrap
 // null from dequeue().?. flushQueue now dequeues the frame to the stack
 // before any write that can re-enter.
-test("rstStream from inside the non-native onWrite callback during flushQueue does not UAF", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rststream.fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
-}, TIMEOUT);
+test(
+  "rstStream from inside the non-native onWrite callback during flushQueue does not UAF",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rststream.fixture.js")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
+  },
+  TIMEOUT,
+);

--- a/test/js/node/http2/node-http2-streams-rehash.test.ts
+++ b/test/js/node/http2/node-http2-streams-rehash.test.ts
@@ -106,3 +106,19 @@ test("http2 client write callback that opens new streams during flushQueue does 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
 });
+
+// With a non-native socket, flushQueue's writer.write() reaches JS onWrite
+// synchronously. If that callback resets the stream being flushed (rstStream
+// -> cleanQueue), the old code would read freed frame.buffer and then unwrap
+// null from dequeue().?. flushQueue now dequeues the frame to the stack
+// before any write that can re-enter.
+test("rstStream from inside the non-native onWrite callback during flushQueue does not UAF", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "node-http2-flush-rststream.fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({ stdout: "ok", exitCode: 0 });
+});


### PR DESCRIPTION
## What

`Stream.flushQueue` held a `*PendingFrame` obtained from `dataFrameQueue.peekFront()` across `writer.write()`. With a non-native socket (e.g. `http2.connect` over a plain Duplex from `createConnection`) that write reaches `_write()` → the JS `onWrite` handler synchronously. If user code reachable from that handler calls `rstStream()` on the stream being flushed, `endStream` → `freeResources` → `cleanQueue` frees every queued `frame.buffer` and replaces `dataFrameQueue` with an empty one. The resumed `flushQueue` would then:

- read the freed `frame.buffer` at the payload write (heap-use-after-free),
- double-subtract `queuedDataSize`/`outboundQueueSize` (integer overflow in debug), and
- unwrap null from the deferred `this.dataFrameQueue.dequeue().?`.

## Reproduction

`test/js/node/http2/node-http2-flush-rststream.fixture.js` wraps a real TCP socket in a `Duplex` (no `._handle`) so `H2FrameParser` takes the JS `onWrite` path, writes 128 KiB so the tail is queued past the 64 KiB initial window, and when `flushQueue` writes the 9-byte DATA header (after the server's WINDOW_UPDATE) the Duplex's `_write` synchronously calls the native `rstStream(id, CANCEL)`.

Before this change (debug/ASAN build):

```
flushStreamQueue 5
padding: 0 size: 16374 ...
write 9                ← dataHeader.write() → onWrite → user JS
rstStream
cleanQueue len: 5 ...  ← frees the frame flushQueue is still holding
panic: integer overflow at h2_frame_parser.zig:1197
```

## Fix

- Dequeue the front frame to the stack **before** any `writer.write()` that can re-enter JS, so `cleanQueue` cannot free it (it's no longer in the queue) and the deferred `dequeue().?` is gone.
- Add `PendingQueue.pushFront` so a partially-sent frame (flow-control-limited) is returned to the front of the queue for the next flush. Reuses the slot vacated by the immediately-preceding `dequeue()` so the fast path is a single index decrement.
- After the write completes, re-check `canSendData()`: if the stream was reset from inside `onWrite`, drop the remainder (matching `cleanQueue`'s accounting) instead of re-queueing into a closed stream; skip the redundant end-stream dispatch `endStream` already did.

## Verification

```
git stash push -- src/
bun bd test test/js/node/http2/node-http2-streams-rehash.test.ts -t "rstStream from inside"
  → (fail)  subprocess panics: integer overflow in cleanQueue
git stash pop
bun bd test test/js/node/http2/node-http2-streams-rehash.test.ts -t "rstStream from inside"
  → (pass)  2.5s
```

The other three `flushQueue` UAF tests in that file, `node-http2-continuation.test.ts`, and `node-http2-invalid-padding.test.ts` continue to pass. The `bun-debug {none,max,aligned}` matrices in `node-http2.test.js` are unchanged vs main.

> Note: #30146 also touches the padded branches of `flushQueue`; whichever lands second will need a small rebase.