### PR TITLE
Fix null deref in `Bun.inspect` when Proxy `getPrototypeOf` trap throws

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5444,7 +5444,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = proto ? proto.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -772,3 +772,43 @@ it("CustomEvent", () => {
     }"
   `);
 });
+
+describe("Proxy in prototype chain", () => {
+  it("does not crash when a Proxy getPrototypeOf trap throws", () => {
+    const obj = {};
+    Object.setPrototypeOf(
+      obj,
+      new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("trap");
+          },
+        },
+      ),
+    );
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+
+  it("does not crash when the prototype is a Proxy wrapping a prototype with a throwing getter", () => {
+    class Base {}
+    Object.defineProperty(Base.prototype, "foo", {
+      get() {
+        throw new Error("bad getter");
+      },
+      enumerable: false,
+    });
+    const obj = new Base();
+    const originalPrototype = Object.getPrototypeOf(obj);
+    Object.setPrototypeOf(obj, new Proxy(originalPrototype, {}));
+    expect(() => Bun.inspect(obj)).not.toThrow();
+  });
+
+  it("does not crash when an expect() result has a Proxy prototype", () => {
+    const v = expect({});
+    const originalPrototype = Object.getPrototypeOf(v);
+    Object.setPrototypeOf(v, new Proxy(originalPrototype, {}));
+    expect(() => Bun.inspect(v)).not.toThrow();
+    expect(() => v.toContainKey(v)).toThrow();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a null pointer dereference in `JSC__JSValue__forEachPropertyImpl` (used by `Bun.inspect`, `console.log`, and `expect` error formatting) when walking the prototype chain of an object whose prototype is a `Proxy`.

When `getPrototype()` is called on a `ProxyObject`, the `getPrototypeOf` trap may throw, causing `getPrototype()` to return an empty `JSValue`. Calling `.getObject()` on an empty `JSValue` then dereferences a null `JSCell*`.

```
JSCJSValueCell.h:92:33: runtime error: member call on null pointer of type 'JSC::JSCell'
    #0 JSC::JSValue::getObject() const
    #1 JSC__JSValue__forEachPropertyImpl<false> bindings.cpp:5447
    #2 JSC__JSValue__forEachProperty bindings.cpp:5461
```

### Repro
```js
const obj = {};
Object.setPrototypeOf(obj, new Proxy({}, {
  getPrototypeOf() { throw new Error("trap"); }
}));
Bun.inspect(obj);
```

The fix mirrors the existing handling of the same call earlier in the function: check the returned `JSValue` before calling `.getObject()` and clear any pending exception from the trap.

## How did you verify your code works?

Added regression tests in `test/js/bun/util/inspect.test.js` covering:
- A `Proxy` prototype with a throwing `getPrototypeOf` trap
- A `Proxy` prototype wrapping a prototype with a throwing getter
- An `expect()` result with a `Proxy` prototype (the original fuzzer scenario)

Found by Fuzzilli. Fingerprint: `0948b210d37148a3`