### PR TITLE
mock.module: pass original exports as factory argument

### DIFF
--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -292,6 +292,41 @@ test("mock.module", async () => {
 });
 ```
 
+### Partial Stubs — Delegating to the Original Module
+
+To replace only some of a module's exports and forward the rest (or wrap the real implementation), accept the first argument to the factory. It's a detached shallow snapshot of the module's exports at the time `mock.module()` is called.
+
+```ts title="partial.test.ts" icon="/icons/typescript.svg"
+import { test, expect, mock } from "bun:test";
+import * as api from "./api";
+
+test("partial stub", async () => {
+  mock.module("./api", original => ({
+    ...original,
+    // Wrap the real `fetch` but leave everything else untouched.
+    fetch: (url: string) => `wrapped: ${original.fetch(url)}`,
+  }));
+
+  const stubbed = await import("./api");
+  expect(stubbed.fetch("/users")).toBe("wrapped: /users");
+});
+```
+
+Don't close over the module's live namespace inside the returned functions:
+
+```ts
+// ❌ Infinite recursion. `api.fetch` has been replaced by this arrow by the
+// time it runs, so it calls itself.
+mock.module("./api", () => ({
+  fetch: (url: string) => `wrapped: ${api.fetch(url)}`,
+}));
+
+// ✅ The factory argument is a snapshot, detached from the live namespace.
+mock.module("./api", original => ({
+  fetch: (url: string) => `wrapped: ${original.fetch(url)}`,
+}));
+```
+
 ### Hoisting & Preloading
 
 To make sure a module is mocked before it's imported, use `--preload` to load your mocks before your tests run.

--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -240,7 +240,7 @@ test("spy with mock implementation", async () => {
 
 ## Module Mocks with mock.module()
 
-Use `mock.module(path: string, callback: () => Object)` to override the behavior of a module.
+Use `mock.module(path: string, callback: (original: any) => Object)` to override the behavior of a module.
 
 ```ts title="test.ts" icon="/icons/typescript.svg"
 import { test, expect, mock } from "bun:test";

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -29,8 +29,23 @@ declare module "bun:test" {
      * value of `factory`. If an export didn't exist before, it is not added to
      * existing import statements. This is a consequence of how ESM works.
      *
+     * The `factory` receives a detached shallow snapshot of the module's
+     * current exports as its first argument, so partial stubs can delegate
+     * to the original implementation without recursing through the live
+     * namespace:
+     *
+     * ```ts
+     * mock.module("./api", original => ({
+     *   ...original,
+     *   fetch: (url: string) => `wrapped: ${original.fetch(url)}`,
+     * }));
+     * ```
+     *
      * @param id module ID to mock
-     * @param factory a function returning an object used as the exports of the mocked module
+     * @param factory a function returning an object that will be used as the
+     *   exports of the mocked module. Receives the current exports as a
+     *   detached shallow snapshot in its first argument (an empty object if
+     *   the module has not been loaded yet).
      *
      * @example
      * ```ts
@@ -47,7 +62,7 @@ declare module "bun:test" {
      * console.log(await readFile("hello.txt", "utf8")); // hello world
      * ```
      */
-    module(id: string, factory: () => any): void | Promise<void>;
+    module(id: string, factory: (original: any) => any): void | Promise<void>;
     /**
      * Restore the previous value of mocks.
      */

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -659,7 +659,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         auto innerScope = DECLARE_THROW_SCOPE(vm);
         JSC::JSObject* sourceObject = sourceExports.getObject();
         JSC::JSObject* snapshot = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
-        JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        // StringsAndSymbols mirrors JS spread (`{ ...original }`), which copies
+        // own enumerable symbol keys too — a CJS `module.exports` can carry them.
+        JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
         sourceObject->methodTable()->getOwnPropertyNames(sourceObject, globalObject, names, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(innerScope, {});
         for (auto& name : names) {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -713,7 +713,10 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         removeFromCJS = true;
         cjsModuleObject = dynamicDowncast<Bun::JSCommonJSModule>(entryValue);
         if (cjsModuleObject && !originalSnapshot) {
+            // exportsObject() is a potentially-throwing JSObject::get — check
+            // before declaring a nested ThrowScope inside buildOriginalSnapshot.
             JSValue cjsExports = cjsModuleObject->exportsObject();
+            RETURN_IF_EXCEPTION(scope, {});
             originalSnapshot = buildOriginalSnapshot(cjsExports);
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -421,7 +421,7 @@ public:
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
 
-    JSObject* executeOnce(JSC::JSGlobalObject* lexicalGlobalObject);
+    JSObject* executeOnce(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue originalExports = {});
 
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {
@@ -466,7 +466,7 @@ Structure* JSModuleMock::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globa
     return Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
 }
 
-JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
+JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue originalExports)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -489,7 +489,12 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     }
 
     JSObject* callback = callbackValue.getObject();
-    JSC::JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, callback, JSC::getCallData(callback), JSC::jsUndefined(), ArgList());
+    JSC::MarkedArgumentBuffer arguments;
+    if (originalExports) {
+        arguments.append(originalExports);
+    }
+    ASSERT(!arguments.hasOverflowed());
+    JSC::JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, callback, JSC::getCallData(callback), JSC::jsUndefined(), arguments);
     RETURN_IF_EXCEPTION(scope, {});
 
     if (!result.isObject()) {
@@ -599,9 +604,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     JSModuleMock* mock = JSModuleMock::create(vm, globalObject->mockModule.mockModuleStructure.getInitializedOnMainThread(globalObject), callback);
 
-    auto getJSValue = [&]() -> JSValue {
+    auto getJSValue = [&](JSC::JSValue originalExports) -> JSValue {
         auto scope = DECLARE_THROW_SCOPE(vm);
-        JSValue result = mock->executeOnce(globalObject);
+        JSValue result = mock->executeOnce(globalObject, originalExports);
         RETURN_IF_EXCEPTION(scope, {});
 
         if (result && result.isObject()) {
@@ -628,11 +633,39 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return result;
     };
 
+    // Build a shallow, detached snapshot of the module's CURRENT exports so the
+    // factory can delegate to originals (`(original) => ({ ...original, foo: () =>
+    // original.foo() })`) without accidentally closing over the live namespace,
+    // which would see the mock's own exports after this call returns and recurse.
+    auto buildOriginalSnapshot = [&](JSC::JSValue sourceExports) -> JSC::JSValue {
+        if (!sourceExports || !sourceExports.isObject()) {
+            return JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
+        }
+        auto innerScope = DECLARE_THROW_SCOPE(vm);
+        JSC::JSObject* sourceObject = sourceExports.getObject();
+        JSC::JSObject* snapshot = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
+        JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+        sourceObject->methodTable()->getOwnPropertyNames(sourceObject, globalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(innerScope, {});
+        for (auto& name : names) {
+            auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            JSC::JSValue value = sourceObject->get(globalObject, name);
+            if (innerScope.exception()) [[unlikely]] {
+                (void)innerScope.tryClearException();
+                value = jsUndefined();
+            }
+            snapshot->putDirect(vm, name, value, 0);
+        }
+        return snapshot;
+    };
+
     bool removeFromESM = false;
     bool removeFromCJS = false;
+    JSC::JSValue originalSnapshot;
 
     auto specifierIdent = JSC::Identifier::fromString(vm, specifierString->value(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSModuleNamespaceObject* moduleNamespaceObject = nullptr;
     if (auto* entry = globalObject->moduleLoader()->registryEntry(specifierIdent)) {
         removeFromESM = true;
         if (auto* mod = entry->record()) {
@@ -645,59 +678,80 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
             if (auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(mod))
                 linked = cyclic->status() >= JSC::CyclicModuleRecord::Status::Linked;
             if (linked) {
-                {
-                    JSC::JSModuleNamespaceObject* moduleNamespaceObject = mod->getModuleNamespace(globalObject);
+                moduleNamespaceObject = mod->getModuleNamespace(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (moduleNamespaceObject) {
+                    originalSnapshot = buildOriginalSnapshot(moduleNamespaceObject);
                     RETURN_IF_EXCEPTION(scope, {});
-                    if (moduleNamespaceObject) {
-                        JSValue exportsValue = getJSValue();
-                        RETURN_IF_EXCEPTION(scope, {});
-                        auto* object = exportsValue.getObject();
-                        removeFromESM = false;
-
-                        if (object) {
-                            JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-                            JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
-                            RETURN_IF_EXCEPTION(scope, {});
-
-                            for (auto& name : names) {
-                                // consistent with regular esm handling code
-                                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-                                JSValue value = object->get(globalObject, name);
-                                if (scope.exception()) [[unlikely]] {
-                                    (void)scope.tryClearException();
-                                    value = jsUndefined();
-                                }
-                                moduleNamespaceObject->overrideExportValue(globalObject, name, value);
-                                RETURN_IF_EXCEPTION(scope, {});
-                            }
-
-                        } else {
-                            // if it's not an object, I guess we just set the default export?
-                            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
-                            RETURN_IF_EXCEPTION(scope, {});
-                        }
-
-                        // TODO: do we need to handle intermediate loading state here?
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("evaluated"_s)), jsBoolean(true), 0);
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("state"_s)), jsNumber(JSC::JSModuleLoader::Status::Ready), 0);
-                    }
                 }
             }
         }
     }
 
+    // If the module was already required (CJS) but not yet imported (ESM),
+    // snapshot the CJS exports object so the factory still sees the real
+    // implementation as its first argument.
     JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
+    Bun::JSCommonJSModule* cjsModuleObject = nullptr;
     if (entryValue) {
         removeFromCJS = true;
-        if (auto* moduleObject = entryValue ? dynamicDowncast<Bun::JSCommonJSModule>(entryValue) : nullptr) {
-            JSValue exportsValue = getJSValue();
+        cjsModuleObject = dynamicDowncast<Bun::JSCommonJSModule>(entryValue);
+        if (cjsModuleObject && !originalSnapshot) {
+            JSValue cjsExports = cjsModuleObject->exportsObject();
+            originalSnapshot = buildOriginalSnapshot(cjsExports);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
+
+    if (!originalSnapshot) {
+        // No prior module — factory still receives a snapshot (an empty object)
+        // for a uniform signature, so `(original) => ...` works regardless of
+        // whether the module was imported before the mock call.
+        originalSnapshot = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
+    }
+
+    if (moduleNamespaceObject) {
+        JSValue exportsValue = getJSValue(originalSnapshot);
+        RETURN_IF_EXCEPTION(scope, {});
+        auto* object = exportsValue.getObject();
+        removeFromESM = false;
+
+        if (object) {
+            JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+            JSObject::getOwnPropertyNames(object, globalObject, names, DontEnumPropertiesMode::Exclude);
             RETURN_IF_EXCEPTION(scope, {});
 
-            moduleObject->putDirect(vm, Bun::builtinNames(vm).exportsPublicName(), exportsValue, 0);
-            moduleObject->hasEvaluated = true;
-            removeFromCJS = false;
+            for (auto& name : names) {
+                // consistent with regular esm handling code
+                auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                JSValue value = object->get(globalObject, name);
+                if (scope.exception()) [[unlikely]] {
+                    (void)scope.tryClearException();
+                    value = jsUndefined();
+                }
+                moduleNamespaceObject->overrideExportValue(globalObject, name, value);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+
+        } else {
+            // if it's not an object, I guess we just set the default export?
+            moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
+            RETURN_IF_EXCEPTION(scope, {});
         }
+
+        // TODO: do we need to handle intermediate loading state here?
+        // entry->putDirect(vm, Identifier::fromString(vm, String("evaluated"_s)), jsBoolean(true), 0);
+        // entry->putDirect(vm, Identifier::fromString(vm, String("state"_s)), jsNumber(JSC::JSModuleLoader::Status::Ready), 0);
+    }
+
+    if (cjsModuleObject) {
+        JSValue exportsValue = getJSValue(originalSnapshot);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        cjsModuleObject->putDirect(vm, Bun::builtinNames(vm).exportsPublicName(), exportsValue, 0);
+        cjsModuleObject->hasEvaluated = true;
+        removeFromCJS = false;
     }
 
     if (removeFromESM) {
@@ -923,7 +977,12 @@ JSC::JSValue runVirtualModule(Zig::GlobalObject* globalObject, BunString* specif
         if (Zig::JSModuleMock* moduleMock = dynamicDowncast<Zig::JSModuleMock>(function)) {
             wasModuleMock = true;
             // module mock
-            result = moduleMock->executeOnce(globalObject);
+            // Factory has not been called yet (the mock was installed before any
+            // import of the spec); pass an empty object so the factory's
+            // `(original) => ...` shape works consistently regardless of whether
+            // the module was imported before the mock call.
+            JSC::JSObject* empty = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
+            result = moduleMock->executeOnce(globalObject, empty);
         } else {
             // regular function
             JSC::MarkedArgumentBuffer arguments;

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -669,7 +669,15 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
                 (void)innerScope.tryClearException();
                 value = jsUndefined();
             }
-            snapshot->putDirect(vm, name, value, 0);
+            // getOwnPropertyNames yields integer indices as canonical numeric
+            // strings ("0", "1", ...); putDirect asserts !parseIndex(name), so
+            // route those through putDirectIndex (e.g. `module.exports = [...]`).
+            if (auto index = parseIndex(name)) {
+                snapshot->putDirectIndex(globalObject, *index, value);
+                RETURN_IF_EXCEPTION(innerScope, {});
+            } else {
+                snapshot->putDirect(vm, name, value, 0);
+            }
         }
         return snapshot;
     };

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -633,16 +633,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         return result;
     };
 
-    // Build a shallow, detached snapshot of the module's CURRENT exports so the
-    // factory can delegate to originals (`(original) => ({ ...original, foo: () =>
-    // original.foo() })`) without accidentally closing over the live namespace,
-    // which would see the mock's own exports after this call returns and recurse.
-    //
-    // Primitives (`module.exports = 42`) and callables (`module.exports = function(){}`
-    // or a class) are returned as-is: the snapshot is meant to preserve CALL
-    // semantics (`original()`, `new original()`, primitive delegation), and the
-    // future in-place override replaces the CJS exports slot rather than mutating
-    // the old value — so the captured reference is already detached.
+    // Detached shallow snapshot so `(original) => ({ ...original, foo: () => original.foo() })`
+    // can't recurse through the live (about-to-be-overwritten) namespace. Primitives and callables
+    // pass through as-is; the CJS apply replaces the exports slot, so the captured ref stays detached.
     auto buildOriginalSnapshot = [&](JSC::JSValue sourceExports) -> JSC::JSValue {
         if (!sourceExports) {
             return JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
@@ -660,7 +653,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         JSC::JSObject* sourceObject = sourceExports.getObject();
         JSC::JSObject* snapshot = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
         // StringsAndSymbols mirrors JS spread (`{ ...original }`), which copies
-        // own enumerable symbol keys too — a CJS `module.exports` can carry them.
+        // own enumerable symbol keys too; a CJS `module.exports` can carry them.
         JSC::PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
         sourceObject->methodTable()->getOwnPropertyNames(sourceObject, globalObject, names, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(innerScope, {});
@@ -713,13 +706,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         }
     }
 
-    // If the module was required (CJS), prefer the CJS exports as the
-    // factory's `original` argument — even when an ESM namespace also exists.
-    // For a callable CJS export (`module.exports = function(){}`) the ESM
-    // namespace is a wrapper object (`{ default: fn, length, name, prototype }`),
-    // which is not what `original()` / `new original()` should be operating
-    // against. `require()` returns the bare function, and so must the snapshot
-    // passed to the factory.
+    // Prefer CJS exports for `original` even when an ESM namespace also exists: for a
+    // callable `module.exports = fn`, the ESM namespace is a `{ default, length, name,
+    // prototype }` wrapper, not the bare function `original()`/`new original()` should target.
     JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
     Bun::JSCommonJSModule* cjsModuleObject = nullptr;
@@ -727,7 +716,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         removeFromCJS = true;
         cjsModuleObject = dynamicDowncast<Bun::JSCommonJSModule>(entryValue);
         if (cjsModuleObject) {
-            // exportsObject() is a potentially-throwing JSObject::get — check
+            // exportsObject() is a potentially-throwing JSObject::get; check
             // before declaring a nested ThrowScope inside buildOriginalSnapshot.
             JSValue cjsExports = cjsModuleObject->exportsObject();
             RETURN_IF_EXCEPTION(scope, {});
@@ -737,9 +726,9 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     }
 
     if (!originalSnapshot) {
-        // No prior module — factory still receives a snapshot (an empty object)
-        // for a uniform signature, so `(original) => ...` works regardless of
-        // whether the module was imported before the mock call.
+        // No prior module, so the factory still receives a snapshot (an empty
+        // object) for a uniform signature, letting `(original) => ...` work
+        // regardless of whether the module was imported before the mock call.
         originalSnapshot = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
     }
 
@@ -1004,11 +993,8 @@ JSC::JSValue runVirtualModule(Zig::GlobalObject* globalObject, BunString* specif
 
         if (Zig::JSModuleMock* moduleMock = dynamicDowncast<Zig::JSModuleMock>(function)) {
             wasModuleMock = true;
-            // module mock
-            // Factory has not been called yet (the mock was installed before any
-            // import of the spec); pass an empty object so the factory's
-            // `(original) => ...` shape works consistently regardless of whether
-            // the module was imported before the mock call.
+            // Mock installed before any import ran, so there are no prior exports;
+            // pass `{}` so `(original) => ...` has a uniform shape either way.
             JSC::JSObject* empty = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
             result = moduleMock->executeOnce(globalObject, empty);
         } else {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -739,10 +739,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
             moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
             RETURN_IF_EXCEPTION(scope, {});
         }
-
-        // TODO: do we need to handle intermediate loading state here?
-        // entry->putDirect(vm, Identifier::fromString(vm, String("evaluated"_s)), jsBoolean(true), 0);
-        // entry->putDirect(vm, Identifier::fromString(vm, String("state"_s)), jsNumber(JSC::JSModuleLoader::Status::Ready), 0);
     }
 
     if (cjsModuleObject) {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -703,16 +703,20 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
         }
     }
 
-    // If the module was already required (CJS) but not yet imported (ESM),
-    // snapshot the CJS exports object so the factory still sees the real
-    // implementation as its first argument.
+    // If the module was required (CJS), prefer the CJS exports as the
+    // factory's `original` argument — even when an ESM namespace also exists.
+    // For a callable CJS export (`module.exports = function(){}`) the ESM
+    // namespace is a wrapper object (`{ default: fn, length, name, prototype }`),
+    // which is not what `original()` / `new original()` should be operating
+    // against. `require()` returns the bare function, and so must the snapshot
+    // passed to the factory.
     JSValue entryValue = globalObject->requireMap()->get(globalObject, specifierString);
     RETURN_IF_EXCEPTION(scope, {});
     Bun::JSCommonJSModule* cjsModuleObject = nullptr;
     if (entryValue) {
         removeFromCJS = true;
         cjsModuleObject = dynamicDowncast<Bun::JSCommonJSModule>(entryValue);
-        if (cjsModuleObject && !originalSnapshot) {
+        if (cjsModuleObject) {
             // exportsObject() is a potentially-throwing JSObject::get — check
             // before declaring a nested ThrowScope inside buildOriginalSnapshot.
             JSValue cjsExports = cjsModuleObject->exportsObject();

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -637,9 +637,24 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     // factory can delegate to originals (`(original) => ({ ...original, foo: () =>
     // original.foo() })`) without accidentally closing over the live namespace,
     // which would see the mock's own exports after this call returns and recurse.
+    //
+    // Primitives (`module.exports = 42`) and callables (`module.exports = function(){}`
+    // or a class) are returned as-is: the snapshot is meant to preserve CALL
+    // semantics (`original()`, `new original()`, primitive delegation), and the
+    // future in-place override replaces the CJS exports slot rather than mutating
+    // the old value — so the captured reference is already detached.
     auto buildOriginalSnapshot = [&](JSC::JSValue sourceExports) -> JSC::JSValue {
-        if (!sourceExports || !sourceExports.isObject()) {
+        if (!sourceExports) {
             return JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 0);
+        }
+        if (!sourceExports.isObject()) {
+            return sourceExports;
+        }
+        // Functions, arrow-functions, and classes all go through as-is so the
+        // factory can do `original()` / `new original()` on a CJS module whose
+        // exports are a function or a class.
+        if (sourceExports.isCallable() || sourceExports.isConstructor()) {
+            return sourceExports;
         }
         auto innerScope = DECLARE_THROW_SCOPE(vm);
         JSC::JSObject* sourceObject = sourceExports.getObject();

--- a/test/js/bun/test/mock/mock-module-array-cjs-fixture.cjs
+++ b/test/js/bun/test/mock/mock-module-array-cjs-fixture.cjs
@@ -1,0 +1,1 @@
+module.exports = ["a", "b", "c"];

--- a/test/js/bun/test/mock/mock-module-callable-cjs-fixture.cjs
+++ b/test/js/bun/test/mock/mock-module-callable-cjs-fixture.cjs
@@ -1,0 +1,3 @@
+module.exports = function callable() {
+  return "callable-real";
+};

--- a/test/js/bun/test/mock/mock-module-callable-cjs-mixed-fixture.cjs
+++ b/test/js/bun/test/mock/mock-module-callable-cjs-mixed-fixture.cjs
@@ -1,0 +1,3 @@
+module.exports = function callableMixed() {
+  return "callable-mixed-real";
+};

--- a/test/js/bun/test/mock/mock-module-symbol-cjs-fixture.cjs
+++ b/test/js/bun/test/mock/mock-module-symbol-cjs-fixture.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  foo: 1,
+  [Symbol.iterator]: function* () {
+    yield 42;
+  },
+};

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -271,3 +271,27 @@ test("factory argument preserves callable CJS exports (`module.exports = functio
   expect(typeof stubbedFn).toBe("function");
   expect(stubbedFn()).toBe("wrapped: callable-real");
 });
+
+test("factory argument prefers CJS exports when a module was both imported and required", async () => {
+  // When a .cjs module is loaded via BOTH `import()` and `require()`, the ESM
+  // namespace is a wrapper `{ default, length, name, prototype }` around the
+  // callable `module.exports`. The factory should still see the bare callable
+  // as `original`, not the ESM wrapper — otherwise `original()` fails.
+  await import("./mock-module-callable-cjs-mixed-fixture.cjs");
+  const realFn: any = require("./mock-module-callable-cjs-mixed-fixture.cjs");
+  expect(typeof realFn).toBe("function");
+  expect(realFn()).toBe("callable-mixed-real");
+
+  let receivedOriginal: any;
+  mock.module("./mock-module-callable-cjs-mixed-fixture.cjs", original => {
+    receivedOriginal = original;
+    return function wrapped() {
+      return `wrapped: ${original()}`;
+    };
+  });
+
+  expect(typeof receivedOriginal).toBe("function");
+  expect(receivedOriginal()).toBe("callable-mixed-real");
+  const stubbedFn: any = require("./mock-module-callable-cjs-mixed-fixture.cjs");
+  expect(stubbedFn()).toBe("wrapped: callable-mixed-real");
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -247,3 +247,27 @@ test("factory argument works for CJS modules loaded via require()", () => {
   expect(second.original()).toBe("cjs-real");
   expect(second.wrapped()).toBe("wrapped: cjs-real");
 });
+
+test("factory argument preserves callable CJS exports (`module.exports = function`)", () => {
+  // The fixture does `module.exports = function callable() { ... }` — the CJS
+  // exports slot is a bare function, not a property bag. When `mock.module`
+  // installs the first override, the factory's `original` must still be
+  // callable so partial stubs can wrap or delegate to the real function.
+  const realFn: any = require("./mock-module-callable-cjs-fixture.cjs");
+  expect(typeof realFn).toBe("function");
+  expect(realFn()).toBe("callable-real");
+
+  let receivedOriginal: any;
+  mock.module("./mock-module-callable-cjs-fixture.cjs", original => {
+    receivedOriginal = original;
+    return function wrapped() {
+      return `wrapped: ${original()}`;
+    };
+  });
+
+  const stubbedFn: any = require("./mock-module-callable-cjs-fixture.cjs");
+  expect(typeof receivedOriginal).toBe("function");
+  expect(receivedOriginal()).toBe("callable-real");
+  expect(typeof stubbedFn).toBe("function");
+  expect(stubbedFn()).toBe("wrapped: callable-real");
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -166,3 +166,84 @@ test("mocking a builtin", async () => {
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
 });
+
+// https://github.com/oven-sh/bun/issues/30242
+// The factory receives the module's current exports as its first argument,
+// so partial stubbing can delegate to the real implementation without
+// recursing through the live namespace (which has been replaced by the
+// mock's own exports by the time the stub runs).
+test("factory receives current exports as first argument (partial-stub delegation)", async () => {
+  mock.module("mock-partial-stub-pkg", () => ({
+    greet: () => "real",
+    leave: () => "goodbye",
+  }));
+  await import("mock-partial-stub-pkg");
+
+  mock.module("mock-partial-stub-pkg", original => ({
+    ...original,
+    greet: () => `wrapped: ${original.greet()}`,
+  }));
+
+  const stubbed = await import("mock-partial-stub-pkg");
+  // @ts-expect-error dynamic package, no types
+  expect(stubbed.greet()).toBe("wrapped: real");
+  // @ts-expect-error dynamic package, no types
+  expect(stubbed.leave()).toBe("goodbye");
+});
+
+test("factory argument is a snapshot — later mutations to the live namespace do not affect it", async () => {
+  mock.module("mock-snapshot-pkg", () => ({
+    value: 1,
+    read: () => 1,
+  }));
+  await import("mock-snapshot-pkg");
+
+  let capturedOriginal: any;
+  mock.module("mock-snapshot-pkg", original => {
+    capturedOriginal = original;
+    return {
+      value: 2,
+      read: () => original.read(),
+    };
+  });
+
+  const stubbed = await import("mock-snapshot-pkg");
+  // @ts-expect-error dynamic package, no types
+  expect(stubbed.value).toBe(2);
+  // @ts-expect-error dynamic package, no types
+  expect(stubbed.read()).toBe(1);
+  // The snapshot is detached from the live namespace — it kept the original values.
+  expect(capturedOriginal.value).toBe(1);
+  expect(capturedOriginal.read()).toBe(1);
+});
+
+test("factory argument is an empty object when the module has not been loaded yet", async () => {
+  let argumentReceived: any;
+  mock.module("mock-never-loaded-before-mock-pkg", original => {
+    argumentReceived = original;
+    return { ok: true };
+  });
+
+  const stubbed = await import("mock-never-loaded-before-mock-pkg");
+  // @ts-expect-error dynamic package, no types
+  expect(stubbed.ok).toBe(true);
+  expect(argumentReceived).toEqual({});
+});
+
+test("factory argument works for CJS modules loaded via require()", () => {
+  mock.module("mock-cjs-partial-stub-pkg", () => ({
+    original: () => "cjs-real",
+  }));
+  // Prime the CJS require cache.
+  const first = require("mock-cjs-partial-stub-pkg");
+  expect(first.original()).toBe("cjs-real");
+
+  mock.module("mock-cjs-partial-stub-pkg", original => ({
+    ...original,
+    wrapped: () => `wrapped: ${original.original()}`,
+  }));
+
+  const second = require("mock-cjs-partial-stub-pkg");
+  expect(second.original()).toBe("cjs-real");
+  expect(second.wrapped()).toBe("wrapped: cjs-real");
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -316,3 +316,24 @@ test("factory argument snapshots CJS exports with integer-index keys (`module.ex
   expect(stubbed.first).toBe("a");
   expect(stubbed.all).toEqual(["a", "b", "c"]);
 });
+
+test("factory argument preserves symbol-keyed CJS exports (matches `{...original}` spread)", () => {
+  // JS spread copies own enumerable symbol keys, so the snapshot must too —
+  // a CJS `module.exports` can carry e.g. `[Symbol.iterator]`.
+  const real: any = require("./mock-module-symbol-cjs-fixture.cjs");
+  expect(real.foo).toBe(1);
+  expect(typeof real[Symbol.iterator]).toBe("function");
+
+  let receivedOriginal: any;
+  mock.module("./mock-module-symbol-cjs-fixture.cjs", original => {
+    receivedOriginal = original;
+    return { ...original, foo: 2 };
+  });
+
+  expect(typeof receivedOriginal[Symbol.iterator]).toBe("function");
+  const stubbed: any = require("./mock-module-symbol-cjs-fixture.cjs");
+  expect(stubbed.foo).toBe(2);
+  // The symbol-keyed prop rides through the `{...original}` spread into the new exports.
+  expect(typeof stubbed[Symbol.iterator]).toBe("function");
+  expect([...stubbed]).toEqual([42]);
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -295,3 +295,24 @@ test("factory argument prefers CJS exports when a module was both imported and r
   const stubbedFn: any = require("./mock-module-callable-cjs-mixed-fixture.cjs");
   expect(stubbedFn()).toBe("wrapped: callable-mixed-real");
 });
+
+test("factory argument snapshots CJS exports with integer-index keys (`module.exports = [...]`)", () => {
+  // The snapshot copies own enumerable properties; getOwnPropertyNames yields
+  // integer indices as numeric strings ("0", "1", ...). Those must route
+  // through putDirectIndex, not putDirect (which asserts !parseIndex in debug).
+  const realArr: any = require("./mock-module-array-cjs-fixture.cjs");
+  expect(realArr).toEqual(["a", "b", "c"]);
+
+  let receivedOriginal: any;
+  mock.module("./mock-module-array-cjs-fixture.cjs", original => {
+    receivedOriginal = original;
+    return { first: original[0], all: [original[0], original[1], original[2]] };
+  });
+
+  expect(receivedOriginal[0]).toBe("a");
+  expect(receivedOriginal[1]).toBe("b");
+  expect(receivedOriginal[2]).toBe("c");
+  const stubbed: any = require("./mock-module-array-cjs-fixture.cjs");
+  expect(stubbed.first).toBe("a");
+  expect(stubbed.all).toEqual(["a", "b", "c"]);
+});

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -168,10 +168,6 @@ test("mocking a builtin", async () => {
 });
 
 // https://github.com/oven-sh/bun/issues/30242
-// The factory receives the module's current exports as its first argument,
-// so partial stubbing can delegate to the real implementation without
-// recursing through the live namespace (which has been replaced by the
-// mock's own exports by the time the stub runs).
 test("factory receives current exports as first argument (partial-stub delegation)", async () => {
   mock.module("mock-partial-stub-pkg", () => ({
     greet: () => "real",
@@ -191,7 +187,7 @@ test("factory receives current exports as first argument (partial-stub delegatio
   expect(stubbed.leave()).toBe("goodbye");
 });
 
-test("factory argument is a snapshot — later mutations to the live namespace do not affect it", async () => {
+test("factory argument is a snapshot, later mutations to the live namespace do not affect it", async () => {
   mock.module("mock-snapshot-pkg", () => ({
     value: 1,
     read: () => 1,
@@ -212,7 +208,7 @@ test("factory argument is a snapshot — later mutations to the live namespace d
   expect(stubbed.value).toBe(2);
   // @ts-expect-error dynamic package, no types
   expect(stubbed.read()).toBe(1);
-  // The snapshot is detached from the live namespace — it kept the original values.
+  // The snapshot is detached from the live namespace; it kept the original values.
   expect(capturedOriginal.value).toBe(1);
   expect(capturedOriginal.read()).toBe(1);
 });
@@ -249,10 +245,8 @@ test("factory argument works for CJS modules loaded via require()", () => {
 });
 
 test("factory argument preserves callable CJS exports (`module.exports = function`)", () => {
-  // The fixture does `module.exports = function callable() { ... }` — the CJS
-  // exports slot is a bare function, not a property bag. When `mock.module`
-  // installs the first override, the factory's `original` must still be
-  // callable so partial stubs can wrap or delegate to the real function.
+  // The fixture does `module.exports = function callable(){...}`; the factory's
+  // `original` must be the bare function (not a property bag) so `original()` works.
   const realFn: any = require("./mock-module-callable-cjs-fixture.cjs");
   expect(typeof realFn).toBe("function");
   expect(realFn()).toBe("callable-real");
@@ -273,10 +267,9 @@ test("factory argument preserves callable CJS exports (`module.exports = functio
 });
 
 test("factory argument prefers CJS exports when a module was both imported and required", async () => {
-  // When a .cjs module is loaded via BOTH `import()` and `require()`, the ESM
-  // namespace is a wrapper `{ default, length, name, prototype }` around the
-  // callable `module.exports`. The factory should still see the bare callable
-  // as `original`, not the ESM wrapper — otherwise `original()` fails.
+  // Loaded via BOTH import() and require(): the ESM namespace is a
+  // `{ default, length, name, prototype }` wrapper, so `original` should be the
+  // bare CJS callable, not the wrapper.
   await import("./mock-module-callable-cjs-mixed-fixture.cjs");
   const realFn: any = require("./mock-module-callable-cjs-mixed-fixture.cjs");
   expect(typeof realFn).toBe("function");
@@ -318,7 +311,7 @@ test("factory argument snapshots CJS exports with integer-index keys (`module.ex
 });
 
 test("factory argument preserves symbol-keyed CJS exports (matches `{...original}` spread)", () => {
-  // JS spread copies own enumerable symbol keys, so the snapshot must too —
+  // JS spread copies own enumerable symbol keys, so the snapshot must too;
   // a CJS `module.exports` can carry e.g. `[Symbol.iterator]`.
   const real: any = require("./mock-module-symbol-cjs-fixture.cjs");
   expect(real.foo).toBe(1);


### PR DESCRIPTION
Fixes #30242

### Before

```ts
const real = await import("./real");

mock.module("./real", () => ({
  ...real,
  // 'real.greet' has been replaced by this arrow by the time it runs
  // → RangeError: Maximum call stack size exceeded
  greet: () => `wrapped: ${real.greet()}`,
}));
```

The in-place mutation of the module's exports on `mock.module()` is intentional — it's how live bindings (`import { foo } from "./m"`) keep observing the mock. But a factory that closes over the namespace it's about to replace has no way to reach the original.

### After

The factory receives a detached shallow snapshot of the module's current exports as its first argument:

```ts
mock.module("./real", original => ({
  ...original,
  greet: () => `wrapped: ${original.greet()}`,
}));
```

- `original` is a plain object snapshot taken before the mock is applied, so it's immune to the subsequent in-place rebinding.
- If the module hasn't been loaded yet at the time of `mock.module()`, the factory still receives an argument — an empty object — so the `(original) => ...` shape works regardless of import ordering.
- Factories that ignore the argument behave exactly as before; this is additive.
- Works for both ESM `import()` and CJS `require()`.

### Scope

- `src/jsc/bindings/BunPlugin.cpp` — build the snapshot in `JSMock__jsModuleMock`, plumb it through `JSModuleMock::executeOnce` as an optional argument. Lazy-path callers in `runVirtualModule` pass an empty object so the factory signature is consistent.
- `test/js/bun/test/mock/mock-module.test.ts` — four regression tests covering partial-stub delegation, snapshot immutability, the "module not yet loaded" case, and the CJS path.
- `docs/test/mocks.mdx` — new "Partial Stubs — Delegating to the Original Module" section with a foot-gun callout.
- `packages/bun-types/test.d.ts` — `factory` signature updated to `(original: any) => any`.