### PR TITLE
fix(ipc): run SendQueue.deinit() from IPCInstance.deinit on getIPCInstance failure

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -3882,7 +3882,6 @@ pub const IPCInstanceUnion = union(enum) {
 
 pub const IPCInstance = struct {
     pub const new = bun.TrivialNew(@This());
-    pub const deinit = bun.TrivialDeinit(@This());
 
     globalThis: *JSGlobalObject,
     /// Embedded per-VM group on `RareData.spawn_ipc_group`; this is just a
@@ -3896,6 +3895,18 @@ pub const IPCInstance = struct {
     pub fn ipc(this: *IPCInstance) ?*IPC.SendQueue {
         return &this.data;
     }
+
+    /// Only reached from the `getIPCInstance` error path. On Windows,
+    /// `windowsConfigureClient` sets `data.socket = .open` before calling
+    /// `uv_read_start`; if that fails it calls `closeSocket()` which queues
+    /// the tracked `_onAfterIPCClosed` task holding `*SendQueue` — so
+    /// `SendQueue.deinit()` must run here to cancel it before this
+    /// allocation (and the embedded `SendQueue`) is freed.
+    pub fn deinit(this: *IPCInstance) void {
+        this.data.deinit();
+        bun.destroy(this);
+    }
+
     pub fn getGlobalThis(this: *IPCInstance) ?*JSGlobalObject {
         return this.globalThis;
     }

--- a/test/js/bun/spawn/spawn.ipc.test.ts
+++ b/test/js/bun/spawn/spawn.ipc.test.ts
@@ -91,3 +91,34 @@ describe("ipc mode advanced", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// getIPCInstance error path: on Windows, windowsConfigureClient can open the
+// pipe, set socket=.open, then fail readStart — at which point closeSocket
+// queued an _onAfterIPCClosed task holding *SendQueue, and instance.deinit()
+// (previously TrivialDeinit) freed it without cancelling. IPCInstance.deinit
+// now runs SendQueue.deinit() so the tracked after_close_task is cancelled on
+// both platforms before the allocation is released.
+it("child with unusable NODE_CHANNEL_FD tears down IPC without crashing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        process.on('error', e => console.log('err', e.code));
+        process.send('x');
+        setImmediate(() => setImmediate(() => console.log('ok')));
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      NODE_CHANNEL_FD: "921",
+      NODE_CHANNEL_SERIALIZATION_MODE: "json",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Unable to start IPC");
+  expect(stdout).toBe("err ERR_IPC_CHANNEL_CLOSED\nok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

Follow-up to #30051, which added `SendQueue.after_close_task` tracking so `SendQueue.deinit()` can cancel a pending `_onAfterIPCClosed` task before the owner frees it.

`IPCInstance.deinit` was still `TrivialDeinit` → `bun.destroy`, so on the `getIPCInstance` error path the embedded `SendQueue` was never deinited and the tracked task was never cancelled.

On Windows, `windowsConfigureClient` sets `data.socket = .open` **before** calling `uv_read_start`. If `uv_read_start` fails, it calls `closeSocket()` which queues the `_onAfterIPCClosed` task (socket was `.open`), returns an error, and `getIPCInstance` then calls `instance.deinit()` — freeing the `IPCInstance` and its embedded `SendQueue` with the task still queued.

## Fix

Replace `TrivialDeinit` with an explicit `deinit` that runs `this.data.deinit()` before `bun.destroy(this)`, so the `after_close_task` cancel path added in #30051 actually fires for this owner too.

## Test

Added a case in `spawn.ipc.test.ts` that drives a child through the `getIPCInstance` error path with an unusable `NODE_CHANNEL_FD` and verifies clean teardown. The specific `uv_read_start`-fails-after-`uv_pipe_open`-succeeds trigger is Windows-only and not deterministically reproducible from userland; the test covers the surrounding error-path teardown on both platforms.

`zig:check-all` passes on all targets.
