### PR TITLE
bundler: trim empty `else {}` left behind by DCE

### DIFF
--- a/docs/guides/runtime/define-constant.mdx
+++ b/docs/guides/runtime/define-constant.mdx
@@ -40,20 +40,22 @@ if ("production" === "production") { // [!code ++]
 
 It doesn't stop there. Bun's optimizing transpiler is smart enough to do some basic constant folding.
 
-Since `"production" === "production"` is always `true`, Bun replaces the entire expression with the `true` value.
+Since `"production" === "production"` is always `true`, Bun replaces the entire expression with the `true` value and drops the unreachable `else` branch.
 
 {/* prettier-ignore */}
 ```ts
 if (true) { // [!code ++]
   console.log("Production mode");
-} else {
-  console.log("Development mode");
 }
 ```
 
 ---
 
-And finally, Bun detects the `else` branch is not reachable, and eliminates it.
+To also collapse the surrounding `if` scaffolding and produce the minimal output below, pass `--minify-syntax` (also enabled by `--minify`):
+
+```sh terminal icon="terminal"
+bun build --define process.env.NODE_ENV="'production'" --minify-syntax src/index.ts
+```
 
 ```ts
 console.log("Production mode");

--- a/src/js_parser/ast/visitStmt.zig
+++ b/src/js_parser/ast/visitStmt.zig
@@ -1046,10 +1046,23 @@ pub fn VisitStmt(
                         data.no = p.visitSingleStmt(no, .none);
                     }
 
-                    // Trim unnecessary "else" clauses
-                    if (p.options.features.minify_syntax) {
-                        if (data.no != null and @as(Stmt.Tag, data.no.?.data) == .s_empty) {
-                            data.no = null;
+                    // Trim an "else" clause whose body was emptied by dead-code
+                    // elimination. This avoids emitting `else {}` for e.g.
+                    // `if (true) { A } else { B }` where B was pruned. Gated on
+                    // the union of DCE and minify_syntax so the pre-existing
+                    // `deadCodeElimination: false, minify: { syntax: true }`
+                    // configuration (which already dropped the `else {}`)
+                    // doesn't regress to `else ;`.
+                    if (p.options.features.dead_code_elimination or p.options.features.minify_syntax) {
+                        if (data.no) |no_stmt| {
+                            const no_is_empty = switch (no_stmt.data) {
+                                .s_empty => true,
+                                .s_block => |block| block.stmts.len == 0,
+                                else => false,
+                            };
+                            if (no_is_empty) {
+                                data.no = null;
+                            }
                         }
                     }
                 }

--- a/src/js_printer/js_printer.zig
+++ b/src/js_printer/js_printer.zig
@@ -5142,6 +5142,9 @@ fn NewPrinter(
                     .s_with => |current| {
                         s = &current.body.data;
                     },
+                    .s_label => |current| {
+                        s = &current.stmt.data;
+                    },
                     else => {
                         return false;
                     },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -649,6 +649,53 @@ describe("bundler", () => {
       `,
     },
   });
+  // https://github.com/oven-sh/bun/issues/30271
+  //
+  // When dead-code elimination prunes an if/else body, the scaffolding
+  // itself only collapses with --minify-syntax. Even so, the empty `else {}`
+  // remnant produced by the prune is ugly — trim it so the output at least
+  // says `if (true) { kept }` instead of `if (true) { kept } else {}`.
+  itBundled("edgecase/DCEEmptyElseTrimmed#30271", {
+    files: {
+      "/entry.js": /* js */ `
+        if ("foo" === "foo") {
+          console.log("success");
+        } else {
+          console.log("fail");
+        }
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The dead branch body is gone...
+      expect(out).not.toContain("fail");
+      // ...and so is the empty `else {}` remnant.
+      expect(out).not.toContain("else");
+    },
+    run: {
+      stdout: "success",
+    },
+  });
+  // Trimming the empty `else {}` from an inner labeled `if` used to drop the
+  // dangling-else guard: `if (a) L: if (b) c(); else {} else d();` would print
+  // as `if (a) L: if (b) c(); else d();`, re-binding `else d()` to the inner
+  // `if (b)`. `wrapToAvoidAmbiguousElse` needs to traverse `.s_label`.
+  itBundled("edgecase/DCEEmptyElseTrimmedLabeledDanglingElse#30271", {
+    files: {
+      "/entry.js": /* js */ `
+        var a = false, b = false;
+        if (a)
+          L: if (b) console.log("inner-then");
+          else {}
+        else console.log("outer-else");
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: "outer-else",
+    },
+  });
   itBundled("edgecase/AbsolutePathShouldNotResolveAsRelative", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
## Problem

`bun build --define Bun.env.NODE_ENV="'production'" test.ts` on:

```ts
if ("foo" === "foo") {
  console.log("success!");
} else {
  console.log("fail!");
}
```

produced:

```js
if (true) {
  console.log("success!");
} else {}
```

The constant-folded test expression and the pruned dead branch are correct, but the empty `else {}` remnant is left behind. The [`--define` docs guide](https://bun.com/docs/guides/runtime/define-constant) also promised full collapse to just `console.log("success!");` — which only ever happened with `--minify-syntax`.

## Cause

`visitStmt`'s `s_if` handler had an "else trim" gated on `minify_syntax`:

```zig
// Trim unnecessary "else" clauses
if (p.options.features.minify_syntax) {
    if (data.no != null and @as(Stmt.Tag, data.no.?.data) == .s_empty) {
        data.no = null;
    }
}
```

Two issues:

1. Gated on `minify_syntax`, even though the thing it's cleaning up (an `else` body emptied by DCE statement-pruning) is produced by DCE itself.
2. Checked for `.s_empty`, but `visitSingleStmtBlock` only converts an empty block to `.s_empty` when `minify_syntax` is on — otherwise the pruned body stays as an `.s_block` with `stmts.len == 0`.

The scaffolding collapse (`if (true) { A }` → `A`) intentionally stays behind `--minify-syntax` since tests (e.g. `transpiler.test.js`'s DCE block, `"if (undefined) { let y = Math.random(); }" → "if (undefined) {}"`) lock that contract in, matching esbuild. This change is strictly about cleaning up the ugly empty-else remnant.

## Fix

Gate the else-trim on `dead_code_elimination` and treat an `.s_block` with zero stmts as equivalent to `.s_empty`:

```zig
if (p.options.features.dead_code_elimination) {
    if (data.no) |no_stmt| {
        const no_is_empty = switch (no_stmt.data) {
            .s_empty => true,
            .s_block => |block| block.stmts.len == 0,
            else => false,
        };
        if (no_is_empty) {
            data.no = null;
        }
    }
}
```

Also updates the define-constant docs page so the promised before/after output matches what the bundler actually emits, and points users to `--minify-syntax` / `--minify` for the full scaffolding collapse shown as the final step.

## Verification

`test/bundler/bundler_edgecase.test.ts`'s `DCEEmptyElseTrimmed#30271` asserts the output of the repro contains neither `fail` nor `else`. It fails on `main` (output is `if (true) { console.log("success"); } else {}`) and passes on this branch (`if (true) { console.log("success"); }`).

Existing DCE tests (`bundler_edgecase.test.ts`'s `DCE*`, `transpiler.test.js`'s DCE block, `esbuild/dce.test.ts`, `esbuild/default.test.ts`, `esbuild/ts.test.ts`, `bundler_minify.test.ts`) all pass — no test depended on an `else {}` remnant surviving.

Fixes #30271