### PR TITLE
webcore/Blob: handle non-FileSink result from fromJSWithTag in getWriter

### DIFF
--- a/src/bun.js/webcore/Blob.zig
+++ b/src/bun.js/webcore/Blob.zig
@@ -2975,7 +2975,12 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        if (stream_start == .FileSink) {
+            stream_start.FileSink.input_path.deinit();
+            stream_start.FileSink.input_path = input_path;
+        } else {
+            stream_start = .{ .FileSink = .{ .input_path = input_path } };
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -194,6 +194,17 @@ it("end does close when not backed by a file descriptor", async () => {
   await Bun.sleep(10); // For the file descriptor leak checker.
 });
 
+it("ignores non-string path / non-int fd in options instead of crashing", async () => {
+  const dir = tmpdirSync();
+  for (const options of [{ path: {} }, { fd: "not-an-int" }, { path: 123 }]) {
+    const file = Bun.file(join(dir, "writer-invalid-options.txt"));
+    const writer = file.writer(options as any);
+    writer.write("ok");
+    await writer.end();
+    expect(await file.text()).toBe("ok");
+  }
+});
+
 it("write result is not cumulative", async () => {
   using _ = fileDescriptorLeakChecker();
   const x = tmpdirSync();


### PR DESCRIPTION
Fuzzer found a debug-build panic in `Bun.file(path).writer(options)`:

```js
const f = Bun.file("/proc/self/status");
f.writer({ path: {} });
```

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
bun.js.webcore.Blob.getWriter
```

### What

`streams.Start.fromJSWithTag(globalThis, options, .FileSink)` returns `.err` (not `.FileSink`) when `options.path` is present but not a string, or `options.fd` is present but not an integer. `Blob.getWriter` then unconditionally does `stream_start.FileSink.input_path = input_path`, which trips the inactive-union-field safety check in debug builds and is UB in release.

### Fix

The Blob already knows its own path — the code always overwrites `input_path` with the Blob's store path regardless of what `fromJSWithTag` parsed from options. So when `fromJSWithTag` returns something other than `.FileSink`, just fall back to a `.FileSink` start with the Blob's `input_path` (same as if no options were passed).

Also `deinit()` the parsed `input_path` before overwriting it, since `fromJSWithTag` may have allocated via `toSlice` when `options.path` was a string.

Fingerprint: `e910278c68a4a740`