### PR TITLE
transpiler: support reactFastRefresh in Bun.Transpiler

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2489,6 +2489,18 @@ declare module "bun" {
      * @default false
      */
     replMode?: boolean;
+
+    /**
+     * Enable React Fast Refresh transform.
+     *
+     * Injects `$RefreshReg$` and `$RefreshSig$` calls so a host runtime
+     * (e.g. `react-refresh/runtime`) can register components and track
+     * hook signatures across updates. Only applies when the effective
+     * loader is `jsx` or `tsx`.
+     *
+     * @default false
+     */
+    reactFastRefresh?: boolean;
   }
 
   /**

--- a/src/bundler/transpiler.zig
+++ b/src/bundler/transpiler.zig
@@ -925,6 +925,7 @@ pub const Transpiler = struct {
                 opts.features.bundler_feature_flags = transpiler.options.bundler_feature_flags;
                 opts.features.repl_mode = transpiler.options.repl_mode;
                 opts.repl_mode = transpiler.options.repl_mode;
+                opts.features.react_fast_refresh = transpiler.options.react_fast_refresh and loader.isJSX();
 
                 if (transpiler.macro_context == null) {
                     transpiler.macro_context = js_ast.Macro.MacroContext.init(transpiler);

--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -43,6 +43,7 @@ pub const Config = struct {
     minify_syntax: bool = false,
     no_macros: bool = false,
     repl_mode: bool = false,
+    react_fast_refresh: bool = false,
 
     pub fn fromJS(this: *Config, globalThis: *jsc.JSGlobalObject, object: jsc.JSValue, allocator: std.mem.Allocator) bun.JSError!void {
         if (object.isUndefinedOrNull()) {
@@ -252,6 +253,10 @@ pub const Config = struct {
 
         if (try object.getBooleanLoose(globalThis, "replMode")) |flag| {
             this.repl_mode = flag;
+        }
+
+        if (try object.getBooleanLoose(globalThis, "reactFastRefresh")) |flag| {
+            this.react_fast_refresh = flag;
         }
 
         if (try object.getTruthy(globalThis, "minify")) |minify| {
@@ -733,7 +738,7 @@ pub fn constructor(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) b
     transpiler.options.auto_import_jsx = config.runtime.auto_import_jsx;
     transpiler.options.inlining = config.runtime.inlining;
     transpiler.options.hot_module_reloading = config.runtime.hot_module_reloading;
-    transpiler.options.react_fast_refresh = false;
+    transpiler.options.react_fast_refresh = config.react_fast_refresh;
     transpiler.options.repl_mode = config.repl_mode;
 
     return this;

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3777,4 +3777,58 @@ const Layout = () => {
     expect(result).toContain("a: 1");
     expect(result).not.toContain("fn(");
   });
+
+  describe("reactFastRefresh", () => {
+    // https://github.com/oven-sh/bun/issues/30295
+    const reactComponent = `
+import { useState } from "react";
+export function App() {
+  const [n, setN] = useState(0);
+  return <h1>{n}</h1>;
+}
+`;
+
+    it("is not applied by default", () => {
+      const t = new Bun.Transpiler({ loader: "tsx" });
+      const out = t.transformSync(reactComponent);
+      expect(out).not.toContain("$RefreshReg$");
+      expect(out).not.toContain("$RefreshSig$");
+    });
+
+    it("injects $RefreshReg$/$RefreshSig$ calls for tsx", () => {
+      const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
+      const out = t.transformSync(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+      expect(out).toContain("$RefreshSig$");
+      expect(out).toContain('from "react-refresh/runtime"');
+    });
+
+    it("injects $RefreshReg$/$RefreshSig$ calls for jsx", () => {
+      const t = new Bun.Transpiler({ loader: "jsx", reactFastRefresh: true });
+      const out = t.transformSync(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+      expect(out).toContain("$RefreshSig$");
+    });
+
+    it("also works on the async transform()", async () => {
+      const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
+      const out = await t.transform(reactComponent);
+      expect(out).toContain("$RefreshReg$");
+      expect(out).toContain("$RefreshSig$");
+    });
+
+    it("does not inject on non-JSX loaders even when enabled", () => {
+      const t = new Bun.Transpiler({ loader: "ts", reactFastRefresh: true });
+      const out = t.transformSync(`export function foo() { return 42; }\n`);
+      expect(out).not.toContain("$RefreshReg$");
+      expect(out).not.toContain("$RefreshSig$");
+    });
+
+    it("does not inject for JSX files without components", () => {
+      const t = new Bun.Transpiler({ loader: "tsx", reactFastRefresh: true });
+      const out = t.transformSync(`export const x = 42;\nexport function notAComponent() { return 42; }\n`);
+      expect(out).not.toContain("$RefreshReg$");
+      expect(out).not.toContain("$RefreshSig$");
+    });
+  });
 });


### PR DESCRIPTION
Fixes #30295

## Repro

`Bun.build({ reactFastRefresh: true })` emits `$RefreshReg$` / `$RefreshSig$` calls for Fast Refresh. `new Bun.Transpiler({ loader: 'tsx' })` did not — and there was no option to turn it on. This forced dev servers that re-transpile a single changed file to fall back to the bundler for every save.

```ts
const src = `
export function App() {
  const [n, setN] = useState(0);
  return <h1>{n}</h1>;
}
`;
const out = new Bun.Transpiler({ loader: 'tsx' }).transformSync(src);
// before: no $RefreshReg$ / $RefreshSig$ anywhere
```

## Cause

`src/runtime/api/JSTranspiler.zig` hardcoded `transpiler.options.react_fast_refresh = false` in the constructor and never parsed a JS-side option.

The runtime/per-file parse path in `src/bundler/transpiler.zig` also never forwarded `transpiler.options.react_fast_refresh` onto `opts.features.react_fast_refresh` — only the bundler's `ParseTask` did. So even if `react_fast_refresh` had been set, the single-file transpile would still have dropped it on the floor.

## Fix

- Add `react_fast_refresh: bool = false` to `JSTranspiler.Config` and parse `reactFastRefresh` via `getBooleanLoose` in `Config.fromJS`, mirroring the JS-side knob that `Bun.build` exposes.
- Replace the hardcoded `false` with `config.react_fast_refresh` in the constructor.
- Forward `transpiler.options.react_fast_refresh` to `opts.features.react_fast_refresh` in the per-file parse switch in `src/bundler/transpiler.zig`, gated on `loader.isJSX()` so the flag is a no-op on `.ts`/`.js`.
- Document `reactFastRefresh?: boolean` on `TranspilerOptions` in `packages/bun-types/bun.d.ts`.

## Verification

```ts
const t = new Bun.Transpiler({ loader: 'tsx', reactFastRefresh: true });
t.transformSync(`
  export function App() {
    const [n, setN] = useState(0);
    return <h1>{n}</h1>;
  }
`);
// now emits:
//   import { register as $RefreshReg$_..., createSignatureFunctionForTransform as $RefreshSig$_... }
//     from 'react-refresh/runtime';
//   ...
//   $RefreshReg$_...(App, 'input.tsx:App');
```

Added tests in `test/bundler/transpiler/transpiler.test.js` covering:
- default (off) on tsx
- enabled on `tsx` and `jsx`
- async `transform()` path
- non-JSX loaders ignore the flag
- JSX without components doesn't inject spuriously

The bundler path (`Bun.build`, `ParseTask.zig`) is untouched; regression test `test/regression/issue/25716.test.ts` still passes.