### PR TITLE
bun build: `--compress=gzip|br|zstd` to emit precompressed outputs

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -740,6 +740,58 @@ To granularly enable certain minifications:
   </Tab>
 </Tabs>
 
+### compress
+
+Emit precompressed `.gz` / `.br` / `.zst` copies of every output file alongside the originals. Useful for serving with `nginx` (`gzip_static` / `brotli_static`), CDNs, or `Bun.serve` static assets without compressing on every request. Compression runs in Bun's thread pool after bundling.
+
+<Tabs>
+  <Tab title="JavaScript">
+    ```ts title="build.ts" icon="/icons/typescript.svg"
+    await Bun.build({
+      entrypoints: ['./index.tsx'],
+      outdir: './out',
+      compress: ['gzip', 'br', 'zstd'],
+    })
+    ```
+  </Tab>
+  <Tab title="CLI">
+    ```bash terminal icon="terminal"
+    bun build ./index.tsx --outdir ./out --compress=gzip,br,zstd
+    ```
+  </Tab>
+</Tabs>
+
+`compress` accepts:
+
+- `true` — gzip only
+- `"gzip" | "br" | "zstd"` — a single algorithm
+- an array of the above
+- an object to control the compression level
+
+<Tabs>
+  <Tab title="JavaScript">
+    ```ts title="build.ts" icon="/icons/typescript.svg"
+    await Bun.build({
+      entrypoints: ['./index.tsx'],
+      outdir: './out',
+      compress: {
+        gzip: true,
+        brotli: true,
+        zstd: true,
+        level: 'max', // or a number
+      },
+    })
+    ```
+  </Tab>
+  <Tab title="CLI">
+    ```bash terminal icon="terminal"
+    bun build ./index.tsx --outdir ./out --compress=all --compress-level=max
+    ```
+  </Tab>
+</Tabs>
+
+Compressed paths are the original output path plus a suffix (`out/index.js` → `out/index.js.gz`). They show up in `result.outputs` with `kind: "compressed"`. Entry points, chunks, assets, and sourcemaps are compressed; bytecode and metafiles are not.
+
 ### external
 
 A list of import paths to consider external. Defaults to `[]`.
@@ -1443,7 +1495,7 @@ interface BuildOutput {
 }
 
 interface BuildArtifact extends Blob {
-  kind: "entry-point" | "chunk" | "asset" | "sourcemap";
+  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "compressed";
   path: string;
   loader: Loader;
   hash: string | null;
@@ -1469,7 +1521,7 @@ Each artifact also contains the following properties:
 
 | Property    | Description                                                                                                                                                  |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `kind`      | What kind of build output this file is. A build generates bundled entrypoints, code-split "chunks", sourcemaps, bytecode, and copied assets (like images).   |
+| `kind`      | What kind of build output this file is. A build generates bundled entrypoints, code-split "chunks", sourcemaps, bytecode, copied assets (like images), and `compressed` copies when [`compress`](#compress) is enabled. |
 | `path`      | Absolute path to the file on disk                                                                                                                            |
 | `loader`    | The loader was used to interpret the file. See [Bundler > Loaders](/bundler/loaders) to see how Bun maps file extensions to the appropriate built-in loader. |
 | `hash`      | The hash of the file contents. Always defined for assets.                                                                                                    |
@@ -1717,6 +1769,18 @@ interface BuildConfig {
         syntax?: boolean;
         identifiers?: boolean;
       };
+  compress?:
+    | boolean
+    | "gzip"
+    | "br"
+    | "zstd"
+    | Array<"gzip" | "br" | "zstd">
+    | {
+        gzip?: boolean;
+        brotli?: boolean;
+        zstd?: boolean;
+        level?: number | "max";
+      };
   /**
    * Ignore dead code elimination/tree-shaking annotations such as @__PURE__ and package.json
    * "sideEffects" fields. This should only be used as a temporary workaround for incorrect
@@ -1785,7 +1849,7 @@ interface BuildArtifact extends Blob {
   path: string;
   loader: Loader;
   hash: string | null;
-  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
+  kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "compressed";
   sourcemap: BuildArtifact | null;
 }
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2747,6 +2747,29 @@ declare module "bun" {
         };
 
     /**
+     * Additionally emit compressed (`.gz` / `.br` / `.zst`) copies of each
+     * output file. Compression runs in Bun's thread pool after bundling.
+     *
+     * - `true` enables gzip
+     * - a string or array of strings selects specific algorithms
+     * - an object lets you pick algorithms and a `level` (`"max"` or a number)
+     *
+     * @default false
+     */
+    compress?:
+      | boolean
+      | "gzip"
+      | "br"
+      | "zstd"
+      | Array<"gzip" | "br" | "zstd">
+      | {
+          gzip?: boolean;
+          brotli?: boolean;
+          zstd?: boolean;
+          level?: number | "max";
+        };
+
+    /**
      * Ignore dead code elimination/tree-shaking annotations such as @__PURE__ and package.json
      * "sideEffects" fields. This should only be used as a temporary workaround for incorrect
      * annotations in libraries.
@@ -3603,7 +3626,7 @@ declare module "bun" {
     path: string;
     loader: Loader;
     hash: string | null;
-    kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode";
+    kind: "entry-point" | "chunk" | "asset" | "sourcemap" | "bytecode" | "compressed";
     sourcemap: BuildArtifact | null;
   }
 

--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -434,6 +434,7 @@ pub fn buildWithVm(ctx: bun.cli.Command.Context, cwd: []const u8, vm: *VirtualMa
                     .sourcemap => {},
                     .module_info => {},
                     .@"metafile-json", .@"metafile-markdown" => {},
+                    .compressed => {},
                 }
             },
         }

--- a/src/bun.js/api/JSBundler.zig
+++ b/src/bun.js/api/JSBundler.zig
@@ -229,6 +229,7 @@ pub const JSBundler = struct {
         force_node_env: options.BundleOptions.ForceNodeEnv = .unspecified,
         code_splitting: bool = false,
         minify: Minify = .{},
+        compress: options.CompressionOptions = .{},
         no_macros: bool = false,
         ignore_dce_annotations: bool = false,
         emit_dce_annotations: ?bool = null,
@@ -711,6 +712,53 @@ pub const JSBundler = struct {
                     }
                 } else {
                     return globalThis.throwInvalidArguments("Expected minify to be a boolean or an object", .{});
+                }
+            }
+
+            if (try config.getTruthy(globalThis, "compress")) |compress| {
+                const enableOne = struct {
+                    fn enableOne(out: *options.CompressionOptions, global: *jsc.JSGlobalObject, str: ZigString.Slice) bun.JSError!void {
+                        defer str.deinit();
+                        if (options.CompressionOptions.Algorithm.map.get(str.slice())) |algo| {
+                            out.enable(algo);
+                        } else {
+                            return global.throwInvalidArguments("compress: invalid algorithm \"{s}\". Must be one of \"gzip\", \"br\", \"zstd\"", .{str.slice()});
+                        }
+                    }
+                }.enableOne;
+
+                if (compress.isBoolean()) {
+                    this.compress.gzip = compress.toBoolean();
+                } else if (compress.isString()) {
+                    try enableOne(&this.compress, globalThis, try compress.toSliceOrNull(globalThis));
+                } else if (compress.jsType().isArray()) {
+                    var iter = try compress.arrayIterator(globalThis);
+                    while (try iter.next()) |item| {
+                        if (!item.isString()) return globalThis.throwInvalidArguments("compress: expected array of strings", .{});
+                        try enableOne(&this.compress, globalThis, try item.toSliceOrNull(globalThis));
+                    }
+                } else if (compress.isObject()) {
+                    if (try compress.getBooleanLoose(globalThis, "gzip")) |v| this.compress.gzip = v;
+                    if (try compress.getBooleanLoose(globalThis, "brotli")) |v| this.compress.brotli = v;
+                    if (try compress.getBooleanLoose(globalThis, "br")) |v| this.compress.brotli = v;
+                    if (try compress.getBooleanLoose(globalThis, "zstd")) |v| this.compress.zstd = v;
+                    if (try compress.getTruthy(globalThis, "level")) |level| {
+                        if (level.isString()) {
+                            const slice = try level.toSliceOrNull(globalThis);
+                            defer slice.deinit();
+                            if (bun.strings.eqlComptime(slice.slice(), "max")) {
+                                this.compress.level = .max;
+                            } else {
+                                return globalThis.throwInvalidArguments("compress.level must be a number or \"max\"", .{});
+                            }
+                        } else if (level.isNumber()) {
+                            this.compress.level = .{ .value = @intFromFloat(@max(0, @min(255, level.asNumber()))) };
+                        } else {
+                            return globalThis.throwInvalidArguments("compress.level must be a number or \"max\"", .{});
+                        }
+                    }
+                } else {
+                    return globalThis.throwInvalidArguments("Expected compress to be a boolean, string, array, or object", .{});
                 }
             }
 
@@ -1794,9 +1842,20 @@ pub const BuildArtifact = struct {
         module_info,
         @"metafile-json",
         @"metafile-markdown",
+        compressed,
 
         pub fn isFileInStandaloneMode(this: OutputKind) bool {
-            return this != .sourcemap and this != .bytecode and this != .module_info and this != .@"metafile-json" and this != .@"metafile-markdown";
+            return switch (this) {
+                .sourcemap, .bytecode, .module_info, .@"metafile-json", .@"metafile-markdown", .compressed => false,
+                else => true,
+            };
+        }
+
+        pub fn isCompressible(this: OutputKind) bool {
+            return switch (this) {
+                .chunk, .asset, .@"entry-point", .sourcemap => true,
+                else => false,
+            };
         }
     };
 

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -2044,6 +2044,7 @@ pub const BundleV2 = struct {
             transpiler.options.minify_syntax = config.minify.syntax;
             transpiler.options.minify_whitespace = config.minify.whitespace;
             transpiler.options.minify_identifiers = config.minify.identifiers;
+            transpiler.options.compress = config.compress;
             transpiler.options.keep_names = config.minify.keep_names;
             transpiler.options.inlining = config.minify.syntax;
             transpiler.options.source_map = config.source_map;

--- a/src/bundler/compress_outputs.zig
+++ b/src/bundler/compress_outputs.zig
@@ -1,0 +1,268 @@
+//! Emit compressed (.gz / .br / .zst) copies of bundler output files.
+//!
+//! Runs after `generateChunksInParallel` has produced the final list of
+//! `OutputFile`s. For every compressible file (entry points, chunks, assets,
+//! and sourcemaps) and every algorithm enabled in `BundleOptions.compress`,
+//! a thread-pool task compresses the buffer with libdeflate / brotli / zstd.
+//! When an `outdir` is set, the compressed bytes are also written to disk.
+
+pub const Task = struct {
+    /// Points into the original (uncompressed) OutputFile's buffer. Not owned.
+    input: []const u8,
+    /// Owned by `bun.default_allocator`.
+    output_path: []const u8,
+    side: ?bun.bake.Side,
+    algorithm: Algorithm,
+    level: options.CompressionOptions.Level,
+    /// Absolute path of the output directory, or empty if not writing to disk.
+    root_path: []const u8,
+
+    result: union(enum) {
+        pending,
+        err: anyerror,
+        buffer: []u8,
+        saved: u32,
+    } = .pending,
+
+    fn compress(input: []const u8, comptime algo: Algorithm, level: options.CompressionOptions.Level) ![]u8 {
+        switch (algo) {
+            .gzip => {
+                bun.libdeflate.load();
+                const compressor = bun.libdeflate.Compressor.alloc(level.@"for"(.gzip)) orelse return error.OutOfMemory;
+                defer compressor.deinit();
+                var out = try bun.default_allocator.alloc(u8, compressor.maxBytesNeeded(input, .gzip));
+                errdefer bun.default_allocator.free(out);
+                const result = compressor.gzip(input, out);
+                if (result.written == 0 and input.len != 0) return error.CompressionFailed;
+                if (bun.default_allocator.realloc(out, result.written)) |shrunk| out = shrunk else |_| {}
+                return out[0..result.written];
+            },
+            .brotli => {
+                const c = bun.brotli.c;
+                var encoded_size: usize = c.BrotliEncoderMaxCompressedSize(input.len);
+                if (encoded_size == 0) encoded_size = input.len + 1024;
+                var out = try bun.default_allocator.alloc(u8, encoded_size);
+                errdefer bun.default_allocator.free(out);
+                const ok = c.BrotliEncoderCompress(
+                    level.@"for"(.brotli),
+                    c.BROTLI_DEFAULT_WINDOW,
+                    .text,
+                    input.len,
+                    input.ptr,
+                    &encoded_size,
+                    out.ptr,
+                );
+                if (ok == 0) return error.CompressionFailed;
+                if (bun.default_allocator.realloc(out, encoded_size)) |shrunk| out = shrunk else |_| {}
+                return out[0..encoded_size];
+            },
+            .zstd => {
+                var out = try bun.default_allocator.alloc(u8, bun.zstd.compressBound(input.len));
+                errdefer bun.default_allocator.free(out);
+                const written = switch (bun.zstd.compress(out, input, level.@"for"(.zstd))) {
+                    .success => |n| n,
+                    .err => return error.CompressionFailed,
+                };
+                if (bun.default_allocator.realloc(out, written)) |shrunk| out = shrunk else |_| {}
+                return out[0..written];
+            },
+        }
+    }
+
+    fn run(ctx: *const Context, task: *Task, _: usize) void {
+        const buffer = switch (task.algorithm) {
+            inline else => |algo| compress(task.input, algo, task.level),
+        } catch |err| {
+            task.result = .{ .err = err };
+            return;
+        };
+
+        if (task.root_path.len == 0) {
+            task.result = .{ .buffer = buffer };
+            return;
+        }
+
+        defer bun.default_allocator.free(buffer);
+        var pathbuf: bun.PathBuffer = undefined;
+        switch (jsc.Node.fs.NodeFS.writeFileWithPathBuffer(&pathbuf, .{
+            .data = .{ .buffer = .{ .buffer = .{
+                .ptr = @constCast(buffer.ptr),
+                .len = @as(u32, @truncate(buffer.len)),
+                .byte_len = @as(u32, @truncate(buffer.len)),
+            } } },
+            .encoding = .buffer,
+            .dirfd = ctx.root_fd,
+            .file = .{ .path = .{ .string = bun.PathString.init(task.output_path) } },
+        })) {
+            .result => task.result = .{ .saved = @truncate(buffer.len) },
+            .err => task.result = .{ .err = error.WriteFailed },
+        }
+    }
+};
+
+const Context = struct {
+    root_fd: bun.FD,
+};
+
+/// Compresses every compressible file in `output_files` using the bundler's
+/// worker pool, appending one new `OutputFile` per (file × algorithm) pair.
+/// When `root_path` is non-empty, the compressed bytes are written there and
+/// the appended `OutputFile`s carry `.saved`; otherwise they carry `.buffer`.
+///
+/// Called only when `c.resolver.opts.compress.any()` is true. Input
+/// `OutputFile`s are expected to have `.buffer` values — the caller forces the
+/// in-memory generation path when compression is enabled so the bytes are
+/// still available here.
+pub fn compressOutputFilesInParallel(
+    c: *LinkerContext,
+    output_files: *std.array_list.Managed(options.OutputFile),
+    root_path: []const u8,
+) !void {
+    const opts = c.resolver.opts.compress;
+    bun.assert(opts.any());
+
+    const original_len = output_files.items.len;
+
+    var root_dir: ?std.fs.Dir = null;
+    defer if (root_dir) |*d| d.close();
+    if (root_path.len > 0) {
+        root_dir = std.fs.cwd().makeOpenPath(root_path, .{}) catch |err| {
+            try c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "Failed to open output directory {s} {f}", .{
+                @errorName(err),
+                bun.fmt.quote(root_path),
+            });
+            return err;
+        };
+        // Subdirectories must exist before the worker pool starts writing
+        // compressed files into them. The compressed paths only ever differ
+        // from the originals by a suffix, so creating directories for the
+        // originals is sufficient.
+        for (output_files.items[0..original_len]) |*f| {
+            if (f.value != .buffer) continue;
+            if (std.fs.path.dirnamePosix(f.dest_path)) |parent| {
+                if (parent.len > 0 and !bun.strings.eqlComptime(parent, ".")) {
+                    try root_dir.?.makePath(parent);
+                }
+            }
+        }
+    }
+
+    var task_count: usize = 0;
+    for (output_files.items[0..original_len]) |*f| {
+        if (!f.output_kind.isCompressible()) continue;
+        if (f.value != .buffer) continue;
+        if (f.value.buffer.bytes.len == 0) continue;
+        task_count += opts.count();
+    }
+
+    const tasks = try bun.default_allocator.alloc(Task, task_count);
+    defer bun.default_allocator.free(tasks);
+
+    var i: usize = 0;
+    for (output_files.items[0..original_len]) |*f| {
+        if (!f.output_kind.isCompressible()) continue;
+        if (f.value != .buffer) continue;
+        const bytes = f.value.buffer.bytes;
+        if (bytes.len == 0) continue;
+        inline for (comptime std.meta.tags(Algorithm)) |algo| {
+            if (@field(opts, @tagName(algo))) {
+                tasks[i] = .{
+                    .input = bytes,
+                    .output_path = bun.handleOom(bun.strings.concat(bun.default_allocator, &.{ f.dest_path, algo.suffix() })),
+                    .side = f.side,
+                    .algorithm = algo,
+                    .level = opts.level,
+                    .root_path = root_path,
+                };
+                i += 1;
+            }
+        }
+    }
+    bun.assert(i == task_count);
+
+    const ctx = Context{
+        .root_fd = if (root_dir) |d| .fromStdDir(d) else .cwd(),
+    };
+
+    if (task_count > 0) {
+        try c.parse_graph.pool.worker_pool.eachPtr(bun.default_allocator, &ctx, Task.run, tasks);
+    }
+
+    // We forced the in-memory generation path so the buffers were available
+    // for the compressor above; now flush the originals to disk and drop the
+    // buffers to match what writeOutputFilesToDisk would have produced.
+    if (root_dir) |dir| {
+        var pathbuf: bun.PathBuffer = undefined;
+        for (output_files.items[0..original_len]) |*f| {
+            if (f.value != .buffer) continue;
+            const bytes = f.value.buffer.bytes;
+            switch (jsc.Node.fs.NodeFS.writeFileWithPathBuffer(&pathbuf, .{
+                .data = .{ .buffer = .{ .buffer = .{
+                    .ptr = @constCast(bytes.ptr),
+                    .len = @as(u32, @truncate(bytes.len)),
+                    .byte_len = @as(u32, @truncate(bytes.len)),
+                } } },
+                .encoding = .buffer,
+                .mode = if (f.is_executable) 0o755 else 0o644,
+                .dirfd = .fromStdDir(dir),
+                .file = .{ .path = .{ .string = bun.PathString.init(f.dest_path) } },
+            })) {
+                .result => {},
+                .err => |err| {
+                    try c.log.addSysError(bun.default_allocator, err, "writing chunk {f}", .{bun.fmt.quote(f.dest_path)});
+                    return error.WriteFailed;
+                },
+            }
+            f.size = bytes.len;
+            f.value.deinit();
+            f.value = .{ .saved = .{} };
+        }
+    }
+
+    try output_files.ensureUnusedCapacity(task_count);
+    for (tasks) |*task| {
+        switch (task.result) {
+            .pending => unreachable,
+            .err => |err| {
+                try c.log.addErrorFmt(null, Logger.Loc.Empty, bun.default_allocator, "{s} compressing {f}", .{
+                    @errorName(err),
+                    bun.fmt.quote(task.output_path),
+                });
+                bun.default_allocator.free(task.output_path);
+            },
+            .buffer => |buf| output_files.appendAssumeCapacity(options.OutputFile.init(.{
+                .data = .{ .buffer = .{ .data = buf, .allocator = bun.default_allocator } },
+                .output_path = task.output_path,
+                .input_path = bun.handleOom(bun.default_allocator.dupe(u8, task.output_path)),
+                .loader = .file,
+                .input_loader = .file,
+                .hash = null,
+                .output_kind = .compressed,
+                .side = task.side,
+                .entry_point_index = null,
+                .is_executable = false,
+            })),
+            .saved => |size| output_files.appendAssumeCapacity(options.OutputFile.init(.{
+                .data = .{ .saved = 0 },
+                .size = size,
+                .output_path = task.output_path,
+                .input_path = bun.handleOom(bun.default_allocator.dupe(u8, task.output_path)),
+                .loader = .file,
+                .input_loader = .file,
+                .hash = null,
+                .output_kind = .compressed,
+                .side = task.side,
+                .entry_point_index = null,
+                .is_executable = false,
+            })),
+        }
+    }
+}
+
+const std = @import("std");
+const bun = @import("bun");
+const options = bun.options;
+const jsc = bun.jsc;
+const Logger = bun.logger;
+const LinkerContext = bun.bundle_v2.LinkerContext;
+const Algorithm = options.CompressionOptions.Algorithm;

--- a/src/bundler/linker_context/generateChunksInParallel.zig
+++ b/src/bundler/linker_context/generateChunksInParallel.zig
@@ -439,7 +439,10 @@ pub fn generateChunksInParallel(
 
     // Don't write to disk if compile mode is enabled - we need buffer values for compilation
     const is_compile = bundler.transpiler.options.compile;
-    if (root_path.len > 0 and !is_compile) {
+    // When --compress is enabled, generate everything in memory so the buffers
+    // can be handed to the thread-pool compressor below.
+    const want_compress = c.resolver.opts.compress.any() and !is_standalone and !is_compile;
+    if (root_path.len > 0 and !is_compile and !want_compress) {
         try c.writeOutputFilesToDisk(root_path, chunks, &output_files, standalone_chunk_contents);
     } else {
         // In-memory build (also used for standalone mode)
@@ -758,6 +761,12 @@ pub fn generateChunksInParallel(
         }
     }
 
+    if (want_compress) {
+        var result = output_files.take();
+        try compress_outputs.compressOutputFilesInParallel(c, &result, root_path);
+        return result;
+    }
+
     if (is_standalone) {
         // For standalone mode, filter to only HTML output files.
         // Deinit dropped items to free their heap allocations (paths, buffers).
@@ -818,3 +827,4 @@ const Loc = Logger.Loc;
 
 const options = bun.options;
 const OutputFile = bun.options.OutputFile;
+const compress_outputs = @import("../compress_outputs.zig");

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -473,6 +473,7 @@ pub const Command = struct {
             entry_naming: []const u8 = "[dir]/[name].[ext]",
             chunk_naming: []const u8 = "./[name]-[hash].[ext]",
             asset_naming: []const u8 = "./[name]-[hash].[ext]",
+            compress: options.CompressionOptions = .{},
             server_components: bool = false,
             react_fast_refresh: bool = false,
             code_splitting: bool = false,

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -195,6 +195,8 @@ pub const build_only_params = [_]ParamType{
     clap.parseParam("--entry-naming <STR>             Customize entry point filenames. Defaults to \"[dir]/[name].[ext]\"") catch unreachable,
     clap.parseParam("--chunk-naming <STR>             Customize chunk filenames. Defaults to \"[name]-[hash].[ext]\"") catch unreachable,
     clap.parseParam("--asset-naming <STR>             Customize asset filenames. Defaults to \"[name]-[hash].[ext]\"") catch unreachable,
+    clap.parseParam("--compress <STR>...              Additionally emit compressed copies of output files - 'gzip', 'br', 'zstd'") catch unreachable,
+    clap.parseParam("--compress-level <STR>           Compression level for --compress, or 'max' for the highest level") catch unreachable,
     clap.parseParam("--react-fast-refresh             Enable React Fast Refresh transform (does not emit hot-module code, use this for testing)") catch unreachable,
     clap.parseParam("--no-bundle                      Transpile file only, do not bundle") catch unreachable,
     clap.parseParam("--emit-dce-annotations           Re-emit DCE annotations in bundles. Enabled by default unless --minify-whitespace is passed.") catch unreachable,
@@ -1497,6 +1499,35 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
         if (args.option("--asset-naming")) |asset_naming| {
             ctx.bundler_options.asset_naming = try strings.concat(allocator, &.{ "./", bun.strings.removeLeadingDotSlash(asset_naming) });
+        }
+
+        for (args.options("--compress")) |compress| {
+            var it = std.mem.splitScalar(u8, compress, ',');
+            while (it.next()) |part_| {
+                const part = std.mem.trim(u8, part_, " ");
+                if (part.len == 0) continue;
+                if (strings.eqlComptime(part, "all")) {
+                    ctx.bundler_options.compress.gzip = true;
+                    ctx.bundler_options.compress.brotli = true;
+                    ctx.bundler_options.compress.zstd = true;
+                } else if (options.CompressionOptions.Algorithm.map.get(part)) |algo| {
+                    ctx.bundler_options.compress.enable(algo);
+                } else {
+                    Output.prettyErrorln("<r><red>error<r><d>:<r> Invalid value for --compress: \"{s}\". Must be one of \"gzip\", \"br\", \"zstd\"", .{part});
+                    Global.exit(1);
+                }
+            }
+        }
+
+        if (args.option("--compress-level")) |level| {
+            if (strings.eqlComptime(level, "max")) {
+                ctx.bundler_options.compress.level = .max;
+            } else if (std.fmt.parseInt(u8, level, 10)) |n| {
+                ctx.bundler_options.compress.level = .{ .value = n };
+            } else |_| {
+                Output.prettyErrorln("<r><red>error<r><d>:<r> Invalid --compress-level: \"{s}\". Must be a number or \"max\"", .{level});
+                Global.exit(1);
+            }
         }
 
         if (args.flag("--server-components")) {

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -63,12 +63,19 @@ pub const BuildCommand = struct {
         var outfile = ctx.bundler_options.outfile;
         const output_to_stdout = !ctx.bundler_options.compile and outfile.len == 0 and ctx.bundler_options.outdir.len == 0;
 
+        if (ctx.bundler_options.compress.any() and ctx.bundler_options.outdir.len == 0) {
+            Output.prettyErrorln("<r><red>error<r><d>:<r> --compress requires --outdir", .{});
+            Global.exit(1);
+            return;
+        }
+
         this_transpiler.options.supports_multiple_outputs = !(output_to_stdout or outfile.len > 0);
 
         this_transpiler.options.public_path = ctx.bundler_options.public_path;
         this_transpiler.options.entry_naming = ctx.bundler_options.entry_naming;
         this_transpiler.options.chunk_naming = ctx.bundler_options.chunk_naming;
         this_transpiler.options.asset_naming = ctx.bundler_options.asset_naming;
+        this_transpiler.options.compress = ctx.bundler_options.compress;
         this_transpiler.options.server_components = ctx.bundler_options.server_components;
         this_transpiler.options.react_fast_refresh = ctx.bundler_options.react_fast_refresh;
         this_transpiler.options.inline_entrypoint_import_meta_main = ctx.bundler_options.inline_entrypoint_import_meta_main;
@@ -669,6 +676,7 @@ pub const BuildCommand = struct {
                     .bytecode => Output.prettyFmt("<d>", true),
                     .module_info => Output.prettyFmt("<d>", true),
                     .@"metafile-json", .@"metafile-markdown" => Output.prettyFmt("<green>", true),
+                    .compressed => Output.prettyFmt("<d>", true),
                 });
 
                 try writer.writeAll(rel_path);
@@ -702,6 +710,7 @@ pub const BuildCommand = struct {
                     .module_info => "module info",
                     .@"metafile-json" => "metafile json",
                     .@"metafile-markdown" => "metafile markdown",
+                    .compressed => "compressed",
                 }});
                 if (Output.enable_ansi_colors_stdout)
                     try writer.writeAll("\x1b[0m");

--- a/src/options.zig
+++ b/src/options.zig
@@ -1815,6 +1815,7 @@ pub const BundleOptions = struct {
     asset_naming: []const u8 = "",
     chunk_naming: []const u8 = "",
     public_path: []const u8 = "",
+    compress: CompressionOptions = .{},
     extension_order: ResolveFileExtensions = .{},
     main_field_extension_order: []const string = &Defaults.MainFieldExtensionOrder,
     /// This list applies to all extension resolution cases. The runtime uses
@@ -2596,6 +2597,78 @@ pub const RouteConfig = struct {
 };
 
 pub const GlobalCache = @import("./resolver/resolver.zig").GlobalCache;
+
+pub const CompressionOptions = struct {
+    gzip: bool = false,
+    brotli: bool = false,
+    zstd: bool = false,
+    level: Level = .default,
+
+    pub const Level = union(enum) {
+        default,
+        max,
+        value: u8,
+
+        pub fn @"for"(this: Level, comptime algo: Algorithm) c_int {
+            return switch (this) {
+                .default => switch (algo) {
+                    .gzip => 6,
+                    .brotli => 6,
+                    .zstd => 3,
+                },
+                .max => switch (algo) {
+                    .gzip => 12,
+                    .brotli => 11,
+                    .zstd => 19,
+                },
+                .value => |v| std.math.clamp(@as(c_int, v), 1, switch (algo) {
+                    .gzip => 12,
+                    .brotli => 11,
+                    .zstd => 19,
+                }),
+            };
+        }
+    };
+
+    pub const Algorithm = enum {
+        gzip,
+        brotli,
+        zstd,
+
+        pub fn suffix(this: Algorithm) [:0]const u8 {
+            return switch (this) {
+                .gzip => ".gz",
+                .brotli => ".br",
+                .zstd => ".zst",
+            };
+        }
+
+        pub const map = bun.ComptimeStringMap(Algorithm, .{
+            .{ "gzip", .gzip },
+            .{ "gz", .gzip },
+            .{ "brotli", .brotli },
+            .{ "br", .brotli },
+            .{ "zstd", .zstd },
+            .{ "zst", .zstd },
+        });
+    };
+
+    pub fn enable(this: *CompressionOptions, algo: Algorithm) void {
+        switch (algo) {
+            .gzip => this.gzip = true,
+            .brotli => this.brotli = true,
+            .zstd => this.zstd = true,
+        }
+    }
+
+    pub fn any(this: CompressionOptions) bool {
+        return this.gzip or this.brotli or this.zstd;
+    }
+
+    pub fn count(this: CompressionOptions) u32 {
+        return @as(u32, @intFromBool(this.gzip)) + @as(u32, @intFromBool(this.brotli)) + @as(u32, @intFromBool(this.zstd));
+    }
+};
 
 pub const PathTemplate = struct {
     data: string = "",

--- a/test/bundler/bundler_compress.test.ts
+++ b/test/bundler/bundler_compress.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { gunzipSync, brotliDecompressSync, zstdDecompressSync } from "node:zlib";
+import { tmpdirSync, bunExe, bunEnv } from "harness";
+import { join } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+
+describe("Bun.build compress", () => {
+  function fixture(dir: string) {
+    Bun.write(
+      join(dir, "entry.js"),
+      `import {greet} from "./dep.js";\nconsole.log(greet, ${JSON.stringify("x".repeat(2000))});\n`,
+    );
+    Bun.write(join(dir, "dep.js"), `export const greet = "hello world";\n`);
+  }
+
+  test("emits .gz/.br/.zst alongside outputs (outdir)", async () => {
+    const dir = tmpdirSync();
+    fixture(dir);
+    const out = join(dir, "out");
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      outdir: out,
+      compress: ["gzip", "br", "zstd"],
+    });
+    expect(result.success).toBe(true);
+
+    const files = readdirSync(out).sort();
+    expect(files).toEqual(["entry.js", "entry.js.br", "entry.js.gz", "entry.js.zst"]);
+
+    const original = readFileSync(join(out, "entry.js"));
+    expect(gunzipSync(readFileSync(join(out, "entry.js.gz"))).equals(original)).toBe(true);
+    expect(brotliDecompressSync(readFileSync(join(out, "entry.js.br"))).equals(original)).toBe(true);
+    expect(zstdDecompressSync(readFileSync(join(out, "entry.js.zst"))).equals(original)).toBe(true);
+
+    const compressed = result.outputs.filter(o => o.kind === "compressed");
+    expect(compressed.length).toBe(3);
+  });
+
+  test("returns compressed Blobs without outdir", async () => {
+    const dir = tmpdirSync();
+    fixture(dir);
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      compress: { gzip: true, level: "max" },
+    });
+    expect(result.success).toBe(true);
+
+    const entry = result.outputs.find(o => o.kind === "entry-point")!;
+    const gz = result.outputs.find(o => o.kind === "compressed" && o.path.endsWith(".gz"))!;
+    expect(gz).toBeDefined();
+
+    const original = Buffer.from(await entry.arrayBuffer());
+    const decompressed = gunzipSync(Buffer.from(await gz.arrayBuffer()));
+    expect(decompressed.equals(original)).toBe(true);
+    expect(gz.size).toBeLessThan(entry.size);
+  });
+
+  test("compress: true enables gzip", async () => {
+    const dir = tmpdirSync();
+    fixture(dir);
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      compress: true,
+    });
+    const kinds = result.outputs.filter(o => o.kind === "compressed").map(o => o.path.split(".").pop());
+    expect(kinds).toEqual(["gz"]);
+  });
+
+  test("compresses sourcemaps too", async () => {
+    const dir = tmpdirSync();
+    fixture(dir);
+    const out = join(dir, "out");
+    const result = await Bun.build({
+      entrypoints: [join(dir, "entry.js")],
+      outdir: out,
+      sourcemap: "linked",
+      compress: "gzip",
+    });
+    expect(result.success).toBe(true);
+    const files = readdirSync(out).sort();
+    expect(files).toContain("entry.js.map.gz");
+    const map = readFileSync(join(out, "entry.js.map"));
+    expect(gunzipSync(readFileSync(join(out, "entry.js.map.gz"))).equals(map)).toBe(true);
+  });
+
+  test("CLI --compress writes to outdir", async () => {
+    const dir = tmpdirSync();
+    fixture(dir);
+    const out = join(dir, "out");
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "build", "./entry.js", "--outdir", out, "--compress=gzip,zstd", "--compress-level=max"],
+      cwd: dir,
+      env: bunEnv,
+    });
+    expect(proc.exitCode).toBe(0);
+    const files = readdirSync(out).sort();
+    expect(files).toEqual(["entry.js", "entry.js.gz", "entry.js.zst"]);
+    const original = readFileSync(join(out, "entry.js"));
+    expect(gunzipSync(readFileSync(join(out, "entry.js.gz"))).equals(original)).toBe(true);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds output compression to `bun build` and `Bun.build`. After chunk generation, compressible outputs (entry points, chunks, assets, sourcemaps) are compressed in the bundler's worker pool and written alongside the originals with `.gz` / `.br` / `.zst` suffixes.

**CLI**
```sh
bun build ./index.ts --outdir=dist --compress=gzip,br,zstd --compress-level=max
```
- `--compress=<algo>` — `gzip`, `br`/`brotli`, `zstd`/`zst`, or `all`. Repeatable or comma-separated.
- `--compress-level=<n>|max` — clamped per algorithm (libdeflate 1–12, brotli 1–11, zstd 1–19).
- Requires `--outdir`.

**`Bun.build`**
```ts
await Bun.build({
  entrypoints: ["./index.ts"],
  outdir: "./dist",
  compress: { gzip: true, brotli: true, zstd: true, level: "max" },
  // also: true | "gzip" | ["gzip", "br"] | ...
});
```
Compressed files appear in `result.outputs` with `kind: "compressed"`. Without `outdir` they come back as in-memory `Blob`s.

### How did you verify your code works?

- New `test/bundler/bundler_compress.test.ts` (5 tests): roundtrips all three formats, outdir + in-memory paths, sourcemap compression, CLI invocation.
- Existing `test/bundler/bun-build-api.test.ts` passes.