### PR TITLE
sql: serialize object/array JSON parameters correctly when prepare: false

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.zig
+++ b/src/sql_jsc/postgres/PostgresRequest.zig
@@ -82,7 +82,25 @@ pub fn writeBind(
             }
             const parameter_field = parameter_fields[i];
             const is_custom_type = std.math.maxInt(short) < parameter_field;
-            break :brk if (is_custom_type) .text else @enumFromInt(@as(short, @intCast(parameter_field)));
+            if (is_custom_type) break :brk .text;
+            // A parameter_field of 0 means the type is unspecified — Parse
+            // was sent with OID 0 so Postgres infers the type from context
+            // (e.g. from `${payload}::jsonb` in the query). The first loop
+            // already chose format=text for this slot, so we must pick a
+            // text-serializing branch here. Values that Signature.generate
+            // classified as `.json` (plain objects and arrays) would
+            // otherwise fall through to the else branch below and get
+            // stringified with `Object.prototype.toString` — producing
+            // `[object Object]` for objects and a comma-joined list for
+            // arrays, both of which fail any jsonb/json cast. Route them
+            // through the JSON branch so the payload is valid JSON, which
+            // also matches what the prepared path does once
+            // ParameterDescription identifies the parameter as jsonb.
+            if (parameter_field == 0) {
+                const inferred = try types.Tag.fromJS(globalObject, value);
+                if (inferred == .json or inferred == .jsonb) break :brk inferred;
+            }
+            break :brk @enumFromInt(@as(short, @intCast(parameter_field)));
         };
         if (value.isEmptyOrUndefinedOrNull()) {
             debug("  -> NULL", .{});

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -1,10 +1,216 @@
 import { SQL } from "bun";
+import { once } from "events";
 import { afterAll, describe, expect, test } from "bun:test";
+import net, { type AddressInfo } from "node:net";
 import * as dockerCompose from "../../docker/index.ts";
 
 // Tests for `prepare: false` (unnamed prepared statements).
 // These verify that parameterized queries work correctly when using unnamed
 // prepared statements, which is critical for PgBouncer compatibility.
+
+// ─────────────────────────────────────────────────────────────────────────
+// Wire-protocol assertions — no external Postgres required.
+//
+// Stand up a minimal mock backend that speaks just enough of the
+// extended-query protocol to accept Parse+Describe+Bind+Execute+Sync from
+// a `prepare: false` client, then inspect the raw bytes the client placed
+// in the Bind message for parameter #0.
+//
+// This is what regressed in #30221: before the fix, `writeBind` fell
+// through to `String.fromJS` for objects when the parsed parameter OID
+// was 0 (Postgres-infers), producing `"[object Object]"` instead of the
+// JSON text the prepared path already writes.
+// ─────────────────────────────────────────────────────────────────────────
+describe("issue #30221: prepare:false JSON-stringifies object parameters", () => {
+  function msg(code: string, payload: Buffer): Buffer {
+    const len = Buffer.alloc(4);
+    len.writeInt32BE(payload.length + 4);
+    return Buffer.concat([Buffer.from(code, "latin1"), len, payload]);
+  }
+  const i32 = (n: number) => {
+    const b = Buffer.alloc(4);
+    b.writeInt32BE(n);
+    return b;
+  };
+  const i16 = (n: number) => {
+    const b = Buffer.alloc(2);
+    b.writeInt16BE(n);
+    return b;
+  };
+  const cstr = (s: string) => Buffer.concat([Buffer.from(s, "utf8"), Buffer.from([0])]);
+
+  const authOk = msg("R", i32(0));
+  const paramStatus = (k: string, v: string) => msg("S", Buffer.concat([cstr(k), cstr(v)]));
+  const backendKeyData = msg("K", Buffer.concat([i32(1), i32(2)]));
+  const readyForQuery = msg("Z", Buffer.from([0x49])); // 'I' = idle
+  const parseComplete = msg("1", Buffer.alloc(0));
+  // Report the parameters back to the client as OID 0 (unspecified), so the
+  // Bind encoding still uses the signature-inferred format. This mirrors
+  // what a real server does when Parse was sent with OID 0 and there's a
+  // `::jsonb` / `::json` cast in the query.
+  const paramDescription = (oids: number[]) => msg("t", Buffer.concat([i16(oids.length), ...oids.map(i32)]));
+  const noData = msg("n", Buffer.alloc(0));
+  const bindComplete = msg("2", Buffer.alloc(0));
+  const cmdComplete = (tag: string) => msg("C", cstr(tag));
+
+  // Bind body layout:
+  //   cstr portal, cstr stmt,
+  //   i16 nFmt, i16[nFmt],
+  //   i16 nParam, (i32 len, bytes)[nParam],
+  //   i16 nResFmt, i16[nResFmt]
+  function extractFirstParam(body: Buffer): { format: number; value: string | null } | null {
+    let o = 0;
+    while (body[o] !== 0) o++;
+    o++; // portal
+    while (body[o] !== 0) o++;
+    o++; // stmt
+    const nFmt = body.readInt16BE(o);
+    o += 2;
+    const formats: number[] = [];
+    for (let i = 0; i < nFmt; i++) {
+      formats.push(body.readInt16BE(o));
+      o += 2;
+    }
+    const nParam = body.readInt16BE(o);
+    o += 2;
+    if (nParam < 1) return null;
+    const plen = body.readInt32BE(o);
+    o += 4;
+    if (plen < 0) return { format: formats[0] ?? 0, value: null };
+    const valueBytes = body.subarray(o, o + plen);
+    // Format codes: 0=text, 1=binary. For nFmt=1, that single code applies
+    // to every parameter; for nFmt=nParam, each parameter has its own.
+    const format = nFmt === 1 ? formats[0] : nFmt === 0 ? 0 : formats[0];
+    return { format, value: valueBytes.toString("utf8") };
+  }
+
+  /// Stand up a one-shot mock PG backend that captures parameter #0 of
+  /// the first Bind message the client sends. The server advertises the
+  /// parameter type as `paramOid` in its ParameterDescription reply so
+  /// the client can cache it for subsequent runs, but the in-flight Bind
+  /// is built from `statement.signature.fields` (OID 0 for json-shaped
+  /// values) — which is exactly the codepath the issue covers.
+  async function captureBindParam(
+    query: (sql: SQL) => Promise<unknown>,
+    paramOids: number[] = [0],
+  ): Promise<{ format: number; value: string | null } | null> {
+    let captured: ReturnType<typeof extractFirstParam> | null = null;
+    const server = net.createServer(socket => {
+      let gotStartup = false;
+      socket.on("data", chunk => {
+        const out: Buffer[] = [];
+        let o = 0;
+        while (o < chunk.length) {
+          if (!gotStartup) {
+            const len = chunk.readInt32BE(o);
+            o += len;
+            gotStartup = true;
+            out.push(
+              authOk,
+              paramStatus("server_version", "16.3"),
+              paramStatus("client_encoding", "UTF8"),
+              paramStatus("standard_conforming_strings", "on"),
+              backendKeyData,
+              readyForQuery,
+            );
+            continue;
+          }
+          const code = chunk[o];
+          const len = chunk.readInt32BE(o + 1);
+          const body = chunk.subarray(o + 5, o + 1 + len);
+          o += 1 + len;
+          switch (code) {
+            case 0x50 /* P Parse    */:
+              out.push(parseComplete);
+              break;
+            case 0x44 /* D Describe */:
+              out.push(paramDescription(paramOids), noData);
+              break;
+            case 0x42 /* B Bind     */:
+              if (captured === null) captured = extractFirstParam(body);
+              out.push(bindComplete);
+              break;
+            case 0x45 /* E Execute  */:
+              out.push(cmdComplete("SELECT 0"));
+              break;
+            case 0x53 /* S Sync     */:
+              out.push(readyForQuery);
+              break;
+            case 0x48 /* H Flush    */:
+            case 0x43 /* C Close    */:
+              break;
+            case 0x58 /* X Terminate*/:
+              socket.end();
+              return;
+          }
+        }
+        if (out.length) socket.write(Buffer.concat(out));
+      });
+    });
+    try {
+      await once(server.listen(0), "listening");
+      const port = (server.address() as AddressInfo).port;
+      await using sql = new SQL({
+        hostname: "127.0.0.1",
+        port,
+        database: "x",
+        max: 1,
+        idleTimeout: 1,
+        prepare: false,
+      });
+      await query(sql);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+    return captured;
+  }
+
+  test("plain object → JSON text (not '[object Object]')", async () => {
+    const param = await captureBindParam(sql => sql`SELECT ${{ hello: "world" }}::jsonb`);
+    // Pre-fix: String.fromJS({}) → "[object Object]"; post-fix: jsonStringifyFast.
+    expect(param).toEqual({ format: 0, value: '{"hello":"world"}' });
+  });
+
+  test("nested object → JSON text", async () => {
+    const payload = { user: { id: 7, tags: ["admin", "beta"] }, active: true };
+    const param = await captureBindParam(sql => sql`SELECT ${payload}::jsonb`);
+    expect(param).toEqual({ format: 0, value: JSON.stringify(payload) });
+  });
+
+  test("plain array → JSON array text (not 'a,b,c')", async () => {
+    const arr = [1, 2, { three: 3 }];
+    const param = await captureBindParam(sql => sql`SELECT ${arr}::jsonb`);
+    // Pre-fix: Array.prototype.toString → "1,2,[object Object]".
+    expect(param).toEqual({ format: 0, value: JSON.stringify(arr) });
+  });
+
+  test("object with ::json cast (not just ::jsonb)", async () => {
+    const param = await captureBindParam(sql => sql`SELECT ${{ a: 1, b: "two" }}::json`);
+    expect(param).toEqual({ format: 0, value: '{"a":1,"b":"two"}' });
+  });
+
+  // Regression guards — make sure the re-derivation in writeBind doesn't
+  // accidentally reroute non-JSON values that the previous behavior
+  // handled correctly (or that other PRs address separately).
+
+  test("string parameter still emits text (not JSON-quoted)", async () => {
+    const param = await captureBindParam(sql => sql`SELECT ${"hello"}::text`);
+    expect(param).toEqual({ format: 0, value: "hello" });
+  });
+
+  test("integer parameter still emits text '42'", async () => {
+    const param = await captureBindParam(sql => sql`SELECT ${42}::int`);
+    // Integers are declared as int4 in the signature, which is binary-
+    // format capable — the server reports OID 0 here but the first-run
+    // path still uses signature types for encoding.
+    expect(param?.value).toBeDefined();
+  });
+
+  test("null parameter is signalled with length=-1", async () => {
+    const param = await captureBindParam(sql => sql`SELECT ${null}::jsonb`);
+    expect(param).toEqual({ format: 0, value: null });
+  });
+});
 
 describe("PostgreSQL prepare: false", async () => {
   let container: { port: number; host: string };
@@ -133,30 +339,26 @@ describe("PostgreSQL prepare: false", async () => {
     }
   });
 
-  // Regression test for https://github.com/oven-sh/bun/issues/30221 —
-  // with `prepare: false`, object parameters bound to a jsonb/json cast
-  // used to be stringified via Object.prototype.toString() ("[object Object]")
-  // instead of JSON.stringify. Matches the `prepare: true` behavior.
-  test("object parameter serializes as JSON for ::jsonb cast", async () => {
+  // Round-trip coverage for https://github.com/oven-sh/bun/issues/30221 —
+  // with `prepare: false`, object/array parameters bound to a jsonb/json
+  // cast were previously stringified via Object.prototype.toString(),
+  // producing "[object Object]". Wire-protocol assertions live in the
+  // mock-server `describe` block above; these exercise the end-to-end
+  // path when a real Postgres is available.
+  test("object parameter round-trips via ::jsonb cast", async () => {
     await using db = new SQL(options);
     const [row] = await db`SELECT ${{ hello: "world" }}::jsonb AS value`;
     expect(row).toEqual({ value: { hello: "world" } });
   });
 
-  test("object parameter serializes as JSON for ::json cast", async () => {
-    await using db = new SQL(options);
-    const [row] = await db`SELECT ${{ a: 1, b: "two" }}::json AS value`;
-    expect(row).toEqual({ value: { a: 1, b: "two" } });
-  });
-
-  test("nested object parameter serializes as JSON for ::jsonb cast", async () => {
+  test("nested object parameter round-trips via ::jsonb cast", async () => {
     await using db = new SQL(options);
     const payload = { user: { id: 7, tags: ["admin", "beta"] }, active: true };
     const [row] = await db`SELECT ${payload}::jsonb AS value`;
     expect(row).toEqual({ value: payload });
   });
 
-  test("array parameter serializes as JSON for ::jsonb cast", async () => {
+  test("array parameter round-trips via ::jsonb cast", async () => {
     await using db = new SQL(options);
     const arr = [1, 2, { three: 3 }];
     const [row] = await db`SELECT ${arr}::jsonb AS value`;

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -1,6 +1,6 @@
 import { SQL } from "bun";
-import { once } from "events";
 import { afterAll, describe, expect, test } from "bun:test";
+import { once } from "events";
 import net, { type AddressInfo } from "node:net";
 import * as dockerCompose from "../../docker/index.ts";
 

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -132,4 +132,34 @@ describe("PostgreSQL prepare: false", async () => {
       expect(actual).toBe(expected);
     }
   });
+
+  // Regression test for https://github.com/oven-sh/bun/issues/30221 —
+  // with `prepare: false`, object parameters bound to a jsonb/json cast
+  // used to be stringified via Object.prototype.toString() ("[object Object]")
+  // instead of JSON.stringify. Matches the `prepare: true` behavior.
+  test("object parameter serializes as JSON for ::jsonb cast", async () => {
+    await using db = new SQL(options);
+    const [row] = await db`SELECT ${{ hello: "world" }}::jsonb AS value`;
+    expect(row).toEqual({ value: { hello: "world" } });
+  });
+
+  test("object parameter serializes as JSON for ::json cast", async () => {
+    await using db = new SQL(options);
+    const [row] = await db`SELECT ${{ a: 1, b: "two" }}::json AS value`;
+    expect(row).toEqual({ value: { a: 1, b: "two" } });
+  });
+
+  test("nested object parameter serializes as JSON for ::jsonb cast", async () => {
+    await using db = new SQL(options);
+    const payload = { user: { id: 7, tags: ["admin", "beta"] }, active: true };
+    const [row] = await db`SELECT ${payload}::jsonb AS value`;
+    expect(row).toEqual({ value: payload });
+  });
+
+  test("array parameter serializes as JSON for ::jsonb cast", async () => {
+    await using db = new SQL(options);
+    const arr = [1, 2, { three: 3 }];
+    const [row] = await db`SELECT ${arr}::jsonb AS value`;
+    expect(row).toEqual({ value: arr });
+  });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -44,10 +44,13 @@ describe("issue #30221: prepare:false JSON-stringifies object parameters", () =>
   const backendKeyData = msg("K", Buffer.concat([i32(1), i32(2)]));
   const readyForQuery = msg("Z", Buffer.from([0x49])); // 'I' = idle
   const parseComplete = msg("1", Buffer.alloc(0));
-  // Report the parameters back to the client as OID 0 (unspecified), so the
-  // Bind encoding still uses the signature-inferred format. This mirrors
-  // what a real server does when Parse was sent with OID 0 and there's a
-  // `::jsonb` / `::json` cast in the query.
+  // The OID reported here doesn't affect the captured Bind: with
+  // `prepare: false` the client writes Parse+Describe+Bind+Execute+Sync
+  // in one batch before reading any reply, so the first Bind is built
+  // from `statement.signature.fields` (OID 0 for json-shaped values)
+  // before this ParameterDescription arrives. A real Postgres would
+  // resolve the `::jsonb` cast and return 3802 here; tests pass any
+  // OID just to keep the client happy for subsequent-run caching.
   const paramDescription = (oids: number[]) => msg("t", Buffer.concat([i16(oids.length), ...oids.map(i32)]));
   const noData = msg("n", Buffer.alloc(0));
   const bindComplete = msg("2", Buffer.alloc(0));

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -100,12 +100,18 @@ describe("issue #30221: prepare:false JSON-stringifies object parameters", () =>
     let captured: ReturnType<typeof extractFirstParam> | null = null;
     const server = net.createServer(socket => {
       let gotStartup = false;
+      // TCP doesn't preserve message boundaries; accumulate partial frames.
+      let pending = Buffer.alloc(0);
       socket.on("data", chunk => {
+        pending = pending.length === 0 ? chunk : Buffer.concat([pending, chunk]);
         const out: Buffer[] = [];
         let o = 0;
-        while (o < chunk.length) {
+        while (o < pending.length) {
           if (!gotStartup) {
-            const len = chunk.readInt32BE(o);
+            // StartupMessage: i32 length, i32 protoVersion, (cstr key, cstr val)*, \0
+            if (pending.length - o < 4) break;
+            const len = pending.readInt32BE(o);
+            if (pending.length - o < len) break;
             o += len;
             gotStartup = true;
             out.push(
@@ -118,9 +124,12 @@ describe("issue #30221: prepare:false JSON-stringifies object parameters", () =>
             );
             continue;
           }
-          const code = chunk[o];
-          const len = chunk.readInt32BE(o + 1);
-          const body = chunk.subarray(o + 5, o + 1 + len);
+          // Regular frame: u8 code, i32 length (includes the length field).
+          if (pending.length - o < 5) break;
+          const code = pending[o];
+          const len = pending.readInt32BE(o + 1);
+          if (pending.length - o < 1 + len) break;
+          const body = pending.subarray(o + 5, o + 1 + len);
           o += 1 + len;
           switch (code) {
             case 0x50 /* P Parse    */:
@@ -147,6 +156,7 @@ describe("issue #30221: prepare:false JSON-stringifies object parameters", () =>
               return;
           }
         }
+        pending = o === pending.length ? Buffer.alloc(0) : pending.subarray(o);
         if (out.length) socket.write(Buffer.concat(out));
       });
     });
@@ -201,12 +211,15 @@ describe("issue #30221: prepare:false JSON-stringifies object parameters", () =>
     expect(param).toEqual({ format: 0, value: "hello" });
   });
 
-  test("integer parameter still emits text '42'", async () => {
+  test("integer parameter keeps the int4 binary-format path", async () => {
     const param = await captureBindParam(sql => sql`SELECT ${42}::int`);
-    // Integers are declared as int4 in the signature, which is binary-
-    // format capable — the server reports OID 0 here but the first-run
-    // path still uses signature types for encoding.
-    expect(param?.value).toBeDefined();
+    // Signature.generate writes OID 23 (int4) for JS numbers — not 0 — so
+    // the new parameter_field==0 branch does NOT fire, and writeBind takes
+    // the existing .int4 arm that emits 4 big-endian bytes in binary format.
+    // Asserting the exact bytes proves the JSON re-derivation didn't steal
+    // this path: under the pre-fix else branch these 4 bytes would instead
+    // have been the ASCII text "42" in format=0.
+    expect(param).toEqual({ format: 1, value: "\u0000\u0000\u0000\x2a" });
   });
 
   test("null parameter is signalled with length=-1", async () => {


### PR DESCRIPTION
Fixes #30221.

## Repro

```ts
import { SQL } from 'bun';
const sql = new SQL({ url: process.env.DATABASE_URL!, prepare: false });
await sql`SELECT ${{ hello: 'world' }}::jsonb AS value`;
// PostgresError: invalid input syntax for type json
//   detail: "Token \"object\" is invalid."
//   where: "JSON data, line 1: [object..."
```

## Cause

With `prepare: false`, the Parse message is sent with parameter OID
`0` to let Postgres infer the type from context (e.g. from the
`::jsonb` cast in the query). That same OID then drives the value-
encoding switch in `writeBind`:

```zig
// src/sql/postgres/PostgresRequest.zig — pre-fix
const parameter_field = parameter_fields[i];
const is_custom_type = std.math.maxInt(short) < parameter_field;
break :brk if (is_custom_type) .text else @enumFromInt(@as(short, @intCast(parameter_field)));
```

`@enumFromInt(0)` is not a defined `Tag`, so the switch falls through
to `else`, which calls `String.fromJS`:

```zig
else => {
    const str = try String.fromJS(value, globalObject); // → "[object Object]"
    ...
}
```

`String.fromJS` on a plain JS object invokes `Object.prototype.toString`
(`"[object Object]"`); arrays get `Array.prototype.toString`
(`"1,2,3"`). Postgres rejects both for any `json`/`jsonb` cast.

The `prepare: true` path worked because `ParameterDescription` fills
`statement.parameters` with real OIDs (`114` / `3802`), which route
to the existing `.jsonb, .json` branch → `jsonStringifyFast`.

## Fix

When `parameter_field == 0`, re-derive the tag from the JS value with
`types.Tag.fromJS` (the same helper `Signature.generate` already uses
to classify the slot). If the value is JSON-shaped (`.json` /
`.jsonb`), dispatch to the JSON branch so `jsonStringifyFast` runs.
Everything else keeps its existing path — Dates, typed arrays,
BigInts, Bools, etc. are unchanged.

Format codes don't need adjusting: for an unspecified slot the first
loop already writes `0` (text), and `.json`/`.jsonb` are text-format
types, so serializer and format-code agree.

## Verification

New tests in `test/js/sql/sql-prepare-false.test.ts` cover:
- object → `::jsonb`
- object → `::json`
- nested object (with inner array) → `::jsonb`
- array → `::jsonb`

Manual repro against local Postgres:
- All four fail on `USE_SYSTEM_BUN=1` (`22P02 invalid input syntax`).
- All four pass on the debug build.

Regression checks that still produce identical output pre/post-fix on
`prepare: false`: `int`/`text`/`float8` scalars, `Date` without cast,
`Uint8Array` → `::bytea`, `BigInt` → `::int8`, `true` → `::bool`, and
`Int32Array` → `::int[]` (still surfaces the pre-existing
`malformed array literal" 1,2,3"` — tracked by #29551 / #29552).