### PR TITLE
ci: enable zstd compression for Docker image layers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             BUN_VERSION=${{ env.BUN_VERSION }}
+          outputs: type=image,push=true,compression=zstd,oci-mediatypes=true
   homebrew:
     name: Release to Homebrew
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add compression=zstd,oci-mediatypes=true to the docker/build-push-action output options to reduce pull times for Docker images.

### What does this PR do?

Enable zstd compression for Docker image layers in the release workflow:

outputs: type=image,push=true,compression=zstd,oci-mediatypes=true

This reduces layer size and can improve pull performance on runtimes that support zstd-compressed OCI layers.

No changes to Dockerfiles or image contents.

### How did you verify your code works?

- Validated that the configuration is valid for docker/build-push-action
- This change only affects layer compression in the output exporter and does not modify build steps or image contents
- Based on Docker Buildx behavior, missing support would fail at pull time rather than silently producing incorrect images

Not fully validated in this repository’s release pipeline.

Notes:
- Behavior should remain unchanged; only layer compression differs
- If a runtime does not support zstd-compressed layers, this can be reverted
- Identified via a CI analysis tool (ci-perf-lint)

Reference:
https://github.com/search?q=docker%2Fbuild-push-action+compression%3Dzstd+language%3Ayaml+path%3A%2F%5E%5C.github%5C%2F%2F&type=code