### PR TITLE
Image.placeholder: add "hash" output and switch data URL to WebP

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -131,11 +131,18 @@ await img.write(Bun.s3("bucket/out.webp"));
 
 ## Placeholders
 
-For a low-quality placeholder to inline in HTML before the real image loads, `.placeholder()` returns a [ThumbHash](https://evanw.github.io/thumbhash/)-rendered ≤32px blur as a `data:` URL — ~400–700 bytes, no client-side decoder needed:
+For a low-quality placeholder to inline in HTML before the real image loads, `.placeholder()` returns a [ThumbHash](https://evanw.github.io/thumbhash/)-rendered ≤32px blur as a `data:image/webp` URL — a few hundred bytes, no client-side decoder needed:
 
 ```ts
 const lqip = await Bun.file("hero.jpg").image().placeholder();
 // <img src={lqip} … /> — then swap to the real URL on load.
+```
+
+For many placeholders on one page, `.placeholder("hash")` returns the raw 5–25 byte ThumbHash as a `Uint8Array` instead — pair with the ~800-byte client-side [ThumbHash decoder](https://github.com/evanw/thumbhash) and per-image cost drops to ≤36 base64 characters, smaller than embedding a WebP `data:` URL per image:
+
+```ts
+const hash = await Bun.file("hero.jpg").image().placeholder("hash");
+const b64 = Buffer.from(hash).toString("base64"); // "HQgKNZiAd3dxd4eHd3eGh3GQCPiI"
 ```
 
 For coarse-to-fine rendering of the image _itself_, encode a progressive JPEG:
@@ -144,7 +151,7 @@ For coarse-to-fine rendering of the image _itself_, encode a progressive JPEG:
 img.jpeg({ progressive: true });
 ```
 
-After the first terminal resolves, `img.width` and `img.height` reflect the _output_ dimensions (they're `-1` before).
+After the first terminal resolves, `img.width` and `img.height` reflect the _output_ dimensions (they're `-1` before). `.placeholder("hash")` is the one exception: the hash is OF the source, so `img.width` / `img.height` afterwards report the original source — matching `.metadata()` on the same instance.
 
 ## `Bun.serve` integration
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8384,17 +8384,32 @@ declare module "bun" {
     dataurl(): Promise<string>;
     /**
      * A [ThumbHash](https://github.com/evanw/thumbhash)-rendered low-quality
-     * placeholder of the *source* image as a `data:image/png;base64,…` URL —
+     * placeholder of the *source* image as a `data:image/webp;base64,…` URL —
      * a ≤32px blur with the right average colour, aspect ratio and rough
-     * structure, ~400–700 bytes. Ready for `<img src>` or Next's
+     * structure, a few hundred bytes. Ready for `<img src>` or Next's
      * `blurDataURL`; no client-side decoder needed.
      *
      * ```ts
      * const lqip = await Bun.file("hero.jpg").image().placeholder();
-     * // "data:image/png;base64,iVBORw0KGgoAAAANSUhE…"
+     * // "data:image/webp;base64,UklGRoQAAABXRUJQ…"
      * ```
      */
     placeholder(as?: "dataurl"): Promise<string>;
+    /**
+     * Raw [ThumbHash](https://github.com/evanw/thumbhash) bytes — a 5–25 byte
+     * compact encoding of the *source* image's average colour, aspect ratio
+     * and rough structure. Pair with the [~800-byte ThumbHash decoder](https://github.com/evanw/thumbhash?tab=readme-ov-file#api-reference)
+     * on the client when shipping many placeholders: one decoder + ≤36 base64
+     * chars per image is smaller than embedding a WebP `data:` URL per image.
+     *
+     * ```ts
+     * const hash = await Bun.file("hero.jpg").image().placeholder("hash");
+     * // Uint8Array(21) [ 29, 8, ... ]
+     * const b64 = Buffer.from(hash).toString("base64");
+     * // "HQgKNZiAd3dxd4eHd3eGh3GQCPiI"
+     * ```
+     */
+    placeholder(as: "hash"): Promise<Uint8Array>;
     /** Run the pipeline and return a `Blob` with the matching `type`. */
     blob(): Promise<Blob>;
     /** Run the pipeline and return base64-encoded output. */

--- a/src/runtime/image/Image.classes.ts
+++ b/src/runtime/image/Image.classes.ts
@@ -60,8 +60,10 @@ export default [
       toBase64: { fn: "doToBase64", length: 0, async: true },
       // toBase64() with the `data:{mime};base64,` prefix.
       dataurl: { fn: "doDataUrl", length: 0, async: true },
-      // ThumbHash-rendered ≤32px PNG data: URL — ~400-700B, ready for
-      // <img src> / blurDataURL.
+      // ThumbHash-based placeholder. Default "dataurl" returns a ≤32px
+      // lossy-WebP `data:` URL (a few hundred bytes, ready for <img src>
+      // / blurDataURL); "hash" returns the raw 5-25 byte ThumbHash as a
+      // Uint8Array for clients that ship the ~800B decoder.
       placeholder: { fn: "doPlaceholder", length: 0, async: true },
       metadata: { fn: "doMetadata", length: 0, async: true },
 

--- a/src/runtime/image/Image.zig
+++ b/src/runtime/image/Image.zig
@@ -577,23 +577,40 @@ pub fn doDataUrl(this: *Image, global: *jsc.JSGlobalObject, cf: *jsc.CallFrame) 
     return this.schedule(global, cf.this(), .{ .encode = this.pipeline.output }, .dataurl);
 }
 
-/// `.placeholder()` — ThumbHash-rendered ≤32px PNG `data:` URL. ~28 chars
-/// of hash → ~400-700 bytes of `data:image/png;base64,…` ready for `<img
-/// src>` / Next's `blurDataURL`. Runs entirely on the work pool; the
-/// pipeline ops (resize/rotate/…) are skipped — a placeholder is OF the
-/// source, not of the output.
+/// `.placeholder()` — ThumbHash-rendered ≤32px WebP `data:` URL. ~28 chars
+/// of hash → a few hundred bytes of `data:image/webp;base64,…` ready for
+/// `<img src>` / Next's `blurDataURL`. Runs entirely on the work pool;
+/// the pipeline ops (resize/rotate/…) are skipped — a placeholder is OF
+/// the source, not of the output.
+///
+/// `placeholder("hash")` returns the raw 25-byte ThumbHash as a
+/// `Uint8Array` — ship the tiny decoder on the client and keep each
+/// image's blur to <40 base64 chars. See https://github.com/evanw/thumbhash.
 pub fn doPlaceholder(this: *Image, global: *jsc.JSGlobalObject, cf: *jsc.CallFrame) bun.JSError!jsc.JSValue {
     const args = cf.arguments();
-    // Single positional `"dataurl"` for now — leaves room for `"hash"` /
-    // `"color"` without growing methods. Anything else throws so the
-    // option space isn't accidentally squatted.
+    // Positional: `"dataurl"` (default) | `"hash"`. `"dataurl"` renders
+    // the hash to a tiny lossy WebP and returns a data: URL; `"hash"`
+    // hands back the raw ThumbHash bytes so users who already ship the
+    // decoder (blurhash-style) pay ~34 base64 chars per image. Anything
+    // else throws so the option space doesn't drift.
+    var placeholder_kind: PipelineTask.PlaceholderKind = .dataurl;
     if (args.len > 0 and !args[0].isUndefinedOrNull()) {
         const s = try args[0].toBunString(global);
         defer s.deref();
-        if (!s.eqlComptime("dataurl"))
-            return global.throwInvalidArguments("Image.placeholder(): only \"dataurl\" is supported", .{});
+        if (s.eqlComptime("dataurl")) {
+            placeholder_kind = .dataurl;
+        } else if (s.eqlComptime("hash")) {
+            placeholder_kind = .hash;
+        } else {
+            return global.throwInvalidArguments("Image.placeholder(): expected \"dataurl\" or \"hash\"", .{});
+        }
     }
-    return this.schedule(global, cf.this(), .placeholder, .dataurl);
+    return this.schedule(
+        global,
+        cf.this(),
+        .{ .placeholder = placeholder_kind },
+        if (placeholder_kind == .hash) .uint8array else .dataurl,
+    );
 }
 
 /// Terminal: encode and write to `path` on the work pool (no round-trip of
@@ -717,7 +734,9 @@ pub fn encodeForBody(this: *Image, global: *jsc.JSGlobalObject, this_value: jsc.
         .err => |e| global.throw("{s}", .{errorMessage(e)}),
         // Preserve errno/path/syscall instead of flattening to DecodeFailed.
         .io_err => |e| global.throwValue(try e.toJS(global)),
-        .meta => unreachable,
+        // The sync body-init path only runs for encode (Request/Response
+        // terminals); placeholder/metadata terminals take the async path.
+        .meta, .hash => unreachable,
     };
 }
 
@@ -877,16 +896,28 @@ pub const PipelineTask = struct {
         /// `null` ⇒ re-encode in the source format (resolved after decode).
         encode: ?codecs.EncodeOptions,
         metadata,
-        /// `.placeholder()` — decode → box-resize ≤100 → ThumbHash → render
-        /// → PNG → `data:` URL. The whole chain runs on the worker; the
-        /// hash itself never crosses the JS boundary unless we add an
-        /// `as: "hash"` option later.
-        placeholder,
+        /// `.placeholder(kind)` — decode → box-resize ≤100 → ThumbHash
+        /// encode, then either render+lossy-WebP → `data:` URL, or hand
+        /// the raw hash bytes back as a `Uint8Array`. Whole chain runs
+        /// on the worker.
+        placeholder: PlaceholderKind,
     };
+
+    /// `"dataurl"` → ≤32px WebP render as a data URL. `"hash"` → the raw
+    /// ThumbHash bytes (≤25) for clients that ship the decoder.
+    pub const PlaceholderKind = enum { dataurl, hash };
 
     pub const Result = union(enum) {
         encoded: struct { out: codecs.Encoded, format: codecs.Format, w: u32, h: u32 },
         meta: struct { w: u32, h: u32, format: codecs.Format },
+        /// Raw ThumbHash bytes from `.placeholder("hash")` — delivered as
+        /// a `Uint8Array`. The worker stores the hash inline since it's
+        /// always ≤ `thumbhash.max_len`; no allocation involved. `w`/`h`
+        /// are the oriented source dims so `then()` can update
+        /// `img.width` / `img.height` the same way the other terminals
+        /// do — a `"hash"` terminal that wins the race mustn't leave the
+        /// getters stuck at -1.
+        hash: struct { bytes: [thumbhash.max_len]u8, len: u8, w: u32, h: u32 },
         err: codecs.Error,
         io_err: bun.sys.Error,
     };
@@ -979,17 +1010,33 @@ pub const PipelineTask = struct {
         // can be over-shrunk and then upscaled, throwing away detail.
         // (flip/flop are pure mirrors that never change w/h, so the hint
         //  stays valid through them.)
-        const hint: codecs.DecodeHint = if (this.pipeline.resize) |r| blk: {
-            var tw = r.w;
-            // r.h==0 means "preserve aspect" — constrain on width only.
-            var th = if (r.h != 0) r.h else r.w;
-            const swap_explicit = this.pipeline.rotate == 90 or this.pipeline.rotate == 270;
-            const swap_exif = this.auto_orient and blk2: {
-                const t = exif.readJpeg(input).transform();
-                break :blk2 t.rotate == 90 or t.rotate == 270;
-            };
-            if (swap_explicit != swap_exif) std.mem.swap(u32, &tw, &th);
-            break :blk .{ .target_w = tw, .target_h = th };
+        //
+        // Only `.encode` tasks want the hint. `.placeholder` and `.metadata`
+        // both report source dims (placeholders are OF the source, metadata
+        // falls through here only for HEIC/AVIF and reports `decoded.width/
+        // height` directly); applying a chained `.resize(...)` hint to
+        // either would silently shrink the decode and make them disagree
+        // with `.metadata()` probe-path results on the same instance.
+        const hint: codecs.DecodeHint = if (this.kind == .encode) blk_hint: {
+            if (this.pipeline.resize) |r| {
+                var tw = r.w;
+                // r.h==0 means "preserve aspect". We can't derive the exact
+                // aspect-preserved target here (don't know src dims yet) so
+                // mirror `r.w` into `th` — harmless for square-ish sources
+                // where both axes clear the same M/8, conservative for
+                // wide-short / tall-narrow where the picker will fall back
+                // to full decode rather than ceil-round the unconstrained
+                // axis and drift `resolveResize`'s aspect derivation.
+                var th = if (r.h != 0) r.h else r.w;
+                const swap_explicit = this.pipeline.rotate == 90 or this.pipeline.rotate == 270;
+                const swap_exif = this.auto_orient and blk2: {
+                    const t = exif.readJpeg(input).transform();
+                    break :blk2 t.rotate == 90 or t.rotate == 270;
+                };
+                if (swap_explicit != swap_exif) std.mem.swap(u32, &tw, &th);
+                break :blk_hint .{ .target_w = tw, .target_h = th };
+            }
+            break :blk_hint .{};
         } else .{};
 
         var decoded = codecs.decode(input, this.max_pixels, hint) catch |e| {
@@ -1017,7 +1064,12 @@ pub const PipelineTask = struct {
         }
 
         if (this.kind == .placeholder) {
-            this.result = makePlaceholder(decoded.rgba, decoded.width, decoded.height) catch |e| .{ .err = e };
+            this.result = makePlaceholder(
+                decoded.rgba,
+                decoded.width,
+                decoded.height,
+                this.kind.placeholder,
+            ) catch |e| .{ .err = e };
             return;
         }
 
@@ -1052,13 +1104,19 @@ pub const PipelineTask = struct {
         this.result = .{ .encoded = .{ .out = out, .format = enc.format, .w = decoded.width, .h = decoded.height } };
     }
 
-    /// `.placeholder()` body — runs on the worker. Input is the decoded RGBA
-    /// at source size; output is a PNG of the ThumbHash render, ready for the
-    /// `.dataurl` deliver. ThumbHash needs ≤100×100, so first downscale with
-    /// `box` (the only filter that's correct for "average everything in a
-    /// cell" — Lanczos would ring into the DCT). The hash itself stays on
-    /// the worker stack; only the rendered PNG crosses back.
-    fn makePlaceholder(rgba: []const u8, sw: u32, sh: u32) codecs.Error!Result {
+    /// `.placeholder(kind)` body — runs on the worker. Input is the decoded
+    /// RGBA at source size. ThumbHash needs ≤100×100, so first downscale
+    /// with `box` (the only filter that's correct for "average everything
+    /// in a cell" — Lanczos would ring into the DCT).
+    ///
+    /// `.hash` returns the raw 25-byte-max ThumbHash. `.dataurl` continues
+    /// through `thumbhash.decode` to a ≤32px render and encodes that as
+    /// lossy WebP — at quality 50 the blur is a few hundred bytes,
+    /// comfortably smaller than the previous PNG encode (PNG's IDAT+CRC
+    /// overhead alone is ~80 bytes before any pixel data). Low quality is
+    /// cheap: ThumbHash's 4-bit-AC quantisation has already washed out
+    /// any detail the WebP encoder could lose.
+    fn makePlaceholder(rgba: []const u8, sw: u32, sh: u32, kind: PlaceholderKind) codecs.Error!Result {
         const max_in: u32 = 100;
         var w = sw;
         var h = sh;
@@ -1079,12 +1137,29 @@ pub const PipelineTask = struct {
         }
         var buf: [thumbhash.max_len]u8 = undefined;
         const hash = thumbhash.encode(&buf, w, h, pixels);
+        if (kind == .hash) {
+            // Report the *source* dims (`sw`/`sh`) rather than the ≤100
+            // DCT input — the hash represents the original image; the
+            // downscale is an internal ThumbHash detail.
+            var result: Result = .{ .hash = .{
+                .bytes = undefined,
+                .len = @intCast(hash.len),
+                .w = sw,
+                .h = sh,
+            } };
+            @memcpy(result.hash.bytes[0..hash.len], hash);
+            return result;
+        }
         const rendered = try thumbhash.decode(hash);
         defer bun.default_allocator.free(rendered.rgba);
-        // Placeholder is a synthetic ThumbHash render, not the source image —
-        // no ICC profile attaches to it.
-        const png_out = try codecs.png.encode(rendered.rgba, rendered.w, rendered.h, -1, null);
-        return .{ .encoded = .{ .out = png_out, .format = .png, .w = rendered.w, .h = rendered.h } };
+        // Lossy WebP at q=50: the render is already a low-frequency blur
+        // so VP8 spends almost nothing on AC detail, and WebP's variable-
+        // length headers (no quantisation table, no inflate preamble)
+        // beat PNG by 3-5× on a 32×32 gradient. (Placeholder is a
+        // synthetic ThumbHash render, not the source image — no ICC
+        // profile attaches to it anyway.)
+        const out = try codecs.webp.encode(rendered.rgba, rendered.w, rendered.h, 50, false, null);
+        return .{ .encoded = .{ .out = out, .format = .webp, .w = rendered.w, .h = rendered.h } };
     }
 
     /// Back on the JS thread.
@@ -1096,8 +1171,12 @@ pub const PipelineTask = struct {
         const global = this.global;
         // Stash final dims here (JS thread) — `run()` is on a WorkPool thread
         // so writing `this.image.*` there would race the synchronous getters.
+        // `.hash` carries source dims for the same reason as `.meta`: even
+        // though the hash has no render size, a caller awaiting only
+        // `.placeholder("hash")` expects `img.width/height` to reflect the
+        // source they just hashed, not stay at -1.
         switch (this.result) {
-            inline .encoded, .meta => |r| {
+            inline .encoded, .meta, .hash => |r| {
                 this.image.last_width = @intCast(r.w);
                 this.image.last_height = @intCast(r.h);
             },
@@ -1168,6 +1247,17 @@ pub const PipelineTask = struct {
                 obj.put(global, jsc.ZigString.static("height"), jsc.JSValue.jsNumber(m.h));
                 obj.put(global, jsc.ZigString.static("format"), jsc.ZigString.init(@tagName(m.format)).toJS(global));
                 try promise.resolve(global, obj);
+            },
+            // `.placeholder("hash")` — the ≤25 raw ThumbHash bytes as a
+            // `Uint8Array`. Always tiny, so copy into a fresh
+            // JSC-allocated array rather than wrapping our stack buffer.
+            .hash => |h| {
+                const arr = jsc.JSValue.createUninitializedUint8Array(global, h.len) catch
+                    return promise.reject(global, error.JSError);
+                const ab = arr.asArrayBuffer(global) orelse
+                    return promise.reject(global, global.createErrorInstance("Image.placeholder: failed to allocate result", .{}));
+                @memcpy(ab.byteSlice()[0..h.len], h.bytes[0..h.len]);
+                try promise.resolve(global, arr);
             },
             .err => |e| try promise.reject(global, rejectError(global, e)),
             .io_err => |e| try promise.reject(global, e.toJS(global)),

--- a/src/runtime/image/thumbhash.zig
+++ b/src/runtime/image/thumbhash.zig
@@ -5,11 +5,11 @@
 //! opponent-colour planes, optionally A) of a ≤100×100 image. Decoding gives a
 //! ≤32px blur with the right average colour, aspect ratio and rough structure.
 //!
-//! `Bun.Image.placeholder()` runs `decode → box-resize ≤100 → encode()` →
-//! `decode()` → PNG-encode → `data:` URL, all on the work pool. The hash
-//! itself is exposed as the intermediate so a future `as: "hash"` option is
-//! one switch away. The encode/decode are scalar f32 and tiny (≤100²·7² mults
-//! at the absolute most); not worth a Highway kernel.
+//! `Bun.Image.placeholder(kind)` runs `decode → box-resize ≤100 → encode()`,
+//! then either returns the raw hash bytes (`"hash"`) or continues through
+//! `decode()` → lossy-WebP → `data:` URL (`"dataurl"`), all on the work
+//! pool. The encode/decode are scalar f32 and tiny (≤100²·7² mults at the
+//! absolute most); not worth a Highway kernel.
 
 /// Maximum hash length: 5-byte header + (has_alpha ? 1 : 0) + ceil((L+P+Q+A
 /// AC counts)/2). Worst case (has_alpha, square) is 5+1+ceil((14+5+5+14)/2)=25.

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -921,29 +921,83 @@ describe("Bun.Image", () => {
       expect(await new Bun.Image(cornersPng).webp().dataurl()).toMatch(/^data:image\/webp;base64,/);
     });
 
-    test(".placeholder() is a ThumbHash-rendered ≤32px PNG data: URL", async () => {
+    test(".placeholder() is a ThumbHash-rendered ≤32px WebP data: URL", async () => {
       // Source big enough to force the ≤100 box-downscale before the DCT;
       // colour gradient so the LPQ coefficients are non-degenerate.
       const src = makePng(80, 60, (x, y) => [(x * 3) & 255, (y * 4) & 255, ((x ^ y) * 7) & 255, 255]);
       const url = await new Bun.Image(src).placeholder();
-      expect(url).toMatch(/^data:image\/png;base64,/);
-      // Typical ThumbHash render PNG-encodes to a few hundred bytes.
-      expect(url.length).toBeLessThan(2000);
+      expect(url).toMatch(/^data:image\/webp;base64,/);
+      // Lossy WebP beats the previous PNG encode by several hundred bytes
+      // on the same ThumbHash render.
+      expect(url.length).toBeLessThan(1200);
       // The data: URL is itself a valid Bun.Image input — verify it decodes
       // to ≤32px on the long side and preserves aspect (80:60 = 4:3).
       const m = await new Bun.Image(url).metadata();
-      expect(m.format).toBe("png");
+      expect(m.format).toBe("webp");
       expect(Math.max(m.width, m.height)).toBeLessThanOrEqual(32);
       expect(m.width / m.height).toBeCloseTo(80 / 60, 0);
       // Average colour: the source's mean R≈118 G≈118 B≈something — sample
-      // the centre pixel of the placeholder; ThumbHash's DC term is exact.
+      // the centre pixel of the placeholder after re-encoding as PNG so we
+      // can read raw pixels. Wide tolerance — LPQ quantisation + 4-bit AC +
+      // 1.25× chroma boost + lossy WebP on top.
       const px = decodePngRaw(await new Bun.Image(url).png().bytes());
       const cx = (px.w >> 1) + (px.h >> 1) * px.w;
-      // Wide tolerance — LPQ quantisation + 4-bit AC + 1.25× chroma boost.
-      expect(Math.abs(px.data[cx * 4] - 119)).toBeLessThan(40);
-      // Explicit "dataurl" arg accepted, anything else throws.
+      expect(Math.abs(px.data[cx * 4] - 119)).toBeLessThan(60);
+      // Explicit "dataurl" arg accepted, unknown strings throw.
       expect(await new Bun.Image(src).placeholder("dataurl")).toBe(url);
-      expect(() => new Bun.Image(src).placeholder("hash" as any)).toThrow(/dataurl/);
+      expect(() => new Bun.Image(src).placeholder("bogus" as any)).toThrow(/dataurl.*hash|hash.*dataurl/);
+    });
+
+    test('.placeholder("hash") returns raw ThumbHash bytes', async () => {
+      const src = makePng(80, 60, (x, y) => [(x * 3) & 255, (y * 4) & 255, ((x ^ y) * 7) & 255, 255]);
+      const img = new Bun.Image(src);
+      const hash = await img.placeholder("hash");
+      // ThumbHash's custom format is 5-byte header + up to 20 nibble-packed
+      // AC bytes — never more than 25 total. Padded base64 of that is ≤36
+      // chars, which is the whole point: users ship the decoder once,
+      // per-image cost is <40 bytes of text in `blurDataURL`.
+      expect(hash).toBeInstanceOf(Uint8Array);
+      expect(hash.length).toBeLessThanOrEqual(25);
+      // Pin the exact bytes so a packing-order regression can't sneak
+      // through behind the bounds check. The fixture is deterministic
+      // gradient → deterministic DCT → deterministic hash.
+      expect(Buffer.from(hash).toString("base64")).toBe("HQgKNZiAd3dxd4eHd3eGh3GQCPiI");
+      // Deterministic across instances, too.
+      const again = await new Bun.Image(src).placeholder("hash");
+      expect(again).toEqual(hash);
+      // Header's landscape bit (bit 15 of the 2-byte h16 field at offset 3)
+      // reflects w>h — source is 80×60 so landscape.
+      expect((hash[4] & 0x80) !== 0).toBe(true);
+      // Round-trip: the matching "dataurl" output is Bun's own ThumbHash
+      // decode of THESE bytes, so constructing a new Image from it must
+      // land on a ≤32px blur with the source's 4:3 aspect ratio. If the
+      // packing order drifted, the round-trip would skew.
+      const url = await new Bun.Image(src).placeholder("dataurl");
+      const m = await new Bun.Image(url).metadata();
+      expect(Math.max(m.width, m.height)).toBeLessThanOrEqual(32);
+      expect(m.width / m.height).toBeCloseTo(80 / 60, 0);
+      // `.placeholder("hash")` reports source dims so `img.width`/`img.height`
+      // aren't stuck at -1 when it's the first awaited terminal.
+      expect(img.width).toBe(80);
+      expect(img.height).toBe(60);
+    });
+
+    test('.placeholder("hash") reports true source dims even after .resize() on a JPEG', async () => {
+      // JPEG decode uses libjpeg-turbo's M/8 IDCT scaling when the
+      // pipeline has a resize hint — `decoded.width/height` become up
+      // to 8× smaller than the source. Placeholders ignore the pipeline
+      // (a placeholder is OF the source), so the hash-result dims must
+      // still report the true source size, matching `.metadata()` on
+      // the same instance.
+      const srcPng = makePng(320, 240, (x, y) => [(x * 3) & 255, (y * 4) & 255, ((x ^ y) * 7) & 255, 255]);
+      const srcJpeg = await new Bun.Image(srcPng).jpeg({ quality: 80 }).bytes();
+      // .resize(40, 30) — at 40×30 target, libjpeg picks 1/8 scaling,
+      // yielding decoded 40×30. Without the fix, img.width would report
+      // 40 instead of 320.
+      const img = new Bun.Image(srcJpeg).resize(40, 30);
+      await img.placeholder("hash");
+      expect(img.width).toBe(320);
+      expect(img.height).toBe(240);
     });
 
     test(".jpeg({progressive: true}) emits SOF2 (multi-scan)", async () => {


### PR DESCRIPTION
Closes #30198.

`Bun.Image#placeholder()` used to render the ThumbHash to a lossless PNG `data:` URL. Two complaints from #30198:

1. The PNG output is ~1.7 KB base64 for a typical image. The ThumbHash format itself is only 5-25 raw bytes (~28-34 base64 chars) — users with many images on a page would rather ship the small decoder once and pay the tiny hash per image.
2. PNG is lossless on a render that is already 4-bit-AC quantised by ThumbHash. A lossy codec at low quality will be much smaller at no visible cost.

### Changes

1. `placeholder("dataurl")` (the default) now emits `data:image/webp;base64,...` at quality 50. On the test fixture (80×60 gradient) the output drops from >1 KB to ~210 bytes. WebP wins over JPEG here because VP8 has no quantisation-table preamble and handles 32×32 smooth blurs in the single-block fast path.
2. `placeholder("hash")` is new: returns the raw ThumbHash as a `Uint8Array` (5-25 bytes). `Buffer.from(hash).toString("base64")` gives the ≤36-char form that pairs with [evanw/thumbhash]'s ~800-byte client decoder.

The existing comment on `doPlaceholder` already anticipated `"hash"` / `"color"` options so no new method was added.

### Verification

```
bun bd test test/js/bun/image/image.test.ts -t placeholder
# (pass) .placeholder() is a ThumbHash-rendered ≤32px WebP data: URL
# (pass) .placeholder("hash") returns raw ThumbHash bytes
```

Size measurements on the 80×60 test source:
- Old (PNG):  1.7 KB base64
- New (WebP):  211 bytes base64
- New (hash):   21 raw / 28 base64 chars

Gate verified fail-before/pass-after by stashing `src/` and `packages/`.
