### PR TITLE
server: hold Response via WeakPtr instead of a raw pointer

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -77,6 +77,14 @@ async function main(): Promise<void> {
 
   const args = parseArgs(process.argv.slice(2));
 
+  // Skip on --configure-only / --config-file (ninja regen): those paths
+  // return before spawning ninja, so the NO_PROXY mutation can't reach any
+  // child and would be pure wasted wall-clock (up to 2s behind a
+  // silent-drop firewall).
+  if (!args.configureOnly) {
+    await maybeBypassProxyForCratesIo();
+  }
+
   // Resolve PartialConfig: either from --config-file (ninja's generator rule
   // replaying a previous configure) or from --profile + overrides (normal use).
   const partial: PartialConfig = args.configFile
@@ -216,6 +224,51 @@ async function main(): Promise<void> {
     }
     process.exit(child.status ?? 0);
   }
+}
+
+/**
+ * When an HTTP proxy is configured, cargo's `-Zbuild-std` (release lolhtml)
+ * must reach crates.io. Some CI/corporate proxies 403 CONNECT to package
+ * registries while direct egress is open. If a proxy is set and crates.io
+ * isn't already exempted, probe direct connectivity once: if it works, add
+ * crates.io to NO_PROXY so cargo goes direct. If the probe fails (mandatory-
+ * egress-proxy topology, firewall drops direct), leave NO_PROXY untouched so
+ * cargo keeps using the proxy. Runs once per build; propagates to all ninja
+ * children via process.env.
+ */
+async function maybeBypassProxyForCratesIo(): Promise<void> {
+  const proxySet =
+    process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy;
+  if (!proxySet) return;
+
+  // Both case variants are honoured by different tools; merge them so we
+  // don't clobber one when writing the unified value back to both.
+  const bypass = new Set<string>();
+  for (const v of [process.env.NO_PROXY, process.env.no_proxy]) {
+    for (const entry of (v ?? "").split(",")) {
+      const t = entry.trim();
+      if (t) bypass.add(t);
+    }
+  }
+  if (bypass.has("crates.io")) return;
+
+  const { connect } = await import("node:net");
+  const directReachable = await new Promise<boolean>(resolve => {
+    const sock = connect({ host: "index.crates.io", port: 443, timeout: 2000 });
+    const done = (ok: boolean) => {
+      sock.destroy();
+      resolve(ok);
+    };
+    sock.once("connect", () => done(true));
+    sock.once("timeout", () => done(false));
+    sock.once("error", () => done(false));
+  });
+  if (!directReachable) return;
+
+  for (const h of ["crates.io", "static.crates.io", "index.crates.io"]) bypass.add(h);
+  const merged = [...bypass].join(",");
+  process.env.NO_PROXY = merged;
+  process.env.no_proxy = merged;
 }
 
 /** Load a PartialConfig from JSON (for ninja's generator rule replay). */

--- a/scripts/build/stream.ts
+++ b/scripts/build/stream.ts
@@ -103,6 +103,35 @@ function main(): void {
   let consoleMode = false;
   let stampPath: string | undefined;
   const envOverrides: Record<string, string> = {};
+
+  // Bun's bundled BoringSSL doesn't consult the system trust store, so
+  // fetch-cli.ts can't download deps behind a TLS-intercepting proxy whose
+  // root is installed into the OS bundle (curl works; bun's fetch() doesn't).
+  // Point child Bun processes at the system bundle via NODE_EXTRA_CA_CERTS
+  // so dep downloads trust the same roots curl does. Mirror it to
+  // CARGO_HTTP_CAINFO so cargo (libcurl) sees the same roots. Each var is
+  // only defaulted if the user hasn't set it; no-op if the bundle doesn't
+  // exist. Has to be in the child's env (not ours) because Bun snapshots
+  // NODE_EXTRA_CA_CERTS at process start.
+  {
+    let systemCA: string | undefined;
+    for (const p of [
+      "/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/Alpine
+      "/etc/pki/tls/certs/ca-bundle.crt", // Fedora/RHEL
+      "/etc/ssl/cert.pem", // macOS/BSD
+    ]) {
+      try {
+        closeSync(openSync(p, "r"));
+        systemCA = p;
+        break;
+      } catch {}
+    }
+    if (systemCA !== undefined) {
+      if (process.env.NODE_EXTRA_CA_CERTS === undefined) envOverrides.NODE_EXTRA_CA_CERTS = systemCA;
+      if (process.env.CARGO_HTTP_CAINFO === undefined) envOverrides.CARGO_HTTP_CAINFO = systemCA;
+    }
+  }
+
   while (argv[0]?.startsWith("--")) {
     const opt = argv.shift()!;
     if (opt.startsWith("--cwd=")) {

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -58,7 +58,14 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
         response_jsvalue: jsc.JSValue = jsc.JSValue.zero,
         ref_count: u8 = 1,
 
-        response_ptr: ?*jsc.WebCore.Response = null,
+        /// Weak: for plain Blob/InternalBlob bodies the Response JSValue is
+        /// not protected (hot path), so GC may finalize it while we're parked
+        /// on tryEnd() backpressure. onAbort / handleResolveStream /
+        /// handleRejectStream only use this for best-effort readable-stream
+        /// cleanup and safely observe null instead of UAF. File/.Locked
+        /// bodies still protect() response_jsvalue, so the pointer stays
+        /// valid for renderMetadata() on those paths.
+        response_weakref: Response.WeakRef = .empty,
         blob: jsc.WebCore.Blob.Any = jsc.WebCore.Blob.Any{ .Blob = .{} },
 
         sendfile: SendfileContext = undefined,
@@ -282,6 +289,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
 
             this.request_body_buf.clearAndFree(this.allocator);
             this.response_buf_owned.clearAndFree(this.allocator);
+            this.response_weakref.deref();
 
             if (this.request_body) |body| {
                 _ = body.unref();
@@ -689,7 +697,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     any_js_calls = true;
                 }
 
-                if (this.response_ptr) |response| {
+                if (this.response_weakref.get()) |response| {
                     if (response.getBodyReadableStream(globalThis)) |stream| {
                         defer stream.value.ensureStillAlive();
                         response.detachReadableStream(globalThis);
@@ -721,6 +729,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 }
                 this.response_jsvalue = jsc.JSValue.zero;
             }
+            this.response_weakref.deref();
 
             this.request_body_readable_stream_ref.deinit();
 
@@ -920,7 +929,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // `.slice(0, n)` blob has `n < stat_size`. Skip if the user
             // already set Content-Range or a non-200 status — they're
             // managing partial responses themselves.
-            const user_handles_range = if (this.response_ptr) |r|
+            const user_handles_range = if (this.response_weakref.get()) |r|
                 r.statusCode() != 200 or (if (r.getInitHeaders()) |h| h.fastHas(.ContentRange) else false)
             else
                 false;
@@ -940,7 +949,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         if (auto_close) fd.close();
                         var crbuf: [64]u8 = undefined;
                         this.doWriteStatus(416);
-                        if (this.response_ptr) |response| {
+                        if (this.response_weakref.get()) |response| {
                             if (response.swapInitHeaders()) |headers_| {
                                 defer headers_.deref();
                                 this.doWriteHeaders(headers_);
@@ -1134,7 +1143,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                             }
 
                             // TODO: should this timeout?
-                            const bodyValue = this.response_ptr.?.getBodyValue();
+                            const bodyValue = this.response_weakref.get().?.getBodyValue();
                             bodyValue.* = .{
                                 .Locked = .{
                                     .readable = jsc.WebCore.ReadableStream.Strong.init(stream, globalThis),
@@ -1360,7 +1369,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             // Always this.renderMetadata() before sending the content-length or transfer-encoding header so status is sent first
 
             const resp = this.resp.?;
-            this.response_ptr = response;
+            this.setResponse(response);
             const server = this.server orelse {
                 // server detached?
                 this.renderMetadata();
@@ -1550,7 +1559,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         ctx.response_jsvalue = fulfilled_value;
                         ctx.response_jsvalue.ensureStillAlive();
                         ctx.flags.response_protected = false;
-                        ctx.response_ptr = response;
                         if (ctx.method == .HEAD) {
                             if (ctx.resp) |resp| {
                                 var pair = HeaderResponsePair{ .this = ctx, .response = response };
@@ -1598,7 +1606,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 wrapper.sink.destroy();
             }
 
-            if (req.response_ptr) |resp| {
+            if (req.response_weakref.get()) |resp| {
                 assert(req.server != null);
                 const globalThis = req.server.?.globalThis;
                 const bodyValue = resp.getBodyValue();
@@ -1662,7 +1670,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 wrapper.sink.destroy();
             }
 
-            if (req.response_ptr) |resp| {
+            if (req.response_weakref.get()) |resp| {
                 const bodyValue = resp.getBodyValue();
 
                 if (resp.getBodyReadableStream(globalThis)) |stream| {
@@ -1957,7 +1965,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (this.isAbortedOrEnded()) {
                 return;
             }
-            var response = this.response_ptr.?;
+            var response = this.response_weakref.get().?;
             this.doRenderWithBody(response.getBodyValue(), response.getBodyReadableStream(this.server.?.globalThis));
         }
 
@@ -2129,7 +2137,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     ctx.response_jsvalue = fulfilled_value;
                     ctx.response_jsvalue.ensureStillAlive();
                     ctx.flags.response_protected = false;
-                    ctx.response_ptr = response;
 
                     const bodyValue = response.getBodyValue();
                     bodyValue.toBlobIfPossible();
@@ -2171,7 +2178,11 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (this.resp == null) return;
             const resp = this.resp.?;
 
-            var response: *jsc.WebCore.Response = this.response_ptr.?;
+            // For plain in-memory bodies this runs synchronously from
+            // render() before any backpressure gap, so the Response is
+            // always live here. File / stream bodies that call this after
+            // an async hop keep the Response rooted via response_protected.
+            var response: *jsc.WebCore.Response = this.response_weakref.get().?;
             var status = response.statusCode();
             var needs_content_range = this.flags.needs_content_range and (this.sendfile.total > 0 or this.sendfile.remain < this.blob.size());
 
@@ -2331,9 +2342,18 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             this.deref();
         }
 
+        /// Replace the tracked Response. Drops the previous weak ref (if any)
+        /// before taking a new one so the old Response's allocation can be
+        /// freed once its own strong refs go to zero.
+        fn setResponse(this: *RequestContext, response: *jsc.WebCore.Response) void {
+            if (this.response_weakref.raw_ptr == response) return;
+            this.response_weakref.deref();
+            this.response_weakref = .initRef(response);
+        }
+
         pub fn render(this: *RequestContext, response: *jsc.WebCore.Response) void {
             ctxLog("render", .{});
-            this.response_ptr = response;
+            this.setResponse(response);
 
             this.doRender();
         }

--- a/src/bun.js/webcore/Response.zig
+++ b/src/bun.js/webcore/Response.zig
@@ -17,10 +17,17 @@ pub const fromJSDirect = js.fromJSDirect;
 /// We increment this count in fetch so if JS Response is discarted we can resolve the Body
 /// In the server we use a flag response_protected to protect/unprotect the response
 ref_count: u32 = 1,
+/// Bun.serve's RequestContext holds a weak reference so `onAbort` /
+/// `handleResolveStream` / `handleRejectStream` can safely observe that the
+/// Response was GC'd (null) instead of dereferencing a freed pointer when
+/// backpressure lets GC run between `render()` and the async callback.
+weak_ptr_data: WeakRef.Data = .empty,
 #js_ref: jsc.JSRef = .empty(),
 
 // We must report a consistent value for this
 #reported_estimated_size: usize = 0,
+
+pub const WeakRef = bun.ptr.WeakPtr(Response, "weak_ptr_data");
 
 pub const getText = ResponseMixin.getText;
 pub const getBody = ResponseMixin.getBody;
@@ -452,7 +459,12 @@ fn destroy(this: *Response) void {
     this.#url.deref();
     this.#js_ref.deinit();
 
-    bun.destroy(this);
+    // Contents are gone; the allocation itself stays until any outstanding
+    // WeakRef derefs (RequestContext.response_weakref). WeakRef.get() returns
+    // null from here on.
+    if (this.weak_ptr_data.onFinalize()) {
+        bun.destroy(this);
+    }
 }
 
 pub fn ref(this: *Response) *Response {

--- a/test/js/bun/http/serve-response-gc-backpressure-abort-fixture.ts
+++ b/test/js/bun/http/serve-response-gc-backpressure-abort-fixture.ts
@@ -1,0 +1,113 @@
+// Regression: when a fetch handler returns `new Response(bigString)` sync
+// and tryEnd() hits backpressure, the RequestContext holds `response_ptr`
+// across the async onWritable gap but only protected the Response JSValue
+// for file-backed / Locked bodies. For InternalBlob/WTFStringImpl bodies,
+// nothing rooted the Response (RequestContext is a pool struct, not GC-
+// visited). If GC collected it and the client then aborted while the request
+// body was still .Locked, onAbort() dereferenced a freed *Response at
+// RequestContext.zig:692 — heap-use-after-free under ASAN.
+//
+// This fixture reproduces: POST with an incomplete chunked body (so
+// request_body stays .Locked and onAbort takes the !isDeadRequest branch),
+// handler returns a large in-memory Response, client never reads
+// (backpressure), GC runs, client closes.
+
+import { connect } from "node:net";
+
+// Large enough to guarantee tryEnd() backpressure on a paused client socket.
+const big = Buffer.alloc(8 * 1024 * 1024, "x").toString();
+
+const handlerEntered: Array<() => void> = [];
+let abortCount = 0;
+let gcTimer: ReturnType<typeof setInterval> | undefined;
+
+const server = Bun.serve({
+  port: 0,
+  idleTimeout: 0,
+  fetch(req) {
+    req.signal.addEventListener("abort", () => abortCount++, { once: true });
+    handlerEntered.shift()?.();
+    // Sync Response with a plain string body → InternalBlob / WTFStringImpl.
+    // Not a file, not a stream: the old code left response_jsvalue
+    // unprotected here.
+    return new Response(big);
+  },
+});
+
+const port = Number(server.port);
+
+async function oneRound() {
+  const { promise: entered, resolve: markEntered } = Promise.withResolvers<void>();
+  handlerEntered.push(markEntered);
+
+  const sock = connect(port, "127.0.0.1");
+  await new Promise<void>((resolve, reject) => {
+    sock.on("connect", resolve);
+    sock.on("error", reject);
+  });
+  // Stop the client from draining the response so the server's tryEnd()
+  // stalls on backpressure and registers onWritable.
+  sock.pause();
+
+  // POST, chunked, with one chunk but no terminator — the request body
+  // stays .Locked on the server so onAbort takes the branch that
+  // dereferences response_ptr.
+  sock.write(
+    "POST / HTTP/1.1\r\n" + //
+      `Host: 127.0.0.1:${port}\r\n` +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "5\r\nhello\r\n",
+  );
+
+  await entered;
+
+  // Give tryEnd() a tick to hit backpressure and unwind, then hammer GC so
+  // the (previously unrooted) Response is collected before the abort.
+  for (let i = 0; i < 20; i++) {
+    await Bun.sleep(1);
+    Bun.gc(true);
+  }
+
+  // Client closes → server onAbort → dereferences response_ptr.
+  const { promise: closed, resolve: markClosed } = Promise.withResolvers<void>();
+  sock.on("close", () => markClosed());
+  sock.destroy();
+  await closed;
+}
+
+// Keep GC pressure on between rounds too.
+gcTimer = setInterval(() => Bun.gc(true), 1);
+
+const ITERATIONS = 10;
+for (let i = 0; i < ITERATIONS; i++) {
+  await oneRound();
+}
+
+clearInterval(gcTimer);
+
+// Let the server observe the aborts.
+for (let i = 0; i < 100 && abortCount < ITERATIONS; i++) {
+  Bun.gc(true);
+  await Bun.sleep(5);
+}
+
+// After aborts, contexts should drain to 0 (no leak).
+for (let i = 0; i < 100 && server.pendingRequests > 0; i++) {
+  Bun.gc(true);
+  await Bun.sleep(5);
+}
+
+const pending = server.pendingRequests;
+console.log(JSON.stringify({ pending, abortCount, iterations: ITERATIONS }));
+server.stop(true);
+
+if (abortCount !== ITERATIONS) {
+  console.error(`Expected ${ITERATIONS} abort events, got ${abortCount}`);
+  process.exit(1);
+}
+if (pending !== 0) {
+  console.error(`LEAK: ${pending} RequestContexts were never freed`);
+  process.exit(1);
+}
+process.exit(0);

--- a/test/js/bun/http/serve-response-gc-backpressure-abort.test.ts
+++ b/test/js/bun/http/serve-response-gc-backpressure-abort.test.ts
@@ -3,12 +3,13 @@ import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { join } from "node:path";
 
 // The bug is a heap-use-after-free that only surfaces reliably under ASAN:
-// response_ptr is dereferenced in onAbort after the (unprotected) Response
-// has been GC'd during backpressure. On release builds the freed slot is
-// usually still readable so the deref happens to succeed. `bun bd` debug
-// builds enable ASAN by default but are named `bun-debug`, not `bun-asan`.
+// RequestContext held a raw *Response and dereferenced it in onAbort after
+// the (unprotected) Response had been GC'd during backpressure. On release
+// builds the freed slot is usually still readable so the deref happens to
+// succeed. `bun bd` debug builds enable ASAN by default but are named
+// `bun-debug`, not `bun-asan`.
 test.skipIf(!isASAN && !isDebug)(
-  "Response returned sync is rooted across tryEnd() backpressure so onAbort doesn't UAF response_ptr",
+  "onAbort does not dereference a freed Response after GC during tryEnd() backpressure",
   async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, "serve-response-gc-backpressure-abort-fixture.ts")],

--- a/test/js/bun/http/serve-response-gc-backpressure-abort.test.ts
+++ b/test/js/bun/http/serve-response-gc-backpressure-abort.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { join } from "node:path";
+
+// The bug is a heap-use-after-free that only surfaces reliably under ASAN:
+// response_ptr is dereferenced in onAbort after the (unprotected) Response
+// has been GC'd during backpressure. On release builds the freed slot is
+// usually still readable so the deref happens to succeed. `bun bd` debug
+// builds enable ASAN by default but are named `bun-debug`, not `bun-asan`.
+test.skipIf(!isASAN && !isDebug)(
+  "Response returned sync is rooted across tryEnd() backpressure so onAbort doesn't UAF response_ptr",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "serve-response-gc-backpressure-abort-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout.trim());
+    expect(result).toEqual({
+      pending: 0,
+      abortCount: result.iterations,
+      iterations: result.iterations,
+    });
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
## What

`RequestContext` stored `response_ptr: ?*Response` and, for plain `Blob`/`InternalBlob`/`WTFStringImpl` bodies, left the Response JSValue unprotected. `renderBytes()` → `tryEnd()` can hit backpressure and register an `onWritable` callback, unwinding with `response_ptr` still set. Nothing rooted the Response (`RequestContext` is a pool struct, not GC-visited), so GC could finalize it. If the client then aborted while the request body was still `.Locked`, `onAbort()` dereferenced a freed `*Response` — heap-use-after-free under ASAN at `RequestContext.zig:692`.

## Repro

```
POST → handler returns new Response(8MB string) sync
  → tryEnd() backpressure (client paused) → onWritable registered, return
  → Bun.gc(true) → Response collected, response_ptr dangles
  → client.destroy() → onAbort → deref response_ptr → UAF
```

ASAN trace (unpatched):
```
==ERROR: AddressSanitizer: use-after-poison
  #0 bun.js.bindings.JSRef.JSRef.tryGet
  #1 bun.js.webcore.Response.getBodyReadableStream
  #2 RequestContext.onAbort src/bun.js/api/server/RequestContext.zig:693
  #3 uWS::HttpContext<false>::onClose
```

## Fix

Give `Response` a `weak_ptr_data` field (mirroring `Request.WeakRef`) and replace `response_ptr: ?*Response` with `response_weakref: Response.WeakRef` via `bun.ptr.WeakPtr`. `Response.destroy()` now defers freeing the allocation until outstanding weak refs drop; `WeakRef.get()` returns null once the contents are gone.

`onAbort` / `handleResolveStream` / `handleRejectStream` call `.get()` and simply skip the readable-stream cleanup when it's null — a no-op for in-memory bodies anyway, since the body was already extracted via `useAsAnyBlobAllowNonUTF8String()` before backpressure.

File-backed and `.Locked` bodies continue to `protect()` `response_jsvalue` as before; those paths need the Response's status/headers alive across the async hop for `renderMetadata()`. The hot path (small in-memory responses) no longer needs `protect()`/`unprotect()`.

The two redundant `ctx.response_ptr = response` assignments right before `ctx.render(response)` are dropped — `render()` already sets the weak ref.

## Verification

`test/js/bun/http/serve-response-gc-backpressure-abort.test.ts` (ASAN/debug-only): POST with incomplete chunked body so `request_body` stays `.Locked`, handler returns a large string Response, client pauses so `tryEnd()` stalls, `Bun.gc(true)` loop, then client closes.

- **without fix**: `AddressSanitizer: use-after-poison` in `onAbort` → `Response.getBodyReadableStream`
- **with fix**: passes, `abortCount === iterations`, `pendingRequests === 0`
