### PR TITLE
bake: validate `app.bundlerOptions` and sub-options are objects

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "ssr", ssr_options);
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const value = minify_options.asBoolean();
+                options.minify_syntax = value;
+                options.minify_identifiers = value;
+                options.minify_whitespace = value;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "bun:test";
+
+test("Bun.serve app.bundlerOptions throws on non-object values instead of crashing", () => {
+  expect(() => Bun.serve({ app: { bundlerOptions: 42 } } as any)).toThrow(
+    "'app.bundlerOptions' must be an object",
+  );
+  expect(() => Bun.serve({ app: { bundlerOptions: "foo" } } as any)).toThrow(
+    "'app.bundlerOptions' must be an object",
+  );
+  expect(() => Bun.serve({ app: { bundlerOptions: true } } as any)).toThrow(
+    "'app.bundlerOptions' must be an object",
+  );
+});
+
+test("Bun.serve app.bundlerOptions.{server,client,ssr} throws on non-object values instead of crashing", () => {
+  for (const key of ["server", "client", "ssr"]) {
+    for (const value of [42, "foo", true, 1n, Symbol("x")]) {
+      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: value } } } as any)).toThrow(
+        `'app.bundlerOptions.${key}' must be an object`,
+      );
+    }
+  }
+});
+
+test("Bun.serve app.bundlerOptions.*.minify throws on non-boolean non-object values instead of crashing", () => {
+  for (const value of [42, "foo", 1n]) {
+    expect(() => Bun.serve({ app: { bundlerOptions: { server: { minify: value } } } } as any)).toThrow(
+      "'app.bundlerOptions.server.minify' must be a boolean or an object",
+    );
+  }
+});

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,25 +1,27 @@
 import { expect, test } from "bun:test";
 
-test("Bun.serve app.bundlerOptions throws on non-object values instead of crashing", () => {
-  expect(() => Bun.serve({ app: { bundlerOptions: 42 } } as any)).toThrow("'app.bundlerOptions' must be an object");
-  expect(() => Bun.serve({ app: { bundlerOptions: "foo" } } as any)).toThrow("'app.bundlerOptions' must be an object");
-  expect(() => Bun.serve({ app: { bundlerOptions: true } } as any)).toThrow("'app.bundlerOptions' must be an object");
+test.each([42, "foo", true])(
+  "Bun.serve app.bundlerOptions throws on non-object value %p instead of crashing",
+  value => {
+    expect(() => Bun.serve({ port: 0, app: { bundlerOptions: value } } as any)).toThrow(
+      "'app.bundlerOptions' must be an object",
+    );
+  },
+);
+
+test.each(
+  ["server", "client", "ssr"].flatMap(key => [42, "foo", true, 1n, Symbol("x")].map(value => [key, value] as const)),
+)("Bun.serve app.bundlerOptions.%s throws on non-object value %p instead of crashing", (key, value) => {
+  expect(() => Bun.serve({ port: 0, app: { bundlerOptions: { [key]: value } } } as any)).toThrow(
+    `'app.bundlerOptions.${key}' must be an object`,
+  );
 });
 
-test("Bun.serve app.bundlerOptions.{server,client,ssr} throws on non-object values instead of crashing", () => {
-  for (const key of ["server", "client", "ssr"]) {
-    for (const value of [42, "foo", true, 1n, Symbol("x")]) {
-      expect(() => Bun.serve({ app: { bundlerOptions: { [key]: value } } } as any)).toThrow(
-        `'app.bundlerOptions.${key}' must be an object`,
-      );
-    }
-  }
-});
-
-test("Bun.serve app.bundlerOptions.*.minify throws on non-boolean non-object values instead of crashing", () => {
-  for (const value of [42, "foo", 1n]) {
-    expect(() => Bun.serve({ app: { bundlerOptions: { server: { minify: value } } } } as any)).toThrow(
+test.each([42, "foo", 1n])(
+  "Bun.serve app.bundlerOptions.server.minify throws on non-boolean non-object value %p instead of crashing",
+  value => {
+    expect(() => Bun.serve({ port: 0, app: { bundlerOptions: { server: { minify: value } } } } as any)).toThrow(
       "'app.bundlerOptions.server.minify' must be a boolean or an object",
     );
-  }
-});
+  },
+);

--- a/test/bake/bundler-options-validation.test.ts
+++ b/test/bake/bundler-options-validation.test.ts
@@ -1,15 +1,9 @@
 import { expect, test } from "bun:test";
 
 test("Bun.serve app.bundlerOptions throws on non-object values instead of crashing", () => {
-  expect(() => Bun.serve({ app: { bundlerOptions: 42 } } as any)).toThrow(
-    "'app.bundlerOptions' must be an object",
-  );
-  expect(() => Bun.serve({ app: { bundlerOptions: "foo" } } as any)).toThrow(
-    "'app.bundlerOptions' must be an object",
-  );
-  expect(() => Bun.serve({ app: { bundlerOptions: true } } as any)).toThrow(
-    "'app.bundlerOptions' must be an object",
-  );
+  expect(() => Bun.serve({ app: { bundlerOptions: 42 } } as any)).toThrow("'app.bundlerOptions' must be an object");
+  expect(() => Bun.serve({ app: { bundlerOptions: "foo" } } as any)).toThrow("'app.bundlerOptions' must be an object");
+  expect(() => Bun.serve({ app: { bundlerOptions: true } } as any)).toThrow("'app.bundlerOptions' must be an object");
 });
 
 test("Bun.serve app.bundlerOptions.{server,client,ssr} throws on non-object values instead of crashing", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`reached unreachable code`) in `JSValue.get()` when `Bun.serve({ app: { bundlerOptions: ... } })` is called with non-object primitive values for `bundlerOptions`, `bundlerOptions.server`, `bundlerOptions.client`, `bundlerOptions.ssr`, or `bundlerOptions.*.minify`.

`JSValue.get()` asserts that the target is an object. The bake config parser called `getOptional()` on values that had never been validated as objects.

Also fixes `minify: false` — the old `if (minify_options.isBoolean() and minify_options.asBoolean())` check only broke out on `true`, so `false` fell through to `getBooleanLoose("whitespace")` on a boolean, hitting the same assertion.

Found by Fuzzilli. Fingerprint `436bf4d64fac6672`.

## How did you verify your code works?

Before:
```js
Bun.serve({ app: { bundlerOptions: { server: 42 } } });
// panic(main thread): reached unreachable code
```

After:
```js
Bun.serve({ app: { bundlerOptions: { server: 42 } } });
// TypeError: 'app.bundlerOptions.server' must be an object
```

Added `test/bake/bundler-options-validation.test.ts` covering all the validated paths.