### PR TITLE
BunString: decide Dead vs Empty via exceptionForInspection() when toWTFString returns null

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -676,6 +676,9 @@ export const lowercaseHeaderNameSIMD: (name: string) => string = $newCppFunction
   1,
 );
 
+export const BunString_fromJSNullNoException: () => { ok: boolean; dead: boolean; hasException: boolean } =
+  $newCppFunction("InternalForTesting.cpp", "jsFunction_BunString_fromJSNullNoException", 0);
+
 export const emitMemoryPressure: (level: "warning" | "critical") => void = $newCppFunction(
   "InternalForTesting.cpp",
   "jsFunction_emitMemoryPressure",

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -253,7 +253,8 @@ BunString toStringRef(JSC::JSGlobalObject* globalObject, JSValue value)
 {
     auto str = value.toWTFString(globalObject);
     if (str.isNull()) [[unlikely]] {
-        return { BunStringTag::Dead };
+        // Dead must imply a pending exception (String.fromJS asserts it).
+        return globalObject->vm().exceptionForInspection() ? BunString { BunStringTag::Dead } : BunString { BunStringTag::Empty };
     }
     if (str.length() == 0) [[unlikely]] {
         return { BunStringTag::Empty };

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -19,6 +19,7 @@
 
 extern "C" BunString BunString__threadIsolatedCopy(const BunString* str);
 extern "C" void BunString__makeThreadShareable(BunString* str);
+extern "C" bool BunString__fromJS(JSC::JSGlobalObject*, JSC::EncodedJSValue, BunString*);
 
 namespace Bun {
 
@@ -242,6 +243,34 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting, (JSC::JSGlobalObject
     }
     return JSValue::encode(jsNumber(firstError));
 #endif
+}
+
+// Nulls a JSString's backing impl so toWTFString returns a null WTF::String
+// with no exception pending (unreachable from JS), then calls BunString__fromJS.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_BunString_fromJSNullNoException, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    JSString* s = jsNontrivialString(vm, "placeholder"_s);
+    uintptr_t* fiber = std::bit_cast<uintptr_t*>(std::bit_cast<char*>(s) + JSString::offsetOfValue());
+    uintptr_t saved = *fiber;
+    *fiber = 0;
+
+    BunString out { BunStringTag::Dead, {} };
+    bool ok = BunString__fromJS(globalObject, JSValue::encode(s), &out);
+    bool hasException = !!scope.exception();
+    if (hasException)
+        scope.clearException();
+
+    // Restore before anything can inspect or collect the cell.
+    *fiber = saved;
+
+    JSObject* result = constructEmptyObject(globalObject);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "ok"_s), jsBoolean(ok));
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "dead"_s), jsBoolean(out.tag == BunStringTag::Dead));
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "hasException"_s), jsBoolean(hasException));
+    return JSValue::encode(result);
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -19,7 +19,6 @@
 
 extern "C" BunString BunString__threadIsolatedCopy(const BunString* str);
 extern "C" void BunString__makeThreadShareable(BunString* str);
-extern "C" bool BunString__fromJS(JSC::JSGlobalObject*, JSC::EncodedJSValue, BunString*);
 
 namespace Bun {
 

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -14,5 +14,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_spawnThreadsForTesting);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_fromJSNullNoException);
 
 }

--- a/test/js/web/fetch/blob-fromjs-stringify.test.ts
+++ b/test/js/web/fetch/blob-fromjs-stringify.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Bun.write with a non-BlobPart value falls through Blob.fromJSWithoutDeferGC's
+// default branch to JSValue.toSlice -> String.fromJS -> BunString__fromJS ->
+// Bun::toStringRef -> toWTFString. Fuzzilli repeatedly (cb01d84a, 16d4efee,
+// 4d4492f1, eac903bf, + a fifth) tripped the debug assertion `Dead =>
+// has_exception` in String.fromJS when toWTFString returned a null WTF::String
+// while vm.exception() was null, under sustained REPRL eval + forced GC.
+//
+// Bun::toStringRef now decides Dead vs Empty by reading
+// vm.exceptionForInspection() (the accessor documented for inspecting pending
+// exceptions without disturbing Throw/CatchScopes) when toWTFString yields
+// null: Dead only when a real exception is pending, else Empty. That edge
+// state is not reproducible from JavaScript (every null-return site in JSC's
+// toWTFString throws first), so these tests pin the observable stringification
+// behavior the fix must preserve.
+describe("Bun.write stringifies non-BlobPart values via Bun::toStringRef", () => {
+  test.each([
+    ["native constructor", ArrayBuffer],
+    ["typed-array constructor", Float64Array],
+    ["host function", Bun.gc],
+    ["plain function", function foo() {}],
+    ["plain object", { a: 1 }],
+  ] as const)("%s", async (_, value) => {
+    using dir = tempDir("blob-fromjs-stringify", {});
+    const p = join(dir, "out.txt");
+    Bun.gc(true);
+    const n = await Bun.write(p, value as any);
+    const expected = String(value);
+    expect(n).toBe(expected.length);
+    expect(readFileSync(p, "utf8")).toBe(expected);
+  });
+
+  test("propagates exception thrown from toString()", () => {
+    using dir = tempDir("blob-fromjs-stringify", {});
+    const err = new TypeError("boom");
+    const value = {
+      toString() {
+        throw err;
+      },
+    };
+    expect(() => Bun.write(join(dir, "throws.txt"), value as any)).toThrow(err);
+  });
+
+  test("empty result from toString()", async () => {
+    using dir = tempDir("blob-fromjs-stringify", {});
+    const p = join(dir, "empty.txt");
+    const n = await Bun.write(p, { toString: () => "" } as any);
+    expect(n).toBe(0);
+    expect(readFileSync(p, "utf8")).toBe("");
+  });
+});

--- a/test/js/web/fetch/blob-fromjs-stringify.test.ts
+++ b/test/js/web/fetch/blob-fromjs-stringify.test.ts
@@ -24,13 +24,14 @@ describe("Bun.write stringifies non-BlobPart values via Bun::toStringRef", () =>
     ["host function", Bun.gc],
     ["plain function", function foo() {}],
     ["plain object", { a: 1 }],
+    ["non-ASCII toString()", { toString: () => "café 🍰" }],
   ] as const)("%s", async (_, value) => {
     using dir = tempDir("blob-fromjs-stringify", {});
     const p = join(dir, "out.txt");
     Bun.gc(true);
     const n = await Bun.write(p, value as any);
     const expected = String(value);
-    expect(n).toBe(expected.length);
+    expect(n).toBe(Buffer.byteLength(expected, "utf8"));
     expect(readFileSync(p, "utf8")).toBe(expected);
   });
 

--- a/test/js/web/fetch/blob-fromjs-stringify.test.ts
+++ b/test/js/web/fetch/blob-fromjs-stringify.test.ts
@@ -1,3 +1,4 @@
+import { BunString_fromJSNullNoException } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { tempDir } from "harness";
 import { readFileSync } from "node:fs";
@@ -13,10 +14,20 @@ import { join } from "node:path";
 // Bun::toStringRef now decides Dead vs Empty by reading
 // vm.exceptionForInspection() (the accessor documented for inspecting pending
 // exceptions without disturbing Throw/CatchScopes) when toWTFString yields
-// null: Dead only when a real exception is pending, else Empty. That edge
-// state is not reproducible from JavaScript (every null-return site in JSC's
-// toWTFString throws first), so these tests pin the observable stringification
-// behavior the fix must preserve.
+// null: Dead only when a real exception is pending, else Empty.
+describe("Bun::toStringRef null-string handling", () => {
+  // The fuzzer state is not reproducible from JavaScript (every null-return
+  // site in JSC's toWTFString throws first), so the native hook fabricates it
+  // and calls the real BunString__fromJS. Before the fix this returned Dead
+  // with no pending exception, which is exactly what fires
+  // debugAssert(has_exception) in String.fromJS.
+  test("null WTF::String with no pending exception maps to Empty, not Dead", () => {
+    const { ok, dead, hasException } = BunString_fromJSNullNoException();
+    expect({ dead, hasException }).not.toEqual({ dead: true, hasException: false });
+    expect(ok).toBe(true);
+  });
+});
+
 describe("Bun.write stringifies non-BlobPart values via Bun::toStringRef", () => {
   test.each([
     ["native constructor", ArrayBuffer],


### PR DESCRIPTION
## What does this PR do?

`Bun::fromJS` / `Bun::toStringRef` map a null `WTF::String` from `JSValue::toWTFString` to `BunStringTag::Dead`. On the Zig side, `String.fromJS` asserts `Dead` implies a pending JSC exception, and the host-function result wrapper relies on that invariant.

Fuzzilli has hit that assertion **five times** under sustained REPRL + forced-GC pressure, always via the same path:

```
S3Client.write("base64", ArrayBuffer)
  -> Blob.writeFileInternal -> Blob.fromJSWithoutDeferGC (else branch)
  -> JSValue.toSlice -> String.fromJS
panic: reached unreachable code   // bun.debugAssert(has_exception)
```

| Fingerprint | PR |
| --- | --- |
| `cb01d84a4d6c4080` | #28554 |
| `16d4efee8ad02d3d` | #29763 |
| `4d4492f16f5b3967` | #30009 |
| `eac903bf…` (+a fifth) | this PR |

i.e. `toWTFString` yielded a null string while `vm.exception()` was null.

**Fix:** when `toWTFString` returns null, decide `Dead` vs `Empty` by reading `vm.exceptionForInspection()` — return `Dead` only when a real exception is pending, otherwise `Empty`. That keeps the `Dead => pending exception` invariant the Zig side depends on, while a null-without-exception string (the fuzzer edge case) becomes `Empty` instead of tripping the assert / propagating a phantom `error.JSError`.

`exceptionForInspection()` is the accessor explicitly documented for "checking for any pending exception without interfering with Throw/CatchScopes." This matters because `Bun::toStringRef` (and `Bun::fromJS`) are called **during error inspection** — e.g. `ZigException.cpp` extracts an error's `message`/`syscall`/`code`/`path` while that exception is still pending. An earlier revision of this fix (the reland of #30009) used `DECLARE_THROW_SCOPE` + `RETURN_IF_EXCEPTION`; its `verify-on-construct` fired `ASSERTION FAILED: exception check validation failed` (SIGABRT) on the `x64-asan` CI job across `snapshot.test.ts`, `test-process-warning.js`, `test-vm-api-handles-getter-errors.js`, `test-child-process-exit-code.js`, and `grpc-js/test-server-deadlines.test.ts`. `exceptionForInspection()` avoids adding any scope, so inspection callers are unaffected.

Supersedes #28554 (Zig-side, `ci_assert`-only), #29763 (same `exceptionForInspection` idea, closed for untestability), and #30009 (ThrowScope, self-closed; never validated against the ASAN suite because its build stage failed — hence the regression above went unnoticed).

## How did you verify your code works?

The null-without-exception state is not reproducible from JavaScript (every null-return site in JSC's `toWTFString` throws first), so a `bun:internal-for-testing` hook fabricates it: `BunString_fromJSNullNoException` nulls a `JSString`'s backing impl so `toWTFString`'s `isString()` fast path yields a null `WTF::String` with no throw scope entered, calls the real `BunString__fromJS`, and reports `{ ok, dead, hasException }`. The hook restores the cell before returning.

- **Without the fix** (only `BunString.cpp` reverted, hook kept): the test fails on exactly `{ dead: true, hasException: false }`, the state that fires `debugAssert(has_exception)` in `String.fromJS`.
- **With the fix**: `toStringRef` returns `Empty`, `ok === true`. 9/9 pass.
- Under `BUN_JSC_validateExceptionChecks=1`, `snapshot.test.ts`, `test-process-warning.js`, and `test-vm-api-handles-getter-errors.js` run clean (they crashed with the ThrowScope revision).
- `blob-fromjs-stringify.test.ts` also pins the observable stringify contract: `Bun.write(path, <non-BlobPart>)` for native/host constructors, functions, objects, and a non-ASCII `toString()` writes `String(value)` and returns its UTF-8 byte length; a throwing `toString()` propagates; an empty `toString()` writes 0 bytes.
- `blob.test.ts`, `blob-oom.test.ts`, `inspect.test.js`, `bun-file.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 19 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/blob-fromjs-stringify.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/blob-fromjs-stringify.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'BunString_fromJSNullNoException' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [5.70s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/fetch/blob-fromjs-stringify.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'BunString_fromJSNullNoException' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [169.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/blob-fromjs-stringify.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/fetch/blob-fromjs-stringify.test.ts:
(pass) Bun::toStringRef null-string handling > null WTF::String with no pending exception maps to Empty, not Dead [35.65ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > native constructor [96.72ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > typed-array constructor [49.17ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > host function [46.91ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > plain function [46.99ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > plain object [112.41ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > non-ASCII toString() [41.72ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > propagates exception thrown from toString() [11.23ms]
(pass) Bun.write stringifies non-BlobPart values via Bun::toStringRef > empty
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 818ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8960ms)
Bundle modules (113ms)
Postprocesss modules (287ms)
Bundle Functions (718ms)
Generate Code (65ms)

[10.15s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal-for-testing.ts                  |  3 ++
 src/jsc/bindings/BunString.cpp                  |  3 +-
 src/jsc/bindings/InternalForTesting.cpp         | 28 +++++++++++
 src/jsc/bindings/InternalForTesting.h           |  1 +
 test/js/web/fetch/blob-fromjs-stringify.test.ts | 67 +++++++++++++++++++++++++
 5 files changed, 101 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 2 rejected · iteration 19

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/js/internal-for-testing.ts                       5      5     34
src/jsc/bindings/BunString.cpp                       8      7     37
src/jsc/bindings/InternalForTesting.cpp              9     12     36
src/jsc/bindings/InternalForTesting.h                5      6     35
test/js/web/fetch/blob-fromjs-stringify.test.ts      6     12     33
```

</details>

<!-- robobun:evidence:end -->