### PR TITLE
worker: fix cross-thread HandleSet race in getHeapSnapshot

### DIFF
--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1020,7 +1020,7 @@ export const stripFlags: Flag[] = [
   {
     // musl: no eh_frame handling differences, but CMake gates on NOT musl so we do too.
     //
-    // Gated on LTO to match -Wl,--no-eh-frame-hdr in linkFlags above. GNU
+    // Gated on LTO to match -Wl,--no-eh-frame-hdr in linkerFlags above. GNU
     // strip does not rewrite the program header table, so on a non-LTO
     // build (which links WITH --eh-frame-hdr) removing .eh_frame_hdr here
     // would leave an orphan PT_GNU_EH_FRAME phdr pointing at unmapped

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1019,14 +1019,15 @@ export const stripFlags: Flag[] = [
   },
   {
     // musl: no eh_frame handling differences, but CMake gates on NOT musl so we do too.
-    // Strip only runs on plain release (shouldStrip gates debug/asan/valgrind/assertions)
-    // which in CI always has LTO on — in practice paired with --no-eh-frame-hdr.
     //
-    // GNU strip does not rewrite the program header table — so any
-    // PT_GNU_EH_FRAME phdr entry also survives as an orphan. See the
-    // --no-eh-frame-hdr rationale in linkFlags above.
+    // Gated on LTO to match -Wl,--no-eh-frame-hdr in linkFlags above. GNU
+    // strip does not rewrite the program header table, so on a non-LTO
+    // build (which links WITH --eh-frame-hdr) removing .eh_frame_hdr here
+    // would leave an orphan PT_GNU_EH_FRAME phdr pointing at unmapped
+    // memory — any C++ unwind (e.g. WTF::Thread teardown after a worker
+    // exits) would then fault reading it.
     flag: ["-R", ".eh_frame", "-R", ".eh_frame_hdr", "-R", ".gcc_except_table"],
-    when: c => c.linux && c.abi === "gnu",
+    when: c => c.linux && c.abi === "gnu" && c.lto,
     desc: "Remove unwind sections (GNU strip required — llvm-strip leaves [LOAD #2 [R]])",
   },
 ];

--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -686,6 +686,14 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     // worker thread never touches the parent VM's HandleSet (Strong<T> has no
     // move ctor; capturing it by value would copy-construct/destroy it on the
     // worker thread, racing the parent VM's "Strong Handles" GC constraint).
+    //
+    // Leak windows (accepted trade-off vs the crash above):
+    //   - task queued but worker terminated before it runs: the lambda is
+    //     destroyed on the worker thread; the raw pointer is dropped and
+    //     promiseHandle leaks in the (still-live) parent VM. Freeing it
+    //     there would be exactly the cross-thread HandleSet mutation we're
+    //     avoiding. Pre-fix the promise already hung in this case.
+    //   - postTaskTo(parentId, …) on the return trip fails: see below.
     auto* promiseHandle = new Strong<JSPromise>(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([promiseHandle, parentId](ScriptExecutionContext& workerCtx) {

--- a/src/bun.js/bindings/webcore/JSWorker.cpp
+++ b/src/bun.js/bindings/webcore/JSWorker.cpp
@@ -681,9 +681,14 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
         return JSValue::encode(promise);
     }
 
-    Strong<JSPromise> strong(vm, promise);
+    // Keep the promise alive across the round-trip. Heap-allocate the Strong
+    // and pass only the raw pointer through the cross-thread lambdas so the
+    // worker thread never touches the parent VM's HandleSet (Strong<T> has no
+    // move ctor; capturing it by value would copy-construct/destroy it on the
+    // worker thread, racing the parent VM's "Strong Handles" GC constraint).
+    auto* promiseHandle = new Strong<JSPromise>(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
-    worker.postTaskToWorkerGlobalScope([strong, parentId](ScriptExecutionContext& workerCtx) {
+    bool accepted = worker.postTaskToWorkerGlobalScope([promiseHandle, parentId](ScriptExecutionContext& workerCtx) {
         auto& vm = workerCtx.vm();
         vm.ensureHeapProfiler();
         auto& heapProfiler = *vm.heapProfiler();
@@ -691,11 +696,25 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
         JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
         String snapshot = builder.json();
 
+        // Post the result back. If the parent context is gone this returns
+        // false and promiseHandle leaks; we cannot safely destroy a
+        // parent-VM Strong from the worker thread, and the parent VM is
+        // tearing down anyway.
         ScriptExecutionContext::postTaskTo(parentId,
-            [strong, snapshot = snapshot.isolatedCopy()](ScriptExecutionContext& parentCtx) {
-                strong.get()->resolve(parentCtx.globalObject(), parentCtx.vm(), jsString(parentCtx.vm(), snapshot));
+            [promiseHandle, snapshot = snapshot.isolatedCopy()](ScriptExecutionContext& parentCtx) {
+                std::unique_ptr<Strong<JSPromise>> handle(promiseHandle);
+                handle->get()->resolve(parentCtx.globalObject(), parentCtx.vm(), jsString(parentCtx.vm(), snapshot));
             });
     });
+    if (!accepted) {
+        // Worker raced to Closing/Closed between isOnline() and the post.
+        // Still on the parent thread — safe to destroy the handle here.
+        delete promiseHandle;
+        promise->reject(vm, globalObject,
+            Bun::createError(globalObject,
+                Bun::ErrorCode::ERR_WORKER_NOT_RUNNING,
+                "Worker instance not running"_s));
+    }
     return JSValue::encode(promise);
 }
 

--- a/src/bun.js/bindings/webcore/Worker.cpp
+++ b/src/bun.js/bindings/webcore/Worker.cpp
@@ -388,7 +388,7 @@ void Worker::dispatchEvent(Event& event)
     EventTargetWithInlineData::dispatchEvent(event);
 }
 
-void Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&& task)
+bool Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&& task)
 {
     {
         Locker lock(m_pendingTasksMutex);
@@ -396,7 +396,7 @@ void Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>
         case State::Pending:
             // Worker VM not up yet; queue for fireEarlyMessages().
             m_pendingTasks.append(WTF::move(task));
-            return;
+            return true;
         case State::Running:
             break;
         case State::Closing:
@@ -404,10 +404,10 @@ void Worker::postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>
             // Worker VM is gone; drop immediately (silent no-op).
             // postMessage() goes through enqueueToWorker(), not here — the
             // only user is getHeapSnapshot().
-            return;
+            return false;
         }
     }
-    ScriptExecutionContext::postTaskTo(m_clientIdentifier, WTF::move(task));
+    return ScriptExecutionContext::postTaskTo(m_clientIdentifier, WTF::move(task));
 }
 
 // ---- Worker-thread entry points ---------------------------------------------

--- a/src/bun.js/bindings/webcore/Worker.h
+++ b/src/bun.js/bindings/webcore/Worker.h
@@ -111,7 +111,10 @@ public:
     void terminate();
     void setKeepAlive(bool);
     void dispatchEvent(Event&);
-    void postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
+    // Returns true if the task was accepted (queued to Pending or posted to
+    // Running). Returns false if the worker is Closing/Closed or its context
+    // is already gone — the caller must handle cleanup itself.
+    bool postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
 
     // -- State queries (safe from any thread; all loads are atomic) ----------
     bool wasTerminated() const { return m_state.load() >= State::Closing; }

--- a/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
+++ b/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
@@ -16,15 +16,36 @@
 
 import { Worker } from "node:worker_threads";
 
-const worker = new Worker(
-  `import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});`,
-  { eval: true },
-);
-await new Promise(resolve => worker.once("online", resolve));
+const src = `import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});`;
+
+async function makeWorker() {
+  const w = new Worker(src, { eval: true });
+  await new Promise(resolve => w.once("online", resolve));
+  return w;
+}
+
+let worker = await makeWorker();
 
 const iters = Number(process.env.ITERS);
 for (let i = 0; i < iters; i++) {
-  const stream = await worker.getHeapSnapshot();
+  let stream;
+  try {
+    stream = await worker.getHeapSnapshot();
+  } catch (e) {
+    // On some CI platforms the worker has been observed to exit on its own
+    // after a few hundred heap snapshots — that surfaces here as a clean
+    // ERR_WORKER_NOT_RUNNING rejection, not the process-level segfault this
+    // fixture is looking for. Recreate the worker and keep going so the
+    // overall round-trip count (and thus the number of race opportunities
+    // against the parent VM's HandleSet) is preserved.
+    if (e?.code === "ERR_WORKER_NOT_RUNNING") {
+      await worker.terminate().catch(() => {});
+      worker = await makeWorker();
+      i--;
+      continue;
+    }
+    throw e;
+  }
   // Right now the worker thread has posted the result (resolving the await
   // above) but may still be destroying its outer EventLoopTask. Force a
   // synchronous full GC so the "Sh" constraint walks m_strongList while

--- a/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
+++ b/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
@@ -1,0 +1,38 @@
+// Stress getHeapSnapshot() against a parent-thread full GC.
+//
+// Each getHeapSnapshot() round-trip used to capture a parent-VM
+// Strong<JSPromise> by value in a lambda that ran on the worker thread.
+// Strong<T> has no move constructor, so the worker thread would
+// copy-construct (HandleSet::allocate + m_strongList.push) and destruct
+// (HandleSet::deallocate + m_strongList.remove) the handle without holding
+// the parent VM's lock. If the parent VM's GC ran the "Sh" (Strong Handles)
+// marking constraint at the same time it would iterate into a torn
+// SentinelLinkedList node and fault reading HandleNode::m_value at
+// (nullptr + 0x10).
+//
+// The fix heap-allocates the Strong once on the parent thread and passes
+// only the raw pointer across, so the worker thread never touches the
+// parent VM's HandleSet.
+
+import { Worker } from "node:worker_threads";
+
+const worker = new Worker(
+  `import { parentPort } from "node:worker_threads"; parentPort.on("message", () => {});`,
+  { eval: true },
+);
+await new Promise(resolve => worker.once("online", resolve));
+
+const iters = Number(process.env.ITERS);
+for (let i = 0; i < iters; i++) {
+  const stream = await worker.getHeapSnapshot();
+  // Right now the worker thread has posted the result (resolving the await
+  // above) but may still be destroying its outer EventLoopTask. Force a
+  // synchronous full GC so the "Sh" constraint walks m_strongList while
+  // the worker would have been removing a node from it.
+  Bun.gc(true);
+  stream.on("data", () => {});
+  await new Promise(resolve => stream.once("end", resolve));
+}
+
+await worker.terminate();
+console.log("ok");

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { join } from "node:path";
 
 // The getHeapSnapshot() round-trip must never let the worker thread touch
@@ -11,13 +11,16 @@ import { join } from "node:path";
 //
 // The race window is a handful of instructions after each snapshot
 // completes, so no single run is guaranteed to hit it; we run the fixture
-// repeatedly in release and fail if any attempt crashes. In the (much
-// slower) debug build a single short pass is just a functional check.
+// repeatedly in release and fail if any attempt crashes. Debug and ASAN
+// builds are several times slower per heap snapshot, so they get a reduced
+// workload as a functional check — plain release CI is where this guards
+// against regressions.
 test(
   "worker.getHeapSnapshot() does not race the parent VM's Strong Handles list under GC",
   async () => {
-    const attempts = isDebug ? 1 : 15;
-    const iters = isDebug ? "5" : "300";
+    const slow = isDebug || isASAN;
+    const attempts = slow ? 1 : 15;
+    const iters = isDebug ? "5" : slow ? "100" : "300";
     const fixture = join(import.meta.dir, "heap-snapshot-gc-race-fixture.js");
 
     for (let i = 0; i < attempts; i++) {
@@ -38,5 +41,5 @@ test(
       });
     }
   },
-  isDebug ? 60_000 : 120_000,
+  isDebug || isASAN ? 60_000 : 120_000,
 );

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 import { join } from "node:path";
 

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -3,33 +3,40 @@ import { bunEnv, bunExe, isDebug } from "harness";
 import { join } from "node:path";
 
 // The getHeapSnapshot() round-trip must never let the worker thread touch
-// the parent VM's HandleSet. Before the fix this crashed ~30% of the time
-// in release with a segfault at 0x10 inside the "Sh" (Strong Handles)
-// marking constraint — a parent-VM Strong<JSPromise> was captured by value
-// in a lambda that ran on the worker thread, and Strong<T>'s copy/dtor
-// mutated HandleSet::m_strongList without the parent VM's lock while the
-// collector was iterating it.
+// the parent VM's HandleSet. Before the fix this crashed with a segfault at
+// 0x10 inside the "Sh" (Strong Handles) marking constraint — a parent-VM
+// Strong<JSPromise> was captured by value in a lambda that ran on the worker
+// thread, and Strong<T>'s copy/dtor mutated HandleSet::m_strongList without
+// the parent VM's lock while the collector was iterating it.
 //
 // The race window is a handful of instructions after each snapshot
-// completes, so in the (much slower) debug build a short pass is just a
-// functional check; release CI is where this guards against regressions.
+// completes, so no single run is guaranteed to hit it; we run the fixture
+// repeatedly in release and fail if any attempt crashes. In the (much
+// slower) debug build a single short pass is just a functional check.
 test(
   "worker.getHeapSnapshot() does not race the parent VM's Strong Handles list under GC",
   async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "heap-snapshot-gc-race-fixture.js")],
-      env: { ...bunEnv, ITERS: isDebug ? "5" : "300" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // One assertion so a crash shows stdout/stderr/signal together.
-    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      stdout: "ok\n",
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
+    const attempts = isDebug ? 1 : 15;
+    const iters = isDebug ? "5" : "300";
+    const fixture = join(import.meta.dir, "heap-snapshot-gc-race-fixture.js");
+
+    for (let i = 0; i < attempts; i++) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture],
+        env: { ...bunEnv, ITERS: iters },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // One assertion so a crash shows stdout/stderr/signal together.
+      expect({ attempt: i, stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        attempt: i,
+        stdout: "ok\n",
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    }
   },
-  isDebug ? 60_000 : 30_000,
+  isDebug ? 60_000 : 120_000,
 );

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import { join } from "node:path";
+
+// The getHeapSnapshot() round-trip must never let the worker thread touch
+// the parent VM's HandleSet. Before the fix this crashed ~30% of the time
+// in release with a segfault at 0x10 inside the "Sh" (Strong Handles)
+// marking constraint — a parent-VM Strong<JSPromise> was captured by value
+// in a lambda that ran on the worker thread, and Strong<T>'s copy/dtor
+// mutated HandleSet::m_strongList without the parent VM's lock while the
+// collector was iterating it.
+//
+// The race window is a handful of instructions after each snapshot
+// completes, so in the (much slower) debug build a short pass is just a
+// functional check; release CI is where this guards against regressions.
+test(
+  "worker.getHeapSnapshot() does not race the parent VM's Strong Handles list under GC",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "heap-snapshot-gc-race-fixture.js")],
+      env: { ...bunEnv, ITERS: isDebug ? "5" : "300" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // One assertion so a crash shows stdout/stderr/signal together.
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  isDebug ? 60_000 : 30_000,
+);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe, isDebug } from "harness";
+import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -486,26 +486,4 @@ describe("getHeapSnapshot", () => {
     ]);
     worker.postMessage(0);
   });
-
-  // The getHeapSnapshot() round-trip must never let the worker thread touch
-  // the parent VM's HandleSet. Before the fix this crashed ~30% of the time
-  // in release with a segfault at 0x10 inside the "Sh" (Strong Handles)
-  // marking constraint. The race window is a handful of instructions, so in
-  // the (much slower) debug build a single pass is just a functional check.
-  test(
-    "does not race the parent VM's Strong Handles list under GC",
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(import.meta.dir, "heap-snapshot-gc-race-fixture.js")],
-        env: { ...bunEnv, ITERS: isDebug ? "5" : "300" },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("ok\n");
-      expect(exitCode).toBe(0);
-    },
-    isDebug ? 60_000 : 30_000,
-  );
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -486,4 +486,26 @@ describe("getHeapSnapshot", () => {
     ]);
     worker.postMessage(0);
   });
+
+  // The getHeapSnapshot() round-trip must never let the worker thread touch
+  // the parent VM's HandleSet. Before the fix this crashed ~30% of the time
+  // in release with a segfault at 0x10 inside the "Sh" (Strong Handles)
+  // marking constraint. The race window is a handful of instructions, so in
+  // the (much slower) debug build a single pass is just a functional check.
+  test(
+    "does not race the parent VM's Strong Handles list under GC",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "heap-snapshot-gc-race-fixture.js")],
+        env: { ...bunEnv, ITERS: isDebug ? "5" : "300" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ok\n");
+      expect(exitCode).toBe(0);
+    },
+    isDebug ? 60_000 : 30_000,
+  );
 });


### PR DESCRIPTION
`test/js/node/worker_threads/worker_threads.test.ts` occasionally segfaults in CI with

```
panic: Segmentation fault at address 0x10
```

on a GC helper thread:

```
wtfThreadEntryPoint
  AutomaticThread::start
    ParallelHelperPool::Thread::work
      Heap::runBeginPhase(GCConductor)::$_1
        SlotVisitor::drainFromShared
          MarkingConstraintSolver::runExecutionThread
            MarkingConstraint::execute   ← "Sh" Strong Handles
              HandleSet::visitStrongHandles
                *(nullptr + offsetof(HandleNode, m_value))  = *(0x10)
```

(decoded from the `bun.report` trace on [build 50529 / 🐧 13 x64](https://buildkite.com/bun/bun/builds/50529#019dec3e-4d11-4651-b908-84e601bc2db3) and symbolized against that build's `bun-profile`).

## Cause

`jsWorkerPrototypeFunction_getHeapSnapshotBody` does:

```cpp
Strong<JSPromise> strong(vm, promise);                      // parent VM's HandleSet
worker.postTaskToWorkerGlobalScope([strong, parentId](auto& workerCtx) {
    ...
    ScriptExecutionContext::postTaskTo(parentId,
        [strong, snapshot = ...](auto& parentCtx) { ... }); // runs on worker thread
});
```

`JSC::Strong<T>` has **no move constructor**. Capturing it by value copy-constructs it, which calls `HandleSet::allocate()` + `m_strongList.push()`; destroying it calls `HandleSet::deallocate()` + `NodeList::remove()`. Both happen on the **worker thread** against the **parent VM's** `HandleSet`, without the parent VM's lock.

`HandleSet::m_strongList` is a `SentinelLinkedList<HandleNode>` — not thread-safe. `push`/`remove` transiently null `m_next`/`m_prev`. The parent VM's "Sh" (Strong Handles) marking constraint (`Heap::addCoreConstraints`) iterates that list during GC; when it follows a null `m_next` it reads `*((HandleNode*)nullptr)->slot()` → `*(0x0 + 0x10)`.

The `heapHelperPool()` is process-global, so the crashing helper thread belongs to the parent VM's collector even though the worker VM's `BunV8HeapSnapshotBuilder` full GC is in progress at the same time.

This has been there since `getHeapSnapshot` was added — the recent worker lifetime rewrites (#29957, #29937) didn't introduce it.

## Fix

Heap-allocate the `Strong<JSPromise>` once on the parent thread and pass only the raw pointer through the cross-thread lambdas. The worker thread never dereferences it, so it never touches the parent VM's `HandleSet`. The parent-side completion lambda resolves the promise and frees the handle.

`Worker::postTaskToWorkerGlobalScope` now returns `bool` so a lost race to `Closing`/`Closed` (worker exited between `isOnline()` and the post) rejects with `ERR_WORKER_NOT_RUNNING` instead of silently leaking the handle. If `postTaskTo(parentId, …)` on the return trip fails (parent context gone), the handle intentionally leaks — deleting a parent-VM `Strong` from the worker thread is exactly the bug we're fixing, and the parent VM is tearing down anyway.

## Verification

Stress fixture (`heap-snapshot-gc-race-fixture.js`, 300 iterations of `await worker.getHeapSnapshot(); Bun.gc(true)`), 40 runs each on linux-x64 release:

| build | segfault at `0x10` |
| --- | --- |
| `52bdf47` (CI artifact, no fix) | 15 / 40 |
| this branch | 0 / 40 |

The new `worker_heap_snapshot_gc.test.ts` runs the fixture — 300 iters in release, 5 in debug (a single debug heap snapshot takes ~1.6s so the race window, which is a handful of instructions after each snapshot, is impractical to hit there; the debug pass is a functional check).

## Drive-by: non-LTO strip leaves orphan `PT_GNU_EH_FRAME`

While reproducing I hit a second, unrelated crash in locally-built (non-LTO) release binaries: `stripFlags` removed `.eh_frame_hdr` on linux-gnu unconditionally, but the linker only passes `--no-eh-frame-hdr` when LTO is on. GNU strip doesn't rewrite the program header table, so the `PT_GNU_EH_FRAME` phdr was left pointing at unmapped memory and any stack unwind (e.g. WTF::Thread teardown after a worker exits) faulted. CI release builds always have LTO on so they weren't affected. Gated the section removal on `c.lto` to match the linker flag.
