### PR TITLE
fix(transpiler): keep numeric binary expressions when fold would inflate output

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2487,6 +2487,38 @@ macro_rules! impl_digit_count_signed {
 impl_digit_count_unsigned!(u8, u16, u32, u64, usize);
 impl_digit_count_signed!(i8, i16, i32, i64, isize);
 
+/// Byte length of `print_non_negative_float`'s output for `value` (plus a
+/// leading `-` byte when negative), mirroring that printer's special cases.
+/// Lives here because `bun_js_parser` can't depend on the printer crate.
+pub fn len_of_js_number(value: f64) -> u32 {
+    if value.is_nan() {
+        return 3; // "NaN"
+    }
+    if value.is_infinite() {
+        return if value.is_sign_negative() { 4 } else { 3 }; // "-1/0" or "1/0"
+    }
+
+    let neg_prefix: u32 = if value.is_sign_negative() { 1 } else { 0 };
+    let abs_value = value.abs();
+
+    let floored = abs_value.floor();
+    let is_integer = (abs_value - floored) == 0.0;
+    if abs_value < (u64::MAX >> 12) as f64 /* maxInt(u52) */ && is_integer {
+        let val = abs_value as u64;
+        // The printer emits `1eN` (3 bytes) for these powers of ten.
+        let int_len: u32 = if pow10_exp_1e4_to_1e9(val).is_some() {
+            3
+        } else {
+            digit_count_u64(val) as u32
+        };
+        return neg_prefix + int_len;
+    }
+
+    // `{}` on f64 is the shortest round-trip form, same as the printer's
+    // float fallback.
+    neg_prefix + count_float(abs_value) as u32
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // SizeFormatter
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -341,6 +341,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// we always fold constant expressions.
     pub(crate) should_fold_typescript_constant_expressions: bool,
 
+    /// Fold numeric arithmetic even when the folded literal prints larger
+    /// than the source. Set where a later consumer needs a concrete number:
+    /// enum bodies, macro/require args, const initializers under inlining.
+    pub(crate) fold_numeric_constants_unconditionally: bool,
+
     pub(crate) emitted_namespace_vars: RefMap,
     pub(crate) is_exported_inside_namespace: RefRefMap,
     pub(crate) local_type_names: StringBoolMap,
@@ -5560,6 +5565,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         _ => {}
                     }
                 }
+                // Size-aware folding can leave literal arithmetic as
+                // `.e_binary`; it is side-effect-free, so keep it removable.
+                // `extract_numeric_values` is non-recursive on purpose:
+                // `known_primitive` recursion overflows on a deep `a+a+a+…`.
+                js_ast::op::Code::BinAdd
+                | js_ast::op::Code::BinSub
+                | js_ast::op::Code::BinMul
+                | js_ast::op::Code::BinDiv
+                | js_ast::op::Code::BinRem
+                | js_ast::op::Code::BinPow => {
+                    if js_ast::Expr::extract_numeric_values(&ex.left.data, &ex.right.data).is_some()
+                    {
+                        return true;
+                    }
+                }
                 _ => {}
             },
             js_ast::ExprData::ETemplate(templ) => {
@@ -8665,6 +8685,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
             should_fold_typescript_constant_expressions: false,
+            fold_numeric_constants_unconditionally: false,
             emitted_namespace_vars: RefMap::default(),
             is_exported_inside_namespace: Default::default(),
             local_type_names: StringBoolMap::default(),

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -339,6 +339,22 @@ impl SideEffects {
                         }
                     }
 
+                    // Size-aware folding can leave literal arithmetic as
+                    // `.e_binary`; it is side-effect-free, so drop it when
+                    // unused. `extract_numeric_values` is non-recursive on
+                    // purpose: `known_primitive` recursion overflows on a
+                    // deep `a+a+a+…`.
+                    Op::Code::BinAdd
+                    | Op::Code::BinSub
+                    | Op::Code::BinMul
+                    | Op::Code::BinDiv
+                    | Op::Code::BinRem
+                    | Op::Code::BinPow => {
+                        if Expr::extract_numeric_values(&bin.left.data, &bin.right.data).is_some() {
+                            return None;
+                        }
+                    }
+
                     _ => {}
                 }
             }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -79,6 +79,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let old_fn_or_arrow_data = self.fn_or_arrow_data_visit;
         let old_fn_only_data = core::mem::take(&mut self.fn_only_data_visit);
+        // Force-fold applies to the immediate initializer only, not to a
+        // nested function body that runs at call time.
+        let old_fold_numeric_constants_unconditionally =
+            self.fold_numeric_constants_unconditionally;
+        self.fold_numeric_constants_unconditionally = false;
         self.fn_or_arrow_data_visit = FnOrArrowDataVisit {
             ..Default::default()
         };
@@ -178,6 +183,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.fn_or_arrow_data_visit = old_fn_or_arrow_data;
         self.fn_only_data_visit = old_fn_only_data;
+        self.fold_numeric_constants_unconditionally = old_fold_numeric_constants_unconditionally;
 
         func
     }
@@ -315,6 +321,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.react_compiler_candidate_name = Some(id.r#ref);
                     self.react_compiler_in_react_hoc = in_hoc;
                 }
+                // An unfolded `E::Binary` initializer fails
+                // `can_be_const_value`, which would silently disable
+                // const-value inlining and the DCE that depends on it.
+                let want_unconditional_numeric_fold = was_const
+                    && !self.vis_scope().is_after_const_local_prefix
+                    && self.options.features.inlining
+                    && matches!(decl.binding.data, BData::BIdentifier(_));
+                let prev_fold_numeric_constants_unconditionally =
+                    self.fold_numeric_constants_unconditionally;
+                if want_unconditional_numeric_fold {
+                    self.fold_numeric_constants_unconditionally = true;
+                }
                 self.visit_expr_in_out(
                     &mut val,
                     ExprIn {
@@ -324,6 +342,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 );
                 self.react_compiler_candidate_name = None;
                 self.react_compiler_in_react_hoc = false;
+                self.fold_numeric_constants_unconditionally =
+                    prev_fold_numeric_constants_unconditionally;
                 decl.value = Some(val);
                 self.decorator_class_name = prev_decorator_class_name;
 
@@ -786,6 +806,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             !SCAN_ONLY,
             "only_scan_imports_and_do_not_visit must not run this."
         );
+
+        // Decorators, `extends`, and the class body visit without routing
+        // through `visit_func`, so reset the force-fold here too.
+        let old_fold_numeric_constants_unconditionally =
+            self.fold_numeric_constants_unconditionally;
+        self.fold_numeric_constants_unconditionally = false;
 
         self.visit_ts_decorators(&mut class.ts_decorators);
 
@@ -1259,6 +1285,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // class name scope
         self.pop_scope();
 
+        self.fold_numeric_constants_unconditionally = old_fold_numeric_constants_unconditionally;
         shadow_ref
     }
 

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -11,6 +11,37 @@ use bun_ast::{
     expr::{Equality, LooseEql, StrictEql},
 };
 
+/// Under `minify_syntax`, fold `left op right` only when the folded literal
+/// prints no longer than the source (`1/3` beats `0.3333333333333333`);
+/// `fold_numeric_constants_unconditionally` bypasses the check. `op_len` is
+/// the printed operator width (2 for `**`, else 1); without
+/// `minify_whitespace` the printer spaces the operator, hence `space_len`.
+fn should_fold_arithmetic<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
+    p: &P<'a, TYPESCRIPT, SCAN_ONLY>,
+    folded_value: f64,
+    left: f64,
+    right: f64,
+    op_len: u32,
+) -> bool {
+    if p.fold_numeric_constants_unconditionally {
+        return true;
+    }
+    if !p.options.features.minify_syntax {
+        return true;
+    }
+    let space_len: u32 = if p.options.features.minify_whitespace {
+        0
+    } else {
+        2
+    };
+    let folded_len = bun_core::fmt::len_of_js_number(folded_value);
+    let source_len = bun_core::fmt::len_of_js_number(left)
+        + op_len
+        + space_len
+        + bun_core::fmt::len_of_js_number(right);
+    folded_len <= source_len
+}
+
 /// Try to optimize "typeof x === 'undefined'" to "typeof x > 'u'" or similar
 /// Returns the optimized expression if successful, None otherwise
 fn try_optimize_typeof_undefined<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
@@ -404,7 +435,10 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p.new_expr(E::Number::new(vals[0] + vals[1]), v.loc);
+                        let folded = vals[0] + vals[1];
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 1) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
 
                     // "'abc' + 'xyz'" => "'abcxyz'"
@@ -443,7 +477,10 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p.new_expr(E::Number::new(vals[0] - vals[1]), v.loc);
+                        let folded = vals[0] - vals[1];
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 1) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
                 }
             }
@@ -451,7 +488,10 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p.new_expr(E::Number::new(vals[0] * vals[1]), v.loc);
+                        let folded = vals[0] * vals[1];
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 1) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
                 }
             }
@@ -459,7 +499,10 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p.new_expr(E::Number::new(vals[0] / vals[1]), v.loc);
+                        let folded = vals[0] / vals[1];
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 1) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
                 }
             }
@@ -467,13 +510,13 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p.new_expr(
-                            // Rust `%` on f64 has libc fmod semantics (LLVM frem),
-                            // which matches what JavaScriptCore does:
-                            // https://github.com/oven-sh/WebKit/blob/7a0b13626e5db69aa5a32d037431d381df5dfb61/Source/JavaScriptCore/runtime/MathCommon.cpp#L574-L597
-                            E::Number::new(vals[0] % vals[1]),
-                            v.loc,
-                        );
+                        // Rust `%` on f64 has libc fmod semantics (LLVM frem),
+                        // which matches what JavaScriptCore does:
+                        // https://github.com/oven-sh/WebKit/blob/7a0b13626e5db69aa5a32d037431d381df5dfb61/Source/JavaScriptCore/runtime/MathCommon.cpp#L574-L597
+                        let folded = vals[0] % vals[1];
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 1) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
                 }
             }
@@ -481,8 +524,10 @@ impl BinaryExpressionVisitor {
                 if p.should_fold_typescript_constant_expressions {
                     if let Some(vals) = Expr::extract_numeric_values(&e_.left.data, &e_.right.data)
                     {
-                        return p
-                            .new_expr(E::Number::new(bun_ast::math::pow(vals[0], vals[1])), v.loc);
+                        let folded = bun_ast::math::pow(vals[0], vals[1]);
+                        if should_fold_arithmetic(p, folded, vals[0], vals[1], 2) {
+                            return p.new_expr(E::Number::new(folded), v.loc);
+                        }
                     }
                 }
             }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1803,8 +1803,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // const binding = await import(`./${process.platform}-${process.arch}.node`);
         //
         // Restored manually before each return.
-        let prev_should_fold_typescript_constant_expressions = true;
+        let prev_should_fold_typescript_constant_expressions =
+            p.should_fold_typescript_constant_expressions;
+        let prev_fold_numeric_constants_unconditionally = p.fold_numeric_constants_unconditionally;
         p.should_fold_typescript_constant_expressions = true;
+        // The transposer needs a fully folded import path, e.g. `import("./a" + 1)`.
+        p.fold_numeric_constants_unconditionally = true;
 
         p.visit_expr(&mut e_.expr);
         p.visit_expr(&mut e_.options);
@@ -1833,11 +1837,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             p.should_fold_typescript_constant_expressions =
                 prev_should_fold_typescript_constant_expressions;
+            p.fold_numeric_constants_unconditionally = prev_fold_numeric_constants_unconditionally;
             *e = p.maybe_transpose_if_import(e_.expr, &state);
             return;
         }
         p.should_fold_typescript_constant_expressions =
             prev_should_fold_typescript_constant_expressions;
+        p.fold_numeric_constants_unconditionally = prev_fold_numeric_constants_unconditionally;
     }
     fn e_call(p: &mut Self, e: &mut Expr, in_: ExprIn) {
         let expr = *e;
@@ -1943,6 +1949,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Restored manually below.
             let old_should_fold_typescript_constant_expressions =
                 p.should_fold_typescript_constant_expressions;
+            let old_fold_numeric_constants_unconditionally =
+                p.fold_numeric_constants_unconditionally;
             let old_is_control_flow_dead = p.is_control_flow_dead;
 
             // We want to forcefully fold constants inside of
@@ -1958,6 +1966,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 p.options.ignore_dce_annotations = true;
                 p.should_fold_typescript_constant_expressions = true;
+                // Macro args and require/import paths are consumed as
+                // concrete values; an unfolded `E::Binary` breaks both.
+                p.fold_numeric_constants_unconditionally = true;
             }
 
             // When a value is targeted by `--drop`, it will be removed.
@@ -1989,6 +2000,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.options.ignore_dce_annotations = old_ce;
             p.should_fold_typescript_constant_expressions =
                 old_should_fold_typescript_constant_expressions;
+            p.fold_numeric_constants_unconditionally = old_fold_numeric_constants_unconditionally;
 
             if method_call_should_be_replaced_with_undefined {
                 p.is_control_flow_dead = old_is_control_flow_dead;
@@ -2429,6 +2441,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             ..Default::default()
         };
 
+        // Force-fold applies to the immediate initializer only, not to an
+        // arrow body that runs at call time.
+        let old_fold_numeric_constants_unconditionally = p.fold_numeric_constants_unconditionally;
+        p.fold_numeric_constants_unconditionally = false;
+
         p.push_scope_for_visit_pass(js_ast::scope::Kind::FunctionArgs, expr.loc)
             .expect("unreachable");
         let dupe: &'a mut [Stmt] = p.arena.alloc_slice_copy(e_.body.stmts.slice());
@@ -2495,6 +2512,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.pop_scope();
 
         p.fn_or_arrow_data_visit = old_fn_or_arrow_data;
+        p.fold_numeric_constants_unconditionally = old_fold_numeric_constants_unconditionally;
 
         // Restore before any further `p.*` call so the stack-local pointer
         // never escapes this frame.

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2189,7 +2189,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // that's what the TypeScript compiler does.
         let old_should_fold_typescript_constant_expressions =
             p.should_fold_typescript_constant_expressions;
+        let old_fold_numeric_constants_unconditionally = p.fold_numeric_constants_unconditionally;
         p.should_fold_typescript_constant_expressions = true;
+        p.fold_numeric_constants_unconditionally = true;
 
         // Create an assignment for each enum value
         for value in values.iter_mut() {
@@ -2316,6 +2318,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.pop_scope();
         p.should_fold_typescript_constant_expressions =
             old_should_fold_typescript_constant_expressions;
+        p.fold_numeric_constants_unconditionally = old_fold_numeric_constants_unconditionally;
 
         let mut value_stmts: StmtList<'a> = BumpVec::with_capacity_in(value_exprs.len(), p.arena);
         // Generate statements from expressions

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -630,6 +630,193 @@ describe("bundler", () => {
       '+"æ"',
     ],
   });
+  // https://github.com/oven-sh/bun/issues/30203
+  // Only fold numeric arithmetic when the folded literal is no longer than
+  // the source expression — `1/3` is shorter than `0.3333333333333333`.
+  itBundled("minify/ConstantFoldingNumericBinarySizeAware", {
+    files: {
+      "/entry.js": `
+        // Expansive folds must be kept as-is
+        capture(1 / 3);
+        capture(2 / 3);
+        capture(1 / 7);
+        capture(10 / 3);
+        // Integer math still folds when it shrinks
+        capture(1 + 2);
+        capture(10 * 10);
+        capture(100 - 50);
+        capture(3 ** 4);
+        // Decimal-result fold that still shrinks (1.1 + 0.2 === 1.3 exactly,
+        // 3 bytes vs the 9-byte source).
+        capture(1.1 + 0.2);
+        // Equal-length boundary: with minify_whitespace off the source model
+        // is \`1 / 8\` = 5 bytes (1 + op + 2 spaces + 1) and the fold \`0.125\`
+        // is also 5 bytes, so \`folded_len <= source_len\` folds it. A \`<\` gate
+        // would wrongly keep it.
+        capture(1 / 8);
+        // Large powers that would inflate should be preserved
+        capture(10 ** 20);
+        // \`2 ** 32\` produced a u64 value outside the lemire table range in
+        // \`fastDigitCount\` and panicked the ASAN build on everything that
+        // imported readable-stream. Guard it explicitly.
+        capture(2 ** 32);
+      `,
+    },
+    minifySyntax: true,
+    capture: ["1 / 3", "2 / 3", "1 / 7", "10 / 3", "3", "100", "50", "81", "1.3", "0.125", "10 ** 20", "2 ** 32"],
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // With `minify_syntax` on but `minify_whitespace` off, the printer emits
+  // a space on either side of a binary operator (`5 / 4`, not `5/4`), so
+  // the source-length model must account for those two extra bytes — or
+  // folds that would shrink output (here `5 / 4` → `1.25`, saving a byte)
+  // get wrongly rejected.
+  itBundled("minify/ConstantFoldingNumericBinaryWithoutMinifyWhitespace", {
+    files: {
+      "/entry.js": `
+        // Shrinking fold: source is 5 chars with spaces, folded is 4.
+        capture(5 / 4);
+        // Inflating fold stays as-is.
+        capture(1 / 3);
+      `,
+    },
+    minifySyntax: true,
+    capture: ["1.25", "1 / 3"],
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // Macro args must always fold to a concrete value, even under `--minify`
+  // where the size-aware check would otherwise reject the fold — the macro
+  // runner calls `Expr.Data.toJS` which only handles literal AST nodes.
+  // Size-aware folding at the call-site itself (outside the macro) still
+  // applies.
+  itBundled("minify/ConstantFoldingMacroArgsAlwaysFold", {
+    files: {
+      "/entry.ts": `
+        import { show } from "./macro" with { type: "macro" };
+        capture(show(1 / 3));
+        capture(1 / 3);
+      `,
+      "/macro.ts": `export function show(x: number): number { return x; }`,
+    },
+    minifySyntax: true,
+    capture: ["0.3333333333333333", "1 / 3"],
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // A `const` initializer that loses the size-aware check would stay as
+  // `E.Binary`, which `canBeConstValue` rejects — so the ref wouldn't make
+  // it into `const_values` and use-site inlining + the DCE it enables
+  // would silently stop working. Force the fold for const decls when
+  // `features.inlining` is on so DCE of the else branch still happens.
+  itBundled("minify/ConstantFoldingConstInitializerFoldsForInlining", {
+    files: {
+      "/entry.ts": `
+        const RATIO = 16 / 9;
+        if (RATIO > 1) capture("big"); else capture("small");
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    capture: [`"big"`],
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // The const-decl force-fold flag must not leak through the function or
+  // arrow body. A nested `() => 1/3` runs at call time, not when the
+  // surrounding `const` is visited, so its arithmetic should obey the
+  // ordinary size-aware gate and stay unfolded.
+  itBundled("minify/ConstantFoldingConstArrowBodyDoesNotForceFold", {
+    files: {
+      "/entry.ts": `
+        const arrowRatio = () => 1 / 3;
+        const funcRatio = function () { return 1 / 3; };
+        export { arrowRatio, funcRatio };
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      // Arrow/function bodies are visited with
+      // fold_numeric_constants_unconditionally reset to false, so 1/3 stays
+      // as a binary expression (18-byte fold > 3-byte source).
+      expect(code).toContain("1 / 3");
+      expect(code).not.toContain("0.3333333333333333");
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // Class bodies — field initializers and static blocks — don't route
+  // through `visitFunc` or the arrow visitor, so they need their own
+  // reset of `fold_numeric_constants_unconditionally`. Without it, a
+  // caller (e.g. const-decl inlining) that force-folded would leak into
+  // the class body and re-introduce the #30203 inflation.
+  itBundled("minify/ConstantFoldingConstClassBodyDoesNotForceFold", {
+    files: {
+      // `const C` must come first so `is_after_const_local_prefix` is still
+      // false when it's visited and `want_unconditional_numeric_fold` fires;
+      // otherwise the visitClass reset has nothing to reset and the test
+      // passes via the ordinary size-aware path instead of exercising the
+      // fix. `function mixin` is hoisted, so the extends reference still
+      // resolves.
+      "/entry.ts": `
+        const C = class extends mixin(1 / 3) {
+          ratio = 1 / 3;
+          static { globalThis.staticRatio = 1 / 3; }
+        };
+        function mixin(x: number) { return class { rate = x; }; }
+        export { C };
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("1 / 3");
+      expect(code).not.toContain("0.3333333333333333");
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // Unused exports whose initializer arithmetic no longer folds to a number
+  // literal (e.g. `1/3` rejected by the size-aware check) must still be
+  // tree-shakable. `exprCanBeRemovedIfUnusedWithoutDCECheck` /
+  // `simplifyUnusedExpr` treat `number op number` arithmetic as
+  // side-effect-free so `classCanBeRemovedIfUnused` /
+  // `stmtsCanBeRemovedIfUnused` still answer true.
+  itBundled("minify/ConstantFoldingTreeShakesUnusedArithmetic", {
+    files: {
+      "/entry.ts": `
+        import { used } from "./lib";
+        console.log(used);
+      `,
+      "/lib.ts": `
+        export class Unused { ratio = 1 / 3; }
+        export let unusedLet = 1 / 3;
+        export var unusedVar = 16 / 9;
+        export const used = "hello";
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).not.toContain("Unused");
+      expect(code).not.toContain("unusedLet");
+      expect(code).not.toContain("unusedVar");
+      expect(code).toContain("hello");
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/30203
+  // Enum bodies must still fully fold so the emitted table has numeric
+  // values, and so later members can reference earlier numeric members.
+  itBundled("minify/ConstantFoldingEnumBodyAlwaysFolds", {
+    files: {
+      "/entry.ts": `
+        enum E { A = 1 / 3, B = A + 1 }
+        capture(E.A);
+        capture(E.B);
+      `,
+    },
+    minifySyntax: true,
+    capture: ["0.3333333333333333 /* A */", "1.3333333333333333 /* B */"],
+  });
   itBundled("minify/ImportMetaHotTreeShaking", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
Fixes #30203.

## Repro

```js
// index.js
console.log(1/3);
```

Before:
```console
$ bun build index.js --minify
console.log(0.3333333333333333);
```

After (matches esbuild):
```console
$ bun build index.js --minify
console.log(1/3);
```

Same for `2/3`, `1/7`, `10/3`, `10**20`, and any arithmetic whose exact IEEE-754 result doesn't round-trip to a short decimal — every one of these inflated the output rather than shrinking it.

## Cause

Every numeric arithmetic fold in the parser (`BinAdd`, `BinSub`, `BinMul`, `BinDiv`, `BinRem`, `BinPow`) gated purely on `should_fold_typescript_constant_expressions` — a file-wide flag set by `minify_syntax` or `inlining`. If the fold ran, it emitted the `E::Number` unconditionally, no matter how long the result printed.

For integer wins (`1+2` → `3`) that's correct. For non-terminating fractions it's a regression: `1/3` is 3 bytes, `0.3333333333333333` is 18.

## Fix

New helper `should_fold_arithmetic(p, folded, left, right, op_len)` in `src/js_parser/visit/visit_binary.rs`:

- Returns true inside TypeScript enum bodies (`tsc` computes enum values eagerly, and later members can reference earlier numeric members — the enum table must have numbers). Tracked via a new `fold_numeric_constants_unconditionally` parser flag that the enum-body visit toggles on and restores.
- Returns true when `minify_syntax` is off (the only callers left are the `features.inlining` file-wide case, where neither folding nor not-folding changes behavior at this stage).
- Otherwise compares `len_of_js_number(folded)` against `len_of_js_number(left) + op_len + space_len + len_of_js_number(right)` and keeps the source expression when the fold would inflate. `space_len` is 2 when `minify_whitespace` is off (the printer emits `5 / 4`, not `5/4`) and 0 otherwise.

`len_of_js_number` is a new helper in `src/bun_core/fmt.rs` (shared so `bun_js_parser` can reach it without depending on the printer crate) that mirrors the printer's special cases (e.g. `1e4` instead of `10000`) so the size check reflects actual emitted bytes. `op_len` is 1 for `+ - * / %` and 2 for `**`.

Three call-site exceptions force the fold regardless of size so downstream consumers still see a concrete literal:
- **Macro arguments** — the macro runner calls `Expr::Data::to_js`, which only handles literal AST nodes.
- **`const` initializers under `features.inlining`** — an unfolded `E::Binary` fails `can_be_const_value`, so the ref never enters `const_values` and use-site inlining + the DCE it enables silently stops. The force-fold flag is reset at function/arrow/class entry so it can't leak into a nested body that runs at call time.
- **Tree-shaking/DCE** — `number op number` arithmetic is now treated as side-effect-free (`extract_numeric_value`, non-recursive to avoid a stack overflow on deep `a+a+a+…` chains) so unused expansive folds like `1/3` are still removed.

## Verification

- `minify/ConstantFoldingNumericBinarySizeAware` — `1/3`, `2/3`, `1/7`, `10/3` kept; integer folds `1+2`, `10*10`, `100-50`, `3**4` folded; wash-case `1.1+0.2` → `1.3` folded; `10**20` and `2**32` kept (the latter also regression-guards a `fastDigitCount` u64 range panic).
- `minify/ConstantFoldingNumericBinaryWithoutMinifyWhitespace` — with whitespace on, `5 / 4` → `1.25` (shrinks) folds, `1 / 3` kept.
- `minify/ConstantFoldingMacroArgsAlwaysFold`, `ConstInitializerFoldsForInlining`, `ConstArrowBodyDoesNotForceFold`, `ConstClassBodyDoesNotForceFold`, `TreeShakesUnusedArithmetic`, `EnumBodyAlwaysFolds` — cover the call-site exceptions and the no-leak guarantee.

All 8 pass on this build; the size-aware tests fail against stock bun, confirming they exercise the fix. `bun build --minify` on the repro now keeps `1/3` and `1/4` and still folds `10/2` → `5`.

## Note on the rebase

Rebased onto current `main` several times as it advanced; the branch is now a single commit. Points worth noting:
- The transpiler's Zig-to-Rust port completed on `main`, which then deleted the orphaned `src/js_parser/**/*.zig` / `src/js_printer/js_printer.zig` reference files. This PR no longer touches any `.zig`; the change is entirely in the live Rust parser (`src/js_parser/*.rs`, `src/bun_core/fmt.rs`).
- #32507 (`ast: shrink Expr/Stmt/Binding`) swapped the `E::Number { value: x }` struct literal for the `E::Number::new(x)` constructor; resolved by keeping the size-aware gate on every arithmetic arm and using the new constructor.
- #32504 (React Compiler integration) added candidate-tracking around the const-initializer `visit_expr` in `visit_decls`, the same spot as this PR's force-fold flag; resolved by running both (react candidate set, fold flag save/set, both restored after the visit).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 60 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [662.60ms]
(pass) bundler > minify/StringAdditionFolding [137.75ms]
(pass) bundler > minify/FunctionExpressionRemoveName [170.71ms]
(pass) bundler > minify/KeepNamesPreservesNames [151.29ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [109.21ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1244.20ms]
(pass) bundler > minify/MergeAdjacentVars [425.06ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [453.14ms]
(pass) bundler > minify/Infinity [117.04ms]
(pass) bundler > minify+whitespace/Infinity [120.21ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [477.06ms]
(pass) bundler > minify/InlineArraySpread [107.37ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [400.56ms]
(pass) bundler > minify/MissingExpressionBlocks [464.58ms]
(pass) bundler > minify/BunRequireStatement [1105.13ms]
(pass) bundler > minify/SwitchUndefined [601.59ms]
(pa
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [46.21ms]
(pass) bundler > minify/StringAdditionFolding [24.58ms]
(pass) bundler > minify/FunctionExpressionRemoveName [9.81ms]
(pass) bundler > minify/KeepNamesPreservesNames [10.50ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [13.11ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [33.64ms]
(pass) bundler > minify/MergeAdjacentVars [34.15ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [19.63ms]
(pass) bundler > minify/Infinity [12.06ms]
(pass) bundler > minify+whitespace/Infinity [6.25ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [18.58ms]
(pass) bundler > minify/InlineArraySpread [19.53ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [15.93ms]
(pass) bundler > minify/MissingExpressionBlocks [15.62ms]
(pass) bundler > minify/BunRequireStatement [28.02ms]
(pass) bundler > minify/SwitchUndefined [22.58ms]
(pass) bundler > minify/RequireInDeadBranch [12.62ms]
(pass) bundler > minify/TypeOfRequire [7.24ms]
(pass) bundler > minify/RequireMainToImportMetaMain [6.83ms]
(pass) bundler > mini
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts
bun test v1.4.0 (6e906e468)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [668.14ms]
(pass) bundler > minify/StringAdditionFolding [115.41ms]
(pass) bundler > minify/FunctionExpressionRemoveName [157.47ms]
(pass) bundler > minify/KeepNamesPreservesNames [113.11ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [90.74ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1280.87ms]
(pass) bundler > minify/MergeAdjacentVars [375.82ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [466.30ms]
(pass) bundler > minify/Infinity [104.55ms]
(pass) bundler > minify+whitespace/Infinity [101.90ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [408.95ms]
(pass) bundler > minify/InlineArraySpread [94.32ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [368.54ms]
(pass) bundler > minify/MissingExpressionBlocks [446.54ms]
(pass) bundler > minify/BunRequireStatement [1031.68ms]
(pass) bundler > minify/SwitchUndefined [583.65ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a99de5b8bc
  features     baseline

23 deps, 129 codegen, 1172 objects in 787ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [10.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [6.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 12ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] fetch zlib
[zlib] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/fmt.rs                     |  32 ++++++
 src/js_parser/p.rs                      |  21 ++++
 src/js_parser/scan/scan_side_effects.rs |  16 +++
 src/js_parser/visit/mod.rs              |  27 +++++
 src/js_parser/visit/visit_binary.rs     |  71 +++++++++---
 src/js_parser/visit/visit_expr.rs       |  20 +++-
 src/js_parser/visit/visit_stmt.rs       |   3 +
 test/bundler/bundler_minify.test.ts     | 187 ++++++++++++++++++++++++++++++++
 8 files changed, 363 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 60

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/bun_core/fmt.rs                          7      8     93
src/js_parser/p.rs                           6      9     93
src/js_parser/scan/scan_side_effects.rs      2      4     92
src/js_parser/visit/mod.rs                  10     11     93
src/js_parser/visit/visit_binary.rs         13     18     95
src/js_parser/visit/visit_expr.rs            8     12     92
src/js_parser/visit/visit_stmt.rs            2      2     92
test/bundler/bundler_minify.test.ts         16     21     91
```

</details>

**root cause** · written by the author bot

The root cause was that the minifier's constant folding always replaced numeric binary expressions with their computed result, even when the printed result, such as 0.3333333333333333 for 1/3, was longer than the original expression, producing larger output than esbuild. The fix makes folding size-aware by adding a lenOfNumber helper that estimates the printed byte length of the folded value and only folds when that length does not exceed the combined length of the operands and operator. TypeScript enum bodies are exempted via a new parser flag that forces unconditional folding there, since…

<!-- robobun:evidence:end -->
