### PR TITLE
process: don't cache Exception cell as process.nextTick on init failure

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3921,12 +3921,18 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionDrainMicrotaskQueue, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
-    JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
+    // Lazy PropertyCallback: must not throw, and must not leak the
+    // JSC::Exception cell as the cached property value on failure.
+    NakedPtr<JSC::Exception> returnedException;
+    JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args, returnedException);
+    if (returnedException) [[unlikely]]
+        return jsUndefined();
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
+        return nextTickFunction;
     }
 
-    return nextTickFunction;
+    return jsUndefined();
 }
 
 static JSValue constructProcessNextTickFn(VM& vm, JSObject* processObject)

--- a/test/js/node/process/process-nexttick-stack-overflow.test.ts
+++ b/test/js/node/process/process-nexttick-stack-overflow.test.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When process.nextTick is accessed for the first time while the stack is
+// already exhausted, the lazy initializer fails. Previously this cached the
+// raw JSC::Exception cell as the value of process.nextTick, which then
+// tripped a debug assertion in JSCell::toStringSlowCase (and threw a bogus
+// "Cannot convert a symbol to a string" in release) when JS later tried to
+// call it and build the "is not a function" error message.
+test("process.nextTick first accessed at max stack depth does not crash", async () => {
+  const src = `
+    let done = false;
+    function F0() {
+      if (done) return;
+      try { F0(); } catch (e) {
+        done = true;
+        try { process.nextTick; } catch (_) {}
+      }
+    }
+    F0();
+    const nt = process.nextTick;
+    if (nt !== undefined && typeof nt !== "function")
+      throw new Error("process.nextTick leaked as a non-function value (typeof " + typeof nt + ")");
+    try { process.nextTick(); } catch (e) {
+      if (!(e instanceof Error)) throw new Error("unexpected throw " + e);
+    }
+    console.log("ok", typeof nt);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toMatch(/^ok (undefined|function)$/);
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/process/process-nexttick-stack-overflow.test.ts
+++ b/test/js/node/process/process-nexttick-stack-overflow.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // When process.nextTick is accessed for the first time while the stack is


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion failure at `JSCell.cpp(268)` (`isSymbol() || isHeapBigInt()`) found by Fuzzilli.

### Root cause

`process.nextTick` is a lazy `PropertyCallback`. On first access, `constructNextTickFn` runs the JS `initializeNextTickQueue` builtin via `JSC::profiledCall`.

If that call fails — e.g. the first ever access to `process.nextTick` happens while the stack is already exhausted — `Interpreter::executeCallImpl` returns the `JSC::Exception*` cell itself as a `JSValue` (via `return throwStackOverflowError(...)` / `RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception())`). `constructNextTickFn` had no exception check and returned that value, which `reifyStaticProperty` then `putDirect`'d as the cached value of `process.nextTick`.

On the next call, JS tries to invoke that raw `Exception` cell (JSType `CellType`, not an object/string/symbol/bigint). The call-IC not-a-function path ends up in `errorDescriptionForValue` → `JSValue::toString` → `JSCell::toStringSlowCase`, which asserts `isSymbol() || isHeapBigInt()` in debug builds and throws a misleading "Cannot convert a symbol to a string" TypeError in release builds.

Minimal repro:
```js
function f() {
  try { f(); } catch (e) {}
  process.nextTick();
}
f();
```

### Fix

Use the `NakedPtr<Exception>&` overload of `profiledCall` so the initializer's exception is caught (lazy `PropertyCallback`s are assumed by JSC not to throw — leaving the exception pending also trips `EXCEPTION_ASSERT(!scope.exception() || !hasSlot)` in LLInt `get_by_id`). On failure, return `jsUndefined()` instead of the `Exception` cell so calling it later produces a normal "is not a function" TypeError rather than a crash.

## How did you verify your code works?

- Original fuzzer repro now exits cleanly with a catchable `TypeError` instead of aborting on the assertion, in both JIT and `useJIT=0` modes.
- Added regression test at `test/js/node/process/process-nexttick-stack-overflow.test.ts` which fails against current `main` (`process.nextTick` leaks as a non-function value) and passes with this change.
- Existing `process-nexttick.test.js` suite still passes.
- `BUN_JSC_validateExceptionChecks=1` passes on the repro.