### PR TITLE
Fix crash in `Bun.file().writer()` when options has non-string `path`

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2974,8 +2974,12 @@ pub fn getWriter(
     };
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
-        stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        var parsed = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
+        if (parsed == .FileSink) {
+            parsed.FileSink.input_path.deinit();
+            parsed.FileSink.input_path = input_path;
+            stream_start = parsed;
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -207,6 +207,18 @@ it("write result is not cumulative", async () => {
   await util.promisify(fs.close)(fd);
 });
 
+it("writer() does not crash when options object has a non-string 'path' property", async () => {
+  const x = tmpdirSync();
+  const dest = path.join(x, "test.txt");
+  const file = Bun.file(dest);
+  const options = {};
+  Object.defineProperty(options, "path", { enumerable: true, value: Uint32Array });
+  const writer = file.writer(options);
+  await writer.write("hello");
+  await writer.end();
+  expect(await Bun.file(dest).text()).toBe("hello");
+});
+
 if (isWindows) {
   it("ENOENT, Windows", () => {
     expect(() => Bun.file("A:\\this-does-not-exist.txt").writer()).toThrow(


### PR DESCRIPTION
## What

Fixes a debug panic / release misbehavior in `Bun.file().writer(options)` when the options object has a `path` property that is not a string (or an `fd` property that is not an integer).

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
runtime.webcore.Blob.getWriter
/workspace/bun/src/runtime/webcore/Blob.zig:2978:21
```

## Why

`streams.Start.fromJSWithTag(..., .FileSink)` returns `.{ .err = ... }` when the options object has a non-string `path` or non-integer `fd`. `getWriter` then unconditionally accessed `stream_start.FileSink.input_path`, which:
- panics in debug (union field access while another field is active)
- in release, the tag stays `.err`, `FileSink.start` falls through `else => {}` without opening the file, and writes silently go nowhere

## How

Since the blob's own `input_path` is always used here (any `path`/`fd` from the options object is immediately overwritten), only apply the parsed options when the result is `.FileSink`. Otherwise keep the already-initialized `stream_start`. Also `deinit` the parsed `input_path` before overwriting it to avoid leaking an allocated slice when a string `path` option is provided.

## Repro

```js
const f = Bun.file("/tmp/out.txt");
const opts = {};
Object.defineProperty(opts, "path", { enumerable: true, value: Uint32Array });
f.writer(opts); // previously crashed in debug
```

Found by Fuzzilli. Fingerprint: `19c486a5819df798`