### PR TITLE
JSTranspiler: fix use-after-free of log messages in async transform()

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -500,9 +500,16 @@ pub const TransformTask = struct {
         var ast_scope = ast_memory_allocator.enter(allocator);
         defer ast_scope.exit();
 
+        // Log message text/locations are allocated from the arena during
+        // parsing/printing, which is freed when this function returns.
+        // Use a temporary log and deep-copy into `this.log` so `then()` can
+        // safely read the messages on the JS thread.
+        var log = logger.Log.init(allocator);
+        log.level = this.log.level;
+        defer bun.handleOom(log.cloneToWithRecycled(&this.log, true));
+
         this.transpiler.setAllocator(allocator);
-        this.transpiler.setLog(&this.log);
-        this.log.msgs.allocator = bun.default_allocator;
+        this.transpiler.setLog(&log);
 
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)

--- a/test/js/bun/transpiler/transpiler-async-log-uaf-fixture.ts
+++ b/test/js/bun/transpiler/transpiler-async-log-uaf-fixture.ts
@@ -1,0 +1,25 @@
+const transpiler = new Bun.Transpiler();
+
+const jobs: Promise<unknown>[] = [];
+for (let i = 0; i < 64; i++) {
+  jobs.push(transpiler.transform("import {a} from 1;\nconst x: = y;\nexport", "ts"));
+}
+// Give the worker threads time to finish run() and tear down their arenas
+// before the JS thread drains the completion tasks.
+Bun.sleepSync(100);
+Bun.gc(true);
+
+const results = await Promise.allSettled(jobs);
+for (const result of results) {
+  if (result.status !== "rejected") {
+    throw new Error("expected rejection");
+  }
+  const reason: any = result.reason;
+  const messages: string[] = Array.isArray(reason?.errors)
+    ? reason.errors.map((e: any) => String(e?.message ?? e))
+    : [String(reason?.message ?? reason)];
+  if (!messages.some(m => m.includes("Expected string"))) {
+    throw new Error("missing expected parse error, got: " + JSON.stringify(messages));
+  }
+}
+console.log("DONE");

--- a/test/js/bun/transpiler/transpiler-async-log-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-log-uaf.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// `Bun.Transpiler.transform()` runs parsing on a worker thread using an arena
+// allocator. Log messages (text + locations) were allocated from that arena,
+// which was freed before the promise was settled on the JS thread, leading to
+// a use-after-free when rendering the error. Run the repro in a subprocess so
+// an ASAN abort is observed as a test failure rather than killing the runner.
+test("async transform with parse errors does not read freed log messages", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "transpiler-async-log-uaf-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout: stdout.trim(),
+    exitCode,
+    signalCode: proc.signalCode,
+    asan: stderr.includes("AddressSanitizer"),
+  }).toEqual({
+    stdout: "DONE",
+    exitCode: 0,
+    signalCode: null,
+    asan: false,
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`Bun.Transpiler.prototype.transform()` (the async variant) runs parsing on a worker thread using a temporary `MimallocArena` that is destroyed when `TransformTask.run()` returns. Error messages written to the log during parsing have their `text` and `location` strings allocated from that arena.

Previously the task's `this.log` was passed directly to the transpiler, so when `then()` later called `this.log.toJS()` on the JS thread, `Msg.clone` → `Data.clone` would `allocator.dupe()` strings that pointed into the already-freed arena.

```
READ of size 29 at 0x71c6152e0038 thread T0
    #0 __asan_memcpy
    #1 mem.Allocator.dupe
    #2 logger.Data.clone            src/logger.zig:232
    #3 logger.Msg.clone             src/logger.zig:440
    #4 BuildMessage.create          src/bun.js/BuildMessage.zig:54
    #5 logger.Log.toJS              src/logger.zig:742
    #6 TransformTask.then           src/bun.js/api/JSTranspiler.zig:568
```

Fix by using a temporary arena-backed log during `run()` and deep-copying it into `this.log` via `cloneToWithRecycled()` before the arena is torn down — the same pattern `RuntimeTranspilerStore` already uses.

## How did you verify your code works?

Minimal repro that crashed ~1/12 runs under ASAN before and passes 50/50 after:

```js
const t = new Bun.Transpiler();
const results = [];
for (let i = 0; i < 50; i++) {
  results.push(t.transform("import {a} from 1;\nconst x: = y;\nexport", "ts"));
}
Bun.gc(true);
await Promise.allSettled(results);
```

Added as `test/js/bun/transpiler/transpiler-async-log-uaf.test.ts`. Existing `test/bundler/transpiler/transpiler.test.js` and `test/js/bun/transpiler/` suites pass.