### PR TITLE
Fix crash in Bun.file().writer() with invalid path/fd options

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2952,6 +2952,7 @@ pub fn getWriter(
     }
 
     var sink = jsc.WebCore.FileSink.init(bun.invalid_fd, this.globalThis.bunVM().eventLoop());
+    errdefer sink.deref();
 
     const input_path: jsc.WebCore.PathOrFileDescriptor = brk: {
         if (store.data.file.pathlike == .fd) {
@@ -2981,7 +2982,6 @@ pub fn getWriter(
                 opts.input_path = input_path;
             },
             .err => |err| {
-                sink.deref();
                 return globalThis.throwValue(try err.toJS(globalThis));
             },
             else => {
@@ -2992,7 +2992,6 @@ pub fn getWriter(
 
     switch (sink.start(stream_start)) {
         .err => |err| {
-            sink.deref();
             return globalThis.throwValue(try err.toJS(globalThis));
         },
         else => {},

--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,19 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        switch (stream_start) {
+            .FileSink => |*opts| {
+                opts.input_path.deinit();
+                opts.input_path = input_path;
+            },
+            .err => |err| {
+                sink.deref();
+                return globalThis.throwValue(try err.toJS(globalThis));
+            },
+            else => {
+                stream_start = .{ .FileSink = .{ .input_path = input_path } };
+            },
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -219,6 +219,30 @@ if (isWindows) {
   });
 }
 
+// On Windows, .writer() takes a code path that ignores these options entirely.
+describe.skipIf(isWindows)("Bun.file().writer() with invalid options", () => {
+  it("throws on non-string path option instead of crashing", () => {
+    const target = join(tmpdirSync(), "out.txt");
+    expect(() => Bun.file(target).writer({ path: 123 } as any)).toThrow(
+      expect.objectContaining({ code: "EINVAL", syscall: "write" }),
+    );
+  });
+
+  it("throws on non-integer fd option instead of crashing", () => {
+    const target = join(tmpdirSync(), "out.txt");
+    expect(() => Bun.file(target).writer({ fd: "not a number" } as any)).toThrow(
+      expect.objectContaining({ code: "EBADF", syscall: "write" }),
+    );
+  });
+
+  it("throws on out-of-range fd option instead of crashing", () => {
+    const target = join(tmpdirSync(), "out.txt");
+    expect(() => Bun.file(target).writer({ fd: -1 } as any)).toThrow(
+      expect.objectContaining({ code: "EBADF", syscall: "write" }),
+    );
+  });
+});
+
 // When a write to a pollable fd returns `.pending`, FileSink takes a
 // `must_be_kept_alive_until_eof` ref on itself so it survives until the
 // buffered data is drained. If the write later fails (e.g. EPIPE because the


### PR DESCRIPTION
## What

`Bun.file(path).writer(options)` crashed with a union access panic in debug builds when the options object contained an invalid `path` (non-string) or `fd` (non-integer) value:

```js
Bun.file("/tmp/x.txt").writer({ path: 123 });
// panic: access of union field 'FileSink' while field 'err' is active
```

## Why

`streams.Start.fromJSWithTag(.FileSink)` returns a `.err` variant when it encounters a non-string `path` or non-integer `fd` in the options object. `Blob.getWriter` immediately dereferenced `.FileSink` on the result without checking the active tag.

## Fix

Switch on the result of `fromJSWithTag`:
- `.FileSink` → free any `input_path` it allocated (previously leaked when the user passed a string `path`) and overwrite it with the Blob's own path as before.
- `.err` → release the sink and throw the error to JS.
- anything else → fall back to a default `.FileSink` start using the Blob's path.

Found by Fuzzilli (fingerprint `12f05ae8416b89bf`).