### PR TITLE
test: pin v-mode set operations with inverted operands

### DIFF
--- a/test/js/bun/jsc/regexp-unicode-sets.test.ts
+++ b/test/js/bun/jsc/regexp-unicode-sets.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+// https://github.com/oven-sh/bun/issues/30183
+//
+// In a v-mode character class, `&&` and `--` were only applied when the right
+// operand was a plain class. An inverted operand such as `\P{...}` went through
+// CharacterClassConstructor::appendInverted in JavaScriptCore's YarrPattern.cpp,
+// which ignored the pending set operation and unioned the operand in, so
+// `[\P{Number}&&\P{Alphabetic}]` matched letters and digits as well.
+//
+// Fixed in oven-sh/WebKit#299, picked up by the WebKit bump in #37352. These
+// tests pin the behaviour of the WebKit build that Bun links against.
+describe("RegExp v flag set operations with inverted operands", () => {
+  const matches = (re: RegExp, input: string) => input.match(re) ?? [];
+
+  test("&& with an inverted property on both sides", () => {
+    // A and U+03BB (Greek lambda) are Alphabetic; 1 and U+0661 (Arabic-Indic
+    // one) are Number; space, !, U+20AC (euro sign) and U+1F600 (emoji) are
+    // neither. Yarr keeps separate tables for code points above U+00FF, so the
+    // input covers both. Before the fix every character matched.
+    expect(matches(/[\P{Number}&&\P{Alphabetic}]/gv, "A1 !\u03BB\u0661\u20AC\u{1F600}")).toEqual([
+      " ",
+      "!",
+      "\u20AC",
+      "\u{1F600}",
+    ]);
+  });
+
+  test("&& chained across three inverted properties", () => {
+    // Before the fix every character matched.
+    expect(matches(/[\P{Letter}&&\P{Number}&&\P{White_Space}]/gv, "A1 !")).toEqual(["!"]);
+  });
+
+  test("-- with an inverted property on the right", () => {
+    // Latin and Greek letters minus the non-lowercase ones leaves the lowercase
+    // letters: a and U+03B1 (alpha) stay, A and U+0391 (capital alpha) go.
+    // Before the fix every character matched.
+    expect(matches(/[[A-Za-z\u0391-\u03A9\u03B1-\u03C9]--\P{Lowercase}]/gv, "aA\u03B1\u03911 ")).toEqual([
+      "a",
+      "\u03B1",
+    ]);
+  });
+
+  test("&& with a built-in class on the left and an inverted property on the right", () => {
+    // \D is a prebuilt class and never went through appendInverted; only the
+    // \P{...} operand did. Before the fix every character matched.
+    expect(matches(/[\D&&\P{Alphabetic}]/gv, "A1 ")).toEqual([" "]);
+  });
+
+  test("&& with an inverted property only on the left", () => {
+    // The left operand is appended before any set operation is pending, so
+    // this worked before the fix as well.
+    expect(matches(/[\P{Number}&&\p{Alphabetic}]/gv, "A1 ")).toEqual(["A"]);
+  });
+
+  test("&& with no inverted operands", () => {
+    // U+2164 ROMAN NUMERAL FIVE is gc=Nl, which is in both Number and Alphabetic.
+    expect(matches(/[\p{Number}&&\p{Alphabetic}]/gv, "A1 \u2164")).toEqual(["\u2164"]);
+  });
+
+  test("union of a literal and an inverted property", () => {
+    // A union is the pending operation once a second operand follows a literal,
+    // so the inverted operand now takes the set operation path too; the literal
+    // 7 has to survive even though \P{Number} excludes it.
+    expect(matches(/[7\P{Number}]/gv, "71 A")).toEqual(["7", " ", "A"]);
+  });
+});


### PR DESCRIPTION
Test only. Adds `test/js/bun/jsc/regexp-unicode-sets.test.ts`.

### Problem
- `/[\P{Number}&&\P{Alphabetic}]/v.test("A")` and `.test("1")` returned `true` (#30183). Any `&&` or `--` whose operand was an inverted property escape behaved like a union.
- Cause was in JavaScriptCore: `CharacterClassConstructor::appendInverted` (`Source/JavaScriptCore/yarr/YarrPattern.cpp`) unioned the inverted operand into the class without checking the pending set operation, unlike `append`.
- The engine fix landed in oven-sh/WebKit#299 and reached Bun through the WebKit bump in #37352 (the pin moved to `09e47774`, the merge commit of that PR; main is now on `caad865e`, which includes it). #30183 is closed. Bun has no test for this path: `test/` has no v-mode set operation coverage, and the V8 corpus in #34365 only exercises nested `[^...]` operands, which took a different path in Yarr and were never broken.

### Fix
- Seven tests: `&&` with inverted operands on both sides, chained three ways, `--` with an inverted right operand, `\D&&\P{...}`, plus three controls that were never broken (inverted left operand only, no inverted operands, and a union whose second operand is inverted, since a pending union now takes the set operation path as well).
- Each test matches one regex against a short string with `/gv` and compares the full match list, so a reappearance of the union behaviour shows up as extra characters in the diff. The intersection and subtraction inputs include characters above U+00FF (and one astral character) because Yarr builds the Latin-1 and the wider table separately and the fix touches both.
- The file lives in `test/js/bun/jsc/`, next to the other coverage added for WebKit bumps, since this never worked in any release and is not a regression.
- Verified:
  - `bun bd test test/js/bun/jsc/regexp-unicode-sets.test.ts` on main (`b7a04310`, WebKit `caad865e`): 7 pass.
  - Same file on a build of `da3851e5` (the commit before #37352, WebKit `447082ab`): the four tests on the broken path fail, the three controls pass.
  - The `jsc` shell shipped in the prebuilt WebKit tarball for `caad865e` (release and debug-asan) gives the expected match lists for every case.

### Background
- The `v` flag (unicode sets mode) lets a character class contain set operations: `[A&&B]` is the intersection and `[A--B]` the difference of two operands.
- Yarr, JavaScriptCore's regex compiler, builds a class by appending operands one at a time into a `CharacterClassConstructor`. Once `&&` or `--` has been seen, each later operand is supposed to be combined with the class built so far through the set operation instead of being added to it. A `\P{...}` operand is appended through a separate inversion path, which is the one that skipped that step.

<details>
<summary>History of this PR</summary>

Opened in May together with oven-sh/WebKit#214, a fix for the same `appendInverted` path. At that time the tests for the broken path were guarded with `test.skipIf` on a runtime probe so they would start running once a WebKit bump picked up the fix. oven-sh/WebKit#299 landed the same change instead, so WebKit#214 has been closed, the guards are removed, and the file moved out of `test/regression/issue/` since the behaviour was never correct before.
</details>
