### PR TITLE
Fix crash in `Bun.file().writer()` with invalid path/fd options

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -2975,7 +2975,11 @@ pub fn getWriter(
 
     if (arguments.len > 0 and arguments.ptr[0].isObject()) {
         stream_start = try jsc.WebCore.streams.Start.fromJSWithTag(globalThis, arguments[0], .FileSink);
-        stream_start.FileSink.input_path = input_path;
+        if (stream_start == .FileSink) {
+            stream_start.FileSink.input_path = input_path;
+        } else {
+            stream_start = .{ .FileSink = .{ .input_path = input_path } };
+        }
     }
 
     switch (sink.start(stream_start)) {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -268,3 +268,17 @@ it.skipIf(!isPosix)("does not leak native FileSink when a pending write fails (E
   // more than that indicates a native leak.
   expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
 });
+
+describe("Bun.file().writer() with invalid options", () => {
+  it.each([
+    ["non-string path", { path: 123 }],
+    ["non-integer fd", { fd: "notanint" }],
+    ["arbitrary object", Bun],
+  ])("does not crash with %s", async (_, options) => {
+    const path = join(tmpdirSync(), "filesink-invalid-options.txt");
+    const writer = Bun.file(path).writer(options as any);
+    writer.write("hello");
+    await writer.end();
+    expect(await Bun.file(path).text()).toBe("hello");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug-mode panic (union safety check) in `Bun.file().writer(options)` when the options object contains a non-string `path` or non-integer `fd` property.

```
panic(main thread): access of union field 'FileSink' while field 'err' is active
```

`Start.fromJSWithTag(.FileSink)` can return `.err` when the options object has an invalid `path`/`fd`, but `Blob.getWriter` unconditionally accessed `stream_start.FileSink.input_path` afterward. Since the Blob already provides its own path/fd (which is what gets written to), we now fall back to the default `FileSink` options with the Blob's `input_path` in that case.

## How did you verify your code works?

Minimal repros that panicked before and now work:

```js
Bun.file("/tmp/x").writer({ path: 123 });
Bun.file("/tmp/x").writer({ fd: "notanint" });
Bun.file("/tmp/x").writer(Bun);
```

Added regression tests to `test/js/bun/util/filesink.test.ts`.

Found by Fuzzilli (fingerprint `a0ee9cd4fa588613`).