### PR TITLE
Give File its own prototype that inherits from Blob.prototype

### DIFF
--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -99,7 +99,7 @@ void DOMFormData::append(const String& name, const String& value)
 
 void DOMFormData::append(const String& name, RefPtr<Blob> blob, const String& filename)
 {
-    blob->setFileName(replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
+    blob->setFileName(filename.isNull() ? emptyString() : replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
     m_items.append({ replaceUnpairedSurrogatesWithReplacementCharacter(String(name)), blob });
 }
 void DOMFormData::remove(const StringView name)
@@ -148,7 +148,7 @@ void DOMFormData::set(const String& name, const String& value)
 
 void DOMFormData::set(const String& name, RefPtr<Blob> blob, const String& filename)
 {
-    blob->setFileName(filename);
+    blob->setFileName(filename.isNull() ? emptyString() : filename);
     set(name, { name, blob });
 }
 

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -2,65 +2,120 @@
 #include "ZigGeneratedClasses.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/InternalFunction.h>
-#include <JavaScriptCore/FunctionPrototype.h>
 #include "JSDOMFile.h"
 
 using namespace JSC;
 
 extern "C" SYSV_ABI void* JSDOMFile__construct(JSC::JSGlobalObject*, JSC::CallFrame* callframe);
-extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObject*, EncodedJSValue);
+extern "C" SYSV_ABI size_t Blob__estimatedSize(void* ptr);
 
-// TODO: make this inehrit from JSBlob instead of InternalFunction
-// That will let us remove this hack for [Symbol.hasInstance] and fix the prototype chain.
-class JSDOMFile : public JSC::InternalFunction {
+extern "C" SYSV_ABI bool BlobPrototype__setName(void* ptr, JSC::EncodedJSValue thisValue, JSC::JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue value);
+
+namespace WebCore {
+JSC_DECLARE_CUSTOM_GETTER(BlobPrototype__nameGetterWrap);
+JSC_DECLARE_CUSTOM_GETTER(BlobPrototype__lastModifiedGetterWrap);
+}
+
+namespace Bun {
+
+static JSC_DEFINE_CUSTOM_SETTER(jsDOMFilePrototypeNameSetter, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue encodedThisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* thisObject = dynamicDowncast<WebCore::JSBlob>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        WebCore::throwDOMAttributeSetterTypeError(lexicalGlobalObject, throwScope, WebCore::JSBlob::info(), attributeName);
+        return false;
+    }
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+    bool result = BlobPrototype__setName(thisObject->wrapped(), encodedThisValue, lexicalGlobalObject, encodedValue);
+    RELEASE_AND_RETURN(throwScope, result);
+}
+
+static const HashTableValue JSDOMFilePrototypeTableValues[] = {
+    { "name"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, WebCore::BlobPrototype__nameGetterWrap, jsDOMFilePrototypeNameSetter } },
+    { "lastModified"_s, static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute), NoIntrinsic, { HashTableValue::GetterSetterType, WebCore::BlobPrototype__lastModifiedGetterWrap, 0 } },
+};
+
+class JSDOMFilePrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSDOMFilePrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSDOMFilePrototype* prototype = new (NotNull, JSC::allocateCell<JSDOMFilePrototype>(vm)) JSDOMFilePrototype(vm, structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        auto* structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+        structure->setMayBePrototype(true);
+        return structure;
+    }
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSDOMFilePrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+private:
+    JSDOMFilePrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        Base::finishCreation(vm);
+        ASSERT(inherits(info()));
+        reifyStaticProperties(vm, WebCore::JSBlob::info(), JSDOMFilePrototypeTableValues, *this);
+        JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    }
+};
+
+const JSC::ClassInfo JSDOMFilePrototype::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFilePrototype) };
+
+class JSDOMFileConstructor final : public JSC::InternalFunction {
     using Base = JSC::InternalFunction;
 
 public:
-    JSDOMFile(JSC::VM& vm, JSC::Structure* structure)
+    JSDOMFileConstructor(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure, call, construct)
     {
     }
 
     DECLARE_INFO;
 
-    static constexpr unsigned StructureFlags = (Base::StructureFlags & ~ImplementsDefaultHasInstance) | ImplementsHasInstance;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {
         return &vm.internalFunctionSpace();
     }
+
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {
         return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(InternalFunctionType, StructureFlags), info());
     }
 
-    void finishCreation(JSC::VM& vm)
-    {
-        Base::finishCreation(vm, 2, "File"_s);
-    }
-
-    static JSDOMFile* create(JSC::VM& vm, JSGlobalObject* globalObject)
+    static JSDOMFileConstructor* create(JSC::VM& vm, JSGlobalObject* globalObject, JSC::JSObject* filePrototype)
     {
         auto* zigGlobal = defaultGlobalObject(globalObject);
-        auto structure = createStructure(vm, globalObject, zigGlobal->functionPrototype());
-        auto* object = new (NotNull, JSC::allocateCell<JSDOMFile>(vm)) JSDOMFile(vm, structure);
+        auto structure = createStructure(vm, globalObject, zigGlobal->JSBlobConstructor());
+        auto* object = new (NotNull, JSC::allocateCell<JSDOMFileConstructor>(vm)) JSDOMFileConstructor(vm, structure);
         object->finishCreation(vm);
 
-        // This is not quite right. But we'll fix it if someone files an issue about it.
-        object->putDirect(vm, vm.propertyNames->prototype, zigGlobal->JSBlobPrototype(), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);
+        object->putDirectWithoutTransition(vm, vm.propertyNames->prototype, filePrototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
 
         return object;
-    }
-
-    static bool customHasInstance(JSObject* object, JSGlobalObject* globalObject, JSValue value)
-    {
-        if (!value.isObject())
-            return false;
-
-        // Note: this breaks [Symbol.hasInstance]
-        // We must do this for now until we update the code generator to export classes
-        return JSDOMFile__hasInstance(JSValue::encode(object), globalObject, JSValue::encode(value));
     }
 
     static JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
@@ -69,7 +124,7 @@ public:
         auto& vm = JSC::getVM(globalObject);
         JSObject* newTarget = asObject(callFrame->newTarget());
         auto* constructor = globalObject->JSDOMFileConstructor();
-        Structure* structure = globalObject->JSBlobStructure();
+        Structure* structure = globalObject->JSDOMFileStructure();
         if (constructor != newTarget) {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -77,7 +132,7 @@ public:
                 // ShadowRealm functions belong to a different global object.
                 getFunctionRealm(lexicalGlobalObject, newTarget));
             RETURN_IF_EXCEPTION(scope, {});
-            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSBlobStructure());
+            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSDOMFileStructure());
             RETURN_IF_EXCEPTION(scope, {});
         }
 
@@ -87,8 +142,9 @@ public:
             return JSValue::encode(JSC::jsUndefined());
         }
 
-        return JSValue::encode(
-            WebCore::JSBlob::create(vm, globalObject, structure, ptr));
+        auto* instance = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+        vm.heap.reportExtraMemoryAllocated(instance, Blob__estimatedSize(ptr));
+        return JSValue::encode(instance);
     }
 
     static JSC_HOST_CALL_ATTRIBUTES EncodedJSValue call(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
@@ -97,15 +153,37 @@ public:
         throwTypeError(lexicalGlobalObject, scope, "Class constructor File cannot be invoked without 'new'"_s);
         return {};
     }
+
+private:
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm, 2, "File"_s);
+    }
 };
 
-const JSC::ClassInfo JSDOMFile::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFile) };
+const JSC::ClassInfo JSDOMFileConstructor::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFileConstructor) };
 
-namespace Bun {
-
-JSC::JSObject* createJSDOMFileConstructor(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+void setupJSDOMFileClassStructure(JSC::LazyClassStructure::Initializer& init)
 {
-    return JSDOMFile::create(vm, globalObject);
+    auto* zigGlobal = defaultGlobalObject(init.global);
+    JSC::JSObject* blobPrototype = zigGlobal->JSBlobPrototype();
+    auto* protoStructure = JSDOMFilePrototype::createStructure(init.vm, init.global, blobPrototype);
+    auto* prototype = JSDOMFilePrototype::create(init.vm, init.global, protoStructure);
+    auto* structure = WebCore::JSBlob::createStructure(init.vm, init.global, prototype);
+    auto* constructor = JSDOMFileConstructor::create(init.vm, init.global, prototype);
+    init.setPrototype(prototype);
+    init.setStructure(structure);
+    init.setConstructor(constructor);
+}
+
+extern "C" SYSV_ABI EncodedJSValue BUN__createJSDOMFile(JSC::JSGlobalObject* lexicalGlobalObject, void* ptr)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto* structure = globalObject->JSDOMFileStructure();
+    auto* instance = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+    vm.heap.reportExtraMemoryAllocated(instance, Blob__estimatedSize(ptr));
+    return JSValue::encode(instance);
 }
 
 }

--- a/src/jsc/bindings/JSDOMFile.h
+++ b/src/jsc/bindings/JSDOMFile.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "root.h"
+#include <JavaScriptCore/LazyClassStructure.h>
 
 namespace Bun {
-JSC::JSObject* createJSDOMFileConstructor(JSC::VM&, JSC::JSGlobalObject*);
+void setupJSDOMFileClassStructure(JSC::LazyClassStructure::Initializer&);
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1989,6 +1989,9 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_JSDirentClassStructure), [](LazyClassStructure::Initializer& init) {
              Bun::initJSDirentClassStructure(init);
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_JSDOMFileClassStructure), [](LazyClassStructure::Initializer& init) {
+             Bun::setupJSDOMFileClassStructure(init);
+         } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSX509CertificateClassStructure), [](LazyClassStructure::Initializer& init) {
              setupX509CertificateClassStructure(init);
          } },
@@ -2358,10 +2361,6 @@ void GlobalObject::finishCreation(VM& vm)
     static const LazyPropertyInit<JSObject> lazyObjectInits[] = {
         { OBJECT_OFFSETOF(GlobalObject, m_JSAsymmetricKeyObjectPrototype), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
              setupAsymmetricKeyObjectPrototype(init);
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_JSDOMFileConstructor), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
-             JSObject* fileConstructor = Bun::createJSDOMFileConstructor(init.vm, init.owner);
-             init.set(fileConstructor);
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_cryptoObject), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
              JSC::JSGlobalObject* globalObject = init.owner;

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -538,6 +538,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_processEnvObject)                                      \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSS3FileStructure)                                    \
+    V(public, JSC::LazyClassStructure, m_JSDOMFileClassStructure)                                            \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_S3ErrorStructure)                                     \
                                                                                                              \
     V(public, JSC::LazyClassStructure, m_JSStatsClassStructure)                                              \
@@ -643,7 +644,6 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_importMetaObjectStructure)                           \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_importMetaBakeObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_asyncBoundFunctionStructure)                         \
-    V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSDOMFileConstructor)                             \
     V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSMIMEParamsConstructor)                          \
     V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSMIMETypeConstructor)                            \
                                                                                                              \
@@ -744,7 +744,8 @@ public:
     JSC::JSWeakMap* napiTypeTags() const { return m_napiTypeTags.getInitializedOnMainThread(this); }
 
     JSObject* cryptoObject() const { return m_cryptoObject.getInitializedOnMainThread(this); }
-    JSObject* JSDOMFileConstructor() const { return m_JSDOMFileConstructor.getInitializedOnMainThread(this); }
+    JSObject* JSDOMFileConstructor() const { return m_JSDOMFileClassStructure.constructorInitializedOnMainThread(this); }
+    JSC::Structure* JSDOMFileStructure() const { return m_JSDOMFileClassStructure.getInitializedOnMainThread(this); }
 
     JSMap* nodeWorkerEnvironmentData() { return m_nodeWorkerEnvironmentData.get(); }
     JSObject* nodeWorkerStdioPorts() { return m_nodeWorkerStdioPorts.get(); }

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -25,7 +25,6 @@
   global                          GlobalObject_getGlobalThis                           PropertyCallback
 
   Bun                             GlobalObject::m_bunObject                            CellProperty|DontDelete|ReadOnly
-  File                            GlobalObject::m_JSDOMFileConstructor                 CellProperty
   crypto                          GlobalObject::m_cryptoObject                         CellProperty
   navigator                       GlobalObject::m_navigatorObject                      CellProperty
   performance                     GlobalObject::m_performanceObject                    CellProperty
@@ -33,6 +32,7 @@
 
   Blob                            GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSBlob]                               ClassStructure
   Buffer                          GlobalObject::m_JSBufferClassStructure               ClassStructure
+  File                            GlobalObject::m_JSDOMFileClassStructure              ClassStructure
   BuildError                      GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSBuildMessage]                       ClassStructure
   BuildMessage                    GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSBuildMessage]                       ClassStructure
   Crypto                          GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSCrypto]                             ClassStructure

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -2,27 +2,32 @@
 #include "ZigGeneratedClasses.h"
 
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
+extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFile(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, const BunString* filename);
 
 namespace WebCore {
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
-    BunString filename = Bun::toString(impl.fileName());
-    Blob__setAsFile(impl.impl(), &filename);
+    void* duped = Blob__dupe(impl.impl());
+    if (impl.fileName().isNull())
+        return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, duped));
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    BunString filename = Bun::toString(impl.fileName());
+    Blob__setAsFile(duped, &filename);
+    return JSC::JSValue::decode(BUN__createJSDOMFile(lexicalGlobalObject, duped));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)
 {
     auto fileNameStr = impl->fileName();
-    BunString filename = Bun::toString(fileNameStr);
+    if (fileNameStr.isNull())
+        return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, impl->impl()));
 
-    JSC::EncodedJSValue encoded = Blob__create(lexicalGlobalObject, impl->impl());
+    BunString filename = Bun::toString(fileNameStr);
+    JSC::EncodedJSValue encoded = BUN__createJSDOMFile(lexicalGlobalObject, impl->impl());
     JSBlob* blob = uncheckedDowncast<JSBlob>(JSC::JSValue::decode(encoded));
     Blob__setAsFile(blob->wrapped(), &filename);
-
     return JSC::JSValue::decode(encoded);
 }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -374,7 +374,7 @@ impl Blob {
             content_type: JsCell::new(self.content_type.get().clone()),
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
-            is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
+            is_jsdom_file: Cell::new(false),
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3246,7 +3246,7 @@ impl BlobExt for Blob {
                                         blob.content_type_was_set.get(),
                                     ),
                                     charset: Cell::new(blob.charset.get()),
-                                    is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
+                                    is_jsdom_file: Cell::new(false),
                                     ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
                                     global_this: Cell::new(blob.global_this.get()),
                                     last_modified: Cell::new(blob.last_modified.get()),
@@ -3511,6 +3511,9 @@ impl BlobExt for Blob {
             // SAFETY: `self` is a heap-allocated *mut Blob (see `Blob::new`); the
             // C++ side wraps it in a JSS3File without taking a second ref.
             return crate::webcore::s3_file::to_js_unchecked(global_object, this);
+        }
+        if self.is_jsdom_file.get() {
+            return BUN__createJSDOMFile(global_object, this.cast::<core::ffi::c_void>());
         }
 
         js::to_js_unchecked(global_object, this)
@@ -6746,22 +6749,12 @@ impl Internal {
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// JSDOMFile__hasInstance / FileOpener / FileCloser
-// ──────────────────────────────────────────────────────────────────────────
-
-// C++ side declares `extern "C" SYSV_ABI bool JSDOMFile__hasInstance(...)` (JSDOMFile.cpp).
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn JSDOMFile__hasInstance(
-        _a: JSValue,
-        _b: &JSGlobalObject,
-        value: JSValue,
-    ) -> bool {
-        jsc::mark_binding();
-        let Some(blob) = value.as_class_ref::<Blob>() else { return false };
-        blob.is_jsdom_file.get()
-    }
+// C++ side defines `SYSV_ABI EncodedJSValue` (JSDOMFile.cpp).
+bun_jsc::jsc_abi_extern! {
+    safe fn BUN__createJSDOMFile(
+        global: &JSGlobalObject,
+        blob: *mut core::ffi::c_void,
+    ) -> JSValue;
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -815,3 +815,283 @@ test.each([
   const blob = new Blob(["abc"], { type });
   expect(blob.slice(0, 1).type).toBe(expected);
 });
+
+// https://github.com/oven-sh/bun/issues/25422
+// https://github.com/oven-sh/bun/issues/26899
+describe("File prototype chain", () => {
+  test("File.prototype is distinct from Blob.prototype and inherits from it", () => {
+    expect(File.prototype).not.toBe(Blob.prototype);
+    expect(Object.getPrototypeOf(File.prototype)).toBe(Blob.prototype);
+  });
+
+  test("new File(...).constructor is File", () => {
+    const file = new File(["hello"], "hello.txt");
+    expect(file.constructor).toBe(File);
+    expect(file.constructor.name).toBe("File");
+  });
+
+  test("File.prototype[Symbol.toStringTag] is 'File'", () => {
+    const file = new File(["hello"], "hello.txt");
+    expect(Object.prototype.toString.call(file)).toBe("[object File]");
+    expect(Object.getOwnPropertyDescriptor(File.prototype, Symbol.toStringTag)).toEqual({
+      value: "File",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  test("real File and Blob instances", () => {
+    const file = new File(["hi"], "f.txt");
+    const blob = new Blob(["hi"]);
+    expect(file instanceof File).toBe(true);
+    expect(file instanceof Blob).toBe(true);
+    expect(blob instanceof File).toBe(false);
+    expect(blob instanceof Blob).toBe(true);
+  });
+
+  test("Proxy getPrototypeOf trap returning File.prototype", () => {
+    class Foo {}
+    const proxy = new Proxy(new Foo(), {
+      getPrototypeOf() {
+        return File.prototype;
+      },
+    });
+    expect(proxy instanceof Foo).toBe(false);
+    expect(proxy instanceof File).toBe(true);
+    expect(proxy instanceof Blob).toBe(true);
+  });
+
+  test("Object.create(File.prototype) is instanceof File", () => {
+    const o = Object.create(File.prototype);
+    expect(o instanceof File).toBe(true);
+    expect(o instanceof Blob).toBe(true);
+  });
+
+  test("Object.create(Blob.prototype) is not instanceof File", () => {
+    const o = Object.create(Blob.prototype);
+    expect(o instanceof File).toBe(false);
+    expect(o instanceof Blob).toBe(true);
+  });
+
+  test("transparent Proxy around a File is instanceof File", () => {
+    const file = new File(["hi"], "a.txt");
+    const proxy = new Proxy(file, {});
+    expect(proxy instanceof File).toBe(true);
+    expect(proxy instanceof Blob).toBe(true);
+    const nested = new Proxy(new Proxy(file, {}), {});
+    expect(nested instanceof File).toBe(true);
+  });
+
+  test("transparent Proxy around a Blob is not instanceof File", () => {
+    const blob = new Blob(["hi"]);
+    const proxy = new Proxy(blob, {});
+    expect(proxy instanceof File).toBe(false);
+    expect(proxy instanceof Blob).toBe(true);
+    const nested = new Proxy(new Proxy(blob, {}), {});
+    expect(nested instanceof File).toBe(false);
+  });
+
+  test("Object.create(blob) is not instanceof File", () => {
+    const blob = new Blob(["hi"]);
+    expect(Object.create(blob) instanceof File).toBe(false);
+    expect(Object.create(blob) instanceof Blob).toBe(true);
+    expect({ __proto__: blob } instanceof File).toBe(false);
+  });
+
+  test("File whose prototype has been set to null", () => {
+    const f = new File(["hi"], "x.txt");
+    Object.setPrototypeOf(f, null);
+    expect(f instanceof File).toBe(false);
+    expect(f instanceof Blob).toBe(false);
+  });
+
+  test("Proxy around File with getPrototypeOf returning Object.prototype", () => {
+    const file = new File(["hi"], "a.txt");
+    const proxy = new Proxy(file, {
+      getPrototypeOf() {
+        return Object.prototype;
+      },
+    });
+    expect(proxy instanceof File).toBe(false);
+  });
+
+  test("subclass of File", () => {
+    class MyFile extends File {}
+    const f = new MyFile(["hi"], "x.txt");
+    expect(f instanceof MyFile).toBe(true);
+    expect(f instanceof File).toBe(true);
+    expect(f instanceof Blob).toBe(true);
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(f))).toBe(File.prototype);
+  });
+
+  test("non-objects", () => {
+    expect((null as any) instanceof File).toBe(false);
+    expect((undefined as any) instanceof File).toBe(false);
+    expect((42 as any) instanceof File).toBe(false);
+    expect(("hi" as any) instanceof File).toBe(false);
+    expect({} instanceof File).toBe(false);
+  });
+
+  test("File instances have Blob methods via inheritance", async () => {
+    const file = new File(["hello"], "hello.txt", { lastModified: 12345 });
+    expect(file.name).toBe("hello.txt");
+    expect(file.lastModified).toBe(12345);
+    expect(await file.text()).toBe("hello");
+    expect(file.size).toBe(5);
+    expect(await file.slice(1, 3).text()).toBe("el");
+  });
+
+  test("structuredClone preserves File prototype", () => {
+    const file = new File(["hello"], "hello.txt", { lastModified: 12345 });
+    const cloned = structuredClone(file);
+    expect(cloned instanceof File).toBe(true);
+    expect(cloned instanceof Blob).toBe(true);
+    expect(cloned.constructor).toBe(File);
+    expect(cloned.name).toBe("hello.txt");
+    expect(cloned.lastModified).toBe(12345);
+  });
+
+  test("structuredClone of Blob stays a Blob", () => {
+    const blob = new Blob(["hello"]);
+    const cloned = structuredClone(blob);
+    expect(cloned instanceof Blob).toBe(true);
+    expect(cloned instanceof File).toBe(false);
+  });
+
+  test("FormData.get returns a File", () => {
+    const fd = new FormData();
+    fd.append("f", new Blob(["hi"]), "x.txt");
+    const got = fd.get("f");
+    expect(got instanceof File).toBe(true);
+    expect((got as File).name).toBe("x.txt");
+  });
+
+  test("FormData.get returns a File for empty or omitted filename", () => {
+    const fd = new FormData();
+    fd.append("a", new Blob(["x"]), "");
+    fd.append("b", new File(["x"], ""));
+    fd.append("c", new Blob(["x"]));
+    fd.set("d", new Blob(["x"]), "");
+    fd.set("e", new File(["x"], ""));
+    fd.set("f", new Blob(["x"]));
+    for (const k of ["a", "b", "c", "d", "e", "f"]) {
+      const v = fd.get(k);
+      expect(v instanceof File).toBe(true);
+      expect((v as File).constructor).toBe(File);
+    }
+  });
+
+  test('multipart part with filename="" round-trips as a File', async () => {
+    const body = '--b\r\nContent-Disposition: form-data; name="f"; filename=""\r\n\r\nhi\r\n--b--\r\n';
+    const fd = await new Response(body, {
+      headers: { "content-type": "multipart/form-data; boundary=b" },
+    }).formData();
+    const v = fd.get("f");
+    expect(v instanceof File).toBe(true);
+    expect((v as File).constructor).toBe(File);
+    expect(await (v as File).text()).toBe("hi");
+  });
+
+  test("Object.getPrototypeOf(File) is Blob", () => {
+    expect(Object.getPrototypeOf(File)).toBe(Blob);
+  });
+
+  test("file.slice() returns a plain Blob", async () => {
+    const f = new File(["hello"], "x.txt", { lastModified: 123 });
+    const s = f.slice(1, 3);
+    expect(s instanceof File).toBe(false);
+    expect(s instanceof Blob).toBe(true);
+    expect(s.constructor).toBe(Blob);
+    expect(Object.prototype.toString.call(s)).toBe("[object Blob]");
+    expect(Object.getPrototypeOf(s)).toBe(Blob.prototype);
+    expect(await s.text()).toBe("el");
+  });
+
+  test("new Response(file).blob() returns a plain Blob", async () => {
+    const f = new File(["hi"], "x.txt", { type: "text/plain" });
+    const b = await new Response(f).blob();
+    expect(b instanceof File).toBe(false);
+    expect(b.constructor).toBe(Blob);
+    expect(Object.prototype.toString.call(b)).toBe("[object Blob]");
+    expect(await b.text()).toBe("hi");
+  });
+
+  test("new Blob([file]) is a plain Blob and stays one through structuredClone", () => {
+    const b = new Blob([new File(["hi"], "x.txt")]);
+    expect(Object.getPrototypeOf(b)).toBe(Blob.prototype);
+    expect(b instanceof File).toBe(false);
+    const c = structuredClone(b);
+    expect(c instanceof File).toBe(false);
+    expect(c.constructor).toBe(Blob);
+    expect(Object.prototype.toString.call(c)).toBe("[object Blob]");
+  });
+
+  test("WebSocket binaryType 'blob' delivers a plain Blob", async () => {
+    using server = Bun.serve({
+      port: 0,
+      websocket: {
+        open(ws) {
+          ws.sendBinary(new Uint8Array([1, 2, 3]));
+        },
+        message() {},
+      },
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response();
+      },
+    });
+    const ws = new WebSocket(`ws://localhost:${server.port}`);
+    ws.binaryType = "blob";
+    const { promise, resolve, reject } = Promise.withResolvers<Blob>();
+    ws.onmessage = e => resolve(e.data);
+    ws.onerror = reject;
+    ws.onclose = () => reject(new Error("closed before message"));
+    try {
+      const data = await promise;
+      expect(data instanceof Blob).toBe(true);
+      expect(data instanceof File).toBe(false);
+      expect(data.constructor).toBe(Blob);
+      expect(Object.prototype.toString.call(data)).toBe("[object Blob]");
+      expect(new Uint8Array(await data.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("name and lastModified are own accessors on File.prototype", () => {
+    expect(Object.getOwnPropertyNames(File.prototype).sort()).toEqual(["constructor", "lastModified", "name"]);
+    const name = Object.getOwnPropertyDescriptor(File.prototype, "name");
+    const lastModified = Object.getOwnPropertyDescriptor(File.prototype, "lastModified");
+    expect(typeof name!.get).toBe("function");
+    expect(typeof lastModified!.get).toBe("function");
+  });
+
+  test("File posted to a Worker has the File prototype before globalThis.File is touched", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const w = new Worker(URL.createObjectURL(new Blob([
+            "self.onmessage = e => postMessage({ctor: e.data.constructor.name, isFile: e.data instanceof File});",
+          ], { type: "text/javascript" })));
+          const { promise, resolve, reject } = Promise.withResolvers();
+          w.onmessage = e => resolve(e.data);
+          w.onerror = reject;
+          w.onmessageerror = reject;
+          w.postMessage(new File(["hi"], "x.txt"));
+          const r = await promise;
+          console.log(JSON.stringify(r));
+          w.terminate();
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ ctor: "File", isFile: true });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #25422.
Closes #26899.

### What does this PR do?

`File.prototype` was the same object as `Blob.prototype`, with a comment saying "This is not quite right. But we'll fix it if someone files an issue about it." To keep `new Blob() instanceof File` false despite that, the `File` constructor installed a custom `[Symbol.hasInstance]` that checked a native flag on the underlying cell instead of walking the prototype chain.

That broke every case where `instanceof` is supposed to consult the prototype chain:

```js
new Proxy(new File([], "f"), {}) instanceof File                          // false, should be true
Object.create(File.prototype) instanceof File                              // false, should be true
new Proxy({}, { getPrototypeOf: () => File.prototype }) instanceof File    // false, should be true
Object.setPrototypeOf(new File([], "f"), null) instanceof File             // true,  should be false
```

It also meant `new File(...).constructor === Blob`, `Object.prototype.toString.call(file) === "[object Blob]"`, and `File.prototype === Blob.prototype`, none of which match browsers or Node.

This gives `File` a real prototype chain:

- `JSDOMFilePrototype` is a new prototype object whose `[[Prototype]]` is `Blob.prototype`. It carries `constructor` and `Symbol.toStringTag`; everything else is inherited from `Blob.prototype`.
- `m_JSDOMFileStructure` is a cached `Structure` on the global object for `File` instances (same `JSBlob` cell type, different prototype).
- `new File(...)`, `structuredClone(file)`, `FormData` file entries, and `Bun.Archive` file entries all allocate with that structure.
- The custom `hasInstance` and its `JSDOMFile__hasInstance` Rust export are deleted. `instanceof File` is now ordinary `OrdinaryHasInstance`.

| Expression | Before | After | Node/browsers |
|---|---|---|---|
| `File.prototype === Blob.prototype` | `true` | `false` | `false` |
| `Object.getPrototypeOf(File.prototype) === Blob.prototype` | n/a | `true` | `true` |
| `new File([], "x").constructor` | `Blob` | `File` | `File` |
| `Object.prototype.toString.call(new File([], "x"))` | `"[object Blob]"` | `"[object File]"` | `"[object File]"` |
| `new Proxy(new File([], "x"), {}) instanceof File` | `false` | `true` | `true` |
| `Object.create(File.prototype) instanceof File` | `false` | `true` | `true` |
| `Object.create(Blob.prototype) instanceof File` | `false` | `false` | `false` |
| `new Blob() instanceof File` | `false` | `false` | `false` |
| `structuredClone(file).constructor` | `Blob` | `File` | `File` |

`Bun.file()` is unchanged (it is a `Blob`, not a `File`).

### How did you verify your code works?

27 new tests in `test/js/web/fetch/blob.test.ts` covering the prototype chain, `constructor`, `Symbol.toStringTag`, `Object.getPrototypeOf(File) === Blob`, proxies (transparent and with traps), `Object.create`, `Object.setPrototypeOf`, subclassing, `structuredClone`, `Worker.postMessage` into a fresh realm, `FormData` append/set with named, empty, and omitted filenames, multipart `filename=""`, WebSocket `binaryType="blob"`, and `file.slice()` / `Response(file).blob()` / `new Blob([file])` staying plain Blobs. Verified fail-before on the unfixed build and pass-after with `bun bd test`.

Also ran the existing blob, FormData, structured-clone, Archive, globals, inspect, body, and response suites locally with no regressions.

Rebased twice onto main. The second rebase moved the `m_JSDOMFileClassStructure` init into main's new `lazyClassStructureInits` table in `ZigGlobalObject.cpp` and dropped the stale `m_JSDOMFileConstructor` entry from `lazyObjectInits`. The `.lut.txt` entry follows main's renamed `m_generatedLazyClasses` neighbours.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->
