### PR TITLE
Fix use-after-free in `Bun.Transpiler` async `transform()` errors

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -503,6 +503,9 @@ pub const TransformTask = struct {
         this.transpiler.setAllocator(allocator);
         this.transpiler.setLog(&this.log);
         this.log.msgs.allocator = bun.default_allocator;
+        defer for (this.log.msgs.items) |*msg| {
+            msg.* = msg.clone(bun.default_allocator) catch msg.*;
+        };
 
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)

--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -504,7 +504,7 @@ pub const TransformTask = struct {
         this.transpiler.setLog(&this.log);
         this.log.msgs.allocator = bun.default_allocator;
         defer for (this.log.msgs.items) |*msg| {
-            msg.* = msg.clone(bun.default_allocator) catch msg.*;
+            msg.* = bun.handleOom(msg.clone(bun.default_allocator));
         };
 
         const jsx = if (this.tsconfig != null)
@@ -590,6 +590,7 @@ pub const TransformTask = struct {
     }
 
     pub fn deinit(this: *TransformTask) void {
+        for (this.log.msgs.items) |*msg| msg.deinit(bun.default_allocator);
         this.log.deinit();
         this.input_code.deinitAndUnprotect();
         this.output_code.deref();

--- a/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-async-error-uaf.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+
+test("concurrent async transform() rejections do not use-after-free", async () => {
+  const transpiler = new Bun.Transpiler({ loader: "tsx" });
+
+  const inputs = [
+    "const {a, a} = b",
+    "class X { @invalid }",
+    "const x: string = ;",
+    "@#$%^ invalid syntax !!!",
+    "function (",
+  ];
+
+  const promises: Promise<unknown>[] = [];
+  for (let i = 0; i < 20; i++) {
+    for (const input of inputs) {
+      promises.push(transpiler.transform(input).catch(e => e));
+    }
+  }
+
+  const results = await Promise.all(promises);
+  expect(results).toHaveLength(20 * inputs.length);
+  for (const result of results) {
+    expect(result).toBeDefined();
+    expect(typeof result).toBe("object");
+  }
+});
+
+test("async transform() error preserves message and notes", async () => {
+  const transpiler = new Bun.Transpiler({ loader: "tsx" });
+
+  const errors = await Promise.all(
+    Array.from({ length: 8 }, () => transpiler.transform("const {a, a} = b").catch(e => e)),
+  );
+
+  for (const err of errors) {
+    expect(err.message).toBe('"a" has already been declared');
+    expect(err.position?.file).toBe("input.tsx");
+    expect(err.position?.lineText).toBe("const {a, a} = b");
+    expect(err.notes).toHaveLength(1);
+    expect(err.notes[0].message).toBe('"a" was originally declared here');
+    expect(err.notes[0].position?.lineText).toBe("const {a, a} = b");
+  }
+});


### PR DESCRIPTION
## What does this PR do?

`TransformTask.run()` creates a per-task `MimallocArena` and points the transpiler's allocator at it for the duration of the parse. When the parser emits diagnostics (error text, notes arrays, location data), those allocations come from that arena. The arena is destroyed at the end of `run()` (worker thread), but the log messages are consumed later in `then()` (main thread) via `log.toJS()` → `BuildMessage.create()` → `Msg.clone()`, which reads the now-freed arena memory.

This showed up as `AddressSanitizer: use-after-poison` when `then()` ran after the destroyed arena's pages had been poisoned, and as garbage error text/notes otherwise.

### Fix

Before the arena is torn down, deep-clone any accumulated log messages into `bun.default_allocator`. Deferred after `defer arena.deinit()` so it runs first (LIFO) while the arena is still valid, and covers every early-return path in `run()`.

## How did you verify your code works?

Minimal repro that crashes under ASAN before this change and passes after:

```js
const t = new Bun.Transpiler({ loader: "tsx" });
await Promise.all(
  Array.from({ length: 5 }, () => t.transform("const {a, a} = b").catch(e => e)),
);
```

Added `test/js/bun/transpiler/transpiler-async-error-uaf.test.ts` which exercises multiple concurrent failing transforms and asserts that the error `message`, `position`, and `notes` are intact.

Found by Fuzzilli.