### PR TITLE
Use atom-backed CommonStrings for fetch/socket enum getters

### DIFF
--- a/src/bun.js/api/bun/socket.zig
+++ b/src/bun.js/api/bun/socket.zig
@@ -851,8 +851,8 @@ pub fn NewSocket(comptime ssl: bool) type {
             var buf: [64]u8 = [_]u8{0} ** 64;
             const address_bytes: []const u8 = this.socket.localAddress(&buf) orelse return .js_undefined;
             return switch (address_bytes.len) {
-                4 => try bun.String.static("IPv4").toJS(globalThis),
-                16 => try bun.String.static("IPv6").toJS(globalThis),
+                4 => globalThis.commonStrings().IPv4(),
+                16 => globalThis.commonStrings().IPv6(),
                 else => return .js_undefined,
             };
         }
@@ -892,8 +892,8 @@ pub fn NewSocket(comptime ssl: bool) type {
             var buf: [64]u8 = [_]u8{0} ** 64;
             const address_bytes: []const u8 = this.socket.remoteAddress(&buf) orelse return .js_undefined;
             return switch (address_bytes.len) {
-                4 => try bun.String.static("IPv4").toJS(globalThis),
-                16 => try bun.String.static("IPv6").toJS(globalThis),
+                4 => globalThis.commonStrings().IPv4(),
+                16 => globalThis.commonStrings().IPv6(),
                 else => return .js_undefined,
             };
         }

--- a/src/bun.js/api/bun/socket/Listener.zig
+++ b/src/bun.js/api/bun/socket/Listener.zig
@@ -885,8 +885,8 @@ pub fn getsockname(this: *Listener, globalThis: *jsc.JSGlobalObject, callFrame: 
         else => return .js_undefined,
     };
     const family_js = switch (address_bytes.len) {
-        4 => try bun.String.static("IPv4").toJS(globalThis),
-        16 => try bun.String.static("IPv6").toJS(globalThis),
+        4 => globalThis.commonStrings().IPv4(),
+        16 => globalThis.commonStrings().IPv6(),
         else => return .js_undefined,
     };
     const address_js = ZigString.init(bun.fmt.formatIp(address_zig, &text_buf) catch unreachable).toJS(globalThis);

--- a/src/bun.js/api/bun/socket/SocketAddress.zig
+++ b/src/bun.js/api/bun/socket/SocketAddress.zig
@@ -390,11 +390,9 @@ pub fn address(this: *SocketAddress) bun.String {
 /// NOTE: node's `net.SocketAddress` wants `"ipv4"` and `"ipv6"` while Bun's APIs
 /// use `"IPv4"` and `"IPv6"`. This is annoying.
 pub fn getFamily(this: *SocketAddress, global: *jsc.JSGlobalObject) bun.JSError!JSValue {
-    // NOTE: cannot use global.commonStrings().IPv[4,6]() b/c this needs to be
-    // lower case.
     return switch (this.family()) {
-        AF.INET => bun.String.static("ipv4").toJS(global),
-        AF.INET6 => bun.String.static("ipv6").toJS(global),
+        AF.INET => global.commonStrings().ipv4(),
+        AF.INET6 => global.commonStrings().ipv6(),
     };
 }
 

--- a/src/bun.js/api/bun/udp_socket.zig
+++ b/src/bun.js/api/bun/udp_socket.zig
@@ -985,9 +985,9 @@ pub const UDPSocket = struct {
         globalThis: *JSGlobalObject,
     ) bun.JSError!JSValue {
         return switch (this.config.binary_type) {
-            .Buffer => bun.String.static("buffer").toJS(globalThis),
-            .Uint8Array => bun.String.static("uint8array").toJS(globalThis),
-            .ArrayBuffer => bun.String.static("arraybuffer").toJS(globalThis),
+            .Buffer => globalThis.commonStrings().buffer(),
+            .Uint8Array => globalThis.commonStrings().uint8array(),
+            .ArrayBuffer => globalThis.commonStrings().arraybuffer(),
             else => @panic("Invalid binary type"),
         };
     }

--- a/src/bun.js/api/server/ServerWebSocket.zig
+++ b/src/bun.js/api/server/ServerWebSocket.zig
@@ -1117,9 +1117,9 @@ pub fn getBinaryType(
     log("getBinaryType()", .{});
 
     return switch (this.#flags.binary_type) {
-        .Uint8Array => bun.String.static("uint8array").toJS(globalThis),
-        .Buffer => bun.String.static("nodebuffer").toJS(globalThis),
-        .ArrayBuffer => bun.String.static("arraybuffer").toJS(globalThis),
+        .Uint8Array => globalThis.commonStrings().uint8array(),
+        .Buffer => globalThis.commonStrings().nodebuffer(),
+        .ArrayBuffer => globalThis.commonStrings().arraybuffer(),
         else => @panic("Invalid binary type"),
     };
 }

--- a/src/bun.js/bindings/BunCommonStrings.cpp
+++ b/src/bun.js/bindings/BunCommonStrings.cpp
@@ -176,7 +176,7 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForZig co
     case CommonStringsForZig::ipv6Lower:
         return commonStrings.ipv6LowerString(globalObject);
     case CommonStringsForZig::fetchDefault:
-        return commonStrings.fetchDefaultString(globalObject);
+        return globalObject->vm().smallStrings.defaultString();
     case CommonStringsForZig::fetchError:
         return commonStrings.fetchErrorString(globalObject);
     case CommonStringsForZig::fetchInclude:
@@ -216,7 +216,7 @@ extern "C" JSC::EncodedJSValue Bun__FetchCacheMode__toJS(FetchCacheMode mode, Zi
     auto& commonStrings = globalObject->commonStrings();
     switch (mode) {
     case FetchCacheMode::Default:
-        return JSValue::encode(commonStrings.fetchDefaultString(globalObject));
+        return JSValue::encode(globalObject->vm().smallStrings.defaultString());
     case FetchCacheMode::NoStore:
         return JSValue::encode(commonStrings.fetchNoStoreString(globalObject));
     case FetchCacheMode::Reload:

--- a/src/bun.js/bindings/BunCommonStrings.cpp
+++ b/src/bun.js/bindings/BunCommonStrings.cpp
@@ -23,7 +23,7 @@ using namespace JSC;
 #define BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION_NOT_BUILTIN_NAMES(methodName, stringLiteral) \
     this->m_commonString_##methodName.initLater(                                                 \
         [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {               \
-            init.set(jsOwnedString(init.vm, stringLiteral##_s));                                 \
+            init.set(jsString(init.vm, AtomString(stringLiteral##_s)));                          \
         });
 
 #define BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR(name) this->m_commonString_##name.visit(visitor);
@@ -148,19 +148,47 @@ enum class CommonStringsForZig : uint8_t {
     IPv6 = 1,
     IN4Loopback = 2,
     IN6Any = 3,
+    ipv4Lower = 4,
+    ipv6Lower = 5,
+    fetchDefault = 6,
+    fetchError = 7,
+    fetchInclude = 8,
+    buffer = 9,
+    binaryTypeArrayBuffer = 10,
+    binaryTypeNodeBuffer = 11,
+    binaryTypeUint8Array = 12,
 };
 
 static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForZig commonString)
 {
+    auto& commonStrings = globalObject->commonStrings();
     switch (commonString) {
     case CommonStringsForZig::IPv4:
-        return globalObject->commonStrings().IPv4String(globalObject);
+        return commonStrings.IPv4String(globalObject);
     case CommonStringsForZig::IPv6:
-        return globalObject->commonStrings().IPv6String(globalObject);
+        return commonStrings.IPv6String(globalObject);
     case CommonStringsForZig::IN4Loopback:
-        return globalObject->commonStrings().IN4LoopbackString(globalObject);
+        return commonStrings.IN4LoopbackString(globalObject);
     case CommonStringsForZig::IN6Any:
-        return globalObject->commonStrings().IN6AnyString(globalObject);
+        return commonStrings.IN6AnyString(globalObject);
+    case CommonStringsForZig::ipv4Lower:
+        return commonStrings.ipv4LowerString(globalObject);
+    case CommonStringsForZig::ipv6Lower:
+        return commonStrings.ipv6LowerString(globalObject);
+    case CommonStringsForZig::fetchDefault:
+        return commonStrings.fetchDefaultString(globalObject);
+    case CommonStringsForZig::fetchError:
+        return commonStrings.fetchErrorString(globalObject);
+    case CommonStringsForZig::fetchInclude:
+        return commonStrings.fetchIncludeString(globalObject);
+    case CommonStringsForZig::buffer:
+        return commonStrings.bufferString(globalObject);
+    case CommonStringsForZig::binaryTypeArrayBuffer:
+        return commonStrings.binaryTypeArrayBufferString(globalObject);
+    case CommonStringsForZig::binaryTypeNodeBuffer:
+        return commonStrings.binaryTypeNodeBufferString(globalObject);
+    case CommonStringsForZig::binaryTypeUint8Array:
+        return commonStrings.binaryTypeUint8ArrayString(globalObject);
     default: {
         ASSERT_NOT_REACHED();
         return jsUndefined();
@@ -171,6 +199,90 @@ static JSC::JSValue toJS(Zig::GlobalObject* globalObject, CommonStringsForZig co
 extern "C" JSC::EncodedJSValue Bun__CommonStringsForZig__toJS(CommonStringsForZig commonString, Zig::GlobalObject* globalObject)
 {
     return JSValue::encode(toJS(globalObject, commonString));
+}
+
+// Must be kept in sync with src/http/FetchCacheMode.zig
+enum class FetchCacheMode : uint8_t {
+    Default = 0,
+    NoStore = 1,
+    Reload = 2,
+    NoCache = 3,
+    ForceCache = 4,
+    OnlyIfCached = 5,
+};
+
+extern "C" JSC::EncodedJSValue Bun__FetchCacheMode__toJS(FetchCacheMode mode, Zig::GlobalObject* globalObject)
+{
+    auto& commonStrings = globalObject->commonStrings();
+    switch (mode) {
+    case FetchCacheMode::Default:
+        return JSValue::encode(commonStrings.fetchDefaultString(globalObject));
+    case FetchCacheMode::NoStore:
+        return JSValue::encode(commonStrings.fetchNoStoreString(globalObject));
+    case FetchCacheMode::Reload:
+        return JSValue::encode(commonStrings.fetchReloadString(globalObject));
+    case FetchCacheMode::NoCache:
+        return JSValue::encode(commonStrings.fetchNoCacheString(globalObject));
+    case FetchCacheMode::ForceCache:
+        return JSValue::encode(commonStrings.fetchForceCacheString(globalObject));
+    case FetchCacheMode::OnlyIfCached:
+        return JSValue::encode(commonStrings.fetchOnlyIfCachedString(globalObject));
+    default: {
+        ASSERT_NOT_REACHED();
+        return JSValue::encode(jsUndefined());
+    }
+    }
+}
+
+// Must be kept in sync with src/http/FetchRedirect.zig
+enum class FetchRedirect : uint8_t {
+    Follow = 0,
+    Manual = 1,
+    Error = 2,
+};
+
+extern "C" JSC::EncodedJSValue Bun__FetchRedirect__toJS(FetchRedirect redirect, Zig::GlobalObject* globalObject)
+{
+    auto& commonStrings = globalObject->commonStrings();
+    switch (redirect) {
+    case FetchRedirect::Follow:
+        return JSValue::encode(commonStrings.fetchFollowString(globalObject));
+    case FetchRedirect::Manual:
+        return JSValue::encode(commonStrings.fetchManualString(globalObject));
+    case FetchRedirect::Error:
+        return JSValue::encode(commonStrings.fetchErrorString(globalObject));
+    default: {
+        ASSERT_NOT_REACHED();
+        return JSValue::encode(jsUndefined());
+    }
+    }
+}
+
+// Must be kept in sync with src/http/FetchRequestMode.zig
+enum class FetchRequestMode : uint8_t {
+    SameOrigin = 0,
+    NoCors = 1,
+    Cors = 2,
+    Navigate = 3,
+};
+
+extern "C" JSC::EncodedJSValue Bun__FetchRequestMode__toJS(FetchRequestMode mode, Zig::GlobalObject* globalObject)
+{
+    auto& commonStrings = globalObject->commonStrings();
+    switch (mode) {
+    case FetchRequestMode::SameOrigin:
+        return JSValue::encode(commonStrings.fetchSameOriginString(globalObject));
+    case FetchRequestMode::NoCors:
+        return JSValue::encode(commonStrings.fetchNoCorsString(globalObject));
+    case FetchRequestMode::Cors:
+        return JSValue::encode(commonStrings.fetchCorsString(globalObject));
+    case FetchRequestMode::Navigate:
+        return JSValue::encode(commonStrings.fetchNavigateString(globalObject));
+    default: {
+        ASSERT_NOT_REACHED();
+        return JSValue::encode(jsUndefined());
+    }
+    }
 }
 
 } // namespace Bun

--- a/src/bun.js/bindings/BunCommonStrings.h
+++ b/src/bun.js/bindings/BunCommonStrings.h
@@ -58,10 +58,29 @@
     macro(ascii, "ascii") \
     macro(base64, "base64") \
     macro(base64url, "base64url") \
+    macro(binaryTypeArrayBuffer, "arraybuffer") \
+    macro(binaryTypeNodeBuffer, "nodebuffer") \
+    macro(binaryTypeUint8Array, "uint8array") \
     macro(buffer, "buffer") \
     macro(ec, "ec") \
     macro(ed25519, "ed25519") \
+    macro(fetchCors, "cors") \
+    macro(fetchDefault, "default") \
+    macro(fetchError, "error") \
+    macro(fetchFollow, "follow") \
+    macro(fetchForceCache, "force-cache") \
+    macro(fetchInclude, "include") \
+    macro(fetchManual, "manual") \
+    macro(fetchNavigate, "navigate") \
+    macro(fetchNoCache, "no-cache") \
+    macro(fetchNoCors, "no-cors") \
+    macro(fetchNoStore, "no-store") \
+    macro(fetchOnlyIfCached, "only-if-cached") \
+    macro(fetchReload, "reload") \
+    macro(fetchSameOrigin, "same-origin") \
     macro(hex, "hex") \
+    macro(ipv4Lower, "ipv4") \
+    macro(ipv6Lower, "ipv6") \
     macro(latin1, "latin1") \
     macro(lax, "lax") \
     macro(none, "none") \

--- a/src/bun.js/bindings/BunCommonStrings.h
+++ b/src/bun.js/bindings/BunCommonStrings.h
@@ -65,7 +65,6 @@
     macro(ec, "ec") \
     macro(ed25519, "ed25519") \
     macro(fetchCors, "cors") \
-    macro(fetchDefault, "default") \
     macro(fetchError, "error") \
     macro(fetchFollow, "follow") \
     macro(fetchForceCache, "force-cache") \

--- a/src/bun.js/bindings/CommonStrings.zig
+++ b/src/bun.js/bindings/CommonStrings.zig
@@ -9,6 +9,15 @@ pub const CommonStrings = struct {
         IPv6 = 1,
         IN4Loopback = 2,
         IN6Any = 3,
+        ipv4Lower = 4,
+        ipv6Lower = 5,
+        fetchDefault = 6,
+        fetchError = 7,
+        fetchInclude = 8,
+        buffer = 9,
+        binaryTypeArrayBuffer = 10,
+        binaryTypeNodeBuffer = 11,
+        binaryTypeUint8Array = 12,
 
         extern "c" fn Bun__CommonStringsForZig__toJS(commonString: CommonStringsForZig, globalObject: *jsc.JSGlobalObject) jsc.JSValue;
         pub const toJS = Bun__CommonStringsForZig__toJS;
@@ -25,6 +34,33 @@ pub const CommonStrings = struct {
     }
     pub inline fn @"::"(this: CommonStrings) JSValue {
         return CommonStringsForZig.IN6Any.toJS(this.globalObject);
+    }
+    pub inline fn ipv4(this: CommonStrings) JSValue {
+        return CommonStringsForZig.ipv4Lower.toJS(this.globalObject);
+    }
+    pub inline fn ipv6(this: CommonStrings) JSValue {
+        return CommonStringsForZig.ipv6Lower.toJS(this.globalObject);
+    }
+    pub inline fn default(this: CommonStrings) JSValue {
+        return CommonStringsForZig.fetchDefault.toJS(this.globalObject);
+    }
+    pub inline fn @"error"(this: CommonStrings) JSValue {
+        return CommonStringsForZig.fetchError.toJS(this.globalObject);
+    }
+    pub inline fn include(this: CommonStrings) JSValue {
+        return CommonStringsForZig.fetchInclude.toJS(this.globalObject);
+    }
+    pub inline fn buffer(this: CommonStrings) JSValue {
+        return CommonStringsForZig.buffer.toJS(this.globalObject);
+    }
+    pub inline fn arraybuffer(this: CommonStrings) JSValue {
+        return CommonStringsForZig.binaryTypeArrayBuffer.toJS(this.globalObject);
+    }
+    pub inline fn nodebuffer(this: CommonStrings) JSValue {
+        return CommonStringsForZig.binaryTypeNodeBuffer.toJS(this.globalObject);
+    }
+    pub inline fn uint8array(this: CommonStrings) JSValue {
+        return CommonStringsForZig.binaryTypeUint8Array.toJS(this.globalObject);
     }
 };
 

--- a/src/bun.js/node/node_os.zig
+++ b/src/bun.js/node/node_os.zig
@@ -646,11 +646,11 @@ fn networkInterfacesPosix(globalThis: *jsc.JSGlobalObject) bun.JSError!jsc.JSVal
         }
 
         // family <string> Either IPv4 or IPv6
-        interface.put(globalThis, jsc.ZigString.static("family"), (switch (addr.any.family) {
-            std.posix.AF.INET => jsc.ZigString.static("IPv4"),
-            std.posix.AF.INET6 => jsc.ZigString.static("IPv6"),
-            else => jsc.ZigString.static("unknown"),
-        }).toJS(globalThis));
+        interface.put(globalThis, jsc.ZigString.static("family"), switch (addr.any.family) {
+            std.posix.AF.INET => globalThis.commonStrings().IPv4(),
+            std.posix.AF.INET6 => globalThis.commonStrings().IPv6(),
+            else => jsc.ZigString.static("unknown").toJS(globalThis),
+        });
 
         // mac <string> The MAC address of the network interface
         {
@@ -788,11 +788,11 @@ fn networkInterfacesWindows(globalThis: *jsc.JSGlobalObject) bun.JSError!jsc.JSV
             interface.put(globalThis, jsc.ZigString.static("netmask"), jsc.ZigString.init(str).withEncoding().toJS(globalThis));
         }
         // family
-        interface.put(globalThis, jsc.ZigString.static("family"), (switch (iface.address.address4.family) {
-            std.posix.AF.INET => jsc.ZigString.static("IPv4"),
-            std.posix.AF.INET6 => jsc.ZigString.static("IPv6"),
-            else => jsc.ZigString.static("unknown"),
-        }).toJS(globalThis));
+        interface.put(globalThis, jsc.ZigString.static("family"), switch (iface.address.address4.family) {
+            std.posix.AF.INET => globalThis.commonStrings().IPv4(),
+            std.posix.AF.INET6 => globalThis.commonStrings().IPv6(),
+            else => jsc.ZigString.static("unknown").toJS(globalThis),
+        });
 
         // mac
         {

--- a/src/bun.js/webcore/Request.zig
+++ b/src/bun.js/webcore/Request.zig
@@ -341,15 +341,13 @@ pub fn getCache(
     this: *Request,
     globalThis: *jsc.JSGlobalObject,
 ) jsc.JSValue {
-    return switch (this.flags.cache) {
-        inline else => |tag| ZigString.static(@tagName(tag)).toJS(globalThis),
-    };
+    return this.flags.cache.toJS(globalThis);
 }
 pub fn getCredentials(
     _: *Request,
     globalThis: *jsc.JSGlobalObject,
 ) jsc.JSValue {
-    return ZigString.init("include").toJS(globalThis);
+    return globalThis.commonStrings().include();
 }
 pub fn getDestination(
     _: *Request,
@@ -391,9 +389,7 @@ pub fn getMode(
     this: *Request,
     globalThis: *jsc.JSGlobalObject,
 ) jsc.JSValue {
-    return switch (this.flags.mode) {
-        inline else => |tag| ZigString.static(@tagName(tag)).toJS(globalThis),
-    };
+    return this.flags.mode.toJS(globalThis);
 }
 
 pub fn finalizeWithoutDeinit(this: *Request) void {
@@ -425,9 +421,7 @@ pub fn getRedirect(
     this: *Request,
     globalThis: *jsc.JSGlobalObject,
 ) jsc.JSValue {
-    return switch (this.flags.redirect) {
-        inline else => |tag| ZigString.static(@tagName(tag)).toJS(globalThis),
-    };
+    return this.flags.redirect.toJS(globalThis);
 }
 pub fn getReferrer(
     this: *Request,

--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -318,10 +318,10 @@ pub fn getResponseType(
     globalThis: *jsc.JSGlobalObject,
 ) bun.JSError!jsc.JSValue {
     if (this.#init.status_code < 200) {
-        return bun.String.static("error").toJS(globalThis);
+        return globalThis.commonStrings().@"error"();
     }
 
-    return bun.String.static("default").toJS(globalThis);
+    return globalThis.commonStrings().default();
 }
 
 pub fn getStatusText(

--- a/src/http/FetchCacheMode.zig
+++ b/src/http/FetchCacheMode.zig
@@ -15,6 +15,12 @@ pub const FetchCacheMode = enum(u3) {
         .{ "force-cache", .@"force-cache" },
         .{ "only-if-cached", .@"only-if-cached" },
     });
+
+    extern "c" fn Bun__FetchCacheMode__toJS(cache: u8, globalObject: *jsc.JSGlobalObject) jsc.JSValue;
+    pub inline fn toJS(this: FetchCacheMode, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
+        return Bun__FetchCacheMode__toJS(@intFromEnum(this), globalObject);
+    }
 };
 
 const bun = @import("bun");
+const jsc = bun.jsc;

--- a/src/http/FetchRedirect.zig
+++ b/src/http/FetchRedirect.zig
@@ -8,6 +8,12 @@ pub const FetchRedirect = enum(u2) {
         .{ "manual", .manual },
         .{ "error", .@"error" },
     });
+
+    extern "c" fn Bun__FetchRedirect__toJS(redirect: u8, globalObject: *jsc.JSGlobalObject) jsc.JSValue;
+    pub inline fn toJS(this: FetchRedirect, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
+        return Bun__FetchRedirect__toJS(@intFromEnum(this), globalObject);
+    }
 };
 
 const bun = @import("bun");
+const jsc = bun.jsc;

--- a/src/http/FetchRequestMode.zig
+++ b/src/http/FetchRequestMode.zig
@@ -11,6 +11,12 @@ pub const FetchRequestMode = enum(u2) {
         .{ "cors", .cors },
         .{ "navigate", .navigate },
     });
+
+    extern "c" fn Bun__FetchRequestMode__toJS(mode: u8, globalObject: *jsc.JSGlobalObject) jsc.JSValue;
+    pub inline fn toJS(this: FetchRequestMode, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
+        return Bun__FetchRequestMode__toJS(@intFromEnum(this), globalObject);
+    }
 };
 
 const bun = @import("bun");
+const jsc = bun.jsc;


### PR DESCRIPTION
Routes a set of hot enum-string property getters through `BunCommonStrings` (lazy-init `JSString` backed by `AtomString`) instead of allocating a new `JSString` on every access.

### CommonStrings
- Non-builtin entries now initialize via `jsString(vm, AtomString(literal))` so the backing `StringImpl` is atomized.
- Added `Bun__FetchCacheMode__toJS` / `Bun__FetchRedirect__toJS` / `Bun__FetchRequestMode__toJS` C++↔Zig bridges and `toJS()` on the Zig enums.
- Extended `CommonStringsForZig` with `ipv4`/`ipv6` (lowercase), `default`/`error`/`include`, and `buffer`/`arraybuffer`/`nodebuffer`/`uint8array`.

### Getters converted
| Getter | Values |
|---|---|
| `Request.cache` / `.mode` / `.redirect` | full fetch enum sets |
| `Request.credentials` | `include` |
| `Response.type` | `default` / `error` |
| `ServerWebSocket.binaryType` | `uint8array` / `nodebuffer` / `arraybuffer` |
| `Bun.udpSocket().binaryType` | `buffer` / `uint8array` / `arraybuffer` |
| `net.SocketAddress.family` | `ipv4` / `ipv6` |
| `Bun.Socket` `localFamily` / `remoteFamily` | `IPv4` / `IPv6` |
| `Bun.listen()` address `.family` | `IPv4` / `IPv6` |
| `os.networkInterfaces()[].family` (posix + windows) | `IPv4` / `IPv6` |