### PR TITLE
resolver: fix sideEffects glob matching on Windows

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -81,6 +81,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "parse_args.rs": "runtime/node/util/parse_args.rs",
   "patch.rs": "patch/patch.rs",
   "postgres.rs": "sql_jsc/postgres.rs",
+  "resolver_jsc.rs": "jsc/resolver_jsc.rs",
   "runtime/dns_jsc/dns.rs": "runtime/dns_jsc/dns.rs",
   "runtime/node/types.rs": "runtime/node/types.rs",
   "runtime/socket/socket.rs": "runtime/socket/socket.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -422,3 +422,26 @@ export const fetchH3Internals = {
 export const fileSinkInternals = {
   liveCount: $newRustFunction("runtime/webcore/FileSink.rs", "TestingAPIs.fileSinkLiveCount", 0) as () => number,
 };
+
+export const packageJsonInternals = {
+  /**
+   * Drives `SideEffects::has_side_effects` on a synthetic `(package_dir,
+   * patterns, runtime_path)` triple so tests can exercise the Windows-path
+   * matching fix for #30320 on any platform.
+   *
+   * Pass a Windows-style `dir` (e.g. `C:\\pkg\\`) and `path` to simulate
+   * Windows behavior — on Linux `path.text` is all `/`, so the bug can
+   * only be reproduced by feeding synthesised strings directly.
+   *
+   * `usePreFix: true` routes through the pre-#30320 `r_fs.join` code path
+   * so tests can assert the bug actually regressed before the fix.
+   *
+   * Returns `true` iff `path` matches any pattern.
+   */
+  sideEffectsHasSideEffects: $newRustFunction("resolver_jsc.rs", "sideEffectsTesting.sideEffectsHasSideEffects", 3) as (
+    dir: string,
+    patterns: string[],
+    path: string,
+    usePreFix?: boolean,
+  ) => boolean,
+};

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -138,3 +138,126 @@ impl StringArrayJsc for [BunString] {
         })
     }
 }
+
+/// Testing bridges for `bun.resolver.package_json.SideEffects`. Exposed
+/// via `bun:internal-for-testing` so the #30320 regression test can drive
+/// the glob/exact matchers with synthetic Windows-style paths on any
+/// host. Not used by production code.
+pub mod side_effects_testing {
+    use super::*;
+    use bun_resolver::package_json::{
+        FileSystemPackageJsonExt, MixedPatterns, SideEffects, StringHashMapUnownedKey,
+    };
+
+    /// Mirrors `PackageJSON::normalize_path_for_glob` — backslashes → slashes.
+    /// Inlined here so the testing helper stays compilable even when the
+    /// resolver's private helper changes signature (it's intentionally private
+    /// in production to keep the matcher's surface small).
+    fn normalize(path: &[u8]) -> Vec<u8> {
+        let mut v = path.to_vec();
+        bun_paths::slashes_to_posix_in_place(&mut v[..]);
+        v
+    }
+
+    /// `sideEffectsHasSideEffects(dir, patterns, path, usePreFix) -> bool`
+    ///
+    /// - `dir`       — absolute directory the package.json "lives in",
+    ///                 with trailing separator. Pass `C:\pkg\` to simulate
+    ///                 a Windows package root on a Linux host.
+    /// - `patterns`  — `sideEffects` array, e.g. `["adapters/**/*.js"]`.
+    /// - `path`      — runtime path the resolver would hand to
+    ///                 `has_side_effects`, e.g. `C:\pkg\adapters\foo.js`.
+    /// - `usePreFix` — when truthy, build patterns through the old
+    ///                 `r_fs.join` path so tests can assert the bug
+    ///                 actually regressed. Default false (fixed path).
+    ///
+    /// Returns `true` iff `path` matches any pattern. Before the fix,
+    /// Windows-shaped inputs always returned `false` because the stored
+    /// pattern carried a leading `/` that the runtime path never did.
+    pub fn side_effects_has_side_effects(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [dir_val, patterns_val, path_val, use_pre_fix_val] = frame.arguments_as_array::<4>();
+        if dir_val.is_undefined() || patterns_val.is_undefined() || path_val.is_undefined() {
+            return Err(global.throw(format_args!(
+                "sideEffectsHasSideEffects(dir, patterns, path, usePreFix?) takes 3 or 4 arguments"
+            )));
+        }
+
+        // `to_bun_string` returns a +1 ref; `bun_core::String` is `Copy` (no
+        // `Drop`), so wrap in `OwnedString` for the scope-exit `deref()`,
+        // including on `?`-early-return paths.
+        let dir_bunstr = OwnedString::new(dir_val.to_bun_string(global)?);
+        let dir_utf8 = dir_bunstr.to_utf8();
+        let path_bunstr = OwnedString::new(path_val.to_bun_string(global)?);
+        let path_utf8 = path_bunstr.to_utf8();
+        let use_pre_fix = use_pre_fix_val.to_boolean();
+
+        if !patterns_val.is_array() {
+            return Err(global.throw_type_error(format_args!(
+                "sideEffectsHasSideEffects: patterns must be an array"
+            )));
+        }
+
+        // SAFETY: `bun_vm()` is non-null on a Bun-owned global; `transpiler.resolver`
+        // is initialized at VM init. We only use the FileSystem field through the
+        // raw pointer; no aliasing with other host fns (JS single-threaded).
+        let vm = global.bun_vm().as_mut();
+        let r_fs: &mut bun_resolver::fs::FileSystem = unsafe { &mut *vm.transpiler.resolver.fs };
+
+        let dir = dir_utf8.slice();
+        let len = patterns_val.get_length(global)? as u32;
+
+        // Build a `SideEffects` value from the patterns just like `parse` would.
+        let mut map = bun_resolver::package_json::SideEffectsMap::with_capacity(len as usize);
+        let mut glob_list = bun_resolver::package_json::GlobList::with_capacity(len as usize);
+        let mut has_globs = false;
+        let mut has_exact = false;
+
+        for i in 0..len {
+            let item = patterns_val.get_index(global, i)?;
+            let item_bunstr = OwnedString::new(item.to_bun_string(global)?);
+            let item_utf8 = item_bunstr.to_utf8();
+            let name = item_utf8.slice();
+
+            // Build the pattern through the same helper production code uses,
+            // OR through the pre-fix `r_fs.join` so the test can observe both.
+            // The fixed path strips package-root-relative leading separators
+            // before `r_fs.abs` (matches `PackageJSON::strip_pattern_root`).
+            let pattern_vec: Vec<u8> = if use_pre_fix {
+                FileSystemPackageJsonExt::join(r_fs, &[dir, name]).to_vec()
+            } else {
+                let mut stripped = name;
+                while let [b'/' | b'\\', rest @ ..] = stripped {
+                    stripped = rest;
+                }
+                r_fs.abs(&[dir, stripped]).to_vec()
+            };
+            let normalized_pattern = normalize(&pattern_vec);
+
+            let is_glob = name.iter().any(|&b| matches!(b, b'*' | b'?' | b'[' | b'{'));
+            if is_glob {
+                glob_list.push(normalized_pattern.into_boxed_slice());
+                has_globs = true;
+            } else {
+                let _ = map.insert(StringHashMapUnownedKey::init(&normalized_pattern), ());
+                has_exact = true;
+            }
+        }
+
+        let side_effects = if has_globs && has_exact {
+            SideEffects::Mixed(MixedPatterns {
+                exact: map,
+                globs: glob_list,
+            })
+        } else if has_globs {
+            SideEffects::Glob(glob_list)
+        } else {
+            SideEffects::Map(map)
+        };
+
+        let matched = side_effects.has_side_effects(path_utf8.slice());
+        Ok(JSValue::js_boolean(matched))
+    }
+}

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -222,6 +222,18 @@ impl PackageJSON {
         bun_paths::slashes_to_posix_in_place(&mut normalized[..]);
         Ok(normalized)
     }
+
+    /// A leading `/` or `\` in a `sideEffects` entry is package-root-relative,
+    /// not filesystem-absolute. Strip any leading separators so `r_fs.abs`
+    /// joins against the package dir instead of discarding it (`path.resolve`
+    /// treats an absolute later component as a new root, and `//x` is still
+    /// absolute after one strip). Matches esbuild's `filepath.Join`. #30320
+    fn strip_pattern_root(mut name: &[u8]) -> &[u8] {
+        while let [b'/' | b'\\', rest @ ..] = name {
+            name = rest;
+        }
+        name
+    }
 }
 
 #[derive(Default)]
@@ -254,7 +266,15 @@ impl SideEffects {
         match self {
             SideEffects::Unspecified => true,
             SideEffects::False => false,
-            SideEffects::Map(map) => map.contains_key(&StringHashMapUnownedKey::init(path)),
+            // Stored patterns are always slash-normalized (see `parse`); the
+            // runtime path may contain native separators on Windows, so we
+            // must normalize it the same way before hashing. See #30320.
+            SideEffects::Map(map) => {
+                let Ok(normalized_path) = PackageJSON::normalize_path_for_glob(path) else {
+                    return true;
+                };
+                map.contains_key(&StringHashMapUnownedKey::init(&normalized_path))
+            }
             SideEffects::Glob(glob_list) => {
                 // Normalize path for cross-platform glob matching
                 let Ok(normalized_path) = PackageJSON::normalize_path_for_glob(path) else {
@@ -269,18 +289,18 @@ impl SideEffects {
                 false
             }
             SideEffects::Mixed(mixed) => {
-                // First check exact matches
-                if mixed
-                    .exact
-                    .contains_key(&StringHashMapUnownedKey::init(path))
-                {
-                    return true;
-                }
-                // Then check glob patterns with normalized path
                 let Ok(normalized_path) = PackageJSON::normalize_path_for_glob(path) else {
                     return true;
                 };
 
+                // First check exact matches
+                if mixed
+                    .exact
+                    .contains_key(&StringHashMapUnownedKey::init(&normalized_path))
+                {
+                    return true;
+                }
+                // Then check glob patterns with normalized path
                 for pattern in mixed.globs.iter() {
                     if glob::r#match(pattern, &normalized_path).matches() {
                         return true;
@@ -749,6 +769,7 @@ impl PackageJSON {
                     map.reserve(items.len());
                     glob_list.reserve(items.len());
 
+                    let dir = json_source.path.name().dir_with_trailing_slash();
                     for item in items {
                         if let Some(name) = item.as_str() {
                             // Skip CSS files as they're not relevant for tree-shaking
@@ -756,23 +777,28 @@ impl PackageJSON {
                                 continue;
                             }
 
-                            // Store the pattern relative to the package directory
-                            let joined: [&[u8]; 2] =
-                                [json_source.path.name().dir_with_trailing_slash(), name];
-
-                            let pattern = r_fs.join(&joined);
+                            // Build the absolute pattern using the same shape as runtime paths
+                            // (`r_fs.abs` / `join_abs_string`) so they compare equal after
+                            // normalization. `r_fs.join` here would produce a different shape
+                            // on Windows (leading `/` before the drive letter) that wouldn't
+                            // match the runtime path. See #30320.
+                            let joined: [&[u8]; 2] = [dir, Self::strip_pattern_root(name)];
+                            let pattern = r_fs.abs(&joined);
+                            let normalized_pattern = Self::normalize_path_for_glob(pattern)
+                                .unwrap_or_else(|_| pattern.to_vec());
 
                             if strings::contains_char(name, b'*')
                                 || strings::contains_char(name, b'?')
                                 || strings::contains_char(name, b'[')
                                 || strings::contains_char(name, b'{')
                             {
-                                // Normalize pattern to use forward slashes for cross-platform compatibility
-                                let normalized_pattern = Self::normalize_path_for_glob(pattern)
-                                    .unwrap_or_else(|_| pattern.to_vec());
                                 glob_list.push(normalized_pattern.into_boxed_slice());
                             } else {
-                                let _ = map.insert(StringHashMapUnownedKey::init(pattern), ());
+                                // Exact-match keys must be normalized to match runtime paths
+                                // (callers feed `hasSideEffects` a path that is also run through
+                                // `normalize_path_for_glob` on lookup).
+                                let _ = map
+                                    .insert(StringHashMapUnownedKey::init(&normalized_pattern), ());
                             }
                         }
                     }
@@ -783,6 +809,7 @@ impl PackageJSON {
                 } else if has_globs {
                     // Only glob patterns
                     glob_list.reserve(items.len());
+                    let dir = json_source.path.name().dir_with_trailing_slash();
                     for item in items {
                         if let Some(name) = item.as_str() {
                             // Skip CSS files as they're not relevant for tree-shaking
@@ -790,12 +817,9 @@ impl PackageJSON {
                                 continue;
                             }
 
-                            // Store the pattern relative to the package directory
-                            let joined: [&[u8]; 2] =
-                                [json_source.path.name().dir_with_trailing_slash(), name];
-
-                            let pattern = r_fs.join(&joined);
-                            // Normalize pattern to use forward slashes for cross-platform compatibility
+                            // See comment above about `r_fs.abs` vs `r_fs.join`.
+                            let joined: [&[u8]; 2] = [dir, Self::strip_pattern_root(name)];
+                            let pattern = r_fs.abs(&joined);
                             let normalized_pattern = Self::normalize_path_for_glob(pattern)
                                 .unwrap_or_else(|_| pattern.to_vec());
                             glob_list.push(normalized_pattern.into_boxed_slice());
@@ -805,13 +829,15 @@ impl PackageJSON {
                 } else {
                     // Only exact matches
                     map.reserve(items.len());
+                    let dir = json_source.path.name().dir_with_trailing_slash();
                     for item in items {
                         if let Some(name) = item.as_str() {
-                            let joined: [&[u8]; 2] =
-                                [json_source.path.name().dir_with_trailing_slash(), name];
-
+                            let joined: [&[u8]; 2] = [dir, Self::strip_pattern_root(name)];
+                            let pattern = r_fs.abs(&joined);
+                            let normalized_pattern = Self::normalize_path_for_glob(pattern)
+                                .unwrap_or_else(|_| pattern.to_vec());
                             let _ =
-                                map.insert(StringHashMapUnownedKey::init(r_fs.join(&joined)), ());
+                                map.insert(StringHashMapUnownedKey::init(&normalized_pattern), ());
                         }
                     }
                     package_json.side_effects = SideEffects::Map(map);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1636,23 +1636,13 @@ impl<'a> Resolver<'a> {
                 result.primary_side_effects_data = match &existing.side_effects {
                     PJSideEffects::Unspecified => SideEffects::HasSideEffects,
                     PJSideEffects::False => SideEffects::NoSideEffectsPackageJson,
-                    PJSideEffects::Map(map) => {
-                        if map.contains_key(&crate::package_json::StringHashMapUnownedKey::init(
-                            path.text(),
-                        )) {
-                            SideEffects::HasSideEffects
-                        } else {
-                            SideEffects::NoSideEffectsPackageJson
-                        }
-                    }
-                    PJSideEffects::Glob(_) => {
-                        if existing.side_effects.has_side_effects(path.text()) {
-                            SideEffects::HasSideEffects
-                        } else {
-                            SideEffects::NoSideEffectsPackageJson
-                        }
-                    }
-                    PJSideEffects::Mixed(_) => {
+                    // Route all three Map/Glob/Mixed branches through
+                    // `has_side_effects`. Stored pattern keys are slash-
+                    // normalized at parse time, so the runtime lookup must
+                    // normalize `path.text` the same way — bypassing that
+                    // call was the bug that dropped every matched file on
+                    // Windows. See #30320.
+                    PJSideEffects::Map(_) | PJSideEffects::Glob(_) | PJSideEffects::Mixed(_) => {
                         if existing.side_effects.has_side_effects(path.text()) {
                             SideEffects::HasSideEffects
                         } else {
@@ -1676,23 +1666,9 @@ impl<'a> Resolver<'a> {
                     result.primary_side_effects_data = match &package_json.side_effects {
                         PJSideEffects::Unspecified => SideEffects::HasSideEffects,
                         PJSideEffects::False => SideEffects::NoSideEffectsPackageJson,
-                        PJSideEffects::Map(map) => {
-                            if map.contains_key(
-                                &crate::package_json::StringHashMapUnownedKey::init(path.text()),
-                            ) {
-                                SideEffects::HasSideEffects
-                            } else {
-                                SideEffects::NoSideEffectsPackageJson
-                            }
-                        }
-                        PJSideEffects::Glob(_) => {
-                            if package_json.side_effects.has_side_effects(path.text()) {
-                                SideEffects::HasSideEffects
-                            } else {
-                                SideEffects::NoSideEffectsPackageJson
-                            }
-                        }
-                        PJSideEffects::Mixed(_) => {
+                        PJSideEffects::Map(_)
+                        | PJSideEffects::Glob(_)
+                        | PJSideEffects::Mixed(_) => {
                             if package_json.side_effects.has_side_effects(path.text()) {
                                 SideEffects::HasSideEffects
                             } else {

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -52,6 +52,11 @@ pub use bun_patch_jsc::testing::patch_apply as patch_patch_testing_ap_is_apply;
 pub use bun_patch_jsc::testing::patch_make_diff as patch_patch_testing_ap_is_make_diff;
 pub use bun_patch_jsc::testing::patch_parse as patch_patch_testing_ap_is_parse;
 
+// Drives `SideEffects::has_side_effects` with synthetic Windows-style paths
+// from `bun:internal-for-testing` so #30320's regression test can reproduce
+// the Windows-path mismatch on any host. See `jsc/resolver_jsc.rs`.
+pub use bun_jsc::resolver_jsc::side_effects_testing::side_effects_has_side_effects as jsc_resolver_jsc_side_effects_testing_side_effects_has_side_effects;
+
 pub use bun_sourcemap_jsc::internal_jsc::testing_find as sourcemap_internal_source_map_testing_ap_is_find;
 pub use bun_sourcemap_jsc::internal_jsc::testing_from_vlq as sourcemap_internal_source_map_testing_ap_is_from_vlq;
 pub use bun_sourcemap_jsc::internal_jsc::testing_to_vlq as sourcemap_internal_source_map_testing_ap_is_to_vlq;

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect } from "bun:test";
-import { isWindows } from "harness";
 import { dedent, itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -341,7 +340,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/PackageJsonSideEffectsArrayKeep", {
-    todo: isWindows,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {foo} from "demo-pkg"
@@ -478,7 +476,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleUseModule", {
-    todo: isWindows,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {foo} from "demo-pkg"
@@ -506,7 +503,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleUseMain", {
-    todo: isWindows,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {foo} from "demo-pkg"
@@ -534,7 +530,6 @@ describe("bundler", () => {
     },
   });
   itBundled("dce/PackageJsonSideEffectsArrayKeepModuleImplicitModule", {
-    todo: isWindows,
     files: {
       "/Users/user/project/src/entry.js": /* js */ `
         import {foo} from "demo-pkg"

--- a/test/regression/issue/30320.test.ts
+++ b/test/regression/issue/30320.test.ts
@@ -1,0 +1,189 @@
+// https://github.com/oven-sh/bun/issues/30320
+//
+// sideEffects glob patterns didn't match on Windows. The pattern was built
+// via `r_fs.join(dir, name)` with `.loose`, which routes through
+// `join_string_buf` → `normalize_string_node_t`. That prepends a leading `/`
+// for absolute inputs, yielding `/C:/proj/node_modules/my-lib/adapters/**/*.js`.
+// Runtime paths, however, come from `r_fs.abs` with `.loose`, which on
+// Windows routes through `_join_abs_string_buf_windows` and emits
+// `C:\proj\node_modules\my-lib\adapters\foo.js` — no leading `/`. After
+// `normalize_path_for_glob` (`\` → `/`) the pattern still started with `/`
+// but the path didn't, so they never matched and Bun treated every file as
+// side-effect-free. Prebid.js
+// (`"sideEffects": ["dist/src/modules/**/*.js"]`) silently lost every bid
+// adapter on Windows. Fixed by building the pattern with `r_fs.abs` so it
+// goes through the same joiner the runtime path uses, plus normalizing the
+// map lookup key at both parse time and lookup time.
+//
+// Reproduces on Linux only via `bun:internal-for-testing`, which drives
+// the real `SideEffects::has_side_effects` code with synthetic Windows-style
+// strings (`C:\pkg\adapters\foo.js`). The end-to-end `bun build` test below
+// doesn't fail on Linux because the resolver never produces Windows-style
+// `path.text` there; Windows CI catches that half of the regression.
+
+import { packageJsonInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+const { sideEffectsHasSideEffects } = packageJsonInternals;
+
+test("#30320 SideEffects matches glob against Windows-style path", () => {
+  // Pre-fix: `r_fs.join("C:\\pkg\\", "adapters/**/*.js")` on any host
+  // produces `/C:/pkg/adapters/**/*.js` (leading slash from
+  // `normalize_string_node_t` for absolute-Windows inputs on `.loose`). The
+  // runtime path `C:\pkg\adapters\foo.js` normalizes to
+  // `C:/pkg/adapters/foo.js` — no leading `/` — so glob never matched.
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["adapters/**/*.js"], "C:\\pkg\\adapters\\foo.js", true)).toBe(false);
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["adapters/**/*.js"], "C:\\pkg\\adapters\\foo.js", false)).toBe(true);
+});
+
+test("#30320 SideEffects matches glob with ./ prefix against Windows-style path", () => {
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["./adapters/**/*.js"], "C:\\pkg\\adapters\\foo.js", true)).toBe(false);
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["./adapters/**/*.js"], "C:\\pkg\\adapters\\foo.js", false)).toBe(true);
+});
+
+test("#30320 SideEffects matches exact pattern against Windows-style path", () => {
+  // Same mismatch on the exact-match side: the stored key was the
+  // leading-`/` form, the runtime lookup key had no leading `/`, so the
+  // hash never collided. (This is the `todo: isWindows` the PR also
+  // removes from PackageJsonSideEffectsArray{Keep,KeepModule*}.)
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["adapters/foo.js"], "C:\\pkg\\adapters\\foo.js", true)).toBe(false);
+  expect(sideEffectsHasSideEffects("C:\\pkg\\", ["adapters/foo.js"], "C:\\pkg\\adapters\\foo.js", false)).toBe(true);
+});
+
+test("#30320 SideEffects mixed (exact + glob) both match against Windows-style paths", () => {
+  // Pre-fix: both halves fail.
+  expect(
+    sideEffectsHasSideEffects(
+      "C:\\pkg\\",
+      ["adapters/specific.js", "adapters/glob/*.js"],
+      "C:\\pkg\\adapters\\specific.js",
+      true,
+    ),
+  ).toBe(false);
+  expect(
+    sideEffectsHasSideEffects(
+      "C:\\pkg\\",
+      ["adapters/specific.js", "adapters/glob/*.js"],
+      "C:\\pkg\\adapters\\glob\\one.js",
+      true,
+    ),
+  ).toBe(false);
+
+  // Post-fix: both halves match.
+  expect(
+    sideEffectsHasSideEffects(
+      "C:\\pkg\\",
+      ["adapters/specific.js", "adapters/glob/*.js"],
+      "C:\\pkg\\adapters\\specific.js",
+      false,
+    ),
+  ).toBe(true);
+  expect(
+    sideEffectsHasSideEffects(
+      "C:\\pkg\\",
+      ["adapters/specific.js", "adapters/glob/*.js"],
+      "C:\\pkg\\adapters\\glob\\one.js",
+      false,
+    ),
+  ).toBe(true);
+
+  // Non-matching path: false either way — regression guard against an
+  // over-eager fix that treats everything as side-effectful.
+  expect(
+    sideEffectsHasSideEffects(
+      "C:\\pkg\\",
+      ["adapters/specific.js", "adapters/glob/*.js"],
+      "C:\\pkg\\adapters\\other.js",
+      false,
+    ),
+  ).toBe(false);
+});
+
+test.skipIf(isWindows)("#30320 SideEffects behaviour on POSIX paths unchanged", () => {
+  // The fix must not regress POSIX matching — it produces the same
+  // absolute pattern on both code paths there. Windows-skipped because
+  // `r_fs.abs` on Windows prepends the current drive letter to any
+  // `/`-rooted input, which the synthetic matching pair can't share.
+  expect(sideEffectsHasSideEffects("/pkg/", ["adapters/**/*.js"], "/pkg/adapters/foo.js", true)).toBe(true);
+  expect(sideEffectsHasSideEffects("/pkg/", ["adapters/**/*.js"], "/pkg/adapters/foo.js", false)).toBe(true);
+
+  expect(sideEffectsHasSideEffects("/pkg/", ["adapters/foo.js"], "/pkg/adapters/foo.js", true)).toBe(true);
+  expect(sideEffectsHasSideEffects("/pkg/", ["adapters/foo.js"], "/pkg/adapters/foo.js", false)).toBe(true);
+});
+
+// End-to-end guard — uses the real bundler. On Windows CI this is the
+// direct reproduction from the issue. On Linux it just verifies the fix
+// didn't regress the already-working POSIX case.
+test("#30320 bundler preserves sideEffects glob imports", async () => {
+  using dir = tempDir("sideeffects-glob-30320", {
+    "node_modules/my-lib/package.json": JSON.stringify({
+      name: "my-lib",
+      version: "1.0.0",
+      main: "index.js",
+      sideEffects: ["adapters/**/*.js"],
+    }),
+    "node_modules/my-lib/index.js": `export const lib = "my-lib";\n`,
+    "node_modules/my-lib/adapters/foo.js": `console.log("foo adapter registered");\n`,
+    "node_modules/my-lib/adapters/bar.js": `console.log("bar adapter registered");\n`,
+    "entry.js": `
+      import "my-lib/adapters/foo.js";
+      import "my-lib/adapters/bar.js";
+      console.log("entry");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Don't pin stderr to empty — ASAN shards can emit benign warnings on a
+  // clean run. Only consult stderr when the build actually failed.
+  expect(stdout).toContain("foo adapter registered");
+  expect(stdout).toContain("bar adapter registered");
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// A leading `/` (or repeated `//`) in a sideEffects entry is package-root-
+// relative, not filesystem-absolute. `r_fs.abs` would treat it as a new root
+// and discard the package dir, silently tree-shaking the file; one strip pass
+// isn't enough for `//`, so the strip loops. Guards the leading-separator
+// strip against a regression of the r_fs.join -> r_fs.abs switch.
+test("#30320 bundler keeps sideEffects entries with leading slashes", async () => {
+  using dir = tempDir("sideeffects-rootslash-30320", {
+    "node_modules/my-lib/package.json": JSON.stringify({
+      name: "my-lib",
+      version: "1.0.0",
+      main: "index.js",
+      sideEffects: ["/adapters/foo.js", "//adapters/bar.js"],
+    }),
+    "node_modules/my-lib/index.js": `export const lib = "my-lib";\n`,
+    "node_modules/my-lib/adapters/foo.js": `console.log("rootslash adapter registered");\n`,
+    "node_modules/my-lib/adapters/bar.js": `console.log("double rootslash adapter registered");\n`,
+    "entry.js": `
+      import "my-lib/adapters/foo.js";
+      import "my-lib/adapters/bar.js";
+      console.log("entry");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("rootslash adapter registered");
+  expect(stdout).toContain("double rootslash adapter registered");
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #30320: on Windows, `sideEffects` globs never matched and every file in a package was treated as side-effect-free. `prebid.js@10.29.0` (`"sideEffects": ["dist/src/modules/**/*.js"]`) silently lost every bid adapter on Windows.

**Cause.** Patterns were built with `r_fs.join({package_dir, name})` (`.loose` platform). That routes through `join_string_buf` → `normalize_string_node_t`, which **prepends a leading `/`** for absolute inputs, so a Windows package dir produced `/C:/proj/node_modules/my-lib/adapters/**/*.js`. Runtime paths instead go through `r_fs.abs` → `_join_abs_string_buf_windows`, emitting `C:\proj\...\foo.js` — no leading `/`. After the shared `\` → `/` pass in `normalize_path_for_glob`, the stored pattern kept a leading `/` the subject never had, so neither glob nor exact-match keys matched. The same mismatch broke exact-match keys, which is why four existing tests were marked `todo: isWindows`.

**Fix.**
1. Build the pattern with `r_fs.abs` instead of `r_fs.join` so it shares the joiner the runtime path uses.
2. Strip a package-root-relative leading `/` or `\` from each entry before joining, so `r_fs.abs` joins against the package dir instead of discarding it (`path.resolve` treats an absolute later component as a new root). Without this, `"/index.js"`-style entries would regress on POSIX where `r_fs.join` previously concatenated them; matches esbuild's `filepath.Join`.
3. Normalize exact-match map keys at parse time and normalize the lookup path in `has_side_effects` (Map/Mixed), so `\` vs `/` no longer affects the hash.
4. Route the `Map`/`Glob`/`Mixed` branches in `finalize_result` through `has_side_effects` so the lookup-side normalization always applies.
5. Drop the `todo: isWindows` markers on the four `PackageJsonSideEffectsArray*` bundler tests this now unsticks.

### How did you verify your code works?

The bug is Windows-only (POSIX paths never gain the leading `/`), so `test/regression/issue/30320.test.ts` drives `SideEffects::has_side_effects` through `bun:internal-for-testing` with synthetic `C:\pkg\...` strings on any host. `usePreFix: true` reproduces the pre-fix `r_fs.join` shape, so the exact and mixed cases **fail without the src fix and pass with it** on Linux (verified locally: reverting the resolver diff makes 2/6 fail, restoring makes all pass). Two end-to-end `bun build` cases guard the real bundler path (glob entries, and a leading-slash entry). Windows CI exercises the original repro directly, and @brynne8 confirmed the build works on Win11.

Closes #30320
Closes #22598