### PR TITLE
lowerDecorators: unique helper-symbol names across classes

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -163,8 +163,51 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.call_runtime(l, name, list)
     }
 
-    /// newSymbol + scope.generated.append in one call.
-    fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
+    /// Allocate a decorator-helper symbol whose name is unique across
+    /// all lowered classes in the file.
+    ///
+    /// Every helper declared at class lowering time ends up in
+    /// `current_scope.generated`. For a top-level class that's
+    /// `module_scope.generated`, which the bundler's NumberRenamer
+    /// doesn't walk — so the printed output falls back to
+    /// `symbol.original_name`. If two classes both asked for "_init",
+    /// both `var _init = …` declarations would end up at module scope
+    /// and collide under `var` hoisting.
+    ///
+    /// To make the printed name unique regardless of which renamer
+    /// runs (bundler, no-op transpile, minifier), we stamp a
+    /// per-parser counter into the `original_name` at creation time.
+    /// `record_declared_symbol` additionally makes the bundler's
+    /// `addTopLevelDeclaredSymbols` see these refs so it can still
+    /// rename them when minifying.
+    ///
+    /// Callers must pass a constant base name (e.g. `b"_dec"`, not a
+    /// pre-numbered `b"_dec2"`) — the counter adds the unique suffix.
+    /// For semantic identifiers whose exact spelling is part of
+    /// observable behavior (a class's inferred name, `arguments`, a
+    /// setter's `v` param) use `new_plain_sym` instead.
+    fn new_sym(&mut self, kind: js_ast::symbol::Kind, base: &'a [u8]) -> Ref {
+        self.decorator_sym_count += 1;
+        let unique = {
+            let mut v = BumpVec::<u8>::new_in(self.arena);
+            v.extend_from_slice(base);
+            let s = bun_alloc::arena_format!(in self.arena, "{}", self.decorator_sym_count);
+            v.extend_from_slice(s.as_bytes());
+            v.into_bump_slice()
+        };
+        let ref_ = self.new_symbol(kind, unique).expect("unreachable");
+        VecExt::append(&mut self.current_scope_mut().generated, ref_);
+        self.record_declared_symbol(ref_);
+        ref_
+    }
+
+    /// Allocate a symbol whose name must be preserved verbatim —
+    /// the inferred class name (e.g. `const Foo = class { … }`
+    /// needs `Foo` for `Foo.name` and decorator-context reporting),
+    /// the `arguments` keyword inside a generated constructor, or a
+    /// setter's `v` parameter that's scoped to its own function.
+    /// No counter suffix, no declared-symbol record.
+    fn new_plain_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
         let ref_ = self.new_symbol(kind, name).expect("unreachable");
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
         ref_
@@ -1049,8 +1092,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if let Some(name) = name_from_context
                     && can_be_class_binding_name(name)
                 {
+                    // Inferred class name from an assignment like `const Foo = class {…}`.
+                    // Must stay verbatim: it's used as the string name passed to the
+                    // class decorator context (see the __decorateElement call below).
                     class.class_name = Some(js_ast::LocRef {
-                        ref_: Some(p.new_sym(js_ast::symbol::Kind::Other, name)),
+                        ref_: Some(p.new_plain_sym(js_ast::symbol::Kind::Other, name)),
                         loc,
                     });
                 }
@@ -1108,12 +1154,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // ── Phase 2: Pre-evaluate decorators/keys ────────
-        let mut dec_counter: usize = 0;
+        // `new_sym` suffixes each base name with a per-parser counter, so
+        // every `_dec`/`_computedKey` gets a unique `original_name` — no
+        // need for a local counter loop.
         let mut class_dec_ref: Option<Ref> = None;
         let mut class_dec_stmt: Stmt = Stmt::empty();
         let mut class_dec_assign_expr: Option<Expr> = None;
         if class_decorators_len > 0 {
-            dec_counter += 1;
             let cdr = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
             class_dec_ref = Some(cdr);
             // Move ownership into the AST node — `class_decorators` is not read
@@ -1142,7 +1189,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut prop_dec_refs: HashMap<usize, Ref> = HashMap::default();
         let mut computed_key_refs: HashMap<usize, Ref> = HashMap::default();
         let mut pre_eval_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut computed_key_counter: usize = 0;
 
         let props_slice: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice.iter_mut().enumerate() {
@@ -1150,13 +1196,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
             if prop.ts_decorators.len_u32() > 0 {
-                dec_counter += 1;
-                let dec_name: &'a [u8] = if dec_counter == 1 {
-                    b"_dec"
-                } else {
-                    p.bump_name(b"_dec", Some(dec_counter))
-                };
-                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, dec_name);
+                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
                 prop_dec_refs.insert(prop_idx, dec_ref);
                 if is_expr {
                     let binding = p.b(B::Identifier { r#ref: dec_ref }, loc);
@@ -1180,13 +1220,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && prop.key.is_some()
                 && prop.ts_decorators.len_u32() > 0
             {
-                computed_key_counter += 1;
-                let key_name: &'a [u8] = if computed_key_counter == 1 {
-                    b"_computedKey"
-                } else {
-                    p.bump_name(b"_computedKey", Some(computed_key_counter))
-                };
-                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, key_name);
+                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_computedKey");
                 computed_key_refs.insert(prop_idx, key_ref);
                 if is_expr {
                     let binding = p.b(B::Identifier { r#ref: key_ref }, loc);
@@ -1299,7 +1333,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
@@ -1451,18 +1484,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 // Undecorated auto-accessor → WeakMap + getter/setter
                 if prop.kind == PropertyKind::AutoAccessor {
-                    let accessor_name: &'a [u8] = 'brk: {
+                    // Base name keeps `_foo` for readability when the key is a
+                    // string literal; `new_sym` tacks on a unique suffix so the
+                    // same property name in another class doesn't collide.
+                    let accessor_base: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
                             if let js_ast::ExprData::EString(s) = &k.data {
                                 break 'brk p.bump_name2(b"_", &s.data);
                             }
                         }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
+                        b"_accessor_storage"
                     };
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_base);
                     let wme = p.new_weak_map_expr(loc);
                     prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
 
@@ -1485,7 +1518,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     };
 
                     // Setter: set foo(v) { __privateSet(this, _foo, v); }
-                    let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
+                    // Setter param `v` lives inside its own function scope — no
+                    // collision with other classes and not useful to suffix.
+                    let setter_param_ref = p.new_plain_sym(js_ast::symbol::Kind::Other, b"v");
                     let this_e2 = p.new_expr(E::This {}, loc);
                     let wm_e2 = p.use_ref(wm_ref, loc);
                     let v_e = p.use_ref(setter_param_ref, loc);
@@ -1699,15 +1734,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             } else if k == 4 {
                 // Decorated public auto-accessor → WeakMap
-                let accessor_name: &'a [u8] = 'brk: {
+                let accessor_base: &'a [u8] = 'brk: {
                     if let js_ast::ExprData::EString(s) = &key_expr.data {
                         break 'brk p.bump_name2(b"_", &s.data);
                     }
-                    let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                    accessor_storage_counter += 1;
-                    name
+                    b"_accessor_storage"
                 };
-                let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_base);
                 private_extra_ref = Some(wm_ref);
                 let wme = p.new_weak_map_expr(loc);
                 prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
@@ -2274,7 +2307,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut ctor_stmts = BumpVec::<Stmt>::new_in(bump);
                 if class.extends.is_some() {
                     let target = p.new_expr(E::Super {}, loc);
-                    let args_ref = p.new_sym(js_ast::symbol::Kind::Unbound, arguments_str);
+                    // `arguments` is a language keyword inside the synthesized
+                    // constructor; it must be emitted as that exact identifier.
+                    let args_ref = p.new_plain_sym(js_ast::symbol::Kind::Unbound, arguments_str);
                     let inner = p.new_expr(
                         E::Identifier {
                             ref_: args_ref,

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -1473,11 +1473,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if prop.kind == PropertyKind::AutoAccessor {
                     // Base name keeps `_foo` for readability when the key is a
                     // string literal; `new_sym` tacks on a unique suffix so the
-                    // same property name in another class doesn't collide.
+                    // same property name in another class doesn't collide. Guard on
+                    // is_identifier: a quoted key like `accessor "foo-bar"` would
+                    // produce `_foo-bar`, valid only for the bundler (NumberRenamer
+                    // sanitizes it) — the transpile path (NoOpRenamer) prints
+                    // original_name verbatim, so fall back to `_accessor_storage`.
                     let accessor_base: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
-                            if let js_ast::ExprData::EString(s) = &k.data {
-                                break 'brk p.bump_name2(b"_", &s.data);
+                            if let Some(mut s) = k.data.e_string() {
+                                if s.is_identifier(p.arena) {
+                                    break 'brk p.bump_name2(b"_", &s.data);
+                                }
                             }
                         }
                         b"_accessor_storage"
@@ -1720,10 +1726,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_arg_count = 6;
                 }
             } else if k == 4 {
-                // Decorated public auto-accessor → WeakMap
+                // Decorated public auto-accessor → WeakMap. See the undecorated
+                // accessor site above for why non-identifier string keys fall back
+                // to `_accessor_storage`.
                 let accessor_base: &'a [u8] = 'brk: {
-                    if let js_ast::ExprData::EString(s) = &key_expr.data {
-                        break 'brk p.bump_name2(b"_", &s.data);
+                    if let Some(mut s) = key_expr.data.e_string() {
+                        if s.is_identifier(p.arena) {
+                            break 'brk p.bump_name2(b"_", &s.data);
+                        }
                     }
                     b"_accessor_storage"
                 };

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -430,19 +430,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Bump-format `_{prefix}{n}` (or just `_{prefix}` when n is omitted).
-    fn bump_name(&self, prefix: &[u8], n: Option<usize>) -> &'a [u8] {
-        let mut v = BumpVec::<u8>::new_in(self.arena);
-        v.extend_from_slice(prefix);
-        if let Some(n) = n {
-            // PORT NOTE: bumpalo Vec<u8> doesn't impl io::Write; format into a
-            // bump String and copy the bytes.
-            let s = bun_alloc::arena_format!(in self.arena, "{}", n);
-            v.extend_from_slice(s.as_bytes());
-        }
-        v.into_bump_slice()
-    }
-
     fn bump_name2(&self, a: &[u8], b: &[u8]) -> &'a [u8] {
         let mut v = BumpVec::<u8>::new_in(self.arena);
         v.extend_from_slice(a);

--- a/src/js_parser/lower/lower_decorators.zig
+++ b/src/js_parser/lower/lower_decorators.zig
@@ -55,8 +55,45 @@ pub fn LowerDecorators(
             return p.callRuntime(l, name, a);
         }
 
-        /// newSymbol + scope.generated.append in one call.
-        fn newSym(p: *P, kind: Symbol.Kind, name: []const u8) Ref {
+        /// Allocate a decorator-helper symbol whose name is unique across
+        /// all lowered classes in the file.
+        ///
+        /// Every helper declared at class lowering time ends up in
+        /// `current_scope.generated`. For a top-level class, that's
+        /// `module_scope.generated`, which the bundler's NumberRenamer
+        /// doesn't walk — so the printed output falls back to
+        /// `symbol.original_name`. If two classes both asked for "_init",
+        /// both `var _init = …` declarations would end up at module scope
+        /// and collide.
+        ///
+        /// To make the printed name unique regardless of which renamer
+        /// runs (bundler, no-op transpile, minifier), we stamp a
+        /// per-parser counter into the `original_name` at creation time.
+        /// `recordDeclaredSymbol` additionally makes the bundler's
+        /// `addTopLevelDeclaredSymbols` see these refs so it can still
+        /// rename them when minifying.
+        ///
+        /// Callers must pass a constant base name (e.g. `"_dec"`, not a
+        /// pre-numbered `"_dec2"`) — the counter adds the unique suffix.
+        /// For semantic identifiers whose exact spelling is part of
+        /// observable behavior (a class's inferred name, `arguments`, a
+        /// setter's `v` param) use `newPlainSym` instead.
+        fn newSym(p: *P, kind: Symbol.Kind, base: []const u8) Ref {
+            p.decorator_sym_count += 1;
+            const unique = bun.handleOom(std.fmt.allocPrint(p.allocator, "{s}{d}", .{ base, p.decorator_sym_count }));
+            const ref = p.newSymbol(kind, unique) catch unreachable;
+            bun.handleOom(p.current_scope.generated.append(p.allocator, ref));
+            p.recordDeclaredSymbol(ref) catch unreachable;
+            return ref;
+        }
+
+        /// Allocate a symbol whose name must be preserved verbatim —
+        /// the inferred class name (e.g. `const Foo = class { … }`
+        /// needs `Foo` for `Foo.name` and decorator-context reporting),
+        /// the `arguments` keyword inside a generated constructor, or a
+        /// setter's `v` parameter that's scoped to its own function.
+        /// No counter suffix, no declared-symbol record.
+        fn newPlainSym(p: *P, kind: Symbol.Kind, name: []const u8) Ref {
             const ref = p.newSymbol(kind, name) catch unreachable;
             bun.handleOom(p.current_scope.generated.append(p.allocator, ref));
             return ref;
@@ -568,7 +605,10 @@ pub fn LowerDecorators(
                     class_name_loc = loc;
                     expr_class_is_anonymous = true;
                     if (name_from_context) |name| {
-                        class.class_name = .{ .ref = newSym(p, .other, name), .loc = loc };
+                        // Inferred class name from an assignment like `const Foo = class {…}`.
+                        // Must stay verbatim: it's used as the string name passed to the
+                        // class decorator context (see the __decorateElement call below).
+                        class.class_name = .{ .ref = newPlainSym(p, .other, name), .loc = loc };
                     }
                 }
             } else {
@@ -599,12 +639,13 @@ pub fn LowerDecorators(
             }
 
             // ── Phase 2: Pre-evaluate decorators/keys ────────
-            var dec_counter: usize = 0;
+            // `newSym` suffixes each base name with a per-parser counter, so
+            // every `_dec`/`_computedKey` gets a unique `original_name` — no
+            // need for a local counter loop.
             var class_dec_ref: ?Ref = null;
             var class_dec_stmt: Stmt = Stmt.empty();
             var class_dec_assign_expr: ?Expr = null;
             if (class_decorators.len > 0) {
-                dec_counter += 1;
                 class_dec_ref = newSym(p, .other, "_dec");
                 const arr = p.newExpr(E.Array{ .items = class_decorators }, loc);
                 if (is_expr) {
@@ -618,17 +659,11 @@ pub fn LowerDecorators(
             var prop_dec_refs = std.AutoHashMapUnmanaged(usize, Ref){};
             var computed_key_refs = std.AutoHashMapUnmanaged(usize, Ref){};
             var pre_eval_stmts = ListManaged(Stmt).init(p.allocator);
-            var computed_key_counter: usize = 0;
 
             for (class.properties, 0..) |*prop, prop_idx| {
                 if (prop.kind == .class_static_block) continue;
                 if (prop.ts_decorators.len > 0) {
-                    dec_counter += 1;
-                    const dec_name = if (dec_counter == 1)
-                        "_dec"
-                    else
-                        std.fmt.allocPrint(p.allocator, "_dec{d}", .{dec_counter}) catch unreachable;
-                    const dec_ref = newSym(p, .other, dec_name);
+                    const dec_ref = newSym(p, .other, "_dec");
                     prop_dec_refs.put(p.allocator, prop_idx, dec_ref) catch unreachable;
                     if (is_expr) {
                         expr_var_decls.append(.{ .binding = p.b(B.Identifier{ .ref = dec_ref }, loc) }) catch unreachable;
@@ -636,12 +671,7 @@ pub fn LowerDecorators(
                     pre_eval_stmts.append(varDecl(p, dec_ref, p.newExpr(E.Array{ .items = prop.ts_decorators }, loc), loc)) catch unreachable;
                 }
                 if (prop.flags.contains(.is_computed) and prop.key != null and prop.ts_decorators.len > 0) {
-                    computed_key_counter += 1;
-                    const key_name = if (computed_key_counter == 1)
-                        "_computedKey"
-                    else
-                        std.fmt.allocPrint(p.allocator, "_computedKey{d}", .{computed_key_counter}) catch unreachable;
-                    const key_ref = newSym(p, .other, key_name);
+                    const key_ref = newSym(p, .other, "_computedKey");
                     computed_key_refs.put(p.allocator, prop_idx, key_ref) catch unreachable;
                     if (is_expr) {
                         expr_var_decls.append(.{ .binding = p.b(B.Identifier{ .ref = key_ref }, loc) }) catch unreachable;
@@ -718,7 +748,6 @@ pub fn LowerDecorators(
             var extracted_static_blocks = ListManaged(*G.ClassStaticBlock).init(p.allocator);
             var prefix_stmts = ListManaged(Stmt).init(p.allocator);
             var private_lowered_map = PrivateLoweredMap{};
-            var accessor_storage_counter: usize = 0;
             var emitted_private_adds = std.AutoHashMapUnmanaged(u32, void){};
             var static_private_add_blocks = ListManaged(Property).init(p.allocator);
 
@@ -818,14 +847,14 @@ pub fn LowerDecorators(
                     }
                     // Undecorated auto-accessor → WeakMap + getter/setter
                     if (prop.kind == .auto_accessor) {
-                        const accessor_name = brk: {
-                            if (prop.key.?.data == .e_string)
-                                break :brk std.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable;
-                            const name = std.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
-                            accessor_storage_counter += 1;
-                            break :brk name;
-                        };
-                        const wm_ref = newSym(p, .other, accessor_name);
+                        // Base name keeps `_foo` for readability when the key is a
+                        // string literal; `newSym` tacks on a unique suffix so the
+                        // same property name in another class doesn't collide.
+                        const accessor_base = if (prop.key.?.data == .e_string)
+                            std.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable
+                        else
+                            "_accessor_storage";
+                        const wm_ref = newSym(p, .other, accessor_base);
                         prefix_stmts.append(varDecl(p, wm_ref, newWeakMapExpr(p, loc), loc)) catch unreachable;
 
                         // Getter: get foo() { return __privateGet(this, _foo); }
@@ -838,7 +867,9 @@ pub fn LowerDecorators(
                         get_fn.* = .{ .body = .{ .stmts = get_body, .loc = loc } };
 
                         // Setter: set foo(v) { __privateSet(this, _foo, v); }
-                        const setter_param_ref = newSym(p, .other, "v");
+                        // Setter param `v` lives inside its own function scope — no
+                        // collision with other classes and not useful to suffix.
+                        const setter_param_ref = newPlainSym(p, .other, "v");
                         const set_body = bun.handleOom(p.allocator.alloc(Stmt, 1));
                         set_body[0] = p.s(S.SExpr{ .value = callRt(p, loc, "__privateSet", &[_]Expr{
                             p.newExpr(E.This{}, loc),
@@ -970,14 +1001,11 @@ pub fn LowerDecorators(
                     }
                 } else if (k == 4) {
                     // Decorated public auto-accessor → WeakMap
-                    const accessor_name = brk: {
-                        if (key_expr.data == .e_string)
-                            break :brk std.fmt.allocPrint(p.allocator, "_{s}", .{key_expr.data.e_string.data}) catch unreachable;
-                        const name = std.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
-                        accessor_storage_counter += 1;
-                        break :brk name;
-                    };
-                    const wm_ref = newSym(p, .other, accessor_name);
+                    const accessor_base = if (key_expr.data == .e_string)
+                        std.fmt.allocPrint(p.allocator, "_{s}", .{key_expr.data.e_string.data}) catch unreachable
+                    else
+                        "_accessor_storage";
+                    const wm_ref = newSym(p, .other, accessor_base);
                     private_extra_ref = wm_ref;
                     prefix_stmts.append(varDecl(p, wm_ref, newWeakMapExpr(p, loc), loc)) catch unreachable;
                     dec_arg_count = 6;
@@ -1339,7 +1367,9 @@ pub fn LowerDecorators(
                     var ctor_stmts = ListManaged(Stmt).init(p.allocator);
                     if (class.extends != null) {
                         const target = p.newExpr(E.Super{}, loc);
-                        const args_ref = newSym(p, .unbound, arguments_str);
+                        // `arguments` is a language keyword inside the synthesized
+                        // constructor; it must be emitted as that exact identifier.
+                        const args_ref = newPlainSym(p, .unbound, arguments_str);
                         const spread = p.newExpr(E.Spread{ .value = p.newExpr(E.Identifier{ .ref = args_ref }, loc) }, loc);
                         const call_args = bun.handleOom(ExprNodeList.initOne(p.allocator, spread));
                         ctor_stmts.append(

--- a/src/js_parser/lower/lower_decorators.zig
+++ b/src/js_parser/lower/lower_decorators.zig
@@ -849,8 +849,13 @@ pub fn LowerDecorators(
                     if (prop.kind == .auto_accessor) {
                         // Base name keeps `_foo` for readability when the key is a
                         // string literal; `newSym` tacks on a unique suffix so the
-                        // same property name in another class doesn't collide.
-                        const accessor_base = if (prop.key.?.data == .e_string)
+                        // same property name in another class doesn't collide. Guard
+                        // on isIdentifier: a quoted key like `accessor "foo-bar"`
+                        // would produce `_foo-bar`, which is a valid base only for the
+                        // bundler (NumberRenamer sanitizes it) — the transpile path
+                        // (NoOpRenamer) prints original_name verbatim, so fall back to
+                        // `_accessor_storage` for non-identifier keys.
+                        const accessor_base = if (prop.key.?.data == .e_string and prop.key.?.data.e_string.isIdentifier(p.allocator))
                             std.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable
                         else
                             "_accessor_storage";
@@ -1000,9 +1005,11 @@ pub fn LowerDecorators(
                         dec_arg_count = 6;
                     }
                 } else if (k == 4) {
-                    // Decorated public auto-accessor → WeakMap
-                    const accessor_base = if (key_expr.data == .e_string)
-                        std.fmt.allocPrint(p.allocator, "_{s}", .{key_expr.data.e_string.data}) catch unreachable
+                    // Decorated public auto-accessor → WeakMap. See the
+                    // undecorated-accessor site above for why non-identifier
+                    // string keys fall back to `_accessor_storage`.
+                    const accessor_base = if (prop.key.?.data == .e_string and prop.key.?.data.e_string.isIdentifier(p.allocator))
+                        std.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable
                     else
                         "_accessor_storage";
                     const wm_ref = newSym(p, .other, accessor_base);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -553,6 +553,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
+    // Counter for generating unique decorator helper symbol names.
+    // Distinct from temp_ref_count which resets per function body —
+    // decorator helpers (_init, _dec, _base, etc.) are declared at the
+    // enclosing scope of the class and must stay unique across every
+    // lowered class in the file. Never reset.
+    pub decorator_sym_count: u32,
+
     // When bundling, hoisted top-level local variables declared with "var" in
     // nested scopes are moved up to be declared in the top-level scope instead.
     // The old "var" statements are turned into regular assignments instead. This
@@ -9348,6 +9355,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             await_target: None,
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
+            decorator_sym_count: 0,
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -433,6 +433,13 @@ pub fn NewParser_(
         temp_refs_to_declare: List(TempRef) = .{},
         temp_ref_count: i32 = 0,
 
+        // Counter for generating unique decorator helper symbol names.
+        // Distinct from temp_ref_count which resets per function body —
+        // decorator helpers (_init, _dec, _base, etc.) are declared at the
+        // enclosing scope of the class and must stay unique across every
+        // lowered class in the file. Never reset.
+        decorator_sym_count: u32 = 0,
+
         // When bundling, hoisted top-level local variables declared with "var" in
         // nested scopes are moved up to be declared in the top-level scope instead.
         // The old "var" statements are turned into regular assignments instead. This

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -975,5 +975,92 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("cls:Foo|cls:Bar|acc:Foo:1|acc:Bar:2\n");
       expect(exitCode).toBe(0);
     });
+
+    // #28010: a parent class's field decorators ran with the child class's
+    // `_dec` array because both classes shared a hoisted `var _dec` at
+    // module scope — so parent-class `context.name` reported child
+    // property names.
+    test("parent-class field decorators keep their own _dec array (#28010)", async () => {
+      using dir = tempDir("es-dec-28010", {
+        "entry.ts": `
+          const logs: string[] = [];
+          function decorate(name: string) {
+            return function (_v: undefined, ctx: any) {
+              return function (init: any) {
+                logs.push(\`\${name}:\${String(ctx.name)}=\${init}\`);
+                return init;
+              };
+            };
+          }
+          class Parent {
+            @decorate("Parent.foo") foo = "parent_foo";
+            @decorate("Parent.shared") shared = "parent_shared";
+          }
+          class Child extends Parent {
+            @decorate("Child.foo") foo = "child_foo";
+            @decorate("Child.childOnly") childOnly = "child_childOnly";
+          }
+          new Child();
+          console.log(logs.join("|"));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe(
+        "Parent.foo:foo=parent_foo|Parent.shared:shared=parent_shared|Child.foo:foo=child_foo|Child.childOnly:childOnly=child_childOnly\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    // #29837: overriding an auto-accessor with the same name in a subclass
+    // threw "Cannot add the same private member more than once" because
+    // both classes' WeakMap-backed storage was allocated as `var _name`
+    // at module scope and collapsed onto one binding.
+    test("subclass can override an auto-accessor of the same name (#29837)", async () => {
+      using dir = tempDir("es-dec-29837", {
+        "entry.js": `
+          class A { accessor name = "A"; }
+          class B extends A {
+            accessor name = "B";
+            logNames() { console.log(this.name); console.log(super.name); }
+          }
+          new B().logNames();
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("B\nA\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -816,6 +816,34 @@ describe("ES Decorators", () => {
   // them into a single binding, so an earlier class's constructor would
   // end up running the last class's initializers.
   describe.concurrent("symbol names stay unique across classes", () => {
+    async function runBundled(
+      dir: string,
+      extraBuildArgs: string[],
+      entry: string,
+    ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", ...extraBuildArgs, "--outfile=out.js", entry],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+      });
+      const [buildStderr, buildExit] = await Promise.all([build.stderr.text(), build.exited]);
+      // Assert on stderr BEFORE exit so a compiler diagnostic shows up in
+      // the failure message instead of just "expected 0, received 1".
+      expect(filterStderr(buildStderr)).toBe("");
+      expect(buildExit).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      return { stdout, stderr: filterStderr(rawStderr), exitCode };
+    }
+
     test("accessor init callbacks fire on the correct class (browser bundle)", async () => {
       using dir = tempDir("es-dec-init-unique-bundle", {
         "entry.ts": `
@@ -832,22 +860,7 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.ts");
       expect(stdout).toBe("foo:X|bar:Y\n");
       expect(exitCode).toBe(0);
     });
@@ -868,22 +881,7 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--no-bundle", "--outfile=out.js", "entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
+      const { stdout, exitCode } = await runBundled(String(dir), ["--no-bundle"], "entry.ts");
       expect(stdout).toBe("A:a:a|B:b:b\n");
       expect(exitCode).toBe(0);
     });
@@ -906,33 +904,19 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.ts");
       expect(stdout).toBe("A=1,B=2,C=3\n");
       expect(exitCode).toBe(0);
     });
 
     test("class decorator addInitializer + accessor initializer in same class", async () => {
-      // Class decorators alone don't exhibit the collision (their
-      // decoration runs at module-top between the `var _init = …`
-      // lines). But a class decorator whose addInitializer fires at
-      // construction time, *plus* a per-instance accessor initializer,
-      // both consult `_init` inside the constructor — the second class
-      // must see its own `_init`, not the last file-level one.
+      // Class decorators alone don't exhibit the collision: their
+      // `__decorateElement` / `__runInitializers(_init, 1, …)` emit at
+      // module top between the two `var _init = …` lines, so each one
+      // binds to the right `_init` at execution time. Adding a per-
+      // instance accessor forces a reference to `_init` from *inside*
+      // the constructor — which runs after both `var _init` have been
+      // reassigned. That's the code path the collision breaks.
       using dir = tempDir("es-dec-mixed", {
         "entry.ts": `
           const log: string[] = [];
@@ -954,24 +938,10 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
-      // Both @mark initializers fire during top-level decoration (in
-      // declaration order), then @acc's init fires per-construction.
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.ts");
+      // @mark's class-level initializers both fire at definition time
+      // (in declaration order), then @acc's per-instance init fires
+      // when each class is constructed.
       expect(stdout).toBe("cls:Foo|cls:Bar|acc:Foo:1|acc:Bar:2\n");
       expect(exitCode).toBe(0);
     });
@@ -1005,22 +975,7 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.ts");
       expect(stdout).toBe(
         "Parent.foo:foo=parent_foo|Parent.shared:shared=parent_shared|Child.foo:foo=child_foo|Child.childOnly:childOnly=child_childOnly\n",
       );
@@ -1043,22 +998,7 @@ describe("ES Decorators", () => {
         `,
       });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      expect(await build.exited).toBe(0);
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        env: bunEnv,
-        cwd: String(dir),
-        stderr: "pipe",
-      });
-      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(filterStderr(rawStderr)).toBe("");
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.js");
       expect(stdout).toBe("B\nA\n");
       expect(exitCode).toBe(0);
     });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1058,5 +1058,25 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("1 2\n");
       expect(exitCode).toBe(0);
     });
+
+    // A quoted accessor key with non-identifier chars (`"foo-bar"`) must not
+    // leak into the helper variable name. The bundler's NumberRenamer
+    // sanitizes it, but the no-bundle/transpile path uses NoOpRenamer, which
+    // prints the name verbatim — so `_foo-bar` would emit
+    // `var _foo-bar = new WeakMap` and fail to parse. We fall back to
+    // `_accessor_storage` for non-identifier keys instead.
+    test("non-identifier string accessor key stays a valid identifier (no-bundle)", async () => {
+      using dir = tempDir("es-dec-nonident-key", {
+        // .js so it isn't gated by the TS accessor-key parser limitation.
+        "entry.js": `
+          class Foo { accessor "foo-bar" = 1; }
+          console.log(new Foo()["foo-bar"]);
+        `,
+      });
+
+      const { stdout, exitCode } = await runBundled(String(dir), ["--no-bundle"], "entry.js");
+      expect(stdout).toBe("1\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1002,5 +1002,61 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("B\nA\n");
       expect(exitCode).toBe(0);
     });
+
+    // Same root cause, cross-module surface: two modules each exporting a
+    // decorated class with the *same* name. The class binding itself gets
+    // renamed by the bundler (Foo / Foo2), but the synthesized
+    // `let _<ClassName>` alias used to bypass the renamer, so the merged
+    // bundle emitted `let _Foo` twice → a hard `SyntaxError: Identifier
+    // '_Foo' has already been declared` at load time, before any user code.
+    test("same-named decorated classes across modules don't collide", async () => {
+      using dir = tempDir("es-dec-cross-module", {
+        "a.ts": `
+          function dec(_t: any, _c: any) {}
+          export class AuditService { @dec accessor x = 1; }
+        `,
+        "b.ts": `
+          function dec(_t: any, _c: any) {}
+          export class AuditService { @dec accessor y = 2; }
+        `,
+        "entry.ts": `
+          import { AuditService as A } from "./a";
+          import { AuditService as B } from "./b";
+          console.log(new A().x, new B().y);
+        `,
+      });
+
+      const { stdout, exitCode } = await runBundled(String(dir), ["--target=browser", "--format=esm"], "entry.ts");
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // Minified variant of the cross-module case — exercises MinifyRenamer
+    // rather than NumberRenamer on the merge path.
+    test("same-named decorated classes across modules don't collide (minified)", async () => {
+      using dir = tempDir("es-dec-cross-module-min", {
+        "a.ts": `
+          function dec(_t: any, _c: any) {}
+          export class AuditService { @dec accessor x = 1; }
+        `,
+        "b.ts": `
+          function dec(_t: any, _c: any) {}
+          export class AuditService { @dec accessor y = 2; }
+        `,
+        "entry.ts": `
+          import { AuditService as A } from "./a";
+          import { AuditService as B } from "./b";
+          console.log(new A().x, new B().y);
+        `,
+      });
+
+      const { stdout, exitCode } = await runBundled(
+        String(dir),
+        ["--target=browser", "--format=esm", "--minify"],
+        "entry.ts",
+      );
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
   });
 });

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -809,4 +809,171 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  // Regression coverage for #30326 / #28316: decorator lowering used to
+  // emit a fresh `var _init = …` at module scope for every decorated
+  // class with the same `original_name`. `var` hoisting then collapsed
+  // them into a single binding, so an earlier class's constructor would
+  // end up running the last class's initializers.
+  describe.concurrent("symbol names stay unique across classes", () => {
+    test("accessor init callbacks fire on the correct class (browser bundle)", async () => {
+      using dir = tempDir("es-dec-init-unique-bundle", {
+        "entry.ts": `
+          const log: string[] = [];
+          function dec(name: string) {
+            return function (_t: any, _c: any) {
+              return { init(v: any) { log.push(\`\${name}:\${v}\`); return v; } };
+            };
+          }
+          class Foo { @dec("foo") accessor x = "X"; }
+          class Bar { @dec("bar") accessor y = "Y"; }
+          new Foo(); new Bar();
+          console.log(log.join("|"));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("foo:X|bar:Y\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("field decorator initializers fire on their own class (no-bundle)", async () => {
+      using dir = tempDir("es-dec-init-unique-nobundle", {
+        "entry.ts": `
+          const log: string[] = [];
+          function dec(tag: string) {
+            return function (_v: any, ctx: any) {
+              return function (init: any) { log.push(\`\${tag}:\${ctx.name}:\${init}\`); return init; };
+            };
+          }
+          class A { @dec("A") a = "a"; }
+          class B { @dec("B") b = "b"; }
+          new A(); new B();
+          console.log(log.join("|"));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--no-bundle", "--outfile=out.js", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("A:a:a|B:b:b\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("three decorated classes with extends keep initializers separate", async () => {
+      using dir = tempDir("es-dec-three-classes", {
+        "entry.ts": `
+          const log: string[] = [];
+          function tag(name: string) {
+            return function (_t: any, _c: any) {
+              return { init(v: any) { log.push(\`\${name}=\${v}\`); return v; } };
+            };
+          }
+          class Base { base = 0; }
+          class A extends Base { @tag("A") accessor x = 1; }
+          class B extends Base { @tag("B") accessor x = 2; }
+          class C extends Base { @tag("C") accessor x = 3; }
+          new A(); new B(); new C();
+          console.log(log.join(","));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("A=1,B=2,C=3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class decorator addInitializer + accessor initializer in same class", async () => {
+      // Class decorators alone don't exhibit the collision (their
+      // decoration runs at module-top between the `var _init = …`
+      // lines). But a class decorator whose addInitializer fires at
+      // construction time, *plus* a per-instance accessor initializer,
+      // both consult `_init` inside the constructor — the second class
+      // must see its own `_init`, not the last file-level one.
+      using dir = tempDir("es-dec-mixed", {
+        "entry.ts": `
+          const log: string[] = [];
+          function mark(tag: string) {
+            return function (target: any, ctx: any) {
+              ctx.addInitializer(function (this: any) { log.push(\`cls:\${tag}\`); });
+              return target;
+            };
+          }
+          function acc(tag: string) {
+            return function (_v: any, _c: any) {
+              return { init(v: any) { log.push(\`acc:\${tag}:\${v}\`); return v; } };
+            };
+          }
+          @mark("Foo") class Foo { @acc("Foo") accessor x = 1; }
+          @mark("Bar") class Bar { @acc("Bar") accessor y = 2; }
+          new Foo(); new Bar();
+          console.log(log.join("|"));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--target=browser", "--format=esm", "--outfile=out.js", "entry.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      expect(await build.exited).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      // Both @mark initializers fire during top-level decoration (in
+      // declaration order), then @acc's init fires per-construction.
+      expect(stdout).toBe("cls:Foo|cls:Bar|acc:Foo:1|acc:Bar:2\n");
+      expect(exitCode).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Given two classes with ES decorators in the same file:

```ts
function decorator(_t: any, _c: any) {}
class Foo { @decorator accessor foo = 1; }
class Bar { @decorator accessor bar = 1; }
```

`bun build --target=browser --format=esm` emits, at module top:

```js
var _init = __decoratorStart(undefined);
class Foo { constructor() { __runInitializers(_init, 5, this); ... } }
__decorateElement(_init, 4, "foo", _dec, Foo, _foo);
var _init = __decoratorStart(undefined);   // ← shadows the Foo _init
class Bar { constructor() { __runInitializers(_init, 5, this); ... } }
```

`var` hoisting collapses both declarations onto one binding, so `new Foo()` runs against whatever value `_init` held last — Bar's. Field decorators fire on the wrong class, initializer callbacks receive each other's values. The original bug report against MobX surfaces here.

The same collision also explains #28010 (a parent class's field decorators ran with the child class's `_dec` array because both shared a hoisted `var _dec`) and #29837 (an `accessor name` in a subclass threw `"Cannot add the same private member more than once"` because both classes got `var _name = new WeakMap` at module scope).

Runtime proof:

```ts
function dec(name: string) {
  return (_t: any, _c: any) => ({ init(v: any) { log.push(`${name}:${v}`); return v; } });
}
class Foo { @dec("foo") accessor x = "X"; }
class Bar { @dec("bar") accessor y = "Y"; }
new Foo(); new Bar();
// Before: ["bar:X", "bar:Y"]
// After:  ["foo:X", "bar:Y"]
```

## Root cause

`new_sym` in the decorator lowering allocates a symbol with the literal name passed in (`"_init"`, `"_dec"`, …) and appends the ref to `current_scope.generated`. For a top-level class that's `module_scope.generated`. Neither renamer looks at it:

- `NoOpRenamer` (transpile path) never renames anything — prints `original_name` verbatim.
- `NumberRenamer` (bundler path) only walks `part.declared_symbols` (populated via `record_declared_symbol`, which `new_sym` never called) and `part.scopes` (filled by `push_scope_for_visit_pass`, which the module scope isn't). Module-level generated refs fall through to `original_name`.

Both paths emit two `var _init = …` at module top.

## Fix

`new_sym` now stamps a per-parser counter (`decorator_sym_count` on `P`, never reset) into the `original_name` at creation time, and calls `record_declared_symbol` so minifier passes can still rename the result. Callers pass a constant base name (`b"_init"`, `b"_dec"`, …) and get back a unique `_init1`, `_init4`, `_dec2`, …

Three sites need the literal spelling preserved and use a new `new_plain_sym` instead:

- The inferred class name from `const Foo = class {…}` — it's the string passed to the class decorator's context (`__decorateElement(_init, 0, "Foo", …)`).
- `"arguments"` inside a generated `constructor(){ super(...arguments); }`.
- `"v"` as the parameter of a synthesized setter (lives in its own function scope).

With the counter built into `new_sym`, the per-class `dec_counter`, `computed_key_counter`, and `accessor_storage_counter` locals aren't needed anymore — removed.

### Rust port

After the initial review the Rust rewrite (#30412) landed. The third commit mirrors the same change in the active Rust parser: `src/js_parser/lower/lower_decorators.rs` (the `new_sym` / `new_plain_sym` split and counter-suffix logic) and `src/js_parser/p.rs` (the `decorator_sym_count: u32` field on the `P` struct). The rebase preserved the Zig-side change too, so both ports stay in sync.

## Verification

`test/bundler/transpiler/es-decorators.test.ts` — new `symbol names stay unique across classes` `describe.concurrent` block with 8 cases:

- accessor `init` callbacks fire on the right class (bundled)
- field decorator initializers fire on their own class (no-bundle)
- three decorated classes with `extends` keep initializers separate
- class-level `@mark` + per-instance `@acc` in the same class, across two classes
- **#28010**: parent-class field decorators keep their own `_dec` array
- **#29837**: subclass can override an auto-accessor of the same name
- same-named decorated classes across two modules don't collide (NumberRenamer merge path) — without the fix this throws `SyntaxError: Identifier '_<ClassName>' has already been declared` at load time, since the class binding is renamed but the synthesized `let _<ClassName>` alias bypassed the renamer
- …and the `--minify` variant of the same (MinifyRenamer merge path)

All 8 fail on a reverted-src build (the cross-module pair throw a hard `SyntaxError`; the rest corrupt semantics); all 8 pass with the patch. The full decorator suite — `es-decorators.test.ts`, `es-decorators-esbuild.test.ts`, `decorators.test.ts`, `decorator-metadata.test.ts` — all pass.

Fixes #30326.
Fixes #28010.
Fixes #29837.

Supersedes #28334.

