### PR TITLE
fix(Blob): preserve nested array elements in fromJS

### DIFF
--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -4284,6 +4284,7 @@ fn fromJSWithoutDeferGC(
                             .Array, .DerivedArray => {
                                 any_arrays = true;
                                 could_have_non_ascii = true;
+                                stack.appendAssumeCapacity(item);
                                 break;
                             },
 


### PR DESCRIPTION
## Summary

Fixes `Blob([["nested"]])` losing the inner array elements.

### Root cause

In `Blob.fromJS()`, when iterating a nested array, the item was pushed into the stack only for the top-level array elements. For nested arrays (arrays within arrays), the element was iterated but never appended to the output stack.

### Fix

Add the missing `stack.appendAssumeCapacity(item)` call in the nested array branch.

### Testing

```js
const b = new Blob([["hello"]]);
console.log(await b.text()); // "hello" (was "")
```