### PR TITLE
webcore/Body: don't alias heap-allocated mime_type into shared Store

### DIFF
--- a/src/runtime/webcore/Body.zig
+++ b/src/runtime/webcore/Body.zig
@@ -764,7 +764,7 @@ pub const Value = union(Tag) {
                                 blob.content_type = mimeType.value;
                                 blob.content_type_allocated = allocated;
                                 blob.content_type_was_set = true;
-                                if (blob.store != null) {
+                                if (blob.store != null and !allocated) {
                                     blob.store.?.mime_type = mimeType;
                                 }
                             }
@@ -1440,7 +1440,7 @@ pub fn Mixin(comptime Type: type) type {
                         blob.content_type = mimeType.value;
                         blob.content_type_allocated = allocated;
                         blob.content_type_was_set = true;
-                        if (blob.store != null) {
+                        if (blob.store != null and !allocated) {
                             blob.store.?.mime_type = mimeType;
                         }
                     }

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -335,7 +335,7 @@ test("Response#blob() slice().type doesn't read freed store.mime_type after GC",
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(["\"\"", "\"application/javascript\""]).toContain(stdout);
+  expect(['""', '"application/javascript"']).toContain(stdout);
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -308,6 +308,37 @@ test("dupeWithContentType does not alias the source's allocated content_type", a
   expect(exitCode).toBe(0);
 });
 
+test("Response#blob() slice().type doesn't read freed store.mime_type after GC", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let slice;
+      async function makeSlice() {
+        const response = new Response("hi", { headers: { "content-type": "application/javascript" } });
+        const blob = await response.blob();
+        slice = blob.slice();
+      }
+      await makeSlice();
+      Bun.gc(true);
+      await Bun.sleep(1);
+      Bun.gc(true);
+      process.stdout.write(JSON.stringify(slice.type));
+    `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(["\"\"", "\"application/javascript\""]).toContain(stdout);
+  expect(exitCode).toBe(0);
+});
+
 test("dupe() preserves allocated content_type for Body clone", () => {
   // Body.Value.clone() goes through Blob.dupe() -> dupeWithContentType(false).
   // That path must deep-copy a heap-allocated content_type rather than drop


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free in `Response#blob()` / `Request#blob()` found by fuzzing.

`MimeType.init()` heap-allocates its `.value` string when the Content-Type isn't one of the recognized static entries (e.g. `"application/javascript"`). The body `.blob()` path stored that heap pointer in **both** `blob.content_type` (owned — freed by `Blob.deinit`) **and** `store.mime_type` (borrowed — never freed by `Store.deinit`).

When another Blob shares the same store (via `.slice()`) and the original Blob is GC'd, reading `slice.type` falls through to `store.mime_type.value` and reads freed memory.

```js
const response = new Response("hi", { headers: { "content-type": "application/javascript" } });
const blob = await response.blob();
const slice = blob.slice();
// ... original blob gets GC'd ...
slice.type; // use-after-free
```

ASAN stack:
```
READ of size 22 at 0x7b9cdedb00c0 thread T0
    #0 __asan_memcpy
    #1 Zig::toStringCopy(ZigString) helpers.h:217
    #2 ZigString__toValueGC bindings.cpp:3507
    #3 bun.js.bindings.ZigString.ZigString.toJS
    #4 bun.js.webcore.Blob.getType Blob.zig:3121
```

## How did you verify your code works?

New regression test in `test/js/web/fetch/blob.test.ts` reads garbage / ASAN-aborts without the fix, returns a valid string with it.