### PR TITLE
test(windows): regression coverage for process.env.hasOwnProperty (#30226)

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -335,6 +335,15 @@ export const lsanDoLeakCheck = $newCppFunction("InternalForTesting.cpp", "jsFunc
 
 export const isASANEnabled: () => boolean = $newCppFunction("InternalForTesting.cpp", "jsFunction_isASANEnabled", 0);
 
+// Drives the `windowsEnv` builtin — the wrapper that turns the process env
+// object into a case-insensitive Proxy on Windows. Exposed for
+// cross-platform testing of the Proxy's trap semantics (see #30226).
+export const createWindowsEnvProxyForTesting: (
+  internalEnv: Record<string, string>,
+  envMapList: string[],
+  editCb: (k: string, v: string | null) => void,
+) => any = $newCppFunction("InternalForTesting.cpp", "jsFunction_createWindowsEnvProxyForTesting", 3);
+
 export const BunString_toThreadSafeRefCountDelta: () => number = $newCppFunction(
   "InternalForTesting.cpp",
   "jsFunction_BunString_toThreadSafeRefCountDelta",

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -4,6 +4,9 @@
 #include "JavaScriptCore/JSCJSValue.h"
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSArrayBufferView.h"
+#include "JavaScriptCore/CallData.h"
+#include "JavaScriptCore/JSFunction.h"
+#include "WebCoreJSBuiltins.h"
 #include "headers-handwritten.h"
 #include "webcore/HTTPHeaderMap.h"
 #include <wtf/text/StringImpl.h>
@@ -70,6 +73,37 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_isASANEnabled, (JSC::JSGlobalObject * global
 #else
     return JSValue::encode(jsBoolean(false));
 #endif
+}
+
+// Drives the `windowsEnv` JS builtin (see `ProcessObjectInternals.ts`) with
+// caller-supplied args, returning the resulting Proxy. On Windows this
+// wrapper is what `process.env` actually is; exposing it here lets tests
+// exercise the Proxy's trap semantics on every platform rather than only
+// when the Windows `createEnvironmentVariablesMap` branch runs.
+//
+// Expected args: (internalEnv: object, envMapList: string[], editCb: (k, v) => void)
+JSC_DEFINE_HOST_FUNCTION(jsFunction_createWindowsEnvProxyForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSFunction* windowsEnv = JSC::JSFunction::create(vm, globalObject, WebCore::processObjectInternalsWindowsEnvCodeGenerator(vm), globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(callFrame->argument(0));
+    args.append(callFrame->argument(1));
+    args.append(callFrame->argument(2));
+
+    JSC::CallData callData = JSC::getCallData(windowsEnv);
+    NakedPtr<JSC::Exception> returnedException = nullptr;
+    auto result = JSC::profiledCall(globalObject, JSC::ProfilingReason::API, windowsEnv, callData, globalObject->globalThis(), args, returnedException);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (returnedException) {
+        throwException(globalObject, scope, returnedException.get());
+        return {};
+    }
+    return JSValue::encode(result);
 }
 
 // Returns the net refcount change on the *original* StringImpl after a

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_createWindowsEnvProxyForTesting);
 
 }

--- a/test/js/node/env-windows.test.ts
+++ b/test/js/node/env-windows.test.ts
@@ -1,3 +1,4 @@
+import { createWindowsEnvProxyForTesting } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
@@ -31,4 +32,97 @@ test.if(isWindows)("process.env is case insensitive on windows", () => {
   delete process.env.DOESNTEXISTAHAHAHAHAHA;
   expect(process.env.doesntexistahahahahaha).toBeUndefined();
   expect(Object.keys(process.env)).not.toInclude("doesntExistAHaHaHaHaHa");
+});
+
+// https://github.com/oven-sh/bun/issues/30226
+// https://github.com/oven-sh/bun/issues/26315
+// https://github.com/oven-sh/bun/issues/9779
+//
+// On Windows, process.env is a Proxy whose `get` trap used to only consult
+// the env map and never fall through to Object.prototype. That made
+// `process.env.hasOwnProperty` (and toString, valueOf, etc.) return undefined,
+// breaking packages like dotenv-expand that call these inherited methods.
+test.if(isWindows)("process.env inherits Object.prototype methods on windows (#30226)", () => {
+  expect(typeof process.env.hasOwnProperty).toBe("function");
+  expect(typeof process.env.toString).toBe("function");
+  expect(typeof process.env.valueOf).toBe("function");
+  expect(typeof process.env.propertyIsEnumerable).toBe("function");
+  expect(typeof process.env.isPrototypeOf).toBe("function");
+
+  expect(process.env.hasOwnProperty("PATH")).toBe(true);
+  expect(process.env.hasOwnProperty("__NOT_A_REAL_ENV_VAR_30226__")).toBe(false);
+  expect(process.env.toString()).toBe("[object Object]");
+
+  // A case-insensitive env var should still be reported by hasOwnProperty.
+  process.env.HAS_OWN_TEST_30226 = "1";
+  try {
+    expect(process.env.hasOwnProperty("HAS_OWN_TEST_30226")).toBe(true);
+    expect(process.env.hasOwnProperty("has_own_test_30226")).toBe(true);
+  } finally {
+    delete process.env.HAS_OWN_TEST_30226;
+  }
+
+  // If a user actually sets an env var whose name collides with an
+  // Object.prototype method, the env var wins (Node.js parity).
+  const original = process.env.HASOWNPROPERTY;
+  try {
+    process.env.HASOWNPROPERTY = "shadow_value";
+    expect(process.env.HASOWNPROPERTY).toBe("shadow_value");
+    expect(process.env.hasOwnProperty).toBe("shadow_value");
+  } finally {
+    if (original === undefined) {
+      delete process.env.HASOWNPROPERTY;
+    } else {
+      process.env.HASOWNPROPERTY = original;
+    }
+    // Once the env var is gone, the inherited method comes back.
+    expect(typeof process.env.hasOwnProperty).toBe("function");
+  }
+});
+
+// This exercises the exact JS builtin that wraps `process.env` on Windows.
+// It runs on every platform so the regression gate on POSIX still catches a
+// broken `windowsEnv` Proxy — the Windows-only test above is skipped on CI
+// lanes that don't run on Windows.
+test("windowsEnv Proxy falls back to Object.prototype for hasOwnProperty (#30226)", () => {
+  const internalEnv: Record<string, string> = { PATH: "/usr/bin", BACON: "yummy" };
+  const envMapList = ["PATH", "BACON"];
+  const edits: Array<[string, string | null]> = [];
+  const env = createWindowsEnvProxyForTesting(internalEnv, envMapList, (k, v) => {
+    edits.push([k, v]);
+  });
+
+  // Inherited Object.prototype methods resolve through the Proxy.
+  expect(typeof env.hasOwnProperty).toBe("function");
+  expect(typeof env.toString).toBe("function");
+  expect(typeof env.valueOf).toBe("function");
+  expect(typeof env.propertyIsEnumerable).toBe("function");
+  expect(typeof env.isPrototypeOf).toBe("function");
+
+  expect(env.hasOwnProperty("PATH")).toBe(true);
+  expect(env.hasOwnProperty("bacon")).toBe(true); // case-insensitive
+  expect(env.hasOwnProperty("__definitely_not_set__")).toBe(false);
+  expect(env.toString()).toBe("[object Object]");
+
+  // Case-insensitive env lookup still wins over the prototype chain.
+  expect(env.PATH).toBe("/usr/bin");
+  expect(env.path).toBe("/usr/bin");
+  expect(env.PaTh).toBe("/usr/bin");
+
+  // Set/delete still round-trip through the edit callback.
+  env.NEW_VAR = "hello";
+  expect(env.new_var).toBe("hello");
+  expect(edits).toContainEqual(["NEW_VAR", "hello"]);
+
+  delete env.new_var;
+  expect(env.NEW_VAR).toBeUndefined();
+  expect(edits).toContainEqual(["NEW_VAR", null]);
+
+  // An env var whose name collides with an Object.prototype method shadows
+  // the inherited method (Node.js parity).
+  env.HASOWNPROPERTY = "shadow";
+  expect(env.HASOWNPROPERTY).toBe("shadow");
+  expect(env.hasOwnProperty).toBe("shadow");
+  delete env.HASOWNPROPERTY;
+  expect(typeof env.hasOwnProperty).toBe("function");
 });

--- a/test/js/node/env-windows.test.ts
+++ b/test/js/node/env-windows.test.ts
@@ -53,6 +53,18 @@ test.if(isWindows)("process.env inherits Object.prototype methods on windows (#3
   expect(process.env.hasOwnProperty("__NOT_A_REAL_ENV_VAR_30226__")).toBe(false);
   expect(process.env.toString()).toBe("[object Object]");
 
+  // `in` matches Node: reports env vars (case-insensitive) and inherited methods.
+  expect("PATH" in process.env).toBe(true);
+  expect("path" in process.env).toBe(true);
+  expect("hasOwnProperty" in process.env).toBe(true);
+  expect("__NOT_A_REAL_ENV_VAR_30226__" in process.env).toBe(false);
+
+  // `JSON.stringify(process.env)` must round-trip via ownKeys and not leak a
+  // `toJSON` property (matches Node on Windows).
+  const roundTrip = JSON.parse(JSON.stringify(process.env));
+  expect(roundTrip).not.toHaveProperty("toJSON");
+  expect(roundTrip.PATH ?? roundTrip.Path ?? roundTrip.path).toBeDefined();
+
   // A case-insensitive env var should still be reported by hasOwnProperty.
   process.env.HAS_OWN_TEST_30226 = "1";
   try {
@@ -85,8 +97,10 @@ test.if(isWindows)("process.env inherits Object.prototype methods on windows (#3
 // broken `windowsEnv` Proxy — the Windows-only test above is skipped on CI
 // lanes that don't run on Windows.
 test("windowsEnv Proxy falls back to Object.prototype for hasOwnProperty (#30226)", () => {
+  // Matches Windows semantics: `internalEnv` stores UPPERCASE keys, while
+  // `envMapList` preserves the original-case names from the OS.
   const internalEnv: Record<string, string> = { PATH: "/usr/bin", BACON: "yummy" };
-  const envMapList = ["PATH", "BACON"];
+  const envMapList = ["Path", "Bacon"];
   const edits: Array<[string, string | null]> = [];
   const env = createWindowsEnvProxyForTesting(internalEnv, envMapList, (k, v) => {
     edits.push([k, v]);
@@ -104,10 +118,25 @@ test("windowsEnv Proxy falls back to Object.prototype for hasOwnProperty (#30226
   expect(env.hasOwnProperty("__definitely_not_set__")).toBe(false);
   expect(env.toString()).toBe("[object Object]");
 
+  // `in` reports both env vars (case-insensitive) and inherited prototype
+  // methods, matching Node.js and the `get` trap.
+  expect("PATH" in env).toBe(true);
+  expect("path" in env).toBe(true);
+  expect("hasOwnProperty" in env).toBe(true);
+  expect("toString" in env).toBe(true);
+  expect("__definitely_not_set__" in env).toBe(false);
+
   // Case-insensitive env lookup still wins over the prototype chain.
   expect(env.PATH).toBe("/usr/bin");
   expect(env.path).toBe("/usr/bin");
   expect(env.PaTh).toBe("/usr/bin");
+
+  // `JSON.stringify(process.env)` must enumerate via ownKeys and emit the
+  // *original-case* names from envMapList (not the uppercased backing keys).
+  // This used to be broken by a stale `toJSON` assignment on the backing
+  // object that returned `{ ...internalEnv }` — uppercase keys.
+  expect(env.toJSON).toBeUndefined();
+  expect(JSON.stringify(env)).toBe('{"Path":"/usr/bin","Bacon":"yummy"}');
 
   // Set/delete still round-trip through the edit callback.
   env.NEW_VAR = "hello";

--- a/test/js/node/env-windows.test.ts
+++ b/test/js/node/env-windows.test.ts
@@ -59,8 +59,8 @@ test.if(isWindows)("process.env inherits Object.prototype methods on windows (#3
   expect("hasOwnProperty" in process.env).toBe(true);
   expect("__NOT_A_REAL_ENV_VAR_30226__" in process.env).toBe(false);
 
-  // `JSON.stringify(process.env)` must round-trip via ownKeys and not leak a
-  // `toJSON` property (matches Node on Windows).
+  // `JSON.stringify(process.env)` must not leak an internal `toJSON` key into
+  // the serialized output, and env vars round-trip (matches Node on Windows).
   const roundTrip = JSON.parse(JSON.stringify(process.env));
   expect(roundTrip).not.toHaveProperty("toJSON");
   expect(roundTrip.PATH ?? roundTrip.Path ?? roundTrip.path).toBeDefined();
@@ -84,11 +84,13 @@ test.if(isWindows)("process.env inherits Object.prototype methods on windows (#3
   } finally {
     if (original === undefined) {
       delete process.env.HASOWNPROPERTY;
+      // With no env var, the inherited method is visible again.
+      expect(typeof process.env.hasOwnProperty).toBe("function");
     } else {
       process.env.HASOWNPROPERTY = original;
+      // A pre-existing env var keeps shadowing the prototype method.
+      expect(process.env.hasOwnProperty).toBe(original);
     }
-    // Once the env var is gone, the inherited method comes back.
-    expect(typeof process.env.hasOwnProperty).toBe("function");
   }
 });
 
@@ -131,12 +133,11 @@ test("windowsEnv Proxy falls back to Object.prototype for hasOwnProperty (#30226
   expect(env.path).toBe("/usr/bin");
   expect(env.PaTh).toBe("/usr/bin");
 
-  // `JSON.stringify(process.env)` must enumerate via ownKeys and emit the
-  // *original-case* names from envMapList (not the uppercased backing keys).
-  // This used to be broken by a stale `toJSON` assignment on the backing
-  // object that returned `{ ...internalEnv }` — uppercase keys.
-  expect(env.toJSON).toBeUndefined();
+  // `JSON.stringify(process.env)` must emit the *original-case* names from
+  // envMapList (not the uppercased backing keys). A naive `toJSON` returning
+  // `{ ...internalEnv }` would leak the canonical UPPERCASE storage keys.
   expect(JSON.stringify(env)).toBe('{"Path":"/usr/bin","Bacon":"yummy"}');
+  expect(Object.keys(JSON.parse(JSON.stringify(env)))).toEqual(["Path", "Bacon"]);
 
   // Set/delete still round-trip through the edit callback.
   env.NEW_VAR = "hello";


### PR DESCRIPTION
Adds regression test coverage for #30226 / #26315 / #9779: `process.env.hasOwnProperty` (and `toString`, `valueOf`, `propertyIsEnumerable`, the custom inspect symbol, etc.) returning `undefined` on Windows because `process.env` is a Proxy whose `get`/`has` traps only consulted the uppercased env map.

## Status: source fix already on main

When this PR was first opened, it also contained the source fix in `src/js/builtins/ProcessObjectInternals.ts`. Since then, `main` independently reimplemented the `windowsEnv` Proxy (during the Rust rewrite, #30412) with equivalent semantics: the `get`/`has` traps now fall through to the env object's own/inherited properties after a case-insensitive env-var miss, and `toJSON` returns original-case keys so `JSON.stringify(process.env)` is correct.

After rebasing onto that, the source-fix hunks became redundant and dropped out. **This PR now only adds the regression tests** (plus a small test-only helper to exercise the Windows Proxy on every platform), so the behavior can't silently regress again — `main` landed the fix without a test guarding it.

## What this adds

- `test/js/node/env-windows.test.ts`:
  - A Windows-only test against the real `process.env`: inherited `Object.prototype` methods are callable, `in` reports both env vars (case-insensitive) and inherited methods, `JSON.stringify` emits original-case keys without leaking `toJSON`, and env-var collisions shadow prototype methods (Node parity).
  - A cross-platform test that drives the `windowsEnv` builtin directly so the regression is caught on POSIX CI too.
- `src/jsc/bindings/InternalForTesting.{cpp,h}` + `src/js/internal-for-testing.ts`: `createWindowsEnvProxyForTesting`, a debug/CI-only host function that constructs the `windowsEnv` Proxy with caller-supplied args. This is the only way to exercise the Windows-specific Proxy on non-Windows lanes.

## Verification

Reverting `main`'s `get` trap to the original (buggy) `internalEnv[p.toUpperCase()]` form makes the cross-platform test fail with `Received: undefined`; restoring it passes. So the test is a genuine guard, not a tautology.

```
(pass) windowsEnv Proxy falls back to Object.prototype for hasOwnProperty (#30226)
```

If a maintainer would rather not take the test-only helper, feel free to close this; the underlying bug is already fixed on `main`.