### PR TITLE
fix(Blob): handle non-FileSink result from writer() options parsing

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,12 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        if (stream_start == .FileSink) {
+            stream_start.FileSink.input_path.deinit();
+            stream_start.FileSink.input_path = input_path;
+        } else {
+            stream_start = .{ .FileSink = .{ .input_path = input_path } };
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,29 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+it("writer() options with non-string path does not crash", async () => {
+  const x = tmpdirSync();
+  const target = path.join(x, "test.txt");
+  const file = Bun.file(target);
+  // @ts-expect-error
+  file.path = Array;
+  const writer = file.writer(file);
+  await writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(target).text()).toBe("hello");
+});
+
+it("writer() options with invalid fd does not crash", async () => {
+  const x = tmpdirSync();
+  const target = path.join(x, "test.txt");
+  const file = Bun.file(target);
+  // @ts-expect-error
+  const writer = file.writer({ fd: "not a number" });
+  await writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(target).text()).toBe("hello");
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in `Bun.file(path).writer(options)` when the options object has a `path` property that isn't a string or an `fd` property that isn't an integer.

`Start.fromJSWithTag(.FileSink)` returns `.err` in these cases, but `Blob.getWriter` unconditionally accessed `stream_start.FileSink.input_path`, triggering a union safety panic in debug builds.

Since `getWriter` always overrides `input_path` with the Blob's own path anyway, the path/fd validation error from the options parser is irrelevant — fall back to a default `.FileSink` start in that case. Also frees any path slice allocated by the parser before overriding it (pre-existing leak).

## Repro

```js
const f = Bun.file("/tmp/x");
f.path = Array; // any non-string
f.writer(f);    // panic: access of union field 'FileSink' while field 'err' is active
```

Found by Fuzzilli. Fingerprint: `7f61b5b6e1d8a757`

## How did you verify your code works?

- Original fuzzer repro no longer panics
- Added regression tests in `test/js/bun/util/filesink.test.ts` covering both the non-string `path` and non-integer `fd` cases
- All existing filesink tests pass