### PR TITLE
Fix crash in Bun.inspect when Proxy getPrototypeOf trap throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5444,7 +5444,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1834,7 +1834,9 @@ extern "C" napi_status napi_get_all_property_names(
                 // Climb up the prototype chain to find inherited properties
                 JSObject* current_object = object;
                 while (!current_object->getOwnPropertyDescriptor(globalObject, key.toPropertyKey(globalObject), desc)) {
-                    JSObject* proto = current_object->getPrototype(globalObject).getObject();
+                    JSValue protoValue = current_object->getPrototype(globalObject);
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSObject* proto = protoValue.getObject();
                     if (!proto) {
                         break;
                     }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -451,6 +451,32 @@ const fixture = [
         },
       },
     ),
+  () => {
+    const proto = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      },
+    );
+    const obj = Object.create(proto);
+    obj[0] = 1;
+    return obj;
+  },
+  () => {
+    const proto = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error("nope");
+        },
+      },
+    );
+    const obj = Object.create(proto);
+    Object.defineProperty(obj, "x", { get: () => 1, enumerable: true, configurable: true });
+    return obj;
+  },
 ];
 
 describe("crash testing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference crash found by Fuzzilli in `Bun.inspect` / `console.log` when printing an object whose prototype chain contains a Proxy with a throwing `getPrototypeOf` trap.

```js
const p = new Proxy({}, { getPrototypeOf() { throw 0; } });
const obj = Object.create(p);
obj[0] = 1;
console.log(obj); // crash
```

When walking the prototype chain in the slow path of `forEachProperty`, `JSObject::getPrototype()` invokes the Proxy `getPrototypeOf` trap. If the trap throws, `getPrototype()` returns an empty `JSValue`, and calling `.getObject()` on it dereferences a null cell pointer.

The fix checks for an empty return value before calling `.getObject()` and clears the exception, matching the existing handling in the fast-path branch of the same function.

Also applies the same fix to `napi_get_all_property_names` which has the identical pattern.

## How did you verify your code works?

Added regression tests to `test/js/bun/util/inspect.test.js` that crash before this change and pass after.