### PR TITLE
Fix use-after-free in Bun.Transpiler.transform() error reporting

### DIFF
--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -590,6 +590,11 @@ pub const TransformTask = struct {
     }
 
     pub fn deinit(this: *TransformTask) void {
+        for (this.log.msgs.items) |*msg| {
+            freeClonedLocation(&msg.data);
+            for (msg.notes) |*note| freeClonedLocation(note);
+            msg.deinit(bun.default_allocator);
+        }
         this.log.deinit();
         this.input_code.deinitAndUnprotect();
         this.output_code.deref();
@@ -597,6 +602,12 @@ pub const TransformTask = struct {
         // Do not free it here — JSTranspiler.deinit handles it.
         this.js_instance.deref();
         bun.destroy(this);
+    }
+
+    fn freeClonedLocation(data: *logger.Data) void {
+        const loc = &(data.location orelse return);
+        bun.default_allocator.free(loc.file);
+        if (loc.line_text) |lt| bun.default_allocator.free(lt);
     }
 };
 

--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -503,6 +503,9 @@ pub const TransformTask = struct {
         this.transpiler.setAllocator(allocator);
         this.transpiler.setLog(&this.log);
         this.log.msgs.allocator = bun.default_allocator;
+        defer for (this.log.msgs.items) |*msg| {
+            msg.* = bun.handleOom(msg.clone(bun.default_allocator));
+        };
 
         const jsx = if (this.tsconfig != null)
             this.tsconfig.?.mergeJSX(this.transpiler.options.jsx)

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -1,26 +1,23 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 test("async transform() rejecting with parse errors does not read freed memory", async () => {
-  const dir = tempDirWithFiles("transpiler-transform-error-uaf", {
-    "index.js": `
-      const transpiler = new Bun.Transpiler();
-      const bad = Buffer.alloc(1000, "const a = 1;\\n").toString() + "const x = ;";
-      const results = await Promise.all(
-        Array.from({ length: 20 }, () => transpiler.transform(bad).then(() => null, e => e)),
-      );
-      for (const e of results) {
-        if (!(e instanceof Error)) throw new Error("expected Error, got " + e);
-        const text = e.errors ? e.errors.map(String).join("\\n") : String(e);
-        if (!/already been declared|Unexpected/.test(text)) throw new Error("bad message: " + text);
-      }
-      console.log("ok");
-    `,
-  });
+  const script = `
+    const transpiler = new Bun.Transpiler();
+    const bad = Buffer.alloc(1000, "const a = 1;\\n").toString() + "const x = ;";
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => transpiler.transform(bad).then(() => null, e => e)),
+    );
+    for (const e of results) {
+      if (!(e instanceof Error)) throw new Error("expected Error, got " + e);
+      const text = e.errors ? e.errors.map(String).join("\\n") : String(e);
+      if (!/already been declared|Unexpected/.test(text)) throw new Error("bad message: " + text);
+    }
+    console.log("ok");
+  `;
 
   const { exitCode, stdout, stderr, signalCode } = Bun.spawnSync({
-    cmd: [bunExe(), "run", "index.js"],
-    cwd: dir,
+    cmd: [bunExe(), "-e", script],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -29,4 +26,4 @@ test("async transform() rejecting with parse errors does not read freed memory",
   const out = stdout.toString();
   const err = stderr.toString();
   expect({ exitCode, signalCode, out, err }).toEqual({ exitCode: 0, signalCode: undefined, out: "ok\n", err: "" });
-});
+}, 60_000);

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -1,21 +1,32 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 test("async transform() rejecting with parse errors does not read freed memory", async () => {
-  const transpiler = new Bun.Transpiler();
-  const bad = Buffer.alloc(1000, "const a = 1;\n").toString() + "const x = ;";
+  const dir = tempDirWithFiles("transpiler-transform-error-uaf", {
+    "index.js": `
+      const transpiler = new Bun.Transpiler();
+      const bad = Buffer.alloc(1000, "const a = 1;\\n").toString() + "const x = ;";
+      const results = await Promise.all(
+        Array.from({ length: 20 }, () => transpiler.transform(bad).then(() => null, e => e)),
+      );
+      for (const e of results) {
+        if (!(e instanceof Error)) throw new Error("expected Error, got " + e);
+        const text = e.errors ? e.errors.map(String).join("\\n") : String(e);
+        if (!/already been declared|Unexpected/.test(text)) throw new Error("bad message: " + text);
+      }
+      console.log("ok");
+    `,
+  });
 
-  const results = await Promise.all(
-    Array.from({ length: 20 }, () =>
-      transpiler.transform(bad).then(
-        () => null,
-        e => e,
-      ),
-    ),
-  );
+  const { exitCode, stdout, stderr, signalCode } = Bun.spawnSync({
+    cmd: [bunExe(), "run", "index.js"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-  for (const e of results) {
-    expect(e).toBeInstanceOf(Error);
-    const text = e.errors ? e.errors.map(String).join("\n") : String(e);
-    expect(text).toMatch(/already been declared|Unexpected/);
-  }
+  const out = stdout.toString();
+  const err = stderr.toString();
+  expect({ exitCode, signalCode, out, err }).toEqual({ exitCode: 0, signalCode: undefined, out: "ok\n", err: "" });
 });

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -5,7 +5,12 @@ test("async transform() rejecting with parse errors does not read freed memory",
   const bad = Buffer.alloc(1000, "const a = 1;\n").toString() + "const x = ;";
 
   const results = await Promise.all(
-    Array.from({ length: 20 }, () => transpiler.transform(bad).then(() => null, e => e)),
+    Array.from({ length: 20 }, () =>
+      transpiler.transform(bad).then(
+        () => null,
+        e => e,
+      ),
+    ),
   );
 
   for (const e of results) {

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -26,4 +26,4 @@ test("async transform() rejecting with parse errors does not read freed memory",
   const out = stdout.toString();
   const err = stderr.toString();
   expect({ exitCode, signalCode, out, err }).toEqual({ exitCode: 0, signalCode: undefined, out: "ok\n", err: "" });
-}, 60_000);
+});

--- a/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+test("async transform() rejecting with parse errors does not read freed memory", async () => {
+  const transpiler = new Bun.Transpiler();
+  const bad = Buffer.alloc(1000, "const a = 1;\n").toString() + "const x = ;";
+
+  const results = await Promise.all(
+    Array.from({ length: 20 }, () => transpiler.transform(bad).then(() => null, e => e)),
+  );
+
+  for (const e of results) {
+    expect(e).toBeInstanceOf(Error);
+    const text = e.errors ? e.errors.map(String).join("\n") : String(e);
+    expect(text).toMatch(/already been declared|Unexpected/);
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a use-after-free when `Bun.Transpiler#transform()` (the async variant) rejects with parse errors.

`TransformTask.run()` runs on a worker thread and uses a `MimallocArena` for parsing. Any parser/lexer diagnostics added to `this.log` have their text (`msg.data.text`, notes) allocated from that arena. The arena is destroyed at the end of `run()`, but the log messages are read later on the JS thread in `then()` via `this.log.toJS()` → `BuildMessage.create()` → `Msg.clone()` → `allocator.dupe(u8, this.text)`, which reads freed arena memory.

Setting `this.log.msgs.allocator = bun.default_allocator` only keeps the `Msg` array alive; the text inside each message still lives in the arena.

The fix clones each log message into `bun.default_allocator` in a `defer` that runs before `arena.deinit()`, so the message contents survive until `then()` runs.

## How did you verify your code works?

Added a regression test that runs 20 concurrent `transform()` calls on source with many parse errors. Under ASAN without the fix this reliably triggers `use-after-poison` at the same PC as the fuzzer report; with the fix it passes cleanly and the error messages/positions are intact.

```
test/js/bun/transpiler/transpiler-transform-error-uaf.test.ts
```

All existing `test/js/bun/transpiler/` and `test/bundler/transpiler/transpiler.test.js` tests continue to pass.