### PR TITLE
expect: stop `toMatchObject` / `toMatchSnapshot` from mutating the received object

### DIFF
--- a/src/bun.js/bindings/BunObject.cpp
+++ b/src/bun.js/bindings/BunObject.cpp
@@ -766,7 +766,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepMatch, (JSGlobalObject * globalObject, J
     std::set<EncodedJSValue> objVisited;
     std::set<EncodedJSValue> subsetVisited;
     MarkedArgumentBuffer gcBuffer;
-    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false, false);
+    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsBoolean(match));
 }

--- a/src/bun.js/bindings/JSValue.zig
+++ b/src/bun.js/bindings/JSValue.zig
@@ -1969,10 +1969,24 @@ pub const JSValue = enum(i64) {
     pub fn jestStrictDeepEquals(this: JSValue, other: JSValue, global: *JSGlobalObject) JSError!bool {
         return bun.jsc.fromJSHostCallGeneric(global, @src(), JSC__JSValue__jestStrictDeepEquals, .{ this, other, global });
     }
-    extern fn JSC__JSValue__jestDeepMatch(this: JSValue, subset: JSValue, global: *JSGlobalObject, replace_props_with_asymmetric_matchers: bool) bool;
-    /// same as `JSValue.deepMatch`, but with jest asymmetric matchers enabled
-    pub fn jestDeepMatch(this: JSValue, subset: JSValue, global: *JSGlobalObject, replace_props_with_asymmetric_matchers: bool) JSError!bool {
-        return bun.jsc.fromJSHostCallGeneric(global, @src(), JSC__JSValue__jestDeepMatch, .{ this, subset, global, replace_props_with_asymmetric_matchers });
+    extern fn JSC__JSValue__jestDeepMatch(this: JSValue, subset: JSValue, global: *JSGlobalObject) bool;
+    /// same as `JSValue.deepMatch`, but with jest asymmetric matchers enabled.
+    ///
+    /// This intentionally does not mutate `this` or `subset`. If you need a
+    /// view of `this` with asymmetric matchers from `subset` substituted in
+    /// (for snapshot output etc.), use `jestSubstituteAsymmetricMatchers` after
+    /// confirming the match passed.
+    pub fn jestDeepMatch(this: JSValue, subset: JSValue, global: *JSGlobalObject) JSError!bool {
+        return bun.jsc.fromJSHostCallGeneric(global, @src(), JSC__JSValue__jestDeepMatch, .{ this, subset, global });
+    }
+    extern fn Bun__JSValue__substituteAsymmetricMatchers(value: JSValue, matchers: JSValue, global: *JSGlobalObject) JSValue;
+    /// Returns a clone of `this` where any asymmetric matchers in `matchers`
+    /// have been substituted in place of the corresponding `this` properties.
+    /// If no substitutions are needed, returns `this` unchanged. Used by
+    /// snapshot serialization so matchers like `expect.any(String)` show up as
+    /// `Any<String>` in the saved snapshot, without mutating the user's value.
+    pub fn jestSubstituteAsymmetricMatchers(this: JSValue, matchers: JSValue, global: *JSGlobalObject) JSError!JSValue {
+        return bun.jsc.fromJSHostCall(global, @src(), Bun__JSValue__substituteAsymmetricMatchers, .{ this, matchers, global });
     }
 
     pub const DiffMethod = enum(u8) {

--- a/src/bun.js/bindings/bindings.cpp
+++ b/src/bun.js/bindings/bindings.cpp
@@ -219,7 +219,6 @@ template bool Bun__deepMatch<true>(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 template bool Bun__deepMatch<false>(
@@ -230,7 +229,6 @@ template bool Bun__deepMatch<false>(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 extern "C" bool Expect_readFlagsAndProcessPromise(JSC::EncodedJSValue instanceValue, JSC::JSGlobalObject* globalObject, ExpectFlags* flags, JSC::EncodedJSValue* value, AsymmetricMatcherConstructorType* constructorType);
@@ -517,7 +515,7 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 // SAFETY: visited property sets are not required when
                 // `enableAsymmetricMatchers` and `isMatchingObjectContaining`
                 // are both true
-                bool match = Bun__deepMatch<true>(otherProp, nullptr, patternObject, nullptr, globalObject, throwScope, nullptr, false, true);
+                bool match = Bun__deepMatch<true>(otherProp, nullptr, patternObject, nullptr, globalObject, throwScope, nullptr, true);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 if (match) {
                     return AsymmetricMatcherResult::PASS;
@@ -1593,6 +1591,12 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
  * properties currently within those stacks. Likely unnecessary, but better to
  * be safe tnan sorry
  *
+ * @note this function is intentionally side-effect free. Earlier versions
+ * mutated the received and/or expected objects in-place when an asymmetric
+ * matcher passed, which leaked back to user code (issue #3521). Callers that
+ * need a substituted view (e.g. snapshot serialization) should produce a clone
+ * via `Bun__substituteAsymmetricMatchers`.
+ *
  * @tparam enableAsymmetricMatchers
  * @param objValue
  * @param seenObjProperties already visited properties of `objValue`.
@@ -1601,7 +1605,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
  * @param globalObject
  * @param throwScope
  * @param gcBuffer
- * @param replacePropsWithAsymmetricMatchers
  * @param isMatchingObjectContaining
  *
  * @return true
@@ -1616,7 +1619,6 @@ bool Bun__deepMatch(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining)
 {
 
@@ -1670,10 +1672,6 @@ bool Bun__deepMatch(
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
-                    if (replacePropsWithAsymmetricMatchers) {
-                        obj->putDirectMayBeIndex(globalObject, property, subsetProp);
-                        RETURN_IF_EXCEPTION(throwScope, false);
-                    }
                     // continue to next subset prop
                     continue;
                 case AsymmetricMatcherResult::NOT_MATCHER:
@@ -1684,10 +1682,6 @@ bool Bun__deepMatch(
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
-                    if (replacePropsWithAsymmetricMatchers) {
-                        subsetObj->putDirectMayBeIndex(globalObject, property, prop);
-                        RETURN_IF_EXCEPTION(throwScope, false);
-                    }
                     // continue to next subset prop
                     continue;
                 case AsymmetricMatcherResult::NOT_MATCHER:
@@ -1716,7 +1710,7 @@ bool Bun__deepMatch(
                 gcBuffer->append(subsetProp);
                 // property cycle detected
                 if (!didInsertProp.second || !didInsertSubset.second) continue;
-                if (!Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining)) {
+                if (!Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, isMatchingObjectContaining)) {
                     return false;
                 }
             }
@@ -1741,6 +1735,115 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
     MarkedArgumentBuffer args;
     bool result = Bun__deepEquals<isStrict, enableAsymmetricMatchers>(global, JSC::JSValue::decode(a), JSC::JSValue::decode(b), args, stack, scope, true);
     RELEASE_AND_RETURN(scope, result);
+}
+
+bool isAsymmetricMatcher(JSValue v)
+{
+    if (!v.isCell()) return false;
+    JSCell* cell = v.asCell();
+    if (cell->type() != JSC::JSType(JSDOMWrapperType)) return false;
+    return dynamicDowncast<JSExpectAnything>(cell)
+        || dynamicDowncast<JSExpectAny>(cell)
+        || dynamicDowncast<JSExpectStringContaining>(cell)
+        || dynamicDowncast<JSExpectStringMatching>(cell)
+        || dynamicDowncast<JSExpectArrayContaining>(cell)
+        || dynamicDowncast<JSExpectObjectContaining>(cell)
+        || dynamicDowncast<JSExpectCloseTo>(cell)
+        || dynamicDowncast<JSExpectCustomAsymmetricMatcher>(cell);
+}
+
+// Walks `value` and `matchers` in parallel and returns a clone of `value`
+// where any asymmetric matchers in `matchers` have been substituted in place
+// of the corresponding `value` properties. If no substitutions were needed the
+// original `value` is returned unchanged (no allocation). Cycles in `value`
+// short-circuit by returning the original value at the cycle point.
+//
+// This is the non-mutating replacement for the old
+// `replacePropsWithAsymmetricMatchers=true` behaviour of `Bun__deepMatch`. It
+// is meant to be called *after* a successful match so the caller can format a
+// snapshot that records matchers (e.g. `Any<String>`) without mutating the
+// user's object. See issue #3521.
+JSValue substituteAsymmetricMatchersImpl(
+    JSGlobalObject* globalObject,
+    ThrowScope& throwScope,
+    JSValue value,
+    JSValue matchers,
+    std::set<EncodedJSValue>& seen,
+    MarkedArgumentBuffer& gcBuffer)
+{
+    if (isAsymmetricMatcher(matchers)) {
+        return matchers;
+    }
+    if (!value.isObject() || !matchers.isObject()) {
+        return value;
+    }
+
+    // Cycle detection on the value side. If we've seen this object before, the
+    // safest thing for snapshot output is to keep the original reference.
+    auto inserted = seen.insert(JSValue::encode(value));
+    if (!inserted.second) return value;
+
+    auto& vm = globalObject->vm();
+    JSObject* valueObj = value.getObject();
+    JSObject* matchersObj = matchers.getObject();
+
+    PropertyNameArrayBuilder matcherProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+    matchersObj->getPropertyNames(globalObject, matcherProps, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(throwScope, value);
+
+    // Recurse into each matcher property to collect the (possibly-)substituted
+    // value. We hold onto these via gcBuffer so the GC doesn't collect a
+    // brand-new clone before we get to use it.
+    JSObject* cloned = nullptr;
+    auto ensureCloned = [&]() -> bool {
+        if (cloned) return true;
+        if (isArray(globalObject, value)) {
+            unsigned len = valueObj->getArrayLength();
+            cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
+        } else {
+            cloned = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype());
+        }
+        if (throwScope.exception()) return false;
+        gcBuffer.append(cloned);
+        // Shallow-copy the value's own properties onto the clone so the
+        // resulting snapshot retains every original property — substitutions
+        // will overwrite individual entries below.
+        PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+        valueObj->getPropertyNames(globalObject, valueProps, DontEnumPropertiesMode::Exclude);
+        if (throwScope.exception()) return false;
+        for (const auto& p : valueProps) {
+            JSValue v = valueObj->getIfPropertyExists(globalObject, p);
+            if (throwScope.exception()) return false;
+            if (v.isEmpty()) continue;
+            cloned->putDirectMayBeIndex(globalObject, p, v);
+            if (throwScope.exception()) return false;
+        }
+        return true;
+    };
+
+    for (const auto& property : matcherProps) {
+        JSValue valueProp = valueObj->getIfPropertyExists(globalObject, property);
+        RETURN_IF_EXCEPTION(throwScope, value);
+        if (valueProp.isEmpty()) continue;
+
+        JSValue matcherProp = matchersObj->get(globalObject, property);
+        RETURN_IF_EXCEPTION(throwScope, value);
+
+        gcBuffer.append(valueProp);
+        gcBuffer.append(matcherProp);
+
+        JSValue substituted = substituteAsymmetricMatchersImpl(globalObject, throwScope, valueProp, matcherProp, seen, gcBuffer);
+        RETURN_IF_EXCEPTION(throwScope, value);
+
+        if (substituted == valueProp) continue;
+
+        gcBuffer.append(substituted);
+        if (!ensureCloned()) return value;
+        cloned->putDirectMayBeIndex(globalObject, property, substituted);
+        RETURN_IF_EXCEPTION(throwScope, value);
+    }
+
+    return cloned ? JSValue(cloned) : value;
 }
 }
 
@@ -2879,7 +2982,7 @@ bool JSC__JSValue__jestStrictDeepEquals(JSC::EncodedJSValue JSValue0, JSC::Encod
 
 #undef IMPL_DEEP_EQUALS_WRAPPER
 
-bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject, bool replacePropsWithAsymmetricMatchers)
+bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject)
 {
     JSValue obj = JSValue::decode(JSValue0);
     JSValue subset = JSValue::decode(JSValue1);
@@ -2889,7 +2992,20 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
     std::set<EncodedJSValue> objVisited;
     std::set<EncodedJSValue> subsetVisited;
     MarkedArgumentBuffer gcBuffer;
-    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, replacePropsWithAsymmetricMatchers, false));
+    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false));
+}
+
+extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::EncodedJSValue valueEncoded, JSC::EncodedJSValue matchersEncoded, JSC::JSGlobalObject* globalObject)
+{
+    JSValue value = JSValue::decode(valueEncoded);
+    JSValue matchers = JSValue::decode(matchersEncoded);
+
+    ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    std::set<EncodedJSValue> seen;
+    MarkedArgumentBuffer gcBuffer;
+    JSValue result = substituteAsymmetricMatchersImpl(globalObject, scope, value, matchers, seen, gcBuffer);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 extern "C" bool Bun__JSValue__isAsyncContextFrame(JSC::EncodedJSValue value)

--- a/src/bun.js/bindings/headers-handwritten.h
+++ b/src/bun.js/bindings/headers-handwritten.h
@@ -453,7 +453,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
  * @param globalObject
  * @param Scope
  * @param gcBuffer
- * @param replacePropsWithAsymmetricMatchers
  * @param isMatchingObjectContaining
  *
  * @return true
@@ -468,7 +467,6 @@ bool Bun__deepMatch(
     JSC::JSGlobalObject* globalObject,
     JSC::ThrowScope& throwScope,
     JSC::MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 extern "C" void Bun__remapStackFramePositions(void*, ZigStackFrame*, size_t);

--- a/src/bun.js/bindings/headers.h
+++ b/src/bun.js/bindings/headers.h
@@ -264,7 +264,7 @@ CPP_DECL bool JSC__JSValue__isSymbol(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isUInt32AsAnyInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__jestDeepEquals(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
-CPP_DECL bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2, bool arg3);
+CPP_DECL bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool JSC__JSValue__jestStrictDeepEquals(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__jsNumberFromChar(unsigned char arg0);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__jsNumberFromDouble(double arg0);

--- a/src/bun.js/test/expect.zig
+++ b/src/bun.js/test/expect.zig
@@ -796,6 +796,12 @@ pub const Expect = struct {
         return .js_undefined;
     }
     pub fn matchAndFmtSnapshot(this: *Expect, globalThis: *JSGlobalObject, value: JSValue, property_matchers: ?JSValue, pretty_value: *std.Io.Writer, comptime fn_name: []const u8) bun.JSError!void {
+        // The value we ultimately serialize for the snapshot. When property
+        // matchers are supplied, this becomes a clone of `value` with the
+        // matchers substituted in (so the snapshot records `Any<String>` etc.)
+        // — never the user's original `value`. Issue #3521.
+        var snapshot_value = value;
+
         if (property_matchers) |_prop_matchers| {
             if (!value.isObject()) {
                 const signature = comptime getSignature(fn_name, "<green>properties<r><d>, <r>hint", false);
@@ -804,7 +810,7 @@ pub const Expect = struct {
 
             const prop_matchers = _prop_matchers;
 
-            if (!try value.jestDeepMatch(prop_matchers, globalThis, true)) {
+            if (!try value.jestDeepMatch(prop_matchers, globalThis)) {
                 // TODO: print diff with properties from propertyMatchers
                 const signature = comptime getSignature(fn_name, "<green>propertyMatchers<r>", false);
                 const fmt = signature ++ "\n\nExpected <green>propertyMatchers<r> to match properties from received object" ++
@@ -814,9 +820,11 @@ pub const Expect = struct {
                 defer formatter.deinit();
                 return globalThis.throwPretty(fmt, .{value.toFmt(&formatter)});
             }
+
+            snapshot_value = try value.jestSubstituteAsymmetricMatchers(prop_matchers, globalThis);
         }
 
-        value.jestSnapshotPrettyFormat(pretty_value, globalThis) catch {
+        snapshot_value.jestSnapshotPrettyFormat(pretty_value, globalThis) catch {
             var formatter = jsc.ConsoleObject.Formatter{ .globalThis = globalThis };
             defer formatter.deinit();
             return globalThis.throw("Failed to pretty format value: {f}", .{value.toFmt(&formatter)});

--- a/src/bun.js/test/expect/toMatchObject.zig
+++ b/src/bun.js/test/expect/toMatchObject.zig
@@ -34,7 +34,7 @@ pub fn toMatchObject(this: *Expect, globalThis: *JSGlobalObject, callFrame: *Cal
 
     const property_matchers = args[0];
 
-    var pass = try received_object.jestDeepMatch(property_matchers, globalThis, true);
+    var pass = try received_object.jestDeepMatch(property_matchers, globalThis);
 
     if (not) pass = !pass;
     if (pass) return .js_undefined;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3528,6 +3528,30 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    // https://github.com/oven-sh/bun/issues/3521
+    test("does not mutate the received object when an asymmetric matcher matches", () => {
+      const obj = { foo: "foo", bar: "bar" };
+      expect(obj).toMatchObject({ bar: expect.any(String) });
+      expect(obj).toEqual({ foo: "foo", bar: "bar" });
+      // Must still match equivalently a second time without surprises.
+      expect(obj).toMatchObject({ bar: expect.any(String) });
+      expect(obj.bar).toBe("bar");
+
+      // Nested asymmetric matchers should not mutate nested objects either.
+      const nested = { a: { b: { c: 42 } }, d: "keep" };
+      expect(nested).toMatchObject({ a: { b: { c: expect.any(Number) } } });
+      expect(nested).toEqual({ a: { b: { c: 42 } }, d: "keep" });
+
+      // The expected/subset object passed in must also not be mutated when
+      // the received side carries the asymmetric matcher.
+      const matcherSentinel = expect.any(String);
+      const matchersFirst = { a: matcherSentinel };
+      expect(matchersFirst).toMatchObject({ a: "hello" });
+      // After the call, matchersFirst.a should still be the asymmetric matcher
+      // rather than the literal string "hello".
+      expect(matchersFirst.a).toBe(matcherSentinel);
+    });
   });
 
   describe("toMatch()", () => {

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -75,3 +75,13 @@ exports[`it will create a snapshot file if it doesn't exist 7`] = `
   "j": Any<RegExp>,
 }
 `;
+
+exports[`toMatchSnapshot with property matchers must not mutate the received object 1`] = `
+{
+  "a": Any<Number>,
+  "b": {
+    "c": Any<String>,
+  },
+  "d": "keep",
+}
+`;

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -62,3 +62,15 @@ describe("toMatchSnapshot errors", () => {
     }).toThrow();
   });
 });
+
+// Regression test for https://github.com/oven-sh/bun/issues/3521 — applied to
+// the snapshot path. The matchers in the snapshot output must come from a
+// *clone*; the user's original object must remain unchanged so they can keep
+// using it after the assertion.
+test("toMatchSnapshot with property matchers must not mutate the received object", () => {
+  const obj = { a: 1, b: { c: "two" }, d: "keep" };
+  expect(obj).toMatchSnapshot({ a: expect.any(Number), b: { c: expect.any(String) } });
+  expect(obj).toEqual({ a: 1, b: { c: "two" }, d: "keep" });
+  expect(obj.a).toBe(1);
+  expect(obj.b.c).toBe("two");
+});


### PR DESCRIPTION
Fixes #3521.

## What was wrong

`Bun__deepMatch` had a `replacePropsWithAsymmetricMatchers` mode that, when an asymmetric matcher (e.g. `expect.any(String)`) passed, replaced the matched property on the user's object with the matcher itself. After

```ts
const obj = { foo: "foo", bar: "bar" };
expect(obj).toMatchObject({ bar: expect.any(String) });
```

`obj.bar` was now `Any<String>`. The same bug also affected `toMatchSnapshot({ ... })` and `toMatchInlineSnapshot({ ... }, ...)` since they share the underlying matcher.

Reported in #3521 in 2023; users have hit it repeatedly across releases since.

## What changed

- `Bun__deepMatch` is now side-effect free. The `replacePropsWithAsymmetricMatchers` parameter and the two `putDirectMayBeIndex` mutations are removed; the function only matches.
- For the snapshot path, which still needs `Any<String>` etc. to land in the saved snapshot, a new helper `Bun__JSValue__substituteAsymmetricMatchers` walks `value` and `matchers` in parallel and returns a *clone* of `value` with matchers substituted in. It allocates lazily — when no substitutions are needed it returns `value` unchanged. `matchAndFmtSnapshot` runs the deep match, then on success feeds the clone (not the original) to the snapshot formatter.
- The result: existing snapshot files keep the same shape (`Any<Boolean>`, `Any<String>`, etc.), but the user's original `value` is left alone.

## Tests

- Added a regression test for `toMatchObject` in `test/js/bun/test/expect.test.js` covering the exact reproduction from the issue, a nested-matcher case, and a case where the asymmetric matcher lives on the `received` side instead of the `expected` side.
- Added a regression test for `toMatchSnapshot` with property matchers in `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts` that asserts the original object is intact while the snapshot still records `Any<...>`.
- Both regression tests fail under `USE_SYSTEM_BUN=1 bun test ...` and pass with `bun bd test ...`.
- All existing `toMatchObject` and snapshot tests still pass; the property-matcher snapshots in `bun-snapshots.test.ts.snap` are unchanged in shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)