### PR TITLE
Unwrap JSC::Exception in promise rejection bindings

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -468,7 +468,10 @@ extern "C" void Bun__onFulfillAsyncModule(
     JSC::JSPromise* promise = uncheckedDowncast<JSC::JSPromise>(JSC::JSValue::decode(encodedPromiseValue));
 
     if (!res->success) {
-        RELEASE_AND_RETURN(scope, promise->reject(vm, JSValue::decode(res->result.err)));
+        JSValue errorValue = JSValue::decode(res->result.err);
+        if (auto* exception = dynamicDowncast<JSC::Exception>(errorValue))
+            errorValue = exception->value();
+        RELEASE_AND_RETURN(scope, promise->reject(vm, errorValue));
     }
 
     auto* specifierValue = Bun::toJS(globalObject, *specifier);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3955,7 +3955,12 @@ JSC::EncodedJSValue JSC__JSPromise__wrap(JSC::JSGlobalObject* globalObject, void
     ASSERT_WITH_MESSAGE(arg0->status() == JSC::JSPromise::Status::Pending, "Promise is already resolved or rejected");
 
     auto& vm = JSC::getVM(arg1);
-    arg0->rejectAsHandled(vm, JSC::JSValue::decode(JSValue2));
+    JSValue value = JSC::JSValue::decode(JSValue2);
+    if (auto* exception = dynamicDowncast<JSC::Exception>(value)) {
+        arg0->rejectAsHandled(vm, exception);
+        return;
+    }
+    arg0->rejectAsHandled(vm, value);
 }
 
 JSC::JSPromise* JSC__JSPromise__rejectedPromise(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue JSValue1)
@@ -3969,6 +3974,8 @@ JSC::JSPromise* JSC__JSPromise__rejectedPromise(JSC::JSGlobalObject* globalObjec
         ASSERT(vm.exceptionForInspection());
         return JSC::JSPromise::create(vm, globalObject->promiseStructure());
     }
+    if (auto* exception = dynamicDowncast<JSC::Exception>(value))
+        value = exception->value();
     return JSC::JSPromise::rejectedPromise(globalObject, value);
 }
 
@@ -4122,7 +4129,12 @@ void JSC__JSInternalPromise__rejectAsHandled(JSC::JSPromise* arg0,
     JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2)
 {
     auto& vm = JSC::getVM(arg1);
-    arg0->rejectAsHandled(vm, JSC::JSValue::decode(JSValue2));
+    JSValue value = JSC::JSValue::decode(JSValue2);
+    if (auto* exception = dynamicDowncast<JSC::Exception>(value)) {
+        arg0->rejectAsHandled(vm, exception);
+        return;
+    }
+    arg0->rejectAsHandled(vm, value);
 }
 void JSC__JSInternalPromise__rejectAsHandledException(JSC::JSPromise* arg0,
     JSC::JSGlobalObject* arg1,
@@ -4135,7 +4147,10 @@ void JSC__JSInternalPromise__rejectAsHandledException(JSC::JSPromise* arg0,
 JSC::JSPromise* JSC__JSInternalPromise__rejectedPromise(JSC::JSGlobalObject* arg0,
     JSC::EncodedJSValue JSValue1)
 {
-    return JSC::JSPromise::rejectedPromise(arg0, JSC::JSValue::decode(JSValue1));
+    JSValue value = JSC::JSValue::decode(JSValue1);
+    if (auto* exception = dynamicDowncast<JSC::Exception>(value))
+        value = exception->value();
+    return JSC::JSPromise::rejectedPromise(arg0, value);
 }
 
 [[ZIG_EXPORT(check_slow)]]
@@ -5325,11 +5340,14 @@ JSC::EncodedJSValue JSC__JSPromise__rejectedPromiseValue(JSC::JSGlobalObject* gl
     JSC::EncodedJSValue JSValue1)
 {
     auto& vm = JSC::getVM(globalObject);
+    JSValue value = JSC::JSValue::decode(JSValue1);
+    if (auto* exception = dynamicDowncast<JSC::Exception>(value))
+        value = exception->value();
     JSC::JSPromise* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     promise->setFlags(static_cast<uint16_t>(JSC::JSPromise::Status::Rejected));
-    promise->setSlot(vm, JSC::JSValue::decode(JSValue1));
+    promise->setSlot(vm, value);
     JSC::ensureStillAliveHere(promise);
-    JSC::ensureStillAliveHere(JSC::JSValue::decode(JSValue1));
+    JSC::ensureStillAliveHere(value);
     return JSC::JSValue::encode(promise);
 }
 

--- a/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts
+++ b/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts
@@ -1,0 +1,30 @@
+import { expect, mock, test } from "bun:test";
+
+// When Bun.write(s3File, ..., options) fails while parsing `options`, the
+// returned promise must be rejected with the underlying Error instance and
+// not the internal JSC::Exception wrapper. Leaking the wrapper caused
+// `e instanceof Error` to be false and, if the value was fed back into a
+// native promise rejection (e.g. mock().mockRejectedValue(e)), triggered
+// ASSERT(!value.inherits<Exception>()) in JSPromise::reject.
+
+test("Bun.write rejection for invalid S3 options is a proper Error", async () => {
+  const s3file = Bun.s3.file("test.txt");
+  // accessKeyId must be a string; passing a number throws an argument-type
+  // error inside getCredentialsWithOptions.
+  const promise = Bun.write(s3file, new Blob(["hello"]), { accessKeyId: 123 as any });
+
+  let caught: unknown;
+  await promise.catch(e => {
+    caught = e;
+  });
+
+  expect(caught).toBeDefined();
+  expect(caught).toBeInstanceOf(Error);
+  expect(Object.prototype.toString.call(caught)).toBe("[object Error]");
+  expect((caught as Error).message).toContain("accessKeyId");
+
+  // Feeding the rejection value back into mockRejectedValue should not crash.
+  const m = mock();
+  m.mockRejectedValue(caught);
+  await expect(m()).rejects.toBe(caught);
+});

--- a/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts
+++ b/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts
@@ -1,16 +1,8 @@
 import { expect, mock, test } from "bun:test";
 
-// When Bun.write(s3File, ..., options) fails while parsing `options`, the
-// returned promise must be rejected with the underlying Error instance and
-// not the internal JSC::Exception wrapper. Leaking the wrapper caused
-// `e instanceof Error` to be false and, if the value was fed back into a
-// native promise rejection (e.g. mock().mockRejectedValue(e)), triggered
-// ASSERT(!value.inherits<Exception>()) in JSPromise::reject.
-
+// Rejection value must be the underlying Error, not the JSC::Exception wrapper.
 test("Bun.write rejection for invalid S3 options is a proper Error", async () => {
   const s3file = Bun.s3.file("test.txt");
-  // accessKeyId must be a string; passing a number throws an argument-type
-  // error inside getCredentialsWithOptions.
   const promise = Bun.write(s3file, new Blob(["hello"]), { accessKeyId: 123 as any });
 
   let caught: unknown;
@@ -23,7 +15,6 @@ test("Bun.write rejection for invalid S3 options is a proper Error", async () =>
   expect(Object.prototype.toString.call(caught)).toBe("[object Error]");
   expect((caught as Error).message).toContain("accessKeyId");
 
-  // Feeding the rejection value back into mockRejectedValue should not crash.
   const m = mock();
   m.mockRejectedValue(caught);
   await expect(m()).rejects.toBe(caught);


### PR DESCRIPTION
### Problem
- `Bun.write(s3file, data, opts)` / `s3file.write(data, opts)` with an invalid option (`acl: "bogus"`, `partSize: -1`, a throwing getter, ...) reject with the raw `JSC::Exception` cell, not the thrown value. `.catch()` sees `[native code: Exception]` with no `message`, and `Object.prototype.toString.call(e)` aborts the process (`ASSERTION FAILED: isSymbol()` in `JSValue::synthesizePrototype`). `server.fetch()` with a throwing handler rejects with the same cell.
- The cause: four call sites pass `global.take_exception(err)`, which is the cell, to `dangerously_create_rejected_promise_value_without_notifying_vm` (`src/runtime/webcore/Blob.rs:1392`, `:4360`, `:4574`, `src/runtime/server/server_body.rs:2385`). Its binding `JSC__JSPromise__rejectedPromiseValue` (`bindings.cpp:5162`) stores the value as is. `JSC__JSPromise__reject` (`:3869`) already unwraps the cell, the sibling bindings did not.

### Fix
- Unwrap `JSC::Exception` to `exception->value()` in `rejectedPromiseValue`, `rejectedPromise`, `JSInternalPromise__rejectedPromise`, the two `rejectAsHandled` bindings, and `Bun__onFulfillAsyncModule`, the same rule as `JSC__JSPromise__reject`.
- Correct because the reason is then exactly the thrown value, Error or not: `throw 1` in a fetch handler rejects `server.fetch()` with `1`. Only `.catch()`/`.then()` callbacks saw the cell (`await` already unwrapped it), so nothing depends on it.
- Verified: `test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts`, plus a 49-case matrix on current main (see Notes): 45 reject with the cell before, 0 after.

### Background
- When JS throws, JSC wraps the value in a `JSC::Exception` cell (value plus captured stack) and sets it pending on the VM. The cell is a bare `JSCell`, not an object, so JS operations on it misbehave or assert.
- `global.take_exception(err)` clears the pending exception and returns that cell (error printers want its stack). `take_error(err)` / `value.to_error()` return the wrapped value, which is what a rejection reason is.
- `dangerously_create_rejected_promise_value_without_notifying_vm` writes the promise result slot directly. What it is given is what `.catch()` receives.

<details><summary>Notes</summary>

Concrete repro (bun 1.4.2 and canary abort with rc 134 on the last line):

```js
const f = new Bun.S3Client({ accessKeyId: "a", secretAccessKey: "b", bucket: "bk", endpoint: "http://127.0.0.1:9" }).file("key");
Bun.write(f, "data", { acl: "bogus-acl" }).catch((e) => {
  console.log(typeof e, e instanceof Error, e?.message, Bun.inspect(e)); // object false undefined [native code: Exception]
  try { console.log(String(e)); } catch (x) { console.log("String(e) threw:", x.message); } // Cannot convert a symbol to a string
  console.log(Object.prototype.toString.call(e)); // aborts
});
```

Fuzzilli first found it as `ASSERT(!value.inherits<Exception>())` in `JSPromise::reject` (JSPromise.cpp:199), with this shape:

```js
const { mock } = Bun.jest(import.meta.path);
const p = Bun.write(Bun.s3.file("test.txt"), new Blob(["hello"]), { accessKeyId: 123 });
p.catch(e => { const m = mock(); m.mockRejectedValue(e); m(); }); // ASSERTION FAILED: !value.inherits<Exception>()
```

Matrix run on main `d316760e8c` with this diff merged: 6 invalid options (`acl`, `storageClass`, `partSize`, `endpoint`, `type: Symbol()`, throwing getter) x 4 sources (`""`, string, `Blob`, `Bun.file`) x (`Bun.write`, `s3file.write`), plus `server.fetch` with a throwing handler. Before: 45/49 reasons are the cell (`jscDescribe` reports `Exception`). After: 49/49 are the real `TypeError`/`RangeError` with the validation message, `Object.prototype.toString.call(e)` is `[object Error]`, and the `server.fetch` reason is the identical thrown object. Non-Error throws keep their identity too (a getter that throws `"plain string"` rejects with that string, `throw Symbol()` in a handler rejects with that symbol).

`s3file.write(data, { type: Symbol() })` validates `type` before the S3 credential path, which is why 4 of the 49 cases were already correct. `s3file.text()/stream()/presign()/unlink()/writer()` with the same options throw the real Error synchronously and were never affected.

#37474 converts these call sites to tracked rejections and unwraps at the Rust layer as part of a larger change. The two do not conflict: with this binding change, any remaining or future caller that hands a taken exception to one of these helpers gets the value, in release builds too.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts"
bun test v1.4.1 (4448a2e21)

test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts:
 9 |   await promise.catch(e => {
10 |     caught = e;
11 |   });
12 | 
13 |   expect(caught).toBeDefined();
14 |   expect(caught).toBeInstanceOf(Error);
                      ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class Error]
Received value: [native code: Exception]

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts:14:18)
(fail) Bun.write rejection for invalid S3 options is a proper Error [54.88ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [3.08s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts:
 9 |   await promise.catch(e => {
10 |     caught = e;
11 |   });
12 | 
13 |   expect(caught).toBeDefined();
14 |   expect(caught).toBeInstanceOf(Error);
                      ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class Error]
Received value: [native code: Exception]

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts:14:18)
(fail) Bun.write rejection for invalid S3 options is a proper Error [0.61ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [617.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts"
bun test v1.4.1 (4448a2e21)

test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts:
(pass) Bun.write rejection for invalid S3 options is a proper Error [74.94ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [3.35s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5ef746659d
  features     baseline

23 deps, 129 codegen, 1172 objects in 1048ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [7.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen .bind.ts → GeneratedBindings.cpp
[7/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [16.00ms]
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ModuleLoader.cpp                  |  5 +++-
 src/jsc/bindings/bindings.cpp                      | 28 ++++++++++++++++++----
 .../s3/s3-write-reject-exception-unwrap.test.ts    | 21 ++++++++++++++++
 3 files changed, 48 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/ModuleLoader.cpp                            5      3     13
src/jsc/bindings/bindings.cpp                                8      7     13
test/js/bun/s3/s3-write-reject-exception-unwrap.test.ts      1      2     13
```

</details>

<!-- robobun:evidence:end -->
