### PR TITLE
ci: add Docker layer caching via GHA cache for build-push-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,8 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             BUN_VERSION=${{ env.BUN_VERSION }}
+          cache-from: type=gha,scope=docker-${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}
   homebrew:
     name: Release to Homebrew
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add GitHub Actions cache for Docker builds in the release workflow.

### What does this PR do?

Enable BuildKit cache for Docker image builds:

cache-from: type=gha,scope=docker-${{ matrix.variant }}
cache-to: type=gha,mode=max,scope=docker-${{ matrix.variant }}

This enables reuse of unchanged Docker build layers across release runs.

### How did you verify your code works?

- Verified that the configuration is valid for docker/build-push-action / BuildKit GHA cache
- This change only affects Docker build cache import/export and does not modify Dockerfiles or image contents

Not fully validated in this repository’s release pipeline.

Notes:
- The cache is expected to be effective on subsequent runs after initial population
- Cache effectiveness may be limited by Dockerfile structure (e.g. layers depending on BUN_VERSION)
- Splitting stable setup and version-dependent steps could improve cache reuse further, but is out of scope for this PR

Reference:
https://docs.docker.com/build/cache/backends/gha/