### PR TITLE
Apply EXIF orientation to Bun.Image HEIC/TIFF/AVIF decodes

### DIFF
--- a/src/jsc/bindings/image_coregraphics_shim.cpp
+++ b/src/jsc/bindings/image_coregraphics_shim.cpp
@@ -72,7 +72,9 @@ struct Syms {
     const uint8_t* (*CFDataGetBytePtr)(CFRef);
     CFRef (*CFStringCreateWithCString)(CFRef, const char*, uint32_t);
     CFRef (*CFNumberCreate)(CFRef, int, const void*);
+    bool (*CFNumberGetValue)(CFRef, int, void*);
     CFRef (*CFDictionaryCreate)(CFRef, const void**, const void**, long, const void*, const void*);
+    const void* (*CFDictionaryGetValue)(CFRef, const void*);
     // CoreGraphics
     CFRef (*CGColorSpaceCreateDeviceRGB)();
     void (*CGColorSpaceRelease)(CFRef);
@@ -85,6 +87,7 @@ struct Syms {
     // ImageIO
     CFRef (*CGImageSourceCreateWithData)(CFRef, CFRef);
     CFRef (*CGImageSourceCreateImageAtIndex)(CFRef, size_t, CFRef);
+    CFRef (*CGImageSourceCopyPropertiesAtIndex)(CFRef, size_t, CFRef);
     CFRef (*CGImageDestinationCreateWithData)(CFRef, CFRef, size_t, CFRef);
     void (*CGImageDestinationAddImage)(CFRef, CFRef, CFRef);
     bool (*CGImageDestinationFinalize)(CFRef);
@@ -98,6 +101,7 @@ struct Syms {
     // address and dereference at use-site).
     CFRef* kCFAllocatorNull;
     CFRef* kCGImageDestinationLossyCompressionQuality;
+    CFRef* kCGImagePropertyOrientation;
     const void* kCFTypeDictionaryKeyCallBacks;
     const void* kCFTypeDictionaryValueCallBacks;
 };
@@ -119,7 +123,9 @@ constexpr struct {
     SYM(CFDataGetBytePtr),
     SYM(CFStringCreateWithCString),
     SYM(CFNumberCreate),
+    SYM(CFNumberGetValue),
     SYM(CFDictionaryCreate),
+    SYM(CFDictionaryGetValue),
     SYM(CGColorSpaceCreateDeviceRGB),
     SYM(CGColorSpaceRelease),
     SYM(CGImageCreate),
@@ -130,6 +136,7 @@ constexpr struct {
     SYM(CGDataProviderRelease),
     SYM(CGImageSourceCreateWithData),
     SYM(CGImageSourceCreateImageAtIndex),
+    SYM(CGImageSourceCopyPropertiesAtIndex),
     SYM(CGImageDestinationCreateWithData),
     SYM(CGImageDestinationAddImage),
     SYM(CGImageDestinationFinalize),
@@ -140,6 +147,7 @@ constexpr struct {
     SYM(vImageVerticalReflect_ARGB8888),
     SYM(kCFAllocatorNull),
     SYM(kCGImageDestinationLossyCompressionQuality),
+    SYM(kCGImagePropertyOrientation),
     SYM(kCFTypeDictionaryKeyCallBacks),
     SYM(kCFTypeDictionaryValueCallBacks),
 };
@@ -180,6 +188,9 @@ const Syms* load()
 constexpr uint32_t kBunCGImageAlphaLast = 3; // straight RGBA, A in byte 3
 constexpr uint32_t kBunCFStringEncodingUTF8 = 0x08000100;
 constexpr int kBunCFNumberDoubleType = 13;
+// CFNumberGetValue type for SInt32 — orientation is stored as a small int in
+// the image-source properties dict.
+constexpr int kBunCFNumberSInt32Type = 3;
 // vImage_Flags — values copied verbatim from <Accelerate/vImage_Types.h>;
 // keep them in sync, the kvImageNoAllocate one used to be wrong (4 vs 512)
 // and silently turned every CG decode into 0xAA garbage in debug builds.
@@ -209,6 +220,31 @@ template<class R, class... A>
 inline R msg(const Syms* s, CFRef recv, CFRef sel, A... a)
 {
     return reinterpret_cast<R (*)(CFRef, CFRef, A...)>(s->objc_msgSend)(recv, sel, a...);
+}
+
+// EXIF orientation (TIFF tag 0x0112) for the first image in `src`. Values
+// 1..8 per EXIF spec; 1 (no-op) is returned for missing/invalid/out-of-range,
+// matching Sharp/libvips's "advisory, never fail decode" treatment.
+//
+// ImageIO parses this out of the container (EXIF TIFF IFD0 for
+// JPEG/TIFF/WebP; HEIC `irot`/`imir` transform properties mapped to EXIF
+// orientation) and exposes it via the properties dict. Apple documents that
+// CGImageSourceCreateImageAtIndex itself does NOT apply the orientation to
+// the returned pixels — the caller is expected to either draw through a
+// transform or rotate the decoded buffer, which is what we do below.
+inline int readOrientation(const Syms* s, CFRef src)
+{
+    CFRef props = s->CGImageSourceCopyPropertiesAtIndex(src, 0, nullptr);
+    if (!props) return 1;
+    int o = 1;
+    CFRef v = const_cast<void*>(s->CFDictionaryGetValue(props, *s->kCGImagePropertyOrientation));
+    if (v) {
+        int32_t raw = 0;
+        if (s->CFNumberGetValue(v, kBunCFNumberSInt32Type, &raw) && raw >= 1 && raw <= 8)
+            o = raw;
+    }
+    s->CFRelease(props);
+    return o;
 }
 
 // Image UTIs in preference order. PNG first (lossless, compact); then formats
@@ -309,6 +345,13 @@ int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_p
     // non-premultiplied alpha, which CGBitmapContext refuses — so the result
     // is straight RGBA with no premul→unpremul quantisation. kvImageNoAllocate
     // makes it write into the caller's bun.default_allocator buffer.
+    //
+    // Pixels come back in their *stored* orientation — EXIF/TIFF orientation
+    // tags (common on iPhone HEIC with Orientation=6) are NOT applied here.
+    // Callers that want Sharp's "auto-orient" behaviour call
+    // bun_coregraphics_orientation() and apply the transform with the
+    // existing flip/rotate vImage kernels, matching the JPEG codepath that
+    // reads the tag in Zig and rotates post-decode. (#30235)
     VBuf buf { out, h, w, w * 4 };
     VFmt fmt { 8, 32, r.cs, kBunCGImageAlphaLast, 0, nullptr, 0 };
     auto rc = s->vImageBuffer_InitWithCGImage(&buf, &fmt, nullptr, r.img, kBunVImageNoAllocate);
@@ -318,6 +361,29 @@ int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_p
     // 0xAA — that's the garbage we shipped before the constant was fixed.
     if (rc != 0 || buf.data != out) return CG_DECODE_FAILED;
     return CG_OK;
+}
+
+// Read EXIF/TIFF orientation tag (IFD0 0x0112) from the first image in the
+// container. Returns 1..8 per EXIF spec; 1 (identity) for missing/invalid/
+// loader-failure, matching Sharp/libvips's "advisory, never fail" policy.
+//
+// Kept separate from decode so the Zig side owns the "apply or skip" decision
+// — `new Bun.Image(..., { autoOrient: false })` still wants raw stored pixels,
+// and the existing JPEG codepath already reads the tag in Zig and rotates
+// post-decode via `Image.applyOrientation`. One small ImageIO query here keeps
+// HEIC/TIFF/AVIF on the same Zig gate.
+int32_t bun_coregraphics_orientation(const uint8_t* bytes, size_t len)
+{
+    auto s = load();
+    if (!s) return 1;
+    Pool pool(s);
+    CFRef data = s->CFDataCreateWithBytesNoCopy(nullptr, bytes, static_cast<long>(len), *s->kCFAllocatorNull);
+    if (!data) return 1;
+    CFRef src = s->CGImageSourceCreateWithData(data, nullptr);
+    int o = src ? readOrientation(s, src) : 1;
+    if (src) s->CFRelease(src);
+    s->CFRelease(data);
+    return o;
 }
 
 // Encode RGBA8 → format. format: 0=jpeg, 1=png, 2=webp, 3=heic, 4=avif.
@@ -559,6 +625,7 @@ int64_t bun_coregraphics_clipboard_change_count()
 // Environment.isMac so they're dead code, but LTO needs the definitions.
 extern "C" int bun_coregraphics_decode(const void*, unsigned long, unsigned long long, void*, void*, void*) { return 1; }
 extern "C" int bun_coregraphics_encode(const void*, unsigned, unsigned, int, int, void*, void*) { return 1; }
+extern "C" int bun_coregraphics_orientation(const void*, unsigned long) { return 1; }
 extern "C" int bun_coregraphics_scale(const void*, unsigned, unsigned, void*, unsigned, unsigned) { return 1; }
 extern "C" int bun_coregraphics_rotate90(const void*, unsigned, unsigned, void*, unsigned) { return 1; }
 extern "C" int bun_coregraphics_reflect(const void*, unsigned, unsigned, void*, int) { return 1; }

--- a/src/runtime/image/Image.zig
+++ b/src/runtime/image/Image.zig
@@ -956,8 +956,8 @@ pub const PipelineTask = struct {
             if (codecs.probe(input, this.max_pixels)) |p| {
                 var w = p.width;
                 var h = p.height;
-                if (this.auto_orient and p.format == .jpeg) {
-                    const t = exif.readJpeg(input).transform();
+                if (this.auto_orient) {
+                    const t = readOrientation(input, p.format).transform();
                     if (t.rotate == 90 or t.rotate == 270) std.mem.swap(u32, &w, &h);
                 }
                 this.result = .{ .meta = .{ .w = w, .h = h, .format = p.format } };
@@ -973,6 +973,11 @@ pub const PipelineTask = struct {
             }
         }
 
+        // Sniff once up front — every orientation query below needs the
+        // format, and the sniffer is already looking at the same bytes the
+        // decoder will.
+        const src_format = codecs.Format.sniff(input) orelse .png;
+
         // Decode-time downscale hint. The IDCT picker constrains in *stored*
         // axes, so any 90/270 rotate that runs before resize — explicit OR
         // EXIF auto-orient — needs the hint axes swapped, otherwise one axis
@@ -985,7 +990,7 @@ pub const PipelineTask = struct {
             var th = if (r.h != 0) r.h else r.w;
             const swap_explicit = this.pipeline.rotate == 90 or this.pipeline.rotate == 270;
             const swap_exif = this.auto_orient and blk2: {
-                const t = exif.readJpeg(input).transform();
+                const t = readOrientation(input, src_format).transform();
                 break :blk2 t.rotate == 90 or t.rotate == 270;
             };
             if (swap_explicit != swap_exif) std.mem.swap(u32, &tw, &th);
@@ -998,12 +1003,13 @@ pub const PipelineTask = struct {
         };
         defer decoded.deinit();
 
-        const src_format = codecs.Format.sniff(input) orelse .png;
-
         // EXIF auto-orient: applied BEFORE any user op so resize targets and
         // metadata report the visually-upright dimensions, the way Sharp does.
-        if (this.auto_orient and src_format == .jpeg) {
-            const orient = exif.readJpeg(input);
+        // Covers JPEG via the Zig APP1 walker and HEIC/TIFF/AVIF via the
+        // system backend (ImageIO/WIC), whose decoders hand back pixels in
+        // their *stored* orientation. (#30235)
+        if (this.auto_orient) {
+            const orient = readOrientation(input, src_format);
             if (orient != .normal) applyOrientation(&decoded, orient) catch |e| {
                 this.result = .{ .err = e };
                 return;
@@ -1242,6 +1248,32 @@ pub const PipelineTask = struct {
         }
         if (r.without_enlargement and (w > sw or h > sh)) return .{ .w = sw, .h = sh };
         return .{ .w = w, .h = h };
+    }
+
+    /// EXIF Orientation for whatever container `input` is. The Zig reader in
+    /// `exif.zig` covers JPEG (APP1/Exif walker — simple enough that a pure-
+    /// Zig parser is worthwhile, and it's the JPEG path that runs on Linux
+    /// where no ImageIO exists). HEIC, TIFF, and AVIF all store orientation
+    /// inside containers with nothing in common with JPEG markers — HEIF's
+    /// `irot`/`imir` transform properties live behind an ISOBMFF box walk,
+    /// and HEIC's Exif item is reached via `iloc`/`iinf` — so we delegate
+    /// to the system backend (ImageIO/WIC), which has already parsed all of
+    /// them. Backends without a reader (or unused `backend == .bun`) return
+    /// 1, matching JPEG's "no Exif segment" fallthrough. (#30235)
+    fn readOrientation(input: []const u8, fmt: codecs.Format) exif.Orientation {
+        const v: u8 = switch (fmt) {
+            .jpeg => @intFromEnum(exif.readJpeg(input)),
+            .heic, .avif, .tiff => blk: {
+                if (codecs.system_backend) |b| if (@hasDecl(b, "orientation"))
+                    if (codecs.backend == .system) break :blk b.orientation(input);
+                break :blk 1;
+            },
+            // PNG eXIf / WebP EXIF chunks exist but are rare (no major
+            // consumer writes them by default). Leaving them at identity
+            // mirrors exif.zig's comment at the top of the file.
+            .png, .webp, .bmp, .gif => 1,
+        };
+        return if (v >= 1 and v <= 8) @enumFromInt(v) else .normal;
     }
 
     fn applyOrientation(d: *codecs.Decoded, orient: exif.Orientation) codecs.Error!void {

--- a/src/runtime/image/Image.zig
+++ b/src/runtime/image/Image.zig
@@ -535,8 +535,15 @@ pub fn doMetadata(this: *Image, global: *jsc.JSGlobalObject, callframe: *jsc.Cal
         if (codecs.probe(buf, this.max_pixels)) |p| {
             var w = p.width;
             var h = p.height;
-            if (this.auto_orient and p.format == .jpeg) {
-                const t = exif.readJpeg(buf).transform();
+            // Route through PipelineTask.readOrientation so all four gates
+            // (JS-thread probe, worker-thread probe, worker-thread decode-
+            // hint, worker-thread applyOrientation) share one reader. Today
+            // probe() returns UnsupportedOnPlatform for HEIC/TIFF/AVIF so
+            // this branch only sees JPEG/PNG/WebP/BMP/GIF, but if probe()
+            // grows a TIFF IFD0 / HEIF `ispe` parser, the sync and async
+            // paths stay in sync for free.
+            if (this.auto_orient) {
+                const t = PipelineTask.readOrientation(buf, p.format).transform();
                 if (t.rotate == 90 or t.rotate == 270) std.mem.swap(u32, &w, &h);
             }
             this.last_width = @intCast(w);
@@ -1003,6 +1010,24 @@ pub const PipelineTask = struct {
         };
         defer decoded.deinit();
 
+        // .metadata on HEIC/AVIF/TIFF reaches here because probe() has no
+        // header parser for them and fell through to a full decode. We only
+        // need w/h/format — swap dimensions numerically from the orientation
+        // tag (same approach the probe-success branch above uses) instead of
+        // physically rotating the just-decoded RGBA buffer the `defer` is
+        // about to free. That keeps .metadata() off a ~w*h*4 scratch
+        // allocation and a vImage rotate pass per call on iPhone-HEIC inputs.
+        if (this.kind == .metadata) {
+            var w = decoded.width;
+            var h = decoded.height;
+            if (this.auto_orient) {
+                const t = readOrientation(input, src_format).transform();
+                if (t.rotate == 90 or t.rotate == 270) std.mem.swap(u32, &w, &h);
+            }
+            this.result = .{ .meta = .{ .w = w, .h = h, .format = src_format } };
+            return;
+        }
+
         // EXIF auto-orient: applied BEFORE any user op so resize targets and
         // metadata report the visually-upright dimensions, the way Sharp does.
         // Covers JPEG via the Zig APP1 walker and HEIC/TIFF/AVIF via the
@@ -1014,12 +1039,6 @@ pub const PipelineTask = struct {
                 this.result = .{ .err = e };
                 return;
             };
-        }
-
-        if (this.kind == .metadata) {
-            // Reached only for HEIC/AVIF (probe fell through).
-            this.result = .{ .meta = .{ .w = decoded.width, .h = decoded.height, .format = src_format } };
-            return;
         }
 
         if (this.kind == .placeholder) {

--- a/src/runtime/image/backend_coregraphics.zig
+++ b/src/runtime/image/backend_coregraphics.zig
@@ -28,6 +28,21 @@ extern fn bun_coregraphics_encode(
     out_len: *usize,
 ) i32;
 
+// Read the first-image EXIF/TIFF orientation tag (1..8). ImageIO parses the
+// JPEG APP1/EXIF IFD, the TIFF IFD0, and HEIC `irot`/`imir` transform
+// properties — all mapped to the same 1..8 enum — so one ImageIO call covers
+// every system-backend format. Returns 1 (identity) on any failure to match
+// Sharp's "advisory, never error the decode" treatment. Used by Image.zig's
+// auto-orient gate for containers whose Zig-side EXIF reader doesn't exist
+// (HEIC's EXIF lives inside an ISOBMFF `iloc`/`iinf` item, nothing like the
+// JPEG APP1 walker in exif.zig). (#30235)
+extern fn bun_coregraphics_orientation(bytes: [*]const u8, len: usize) i32;
+
+pub fn orientation(bytes: []const u8) u8 {
+    const raw = bun_coregraphics_orientation(bytes.ptr, bytes.len);
+    return if (raw >= 1 and raw <= 8) @intCast(raw) else 1;
+}
+
 const CG_OK = 0;
 const CG_UNAVAILABLE = 1;
 const CG_DECODE_FAILED = 2;

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -830,6 +830,79 @@ describe("Bun.Image", () => {
         expect((await new Bun.Image(out).metadata()).format).toBe(fmt);
       });
     }
+
+    // Regression for #30235. ImageIO's CGImageSourceCreateImageAtIndex hands
+    // back pixels in their *stored* orientation — iPhone HEIC (and any EXIF/
+    // TIFF orientation-carrying container) looks rotated 90° vs how Preview /
+    // Photos render it. The auto-orient gate used to be JPEG-only because
+    // exif.zig's walker is JPEG-only; now the gate queries the system backend
+    // (ImageIO on macOS, WIC on Windows) for HEIC/TIFF/AVIF and then runs the
+    // existing flip→flop→rotate pipeline, so Bun matches Sharp.
+    //
+    // TIFF is the test vehicle because (a) it routes through the same system
+    // backend on macOS/Windows, and (b) it's the only orientation-carrying
+    // format simple enough to hand-craft without a codec. A bug in the system
+    // backend shows up identically for HEIC.
+    test.skipIf(!isMacOS)("TIFF Orientation=6 auto-rotates via system backend", async () => {
+      // Hand-roll a 4×2 uncompressed RGB TIFF with Orientation=6. Little-
+      // endian ("II"), 10 IFD entries, BitsPerSample stored inline at byte
+      // 134 (count=3 * sizeof(SHORT) > 4 → offset), pixels at byte 140.
+      // Tags must be sorted by ID per TIFF §2.
+      const tiff = new Uint8Array(164);
+      const dv = new DataView(tiff.buffer);
+      tiff.set([0x49, 0x49, 0x2a, 0x00], 0); // "II" + magic 42
+      dv.setUint32(4, 8, true); // IFD0 at byte 8
+      dv.setUint16(8, 10, true); // 10 entries
+      const writeEntry = (i: number, tag: number, type: number, count: number, value: number) => {
+        const e = 10 + i * 12;
+        dv.setUint16(e, tag, true);
+        dv.setUint16(e + 2, type, true);
+        dv.setUint32(e + 4, count, true);
+        dv.setUint32(e + 8, value, true);
+      };
+      //          tag   type        count  value/offset
+      writeEntry(0, 0x0100, 4, 1, 4); //    ImageWidth      = 4
+      writeEntry(1, 0x0101, 4, 1, 2); //    ImageLength     = 2
+      writeEntry(2, 0x0102, 3, 3, 134); //  BitsPerSample   → offset 134
+      writeEntry(3, 0x0103, 3, 1, 1); //    Compression     = none
+      writeEntry(4, 0x0106, 3, 1, 2); //    PhotoInterp     = RGB
+      writeEntry(5, 0x0111, 4, 1, 140); //  StripOffsets    → offset 140
+      writeEntry(6, 0x0112, 3, 1, 6); //    Orientation     = 6 (rotate 90° CW)
+      writeEntry(7, 0x0115, 3, 1, 3); //    SamplesPerPixel = 3
+      writeEntry(8, 0x0116, 4, 1, 2); //    RowsPerStrip    = 2
+      writeEntry(9, 0x0117, 4, 1, 24); //   StripByteCounts = 24
+      dv.setUint32(130, 0, true); // next IFD = 0
+      // BitsPerSample: 3 × u16 = 8, 8, 8
+      dv.setUint16(134, 8, true);
+      dv.setUint16(136, 8, true);
+      dv.setUint16(138, 8, true);
+      // 4×2 RGB pixels — distinctive so a misread shows up as a crash or
+      // wrong-colour PNG, not a silently equal output.
+      const pixels = [
+        255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128, //
+        64, 64, 64, 200, 200, 200, 32, 64, 96, 100, 150, 200,
+      ];
+      for (let i = 0; i < pixels.length; i++) tiff[140 + i] = pixels[i];
+
+      // Without my fix: reports stored dims 4×2. With the fix: orientation
+      // swaps the axes so dims come back as 2×4.
+      const oriented = await new Bun.Image(tiff).metadata();
+      expect(oriented).toEqual({ width: 2, height: 4, format: "tiff" });
+
+      // Opting out of auto-orient should still land on the stored dims, so
+      // the fix didn't silently hard-wire the rotation into the decoder.
+      const raw = await new Bun.Image(tiff, { autoOrient: false }).metadata();
+      expect(raw).toEqual({ width: 4, height: 2, format: "tiff" });
+
+      // End-to-end: the reported fix workflow — resize → webp encode — must
+      // produce a WebP with the swapped aspect ratio, not the stored one.
+      // Source is 2:4 upright; fit:"inside" into 100×100 gives 50×100 (height
+      // hits the cap first), so a passing build has height > width — whereas
+      // the un-fixed stored-orientation path would hand back 100×50.
+      const webp = await new Bun.Image(tiff).resize(100, 100, { fit: "inside" }).webp({ quality: 80 }).bytes();
+      const reMeta = await new Bun.Image(webp).metadata();
+      expect(reMeta.height).toBeGreaterThan(reMeta.width);
+    });
   });
 
   // @intFromFloat on NaN/Inf is UB; these used to abort the process.

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -879,8 +879,30 @@ describe("Bun.Image", () => {
       // 4×2 RGB pixels — distinctive so a misread shows up as a crash or
       // wrong-colour PNG, not a silently equal output.
       const pixels = [
-        255, 0, 0, 0, 255, 0, 0, 0, 255, 128, 128, 128, //
-        64, 64, 64, 200, 200, 200, 32, 64, 96, 100, 150, 200,
+        255,
+        0,
+        0,
+        0,
+        255,
+        0,
+        0,
+        0,
+        255,
+        128,
+        128,
+        128, //
+        64,
+        64,
+        64,
+        200,
+        200,
+        200,
+        32,
+        64,
+        96,
+        100,
+        150,
+        200,
       ];
       for (let i = 0; i < pixels.length; i++) tiff[140 + i] = pixels[i];
 

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -918,12 +918,12 @@ describe("Bun.Image", () => {
 
       // End-to-end: the reported fix workflow — resize → webp encode — must
       // produce a WebP with the swapped aspect ratio, not the stored one.
-      // Source is 2:4 upright; fit:"inside" into 100×100 gives 50×100 (height
-      // hits the cap first), so a passing build has height > width — whereas
-      // the un-fixed stored-orientation path would hand back 100×50.
+      // Source is 2:4 upright; fit:"inside" into a 100×100 box scales to
+      // 50×100 (height hits the cap first) — pin the exact dims so anything
+      // but the post-orient scaling regresses loudly, not just "not square".
+      // The un-fixed stored-orientation path would have landed at 100×50.
       const webp = await new Bun.Image(tiff).resize(100, 100, { fit: "inside" }).webp({ quality: 80 }).bytes();
-      const reMeta = await new Bun.Image(webp).metadata();
-      expect(reMeta.height).toBeGreaterThan(reMeta.width);
+      expect(await new Bun.Image(webp).metadata()).toEqual({ width: 50, height: 100, format: "webp" });
     });
   });
 


### PR DESCRIPTION
Fixes #30235

### Repro
```js
// 1920×1440 HEIC out of Photos (Orientation=6 → display portrait)
await new Bun.Image("iphone.HEIC")
  .resize(800, { fit: "inside" })
  .webp({ quality: 80 })
  .write("thumb.webp");
// thumb.webp is sideways: 800×600 instead of 600×800
```

### Cause
`bun_coregraphics_decode` calls `CGImageSourceCreateImageAtIndex` with `nullptr` options — ImageIO returns pixels in the container's *stored* orientation. iPhone HEIC almost always sets `Orientation=6` (landscape sensor, portrait display), so the RGBA buffer handed back was rotated 90° vs how Photos / Preview render the same file.

The auto-orient gate in `Image.zig` was `src_format == .jpeg` because `exif.zig`'s walker is JPEG-APP1-only. HEIC's Exif lives inside ISOBMFF item-location boxes (nothing like JPEG markers) and its `irot`/`imir` transform properties live in `meta → iprp → ipco` — no shared parser with JPEG, and none written.

### Fix
Expose orientation from the system backend, widen the Zig gate.

- `src/jsc/bindings/image_coregraphics_shim.cpp` — new `bun_coregraphics_orientation(bytes, len)`. One `CGImageSourceCopyPropertiesAtIndex` + `kCGImagePropertyOrientation` lookup; covers JPEG APP1, TIFF IFD0, HEIC `irot`/`imir`, AVIF Exif — ImageIO parses all four formats into the same 1..8 enum, so the Zig side never has to know about the per-container layout.
- `src/runtime/image/backend_coregraphics.zig` — extern decl + `pub fn orientation(bytes) u8` wrapper.
- `src/runtime/image/Image.zig` — add `PipelineTask.readOrientation(input, fmt)`: JPEG continues to use `exif.readJpeg` (so Linux stays covered); HEIC/TIFF/AVIF delegate to `system_backend.orientation` under a `@hasDecl`-gated dispatch. The three gates that previously hard-coded `p.format == .jpeg` / `src_format == .jpeg` (metadata fast path, decode-hint axis swap, `applyOrientation` call) now read any format. Pixel path is unchanged — the existing flip → flop → rotate via `codecs.flip`/`codecs.rotate` already dispatches to vImage on macOS.
- `test/js/bun/image/image.test.ts` — regression test. Hand-rolled 4×2 uncompressed-RGB TIFF with `Orientation=6`; asserts `metadata()` returns `{ width: 2, height: 4 }` with `autoOrient` default and `{ width: 4, height: 2 }` with `autoOrient: false`, and that a `.resize(100, 100, { fit: "inside" }).webp()` round-trip lands upright. `skipIf(!isMacOS)` — TIFF here exercises the same system-backend codepath HEIC would, and TIFF is the only orientation-carrying container simple enough to build without a codec.

### Scope notes
- `autoOrient: false` still lands on raw stored pixels — the apply step remains gated on `this.auto_orient`.
- Windows (WIC) has no metadata reader here yet; `@hasDecl` falls through to orientation=1, matching today's behaviour. Follow-up if someone hits the same issue on Windows.
- JPEG keeps using `exif.readJpeg` even on macOS because JPEG decode routes to libjpeg-turbo, not ImageIO — no risk of double-application.
