### PR TITLE
Guarantee pending exception when BunString__fromJS returns Dead

### DIFF
--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -61,9 +61,21 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__WTFStringImpl__ref(WTF::StringImpl*
 
 extern "C" [[ZIG_EXPORT(nothrow)]] bool BunString__fromJS(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue encodedValue, BunString* bunString)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue value = JSC::JSValue::decode(encodedValue);
     *bunString = Bun::toString(globalObject, value);
-    return bunString->tag != BunStringTag::Dead;
+    if (bunString->tag == BunStringTag::Dead) [[unlikely]] {
+        // Zig's String.fromJS asserts that a Dead result implies a pending
+        // exception. toWTFString almost always throws before returning a null
+        // String, but there are rare paths where it does not; guarantee the
+        // invariant here so the caller never sees Dead without an exception.
+        if (!scope.exception()) [[unlikely]]
+            throwOutOfMemoryError(globalObject, scope);
+        return false;
+    }
+    scope.release();
+    return true;
 }
 
 extern "C" [[ZIG_EXPORT(nothrow)]] BunString BunString__createAtom(const char* bytes, size_t length)

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -84,3 +84,21 @@ test("Bun.file(path).stat() returns stats", async () => {
   expect(stat).toBeDefined();
   expect(stat.size).toBe(13); // "Hello, world!" is 13 bytes
 });
+
+test("Bun.write() with a native constructor as data stringifies it", async () => {
+  // Hits the generic toSlice fallback in Blob.fromJSWithoutDeferGC; BunString__fromJS
+  // must never return Dead without a pending exception or the debug assert in
+  // String.fromJS trips.
+  const dir = tempDirWithFiles("bun-write-ctor", {});
+  const file = Bun.file(path.join(dir, "out.txt"));
+  await Bun.write(file, ArrayBuffer as any);
+  expect(await file.text()).toBe(ArrayBuffer.toString());
+});
+
+test("S3Client.write() with a native constructor as data does not assert", async () => {
+  const s3 = new Bun.S3Client();
+  // Missing credentials, so the upload itself rejects — we only care that the
+  // Blob conversion of `ArrayBuffer` (a JSFunction) did not trip a debug
+  // assertion in String.fromJS on the way there.
+  await expect(s3.write("key", ArrayBuffer as any)).rejects.toThrow();
+});


### PR DESCRIPTION
Fuzzilli fingerprint: `6659a56d731cb1be`

## What

Zig's `String.fromJS` does:

```zig
const ok = bun.cpp.BunString__fromJS(globalObject, value, &out);
const has_exception = scope.hasExceptionOrFalseWhenAssertionsAreDisabled();
if (ok) {
    bun.debugAssert(out.tag != .Dead);
} else {
    bun.debugAssert(has_exception);   // ← panicked here
}
```

`BunString__fromJS` returns `false` iff `toWTFString()` produced a null `WTF::String` (which becomes `BunStringTag::Dead`). Almost every path that yields a null string also throws (object `toString()` threw, rope OOM, termination trap), but Fuzzilli hit a state where the string came back null with no exception pending, tripping the `debugAssert(has_exception)` and crashing with `reached unreachable code`.

Stack:
```
String.fromJS
JSValue.toSlice
Blob.fromJSWithoutDeferGC
Blob.fromJSMovable
Blob.writeFileInternal
```

Reached via `new Bun.S3Client().write("key", ArrayBuffer)` — the `ArrayBuffer` constructor falls through to the generic `toSlice` branch in `Blob.fromJSWithoutDeferGC`. The crash was flaky (REPRL state from prior iterations), and I could not reproduce it deterministically, but the invariant violation is well-defined.

## Fix

Wrap the conversion in `BunString__fromJS` with a `ThrowScope` and, when the result is `Dead` with no pending exception, throw an `OutOfMemoryError` (what JSC itself uses for null-string failures). The Zig side then always sees `!ok → has_exception`, and release builds no longer risk returning `error.JSError` up through `toJSHostCall` with no VM exception attached.

Verified clean under `BUN_JSC_validateExceptionChecks=1` for both the success path and the throwing-`toString` path.

## Tests

Added two tests to `test/js/web/fetch/blob-write.test.ts` exercising `Bun.write(file, ArrayBuffer)` and `S3Client.write(key, ArrayBuffer)` to lock in the code path.