### PR TITLE
Blob.writer: don't assume Start.fromJSWithTag returns .FileSink

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2974,8 +2974,12 @@ pub fn getWriter(
     };
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
-        stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        const parsed = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
+        if (parsed == .FileSink) {
+            parsed.FileSink.input_path.deinit();
+            stream_start = parsed;
+            stream_start.FileSink.input_path = input_path;
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -268,3 +268,21 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
 });
+
+it("Bun.file().writer() with invalid path/fd in options does not crash", async () => {
+  const dir = tmpdirSync();
+  const target = join(dir, "out.txt");
+  const blob = Bun.file(target);
+
+  // These previously panicked with "access of union field 'FileSink' while
+  // field 'err' is active" because fromJSWithTag returns .err for a
+  // non-string path / non-integer fd and the caller assumed .FileSink.
+  for (const options of [{ path: 123 }, { fd: "nope" }, { fd: {} }]) {
+    // @ts-expect-error intentionally bogus options
+    const sink = blob.writer(options);
+    sink.write("hello");
+    await sink.end();
+    expect(await Bun.file(target).text()).toBe("hello");
+    await Bun.file(target).unlink();
+  }
+});


### PR DESCRIPTION
## What does this PR do?

`Bun.file(path).writer(options)` panics in safe builds when `options` contains a non-string `path` or non-integer `fd`:

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
```

`streams.Start.fromJSWithTag(.FileSink)` returns `.err` for those inputs, but `Blob.getWriter` unconditionally wrote to `.FileSink.input_path` on the result.

Now we only adopt the parsed result when its tag is `.FileSink`; otherwise we keep the default `stream_start`, which already points at the blob's own path/fd. The blob's `input_path` always overrides any user-supplied `path`/`fd` anyway, so this just skips the crash path without changing observable behavior in the valid case.

Also `deinit()` the parsed `input_path` before overriding it so a user-supplied string `path` doesn't leak.

## How did you verify your code works?

Added a regression test in `test/js/bun/util/filesink.test.ts` that calls `blob.writer({ path: 123 })`, `blob.writer({ fd: "nope" })`, and `blob.writer({ fd: {} })` and asserts the sink still writes to the blob's path. Panics on the previous build, passes now.

Found by Fuzzilli (fingerprint `3621cd40bf6d19ae`).