### PR TITLE
Skip `dist/` and `build/` by default during `bun test` discovery

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -201,7 +201,7 @@ pathIgnorePatterns = ["vendor/**", "submodules/**", "fixtures/**"]
 
 Equivalent CLI flag: `--path-ignore-patterns`. CLI flags override the `bunfig.toml` value entirely.
 
-When `pathIgnorePatterns` is not set, Bun falls back to a built-in default list (`**/dist/**`, `**/build/**`) so compiled copies of test files under conventional output directories aren't discovered twice. Providing any value -- including an empty array `pathIgnorePatterns = []` -- disables the defaults.
+When `pathIgnorePatterns` is not set, Bun falls back to a built-in default list (`**/dist/**`, `**/build/**`) so compiled copies of test files under conventional output directories aren't discovered twice. Providing any value -- including an empty array `pathIgnorePatterns = []` -- disables the defaults. The defaults only affect auto-discovery: explicit CLI paths like `bun test ./build/foo.test.ts` still run. User-configured patterns apply to explicit arguments too.
 
 ### `test.smol`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -201,6 +201,8 @@ pathIgnorePatterns = ["vendor/**", "submodules/**", "fixtures/**"]
 
 Equivalent CLI flag: `--path-ignore-patterns`. CLI flags override the `bunfig.toml` value entirely.
 
+When `pathIgnorePatterns` is not set, Bun falls back to a built-in default list (`**/dist/**`, `**/build/**`) so compiled copies of test files under conventional output directories aren't discovered twice. Providing any value -- including an empty array `pathIgnorePatterns = []` -- disables the defaults.
+
 ### `test.smol`
 
 Same as the top-level `smol` field, but only applies to `bun test`.

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -112,6 +112,22 @@ bun test --path-ignore-patterns 'vendor/**' --path-ignore-patterns 'fixtures/**'
 
 Bun prunes directories matching a pattern during scanning and never traverses their contents, so ignoring a large directory tree is cheap.
 
+#### Default Patterns
+
+If `pathIgnorePatterns` is not configured, Bun uses these defaults:
+
+```toml title="implicit defaults"
+pathIgnorePatterns = ["**/dist/**", "**/build/**"]
+```
+
+This prevents compiled copies of test files (for example, from `tsc` writing to `build/`) from being picked up alongside the originals in `src/`. Providing any explicit value -- including an empty array -- replaces the default list:
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+# Run tests from `dist/` and `build/` as well as everywhere else.
+pathIgnorePatterns = []
+```
+
 #### Common Use Cases
 
 ```toml title="bunfig.toml" icon="settings"

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -128,6 +128,8 @@ This prevents compiled copies of test files (for example, from `tsc` writing to 
 pathIgnorePatterns = []
 ```
 
+The defaults only affect auto-discovery. Explicit file or directory arguments on the CLI (for example, `bun test ./build/foo.test.ts` or `bun test ./build`) still run the specified tests even when the defaults are active -- if you point at a path, Bun trusts you. Any patterns you configure yourself still apply to explicit arguments, so `pathIgnorePatterns = ["**/build/**"]` will filter the file out whether auto-discovered or named on the CLI.
+
 #### Common Use Cases
 
 ```toml title="bunfig.toml" icon="settings"

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -682,8 +682,7 @@ impl<'a> Parser<'a> {
                             }
                             ExprData::EArray(arr) => {
                                 let items = arr.items.slice();
-                                // An explicit empty array opts out of the default
-                                // ignore patterns without supplying any of its own.
+                                // An explicit empty array opts out of the defaults.
                                 self.ctx.test_options.path_ignore_patterns_configured = true;
                                 if items.is_empty() {
                                     break 'brk;

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -678,9 +678,13 @@ impl<'a> Parser<'a> {
                             ExprData::EString(s) => {
                                 self.ctx.test_options.path_ignore_patterns =
                                     vec![estring_to_owned(s, self.bump)];
+                                self.ctx.test_options.path_ignore_patterns_configured = true;
                             }
                             ExprData::EArray(arr) => {
                                 let items = arr.items.slice();
+                                // An explicit empty array opts out of the default
+                                // ignore patterns without supplying any of its own.
+                                self.ctx.test_options.path_ignore_patterns_configured = true;
                                 if items.is_empty() {
                                     break 'brk;
                                 }

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
+          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
         },
         minify: {
           syntax: !debug,

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -411,6 +411,10 @@ pub struct TestOptions {
     pub coverage: CodeCoverageOptions,
     pub path_ignore_patterns: Vec<Box<[u8]>>,
     pub path_ignore_patterns_from_cli: bool,
+    /// True if `pathIgnorePatterns` was explicitly set by the user via the
+    /// CLI flag or `bunfig.toml`. When false, the scanner falls back to its
+    /// built-in defaults (e.g. `**/dist/**`, `**/build/**`).
+    pub path_ignore_patterns_configured: bool,
     pub test_filter_pattern: Option<Box<[u8]>>,
     /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free
     /// of `jsc/` references. Read via `test_filter_regex()`.
@@ -495,6 +499,7 @@ impl Default for TestOptions {
             coverage: CodeCoverageOptions::default(),
             path_ignore_patterns: Vec::new(),
             path_ignore_patterns_from_cli: false,
+            path_ignore_patterns_configured: false,
             test_filter_pattern: None,
             test_filter_regex: None,
             // Under ASAN every spawned `bun` child is several-× heavier in

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -411,9 +411,8 @@ pub struct TestOptions {
     pub coverage: CodeCoverageOptions,
     pub path_ignore_patterns: Vec<Box<[u8]>>,
     pub path_ignore_patterns_from_cli: bool,
-    /// True if `pathIgnorePatterns` was explicitly set by the user via the
-    /// CLI flag or `bunfig.toml`. When false, the scanner falls back to its
-    /// built-in defaults (e.g. `**/dist/**`, `**/build/**`).
+    /// Set when `pathIgnorePatterns` comes from the CLI flag or `bunfig.toml`;
+    /// unset means the scanner uses its built-in defaults.
     pub path_ignore_patterns_configured: bool,
     pub test_filter_pattern: Option<Box<[u8]>>,
     /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1825,6 +1825,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         ctx.test_options.path_ignore_patterns =
             slice_to_owned(args.options(b"--path-ignore-patterns"));
         ctx.test_options.path_ignore_patterns_from_cli = true;
+        ctx.test_options.path_ignore_patterns_configured = true;
     }
 
     if let Some(bail) = args.option(b"--bail") {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -24,11 +24,8 @@ pub struct Scanner<'a> {
     /// Glob patterns for paths to ignore. Matched against the path relative to the
     /// project root (top_level_dir). When a file matches any pattern, it is excluded.
     pub(crate) path_ignore_patterns: &'a [&'a [u8]],
-    /// Whether `path_ignore_patterns` are the built-in defaults (see
-    /// `DEFAULT_PATH_IGNORE_PATTERNS`) vs a list configured by the user via
-    /// `--path-ignore-patterns` or `bunfig.toml`. When true, explicit file/directory
-    /// arguments bypass the matching defaults — otherwise running
-    /// `bun test ./build/foo.test.ts` would silently match nothing.
+    /// True when `path_ignore_patterns` is `DEFAULT_PATH_IGNORE_PATTERNS`
+    /// rather than user-configured; `scan_explicit` only bypasses defaults.
     pub(crate) path_ignore_patterns_are_defaults: bool,
     pub(crate) dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
@@ -138,36 +135,23 @@ impl<'a> Scanner<'a> {
         self.scan_internal(path_literal, ScanMode::AutoDiscover)
     }
 
-    /// Like `scan`, but the path came from an explicit command-line argument
-    /// (`bun test ./build/foo.test.ts`). When the patterns in play are the
-    /// Scanner's built-in defaults, drop only the ones matching the explicit
-    /// root for this invocation (see `scan_internal`) — the user pointed at
-    /// this file/directory, so silently dropping it would be surprising. Any
-    /// patterns the user configured themselves still apply.
+    /// Like `scan`, but for an explicit CLI path (`bun test ./build/foo.test.ts`):
+    /// default ignore patterns matching the path itself are dropped for this
+    /// invocation so the named file/directory runs. User-configured patterns
+    /// still apply.
     pub(crate) fn scan_explicit(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
         self.scan_internal(path_literal, ScanMode::ExplicitPath)
     }
 
     fn scan_internal(&mut self, path_literal: &[u8], mode: ScanMode) -> Result<(), ScanError> {
-        // Explicit paths narrow the built-in defaults only: any pattern that
-        // would match the explicit root itself is dropped for this scan, but
-        // every other default keeps pruning. So `bun test ./build/foo.test.ts`
-        // drops `**/build/**` and runs the named file, while
-        // `bun test ./packages/foo` keeps both defaults and still prunes
-        // `packages/foo/dist/`. User-configured patterns are untouched.
-        //
-        // Stored on the heap so `self.path_ignore_patterns` can alias a slice
-        // into it for the duration of this scan; restored via the RAII guard
-        // so `?` early-returns also clean up.
         let saved_patterns = self.path_ignore_patterns;
         let narrowed: Option<Box<[&'static [u8]]>> = if matches!(mode, ScanMode::ExplicitPath)
             && self.path_ignore_patterns_are_defaults
         {
-            // Match each default against the root's project-relative path. An
-            // empty `rel_path` means the explicit arg *is* the project root, so
-            // no default matches it (keep them all) — matching the raw absolute
-            // `path_literal` would wrongly drop `**/build/**` for a project that
-            // merely lives under a `build`/`dist` ancestor (e.g. `/opt/build/app`).
+            // Match against the project-relative path: an empty `rel_path` means
+            // the arg is the project root itself, which no default matches, so
+            // all stay active (a `build`/`dist` ancestor outside the project
+            // must not drop a default).
             let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
             let mut kept: Vec<&'static [u8]> = Vec::with_capacity(self.path_ignore_patterns.len());
             for &pattern in self.path_ignore_patterns {
@@ -505,24 +489,18 @@ impl<'a> Scanner<'a> {
 
 pub(crate) const TEST_NAME_SUFFIXES: [&[u8]; 4] = [b".test", b"_test", b".spec", b"_spec"];
 
-/// Glob patterns applied when the user has not configured
-/// `pathIgnorePatterns` (neither in `bunfig.toml` nor via
-/// `--path-ignore-patterns`). Matches the relative path from the project
-/// root, so these patterns prune the conventional output directories at any
-/// depth. An explicit (even empty) user configuration replaces this list.
+/// Ignore patterns used when `pathIgnorePatterns` is not configured. Any
+/// explicit user configuration (even an empty array) replaces this list.
 pub(crate) const DEFAULT_PATH_IGNORE_PATTERNS: [&[u8]; 2] = [b"**/dist/**", b"**/build/**"];
 
-/// Returns true if `pattern` matches `rel_path`. Handles the same two-attempt
-/// glob behavior as the main scanner match: try the raw relative path first,
-/// then retry with a trailing `/` for `**` patterns (so `**/build/**` matches
-/// the bare directory name `packages/sub/build` as well as files under it).
+/// Whether `pattern` matches `rel_path`, retrying with a trailing `/` for
+/// `**` patterns so `**/build/**` also matches the bare directory name.
 fn pattern_matches_path(pattern: &[u8], rel_path: &[u8]) -> bool {
     if bun_glob::r#match(pattern, rel_path).matches() {
         return true;
     }
-    // Only try trailing separator for ** patterns (e.g. "vendor/**").
-    // Single-star patterns like "vendor/*" must not prune entire
-    // directories because * doesn't cross directory boundaries.
+    // Trailing-separator retry is only valid for ** patterns; a single `*`
+    // doesn't cross directory boundaries and must not prune whole trees.
     if rel_path.is_empty()
         || rel_path[rel_path.len() - 1] == b'/'
         || strings::index_of(pattern, b"**").is_none()

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -174,7 +174,7 @@ impl<'a> Scanner<'a> {
                     // SAFETY: all entries in DEFAULT_PATH_IGNORE_PATTERNS are
                     // &'static [u8] byte-string literals; the `_are_defaults`
                     // flag guarantees that's the slice we're iterating.
-                    kept.push(unsafe { &*(pattern as *const [u8]) });
+                    kept.push(unsafe { &*core::ptr::from_ref::<[u8]>(pattern) });
                 }
             }
             Some(kept.into_boxed_slice())
@@ -199,7 +199,7 @@ impl<'a> Scanner<'a> {
             }
         }
         let _restore: RestorePatterns<'_, 'a> = RestorePatterns {
-            scanner: self as *mut _,
+            scanner: core::ptr::from_mut(self),
             saved: saved_patterns,
             active: narrowed.is_some(),
             _m: core::marker::PhantomData,

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -153,13 +153,11 @@ impl<'a> Scanner<'a> {
             // all stay active (a `build`/`dist` ancestor outside the project
             // must not drop a default).
             let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
-            let mut kept: Vec<&'static [u8]> = Vec::with_capacity(self.path_ignore_patterns.len());
-            for &pattern in self.path_ignore_patterns {
+            let mut kept: Vec<&'static [u8]> =
+                Vec::with_capacity(DEFAULT_PATH_IGNORE_PATTERNS.len());
+            for &pattern in DEFAULT_PATH_IGNORE_PATTERNS.iter() {
                 if !pattern_matches_path(pattern, rel_path) {
-                    // SAFETY: all entries in DEFAULT_PATH_IGNORE_PATTERNS are
-                    // &'static [u8] byte-string literals; the `_are_defaults`
-                    // flag guarantees that's the slice we're iterating.
-                    kept.push(unsafe { &*core::ptr::from_ref::<[u8]>(pattern) });
+                    kept.push(pattern);
                 }
             }
             Some(kept.into_boxed_slice())

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -148,15 +148,35 @@ impl<'a> Scanner<'a> {
     }
 
     fn scan_internal(&mut self, path_literal: &[u8], mode: ScanMode) -> Result<(), ScanError> {
-        // Explicit paths bypass the built-in defaults only. User-configured
-        // patterns stay in effect either way. Swap the field in place and
-        // restore it on scope exit so `?` early-returns also clean up.
+        // Explicit paths narrow the built-in defaults only: any pattern that
+        // would match the explicit root itself is dropped for this scan, but
+        // every other default keeps pruning. So `bun test ./build/foo.test.ts`
+        // drops `**/build/**` and runs the named file, while
+        // `bun test ./packages/foo` keeps both defaults and still prunes
+        // `packages/foo/dist/`. User-configured patterns are untouched.
+        //
+        // Stored on the heap so `self.path_ignore_patterns` can alias a slice
+        // into it for the duration of this scan; restored via the RAII guard
+        // so `?` early-returns also clean up.
         let saved_patterns = self.path_ignore_patterns;
-        let bypass_defaults =
-            matches!(mode, ScanMode::ExplicitPath) && self.path_ignore_patterns_are_defaults;
-        if bypass_defaults {
-            self.path_ignore_patterns = &[];
-        }
+        let narrowed: Option<Box<[&'static [u8]]>> = if matches!(mode, ScanMode::ExplicitPath)
+            && self.path_ignore_patterns_are_defaults
+        {
+            let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
+            let rel_source: &[u8] = if rel_path.is_empty() { path_literal } else { rel_path };
+            let mut kept: Vec<&'static [u8]> = Vec::with_capacity(self.path_ignore_patterns.len());
+            for &pattern in self.path_ignore_patterns {
+                if !pattern_matches_path(pattern, rel_source) {
+                    // SAFETY: all entries in DEFAULT_PATH_IGNORE_PATTERNS are
+                    // &'static [u8] byte-string literals; the `_are_defaults`
+                    // flag guarantees that's the slice we're iterating.
+                    kept.push(unsafe { &*(pattern as *const [u8]) });
+                }
+            }
+            Some(kept.into_boxed_slice())
+        } else {
+            None
+        };
         // RAII guard so early-returns still restore the field.
         struct RestorePatterns<'r, 'a> {
             scanner: *mut Scanner<'a>,
@@ -177,9 +197,15 @@ impl<'a> Scanner<'a> {
         let _restore: RestorePatterns<'_, 'a> = RestorePatterns {
             scanner: self as *mut _,
             saved: saved_patterns,
-            active: bypass_defaults,
+            active: narrowed.is_some(),
             _m: core::marker::PhantomData,
         };
+        if let Some(ref kept) = narrowed {
+            // SAFETY: lifetime-erase; `narrowed` lives until end of this
+            // function (after the RAII guard restores).
+            self.path_ignore_patterns =
+                unsafe { core::slice::from_raw_parts(kept.as_ptr(), kept.len()) };
+        }
 
         let mut scan_dir_buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
@@ -368,34 +394,9 @@ impl<'a> Scanner<'a> {
             return false;
         }
         let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
-
-        // Build rel_path + '/' once. rel_path is a relative path from the project
-        // root; 4096 bytes covers any sane test directory depth (POSIX PATH_MAX).
-        let mut buf = [0u8; 4096];
-        let rel_with_slash: Option<&[u8]> = if !rel_path.is_empty()
-            && rel_path.len() < buf.len()
-            && rel_path[rel_path.len() - 1] != b'/'
-        {
-            buf[..rel_path.len()].copy_from_slice(rel_path);
-            buf[rel_path.len()] = b'/';
-            Some(&buf[..rel_path.len() + 1])
-        } else {
-            None
-        };
-
         for pattern in self.path_ignore_patterns {
-            if bun_glob::r#match(pattern, rel_path).matches() {
+            if pattern_matches_path(pattern, rel_path) {
                 return true;
-            }
-            // Only try trailing separator for ** patterns (e.g. "vendor/**").
-            // Single-star patterns like "vendor/*" must not prune entire
-            // directories because * doesn't cross directory boundaries.
-            if let Some(p) = rel_with_slash {
-                if strings::index_of(pattern, b"**").is_some() {
-                    if bun_glob::r#match(pattern, p).matches() {
-                        return true;
-                    }
-                }
             }
         }
         false
@@ -505,6 +506,32 @@ pub(crate) const TEST_NAME_SUFFIXES: [&[u8]; 4] = [b".test", b"_test", b".spec",
 /// root, so these patterns prune the conventional output directories at any
 /// depth. An explicit (even empty) user configuration replaces this list.
 pub(crate) const DEFAULT_PATH_IGNORE_PATTERNS: [&[u8]; 2] = [b"**/dist/**", b"**/build/**"];
+
+/// Returns true if `pattern` matches `rel_path`. Handles the same two-attempt
+/// glob behavior as the main scanner match: try the raw relative path first,
+/// then retry with a trailing `/` for `**` patterns (so `**/build/**` matches
+/// the bare directory name `packages/sub/build` as well as files under it).
+fn pattern_matches_path(pattern: &[u8], rel_path: &[u8]) -> bool {
+    if bun_glob::r#match(pattern, rel_path).matches() {
+        return true;
+    }
+    // Only try trailing separator for ** patterns (e.g. "vendor/**").
+    // Single-star patterns like "vendor/*" must not prune entire
+    // directories because * doesn't cross directory boundaries.
+    if rel_path.is_empty()
+        || rel_path[rel_path.len() - 1] == b'/'
+        || strings::index_of(pattern, b"**").is_none()
+    {
+        return false;
+    }
+    let mut buf = [0u8; 4096];
+    if rel_path.len() >= buf.len() {
+        return false;
+    }
+    buf[..rel_path.len()].copy_from_slice(rel_path);
+    buf[rel_path.len()] = b'/';
+    bun_glob::r#match(pattern, &buf[..rel_path.len() + 1]).matches()
+}
 
 #[derive(Copy, Clone)]
 enum ScanMode {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -27,6 +27,9 @@ pub struct Scanner<'a> {
     /// True when `path_ignore_patterns` is `DEFAULT_PATH_IGNORE_PATTERNS`
     /// rather than user-configured; `scan_explicit` only bypasses defaults.
     pub(crate) path_ignore_patterns_are_defaults: bool,
+    /// Bit `i` set disables `DEFAULT_PATH_IGNORE_PATTERNS[i]` for the current
+    /// scan; recomputed at the start of every scan.
+    disabled_defaults_mask: u8,
     pub(crate) dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
     pub(crate) test_files: Vec<Interned>,
@@ -88,6 +91,7 @@ impl<'a> Scanner<'a> {
             filter_names: &[],
             path_ignore_patterns: &[],
             path_ignore_patterns_are_defaults: false,
+            disabled_defaults_mask: 0,
             dirs_to_scan: Fifo::new(),
             options: &transpiler.options,
             fs: transpiler.fs,
@@ -144,54 +148,19 @@ impl<'a> Scanner<'a> {
     }
 
     fn scan_internal(&mut self, path_literal: &[u8], mode: ScanMode) -> Result<(), ScanError> {
-        let saved_patterns = self.path_ignore_patterns;
-        let narrowed: Option<Box<[&'static [u8]]>> = if matches!(mode, ScanMode::ExplicitPath)
-            && self.path_ignore_patterns_are_defaults
-        {
+        // Recomputed per scan, so no restore is needed on early return.
+        self.disabled_defaults_mask = 0;
+        if matches!(mode, ScanMode::ExplicitPath) && self.path_ignore_patterns_are_defaults {
             // Match against the project-relative path: an empty `rel_path` means
             // the arg is the project root itself, which no default matches, so
             // all stay active (a `build`/`dist` ancestor outside the project
             // must not drop a default).
             let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
-            let mut kept: Vec<&'static [u8]> =
-                Vec::with_capacity(DEFAULT_PATH_IGNORE_PATTERNS.len());
-            for &pattern in DEFAULT_PATH_IGNORE_PATTERNS.iter() {
-                if !pattern_matches_path(pattern, rel_path) {
-                    kept.push(pattern);
+            for (i, &pattern) in DEFAULT_PATH_IGNORE_PATTERNS.iter().enumerate() {
+                if pattern_matches_path(pattern, rel_path) {
+                    self.disabled_defaults_mask |= 1 << i;
                 }
             }
-            Some(kept.into_boxed_slice())
-        } else {
-            None
-        };
-        // RAII guard so early-returns still restore the field.
-        struct RestorePatterns<'r, 'a> {
-            scanner: *mut Scanner<'a>,
-            saved: &'a [&'a [u8]],
-            active: bool,
-            _m: core::marker::PhantomData<&'r ()>,
-        }
-        impl<'r, 'a> Drop for RestorePatterns<'r, 'a> {
-            fn drop(&mut self) {
-                if self.active {
-                    // SAFETY: the guard is only alive for the duration of
-                    // `scan_internal`, which holds `&mut self`; no other
-                    // aliasing exists.
-                    unsafe { (*self.scanner).path_ignore_patterns = self.saved };
-                }
-            }
-        }
-        let _restore: RestorePatterns<'_, 'a> = RestorePatterns {
-            scanner: core::ptr::from_mut(self),
-            saved: saved_patterns,
-            active: narrowed.is_some(),
-            _m: core::marker::PhantomData,
-        };
-        if let Some(ref kept) = narrowed {
-            // SAFETY: lifetime-erase; `narrowed` lives until end of this
-            // function (after the RAII guard restores).
-            self.path_ignore_patterns =
-                unsafe { core::slice::from_raw_parts(kept.as_ptr(), kept.len()) };
         }
 
         let mut scan_dir_buf = PathBuffer::uninit();
@@ -381,7 +350,11 @@ impl<'a> Scanner<'a> {
             return false;
         }
         let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
-        for pattern in self.path_ignore_patterns {
+        for (i, pattern) in self.path_ignore_patterns.iter().enumerate() {
+            if self.path_ignore_patterns_are_defaults && (self.disabled_defaults_mask >> i) & 1 != 0
+            {
+                continue;
+            }
             if pattern_matches_path(pattern, rel_path) {
                 return true;
             }

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -27,8 +27,8 @@ pub struct Scanner<'a> {
     /// Whether `path_ignore_patterns` are the built-in defaults (see
     /// `DEFAULT_PATH_IGNORE_PATTERNS`) vs a list configured by the user via
     /// `--path-ignore-patterns` or `bunfig.toml`. When true, explicit file/directory
-    /// arguments bypass the patterns — otherwise running `bun test build/foo.test.ts`
-    /// would silently match nothing.
+    /// arguments bypass the matching defaults — otherwise running
+    /// `bun test ./build/foo.test.ts` would silently match nothing.
     pub(crate) path_ignore_patterns_are_defaults: bool,
     pub(crate) dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
@@ -139,10 +139,11 @@ impl<'a> Scanner<'a> {
     }
 
     /// Like `scan`, but the path came from an explicit command-line argument
-    /// (`bun test ./build/foo.test.ts`). When the only patterns in play are the
-    /// Scanner's built-in defaults, skip them for this invocation — the user
-    /// pointed at this file/directory, so silently dropping it would be
-    /// surprising. Any patterns the user configured themselves still apply.
+    /// (`bun test ./build/foo.test.ts`). When the patterns in play are the
+    /// Scanner's built-in defaults, drop only the ones matching the explicit
+    /// root for this invocation (see `scan_internal`) — the user pointed at
+    /// this file/directory, so silently dropping it would be surprising. Any
+    /// patterns the user configured themselves still apply.
     pub(crate) fn scan_explicit(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
         self.scan_internal(path_literal, ScanMode::ExplicitPath)
     }
@@ -162,15 +163,15 @@ impl<'a> Scanner<'a> {
         let narrowed: Option<Box<[&'static [u8]]>> = if matches!(mode, ScanMode::ExplicitPath)
             && self.path_ignore_patterns_are_defaults
         {
+            // Match each default against the root's project-relative path. An
+            // empty `rel_path` means the explicit arg *is* the project root, so
+            // no default matches it (keep them all) — matching the raw absolute
+            // `path_literal` would wrongly drop `**/build/**` for a project that
+            // merely lives under a `build`/`dist` ancestor (e.g. `/opt/build/app`).
             let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
-            let rel_source: &[u8] = if rel_path.is_empty() {
-                path_literal
-            } else {
-                rel_path
-            };
             let mut kept: Vec<&'static [u8]> = Vec::with_capacity(self.path_ignore_patterns.len());
             for &pattern in self.path_ignore_patterns {
-                if !pattern_matches_path(pattern, rel_source) {
+                if !pattern_matches_path(pattern, rel_path) {
                     // SAFETY: all entries in DEFAULT_PATH_IGNORE_PATTERNS are
                     // &'static [u8] byte-string literals; the `_are_defaults`
                     // flag guarantees that's the slice we're iterating.

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -163,7 +163,11 @@ impl<'a> Scanner<'a> {
             && self.path_ignore_patterns_are_defaults
         {
             let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path_literal);
-            let rel_source: &[u8] = if rel_path.is_empty() { path_literal } else { rel_path };
+            let rel_source: &[u8] = if rel_path.is_empty() {
+                path_literal
+            } else {
+                rel_path
+            };
             let mut kept: Vec<&'static [u8]> = Vec::with_capacity(self.path_ignore_patterns.len());
             for &pattern in self.path_ignore_patterns {
                 if !pattern_matches_path(pattern, rel_source) {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -24,6 +24,12 @@ pub struct Scanner<'a> {
     /// Glob patterns for paths to ignore. Matched against the path relative to the
     /// project root (top_level_dir). When a file matches any pattern, it is excluded.
     pub(crate) path_ignore_patterns: &'a [&'a [u8]],
+    /// Whether `path_ignore_patterns` are the built-in defaults (see
+    /// `DEFAULT_PATH_IGNORE_PATTERNS`) vs a list configured by the user via
+    /// `--path-ignore-patterns` or `bunfig.toml`. When true, explicit file/directory
+    /// arguments bypass the patterns — otherwise running `bun test build/foo.test.ts`
+    /// would silently match nothing.
+    pub(crate) path_ignore_patterns_are_defaults: bool,
     pub(crate) dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
     pub(crate) test_files: Vec<Interned>,
@@ -84,6 +90,7 @@ impl<'a> Scanner<'a> {
             exclusion_names: &[],
             filter_names: &[],
             path_ignore_patterns: &[],
+            path_ignore_patterns_are_defaults: false,
             dirs_to_scan: Fifo::new(),
             options: &transpiler.options,
             fs: transpiler.fs,
@@ -128,6 +135,52 @@ impl<'a> Scanner<'a> {
     }
 
     pub(crate) fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
+        self.scan_internal(path_literal, ScanMode::AutoDiscover)
+    }
+
+    /// Like `scan`, but the path came from an explicit command-line argument
+    /// (`bun test ./build/foo.test.ts`). When the only patterns in play are the
+    /// Scanner's built-in defaults, skip them for this invocation — the user
+    /// pointed at this file/directory, so silently dropping it would be
+    /// surprising. Any patterns the user configured themselves still apply.
+    pub(crate) fn scan_explicit(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
+        self.scan_internal(path_literal, ScanMode::ExplicitPath)
+    }
+
+    fn scan_internal(&mut self, path_literal: &[u8], mode: ScanMode) -> Result<(), ScanError> {
+        // Explicit paths bypass the built-in defaults only. User-configured
+        // patterns stay in effect either way. Swap the field in place and
+        // restore it on scope exit so `?` early-returns also clean up.
+        let saved_patterns = self.path_ignore_patterns;
+        let bypass_defaults =
+            matches!(mode, ScanMode::ExplicitPath) && self.path_ignore_patterns_are_defaults;
+        if bypass_defaults {
+            self.path_ignore_patterns = &[];
+        }
+        // RAII guard so early-returns still restore the field.
+        struct RestorePatterns<'r, 'a> {
+            scanner: *mut Scanner<'a>,
+            saved: &'a [&'a [u8]],
+            active: bool,
+            _m: core::marker::PhantomData<&'r ()>,
+        }
+        impl<'r, 'a> Drop for RestorePatterns<'r, 'a> {
+            fn drop(&mut self) {
+                if self.active {
+                    // SAFETY: the guard is only alive for the duration of
+                    // `scan_internal`, which holds `&mut self`; no other
+                    // aliasing exists.
+                    unsafe { (*self.scanner).path_ignore_patterns = self.saved };
+                }
+            }
+        }
+        let _restore: RestorePatterns<'_, 'a> = RestorePatterns {
+            scanner: self as *mut _,
+            saved: saved_patterns,
+            active: bypass_defaults,
+            _m: core::marker::PhantomData,
+        };
+
         let mut scan_dir_buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
         let path: &[u8] = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf);
@@ -445,3 +498,16 @@ impl<'a> Scanner<'a> {
 }
 
 pub(crate) const TEST_NAME_SUFFIXES: [&[u8]; 4] = [b".test", b"_test", b".spec", b"_spec"];
+
+/// Glob patterns applied when the user has not configured
+/// `pathIgnorePatterns` (neither in `bunfig.toml` nor via
+/// `--path-ignore-patterns`). Matches the relative path from the project
+/// root, so these patterns prune the conventional output directories at any
+/// depth. An explicit (even empty) user configuration replaces this list.
+pub(crate) const DEFAULT_PATH_IGNORE_PATTERNS: [&[u8]; 2] = [b"**/dist/**", b"**/build/**"];
+
+#[derive(Copy, Clone)]
+enum ScanMode {
+    AutoDiscover,
+    ExplicitPath,
+}

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2349,11 +2349,8 @@ impl TestCommand {
         vm.ensure_debugger(false)?;
 
         let mut scanner = Scanner::init(&vm.transpiler, ctx.positionals.len()).expect("oom");
-        // When the user hasn't configured `pathIgnorePatterns`, fall back to
-        // the scanner's built-in defaults so conventional output directories
-        // (`dist/`, `build/`) don't duplicate tests into the run. The
-        // `_are_defaults` flag lets `scan_explicit` know it can safely bypass
-        // them when the user names a path directly on the CLI.
+        // Unconfigured pathIgnorePatterns falls back to the built-in defaults
+        // so `dist/`/`build/` copies don't run tests twice.
         if ctx.test_options.path_ignore_patterns_configured {
             // SAFETY: lifetime-erase; `path_ignore_patterns_view` lives in this never-returning
             // frame, underlying bytes live in `ctx` (process-lifetime).
@@ -2381,9 +2378,6 @@ impl TestCommand {
         if has_relative_path {
             // One of the files is a filepath. Instead of treating the
             // arguments as filters, treat them as filepaths.
-            // `scan_explicit` bypasses the Scanner's built-in default
-            // ignore patterns so `bun test ./build/foo.test.ts` isn't
-            // silently filtered out; any user-configured patterns still apply.
             let file_or_dirnames = &ctx.positionals[1..];
             for arg in file_or_dirnames {
                 match scanner.scan_explicit(arg) {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2349,10 +2349,21 @@ impl TestCommand {
         vm.ensure_debugger(false)?;
 
         let mut scanner = Scanner::init(&vm.transpiler, ctx.positionals.len()).expect("oom");
-        // SAFETY: lifetime-erase; `path_ignore_patterns_view` lives in this never-returning
-        // frame, underlying bytes live in `ctx` (process-lifetime).
-        scanner.path_ignore_patterns =
-            unsafe { bun_ptr::detach_lifetime(&path_ignore_patterns_view[..]) };
+        // When the user hasn't configured `pathIgnorePatterns`, fall back to
+        // the scanner's built-in defaults so conventional output directories
+        // (`dist/`, `build/`) don't duplicate tests into the run. The
+        // `_are_defaults` flag lets `scan_explicit` know it can safely bypass
+        // them when the user names a path directly on the CLI.
+        if ctx.test_options.path_ignore_patterns_configured {
+            // SAFETY: lifetime-erase; `path_ignore_patterns_view` lives in this never-returning
+            // frame, underlying bytes live in `ctx` (process-lifetime).
+            scanner.path_ignore_patterns =
+                unsafe { bun_ptr::detach_lifetime(&path_ignore_patterns_view[..]) };
+            scanner.path_ignore_patterns_are_defaults = false;
+        } else {
+            scanner.path_ignore_patterns = &scanner::DEFAULT_PATH_IGNORE_PATTERNS;
+            scanner.path_ignore_patterns_are_defaults = true;
+        }
         let has_relative_path = 'hr: {
             for arg in &ctx.positionals {
                 if bun_paths::is_absolute(arg)
@@ -2369,10 +2380,13 @@ impl TestCommand {
         };
         if has_relative_path {
             // One of the files is a filepath. Instead of treating the
-            // arguments as filters, treat them as filepaths
+            // arguments as filters, treat them as filepaths.
+            // `scan_explicit` bypasses the Scanner's built-in default
+            // ignore patterns so `bun test ./build/foo.test.ts` isn't
+            // silently filtered out; any user-configured patterns still apply.
             let file_or_dirnames = &ctx.positionals[1..];
             for arg in file_or_dirnames {
-                match scanner.scan(arg) {
+                match scanner.scan_explicit(arg) {
                     Ok(()) => {}
                     Err(scanner::ScanError::OutOfMemory) => bun::out_of_memory(),
                     // don't error if multiple are passed; one might fail

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -465,14 +465,16 @@ test("explicit test", () => {
     });
 
     test("explicit path still honors user-configured pathIgnorePatterns", () => {
-      // The bypass only skips built-in defaults — a user who writes
-      // `pathIgnorePatterns = ["**/build/**"]` meant it.
+      // The bypass only skips built-in defaults — a user who writes their
+      // own pattern meant it. Use a directory name that has no overlap
+      // with the defaults so a buggy implementation can't pass this just
+      // because the defaults happened to match the same path.
       const dir = tempDirWithFiles("path-ignore-explicit-honors-user", {
         "bunfig.toml": `
 [test]
-pathIgnorePatterns = ["**/build/**"]
+pathIgnorePatterns = ["**/user-ignored/**"]
 `,
-        "build/explicit.test.ts": `
+        "user-ignored/explicit.test.ts": `
 import { test, expect } from "bun:test";
 test("explicit test", () => {
   expect(1).toBe(1);
@@ -480,13 +482,14 @@ test("explicit test", () => {
 `,
       });
 
-      const result = Bun.spawnSync([bunExe(), "test", "./build/explicit.test.ts"], {
+      const result = Bun.spawnSync([bunExe(), "test", "./user-ignored/explicit.test.ts"], {
         cwd: dir,
         env: bunEnv,
         stdio: [null, null, "pipe"],
       });
 
       const stderr = result.stderr.toString("utf-8");
+      expect(stderr).not.toContain("explicit test");
       expect(stderr).not.toContain("1 pass");
       expect(result.exitCode).not.toBe(0);
     });

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -493,5 +493,39 @@ test("explicit test", () => {
       expect(stderr).not.toContain("1 pass");
       expect(result.exitCode).not.toBe(0);
     });
+
+    test("explicit dir still prunes nested default-ignored directories", () => {
+      // Narrowing behavior: `bun test ./packages/foo` drops only the default
+      // patterns that match the scan root itself (none, in this case) — the
+      // other defaults keep pruning nested `dist/`/`build/`, so a duplicate
+      // `packages/foo/dist/foo.test.ts` is NOT discovered alongside the
+      // original in `packages/foo/src/`.
+      const dir = tempDirWithFiles("path-ignore-narrow-nested", {
+        "packages/foo/src/foo.test.ts": `
+import { test, expect } from "bun:test";
+test("original test", () => {
+  expect(1).toBe(1);
+});
+`,
+        "packages/foo/dist/foo.test.ts": `
+import { test, expect } from "bun:test";
+test("duplicate test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test", "./packages/foo"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("original test");
+      expect(stderr).not.toContain("duplicate test");
+      expect(stderr).toContain("1 pass");
+      expect(result.exitCode).toBe(0);
+    });
   });
 });

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -527,5 +527,42 @@ test("duplicate test", () => {
       expect(stderr).toContain("1 pass");
       expect(result.exitCode).toBe(0);
     });
+
+    test("explicit absolute project root keeps defaults when path contains a build/ ancestor", () => {
+      // Narrowing matches each default against the root's *project-relative*
+      // path. When the explicit arg resolves to the project root itself that
+      // relative path is empty, so no default is dropped — even if the
+      // project's absolute path contains a `build`/`dist` segment (e.g. a
+      // Docker `WORKDIR /build`). Passing the absolute cwd (`bun test "$PWD"`)
+      // must behave like `bun test`: matching the raw absolute path instead of
+      // the empty relative path would wrongly drop `**/build/**` here.
+      const dir = tempDirWithFiles("path-ignore-build-ancestor", {
+        "build/app/src/only.test.ts": `
+import { test, expect } from "bun:test";
+test("original test", () => {
+  expect(1).toBe(1);
+});
+`,
+        "build/app/build/duplicate.test.ts": `
+import { test, expect } from "bun:test";
+test("duplicate test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+      const projectRoot = `${dir}/build/app`;
+
+      const result = Bun.spawnSync([bunExe(), "test", projectRoot], {
+        cwd: projectRoot,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("original test");
+      expect(stderr).not.toContain("duplicate test");
+      expect(stderr).toContain("1 pass");
+      expect(result.exitCode).toBe(0);
+    });
   });
 });

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -489,6 +489,8 @@ test("explicit test", () => {
       });
 
       const stderr = result.stderr.toString("utf-8");
+      // Positive anchor: the file was discovered-then-filtered, not crashed.
+      expect(stderr).toContain("The following filters did not match any test files");
       expect(stderr).not.toContain("explicit test");
       expect(stderr).not.toContain("1 pass");
       expect(result.exitCode).not.toBe(0);

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("pathIgnorePatterns", () => {
   test("bunfig - single pattern string", () => {
@@ -346,7 +346,7 @@ test("deeper ignored test", () => {
       ["build nested", "packages/sub/build/src/duplicate.test.ts"],
       ["dist nested", "packages/sub/dist/duplicate.test.ts"],
     ])("skips %s by default", (_label, duplicatePath) => {
-      const dir = tempDirWithFiles("path-ignore-default", {
+      using dir = tempDir("path-ignore-default", {
         "src/only.test.ts": `
 import { test, expect } from "bun:test";
 test("original test", () => {
@@ -378,7 +378,7 @@ test("duplicate test", () => {
       // When the user opts into a custom list, they take responsibility
       // for the entire list — the defaults no longer apply, matching
       // Vitest's replace semantics.
-      const dir = tempDirWithFiles("path-ignore-override", {
+      using dir = tempDir("path-ignore-override", {
         "bunfig.toml": `
 [test]
 pathIgnorePatterns = ["fixtures/**"]
@@ -421,7 +421,7 @@ test("should be ignored", () => {
       // If the user names a file directly on the CLI, they clearly want
       // to run it — even if it sits under `build/`. The built-in defaults
       // must not silently filter it out.
-      const dir = tempDirWithFiles("path-ignore-explicit-file", {
+      using dir = tempDir("path-ignore-explicit-file", {
         "build/explicit.test.ts": `
 import { test, expect } from "bun:test";
 test("explicit test", () => {
@@ -443,7 +443,7 @@ test("explicit test", () => {
     });
 
     test("explicit directory path bypasses the defaults", () => {
-      const dir = tempDirWithFiles("path-ignore-explicit-dir", {
+      using dir = tempDir("path-ignore-explicit-dir", {
         "build/nested/explicit.test.ts": `
 import { test, expect } from "bun:test";
 test("explicit test", () => {
@@ -469,7 +469,7 @@ test("explicit test", () => {
       // own pattern meant it. Use a directory name that has no overlap
       // with the defaults so a buggy implementation can't pass this just
       // because the defaults happened to match the same path.
-      const dir = tempDirWithFiles("path-ignore-explicit-honors-user", {
+      using dir = tempDir("path-ignore-explicit-honors-user", {
         "bunfig.toml": `
 [test]
 pathIgnorePatterns = ["**/user-ignored/**"]
@@ -500,7 +500,7 @@ test("explicit test", () => {
       // other defaults keep pruning nested `dist/`/`build/`, so a duplicate
       // `packages/foo/dist/foo.test.ts` is NOT discovered alongside the
       // original in `packages/foo/src/`.
-      const dir = tempDirWithFiles("path-ignore-narrow-nested", {
+      using dir = tempDir("path-ignore-narrow-nested", {
         "packages/foo/src/foo.test.ts": `
 import { test, expect } from "bun:test";
 test("original test", () => {
@@ -536,7 +536,7 @@ test("duplicate test", () => {
       // Docker `WORKDIR /build`). Passing the absolute cwd (`bun test "$PWD"`)
       // must behave like `bun test`: matching the raw absolute path instead of
       // the empty relative path would wrongly drop `**/build/**` here.
-      const dir = tempDirWithFiles("path-ignore-build-ancestor", {
+      using dir = tempDir("path-ignore-build-ancestor", {
         "build/app/src/only.test.ts": `
 import { test, expect } from "bun:test";
 test("original test", () => {

--- a/test/cli/test/path-ignore-patterns.test.ts
+++ b/test/cli/test/path-ignore-patterns.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 
 describe("pathIgnorePatterns", () => {
   test("bunfig - single pattern string", () => {
@@ -226,7 +226,10 @@ test("should pass", () => {
     expect(result.exitCode).toBe(1);
   });
 
-  test("bunfig - empty array is a no-op", () => {
+  test("bunfig - empty array opts out of built-in defaults", () => {
+    // An explicit empty array in bunfig is how users opt out of the
+    // default `**/dist/**` / `**/build/**` patterns. Place a test inside
+    // `build/` and confirm it still runs.
     using dir = tempDir("path-ignore", {
       "bunfig.toml": `
 [test]
@@ -235,6 +238,12 @@ pathIgnorePatterns = []
       "test.test.ts": `
 import { test, expect } from "bun:test";
 test("should pass", () => {
+  expect(true).toBe(true);
+});
+`,
+      "build/built.test.ts": `
+import { test, expect } from "bun:test";
+test("should also pass", () => {
   expect(true).toBe(true);
 });
 `,
@@ -248,7 +257,8 @@ test("should pass", () => {
 
     const stderr = result.stderr.toString("utf-8");
     expect(stderr).toContain("test.test.ts");
-    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("built.test.ts");
+    expect(stderr).toContain("2 pass");
     expect(result.exitCode).toBe(0);
   });
 
@@ -324,5 +334,161 @@ test("deeper ignored test", () => {
     expect(stderr).not.toContain("deeper.test.ts");
     expect(stderr).toContain("1 pass");
     expect(result.exitCode).toBe(0);
+  });
+
+  describe("default patterns", () => {
+    // Without any configuration, `bun test` should skip conventional
+    // output directories so `tsc`/bundler artifacts don't duplicate the
+    // tests found in `src/`. See issue #30282.
+    test.each([
+      ["build", "build/src/duplicate.test.ts"],
+      ["dist", "dist/duplicate.test.ts"],
+      ["build nested", "packages/sub/build/src/duplicate.test.ts"],
+      ["dist nested", "packages/sub/dist/duplicate.test.ts"],
+    ])("skips %s by default", (_label, duplicatePath) => {
+      const dir = tempDirWithFiles("path-ignore-default", {
+        "src/only.test.ts": `
+import { test, expect } from "bun:test";
+test("original test", () => {
+  expect(1).toBe(1);
+});
+`,
+        [duplicatePath]: `
+import { test, expect } from "bun:test";
+test("duplicate test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("only.test.ts");
+      expect(stderr).not.toContain("duplicate.test.ts");
+      expect(stderr).toContain("1 pass");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("user-configured pathIgnorePatterns replaces the defaults", () => {
+      // When the user opts into a custom list, they take responsibility
+      // for the entire list — the defaults no longer apply, matching
+      // Vitest's replace semantics.
+      const dir = tempDirWithFiles("path-ignore-override", {
+        "bunfig.toml": `
+[test]
+pathIgnorePatterns = ["fixtures/**"]
+`,
+        "src/only.test.ts": `
+import { test, expect } from "bun:test";
+test("original test", () => {
+  expect(1).toBe(1);
+});
+`,
+        "build/kept.test.ts": `
+import { test, expect } from "bun:test";
+test("kept test", () => {
+  expect(1).toBe(1);
+});
+`,
+        "fixtures/skipped.test.ts": `
+import { test, expect } from "bun:test";
+test("should be ignored", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("only.test.ts");
+      expect(stderr).toContain("kept.test.ts");
+      expect(stderr).not.toContain("skipped.test.ts");
+      expect(stderr).toContain("2 pass");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("explicit file path bypasses the defaults", () => {
+      // If the user names a file directly on the CLI, they clearly want
+      // to run it — even if it sits under `build/`. The built-in defaults
+      // must not silently filter it out.
+      const dir = tempDirWithFiles("path-ignore-explicit-file", {
+        "build/explicit.test.ts": `
+import { test, expect } from "bun:test";
+test("explicit test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test", "./build/explicit.test.ts"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("explicit.test.ts");
+      expect(stderr).toContain("1 pass");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("explicit directory path bypasses the defaults", () => {
+      const dir = tempDirWithFiles("path-ignore-explicit-dir", {
+        "build/nested/explicit.test.ts": `
+import { test, expect } from "bun:test";
+test("explicit test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test", "./build"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).toContain("explicit.test.ts");
+      expect(stderr).toContain("1 pass");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("explicit path still honors user-configured pathIgnorePatterns", () => {
+      // The bypass only skips built-in defaults — a user who writes
+      // `pathIgnorePatterns = ["**/build/**"]` meant it.
+      const dir = tempDirWithFiles("path-ignore-explicit-honors-user", {
+        "bunfig.toml": `
+[test]
+pathIgnorePatterns = ["**/build/**"]
+`,
+        "build/explicit.test.ts": `
+import { test, expect } from "bun:test";
+test("explicit test", () => {
+  expect(1).toBe(1);
+});
+`,
+      });
+
+      const result = Bun.spawnSync([bunExe(), "test", "./build/explicit.test.ts"], {
+        cwd: dir,
+        env: bunEnv,
+        stdio: [null, null, "pipe"],
+      });
+
+      const stderr = result.stderr.toString("utf-8");
+      expect(stderr).not.toContain("1 pass");
+      expect(result.exitCode).not.toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### What

Closes #30282.

`bun test` walked every non-`node_modules` directory under the project root. If `tsc` or a bundler mirrored `src/` into `build/` or `dist/` the copied `*.test.*` files were picked up alongside the originals, so every test ran twice.

### Fix

`Scanner` now falls back to `["**/dist/**", "**/build/**"]` when the user hasn't set `pathIgnorePatterns` (neither via `bunfig.toml` nor via `--path-ignore-patterns`). Any explicit configuration -- including an empty array -- opts out of the defaults, matching Vitest's replace semantics.

Explicit file/directory arguments on the CLI bypass the built-in defaults so `bun test ./build/foo.test.ts` and `bun test ./build` keep working. Only the defaults that match the explicit path itself are dropped (tracked in a per-scan bitmask), so `bun test ./packages/foo` still prunes a nested `packages/foo/dist/`. User-configured patterns always apply to explicit arguments.

### Tests

`test/cli/test/path-ignore-patterns.test.ts`:
- `skips build/dist by default` (and nested variants) -- the core fix
- `user-configured pathIgnorePatterns replaces the defaults`
- `empty array opts out of built-in defaults`
- `explicit file/directory path bypasses the defaults`
- `explicit path still honors user-configured pathIgnorePatterns`

All 20 tests pass locally on the debug (ASAN) build; the default-pattern tests fail when the fix is removed.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 21 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/path-ignore-patterns.test.ts
bun test v1.4.0 (4d5e632f7)

test/cli/test/path-ignore-patterns.test.ts:
(pass) pathIgnorePatterns > bunfig - single pattern string [313.04ms]
(pass) pathIgnorePatterns > bunfig - array of patterns [288.31ms]
(pass) pathIgnorePatterns > bunfig - glob pattern with ** [282.94ms]
(pass) pathIgnorePatterns > CLI flag - single pattern [282.41ms]
(pass) pathIgnorePatterns > CLI flag - multiple patterns [280.68ms]
(pass) pathIgnorePatterns > bunfig - invalid config type [113.74ms]
(pass) pathIgnorePatterns > bunfig - invalid array item [120.27ms]
(pass) pathIgnorePatterns > bunfig - empty array opts out of built-in defaults [297.14ms]
(pass) pathIgnorePatterns > CLI flag overrides bunfig [285.23ms]
(pass) pathIgnorePatterns > bare directory name pattern prunes entire subtree [280.29ms]
367 |         stdio: [null, null, "pipe"],
368 |       });
369 | 
370 |       const stderr = result.stderr.toString("utf-8");
371 |       expect(stderr).toContain("only.test.ts");
372 |       expect(stderr).not.toConta
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c577f9e8b)

test/cli/test/path-ignore-patterns.test.ts:
(pass) pathIgnorePatterns > bunfig - single pattern string [66.58ms]
(pass) pathIgnorePatterns > bunfig - array of patterns [20.53ms]
(pass) pathIgnorePatterns > bunfig - glob pattern with ** [24.85ms]
(pass) pathIgnorePatterns > CLI flag - single pattern [24.57ms]
(pass) pathIgnorePatterns > CLI flag - multiple patterns [17.87ms]
(pass) pathIgnorePatterns > bunfig - invalid config type [4.73ms]
(pass) pathIgnorePatterns > bunfig - invalid array item [2.04ms]
(pass) pathIgnorePatterns > bunfig - empty array opts out of built-in defaults [15.27ms]
(pass) pathIgnorePatterns > CLI flag overrides bunfig [20.73ms]
(pass) pathIgnorePatterns > bare directory name pattern prunes entire subtree [32.44ms]
(pass) pathIgnorePatterns > default patterns > skips build by default [20.85ms]
(pass) pathIgnorePatterns > default patterns > skips dist by default [11.63ms]
(pass) pathIgnorePatterns > default patterns > skips build nested by default [17.95ms]
(pass) pathIgnorePatterns > default patterns > skips dist nested by default [11.24ms]
(pass) pathIgnorePatterns > default patterns > user-configured pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/path-ignore-patterns.test.ts
bun test v1.4.0 (4d5e632f7)

test/cli/test/path-ignore-patterns.test.ts:
(pass) pathIgnorePatterns > bunfig - single pattern string [313.75ms]
(pass) pathIgnorePatterns > bunfig - array of patterns [291.60ms]
(pass) pathIgnorePatterns > bunfig - glob pattern with ** [289.25ms]
(pass) pathIgnorePatterns > CLI flag - single pattern [284.57ms]
(pass) pathIgnorePatterns > CLI flag - multiple patterns [288.80ms]
(pass) pathIgnorePatterns > bunfig - invalid config type [115.08ms]
(pass) pathIgnorePatterns > bunfig - invalid array item [116.26ms]
(pass) pathIgnorePatterns > bunfig - empty array opts out of built-in defaults [306.80ms]
(pass) pathIgnorePatterns > CLI flag overrides bunfig [288.86ms]
(pass) pathIgnorePatterns > bare directory name pattern prunes entire subtree [295.69ms]
(pass) pathIgnorePatterns > default patterns > skips build by default [291.34ms]
(pass) pathIgnorePatterns > default patterns > skips dist by default [339.46ms]
(pass) pathIgnorePatterns > default patterns > skips buil
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1169ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/24] gen cpp.rs (cppbind)
[4/24] gen JS modules (bundle-modules)
Preprocess modules (8541ms)
Bundle modules (40ms)
Postprocesss modules (261ms)
Bundle Functions (758ms)
Generate Code (29ms)

[9.66s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/bori
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/bunfig.mdx                    |   2 +
 docs/test/configuration.mdx                |  18 +++
 src/bunfig/bunfig.rs                       |   3 +
 src/options_types/context.rs               |   4 +
 src/runtime/cli/Arguments.rs               |   1 +
 src/runtime/cli/test/Scanner.rs            | 101 ++++++++----
 src/runtime/cli/test_command.rs            |  20 ++-
 test/cli/test/path-ignore-patterns.test.ts | 246 ++++++++++++++++++++++++++++-
 8 files changed, 360 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 21

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/runtime/bunfig.mdx                         3      3     45
docs/test/configuration.mdx                     4      4     45
src/bunfig/bunfig.rs                            1      1     46
src/options_types/context.rs                    1      2     46
src/runtime/cli/Arguments.rs                    1      1     46
src/runtime/cli/test/Scanner.rs                30     28     46
src/runtime/cli/test_command.rs                 6      5     46
test/cli/test/path-ignore-patterns.test.ts     10     12     45
```

</details>

<!-- robobun:evidence:end -->
