### PR TITLE
Bun.Image: AVIF decode and encode on Linux via dlopen'd libavif

### DIFF
--- a/scripts/build/deps/index.ts
+++ b/scripts/build/deps/index.ts
@@ -56,6 +56,10 @@ export const allDeps: readonly Dependency[] = [
   libjpegTurbo,
   libspng,
   libwebp,
+  // AVIF on Linux is dlopen'd at first use (libavif.so.16 / libdav1d.so.7
+  // from the distro's packages — `apt install libavif16`), so there's no
+  // vendored build here. See src/runtime/image/codec_avif.rs and
+  // src/jsc/bindings/image_avif_shim.cpp.
   cares,
   hdrhistogram,
   highway,

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -150,6 +150,10 @@ const noUnify: readonly string[] = [
   // keeping it out of unified bundles avoids the macro pollution (`min`/`max`
   // /`ERROR`/etc.) leaking into siblings.
   "src/jsc/bindings/image_wic_shim.cpp",
+  // dlopen'd libavif loader + decode/encode wrapper. Linux-only; stubbed
+  // elsewhere. Keeping it standalone avoids the pinned avif struct layouts
+  // leaking into siblings' symbol namespaces.
+  "src/jsc/bindings/image_avif_shim.cpp",
 ];
 
 /**

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -501,9 +501,12 @@ void bun_avif_free_output(uint8_t* data)
 
 #else
 
-// Non-Linux (or Android): stub so the link succeeds. The Rust wrapper only
-// references these from inside `#[cfg(target_os = "linux")]` so they're
-// dead code on other targets, but the symbols still need definitions.
+// Non-Linux (or Android): `pub mod codec_avif` in mod.rs is gated on
+// `#[cfg(target_os = "linux")]`, so the Rust-side `extern "C"` block is
+// never compiled on other targets and nothing references these symbols.
+// Kept as belt-and-braces in case the module cfg gate is ever relaxed
+// — unlike the sibling image_coregraphics_shim / image_wic_shim stubs,
+// these are NOT currently link-required.
 #include <cstddef>
 #include <cstdint>
 extern "C" int32_t bun_avif_probe(const uint8_t*, size_t, uint64_t, uint32_t*, uint32_t*) { return 1; }

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -261,7 +261,7 @@ extern "C" {
 // same knobs. Both of libavif's pre-parse limits fire inside
 // `avifDecoderParse` *before* w/h are exposed, so if they trip the
 // rejection comes through as DecodeFailed — masking the shim's own pixel-
-// count check. We want the rejection outcome to come from codecs.guard
+// count check. We want the rejection outcome to come from codecs::guard
 // (ERR_IMAGE_TOO_MANY_PIXELS, matching jpeg/png/webp), so:
 //
 //   • `imageDimensionLimit` (default 32768 per side) → set to 0 to

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -3,8 +3,8 @@
 // function pointers so the binary has no hard dependency on libavif or its
 // codec plugins (dav1d for decode; aom/rav1e/SvtAv1Enc for encode). If the
 // user hasn't `apt install libavif16` (or equivalent), the first call
-// returns `AVIF_UNAVAILABLE` and codecs.zig surfaces
-// `error.UnsupportedOnPlatform` — the same failure mode we'd get with no
+// returns `AVIF_UNAVAILABLE` and codecs.rs surfaces
+// `Error::UnsupportedOnPlatform` — the same failure mode we'd get with no
 // static codec at all.
 //
 // Why dlopen instead of `-lavif -ldav1d -laom -...`: link-time dependencies
@@ -81,7 +81,7 @@ struct AvifImage {
     avifBool imageOwnsAlphaPlane;
     avifBool alphaPremultiplied;
     // ICC Profile — bun_avif_decode reads this post-parse and hands it to
-    // the Zig wrapper; bun_avif_encode uses the setter (avifImageSetProfileICC)
+    // the Rust wrapper; bun_avif_encode uses the setter (avifImageSetProfileICC)
     // instead of writing here directly so libavif copies the bytes under
     // its own allocator.
     AvifRwData icc;
@@ -247,8 +247,8 @@ const Syms* load()
 
 } // namespace
 
-// ── C ABI for Zig ──────────────────────────────────────────────────────────
-// Return codes mirror the CoreGraphics shim so codecs.zig's Error mapping is
+// ── C ABI for Rust ─────────────────────────────────────────────────────────
+// Return codes mirror the CoreGraphics shim so codecs.rs's Error mapping is
 // uniform across backends.
 constexpr int kAvifUnavailable = 1;
 constexpr int kAvifDecodeFailed = 2;
@@ -271,7 +271,7 @@ extern "C" {
 //     API explicitly documents that it can only be *reduced*, not
 //     raised; the header warns about uint32 arithmetic overflow at
 //     larger values. So for `maxPixels` opt-ins above 268MP the AVIF
-//     path still rejects with DecodeFailed — a known gap the Zig guard
+//     path still rejects with DecodeFailed — a known gap the Rust guard
 //     can't help with. In practice 268MP is ~16k × 16k, well above the
 //     input a Sharp-style web pipeline sees; users past that point are
 //     in "custom libavif build" territory anyway.
@@ -318,11 +318,11 @@ int32_t bun_avif_probe(const uint8_t* bytes, size_t len, uint64_t max_pixels,
 // Full decode: fill `out` (w*h*4 bytes, caller-allocated) with straight-alpha
 // RGBA8 pixels, and write the source's ICC profile (from the `colr` box)
 // into a freshly `malloc`'d buffer at `*out_icc_ptr` with `*out_icc_size`
-// bytes — `NULL`/`0` when the container had no profile. The Zig wrapper
-// re-homes those bytes into bun.default_allocator and then calls `free()`
-// on the libavif-malloc'd source.
+// bytes — `NULL`/`0` when the container had no profile. The Rust wrapper
+// copies those bytes into a global-allocator `Vec<u8>` and then calls
+// `libc::free()` on the shim's buffer.
 //
-// Two-phase: the Zig side calls this twice — once with `out=nullptr` to
+// Two-phase: the Rust side calls this twice — once with `out=nullptr` to
 // read dims from the container (so it can allocate the RGBA buffer), then
 // once with `out=buf` to run the AV1 decode + YUV→RGB into that buffer.
 // The first call stops at `avifDecoderParse` (ispe-box cheap), the second
@@ -354,7 +354,7 @@ int32_t bun_avif_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
     uint64_t pixels = static_cast<uint64_t>(img->width) * img->height;
     if (pixels > max_pixels) return kAvifTooManyPixels;
 
-    // Phase 1: just return dims so Zig can allocate.
+    // Phase 1: just return dims so Rust can allocate.
     *out_w = img->width;
     *out_h = img->height;
     if (!out) return 0;
@@ -413,7 +413,7 @@ int32_t bun_avif_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
 // If libavif has no encoder registered (a decode-only build, e.g. Alpine's
 // minimal libavif without aom/rav1e/SvtAv1Enc), `avifEncoderWrite` returns
 // AVIF_RESULT_NO_CODEC_AVAILABLE and we surface EncodeFailed. The caller
-// (Zig codecs.encode → .avif arm) maps that through to
+// (Rust codecs.encode → .avif arm) maps that through to
 // `ERR_IMAGE_ENCODE_FAILED`, which is the right contract for "the codec
 // is present but can't encode this input".
 int32_t bun_avif_encode(const uint8_t* rgba, uint32_t w, uint32_t h,
@@ -501,9 +501,9 @@ void bun_avif_free_output(uint8_t* data)
 
 #else
 
-// Non-Linux (or Android): stub so the link succeeds. Zig only calls these
-// under `Environment.isLinux and !isAndroid` so they're dead code, but LTO
-// needs the definitions.
+// Non-Linux (or Android): stub so the link succeeds. The Rust wrapper only
+// references these from inside `#[cfg(target_os = "linux")]` so they're
+// dead code on other targets, but the symbols still need definitions.
 #include <cstddef>
 #include <cstdint>
 extern "C" int32_t bun_avif_probe(const uint8_t*, size_t, uint64_t, uint32_t*, uint32_t*) { return 1; }

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -1,0 +1,514 @@
+// libavif AVIF decode + encode for Bun.Image on Linux. Pattern mirrors
+// image_coregraphics_shim.cpp: every libavif call goes through dlsym'd
+// function pointers so the binary has no hard dependency on libavif or its
+// codec plugins (dav1d for decode; aom/rav1e/SvtAv1Enc for encode). If the
+// user hasn't `apt install libavif16` (or equivalent), the first call
+// returns `AVIF_UNAVAILABLE` and codecs.zig surfaces
+// `error.UnsupportedOnPlatform` — the same failure mode we'd get with no
+// static codec at all.
+//
+// Why dlopen instead of `-lavif -ldav1d -laom -...`: link-time dependencies
+// would make bun refuse to start on any host without libavif installed
+// — e.g. most minimal Docker images — and would balloon the NEEDED list.
+// The feature is AVIF decode+encode; the cost should be paid by users who
+// actually hit that path.
+//
+// Symbol resolution stays lazy (dlsym) and scope-local (RTLD_LOCAL,
+// default), so the binary still has no libavif/libdav1d load command and
+// no aom_*/dav1d_*/svt_* symbols leak into the process-wide global scope.
+// dav1d (decode) and the AV1 encoder libavif was linked against (aom /
+// rav1e / SvtAv1Enc — distro-dependent) are loaded transitively:
+// libavif.so already links against them via DT_NEEDED, so RTLD_NOW on
+// libavif pulls them into libavif's load group where libavif's own
+// in-library `availableCodecs[]` dispatch can call them.
+//
+// Pinned struct layouts: we mirror the subset of `avifDecoder`,
+// `avifRGBImage`, `avifImage`, `avifRWData`, and `avifEncoder` we actually
+// touch, matching the 1.0.0 public ABI (which libavif's own header
+// explicitly marks stable via "Version 1.0.0 ends here." markers). Fields
+// we don't use are named `_reservedN` to make drift visible at diff-time
+// if someone ever bumps the pinned version.
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib> // malloc (ICC-profile copy in bun_avif_decode)
+#include <cstring>
+#include <dlfcn.h>
+
+namespace {
+
+// ── Pinned libavif ABI (v1.0.0, stable through 1.x) ────────────────────────
+// Only the fields we read/write are named; the rest are byte-counted reserves
+// so field offsets match the real struct. Source of truth: the `typedef
+// struct avifDecoder`/`avifRGBImage` blocks in avif.h from libavif 1.0.0.
+
+using avifBool = int;
+using avifResult = int;
+constexpr avifResult kAvifResultOk = 0;
+constexpr int kAvifRgbFormatRGBA = 1; // enum avifRGBFormat index
+constexpr uint32_t kAvifStrictPixiRequired = 1 << 0;
+// avifPixelFormat enum values from avif.h:283-290.
+constexpr int kAvifPixelFormatYuv420 = 3;
+constexpr int kAvifSpeedDefault = -1;
+
+// avifRWData — trivial pair matching avif.h:248-252. Forward-declared here
+// because `AvifImage` embeds one (for the ICC profile) and the dlsym table
+// takes a pointer to it.
+struct AvifRwData {
+    uint8_t* data;
+    size_t size;
+};
+
+// Subset of `avifImage` mirrored down through the `icc` RWData field so
+// decode() can pull the ICC profile out without going through a setter.
+// Names match the real header 1:1; the YUV/alpha pointers are opaque to us
+// but have to be laid out so the `icc` offset matches the real struct.
+// Matches the 1.0.0 stable ABI (field order frozen by libavif).
+struct AvifImage {
+    uint32_t width;
+    uint32_t height;
+    uint32_t depth;
+    int yuvFormat; // avifPixelFormat
+    int yuvRange;
+    int yuvChromaSamplePosition;
+    uint8_t* yuvPlanes[3]; // AVIF_PLANE_COUNT_YUV = 3
+    uint32_t yuvRowBytes[3];
+    avifBool imageOwnsYUVPlanes;
+    uint8_t* alphaPlane;
+    uint32_t alphaRowBytes;
+    avifBool imageOwnsAlphaPlane;
+    avifBool alphaPremultiplied;
+    // ICC Profile — bun_avif_decode reads this post-parse and hands it to
+    // the Zig wrapper; bun_avif_encode uses the setter (avifImageSetProfileICC)
+    // instead of writing here directly so libavif copies the bytes under
+    // its own allocator.
+    AvifRwData icc;
+    // ... more fields (CICP, CLLI, transform, exif/xmp, …) we don't touch.
+};
+
+// Subset of `avifDecoder` up through the "Version 1.0.0 ends here." marker.
+// Names match the real header 1:1 so drifting fields show up in review as
+// a struct edit rather than a silent offset shift.
+struct AvifDecoder {
+    int codecChoice; // avifCodecChoice
+    int maxThreads;
+    int requestedSource; // avifDecoderSource
+    avifBool allowProgressive;
+    avifBool allowIncremental;
+    avifBool ignoreExif;
+    avifBool ignoreXMP;
+    uint32_t imageSizeLimit;
+    uint32_t imageDimensionLimit;
+    uint32_t imageCountLimit;
+    uint32_t strictFlags; // avifStrictFlags
+    // Outputs
+    AvifImage* image;
+    // Trailing fields (imageIndex, imageCount, diagnostics, io, …) go here;
+    // we never read them so the struct can end.
+};
+
+// Subset of `avifRGBImage`. We zero the struct ourselves (std::memset at
+// the two call sites) before calling avifRGBImageSetDefaults — that
+// function then field-assigns every member of the *real* struct libavif
+// thinks it has (no internal memset). The trailing `_reserved[48]` is
+// there to absorb those assignments if a future same-SONAME libavif adds
+// fields after `rowBytes` (avif.h explicitly invites this with "Version
+// 1.0.0 ends here. Add any new members after this line") — without it
+// the setter would write past our stack-allocated mirror. 48 bytes
+// covers the full 1.x struct with ~40 bytes of headroom.
+struct AvifRgbImage {
+    uint32_t width;
+    uint32_t height;
+    uint32_t depth;
+    int format; // avifRGBFormat
+    int chromaUpsampling;
+    int chromaDownsampling;
+    avifBool avoidLibYUV;
+    avifBool ignoreAlpha;
+    avifBool alphaPremultiplied;
+    avifBool isFloat;
+    int maxThreads;
+    uint8_t* pixels;
+    uint32_t rowBytes;
+    uint8_t _reserved[48]; // slack for trailing 1.x fields (~8 bytes today)
+};
+
+// ── Dlsym table ────────────────────────────────────────────────────────────
+struct Syms {
+    // Decode surface
+    AvifDecoder* (*avifDecoderCreate)();
+    void (*avifDecoderDestroy)(AvifDecoder*);
+    avifResult (*avifDecoderSetIOMemory)(AvifDecoder*, const uint8_t*, size_t);
+    avifResult (*avifDecoderParse)(AvifDecoder*);
+    avifResult (*avifDecoderNextImage)(AvifDecoder*);
+    void (*avifRGBImageSetDefaults)(AvifRgbImage*, const AvifImage*);
+    avifResult (*avifImageYUVToRGB)(const AvifImage*, AvifRgbImage*);
+    // Encode surface
+    AvifImage* (*avifImageCreate)(uint32_t w, uint32_t h, uint32_t depth, int yuvFormat);
+    void (*avifImageDestroy)(AvifImage*);
+    avifResult (*avifImageRGBToYUV)(AvifImage*, const AvifRgbImage*);
+    // Attaches an ICC profile to the image before encode. libavif copies the
+    // bytes into its own allocator, so the caller can free the source right
+    // after the call returns.
+    avifResult (*avifImageSetProfileICC)(AvifImage*, const uint8_t* icc, size_t iccSize);
+    // avifEncoder is declared `void*` here because its mirror struct lives
+    // further down; bun_avif_encode() reinterpret_casts the create() return
+    // and writes quality/speed/etc. directly. Same ABI-pinned-mirror bucket
+    // as AvifDecoder / AvifRgbImage — not truly opaque.
+    void* (*avifEncoderCreate)();
+    void (*avifEncoderDestroy)(void*);
+    avifResult (*avifEncoderWrite)(void*, const AvifImage*, AvifRwData*);
+    void (*avifRWDataFree)(AvifRwData*);
+};
+
+#define SYM(x) { offsetof(Syms, x), #x }
+constexpr struct {
+    size_t off;
+    const char* name;
+} kFields[] = {
+    SYM(avifDecoderCreate),
+    SYM(avifDecoderDestroy),
+    SYM(avifDecoderSetIOMemory),
+    SYM(avifDecoderParse),
+    SYM(avifDecoderNextImage),
+    SYM(avifRGBImageSetDefaults),
+    SYM(avifImageYUVToRGB),
+    SYM(avifImageCreate),
+    SYM(avifImageDestroy),
+    SYM(avifImageRGBToYUV),
+    SYM(avifImageSetProfileICC),
+    SYM(avifEncoderCreate),
+    SYM(avifEncoderDestroy),
+    SYM(avifEncoderWrite),
+    SYM(avifRWDataFree),
+};
+#undef SYM
+
+// Subset of `avifEncoder` — only the fields we set before calling
+// avifEncoderWrite. Layout matches avif.h's `typedef struct avifEncoder`
+// from line 1507. Same 1.0.0-stable pin rationale as AvifDecoder above.
+struct AvifEncoder {
+    int codecChoice;
+    int maxThreads;
+    int speed;
+    int keyframeInterval;
+    uint64_t timescale;
+    int repetitionCount;
+    uint32_t extraLayerCount;
+    int quality;
+    int qualityAlpha;
+    int minQuantizer;
+    int maxQuantizer;
+    int minQuantizerAlpha;
+    int maxQuantizerAlpha;
+    int tileRowsLog2;
+    int tileColsLog2;
+    avifBool autoTiling;
+    // scalingMode (avifScalingMode = { avifFraction horizontal; avifFraction vertical; }
+    // where avifFraction = { int32_t n; int32_t d }) → 16 bytes.
+    uint8_t scalingMode[16];
+    // Trailing fields (ioStats, diag, data, csOptions, …) — unused.
+};
+
+// Debian/Ubuntu/Fedora/Alpine all ship libavif.so.16 (1.0+); libavif.so.15
+// (0.11), libavif.so.14 (0.10.x), libavif.so.13 (0.9) were in older LTS
+// releases. Our pinned struct layout matches 1.0+, so we only claim 16; if
+// a user is on 0.x the decoder just stays unavailable.
+const Syms* load()
+{
+    static const Syms* table = []() -> const Syms* {
+        static Syms s {};
+        // RTLD_NOW so libavif's own NEEDED entries (libdav1d plus the
+        // AV1 encoder libs) are resolved eagerly — we never dlsym them
+        // directly, but libavif does and we want the "is the decoder
+        // usable" question answered at load time, not on the first
+        // decode().
+        // Default scope (RTLD_LOCAL) on purpose: libavif's codec dispatch
+        // is an in-library `availableCodecs[]` table with direct function
+        // pointers, not dlopen(NULL) + dlsym, so DT_NEEDED resolution
+        // within libavif's own load group is enough. RTLD_GLOBAL would
+        // additionally promote hundreds of aom_*/dav1d_*/svt_* symbols
+        // into the process-wide scope and invite version-skew collisions
+        // with native addons bundling their own copies.
+        void* lib = dlopen("libavif.so.16", RTLD_NOW);
+        if (!lib) return nullptr;
+        auto base = reinterpret_cast<char*>(&s);
+        for (auto& f : kFields) {
+            void* p = dlsym(lib, f.name);
+            if (!p) return nullptr;
+            *reinterpret_cast<void**>(base + f.off) = p;
+        }
+        return &s;
+    }();
+    return table;
+}
+
+} // namespace
+
+// ── C ABI for Zig ──────────────────────────────────────────────────────────
+// Return codes mirror the CoreGraphics shim so codecs.zig's Error mapping is
+// uniform across backends.
+constexpr int kAvifUnavailable = 1;
+constexpr int kAvifDecodeFailed = 2;
+constexpr int kAvifEncodeFailed = 3;
+constexpr int kAvifTooManyPixels = 4; // match CG_TOO_MANY_PIXELS
+
+extern "C" {
+
+// Common decoder setup. Split out so probe() and decode() apply the exact
+// same knobs. Both of libavif's pre-parse limits fire inside
+// `avifDecoderParse` *before* w/h are exposed, so if they trip the
+// rejection comes through as DecodeFailed — masking the shim's own pixel-
+// count check. We want the rejection outcome to come from codecs.guard
+// (ERR_IMAGE_TOO_MANY_PIXELS, matching jpeg/png/webp), so:
+//
+//   • `imageDimensionLimit` (default 32768 per side) → set to 0 to
+//     disable. Panoramas/wide UI banners can legitimately cross 32768
+//     on one side while staying under the total-pixel cap.
+//   • `imageSizeLimit` (default 16384² = 268MP) → left at default. The
+//     API explicitly documents that it can only be *reduced*, not
+//     raised; the header warns about uint32 arithmetic overflow at
+//     larger values. So for `maxPixels` opt-ins above 268MP the AVIF
+//     path still rejects with DecodeFailed — a known gap the Zig guard
+//     can't help with. In practice 268MP is ~16k × 16k, well above the
+//     input a Sharp-style web pipeline sees; users past that point are
+//     in "custom libavif build" territory anyway.
+static void configureDecoder(AvifDecoder* dec)
+{
+    dec->maxThreads = 1;
+    dec->ignoreExif = 1;
+    dec->ignoreXMP = 1;
+    dec->strictFlags &= ~kAvifStrictPixiRequired;
+    dec->imageDimensionLimit = 0;
+}
+
+// Probe: fill out_w/out_h from the AVIF container header. No AV1 decode.
+int32_t bun_avif_probe(const uint8_t* bytes, size_t len, uint64_t max_pixels,
+    uint32_t* out_w, uint32_t* out_h)
+{
+    auto s = load();
+    if (!s) return kAvifUnavailable;
+
+    AvifDecoder* dec = s->avifDecoderCreate();
+    if (!dec) return kAvifDecodeFailed;
+    struct R {
+        const Syms* s;
+        AvifDecoder* d;
+        ~R() { s->avifDecoderDestroy(d); }
+    } r { s, dec };
+
+    configureDecoder(dec);
+
+    if (s->avifDecoderSetIOMemory(dec, bytes, len) != kAvifResultOk) return kAvifDecodeFailed;
+    if (s->avifDecoderParse(dec) != kAvifResultOk) return kAvifDecodeFailed;
+
+    AvifImage* img = dec->image;
+    if (!img || img->width == 0 || img->height == 0) return kAvifDecodeFailed;
+
+    uint64_t pixels = static_cast<uint64_t>(img->width) * img->height;
+    if (pixels > max_pixels) return kAvifTooManyPixels;
+
+    *out_w = img->width;
+    *out_h = img->height;
+    return 0;
+}
+
+// Full decode: fill `out` (w*h*4 bytes, caller-allocated) with straight-alpha
+// RGBA8 pixels, and write the source's ICC profile (from the `colr` box)
+// into a freshly `malloc`'d buffer at `*out_icc_ptr` with `*out_icc_size`
+// bytes — `NULL`/`0` when the container had no profile. The Zig wrapper
+// re-homes those bytes into bun.default_allocator and then calls `free()`
+// on the libavif-malloc'd source.
+//
+// Two-phase: the Zig side calls this twice — once with `out=nullptr` to
+// read dims from the container (so it can allocate the RGBA buffer), then
+// once with `out=buf` to run the AV1 decode + YUV→RGB into that buffer.
+// The first call stops at `avifDecoderParse` (ispe-box cheap), the second
+// runs `avifDecoderNextImage` + `avifImageYUVToRGB`. Cheap to re-create
+// the decoder relative to the AV1 decode itself.
+int32_t bun_avif_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
+    uint32_t* out_w, uint32_t* out_h, uint8_t* out,
+    uint8_t** out_icc_ptr, size_t* out_icc_size)
+{
+    auto s = load();
+    if (!s) return kAvifUnavailable;
+
+    AvifDecoder* dec = s->avifDecoderCreate();
+    if (!dec) return kAvifDecodeFailed;
+    struct R {
+        const Syms* s;
+        AvifDecoder* d;
+        ~R() { s->avifDecoderDestroy(d); }
+    } r { s, dec };
+
+    configureDecoder(dec);
+
+    if (s->avifDecoderSetIOMemory(dec, bytes, len) != kAvifResultOk) return kAvifDecodeFailed;
+    if (s->avifDecoderParse(dec) != kAvifResultOk) return kAvifDecodeFailed;
+
+    AvifImage* img = dec->image;
+    if (!img || img->width == 0 || img->height == 0) return kAvifDecodeFailed;
+
+    uint64_t pixels = static_cast<uint64_t>(img->width) * img->height;
+    if (pixels > max_pixels) return kAvifTooManyPixels;
+
+    // Phase 1: just return dims so Zig can allocate.
+    *out_w = img->width;
+    *out_h = img->height;
+    if (!out) return 0;
+
+    if (s->avifDecoderNextImage(dec) != kAvifResultOk) return kAvifDecodeFailed;
+
+    // Belt-and-braces: libavif's single-tile non-grid path can overwrite
+    // `decoder->image->width/height` with the AV1-stream dims during
+    // NextImage (via avifImageStealPlanes). The `pixels > max_pixels`
+    // check above and the *out_w/*out_h capture both saw the
+    // pre-NextImage ispe values, so a hostile AVIF with a small ispe box
+    // but a larger AV1 OBU stream would pass both checks and then have
+    // avifImageYUVToRGB write the post-NextImage extent into a buffer
+    // sized for the ispe extent. Re-check here before the write runs.
+    if (img->width != *out_w || img->height != *out_h) return kAvifDecodeFailed;
+
+    AvifRgbImage rgb;
+    std::memset(&rgb, 0, sizeof(rgb));
+    s->avifRGBImageSetDefaults(&rgb, img);
+    rgb.depth = 8;
+    rgb.format = kAvifRgbFormatRGBA;
+    rgb.maxThreads = 1;
+    rgb.alphaPremultiplied = 0;
+    rgb.pixels = out;
+    rgb.rowBytes = img->width * 4;
+    if (s->avifImageYUVToRGB(img, &rgb) != kAvifResultOk) return kAvifDecodeFailed;
+
+    // Copy out the ICC profile if one was present. The decoder owns
+    // `img->icc.data` (it's freed by avifDecoderDestroy when the RAII
+    // guard above fires), so hand the caller a separate malloc'd buffer —
+    // matches the ownership contract for the RGBA buffer.
+    *out_icc_ptr = nullptr;
+    *out_icc_size = 0;
+    if (img->icc.data != nullptr && img->icc.size > 0) {
+        uint8_t* icc_copy = static_cast<uint8_t*>(std::malloc(img->icc.size));
+        if (icc_copy == nullptr) {
+            // Pixels are already filled in; treat an ICC OOM as "no profile"
+            // rather than failing the whole decode — jpeg/png do the same.
+            return 0;
+        }
+        std::memcpy(icc_copy, img->icc.data, img->icc.size);
+        *out_icc_ptr = icc_copy;
+        *out_icc_size = img->icc.size;
+    }
+    return 0;
+}
+
+// Encode RGBA8 → AVIF bitstream. YUV420 + 8-bit depth + straight alpha —
+// the subsampling/depth combo distros' libavif reliably supports across
+// every bundled encoder (aom / rav1e / SVT-AV1). Quality is libavif's
+// native 0-100 scale (0 = worst, 100 = best); whatever encoder libavif
+// picks at runtime honours it natively. On success, `*out_data` points at
+// a libavif-malloc'd buffer that the caller must free via
+// `bun_avif_free_output`; `*out_size` is its length.
+//
+// If libavif has no encoder registered (a decode-only build, e.g. Alpine's
+// minimal libavif without aom/rav1e/SvtAv1Enc), `avifEncoderWrite` returns
+// AVIF_RESULT_NO_CODEC_AVAILABLE and we surface EncodeFailed. The caller
+// (Zig codecs.encode → .avif arm) maps that through to
+// `ERR_IMAGE_ENCODE_FAILED`, which is the right contract for "the codec
+// is present but can't encode this input".
+int32_t bun_avif_encode(const uint8_t* rgba, uint32_t w, uint32_t h,
+    int quality, const uint8_t* icc, size_t icc_size,
+    uint8_t** out_data, size_t* out_size)
+{
+    auto s = load();
+    if (!s) return kAvifUnavailable;
+
+    // Build an empty 8-bit YUV420 image at the caller's dimensions.
+    AvifImage* img = s->avifImageCreate(w, h, 8, kAvifPixelFormatYuv420);
+    if (!img) return kAvifEncodeFailed;
+    struct RImg {
+        const Syms* s;
+        AvifImage* i;
+        ~RImg() { s->avifImageDestroy(i); }
+    } rimg { s, img };
+
+    // Attach the source ICC profile before encode so it lands in the
+    // output's `colr` box. libavif copies the bytes into its own allocator,
+    // so the caller can free `icc` right after this returns. A non-zero
+    // return here means the profile allocation failed inside libavif —
+    // drop it rather than fail the encode; an AVIF without a profile is
+    // still valid (implicitly sRGB via CICP). Same contract as jpeg/png.
+    if (icc != nullptr && icc_size > 0) {
+        (void)s->avifImageSetProfileICC(img, icc, icc_size);
+    }
+
+    // Feed in the straight-alpha RGBA8 source. libavif allocates the YUV+A
+    // planes itself during avifImageRGBToYUV.
+    AvifRgbImage rgb;
+    std::memset(&rgb, 0, sizeof(rgb));
+    s->avifRGBImageSetDefaults(&rgb, img);
+    rgb.depth = 8;
+    rgb.format = kAvifRgbFormatRGBA;
+    rgb.maxThreads = 1;
+    rgb.alphaPremultiplied = 0;
+    rgb.pixels = const_cast<uint8_t*>(rgba); // avifRGBImage.pixels is non-const in the header; we never write
+    rgb.rowBytes = w * 4;
+    if (s->avifImageRGBToYUV(img, &rgb) != kAvifResultOk) return kAvifEncodeFailed;
+
+    AvifEncoder* enc = reinterpret_cast<AvifEncoder*>(s->avifEncoderCreate());
+    if (!enc) return kAvifEncodeFailed;
+    struct REnc {
+        const Syms* s;
+        AvifEncoder* e;
+        ~REnc() { s->avifEncoderDestroy(e); }
+    } renc { s, enc };
+
+    // Single-threaded on purpose: Bun.Image runs on WorkPool and each task
+    // already owns a job slot, so multi-threaded AV1 encode inside a single
+    // slot would oversubscribe. autoTiling would pick 1×1 tiles at
+    // maxThreads=1 anyway, so it's left at the avifEncoderCreate default.
+    enc->maxThreads = 1;
+    enc->quality = quality;
+    enc->qualityAlpha = quality;
+    enc->speed = kAvifSpeedDefault; // defer to whichever encoder; rav1e/aom both have reasonable defaults
+    // The remaining (deprecated) quantizer fields stay at avifEncoderCreate's
+    // defaults — libavif derives them from `quality` when left alone.
+
+    AvifRwData output { nullptr, 0 };
+    if (s->avifEncoderWrite(enc, img, &output) != kAvifResultOk) {
+        s->avifRWDataFree(&output);
+        return kAvifEncodeFailed;
+    }
+    *out_data = output.data;
+    *out_size = output.size;
+    return 0;
+}
+
+// Matches bun_avif_encode's output lifetime. Wraps libavif's own
+// allocator-aware deallocator so encode() can hand the buffer straight to
+// JS via ArrayBuffer.toJSWithContext without a dupe — same ownership
+// pattern as WebPFree / tj3Free.
+void bun_avif_free_output(uint8_t* data)
+{
+    if (!data) return;
+    auto s = load();
+    if (!s) return;
+    AvifRwData d { data, 0 };
+    s->avifRWDataFree(&d);
+}
+
+} // extern "C"
+
+#else
+
+// Non-Linux (or Android): stub so the link succeeds. Zig only calls these
+// under `Environment.isLinux and !isAndroid` so they're dead code, but LTO
+// needs the definitions.
+#include <cstddef>
+#include <cstdint>
+extern "C" int32_t bun_avif_probe(const uint8_t*, size_t, uint64_t, uint32_t*, uint32_t*) { return 1; }
+extern "C" int32_t bun_avif_decode(const uint8_t*, size_t, uint64_t, uint32_t*, uint32_t*, uint8_t*, uint8_t**, size_t*) { return 1; }
+extern "C" int32_t bun_avif_encode(const uint8_t*, uint32_t, uint32_t, int, const uint8_t*, size_t, uint8_t**, size_t*) { return 1; }
+extern "C" void bun_avif_free_output(uint8_t*) {}
+
+#endif

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -391,9 +391,11 @@ int32_t bun_avif_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
     if (img->icc.data != nullptr && img->icc.size > 0) {
         uint8_t* icc_copy = static_cast<uint8_t*>(std::malloc(img->icc.size));
         if (icc_copy == nullptr) {
-            // Pixels are already filled in; treat an ICC OOM as "no profile"
-            // rather than failing the whole decode — jpeg/png do the same.
-            return 0;
+            // Don't degrade to "no profile": that silently reinterprets
+            // P3/Adobe RGB pixels as sRGB (#30197). Fail the decode, the
+            // same refusal-to-swallow the sibling codecs apply to the ICC
+            // dupe.
+            return kAvifDecodeFailed;
         }
         std::memcpy(icc_copy, img->icc.data, img->icc.size);
         *out_icc_ptr = icc_copy;

--- a/src/jsc/bindings/image_avif_shim.cpp
+++ b/src/jsc/bindings/image_avif_shim.cpp
@@ -505,8 +505,8 @@ void bun_avif_free_output(uint8_t* data)
 // `#[cfg(target_os = "linux")]`, so the Rust-side `extern "C"` block is
 // never compiled on other targets and nothing references these symbols.
 // Kept as belt-and-braces in case the module cfg gate is ever relaxed
-// — unlike the sibling image_coregraphics_shim / image_wic_shim stubs,
-// these are NOT currently link-required.
+// — unlike the sibling image_wic_shim stubs (`backend_wic` is compiled
+// on every target), these are NOT currently link-required.
 #include <cstddef>
 #include <cstdint>
 extern "C" int32_t bun_avif_probe(const uint8_t*, size_t, uint64_t, uint32_t*, uint32_t*) { return 1; }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -938,6 +938,21 @@ impl Image {
         // in memory it's cheaper to do it inline than to bounce off the WorkPool
         // (~0.4 ms roundtrip). Path-backed sources still go async for the file I/O.
         if let Some(buf) = self.js_thread_bytes(callframe.this(), global) {
+            // AVIF's probe is via dlopen'd libavif — the first call triggers
+            // a synchronous `dlopen("libavif.so.16", RTLD_NOW)` that also
+            // eagerly resolves dav1d + aom/rav1e/SvtAv1Enc. Doing that on
+            // the JS thread would stall the event loop on first use; force
+            // AVIF through the async path even with inline bytes. JPEG/PNG/
+            // WebP/BMP/GIF probes are pure Rust and stay sync.
+            // `Format::sniff` is just byte reads.
+            if codecs::Format::sniff(buf) == Some(codecs::Format::Avif) {
+                return self.schedule(
+                    global,
+                    callframe.this(),
+                    Kind::Metadata,
+                    Deliver::Uint8Array,
+                );
+            }
             match codecs::probe(buf, self.max_pixels) {
                 Ok(p) => {
                     let mut w = p.width;
@@ -963,7 +978,9 @@ impl Image {
                     );
                     return Ok(JSPromise::resolved_promise_value(global, obj));
                 }
-                // HEIC/AVIF need the system backend → fall through to async.
+                // HEIC/TIFF need the system backend → fall through to async.
+                // AVIF was diverted to async above via the pre-sniff, so it
+                // never reaches this arm.
                 Err(codecs::Error::UnsupportedOnPlatform) => {}
                 Err(e) => {
                     return Ok(JSPromise::rejected_promise(global, reject_error(global, e))
@@ -1644,8 +1661,10 @@ impl PipelineTask {
                     };
                     return;
                 }
-                // HEIC/AVIF have no header probe — fall through to full decode
-                // via the system backend.
+                // HEIC/TIFF have no header probe — fall through to full
+                // decode via the system backend. AVIF goes this route too
+                // on hosts without libavif.so.16 (the dlopen'd probe path
+                // returns UnsupportedOnPlatform there).
                 Err(codecs::Error::UnsupportedOnPlatform) => {}
                 Err(e) => {
                     self.result = TaskResult::Err(e);
@@ -1704,7 +1723,9 @@ impl PipelineTask {
         }
 
         if matches!(self.kind, Kind::Metadata) {
-            // Reached only for HEIC/AVIF (probe fell through).
+            // Reached for HEIC/TIFF (and AVIF on hosts without libavif's
+            // header probe) — the cheap probe() fell through so we're
+            // reading dims out of the full decode.
             self.result = TaskResult::Meta {
                 w: decoded.width,
                 h: decoded.height,
@@ -1748,7 +1769,9 @@ impl PipelineTask {
         // method). The pipeline doesn't colour-convert the RGBA, so dropping
         // the profile reinterprets a non-sRGB source (Display-P3, Adobe RGB,
         // Jpegli XYB) as sRGB and visibly shifts the colours — see #30197.
-        // JPEG/PNG/WebP embed it; HEIC/AVIF via the system backend do not.
+        // JPEG/PNG/WebP embed it; AVIF on Linux via the dlopen'd libavif
+        // embeds it too (avifImageSetProfileICC). HEIC via the system
+        // backend, and AVIF via the system backend, currently do not.
         if enc.icc_profile.is_none() {
             // `EncodeOptions.icc_profile` borrows for the duration of `encode()`
             // (raw `NonNull<[u8]>`); `decoded` outlives the call below.

--- a/src/runtime/image/README.md
+++ b/src/runtime/image/README.md
@@ -5,24 +5,35 @@ off the JS thread.
 
 ## Layout
 
-| file                                  | owns                                                                                                            | touch when                               |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `Image.classes.ts`                    | JS surface (codegen input)                                                                                      | adding/renaming a JS method              |
-| `Image.rs`                            | JS↔native glue: arg parsing, op recording, `ConcurrentPromiseTask` scheduling, result delivery                 | new options, new chainable, new terminal |
-| `codecs.rs`                           | thin `extern fn` wrappers over libjpeg-turbo / libspng / libwebp + the `Format` sniffer + the pixel-limit guard | bumping a codec, adding a format         |
-| `exif.rs`                             | JPEG APP1/TIFF Orientation reader (tag 0x0112 only)                                                             | extending EXIF coverage                  |
-| `quantize.rs`                         | median-cut RGBA → palette for `png({palette})`                                                                  | dithering, perceptual weighting          |
-| `backend_coregraphics.rs`             | macOS ImageIO/CoreGraphics, lazy `dlopen`                                                                       | macOS-specific behaviour                 |
-| `backend_wic.rs`                      | Windows WIC, COM                                                                                                | Windows-specific behaviour               |
-| `../bun.js/bindings/image_resize.cpp` | highway resize/rotate/flip/modulate kernels (`bun_image_*` C ABI)                                               | new filter, perf work                    |
+| file                                     | owns                                                                                                            | touch when                               |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `Image.classes.ts`                       | JS surface (codegen input)                                                                                      | adding/renaming a JS method              |
+| `Image.rs`                               | JS↔native glue: arg parsing, op recording, `ConcurrentPromiseTask` scheduling, result delivery                 | new options, new chainable, new terminal |
+| `codecs.rs`                              | thin `extern fn` wrappers over libjpeg-turbo / libspng / libwebp + the `Format` sniffer + the pixel-limit guard | bumping a codec, adding a format         |
+| `codec_avif.rs`                          | Rust wrapper over `bun_avif_*` in `image_avif_shim.cpp`. Linux only.                                            | bumping pinned libavif ABI               |
+| `exif.rs`                                | JPEG APP1/TIFF Orientation reader (tag 0x0112 only)                                                             | extending EXIF coverage                  |
+| `quantize.rs`                            | median-cut RGBA → palette for `png({palette})`                                                                  | dithering, perceptual weighting          |
+| `backend_coregraphics.rs`                | macOS ImageIO/CoreGraphics, lazy `dlopen`                                                                       | macOS-specific behaviour                 |
+| `backend_wic.rs`                         | Windows WIC, COM                                                                                                | Windows-specific behaviour               |
+| `../bun.js/bindings/image_resize.cpp`    | highway resize/rotate/flip/modulate kernels (`bun_image_*` C ABI)                                               | new filter, perf work                    |
+| `../bun.js/bindings/image_avif_shim.cpp` | dlopen'd libavif.so.16 loader + decode/encode wrapper; pinned v1.0.0 struct layout                              | libavif ABI bumps                        |
 
 `system_backend` in `codecs.rs` is a cfg-gated module re-export — absent on Linux (callers gate on `HAS_SYSTEM_BACKEND`), so the dispatch
 compiles away. On macOS/Windows the backend is tried first; it returns
 a `BackendUnavailable` error for anything it can't do (palette PNG, lossless
 WebP, dlopen miss) and the static path takes over.
 
-The codecs themselves are vendored via `scripts/build/deps/{libjpeg-turbo,libspng,libwebp}.ts`.
-`patches/libjpeg-turbo/` carries the 8-bit-only patch + the j12/j16 stub overlay.
+The JPEG/PNG/WebP codecs are vendored and statically linked via
+`scripts/build/deps/{libjpeg-turbo,libspng,libwebp}.ts`; `patches/libjpeg-turbo/`
+carries the 8-bit-only patch + the j12/j16 stub overlay. AVIF is different:
+`image_avif_shim.cpp` dlopens `libavif.so.16` at first use and dlsyms the
+decoder + encoder entry points, so bun has no link-time dependency on
+libavif/dav1d — the feature works only where the distro ships those packages
+(Debian trixie+, Ubuntu 24.04+, Fedora 39+, Alpine 3.20+) and falls back to
+`ERR_IMAGE_FORMAT_UNSUPPORTED` everywhere else. Encode uses whichever AV1
+encoder libavif was linked against (aom / rav1e / SvtAv1Enc); a decode-only
+libavif build surfaces `ERR_IMAGE_ENCODE_FAILED`. macOS/Windows decode and
+encode AVIF via their respective system backends.
 
 ## Adding a chainable op
 

--- a/src/runtime/image/README.md
+++ b/src/runtime/image/README.md
@@ -15,8 +15,8 @@ off the JS thread.
 | `quantize.rs`                            | median-cut RGBA → palette for `png({palette})`                                                                  | dithering, perceptual weighting          |
 | `backend_coregraphics.rs`                | macOS ImageIO/CoreGraphics, lazy `dlopen`                                                                       | macOS-specific behaviour                 |
 | `backend_wic.rs`                         | Windows WIC, COM                                                                                                | Windows-specific behaviour               |
-| `../bun.js/bindings/image_resize.cpp`    | highway resize/rotate/flip/modulate kernels (`bun_image_*` C ABI)                                               | new filter, perf work                    |
-| `../bun.js/bindings/image_avif_shim.cpp` | dlopen'd libavif.so.16 loader + decode/encode wrapper; pinned v1.0.0 struct layout                              | libavif ABI bumps                        |
+| `../../jsc/bindings/image_resize.cpp`    | highway resize/rotate/flip/modulate kernels (`bun_image_*` C ABI)                                               | new filter, perf work                    |
+| `../../jsc/bindings/image_avif_shim.cpp` | dlopen'd libavif.so.16 loader + decode/encode wrapper; pinned v1.0.0 struct layout                              | libavif ABI bumps                        |
 
 `system_backend` in `codecs.rs` is a cfg-gated module re-export — absent on Linux (callers gate on `HAS_SYSTEM_BACKEND`), so the dispatch
 compiles away. On macOS/Windows the backend is tried first; it returns

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -171,18 +171,18 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
         return Err(codecs::Error::DecodeFailed);
     }
 
-    // Fallible alloc — match jpeg/png/webp: ~1 GiB ceiling via `max_pixels`
-    // enforced by the shim already, but a hostile 16k×16k input still asks
-    // for a 1 GiB RGBA. Let the OOM propagate instead of aborting.
+    // Fallible alloc — ~1 GiB ceiling via `max_pixels` is enforced by the
+    // shim already, but a hostile 16k×16k input still asks for a 1 GiB
+    // RGBA. `vec![0u8; n]` aborts on OOM, so split into a fallible reserve
+    // + zero-fill resize: same observable bytes as the sibling codecs
+    // (see `codec_jpeg.rs`'s PERF(port) note about zero-init), but OOM
+    // propagates instead of aborting the process.
     let pixels = usize::try_from(w).expect("int cast") * usize::try_from(h).expect("int cast") * 4;
     let mut out: Vec<u8> = Vec::new();
     if out.try_reserve_exact(pixels).is_err() {
         return Err(codecs::Error::OutOfMemory);
     }
-    // SAFETY: `try_reserve_exact` guarantees capacity ≥ pixels and the Vec
-    // is empty; set_len is safe because the shim will fill every byte on
-    // success (and we discard the Vec on error before observing contents).
-    unsafe { out.set_len(pixels) };
+    out.resize(pixels, 0);
 
     let mut w2: u32 = 0;
     let mut h2: u32 = 0;

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -79,8 +79,9 @@ fn map_encode_err(rc: i32) -> codecs::Error {
     }
 }
 
-/// RAII wrapper that frees a libc-malloc'd ICC buffer on drop unless
-/// `take()` is called first. Null-safe.
+/// RAII wrapper that frees a libc-malloc'd ICC buffer on drop. Null-safe.
+/// `into_owned()` copies the bytes into a `Vec<u8>` before `Drop` fires,
+/// so callers never have to call `libc::free` directly.
 struct IccBuf {
     ptr: *mut u8,
     size: usize,
@@ -204,7 +205,7 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
         AVIF_OK => {}
         // At this call site `max_pixels` is the phase-1 alloc bound, not
         // the user's `maxPixels` — TooManyPixels firing here means a
-        // hostile larger-swap, which `pinForTask`'s invariant (and the
+        // hostile larger-swap, which `pin_for_task`'s invariant (and the
         // sibling codec_jpeg/codec_webp) surface as DecodeFailed. Remap.
         AVIF_TOO_MANY_PIXELS => return Err(codecs::Error::DecodeFailed),
         _ => return Err(map_decode_err(rc)),

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -1,0 +1,311 @@
+//! AVIF decode + encode for `Bun.Image` on Linux, via libavif + libdav1d (and
+//! whichever AV1 encoder the distro bundled — typically aom, rav1e, and/or
+//! SVT-AV1) loaded at runtime. Dispatch lives in codecs.rs; this file is a
+//! thin Rust-side wrapper over `image_avif_shim.cpp` — the shim does the
+//! dlopen, holds the dlsym table, and speaks libavif's ABI. If libavif isn't
+//! installed the shim returns `AVIF_UNAVAILABLE` and we surface
+//! `Error::UnsupportedOnPlatform` (same contract as a mac/win system-backend
+//! miss); if libavif is present but has no registered encoder (rare — an
+//! explicit decode-only build), encode fails as `EncodeFailed`.
+//!
+//! macOS and Windows continue to use the OS codec (ImageIO/WIC) via
+//! `backend_*` — see `codecs.rs`'s dispatch for how the two paths combine.
+
+use core::ffi::{c_int, c_void};
+use core::ptr::NonNull;
+
+use super::codecs;
+use crate::encoded_wrap_free;
+
+const AVIF_OK: i32 = 0;
+const AVIF_UNAVAILABLE: i32 = 1;
+// AVIF_DECODE_FAILED = 2 / AVIF_ENCODE_FAILED = 3 fall through the `else` arms.
+const AVIF_TOO_MANY_PIXELS: i32 = 4;
+
+// `bun_avif_*` live in src/jsc/bindings/image_avif_shim.cpp. Return codes:
+//   0                    → success
+//   AVIF_UNAVAILABLE     → libavif.so.16 not installed or dlsym missed a
+//                          required symbol; surface UnsupportedOnPlatform
+//                          (same as a mac/win system-backend miss).
+//   AVIF_DECODE_FAILED   → libavif's own decode error; surface DecodeFailed.
+//   AVIF_ENCODE_FAILED   → libavif's own encode error (also used for "no
+//                          codec registered"); surface EncodeFailed.
+//   AVIF_TOO_MANY_PIXELS → the shim's pre-decode pixel guard fired; map to
+//                          TooManyPixels so callers get the same error code
+//                          jpeg/png/webp produce.
+unsafe extern "C" {
+    fn bun_avif_probe(
+        bytes: *const u8,
+        len: usize,
+        max_pixels: u64,
+        out_w: *mut u32,
+        out_h: *mut u32,
+    ) -> i32;
+    fn bun_avif_decode(
+        bytes: *const u8,
+        len: usize,
+        max_pixels: u64,
+        out_w: *mut u32,
+        out_h: *mut u32,
+        out: *mut u8, // nullable
+        out_icc_ptr: *mut *mut u8,
+        out_icc_size: *mut usize,
+    ) -> i32;
+    fn bun_avif_encode(
+        rgba: *const u8,
+        w: u32,
+        h: u32,
+        quality: c_int,
+        icc: *const u8, // nullable
+        icc_size: usize,
+        out_data: *mut *mut u8,
+        out_size: *mut usize,
+    ) -> i32;
+    fn bun_avif_free_output(data: *mut c_void);
+}
+
+// libc `free()` for the malloc'd ICC buffer the shim hands us.
+unsafe extern "C" {
+    fn free(p: *mut c_void);
+}
+
+fn map_decode_err(rc: i32) -> codecs::Error {
+    match rc {
+        AVIF_UNAVAILABLE => codecs::Error::UnsupportedOnPlatform,
+        AVIF_TOO_MANY_PIXELS => codecs::Error::TooManyPixels,
+        _ => codecs::Error::DecodeFailed,
+    }
+}
+
+fn map_encode_err(rc: i32) -> codecs::Error {
+    match rc {
+        AVIF_UNAVAILABLE => codecs::Error::UnsupportedOnPlatform,
+        _ => codecs::Error::EncodeFailed,
+    }
+}
+
+/// RAII wrapper that frees a libc-malloc'd ICC buffer on drop unless
+/// `take()` is called first. Null-safe.
+struct IccBuf {
+    ptr: *mut u8,
+    size: usize,
+}
+
+impl IccBuf {
+    fn new() -> Self {
+        Self {
+            ptr: core::ptr::null_mut(),
+            size: 0,
+        }
+    }
+
+    /// Copy the bytes into a `Vec<u8>` (global allocator) and leave the
+    /// libc buffer to be freed by `Drop`. Returns `None` if the buffer is
+    /// empty or allocation fails.
+    fn into_owned(self) -> Option<Vec<u8>> {
+        if self.ptr.is_null() || self.size == 0 {
+            return None;
+        }
+        // SAFETY: the shim's allocation is exactly `self.size` bytes at `self.ptr`;
+        // we copy them out before `Drop` frees the source.
+        let slice: &[u8] = unsafe { core::slice::from_raw_parts(self.ptr, self.size) };
+        // Fallible alloc — an OOM dropping the profile is fine (AVIF without
+        // ICC is still valid, implicitly sRGB via CICP), same as jpeg/png.
+        let mut v: Vec<u8> = Vec::new();
+        if v.try_reserve_exact(self.size).is_err() {
+            return None;
+        }
+        v.extend_from_slice(slice);
+        Some(v)
+    }
+}
+
+impl Drop for IccBuf {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: the shim allocates via std::malloc; free() is the matching deallocator.
+            unsafe { free(self.ptr.cast::<c_void>()) };
+        }
+    }
+}
+
+pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
+    // Two-phase so the output buffer can live in the global allocator
+    // (matches jpeg/png/webp ownership contract): phase 1 runs
+    // `avifDecoderParse` and returns dims; phase 2 runs the AV1 decode and
+    // fills the caller-provided buffer. The shim re-opens the decoder
+    // between phases, which is cheap relative to the AV1 decode itself.
+    //
+    // `bytes` is a borrowed view of a JS ArrayBuffer the user can still
+    // WRITE (the pin only blocks detach), so a hostile caller can swap in
+    // a different AVIF between the two parses. Phase 1 sizes the
+    // allocation from the first ispe; phase 2 parses again on the
+    // (possibly mutated) bytes and would happily write `w₂·h₂·4` bytes
+    // into the `w₁·h₁·4` alloc if unchecked. Harden the same way
+    // codec_jpeg/codec_webp do: tell phase 2 to refuse anything larger
+    // than phase 1's pixel product (reuses the shim's existing
+    // `pixels > max_pixels` check), then post-check dims are unchanged
+    // so a SMALLER swap (which would leave tail rows uninitialised)
+    // also degrades to DecodeFailed rather than returning junk.
+    let mut w: u32 = 0;
+    let mut h: u32 = 0;
+    // IccBuf's Drop frees the libc malloc'd buffer on every early return
+    // between here and `into_owned()` — the dimension post-check, an OOM
+    // on the RGBA alloc, anything else. Null until phase 2 writes it, so
+    // on phase-1 error paths this is a no-op.
+    let mut icc = IccBuf::new();
+    // SAFETY: bytes.ptr/len come from a valid live slice; the `*mut u32`
+    // / `*mut *mut u8` / `*mut usize` out-params are all valid locals.
+    let rc = unsafe {
+        bun_avif_decode(
+            bytes.as_ptr(),
+            bytes.len(),
+            max_pixels,
+            &raw mut w,
+            &raw mut h,
+            core::ptr::null_mut(),
+            &raw mut icc.ptr,
+            &raw mut icc.size,
+        )
+    };
+    if rc != AVIF_OK {
+        return Err(map_decode_err(rc));
+    }
+    if w == 0 || h == 0 {
+        return Err(codecs::Error::DecodeFailed);
+    }
+
+    // Fallible alloc — match jpeg/png/webp: ~1 GiB ceiling via `max_pixels`
+    // enforced by the shim already, but a hostile 16k×16k input still asks
+    // for a 1 GiB RGBA. Let the OOM propagate instead of aborting.
+    let pixels = usize::try_from(w).expect("int cast") * usize::try_from(h).expect("int cast") * 4;
+    let mut out: Vec<u8> = Vec::new();
+    if out.try_reserve_exact(pixels).is_err() {
+        return Err(codecs::Error::OutOfMemory);
+    }
+    // SAFETY: `try_reserve_exact` guarantees capacity ≥ pixels and the Vec
+    // is empty; set_len is safe because the shim will fill every byte on
+    // success (and we discard the Vec on error before observing contents).
+    unsafe { out.set_len(pixels) };
+
+    let mut w2: u32 = 0;
+    let mut h2: u32 = 0;
+    let phase1_pixels = u64::from(w) * u64::from(h);
+    // SAFETY: same as the phase-1 call; `out.as_mut_ptr()` is valid for
+    // `pixels` bytes as reserved above.
+    let rc = unsafe {
+        bun_avif_decode(
+            bytes.as_ptr(),
+            bytes.len(),
+            phase1_pixels,
+            &raw mut w2,
+            &raw mut h2,
+            out.as_mut_ptr(),
+            &raw mut icc.ptr,
+            &raw mut icc.size,
+        )
+    };
+    match rc {
+        AVIF_OK => {}
+        // At this call site `max_pixels` is the phase-1 alloc bound, not
+        // the user's `maxPixels` — TooManyPixels firing here means a
+        // hostile larger-swap, which `pinForTask`'s invariant (and the
+        // sibling codec_jpeg/codec_webp) surface as DecodeFailed. Remap.
+        AVIF_TOO_MANY_PIXELS => return Err(codecs::Error::DecodeFailed),
+        _ => return Err(map_decode_err(rc)),
+    }
+    if w2 != w || h2 != h {
+        return Err(codecs::Error::DecodeFailed);
+    }
+
+    // Re-home the ICC profile into the global allocator; if the dupe OOMs
+    // we drop the profile and keep the pixels (jpeg/png do the same — see
+    // #30197 rationale; an AVIF without ICC is still valid, implicitly
+    // sRGB via CICP).
+    let icc_profile = icc.into_owned();
+
+    Ok(codecs::Decoded {
+        rgba: out,
+        width: w,
+        height: h,
+        icc_profile,
+    })
+}
+
+/// Header-only dimensions probe for `.metadata()`. libavif's parse() stops
+/// before sample decode, so this reads the ispe box and returns — roughly
+/// PNG-IHDR-cheap, not "full AV1 decode".
+pub fn probe(bytes: &[u8], max_pixels: u64) -> Result<(u32, u32), codecs::Error> {
+    let mut w: u32 = 0;
+    let mut h: u32 = 0;
+    // SAFETY: bytes.ptr/len come from a valid live slice; the out-params are valid locals.
+    let rc = unsafe {
+        bun_avif_probe(
+            bytes.as_ptr(),
+            bytes.len(),
+            max_pixels,
+            &raw mut w,
+            &raw mut h,
+        )
+    };
+    if rc != AVIF_OK {
+        return Err(map_decode_err(rc));
+    }
+    if w == 0 || h == 0 {
+        return Err(codecs::Error::DecodeFailed);
+    }
+    Ok((w, h))
+}
+
+pub fn encode(
+    rgba: &[u8],
+    w: u32,
+    h: u32,
+    quality: u8,
+    icc_profile: Option<&[u8]>,
+) -> Result<codecs::Encoded, codecs::Error> {
+    // libavif's `quality` is 0-100 (AVIF_QUALITY_WORST .. AVIF_QUALITY_BEST),
+    // matching our `EncodeOptions.quality` verbatim — no remap needed.
+    // ICC bytes are attached via `avifImageSetProfileICC` inside the shim;
+    // libavif copies into its own allocator, so our caller keeps the
+    // borrow. See #30197 for why dropping the profile matters.
+    let mut out: *mut u8 = core::ptr::null_mut();
+    let mut out_size: usize = 0;
+    let (icc_ptr, icc_len) = match icc_profile {
+        Some(p) if !p.is_empty() => (p.as_ptr(), p.len()),
+        _ => (core::ptr::null(), 0),
+    };
+    // SAFETY: rgba.ptr/len describe a valid readable buffer of w*h*4 bytes;
+    // icc_ptr is either null or valid for icc_len bytes; out/out_size are
+    // valid `*mut` locals.
+    let rc = unsafe {
+        bun_avif_encode(
+            rgba.as_ptr(),
+            w,
+            h,
+            c_int::from(quality),
+            icc_ptr,
+            icc_len,
+            &raw mut out,
+            &raw mut out_size,
+        )
+    };
+    if rc != AVIF_OK {
+        return Err(map_encode_err(rc));
+    }
+    if out.is_null() || out_size == 0 {
+        return Err(codecs::Error::EncodeFailed);
+    }
+    // The shim owns the buffer via libavif's `avifRWData`. Hand the raw
+    // pointer+size to JS via `Encoded`; Drop calls `avifRWDataFree`
+    // (wrapped in `bun_avif_free_output`) — same zero-copy ownership model
+    // as WebPFree / tj3Free.
+    // SAFETY: `out` is non-null and `out_size` bytes are valid as returned by the shim.
+    let bytes = unsafe {
+        NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(out, out_size))
+    };
+    Ok(codecs::Encoded {
+        bytes,
+        free: encoded_wrap_free!(bun_avif_free_output),
+    })
+}

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -296,9 +296,8 @@ pub fn encode(
     // (wrapped in `bun_avif_free_output`) — same zero-copy ownership model
     // as WebPFree / tj3Free.
     // SAFETY: `out` is non-null and `out_size` bytes are valid as returned by the shim.
-    let bytes = unsafe {
-        NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(out, out_size))
-    };
+    let bytes =
+        unsafe { NonNull::new_unchecked(core::ptr::slice_from_raw_parts_mut(out, out_size)) };
     Ok(codecs::Encoded {
         bytes,
         free: encoded_wrap_free!(bun_avif_free_output),

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -64,11 +64,6 @@ unsafe extern "C" {
     fn bun_avif_free_output(data: *mut c_void);
 }
 
-// libc `free()` for the malloc'd ICC buffer the shim hands us.
-unsafe extern "C" {
-    fn free(p: *mut c_void);
-}
-
 fn map_decode_err(rc: i32) -> codecs::Error {
     match rc {
         AVIF_UNAVAILABLE => codecs::Error::UnsupportedOnPlatform,
@@ -123,8 +118,8 @@ impl IccBuf {
 impl Drop for IccBuf {
     fn drop(&mut self) {
         if !self.ptr.is_null() {
-            // SAFETY: the shim allocates via std::malloc; free() is the matching deallocator.
-            unsafe { free(self.ptr.cast::<c_void>()) };
+            // SAFETY: the shim allocates via std::malloc; libc::free is the matching deallocator.
+            unsafe { libc::free(self.ptr.cast::<c_void>()) };
         }
     }
 }

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -97,7 +97,7 @@ impl IccBuf {
 
     /// Copy the bytes into a `Vec<u8>` (global allocator) and leave the
     /// libc buffer to be freed by `Drop`. Returns `None` if the buffer is
-    /// empty or allocation fails.
+    /// empty.
     fn into_owned(self) -> Option<Vec<u8>> {
         if self.ptr.is_null() || self.size == 0 {
             return None;
@@ -105,14 +105,10 @@ impl IccBuf {
         // SAFETY: the shim's allocation is exactly `self.size` bytes at `self.ptr`;
         // we copy them out before `Drop` frees the source.
         let slice: &[u8] = unsafe { core::slice::from_raw_parts(self.ptr, self.size) };
-        // Fallible alloc — an OOM dropping the profile is fine (AVIF without
-        // ICC is still valid, implicitly sRGB via CICP), same as jpeg/png.
-        let mut v: Vec<u8> = Vec::new();
-        if v.try_reserve_exact(self.size).is_err() {
-            return None;
-        }
-        v.extend_from_slice(slice);
-        Some(v)
+        // OOM on the dupe aborts rather than silently dropping colour
+        // management — matching codec_jpeg/png/webp and the #30197
+        // rationale ("no profile" reinterprets P3/Adobe RGB as sRGB).
+        Some(slice.to_vec())
     }
 }
 
@@ -213,10 +209,9 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
         return Err(codecs::Error::DecodeFailed);
     }
 
-    // Re-home the ICC profile into the global allocator; if the dupe OOMs
-    // we drop the profile and keep the pixels (jpeg/png do the same — see
-    // #30197 rationale; an AVIF without ICC is still valid, implicitly
-    // sRGB via CICP).
+    // Re-home the ICC profile into the global allocator (OOM on the dupe
+    // aborts rather than silently dropping colour management — same
+    // contract as the sibling codecs, see the #30197 rationale there).
     let icc_profile = icc.into_owned();
 
     Ok(codecs::Decoded {

--- a/src/runtime/image/codec_avif.rs
+++ b/src/runtime/image/codec_avif.rs
@@ -174,9 +174,8 @@ pub fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::
     // Fallible alloc — ~1 GiB ceiling via `max_pixels` is enforced by the
     // shim already, but a hostile 16k×16k input still asks for a 1 GiB
     // RGBA. `vec![0u8; n]` aborts on OOM, so split into a fallible reserve
-    // + zero-fill resize: same observable bytes as the sibling codecs
-    // (see `codec_jpeg.rs`'s PERF(port) note about zero-init), but OOM
-    // propagates instead of aborting the process.
+    // + zero-fill resize: same observable bytes as the sibling codecs,
+    // but OOM propagates instead of aborting the process.
     let pixels = usize::try_from(w).expect("int cast") * usize::try_from(h).expect("int cast") * 4;
     let mut out: Vec<u8> = Vec::new();
     if out.try_reserve_exact(pixels).is_err() {

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -43,9 +43,6 @@ pub use super::codec_avif as avif;
 /// `true` on platforms where `system_backend` is present.
 const HAS_SYSTEM_BACKEND: bool = cfg!(any(target_os = "macos", windows));
 
-/// `true` on platforms where the dlopen'd libavif codec is compiled in.
-pub const HAS_AVIF_CODEC: bool = cfg!(target_os = "linux");
-
 /// Process-global selector exposed as `Bun.Image.backend`.
 ///
 /// `.system` (default on darwin/windows) is the perf-optimal hybrid:

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -235,7 +235,7 @@ pub struct Decoded {
     pub(crate) width: u32,
     pub(crate) height: u32,
     /// ICC color profile bytes pulled from the source container (JPEG APP2,
-    /// PNG iCCP, WebP ICCP), global-allocator-owned. `None` when the
+    /// PNG iCCP, WebP ICCP, AVIF colr on Linux), global-allocator-owned. `None` when the
     /// source didn't carry one or the decode path doesn't extract it —
     /// BMP/GIF (no ICC chunk) and system backends (which already colour-
     /// manage into sRGB during decode, so the profile is no longer
@@ -495,7 +495,7 @@ pub struct EncodeOptions {
     /// JPEG only: emit a progressive scan script (coarse-to-fine render).
     pub(crate) progressive: bool,
     /// ICC profile to embed in the output container (JPEG APP2, PNG iCCP,
-    /// WebP ICCP). `None` ⇒ no profile chunk/marker is written. The
+    /// WebP ICCP, AVIF colr on Linux). `None` ⇒ no profile chunk/marker is written. The
     /// pipeline forwards this from the decode step so a non-sRGB source
     /// (P3, Adobe RGB, XYB/Jpegli) preserves its colour meaning through
     /// re-encode. Borrowed; the caller retains ownership.

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -28,8 +28,23 @@ pub use super::backend_coregraphics as system_backend;
 #[cfg(windows)]
 pub use super::backend_wic as system_backend;
 
+/// AVIF decode + encode on Linux via dlopen'd libavif (+ transitively libdav1d
+/// for decode and whichever AV1 encoder — aom/rav1e/SvtAv1Enc — the distro
+/// bundled for encode). See `src/jsc/bindings/image_avif_shim.cpp`. Nothing is
+/// linked statically; if libavif isn't installed the shim returns
+/// AVIF_UNAVAILABLE at the first call and we surface `UnsupportedOnPlatform`
+/// (same contract as a mac/win system-backend miss). A libavif built without
+/// any registered AV1 encoder surfaces `EncodeFailed` on `.avif()`. Android
+/// is excluded because the shim itself is gated on `__linux__ && !__ANDROID__`.
+/// macOS/Windows handle AVIF via `system_backend`.
+#[cfg(target_os = "linux")]
+pub use super::codec_avif as avif;
+
 /// `true` on platforms where `system_backend` is present.
 const HAS_SYSTEM_BACKEND: bool = cfg!(any(target_os = "macos", windows));
+
+/// `true` on platforms where the dlopen'd libavif codec is compiled in.
+pub const HAS_AVIF_CODEC: bool = cfg!(target_os = "linux");
 
 /// Process-global selector exposed as `Bun.Image.backend`.
 ///
@@ -41,10 +56,15 @@ const HAS_SYSTEM_BACKEND: bool = cfg!(any(target_os = "macos", windows));
 ///     and the `quality` scale match Linux.
 ///   • lanczos3 resize, rotate90, flip → vImage (AMX, ~3-6× the Highway
 ///     kernel on the geometry step).
-///   • heic/avif decode+encode → ImageIO/WIC (no static codec).
+///   • heic decode+encode → ImageIO/WIC (no static codec).
+///   • avif decode+encode → ImageIO/WIC on mac/win; on Linux, dlopen'd
+///     libavif (see `codec_avif.rs`).
 ///
-/// `.bun` skips the OS layer entirely (Highway geometry, heic/avif throw)
-/// so behaviour is byte-identical to a Linux build.
+/// `.bun` skips the OS layer entirely: Highway geometry everywhere, heic
+/// throws `UnsupportedOnPlatform` on every platform (no static codec),
+/// avif uses the dlopen'd libavif on Linux and throws
+/// `UnsupportedOnPlatform` elsewhere (the `avif` module is compiled out
+/// on mac/win).
 ///
 /// Unsynchronised: written from JS, read from WorkPool — a torn read of a
 /// 1-byte enum is fine and the worst case is one task using the previous
@@ -100,7 +120,12 @@ pub enum Format {
     Webp,
     /// System-backend-only on macOS/Windows; no static codec.
     Heic,
-    /// System-backend-only on macOS/Windows; no static codec.
+    /// Decode + encode via dlopen'd libavif on Linux (libavif pulls in dav1d
+    /// for decode and whichever AV1 encoder the distro bundled — typically
+    /// aom, rav1e, and/or SVT-AV1 — for encode). System backend (ImageIO/WIC)
+    /// on macOS/Windows. Linux without libavif installed returns
+    /// `UnsupportedOnPlatform`; a libavif that was built decode-only returns
+    /// `EncodeFailed` when you call `.avif()`.
     Avif,
     /// Decode-only. Static `BI_RGB`/`BI_BITFIELDS` parser everywhere; the
     /// system backend is tried first (covers RLE/JPEG-in-BMP). The Windows
@@ -239,8 +264,9 @@ pub enum Error {
     /// BEFORE allocating the full RGBA buffer.
     #[error("TooManyPixels")]
     TooManyPixels,
-    /// HEIC/AVIF on a platform with no system backend (Linux), or the system
-    /// backend declined and there's no static codec to fall back to.
+    /// HEIC on a platform with no system backend (Linux), AVIF on Linux
+    /// without libavif.so.16 installed, or the system backend declined
+    /// and there's no static codec to fall back to.
     #[error("UnsupportedOnPlatform")]
     UnsupportedOnPlatform,
     #[error("OutOfMemory")]
@@ -277,8 +303,19 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64, hint: DecodeHint) -> Result<
         // system libz). The OS backend is purely a *capability* fallback for
         // containers we don't link a decoder for — and `backend == .bun` opts
         // out of even that so behaviour is identical to Linux.
-        Format::Heic | Format::Avif | Format::Tiff => match decode_via_system(bytes, max_pixels)? {
+        Format::Heic | Format::Tiff => match decode_via_system(bytes, max_pixels)? {
             Some(d) => Ok(d),
+            None => Err(Error::UnsupportedOnPlatform),
+        },
+        // AVIF: system backend (ImageIO/WIC) on macOS/Windows, dlopen'd
+        // libavif + libdav1d on Linux. Same capability-fallback pattern as
+        // BMP/GIF — mac/win users never trigger the dlopen path because
+        // ImageIO/WIC satisfy the call first.
+        Format::Avif => match decode_via_system(bytes, max_pixels)? {
+            Some(d) => Ok(d),
+            #[cfg(target_os = "linux")]
+            None => avif::decode(bytes, max_pixels),
+            #[cfg(not(target_os = "linux"))]
             None => Err(Error::UnsupportedOnPlatform),
         },
         // BMP/GIF have static decoders so Linux (and `backend == .bun`) work;
@@ -407,9 +444,25 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             // actually decodes it (system backend on mac/win, else error).
             return Err(Error::UnsupportedOnPlatform);
         }
-        Format::Heic | Format::Avif => {
-            // System backend handles these; fall through to a full decode if
-            // available, otherwise UnsupportedOnPlatform.
+        Format::Heic => {
+            // System backend handles this; the probe path currently surfaces
+            // UnsupportedOnPlatform everywhere — a real dimensions read would
+            // need to go through the backend's decode+stash pattern.
+            return Err(Error::UnsupportedOnPlatform);
+        }
+        Format::Avif => {
+            // Linux: libavif's parse() reads the ispe box without decoding
+            // the AV1 stream — cheap enough to be our real probe path.
+            // mac/win have no static codec here, so falling through to
+            // UnsupportedOnPlatform matches the probe-only path's current
+            // behaviour on those platforms.
+            #[cfg(target_os = "linux")]
+            {
+                let (pw, ph) = avif::probe(bytes, max_pixels)?;
+                w = pw;
+                h = ph;
+            }
+            #[cfg(not(target_os = "linux"))]
             return Err(Error::UnsupportedOnPlatform);
         }
     }
@@ -569,7 +622,7 @@ pub(crate) fn encode(
         // libjpeg-turbo's, and it can't honour compressionLevel/palette/
         // lossless, so using it for jpeg/png/webp would make output bytes
         // diverge from Linux for no speed win.
-        Format::Heic | Format::Avif => {
+        Format::Heic => {
             #[cfg(any(target_os = "macos", windows))]
             if use_system() {
                 return match system_backend::BackendError::split(system_backend::encode(
@@ -581,6 +634,27 @@ pub(crate) fn encode(
                     Err(e) => Err(e),
                 };
             }
+            Err(Error::UnsupportedOnPlatform)
+        }
+        // AVIF encode: system backend on mac/win (ImageIO/WIC wrap the OS
+        // AV1 encoder), dlopen'd libavif on Linux. Same capability-fallback
+        // shape as decode — system path first on mac/win (on Linux
+        // `system_backend` is comptime-absent), dlopen'd libavif when the
+        // system path is unavailable or the runtime backend is `.bun`.
+        Format::Avif => {
+            #[cfg(any(target_os = "macos", windows))]
+            if use_system() {
+                return match system_backend::BackendError::split(system_backend::encode(
+                    rgba, width, height, &opts,
+                )) {
+                    Ok(Some(buf)) => Ok(Encoded::from_owned(buf)),
+                    Ok(None) => Err(Error::UnsupportedOnPlatform),
+                    Err(e) => Err(e),
+                };
+            }
+            #[cfg(target_os = "linux")]
+            return avif::encode(rgba, width, height, opts.quality, icc);
+            #[cfg(not(target_os = "linux"))]
             Err(Error::UnsupportedOnPlatform)
         }
         // Decode-only formats — no .bmp()/.tiff()/.gif() chain methods, so the

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -32,6 +32,13 @@ pub mod codec_bmp;
 #[path = "codec_gif.rs"]
 pub mod codec_gif;
 
+// AVIF on Linux is dlopen'd at runtime — see `codec_avif.rs` header and
+// `src/jsc/bindings/image_avif_shim.cpp`. Linux-only; other targets route
+// AVIF through their `system_backend` (or throw UnsupportedOnPlatform).
+#[cfg(target_os = "linux")]
+#[path = "codec_avif.rs"]
+pub mod codec_avif;
+
 #[cfg(target_os = "macos")]
 #[path = "backend_coregraphics.rs"]
 pub mod backend_coregraphics;

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -133,6 +133,21 @@ const tinyJpeg = await new Bun.Image(tinyPng).jpeg({ quality: 80 }).bytes();
 const tinyWebp = await new Bun.Image(tinyPng).webp({ quality: 80 }).bytes();
 const tinyWebpLossless = await new Bun.Image(tinyPng).webp({ lossless: true }).bytes();
 
+// 1×1 white pixel AVIF (libavif tests/data/white_1x1.avif). Not generated
+// on the fly — AVIF encode on Linux is dlopen-gated on libavif.so.16
+// having an AV1 encoder linked in, which a hermetic fuzz file can't assume.
+// Same bytes as in image.test.ts; kept here so this file stays standalone-
+// runnable.
+const tinyAvif = Buffer.from(
+  "AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUEAAADybWV0YQAAAAAAAAAoaGRs" +
+    "cgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAe" +
+    "aWxvYwAAAABEAAABAAEAAAABAAABGgAAABcAAAAoaWluZgAAAAAAAQAAABppbmZlAgAA" +
+    "AAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAAAB" +
+    "AAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgSAAAAAAABNjb2xybmNseAABAA0ABoAAAAAX" +
+    "aXBtYQAAAAAAAAABAAEEAQKDBAAAAB9tZGF0EgAKBzgABhAQ0GkyCh/wP///xAAAr3A=",
+  "base64",
+);
+
 /** Assert the promise either rejects or resolves — never aborts/hangs. */
 async function survives(p: Promise<unknown>): Promise<"rejected" | "resolved"> {
   try {
@@ -764,17 +779,32 @@ describe("random-byte fuzz", () => {
 
   // Mutate one byte of each known-good fixture at every offset — catches
   // codec parsers that trust a length/type byte without bounds-checking.
-  for (const [name, fixture] of [
+  // The AVIF fixture is Linux-only — on mac/win the same bytes go through
+  // the ImageIO/WIC decoder, which has its own hardening surface and isn't
+  // what this file's meant to exercise.
+  const fuzzFormats: Array<readonly [string, Uint8Array]> = [
     ["png", tinyPng],
     ["jpeg", tinyJpeg],
     ["webp-lossless", tinyWebpLossless],
-  ] as const) {
-    test.concurrent(`${name}: single-byte flip at every offset`, async () => {
-      for (let off = 0; off < fixture.length; off++) {
-        const mut = Buffer.from(fixture);
-        mut[off] ^= 0xff;
-        await survives(new Bun.Image(mut).bytes());
-      }
-    });
+  ];
+  if (process.platform === "linux") fuzzFormats.push(["avif", tinyAvif]);
+  for (const [name, fixture] of fuzzFormats) {
+    // Raise the per-test timeout for AVIF: a handful of flips end up producing
+    // bytes that still decode (some mdat corruption doesn't reach the bit
+    // reader), triggering real AV1 decode at ~40ms each under ASAN. 305 flips
+    // × worst-case ~60% full-decode ratio blows past Jest's 5s default. JPEG/
+    // PNG/WebP flips all reject in parse so they don't need it.
+    const perTestTimeout = name === "avif" ? 30_000 : undefined;
+    test.concurrent(
+      `${name}: single-byte flip at every offset`,
+      async () => {
+        for (let off = 0; off < fixture.length; off++) {
+          const mut = Buffer.from(fixture);
+          mut[off] ^= 0xff;
+          await survives(new Bun.Image(mut).bytes());
+        }
+      },
+      perTestTimeout,
+    );
   }
 });

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -10,7 +10,7 @@
 // Kept in its own file so the happy-path image.test.ts stays readable.
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { gcTick, isASAN, rss, tempDir } from "harness";
+import { bunEnv, bunExe, gcTick, isASAN, rss, tempDir } from "harness";
 import { join } from "node:path";
 import zlib from "node:zlib";
 
@@ -147,6 +147,33 @@ const tinyAvif = Buffer.from(
     "aXBtYQAAAAAAAAABAAEEAQKDBAAAAB9tZGF0EgAKBzgABhAQ0GkyCh/wP///xAAAr3A=",
   "base64",
 );
+
+// libavif is dlopen'd at runtime (libavif.so.16). Where it's absent, flipping
+// bytes of an AVIF fixture only exercises the dlopen-miss rejection 305 times
+// — no AV1-parser hardening value, and the extra concurrent decode load
+// destabilises the timing-sensitive leak tests below. Probe once (same logic
+// as avifProbeAvailable in image.test.ts) and run the AVIF fuzz only where
+// libavif can actually decode.
+const avifFuzzAvailable =
+  process.platform === "linux" &&
+  (() => {
+    try {
+      const proc = Bun.spawnSync({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const b = Buffer.from(${JSON.stringify(tinyAvif.toString("base64"))}, "base64");` +
+            `new Bun.Image(b).metadata().then(() => process.exit(0), e => process.exit(e?.code === "ERR_IMAGE_FORMAT_UNSUPPORTED" ? 2 : 1));`,
+        ],
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "ignore",
+      });
+      return proc.exitCode !== 2;
+    } catch {
+      return false;
+    }
+  })();
 
 /** Assert the promise either rejects or resolves — never aborts/hangs. */
 async function survives(p: Promise<unknown>): Promise<"rejected" | "resolved"> {
@@ -779,15 +806,15 @@ describe("random-byte fuzz", () => {
 
   // Mutate one byte of each known-good fixture at every offset — catches
   // codec parsers that trust a length/type byte without bounds-checking.
-  // The AVIF fixture is Linux-only — on mac/win the same bytes go through
-  // the ImageIO/WIC decoder, which has its own hardening surface and isn't
-  // what this file's meant to exercise.
+  // AVIF is included only where libavif can decode (see avifFuzzAvailable):
+  // mac/win route these bytes through ImageIO/WIC, which this file doesn't
+  // target, and a libavif-less host would just re-test the dlopen-miss path.
   const fuzzFormats: Array<readonly [string, Uint8Array]> = [
     ["png", tinyPng],
     ["jpeg", tinyJpeg],
     ["webp-lossless", tinyWebpLossless],
   ];
-  if (process.platform === "linux") fuzzFormats.push(["avif", tinyAvif]);
+  if (avifFuzzAvailable) fuzzFormats.push(["avif", tinyAvif]);
   for (const [name, fixture] of fuzzFormats) {
     // Raise the per-test timeout for AVIF: a handful of flips end up producing
     // bytes that still decode (some mdat corruption doesn't reach the bit

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -816,22 +816,17 @@ describe("random-byte fuzz", () => {
   ];
   if (avifFuzzAvailable) fuzzFormats.push(["avif", tinyAvif]);
   for (const [name, fixture] of fuzzFormats) {
-    // Raise the per-test timeout for AVIF: a handful of flips end up producing
-    // bytes that still decode (some mdat corruption doesn't reach the bit
-    // reader), triggering real AV1 decode at ~40ms each under ASAN. 305 flips
-    // × worst-case ~60% full-decode ratio blows past Jest's 5s default. JPEG/
-    // PNG/WebP flips all reject in parse so they don't need it.
-    const perTestTimeout = name === "avif" ? 30_000 : undefined;
-    test.concurrent(
-      `${name}: single-byte flip at every offset`,
-      async () => {
-        for (let off = 0; off < fixture.length; off++) {
-          const mut = Buffer.from(fixture);
-          mut[off] ^= 0xff;
-          await survives(new Bun.Image(mut).bytes());
-        }
-      },
-      perTestTimeout,
-    );
+    test.concurrent(`${name}: single-byte flip at every offset`, async () => {
+      // Each decode runs on the WorkPool, so fire all flips and await the
+      // batch — serial awaits made the AVIF variant (~40ms per surviving
+      // AV1 decode under ASAN) crawl past the default test budget.
+      const flips: Promise<unknown>[] = [];
+      for (let off = 0; off < fixture.length; off++) {
+        const mut = Buffer.from(fixture);
+        mut[off] ^= 0xff;
+        flips.push(survives(new Bun.Image(mut).bytes()));
+      }
+      await Promise.all(flips);
+    });
   }
 });

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1043,6 +1043,25 @@ describe("Bun.Image", () => {
         const meta = await new Bun.Image(out).metadata();
         expect(meta).toEqual({ width: 4, height: 3, format: "avif" });
       });
+
+      // Negative companion to the round-trip test above, preserving the
+      // pre-AVIF assertion that `.avif()` on a Linux host WITHOUT libavif
+      // rejects with FORMAT_UNSUPPORTED (the "install a package" signal,
+      // distinct from ENCODE_FAILED's "encoder choked"). `hasAvifRuntime`
+      // is false only when the decode probe exited 2 — a clean
+      // FORMAT_UNSUPPORTED rejection, i.e. libavif.so.16 genuinely absent
+      // — so this runs exactly on the shards the positive test skips. The
+      // encode probe can't stand in for this assertion: it treats both
+      // error codes as "skip", so a regression that mapped AVIF_UNAVAILABLE
+      // to EncodeFailed would otherwise ship green.
+      test.skipIf(hasAvifRuntime)(
+        "encode .avif() rejects ERR_IMAGE_FORMAT_UNSUPPORTED when libavif absent",
+        async () => {
+          await expect(new Bun.Image(cornersPng).avif().bytes()).rejects.toMatchObject({
+            code: "ERR_IMAGE_FORMAT_UNSUPPORTED",
+          });
+        },
+      );
     } else {
       // HEIC/AVIF encode availability is *machine*-specific, not platform:
       //   • macOS: HEVC ships unconditionally; AV1 encode goes through

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1,6 +1,6 @@
 import { S3Client } from "bun";
 import { afterAll, describe, expect, test } from "bun:test";
-import { isMacOS, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir } from "harness";
 import zlib from "node:zlib";
 import { join } from "path";
 
@@ -78,6 +78,62 @@ function cornerPattern(x: number, y: number): [number, number, number, number] {
   return [128, 128, 128, 255];
 }
 const cornersPng = makePng(4, 3, cornerPattern);
+
+// 1×1 white pixel AVIF, 305 bytes (libavif tests/data/white_1x1.avif). Used
+// both as a probe payload (cheap — libavif parses it in sub-ms) and as the
+// fixture for the decode tests in the HEIC/AVIF describe block. Hoisted to
+// module scope so the three probes below (`hasAvifRuntime` for decode,
+// `hasAvifEncoderLibrary` for encode, `hasAvifIccRuntime` for the ICC
+// round-trip) share the same bytes.
+const white1x1Avif = Buffer.from(
+  "AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUEAAADybWV0YQAAAAAAAAAoaGRsc" +
+    "gAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAe" +
+    "aWxvYwAAAABEAAABAAEAAAABAAABGgAAABcAAAAoaWluZgAAAAAAAQAAABppbmZlAgA" +
+    "AAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAA" +
+    "ABAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgSAAAAAAABNjb2xybmNseAABAA0ABoAAA" +
+    "AAXaXBtYQAAAAAAAAABAAEEAQKDBAAAAB9tZGF0EgAKBzgABhAQ0GkyCh/wP///xAAA" +
+    "r3A=",
+  "base64",
+);
+
+// Subprocess gate used by the three AVIF test groups. Runs a tiny
+// `Bun.Image` operation in a child process and inspects its exit code:
+//   0 → feature available, run the test strictly
+//   2 → explicit ERR_IMAGE_FORMAT_UNSUPPORTED / ERR_IMAGE_ENCODE_FAILED →
+//       the relevant lib/encoder isn't installed, skip cleanly
+//   anything else (crash, unexpected error, signal) → let the real test
+//       run so the regression surfaces instead of being hidden as a skip
+// The subprocess matches exactly what the shim's `dlopen("libavif.so.16")`
+// does, so it works on glibc and musl alike — unlike `ldconfig -p`, which
+// is a no-op stub on Alpine.
+function avifProbeAvailable(scriptBody: string): boolean {
+  if (!isLinux) return false;
+  try {
+    const proc = Bun.spawnSync({
+      cmd: [bunExe(), "-e", scriptBody],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    return proc.exitCode !== 2;
+  } catch {
+    return false;
+  }
+}
+
+// Script body: "can libavif decode a valid 1×1 AVIF header?" — exits 0 on
+// success, 2 on UnsupportedOnPlatform, 1 on any other error.
+const avifDecodeProbeScript =
+  `const b = Buffer.from(${JSON.stringify(white1x1Avif.toString("base64"))}, "base64");` +
+  `new Bun.Image(b).metadata().then(() => process.exit(0), e => process.exit(e?.code === "ERR_IMAGE_FORMAT_UNSUPPORTED" ? 2 : 1));`;
+
+// Script body: "can libavif encode cornersPng to AVIF?" — exits 0 on
+// success, 2 on {UNSUPPORTED, ENCODE_FAILED} (missing library or no AV1
+// encoder plugin linked in), 1 on any other error.
+const avifEncodeProbeScript =
+  `const png = Buffer.from(${JSON.stringify(Buffer.from(cornersPng).toString("base64"))}, "base64");` +
+  `new Bun.Image(png).avif({ quality: 50 }).bytes()` +
+  `.then(() => process.exit(0), e => process.exit((e?.code === "ERR_IMAGE_FORMAT_UNSUPPORTED" || e?.code === "ERR_IMAGE_ENCODE_FAILED") ? 2 : 1));`;
 
 // 16×16 grey gradient — large enough that the lanczos window has real support.
 const gradientPng = makePng(16, 16, (x, y) => {
@@ -778,6 +834,26 @@ describe("Bun.Image", () => {
       expect(String.fromCharCode(...lossless.subarray(12, 16))).toBe("VP8L");
       expect(extractWebpIccp(lossless)).toBeNull();
     });
+
+    // ── AVIF ICC carry-through — libavif stashes the profile in a `colr`
+    // box with type `prof`. Rather than hand-parse ISOBMFF here to extract
+    // it, round-trip through AVIF and back to PNG and check the iCCP
+    // chunk survives — same decode+encode path a Sharp user would hit.
+    // Gated on the machine having libavif with an AV1 encoder linked in.
+    const hasAvifIccRuntime = avifProbeAvailable(avifDecodeProbeScript) && avifProbeAvailable(avifEncodeProbeScript);
+
+    test.skipIf(!hasAvifIccRuntime)("PNG iCCP → AVIF → PNG preserves the ICC profile byte-for-byte", async () => {
+      // PNG-with-iCCP → AVIF. Inside libavif the profile rides in the
+      // `colr` box. Decode that AVIF back through Bun.Image and re-encode
+      // to PNG — the iCCP chunk must reappear with identical bytes.
+      const srcPng = pngWithIccp(cornersPng, fakeProfile);
+      const avif = await new Bun.Image(srcPng).avif({ quality: 70 }).bytes();
+      expect(String.fromCharCode(...avif.subarray(4, 8))).toBe("ftyp");
+      const outPng = await new Bun.Image(avif).png().bytes();
+      const got = extractPngIccp(outPng);
+      expect(got).not.toBeNull();
+      expect(Array.from(got!)).toEqual(Array.from(fakeProfile));
+    });
   });
 
   // EXIF: build a minimal JPEG via Bun.Image, then splice in an APP1 segment
@@ -849,18 +925,123 @@ describe("Bun.Image", () => {
 
     test("sniffer recognises ftyp brands", async () => {
       // metadata() will fail (not a real image) but the FORMAT in the error
-      // path proves the sniffer routed correctly. On Linux it's
-      // UnsupportedOnPlatform; on macOS/Windows the system codec rejects.
+      // path proves the sniffer routed correctly. On Linux HEIC is
+      // UnsupportedOnPlatform; AVIF now has a runtime-loaded decoder
+      // (dlopen'd libavif+dav1d) and the malformed header fails libavif's
+      // parse as DecodeFailed — unless libavif isn't installed, in which
+      // case it rejects as UnsupportedOnPlatform. Either way, metadata()
+      // rejects; we don't pin the code because both are valid.
       await expect(new Bun.Image(heicHdr).metadata()).rejects.toThrow();
       await expect(new Bun.Image(avifHdr).metadata()).rejects.toThrow();
     });
 
-    if (!isMacOS && !isWindows) {
-      test("encode .heic()/.avif() rejects ERR_IMAGE_FORMAT_UNSUPPORTED on Linux", async () => {
-        for (const fmt of ["heic", "avif"] as const)
-          await expect(new Bun.Image(cornersPng)[fmt]().bytes()).rejects.toMatchObject({
-            code: "ERR_IMAGE_FORMAT_UNSUPPORTED",
-          });
+    // Linux gained AVIF decode + encode via dlopen'd libavif in #30199.
+    // Decode pulls in dav1d (transitively from libavif's NEEDED entry);
+    // encode uses whichever AV1 encoder the distro bundled with libavif —
+    // typically aom, rav1e, and/or SVT-AV1. These fixtures are from
+    // libavif's own test suite (see tests/data/). Pin the branch to
+    // `isLinux` rather than `!isMacOS && !isWindows` so a future non-desktop
+    // target (freebsd/android/...) that also lacks AVIF doesn't start
+    // falsely claiming to have it.
+    //
+    // Dlopen means "works if libavif.so.16 is on the host", not "works on
+    // every Linux shard". Probe by running a tiny decode in a subprocess
+    // (sync, cheap — the fixture is 305 bytes and libavif parses it in
+    // sub-ms) and skip the decode-requires-libavif tests cleanly on
+    // shards (minimal Docker, musl without `libavif` apk, pre-trixie
+    // Debian) that lack the package. Using a subprocess rather than
+    // `ldconfig -p` matches exactly what the shim's
+    // `dlopen("libavif.so.16")` does — works on glibc and musl alike,
+    // whereas `ldconfig -p` is a no-op stub on Alpine/musl.
+    const hasAvifRuntime = avifProbeAvailable(avifDecodeProbeScript);
+    if (isLinux) {
+      // 4×4 AVIF, 330 bytes (libavif tests/data/extended_pixi.avif). Used
+      // for the maxPixels guard test — 16 pixels is comfortably over a
+      // small limit without inflating the fixture size.
+      const pixi4x4Avif = Buffer.from(
+        "AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADxbWV0YQAAAAAAAAAhaGRs" +
+          "cgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAAAAAAAOcGl0bQAAAAAAAQAAAB5pbG9jAA" +
+          "AAAEQAAAEAAQAAAAEAAAEZAAAAMQAAAChpaW5mAAAAAAABAAAAGmluZmUCAAAAAAEA" +
+          "AGF2MDFDb2xvcgAAAABwaXBycAAAAFFpcGNvAAAAFGlzcGUAAAAAAAAABAAAAAQAAA" +
+          "AWcGl4aQAAAAEDCAgIAgACIAIgAAAADGF2MUOBAA0AAAAAE2NvbHJuY2x4AAIAAgAC" +
+          "gAAAABdpcG1hAAAAAAAAAAEAAQQBAoMEAAAAOW1kYXQSAAoFGAR9gUgyJhfACSSSRA" +
+          "BOQpsmXwal4c1e451a75FxWtQXOrIX0TGFWyby7pvW",
+        "base64",
+      );
+
+      test.skipIf(!hasAvifRuntime)("decode AVIF: metadata() returns dimensions", async () => {
+        expect(await new Bun.Image(white1x1Avif).metadata()).toEqual({
+          width: 1,
+          height: 1,
+          format: "avif",
+        });
+      });
+
+      test.skipIf(!hasAvifRuntime)("decode AVIF: round-trip through PNG", async () => {
+        const png = await new Bun.Image(white1x1Avif).png().bytes();
+        expect(png[0]).toBe(0x89);
+        expect(String.fromCharCode(png[1], png[2], png[3])).toBe("PNG");
+        const { w, h, data } = decodePngRaw(png);
+        expect(w).toBe(1);
+        expect(h).toBe(1);
+        // AV1 quantizes pure white; accept anything ≥240 on each channel
+        // and a fully-opaque alpha. The point of the assertion is "a white
+        // pixel stays roughly white", not byte-exactness through a lossy
+        // codec — Y'CbCr → RGB → Y'CbCr has rounding at each step.
+        const [r, g, b, a] = rgbaAt(data, 1, 0, 0);
+        expect(r).toBeGreaterThanOrEqual(240);
+        expect(g).toBeGreaterThanOrEqual(240);
+        expect(b).toBeGreaterThanOrEqual(240);
+        expect(a).toBe(255);
+      });
+
+      test.skipIf(!hasAvifRuntime)("decode AVIF honours maxPixels", async () => {
+        // The ERR code is the contract — callers (Sharp migrants) branch on
+        // it to distinguish "too big" from "corrupt". Exercise an AVIF that
+        // actually exceeds maxPixels so the post-parse guard has to fire;
+        // an earlier pass pushed maxPixels into libavif's own imageSizeLimit
+        // and the parse failed first, turning this into ERR_IMAGE_DECODE_FAILED.
+        await expect(new Bun.Image(pixi4x4Avif, { maxPixels: 5 }).metadata()).rejects.toMatchObject({
+          code: "ERR_IMAGE_TOO_MANY_PIXELS",
+        });
+        // Edge case: maxPixels: 0 → reject everything, including 1×1.
+        await expect(new Bun.Image(white1x1Avif, { maxPixels: 0 }).metadata()).rejects.toMatchObject({
+          code: "ERR_IMAGE_TOO_MANY_PIXELS",
+        });
+        // Same contract on the full decode path, not just metadata().
+        await expect(new Bun.Image(pixi4x4Avif, { maxPixels: 15 }).png().bytes()).rejects.toMatchObject({
+          code: "ERR_IMAGE_TOO_MANY_PIXELS",
+        });
+      });
+
+      test("encode .heic() rejects ERR_IMAGE_FORMAT_UNSUPPORTED on Linux", async () => {
+        // No vendored HEVC encoder and Linux has no OS codec.
+        await expect(new Bun.Image(cornersPng).heic().bytes()).rejects.toMatchObject({
+          code: "ERR_IMAGE_FORMAT_UNSUPPORTED",
+        });
+      });
+
+      // Positive AVIF encode test, gated on the Linux distro shipping a
+      // libavif that has an AV1 encoder linked in. Probe the way we'd
+      // measure the feature in production: try an actual encode of our
+      // cornersPng in a subprocess and inspect the exit code. Same
+      // libc-agnostic strategy as `hasAvifRuntime` above. Probe returns
+      // `exitCode !== 2`, so skips only on explicit
+      // FORMAT_UNSUPPORTED/ENCODE_FAILED (genuinely no encoder) —
+      // crashes, asserts, or unexpected errors let the real test run
+      // and fail loudly. Decode-only libavif builds (rare — Alpine
+      // minimal) skip cleanly.
+      const hasAvifEncoderLibrary = hasAvifRuntime && avifProbeAvailable(avifEncodeProbeScript);
+
+      test.skipIf(!hasAvifEncoderLibrary)("encode .avif() round-trips on Linux", async () => {
+        // The machine has an AV1 encoder plugin in libavif's NEEDED — the
+        // dispatch MUST produce bytes. Strict assertion, no tolerance arm.
+        const out = await new Bun.Image(cornersPng).avif({ quality: 50 }).bytes();
+        // ISOBMFF `ftyp` box signature at offset 4-8.
+        expect(String.fromCharCode(...out.subarray(4, 8))).toBe("ftyp");
+        // Decode back through the dlopen'd decoder and pin dimensions.
+        const meta = await new Bun.Image(out).metadata();
+        expect(meta).toEqual({ width: 4, height: 3, format: "avif" });
       });
     } else {
       // HEIC/AVIF encode availability is *machine*-specific, not platform:


### PR DESCRIPTION
Closes #30199.

## What this does

Adds AVIF **decode and encode** on Linux. macOS (ImageIO) and Windows (WIC) already handled AVIF through their system backends; Linux had no codec wired, so `new Bun.Image(avifBytes).metadata()`, `.png()`, and `.avif()` all returned `ERR_IMAGE_FORMAT_UNSUPPORTED`. The same code that worked in dev on a Mac broke in prod on a Linux server.

## Approach

Per the review request, libavif is **dlopen'd at runtime** (`dlopen("libavif.so.16", RTLD_NOW)`), not vendored or statically linked. libavif transitively provides dav1d for decode and whichever AV1 encoder the distro bundled (aom / rav1e / SvtAv1Enc) for encode. Bun keeps no link-time dependency on libavif or dav1d:

- libavif not installed → `ERR_IMAGE_FORMAT_UNSUPPORTED`, exactly the prior behaviour.
- libavif built decode-only (no AV1 encoder linked) → `.avif()` surfaces `ERR_IMAGE_ENCODE_FAILED`.
- macOS/Windows keep using the system backend and never touch the dlopen path.

### Pieces

- **C++ shim** `src/jsc/bindings/image_avif_shim.cpp`: the dlopen/dlsym loader. Pins the libavif 1.0.0 stable struct layout and exports `bun_avif_probe` / `bun_avif_decode` / `bun_avif_encode` / `bun_avif_free_output`. Hardening from the review cycle: two-phase decode (size probe → bounded alloc → fill), TOCTOU pixel guard, a post-`avifDecoderNextImage` dimension recheck that closes the ispe-vs-AV1-stream heap-overflow, `RTLD_LOCAL` to avoid aom/dav1d/svt symbol pollution, `imageDimensionLimit = 0` so libavif's default 32768-per-side cap doesn't reject panoramas that are under `maxPixels`, and ICC profile plumbing on both decode (`avifImage.icc`) and encode (`avifImageSetProfileICC`, see #30197).
- **Rust wrapper** `src/runtime/image/codec_avif.rs`: `unsafe extern "C"` bindings, an RAII `IccBuf`, fallible `try_reserve_exact` allocation, and a map from shim result codes to `codecs::Error`.
- **Dispatch** `src/runtime/image/codecs.rs`: `.avif` decode / probe / encode route to the dlopen'd codec on Linux and to the system backend on macOS/Windows. `Image.rs` pre-sniffs AVIF so the first (synchronous) `dlopen` stays off the JS thread.

## Verification

`test/js/bun/image/image.test.ts` and `image-adversarial.test.ts` cover decode (metadata, round-trip through PNG, `maxPixels`), encode (`.avif()` round-trip, ICC byte-for-byte preservation), and single-byte-flip fuzz. They gate on a runtime libavif probe (`avifProbeAvailable`, a subprocess that exits 2 only on `ERR_IMAGE_FORMAT_UNSUPPORTED`) so they run strictly where libavif is installed and skip cleanly where it is not. In a container without `libavif.so.16`: 93 pass / 7 skip / 0 fail for `image.test.ts`, and `image-adversarial.test.ts` green.

## Rebase note

Rebased onto current main, which had landed the Rust rewrite of the image subsystem (#30412). Ported the codec from Zig to Rust and re-wired the dispatch. One content conflict, `src/runtime/image/README.md`: main had renamed the layout table from Zig to Rust file names, so I kept main's Rust names and re-added the two AVIF rows (`codec_avif.rs`, `image_avif_shim.cpp`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 27 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/image/image-adversarial.test.ts test/js/bun/image/image.test.ts

<!-- robobun:evidence:end -->