### PR TITLE
Fix crash when `new Bun.Terminal()` receives a non-object argument

### DIFF
--- a/src/js/internal/sql/errors.ts
+++ b/src/js/internal/sql/errors.ts
@@ -25,7 +25,7 @@ export interface PostgresErrorOptions {
   routine?: string | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 interface PostgresError {
   detail?: string | undefined;
   hint?: string | undefined;
@@ -79,7 +79,7 @@ export interface SQLiteErrorOptions {
   byteOffset?: number | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 interface SQLiteError {
   byteOffset?: number | undefined;
 }
@@ -106,7 +106,7 @@ export interface MySQLErrorOptions {
   sqlState?: string | undefined;
 }
 
-// oxlint-disable-next-line typescript-eslint(no-unsafe-declaration-merging)
+// oxlint-disable-next-line typescript-eslint/no-unsafe-declaration-merging
 interface MySQLError {
   errno?: number | undefined;
   sqlState?: string | undefined;

--- a/src/runtime/api/bun/Terminal.zig
+++ b/src/runtime/api/bun/Terminal.zig
@@ -297,7 +297,7 @@ pub fn constructor(
     const args = callframe.argumentsAsArray(1);
     const js_options = args[0];
 
-    if (js_options.isUndefinedOrNull()) {
+    if (!js_options.isObject()) {
         return globalObject.throw("Terminal constructor requires an options object", .{});
     }
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -92,6 +92,14 @@ describe("Bun.Terminal", () => {
     test("throws when options is undefined", () => {
       expect(() => new Bun.Terminal(undefined as any)).toThrow();
     });
+
+    test("throws when options is not an object", () => {
+      expect(() => new Bun.Terminal(8 as any)).toThrow();
+      expect(() => new Bun.Terminal("hello" as any)).toThrow();
+      expect(() => new Bun.Terminal(true as any)).toThrow();
+      expect(() => new Bun.Terminal(1n as any)).toThrow();
+      expect(() => new Bun.Terminal(Symbol() as any)).toThrow();
+    });
   });
 
   describe("write", () => {


### PR DESCRIPTION
Fuzzilli found a debug assertion failure in `Bun.Terminal` when the constructor is called with a primitive value:

```js
new Bun.Terminal(8);
```

```
panic(main thread): reached unreachable code
jsc.JSValue.JSValue.get
/workspace/bun/src/jsc/JSValue.zig:1534:24
jsc.JSValue.JSValue.getOptional
/workspace/bun/src/jsc/JSValue.zig:1886:34
runtime.api.bun.Terminal.Options.parseFromJS
/workspace/bun/src/runtime/api/bun/Terminal.zig:122:39
```

The constructor checked for `undefined`/`null` but passed any other value (numbers, strings, booleans, bigints, symbols) straight to `Options.parseFromJS`, which calls `JSValue.get` and asserts the target is an object.

Now the constructor rejects any non-object argument with the existing "Terminal constructor requires an options object" error.

Fingerprint: `2bd73cb78c0aa42e`