### PR TITLE
Honor windowBits / memLevel / strategy in Bun.deflateSync

### DIFF
--- a/src/runtime/api/BunObject.zig
+++ b/src/runtime/api/BunObject.zig
@@ -1608,8 +1608,8 @@ pub const JSZlib = struct {
     }
 
     pub fn gunzipOrInflateSync(globalThis: *JSGlobalObject, buffer: jsc.Node.StringOrBuffer, options_val_: ?JSValue, is_gzip: bool) bun.JSError!JSValue {
+        // Defaults: gunzip → 31 (gzip wrap), inflate → -15 (raw deflate).
         var opts = zlib.Options{
-            .gzip = is_gzip,
             .windowBits = if (is_gzip) 31 else -15,
         };
 
@@ -1617,6 +1617,15 @@ pub const JSZlib = struct {
         if (options_val_) |options_val| {
             if (try options_val.get(globalThis, "windowBits")) |window| {
                 opts.windowBits = try window.coerce(i32, globalThis);
+                // node:zlib's Gunzip class adds 16 to a windowBits in 8..15
+                // before forwarding to inflateInit2_ so callers can ask for a
+                // smaller window without losing the gzip wrapper. Mirror that
+                // here — without the +16, `Bun.gunzipSync(gzipped, {windowBits: 15})`
+                // would ask zlib to read gzip bytes as zlib-wrapped and fail
+                // with "incorrect header check".
+                if (is_gzip and opts.windowBits >= 8 and opts.windowBits <= 15) {
+                    opts.windowBits += 16;
+                }
                 library = .zlib;
             }
 
@@ -1738,11 +1747,33 @@ pub const JSZlib = struct {
     ) bun.JSError!JSValue {
         var level: ?i32 = null;
         var library: Library = .zlib;
-        var windowBits: i32 = 0;
+        // Defaults: gzipSync → 31 (gzip wrap), deflateSync → -15 (raw deflate, the
+        // historical default — `Bun.deflateSync(buf)` without options has always
+        // produced raw deflate, so callers may be relying on it).
+        var windowBits: i32 = if (is_gzip) 31 else -15;
+        var memLevel: i32 = 8;
+        var strategy: i32 = 0;
 
         if (options_val_) |options_val| {
             if (try options_val.get(globalThis, "windowBits")) |window| {
                 windowBits = try window.coerce(i32, globalThis);
+                // Mirror node:zlib's Gzip class: a windowBits in 8..15 stays in
+                // gzip mode by adding 16. This is also the reason `+16` cannot
+                // be applied unconditionally — values in 24..31 are already
+                // gzip-wrapped and negative values mean raw deflate.
+                if (is_gzip and windowBits >= 8 and windowBits <= 15) {
+                    windowBits += 16;
+                }
+                library = .zlib;
+            }
+
+            if (try options_val.get(globalThis, "memLevel")) |memLevel_value| {
+                memLevel = try memLevel_value.coerce(i32, globalThis);
+                library = .zlib;
+            }
+
+            if (try options_val.get(globalThis, "strategy")) |strategy_value| {
+                strategy = try strategy_value.coerce(i32, globalThis);
                 library = .zlib;
             }
 
@@ -1775,8 +1806,9 @@ pub const JSZlib = struct {
                 );
 
                 var reader = zlib.ZlibCompressorArrayList.init(compressed, &list, allocator, .{
-                    .windowBits = 15,
-                    .gzip = is_gzip,
+                    .windowBits = windowBits,
+                    .memLevel = memLevel,
+                    .strategy = strategy,
                     .level = level orelse 6,
                 }) catch |err| {
                     defer list.deinit(allocator);

--- a/src/zlib/zlib.zig
+++ b/src/zlib/zlib.zig
@@ -523,9 +523,17 @@ pub const ZlibReaderArrayList = struct {
 };
 
 pub const Options = struct {
-    gzip: bool = false,
     level: c_int = 6,
     method: c_int = 8,
+    /// Passed verbatim to `deflateInit2_` / `inflateInit2_`.
+    /// Zlib interprets the sign and range:
+    ///   8..15:    zlib header/trailer
+    ///   -8..-15:  raw deflate (no header/trailer)
+    ///   24..31:   gzip header/trailer (16 + 8..15)
+    /// The compressor used to flip the sign / add 16 internally based on a
+    /// separate `gzip` boolean, but that meant the caller's `windowBits` was
+    /// silently dropped on the compress path. Callers now compute the final
+    /// value and pass it through directly.
     windowBits: c_int = 15,
     memLevel: c_int = 8,
     strategy: c_int = 0,
@@ -837,7 +845,7 @@ pub const ZlibCompressorArrayList = struct {
             &zlib_reader.zlib,
             options.level,
             options.method,
-            if (!options.gzip) -options.windowBits else options.windowBits + 16,
+            options.windowBits,
             options.memLevel,
             options.strategy,
             zlibVersion(),

--- a/test/js/bun/util/zlib.test.ts
+++ b/test/js/bun/util/zlib.test.ts
@@ -1,0 +1,147 @@
+// Tests for Bun.deflateSync / Bun.gzipSync / Bun.inflateSync / Bun.gunzipSync.
+//
+// Issue #30276: `windowBits` was parsed but discarded on the compress path,
+// so `Bun.deflateSync(buf, {windowBits: 15})` produced raw deflate instead of
+// zlib-wrapped output. The fix passes `windowBits` (and `memLevel`/`strategy`)
+// straight through to `deflateInit2_` and adjusts only when needed to mirror
+// node:zlib's Gzip/Gunzip wrapper conventions.
+
+import { describe, expect, test } from "bun:test";
+import * as zlib from "node:zlib";
+
+// `"hello".repeat(...)` is intentionally avoided in the debug build; this is
+// large enough to exercise the >64-byte / >512-byte allocation branches and
+// still cheap.
+const payload = Buffer.alloc(500, "hello");
+
+const ZLIB_HEADER_BYTE_0 = 0x78; // CMF for a 32K window at default/max compression.
+const GZIP_HEADER_BYTE_0 = 0x1f;
+const GZIP_HEADER_BYTE_1 = 0x8b;
+
+describe("Bun.deflateSync windowBits (issue #30276)", () => {
+  test("windowBits: 15 produces zlib-wrapped output that matches node:zlib", () => {
+    // Before the fix this returned the same 12-byte raw deflate as windowBits: -15.
+    const compressed = Bun.deflateSync(payload, { level: 9, windowBits: 15 });
+
+    // zlib format: 2-byte header where (CMF<<8 | FLG) is divisible by 31, then
+    // deflate data, then a 4-byte Adler32 trailer.
+    expect(compressed[0]).toBe(ZLIB_HEADER_BYTE_0);
+    expect(((compressed[0] << 8) | compressed[1]) % 31).toBe(0);
+
+    // Byte-for-byte parity with node:zlib using the same options is the strong
+    // signal that windowBits actually reached deflateInit2_ — a roundtrip
+    // through inflate would also pass if the option were silently dropped, as
+    // long as the headers were self-consistent.
+    expect(Buffer.from(compressed)).toEqual(zlib.deflateSync(payload, { level: 9, windowBits: 15 }));
+  });
+
+  test("windowBits: -15 produces raw deflate (matches node:zlib.deflateRawSync)", () => {
+    const compressed = Bun.deflateSync(payload, { level: 9, windowBits: -15 });
+
+    expect(compressed[0]).not.toBe(ZLIB_HEADER_BYTE_0);
+    expect(compressed[0]).not.toBe(GZIP_HEADER_BYTE_0);
+
+    // node:zlib.deflateRawSync internally negates windowBits.
+    expect(Buffer.from(compressed)).toEqual(zlib.deflateRawSync(payload, { level: 9, windowBits: 15 }));
+  });
+
+  test("default (no options) is raw deflate — backwards compatible", () => {
+    // `Bun.deflateSync(buf)` has always produced raw deflate; preserve that to
+    // avoid breaking callers that pair it with `Bun.inflateSync(buf)` (also raw
+    // by default).
+    const compressed = Bun.deflateSync(payload);
+    expect(compressed[0]).not.toBe(ZLIB_HEADER_BYTE_0);
+    expect(compressed[0]).not.toBe(GZIP_HEADER_BYTE_0);
+    expect(Buffer.from(Bun.inflateSync(compressed))).toEqual(payload);
+  });
+
+  test("windowBits: 15 vs -15 produce different output", () => {
+    // The bug report's exact symptom: identical output regardless of sign.
+    const wrapped = Bun.deflateSync(payload, { level: 9, windowBits: 15 });
+    const raw = Bun.deflateSync(payload, { level: 9, windowBits: -15 });
+    expect(wrapped.length).toBeGreaterThan(raw.length);
+    expect(Buffer.from(wrapped)).not.toEqual(raw);
+  });
+
+  test("smaller windowBits changes the CMF byte", () => {
+    // CMF's upper nibble is windowBits - 8; a 9-bit window encodes as 0x18,
+    // a 15-bit window as 0x78. This proves the user's value reached zlib.
+    const small = Bun.deflateSync(payload, { level: 9, windowBits: 9 });
+    expect(small[0]).toBe(0x18);
+    expect(Buffer.from(small)).toEqual(zlib.deflateSync(payload, { level: 9, windowBits: 9 }));
+    expect(Buffer.from(Bun.inflateSync(small, { windowBits: 15 }))).toEqual(payload);
+  });
+
+  test("output is readable by node:zlib.inflateSync", () => {
+    const compressed = Bun.deflateSync(payload, { level: 9, windowBits: 15 });
+    expect(Buffer.from(zlib.inflateSync(compressed))).toEqual(payload);
+  });
+});
+
+describe("Bun.deflateSync memLevel & strategy", () => {
+  // Byte-for-byte equality against node:zlib with the same option proves the
+  // value reached deflateInit2_ (a mere roundtrip would pass even if dropped).
+  test("memLevel propagates to zlib", () => {
+    const compressed = Bun.deflateSync(payload, { level: 9, windowBits: 15, memLevel: 1 });
+    expect(Buffer.from(compressed)).toEqual(zlib.deflateSync(payload, { level: 9, windowBits: 15, memLevel: 1 }));
+    expect(Buffer.from(Bun.inflateSync(compressed, { windowBits: 15 }))).toEqual(payload);
+  });
+
+  test("strategy propagates to zlib", () => {
+    const compressed = Bun.deflateSync(payload, {
+      level: 9,
+      windowBits: 15,
+      strategy: zlib.constants.Z_HUFFMAN_ONLY,
+    });
+    expect(Buffer.from(compressed)).toEqual(
+      zlib.deflateSync(payload, { level: 9, windowBits: 15, strategy: zlib.constants.Z_HUFFMAN_ONLY }),
+    );
+    expect(Buffer.from(Bun.inflateSync(compressed, { windowBits: 15 }))).toEqual(payload);
+  });
+});
+
+describe("Bun.gzipSync windowBits", () => {
+  test("default produces gzip-wrapped output", () => {
+    const compressed = Bun.gzipSync(payload, { level: 9 });
+    expect(compressed[0]).toBe(GZIP_HEADER_BYTE_0);
+    expect(compressed[1]).toBe(GZIP_HEADER_BYTE_1);
+    expect(Buffer.from(zlib.gunzipSync(compressed))).toEqual(payload);
+  });
+
+  // Mirrors node:zlib's Gzip class: a windowBits in 8..15 stays in gzip mode
+  // (the +16 is applied so 15 becomes 31). Without the adjustment, asking for
+  // gzip with windowBits: 15 would silently produce zlib-wrapped output.
+  test("windowBits: 15 stays in gzip mode and matches node:zlib", () => {
+    const compressed = Bun.gzipSync(payload, { level: 9, windowBits: 15 });
+    expect(compressed[0]).toBe(GZIP_HEADER_BYTE_0);
+    expect(compressed[1]).toBe(GZIP_HEADER_BYTE_1);
+    expect(Buffer.from(compressed)).toEqual(zlib.gzipSync(payload, { level: 9, windowBits: 15 }));
+  });
+
+  test("windowBits: 31 (explicit gzip) works", () => {
+    const compressed = Bun.gzipSync(payload, { level: 9, windowBits: 31 });
+    expect(compressed[0]).toBe(GZIP_HEADER_BYTE_0);
+    expect(compressed[1]).toBe(GZIP_HEADER_BYTE_1);
+    expect(Buffer.from(Bun.gunzipSync(compressed))).toEqual(payload);
+  });
+});
+
+describe("Bun.gunzipSync windowBits", () => {
+  // Mirror of the compress-side +16: a windowBits in 8..15 on gunzip must stay
+  // in gunzip mode, otherwise zlib reads gzip bytes as zlib-wrapped and errors
+  // with "incorrect header check".
+  const gzipped = Bun.gzipSync(payload);
+
+  test("windowBits: 15 decompresses gzip data (matches node:zlib)", () => {
+    expect(Buffer.from(Bun.gunzipSync(gzipped, { windowBits: 15 }))).toEqual(payload);
+    expect(zlib.gunzipSync(gzipped, { windowBits: 15 })).toEqual(payload);
+  });
+});
+
+describe("Bun.deflateSync / Bun.inflateSync roundtrip", () => {
+  test.each([-15, 15, 9, 11, 13] as const)("windowBits: %d", bits => {
+    const compressed = Bun.deflateSync(payload, { windowBits: bits });
+    const decompressed = Bun.inflateSync(compressed, { windowBits: bits });
+    expect(Buffer.from(decompressed)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #30276. `Bun.deflateSync` ignored the `windowBits` option (and `memLevel` / `strategy` — parsed but discarded), so:

```js
Bun.deflateSync(buf, { level: 9, windowBits: 15 })   // produced raw deflate
Bun.deflateSync(buf, { level: 9, windowBits: -15 })  // produced raw deflate (same bytes!)
```

Both calls returned identical raw-deflate output, regardless of the `windowBits` sign or magnitude. The `windowBits` parsed from JS was thrown away and the compressor was always called with `windowBits = 15`, with the zlib/raw/gzip wrapping decided by a separate `gzip` boolean.

After this PR, `Bun.deflateSync(buf, {windowBits: 15})` matches `node:zlib.deflateSync(buf, {windowBits: 15})` byte-for-byte:

```
Bun.deflateSync windowBits: 15  → Uint8Array(18) [120, 218, 203, 72, 205, 201, …]
Bun.deflateSync windowBits: -15 → Uint8Array(12) [203, 72, 205, 201, 201, 207, …]
node:zlib.deflateSync wB: 15    → Uint8Array(18) [120, 218, 203, 72, 205, 201, …]
node:zlib.deflateRawSync wB: 15 → Uint8Array(12) [203, 72, 205, 201, 201, 207, …]
```

### How

- Drop `Options.gzip` from `src/zlib/zlib.zig` and pass `windowBits` straight to `deflateInit2_` / `inflateInit2_`.
- In `gzipOrDeflateSync` and `gunzipOrInflateSync`, parse `windowBits` / `memLevel` / `strategy` and forward them to the compressor.
- Defaults are unchanged: `Bun.deflateSync(buf)` → raw deflate (`-15`), `Bun.gzipSync(buf)` → gzip (`31`). This preserves the historical behavior (callers pair `deflateSync` with `inflateSync`, both raw by default).
- For gzip/gunzip, mirror node:zlib's `Gzip`/`Gunzip` classes: a user-supplied `windowBits` in the `8..15` range gets `+16` added so it stays in gzip mode. Without this, `Bun.gzipSync(buf, {windowBits: 15})` would silently produce zlib-wrapped output and `Bun.gunzipSync(gzipped, {windowBits: 15})` would error with `"incorrect header check"`.

Also fixes #6280 — `Bun.gzipSync(buf, {windowBits: -15})` no longer errors with `"Invalid buffer"` (the old code did `windowBits + 16 = 1`, an invalid value); negative values now pass through verbatim.

### How was this tested?

Verified with the issue's exact repro that the output now matches `node:zlib.deflateSync` byte-for-byte.

Added `test/js/bun/util/zlib.test.ts` (17 tests, all passing on this build, 11 fail on system Bun) covering:
- `windowBits: 15` / `-15` / `9` produce zlib-wrapped / raw / smaller-window output that matches `node:zlib` byte-for-byte
- `memLevel` and `strategy` actually reach `deflateInit2_` (byte-match against `node:zlib`)
- `Bun.gzipSync(buf, {windowBits: 15})` stays in gzip mode (matches `node:zlib.gzipSync`)
- `Bun.gunzipSync(gzipped, {windowBits: 15})` decompresses gzip data instead of erroring
- Roundtrip parity for `windowBits ∈ {-15, 15, 9, 11, 13}`

Existing zlib tests continue to pass (`test/js/node/zlib/zlib.test.js` — 376 pass, 0 fail; the regression suite for #18413 / #17793 — 30 pass).

Fixes #30276
Fixes #6280

🤖 Generated with [Claude Code](https://claude.com/claude-code)