### PR TITLE
Fix panic in Bun.file().writer() with invalid path/fd options

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2974,8 +2974,11 @@ pub fn getWriter(
     };
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
-        stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        const parsed = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
+        if (parsed == .FileSink) {
+            stream_start.FileSink.chunk_size = parsed.FileSink.chunk_size;
+            parsed.FileSink.input_path.deinit();
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,24 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+it("writer() does not crash when options contain a non-string path", async () => {
+  const dir = tmpdirSync();
+  const file = Bun.file(join(dir, "writer-bad-path.txt"));
+  const writer = file.writer({ path: {} } as any);
+  await writer.write("hello");
+  await writer.end();
+  expect(await file.text()).toBe("hello");
+});
+
+it("writer() does not crash when options contain a non-integer fd", async () => {
+  const dir = tmpdirSync();
+  const file = Bun.file(join(dir, "writer-bad-fd.txt"));
+  const writer = file.writer({ fd: "not a number" } as any);
+  await writer.write("hello");
+  await writer.end();
+  expect(await file.text()).toBe("hello");
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in debug builds when calling `Bun.file(path).writer(options)` where `options` contains a non-string `path` or non-integer `fd` property.

```js
Bun.file("/tmp/x").writer({ path: {} });
// panic(main thread): access of union field 'FileSink' while field 'err' is active
```

`streams.Start.fromJSWithTag(.FileSink)` returns `.err` when the options object has an invalid `path`/`fd`, but `Blob.getWriter` unconditionally accessed `.FileSink.input_path` on the result.

Since `getWriter` always overrides `input_path` with the blob's own path anyway, the `path`/`fd` from the options object are irrelevant to this caller. The fix copies only `chunk_size` from the parsed options when the result is `.FileSink`, and frees the parsed `input_path` (which was previously leaked when it was an allocated string).

## How did you verify your code works?

Added regression tests to `test/js/bun/util/filesink.test.ts` covering both the non-string `path` and non-integer `fd` cases.

Found by Fuzzilli, fingerprint `1629533a7e86af53`.