### PR TITLE
install: use uppercase %2F for scoped package manifest URLs

### DIFF
--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -171,7 +171,7 @@ pub const DependencyUrlFormatter = struct {
         var remain = this.url;
         while (strings.indexOfChar(remain, '/')) |slash| {
             try writer.writeAll(remain[0..slash]);
-            try writer.writeAll("%2f");
+            try writer.writeAll("%2F");
             remain = remain[slash + 1 ..];
         }
         try writer.writeAll(remain);

--- a/src/install/NetworkTask.zig
+++ b/src/install/NetworkTask.zig
@@ -206,7 +206,7 @@ pub fn forManifest(
         var stack_fallback_allocator = std.heap.stackFallback(512, arena.allocator());
         var encoded_name = name;
         if (strings.containsChar(name, '/')) {
-            encoded_name = try std.mem.replaceOwned(u8, stack_fallback_allocator.get(), name, "/", "%2f");
+            encoded_name = try std.mem.replaceOwned(u8, stack_fallback_allocator.get(), name, "/", "%2F");
         }
 
         const tmp = bun.jsc.URL.join(

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -465,10 +465,10 @@ it("should handle @scoped names", async () => {
     env,
   });
   const err = await stderr.text();
-  expect(err.split(/\r?\n/)).toContain(`error: GET http://localhost:${port}/@bar%2fbaz - 404`);
+  expect(err.split(/\r?\n/)).toContain(`error: GET http://localhost:${port}/@bar%2Fbaz - 404`);
   expect(await stdout.text()).toEqual(expect.stringContaining("bun add v1."));
   expect(await exited).toBe(1);
-  expect(urls.sort()).toEqual([`${root_url}/@bar%2fbaz`]);
+  expect(urls.sort()).toEqual([`${root_url}/@bar%2Fbaz`]);
   expect(requested).toBe(1);
   try {
     await access(join(package_dir, "bun.lockb"));

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -48,7 +48,7 @@ it("should create selected template with @ prefix", async () => {
 
   const err = await stderr.text();
   expect(err.split(/\r?\n/)).toContain(
-    `error: GET https://registry.npmjs.org/@quick-start%2fcreate-some-template - 404`,
+    `error: GET https://registry.npmjs.org/@quick-start%2Fcreate-some-template - 404`,
   );
 });
 
@@ -63,7 +63,7 @@ it("should create selected template with @ prefix implicit `/create`", async () 
   });
 
   const err = await stderr.text();
-  expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2fcreate - 404`);
+  expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2Fcreate - 404`);
   await exited;
 });
 
@@ -78,7 +78,7 @@ it("should create selected template with @ prefix implicit `/create` with versio
   });
 
   const err = await stderr.text();
-  expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2fcreate - 404`);
+  expect(err.split(/\r?\n/)).toContain(`error: GET https://registry.npmjs.org/@second-quick-start%2Fcreate - 404`);
 
   await exited;
 });

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4939,7 +4939,9 @@ test("scoped package manifest url uses uppercase %2F", async () => {
       // Tarball download.
       if (url.pathname.endsWith("/has-bin-entry-1.0.0.tgz")) {
         return new Response(
-          Bun.file(join(import.meta.dir, "registry", "packages", "@scoped", "has-bin-entry", "has-bin-entry-1.0.0.tgz")),
+          Bun.file(
+            join(import.meta.dir, "registry", "packages", "@scoped", "has-bin-entry", "has-bin-entry-1.0.0.tgz"),
+          ),
         );
       }
 
@@ -4957,10 +4959,7 @@ test("scoped package manifest url uses uppercase %2F", async () => {
         },
       }),
     ),
-    write(
-      join(packageDir, ".npmrc"),
-      `@scoped:registry=http://localhost:${server.port}/\n`,
-    ),
+    write(join(packageDir, ".npmrc"), `@scoped:registry=http://localhost:${server.port}/\n`),
   ]);
 
   const { stdout, stderr, exited } = spawn({

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4971,15 +4971,78 @@ test("scoped package manifest url uses uppercase %2F", async () => {
   });
   const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
 
-  // Assertion on the raw URL bun produced: must NOT be lowercase %2f.
-  const manifestHit = manifestPaths.find(p => p.includes("has-bin-entry"));
-  expect(manifestHit).toBeDefined();
-  expect(manifestHit).not.toContain("%2f");
-  expect(manifestHit).toContain("%2F");
+  // Assertion on the raw URL bun produced: every manifest request must use
+  // uppercase %2F and never lowercase %2f. Filter to manifest paths (they end
+  // with the package name, tarballs end with .tgz).
+  const manifestHits = manifestPaths.filter(
+    p =>
+      p.endsWith("@scoped/has-bin-entry") ||
+      p.endsWith("@scoped%2Fhas-bin-entry") ||
+      p.endsWith("@scoped%2fhas-bin-entry"),
+  );
+  expect(manifestHits.length).toBeGreaterThan(0);
+  for (const hit of manifestHits) {
+    expect(hit).not.toContain("%2f");
+    expect(hit).toContain("%2F");
+  }
 
   expect(err).not.toContain("error:");
   expect(err).not.toContain("404");
   expect(out).toContain("+ @scoped/has-bin-entry@1.0.0");
+  expect(code).toBe(0);
+});
+
+// Companion to the regression test above: `bun pm view` goes through
+// `DependencyUrlFormatter` (src/bun_core/fmt.zig), not the install manifest
+// path, and that encoder had the same lowercase-%2f bug.
+test("bun pm view uses uppercase %2F for scoped names", async () => {
+  const manifestPaths: string[] = [];
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      manifestPaths.push(url.pathname);
+      // Reject lowercase like GitLab.
+      if (url.pathname.includes("%2f")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.pathname.endsWith("@scoped%2Fhas-bin-entry")) {
+        return Response.json({
+          name: "@scoped/has-bin-entry",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": { name: "@scoped/has-bin-entry", version: "1.0.0" },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // pm view needs a clean project dir without bunfig.toml overriding our
+  // scoped registry; use a fresh tempDir rather than the shared packageDir.
+  const viewDir = tempDirWithFiles("pm-view-scoped", {
+    "package.json": JSON.stringify({ name: "x", version: "0.0.1" }),
+    ".npmrc": `@scoped:registry=http://localhost:${server.port}/\n`,
+  });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "view", "@scoped/has-bin-entry"],
+    cwd: viewDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  const hits = manifestPaths.filter(p => p.includes("has-bin-entry"));
+  expect(hits.length).toBeGreaterThan(0);
+  for (const hit of hits) {
+    expect(hit).not.toContain("%2f");
+    expect(hit).toContain("%2F");
+  }
+  expect(err).not.toContain("error:");
+  expect(out).toContain("@scoped/has-bin-entry@1.0.0");
   expect(code).toBe(0);
 });
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4897,6 +4897,93 @@ test("name from manifest is scoped and url encoded", async () => {
   ]);
 });
 
+// Regression test for https://github.com/oven-sh/bun/issues/30311
+// Bun was encoding the '/' in scoped package manifest URLs as lowercase '%2f'.
+// GitLab's npm registry (and any registry that doesn't normalize per RFC 3986
+// §6.2.2.1) returns 404 for the lowercase form. The npm CLI uses uppercase
+// '%2F' so we match that.
+test("scoped package manifest url uses uppercase %2F", async () => {
+  const manifestPaths: string[] = [];
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      // Record the raw (not normalized) path so the test can see the exact
+      // bytes bun put on the wire. URL constructor preserves %2F/%2f casing.
+      manifestPaths.push(url.pathname);
+
+      // Simulate GitLab: reject lowercase %2f, accept uppercase %2F or
+      // an unencoded slash. This is the exact discriminator from the bug.
+      if (url.pathname.includes("%2f")) {
+        return new Response("not found", { status: 404 });
+      }
+
+      // Manifest for @scoped/has-bin-entry.
+      if (url.pathname.endsWith("@scoped%2Fhas-bin-entry") || url.pathname.endsWith("@scoped/has-bin-entry")) {
+        return Response.json({
+          name: "@scoped/has-bin-entry",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "@scoped/has-bin-entry",
+              version: "1.0.0",
+              dist: {
+                shasum: "611b2b566718e05e8643fe872923ed91342b039a",
+                tarball: `http://localhost:${server.port}/@scoped/has-bin-entry/-/has-bin-entry-1.0.0.tgz`,
+              },
+            },
+          },
+        });
+      }
+
+      // Tarball download.
+      if (url.pathname.endsWith("/has-bin-entry-1.0.0.tgz")) {
+        return new Response(
+          Bun.file(join(import.meta.dir, "registry", "packages", "@scoped", "has-bin-entry", "has-bin-entry-1.0.0.tgz")),
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "@scoped/has-bin-entry": "1.0.0",
+        },
+      }),
+    ),
+    write(
+      join(packageDir, ".npmrc"),
+      `@scoped:registry=http://localhost:${server.port}/\n`,
+    ),
+  ]);
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  // Assertion on the raw URL bun produced: must NOT be lowercase %2f.
+  const manifestHit = manifestPaths.find(p => p.includes("has-bin-entry"));
+  expect(manifestHit).toBeDefined();
+  expect(manifestHit).not.toContain("%2f");
+  expect(manifestHit).toContain("%2F");
+
+  expect(err).not.toContain("error:");
+  expect(err).not.toContain("404");
+  expect(out).toContain("+ @scoped/has-bin-entry@1.0.0");
+  expect(code).toBe(0);
+});
+
 describe("update", () => {
   test("duplicate peer dependency (one package is invalid_package_id)", async () => {
     await write(

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -762,7 +762,7 @@ describe("Large payload via ipc pipe", () => {
     customRegistry: (urls, ctx) => {
       return async (request: Request) => {
         urls.push(request.url);
-        const url = request.url.replaceAll("%2f", "/");
+        const url = request.url.replaceAll("%2f", "/").replaceAll("%2F", "/");
         expect(request.method).toBe("GET");
         if (url.endsWith(".tgz")) {
           return new Response(Bun.file(join(tgzTempDir, url.slice(url.lastIndexOf("/") + 1).toLowerCase())));

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -613,7 +613,7 @@ describe.concurrent.each(["hoisted", "isolated"] as const)("tarball download fai
       const urls: string[] = [];
       let tarballStatus = 200;
       setContextHandler(ctx, async request => {
-        const url = request.url.replaceAll("%2f", "/");
+        const url = request.url.replaceAll("%2f", "/").replaceAll("%2F", "/");
         urls.push(url);
         if (url.endsWith(".tgz")) {
           if (tarballStatus !== 200) {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -642,7 +642,7 @@ describe.concurrent("bun-install", () => {
   it("should handle @scoped authentication", async () => {
     await withContext(defaultOpts, async ctx => {
       let seen_token = false;
-      const url = `${ctx.registry_url}@foo%2fbar`;
+      const url = `${ctx.registry_url}@foo%2Fbar`;
       const urls: string[] = [];
       setContextHandler(ctx, async request => {
         expect(request.method).toBe("GET");
@@ -3202,7 +3202,7 @@ describe.concurrent("bun-install", () => {
         "1 package installed",
       ]);
       expect(await exited).toBe(0);
-      expect(urls.sort()).toEqual([`${ctx.registry_url}@barn%2fmoo`, `${ctx.registry_url}@barn/moo-0.1.0.tgz`]);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}@barn%2Fmoo`, `${ctx.registry_url}@barn/moo-0.1.0.tgz`]);
       expect(ctx.requested).toBe(2);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "moo"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
@@ -3337,7 +3337,7 @@ describe.concurrent("bun-install", () => {
       ]);
       expect(await exited1).toBe(0);
       expect(urls.sort()).toEqual([
-        `${ctx.registry_url}@barn%2fmoo`,
+        `${ctx.registry_url}@barn%2Fmoo`,
         `${ctx.registry_url}@barn/moo-0.1.0.tgz`,
         `${ctx.registry_url}bar`,
         `${ctx.registry_url}bar-0.0.2.tgz`,

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -201,7 +201,7 @@ for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }]) {
     ]);
     expect(await exited1).toBe(0);
     expect(urls.sort()).toEqual([
-      `${root_url}/@barn%2fmoo`,
+      `${root_url}/@barn%2Fmoo`,
       `${root_url}/@barn/moo-0.1.0.tgz`,
       `${root_url}/baz`,
       `${root_url}/baz-0.0.3.tgz`,
@@ -264,7 +264,7 @@ for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }]) {
     }
     expect(await exited2).toBe(0);
     expect(urls.sort()).toEqual([
-      `${root_url}/@barn%2fmoo`,
+      `${root_url}/@barn%2Fmoo`,
       `${root_url}/@barn/moo-0.1.0.tgz`,
       `${root_url}/baz`,
       tilde ? `${root_url}/baz-0.0.5.tgz` : `${root_url}/baz-0.0.3.tgz`,

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1149,7 +1149,7 @@ describe("package name aliases", () => {
     const paths = urls.map(u => new URL(u).pathname);
     // The manifest request must be for the real package, and must never hit
     // the squatter package name.
-    expect(paths).toContain("/@anthropic-ai%2fclaude-code");
+    expect(paths).toContain("/@anthropic-ai%2Fclaude-code");
     expect(paths).not.toContain("/claude");
     // Install fails because the mock registry 404s; that's fine, we only care
     // about which manifest was requested.

--- a/test/cli/install/dummy.registry.ts
+++ b/test/cli/install/dummy.registry.ts
@@ -82,7 +82,7 @@ function defaultHandler(): Response {
 
 /**
  * Extract the test ID prefix from a URL path.
- * URL format: /test-123/package-name or /test-123/@scope%2fpackage-name
+ * URL format: /test-123/package-name or /test-123/@scope%2Fpackage-name
  */
 function extractTestPrefix(url: string): { prefix: string; remainingPath: string } | null {
   const urlObj = new URL(url);
@@ -171,7 +171,7 @@ export function dummyRegistryForContext(
   let retryCountsByURL = new Map<string, number>();
   const _handler: Handler = async request => {
     urls.push(request.url);
-    const url = request.url.replaceAll("%2f", "/");
+    const url = request.url.replaceAll("%2f", "/").replaceAll("%2F", "/");
 
     let status = 200;
 
@@ -247,7 +247,7 @@ export function dummyRegistry(
   let retryCountsByURL = new Map<string, number>();
   const _handler: Handler = async request => {
     urls.push(request.url);
-    const url = request.url.replaceAll("%2f", "/");
+    const url = request.url.replaceAll("%2f", "/").replaceAll("%2F", "/");
 
     let status = 200;
 


### PR DESCRIPTION
Fixes #30311.
Fixes #26241.

## Problem

Since bun 1.3.0 (from #5716), bun percent-encodes the `/` between scope and
name for private-registry manifest requests as **lowercase** `%2f`:

```
GET /api/v4/packages/npm/@myorg%2fsomepackage
```

GitLab's npm registry returns 404 for this URL. It does not normalize `%2f`
to `/` and does not treat `%2f` and `%2F` as equivalent, so the scoped
package lookup fails. bun 1.2.23 sent the unencoded slash, which GitLab
accepted.

## Fix

One-character change in `src/install/NetworkTask.zig` — encode as uppercase
`%2F` instead of `%2f`.

This matches:

- **npm CLI** — the reference implementation uses `%2F`.
- **RFC 3986 §2.1** — "URI producers and normalizers should use uppercase
  hexadecimal digits for all percent-encodings."
- **The existing comment on the line above** — which refers to
  `@storybook%2Faddons` as the expected form.
- **Elsewhere in the codebase** — `src/install/PackageManager/patchPackage.zig:503`
  already uses uppercase `%2F`.

`%2F` is accepted by AWS CodeArtifact, Azure Artifacts, npmjs.org,
Verdaccio, and GitLab. No known registry accepts `%2f` but rejects `%2F`.

## Verification

New test in `test/cli/install/bun-install-registry.test.ts` spins up a
`Bun.serve` mock GitLab-style registry that 404s any URL containing
lowercase `%2f` and serves a manifest only for uppercase `%2F`. The test
then asserts both that bun put `%2F` on the wire **and** that `bun install`
completes successfully.

Gate check:

- **without the fix** (system bun 1.3.14): test fails with
  `Received: "/@scoped%2fhas-bin-entry"`.
- **with the fix** (`bun bd`): passes, bun sends `%2F`, install succeeds.