### PR TITLE
Fix LazyProperty assertion when util.inspect lazy init throws

### DIFF
--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -28,9 +28,9 @@ Structure* createUtilInspectOptionsStructure(VM& vm, JSC::JSGlobalObject* global
 JSObject* createInspectOptionsObject(VM& vm, Zig::GlobalObject* globalObject, unsigned max_depth, bool colors)
 {
     JSFunction* stylizeFn = colors ? globalObject->utilInspectStylizeColorFunction() : globalObject->utilInspectStylizeNoColorFunction();
-    if (!stylizeFn) return nullptr;
+    if (vm.exceptionForInspection()) return nullptr;
     JSObject* options = JSC::constructEmptyObject(vm, globalObject->utilInspectOptionsStructure());
-    options->putDirectOffset(vm, 0, stylizeFn);
+    options->putDirectOffset(vm, 0, stylizeFn ? JSValue(stylizeFn) : jsUndefined());
     options->putDirectOffset(vm, 1, jsNumber(max_depth));
     options->putDirectOffset(vm, 2, jsBoolean(colors));
     return options;
@@ -57,8 +57,8 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     auto callData = JSC::getCallData(functionToCall);
     MarkedArgumentBuffer arguments;
     arguments.append(jsNumber(depth));
-    arguments.append(options);
-    arguments.append(inspectFn);
+    arguments.append(options ? JSValue(options) : jsUndefined());
+    arguments.append(inspectFn ? JSValue(inspectFn) : jsUndefined());
 
     auto inspectRet = JSC::profiledCall(globalObject, ProfilingReason::API, functionToCall, callData, thisValue, arguments);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2080,10 +2080,10 @@ void GlobalObject::finishCreation(VM& vm)
         [](const Initializer<JSFunction>& init) {
             auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
             RELEASE_ASSERT(nodeUtilValue.isObject());
             auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
             ASSERT(prop);
             init.set(uncheckedDowncast<JSFunction>(prop));
         });
@@ -2106,21 +2106,23 @@ void GlobalObject::finishCreation(VM& vm)
         [](const Initializer<JSFunction>& init) {
             auto scope = DECLARE_THROW_SCOPE(init.vm);
             JSC::MarkedArgumentBuffer args;
-            args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-            RETURN_IF_EXCEPTION(scope, );
+            JSFunction* inspectFn = uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction();
+            if (scope.exception() || !inspectFn) [[unlikely]]
+                return init.property.setMayBeNull(init.vm, init.owner, nullptr);
+            args.append(inspectFn);
 
             JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
 
             JSC::CallData callData = JSC::getCallData(getStylize);
             NakedPtr<JSC::Exception> returnedException = nullptr;
             auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
 
             if (returnedException) {
                 throwException(init.owner, scope, returnedException.get());
             }
-            RETURN_IF_EXCEPTION(scope, );
+            RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
             init.set(uncheckedDowncast<JSFunction>(result));
         });
 

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -213,6 +213,8 @@ JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototype_inspectCustom, (JSC::JSGlob
 
     JSFunction* utilInspect = globalObject->utilInspectFunction();
     RETURN_IF_EXCEPTION(throwScope, {});
+    if (!utilInspect) [[unlikely]]
+        return JSValue::encode(jsNontrivialString(vm, "BroadcastChannel"_s));
     auto callData = JSC::getCallData(utilInspect);
     MarkedArgumentBuffer arguments;
     arguments.append(inputObj);

--- a/test/js/bun/util/inspect-util-load-failure.test.ts
+++ b/test/js/bun/util/inspect-util-load-failure.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When node:util fails to load (e.g. a builtin it depends on was deleted), inspecting an
+// object with a custom inspect method previously tripped a RELEASE_ASSERT in
+// JSC::LazyProperty because the initLater lambda returned without calling init.set().
+test.concurrent("Bun.inspect custom inspect does not crash when node:util cannot load", async () => {
+  const src = `
+    void process.stdout;
+    delete Function.prototype.bind;
+    const obj = { [Symbol.for("nodejs.util.inspect.custom")]() { return "ok"; } };
+    try { Bun.inspect(obj); } catch {}
+    try { Bun.inspect(obj); } catch {}
+    try { Bun.inspect(obj, { colors: true }); } catch {}
+    process.stdout.write("done");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(proc.signalCode).toBeNull();
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(stdout).toBe("done");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("BroadcastChannel custom inspect does not crash when node:util cannot load", async () => {
+  const src = `
+    void process.stdout;
+    delete Function.prototype.bind;
+    const bc = new BroadcastChannel("x");
+    bc.unref();
+    const fn = bc[Symbol.for("nodejs.util.inspect.custom")];
+    try { fn.call(bc, 2, {}); } catch {}
+    try { fn.call(bc, 2, {}); } catch {}
+    process.stdout.write("done");
+    process.exit(0);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(proc.signalCode).toBeNull();
+  expect(stderr).not.toContain("ASSERTION FAILED");
+  expect(stdout).toBe("done");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/util/inspect-util-load-failure.test.ts
+++ b/test/js/bun/util/inspect-util-load-failure.test.ts
@@ -37,7 +37,6 @@ test.concurrent("BroadcastChannel custom inspect does not crash when node:util c
     try { fn.call(bc, 2, {}); } catch {}
     try { fn.call(bc, 2, {}); } catch {}
     process.stdout.write("done");
-    process.exit(0);
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", src],


### PR DESCRIPTION
Fuzzilli found a crash with fingerprint `LazyPropertyInlines.h(105)`:

```
ASSERTION FAILED: !(initializer.property.m_pointer & lazyTag)
JavaScriptCore/LazyPropertyInlines.h(105) : static ElementType *JSC::LazyProperty<JSGlobalObject, JSFunction>::callFunc(const Initializer &)
```

## Repro

```js
delete Function.prototype.bind;
const obj = { [Symbol.for("nodejs.util.inspect.custom")]() { return "x"; } };
Bun.inspect(obj);
```

## Root cause

`m_utilInspectFunction` is a `LazyProperty<JSGlobalObject, JSFunction>` whose `initLater` lambda loads `node:util` via `internalModuleRegistry()->requireId(...)`. Loading that module executes JS (primordials, etc.), which can throw if userland has tampered with builtins it depends on (e.g. deleted `Function.prototype.bind`).

When that happens the lambda does `RETURN_IF_EXCEPTION(scope, );` and returns **without** calling `init.set()`. `LazyProperty::callFunc` then hits `RELEASE_ASSERT(!(m_pointer & lazyTag))` because the pointer was never overwritten. The same pattern exists in `m_utilInspectStylizeColorFunction`.

## Fix

- In both `initLater` lambdas, on the exception/failure path call `init.property.setMayBeNull(init.vm, init.owner, nullptr)` before returning so the `LazyProperty` contract is satisfied and the exception propagates normally.
- Teach the callers to tolerate a null result on subsequent calls (after the property has been permanently set to null): `JSC__JSValue__callCustomInspectFunction` and `createInspectOptionsObject` substitute `jsUndefined()` for the missing inspect/stylize function, and `jsBroadcastChannelPrototype_inspectCustom` falls back to the plain `"BroadcastChannel"` string.

After the fix, the repro throws a regular `TypeError` from the failed `node:util` load on the first call and degrades gracefully on subsequent calls instead of aborting.