### PR TITLE
docs: list supported lifecycle scripts, note that npm's `dependencies` script is not implemented

### DIFF
--- a/docs/pm/lifecycle.mdx
+++ b/docs/pm/lifecycle.mdx
@@ -3,14 +3,43 @@ title: "Lifecycle scripts"
 description: "How Bun handles package lifecycle scripts securely"
 ---
 
-Packages on `npm` can define _lifecycle scripts_ in their `package.json`. These are some of the most common, among [many others](https://docs.npmjs.com/cli/v10/using-npm/scripts):
+Packages on `npm` can define _lifecycle scripts_ in their `package.json`. These scripts are arbitrary shell commands that the package manager is expected to run at the appropriate time. Because running arbitrary code is a security risk, Bun does not execute arbitrary lifecycle scripts by default, unlike other `npm` clients.
 
-- `preinstall`: Runs before the package is installed
-- `postinstall`: Runs after the package is installed
-- `preuninstall`: Runs before the package is uninstalled
-- `prepublishOnly`: Runs before the package is published
+## Supported lifecycle scripts
 
-These scripts are arbitrary shell commands that the package manager is expected to run at the appropriate time. Because running arbitrary code is a security risk, Bun does not execute arbitrary lifecycle scripts by default, unlike other `npm` clients.
+Bun invokes a fixed subset of the [npm lifecycle scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts). Other package-manager hooks from that page (for example `dependencies`, `preuninstall`, `postuninstall`) are **not** invoked by Bun.
+
+Note that this section is about _package-manager_ hooks. Generic `pre<name>` / `post<name>` wrappers still run around any matching `bun run <name>` — so for example `bun run build` will still invoke `prebuild` and `postbuild` if they exist.
+
+During `bun install`, `bun add`, `bun remove`, and `bun update`, Bun runs these scripts in this order:
+
+- `preinstall`
+- `install`
+- `postinstall`
+- `preprepare` (root, `git:`, and `github:` packages only)
+- `prepare` (root, `git:`, `github:`, and workspace packages)
+- `postprepare` (root, `git:`, and `github:` packages only)
+
+The prepare-family hooks (`preprepare`, `prepare`, `postprepare`) are not run for tarballs fetched from the npm registry — by convention those scripts are only meaningful for source checkouts.
+
+<Note>
+  Unlike npm, Bun runs the **root** project's install-time scripts as a single batch **after** `node_modules` is
+  populated, the lockfile is saved, and dependency scripts have finished. Root `preinstall` does **not** run before
+  dependencies are fetched. This means common npm patterns (e.g. writing `.npmrc` from a root `preinstall` so dependency
+  downloads pick it up) don't work under Bun — configure registry credentials before invoking `bun install` instead.
+</Note>
+
+During `bun publish` and `bun pm pack`, Bun runs:
+
+- `prepublishOnly`: Before packing (only on publish, not on plain pack)
+- `prepack`: Before packing
+- `prepare`: Before packing
+- `postpack`: After packing
+- `publish` / `postpublish`: After the tarball is uploaded (publish only)
+
+During `bun pm version`, Bun runs `preversion`, `version`, and `postversion`.
+
+Lifecycle scripts of installed dependencies only run for trusted packages (see [`trustedDependencies`](#trusteddependencies) below). Workspace packages are always trusted.
 
 ---
 


### PR DESCRIPTION
## What

Rewrite the top of `docs/pm/lifecycle.mdx` to list exactly which lifecycle scripts Bun runs, grouped by command, and to explicitly note that npm's `dependencies` script (and a few other npm hooks) are not invoked by Bun.

## Why

[The docs today](https://bun.sh/docs/pm/lifecycle) linked out to [npm's scripts page](https://docs.npmjs.com/cli/v10/using-npm/scripts) with "there are many others." A reader could reasonably read that and assume npm's [`dependencies` script](https://docs.npmjs.com/cli/v10/using-npm/scripts#dependencies) — which runs after `node_modules` changes — would run after `bun add`/`bun remove`. It does not.

The old "most common" bullet list also presented `preuninstall` and `prepublishOnly` as lifecycle scripts without qualifying which commands actually invoke them, which was misleading.

## What now

The page now lists, by command, the exact set Bun supports:

- `bun install` / `add` / `remove` / `update`: `preinstall`, `install`, `postinstall`, plus `preprepare`/`prepare`/`postprepare` for root, `git:`, `github:`, and (for `prepare`) workspace packages only (source: `src/install/lockfile.zig:58`, `src/install/lockfile/Package/Scripts.zig:159`)
- `bun publish` / `bun pm pack`: `prepublishOnly`, `prepack`, `prepare`, `postpack`, `publish`, `postpublish` (source: `src/cli/pack_command.zig:1259`)
- `bun pm version`: `preversion`, `version`, `postversion` (source: `src/cli/pm_version_command.zig:74`)

It explicitly calls out that npm package-manager hooks `dependencies`, `preuninstall`, and `postuninstall` are **not** invoked, and notes two Bun-specific behaviors surfaced in review:

- Root install-time scripts run as a single batch **after** `node_modules` is populated (a divergence from npm's `preinstall` timing; source: `src/install/PackageManager/install_with_manager.zig:935`).
- Generic `pre<name>` / `post<name>` wrappers still fire via `bun run <name>` (source: `src/cli/run_command.zig:1763`), so e.g. `prerestart` is reachable and is not listed as "not invoked."

Fixes #30247

## Rebase note

Rebased onto current `main`, which had meanwhile restructured this file (editorial pass #33112 and the new "Behavior of the `trustedDependencies` field` section from #31027). Resolved by keeping all of main's content intact (the `postinstall`, `trustedDependencies` + behavior-table, and `--ignore-scripts` sections) and replacing only main's misleading intro bullet list with the new "Supported lifecycle scripts" section. The trust-summary sentence now links to main's `trustedDependencies` section rather than restating the allow-list rules, so the two don't drift.
