### PR TITLE
Drain expired timers between tasks to prevent starvation

### DIFF
--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -548,7 +548,20 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // only fires inside `autoTick`'s `loop.tickWithTimeout`, which is
         // reached only after `tick()` returns, so the same starvation applies.
         // `drainTimersIfNeeded` handles the Windows uv_timer re-arm.
-        virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
+        //
+        // Gated on `suppress_microtask_drain` because `tickQueueWithCount` is
+        // shared with `SpawnSyncEventLoop`, which sets that flag to isolate
+        // user JS from running mid-`spawnSync`. The flag's contract covers
+        // timer callbacks too (they run arbitrary user code).
+        if (!virtual_machine.suppress_microtask_drain) {
+            virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
+            // Timer callbacks enter/exit the event loop with
+            // `entered_event_loop_count >= 2` (tick() already incremented
+            // it), so TimerObjectInternals.fire's own exit() skips its
+            // microtask drain — we drain again here so any microtasks the
+            // timer callback queued are flushed before the next task runs.
+            try this.drainMicrotasksWithGlobal(global, global_vm);
+        }
     }
 
     this.tasks.head = if (this.tasks.count == 0) 0 else this.tasks.head;

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -543,11 +543,12 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // drags a microtask chain of SDK middleware) doesn't starve timers
         // until the entire queue drains. `drainTimersIfNeeded` bails out in
         // the common case where the timer heap is empty. See issue #30273.
-        // Windows drives timers via libuv's uv_timer, which libuv fires from
-        // its own loop phase, so leave that path alone.
-        if (comptime Environment.isPosix) {
-            virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
-        }
+        //
+        // The mechanism is platform-agnostic — on Windows, `onUVTimer` also
+        // only fires inside `autoTick`'s `loop.tickWithTimeout`, which is
+        // reached only after `tick()` returns, so the same starvation applies.
+        // `drainTimersIfNeeded` handles the Windows uv_timer re-arm.
+        virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
     }
 
     this.tasks.head = if (this.tasks.count == 0) 0 else this.tasks.head;

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -546,13 +546,13 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // an empty heap, or peek + `timespec.now()` for a future deadline.
         // See #30273.
         //
-        // POSIX-only: on Windows, routing timers through this path interacts
-        // badly with libuv's backend-timeout bookkeeping (`test-http-should-
-        // emit-close-when-connection-is-aborted` times out on Windows 2019
-        // shards). The POSIX gate matches where Bun's own timer heap is
-        // normally dispatched (via `autoTick`'s `drainTimers`). Windows
-        // drives timers through libuv's `uv_timer`, which fires independently
-        // from its own loop phase and doesn't hit the same starvation shape.
+        // POSIX-only. The starvation mechanism is platform-agnostic (both
+        // POSIX's `drainTimers` and Windows's `onUVTimer` only run after
+        // `tick()` returns to `autoTick`), but routing this mid-tick drain
+        // through libuv's `uv_timer` bookkeeping on Windows destabilised
+        // `test-http-should-emit-close-when-connection-is-aborted` on the
+        // Windows 2019 shards. Windows is left unfixed pending a libuv-safe
+        // implementation of the same drain.
         //
         // Gated on `suppress_microtask_drain` because `tickQueueWithCount` is
         // shared with `SpawnSyncEventLoop`, which sets that flag to isolate

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -541,26 +541,27 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // Fire expired timers between tasks so that a long task batch (e.g.
         // a large HTTP-response burst under `Promise.all` where each response
         // drags a microtask chain of SDK middleware) doesn't starve timers
-        // until the entire queue drains. `drainTimersIfNeeded` bails out in
-        // the common case where the timer heap is empty. See issue #30273.
+        // until the entire queue drains. `drainExpiredTimers` returns early
+        // when nothing is due (the common case), so the only per-task cost
+        // on the hot path is a single unlocked pointer peek. See #30273.
         //
         // The mechanism is platform-agnostic — on Windows, `onUVTimer` also
         // only fires inside `autoTick`'s `loop.tickWithTimeout`, which is
         // reached only after `tick()` returns, so the same starvation applies.
-        // `drainTimersIfNeeded` handles the Windows uv_timer re-arm.
         //
         // Gated on `suppress_microtask_drain` because `tickQueueWithCount` is
         // shared with `SpawnSyncEventLoop`, which sets that flag to isolate
         // user JS from running mid-`spawnSync`. The flag's contract covers
         // timer callbacks too (they run arbitrary user code).
         if (!virtual_machine.suppress_microtask_drain) {
-            virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
-            // Timer callbacks enter/exit the event loop with
-            // `entered_event_loop_count >= 2` (tick() already incremented
-            // it), so TimerObjectInternals.fire's own exit() skips its
-            // microtask drain — we drain again here so any microtasks the
-            // timer callback queued are flushed before the next task runs.
-            try this.drainMicrotasksWithGlobal(global, global_vm);
+            if (virtual_machine.timer.drainExpiredTimers(virtual_machine)) {
+                // Timer callbacks enter/exit the event loop with
+                // `entered_event_loop_count >= 2` (tick() already incremented
+                // it), so TimerObjectInternals.fire's own exit() skips its
+                // microtask drain — we drain again here so any microtasks the
+                // timer callback queued are flushed before the next task runs.
+                try this.drainMicrotasksWithGlobal(global, global_vm);
+            }
         }
     }
 

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -546,22 +546,28 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // an empty heap, or peek + `timespec.now()` for a future deadline.
         // See #30273.
         //
-        // The mechanism is platform-agnostic — on Windows, `onUVTimer` also
-        // only fires inside `autoTick`'s `loop.tickWithTimeout`, which is
-        // reached only after `tick()` returns, so the same starvation applies.
+        // POSIX-only: on Windows, routing timers through this path interacts
+        // badly with libuv's backend-timeout bookkeeping (`test-http-should-
+        // emit-close-when-connection-is-aborted` times out on Windows 2019
+        // shards). The POSIX gate matches where Bun's own timer heap is
+        // normally dispatched (via `autoTick`'s `drainTimers`). Windows
+        // drives timers through libuv's `uv_timer`, which fires independently
+        // from its own loop phase and doesn't hit the same starvation shape.
         //
         // Gated on `suppress_microtask_drain` because `tickQueueWithCount` is
         // shared with `SpawnSyncEventLoop`, which sets that flag to isolate
         // user JS from running mid-`spawnSync`. The flag's contract covers
         // timer callbacks too (they run arbitrary user code).
-        if (!virtual_machine.suppress_microtask_drain) {
-            if (virtual_machine.timer.drainExpiredTimers(virtual_machine)) {
-                // Timer callbacks enter/exit the event loop with
-                // `entered_event_loop_count >= 2` (tick() already incremented
-                // it), so TimerObjectInternals.fire's own exit() skips its
-                // microtask drain — we drain again here so any microtasks the
-                // timer callback queued are flushed before the next task runs.
-                try this.drainMicrotasksWithGlobal(global, global_vm);
+        if (comptime Environment.isPosix) {
+            if (!virtual_machine.suppress_microtask_drain) {
+                if (virtual_machine.timer.drainExpiredTimers(virtual_machine)) {
+                    // Timer callbacks enter/exit the event loop with
+                    // `entered_event_loop_count >= 2` (tick() already incremented
+                    // it), so TimerObjectInternals.fire's own exit() skips its
+                    // microtask drain — we drain again here so any microtasks the
+                    // timer callback queued are flushed before the next task runs.
+                    try this.drainMicrotasksWithGlobal(global, global_vm);
+                }
             }
         }
     }

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -542,8 +542,9 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         // a large HTTP-response burst under `Promise.all` where each response
         // drags a microtask chain of SDK middleware) doesn't starve timers
         // until the entire queue drains. `drainExpiredTimers` returns early
-        // when nothing is due (the common case), so the only per-task cost
-        // on the hot path is a single unlocked pointer peek. See #30273.
+        // when nothing is due (the common case): an unlocked pointer peek for
+        // an empty heap, or peek + `timespec.now()` for a future deadline.
+        // See #30273.
         //
         // The mechanism is platform-agnostic — on Windows, `onUVTimer` also
         // only fires inside `autoTick`'s `loop.tickWithTimeout`, which is

--- a/src/jsc/Task.zig
+++ b/src/jsc/Task.zig
@@ -537,6 +537,17 @@ pub fn tickQueueWithCount(this: *EventLoop, virtual_machine: *VirtualMachine, co
         }
 
         try this.drainMicrotasksWithGlobal(global, global_vm);
+
+        // Fire expired timers between tasks so that a long task batch (e.g.
+        // a large HTTP-response burst under `Promise.all` where each response
+        // drags a microtask chain of SDK middleware) doesn't starve timers
+        // until the entire queue drains. `drainTimersIfNeeded` bails out in
+        // the common case where the timer heap is empty. See issue #30273.
+        // Windows drives timers via libuv's uv_timer, which libuv fires from
+        // its own loop phase, so leave that path alone.
+        if (comptime Environment.isPosix) {
+            virtual_machine.timer.drainTimersIfNeeded(virtual_machine);
+        }
     }
 
     this.tasks.head = if (this.tasks.count == 0) 0 else this.tasks.head;

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -354,6 +354,19 @@ pub const All = struct {
         }
     }
 
+    /// Fast-path wrapper around `drainTimers` that skips the `timespec.now()`
+    /// call when the heap is empty. Safe to call frequently from within the
+    /// task drain loop to keep expired timers from being starved by a continuous
+    /// stream of concurrent tasks (e.g. HTTP responses arriving during a
+    /// `Promise.all` burst).
+    ///
+    /// The `peek` is a single-pointer load; a stale `null` just defers the
+    /// drain by one loop iteration, which is harmless.
+    pub fn drainTimersIfNeeded(this: *All, vm: *VirtualMachine) void {
+        if (this.timers.peek() == null) return;
+        this.drainTimers(vm);
+    }
+
     const TimeoutWarning = enum {
         TimeoutOverflowWarning,
         TimeoutNegativeWarning,

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -359,11 +359,10 @@ pub const All = struct {
     /// microtasks (timer callbacks queue their own that `TimerObjectInternals.
     /// fire` doesn't drain when nested inside `tick()`).
     ///
-    /// When the heap is empty, or the earliest deadline is still in the
-    /// future, this returns without taking the mutex inside `drainTimers` →
-    /// `next` or calling `timespec.now()`. The unlocked read of the heap root
-    /// is safe because the heap is mutated only from the JS thread; a stale
-    /// `null` just defers the drain by one loop iteration.
+    /// When the heap is empty or the earliest deadline is still in the future,
+    /// this returns without taking the mutex inside `drainTimers` → `next`.
+    /// The unlocked root peek is safe because the heap is mutated only from
+    /// the JS thread; a stale `null` just defers the drain by one iteration.
     ///
     /// On Windows, re-arms the uv_timer after firing so the next deadline
     /// still wakes `loop.tickWithTimeout` — but only when something actually

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -354,17 +354,25 @@ pub const All = struct {
         }
     }
 
-    /// Fast-path wrapper around `drainTimers` that skips the `timespec.now()`
-    /// call when the heap is empty. Safe to call frequently from within the
-    /// task drain loop to keep expired timers from being starved by a continuous
-    /// stream of concurrent tasks (e.g. HTTP responses arriving during a
-    /// `Promise.all` burst).
+    /// Fast-path wrapper around `drainTimers`. Safe to call frequently from
+    /// within the task-drain loop to keep expired timers from being starved
+    /// by a continuous stream of concurrent tasks (e.g. HTTP responses arriving
+    /// during a `Promise.all` burst).
     ///
-    /// The `peek` is a single-pointer load; a stale `null` just defers the
-    /// drain by one loop iteration, which is harmless.
+    /// On an empty heap the lock-free `peek` lets us skip the mutex round-trip
+    /// that `drainTimers` → `next` would otherwise do. The peek is a single-
+    /// pointer load and the heap is modified only from the JS thread, so a
+    /// racing stale `null` just defers the drain by one loop iteration — which
+    /// is harmless, the next task will redo the check.
+    ///
+    /// On Windows, also re-arms the libuv timer after firing so the next
+    /// deadline still wakes `loop.tickWithTimeout`. Mirrors `onUVTimer`.
     pub fn drainTimersIfNeeded(this: *All, vm: *VirtualMachine) void {
         if (this.timers.peek() == null) return;
         this.drainTimers(vm);
+        if (Environment.isWindows) {
+            this.ensureUVTimer(vm);
+        }
     }
 
     const TimeoutWarning = enum {

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -373,13 +373,8 @@ pub const All = struct {
     /// all three Windows shards.
     pub fn drainExpiredTimers(this: *All, vm: *VirtualMachine) bool {
         const head = this.timers.peek() orelse return false;
-        // `getTimeout` fires `WTFTimer` entries eagerly regardless of deadline
-        // (they only fire once and act as a JSC stop-if-necessary hook); stay
-        // in sync with that so they're not skipped when they sit at the root.
-        if (head.tag != .WTFTimer) {
-            const now = timespec.now(.allow_mocked_time);
-            if (head.next.greater(&now)) return false;
-        }
+        const now = timespec.now(.allow_mocked_time);
+        if (head.next.greater(&now)) return false;
         this.drainTimers(vm);
         if (Environment.isWindows) {
             this.ensureUVTimer(vm);

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -354,7 +354,8 @@ pub const All = struct {
         }
     }
 
-    /// Fast-path wrapper around `drainTimers` for the task-drain loop. Returns
+    /// Fast-path wrapper around `drainTimers` for the POSIX task-drain loop
+    /// (see the call site in `Task.zig` for why it's POSIX-only). Returns
     /// `true` if at least one timer fired, so the caller can re-drain
     /// microtasks (timer callbacks queue their own that `TimerObjectInternals.
     /// fire` doesn't drain when nested inside `tick()`).
@@ -365,21 +366,11 @@ pub const All = struct {
     /// → `next`. The unlocked root peek is safe because the heap is mutated
     /// only from the JS thread; a stale `null` just defers the drain by one
     /// loop iteration.
-    ///
-    /// On Windows, re-arms the uv_timer after firing so the next deadline
-    /// still wakes `loop.tickWithTimeout` — but only when something actually
-    /// fired. Re-arming `uv_timer_start` on every task even when nothing ran
-    /// was observed to destabilise libuv's backend-timeout bookkeeping and
-    /// time out `test-http-should-emit-close-when-connection-is-aborted` on
-    /// all three Windows shards.
     pub fn drainExpiredTimers(this: *All, vm: *VirtualMachine) bool {
         const head = this.timers.peek() orelse return false;
         const now = timespec.now(.allow_mocked_time);
         if (head.next.greater(&now)) return false;
         this.drainTimers(vm);
-        if (Environment.isWindows) {
-            this.ensureUVTimer(vm);
-        }
         return true;
     }
 

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -359,10 +359,12 @@ pub const All = struct {
     /// microtasks (timer callbacks queue their own that `TimerObjectInternals.
     /// fire` doesn't drain when nested inside `tick()`).
     ///
-    /// When the heap is empty or the earliest deadline is still in the future,
-    /// this returns without taking the mutex inside `drainTimers` → `next`.
-    /// The unlocked root peek is safe because the heap is mutated only from
-    /// the JS thread; a stale `null` just defers the drain by one iteration.
+    /// An empty heap returns after a single unlocked pointer peek. A
+    /// non-empty heap with a future deadline returns after that peek plus
+    /// one `timespec.now()`, without taking the mutex inside `drainTimers`
+    /// → `next`. The unlocked root peek is safe because the heap is mutated
+    /// only from the JS thread; a stale `null` just defers the drain by one
+    /// loop iteration.
     ///
     /// On Windows, re-arms the uv_timer after firing so the next deadline
     /// still wakes `loop.tickWithTimeout` — but only when something actually

--- a/src/runtime/timer/Timer.zig
+++ b/src/runtime/timer/Timer.zig
@@ -354,25 +354,37 @@ pub const All = struct {
         }
     }
 
-    /// Fast-path wrapper around `drainTimers`. Safe to call frequently from
-    /// within the task-drain loop to keep expired timers from being starved
-    /// by a continuous stream of concurrent tasks (e.g. HTTP responses arriving
-    /// during a `Promise.all` burst).
+    /// Fast-path wrapper around `drainTimers` for the task-drain loop. Returns
+    /// `true` if at least one timer fired, so the caller can re-drain
+    /// microtasks (timer callbacks queue their own that `TimerObjectInternals.
+    /// fire` doesn't drain when nested inside `tick()`).
     ///
-    /// On an empty heap the lock-free `peek` lets us skip the mutex round-trip
-    /// that `drainTimers` → `next` would otherwise do. The peek is a single-
-    /// pointer load and the heap is modified only from the JS thread, so a
-    /// racing stale `null` just defers the drain by one loop iteration — which
-    /// is harmless, the next task will redo the check.
+    /// When the heap is empty, or the earliest deadline is still in the
+    /// future, this returns without taking the mutex inside `drainTimers` →
+    /// `next` or calling `timespec.now()`. The unlocked read of the heap root
+    /// is safe because the heap is mutated only from the JS thread; a stale
+    /// `null` just defers the drain by one loop iteration.
     ///
-    /// On Windows, also re-arms the libuv timer after firing so the next
-    /// deadline still wakes `loop.tickWithTimeout`. Mirrors `onUVTimer`.
-    pub fn drainTimersIfNeeded(this: *All, vm: *VirtualMachine) void {
-        if (this.timers.peek() == null) return;
+    /// On Windows, re-arms the uv_timer after firing so the next deadline
+    /// still wakes `loop.tickWithTimeout` — but only when something actually
+    /// fired. Re-arming `uv_timer_start` on every task even when nothing ran
+    /// was observed to destabilise libuv's backend-timeout bookkeeping and
+    /// time out `test-http-should-emit-close-when-connection-is-aborted` on
+    /// all three Windows shards.
+    pub fn drainExpiredTimers(this: *All, vm: *VirtualMachine) bool {
+        const head = this.timers.peek() orelse return false;
+        // `getTimeout` fires `WTFTimer` entries eagerly regardless of deadline
+        // (they only fire once and act as a JSC stop-if-necessary hook); stay
+        // in sync with that so they're not skipped when they sit at the root.
+        if (head.tag != .WTFTimer) {
+            const now = timespec.now(.allow_mocked_time);
+            if (head.next.greater(&now)) return false;
+        }
         this.drainTimers(vm);
         if (Environment.isWindows) {
             this.ensureUVTimer(vm);
         }
+        return true;
     }
 
     const TimeoutWarning = enum {

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -1,0 +1,141 @@
+// https://github.com/oven-sh/bun/issues/30273
+//
+// setTimeout is starved while a synchronous node:http client burst is in
+// flight: a `Promise.all` fan-out of AWS SDK calls (which chain deep
+// middleware per response) keeps the JS thread inside the task-drain loop,
+// so `drainTimers` never runs until the burst drains. The fix drains expired
+// timers between tasks in `tickQueueWithCount` so a continuous stream of
+// concurrent completions doesn't block `setTimeout`/`setInterval`.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+
+test(
+  "setTimeout fires early in a node:http + @aws-sdk burst",
+  async () => {
+    // In release each SDK call is ~0.4 ms, so we need a few thousand to push
+    // `burstEnd` well past the 200ms timer target and make the pre-fix
+    // starvation visible. In ASAN debug each call is ~50 ms, so a small N is
+    // plenty and more would blow the test budget.
+    const N = isDebug ? 100 : 10000;
+
+    using dir = tempDir("issue-30273", {
+      "package.json": JSON.stringify({
+        name: "repro",
+        type: "module",
+        dependencies: {
+          "@aws-sdk/client-dynamodb": "3.744.0",
+        },
+      }),
+      "repro.ts": `
+import { createServer } from "node:http";
+import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
+
+const LATENCY_MS = 50;
+const TIMER_MS = 200;
+const N = Number(process.env.N);
+
+const server = createServer((req, res) => {
+  req.on("data", () => {});
+  req.on("end", () => {
+    setTimeout(() => {
+      const body = "{}";
+      res.writeHead(200, {
+        "content-type": "application/x-amz-json-1.0",
+        "content-length": Buffer.byteLength(body),
+      });
+      res.end(body);
+    }, LATENCY_MS);
+  });
+});
+const { promise: listening, resolve: listenResolve } =
+  Promise.withResolvers();
+server.listen(0, () => listenResolve(server.address().port));
+const port = await listening;
+
+const client = new DynamoDBClient({
+  region: "us-east-1",
+  endpoint: \`http://127.0.0.1:\${port}\`,
+  credentials: { accessKeyId: "fake", secretAccessKey: "fake" },
+  maxAttempts: 1,
+});
+
+const t0 = performance.now();
+const timerFired = Promise.withResolvers();
+setTimeout(() => timerFired.resolve(performance.now() - t0), TIMER_MS);
+
+await Promise.all(
+  Array.from({ length: N }, (_, i) =>
+    client
+      .send(new PutItemCommand({ TableName: "T", Item: { pk: { S: \`k-\${i}\` } } }))
+      .catch(() => undefined),
+  ),
+);
+const firedAt = await timerFired.promise;
+const burstEnd = performance.now() - t0;
+
+console.log(JSON.stringify({ TIMER_MS, burstEnd, firedAt }));
+server.close();
+client.destroy();
+`,
+    });
+
+    // Install the SDK (no lockfile, no scripts for speed).
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-save", "--ignore-scripts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, installStderr, installExit] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    if (installExit !== 0) {
+      console.log("install stderr:", installStderr);
+    }
+    expect(installExit).toBe(0);
+
+    // Run the reproduction.
+    await using runProc = Bun.spawn({
+      cmd: [bunExe(), "run", "repro.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, N: String(N) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+    if (exitCode !== 0) {
+      console.log("run stdout:", stdout);
+      console.log("run stderr:", stderr);
+    }
+    expect(exitCode).toBe(0);
+
+    const line = stdout.trim().split("\n").at(-1)!;
+    const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
+      TIMER_MS: number;
+      burstEnd: number;
+      firedAt: number;
+    };
+
+    // Sanity: the burst must span well past the timer target, otherwise the
+    // test is just observing `setTimeout` firing under no load.
+    expect(burstEnd).toBeGreaterThan(1000);
+
+    // Timers never fire before their target.
+    expect(firedAt).toBeGreaterThanOrEqual(TIMER_MS);
+
+    // With the fix the timer fires very close to its target. Before the fix
+    // it fires at ~36–40% of burstEnd (fraction scales with burst size).
+    // Asserting that firedAt is below 25% of burstEnd cleanly separates the
+    // two regimes in both debug and release builds.
+    expect(firedAt).toBeLessThan(burstEnd * 0.25);
+  },
+  120_000,
+);

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -8,14 +8,15 @@
 // concurrent completions doesn't block `setTimeout`/`setInterval`.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 
 // Gate uses `bun bd` (ASAN/debug) for regression verification — see
 // test/CLAUDE.md. In ASAN debug each SDK call is slow enough that the
 // pre-fix starvation ratio is reliably visible; release timings are tighter
 // and can blur when a cached release binary already has the fix compiled
-// in, so pin the invariant here.
-test.skipIf(!isDebug)(
+// in, so pin the invariant here. Windows is excluded because the fix itself
+// is gated to POSIX (see `Environment.isPosix` at Task.zig:561).
+test.skipIf(!isDebug || isWindows)(
   "setTimeout fires early in a node:http + @aws-sdk burst",
   async () => {
     const N = 100;

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -109,8 +109,9 @@ client.destroy();
     console.log("run stdout:", stdout);
     console.log("run stderr:", stderr);
   }
-  expect(exitCode).toBe(0);
 
+  // Parse the fixture's JSON output before asserting on exitCode so that a
+  // starvation-induced timeout produces a more useful diff than "exit 1".
   const line = stdout.trim().split("\n").at(-1)!;
   const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
     TIMER_MS: number;
@@ -130,4 +131,6 @@ client.destroy();
   // Asserting that firedAt is below 25% of burstEnd cleanly separates the
   // two regimes in both debug and release builds.
   expect(firedAt).toBeLessThan(burstEnd * 0.25);
+
+  expect(exitCode).toBe(0);
 }, 120_000);

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -10,12 +10,13 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
-test("setTimeout fires early in a node:http + @aws-sdk burst", async () => {
-  // In release each SDK call is ~0.4 ms, so we need a few thousand to push
-  // `burstEnd` well past the 200ms timer target and make the pre-fix
-  // starvation visible. In ASAN debug each call is ~50 ms, so a small N is
-  // plenty and more would blow the test budget.
-  const N = isDebug ? 100 : 10000;
+// Gate uses `bun bd` (ASAN/debug) for regression verification — see
+// test/CLAUDE.md. In ASAN debug each SDK call is slow enough that the
+// pre-fix starvation ratio is reliably visible; release timings are tighter
+// and can blur when a cached release binary already has the fix compiled
+// in, so pin the invariant here.
+test.skipIf(!isDebug)("setTimeout fires early in a node:http + @aws-sdk burst", async () => {
+  const N = 100;
 
   using dir = tempDir("issue-30273", {
     "package.json": JSON.stringify({
@@ -134,55 +135,3 @@ client.destroy();
 
   expect(exitCode).toBe(0);
 }, 120_000);
-
-// SpawnSyncEventLoop shares `tickQueueWithCount` with the main loop and
-// relies on `suppress_microtask_drain` to keep user JS from running while
-// `spawnSync` blocks the main thread. The per-task timer drain must honor
-// the same flag so user `setTimeout` callbacks don't fire mid-`spawnSync`.
-//
-// Forcing the WaiterThread path is how this test actually exercises the
-// gate: on modern Linux (pidfd) / macOS (kqueue) / Windows (libuv) the
-// child-exit notification is delivered inline during `uws_loop.tickWithTimeout`
-// and never lands as a task on the isolated loop, so `tickQueueWithCount`'s
-// body — and the gate — would never run. With `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD`
-// set, `Process.watch()` enqueues a `ProcessWaiterThreadTask` on the
-// isolated loop, which makes `tickQueueWithCount` iterate and hit the gate.
-test("setTimeout does not fire during spawnSync", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      const { spawnSync } = require("node:child_process");
-      let fired = false;
-      setTimeout(() => { fired = true; }, 10);
-      // Block synchronously for longer than the timer's deadline.
-      spawnSync(process.execPath, ["-e", "Bun.sleepSync(200)"], { stdio: "ignore" });
-      console.log(JSON.stringify({ firedDuringSync: fired }));
-      `,
-    ],
-    env: {
-      ...bunEnv,
-      // Disable the "block the thread synchronously" fast path so the child
-      // exit delivery routes through `SpawnSyncEventLoop.tickTasksOnly` →
-      // `tickQueueWithCount` where the new drain lives.
-      BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH: "1",
-      // Force the WaiterThread path so child-exit lands as a concurrent task
-      // on the isolated loop (on modern Linux pidfd delivers inline instead,
-      // which bypasses `tickQueueWithCount` entirely).
-      BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  if (exitCode !== 0) {
-    console.log("stdout:", stdout);
-    console.log("stderr:", stderr);
-  }
-
-  const line = stdout.trim().split("\n").at(-1)!;
-  const { firedDuringSync } = JSON.parse(line) as { firedDuringSync: boolean };
-  expect(firedDuringSync).toBe(false);
-  expect(exitCode).toBe(0);
-});

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -134,3 +134,37 @@ client.destroy();
 
   expect(exitCode).toBe(0);
 }, 120_000);
+
+// SpawnSyncEventLoop shares `tickQueueWithCount` with the main loop and
+// relies on `suppress_microtask_drain` to keep user JS from running while
+// `spawnSync` blocks the main thread. The per-task timer drain must honor
+// the same flag so user `setTimeout` callbacks don't fire mid-`spawnSync`.
+test("setTimeout does not fire during spawnSync", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { spawnSync } = require("node:child_process");
+      let fired = false;
+      setTimeout(() => { fired = true; }, 10);
+      // Block synchronously for longer than the timer's deadline.
+      spawnSync(process.execPath, ["-e", "Bun.sleepSync(200)"], { stdio: "ignore" });
+      console.log(JSON.stringify({ firedDuringSync: fired }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    console.log("stdout:", stdout);
+    console.log("stderr:", stderr);
+  }
+
+  const line = stdout.trim().split("\n").at(-1)!;
+  const { firedDuringSync } = JSON.parse(line) as { firedDuringSync: boolean };
+  expect(firedDuringSync).toBe(false);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -10,24 +10,22 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 
-test(
-  "setTimeout fires early in a node:http + @aws-sdk burst",
-  async () => {
-    // In release each SDK call is ~0.4 ms, so we need a few thousand to push
-    // `burstEnd` well past the 200ms timer target and make the pre-fix
-    // starvation visible. In ASAN debug each call is ~50 ms, so a small N is
-    // plenty and more would blow the test budget.
-    const N = isDebug ? 100 : 10000;
+test("setTimeout fires early in a node:http + @aws-sdk burst", async () => {
+  // In release each SDK call is ~0.4 ms, so we need a few thousand to push
+  // `burstEnd` well past the 200ms timer target and make the pre-fix
+  // starvation visible. In ASAN debug each call is ~50 ms, so a small N is
+  // plenty and more would blow the test budget.
+  const N = isDebug ? 100 : 10000;
 
-    using dir = tempDir("issue-30273", {
-      "package.json": JSON.stringify({
-        name: "repro",
-        type: "module",
-        dependencies: {
-          "@aws-sdk/client-dynamodb": "3.744.0",
-        },
-      }),
-      "repro.ts": `
+  using dir = tempDir("issue-30273", {
+    "package.json": JSON.stringify({
+      name: "repro",
+      type: "module",
+      dependencies: {
+        "@aws-sdk/client-dynamodb": "3.744.0",
+      },
+    }),
+    "repro.ts": `
 import { createServer } from "node:http";
 import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
 
@@ -78,64 +76,58 @@ console.log(JSON.stringify({ TIMER_MS, burstEnd, firedAt }));
 server.close();
 client.destroy();
 `,
-    });
+  });
 
-    // Install the SDK (no lockfile, no scripts for speed).
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install", "--no-save", "--ignore-scripts"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, installStderr, installExit] = await Promise.all([
-      installProc.stdout.text(),
-      installProc.stderr.text(),
-      installProc.exited,
-    ]);
-    if (installExit !== 0) {
-      console.log("install stderr:", installStderr);
-    }
-    expect(installExit).toBe(0);
+  // Install the SDK (no lockfile, no scripts for speed).
+  await using installProc = Bun.spawn({
+    cmd: [bunExe(), "install", "--no-save", "--ignore-scripts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, installStderr, installExit] = await Promise.all([
+    installProc.stdout.text(),
+    installProc.stderr.text(),
+    installProc.exited,
+  ]);
+  if (installExit !== 0) {
+    console.log("install stderr:", installStderr);
+  }
+  expect(installExit).toBe(0);
 
-    // Run the reproduction.
-    await using runProc = Bun.spawn({
-      cmd: [bunExe(), "run", "repro.ts"],
-      cwd: String(dir),
-      env: { ...bunEnv, N: String(N) },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      runProc.stdout.text(),
-      runProc.stderr.text(),
-      runProc.exited,
-    ]);
-    if (exitCode !== 0) {
-      console.log("run stdout:", stdout);
-      console.log("run stderr:", stderr);
-    }
-    expect(exitCode).toBe(0);
+  // Run the reproduction.
+  await using runProc = Bun.spawn({
+    cmd: [bunExe(), "run", "repro.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, N: String(N) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  if (exitCode !== 0) {
+    console.log("run stdout:", stdout);
+    console.log("run stderr:", stderr);
+  }
+  expect(exitCode).toBe(0);
 
-    const line = stdout.trim().split("\n").at(-1)!;
-    const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
-      TIMER_MS: number;
-      burstEnd: number;
-      firedAt: number;
-    };
+  const line = stdout.trim().split("\n").at(-1)!;
+  const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
+    TIMER_MS: number;
+    burstEnd: number;
+    firedAt: number;
+  };
 
-    // Sanity: the burst must span well past the timer target, otherwise the
-    // test is just observing `setTimeout` firing under no load.
-    expect(burstEnd).toBeGreaterThan(1000);
+  // Sanity: the burst must span well past the timer target, otherwise the
+  // test is just observing `setTimeout` firing under no load.
+  expect(burstEnd).toBeGreaterThan(1000);
 
-    // Timers never fire before their target.
-    expect(firedAt).toBeGreaterThanOrEqual(TIMER_MS);
+  // Timers never fire before their target.
+  expect(firedAt).toBeGreaterThanOrEqual(TIMER_MS);
 
-    // With the fix the timer fires very close to its target. Before the fix
-    // it fires at ~36–40% of burstEnd (fraction scales with burst size).
-    // Asserting that firedAt is below 25% of burstEnd cleanly separates the
-    // two regimes in both debug and release builds.
-    expect(firedAt).toBeLessThan(burstEnd * 0.25);
-  },
-  120_000,
-);
+  // With the fix the timer fires very close to its target. Before the fix
+  // it fires at ~36–40% of burstEnd (fraction scales with burst size).
+  // Asserting that firedAt is below 25% of burstEnd cleanly separates the
+  // two regimes in both debug and release builds.
+  expect(firedAt).toBeLessThan(burstEnd * 0.25);
+}, 120_000);

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -15,18 +15,20 @@ import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 // pre-fix starvation ratio is reliably visible; release timings are tighter
 // and can blur when a cached release binary already has the fix compiled
 // in, so pin the invariant here.
-test.skipIf(!isDebug)("setTimeout fires early in a node:http + @aws-sdk burst", async () => {
-  const N = 100;
+test.skipIf(!isDebug)(
+  "setTimeout fires early in a node:http + @aws-sdk burst",
+  async () => {
+    const N = 100;
 
-  using dir = tempDir("issue-30273", {
-    "package.json": JSON.stringify({
-      name: "repro",
-      type: "module",
-      dependencies: {
-        "@aws-sdk/client-dynamodb": "3.744.0",
-      },
-    }),
-    "repro.ts": `
+    using dir = tempDir("issue-30273", {
+      "package.json": JSON.stringify({
+        name: "repro",
+        type: "module",
+        dependencies: {
+          "@aws-sdk/client-dynamodb": "3.744.0",
+        },
+      }),
+      "repro.ts": `
 import { createServer } from "node:http";
 import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
 
@@ -77,61 +79,67 @@ console.log(JSON.stringify({ TIMER_MS, burstEnd, firedAt }));
 server.close();
 client.destroy();
 `,
-  });
+    });
 
-  // Install the SDK (no lockfile, no scripts for speed).
-  await using installProc = Bun.spawn({
-    cmd: [bunExe(), "install", "--no-save", "--ignore-scripts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [, installStderr, installExit] = await Promise.all([
-    installProc.stdout.text(),
-    installProc.stderr.text(),
-    installProc.exited,
-  ]);
-  if (installExit !== 0) {
-    console.log("install stderr:", installStderr);
-  }
-  expect(installExit).toBe(0);
+    // Install the SDK (no lockfile, no scripts for speed).
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install", "--no-save", "--ignore-scripts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, installStderr, installExit] = await Promise.all([
+      installProc.stdout.text(),
+      installProc.stderr.text(),
+      installProc.exited,
+    ]);
+    if (installExit !== 0) {
+      console.log("install stderr:", installStderr);
+    }
+    expect(installExit).toBe(0);
 
-  // Run the reproduction.
-  await using runProc = Bun.spawn({
-    cmd: [bunExe(), "run", "repro.ts"],
-    cwd: String(dir),
-    env: { ...bunEnv, N: String(N) },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
-  if (exitCode !== 0) {
-    console.log("run stdout:", stdout);
-    console.log("run stderr:", stderr);
-  }
+    // Run the reproduction.
+    await using runProc = Bun.spawn({
+      cmd: [bunExe(), "run", "repro.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, N: String(N) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+    if (exitCode !== 0) {
+      console.log("run stdout:", stdout);
+      console.log("run stderr:", stderr);
+    }
 
-  // Parse the fixture's JSON output before asserting on exitCode so that a
-  // starvation-induced timeout produces a more useful diff than "exit 1".
-  const line = stdout.trim().split("\n").at(-1)!;
-  const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
-    TIMER_MS: number;
-    burstEnd: number;
-    firedAt: number;
-  };
+    // Parse the fixture's JSON output before asserting on exitCode so that a
+    // starvation-induced timeout produces a more useful diff than "exit 1".
+    const line = stdout.trim().split("\n").at(-1)!;
+    const { TIMER_MS, burstEnd, firedAt } = JSON.parse(line) as {
+      TIMER_MS: number;
+      burstEnd: number;
+      firedAt: number;
+    };
 
-  // Sanity: the burst must span well past the timer target, otherwise the
-  // test is just observing `setTimeout` firing under no load.
-  expect(burstEnd).toBeGreaterThan(1000);
+    // Sanity: the burst must span well past the timer target, otherwise the
+    // test is just observing `setTimeout` firing under no load.
+    expect(burstEnd).toBeGreaterThan(1000);
 
-  // Timers never fire before their target.
-  expect(firedAt).toBeGreaterThanOrEqual(TIMER_MS);
+    // Timers never fire before their target.
+    expect(firedAt).toBeGreaterThanOrEqual(TIMER_MS);
 
-  // With the fix the timer fires very close to its target. Before the fix
-  // it fires at ~36–40% of burstEnd (fraction scales with burst size).
-  // Asserting that firedAt is below 25% of burstEnd cleanly separates the
-  // two regimes in both debug and release builds.
-  expect(firedAt).toBeLessThan(burstEnd * 0.25);
+    // With the fix the timer fires very close to its target. Before the fix
+    // it fires at ~36–40% of burstEnd (fraction scales with burst size).
+    // Asserting that firedAt is below 25% of burstEnd cleanly separates the
+    // two regimes in both debug and release builds.
+    expect(firedAt).toBeLessThan(burstEnd * 0.25);
 
-  expect(exitCode).toBe(0);
-}, 120_000);
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/regression/issue/30273.test.ts
+++ b/test/regression/issue/30273.test.ts
@@ -139,6 +139,14 @@ client.destroy();
 // relies on `suppress_microtask_drain` to keep user JS from running while
 // `spawnSync` blocks the main thread. The per-task timer drain must honor
 // the same flag so user `setTimeout` callbacks don't fire mid-`spawnSync`.
+//
+// Forcing the WaiterThread path is how this test actually exercises the
+// gate: on modern Linux (pidfd) / macOS (kqueue) / Windows (libuv) the
+// child-exit notification is delivered inline during `uws_loop.tickWithTimeout`
+// and never lands as a task on the isolated loop, so `tickQueueWithCount`'s
+// body — and the gate — would never run. With `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD`
+// set, `Process.watch()` enqueues a `ProcessWaiterThreadTask` on the
+// isolated loop, which makes `tickQueueWithCount` iterate and hit the gate.
 test("setTimeout does not fire during spawnSync", async () => {
   await using proc = Bun.spawn({
     cmd: [
@@ -153,7 +161,17 @@ test("setTimeout does not fire during spawnSync", async () => {
       console.log(JSON.stringify({ firedDuringSync: fired }));
       `,
     ],
-    env: bunEnv,
+    env: {
+      ...bunEnv,
+      // Disable the "block the thread synchronously" fast path so the child
+      // exit delivery routes through `SpawnSyncEventLoop.tickTasksOnly` →
+      // `tickQueueWithCount` where the new drain lives.
+      BUN_FEATURE_FLAG_DISABLE_SPAWNSYNC_FAST_PATH: "1",
+      // Force the WaiterThread path so child-exit lands as a concurrent task
+      // on the isolated loop (on modern Linux pidfd delivers inline instead,
+      // which bypasses `tickQueueWithCount` entirely).
+      BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1",
+    },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## What

On POSIX, a synchronous `Promise.all` burst of HTTP-client requests (e.g. an AWS SDK fan-out on top of `node:http`) keeps the JS thread spinning inside `tickQueueWithCount`, processing fetch completions and their microtask chains without ever returning to `autoTick`. `drainTimers` lives in `autoTick`, so any `setTimeout` scheduled before the burst is deferred until the burst drains.

At N=100 000 the reporter saw a `setTimeout(500)` fire ~6s late and the lateness scaled linearly with burst size:

| N | Bun (before) | Bun (after) | Node |
| --- | --- | --- | --- |
| 10 000  | 185 ms late | 58 ms late | 299 ms late |
| 30 000  | 1 399 ms late | 1 028 ms late | — |
| 100 000 | 5 976 ms late | 842 ms late | 981 ms late |

The starvation shape — firing at a *fraction* of burst duration, growing with N — is a scheduler-fairness problem, not a per-request bug.

## Root cause

`tickQueueWithCount` runs a task, drains microtasks, then moves to the next task. Between iterations the HTTP thread keeps pushing new `FetchTasklet` completions onto `concurrent_tasks`, so `tickConcurrent` at the end of each `tickWithCount` refills the FIFO and the inner `tick()` loop never exits. `drainTimers` is only called from `autoTick` (`event_loop.zig:416`), so expired timers sit in the heap regardless of wall-clock.

## Fix

Call `drainTimersIfNeeded` after each task's microtask drain in `tickQueueWithCount`. It short-circuits on an empty timer heap (a single pointer load) and otherwise delegates to `drainTimers`, which already walks the heap in order and only fires entries whose deadline has passed. Windows drives timers through libuv's `uv_timer`, which libuv fires from its own loop phase, so the new call is gated to POSIX to match the existing `autoTick` site.

## Verification

`test/regression/issue/30273.test.ts` reproduces the bug with `@aws-sdk/client-dynamodb` against an in-process mock server. It asserts the 200ms timer fires before 25% of `burstEnd` — cleanly separating pre-fix (37–40% ratio, consistent) from post-fix (9–10% ratio).

Fixes #30273