### PR TITLE
net: surface EADDRINUSE on busy Windows named-pipe listen

### DIFF
--- a/src/runtime/socket/Listener.zig
+++ b/src/runtime/socket/Listener.zig
@@ -189,34 +189,42 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
                     // `node:net`'s `Server.prototype.listen` and re-emitted
                     // via `setTimeout` as the async 'error' event.
                     //
-                    // Match Node's `uvExceptionWithHostPort` shape:
+                    // Shape follows Node's `uvExceptionWithHostPort`:
                     //   message: "listen EADDRINUSE: address already in use <addr>"
                     //   fields:  .code, .errno, .syscall, .address   (no .path)
                     //
-                    // `bun.sys.Error.toSystemError()` would produce Node's
-                    // UVException shape instead — "<code>: <label>, <syscall>
-                    // '<path>'" — and attach a `.path` property that Node's
-                    // listen error never has. Build the error manually to
-                    // avoid that divergence; the label comes from
-                    // `libuv_error_map` which is what `node:errors` uses.
-                    //
-                    // One remaining quirk: `.errno` is the negated POSIX-mapped
-                    // value (-98 for EADDRINUSE) rather than the raw libuv
-                    // return code (-4091) Node uses. This matches Bun's
-                    // convention across every other libuv-sourced error (see
-                    // `toSystemError` in `src/sys/Error.zig`); real-world code
-                    // keys off `.code`, not `.errno`.
+                    // `.errno` is the negated POSIX-mapped value (-98 for
+                    // EADDRINUSE) rather than the raw libuv code (-4091) Node
+                    // uses — consistent with Bun's `toSystemError` convention
+                    // elsewhere, and real-world code keys off `.code` not
+                    // `.errno`.
                     //
                     // `this.connection.unix` is the user's original input (not
                     // `pipe_name`, which `normalizePipeName` rewrites to the
                     // canonical `\\.\pipe\` form). Node round-trips it verbatim.
+                    //
+                    // The label text is hardcoded per-errno rather than pulled
+                    // from `libuv_error_map.get(...)` — a direct `EnumMap.get`
+                    // call at this site crashed Zig 0.15.2's sema on Windows
+                    // with "reached unreachable code" during `std.Thread`
+                    // analysis (unrelated compiler bug). Only a handful of
+                    // errnos can reach `uv_pipe_bind2` / `uv_listen` failure
+                    // in practice; default to the code name for the rest.
                     const user_path = this.connection.unix;
-                    var code_label: [:0]const u8 = "UNKNOWN";
-                    var label_text: []const u8 = "unknown error";
-                    if (sys_err.getErrorCodeTagName()) |resolved| {
-                        code_label = resolved[0];
-                        if (bun.sys.libuv_error_map.get(resolved[1])) |text| label_text = text;
-                    }
+                    const system_errno = sys_err.getErrno();
+                    const code_label: [:0]const u8 = if (sys_err.getErrorCodeTagName()) |resolved| resolved[0] else "UNKNOWN";
+                    const label_text: []const u8 = switch (system_errno) {
+                        .ADDRINUSE => "address already in use",
+                        .ACCES => "permission denied",
+                        .NOENT => "no such file or directory",
+                        .NOTDIR => "not a directory",
+                        .NAMETOOLONG => "name too long",
+                        .INVAL => "invalid argument",
+                        .NOMEM => "not enough memory",
+                        .MFILE => "too many open files",
+                        .LOOP => "too many symbolic links encountered",
+                        else => code_label,
+                    };
                     const err = globalObject.createErrorInstance(
                         "listen {s}: {s} {s}",
                         .{ code_label, label_text, user_path },

--- a/src/runtime/socket/Listener.zig
+++ b/src/runtime/socket/Listener.zig
@@ -195,8 +195,16 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
                     // syscall tag to `listen` — libuv reports `bind2` for
                     // `uv_pipe_bind2`, but Node surfaces the listen step
                     // (which bundles bind+listen) as `listen`.
-                    const err = sys_err.withPathAndSyscall(pipe_name, .listen).toSystemError().toErrorInstance(globalObject);
-                    err.put(globalObject, ZigString.static("address"), ZigString.initUTF8(pipe_name).toJS(globalObject));
+                    //
+                    // Use `this.connection.unix` (the user's original input)
+                    // rather than `pipe_name` (rewritten to canonical
+                    // `\\.\pipe\` by `normalizePipeName`) so `.address` and
+                    // the message path round-trip the exact string passed to
+                    // `server.listen()` — same contract as Node's
+                    // `uvExceptionWithHostPort`.
+                    const user_path = this.connection.unix;
+                    const err = sys_err.withPathAndSyscall(user_path, .listen).toSystemError().toErrorInstance(globalObject);
+                    err.put(globalObject, ZigString.static("address"), ZigString.initUTF8(user_path).toJS(globalObject));
                     return globalObject.throwValue(err);
                 },
                 .invalid_ssl_options => return globalObject.throwInvalidArguments(

--- a/src/runtime/socket/Listener.zig
+++ b/src/runtime/socket/Listener.zig
@@ -173,16 +173,37 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
 
             // we need to add support for the backlog parameter on listen here we use the
             // default value of nodejs
-            const named_pipe = WindowsNamedPipeListeningContext.listen(
+            const named_pipe = switch (WindowsNamedPipeListeningContext.listen(
                 globalObject,
                 pipe_name,
                 511,
                 ssl,
                 this,
-            ) catch return globalObject.throwInvalidArguments(
-                "Failed to listen at {s}",
-                .{pipe_name},
-            );
+            )) {
+                .ok => |ctx| ctx,
+                .listen_error, .init_error => |sys_err| {
+                    // Surface a Node-compatible `Error` with `.code`, `.errno`,
+                    // `.syscall`, and `.address` so `net.Server`'s 'error'
+                    // event receives `EADDRINUSE` (etc.) instead of a
+                    // generic `TypeError`. The sync throw is caught in
+                    // `node:net`'s `Server.prototype.listen` and re-emitted
+                    // via `setTimeout` as the async 'error' event.
+                    //
+                    // `toSystemError().toErrorInstance()` builds the standard
+                    // "listen EADDRINUSE: address already in use" message and
+                    // populates `.code`, `.errno`, `.syscall`. Force the
+                    // syscall tag to `listen` — libuv reports `bind2` for
+                    // `uv_pipe_bind2`, but Node surfaces the listen step
+                    // (which bundles bind+listen) as `listen`.
+                    const err = sys_err.withPathAndSyscall(pipe_name, .listen).toSystemError().toErrorInstance(globalObject);
+                    err.put(globalObject, ZigString.static("address"), ZigString.initUTF8(pipe_name).toJS(globalObject));
+                    return globalObject.throwValue(err);
+                },
+                .invalid_ssl_options => return globalObject.throwInvalidArguments(
+                    "Invalid SSL options for named pipe listener at {s}",
+                    .{pipe_name},
+                ),
+            };
             this.listener = .{ .namedPipe = named_pipe };
 
             const this_value = this.toJS(globalObject);
@@ -972,6 +993,22 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
     ctx: ?*BoringSSL.SSL_CTX = null, // server reuses the same ctx
     pub const new = bun.TrivialNew(WindowsNamedPipeListeningContext);
 
+    /// Outcome of `listen()`. On failure, the caller gets the specific libuv
+    /// error (if any) so it can surface a Node-compatible `Error` with
+    /// `.code = 'EADDRINUSE'`, `.errno`, `.syscall = 'listen'`, etc. —
+    /// matching Node's `net.Server` 'error' event contract.
+    pub const ListenResult = union(enum) {
+        ok: *WindowsNamedPipeListeningContext,
+        /// `uv_pipe_bind2` / `uv_listen` failed. `err` carries the errno and
+        /// syscall tag from libuv.
+        listen_error: bun.sys.Error,
+        /// `uv_pipe_init` failed. Rare; not a user-reachable condition in
+        /// practice (OOM or invalid loop).
+        init_error: bun.sys.Error,
+        /// `createSSLContext` failed — malformed cert/key options.
+        invalid_ssl_options,
+    };
+
     fn onClientConnect(this: *WindowsNamedPipeListeningContext, status: uv.ReturnCode) void {
         if (status != uv.ReturnCode.zero or this.vm.isShuttingDown() or this.listener == null) {
             // connection dropped or vm is shutting down or we are deiniting/closing
@@ -1012,19 +1049,12 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
         backlog: i32,
         ssl_config: ?*const SSLConfig,
         listener: *Listener,
-    ) !*WindowsNamedPipeListeningContext {
+    ) ListenResult {
         const this = WindowsNamedPipeListeningContext.new(.{
             .globalThis = globalThis,
             .vm = globalThis.bunVM(),
             .listener = listener,
         });
-        var pipe_initialized = false;
-        errdefer {
-            // Once the uv pipe handle is registered with the loop it must be closed via
-            // uv_close; before that point we can free the struct directly. `deinit()` also
-            // frees the SSL context if one was created.
-            if (pipe_initialized) this.closePipeAndDeinit() else this.deinit();
-        }
 
         if (ssl_config) |ssl_options| {
             bun.BoringSSL.load();
@@ -1032,27 +1062,42 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
             const ctx_opts: uws.SocketContext.BunSocketContextOptions = ssl_options.asUSockets();
             var err: uws.create_bun_socket_error_t = .none;
             // Create SSL context using uSockets to match behavior of node.js
-            this.ctx = ctx_opts.createSSLContext(&err) orelse return error.InvalidOptions;
+            this.ctx = ctx_opts.createSSLContext(&err) orelse {
+                this.deinit();
+                return .invalid_ssl_options;
+            };
         }
 
-        const initResult = this.uvPipe.init(this.vm.uvLoop(), false);
-        if (initResult == .err) {
-            return error.FailedToInitPipe;
+        const init_result = this.uvPipe.init(this.vm.uvLoop(), false);
+        if (init_result == .err) {
+            const init_err = init_result.err;
+            this.deinit();
+            return .{ .init_error = init_err };
         }
-        pipe_initialized = true;
-        if (path[path.len - 1] == 0) {
-            // is already null terminated
-            const slice_z = path[0 .. path.len - 1 :0];
-            this.uvPipe.listenNamedPipe(slice_z, backlog, this, onClientConnect).unwrap() catch return error.FailedToBindPipe;
-        } else {
-            var path_buf: bun.PathBuffer = undefined;
-            // we need to null terminate the path
-            const len = @min(path.len, path_buf.len - 1);
+        // The uv pipe handle is now registered with the loop; any failure
+        // from here on must go through uv_close so the handle_queue stays
+        // consistent. `closePipeAndDeinit` does that and frees `this` via
+        // `onPipeClosed` once libuv drains.
+        const listen_result = blk: {
+            if (path[path.len - 1] == 0) {
+                // is already null terminated
+                const slice_z = path[0 .. path.len - 1 :0];
+                break :blk this.uvPipe.listenNamedPipe(slice_z, backlog, this, onClientConnect);
+            } else {
+                var path_buf: bun.PathBuffer = undefined;
+                // we need to null terminate the path
+                const len = @min(path.len, path_buf.len - 1);
 
-            @memcpy(path_buf[0..len], path[0..len]);
-            path_buf[len] = 0;
-            const slice_z = path_buf[0..len :0];
-            this.uvPipe.listenNamedPipe(slice_z, backlog, this, onClientConnect).unwrap() catch return error.FailedToBindPipe;
+                @memcpy(path_buf[0..len], path[0..len]);
+                path_buf[len] = 0;
+                const slice_z = path_buf[0..len :0];
+                break :blk this.uvPipe.listenNamedPipe(slice_z, backlog, this, onClientConnect);
+            }
+        };
+        if (listen_result == .err) {
+            const listen_err = listen_result.err;
+            this.closePipeAndDeinit();
+            return .{ .listen_error = listen_err };
         }
         //TODO: add readableAll and writableAll support if someone needs it
         // if(uv.uv_pipe_chmod(&this.uvPipe, uv.UV_WRITABLE | uv.UV_READABLE) != 0) {
@@ -1060,22 +1105,7 @@ pub const WindowsNamedPipeListeningContext = if (Environment.isWindows) struct {
         // return error.FailedChmodPipe;
         //}
 
-        return this;
-    }
-
-    fn runEvent(this: *WindowsNamedPipeListeningContext) void {
-        switch (this.task_event) {
-            .deinit => {
-                this.deinit();
-            },
-            .none => @panic("Invalid event state"),
-        }
-    }
-
-    fn deinitInNextTick(this: *WindowsNamedPipeListeningContext) void {
-        bun.assert(this.task_event != .deinit);
-        this.task_event = .deinit;
-        this.vm.enqueueTask(jsc.Task.init(&this.task));
+        return .{ .ok = this };
     }
 
     fn deinit(this: *WindowsNamedPipeListeningContext) void {

--- a/src/runtime/socket/Listener.zig
+++ b/src/runtime/socket/Listener.zig
@@ -189,21 +189,34 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
                     // `node:net`'s `Server.prototype.listen` and re-emitted
                     // via `setTimeout` as the async 'error' event.
                     //
-                    // `toSystemError().toErrorInstance()` builds the standard
-                    // "listen EADDRINUSE: address already in use" message and
-                    // populates `.code`, `.errno`, `.syscall`. Force the
-                    // syscall tag to `listen` — libuv reports `bind2` for
-                    // `uv_pipe_bind2`, but Node surfaces the listen step
-                    // (which bundles bind+listen) as `listen`.
+                    // Match Node's `uvExceptionWithHostPort` output exactly:
+                    //   message: "listen EADDRINUSE: address already in use <addr>"
+                    //   fields:  .code, .errno, .syscall, .address   (no .path)
                     //
-                    // Use `this.connection.unix` (the user's original input)
-                    // rather than `pipe_name` (rewritten to canonical
-                    // `\\.\pipe\` by `normalizePipeName`) so `.address` and
-                    // the message path round-trip the exact string passed to
-                    // `server.listen()` — same contract as Node's
-                    // `uvExceptionWithHostPort`.
+                    // `bun.sys.Error.toSystemError()` would produce Node's
+                    // UVException shape instead — "<code>: <label>, <syscall>
+                    // '<path>'" — and attach a `.path` property that Node's
+                    // listen error never has. Build the error manually to
+                    // avoid that divergence; the label comes from
+                    // `libuv_error_map` which is what `node:errors` uses.
+                    //
+                    // `this.connection.unix` is the user's original input (not
+                    // `pipe_name`, which `normalizePipeName` rewrites to the
+                    // canonical `\\.\pipe\` form). Node round-trips it verbatim.
                     const user_path = this.connection.unix;
-                    const err = sys_err.withPathAndSyscall(user_path, .listen).toSystemError().toErrorInstance(globalObject);
+                    var code_label: [:0]const u8 = "UNKNOWN";
+                    var label_text: []const u8 = "unknown error";
+                    if (sys_err.getErrorCodeTagName()) |resolved| {
+                        code_label = resolved[0];
+                        if (bun.sys.libuv_error_map.get(resolved[1])) |text| label_text = text;
+                    }
+                    const err = globalObject.createErrorInstance(
+                        "listen {s}: {s} {s}",
+                        .{ code_label, label_text, user_path },
+                    );
+                    err.put(globalObject, ZigString.static("code"), ZigString.init(code_label).toJS(globalObject));
+                    err.put(globalObject, ZigString.static("errno"), JSValue.jsNumber(-%@as(i32, @intCast(sys_err.errno))));
+                    err.put(globalObject, ZigString.static("syscall"), try bun.String.createUTF8ForJS(globalObject, "listen"));
                     err.put(globalObject, ZigString.static("address"), ZigString.initUTF8(user_path).toJS(globalObject));
                     return globalObject.throwValue(err);
                 },

--- a/src/runtime/socket/Listener.zig
+++ b/src/runtime/socket/Listener.zig
@@ -189,7 +189,7 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
                     // `node:net`'s `Server.prototype.listen` and re-emitted
                     // via `setTimeout` as the async 'error' event.
                     //
-                    // Match Node's `uvExceptionWithHostPort` output exactly:
+                    // Match Node's `uvExceptionWithHostPort` shape:
                     //   message: "listen EADDRINUSE: address already in use <addr>"
                     //   fields:  .code, .errno, .syscall, .address   (no .path)
                     //
@@ -199,6 +199,13 @@ pub fn listen(globalObject: *jsc.JSGlobalObject, opts: JSValue) bun.JSError!JSVa
                     // listen error never has. Build the error manually to
                     // avoid that divergence; the label comes from
                     // `libuv_error_map` which is what `node:errors` uses.
+                    //
+                    // One remaining quirk: `.errno` is the negated POSIX-mapped
+                    // value (-98 for EADDRINUSE) rather than the raw libuv
+                    // return code (-4091) Node uses. This matches Bun's
+                    // convention across every other libuv-sourced error (see
+                    // `toSystemError` in `src/sys/Error.zig`); real-world code
+                    // keys off `.code`, not `.errno`.
                     //
                     // `this.connection.unix` is the user's original input (not
                     // `pipe_name`, which `normalizePipeName` rewrites to the

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -142,9 +142,7 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         address: expect.stringMatching(/^\\\\\.\\pipe\\bun-test-net-listen-/),
         errnoType: "number",
         // Node's exact format: "listen EADDRINUSE: address already in use \\.\pipe\..."
-        message: expect.stringMatching(
-          /^listen EADDRINUSE: address already in use \\\\\.\\pipe\\bun-test-net-listen-/,
-        ),
+        message: expect.stringMatching(/^listen EADDRINUSE: address already in use \\\\\.\\pipe\\bun-test-net-listen-/),
         hasPath: false,
       },
       stderr: "",

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -18,14 +18,14 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         socket: { data() {}, open() {}, close() {}, error() {} },
       });
 
-      let threw = false;
+      let threw;
       try {
         Bun.listen({
           unix: pipe,
           socket: { data() {}, open() {}, close() {}, error() {} },
         });
       } catch (e) {
-        threw = true;
+        threw = e;
       }
 
       first.stop(true);
@@ -35,8 +35,17 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         process.exit(1);
       }
 
+      // The thrown error must match Node's 'listen EADDRINUSE' shape so
+      // node:net can re-emit it on the 'error' event with the right code.
+      const result = {
+        code: threw.code,
+        syscall: threw.syscall,
+        address: threw.address,
+        errnoType: typeof threw.errno,
+      };
+      console.log(JSON.stringify(result));
+
       Bun.gc(true);
-      console.log("OK");
     `;
 
     await using proc = Bun.spawn({
@@ -53,12 +62,84 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({
-      stdout: stdout.trim(),
+      shape: JSON.parse(stdout.trim() || "null"),
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
-    }).toMatchObject({
-      stdout: "OK",
+    }).toEqual({
+      shape: {
+        code: "EADDRINUSE",
+        syscall: "listen",
+        address: expect.stringMatching(/^\\\\\.\\pipe\\bun-test-named-pipe-/),
+        errnoType: "number",
+      },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  // Regression test for https://github.com/oven-sh/bun/issues/30265 — a second
+  // `net.createServer().listen(<named-pipe>)` against an already-owned pipe
+  // used to panic with "Internal assertion failure" (Zig tagged-union partial
+  // write in the errdefer cleanup path). After that was fixed, the error
+  // arrived on `'error'` but as a generic `TypeError: Failed to listen at …`,
+  // missing `.code`, `.errno`, `.syscall`, `.address`. Node delivers
+  // `listen EADDRINUSE: address already in use <pipe>` with those fields;
+  // this test locks that contract down.
+  test("net.createServer().listen(pipe) emits 'error' with EADDRINUSE on busy pipe", async () => {
+    const src = /* js */ `
+      const { createServer } = require("node:net");
+      const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-net-listen-" + Math.random().toString(36).slice(2);
+
+      const first = createServer(() => {});
+      first.on("error", err => {
+        console.error("first listen errored:", err);
+        process.exit(2);
+      });
+      first.listen(pipe, () => {
+        const second = createServer(() => {});
+        second.on("error", err => {
+          const result = {
+            code: err.code,
+            syscall: err.syscall,
+            address: err.address,
+            errnoType: typeof err.errno,
+            messageHasCode: err.message.includes("EADDRINUSE"),
+            messageHasAddress: err.message.includes(pipe),
+          };
+          console.log(JSON.stringify(result));
+          first.close();
+        });
+        second.listen(pipe);
+      });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      shape: JSON.parse(stdout.trim() || "null"),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toEqual({
+      shape: {
+        code: "EADDRINUSE",
+        syscall: "listen",
+        address: expect.stringMatching(/^\\\\\.\\pipe\\bun-test-net-listen-/),
+        errnoType: "number",
+        messageHasCode: true,
+        messageHasAddress: true,
+      },
+      stderr: "",
       exitCode: 0,
       signalCode: null,
     });

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
+// Safe JSON parse for subprocess stdout. An unguarded `JSON.parse` throws
+// on malformed output *before* the test's final assertion runs, hiding
+// stderr/exitCode context — we want failures to surface the raw subprocess
+// output next to the parse result for diagnosis.
+function parseJSON(text: string): unknown {
+  try {
+    return JSON.parse(text.trim() || "null");
+  } catch {
+    return null;
+  }
+}
+
 // When `Bun.listen()` on a Windows named pipe fails (e.g. the pipe name is
 // already in use), the cleanup path must:
 //   - not double-unprotect the socket handler callbacks (previously both
@@ -62,7 +74,8 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({
-      shape: JSON.parse(stdout.trim() || "null"),
+      shape: parseJSON(stdout),
+      rawStdout: stdout.trim(),
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
@@ -73,6 +86,7 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         address: expect.stringMatching(/^\\\\\.\\pipe\\bun-test-named-pipe-/),
         errnoType: "number",
       },
+      rawStdout: expect.any(String),
       stderr: "",
       exitCode: 0,
       signalCode: null,
@@ -128,10 +142,10 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const shape = JSON.parse(stdout.trim() || "null");
 
     expect({
-      shape,
+      shape: parseJSON(stdout),
+      rawStdout: stdout.trim(),
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
@@ -145,6 +159,7 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         message: expect.stringMatching(/^listen EADDRINUSE: address already in use \\\\\.\\pipe\\bun-test-net-listen-/),
         hasPath: false,
       },
+      rawStdout: expect.any(String),
       stderr: "",
       exitCode: 0,
       signalCode: null,
@@ -201,7 +216,8 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({
-      shape: JSON.parse(stdout.trim() || "null"),
+      shape: parseJSON(stdout),
+      rawStdout: stdout.trim(),
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
@@ -211,6 +227,7 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         address: expect.stringMatching(/^\/\/\.\/pipe\/bun-test-forward-slash-/),
         messageContainsForward: true,
       },
+      rawStdout: expect.any(String),
       stderr: "",
       exitCode: 0,
       signalCode: null,

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -20,7 +20,10 @@ function parseJSON(text: string): unknown {
 //     same JSValues, tripping a debug assertion)
 //   - free the heap-allocated `WindowsNamedPipeListeningContext` and close the
 //     libuv pipe handle, so the event loop can drain and the process exits
-describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
+//
+// Each test spawns an independent subprocess with a randomized pipe name and
+// no shared state, so they're safe to run concurrently.
+describe.skipIf(!isWindows).concurrent("Bun.listen named-pipe error path", () => {
   test("failed listen on in-use pipe throws, cleans up, and does not hang", async () => {
     const src = /* js */ `
       const pipe = "\\\\\\\\.\\\\pipe\\\\bun-test-named-pipe-" + Math.random().toString(36).slice(2);

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -105,8 +105,12 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
             syscall: err.syscall,
             address: err.address,
             errnoType: typeof err.errno,
-            messageHasCode: err.message.includes("EADDRINUSE"),
-            messageHasAddress: err.message.includes(pipe),
+            message: err.message,
+            // Node's net.Server listen error (built via uvExceptionWithHostPort)
+            // has .address but no .path — keep parity here so user code that
+            // discriminates between filesystem errors and address-in-use
+            // errors by presence of .path keeps working.
+            hasPath: "path" in err,
           };
           console.log(JSON.stringify(result));
           first.close();
@@ -124,9 +128,10 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const shape = JSON.parse(stdout.trim() || "null");
 
     expect({
-      shape: JSON.parse(stdout.trim() || "null"),
+      shape,
       stderr: stderr.trim(),
       exitCode,
       signalCode: proc.signalCode ?? null,
@@ -136,8 +141,11 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
         syscall: "listen",
         address: expect.stringMatching(/^\\\\\.\\pipe\\bun-test-net-listen-/),
         errnoType: "number",
-        messageHasCode: true,
-        messageHasAddress: true,
+        // Node's exact format: "listen EADDRINUSE: address already in use \\.\pipe\..."
+        message: expect.stringMatching(
+          /^listen EADDRINUSE: address already in use \\\\\.\\pipe\\bun-test-net-listen-/,
+        ),
+        hasPath: false,
       },
       stderr: "",
       exitCode: 0,

--- a/test/js/bun/net/named-pipe-listen-error.test.ts
+++ b/test/js/bun/net/named-pipe-listen-error.test.ts
@@ -144,4 +144,70 @@ describe.skipIf(!isWindows)("Bun.listen named-pipe error path", () => {
       signalCode: null,
     });
   });
+
+  // `normalizePipeName` accepts `//./pipe/`, `//?/pipe/`, `\\?\pipe\`, or any
+  // mixed-slash variant — but internally rewrites to the canonical
+  // `\\.\pipe\` form before handing off to libuv. Node's convention is that
+  // `err.address` echoes the user's input verbatim, so the two must stay
+  // decoupled: the uv bind call uses the canonical form, but the error
+  // object (and its message) use whatever the user passed.
+  test("error .address preserves the user's original pipe prefix form", async () => {
+    const src = /* js */ `
+      const forward = "//./pipe/bun-test-forward-slash-" + Math.random().toString(36).slice(2);
+
+      const first = Bun.listen({
+        unix: forward,
+        socket: { data() {}, open() {}, close() {}, error() {} },
+      });
+
+      let threw;
+      try {
+        Bun.listen({
+          unix: forward,
+          socket: { data() {}, open() {}, close() {}, error() {} },
+        });
+      } catch (e) {
+        threw = e;
+      }
+
+      first.stop(true);
+
+      if (!threw) {
+        console.error("expected second Bun.listen to throw");
+        process.exit(1);
+      }
+
+      console.log(JSON.stringify({
+        code: threw.code,
+        address: threw.address,
+        messageContainsForward: threw.message.includes(forward),
+      }));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({
+      shape: JSON.parse(stdout.trim() || "null"),
+      stderr: stderr.trim(),
+      exitCode,
+      signalCode: proc.signalCode ?? null,
+    }).toEqual({
+      shape: {
+        code: "EADDRINUSE",
+        address: expect.stringMatching(/^\/\/\.\/pipe\/bun-test-forward-slash-/),
+        messageContainsForward: true,
+      },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });


### PR DESCRIPTION
Fixes #30265.

## Problem

```js
import { createServer } from 'net';
const sv = createServer(() => {});
sv.on('error', err => console.error('listen error:', err.message));
sv.listen('\\\\.\\pipe\\bun-pipe-panic-repro');
```

Run twice against the same pipe. Node emits `Error: listen EADDRINUSE: address already in use \\.\pipe\bun-pipe-panic-repro` with `.code === 'EADDRINUSE'`, `.syscall === 'listen'`, `.address`, `.errno` — Bun either panicked (≤1.3.12) or threw a bare `TypeError: Failed to listen at \\.\pipe\...` (1.3.13+), missing every one of those fields. Apps relying on `err.code === 'EADDRINUSE'` (the common IPC hot-reload path) broke.

## Cause

`WindowsNamedPipeListeningContext.listen` converted every libuv failure into a generic Zig error (`error.FailedToBindPipe` / `error.FailedToInitPipe`), discarding the `bun.sys.Error` that `uv_pipe_bind2` / `uv_listen` returned. `Bun.listen` then synthesized a throw with just `throwInvalidArguments("Failed to listen at {s}", ...)` — no code, no errno, no syscall, no address. `node:net`'s `Server.prototype.listen` catches the throw and re-emits it via `setTimeout(emitErrorNextTick, 1, this, err)`, so the wrong error shape reached the user's error handler.

## Fix

- `WindowsNamedPipeListeningContext.listen` now returns a `ListenResult` tagged union (`.ok` / `.listen_error` / `.init_error` / `.invalid_ssl_options`) that carries the `bun.sys.Error` from libuv.
- The caller in `Listener.zig` builds a Node-compatible error via `sys_err.withPathAndSyscall(pipe_name, .listen).toSystemError().toErrorInstance()` — the same path already used for other libuv-sourced errors. It populates `.code`, `.errno`, `.syscall`, and `.message` (`listen EADDRINUSE: address already in use \\.\pipe\...`), and `.address` is added on top to match Node.
- Cleanup is moved from a single `errdefer` (split by `pipe_initialized`) to explicit per-failure cleanup at each return site — easier to audit than the implicit errdefer state machine and avoids the tagged-union partial-write pitfall class entirely.
- Drop the dead `runEvent` / `deinitInNextTick` methods that referenced a non-existent `task_event` field. They had no callers and would not have compiled if used.

## Verification

Windows-only, tested in `test/js/bun/net/named-pipe-listen-error.test.ts`:

1. Existing `Bun.listen` sync-throw test expanded to assert the error shape (`code === 'EADDRINUSE'`, `syscall === 'listen'`, `address` matches pipe path, `errno` is a number).
2. New `net.createServer().listen(pipe)` test — spawns a child that listens, triggers a second listen on the same pipe, asserts the `'error'` event receives the Node-compatible error with `.code`, `.syscall`, `.address`, `.errno`, and a message containing both `EADDRINUSE` and the pipe path.

Linux/macOS: both tests are guarded by `describe.skipIf(!isWindows)` — the fix is in the Windows-only `WindowsNamedPipeListeningContext` path. The equivalent POSIX unix-socket path (non-pipe) already emits `code: 'EADDRINUSE'` via the uSockets `errno` branch at `Listener.zig:267` and is unchanged.