### PR TITLE
bun -p: return module completion value, not first yielded await

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3584,7 +3584,28 @@ JSC::JSValue EvalGlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGloba
     RETURN_IF_EXCEPTION(scope, result);
 
     if (Bun__VM__specifierIsEvalEntryPoint(globalObject->bunVM(), JSValue::encode(key))) {
-        Bun__VM__setEntryPointEvalResultESM(globalObject->bunVM(), JSValue::encode(result));
+        // For a module with top-level `await`, JSC compiles the body as a
+        // generator and the first call into evaluate() yields the awaited
+        // value — NOT the module's final completion value. If we captured
+        // that yielded value here, `bun -p '(await 1) + 1'` would print `1`
+        // instead of `2`. The resume path (asyncModuleExecutionResume in
+        // WebKit) calls module->evaluate() directly and bypasses this hook,
+        // so we can't rely on a later call to overwrite the captured value.
+        //
+        // Instead, when the module yielded, capture the async capability's
+        // promise. Its resolution value is the module's final completion
+        // value; the --print loop in bun.js.zig already unwraps promises
+        // via asAnyPromise + Bun__onResolveEntryPointResult.
+        JSC::JSValue valueToStore = result;
+        if (auto* moduleRecord = dynamicDowncast<JSC::AbstractModuleRecord>(moduleRecordValue)) {
+            JSC::JSValue state = moduleRecord->internalField(JSC::AbstractModuleRecord::Field::State).get();
+            bool moduleYielded = state.isNumber() && state.asNumber() != static_cast<int32_t>(JSC::JSGenerator::State::Executing);
+            if (moduleYielded) {
+                if (auto* capability = moduleRecord->asyncCapability())
+                    valueToStore = capability;
+            }
+        }
+        Bun__VM__setEntryPointEvalResultESM(globalObject->bunVM(), JSValue::encode(valueToStore));
     }
 
     return result;

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -110,20 +110,22 @@ describe("--print for cjs/esm", () => {
     rmSync(cwd, { recursive: true, force: true });
   });
   // https://github.com/oven-sh/bun/issues/30207
-  test.each([
+  describe.each([
     { expr: "(await 1) + 1", expected: "2" },
     { expr: 'await Promise.resolve("hello") + " world"', expected: "hello world" },
     { expr: "(await 1) + (await 2)", expected: "3" },
     // no top-level await — still returns the expression value.
     { expr: "1 + 1", expected: "2" },
-  ])("bun -p $expr → $expected", async ({ expr, expected }) => {
-    const { stdout, stderr, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), "-p", expr],
-      env: bunEnv,
+  ])("bun -p $expr", ({ expr, expected }) => {
+    test(`→ ${expected}`, async () => {
+      const { stdout, stderr, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), "-p", expr],
+        env: bunEnv,
+      });
+      expect(stderr.toString("utf8")).toBe("");
+      expect(stdout.toString("utf8")).toBe(`${expected}\n`);
+      expect(exitCode).toBe(0);
     });
-    expect(stderr.toString("utf8")).toBe("");
-    expect(stdout.toString("utf8")).toBe(`${expected}\n`);
-    expect(exitCode).toBe(0);
   });
   test("forced cjs", async () => {
     let { stdout, stderr, exitCode } = Bun.spawnSync({

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -109,6 +109,22 @@ describe("--print for cjs/esm", () => {
     expect(exitCode).toBe(0);
     rmSync(cwd, { recursive: true, force: true });
   });
+  // https://github.com/oven-sh/bun/issues/30207
+  test.each([
+    { expr: "(await 1) + 1", expected: "2" },
+    { expr: 'await Promise.resolve("hello") + " world"', expected: "hello world" },
+    { expr: "(await 1) + (await 2)", expected: "3" },
+    // no top-level await — still returns the expression value.
+    { expr: "1 + 1", expected: "2" },
+  ])("bun -p $expr → $expected", async ({ expr, expected }) => {
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), "-p", expr],
+      env: bunEnv,
+    });
+    expect(stderr.toString("utf8")).toBe("");
+    expect(stdout.toString("utf8")).toBe(`${expected}\n`);
+    expect(exitCode).toBe(0);
+  });
   test("forced cjs", async () => {
     let { stdout, stderr, exitCode } = Bun.spawnSync({
       cmd: [bunExe(), "--print", "module.exports; 123"],


### PR DESCRIPTION
## Repro

```console
$ bun -p '(await 1) + 1'
1
$ bun -p 'await Promise.resolve("hello") + " world"'
hello
```

Expected: `2` and `hello world`.

## Cause

`--print` uses ESM module evaluation and captures the last expression
value via `EvalGlobalObject::moduleLoaderEvaluate` in
`src/bun.js/bindings/ZigGlobalObject.cpp`. For a module with top-level
`await`, JSC generator-ifies the body; the first call into
`moduleLoader->evaluate()` yields the awaited value (`1`), not the
module's final completion value (`2`). That yielded value was stored as
the eval result.

The async resume path (`asyncModuleExecutionResume` in
`vendor/WebKit/.../JSMicrotask.cpp`) calls `module->evaluate()`
directly and bypasses the `moduleLoaderEvaluate` hook, so the hook
could never observe the final value and correct itself.

## Fix

After the initial `evaluateNonVirtual` call, inspect the module
record's generator state. If it yielded (state is a number other than
`Executing`), the module still has work left and `result` is the
awaited value. Store the module's `asyncCapability()` promise instead
— its eventual resolution is the module's actual completion value.

The `bun -p` loop in `src/bun.js.zig` already unwraps promises via
`asAnyPromise` + `Bun__onResolveEntryPointResult`, so no Zig-side
changes are needed. For non-TLA modules, behavior is unchanged (state
is `Executing`, `result` stored as before).

## Verification

- `USE_SYSTEM_BUN=1 bun test test/cli/run/run-eval.test.ts -t 'bun -p'` → 3 fail, 1 pass
- `bun bd test test/cli/run/run-eval.test.ts -t 'bun -p'` → 4 pass
- Full `test/cli/run/run-eval.test.ts` (33 tests) and TLA regression tests still pass.

Fixes #30207