### PR TITLE
resolver: allow `@`-prefixed subpaths under wildcard `exports`

### DIFF
--- a/src/resolver/package_json.zig
+++ b/src/resolver/package_json.zig
@@ -1456,21 +1456,27 @@ pub const ESModule = struct {
             if (strings.startsWith(package.name, ".") or strings.indexAnyComptime(package.name, "\\%") != null)
                 return null;
 
+            // A version delimiter `@` is only valid within the package-name portion of
+            // the specifier. Searching the entire specifier misparses wildcard subpaths
+            // whose matched substring contains `@` (e.g. `test-pkg/@scope/sub/index.js`
+            // or `ember-source/@ember/renderer/...`) as if the package had a version.
             const offset: usize = if (package.name.len == 0 or package.name[0] != '@') 0 else 1;
-            if (strings.indexOfChar(specifier[offset..], '@')) |at| {
-                package.version = parseVersion(specifier[offset..][at..]) orelse "";
-                if (package.version.len == 0) {
-                    package.version = specifier[offset..][at..];
-                    if (package.version.len > 0 and package.version[0] == '@') {
-                        package.version = package.version[1..];
+            if (offset < package.name.len) {
+                if (strings.indexOfChar(specifier[offset..package.name.len], '@')) |at| {
+                    package.version = parseVersion(specifier[offset..][at..]) orelse "";
+                    if (package.version.len == 0) {
+                        package.version = specifier[offset..][at..];
+                        if (package.version.len > 0 and package.version[0] == '@') {
+                            package.version = package.version[1..];
+                        }
                     }
-                }
-                package.name = specifier[0 .. at + offset];
+                    package.name = specifier[0 .. at + offset];
 
-                parseSubpath(&package.subpath, specifier[@min(package.name.len + package.version.len + 1, specifier.len)..], subpath_buf);
-            } else {
-                parseSubpath(&package.subpath, specifier[package.name.len..], subpath_buf);
+                    parseSubpath(&package.subpath, specifier[@min(package.name.len + package.version.len + 1, specifier.len)..], subpath_buf);
+                    return package;
+                }
             }
+            parseSubpath(&package.subpath, specifier[package.name.len..], subpath_buf);
 
             return package;
         }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -567,9 +567,10 @@ describe("wildcard exports with @ in matched subpath", () => {
     );
   });
 
-  // Regression guard for the scoped-package version split: `@scope/pkg@ver/sub`
-  // must still strip the version (the `@` delimiter sits at index 10, inside
-  // the 16-char name span, so the version branch still fires).
+  // Regression guard for the scoped-package version split: the `@version`
+  // delimiter still falls inside the name span `parseName` returns (between
+  // the leading `@` and the second `/`), so the version branch must still
+  // fire for `@scope/pkg@ver/sub`.
   it.concurrent("still strips @version after a scoped package name", () => {
     using dir = tempDir("resolver-wildcard-scoped-versioned", {
       "package.json": JSON.stringify({ name: "host" }),

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -485,6 +485,89 @@ it.skipIf(isWindows)("browser map resolution handles relative paths longer than 
   expect(exitCode).toBe(0);
 });
 
+// ESModule.Package.parse scanned the entire specifier for an `@` to split off a
+// version. For wildcard `exports` maps the matched substring can contain `@`
+// (e.g. `ember-source/@ember/renderer/...`, `pkg/@scope/sub`) — those `@`s
+// aren't version delimiters, they're subpath content. The version split must
+// be bounded to the package-name portion of the specifier.
+// https://github.com/oven-sh/bun/issues/30187
+describe("wildcard exports with @ in matched subpath", () => {
+  it.concurrent("resolves a subpath whose wildcard match starts with @", () => {
+    using dir = tempDir("resolver-wildcard-at-scoped", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/test-pkg/package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+        exports: { "./*": "./dist/packages/*" },
+      }),
+      "node_modules/test-pkg/dist/packages/plain/index.js": "export default 'plain';",
+      "node_modules/test-pkg/dist/packages/@scope/sub/index.js": "export default 'scoped';",
+    });
+    const root = String(dir);
+
+    expect(Bun.resolveSync("test-pkg/plain/index.js", root)).toBe(
+      join(root, "node_modules/test-pkg/dist/packages/plain/index.js"),
+    );
+    expect(Bun.resolveSync("test-pkg/@scope/sub/index.js", root)).toBe(
+      join(root, "node_modules/test-pkg/dist/packages/@scope/sub/index.js"),
+    );
+  });
+
+  it.concurrent("resolves a subpath that contains `@` mid-segment", () => {
+    using dir = tempDir("resolver-wildcard-at-mid", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/test-pkg/package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+        exports: { "./*": "./dist/packages/*" },
+      }),
+      "node_modules/test-pkg/dist/packages/with@sign/sub/index.js": "export default 'sign';",
+    });
+    const root = String(dir);
+
+    expect(Bun.resolveSync("test-pkg/with@sign/sub/index.js", root)).toBe(
+      join(root, "node_modules/test-pkg/dist/packages/with@sign/sub/index.js"),
+    );
+  });
+
+  it.concurrent("resolves an @-prefixed subpath under a scoped package", () => {
+    using dir = tempDir("resolver-wildcard-at-scoped-pkg", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/@my/pkg/package.json": JSON.stringify({
+        name: "@my/pkg",
+        version: "1.0.0",
+        exports: { "./*": "./dist/*" },
+      }),
+      "node_modules/@my/pkg/dist/@inner/bar/index.js": "export default 'inner';",
+    });
+    const root = String(dir);
+
+    expect(Bun.resolveSync("@my/pkg/@inner/bar/index.js", root)).toBe(
+      join(root, "node_modules/@my/pkg/dist/@inner/bar/index.js"),
+    );
+  });
+
+  // Regression guard: `@version` specifiers immediately following the package
+  // name must still be stripped. We don't install alternative versions; we just
+  // verify `pkg@1.0.0/subpath` still resolves to the same file as `pkg/subpath`.
+  it.concurrent("still strips a trailing @version after the package name", () => {
+    using dir = tempDir("resolver-wildcard-versioned", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/test-pkg/package.json": JSON.stringify({
+        name: "test-pkg",
+        version: "1.0.0",
+        exports: { "./*": "./dist/packages/*" },
+      }),
+      "node_modules/test-pkg/dist/packages/plain/index.js": "export default 'plain';",
+    });
+    const root = String(dir);
+
+    expect(Bun.resolveSync("test-pkg@1.0.0/plain/index.js", root)).toBe(
+      join(root, "node_modules/test-pkg/dist/packages/plain/index.js"),
+    );
+  });
+});
+
 // dirInfoCachedMaybeLog reads the rfs.entries cache without checking the union
 // tag. If readDirectory() previously failed with a non-ENOENT error (e.g.
 // EACCES), a `.err` variant is stored there; re-resolving the directory after

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -566,6 +566,26 @@ describe("wildcard exports with @ in matched subpath", () => {
       join(root, "node_modules/test-pkg/dist/packages/plain/index.js"),
     );
   });
+
+  // Regression guard for the scoped-package version split: `@scope/pkg@ver/sub`
+  // must still strip the version (the `@` delimiter sits at index 10, inside
+  // the 16-char name span, so the version branch still fires).
+  it.concurrent("still strips @version after a scoped package name", () => {
+    using dir = tempDir("resolver-wildcard-scoped-versioned", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/@my/pkg/package.json": JSON.stringify({
+        name: "@my/pkg",
+        version: "1.0.0",
+        exports: { "./*": "./dist/*" },
+      }),
+      "node_modules/@my/pkg/dist/sub/index.js": "export default 'sub';",
+    });
+    const root = String(dir);
+
+    expect(Bun.resolveSync("@my/pkg@1.0.0/sub/index.js", root)).toBe(
+      join(root, "node_modules/@my/pkg/dist/sub/index.js"),
+    );
+  });
 });
 
 // dirInfoCachedMaybeLog reads the rfs.entries cache without checking the union


### PR DESCRIPTION
Fixes #30187.

## Repro

A wildcard `exports` pattern `"./*": "./dist/packages/*"` failed to
resolve subpaths whose matched substring starts with `@`:

```console
$ bun --print 'await Bun.resolve("test-pkg/@scope/sub/index.js", process.cwd())'
error: Cannot find module 'test-pkg/@scope/sub/index.js' from '/tmp/test'
```

Node resolves it fine. The file exists on disk — it's purely a specifier
parsing bug.

Motivating real-world case: `ember-source@6.12`'s `package.json` is
`{ "exports": { "./*": "./dist/packages/*" } }` and its internal
subpackages live at `dist/packages/@ember/*`, `dist/packages/@glimmer/*`,
`dist/packages/@simple-dom/*`. Every one of those subpaths failed in Bun.

## Cause

`ESModule.Package.parse` in `src/resolver/package_json.zig` scanned the
**entire** specifier for `@` to split off `pkg@version`:

```zig
const offset: usize = if (package.name.len == 0 or package.name[0] != '@') 0 else 1;
if (strings.indexOfChar(specifier[offset..], '@')) |at| { ... }
```

For `test-pkg/@scope/sub/index.js` this found the `@` at index 9 (start
of `@scope`) and misparsed it as a version delimiter — the name became
`test-pkg/`, the "version" became `scope`, and the subpath parse read
from the wrong offset. The resolver then went looking for a package
called `test-pkg/` in `node_modules`, didn't find it, and errored.

Same shape for any `@` past the first `/`: `pkg/with@sign/sub` failed too.

## Fix

`parseName` already bounds the name to the first `/` (or the second `/`
for scoped names). A version delimiter `@` can only appear **within**
that span — e.g. in `test-pkg@1.0.0/sub`, the `@` is at index 8 and
`package.name.len` is 14. Restrict the search to
`specifier[offset..package.name.len]` and any `@` outside it is subpath
content, so the no-version branch fires and `parseSubpath` gets the
correct slice.

## Verification

All three failing forms from the issue now resolve:

```console
$ bun --print 'await Bun.resolve("test-pkg/plain/index.js", process.cwd())'
.../test-pkg/dist/packages/plain/index.js
$ bun --print 'await Bun.resolve("test-pkg/@scope/sub/index.js", process.cwd())'
.../test-pkg/dist/packages/@scope/sub/index.js
$ bun --print 'await Bun.resolve("test-pkg/with@sign/sub/index.js", process.cwd())'
.../test-pkg/dist/packages/with@sign/sub/index.js
```

ember-source-shaped specifiers (`@ember/*`, `@glimmer/*`,
`@simple-dom/*` via a wildcard) all resolve.

New tests in `test/js/bun/resolve/resolve.test.ts`:

- `@`-prefixed subpath under a plain package (`test-pkg/@scope/sub`)
- Mid-segment `@` (`test-pkg/with@sign/sub`)
- `@`-prefixed subpath under a scoped package (`@my/pkg/@inner/bar`)
- Regression guard: `pkg@1.0.0/subpath` still strips the version