### PR TITLE
Fix use-after-free resolving external URL specifiers with non-ASCII characters

### DIFF
--- a/src/bun.js/VirtualMachine.zig
+++ b/src/bun.js/VirtualMachine.zig
@@ -1927,7 +1927,7 @@ pub fn resolveMaybeNeedsTrailingSlash(
     if (jsc.ModuleLoader.HardcodedModule.Alias.get(specifier_utf8.slice(), .bun, .{})) |hardcoded| {
         res.* = ErrorableString.ok(
             if (is_user_require_resolve and hardcoded.node_builtin)
-                specifier
+                specifier.dupeRef()
             else
                 bun.String.init(hardcoded.path),
         );
@@ -2010,7 +2010,10 @@ pub fn resolveMaybeNeedsTrailingSlash(
             bun.String.empty;
     }
 
-    res.* = ErrorableString.ok(bun.String.init(result.path));
+    // `result.path` can be a slice into `specifier_utf8` (e.g. http:// specifiers that
+    // the resolver marks external without copying), so clone it for the same reason as
+    // `result.query_string` above. Callers must deref `res.result.value` on success.
+    res.* = ErrorableString.ok(bun.String.cloneUTF8(result.path));
 }
 
 pub const main_file_name: string = "bun:main";

--- a/src/bun.js/api/BunObject.zig
+++ b/src/bun.js/api/BunObject.zig
@@ -847,6 +847,7 @@ fn doResolveWithArgs(ctx: *jsc.JSGlobalObject, specifier: bun.String, from: bun.
     if (!errorable.success) {
         return ctx.throwValue(errorable.result.err.value);
     }
+    defer errorable.result.value.deref();
 
     if (!query_string.isEmpty()) {
         var stack = std.heap.stackFallback(1024, ctx.allocator());

--- a/src/bun.js/bindings/NodeModuleModule.zig
+++ b/src/bun.js/bindings/NodeModuleModule.zig
@@ -34,6 +34,7 @@ fn findPath(
     } else findPathInner(request_bun_str, bun.String.static(""), global);
 
     if (found) |str| {
+        defer str.deref();
         return str.toJS(global);
     }
 

--- a/src/bun.js/bindings/NodeModuleModule.zig
+++ b/src/bun.js/bindings/NodeModuleModule.zig
@@ -19,7 +19,7 @@ fn findPath(
     }
 
     // for each path
-    const found = if (paths_maybe) |paths| found: {
+    var found = if (paths_maybe) |paths| found: {
         var iter = try paths.iterator(global);
         while (try iter.next()) |path| {
             const cur_path = try bun.String.fromJS(path, global);
@@ -33,9 +33,8 @@ fn findPath(
         break :found null;
     } else findPathInner(request_bun_str, bun.String.static(""), global);
 
-    if (found) |str| {
-        defer str.deref();
-        return str.toJS(global);
+    if (found) |*str| {
+        return str.transferToJS(global);
     }
 
     return .false;

--- a/src/bun.js/bindings/ZigGlobalObject.cpp
+++ b/src/bun.js/bindings/ZigGlobalObject.cpp
@@ -3331,11 +3331,14 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     if (res.success) {
         if (!queryString.isEmpty()) {
             auto result = JSC::Identifier::fromString(globalObject->vm(), makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+            res.result.value.deref();
             queryString.deref();
             return result;
         }
 
-        return Identifier::fromString(globalObject->vm(), res.result.value.toWTFString(BunString::ZeroCopy));
+        auto result = Identifier::fromString(globalObject->vm(), res.result.value.toWTFString(BunString::ZeroCopy));
+        res.result.value.deref();
+        return result;
     } else {
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         throwException(scope, res.result.err, globalObject);
@@ -3435,6 +3438,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             queryString.deref();
         }
 
+        resolved.result.value.deref();
         moduleNameZ.deref();
         sourceOriginZ.deref();
     }

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -579,3 +579,38 @@ it.skipIf(isWindows)("browser map resolution handles relative paths longer than 
     }
   });
 }
+
+describe("resolving external URL specifiers with non-ASCII characters", () => {
+  // The resolver returns http://, https://, and // specifiers as-is (marked external).
+  // When the specifier contains non-ASCII characters, the intermediate UTF-8 buffer
+  // is heap-allocated and freed before the caller reads the result, so the resolved
+  // path must be cloned rather than borrowed.
+  it.each([
+    ["http://localhost/path?query=´5&foo=bar"],
+    ["http://localhost/´path?query=a"],
+    ["http://localhost/´path"],
+    ["https://example/´"],
+    ["//example/´?q"],
+  ])("Bun.resolveSync(%j)", specifier => {
+    expect(Bun.resolveSync(specifier, import.meta.dir)).toBe(specifier);
+  });
+
+  it("import.meta.resolveSync", () => {
+    const specifier = "http://localhost/path?query=´5&foo=bar";
+    expect(import.meta.resolveSync(specifier)).toBe(specifier);
+  });
+
+  it("require with non-ASCII http specifier does not crash", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `try { require("http://localhost/path?query=´5&foo=bar"); } catch (e) { console.log("caught", e.constructor.name); }`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stderr).not.toContain("panic");
+    expect(stdout).toContain("caught");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -612,8 +612,7 @@ describe("resolving external URL specifiers with non-ASCII characters", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("AddressSanitizer");
-    expect(stderr).not.toContain("panic");
+    expect(stderr).toBe("");
     expect(stdout).toContain("caught");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -602,7 +602,11 @@ describe("resolving external URL specifiers with non-ASCII characters", () => {
 
   it("require with non-ASCII http specifier does not crash", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `try { require("http://localhost/path?query=´5&foo=bar"); } catch (e) { console.log("caught", e.constructor.name); }`],
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { require("http://localhost/path?query=´5&foo=bar"); } catch (e) { console.log("caught", e.constructor.name); }`,
+      ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
## What

Fixes an ASAN use-after-poison crash when resolving `http://`, `https://`, or `//` specifiers that contain non-ASCII characters.

```js
Bun.resolveSync("http://localhost/path?query=´5&foo=bar", import.meta.dir);
// or
require("http://localhost/path?query=´5&foo=bar");
```

## Why

When a specifier contains non-ASCII characters, `specifier.toUTF8()` in `resolveMaybeNeedsTrailingSlash` heap-allocates a UTF-8 buffer (because the underlying WTF string is Latin-1 or UTF-16 and needs converting). For `http://`, `https://`, and `//` prefixes the resolver marks the specifier as external and returns a `Path.init(import_path)` that points directly into that temporary buffer.

`resolveMaybeNeedsTrailingSlash` then wrapped that slice in a borrowing `bun.String.init(result.path)` and freed the buffer via `defer specifier_utf8.deinit()` before returning. Callers in both Zig (`doResolveWithArgs`) and C++ (`moduleLoaderResolve`, `moduleLoaderImportModule`) subsequently read poisoned memory when formatting or converting the result to a JS string.

The `query_string` out-param had already been fixed to clone in the same way; `result.path` needed the same treatment.

## How

- Clone `result.path` into an owned `bun.String` via `bun.String.cloneUTF8`.
- The hardcoded-builtin branch that returned `specifier` now returns `specifier.dupeRef()` so all success paths return an owned string.
- All callers (`doResolveWithArgs`, `NodeModuleModule.findPath`, and the two C++ `Zig__GlobalObject__resolve` call sites) now `deref()` the successful result after use.

This also fixes a pre-existing leak where `onResolveJSC` (plugin onResolve) returned an owned WTFStringImpl that was never deref'd.

Found by Fuzzilli.