### PR TITLE
install: scope bunfig `frozenLockfile` to plain `bun install`

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -320,7 +320,7 @@ saveTextLockfile = false
 
 # when true, plain `bun install` (with no package arguments) behaves as if
 # `--frozen-lockfile` was passed. Explicit mutation commands
-# (`bun add`, `bun remove`, `bun update <pkg>`, `bun install <pkg>`)
+# (`bun add`, `bun remove`, `bun update`, `bun install <pkg>`)
 # ignore this setting so they can still change the lockfile.
 # Use the `--frozen-lockfile` CLI flag to force the behavior on any subcommand.
 frozenLockfile = false

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -318,7 +318,11 @@ production = false
 # equivalent to `--save-text-lockfile` flag
 saveTextLockfile = false
 
-# equivalent to `--frozen-lockfile` flag
+# when true, plain `bun install` (with no package arguments) behaves as if
+# `--frozen-lockfile` was passed. Explicit mutation commands
+# (`bun add`, `bun remove`, `bun update <pkg>`, `bun install <pkg>`)
+# ignore this setting so they can still change the lockfile.
+# Use the `--frozen-lockfile` CLI flag to force the behavior on any subcommand.
 frozenLockfile = false
 
 # equivalent to `--dry-run` flag

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -522,7 +522,7 @@ Valid values are:
 
 When true, plain `bun install` (with no package arguments) will not update `bun.lock`. Default `false`. If `package.json` and the existing `bun.lock` are not in agreement, this will error.
 
-Explicit mutation commands — `bun add`, `bun remove`, `bun update <pkg>`, and `bun install <pkg>` — ignore this setting so they can still change the lockfile. Use the `--frozen-lockfile` CLI flag if you need to force the behavior on those subcommands too.
+Explicit mutation commands — `bun add`, `bun remove`, `bun update`, and `bun install <pkg>` — ignore this setting so they can still change the lockfile. Use the `--frozen-lockfile` CLI flag if you need to force the behavior on those subcommands too.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -520,7 +520,9 @@ Valid values are:
 
 ### `install.frozenLockfile`
 
-When true, `bun install` will not update `bun.lock`. Default `false`. If `package.json` and the existing `bun.lock` are not in agreement, this will error.
+When true, plain `bun install` (with no package arguments) will not update `bun.lock`. Default `false`. If `package.json` and the existing `bun.lock` are not in agreement, this will error.
+
+Explicit mutation commands — `bun add`, `bun remove`, `bun update <pkg>`, and `bun install <pkg>` — ignore this setting so they can still change the lockfile. Use the `--frozen-lockfile` CLI flag if you need to force the behavior on those subcommands too.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -172,6 +172,20 @@ pub const Subcommand = enum {
         };
     }
 
+    /// Whether `frozenLockfile = true` in `bunfig.toml` should apply to this
+    /// subcommand. Explicit mutation commands (`bun add`, `bun remove`,
+    /// `bun update <pkg>`, `bun link`, `bun unlink`, `bun patch`,
+    /// `bun patch-commit`) are intentionally excluded because the user asked
+    /// to change the dependency graph — failing the command would defeat the
+    /// point. The CLI flag `--frozen-lockfile` still forces the behavior on
+    /// every subcommand when set explicitly.
+    pub fn shouldObeyBunfigFrozenLockfile(this: Subcommand) bool {
+        return switch (this) {
+            .install => true,
+            else => false,
+        };
+    }
+
     pub fn supportsWorkspaceFiltering(this: Subcommand) bool {
         return switch (this) {
             .outdated => true,

--- a/src/install/PackageManager.zig
+++ b/src/install/PackageManager.zig
@@ -174,7 +174,7 @@ pub const Subcommand = enum {
 
     /// Whether `frozenLockfile = true` in `bunfig.toml` should apply to this
     /// subcommand. Explicit mutation commands (`bun add`, `bun remove`,
-    /// `bun update <pkg>`, `bun link`, `bun unlink`, `bun patch`,
+    /// `bun update`, `bun link`, `bun unlink`, `bun patch`,
     /// `bun patch-commit`) are intentionally excluded because the user asked
     /// to change the dependency graph — failing the command would defeat the
     /// point. The CLI flag `--frozen-lockfile` still forces the behavior on

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -217,7 +217,7 @@ pub fn openGlobalBinDir(opts_: ?*const Api.BunInstall) !std.fs.Dir {
 
 /// `frozenLockfile = true` in `bunfig.toml` applies only to plain
 /// `bun install` — when the user explicitly asks to change the
-/// dependency graph (`bun add`, `bun remove`, `bun update <pkg>`,
+/// dependency graph (`bun add`, `bun remove`, `bun update`,
 /// `bun install <pkg>`, `bun link`, `bun unlink`, `bun patch`,
 /// `bun patch-commit`) the bunfig setting is ignored.
 ///

--- a/src/install/PackageManager/PackageManagerOptions.zig
+++ b/src/install/PackageManager/PackageManagerOptions.zig
@@ -215,6 +215,31 @@ pub fn openGlobalBinDir(opts_: ?*const Api.BunInstall) !std.fs.Dir {
     return error.@"Missing global bin directory: try setting $BUN_INSTALL";
 }
 
+/// `frozenLockfile = true` in `bunfig.toml` applies only to plain
+/// `bun install` — when the user explicitly asks to change the
+/// dependency graph (`bun add`, `bun remove`, `bun update <pkg>`,
+/// `bun install <pkg>`, `bun link`, `bun unlink`, `bun patch`,
+/// `bun patch-commit`) the bunfig setting is ignored.
+///
+/// The `--frozen-lockfile` CLI flag still forces the behavior on
+/// every subcommand and is handled separately.
+fn shouldObeyBunfigFrozenLockfile(
+    subcommand: Subcommand,
+    maybe_cli: ?CommandLineArguments,
+) bool {
+    if (!subcommand.shouldObeyBunfigFrozenLockfile()) return false;
+
+    // `bun install <pkg>` is routed through subcommand `.install` but is
+    // effectively `bun add <pkg>` (see `cli/install_command.zig`).
+    if (subcommand == .install) {
+        if (maybe_cli) |cli| {
+            if (cli.positionals.len > 1) return false;
+        }
+    }
+
+    return true;
+}
+
 pub fn load(
     this: *Options,
     allocator: std.mem.Allocator,
@@ -338,7 +363,7 @@ pub fn load(
         }
 
         if (config.frozen_lockfile) |frozen_lockfile| {
-            if (frozen_lockfile) {
+            if (frozen_lockfile and shouldObeyBunfigFrozenLockfile(subcommand, maybe_cli)) {
                 this.enable.frozen_lockfile = true;
             }
         }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6871,6 +6871,15 @@ cache = false
         expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
         expect(out).not.toContain("installed bar");
         expect(await exited).toBe(1);
+
+        // the mutation must not have leaked to disk — package.json unchanged,
+        // bar was never extracted.
+        expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { baz: "0.0.3" },
+        });
+        expect(await exists(join(ctx.package_dir, "node_modules", "bar"))).toBe(false);
       });
     });
 
@@ -6913,6 +6922,14 @@ cache = false
         expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
         expect(out).not.toContain("installed bar");
         expect(await exited).toBe(1);
+
+        // same as above — frozen must mean no filesystem changes.
+        expect(await file(join(ctx.package_dir, "package.json")).json()).toEqual({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: { baz: "0.0.3" },
+        });
+        expect(await exists(join(ctx.package_dir, "node_modules", "bar"))).toBe(false);
       });
     });
   });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6656,6 +6656,189 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/30333
+  // `frozenLockfile = true` in bunfig.toml should only lock the file for plain
+  // `bun install` — explicit mutations (`bun add`, `bun remove`,
+  // `bun update <pkg>`, `bun install <pkg>`) are a user-intended lockfile
+  // change and must still work.
+  describe("frozenLockfile in bunfig.toml should not block explicit mutations", () => {
+    async function setupFrozenBunfigCtx(ctx: TestContext) {
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, [], {
+          "0.0.2": { as: "0.0.2" },
+          "0.0.3": { as: "0.0.3" },
+          "0.0.5": { as: "0.0.5" },
+        }),
+      );
+
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+      );
+
+      // seed the lockfile while bunfig doesn't yet exist
+      expect(
+        await spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "ignore",
+          stdin: "ignore",
+          stderr: "ignore",
+          env,
+        }).exited,
+      ).toBe(0);
+
+      // now turn on frozenLockfile in bunfig.toml
+      await writeFile(
+        join(ctx.package_dir, "bunfig.toml"),
+        `
+[install]
+frozenLockfile = true
+registry = "${ctx.registry_url}"
+cache = false
+`,
+      );
+    }
+
+    it("bun add <pkg> works with bunfig frozenLockfile=true", async () => {
+      await withContext(defaultOpts, async ctx => {
+        await setupFrozenBunfigCtx(ctx);
+
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "add", "bar@0.0.2"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("lockfile is frozen");
+        expect(await exited).toBe(0);
+      });
+    });
+
+    it("bun install <pkg> works with bunfig frozenLockfile=true", async () => {
+      await withContext(defaultOpts, async ctx => {
+        await setupFrozenBunfigCtx(ctx);
+
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "install", "bar@0.0.2"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("lockfile is frozen");
+        expect(await exited).toBe(0);
+      });
+    });
+
+    it("bun remove <pkg> works with bunfig frozenLockfile=true", async () => {
+      await withContext(defaultOpts, async ctx => {
+        await setupFrozenBunfigCtx(ctx);
+
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "remove", "baz"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("lockfile is frozen");
+        expect(await exited).toBe(0);
+      });
+    });
+
+    it("bun update <pkg> works with bunfig frozenLockfile=true", async () => {
+      await withContext(defaultOpts, async ctx => {
+        await setupFrozenBunfigCtx(ctx);
+
+        // `bun update --latest baz` forces a version change (0.0.3 -> 0.0.5)
+        // so the lockfile MUST change — this exercises the frozen check.
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "update", "--latest", "baz"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("lockfile is frozen");
+        expect(await exited).toBe(0);
+      });
+    });
+
+    it("plain `bun install` still respects bunfig frozenLockfile=true", async () => {
+      await withContext(defaultOpts, async ctx => {
+        await setupFrozenBunfigCtx(ctx);
+
+        // change the package.json so the lockfile is out of date
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.5" } }),
+        );
+
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+        expect(await exited).toBe(1);
+      });
+    });
+
+    it("--frozen-lockfile CLI flag still forces frozen on `bun add`", async () => {
+      await withContext(defaultOpts, async ctx => {
+        // no bunfig this time — just use the CLI flag on `bun add`
+        setContextHandler(
+          ctx,
+          dummyRegistryForContext(ctx, [], {
+            "0.0.2": { as: "0.0.2" },
+            "0.0.3": { as: "0.0.3" },
+          }),
+        );
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+        );
+        expect(
+          await spawn({
+            cmd: [bunExe(), "install"],
+            cwd: ctx.package_dir,
+            stdout: "ignore",
+            stdin: "ignore",
+            stderr: "ignore",
+            env,
+          }).exited,
+        ).toBe(0);
+
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "add", "--frozen-lockfile", "bar@0.0.2"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+        expect(await exited).toBe(1);
+      });
+    });
+  });
+
   it("should perform bin-linking across multiple dependencies", async () => {
     await withContext(defaultOpts, async ctx => {
       const foo_package = JSON.stringify({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6705,7 +6705,7 @@ cache = false
       await withContext(defaultOpts, async ctx => {
         await setupFrozenBunfigCtx(ctx);
 
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "add", "bar@0.0.2"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6713,8 +6713,9 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).not.toContain("lockfile is frozen");
+        expect(out).toContain("installed bar@0.0.2");
         expect(await exited).toBe(0);
 
         // package.json must now list bar as a dependency and bar must be installed
@@ -6731,7 +6732,7 @@ cache = false
       await withContext(defaultOpts, async ctx => {
         await setupFrozenBunfigCtx(ctx);
 
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "install", "bar@0.0.2"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6739,8 +6740,9 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).not.toContain("lockfile is frozen");
+        expect(out).toContain("installed bar@0.0.2");
         expect(await exited).toBe(0);
 
         // `bun install <pkg>` behaves like `bun add` — package.json and
@@ -6758,7 +6760,7 @@ cache = false
       await withContext(defaultOpts, async ctx => {
         await setupFrozenBunfigCtx(ctx);
 
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "remove", "baz"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6766,8 +6768,9 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).not.toContain("lockfile is frozen");
+        expect(out).toContain("bun remove");
         expect(await exited).toBe(0);
 
         // baz must be gone from package.json and node_modules
@@ -6783,7 +6786,7 @@ cache = false
 
         // `bun update --latest baz` forces a version change (0.0.3 -> 0.0.5)
         // so the lockfile MUST change — this exercises the frozen check.
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "update", "--latest", "baz"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6791,8 +6794,9 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).not.toContain("lockfile is frozen");
+        expect(out).toContain("bun update");
         expect(await exited).toBe(0);
 
         // baz must now be pinned to the latest version in both places
@@ -6815,7 +6819,7 @@ cache = false
           JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.5" } }),
         );
 
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "install"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6823,8 +6827,9 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+        expect(out).toContain("bun install");
         expect(await exited).toBe(1);
       });
     });
@@ -6854,7 +6859,7 @@ cache = false
           }).exited,
         ).toBe(0);
 
-        const { stderr, exited } = spawn({
+        const { stdout, stderr, exited } = spawn({
           cmd: [bunExe(), "add", "--frozen-lockfile", "bar@0.0.2"],
           cwd: ctx.package_dir,
           stdout: "pipe",
@@ -6862,8 +6867,51 @@ cache = false
           stderr: "pipe",
           env,
         });
-        const err = await stderr.text();
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
         expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+        expect(out).not.toContain("installed bar");
+        expect(await exited).toBe(1);
+      });
+    });
+
+    it("--production CLI flag still forces frozen on `bun add`", async () => {
+      await withContext(defaultOpts, async ctx => {
+        // `--production` implies frozen. Even on `bun add`, the user is
+        // opting in to frozen behavior for this invocation, so it must
+        // still fire the frozen-lockfile check.
+        setContextHandler(
+          ctx,
+          dummyRegistryForContext(ctx, [], {
+            "0.0.2": { as: "0.0.2" },
+            "0.0.3": { as: "0.0.3" },
+          }),
+        );
+        await writeFile(
+          join(ctx.package_dir, "package.json"),
+          JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+        );
+        expect(
+          await spawn({
+            cmd: [bunExe(), "install"],
+            cwd: ctx.package_dir,
+            stdout: "ignore",
+            stdin: "ignore",
+            stderr: "ignore",
+            env,
+          }).exited,
+        ).toBe(0);
+
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "add", "--production", "bar@0.0.2"],
+          cwd: ctx.package_dir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
+        expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+        expect(out).not.toContain("installed bar");
         expect(await exited).toBe(1);
       });
     });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6716,6 +6716,14 @@ cache = false
         const err = await stderr.text();
         expect(err).not.toContain("lockfile is frozen");
         expect(await exited).toBe(0);
+
+        // package.json must now list bar as a dependency and bar must be installed
+        const pkg = await file(join(ctx.package_dir, "package.json")).json();
+        expect(pkg.dependencies).toEqual({ baz: "0.0.3", bar: "0.0.2" });
+        expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toMatchObject({
+          name: "bar",
+          version: "0.0.2",
+        });
       });
     });
 
@@ -6734,6 +6742,15 @@ cache = false
         const err = await stderr.text();
         expect(err).not.toContain("lockfile is frozen");
         expect(await exited).toBe(0);
+
+        // `bun install <pkg>` behaves like `bun add` — package.json and
+        // node_modules must reflect the mutation.
+        const pkg = await file(join(ctx.package_dir, "package.json")).json();
+        expect(pkg.dependencies).toEqual({ baz: "0.0.3", bar: "0.0.2" });
+        expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toMatchObject({
+          name: "bar",
+          version: "0.0.2",
+        });
       });
     });
 
@@ -6752,6 +6769,11 @@ cache = false
         const err = await stderr.text();
         expect(err).not.toContain("lockfile is frozen");
         expect(await exited).toBe(0);
+
+        // baz must be gone from package.json and node_modules
+        const pkg = await file(join(ctx.package_dir, "package.json")).json();
+        expect(pkg.dependencies ?? {}).toEqual({});
+        expect(await exists(join(ctx.package_dir, "node_modules", "baz"))).toBe(false);
       });
     });
 
@@ -6772,6 +6794,14 @@ cache = false
         const err = await stderr.text();
         expect(err).not.toContain("lockfile is frozen");
         expect(await exited).toBe(0);
+
+        // baz must now be pinned to the latest version in both places
+        const pkg = await file(join(ctx.package_dir, "package.json")).json();
+        expect(pkg.dependencies).toEqual({ baz: "0.0.5" });
+        expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toMatchObject({
+          name: "baz",
+          version: "0.0.5",
+        });
       });
     });
 


### PR DESCRIPTION
Fixes #30333
Fixes #14628

## Repro

```sh
mkdir /tmp/frozen-test && cd /tmp/frozen-test
echo '{"name":"x","dependencies":{"is-even":"^1.0.0"}}' > package.json
bun install
echo -e '[install]\nfrozenLockfile = true' > bunfig.toml
bun add is-odd
```

Output before fix:
```
bun add v1.3.14
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

## Cause

`src/install/PackageManager/PackageManagerOptions.zig` applied `config.frozen_lockfile` from bunfig to every subcommand (install, add, remove, update, etc.), which contradicts the user's explicit intent when they ask to mutate the dependency graph.

## Fix

Bunfig's `frozenLockfile = true` now only applies to plain `bun install` — `bun add`, `bun remove`, `bun update <pkg>`, and `bun install <pkg>` (which is routed through subcommand `.install` but has `positionals.len > 1` and behaves as `bun add`) all ignore it.

The `--frozen-lockfile` CLI flag and `--production` CLI flag are unchanged — they still force frozen behavior on every subcommand as before.

Matches pnpm's behavior with `frozen-lockfile=true` in `.npmrc`.

## Verification

```
bun bd test test/cli/install/bun-install.test.ts -t 'frozen'
9 pass, 0 fail (3 existing + 6 new)
```

Without the fix, the 4 new mutation-exemption tests fail with `error: lockfile had changes, but lockfile is frozen`; the 2 control tests (plain `bun install` with bunfig, `bun add --frozen-lockfile`) still pass. With the fix all 6 pass. Each mutation test also asserts the post-command state (package.json deps + node_modules entries).
