### PR TITLE
Fix crash inspecting WeakMap/WeakSet with user-defined size property

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2766,7 +2766,7 @@ pub const Formatter = struct {
 
                 const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
-                if (length == 0) {
+                if (length == 0 or value.jsType() == .WeakMap) {
                     return writer.print("{s} {{}}", .{map_name});
                 }
 
@@ -2873,7 +2873,7 @@ pub const Formatter = struct {
 
                 const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
-                if (length == 0) {
+                if (length == 0 or value.jsType() == .WeakSet) {
                     return writer.print("{s} {{}}", .{set_name});
                 }
 

--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,6 +2757,10 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                if (value.jsType() == .WeakMap) {
+                    return writer.writeAll("WeakMap {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2764,9 +2768,9 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = "Map";
 
-                if (length == 0 or value.jsType() == .WeakMap) {
+                if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
                 }
 
@@ -2864,6 +2868,10 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                if (value.jsType() == .WeakSet) {
+                    return writer.writeAll("WeakSet {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2871,9 +2879,9 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = "Set";
 
-                if (length == 0 or value.jsType() == .WeakSet) {
+                if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});
                 }
 

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1316,7 +1316,7 @@ pub const JestPrettyFormat = struct {
 
                     const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
-                    if (length == 0) {
+                    if (length == 0 or value.jsType() == .WeakMap) {
                         return writer.print("{s} {{}}", .{map_name});
                     }
 
@@ -1346,7 +1346,7 @@ pub const JestPrettyFormat = struct {
 
                     const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
-                    if (length == 0) {
+                    if (length == 0 or value.jsType() == .WeakSet) {
                         return writer.print("{s} {{}}", .{set_name});
                     }
 

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,6 +1307,10 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    if (value.jsType() == .WeakMap) {
+                        return writer.writeAll("WeakMap {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1314,9 +1318,9 @@ pub const JestPrettyFormat = struct {
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const map_name = "Map";
 
-                    if (length == 0 or value.jsType() == .WeakMap) {
+                    if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
                     }
 
@@ -1335,6 +1339,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    if (value.jsType() == .WeakSet) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.writeAll("WeakSet {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1344,9 +1353,9 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const set_name = "Set";
 
-                    if (length == 0 or value.jsType() == .WeakSet) {
+                    if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});
                     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,15 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+it("WeakMap/WeakSet with a user-defined size property", () => {
+  const wm = new WeakMap();
+  wm.size = 1000;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  expect(() => expect(wm).toEqual({})).toThrow();
+
+  const ws = new WeakSet();
+  ws.size = 1000;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  expect(() => expect(ws).toEqual({})).toThrow();
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`assertNoExceptionExceptTermination`) found by Fuzzilli (fingerprint `b5b7f0a578601206`).

Repro:
```js
const wm = new WeakMap();
wm.size = 1000;
Bun.inspect(wm); // threw "Type error"
expect(wm).toEqual({}); // crashed debug builds
```

`WeakMap`/`WeakSet` share the `.Map`/`.Set` formatting paths in both `ConsoleObject.zig` and `pretty_format.zig`. Those paths read `.size` and, when non-zero, iterate via `JSC::forEachInIterable`. `WeakMap`/`WeakSet` have no native `.size` and are not iterable, so a user-assigned `size` own property caused `forEachInIterable` to throw a `TypeError`.

In the `expect()` diff path, `DiffFormatter` swallowed that `JSError` with `catch {}` without clearing the pending VM exception, which was then observed by the next `ThrowScope` and tripped the assertion.

### Fix
- Never attempt to iterate `WeakMap`/`WeakSet` when formatting — always print `WeakMap {}` / `WeakSet {}`.
- Clear any pending VM exception when `JestPrettyFormat.format` fails inside `DiffFormatter`.

## How did you verify your code works?

Added a regression test in `test/js/bun/util/inspect.test.js`.