### PR TITLE
Fix crash when inspecting WeakMap/WeakSet with user-assigned .size

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,6 +2757,10 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                if (value.jsType() == .WeakMap) {
+                    return writer.writeAll("WeakMap {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2764,7 +2768,7 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                const map_name = "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,6 +2868,10 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                if (value.jsType() == .WeakSet) {
+                    return writer.writeAll("WeakSet {}");
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
@@ -2871,7 +2879,7 @@ pub const Formatter = struct {
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
 
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                const set_name = "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                this.globalThis.clearException();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,6 +1307,10 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    if (value.jsType() == .WeakMap) {
+                        return writer.writeAll("WeakMap {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1314,7 +1318,7 @@ pub const JestPrettyFormat = struct {
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
 
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
+                    const map_name = "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,6 +1339,11 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    if (value.jsType() == .WeakSet) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.writeAll("WeakSet {}");
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1344,7 +1353,7 @@ pub const JestPrettyFormat = struct {
 
                     this.writeIndent(Writer, writer_) catch {};
 
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
+                    const set_name = "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -778,9 +778,11 @@ it("WeakMap/WeakSet with a user-assigned .size property", () => {
   wm.size = 5;
   expect(Bun.inspect(wm)).toBe("WeakMap {}");
   expect(() => expect(wm).toEqual({})).toThrow();
+  expect(() => expect(wm).toStrictEqual({})).toThrow();
 
   const ws = new WeakSet();
   ws.size = 5;
   expect(Bun.inspect(ws)).toBe("WeakSet {}");
   expect(() => expect(ws).toEqual({})).toThrow();
+  expect(() => expect(ws).toStrictEqual({})).toThrow();
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,15 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+it("WeakMap/WeakSet with a user-assigned .size property", () => {
+  const wm = new WeakMap();
+  wm.size = 5;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+  expect(() => expect(wm).toEqual({})).toThrow();
+
+  const ws = new WeakSet();
+  ws.size = 5;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+  expect(() => expect(ws).toEqual({})).toThrow();
+});


### PR DESCRIPTION
Fuzzilli fingerprint: `8292463452de4ca1`

## What

`Bun.inspect()` and `expect().toEqual()` / `.toStrictEqual()` would throw (and in the `expect` case, trip a debug assertion and abort) when given a `WeakMap` or `WeakSet` that had a user-assigned `.size` property.

```js
const wm = new WeakMap();
wm.size = 5;
Bun.inspect(wm);           // TypeError: Type error
expect(wm).toEqual({});    // ASSERTION FAILED: !exception() || m_vm.hasPendingTerminationException()
```

## Why

Both formatters (`ConsoleObject.zig` and `pretty_format.zig`) share the same code path for `Map`/`WeakMap` and `Set`/`WeakSet`. They read `.size` as a regular JS property to decide whether to iterate entries. `WeakMap`/`WeakSet` have no native `.size`, so this normally returned `undefined → 0` and printed `WeakMap {}`.

When user code assigns a non-zero `.size`, the formatter calls `forEachInIterable` on the WeakMap, which throws because WeakMaps are not iterable. In `DiffFormatter` this Zig error was caught with `catch {}` but the pending JS exception was not cleared, so the subsequent `this.throw()` hit an `ExceptionScope` assertion.

## Fix

- Short-circuit `WeakMap`/`WeakSet` in both formatters to always emit `WeakMap {}` / `WeakSet {}` before reading `.size` — their entries can never be enumerated anyway.
- Clear any pending JS exception in `DiffFormatter` when swallowing a format error, so a future formatter exception can't leave the VM in a bad state.