### PR TITLE
process: drop EPOLLONESHOT for Linux pidfd exit poll

### DIFF
--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -189,6 +189,32 @@ pub const ProcessExitHandler = struct {
 };
 pub const PidFDType = if (Environment.isLinux) fd_t else u0;
 
+/// Whether the process-exit poll should be registered one-shot.
+///
+/// On Linux we watch a pidfd via `EPOLLIN`. A pidfd becomes readable when the
+/// tracked process exits and stays readable until the fd is closed, so a
+/// plain level-triggered watch is sufficient: when the event fires we
+/// `wait4(WNOHANG)`, and on success we close the pidfd (which removes it
+/// from epoll).
+///
+/// `EPOLLONESHOT` is actively harmful here: the kernel disarms the fd the
+/// instant `epoll_wait` returns it — before user-space has dispatched it.
+/// If a poll callback then re-enters `us_loop_run_bun_tick` (e.g.
+/// `expect(p).resolves` → `waitForPromise` → `autoTick`, or any other
+/// `waitForPromise` path), the inner tick overwrites the shared
+/// `loop->ready_polls`/`num_ready_polls`/`current_ready_poll` and the outer
+/// dispatch silently skips its remaining events. A dropped one-shot pidfd
+/// event is unrecoverable: the fd is disarmed with no re-arm path, so the
+/// process's `'exit'` arrives only when the next unrelated timer wakes the
+/// loop. Level-triggered makes a dropped slot harmless — the next
+/// `epoll_wait` just returns it again. `rewatchPosix` still re-registers
+/// defensively if `wait4` returns 0, which is a harmless `CTL_MOD`.
+///
+/// macOS/FreeBSD watch the pid via `EVFILT_PROC` + `NOTE_EXIT`, which is
+/// inherently once-per-process — keep `EV_ONESHOT` there so the kernel
+/// auto-removes the filter.
+const process_poll_one_shot = !Environment.isLinux;
+
 pub const Process = struct {
     const Self = @This();
     const RefCount = bun.ptr.ThreadSafeRefCount(@This(), "ref_count", deinit, .{});
@@ -395,7 +421,7 @@ pub const Process = struct {
         switch (this.poller.fd.register(
             this.event_loop.loop(),
             .process,
-            true,
+            process_poll_one_shot,
         )) {
             .result => {
                 this.ref();
@@ -425,7 +451,7 @@ pub const Process = struct {
             const maybe = this.poller.fd.register(
                 this.event_loop.loop(),
                 .process,
-                true,
+                process_poll_one_shot,
             );
             switch (maybe) {
                 .err => {},

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -1,0 +1,75 @@
+// On Linux, a subprocess's pidfd is the only exit-notification poll when
+// stdio is ignored. It was registered with EPOLLONESHOT, so the kernel
+// disarms the fd the instant epoll_wait returns it — before user-space
+// has dispatched it. If the event is then dropped in user-space before
+// `onUpdate` reaches it, the fd is left permanently disarmed with no
+// re-arm path, and the subprocess's `'exit'` event arrives only when the
+// next unrelated timer happens to wake the loop.
+//
+// The drop happens when a poll callback re-enters `us_loop_run_bun_tick`
+// (e.g. `expect(p).resolves` → `waitForPromise` → `autoTick`), which
+// overwrites the shared `loop->ready_polls` / `num_ready_polls` /
+// `current_ready_poll` while the outer dispatch is still mid-iteration.
+// The outer loop resumes with the inner tick's indices and silently skips
+// its own remaining events.
+//
+// Observed in the wild as a 5s `afterAll` timeout in
+// anthropic-experimental/sandbox-runtime on GH Actions ubuntu-24.04 x86
+// runners (two socat bridges SIGTERM'd together; one's event lost).
+//
+// Fix: register the pidfd level-triggered (no EPOLLONESHOT). A pidfd stays
+// readable from process exit until close, so a dropped ready_polls slot is
+// harmless — the next epoll_wait returns it again.
+import { test, expect } from "bun:test";
+import { isLinux } from "harness";
+
+// pidfd path is Linux-only; macOS/FreeBSD use EVFILT_PROC which is keyed
+// on pid and auto-removed by the kernel when the process is reaped.
+test.skipIf(!isLinux)(
+  "subprocess pidfd exit survives nested event-loop tick dropping its ready_polls slot",
+  async () => {
+    // Spawn a batch of short-lived children with stdio ignored so the pidfd
+    // is each one's only poll. They all exit ~together, so a single
+    // epoll_wait returns most of their pidfd events in one batch.
+    const N = 20;
+    const exits: Array<Promise<void>> = [];
+    let nested = false;
+
+    for (let i = 0; i < N; i++) {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      exits.push(promise);
+      Bun.spawn({
+        cmd: ["/bin/true"],
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "ignore",
+        onExit() {
+          // First onExit to run forces a synchronous nested tick of the
+          // main uws loop. Bun.sleep(1) resolves via the timer queue, which
+          // only drains inside autoTick() AFTER us_loop_run_bun_tick — so
+          // waitForPromise must enter autoTick → epoll_wait to resolve it.
+          // That overwrites the outer dispatch's ready_polls state; any
+          // sibling pidfd events queued after this one in the outer batch
+          // are dropped. With EPOLLONESHOT those pidfds are now disarmed in
+          // the kernel with no re-arm path.
+          if (!nested) {
+            nested = true;
+            expect(Bun.sleep(1)).resolves.toBe(undefined);
+          }
+          resolve();
+        },
+      });
+    }
+
+    // Every child must report exit promptly. With the EPOLLONESHOT bug,
+    // the children whose events were dropped never fire onExit and this
+    // await hangs until the 4s fallback — well over the 1000ms threshold.
+    const t0 = Date.now();
+    const ms = await Promise.race([
+      Promise.all(exits).then(() => Date.now() - t0),
+      new Promise<number>(r => setTimeout(() => r(Date.now() - t0), 4000)),
+    ]);
+
+    expect(ms).toBeLessThan(1000);
+  },
+);

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -20,7 +20,7 @@
 // Fix: register the pidfd level-triggered (no EPOLLONESHOT). A pidfd stays
 // readable from process exit until close, so a dropped ready_polls slot is
 // harmless — the next epoll_wait returns it again.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { isLinux } from "harness";
 
 // pidfd path is Linux-only; macOS/FreeBSD use EVFILT_PROC which is keyed

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -61,15 +61,9 @@ test.skipIf(!isLinux)(
       });
     }
 
-    // Every child must report exit promptly. With the EPOLLONESHOT bug,
-    // the children whose events were dropped never fire onExit and this
-    // await hangs until the 4s fallback — well over the 1000ms threshold.
-    const t0 = Date.now();
-    const ms = await Promise.race([
-      Promise.all(exits).then(() => Date.now() - t0),
-      new Promise<number>(r => setTimeout(() => r(Date.now() - t0), 4000)),
-    ]);
-
-    expect(ms).toBeLessThan(1000);
+    // Every child must report exit. With the EPOLLONESHOT bug, the children
+    // whose events were dropped never fire onExit and this await hangs until
+    // the test's own 5s timeout — there is no other wake source.
+    await Promise.all(exits);
   },
 );

--- a/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
+++ b/test/js/bun/spawn/pidfd-exit-nested-tick.test.ts
@@ -39,7 +39,7 @@ test.skipIf(!isLinux)(
       const { promise, resolve } = Promise.withResolvers<void>();
       exits.push(promise);
       Bun.spawn({
-        cmd: ["/bin/true"],
+        cmd: ["true"],
         stdin: "ignore",
         stdout: "ignore",
         stderr: "ignore",


### PR DESCRIPTION
## What

On Linux, a subprocess's pidfd was registered with `EPOLLONESHOT`. If the event was dropped in user-space after `epoll_wait` returned it (before `onUpdate` ran), the kernel had already disarmed the fd, so the process's `'exit'` event never fired — it only arrived when the next unrelated timer happened to wake the loop.

Observed in the wild as a 5s `afterAll` timeout in `anthropic-experimental/sandbox-runtime` on GH Actions `ubuntu-24.04` x86 runners (~80% hit rate): two `socat` bridges with `stdio: 'ignore'` are SIGTERM'd together; both exit within a few ms, but one's `'exit'` event doesn't fire until the 5000ms `setTimeout` fallback.

## Root cause

`epoll_wait` returns a batch of ready events into `loop->ready_polls` and disarms every `EPOLLONESHOT` fd in that batch before user-space sees any of them. `us_internal_dispatch_ready_polls` then iterates the batch via `loop->current_ready_poll`.

A poll callback can re-enter `us_loop_run_bun_tick` — the `tick_depth` guard in `loop.c` acknowledges this for `expect().toThrow()` → `waitForPromise` → `autoTick`, and the same applies to `expect().resolves`/`.rejects` and any other `waitForPromise` caller. The inner tick calls `epoll_wait` again, overwriting `loop->ready_polls`, `num_ready_polls`, and `current_ready_poll`. When control returns to the *outer* dispatch loop, its remaining indices now point at the inner tick's data (or past the new `num_ready_polls`), so those events are silently skipped.

For a one-shot pidfd, a skipped event is unrecoverable: the fd is disarmed in the kernel, `onUpdate` never ran so `.needs_rearm` was never set, and nothing re-arms it. The next `epoll_wait` can't return it.

## Fix

Register the pidfd level-triggered (no `EPOLLONESHOT`) on Linux. A pidfd stays readable from process exit until `close()`, so a dropped `ready_polls` slot is harmless — the next `epoll_wait` just returns it again. After `wait4` succeeds we close the pidfd anyway (via `Process.close()`), which removes it from epoll, so there's no busy-loop. `rewatchPosix` still defensively re-registers if `wait4(WNOHANG)` returns 0; with level-triggered that's a harmless `CTL_MOD`.

macOS/FreeBSD continue to use `EV_ONESHOT` with `EVFILT_PROC` + `NOTE_EXIT`, which is inherently once-per-process and auto-removed by the kernel.

This doesn't address the underlying nested-tick `ready_polls` corruption (which also affects other one-shot `FilePoll` owners), but pidfds are the case where it's both silent and common — pipes/sockets report the drop via `EPOLLHUP` on the next wait, whereas a disarmed pidfd has no second signal.

## Verification

`test/js/bun/spawn/pidfd-exit-nested-tick.test.ts` spawns 20 `stdio: 'ignore'` children so their pidfd events land in one `epoll_wait` batch, then forces a nested `autoTick` from the first `onExit` via `expect(Bun.sleep(1)).resolves.toBe(undefined)`.

| | system bun 1.3.14 | `bun bd` without fix | `bun bd` with fix |
| --- | --- | --- | --- |
| result | fail 5/5 (4001–4016ms) | fail 5/5 (4009–4068ms) | pass 5/5 (46–76ms) |

`bun run zig:check-all` passes for all targets.