### PR TITLE
Add regression test for Bun.file().writer() with invalid path/fd in options

### DIFF
--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -698,4 +698,43 @@ it("fs.promises.writeFile with iterables under GC pressure does not crash", asyn
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+});
+
+it("Bun.file().writer() ignores invalid path/fd in options instead of crashing", async () => {
+  using dir = tempDir("filesink-writer-invalid-options", {});
+
+  // `fd` in options is not an integer: previously this panicked accessing the
+  // wrong union field after `fromJSWithTag` returned `.err`.
+  {
+    const file = Bun.file(join(dir, "a.txt")) as any;
+    file.fd = Int16Array;
+    const writer = file.writer(file);
+    writer.write("a");
+    await writer.end();
+    expect(await Bun.file(join(dir, "a.txt")).text()).toBe("a");
+  }
+
+  // Explicit non-integer `fd` in options object.
+  {
+    const writer = Bun.file(join(dir, "b.txt")).writer({ fd: "nope" } as any);
+    writer.write("b");
+    await writer.end();
+    expect(await Bun.file(join(dir, "b.txt")).text()).toBe("b");
+  }
+
+  // Non-string `path` in options object.
+  {
+    const writer = Bun.file(join(dir, "c.txt")).writer({ path: 123 } as any);
+    writer.write("c");
+    await writer.end();
+    expect(await Bun.file(join(dir, "c.txt")).text()).toBe("c");
+  }
+
+  // String `path` in options is parsed but overridden by the Blob's own path.
+  {
+    const writer = Bun.file(join(dir, "d.txt")).writer({ path: join(dir, "ignored.txt") } as any);
+    writer.write("d");
+    await writer.end();
+    expect(await Bun.file(join(dir, "d.txt")).text()).toBe("d");
+  }
 });


### PR DESCRIPTION
## What

Adds a regression test for `Bun.file(path).writer(options)` when the options object has a non-string `path` or non-integer `fd` property.

```js
const f = Bun.file("/tmp/out.txt");
f.fd = Int16Array;
f.writer(f); // previously panicked in safe builds
```

## Why

In the Zig implementation, `Start.fromJSWithTag(..., .FileSink)` returned a `.err` variant for these inputs, and `Blob.getWriter` accessed `.FileSink` unconditionally, panicking with `access of union field 'FileSink' while field 'err' is active`.

The Rust port (`Blob.rs`) already checks `if let streams::Start::FileSink(...)` before accessing the variant and falls back to the Blob's own path otherwise, so the crash no longer reproduces on main. This PR adds test coverage to guard against regression.

Fuzzer fingerprint: `defc7abf146bf165`
