### PR TITLE
http2: give Http2Stream its own per-stream idle timer

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -360,6 +360,9 @@ const bunHTTP2Session = Symbol.for("::bunhttp2session::");
 const bunHTTP2Headers = Symbol.for("::bunhttp2headers::");
 const bunHTTP2AsyncContextFrame = Symbol("::bunhttp2asynccontextframe::");
 const bunHTTP2SessionTeardownFrame = Symbol("::bunhttp2sessionteardownframe::");
+// Outbound-progress snapshots for idle timers (node's chunksSentSinceLastWrite).
+const kTimeoutBytesSnapshot = Symbol("timeoutBytesSnapshot");
+const kTimeoutWrittenSnapshot = Symbol("timeoutWrittenSnapshot");
 // Sentinel for bunHTTP2SessionTeardownFrame: a captured frame can itself be
 // undefined (the root context), so "no teardown in progress" needs its own value.
 const kNoSessionTeardown = Symbol("::bunhttp2noteardown::");
@@ -2194,6 +2197,7 @@ function validateWindowSize(windowSize) {
 hideFromStack(validateWindowSize);
 
 function pushToStream(stream, data) {
+  stream._unrefTimer();
   if (data && stream[bunHTTP2StreamStatus] & StreamState.Closed) {
     if (!stream._readableState.ended) {
       // closed, but not ended, so resume and push null to end the stream
@@ -2399,6 +2403,10 @@ function markStreamClosed(stream: Http2Stream) {
 
   if ((status & StreamState.Closed) === 0) {
     stream[bunHTTP2StreamStatus] = status | StreamState.Closed;
+    // node closeStream(): every close path disarms the stream's idle timer.
+    clearTimeout(stream[kTimeout]);
+    stream[kTimeout] = null;
+    stream.removeAllListeners("timeout");
     publishStreamCloseChannel(stream);
 
     markWritableDone(stream);
@@ -2490,6 +2498,9 @@ class Http2Stream extends Duplex {
   [bunHTTP2AsyncContextFrame] = $getInternalField($asyncContext, 0);
 
   rstCode: number | undefined = undefined;
+  timeout: number | undefined = undefined;
+  [kTimeout]: ReturnType<typeof setTimeout> | null = null;
+  [kTimeoutWrittenSnapshot]: number = 0;
   [bunHTTP2Headers]: any;
   [kInfoHeaders]: any;
   #sentTrailers: any;
@@ -2588,6 +2599,8 @@ class Http2Stream extends Duplex {
       throw $ERR_HTTP2_TRAILERS_NOT_READY();
     }
 
+    this._unrefTimer();
+
     if (headers == undefined) {
       headers = {};
     } else if (!$isObject(headers) || $isArray(headers)) {
@@ -2631,10 +2644,52 @@ class Http2Stream extends Duplex {
     }
   }
 
-  setTimeout(timeout, callback) {
+  setTimeout(msecs, callback) {
+    if (this.destroyed) return this;
+
+    this.timeout = msecs;
+
+    msecs = getTimerDuration(msecs, "msecs");
+
+    clearTimeout(this[kTimeout]);
+
+    if (msecs === 0) {
+      if (callback !== undefined) {
+        validateFunction(callback, "callback");
+        this.removeListener("timeout", callback);
+      }
+    } else {
+      const socket = this[bunHTTP2Session]?.[bunHTTP2Socket];
+      this[kTimeoutWrittenSnapshot] = socket?._handle?.bytesWritten ?? socket?.bytesWritten ?? 0;
+      this[kTimeout] = setTimeout(this._onTimeout.bind(this), msecs).unref();
+
+      if (callback !== undefined) {
+        validateFunction(callback, "callback");
+        this.once("timeout", callback);
+      }
+    }
+    return this;
+  }
+
+  _onTimeout() {
+    if (this.destroyed) return;
+    // node callTimeout: this stream's pending write still making wire progress is not idle.
     const session = this[bunHTTP2Session];
-    if (!session) return;
-    session.setTimeout(timeout, callback);
+    if (session && this.writableLength > 0) {
+      const socket = session[bunHTTP2Socket];
+      const bytesWritten = socket?._handle?.bytesWritten ?? socket?.bytesWritten ?? 0;
+      if (bytesWritten !== this[kTimeoutWrittenSnapshot]) {
+        this[kTimeoutWrittenSnapshot] = bytesWritten;
+        this[kTimeout]?.refresh();
+        return;
+      }
+    }
+    this.emit("timeout");
+  }
+
+  _unrefTimer() {
+    const timer = this[kTimeout];
+    if (timer) timer.refresh();
   }
 
   get closed() {
@@ -3024,6 +3079,7 @@ class Http2Stream extends Duplex {
       this.once("ready", this._writev.bind(this, data, callback));
       return;
     }
+    this._unrefTimer();
     const writevPerf = this[kPerfState];
     if (writevPerf !== undefined) {
       if (writevPerf.firstByteSent === 0) writevPerf.firstByteSent = performance.now() - writevPerf.start;
@@ -3086,6 +3142,7 @@ class Http2Stream extends Duplex {
       this.once("ready", this._write.bind(this, chunk, encoding, callback));
       return;
     }
+    this._unrefTimer();
     const writePerf = this[kPerfState];
     if (writePerf !== undefined) {
       if (writePerf.firstByteSent === 0) writePerf.firstByteSent = performance.now() - writePerf.start;
@@ -3281,6 +3338,7 @@ function doSendFileFD(options, fd, headers, err, stat) {
         cb();
         return;
       }
+      stream._unrefTimer();
       const status = native.writeStream(stream.id, chunk, undefined, false, cb, true);
       if (status & kWriteFlushedWithoutCallback) process.nextTick(cb);
     },
@@ -3432,6 +3490,7 @@ class ServerHttp2Stream extends Http2Stream {
     if (!parser) {
       throw $ERR_HTTP2_INVALID_STREAM();
     }
+    this._unrefTimer();
     headers = { ...headers };
     assertNoConnectionHeaders(headers);
     // Thrown synchronously like node, before a promised stream id is reserved.
@@ -3646,6 +3705,8 @@ class ServerHttp2Stream extends Http2Stream {
       throw $ERR_HTTP2_HEADERS_AFTER_RESPOND();
     }
 
+    this._unrefTimer();
+
     if (headers == undefined) {
       headers = {};
     } else if (!$isObject(headers) || $isArray(headers)) {
@@ -3714,6 +3775,8 @@ class ServerHttp2Stream extends Http2Stream {
     if (this.sentTrailers) {
       throw $ERR_HTTP2_TRAILERS_ALREADY_SENT();
     }
+
+    this._unrefTimer();
 
     // Raw (flat [name, value, ...] array) headers form: the pairs are encoded
     // on the wire in their given order; a default :status is prepended and a
@@ -4320,6 +4383,7 @@ class ServerHttp2Session extends Http2Session {
       flags: number,
     ) {
       if (!self || typeof stream !== "object" || self.closed || stream.closed) return;
+      stream._unrefTimer();
       const requestPerf = stream[kPerfState];
       if (requestPerf !== undefined && requestPerf.firstHeader === 0) {
         requestPerf.firstHeader = performance.now() - requestPerf.start;
@@ -4550,10 +4614,7 @@ class ServerHttp2Session extends Http2Session {
     this.destroy(error);
   }
   #onTimeout() {
-    const parser = this.#parser;
-    if (parser) {
-      parser.forEachStream(emitTimeout);
-    }
+    // node: session idle timeouts emit on the session only, never on streams.
     this.emit("timeout");
   }
   #onDrain() {
@@ -4993,13 +5054,6 @@ class ServerHttp2Session extends Http2Session {
     process.nextTick(emitSessionCloseNT, this, asyncFrame);
   }
 }
-function emitTimeout(session: ClientHttp2Session) {
-  session.emit("timeout");
-}
-// Outbound-progress snapshot taken the last time the session's idle timer expired while writes
-// were still pending (see sessionTimerExpired / node's chunksSentSinceLastWrite).
-const kTimeoutBytesSnapshot = Symbol("timeoutBytesSnapshot");
-const kTimeoutWrittenSnapshot = Symbol("timeoutWrittenSnapshot");
 let sessionHasPendingWrite = false;
 function checkStreamWritePending(stream: Http2Stream) {
   if (stream.writableLength > 0) sessionHasPendingWrite = true;
@@ -5083,8 +5137,8 @@ function sessionTimerExpired(session: Http2Session) {
         return;
       }
     }
-    parser.forEachStream(emitTimeout);
   }
+  // node: session idle timeouts emit on the session only, never on streams.
   session.emit("timeout");
 }
 function destroySelfOnEnd(this: Http2Stream) {
@@ -5310,6 +5364,7 @@ class ClientHttp2Session extends Http2Session {
         flags: number,
       ) => {
         if (!self || typeof stream !== "object" || stream.rstCode) return;
+        stream._unrefTimer();
         let rawheaders = headersTuple[0];
         let headers = headersTuple[1];
         if (self.#strictFieldWhitespaceValidation) {
@@ -5631,10 +5686,7 @@ class ClientHttp2Session extends Http2Session {
     this.destroy(error);
   }
   #onTimeout() {
-    const parser = this.#parser;
-    if (parser) {
-      parser.forEachStream(emitTimeout);
-    }
+    // node: session idle timeouts emit on the session only, never on streams.
     this.emit("timeout");
   }
   #onDrain() {

--- a/test/regression/issue/30307.test.ts
+++ b/test/regression/issue/30307.test.ts
@@ -1,0 +1,128 @@
+// https://github.com/oven-sh/bun/issues/30307
+
+import { describe, expect, it } from "bun:test";
+import { isASAN } from "harness";
+import { once } from "node:events";
+import http2 from "node:http2";
+
+const SCALE = isASAN ? 4 : 1;
+
+describe("#30307", () => {
+  it("req.setTimeout does not fire on completed streams after a session-idle gap", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+
+    const listening = once(server, "listening");
+    server.listen(0);
+    await listening;
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    try {
+      await once(client, "connect");
+      {
+        const warmup = client.request({ ":path": "/" });
+        warmup.resume();
+        warmup.end();
+        await once(warmup, "end");
+      }
+
+      const STREAM_TIMEOUT_MS = 150 * SCALE;
+      const IDLE_BARRIER_MS = 2 * STREAM_TIMEOUT_MS;
+
+      const timeoutFires: string[] = [];
+      async function doRequest(label: string) {
+        const req = client.request({ ":path": "/" });
+        req.setTimeout(STREAM_TIMEOUT_MS, () => {
+          timeoutFires.push(label);
+        });
+        req.resume();
+        req.end();
+        await once(req, "end");
+      }
+
+      await doRequest("req-1");
+      await doRequest("req-2");
+      await doRequest("req-3");
+      await doRequest("req-4");
+
+      client.setTimeout(IDLE_BARRIER_MS);
+      await once(client, "timeout");
+
+      await doRequest("req-5");
+
+      expect(timeoutFires).toEqual([]);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("session-level setTimeout does not emit 'timeout' on live streams", async () => {
+    const server = http2.createServer();
+    server.on("stream", _stream => {});
+
+    const listening = once(server, "listening");
+    server.listen(0);
+    await listening;
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    try {
+      await once(client, "connect");
+
+      const streamFired: string[] = [];
+      const req1 = client.request({ ":path": "/a" });
+      const req2 = client.request({ ":path": "/b" });
+      req1.on("error", () => {});
+      req2.on("error", () => {});
+      req1.on("timeout", () => streamFired.push("req1"));
+      req2.on("timeout", () => streamFired.push("req2"));
+      req1.end();
+      req2.end();
+
+      client.setTimeout(150 * SCALE);
+      await once(client, "timeout");
+
+      expect(streamFired).toEqual([]);
+
+      req1.close(http2.constants.NGHTTP2_CANCEL);
+      req2.close(http2.constants.NGHTTP2_CANCEL);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  it("req.setTimeout does not fire on a completed stream whose body is never read", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("a response body the client never reads");
+    });
+
+    const listening = once(server, "listening");
+    server.listen(0);
+    await listening;
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    const client = http2.connect(`http://localhost:${port}`);
+    try {
+      await once(client, "connect");
+
+      const fired: string[] = [];
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.setTimeout(150 * SCALE, () => fired.push("req"));
+      req.end();
+
+      client.setTimeout(2 * 150 * SCALE);
+      await once(client, "timeout");
+
+      expect(fired).toEqual([]);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #30307

### Problem

- `@fastify/http-proxy` over HTTP/2 logs `FST_REPLY_FROM_HTTP2_REQUEST_TIMEOUT` bursts after any idle gap >= its `requestTimeout`, even though every proxied response is 200 OK.
- `@fastify/reply-from` arms `req.setTimeout(requestTimeout, cb)` on each outgoing `Http2Stream`; on Bun that path was broken two ways.

### Cause

- `Http2Stream.prototype.setTimeout` delegated to `session.setTimeout`, so every per-stream callback accumulated as a `once('timeout')` listener on the shared session, and one session idle fire ran them all at once, including callbacks for streams that had already ended.
- The session timer expiry (`sessionTimerExpired` and both socket `#onTimeout` handlers) broadcast `'timeout'` to every stream still tracked by the parser via `forEachStream(emitTimeout)`. In Node, a session-level idle timeout emits on the session only.

### Fix

- `Http2Stream.setTimeout(ms, cb)` now arms a per-instance unref'd timer (`kTimeout` from `internal/timers`), mirroring Node's `setStreamTimeout`: sets `this.timeout`, validates, returns `this`.
- `_onTimeout` mirrors Node's `callTimeout`: if a pending write has made wire progress since the timer was armed or last expired (socket `bytesWritten` snapshot), the stream is not idle, so the timer refreshes instead of emitting.
- `_unrefTimer()` refreshes the timer on stream activity, mirroring Node's `kUpdateTimer`: inbound DATA (`pushToStream`), inbound HEADERS (both `streamHeaders` handlers), outbound DATA (`_write`/`_writev`), and outbound HEADERS (`respond`, `pushStream`, `additionalHeaders`, `sendTrailers`).
- `markStreamClosed` disarms the timer and removes `'timeout'` listeners on every close transition (explicit `close()`, `_destroy`, and the END_STREAM completion that defers destroy while the body is buffered), mirroring Node's `closeStream()`.
- Both session `#onTimeout` handlers and `sessionTimerExpired` no longer cascade to streams; session idle timeouts emit on the session only. The session timer's existing write-progress refresh logic is unchanged.
- `timeout`/`[kTimeout]` are declared in the class body so the hot-path `_unrefTimer()` read stays monomorphic.

### Verification

- `test/regression/issue/30307.test.ts` (3 tests): completed streams after a session-idle gap, live streams on session timeout, and a completed stream whose body is never read (the deferred-destroy path). All 3 fail on `main`, pass with this diff.
- `test/js/node/http2/node-http2.test.js`: 357 pass, 0 fail.
- Node upstream compat: `test-http2-timeouts`, `test-http2-session-timeout`, `test-http2-server-timeout`, `test-http2-server-settimeout-no-callback`, both compat `settimeout` tests, `test-http2-trailers`, `test-http2-info-headers`, `test-http2-server-close-idle-connection`, and every other timeout-touching `test-http2-*.js` not in `test/expectations.txt` all pass.
- The reporter's fastify repro is silent on this branch (all 200 OK, no warnings), matching Node.

### Background

- Node gives the session and each stream an independent idle timer; any frame-level activity on an object refreshes that object's timer, and closing a stream disarms its timer. Bun previously funneled stream timers into the session's socket timer, which is what made idle gaps fire every accumulated callback at once.
- This was re-applied twice across upstream rewrites of `src/js/node/http2.ts` (#31584, then the v26.3.0 compat work); the bug survived both because `Http2Stream.setTimeout` still delegated to the session and the cascade remained.

<details>
<summary>Superseded earlier account (pre-rebase)</summary>

The original PR targeted the pre-#31584 `http2.ts`, where `session.setTimeout` forwarded to `socket.setTimeout` and the callbacks accumulated on the socket instead of the session. The fix shape was the same (per-stream timer, refresh points, no cascade); the rebases re-applied it onto the rewritten module and extended it with the review findings (outbound HEADERS refresh points, `markStreamClosed` consolidation, write-progress guard, `removeAllListeners('timeout')` on close).

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 12 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30307.test.ts"
bun test v1.4.0 (b30de2805)

test/regression/issue/30307.test.ts:
51 |       client.setTimeout(IDLE_BARRIER_MS);
52 |       await once(client, "timeout");
53 | 
54 |       await doRequest("req-5");
55 | 
56 |       expect(timeoutFires).toEqual([]);
                                ^
error: expect(received).toEqual(expected)

- []
+ [
+   "req-1",
+   "req-2",
+   "req-3",
+   "req-4",
+ ]

- Expected  - 1
+ Received  + 6

      at <anonymous> (/workspace/bun/test/regression/issue/30307.test.ts:56:28)
(fail) #30307 > req.setTimeout does not fire on completed streams after a session-idle gap [2225.53ms]
83 |       req2.end();
84 | 
85 |       client.setTimeout(150 * SCALE);
86 |       await once(client, "timeout");
87 | 
88 |       expect(streamFired).toEqual([]);
                               ^
error: expect(received).toEqual(expected)

- []
+ [
+   "req2",
+   "req1",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/regression/issue/30307.test.ts:88:27)
(fail) #30307 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cf8f5442f)

test/regression/issue/30307.test.ts:
(pass) #30307 > req.setTimeout does not fire on completed streams after a session-idle gap [320.63ms]
(pass) #30307 > session-level setTimeout does not emit 'timeout' on live streams [304.46ms]
(pass) #30307 > req.setTimeout does not fire on a completed stream whose body is never read [603.30ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [1418.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/30307.test.ts"
bun test v1.4.0 (b30de2805)

test/regression/issue/30307.test.ts:
(pass) #30307 > req.setTimeout does not fire on completed streams after a session-idle gap [2245.45ms]
(pass) #30307 > session-level setTimeout does not emit 'timeout' on live streams [1375.16ms]
(pass) #30307 > req.setTimeout does not fire on a completed stream whose body is never read [2532.53ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [9.38s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 629ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (8173ms)
Bundle modules (38ms)
Postprocesss modules (265ms)
Bundle Functions (741ms)
Generate Code (29ms)

[9.27s] Bundled "src/js" for production
  2628 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                |  90 +++++++++++++++++++------
 test/regression/issue/30307.test.ts | 128 ++++++++++++++++++++++++++++++++++++
 2 files changed, 199 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js/node/http2.ts                    54     61     47
test/regression/issue/30307.test.ts      8     10     44
```

</details>

**root cause** · written by the author bot

Bun's HTTP/2 implementation conflated session and stream idle timeouts, so a session-level timeout expiring after an idle gap was also emitted on streams that had completed or were otherwise inactive, which @fastify/reply-from interpreted as per-request timeouts. The timeout suppression logic also checked session-wide buffered writes instead of each stream's own outbound progress, diverging from Node's per-stream writeQueueSize gating. The fix gives each stream an independent unref'd timer that is refreshed on stream activity (data delivery, writes, headers, push promises, and file sends) a…

<!-- robobun:evidence:end -->