### PR TITLE
Serve sibling files next to an HTML entry with the right Content-Type

### DIFF
--- a/src/runtime/server/HTMLBundle.zig
+++ b/src/runtime/server/HTMLBundle.zig
@@ -143,6 +143,14 @@ pub const Route = struct {
             return;
         };
 
+        // `bun ./index.html` matches `/*`, so any URL that didn't hit a more
+        // specific route ends up here. For paths referencing a file that lives
+        // next to the HTML on disk (e.g. pre-bundled SvelteKit
+        // `<link rel="modulepreload">` targets), serve that file directly
+        // with a correct Content-Type instead of falling through to the SPA
+        // HTML response. https://github.com/oven-sh/bun/issues/30193
+        if (this.trySendSiblingFile(req, resp, is_head)) return;
+
         if (server.config().isDevelopment()) {
             if (server.devServer()) |dev| {
                 // DevServer's HMR path is *uws.Request-typed; H3 isn't routed
@@ -213,6 +221,133 @@ pub const Route = struct {
                 }
             },
         }
+    }
+
+    /// Try to serve a file that lives next to the HTML on disk. Returns true
+    /// if the response has been (or will be) sent, false if the caller should
+    /// continue with its normal HTML fallback.
+    ///
+    /// Scope: GET/HEAD only, same-origin paths that resolve to a regular
+    /// file **strictly inside** the HTML's directory. The HTML itself is
+    /// never served this way — that path falls through to the bundler so the
+    /// transformed/injected HTML is returned. An empty path, "/", or a
+    /// query/fragment-only URL are likewise passed through.
+    fn trySendSiblingFile(this: *Route, req: uws.AnyRequest, resp: HTTPResponse, is_head: bool) bool {
+        // RangeRequest / FileRoute.on rely on GET/HEAD semantics; any other
+        // method should flow through to the usual path where a 405/fallback
+        // is emitted.
+        const method = bun.http.Method.find(req.method()) orelse return false;
+        if (method != .GET and method != .HEAD) return false;
+
+        const raw_url = req.url();
+        // Strip query string and hash. uWS usually hands us the path-only
+        // portion, but be defensive: the code below assumes only a path.
+        const path_end = std.mem.indexOfAny(u8, raw_url, "?#") orelse raw_url.len;
+        const url_path_raw = raw_url[0..path_end];
+
+        // `bun ./index.html` always mounts the HTML at "/*"; the request URL
+        // is therefore absolute. Reject anything else so we don't join
+        // relative segments against the HTML directory.
+        if (url_path_raw.len == 0 or url_path_raw[0] != '/') return false;
+        // "/" is the HTML route itself.
+        if (url_path_raw.len == 1) return false;
+        // A NUL byte makes the path unusable as a [:0] path. Bail.
+        if (std.mem.indexOfScalar(u8, url_path_raw, 0) != null) return false;
+
+        // Percent-decode into a stack buffer. The URL path can't grow during
+        // decoding, so the input length is an upper bound.
+        var decoded_buf: bun.PathBuffer = undefined;
+        if (url_path_raw.len > decoded_buf.len) return false;
+        var fbs = std.io.fixedBufferStream(decoded_buf[0..]);
+        const decoded_len = PercentEncoding.decode(
+            @TypeOf(fbs.writer()),
+            fbs.writer(),
+            url_path_raw,
+        ) catch return false;
+        const decoded_path = decoded_buf[0..decoded_len];
+
+        // Compute the HTML file's directory. The bundle path is stored as an
+        // absolute filesystem path on the HTMLBundle.
+        const html_path = this.bundle.data.path;
+        const html_dir = bun.path.dirname(html_path, .auto);
+        if (html_dir.len == 0) return false;
+
+        // `joinAbsStringBuf` follows Node's `path.resolve` semantics: if any
+        // part is absolute, earlier parts are discarded. Our decoded URL path
+        // always starts with `/`, so strip the leading separator(s) and treat
+        // it as relative to html_dir. Without this, `/_app/…` would resolve
+        // to the filesystem root instead of `<html_dir>/_app/…`.
+        var rel_start: usize = 0;
+        while (rel_start < decoded_path.len and (decoded_path[rel_start] == '/' or decoded_path[rel_start] == '\\')) {
+            rel_start += 1;
+        }
+        const rel_path = decoded_path[rel_start..];
+        if (rel_path.len == 0) return false;
+
+        // Join html_dir + rel_path and normalize. `joinAbsStringBuf` resolves
+        // `.` / `..` segments, so traversal attempts collapse to a path we
+        // can validate.
+        var joined_buf: bun.PathBuffer = undefined;
+        const joined = bun.path.joinAbsStringBuf(
+            html_dir,
+            &joined_buf,
+            &[_][]const u8{rel_path},
+            .auto,
+        );
+
+        // Require the normalized path to stay strictly inside html_dir (the
+        // separator guard prevents `/foo/barbaz` matching base `/foo/bar`).
+        if (!bun.strings.startsWith(joined, html_dir)) return false;
+        if (joined.len <= html_dir.len) return false;
+        const sep = joined[html_dir.len];
+        if (sep != '/' and sep != '\\') return false;
+
+        // Don't serve the HTML file itself as a raw static asset — the
+        // bundler needs to transform it first.
+        if (bun.strings.eql(joined, html_path)) return false;
+
+        // Null-terminate for stat + open.
+        var nt_buf: bun.PathBuffer = undefined;
+        if (joined.len >= nt_buf.len) return false;
+        @memcpy(nt_buf[0..joined.len], joined);
+        nt_buf[joined.len] = 0;
+        const joined_z: [:0]const u8 = nt_buf[0..joined.len :0];
+
+        // Must be a regular file, not a directory / missing. Absolute path
+        // means the dirfd is just a placeholder.
+        switch (bun.sys.existsAtType(bun.FD.cwd(), joined_z)) {
+            .err => return false,
+            .result => |kind| if (kind != .file) return false,
+        }
+        debug("serving sibling file: {s}", .{joined});
+
+        // Blob.Store keeps ownership of the path string and frees it in its
+        // deinit, so dupe off the stack buffer. Using `default_allocator`
+        // (mimalloc) matches what the Store expects — Store.deinit calls
+        // `this.allocator.free` on the path when it's a `.string`.
+        const owned_path = bun.handleOom(bun.default_allocator.dupe(u8, joined));
+        var path_or_fd: jsc.Node.PathOrFileDescriptor = .{
+            .path = .{ .string = bun.PathString.init(owned_path) },
+        };
+
+        const global = this.bundle.data.global;
+        var blob = jsc.WebCore.Blob.findOrCreateFileFromPath(
+            &path_or_fd,
+            global,
+            false,
+        );
+        blob.globalThis = global;
+        // Hand the FileRoute a reference to this server so
+        // onStaticRequestComplete balances the onPendingRequest call inside
+        // FileRoute.on.
+        const file_route = FileRoute.initFromBlob(blob, .{ .server = this.server });
+        defer file_route.deref();
+        if (is_head) {
+            file_route.onHEADRequest(req, resp);
+        } else {
+            file_route.onRequest(req, resp);
+        }
+        return true;
     }
 
     /// Schedule a bundle to be built.
@@ -521,8 +656,10 @@ pub const Route = struct {
 
 const debug = bun.Output.scoped(.HTMLBundle, .hidden);
 
+const FileRoute = @import("./FileRoute.zig");
 const StaticRoute = @import("./StaticRoute.zig");
 const std = @import("std");
+const PercentEncoding = @import("../../../url.zig").PercentEncoding;
 
 const bun = @import("bun");
 const strings = bun.strings;

--- a/test/js/bun/http/bun-serve-html-entry-sibling-assets.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry-sibling-assets.test.ts
@@ -1,0 +1,114 @@
+// https://github.com/oven-sh/bun/issues/30193 — when a pre-bundled static
+// site (e.g. SvelteKit's `@sveltejs/adapter-static`) sits next to
+// `index.html`, requests for the hashed asset files referenced via
+// `<link rel="modulepreload">` and `<link rel="stylesheet">` were falling
+// through to the SPA HTML, arriving with `Content-Type: text/html`.
+// Firefox then refuses to execute the script because the MIME type is
+// wrong.
+//
+// The fix serves siblings directly via `FileRoute` before the SPA
+// fallback. This file isolates the new coverage so sandbox environments
+// that break the older tests in `bun-serve-html-entry.test.ts` (they
+// assume `localhost` resolves to IPv4) don't mix with the pass/fail
+// signal for this change.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+
+describe.each(["development", "production"])("bun ./index.html — sibling assets on disk (%s)", NODE_ENV => {
+  test(`serves .js / .css with correct MIME, path traversal is rejected (${NODE_ENV})`, async () => {
+    const dir = tempDirWithFiles("html-entry-sibling-assets-" + NODE_ENV, {
+      "index.html": /*html*/ `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link href="./_app/immutable/entry/start.abc123.js" rel="modulepreload">
+    <link href="./_app/immutable/chunks/chunk1.abc123.js" rel="modulepreload">
+    <link href="./_app/immutable/assets/style.abc123.css" rel="stylesheet">
+  </head>
+  <body><div id="app">hello</div></body>
+</html>`,
+      "_app/immutable/entry/start.abc123.js": `export const MARKER = "SIBLING_JS_OK";\n`,
+      "_app/immutable/chunks/chunk1.abc123.js": `export const CHUNK = "SIBLING_CHUNK_OK";\n`,
+      "_app/immutable/assets/style.abc123.css": `body{background:#ff00aa}\n`,
+    });
+
+    await using proc = Bun.spawn({
+      // Pin to 127.0.0.1 so fetch() lands on the same family the server
+      // bound to. Default `localhost` resolves to IPv6 in some sandboxes
+      // where Bun.serve then only binds ::1 and IPv4 fetch fails.
+      cmd: [bunExe(), "index.html", "--port=0", "--hostname=127.0.0.1"],
+      env: { ...bunEnv, NODE_ENV },
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    // Pull the port the server picked from stdout. Wait for a trailing "/"
+    // so a chunked port number doesn't match early.
+    let serverUrl = "";
+    const decoder = new TextDecoder();
+    let stdout_acc = "";
+    for await (const chunk of proc.stdout) {
+      stdout_acc += decoder.decode(chunk, { stream: true });
+      const matched = stdout_acc.match(/http:\/\/127\.0\.0\.1:\d+\//);
+      if (matched) {
+        serverUrl = matched[0].replace(/\/$/, "");
+        break;
+      }
+    }
+    expect(serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    try {
+      // `.js` modulepreload target — must be served as javascript with the
+      // real file bytes, NOT the bundled HTML.
+      const jsRes = await fetch(`${serverUrl}/_app/immutable/entry/start.abc123.js`);
+      expect({
+        status: jsRes.status,
+        // Canonical MIME for `.js` is `text/javascript` (with or without
+        // a charset suffix).
+        contentType: (jsRes.headers.get("content-type") ?? "").split(";")[0].trim(),
+      }).toEqual({ status: 200, contentType: "text/javascript" });
+      expect(await jsRes.text()).toContain("SIBLING_JS_OK");
+
+      // Chunk file from a subdirectory.
+      const chunkRes = await fetch(`${serverUrl}/_app/immutable/chunks/chunk1.abc123.js`);
+      expect(chunkRes.status).toBe(200);
+      expect((chunkRes.headers.get("content-type") ?? "").split(";")[0].trim()).toBe("text/javascript");
+      expect(await chunkRes.text()).toContain("SIBLING_CHUNK_OK");
+
+      // Stylesheet sibling.
+      const cssRes = await fetch(`${serverUrl}/_app/immutable/assets/style.abc123.css`);
+      expect({
+        status: cssRes.status,
+        contentType: (cssRes.headers.get("content-type") ?? "").split(";")[0].trim(),
+      }).toEqual({ status: 200, contentType: "text/css" });
+      expect(await cssRes.text()).toContain("#ff00aa");
+
+      // Unknown path still falls back to the bundled HTML (SPA behaviour).
+      const unknownRes = await fetch(`${serverUrl}/does-not-exist-anywhere.js`);
+      expect(unknownRes.status).toBe(200);
+      expect(unknownRes.headers.get("content-type") ?? "").toContain("text/html");
+
+      // Path traversal attempts must not escape the HTML's directory.
+      // uWS collapses `..` segments in the raw URL, so percent-encoded
+      // separators are the only traversal vector that survives to our
+      // handler — they must still resolve outside html_dir and fall back
+      // to the SPA HTML.
+      const travRes = await fetch(`${serverUrl}/..%2F..%2F..%2Fetc%2Fpasswd`);
+      expect(travRes.status).toBe(200);
+      expect(travRes.headers.get("content-type") ?? "").toContain("text/html");
+      expect(await travRes.text()).not.toContain("root:");
+
+      // Requesting `/index.html` must still go through the HTML bundler
+      // (bundled output), not return the raw file bytes.
+      const idxRes = await fetch(`${serverUrl}/index.html`);
+      expect(idxRes.status).toBe(200);
+      expect(idxRes.headers.get("content-type") ?? "").toContain("text/html");
+      // Bundler injects a `<script type="module">` referencing the JS
+      // chunk; the raw HTML on disk doesn't have one.
+      expect(await idxRes.text()).toMatch(/<script[^>]*type="module"/);
+    } finally {
+      proc.kill();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`bun ./index.html` against a pre-bundled static site (SvelteKit's
`@sveltejs/adapter-static`, etc.) returned the SPA HTML with
`Content-Type: text/html` for every referenced asset:

```console
$ curl -s -I http://localhost:3000/_app/immutable/entry/start.abc123.js
HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
etag: "42f1b413b6b98688"
Content-Length: 958
```

Firefox refuses to execute a `<script>` whose MIME type is
`text/html`, so `<link rel="modulepreload" href="…">` / `<link
rel="stylesheet" href="…">` targets that happened to live next to
`index.html` on disk silently failed to load.

## Cause

`bun ./index.html` bundles the HTML and mounts the `HTMLBundle.Route`
at `/*`. Bundler-produced chunk paths register as more-specific
static routes and match first, but a URL like
`/_app/immutable/entry/start.abc123.js` (which references a
already-hashed file from another build tool) hits the `/*` route, and
`HTMLBundle.Route.onAnyRequest` simply served the bundled HTML as an
SPA fallback.

## Fix

Before the SPA fallback, try the request path against the filesystem
relative to the HTML's directory. If a regular file exists there,
serve it through `FileRoute` so the Content-Type comes from the
extension and `Last-Modified` / range support works.

The check is strict:

- **GET / HEAD only** — other methods flow through to the usual 405/SPA
  path.
- **Same-origin, inside html_dir only** — the decoded URL is joined
  against `dirname(html_path)` via `joinAbsStringBuf` (resolves
  `.`/`..`). A `startsWith(html_dir) + separator` check rejects
  anything outside the directory, so `/../../etc/passwd` and
  `/..%2F..%2Fetc%2Fpasswd` both fall through to the HTML.
- **HTML itself excluded** — `/` and `/index.html` always go through
  the bundler so the transformed/injected HTML is returned.
- **Missing / non-regular files fall through** — SPA behaviour for
  unknown routes is preserved.

## Verification

```console
$ curl -s -I http://localhost:3000/_app/immutable/entry/start.abc123.js
HTTP/1.1 200 OK
Content-Type: text/javascript;charset=utf-8
last-modified: …
content-length: 50

$ curl -s -I http://localhost:3000/_app/immutable/assets/style.abc123.css
HTTP/1.1 200 OK
Content-Type: text/css;charset=utf-8
…

$ curl -s -I http://localhost:3000/does-not-exist.js
HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8   # SPA fallback preserved
```

Test covers `development` + `production` modes: .js / .css MIME,
sibling chunks in subdirs, SPA fallback for unknown routes, path
traversal (`..` and `%2F` encoded), and that `/index.html` still
goes through the bundler.

Fixes #30193