### PR TITLE
Register all top-level symbols before walking nested scopes in bundler renamer

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.zig
+++ b/src/bundler/linker_context/renameSymbolsInChunk.zig
@@ -278,10 +278,12 @@ pub fn renameSymbolsInChunk(
                 }
             },
         }
-        // Bulk-release every NumberScope we borrowed from the pool while
-        // processing this file. The recursive walk has already put each scope
-        // back individually; this is just a defensive reset that matches the
-        // previous per-part behavior.
+        // Bulk-reclaim hive slots for NumberScopes that the linear-chain walk
+        // in `assignNamesRecursiveWithNumberScope` acquired but did not put
+        // back individually — the single `defer put(s)` there only returns the
+        // final scope in each chain, so without this reset intermediate slots
+        // stay marked used and the 128-slot hive eventually spills to the
+        // arena fallback.
         r.number_scope_pool.hive.used = @TypeOf(r.number_scope_pool.hive.used).initEmpty();
     }
 

--- a/src/bundler/linker_context/renameSymbolsInChunk.zig
+++ b/src/bundler/linker_context/renameSymbolsInChunk.zig
@@ -145,6 +145,30 @@ pub fn renameSymbolsInChunk(
     var sorted = &sorted_;
     defer sorted.deinit();
 
+    // Two passes are required so that every top-level symbol is registered in
+    // `r.root` before any nested scope is visited. Without this, a local
+    // binding in file/part N could collide-rename into a name that is later
+    // claimed by a top-level symbol in file/part M (M > N), silently shadowing
+    // it in the output. See https://github.com/oven-sh/bun/issues/30269.
+    //
+    // Pass 1 adds all top-level symbols for the chunk (across every file).
+    // Pass 2 recurses into the nested scopes; by then `r.root` is fully
+    // populated so `findUnusedName` sees every potential top-level collision.
+    //
+    // `nested_scopes` stores the scopes to walk in pass 2, one entry per file
+    // in the same order as `files_in_order`. For ESM/no-wrap the entry is the
+    // concatenation of `part.scopes` for every live part. For CJS-wrapped
+    // files the entry is the single module scope (the whole module body lives
+    // inside the wrapper closure, so it's all "nested").
+    var nested_scopes: std.array_list.Managed([]const *js_ast.Scope) = try .initCapacity(r.temp_allocator, files_in_order.len);
+    defer nested_scopes.deinit();
+
+    // Scratch buffer reused across files to accumulate `part.scopes`.
+    var scopes_scratch = std.array_list.Managed(*js_ast.Scope).init(r.temp_allocator);
+    defer scopes_scratch.deinit();
+
+    // Pass 1: add all top-level symbols across the whole chunk, and stash the
+    // nested scopes that pass 2 will visit.
     for (files_in_order) |source_index| {
         const wrap = all_flags[source_index].wrap;
         const parts: []const Part = all_parts[source_index].slice();
@@ -213,7 +237,13 @@ pub fn renameSymbolsInChunk(
                         }
                     }
                 }
-                r.assignNamesRecursiveWithNumberScope(&r.root, &all_module_scopes[source_index], source_index, sorted);
+
+                // Pass 2 will walk the module scope itself (the module body is
+                // inside the CJS wrapper closure, so everything in it is nested
+                // from the renamer's point of view).
+                const one = try r.temp_allocator.alloc(*js_ast.Scope, 1);
+                one[0] = &all_module_scopes[source_index];
+                nested_scopes.appendAssumeCapacity(one);
                 continue;
             },
 
@@ -238,15 +268,29 @@ pub fn renameSymbolsInChunk(
             else => {},
         }
 
+        scopes_scratch.clearRetainingCapacity();
         for (parts) |*part| {
             if (!part.is_live) continue;
 
             r.addTopLevelDeclaredSymbols(part.declared_symbols);
-            for (part.scopes) |scope| {
-                r.assignNamesRecursiveWithNumberScope(&r.root, scope, source_index, sorted);
-            }
-            r.number_scope_pool.hive.used = @TypeOf(r.number_scope_pool.hive.used).initEmpty();
+            try scopes_scratch.appendSlice(part.scopes);
         }
+
+        const stashed = try r.temp_allocator.dupe(*js_ast.Scope, scopes_scratch.items);
+        nested_scopes.appendAssumeCapacity(stashed);
+    }
+
+    // Pass 2: now that `r.root` has every top-level symbol in the chunk,
+    // recurse into each file's nested scopes to rename collisions.
+    for (files_in_order, nested_scopes.items) |source_index, scopes| {
+        for (scopes) |scope| {
+            r.assignNamesRecursiveWithNumberScope(&r.root, scope, source_index, sorted);
+        }
+        // Bulk-release every NumberScope we borrowed from the pool while
+        // processing this file. The recursive walk has already put each scope
+        // back individually; this is just a defensive reset that matches the
+        // previous per-part behavior.
+        r.number_scope_pool.hive.used = @TypeOf(r.number_scope_pool.hive.used).initEmpty();
     }
 
     return r.toRenamer();

--- a/src/bundler/linker_context/renameSymbolsInChunk.zig
+++ b/src/bundler/linker_context/renameSymbolsInChunk.zig
@@ -154,21 +154,8 @@ pub fn renameSymbolsInChunk(
     // Pass 1 adds all top-level symbols for the chunk (across every file).
     // Pass 2 recurses into the nested scopes; by then `r.root` is fully
     // populated so `findUnusedName` sees every potential top-level collision.
-    //
-    // `nested_scopes` stores the scopes to walk in pass 2, one entry per file
-    // in the same order as `files_in_order`. For ESM/no-wrap the entry is the
-    // concatenation of `part.scopes` for every live part. For CJS-wrapped
-    // files the entry is the single module scope (the whole module body lives
-    // inside the wrapper closure, so it's all "nested").
-    var nested_scopes: std.array_list.Managed([]const *js_ast.Scope) = try .initCapacity(r.temp_allocator, files_in_order.len);
-    defer nested_scopes.deinit();
 
-    // Scratch buffer reused across files to accumulate `part.scopes`.
-    var scopes_scratch = std.array_list.Managed(*js_ast.Scope).init(r.temp_allocator);
-    defer scopes_scratch.deinit();
-
-    // Pass 1: add all top-level symbols across the whole chunk, and stash the
-    // nested scopes that pass 2 will visit.
+    // Pass 1: add every top-level symbol in the chunk to `r.root`.
     for (files_in_order) |source_index| {
         const wrap = all_flags[source_index].wrap;
         const parts: []const Part = all_parts[source_index].slice();
@@ -237,13 +224,10 @@ pub fn renameSymbolsInChunk(
                         }
                     }
                 }
-
-                // Pass 2 will walk the module scope itself (the module body is
-                // inside the CJS wrapper closure, so everything in it is nested
-                // from the renamer's point of view).
-                const one = try r.temp_allocator.alloc(*js_ast.Scope, 1);
-                one[0] = &all_module_scopes[source_index];
-                nested_scopes.appendAssumeCapacity(one);
+                // The module body is inside the CJS wrapper closure, so all
+                // of its symbols are treated as nested by the renamer; pass 2
+                // will walk `all_module_scopes[source_index]`. No per-part
+                // top-level symbols to add here.
                 continue;
             },
 
@@ -268,23 +252,31 @@ pub fn renameSymbolsInChunk(
             else => {},
         }
 
-        scopes_scratch.clearRetainingCapacity();
         for (parts) |*part| {
             if (!part.is_live) continue;
-
             r.addTopLevelDeclaredSymbols(part.declared_symbols);
-            try scopes_scratch.appendSlice(part.scopes);
         }
-
-        const stashed = try r.temp_allocator.dupe(*js_ast.Scope, scopes_scratch.items);
-        nested_scopes.appendAssumeCapacity(stashed);
     }
 
     // Pass 2: now that `r.root` has every top-level symbol in the chunk,
     // recurse into each file's nested scopes to rename collisions.
-    for (files_in_order, nested_scopes.items) |source_index, scopes| {
-        for (scopes) |scope| {
-            r.assignNamesRecursiveWithNumberScope(&r.root, scope, source_index, sorted);
+    for (files_in_order) |source_index| {
+        const wrap = all_flags[source_index].wrap;
+        switch (wrap) {
+            .cjs => {
+                // For CJS-wrapped modules, the entire module scope is nested
+                // (it lives inside the wrapper closure). Walk it directly.
+                r.assignNamesRecursiveWithNumberScope(&r.root, &all_module_scopes[source_index], source_index, sorted);
+            },
+            else => {
+                const parts: []const Part = all_parts[source_index].slice();
+                for (parts) |*part| {
+                    if (!part.is_live) continue;
+                    for (part.scopes) |scope| {
+                        r.assignNamesRecursiveWithNumberScope(&r.root, scope, source_index, sorted);
+                    }
+                }
+            },
         }
         // Bulk-release every NumberScope we borrowed from the pool while
         // processing this file. The recursive walk has already put each scope

--- a/test/regression/issue/30269.test.ts
+++ b/test/regression/issue/30269.test.ts
@@ -88,10 +88,10 @@ test("#30269 bundler doesn't rename a nested local into another top-level symbol
   });
   {
     const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect(stderr).not.toContain("error");
-    expect(exitCode).toBe(0);
-    // `stdout` carries the "Bundled N modules" banner; referenced to keep it.
+    // `stdout` carries the "Bundled N modules" banner; assert on it before
+    // the exit-code check so a build failure shows what bun actually printed.
     expect(stdout).toContain("out.js");
+    expect(exitCode, stderr).toBe(0);
   }
 
   await using run = Bun.spawn({

--- a/test/regression/issue/30269.test.ts
+++ b/test/regression/issue/30269.test.ts
@@ -91,7 +91,8 @@ test("#30269 bundler doesn't rename a nested local into another top-level symbol
     // `stdout` carries the "Bundled N modules" banner; assert on it before
     // the exit-code check so a build failure shows what bun actually printed.
     expect(stdout).toContain("out.js");
-    expect(exitCode, stderr).toBe(0);
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   }
 
   await using run = Bun.spawn({
@@ -107,5 +108,6 @@ test("#30269 bundler doesn't rename a nested local into another top-level symbol
   // Asserting on stdout + exit code is enough; stderr can hold unrelated
   // debug-build warnings (e.g. MADV_DONTNEED) that we don't want to flake on.
   expect(stdout).toBe("ok: true\n");
+  if (exitCode !== 0) expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/30269.test.ts
+++ b/test/regression/issue/30269.test.ts
@@ -14,7 +14,7 @@
 // Fix: split the single-pass interleaved loop into two passes — register
 // all top-level symbols for the whole chunk first, then walk nested scopes.
 // Matches esbuild's structure.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 test("#30269 bundler doesn't rename a nested local into another top-level symbol's name", async () => {

--- a/test/regression/issue/30269.test.ts
+++ b/test/regression/issue/30269.test.ts
@@ -1,0 +1,110 @@
+// https://github.com/oven-sh/bun/issues/30269
+//
+// The ESM bundler renamer used to interleave two operations per part:
+//   1. register that part's top-level symbols in the root scope, and
+//   2. walk that part's nested scopes to rename collisions with the root.
+//
+// Because nested-scope walking for part N happened before part M>N's
+// top-level symbols had been registered, a local binding in part N could be
+// renamed to a name (`r` → `r2`) that later became a top-level symbol in
+// part M (here the `r2` function). The local `r2` then shadowed the
+// top-level `r2`, and callers inside `typecheck` invoked an `Expression`
+// instance instead of the function.
+//
+// Fix: split the single-pass interleaved loop into two passes — register
+// all top-level symbols for the whole chunk first, then walk nested scopes.
+// Matches esbuild's structure.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test("#30269 bundler doesn't rename a nested local into another top-level symbol's name", async () => {
+  using dir = tempDir("bun-issue-30269", {
+    // Importing this forces Bun's ESM renamer to treat `r` as a conflicting
+    // name at the chunk's root scope. Removing `conflict.r()` from main.js
+    // hides the bug.
+    "conflict.js": `
+      export function r() {
+        return "top-level r";
+      }
+    `,
+    // `typecheck` has a nested \`let r\`. The renamer picks \`r2\` for it —
+    // but \`r2\` is already a top-level function in the same file.
+    "module.js": `
+      class Expression {}
+
+      export function run() {
+        const result = typecheck({ left: new Expression(), op: {}, right: {} });
+        if (result !== true) throw new Error("expected true");
+        return result;
+      }
+
+      function typecheck(node) {
+        let r, t, c;
+        block: {
+          let k = node.left;
+          let I = node.op;
+          let q = node.right;
+          r = k;
+          t = I;
+          c = q;
+          break block;
+        }
+
+        let d = r;
+        let n = t;
+        let s = c;
+        return r2().bo4(d, n, s).a();
+      }
+
+      function r2() {
+        return {
+          bo4() {
+            return {
+              a() {
+                return true;
+              },
+            };
+          },
+        };
+      }
+    `,
+    "main.js": `
+      import * as conflict from "./conflict.js";
+      import { run } from "./module.js";
+
+      conflict.r();
+      console.log("ok:", run());
+    `,
+  });
+
+  // Bundle, then run the bundled file. The renamer bug is triggered during
+  // bundling; executing the bundle is what surfaces the TypeError.
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--outfile", "out.js", "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  {
+    const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(stderr).not.toContain("error");
+    expect(exitCode).toBe(0);
+    // `stdout` carries the "Bundled N modules" banner; referenced to keep it.
+    expect(stdout).toContain("out.js");
+  }
+
+  await using run = Bun.spawn({
+    cmd: [bunExe(), "out.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+  // On the buggy build this stderr contains:
+  //   TypeError: r2 is not a function. (In 'r2()', 'r2' is an instance of Expression)
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok: true\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/30269.test.ts
+++ b/test/regression/issue/30269.test.ts
@@ -104,7 +104,8 @@ test("#30269 bundler doesn't rename a nested local into another top-level symbol
   const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
   // On the buggy build this stderr contains:
   //   TypeError: r2 is not a function. (In 'r2()', 'r2' is an instance of Expression)
-  expect(stderr).toBe("");
+  // Asserting on stdout + exit code is enough; stderr can hold unrelated
+  // debug-build warnings (e.g. MADV_DONTNEED) that we don't want to flake on.
   expect(stdout).toBe("ok: true\n");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #30269.

### Reproduction

```js
// conflict.js
export function r() { return "top-level r"; }

// module.js
function typecheck(node) {
  let r, t, c;
  // ...
  return r2().bo4(d, n, s).a();
}
function r2() { /* ... */ }
export function run() { return typecheck({ left: new Expression(), op:{}, right:{} }); }

// main.js
import * as conflict from "./conflict.js";
import { run } from "./module.js";
conflict.r();   // <-- pulls "r" into the chunk root scope
run();
```

`bun main.js` runs correctly. `bun build main.js` emits code that crashes with:

```
TypeError: r2 is not a function. (In 'r2()', 'r2' is an instance of Expression)
      at typecheck (out.js:29:10)
```

### Root cause

`renameSymbolsInChunk` (src/bundler/linker_context/renameSymbolsInChunk.zig) interleaved two operations in a single per-part loop:

1. `addTopLevelDeclaredSymbols(part.declared_symbols)` — register this part's top-level refs in `r.root`.
2. `assignNamesRecursiveWithNumberScope(&r.root, scope, ...)` — walk this part's nested scopes to rename collisions.

Because (2) for part N ran before (1) for part M > N, a local binding in part N could collide-rename into a name later claimed by a top-level symbol in part M, silently shadowing it.

Concretely: the local `let r` in `typecheck` is renamed to `r2` (to avoid `conflict.r`), but the top-level `function r2` from the *same* file lives in a later part whose top-level symbols haven't been registered yet. `findUnusedName` sees `r2` as available and picks it. The subsequent `return r2()` in the same scope then resolves to the renamed local.

### Fix

Split the single pass into two passes, matching esbuild's structure:

1. **Pass 1** iterates every file in the chunk, registers every top-level symbol (wrapper refs, external imports/exports for CJS, and `part.declared_symbols` for ESM/no-wrap), and stashes the nested scopes to visit.
2. **Pass 2** walks the stashed nested scopes now that `r.root` is fully populated. `findUnusedName` sees every top-level collision and picks a unique name (`r3` in this repro).

### Verification

- New regression test `test/regression/issue/30269.test.ts` bundles the repro and runs the output. Fails on `main` with the above `TypeError`, passes with this change.
- Full `test/bundler/esbuild/default.test.ts` (150/150 pass), `importstar.test.ts` (72/72 pass), `splitting.test.ts` (20/20 pass), `bundler_cjs.test.ts` (6/6 pass), `bundler_cjs2esm.test.ts` (35/35 pass), `bundler_bun.test.ts` + `bun-build-api.test.ts` (48/48 pass).

### Output before / after

```diff
 function typecheck(node) {
-  let r2, t, c;
+  let r3, t, c;
   block: {
     let k = node.left;
-    r2 = k;
+    r3 = k;
     ...
   }
-  let d = r2;
+  let d = r3;
   return r2().bo4(d, n, s).a();   // <- now resolves to the top-level r2 function
 }
 function r2() { /* ... */ }
```
