### PR TITLE
Fix crash in Blob.writer() when options contain invalid path or fd

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,19 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        switch (stream_start) {
+            .FileSink => |*file_sink| {
+                file_sink.input_path.deinit();
+                file_sink.input_path = input_path;
+            },
+            .err => |err| {
+                sink.deref();
+                return globalThis.throwValue(try err.toJS(globalThis));
+            },
+            else => {
+                stream_start = .{ .FileSink = .{ .input_path = input_path } };
+            },
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -268,3 +268,13 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
 });
+
+it("writer() throws instead of crashing when options has a non-string path", () => {
+  const file = Bun.file(join(tmpdirSync(), "writer-invalid-path.txt"));
+  expect(() => file.writer({ path: Int32Array } as any)).toThrow();
+});
+
+it("writer() throws instead of crashing when options has an invalid fd", () => {
+  const file = Bun.file(join(tmpdirSync(), "writer-invalid-fd.txt"));
+  expect(() => file.writer({ fd: "not-a-number" } as any)).toThrow();
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `Blob.prototype.writer()` when the options object contains a `path` property that is not a string, or an `fd` property that is not a valid file descriptor.

```js
const file = Bun.file("/proc/self/status");
file.path = Int32Array;
file.writer(file); // panic: access of union field 'FileSink' while field 'err' is active
```

`streams.Start.fromJSWithTag(.FileSink)` returns the `.err` variant of the `Start` union in these cases, but `getWriter` unconditionally accessed `.FileSink` on the result. In debug/ASAN builds this triggered a safety-check panic; in release builds it was undefined behavior.

The fix handles the `.err` variant by throwing a proper JS error (and cleaning up the allocated sink), and also frees the `input_path` returned by `fromJSWithTag` before overwriting it with the blob's own path to avoid a small leak when a string `path` option is passed.

## How did you verify your code works?

Added regression tests in `test/js/bun/util/filesink.test.ts` covering both the invalid `path` and invalid `fd` cases. All existing FileSink tests continue to pass.

Found by Fuzzilli (fingerprint `0e27c6a3000551ff`).