### PR TITLE
Detect $HOME/~/${HOME} completion lines in .zshrc

### DIFF
--- a/src/cli/install_completions_command.zig
+++ b/src/cli/install_completions_command.zig
@@ -500,7 +500,15 @@ pub const InstallCompletionsCommand = struct {
                 const contents = buf[0..read];
 
                 // Do they possibly have it in the file already?
-                if (strings.contains(contents, completions_path) or strings.contains(contents, "# bun completions\n")) {
+                // Match the absolute path we'd write, the "# bun completions" marker
+                // we'd write above it, or any existing reference to the _bun file
+                // under a .bun directory — this catches hand-edited variants using
+                // `$HOME`, `${HOME}`, or `~` instead of a hardcoded home path
+                // (see https://github.com/oven-sh/bun/issues/30335).
+                if (strings.contains(contents, completions_path) or
+                    strings.contains(contents, "# bun completions\n") or
+                    strings.contains(contents, "/.bun/_bun"))
+                {
                     break :brk false;
                 }
 

--- a/test/regression/issue/30335.test.ts
+++ b/test/regression/issue/30335.test.ts
@@ -33,11 +33,7 @@ async function runCompletions(home: string) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 
@@ -50,17 +46,37 @@ function countBunSourceLines(zshrc: string): number {
   return (zshrc.match(/source\s+"?[^"\s]*\.bun\/_bun/g) ?? []).length;
 }
 
-test.if(isPosix)(
-  "bun completions doesn't duplicate when .zshrc uses $HOME instead of a hardcoded path",
-  async () => {
-    const zshrcBefore = [
-      "# some existing config",
-      'export PATH="/usr/local/bin:$PATH"',
-      "",
-      '[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"',
-      "",
-    ].join("\n");
-    using dir = tempDir("bun-completions-30335-home", {
+test.if(isPosix)("bun completions doesn't duplicate when .zshrc uses $HOME instead of a hardcoded path", async () => {
+  const zshrcBefore = [
+    "# some existing config",
+    'export PATH="/usr/local/bin:$PATH"',
+    "",
+    '[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"',
+    "",
+  ].join("\n");
+  using dir = tempDir("bun-completions-30335-home", {
+    ".bun/.keep": "",
+    ".zshrc": zshrcBefore,
+  });
+  const home = String(dir);
+
+  const { exitCode } = await runCompletions(home);
+  expect(exitCode).toBe(0);
+
+  const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+  // No duplicate line appended — the $HOME reference is recognised.
+  expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  // And the user's original line is untouched.
+  expect(zshrcAfter).toBe(zshrcBefore);
+});
+
+test.if(isPosix)("bun completions doesn't duplicate for ~ or ${HOME} variants", async () => {
+  for (const snippet of [
+    '[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"',
+    '[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"',
+  ]) {
+    const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
+    using dir = tempDir("bun-completions-30335-variant", {
       ".bun/.keep": "",
       ".zshrc": zshrcBefore,
     });
@@ -70,59 +86,30 @@ test.if(isPosix)(
     expect(exitCode).toBe(0);
 
     const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
-    // No duplicate line appended — the $HOME reference is recognised.
     expect(countBunSourceLines(zshrcAfter)).toBe(1);
-    // And the user's original line is untouched.
     expect(zshrcAfter).toBe(zshrcBefore);
-  },
-);
+  }
+});
 
-test.if(isPosix)(
-  "bun completions doesn't duplicate for ~ or ${HOME} variants",
-  async () => {
-    for (const snippet of [
-      '[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"',
-      '[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"',
-    ]) {
-      const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
-      using dir = tempDir("bun-completions-30335-variant", {
-        ".bun/.keep": "",
-        ".zshrc": zshrcBefore,
-      });
-      const home = String(dir);
+test.if(isPosix)("bun completions still appends on a zshrc that doesn't reference _bun", async () => {
+  // Sanity check: we haven't broken the fresh-install path. A .zshrc with
+  // no existing bun snippet (and no marker comment) should still get one.
+  const zshrcBefore = 'export PATH="/usr/local/bin:$PATH"\n';
+  using dir = tempDir("bun-completions-30335-fresh", {
+    ".bun/.keep": "",
+    ".zshrc": zshrcBefore,
+  });
+  const home = String(dir);
 
-      const { exitCode } = await runCompletions(home);
-      expect(exitCode).toBe(0);
+  const { exitCode } = await runCompletions(home);
+  expect(exitCode).toBe(0);
 
-      const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
-      expect(countBunSourceLines(zshrcAfter)).toBe(1);
-      expect(zshrcAfter).toBe(zshrcBefore);
-    }
-  },
-);
-
-test.if(isPosix)(
-  "bun completions still appends on a zshrc that doesn't reference _bun",
-  async () => {
-    // Sanity check: we haven't broken the fresh-install path. A .zshrc with
-    // no existing bun snippet (and no marker comment) should still get one.
-    const zshrcBefore = 'export PATH="/usr/local/bin:$PATH"\n';
-    using dir = tempDir("bun-completions-30335-fresh", {
-      ".bun/.keep": "",
-      ".zshrc": zshrcBefore,
-    });
-    const home = String(dir);
-
-    const { exitCode } = await runCompletions(home);
-    expect(exitCode).toBe(0);
-
-    const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
-    expect(zshrcAfter).toContain("# bun completions");
-    expect(countBunSourceLines(zshrcAfter)).toBe(1);
-    // Running a second time must not append again.
-    const { exitCode: exit2 } = await runCompletions(home);
-    expect(exit2).toBe(0);
-    const zshrcAfter2 = readFileSync(join(home, ".zshrc"), "utf8");
-    expect(zshrcAfter2).toBe(zshrcAfter);
-  },
-);
+  const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(zshrcAfter).toContain("# bun completions");
+  expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  // Running a second time must not append again.
+  const { exitCode: exit2 } = await runCompletions(home);
+  expect(exit2).toBe(0);
+  const zshrcAfter2 = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(zshrcAfter2).toBe(zshrcAfter);
+});

--- a/test/regression/issue/30335.test.ts
+++ b/test/regression/issue/30335.test.ts
@@ -72,10 +72,12 @@ test.if(isPosix)("bun completions doesn't duplicate when .zshrc uses $HOME inste
 
 // One test per variant so a failure names the specific form that regressed
 // instead of bailing at the first mismatch inside a shared loop.
-test.if(isPosix).each([
-  ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
-  ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
-])("bun completions doesn't duplicate for %s", async snippet => {
+test
+  .if(isPosix)
+  .each([
+    ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
+    ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
+  ])("bun completions doesn't duplicate for %s", async snippet => {
   const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
   using dir = tempDir("bun-completions-30335-variant", {
     ".bun/.keep": "",

--- a/test/regression/issue/30335.test.ts
+++ b/test/regression/issue/30335.test.ts
@@ -70,25 +70,25 @@ test.if(isPosix)("bun completions doesn't duplicate when .zshrc uses $HOME inste
   expect(zshrcAfter).toBe(zshrcBefore);
 });
 
-test.if(isPosix)("bun completions doesn't duplicate for ~ or ${HOME} variants", async () => {
-  for (const snippet of [
-    '[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"',
-    '[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"',
-  ]) {
-    const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
-    using dir = tempDir("bun-completions-30335-variant", {
-      ".bun/.keep": "",
-      ".zshrc": zshrcBefore,
-    });
-    const home = String(dir);
+// One test per variant so a failure names the specific form that regressed
+// instead of bailing at the first mismatch inside a shared loop.
+test.if(isPosix).each([
+  ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
+  ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
+])("bun completions doesn't duplicate for %s", async snippet => {
+  const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
+  using dir = tempDir("bun-completions-30335-variant", {
+    ".bun/.keep": "",
+    ".zshrc": zshrcBefore,
+  });
+  const home = String(dir);
 
-    const { exitCode } = await runCompletions(home);
-    expect(exitCode).toBe(0);
+  const { exitCode } = await runCompletions(home);
+  expect(exitCode).toBe(0);
 
-    const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
-    expect(countBunSourceLines(zshrcAfter)).toBe(1);
-    expect(zshrcAfter).toBe(zshrcBefore);
-  }
+  const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  expect(zshrcAfter).toBe(zshrcBefore);
 });
 
 test.if(isPosix)("bun completions still appends on a zshrc that doesn't reference _bun", async () => {

--- a/test/regression/issue/30335.test.ts
+++ b/test/regression/issue/30335.test.ts
@@ -61,13 +61,13 @@ test.if(isPosix)("bun completions doesn't duplicate when .zshrc uses $HOME inste
   const home = String(dir);
 
   const { exitCode } = await runCompletions(home);
-  expect(exitCode).toBe(0);
 
   const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
   // No duplicate line appended — the $HOME reference is recognised.
   expect(countBunSourceLines(zshrcAfter)).toBe(1);
   // And the user's original line is untouched.
   expect(zshrcAfter).toBe(zshrcBefore);
+  expect(exitCode).toBe(0);
 });
 
 // One test per variant so a failure names the specific form that regressed
@@ -84,11 +84,11 @@ test.if(isPosix).each([
   const home = String(dir);
 
   const { exitCode } = await runCompletions(home);
-  expect(exitCode).toBe(0);
 
   const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
   expect(countBunSourceLines(zshrcAfter)).toBe(1);
   expect(zshrcAfter).toBe(zshrcBefore);
+  expect(exitCode).toBe(0);
 });
 
 test.if(isPosix)("bun completions still appends on a zshrc that doesn't reference _bun", async () => {
@@ -102,14 +102,15 @@ test.if(isPosix)("bun completions still appends on a zshrc that doesn't referenc
   const home = String(dir);
 
   const { exitCode } = await runCompletions(home);
-  expect(exitCode).toBe(0);
 
   const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
   expect(zshrcAfter).toContain("# bun completions");
   expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  expect(exitCode).toBe(0);
+
   // Running a second time must not append again.
   const { exitCode: exit2 } = await runCompletions(home);
-  expect(exit2).toBe(0);
   const zshrcAfter2 = readFileSync(join(home, ".zshrc"), "utf8");
   expect(zshrcAfter2).toBe(zshrcAfter);
+  expect(exit2).toBe(0);
 });

--- a/test/regression/issue/30335.test.ts
+++ b/test/regression/issue/30335.test.ts
@@ -1,0 +1,128 @@
+// https://github.com/oven-sh/bun/issues/30335
+//
+// `bun completions` (invoked by `bun upgrade` with IS_BUN_AUTO_UPDATE=true)
+// used to detect an already-installed completions snippet by looking only for
+// the absolute `completions_path` string or the literal "# bun completions"
+// marker comment. Users who rewrite the snippet to use `$HOME`/`${HOME}`/`~`
+// so .zshrc is portable across machines, and drop the marker comment, would
+// get a second hardcoded copy appended on every `bun upgrade`.
+//
+// Fix: additionally treat any existing reference to `/.bun/_bun` (the zsh
+// completions filename under `.bun/`) as evidence that the user already has
+// the snippet loaded in some form, so bun doesn't append its own copy.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+async function runCompletions(home: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "completions", join(home, ".bun")],
+    env: {
+      ...bunEnv,
+      HOME: home,
+      SHELL: "/bin/zsh",
+      IS_BUN_AUTO_UPDATE: "true",
+      // Force the zshrc-detection path: no ZDOTDIR, no $fpath override, no
+      // XDG_DATA_HOME — so the command lands on $HOME/.zshrc and ~/.bun as
+      // the completions dir (the exact path we pass in).
+      ZDOTDIR: "",
+      XDG_DATA_HOME: "",
+      fpath: "",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+// Count `source "…_bun"` occurrences. The full snippet bun writes
+// references the path twice on one line (in the `[ -s "…" ]` test and the
+// `source "…"`), so each snippet contributes one match here. One match =
+// user's own line is the only one. Two matches = bun appended a duplicate
+// next to the user's hand-edited line — the 30335 bug.
+function countBunSourceLines(zshrc: string): number {
+  return (zshrc.match(/source\s+"?[^"\s]*\.bun\/_bun/g) ?? []).length;
+}
+
+test.if(isPosix)(
+  "bun completions doesn't duplicate when .zshrc uses $HOME instead of a hardcoded path",
+  async () => {
+    const zshrcBefore = [
+      "# some existing config",
+      'export PATH="/usr/local/bin:$PATH"',
+      "",
+      '[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"',
+      "",
+    ].join("\n");
+    using dir = tempDir("bun-completions-30335-home", {
+      ".bun/.keep": "",
+      ".zshrc": zshrcBefore,
+    });
+    const home = String(dir);
+
+    const { exitCode } = await runCompletions(home);
+    expect(exitCode).toBe(0);
+
+    const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+    // No duplicate line appended — the $HOME reference is recognised.
+    expect(countBunSourceLines(zshrcAfter)).toBe(1);
+    // And the user's original line is untouched.
+    expect(zshrcAfter).toBe(zshrcBefore);
+  },
+);
+
+test.if(isPosix)(
+  "bun completions doesn't duplicate for ~ or ${HOME} variants",
+  async () => {
+    for (const snippet of [
+      '[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"',
+      '[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"',
+    ]) {
+      const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
+      using dir = tempDir("bun-completions-30335-variant", {
+        ".bun/.keep": "",
+        ".zshrc": zshrcBefore,
+      });
+      const home = String(dir);
+
+      const { exitCode } = await runCompletions(home);
+      expect(exitCode).toBe(0);
+
+      const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+      expect(countBunSourceLines(zshrcAfter)).toBe(1);
+      expect(zshrcAfter).toBe(zshrcBefore);
+    }
+  },
+);
+
+test.if(isPosix)(
+  "bun completions still appends on a zshrc that doesn't reference _bun",
+  async () => {
+    // Sanity check: we haven't broken the fresh-install path. A .zshrc with
+    // no existing bun snippet (and no marker comment) should still get one.
+    const zshrcBefore = 'export PATH="/usr/local/bin:$PATH"\n';
+    using dir = tempDir("bun-completions-30335-fresh", {
+      ".bun/.keep": "",
+      ".zshrc": zshrcBefore,
+    });
+    const home = String(dir);
+
+    const { exitCode } = await runCompletions(home);
+    expect(exitCode).toBe(0);
+
+    const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+    expect(zshrcAfter).toContain("# bun completions");
+    expect(countBunSourceLines(zshrcAfter)).toBe(1);
+    // Running a second time must not append again.
+    const { exitCode: exit2 } = await runCompletions(home);
+    expect(exit2).toBe(0);
+    const zshrcAfter2 = readFileSync(join(home, ".zshrc"), "utf8");
+    expect(zshrcAfter2).toBe(zshrcAfter);
+  },
+);


### PR DESCRIPTION
Fixes #30335.

## Reproduction

A `.zshrc` with a hand-edited `$HOME`-based source line and no `# bun completions` marker:

```sh
# some existing config
export PATH="/usr/local/bin:$PATH"

[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
```

Running `bun completions` (as `bun upgrade` does, via `IS_BUN_AUTO_UPDATE=true`) appends a second hardcoded copy:

```sh
[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"

# bun completions
[ -s "/Users/alice/.bun/_bun" ] && source "/Users/alice/.bun/_bun"
```

On every subsequent upgrade where the user re-edits the line to use `$HOME`/`~`/`${HOME}`, another duplicate is added.

## Cause

`src/cli/install_completions_command.zig` detects an already-installed snippet only by matching:

1. The literal absolute path it would write (`/Users/alice/.bun/_bun`), or
2. The `# bun completions` marker comment.

`$HOME/.bun/_bun`, `${HOME}/.bun/_bun`, and `~/.bun/_bun` are none of the above, so without the marker comment bun doesn't recognise the existing line and appends its own hardcoded copy.

## Fix

Also treat any existing reference to `/.bun/_bun` (the zsh completions file under `.bun/`) as evidence that the snippet is already loaded. One extra `strings.contains` check before the append.

## Verification

`test/regression/issue/30335.test.ts` covers:

- `.zshrc` using `$HOME/.bun/_bun` (no marker comment) → no duplicate appended
- `.zshrc` using `~/.bun/_bun` and `${HOME}/.bun/_bun` variants → no duplicate appended
- Fresh `.zshrc` with no `_bun` reference → snippet still appended, and a second run does not append again (regression guard for the existing detection paths)

All three pass on the patched binary and the first two fail on `USE_SYSTEM_BUN=1`.