### PR TITLE
node:http2 client stalls when peer raises SETTINGS_INITIAL_WINDOW_SIZE after streams are open

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.zig
+++ b/src/runtime/api/bun/h2_frame_parser.zig
@@ -2458,12 +2458,14 @@ pub const H2FrameParser = struct {
             this.sendGoAway(frame.streamIdentifier, ErrorCode.PROTOCOL_ERROR, "Settings frame on connection stream", this.lastStreamID, true);
             return data.len;
         }
-        defer if (!isACK) this.sendSettingsACK();
+        var should_ack = false;
+        defer if (should_ack) this.sendSettingsACK();
 
         const settingByteSize = SettingsPayloadUnit.byteSize;
         if (frame.length > 0) {
             if (isACK or frame.length % settingByteSize != 0) {
                 log("invalid settings frame size", .{});
+                should_ack = false;
                 this.sendGoAway(frame.streamIdentifier, ErrorCode.FRAME_SIZE_ERROR, "Invalid settings frame size", this.lastStreamID, true);
                 return data.len;
             }
@@ -2488,9 +2490,9 @@ pub const H2FrameParser = struct {
                             const stream = item.*;
                             // Adjust the stream's local window size by the delta
                             if (delta >= 0) {
-                                stream.windowSize +|= @intCast(@as(u64, @intCast(delta)));
+                                stream.windowSize +|= @as(u64, @intCast(delta));
                             } else {
-                                stream.windowSize -|= @intCast(@as(u64, @intCast(-delta)));
+                                stream.windowSize -|= @as(u64, @intCast(-delta));
                             }
                         }
                         log("adjusted stream windows by delta {} (old: {}, new: {})", .{ delta, old_size, new_size });
@@ -2499,25 +2501,15 @@ pub const H2FrameParser = struct {
 
                 this.dispatch(.onLocalSettings, this.localSettings.toJS(this.handlers.globalObject));
             } else {
+                should_ack = true;
                 defer _ = this.flush();
                 defer this.incrementWindowSizeIfNeeded();
                 log("empty settings has remoteSettings? {}", .{this.remoteSettings != null});
                 if (this.remoteSettings == null) {
 
-                    // ok empty settings so default settings
                     var remoteSettings: FullSettingsPayload = .{};
                     this.remoteSettings = remoteSettings;
                     log("remoteSettings.initialWindowSize: {} {} {}", .{ remoteSettings.initialWindowSize, this.remoteUsedWindowSize, this.remoteWindowSize });
-
-                    if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
-                        var it = this.streams.valueIterator();
-                        while (it.next()) |item| {
-                            const stream = item.*;
-                            if (remoteSettings.initialWindowSize >= stream.remoteWindowSize) {
-                                stream.remoteWindowSize = remoteSettings.initialWindowSize;
-                            }
-                        }
-                    }
                     this.dispatch(.onRemoteSettings, remoteSettings.toJS(this.handlers.globalObject));
                 }
             }
@@ -2526,29 +2518,45 @@ pub const H2FrameParser = struct {
             return 0;
         }
         if (handleIncommingPayload(this, data, frame.streamIdentifier)) |content| {
+            should_ack = true;
             defer _ = this.flush();
             defer this.incrementWindowSizeIfNeeded();
-            var remoteSettings: FullSettingsPayload = this.remoteSettings orelse .{};
+            const oldRemoteSettings: FullSettingsPayload = this.remoteSettings orelse .{};
+            var remoteSettings: FullSettingsPayload = oldRemoteSettings;
             var i: usize = 0;
             const payload = content.data;
             while (i < payload.len) {
                 defer i += settingByteSize;
                 var unit: SettingsPayloadUnit = undefined;
                 SettingsPayloadUnit.from(&unit, payload[i .. i + settingByteSize], 0, true);
+                if (@as(SettingsType, @enumFromInt(unit.type)) == .SETTINGS_INITIAL_WINDOW_SIZE and unit.value > MAX_WINDOW_SIZE) {
+                    should_ack = false;
+                    this.readBuffer.reset();
+                    this.sendGoAway(0, ErrorCode.FLOW_CONTROL_ERROR, "Invalid initial window size", this.lastStreamID, true);
+                    return content.end;
+                }
                 remoteSettings.updateWith(unit);
                 log("remoteSettings: {} {} isServer: {}", .{ @as(SettingsType, @enumFromInt(unit.type)), unit.value, this.isServer });
             }
             this.readBuffer.reset();
             this.remoteSettings = remoteSettings;
             log("remoteSettings.initialWindowSize: {} {} {}", .{ remoteSettings.initialWindowSize, this.remoteUsedWindowSize, this.remoteWindowSize });
-            if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
+            if (remoteSettings.initialWindowSize != oldRemoteSettings.initialWindowSize) {
+                // Per RFC 7540 Section 6.9.2, SETTINGS_INITIAL_WINDOW_SIZE changes
+                // apply to existing streams by adjusting their windows by the delta.
+                const old_size: i64 = @intCast(oldRemoteSettings.initialWindowSize);
+                const new_size: i64 = @intCast(remoteSettings.initialWindowSize);
+                const delta = new_size - old_size;
                 var it = this.streams.valueIterator();
                 while (it.next()) |item| {
                     const stream = item.*;
-                    if (remoteSettings.initialWindowSize >= stream.remoteWindowSize) {
-                        stream.remoteWindowSize = remoteSettings.initialWindowSize;
+                    if (delta > 0) {
+                        stream.remoteWindowSize +|= @as(u64, @intCast(delta));
+                    } else {
+                        stream.remoteWindowSize -|= @as(u64, @intCast(-delta));
                     }
                 }
+                log("adjusted remote stream windows by delta {} (old: {}, new: {})", .{ delta, old_size, new_size });
             }
             this.dispatch(.onRemoteSettings, remoteSettings.toJS(this.handlers.globalObject));
             return content.end;

--- a/test/js/node/http2/node-http2-flow-control.test.ts
+++ b/test/js/node/http2/node-http2-flow-control.test.ts
@@ -1,0 +1,255 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import http2 from "node:http2";
+import net from "node:net";
+
+const FRAME_DATA = 0x0;
+const FRAME_HEADERS = 0x1;
+const FRAME_SETTINGS = 0x4;
+const FRAME_WINDOW_UPDATE = 0x8;
+const DEFAULT_WINDOW_SIZE = 65_535;
+const FLAG_ACK = 0x1;
+const FLAG_END_STREAM = 0x1;
+const FLAG_END_HEADERS = 0x4;
+const SETTING_INITIAL_WINDOW_SIZE = 0x4;
+
+function frame(type: number, flags: number, streamId: number, payload = Buffer.alloc(0)) {
+  const buf = Buffer.alloc(9 + payload.length);
+  buf.writeUIntBE(payload.length, 0, 3);
+  buf[3] = type;
+  buf[4] = flags;
+  buf.writeUInt32BE(streamId & 0x7fffffff, 5);
+  payload.copy(buf, 9);
+  return buf;
+}
+
+function setting(id: number, value: number) {
+  const buf = Buffer.alloc(6);
+  buf.writeUInt16BE(id, 0);
+  buf.writeUInt32BE(value >>> 0, 2);
+  return buf;
+}
+
+function windowUpdate(increment: number) {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32BE(increment & 0x7fffffff);
+  return buf;
+}
+
+function closeServer(server: net.Server, sockets: Set<net.Socket>) {
+  return new Promise<void>((resolve, reject) => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+}
+
+async function withRawH2Server(
+  onFrame: (socket: net.Socket, type: number, flags: number, streamId: number, len: number) => void | boolean,
+  fn: (url: string) => Promise<void>,
+) {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer(socket => {
+    let buf = Buffer.alloc(0);
+    let prefaceSeen = false;
+
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    socket.on("data", chunk => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!prefaceSeen) {
+        if (buf.length < 24) return;
+        expect(buf.subarray(0, 24).toString()).toBe("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+        buf = buf.subarray(24);
+        prefaceSeen = true;
+        socket.write(frame(FRAME_SETTINGS, 0, 0));
+      }
+
+      while (buf.length >= 9) {
+        const len = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + len) return;
+
+        const type = buf[3];
+        const flags = buf[4];
+        const streamId = buf.readUInt32BE(5) & 0x7fffffff;
+        buf = buf.subarray(9 + len);
+
+        if (type === FRAME_SETTINGS && !(flags & FLAG_ACK)) {
+          socket.write(frame(FRAME_SETTINGS, FLAG_ACK, 0));
+          continue;
+        }
+
+        if (onFrame(socket, type, flags, streamId, len)) {
+          return;
+        }
+      }
+    });
+  });
+
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await closeServer(server, sockets);
+  }
+}
+
+function post(client: http2.ClientHttp2Session, payload: Buffer) {
+  return new Promise<{ status: number; writeCallbackFired: boolean }>((resolve, reject) => {
+    let status = 0;
+    let writeCallbackFired = false;
+    const req = client.request({ ":method": "POST", ":path": "/" });
+
+    req.on("response", headers => {
+      status = Number(headers[":status"]);
+    });
+    req.on("end", () => resolve({ status, writeCallbackFired }));
+    req.on("error", reject);
+    req.resume();
+    req.end(payload, () => {
+      writeCallbackFired = true;
+    });
+  });
+}
+
+test("http2 client applies remote initialWindowSize changes to open stream write callbacks", async () => {
+  let bumpedWindow = false;
+
+  await withRawH2Server(
+    (socket, type, flags, streamId) => {
+      if (type === FRAME_HEADERS && !bumpedWindow) {
+        bumpedWindow = true;
+        // Send the SETTINGS update after a request stream already exists. The
+        // queued tail of the request body must be released by the settings delta.
+        socket.write(frame(FRAME_WINDOW_UPDATE, 0, 0, windowUpdate(16 * 1024 * 1024)));
+        socket.write(frame(FRAME_SETTINGS, 0, 0, setting(SETTING_INITIAL_WINDOW_SIZE, 256 * 1024)));
+        return false;
+      }
+
+      if (type === FRAME_DATA && flags & FLAG_END_STREAM) {
+        socket.write(frame(FRAME_HEADERS, FLAG_END_HEADERS | FLAG_END_STREAM, streamId, Buffer.from([0x88])));
+      }
+      return false;
+    },
+    async url => {
+      const client = http2.connect(url);
+      await once(client, "connect");
+
+      try {
+        const payload = Buffer.alloc(86_155, "x");
+        const responses = await Promise.all(Array.from({ length: 16 }, () => post(client, payload)));
+
+        expect(responses).toEqual(Array.from({ length: 16 }, () => ({ status: 200, writeCallbackFired: true })));
+      } finally {
+        client.close();
+      }
+    },
+  );
+});
+
+test("http2 client keeps a negative stream window after remote initialWindowSize shrinks", async () => {
+  let resolveInitialSettingsAck: () => void = () => {};
+  const initialSettingsAck = new Promise<void>(resolve => {
+    resolveInitialSettingsAck = resolve;
+  });
+  let bumpedWindow = false;
+  let smallStreamUpdateSent = false;
+  let settingsAckSeen = false;
+  let sentEnoughStreamCredit = false;
+  let settingsAcksAfterShrink = 0;
+  let dataBytes = 0;
+  let sentDataBeforePositiveWindow = false;
+  let shrinkingStreamId = 0;
+
+  await withRawH2Server(
+    (socket, type, flags, streamId, len) => {
+      if (type === FRAME_SETTINGS && flags & FLAG_ACK && !bumpedWindow) {
+        resolveInitialSettingsAck();
+        return false;
+      }
+
+      if (type === FRAME_HEADERS && !bumpedWindow) {
+        bumpedWindow = true;
+        shrinkingStreamId = streamId;
+        socket.write(frame(FRAME_WINDOW_UPDATE, 0, 0, windowUpdate(16 * 1024 * 1024)));
+        return false;
+      }
+
+      if (type === FRAME_DATA) {
+        dataBytes += len;
+        if (smallStreamUpdateSent && !settingsAckSeen && dataBytes > DEFAULT_WINDOW_SIZE) {
+          sentDataBeforePositiveWindow = true;
+        }
+        if (!smallStreamUpdateSent && dataBytes >= 32 * 1024) {
+          smallStreamUpdateSent = true;
+          socket.write(frame(FRAME_SETTINGS, 0, 0, setting(SETTING_INITIAL_WINDOW_SIZE, 16 * 1024)));
+          socket.write(frame(FRAME_WINDOW_UPDATE, 0, shrinkingStreamId, windowUpdate(10 * 1024)));
+          socket.write(frame(FRAME_SETTINGS, 0, 0));
+        }
+        if (flags & FLAG_END_STREAM) {
+          socket.write(frame(FRAME_HEADERS, FLAG_END_HEADERS | FLAG_END_STREAM, streamId, Buffer.from([0x88])));
+        }
+        return false;
+      }
+
+      if (type === FRAME_SETTINGS && flags & FLAG_ACK && smallStreamUpdateSent && !sentEnoughStreamCredit) {
+        settingsAcksAfterShrink++;
+        if (settingsAcksAfterShrink >= 2) {
+          settingsAckSeen = true;
+          expect(sentDataBeforePositiveWindow).toBe(false);
+          sentEnoughStreamCredit = true;
+          socket.write(frame(FRAME_WINDOW_UPDATE, 0, shrinkingStreamId, windowUpdate(60 * 1024)));
+        }
+      }
+      return false;
+    },
+    async url => {
+      const client = http2.connect(url);
+      await once(client, "connect");
+      await initialSettingsAck;
+
+      try {
+        const response = await post(client, Buffer.alloc(DEFAULT_WINDOW_SIZE + 14_465, "x"));
+
+        expect(response).toEqual({ status: 200, writeCallbackFired: true });
+        expect(settingsAckSeen).toBe(true);
+      } finally {
+        client.close();
+      }
+    },
+  );
+});
+
+test("http2 client rejects SETTINGS_INITIAL_WINDOW_SIZE above 2^31-1", async () => {
+  await withRawH2Server(
+    (socket, type) => {
+      if (type === FRAME_HEADERS) {
+        socket.write(frame(FRAME_SETTINGS, 0, 0, setting(SETTING_INITIAL_WINDOW_SIZE, 0x80000000)));
+        return true;
+      }
+      return false;
+    },
+    async url => {
+      const client = http2.connect(url);
+      await once(client, "connect");
+
+      const error = new Promise<Error & { code?: string }>(resolve => client.once("error", resolve));
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.end();
+
+      try {
+        const err = await error;
+        expect(err.code).toBe("ERR_HTTP2_SESSION_ERROR");
+        expect(err.message).toBe("Session closed with error code NGHTTP2_FLOW_CONTROL_ERROR");
+      } finally {
+        client.destroy();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Concurrent `node:http2` client requests can hang indefinitely when request bodies exceed the default HTTP/2 stream window and the peer later raises `SETTINGS_INITIAL_WINDOW_SIZE`.

This surfaced through `@grpc/grpc-js` and Pulumi: a unary gRPC call writes a request body, calls `end()`, and then waits forever because the HTTP/2 stream never finishes. Node.js completes the same workload.

Observed on:

- Bun 1.3.10 and 1.3.13
- macOS arm64
- `@grpc/grpc-js` 1.14.3
- Pulumi language runtime: `runtime: bun`

## Impact

Pulumi waits forever because the grpc-js unary callback is never called. There is no exception, no stream error, no process crash, and the Bun process remains idle with TCP sockets still established.

## Concrete Trace

In a hung Pulumi preview, the Pulumi JS SDK started this RPC:

```text
start ctfd:index/file:File tunnel-file-tunnel.zip contentb64=0 bytes=87136 jsonbytes=86155
```

The Pulumi language-host proxy never logged a matching received `RegisterResource` for that resource.

Instrumenting `@grpc/grpc-js` showed the corresponding HTTP/2 stream:

```text
transport create call=431 method=/pulumirpc.ResourceMonitor/RegisterResource
subchannel write call=431 bytes=87141
subchannel halfClose call=431
```

But these events never happened:

```text
subchannel write-callback-ok call=431
transport stream-close call=431
```

Other smaller streams completed because their bodies fit within the default stream window, so this is not a hard request-size limit.

## Root Cause

The request body is above the default HTTP/2 per-stream window of 65,535 bytes, so Bun queues remaining DATA frames until flow-control credit arrives.

The peer sends a connection-level `WINDOW_UPDATE`, then a `SETTINGS` frame that raises `SETTINGS_INITIAL_WINDOW_SIZE`. Per [RFC 7540 section 6.9.2](https://www.rfc-editor.org/rfc/rfc7540#section-6.9.2), when `INITIAL_WINDOW_SIZE` changes, existing streams' send windows must be adjusted by the delta between the new and old values.

Bun instead compared the new per-stream `initialWindowSize` with the connection-level `remoteWindowSize`:

```zig
if (remoteSettings.initialWindowSize >= this.remoteWindowSize) {
    ...
}
```

When the connection window had already been raised, that condition was false, so Bun never updated existing streams' `remoteWindowSize`. Queued DATA frames stayed stream-window-limited, the write callback remained pending, and grpc-js/Pulumi waited forever.

## Fix

Store the previous remote settings, compute the `SETTINGS_INITIAL_WINDOW_SIZE` delta, and apply that delta to every existing stream's remote send window.

This preserves existing per-stream `WINDOW_UPDATE` credit and lets queued request DATA flush once the stream window becomes positive again. The regression test also covers the shrink case from [RFC 7540 section 6.9.2](https://www.rfc-editor.org/rfc/rfc7540#section-6.9.2): after a reduced initial stream window and an insufficient stream `WINDOW_UPDATE`, queued DATA remains blocked until enough stream credit arrives.

The fix also rejects peer `SETTINGS_INITIAL_WINDOW_SIZE` values above `2^31 - 1` with a connection `FLOW_CONTROL_ERROR`, matching the HTTP/2 flow-control limit.

It also avoids sending a SETTINGS ACK after responding to a malformed SETTINGS frame with GOAWAY, which was a pre-existing latent bug.

## Validation

Original repro notes:

- Real Pulumi hang reproduced with Bun 1.3.13.
- Standalone grpc-js + Go gRPC repro hangs with Bun 1.3.13 and passes with patched Bun.
- Real Pulumi workload completes with a patched release build.

Regression checks:

```sh
USE_SYSTEM_BUN=1 bun test test/js/node/http2/node-http2-flow-control.test.ts
bun bd test test/js/node/http2/node-http2-flow-control.test.ts
/private/tmp/bun-upstream/build/release/bun test test/js/node/http2/node-http2-flow-control.test.ts
```

When run against Bun 1.3.13, the flow-control regression cases fail. The full test file passes with the patched debug and release builds.
