### PR TITLE
Fix TLA sibling import running before shared dep settles (#30259)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "39862040be27e0b6e1d103aaa5dc6796f21a581f";
+export const WEBKIT_VERSION = "88b2f7a2159c913f7dd0d73c0e88d66138cd67ba";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
+++ b/test/js/bun/resolve/dynamic-import-tla-cycle.test.ts
@@ -122,3 +122,80 @@ test("static sibling import waits for an async-pending SCC from the same Evaluat
   expect(stdout.trim()).toBe("got: c");
   expect(exitCode).toBe(0);
 });
+
+// #30259: same narrowing as above, but the TLA dep has NO async deps of its own
+// (pendingAsyncDependencies == 0) and is re-imported by a sibling subtree in the
+// same Evaluate(). Previously the discriminator was only "body has been entered"
+// which is also true here — `await.ts` is suspended at its first await — so the
+// sibling skipped the wait and ran with `foo` still in TDZ. The discriminator
+// must additionally check the dep entered EvaluatingAsync in a *prior*
+// Evaluate(); within the same DFS the spec wait is required.
+test("static sibling import waits for a TLA dep that suspended earlier in the same Evaluate()", async () => {
+  using dir = tempDir("static-sibling-tla", {
+    "root.ts": `
+      import { foo } from "./await.ts";
+      import "./child.ts";
+      void foo;
+    `,
+    "await.ts": `
+      await 0;
+      export const foo = 123;
+    `,
+    "child.ts": `
+      import { foo } from "./await.ts";
+      console.log(foo);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "root.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("123");
+  expect(exitCode).toBe(0);
+});
+
+// Same as above but the TLA dep is reached indirectly through different parents
+// (so neither parent is on the DFS stack when the second one visits it). Guards
+// against discriminating by "is an asyncParentModule on the stack".
+test("static sibling import waits for an indirectly-shared TLA dep in the same Evaluate()", async () => {
+  using dir = tempDir("static-sibling-tla-indirect", {
+    "root.ts": `
+      import "./a.ts";
+      import "./b.ts";
+    `,
+    "a.ts": `
+      import { foo } from "./await.ts";
+      void foo;
+    `,
+    "b.ts": `
+      import { foo } from "./await.ts";
+      console.log(foo);
+    `,
+    "await.ts": `
+      await 0;
+      export const foo = 456;
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "root.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("456");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #30259. Bumps WebKit to `88b2f7a2159c913f7dd0d73c0e88d66138cd67ba` (oven-sh/WebKit#215, merged).

## What

A static import that re-imports a TLA dep already visited by a sibling earlier in the **same** `Evaluate()` pass was skipping the spec-mandated wait and running with the dep's post-`await` bindings still in TDZ:

```ts
// root.ts
import { foo } from "./await.ts"; // await.ts → EvaluatingAsync, suspended at `await 0`
import "./child.ts";              // child.ts visits await.ts, skips wait, runs too early

// await.ts
await 0;
export const foo = 123;

// child.ts
import { foo } from "./await.ts";
console.log(foo); // ReferenceError: Cannot access 'foo' before initialization
```

## Why

The Bun-specific skip at `innerModuleEvaluation` 11.c.v (which avoids self-deadlock when `require(esm)` / dynamic import re-enters a TLA module from inside its own suspension) used `pendingAsyncDependencies == 0` as the discriminator for "body already entered". A TLA dep with no async deps of its own also has count 0 after suspending at its first `await` within the same DFS, so the discriminator matched the sibling case.

## How (oven-sh/WebKit#215)

Snapshot `vm.moduleAsyncEvaluationCount()` at the start of each `Evaluate()` and thread it through `innerModuleEvaluation` as `asyncOrderWatermark`. Only skip the wait when the cycle root's `asyncEvaluationOrder()` **predates** the watermark (i.e. it became `EvaluatingAsync` in a *prior* `Evaluate()` — the re-entrant deadlock case). Siblings that transition during the current DFS get `order >= watermark` and keep the spec wait.

## Tests

Two regression tests in `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts`:
- direct sibling re-import (the issue repro)
- indirectly-shared TLA dep through different parents (guards against discriminating by "asyncParentModule on stack")

Existing re-entrancy / deadlock-avoidance tests in the same file continue to pass.