### PR TITLE
Don't iterate WeakMap/WeakSet when formatting

### DIFF
--- a/src/bun.js/ConsoleObject.zig
+++ b/src/bun.js/ConsoleObject.zig
@@ -2757,14 +2757,19 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2869,19 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            }; // TODO:
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            }; // TODO:
         }
 
         var received_slice = received_buf.written();

--- a/src/bun.js/test/diff_format.zig
+++ b/src/bun.js/test/diff_format.zig
@@ -45,7 +45,7 @@ pub const DiffFormatter = struct {
                 fmt_options,
             ) catch {
                 this.globalThis.clearException();
-            }; // TODO:
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -56,7 +56,7 @@ pub const DiffFormatter = struct {
                 fmt_options,
             ) catch {
                 this.globalThis.clearException();
-            }; // TODO:
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/bun.js/test/pretty_format.zig
+++ b/src/bun.js/test/pretty_format.zig
@@ -1307,14 +1307,19 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,6 +1340,14 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    if (is_weak) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1343,8 +1356,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3528,6 +3528,18 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    test("WeakMap/WeakSet with user-set size property does not crash diff formatter", () => {
+      const wm = new WeakMap();
+      wm.size = 2;
+      expect(() => expect(wm).toMatchObject({ 0: 1 })).toThrow();
+      expect(wm).not.toMatchObject({ 0: 1 });
+
+      const ws = new WeakSet();
+      ws.size = 2;
+      expect(() => expect(ws).toMatchObject({ 0: 1 })).toThrow();
+      expect(ws).not.toMatchObject({ 0: 1 });
+    });
   });
 
   describe("toMatch()", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -364,6 +364,16 @@ it("inspect", () => {
     value: "not a number",
   });
   expect(Bun.inspect(mapWithOverriddenSize)).toBe("Map {}");
+
+  // Regression test: WeakMap/WeakSet are not iterable, so a user-set size
+  // property must not cause the formatter to attempt iteration.
+  const weakMapWithSize = new WeakMap();
+  weakMapWithSize.size = 2;
+  expect(Bun.inspect(weakMapWithSize)).toBe("WeakMap {}");
+
+  const weakSetWithSize = new WeakSet();
+  weakSetWithSize.size = 2;
+  expect(Bun.inspect(weakSetWithSize)).toBe("WeakSet {}");
   expect(Bun.inspect(<div>foo</div>)).toBe("<div>foo</div>");
   expect(Bun.inspect(<div hello>foo</div>)).toBe("<div hello=true>foo</div>");
   expect(Bun.inspect(<div hello={1}>foo</div>)).toBe("<div hello=1>foo</div>");


### PR DESCRIPTION
WeakMap and WeakSet are not iterable. When a user sets a `.size` property on one, the Map/Set formatter would try to `forEach()` it, throwing a TypeError.

```js
const wm = new WeakMap();
wm.size = 2;
Bun.inspect(wm); // TypeError: Type error
```

In the `toMatchObject` diff path, this exception was swallowed by `catch {}` but left pending on the VM, tripping `assertNoExceptionExceptTermination` on the next format call:

```js
const wm = new WeakMap();
wm.size = 2;
expect(wm).toMatchObject({ 0: 1 }); // assertion failure in debug builds
```

- Always print `WeakMap {}` / `WeakSet {}` without reading `.size` or iterating, in both `ConsoleObject.zig` and `test/pretty_format.zig`.
- Clear pending exceptions when `DiffFormatter` swallows format errors.

Found by Fuzzilli (fingerprint `ae31b0e4f9d83d94`).