### PR TITLE
tty: update process.stdin.isRaw after setRawMode succeeds on Windows

### DIFF
--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -62,25 +62,25 @@ Object.defineProperty(ReadStream, "prototype", {
           const err = ttySetMode(flag);
           if (err) {
             this.emit("error", new Error("setRawMode failed with errno: " + err));
+            return this;
           }
-          return this;
-        }
+        } else {
+          const handle = this.$bunNativePtr;
+          if (!handle) {
+            this.emit("error", new Error("setRawMode failed because it was called on something that is not a TTY"));
+            return this;
+          }
 
-        const handle = this.$bunNativePtr;
-        if (!handle) {
-          this.emit("error", new Error("setRawMode failed because it was called on something that is not a TTY"));
-          return this;
-        }
+          // If you call setRawMode before you call on('data'), the stream will
+          // not be constructed, leading to EBADF
+          // This corresponds to the `ensureConstructed` function in `native-readable.ts`
+          this.$start();
 
-        // If you call setRawMode before you call on('data'), the stream will
-        // not be constructed, leading to EBADF
-        // This corresponds to the `ensureConstructed` function in `native-readable.ts`
-        this.$start();
-
-        const err = handle.setRawMode(flag);
-        if (err) {
-          this.emit("error", err);
-          return this;
+          const err = handle.setRawMode(flag);
+          if (err) {
+            this.emit("error", err);
+            return this;
+          }
         }
       } else {
         const err = ttySetMode(this.fd, flag);

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -18,10 +18,7 @@ describe("ReadStream.prototype.setRawMode", () => {
         bunExe(),
         "-e",
         `
-          if (!process.stdin.isTTY) {
-            process.stdout.write("SKIP:stdin is not a TTY");
-            process.exit(0);
-          }
+          const isTTY = process.stdin.isTTY;
           const before = process.stdin.isRaw;
           const ret = process.stdin.setRawMode(true);
           const afterTrue = process.stdin.isRaw;
@@ -30,6 +27,7 @@ describe("ReadStream.prototype.setRawMode", () => {
           process.stdout.write(
             "RESULT " +
               JSON.stringify({
+                isTTY,
                 before,
                 afterTrue,
                 afterFalse,
@@ -46,7 +44,6 @@ describe("ReadStream.prototype.setRawMode", () => {
         data(_t, chunk: Uint8Array) {
           output += decoder.decode(chunk, { stream: true });
           if (output.includes("RESULT ") && output.includes("}")) done.resolve();
-          if (output.includes("SKIP:")) done.resolve();
         },
         exit() {
           eof.resolve();
@@ -60,14 +57,15 @@ describe("ReadStream.prototype.setRawMode", () => {
     proc.terminal?.close();
     output += decoder.decode();
 
-    // Bun.Terminal always gives the child a TTY stdin (openpty / ConPTY), so
-    // the SKIP path should never trigger. If RESULT is missing for any
-    // reason, surface the raw terminal output rather than a bare null match.
+    // Bun.Terminal always gives the child a TTY stdin (openpty / ConPTY). If
+    // RESULT is missing for any reason, surface the raw terminal output
+    // rather than a bare null match.
     const match = output.match(/RESULT (\{[^}]*\})/);
     if (!match) {
       throw new Error("child did not emit RESULT; terminal output was: " + JSON.stringify(output));
     }
     expect(JSON.parse(match[1])).toEqual({
+      isTTY: true,
       before: false,
       afterTrue: true,
       afterFalse: false,

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -18,6 +18,8 @@ describe("ReadStream.prototype.setRawMode", () => {
         bunExe(),
         "-e",
         `
+          let err;
+          process.stdin.on("error", e => (err = String(e)));
           const isTTY = process.stdin.isTTY;
           const before = process.stdin.isRaw;
           const ret = process.stdin.setRawMode(true);
@@ -32,6 +34,7 @@ describe("ReadStream.prototype.setRawMode", () => {
                 afterTrue,
                 afterFalse,
                 returnsThis: ret === process.stdin,
+                ...(err ? { err } : {}),
               }),
           );
           process.exit(0);
@@ -39,7 +42,8 @@ describe("ReadStream.prototype.setRawMode", () => {
       ],
       env: bunEnv,
       terminal: {
-        cols: 80,
+        // Wide enough that ConPTY does not hard-wrap the RESULT line.
+        cols: 200,
         rows: 24,
         data(_t, chunk: Uint8Array) {
           output += decoder.decode(chunk, { stream: true });
@@ -57,10 +61,15 @@ describe("ReadStream.prototype.setRawMode", () => {
     proc.terminal?.close();
     output += decoder.decode();
 
+    // ConPTY injects VT escape sequences and CR around the payload; strip
+    // them so the RESULT JSON can be matched regardless of where the
+    // terminal emulator decides to park the cursor.
+    const stripped = Bun.stripANSI(output).replace(/[\r\n]/g, "");
+
     // Bun.Terminal always gives the child a TTY stdin (openpty / ConPTY). If
     // RESULT is missing for any reason, surface the raw terminal output
     // rather than a bare null match.
-    const match = output.match(/RESULT (\{[^}]*\})/);
+    const match = stripped.match(/RESULT (\{[^}]*\})/);
     if (!match) {
       throw new Error("child did not emit RESULT; terminal output was: " + JSON.stringify(output));
     }

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -60,9 +60,14 @@ describe("ReadStream.prototype.setRawMode", () => {
     proc.terminal?.close();
     output += decoder.decode();
 
+    // Bun.Terminal always gives the child a TTY stdin (openpty / ConPTY), so
+    // the SKIP path should never trigger. If RESULT is missing for any
+    // reason, surface the raw terminal output rather than a bare null match.
     const match = output.match(/RESULT (\{[^}]*\})/);
-    expect(match).not.toBeNull();
-    expect(JSON.parse(match![1])).toEqual({
+    if (!match) {
+      throw new Error("child did not emit RESULT; terminal output was: " + JSON.stringify(output));
+    }
+    expect(JSON.parse(match[1])).toEqual({
       before: false,
       afterTrue: true,
       afterFalse: false,

--- a/test/js/node/tty.test.ts
+++ b/test/js/node/tty.test.ts
@@ -1,6 +1,75 @@
-import { describe, expect, it } from "bun:test";
-import { isWindows } from "harness";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { WriteStream } from "node:tty";
+
+describe("ReadStream.prototype.setRawMode", () => {
+  // Regression: on Windows, the `fd === 0` branch returned early on success
+  // without ever reaching `this.isRaw = flag`, so `process.stdin.isRaw` stayed
+  // `false` after a successful `setRawMode(true)`. On POSIX this already
+  // worked; the test runs on both to lock the behaviour in.
+  test("updates isRaw on process.stdin after a successful call", async () => {
+    let output = "";
+    const decoder = new TextDecoder();
+    const done = Promise.withResolvers<void>();
+    const eof = Promise.withResolvers<void>();
+
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          if (!process.stdin.isTTY) {
+            process.stdout.write("SKIP:stdin is not a TTY");
+            process.exit(0);
+          }
+          const before = process.stdin.isRaw;
+          const ret = process.stdin.setRawMode(true);
+          const afterTrue = process.stdin.isRaw;
+          process.stdin.setRawMode(false);
+          const afterFalse = process.stdin.isRaw;
+          process.stdout.write(
+            "RESULT " +
+              JSON.stringify({
+                before,
+                afterTrue,
+                afterFalse,
+                returnsThis: ret === process.stdin,
+              }),
+          );
+          process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      terminal: {
+        cols: 80,
+        rows: 24,
+        data(_t, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+          if (output.includes("RESULT ") && output.includes("}")) done.resolve();
+          if (output.includes("SKIP:")) done.resolve();
+        },
+        exit() {
+          eof.resolve();
+        },
+      },
+    });
+
+    await Promise.race([done.promise, eof.promise]);
+    proc.kill();
+    await proc.exited;
+    proc.terminal?.close();
+    output += decoder.decode();
+
+    const match = output.match(/RESULT (\{[^}]*\})/);
+    expect(match).not.toBeNull();
+    expect(JSON.parse(match![1])).toEqual({
+      before: false,
+      afterTrue: true,
+      afterFalse: false,
+      returnsThis: true,
+    });
+  });
+});
 
 describe("WriteStream.prototype.getColorDepth", () => {
   it("iTerm ancient", () => {


### PR DESCRIPTION
## What

`process.stdin.isRaw` now reflects the current raw mode on Windows after `process.stdin.setRawMode(flag)` succeeds, matching Node.js and Bun on POSIX.

## Repro (Windows, real terminal)

```js
process.stdin.setRawMode(true);
console.log(process.stdin.isRaw); // before: false — after: true
process.stdin.setRawMode(false);
process.exit(0);
```

## Root cause

In `src/js/node/tty.ts`, the Windows `fd === 0` branch of `ReadStream.prototype.setRawMode` did:

```js
if (this.fd === 0) {
  const err = ttySetMode(flag);
  if (err) {
    this.emit("error", new Error("setRawMode failed with errno: " + err));
  }
  return this;   // ← returns on BOTH error and success
}
// ...
this.isRaw = flag;  // ← never reached for Windows stdin
```

so `this.isRaw = flag` at the end of the method was unreachable for `process.stdin` on Windows. The other two paths (Windows `fd !== 0` and POSIX) only return early on error and fall through to the assignment.

Any code that reads `isRaw` to decide whether to restore cooked mode on teardown (e.g. `readline`'s `_setRawMode`, which consults `input.isRaw`) would always restore cooked mode on Windows, which can leave a pending cooked `ReadConsole` blocking the next raw-mode consumer until the user presses Enter.

## Fix

Restructure so the `fd === 0` case only returns early on error and otherwise falls through to the shared `this.isRaw = flag` assignment — same shape as the other branches.

## Verification

Added a test in `test/js/node/tty.test.ts` that spawns a child in a `Bun.Terminal` (so stdin is a real TTY on both POSIX and Windows/ConPTY), calls `setRawMode(true)` / `setRawMode(false)`, and asserts `isRaw` tracks the mode and the method returns `this`.

```
bun bd test test/js/node/tty.test.ts
 4 pass
 0 fail
```

The affected code path is guarded by `process.platform === "win32"` (inlined at bundle time), so the fail-before/pass-after delta is only observable on Windows CI. On POSIX the test locks in the existing (already correct) behaviour.


Fixes #9853

