### PR TITLE
fix(test --isolate): repoint NapiEnv at new global during swap

### DIFF
--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -617,6 +617,11 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
+    // NapiEnv holds a raw Zig::GlobalObject*; deferred NAPI finalizers from the
+    // previous file still reference those envs after this swap. Repoint and
+    // re-own them before the old global becomes collectable.
+    globalObject->adoptNapiEnvsForTestIsolation(oldGlobal);
+
     // Drop the permanent root on the previous global so its module registry,
     // require.cache, and user objects become collectable. JSC's CodeCache and
     // Bun's RuntimeTranspilerCache are VM/process scoped and survive.
@@ -3770,6 +3775,25 @@ bool GlobalObject::hasNapiFinalizers() const
     }
 
     return false;
+}
+
+// `bun test --isolate` creates a fresh Zig::GlobalObject per test file on the
+// same JSC::VM and gcUnprotect()s the previous one. NapiEnvs created by the
+// previous file are still referenced from queued NapiFinalizerTasks and from
+// weak-handle owners that fire during later GCs, but NapiEnv::m_globalObject
+// is a raw pointer — once the old global is swept, every env->globalObject()
+// call (handle-scope open, Finalizer.run, napi_async_work completion, …)
+// dereferences freed memory. Repoint the envs at the new global and move
+// ownership so the new global keeps them alive and reports their pending
+// finalizers via hasNapiFinalizers().
+void GlobalObject::adoptNapiEnvsForTestIsolation(GlobalObject* fromGlobal)
+{
+    ASSERT(&vm() == &fromGlobal->vm());
+    ASSERT(m_napiEnvs.isEmpty());
+    for (auto& env : fromGlobal->m_napiEnvs) {
+        env->setGlobalObject(this);
+    }
+    m_napiEnvs = std::exchange(fromGlobal->m_napiEnvs, {});
 }
 
 void GlobalObject::setNodeWorkerEnvironmentData(JSMap* data) { m_nodeWorkerEnvironmentData.set(vm(), this, data); }

--- a/src/bun.js/bindings/ZigGlobalObject.h
+++ b/src/bun.js/bindings/ZigGlobalObject.h
@@ -781,6 +781,7 @@ public:
     Ref<NapiEnv> makeNapiEnv(const napi_module&);
     napi_env makeNapiEnvForFFI();
     bool hasNapiFinalizers() const;
+    void adoptNapiEnvsForTestIsolation(GlobalObject* fromGlobal);
 
 private:
     DOMGuardedObjectSet m_guardedObjects WTF_GUARDED_BY_LOCK(m_gcLock);

--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -380,12 +380,18 @@ public:
     }
 
     inline Zig::GlobalObject* globalObject() const { return m_globalObject; }
-    // Test isolation (`bun test --isolate`) swaps the Zig::GlobalObject while the
-    // JSC::VM stays alive. NapiEnvs outlive their original global — they're held
-    // by queued NapiFinalizerTasks and by weak-handle callbacks that fire after
-    // the old global is swept — so this raw pointer must be repointed at the
-    // replacement global during the swap.
-    inline void setGlobalObject(Zig::GlobalObject* globalObject) { m_globalObject = globalObject; }
+    // Only for GlobalObject::adoptNapiEnvsForTestIsolation(): `bun test
+    // --isolate` swaps the Zig::GlobalObject while the JSC::VM stays alive.
+    // NapiEnvs outlive their original global — they're held by queued
+    // NapiFinalizerTasks and by weak-handle callbacks that fire after the old
+    // global is swept — so this raw pointer must be repointed at the
+    // replacement global during the swap. m_vm is fixed at construction; the
+    // replacement must live in the same VM.
+    inline void setGlobalObject(Zig::GlobalObject* globalObject)
+    {
+        ASSERT(&JSC::getVM(globalObject) == &m_vm);
+        m_globalObject = globalObject;
+    }
     inline const napi_module& napiModule() const { return m_napiModule; }
     inline JSC::VM& vm() const { return m_vm; }
     inline std::optional<JSC::JSValue> pendingException() const

--- a/src/bun.js/bindings/napi.h
+++ b/src/bun.js/bindings/napi.h
@@ -380,6 +380,12 @@ public:
     }
 
     inline Zig::GlobalObject* globalObject() const { return m_globalObject; }
+    // Test isolation (`bun test --isolate`) swaps the Zig::GlobalObject while the
+    // JSC::VM stays alive. NapiEnvs outlive their original global — they're held
+    // by queued NapiFinalizerTasks and by weak-handle callbacks that fire after
+    // the old global is swept — so this raw pointer must be repointed at the
+    // replacement global during the swap.
+    inline void setGlobalObject(Zig::GlobalObject* globalObject) { m_globalObject = globalObject; }
     inline const napi_module& napiModule() const { return m_napiModule; }
     inline JSC::VM& vm() const { return m_vm; }
     inline std::optional<JSC::JSValue> pendingException() const

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -11,6 +11,7 @@
 
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
@@ -34,6 +35,9 @@ describe.skipIf(isWindows)("bun test --isolate with NAPI finalizers pending acro
     });
     if (!install.success) {
       throw new Error("napi-app build failed:\n" + install.stderr.toString());
+    }
+    if (!existsSync(addonPath)) {
+      throw new Error(`napi-app build succeeded but ${addonPath} is missing:\n${install.stderr.toString()}`);
     }
   }, 120_000);
 
@@ -73,20 +77,27 @@ describe.skipIf(isWindows)("bun test --isolate with NAPI finalizers pending acro
         BUN_JSC_collectContinuously: "1",
       },
       cwd: String(dir),
-      stdout: "pipe",
+      // The addon printf()s "finalizer\n" per wrapped object — up to 20k lines
+      // of fully-buffered libc stdio we don't need and which may or may not be
+      // flushed depending on the build's exit path.
+      stdout: "ignore",
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-    // The addon's finalizer prints "finalizer" to stdout for every wrapped
-    // object. Seeing them proves deferred finalizers actually ran (against a
-    // live global) rather than being silently dropped.
-    expect(stdout).toContain("finalizer");
-    // On crash the runner aborts mid-run and never prints the pass/fail
-    // summary; assert the summary before the exit code for a readable diff.
-    expect(stderr).toContain("20 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
+    // On crash the runner aborts mid-run and never reaches the pass/fail
+    // summary. No --retry is set, so a single panic is terminal. Asserting
+    // the full summary + signal together keeps the diff actionable when it
+    // regresses.
+    expect({
+      summary: stderr.split("\n").filter(l => / pass| fail|^Ran /.test(l)),
+      exitCode,
+      signalCode: proc.signalCode,
+    }).toEqual({
+      summary: [" 20 pass", " 0 fail", expect.stringMatching(/^Ran 20 tests across 20 files\./)],
+      exitCode: 0,
+      signalCode: null,
+    });
   }, 120_000);
 });

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -11,8 +11,8 @@
 
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 const napiAppDir = join(import.meta.dir, "..", "..", "napi", "napi-app");

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -75,6 +75,14 @@ describe.skipIf(isWindows)("bun test --isolate with NAPI finalizers pending acro
       env: {
         ...bunEnv,
         BUN_JSC_collectContinuously: "1",
+        // CI ASAN sets this on the outer test and bunEnv inherits
+        // process.env; NAPI module init (napi_create_function →
+        // napi_set_named_property) has a pre-existing unchecked-exception
+        // scope that is unrelated to the global-swap UAF under test, so
+        // keep the validator off in the child like the other NAPI tests in
+        // no-validate-exceptions.txt.
+        BUN_JSC_validateExceptionChecks: undefined,
+        BUN_JSC_dumpSimulatedThrows: undefined,
       },
       cwd: String(dir),
       // The addon printf()s "finalizer\n" per wrapped object — up to 20k lines

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -1,0 +1,96 @@
+// https://github.com/oven-sh/bun/issues/30205
+//
+// `bun test --isolate` swaps the Zig::GlobalObject between test files while
+// keeping the JSC::VM alive. NapiEnv caches the global as a raw pointer; when
+// deferred NAPI finalizers (NapiFinalizerTask) from a previous file ran after
+// the swap, they opened a handle scope on the old, already-swept global and
+// hit Heap::addToRememberedSet(!isMarked(cell)) → segfault at 0x68/0xD0.
+//
+// collectContinuously keeps the concurrent collector running so the old
+// global and its wrapped objects are reliably swept between files.
+
+import { spawnSync } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
+
+const napiAppDir = join(import.meta.dir, "..", "..", "napi", "napi-app");
+const addonPath = join(napiAppDir, "build", "Debug", "async_finalize_addon.node");
+
+// collectContinuously is very slow under Windows + ASAN in CI (see 29519);
+// the path under test is platform-agnostic so posix coverage is sufficient.
+describe.skipIf(isWindows)("bun test --isolate with NAPI finalizers pending across files", () => {
+  beforeAll(() => {
+    // async_finalize_addon uses NAPI_VERSION 8 (not experimental), so its
+    // napi_wrap finalizers are deferred to the event loop via
+    // NapiFinalizerTask instead of running during the GC sweep.
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: napiAppDir,
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "inherit",
+    });
+    if (!install.success) {
+      throw new Error("napi-app build failed:\n" + install.stderr.toString());
+    }
+  }, 120_000);
+
+  test("deferred finalizers from a prior file see a live global", async () => {
+    const files: Record<string, string> = {};
+    // Zig::GlobalObject sits in an IsoSubspace whose slot isn't recycled
+    // until enough swaps have accumulated; 20 files is the minimum observed
+    // to reliably reuse the old global's memory under a release build.
+    for (let i = 0; i < 20; i++) {
+      // Each file loads the addon (fresh NapiEnv per global), wraps a batch
+      // of objects, then roots some Buffer ballast on globalThis so the old
+      // global's object graph is non-trivial when the next file's allocations
+      // trigger a sweep. That sweep collects the wrapped objects and their
+      // weak-handle callbacks enqueue NapiFinalizerTasks still holding the
+      // previous file's NapiEnv.
+      files[`file-${i}.test.ts`] = `
+        import { test, expect } from "bun:test";
+        const addon = require(${JSON.stringify(addonPath)});
+        test("wrap pressure ${i}", () => {
+          for (let j = 0; j < 500; j++) addon.create_ref();
+          globalThis.__leak = [];
+          for (let j = 0; j < 500; j++) {
+            globalThis.__leak.push(Buffer.alloc(8192, j));
+            addon.create_ref();
+          }
+          expect(typeof addon.create_ref).toBe("function");
+        });
+      `;
+    }
+
+    using dir = tempDir("napi-isolate-finalizer", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "."],
+      env: {
+        ...bunEnv,
+        BUN_JSC_collectContinuously: "1",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    // The addon's finalizer prints "finalizer" to stdout for every wrapped
+    // object. Seeing them proves deferred finalizers actually ran (against a
+    // live global) rather than being silently dropped.
+    expect(stdout).toContain("finalizer");
+    // On crash the runner aborts mid-run and never prints the pass/fail
+    // summary; assert the summary before the exit code for a readable diff.
+    expect(stderr).toContain("20 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  }, 120_000);
+});

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -77,11 +77,7 @@ describe.skipIf(isWindows)("bun test --isolate with NAPI finalizers pending acro
       stderr: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // The addon's finalizer prints "finalizer" to stdout for every wrapped
     // object. Seeing them proves deferred finalizers actually ran (against a


### PR DESCRIPTION
Fixes #30205 (also the remaining half of #30191).

## Repro

Any test suite that loads a NAPI module under `bun test --isolate` (or `--parallel`, which implies `--isolate` per worker). Minimal:

```sh
# 20 files, each: require(<.node addon with deferred finalizers>), napi_wrap a batch
bun test --isolate .
```

Release builds segfault at `0x68`/`0xD0`/`0xE00000020`; debug builds assert `isMarked(cell)` in `JSC::Heap::addToRememberedSet`. The reporter's `workglow-dev/libs` suite hits it on every `bun run test:bun:unit` (the panics are masked by `retry = 1` so the exit code stays 0).

## Root cause

`NapiEnv::m_globalObject` is a raw `Zig::GlobalObject*`. `Zig__GlobalObject__createForTestIsolation` creates a new global and `gcUnprotect()`s the old one, but never touches the `NapiEnv`s the old global created. Those envs are kept alive by `NapiEnv::Ref` held in queued `NapiFinalizerTask`s (and by weak-handle owners that fire `napi_internal_enqueue_finalizer` when the old graph is swept on a later GC). When the deferred finalizer runs on the event loop:

```
NapiFinalizerTask.runOnJSThread
  → Finalizer.run
    → NapiHandleScope.open(env, false)
      → NapiHandleScope__open(env, false)
        → NapiHandleScope::open(env->globalObject(), …)   // stale raw pointer
          → globalObject->m_currentNapiHandleScopeImpl.set(vm, globalObject, impl)
            → vm.writeBarrier(globalObject, …)
              → Heap::addToRememberedSet(globalObject)     // cell is swept → ASSERT / segfault
```

Every `process_dlopen` in the `Features:` line of the reporter's panics is the fingerprint.

This is distinct from #29519 / PR #29573: that `DeferGC` protects the *new* global during `finishCreation`; this is the *old* global being written to long after the swap, via a raw pointer the swap never updated.

## Fix

During the swap, move `oldGlobal->m_napiEnvs` into the new global and set each env's `m_globalObject` to the new global. This is done inside the existing `DeferGC` scope, before `gcUnprotect(oldGlobal)`, so the envs never observe an unprotected pointer. The new global keeps them alive and reports their pending finalizers via `hasNapiFinalizers()`; every `env->globalObject()` caller (`NapiHandleScope`, `Finalizer.run`, `napi_async_work::runFromJS`, `ThreadSafeFunction`, `toJS(napi_env)`) now sees a live, `gcProtect()`'d global.

## Verification

New regression test in `test/regression/issue/30205.test.ts` spawns `bun test --isolate` over 20 files that each `require` the existing `test/napi/napi-app/async_finalize_addon` (NAPI v8, deferred finalizers) and wrap 1000 objects with Buffer ballast rooted on `globalThis`, under `BUN_JSC_collectContinuously=1`.

| build | before fix | after fix |
| --- | --- | --- |
| debug (ASAN) | `ASSERTION FAILED: isMarked(cell)` — 10/10 | 20 pass, 0 fail — 3/3 |
| release (system bun) | `panic: Segmentation fault at address 0x68` — 8/8 | — |

The reporter's `sharp` repro (20 files, no `collectContinuously`) also passes 3/3 after the fix and 3/3 under `--parallel=4 --retry=1 --max-concurrency=20`.