### PR TITLE
Fix HTMLRewriter use-after-free when handler rejects during end()

### DIFF
--- a/src/bun.js/api/html_rewriter.zig
+++ b/src/bun.js/api/html_rewriter.zig
@@ -573,7 +573,7 @@ pub const HTMLRewriter = struct {
         ) ?JSValue {
             bun.handleOom(sink.bytes.growBy(bytes.len));
             const global = sink.global;
-            var response = sink.response;
+            const response = sink.response;
 
             sink.rewriter.?.write(bytes) catch {
                 if (is_async) {
@@ -585,8 +585,6 @@ pub const HTMLRewriter = struct {
             };
 
             sink.rewriter.?.end() catch {
-                if (!is_async) response.finalize();
-                sink.response = undefined;
                 if (is_async) {
                     response.getBodyValue().toErrorInstance(.{ .Message = createLOLHTMLStringError() }, global) catch {}; // TODO: properly propagate exception upwards
                     return null;

--- a/test/js/workerd/html-rewriter-end-error.test.ts
+++ b/test/js/workerd/html-rewriter-end-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+
+describe("HTMLRewriter", () => {
+  // When transforming a string or ArrayBuffer, lol-html may invoke the text
+  // handler from end() for the final lastInTextNode chunk. If that handler
+  // returns a rejected promise, the output Response is still owned by its JS
+  // wrapper and must not be destroyed directly — previously this caused a
+  // use-after-free when the wrapper was later garbage collected.
+  it("does not crash when a document text handler rejects during end() on an ArrayBuffer input", () => {
+    for (let i = 0; i < 50; i++) {
+      const rewriter = new HTMLRewriter();
+      rewriter.onDocument({
+        text(chunk) {
+          if (chunk.lastInTextNode) {
+            return Promise.reject(new Error("boom"));
+          }
+        },
+      });
+      expect(() => rewriter.transform(new Uint8Array([97, 98, 99]).buffer)).toThrow();
+      Bun.gc(true);
+    }
+  });
+
+  it("does not crash when a document text handler rejects during end() on a string input", () => {
+    for (let i = 0; i < 50; i++) {
+      const rewriter = new HTMLRewriter();
+      rewriter.onDocument({
+        text(chunk) {
+          if (chunk.lastInTextNode) {
+            return Promise.reject(new Error("boom"));
+          }
+        },
+      });
+      expect(() => rewriter.transform("abc")).toThrow();
+      Bun.gc(true);
+    }
+  });
+});

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -493,6 +493,36 @@ describe("HTMLRewriter", () => {
     expect(lastInTextNode).toBeBoolean();
   });
 
+  it("does not crash when a document text handler rejects during end() on an ArrayBuffer input", () => {
+    for (let i = 0; i < 50; i++) {
+      const rewriter = new HTMLRewriter();
+      rewriter.onDocument({
+        text(chunk) {
+          if (chunk.lastInTextNode) {
+            return Promise.reject(new Error("boom"));
+          }
+        },
+      });
+      expect(() => rewriter.transform(new Uint8Array([97, 98, 99]).buffer)).toThrow();
+      Bun.gc(true);
+    }
+  });
+
+  it("does not crash when a document text handler rejects during end() on a string input", () => {
+    for (let i = 0; i < 50; i++) {
+      const rewriter = new HTMLRewriter();
+      rewriter.onDocument({
+        text(chunk) {
+          if (chunk.lastInTextNode) {
+            return Promise.reject(new Error("boom"));
+          }
+        },
+      });
+      expect(() => rewriter.transform("abc")).toThrow();
+      Bun.gc(true);
+    }
+  });
+
   it("it supports selfClosing", async () => {
     const selfClosing = {};
     await new HTMLRewriter()

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -493,36 +493,6 @@ describe("HTMLRewriter", () => {
     expect(lastInTextNode).toBeBoolean();
   });
 
-  it("does not crash when a document text handler rejects during end() on an ArrayBuffer input", () => {
-    for (let i = 0; i < 50; i++) {
-      const rewriter = new HTMLRewriter();
-      rewriter.onDocument({
-        text(chunk) {
-          if (chunk.lastInTextNode) {
-            return Promise.reject(new Error("boom"));
-          }
-        },
-      });
-      expect(() => rewriter.transform(new Uint8Array([97, 98, 99]).buffer)).toThrow();
-      Bun.gc(true);
-    }
-  });
-
-  it("does not crash when a document text handler rejects during end() on a string input", () => {
-    for (let i = 0; i < 50; i++) {
-      const rewriter = new HTMLRewriter();
-      rewriter.onDocument({
-        text(chunk) {
-          if (chunk.lastInTextNode) {
-            return Promise.reject(new Error("boom"));
-          }
-        },
-      });
-      expect(() => rewriter.transform("abc")).toThrow();
-      Bun.gc(true);
-    }
-  });
-
   it("it supports selfClosing", async () => {
     const selfClosing = {};
     await new HTMLRewriter()


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in `HTMLRewriter.transform()` that caused flaky SIGSEGV crashes found by fuzzing.

When transforming a string or ArrayBuffer, the body is buffered synchronously and fed to lol-html via `write()` followed by `end()`. If a document/element handler returns a rejected promise for the final `lastInTextNode` chunk (emitted from `end()`), the `end() catch` branch in `BufferOutputSink.runOutputSink` would call `response.finalize()` directly on the output `Response`.

That `Response` is already owned by its JS wrapper cell (created earlier in `init()` via `sink.response.toJS()`), so destroying it in-place left the wrapper's `m_ctx` pointing at freed memory. When GC later swept the wrapper, its destructor invoked `Response.finalize()` again on that freed pointer:

```
AddressSanitizer: use-after-poison
    #0 bun.js.bindings.JSRef.JSRef.deinit        src/bun.js/bindings/JSRef.zig:188
    #1 bun.js.bindings.JSRef.JSRef.finalize      src/bun.js/bindings/JSRef.zig:200
    #2 bun.js.webcore.Response.finalize          src/bun.js/webcore/Response.zig:474
    #3 ResponseClass__finalize                   codegen/ZigGeneratedClasses.zig:17250
    #4 WebCore::JSResponse::~JSResponse()        codegen/ZigGeneratedClasses.cpp:54979
```

The `write()` error path (just above it) already handled this correctly by returning the error and letting the JS wrapper own the Response lifetime. This PR makes the `end()` error path do the same — drop the manual `response.finalize()` and `sink.response = undefined`.

## How did you verify your code works?

Minimal repro that reliably triggers the ASAN error before the fix and passes cleanly after:

```js
const rewriter = new HTMLRewriter();
rewriter.onDocument({
  text(chunk) {
    if (chunk.lastInTextNode) {
      return Promise.reject(new Error("boom"));
    }
  },
});
try {
  rewriter.transform(new Uint8Array([97, 98, 99]).buffer);
} catch (e) {}
Bun.gc(true);
```

Added regression tests in `test/js/workerd/html-rewriter.test.js` covering both ArrayBuffer and string inputs. All existing HTMLRewriter tests pass.