### PR TITLE
Fix crash in Bun.file().writer() with non-string path option

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2976,6 +2976,7 @@ pub fn getWriter(
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
         if (stream_start == .FileSink) {
+            stream_start.FileSink.input_path.deinit();
             stream_start.FileSink.input_path = input_path;
         } else {
             stream_start = .{ .FileSink = .{ .input_path = input_path } };

--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,11 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        if (stream_start == .FileSink) {
+            stream_start.FileSink.input_path = input_path;
+        } else {
+            stream_start = .{ .FileSink = .{ .input_path = input_path } };
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2952,6 +2952,7 @@ pub fn getWriter(
     }
 
     var sink = jsc.WebCore.FileSink.init(bun.invalid_fd, this.globalThis.bunVM().eventLoop());
+    errdefer sink.deref();
 
     const input_path: jsc.WebCore.PathOrFileDescriptor = brk: {
         if (store.data.file.pathlike == .fd) {
@@ -2985,7 +2986,6 @@ pub fn getWriter(
 
     switch (sink.start(stream_start)) {
         .err => |err| {
-            sink.deref();
             return globalThis.throwValue(try err.toJS(globalThis));
         },
         else => {},

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -209,12 +209,12 @@ it("write result is not cumulative", async () => {
 
 it("ignores non-string path and invalid fd in options", async () => {
   const x = tmpdirSync();
-  const file = Bun.file(path.join(x, "test.txt"));
-  for (const options of [{ path: {} }, { path: 123 }, { fd: "not a number" }, file]) {
+  for (const [i, options] of [{ path: {} }, { path: 123 }, { fd: "not a number" }, Bun.file(path.join(x, "3.txt"))].entries()) {
+    const file = Bun.file(path.join(x, `${i}.txt`));
     const writer = file.writer(options as any);
-    await writer.write("hello");
+    await writer.write("hello" + i);
     await writer.end();
-    expect(await file.text()).toBe("hello");
+    expect(await file.text()).toBe("hello" + i);
   }
 });
 

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -209,7 +209,12 @@ it("write result is not cumulative", async () => {
 
 it("ignores non-string path and invalid fd in options", async () => {
   const x = tmpdirSync();
-  for (const [i, options] of [{ path: {} }, { path: 123 }, { fd: "not a number" }, Bun.file(path.join(x, "3.txt"))].entries()) {
+  for (const [i, options] of [
+    { path: {} },
+    { path: 123 },
+    { fd: "not a number" },
+    Bun.file(path.join(x, "3.txt")),
+  ].entries()) {
     const file = Bun.file(path.join(x, `${i}.txt`));
     const writer = file.writer(options as any);
     await writer.write("hello" + i);

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,17 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+it("ignores non-string path and invalid fd in options", async () => {
+  const x = tmpdirSync();
+  const file = Bun.file(path.join(x, "test.txt"));
+  for (const options of [{ path: {} }, { path: 123 }, { fd: "not a number" }, file]) {
+    const writer = file.writer(options as any);
+    await writer.write("hello");
+    await writer.end();
+    expect(await file.text()).toBe("hello");
+  }
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -218,6 +218,27 @@ it("ignores non-string path and invalid fd in options", async () => {
   }
 });
 
+it("does not leak native FileSink when options getter throws", async () => {
+  const x = tmpdirSync();
+  const file = Bun.file(path.join(x, "test.txt"));
+  const options = {
+    get highWaterMark(): number {
+      throw new Error("boom");
+    },
+  };
+
+  const baseline = fileSinkInternals.liveCount();
+  for (let i = 0; i < 8; i++) {
+    expect(() => file.writer(options)).toThrow("boom");
+  }
+  for (let i = 0; i < 50; i++) {
+    Bun.gc(true);
+    if (fileSinkInternals.liveCount() <= baseline) break;
+    await Bun.sleep(10);
+  }
+  expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -223,7 +223,10 @@ it("ignores non-string path and invalid fd in options", async () => {
   }
 });
 
-it("does not leak native FileSink when options getter throws", async () => {
+// On Windows, Blob.writer() ignores the options object entirely (it opens the
+// fd directly without calling fromJSWithTag), so the throwing getter is never
+// invoked and there is nothing to leak.
+it.skipIf(isWindows)("does not leak native FileSink when options getter throws", async () => {
   const x = tmpdirSync();
   const file = Bun.file(path.join(x, "test.txt"));
   const options = {


### PR DESCRIPTION
## What

Fixes a panic in `Bun.file(...).writer(options)` when `options.path` is not a string or `options.fd` is not an integer.

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
```

## Why

`streams.Start.fromJSWithTag(..., .FileSink)` returns the `.err` variant of the `Start` union when `options.path` is present but not a string (or `options.fd` is not an integer). `Blob.getWriter` then unconditionally wrote to `stream_start.FileSink.input_path`, which is a safety-checked illegal union field access in debug builds.

Since the Blob already knows its own path and always overrides `options.path` / `options.fd` immediately after parsing, the fix is to only override `input_path` when parsing produced a `.FileSink` result, and otherwise fall back to the Blob's own path with default options.

## Repro

```js
Bun.file("/tmp/x.txt").writer({ path: {} });
```

Found by Fuzzilli (fingerprint `d643440b1bb56ce8`).