### PR TITLE
repl: strip trailing CR when loading history (Windows CRLF)

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -254,7 +254,10 @@ impl History {
             sys::Result::Err(_) => return Ok(()),
         };
 
-        for line in content.split(|b: &u8| *b == b'\n') {
+        for mut line in content.split(|b: &u8| *b == b'\n') {
+            if line.last() == Some(&b'\r') {
+                line = &line[..line.len() - 1];
+            }
             if !line.is_empty() {
                 self.entries.push(Box::<[u8]>::from(line));
             }

--- a/src/runtime/cli/repl.zig
+++ b/src/runtime/cli/repl.zig
@@ -196,7 +196,8 @@ const History = struct {
         defer self.allocator.free(content);
 
         var lines = std.mem.splitScalar(u8, content, '\n');
-        while (lines.next()) |line| {
+        while (lines.next()) |line_| {
+            const line = if (line_.len > 0 and line_[line_.len - 1] == '\r') line_[0 .. line_.len - 1] else line_;
             if (line.len > 0) {
                 const entry = try self.allocator.dupe(u8, line);
                 try self.entries.append(entry);

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -910,6 +910,40 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe("history file", () => {
+    // A history file written on Windows can contain CRLF line endings. Loading
+    // it must strip the trailing '\r' so entries don't carry a stray CR through
+    // recall, .history output, or the next save.
+    test("strips CRLF when loading existing history", async () => {
+      using dir = tempDir("repl-history-crlf", {
+        ".bun_repl_history": "old_one\r\nold_two\r\n",
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "repl"],
+        stdin: Buffer.from("new_three\n.exit\n"),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...bunEnv,
+          TERM: "dumb",
+          NO_COLOR: "1",
+          HOME: String(dir),
+          USERPROFILE: String(dir), // Windows fallback
+        },
+      });
+      const exitCode = await proc.exited;
+      expect(exitCode).toBe(0);
+
+      const saved = await Bun.file(path.join(String(dir), ".bun_repl_history")).text();
+      // Saved history must not preserve carriage returns from the original file.
+      expect(saved).not.toContain("\r");
+      expect(saved).toContain("old_one\n");
+      expect(saved).toContain("old_two\n");
+      expect(saved).toContain("new_three\n");
+    });
+  });
 });
 
 // Interactive terminal-based REPL tests

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -934,7 +934,6 @@ describe.concurrent("Bun REPL", () => {
         },
       });
       const exitCode = await proc.exited;
-      expect(exitCode).toBe(0);
 
       const saved = await Bun.file(path.join(String(dir), ".bun_repl_history")).text();
       // Saved history must not preserve carriage returns from the original file.
@@ -942,6 +941,7 @@ describe.concurrent("Bun REPL", () => {
       expect(saved).toContain("old_one\n");
       expect(saved).toContain("old_two\n");
       expect(saved).toContain("new_three\n");
+      expect(exitCode).toBe(0);
     });
   });
 });


### PR DESCRIPTION
History files written with CRLF line endings (e.g. on Windows, or after editing in an editor that converts EOLs) carried the trailing '\r' into each entry. The CR then leaked into recall, .history output, and was re-saved verbatim, compounding the corruption on every session.

Mirror the pattern used in ini.zig: strip '\r' before treating the line as an entry.

I could not run `bun bd test` in this environment (missing clang-21), but verified with the system bun that the new test fails before the fix and the change is a one-line copy of the established pattern.

## What does this PR do?
Fixes a CRLF handling bug in the Bun REPL's history loader.

History.load in [src/repl.zig](https://github.com/Samuell1/bun/blob/claude/fix-windows-issues-4X3tQ/src/repl.zig) split the history file on '\n' only, so when the file used CRLF line endings (common on Windows, or after editing in a CRLF-defaulting editor), every loaded entry kept a trailing '\r'. The stray CR then leaked into:

arrow-key recall (the cursor jumped to column 0 after the recalled text),
.history output,
the next .save — which wrote the same CRs back, compounding the corruption on every subsequent session.
The fix mirrors the existing pattern in [src/ini.zig:60](https://github.com/Samuell1/bun/blob/claude/fix-windows-issues-4X3tQ/src/ini.zig#L60): strip a trailing '\r' before treating the line as an entry.

## How did you verify your code works?
Added a regression test in [test/js/bun/repl/repl.test.ts](https://github.com/Samuell1/bun/blob/claude/fix-windows-issues-4X3tQ/test/js/bun/repl/repl.test.ts) ("strips CRLF when loading existing history") that:

Seeds a temp $HOME with a .bun_repl_history containing old_one\r\nold_two\r\n,
Spawns bun repl, evaluates one new line, then .exit (forcing load → modify → save),
Re-reads the saved history and asserts there are no \r bytes and all three entries are present.
Verified the test fails against an unpatched Bun (system bun reproduced old_one\r\nold_two\r\nnew_three\n in the saved file).

Could not run bun bd test to confirm the patched build passes — sandbox is missing clang-21. Please run locally before merging:

bun bd test test/js/bun/repl/repl.test.ts -t "strips CRLF"
