### PR TITLE
crypto: release callback Strong and ctx on CryptoJob.init failure

### DIFF
--- a/src/bun.js/node/node_crypto_binding.zig
+++ b/src/bun.js/node/node_crypto_binding.zig
@@ -135,7 +135,10 @@ fn CryptoJob(comptime Ctx: type) type {
                 .ctx = ctx.*,
                 .callback = .create(callback.withAsyncContextIfNeeded(global), global),
             });
-            errdefer bun.destroy(job);
+            // If `ctx.init` throws, we must release the callback `Strong` and any resources the
+            // ctx already owns (e.g. `Scrypt` has already protected its password/salt buffers in
+            // `fromJS`). `deinit` handles all of that; `poll.unref` is a no-op while inactive.
+            errdefer job.deinit();
             try job.ctx.init(global);
             job.any_task = jsc.AnyTask.New(@This(), &runFromJS).init(job);
             return job;
@@ -671,6 +674,9 @@ const Scrypt = struct {
     }
 
     fn init(this: *Scrypt, global: *JSGlobalObject) JSError!void {
+        if (this.keylen > jsc.VirtualMachine.synthetic_allocation_limit) {
+            return global.throwOutOfMemory();
+        }
         const buf, const bytes = try jsc.ArrayBuffer.alloc(global, .ArrayBuffer, this.keylen);
 
         // to be filled in later

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// When `crypto.scrypt` fails to allocate the output buffer (OOM for a huge
+// `keylen`), `CryptoJob.init` takes the error path. Previously the `errdefer`
+// only freed the job allocation and leaked the callback `Strong` plus the
+// protected password/salt buffers.
+//
+// `heapStats().protectedObjectTypeCounts` counts both `protect()`ed values and
+// `HandleSet` strong handles, so it catches both the protected input buffers
+// and the callback Strong.
+//
+// Run in a subprocess so that on builds without the synthetic-limit check
+// (where the 2 GiB allocation succeeds and scrypt jobs start running) we can
+// exit immediately after measuring instead of waiting for them to complete.
+test("scrypt async does not leak callback/buffers when output allocation fails", async () => {
+  using dir = tempDir("scrypt-oom-leak", {
+    "check.js": `
+      const crypto = require("node:crypto");
+      const { heapStats } = require("bun:jsc");
+
+      function protectedCounts() {
+        Bun.gc(true);
+        const counts = heapStats().protectedObjectTypeCounts;
+        return {
+          Function: counts.Function ?? 0,
+          Uint8Array: counts.Uint8Array ?? 0,
+        };
+      }
+
+      const before = protectedCounts();
+
+      let thrown = 0;
+      for (let i = 0; i < 50; i++) {
+        try {
+          crypto.scrypt(Buffer.from("password"), Buffer.from("salt"), 0x7fffffff, function cb() {});
+        } catch {
+          thrown++;
+        }
+      }
+
+      const after = protectedCounts();
+
+      console.log(JSON.stringify({ thrown, before, after }));
+      process.exit(0);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "check.js"],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: String(16 * 1024 * 1024) },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+
+  const { thrown, before, after } = JSON.parse(stdout.trim());
+
+  // The error path must have been exercised; if allocation didn't fail,
+  // this test isn't measuring anything meaningful.
+  expect(thrown).toBe(50);
+
+  // Each failed call previously leaked 1 Function (callback Strong) and
+  // 2 Uint8Array (password + salt). With the fix, counts return to baseline.
+  expect({
+    Function: after.Function - before.Function,
+    Uint8Array: after.Uint8Array - before.Uint8Array,
+  }).toEqual({
+    Function: 0,
+    Uint8Array: 0,
+  });
+
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -75,4 +75,4 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
   });
 
   expect(exitCode).toBe(0);
-}, 30_000);
+});


### PR DESCRIPTION
## What

`CryptoJob.init` creates a `Strong` for the callback and copies the ctx (which, for `Scrypt`, already holds protected password/salt buffers from `fromJS`), then calls `job.ctx.init(global)`. If that throws, the old `errdefer bun.destroy(job)` only freed the allocation — the callback `Strong` and the ctx's protected values were never released.

## Repro

```js
crypto.scrypt(Buffer.from('pw'), Buffer.from('salt'), 0x7fffffff, cb);
```

With a 2 GiB `keylen`, `jsc.ArrayBuffer.alloc` in `Scrypt.init` can throw OOM. Under `ulimit -v 1GB` on a release build, 50 iterations leave `heapStats().protectedObjectTypeCounts` at `{ Function: 50, Uint8Array: 100 }` — one callback + two input buffers leaked per call. (JSC's `forEachProtectedCell` counts both `protect()` and `HandleSet` strong handles, so both leak sources show up.)

## Fix

Change `errdefer bun.destroy(job)` → `errdefer job.deinit()`. `deinit` already does `ctx.deinit()` + `poll.unref` (no-op while inactive) + `callback.deinit()` + `bun.destroy`, so this is the complete cleanup path. Safe for both `CryptoJob` instantiations:

- `Scrypt`: `buf` defaults to `.empty` so `buf.deinit()` is a no-op when `init` failed before creating it; `password`/`salt` were protected in `fromJS` and need unprotecting regardless.
- `random.JobCtx`: `init` never throws in practice (just `value.protect()`).

## Testing

`ulimit -v` can't be used under ASAN (shadow memory needs ~14 TB of virtual address space), and there's no JSC option that constrains typed-array backing-store allocation. So `Scrypt.init` now checks `synthetic_allocation_limit` before allocating — same pattern as `Blob`/`node_fs` — which lets the test trigger the error path deterministically via `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT`.

The test spawns a subprocess (so pending jobs in the unfixed case don't keep the process alive), runs 50 failing scrypt calls, and asserts the protected Function/Uint8Array deltas are zero.

Verified:
- `bun bd test test/js/node/crypto/scrypt.test.ts` passes
- With only the synthetic check but without the errdefer fix: fails at the leak assertion with `{ Function: 50, Uint8Array: 100 }`
- `test-crypto-scrypt.js`, `crypto.test.ts`, `crypto-random.test.ts` all still pass