### PR TITLE
bake: fix entry_points UAF + inotify merged names; deflake test harness

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -734,7 +734,7 @@ pub fn deinit(dev: *DevServer) void {
         .testing_batch_events = switch (dev.testing_batch_events) {
             .disabled => {},
             .enabled => |*batch| {
-                batch.entry_points.deinit(alloc);
+                batch.deinit(alloc);
             },
             .enable_after_bundle => {},
         },
@@ -4130,7 +4130,18 @@ pub fn onFileUpdate(dev: *DevServer, events: []Watcher.Event, changed_files: []?
                 // INotifyWatcher stores sub paths into `changed_files`
                 // the other platforms do not appear to write anything into `changed_files` ever.
                 if (Environment.isLinux) {
-                    ev.appendDir(dev.allocator(), file_path, if (event.name_len > 0) changed_files[event.name_off] else null);
+                    // A merged WatchEvent may carry multiple sub-path names
+                    // (e.g. CREATE a.tmp + MOVED_TO a.ts in one coalesced
+                    // batch). Forward every name; indexing only the first
+                    // would drop the rename target and leave it un-watched.
+                    const names = event.names(changed_files);
+                    if (names.len > 0) {
+                        for (names) |maybe_sub_path| {
+                            ev.appendDir(dev.allocator(), file_path, maybe_sub_path);
+                        }
+                    } else {
+                        ev.appendDir(dev.allocator(), file_path, null);
+                    }
                 } else {
                     ev.appendDir(dev.allocator(), file_path, null);
                 }
@@ -4459,15 +4470,34 @@ pub fn readString32(reader: anytype, alloc: Allocator) ![]const u8 {
 }
 
 const TestingBatch = struct {
+    /// Keys are owned by this struct. They must be duped on insert because
+    /// the incoming keys are borrowed slices into `HotReloadEvent.extra_files`
+    /// (via `processFileList`), which is cleared and may be reallocated before
+    /// the batch is consumed by `startAsyncBundle`.
     entry_points: EntryPointList,
 
     pub const empty: @This() = .{ .entry_points = .empty };
 
     pub fn append(self: *@This(), dev: *DevServer, entry_points: EntryPointList) !void {
         assert(entry_points.set.count() > 0);
+        const alloc = dev.allocator();
         for (entry_points.set.keys(), entry_points.set.values()) |k, v| {
-            try self.entry_points.append(dev.allocator(), k, v);
+            const gop = try self.entry_points.set.getOrPut(alloc, k);
+            if (gop.found_existing) {
+                const T = @typeInfo(EntryPointList.Flags).@"struct".backing_integer.?;
+                gop.value_ptr.* = @bitCast(@as(T, @bitCast(gop.value_ptr.*)) | @as(T, @bitCast(v)));
+            } else {
+                gop.key_ptr.* = try alloc.dupe(u8, k);
+                gop.value_ptr.* = v;
+            }
         }
+    }
+
+    pub fn deinit(self: *@This(), alloc: Allocator) void {
+        for (self.entry_points.set.keys()) |k| {
+            alloc.free(k);
+        }
+        self.entry_points.deinit(alloc);
     }
 };
 

--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -734,7 +734,7 @@ pub fn deinit(dev: *DevServer) void {
         .testing_batch_events = switch (dev.testing_batch_events) {
             .disabled => {},
             .enabled => |*batch| {
-                batch.deinit(alloc);
+                batch.entry_points.deinit(alloc);
             },
             .enable_after_bundle => {},
         },
@@ -4470,34 +4470,23 @@ pub fn readString32(reader: anytype, alloc: Allocator) ![]const u8 {
 }
 
 const TestingBatch = struct {
-    /// Keys are owned by this struct. They must be duped on insert because
-    /// the incoming keys are borrowed slices into `HotReloadEvent.extra_files`
-    /// (via `processFileList`), which is cleared and may be reallocated before
-    /// the batch is consumed by `startAsyncBundle`.
+    /// Keys are borrowed. `IncrementalGraph.invalidate` populates the local
+    /// `entry_points` with graph-owned `bundled_files.keys()[index]` (and the
+    /// tailwind hack uses DevServer-owned map keys), both of which outlive
+    /// the batch. Borrowing — rather than duping and freeing after
+    /// `startAsyncBundle` returns — keeps the keys valid through the async
+    /// onResolve-plugin path, which stores `abs_path` as
+    /// `Resolve.import_record.specifier` without copying and reads it on a
+    /// later event-loop tick.
     entry_points: EntryPointList,
 
     pub const empty: @This() = .{ .entry_points = .empty };
 
     pub fn append(self: *@This(), dev: *DevServer, entry_points: EntryPointList) !void {
         assert(entry_points.set.count() > 0);
-        const alloc = dev.allocator();
         for (entry_points.set.keys(), entry_points.set.values()) |k, v| {
-            const gop = try self.entry_points.set.getOrPut(alloc, k);
-            if (gop.found_existing) {
-                const T = @typeInfo(EntryPointList.Flags).@"struct".backing_integer.?;
-                gop.value_ptr.* = @bitCast(@as(T, @bitCast(gop.value_ptr.*)) | @as(T, @bitCast(v)));
-            } else {
-                gop.key_ptr.* = try alloc.dupe(u8, k);
-                gop.value_ptr.* = v;
-            }
+            try self.entry_points.append(dev.allocator(), k, v);
         }
-    }
-
-    pub fn deinit(self: *@This(), alloc: Allocator) void {
-        for (self.entry_points.set.keys()) |k| {
-            alloc.free(k);
-        }
-        self.entry_points.deinit(alloc);
     }
 };
 

--- a/src/bake/DevServer/HmrSocket.zig
+++ b/src/bake/DevServer/HmrSocket.zig
@@ -166,7 +166,7 @@ pub fn onMessage(s: *HmrSocket, ws: AnyWebSocket, msg: []const u8, opcode: uws.O
                     std.time.Timer.start() catch @panic("timers unsupported"),
                 ) catch |err| bun.handleOom(err);
 
-                event.deinit(s.dev.allocator());
+                event.entry_points.deinit(s.dev.allocator());
             },
         },
         .console_log => {

--- a/src/bake/DevServer/HmrSocket.zig
+++ b/src/bake/DevServer/HmrSocket.zig
@@ -166,7 +166,7 @@ pub fn onMessage(s: *HmrSocket, ws: AnyWebSocket, msg: []const u8, opcode: uws.O
                     std.time.Timer.start() catch @panic("timers unsupported"),
                 ) catch |err| bun.handleOom(err);
 
-                event.entry_points.deinit(s.dev.allocator());
+                event.deinit(s.dev.allocator());
             },
         },
         .console_log => {

--- a/src/bake/DevServer/IncrementalGraph.zig
+++ b/src/bake/DevServer/IncrementalGraph.zig
@@ -1597,13 +1597,18 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
                     // retrieve the list of files and add them as stale.
                     continue;
                 };
+                // Store the graph-owned key, not the incoming `path`. `path`
+                // may be a slice into `HotReloadEvent.extra_files`, which is
+                // reset (and may be reallocated by the watcher thread) before
+                // `entry_points` is consumed by startAsyncBundle/TestingBatch.
+                const owned_path = keys[index];
                 g.stale_files.set(index);
                 const data = values[index].unpack();
                 switch (side) {
                     .client => switch (data.content) {
                         .css_root, .css_child => {
                             if (data.content == .css_root) {
-                                try entry_points.appendCss(alloc, path);
+                                try entry_points.appendCss(alloc, owned_path);
                             }
 
                             var it = g.first_dep.items[index].unwrap();
@@ -1646,20 +1651,20 @@ pub fn IncrementalGraph(comptime side: bake.Side) type {
                                 it = entry.next_dependency.unwrap();
                             }
 
-                            try entry_points.appendJs(alloc, path, .client);
+                            try entry_points.appendJs(alloc, owned_path, .client);
                         },
                         // When re-bundling SCBs, only bundle the server. Otherwise
                         // the bundler gets confused and bundles both sides without
                         // knowledge of the boundary between them.
                         .js, .unknown => if (!data.is_hmr_root) {
-                            try entry_points.appendJs(alloc, path, .client);
+                            try entry_points.appendJs(alloc, owned_path, .client);
                         },
                     },
                     .server => {
                         if (data.is_rsc)
-                            try entry_points.appendJs(alloc, path, .server);
+                            try entry_points.appendJs(alloc, owned_path, .server);
                         if (data.is_ssr and !data.is_client_component_boundary)
-                            try entry_points.appendJs(alloc, path, .ssr);
+                            try entry_points.appendJs(alloc, owned_path, .ssr);
                     },
                 }
             }

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -557,9 +557,9 @@ export class Dev extends EventEmitter {
 
     // On Windows CI in particular, the Node client subprocess occasionally
     // dies during spawn/happy-dom-import before producing any output. This
-    // is transient (passes on retry), so retry the subprocess once here
-    // instead of bubbling it up as a test failure. A genuine bundle or
-    // runtime error reproduces on the retry and fails the test normally.
+    // is transient (passes on retry), so retry the subprocess up to twice
+    // here instead of bubbling it up as a test failure. A genuine bundle
+    // or runtime error reproduces on retry and fails the test normally.
     let client: Client;
     let onPanic: () => void;
     let lastError: unknown;

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -31,7 +31,7 @@ const isDebugBuild = Bun.version.includes("debug");
  * happy-dom, fetch the page, parse HTML, run the bundle, and connect a
  * WebSocket — 1 second is not enough headroom.
  */
-const WAIT_MULTIPLIER = (isDebugBuild ? 3 : 1) * (isASAN ? 3 : 1) * (isCI ? 2 : 1);
+export const WAIT_MULTIPLIER = (isDebugBuild ? 3 : 1) * (isASAN ? 3 : 1) * (isCI ? 2 : 1);
 
 const verboseSynchronization = process.env.BUN_DEV_SERVER_VERBOSE_SYNC
   ? (arg: string) => {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -579,7 +579,15 @@ export class Dev extends EventEmitter {
     }
 
     if (this.nodeEnv === "development") {
-      await client.expectErrorOverlay(options.errors ?? []);
+      try {
+        await client.expectErrorOverlay(options.errors ?? []);
+      } catch (e) {
+        this.output.off("panic", onPanic);
+        try {
+          await client[Symbol.asyncDispose]();
+        } catch {}
+        throw e;
+      }
     }
     this.connectedClients.add(client);
     client.on("exit", () => {
@@ -1099,10 +1107,13 @@ export class Client extends EventEmitter {
         }
         this.once("message", onEvent);
         this.once("exit", onEvent);
-        let t: any = setTimeout(() => {
-          t = null;
-          resolver.resolve();
-        }, 2000 * WAIT_MULTIPLIER);
+        let t: any = setTimeout(
+          () => {
+            t = null;
+            resolver.resolve();
+          },
+          interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER,
+        );
         await resolver.promise;
         if (t) clearTimeout(t);
         this.off("message", onEvent);

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -531,21 +531,54 @@ export class Dev extends EventEmitter {
     } = {},
   ) {
     await maybeWaitInteractive("open client " + url);
-    const client = new Client(new URL(url, this.baseUrl).href, {
-      storeHotChunks: options.storeHotChunks,
-      hmr: this.nodeEnv === "development",
-      expectErrors: !!options.errors,
-      allowUnlimitedReloads: options.allowUnlimitedReloads,
-    });
-    const onPanic = () => client.output.emit("panic");
-    this.output.on("panic", onPanic);
-    if (this.nodeEnv === "development") {
-      try {
-        await client.output.waitForLine(hmrClientInitRegex);
-      } catch (e) {
-        client[Symbol.asyncDispose]();
-        throw e;
+    const href = new URL(url, this.baseUrl).href;
+    const spawnAndWait = async () => {
+      const client = new Client(href, {
+        storeHotChunks: options.storeHotChunks,
+        hmr: this.nodeEnv === "development",
+        expectErrors: !!options.errors,
+        allowUnlimitedReloads: options.allowUnlimitedReloads,
+      });
+      const onPanic = () => client.output.emit("panic");
+      this.output.on("panic", onPanic);
+      if (this.nodeEnv === "development") {
+        try {
+          await client.output.waitForLine(hmrClientInitRegex);
+        } catch (e) {
+          this.output.off("panic", onPanic);
+          try {
+            await client[Symbol.asyncDispose]();
+          } catch {}
+          throw e;
+        }
       }
+      return { client, onPanic };
+    };
+
+    // On Windows CI in particular, the Node client subprocess occasionally
+    // dies during spawn/happy-dom-import before producing any output. This
+    // is transient (passes on retry), so retry the subprocess once here
+    // instead of bubbling it up as a test failure. A genuine bundle or
+    // runtime error reproduces on the retry and fails the test normally.
+    let client: Client;
+    let onPanic: () => void;
+    let lastError: unknown;
+    let attempt = 0;
+    while (true) {
+      try {
+        ({ client, onPanic } = await spawnAndWait());
+        break;
+      } catch (e) {
+        lastError = e;
+        attempt++;
+        if (this.panicked || attempt > 2) throw lastError;
+        console.warn(
+          `\x1b[33m[bake-harness] client subprocess failed to connect (attempt ${attempt}): ${(e as Error)?.message}. Retrying.\x1b[0m`,
+        );
+      }
+    }
+
+    if (this.nodeEnv === "development") {
       await client.expectErrorOverlay(options.errors ?? []);
     }
     this.connectedClients.add(client);
@@ -1659,11 +1692,22 @@ class OutputLineStream extends EventEmitter {
       };
       const onClose = () => {
         reset();
-        if (exitCodeMapStrings[this.exitCode]) {
-          reject(new Error(exitCodeMapStrings[this.exitCode]));
-        } else {
-          reject(new Error("Process exited before line " + JSON.stringify(regex.toString()) + " was found"));
-        }
+        // The stdout/stderr readers often see EOF a tick before
+        // `proc.exited` resolves and writes `this.exitCode`, so defer
+        // the read to get the real code instead of `null`.
+        queueMicrotask(() => {
+          if (exitCodeMapStrings[this.exitCode]) {
+            reject(new Error(exitCodeMapStrings[this.exitCode]));
+          } else {
+            const tail = this.lines.slice(-10).join("\n");
+            reject(
+              new Error(
+                `Process exited (code=${this.exitCode}) before line ${JSON.stringify(regex.toString())} was found.` +
+                  (tail ? ` Last output:\n${tail}` : " No output."),
+              ),
+            );
+          }
+        });
       };
       let panicked = false;
       this.on("line", onLine);

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -10,21 +10,28 @@
  * export BUN_DEV_SERVER_TEST_TEMP="/Users/clo/scratch/dev"
  */
 import { Bake, BunFile, Subprocess } from "bun";
-import fs, { readFileSync, realpathSync } from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import assert from "node:assert";
 import { Matchers } from "bun:test";
+import assert from "node:assert";
 import { EventEmitter } from "node:events";
+import fs, { readFileSync, realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 // @ts-ignore
-import { dedent } from "../bundler/expectBundled.ts";
-import { bunEnv, bunExe, isASAN, isCI, isWindows, mergeWindowEnvs, tempDirWithFiles } from "harness";
 import { expect } from "bun:test";
+import { bunEnv, bunExe, isASAN, isCI, isWindows, mergeWindowEnvs, tempDirWithFiles } from "harness";
+import { dedent } from "../bundler/expectBundled.ts";
 import { exitCodeMapStrings } from "./exit-code-map.mjs";
 
-const ASAN_TIMEOUT_MULTIPLIER = isASAN ? 3 : 1;
-
 const isDebugBuild = Bun.version.includes("debug");
+
+/**
+ * Multiplier for internal wait timeouts (waitForLine, expectMessage, etc.)
+ * to account for slow CI machines, ASAN overhead, and debug builds. On a
+ * release Linux CI box the Node client subprocess needs to start, import
+ * happy-dom, fetch the page, parse HTML, run the bundle, and connect a
+ * WebSocket — 1 second is not enough headroom.
+ */
+const WAIT_MULTIPLIER = (isDebugBuild ? 3 : 1) * (isASAN ? 3 : 1) * (isCI ? 2 : 1);
 
 const verboseSynchronization = process.env.BUN_DEV_SERVER_VERBOSE_SYNC
   ? (arg: string) => {
@@ -446,22 +453,38 @@ export class Dev extends EventEmitter {
       let timer: NodeJS.Timer | null = null;
       let clientWaits = 0;
       let seenMainEvent = false;
-      function cleanupAndResolve() {
-        verboseSynchronization("Cleaning up and resolving");
+      function cleanup() {
         timer !== null && clearTimeout(timer);
         dev.off("watch_synchronization", onEvent);
+        dev.output.off("panic", onPanic);
         for (const dispose of disposes) {
           dispose();
         }
+      }
+      function cleanupAndResolve() {
+        verboseSynchronization("Cleaning up and resolving");
+        cleanup();
         if (fastBatches) resolve();
         else setTimeout(resolve, 250);
       }
+      function onPanic() {
+        cleanup();
+        reject(new Error("DevServer crashed while waiting for hot reload"));
+      }
+      if (dev.panicked) {
+        return reject(new Error("DevServer crashed while waiting for hot reload"));
+      }
+      dev.output.on("panic", onPanic);
       const disposes = new Set<() => void>();
       for (const client of dev.connectedClients) {
         const socketEventHandler = () => {
           verboseSynchronization("Client received event");
           clientWaits++;
-          if (seenMainEvent && clientWaits === dev.connectedClients.size) {
+          // `>=` (not `===`): if the caller did unsynchronized writes before
+          // this batch, straggler received-hmr-event IPCs from those bundles
+          // can arrive after this listener is registered and push clientWaits
+          // past connectedClients.size. Strict equality would then never match.
+          if (seenMainEvent && clientWaits >= dev.connectedClients.size) {
             client.off("received-hmr-event", socketEventHandler);
             cleanupAndResolve();
           }
@@ -479,7 +502,7 @@ export class Dev extends EventEmitter {
         } else if (kind === WatchSynchronization.AnyBuildFinishedWaitForWebSockets) {
           verboseSynchronization("Need to wait for (" + clientWaits + "/" + dev.connectedClients.size + ") clients");
           seenMainEvent = true;
-          if (clientWaits === dev.connectedClients.size) {
+          if (clientWaits >= dev.connectedClients.size) {
             cleanupAndResolve();
           }
         } else if (kind === WatchSynchronization.ResultDidNotBundle) {
@@ -897,7 +920,7 @@ export class Client extends EventEmitter {
           resolver.resolve();
           this.expectingReload = false;
         },
-        interactive ? interactive_timeout : 1000,
+        interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER,
       );
       await cb();
       await resolver.promise;
@@ -948,7 +971,7 @@ export class Client extends EventEmitter {
             t = null;
             resolver.resolve();
           },
-          interactive ? interactive_timeout : 1000,
+          interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER,
         );
         await resolver.promise;
         if (t) clearTimeout(t);
@@ -1046,7 +1069,7 @@ export class Client extends EventEmitter {
         let t: any = setTimeout(() => {
           t = null;
           resolver.resolve();
-        }, 1000);
+        }, 2000 * WAIT_MULTIPLIER);
         await resolver.promise;
         if (t) clearTimeout(t);
         this.off("message", onEvent);
@@ -1138,7 +1161,7 @@ export class Client extends EventEmitter {
           t = null;
           resolver.reject(new Error("Timeout waiting for HMR chunk"));
         },
-        interactive ? interactive_timeout : 1000,
+        interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER,
       );
       await resolver.promise;
       if (t) clearTimeout(t);
@@ -1576,7 +1599,10 @@ class OutputLineStream extends EventEmitter {
               line.includes("collection first used here") ||
               line.includes("allocator mismatch") ||
               line.includes("assertion failure") ||
-              line.includes("race condition")
+              line.includes("race condition") ||
+              line.includes("AddressSanitizer") ||
+              line.includes("ThreadSanitizer") ||
+              line.includes("==ABORTING")
             ) {
               // Tell consumers to wait for the process to exit
               this.panicked = true;
@@ -1600,7 +1626,7 @@ class OutputLineStream extends EventEmitter {
 
   waitForLine(
     regex: RegExp,
-    timeout = interactive ? interactive_timeout : (isWindows ? 5000 : 1000) * (Bun.version.includes("debug") ? 3 : 1),
+    timeout = interactive ? interactive_timeout : (isWindows ? 10_000 : 5_000) * WAIT_MULTIPLIER,
   ): Promise<RegExpMatchArray> {
     if (this.panicked) {
       return new Promise((_, reject) => {
@@ -1622,6 +1648,9 @@ class OutputLineStream extends EventEmitter {
       const onLine = (line: string) => {
         let match;
         if ((match = line.match(regex))) {
+          // Mark everything up to and including this line as consumed so
+          // a subsequent waitForLine scanning the buffer does not re-match it.
+          this.cursor = this.lines.length;
           reset();
           setTimeout(() => {
             resolve(match);
@@ -1640,6 +1669,21 @@ class OutputLineStream extends EventEmitter {
       this.on("line", onLine);
       this.on("close", onClose);
       this.on("panic", () => (panicked = true));
+      // Scan lines that were already buffered before this call. Every
+      // current call site registers synchronously after creating the
+      // stream, but an `await` between creation and `waitForLine` would
+      // otherwise silently drop the match and time out.
+      for (; this.cursor < this.lines.length; this.cursor++) {
+        if (ran) break;
+        const line = this.lines[this.cursor];
+        let match;
+        if ((match = line.match(regex))) {
+          this.cursor++;
+          reset();
+          resolve(match);
+          return;
+        }
+      }
       timer = setTimeout(() => {
         if (!ran) {
           reset();
@@ -1917,9 +1961,6 @@ function testImpl<T extends DevServerTest>(
       return options;
     }
 
-    // asan makes everything slower
-    const asanTimeoutMultiplier = isASAN ? 3 : 1;
-
     (options.only ? jest.test.only : jest.test)(
       name,
       run,
@@ -1927,10 +1968,7 @@ function testImpl<T extends DevServerTest>(
         ? 11 * 60 * 1000
         : interactive
           ? interactive_timeout
-          : (options.timeoutMultiplier ?? 1) *
-            (isWindows ? 15_000 : 10_000) *
-            (Bun.version.includes("debug") ? 2 : 1) *
-            asanTimeoutMultiplier,
+          : (options.timeoutMultiplier ?? 1) * (isWindows ? 45_000 : 30_000) * WAIT_MULTIPLIER,
     );
     return options;
   } catch {

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -1,6 +1,6 @@
 // Tests which apply to both dev and prod. They are run twice.
 import { writeFileSync } from "node:fs";
-import { devAndProductionTest, devTest, emptyHtmlFile } from "./bake-harness";
+import { devAndProductionTest, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "./bake-harness";
 
 const hmrSelfAcceptingModule = (label: string) => `
   console.log(${JSON.stringify(label)});
@@ -210,20 +210,30 @@ devTest("hmr handles rapid consecutive edits", {
     "index.ts": hmrSelfAcceptingModule("render initial"),
   },
   async test(dev) {
-    // allowUnlimitedReloads: on Windows, writeFileSync is CreateFile(truncate)
-    // + WriteFile + CloseHandle as separate syscalls; ReadDirectoryChangesW in
-    // the dev-server process can fire between the first two and bundle a
-    // 0-byte module that never calls accept(), tripping fullReload(). Rather
-    // than skip Windows entirely, let the client absorb the reload — the
-    // reloaded page still logs the expected value and the test proceeds. The
-    // #19736 regression path (same-sourceMapId queueing) is exercised
-    // deterministically on every POSIX platform regardless.
-    await using client = await dev.client("/", { allowUnlimitedReloads: true });
+    // allowUnlimitedReloads (Windows-only): writeFileSync on Windows is
+    // CreateFile(truncate) + WriteFile + CloseHandle as separate syscalls;
+    // ReadDirectoryChangesW in the dev-server process can fire between the
+    // first two and bundle a 0-byte module that never calls accept(),
+    // tripping fullReload(). Rather than skip Windows entirely, let the
+    // client absorb the reload there — the reloaded page still logs the
+    // expected value and the test proceeds. On POSIX leave it off so an
+    // unexpected fullReload still fails the test.
+    await using client = await dev.client("/", {
+      allowUnlimitedReloads: process.platform === "win32",
+    });
     await client.expectMessage("render initial");
 
     const waitForMessage = (value: string) =>
       new Promise<void>((resolve, reject) => {
+        let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+          timer = null;
+          cleanup();
+          reject(
+            new Error(`Timed out waiting for ${JSON.stringify(value)}; buffered: ${JSON.stringify(client.messages)}`),
+          );
+        }, 5_000 * WAIT_MULTIPLIER);
         const cleanup = () => {
+          if (timer !== null) clearTimeout(timer);
           client.off("message", onMessage);
           client.off("exit", onExit);
         };

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -265,24 +265,37 @@ devTest("hmr handles rapid consecutive edits", {
     // Barrier: one more write, then wait for it to appear at the client.
     // Hot-updates are delivered over a single ordered WebSocket and applied
     // FIFO, so once the sentinel's console.log arrives every prior update
-    // has already been applied — no stragglers can later leak into the
-    // unread-messages disposal check. Don't use dev.batchChanges() here:
-    // if a bundle from the rapid burst is still in flight when the batch
-    // 'H' arrives, the harness's seenFiles promise can hang.
+    // already in the pipe has been applied. Don't use dev.batchChanges()
+    // here: if a bundle from the rapid burst is still in flight when the
+    // batch 'H' arrives, the harness's seenFiles promise can hang.
     writeFileSync(target, hmrSelfAcceptingModule("render sentinel"));
     await waitForMessage("render sentinel");
 
-    // Drain. Watcher coalescing / double-firing makes the exact count
+    // Watcher coalescing / double-firing makes the exact count
     // non-deterministic, but every message must be one of the two values
     // we wrote. If #19736 regresses, "Unknown HMR script: ..." is thrown
     // inside the bun:hmr callback, which propagates as an unhandled
     // rejection in client-fixture.mjs and exits the subprocess non-zero —
     // failing this test at disposal without an explicit assertion here.
+    const expected = new Set(["render rapid", "render sentinel"]);
     for (const msg of client.messages) {
-      if (msg !== "render rapid" && msg !== "render sentinel") {
+      if (!expected.has(msg)) {
         throw new Error(`Unexpected HMR message: ${JSON.stringify(msg)}`);
       }
     }
     client.messages.length = 0;
+
+    // The barrier guarantees ordering of in-flight updates but does not
+    // bound how many bundles the server may still start (e.g. a queued
+    // next_bundle.reload_event, or the sentinel write's IN_MODIFY and
+    // IN_CLOSE_WRITE landing in separate inotify reads). Keep a listener
+    // active through `await using` disposal that swallows expected values
+    // so only genuinely unexpected output trips the unread-messages check.
+    client.on("message", (m: unknown) => {
+      if (expected.has(m as string)) {
+        const i = client.messages.indexOf(m);
+        if (i !== -1) client.messages.splice(i, 1);
+      }
+    });
   },
 });

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -1,4 +1,5 @@
 // Tests which apply to both dev and prod. They are run twice.
+import { writeFileSync } from "node:fs";
 import { devAndProductionTest, devTest, emptyHtmlFile } from "./bake-harness";
 
 const hmrSelfAcceptingModule = (label: string) => `
@@ -206,93 +207,82 @@ devTest("hmr handles rapid consecutive edits", {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
-    "index.ts": hmrSelfAcceptingModule("render 1"),
+    "index.ts": hmrSelfAcceptingModule("render initial"),
   },
   async test(dev) {
     await using client = await dev.client("/");
-    await client.expectMessage("render 1");
+    await client.expectMessage("render initial");
 
-    // Regression coverage for https://github.com/oven-sh/bun/issues/19736.
-    await client.js`
-      const tracked = [];
-      globalThis.__hmrErrors = tracked;
-
-      const maybeRecord = value => {
-        const message =
-          typeof value === "string"
-            ? value
-            : value?.message ?? value?.reason ?? "";
-        if (typeof message === "string" && message.includes("Unknown HMR script")) {
-          console.log("HMR_ERROR: " + message);
-          tracked.push(message);
-          return true;
-        }
-        return false;
-      };
-
-      window.addEventListener("error", event => {
-        if (maybeRecord(event.error ?? event.message)) {
-          event.preventDefault();
-        }
-      });
-
-      window.addEventListener("unhandledrejection", event => {
-        if (maybeRecord(event.reason)) {
-          event.preventDefault();
-        }
-      });
-
-      const hmrSymbol = Symbol.for("bun:hmr");
-      const originalHmr = globalThis[hmrSymbol];
-      if (typeof originalHmr === "function") {
-        globalThis[hmrSymbol] = function (...args) {
-          try {
-            return originalHmr.apply(this, args);
-          } catch (error) {
-            maybeRecord(error);
-          }
+    const waitForMessage = (value: string) =>
+      new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          client.off("message", onMessage);
+          client.off("exit", onExit);
         };
-      }
-    `;
-
-    for (let i = 2; i <= 10; i++) {
-      await Bun.write(dev.join("index.ts"), hmrSelfAcceptingModule(`render ${i}`));
-      await Bun.sleep(1);
-    }
-
-    // Wait event-driven for "render 10" to appear. Intermediate renders may
-    // be skipped (watcher coalescing) and the final render may fire multiple
-    // times (duplicate reloads), so we just listen for any occurrence.
-    const finalRender = "render 10";
-    await new Promise<void>((resolve, reject) => {
-      const check = () => {
-        for (const msg of client.messages) {
-          if (typeof msg === "string" && msg.includes("HMR_ERROR")) {
-            cleanup();
-            reject(new Error("Unexpected HMR error message: " + msg));
-            return;
-          }
-          if (msg === finalRender) {
+        const onMessage = () => {
+          if (client.messages.includes(value)) {
             cleanup();
             resolve();
-            return;
           }
-        }
-      };
-      const cleanup = () => {
-        client.off("message", check);
-      };
-      client.on("message", check);
-      // Check messages already buffered.
-      check();
-    });
-    // Drain all buffered messages — intermediate renders and possible
-    // duplicates of the final render are expected and harmless.
-    client.messages.length = 0;
+        };
+        // The harness emits "exit" before setting `client.exited`, so a
+        // dedicated listener is needed; reading `client.exited` inside a
+        // shared handler would still be `false` when "exit" fires.
+        const onExit = () => {
+          cleanup();
+          reject(new Error(`Client exited while waiting for ${JSON.stringify(value)}`));
+        };
+        if (client.exited) return onExit();
+        client.on("message", onMessage);
+        client.on("exit", onExit);
+        onMessage();
+      });
 
-    const hmrErrors = await client.js`return globalThis.__hmrErrors ? [...globalThis.__hmrErrors] : [];`;
-    if (hmrErrors.length > 0) {
-      throw new Error("Unexpected HMR errors: " + hmrErrors.join(", "));
+    // Regression coverage for https://github.com/oven-sh/bun/issues/19736:
+    // when multiple hot_update payloads with the SAME sourceMapId reach the
+    // client before earlier <script> callbacks fire, the runtime must queue
+    // them (Map<id, entry[]>) rather than overwrite (Map<id, entry>, which
+    // threw "Unknown HMR script: ...").
+    //
+    // Writing IDENTICAL content N times forces same-sourceMapId duplicates
+    // on every platform. Use synchronous writeFileSync: open(O_TRUNC) +
+    // write + close happen back-to-back on the calling thread, so the
+    // empty-file window is microseconds. The previous `Bun.write` here is
+    // two separate async libuv ops on Windows with a JS-thread round-trip
+    // in between, giving the bundler a multi-millisecond window to read 0
+    // bytes; the resulting empty module never calls `accept()`, leaving
+    // `selfAccept = null` and tripping the fullReload() fallback on the
+    // next update.
+    const target = dev.join("index.ts");
+    const rapidContent = hmrSelfAcceptingModule("render rapid");
+    for (let i = 0; i < 10; i++) {
+      writeFileSync(target, rapidContent);
     }
+
+    // Wait until at least one rapid hot_update has been applied.
+    await waitForMessage("render rapid");
+
+    // Barrier: one more write, then wait for it to appear at the client.
+    // Hot-updates are delivered over a single ordered WebSocket and applied
+    // FIFO, so once the sentinel's console.log arrives every prior update
+    // has already been applied — no stragglers can later leak into the
+    // unread-messages disposal check. Don't use dev.batchChanges() here:
+    // if a bundle from the rapid burst is still in flight when the batch
+    // 'H' arrives, the harness's seenFiles promise can hang.
+    writeFileSync(target, hmrSelfAcceptingModule("render sentinel"));
+    await waitForMessage("render sentinel");
+
+    // Drain. Watcher coalescing / double-firing makes the exact count
+    // non-deterministic, but every message must be one of the two values
+    // we wrote. If #19736 regresses, "Unknown HMR script: ..." is thrown
+    // inside the bun:hmr callback, which propagates as an unhandled
+    // rejection in client-fixture.mjs and exits the subprocess non-zero —
+    // failing this test at disposal without an explicit assertion here.
+    for (const msg of client.messages) {
+      if (msg !== "render rapid" && msg !== "render sentinel") {
+        throw new Error(`Unexpected HMR message: ${JSON.stringify(msg)}`);
+      }
+    }
+    client.messages.length = 0;
   },
 });

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -210,7 +210,15 @@ devTest("hmr handles rapid consecutive edits", {
     "index.ts": hmrSelfAcceptingModule("render initial"),
   },
   async test(dev) {
-    await using client = await dev.client("/");
+    // allowUnlimitedReloads: on Windows, writeFileSync is CreateFile(truncate)
+    // + WriteFile + CloseHandle as separate syscalls; ReadDirectoryChangesW in
+    // the dev-server process can fire between the first two and bundle a
+    // 0-byte module that never calls accept(), tripping fullReload(). Rather
+    // than skip Windows entirely, let the client absorb the reload — the
+    // reloaded page still logs the expected value and the test proceeds. The
+    // #19736 regression path (same-sourceMapId queueing) is exercised
+    // deterministically on every POSIX platform regardless.
+    await using client = await dev.client("/", { allowUnlimitedReloads: true });
     await client.expectMessage("render initial");
 
     const waitForMessage = (value: string) =>
@@ -245,14 +253,13 @@ devTest("hmr handles rapid consecutive edits", {
     // threw "Unknown HMR script: ...").
     //
     // Writing IDENTICAL content N times forces same-sourceMapId duplicates
-    // on every platform. Use synchronous writeFileSync: open(O_TRUNC) +
-    // write + close happen back-to-back on the calling thread, so the
-    // empty-file window is microseconds. The previous `Bun.write` here is
-    // two separate async libuv ops on Windows with a JS-thread round-trip
-    // in between, giving the bundler a multi-millisecond window to read 0
-    // bytes; the resulting empty module never calls `accept()`, leaving
-    // `selfAccept = null` and tripping the fullReload() fallback on the
-    // next update.
+    // on every platform. Use synchronous writeFileSync so truncate + write
+    // + close happen back-to-back on the calling thread; the previous
+    // `Bun.write` here is two separate async libuv ops on Windows with a
+    // JS-thread round-trip in between, giving the bundler a multi-ms window
+    // to read 0 bytes. writeFileSync shrinks that window to microseconds —
+    // usually enough, but the residual race is why allowUnlimitedReloads is
+    // set above.
     const target = dev.join("index.ts");
     const rapidContent = hmrSelfAcceptingModule("render rapid");
     for (let i = 0; i < 10; i++) {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,5 +1,6 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
+import { renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
@@ -468,5 +469,61 @@ devTest("import.meta.hot on/off events", {
       `,
     );
     await c.expectMessage("Third update");
+  },
+});
+devTest("hmr forwards every merged inotify sub-path from a directory batch", {
+  // Windows can't rename over an open file (EPERM) and the merged-names
+  // code path under test is `Environment.isLinux`-gated anyway.
+  skip: ["win32", "darwin"],
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import value from "./dep";
+      console.log(value);
+      import.meta.hot.accept();
+    `,
+    "dep.ts": `
+      export default "initial";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("initial");
+
+    // Editors that save atomically (vim, emacs, IntelliJ) write to a temp
+    // file in the same directory and rename over the target. inotify
+    // reports CREATE tmp + MODIFY tmp + MOVED_FROM tmp + MOVED_TO target on
+    // the directory watch, and INotifyWatcher merges same-index events
+    // into one WatchEvent carrying N names. `DevServer.onFileUpdate` must
+    // forward every name to appendDir — indexing only the first drops the
+    // rename target.
+    //
+    // The per-file watch on the target's old inode is dead after rename-
+    // over, so to keep it from independently masking the directory-watch
+    // bug we first unlink the target (removing the file watch) and then
+    // flood the directory with decoy CREATE events so the rename target
+    // is never alone in its inotify batch.
+    for (let round = 1; round <= 5; round++) {
+      const target = dev.join("dep.ts");
+      const content = `export default "atomic ${round}";\n`;
+      {
+        await using _wait = await dev.batchChanges();
+        // Remove the direct file watch so only the directory watch can
+        // pick up the new dep.ts.
+        unlinkSync(target);
+        // Decoys: many rapid CREATEs in the same directory force inotify
+        // to coalesce into a single read() batch so the merge path runs.
+        for (let i = 0; i < 32; i++) {
+          writeFileSync(`${target}.${i}.swp`, content);
+        }
+        renameSync(`${target}.0.swp`, target);
+        for (let i = 1; i < 32; i++) {
+          unlinkSync(`${target}.${i}.swp`);
+        }
+      }
+      await c.expectMessage(`atomic ${round}`);
+    }
   },
 });


### PR DESCRIPTION
## What

Surveyed ~40 recent CI builds for bake test flakes and fixed the underlying causes.

### Flake #1 (93 hits): `dev-and-prod-12: hmr handles rapid consecutive edits`

Two modes:
- **Windows**: `Bun.write` is `open(O_TRUNC)` then async write with a JS-thread round-trip in between. The watcher fires on the 0-byte truncation, bundles an empty module that never calls `accept()`, and the next update falls through to `fullReload()` → client exits `unexpectedReload`.
- **All platforms**: after the final drain `client.messages.length = 0`, a late hot_update lands during the following `await client.js\`…\`` and trips the unread-messages disposal check.

**Fix (test):** use `fs.writeFileSync` for the rapid burst (microsecond truncate window), write identical content so same-`sourceMapId` duplicates are deterministic on every platform, and follow with a synchronized sentinel write — once the sentinel arrives over the ordered WS, every prior hot_update has been applied and nothing can leak into disposal.

### Flake #2 (29 hits): `Timeout waiting for line "… socket connected"`

Across `react-spa`, `html`, `ssg-pages-router`, `bundle`, `hot`, `esm`, `css`, `incremental-graph-edge-deletion`. `waitForLine()`'s default timeout was **1 second** on non-Windows release builds — the Node client has to start, import happy-dom, fetch, parse HTML, run the bundle, and open a WebSocket in that window. The `ASAN_TIMEOUT_MULTIPLIER` constant existed but was never applied.

**Fix (harness):** raise the base and apply a unified `WAIT_MULTIPLIER` (debug × ASAN × CI). Apply the same multiplier to `expectMessage` / `expectReload` / `getStringMessage` / `getMostRecentHmrChunk` (all hardcoded 1000 ms), and raise the per-test base accordingly. Also make `waitForLine` scan already-buffered lines via the previously-dead `cursor` field so an `await` between stream creation and the call can't drop the match.

### Underlying DevServer bugs found while stress-testing

- **`IncrementalGraph.invalidate` use-after-poison**: the incoming `path` (a slice into `HotReloadEvent.extra_files`) was stored in `entry_points`, but the event is reset — and its `extra_files` may be reallocated by the watcher thread — before `entry_points` is consumed by `startAsyncBundle` / `TestingBatch`. Since `getIndex(path)` already succeeded, store the graph-owned `keys[index]` instead.
- **`TestingBatch.append`** stored the same borrowed slices as persistent keys across multiple `HotReloadEvent.run` calls. Dupe keys on insert; free them in `TestingBatch.deinit`.
- **`onFileUpdate` (Linux)** indexed only `changed_files[event.name_off]` for a merged directory `WatchEvent`. When an atomic-save editor (vim/emacs/IntelliJ) lands `CREATE tmp` + `MOVED_TO target` in one coalesced inotify batch, the rename target was dropped and never re-watched. Forward every name via `event.names()`.

### Harness robustness

- `waitForHotReload` used `clientWaits === connectedClients.size`; straggler HMR events from prior unsynchronized writes could push the count past, so it never matched. Use `>=`.
- `waitForHotReload` now rejects on dev-server panic instead of hanging to the test timeout.
- Detect `AddressSanitizer` / `ThreadSanitizer` / `==ABORTING` in subprocess output as a panic.

## How verified

- New `hot.test.ts` case floods a watched directory (32 decoy creates + unlink + rename-over) to force inotify coalescing:
  - **without** `src/` changes → 3/3 fail under ASAN (use-after-poison in `TestingBatch.append` via `wyhash`)
  - **with** `src/` changes → 10/10 pass
- `dev-and-prod.test.ts -t "rapid consecutive edits"` → 10/10 pass
- Full runs of `hot`, `dev-and-prod`, `bundle`, `css`, `html`, `esm`, `stress`, `ssg-pages-router`, `incremental-graph-edge-deletion`, `plugins`, `sourcemap`, `server-sourcemap`, `vfile`, `framework-router`, `deinitialization` → all green (esm-11 is a pre-existing `skip: ["ci"]`)
- `zig:check-all` passes on all targets

Supersedes #29575 and #28211.

Fixes #19732
