### PR TITLE
Fix crash in `Bun.file().writer()` with invalid path/fd options

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,19 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        switch (stream_start) {
+            .err => |err| {
+                sink.deref();
+                return globalThis.throwValue(try err.toJS(globalThis));
+            },
+            .FileSink => |*file| {
+                file.input_path.deinit();
+                file.input_path = input_path;
+            },
+            else => {
+                stream_start = .{ .FileSink = .{ .input_path = input_path } };
+            },
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,13 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+it.skipIf(isWindows)("writer() throws on invalid options instead of crashing", () => {
+  const file = Bun.file(path.join(tmpdirSync(), "test.txt"));
+  expect(() => file.writer({ path: 123 })).toThrow(expect.objectContaining({ code: "EINVAL" }));
+  expect(() => file.writer({ fd: "not a number" })).toThrow(expect.objectContaining({ code: "EBADF" }));
+  expect(() => file.writer({ fd: -9999.5 })).toThrow(expect.objectContaining({ code: "EBADF" }));
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
Fuzzer fingerprint: `2b96d44db8b7b9ba`

## What

`Bun.file(...).writer(options)` crashed with a union-tag safety panic when `options` contained a non-string `path` or non-integer `fd`:

```js
Bun.file("/tmp/x").writer({ path: 123 });
// panic(main thread): access of union field 'FileSink' while field 'err' is active
```

## Why

`streams.Start.fromJSWithTag` returns a `.err` variant of the `Start` union when the `path`/`fd` options are the wrong type. `Blob.getWriter` then unconditionally accessed `stream_start.FileSink.input_path`, which panics in debug builds when the active tag is `.err` (and is UB in release).

## Fix

Switch on the returned tag: throw a proper JS error for `.err`, and only overwrite `input_path` when the tag is `.FileSink`. Also deinit the allocated path slice returned by `fromJSWithTag` before overwriting it with the blob's own path to avoid a small leak.