### PR TITLE
Fix use-after-free in Bun.Transpiler async transform error messages

### DIFF
--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -504,6 +504,10 @@ pub const TransformTask = struct {
         this.transpiler.setLog(&this.log);
         this.log.msgs.allocator = bun.default_allocator;
 
+        defer for (this.log.msgs.items) |*msg| {
+            msg.* = bun.handleOom(msg.clone(bun.default_allocator));
+        };
+
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)
         else

--- a/src/bun.js/api/JSTranspiler.zig
+++ b/src/bun.js/api/JSTranspiler.zig
@@ -591,6 +591,7 @@ pub const TransformTask = struct {
     }
 
     pub fn deinit(this: *TransformTask) void {
+        for (this.log.msgs.items) |*msg| msg.deinit(bun.default_allocator);
         this.log.deinit();
         this.input_code.deinitAndUnprotect();
         this.output_code.deref();

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+
+test("concurrent async transform() with parse errors produces correct error messages", async () => {
+  const transpiler = new Bun.Transpiler();
+
+  const promises: Promise<unknown>[] = [];
+  for (let i = 0; i < 100; i++) {
+    promises.push(transpiler.transform("const x = ;", "js").catch(e => e));
+  }
+
+  const errors = await Promise.all(promises);
+  for (const err of errors) {
+    expect(String(err)).toContain("Unexpected");
+  }
+});
+
+test("concurrent async transform() with redeclaration errors produces correct error messages", async () => {
+  const transpiler = new Bun.Transpiler();
+
+  const promises: Promise<unknown>[] = [];
+  for (let i = 0; i < 100; i++) {
+    promises.push(transpiler.transform("const x = 1; const x = 2;", "js").catch(e => e));
+  }
+
+  const errors = await Promise.all(promises);
+  for (const err of errors) {
+    expect(String(err)).toContain(`"x"`);
+  }
+});


### PR DESCRIPTION
## What

`Bun.Transpiler.prototype.transform()` rejects with corrupted error messages (or crashes under ASAN) when parsing fails and multiple transforms run concurrently.

## Why

`TransformTask.run()` creates a per-task `MimallocArena` and sets it as the transpiler's allocator. When parsing fails, the parser and lexer allocate error message text (and notes) in that arena via `allocPrint(p.allocator, ...)`. The arena is destroyed via `defer arena.deinit()` when `run()` returns from the worker thread.

Later, `then()` runs on the JS thread and calls `this.log.toJS()`, which clones each message by reading `msg.data.text`. By then the text points into the destroyed arena, so the read is a use-after-free. In release builds this surfaces as garbage bytes in the rejection message; in ASAN debug builds it aborts with `use-after-poison`.

## How

Before the arena is torn down, deep-clone each log message into `bun.default_allocator` so the text survives until the promise is rejected. `Msg.clone()` already recursively copies `data.text`, `location`, and `notes`.

## Test

Added `test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts` which queues 100 concurrent `transform()` calls with invalid source and asserts every rejection contains the expected parser error text. Before this change the test fails with garbage bytes in the message (and segfaults) on the stock release build, and aborts under ASAN.