### PR TITLE
Fix null deref in Bun.inspect when Proxy prototype trap throws

### DIFF
--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -5369,10 +5369,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5444,7 +5445,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue nextProto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!nextProto)
+                break;
+            iterating = nextProto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeBunSnapshot, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
 it("prototype", () => {
@@ -465,6 +465,49 @@ describe("crash testing", () => {
       }
     });
   }
+
+  it.concurrent.each([
+    [
+      "throwing get trap",
+      `
+        const o = {};
+        Object.setPrototypeOf(o, new Proxy({ foo: 1 }, {
+          get(t, k) { if (typeof k === "symbol") return undefined; throw new Error("nope"); },
+        }));
+        Bun.inspect(o);
+      `,
+    ],
+    [
+      "throwing getPrototypeOf trap",
+      `
+        const o = {};
+        Object.setPrototypeOf(o, new Proxy({ foo: 1 }, {
+          getPrototypeOf() { throw new Error("nope"); },
+        }));
+        Bun.inspect(o);
+      `,
+    ],
+    [
+      "getter throws after side-effect from prior getter",
+      `
+        const { expect } = Bun.jest("");
+        const e = expect(1);
+        Object.setPrototypeOf(e, new Proxy(Object.getPrototypeOf(e), {}));
+        Bun.inspect(e);
+      `,
+    ],
+  ])("Proxy prototype with %s doesn't crash", async (_, code) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code + '\nconsole.log("OK");'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("OK\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("possibly formatted emojis log", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `Bun.inspect()` / `console.log()` when formatting an object whose prototype is a `Proxy` with throwing traps.

`JSC__JSValue__forEachPropertyImpl` walks the prototype chain to enumerate properties for formatting. When the prototype is a `Proxy`:

1. If the Proxy `get` trap throws (or delegates to a getter that throws), `getPropertySlot` returns `false` with a pending exception. The `CLEAR_IF_EXCEPTION` was placed *after* the `continue`, so the exception was never cleared and leaked into later operations.

2. `iterating->getPrototype(globalObject).getObject()` was called without an exception check. A throwing `getPrototypeOf` trap (or any pending exception) makes `getPrototype` return an empty `JSValue`; calling `.getObject()` on that dereferences a null `JSCell`.

### Repro

```js
const o = {};
Object.setPrototypeOf(o, new Proxy({ foo: 1 }, {
  getPrototypeOf() { throw new Error("nope"); },
}));
Bun.inspect(o); // segfault
```

Also reproducible via `expect()`:
```js
const { expect } = Bun.jest("");
const e = expect(1);
Object.setPrototypeOf(e, new Proxy(Object.getPrototypeOf(e), {}));
Bun.inspect(e); // segfault — accessing .rejects then .resolves throws
```

## How did you verify your code works?

Added regression tests in `test/js/bun/util/inspect.test.js` covering all three crash variants (throwing `get` trap, throwing `getPrototypeOf` trap, stateful getter that throws on second access). Verified they segfault on the baked release build and pass on the debug build with this fix.

Fuzzilli fingerprint: `0decaebd1bf2d774`