### PR TITLE
Add install.blockExoticSubdeps to reject non-registry transitive deps

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -774,6 +774,38 @@ minimumReleaseAge = 259200
 minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
 ```
 
+### `install.blockExoticSubdeps`
+
+When set to `true`, `bun install` fails if any _transitive_ dependency is
+**specified** with a non-registry source — a git URL, GitHub reference,
+remote or local tarball, local folder (`file:`), symlink (`link:`), or a
+literal `workspace:` reference pulled in by a non-workspace parent. Direct
+dependencies of the root package (and any workspace package) are not
+restricted. Default `false`.
+
+For workspace redirection the check inspects the specifier written in each
+nested `package.json`, not the final resolution, so enabling this does not
+interact with `install.linkWorkspacePackages` — a registry package asking
+for a plain semver range is still allowed even if Bun redirects it to a
+local workspace copy. Root `overrides`/`resolutions` replace the nested
+specifier before the check runs: an override pointing a transitive
+dependency at a registry version clears a block, while an override
+pointing one at a non-registry source is itself blocked. `catalog:`
+references are always allowed since the root defines the catalog.
+
+```toml title="bunfig.toml" icon="settings"
+[install]
+blockExoticSubdeps = true
+```
+
+This mirrors [pnpm's `blockExoticSubdeps`](https://pnpm.io/11.x/supply-chain-security#prevent-exotic-transitive-dependencies)
+and helps harden against supply-chain attacks where a registry package
+smuggles in code from an arbitrary URL through an indirect dependency.
+The check runs after resolution, so Bun may still clone or download an
+exotic URL to determine the dependency graph before aborting; the block
+prevents installation into `node_modules` and any lifecycle scripts from
+running.
+
 ## `bun run`
 
 The `[run]` section configures the `bun run` command. These settings also apply to the `bun` command when running a file, script, or executable.

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1385,6 +1385,13 @@ impl<'a> Parser<'a> {
             install.global_store = Some(v);
         }
 
+        if let Some(v) = install_obj
+            .get(b"blockExoticSubdeps")
+            .and_then(|e| e.as_bool())
+        {
+            install.block_exotic_subdeps = Some(v);
+        }
+
         if let Some(lockfile_expr) = install_obj.get(b"lockfile") {
             if let Some(lockfile) = lockfile_expr.get(b"print") {
                 self.expect_string(&lockfile)?;

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1474,6 +1474,12 @@ mod draft {
             }
         }
 
+        if let Some(block_exotic_subdeps) = out.get(b"block-exotic-subdeps") {
+            if let Some(value) = block_exotic_subdeps.as_bool() {
+                install.block_exotic_subdeps = Some(value);
+            }
+        }
+
         if let Some(install_strategy_expr) = out.get(b"install-strategy") {
             if let Some(install_strategy_str) = install_strategy_expr.as_string(bump) {
                 if install_strategy_str == b"hoisted" {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -54,6 +54,8 @@ pub mod Command {
 pub mod add_catalog;
 #[path = "PackageManager/add_remove_with_filter.rs"]
 pub mod add_remove_with_filter;
+#[path = "PackageManager/block_exotic_subdeps.rs"]
+pub mod block_exotic_subdeps;
 #[path = "PackageManager/CommandLineArguments.rs"]
 pub mod command_line_arguments;
 #[path = "PackageManager/install_with_manager.rs"]
@@ -1407,6 +1409,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        block_exotic_subdeps,
     } = bunfig;
 
     if let Some(registry) = default_registry {
@@ -1462,6 +1465,7 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
         hoist_pattern,
         hoist,
         offline,
+        block_exotic_subdeps,
     );
 }
 

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -497,6 +497,11 @@ impl Options {
                 self.offline = OfflineMode::Offline;
             }
 
+            if let Some(block_exotic_subdeps) = config.block_exotic_subdeps {
+                self.enable
+                    .set(Enable::BLOCK_EXOTIC_SUBDEPS, block_exotic_subdeps);
+            }
+
             if let Some(security_scanner) = config.security_scanner.as_deref() {
                 self.security_scanner = Some(leak_static(security_scanner));
                 self.do_.set(Do::PREFETCH_RESOLVED_TARBALLS, false);
@@ -1006,7 +1011,12 @@ bitflags::bitflags! {
         /// install. Off by default; set BUN_INSTALL_GLOBAL_STORE=1 or
         /// `install.globalStore = true` in bunfig to enable.
         const GLOBAL_VIRTUAL_STORE   = 1 << 9;
-        // _: u6 padding
+
+        /// Reject transitive deps specified with a non-registry source (git,
+        /// github, tarball, folder, symlink, workspace). Root-level deps are
+        /// exempt. See `block_exotic_subdeps.rs`.
+        const BLOCK_EXOTIC_SUBDEPS   = 1 << 10;
+        // _: u5 padding
     }
 }
 
@@ -1113,5 +1123,9 @@ impl Enable {
     #[inline]
     pub(crate) fn global_virtual_store(self) -> bool {
         self.contains(Enable::GLOBAL_VIRTUAL_STORE)
+    }
+    #[inline]
+    pub fn block_exotic_subdeps(self) -> bool {
+        self.contains(Enable::BLOCK_EXOTIC_SUBDEPS)
     }
 }

--- a/src/install/PackageManager/block_exotic_subdeps.rs
+++ b/src/install/PackageManager/block_exotic_subdeps.rs
@@ -1,0 +1,208 @@
+//! Enforces `install.blockExoticSubdeps`: fails the install when any
+//! *transitive* dependency is specified with a non-registry source (git,
+//! github, tarball URL, folder, symlink, or a `workspace:` ref from a
+//! non-workspace parent). Direct deps of the root and of workspace packages
+//! are exempt. Modeled on pnpm:
+//! https://pnpm.io/11.x/supply-chain-security#prevent-exotic-transitive-dependencies
+//!
+//! Classification layers (see `classify`): `catalog:` literals are
+//! root-authored and skipped first; then the child's `Resolution::Tag`
+//! decides; only a `.workspace` resolution falls back to re-inferring the
+//! parent's literal, because `linkWorkspacePackages` can rewrite a plain
+//! semver to a workspace. Root `overrides`/`resolutions` take priority over
+//! the transitive literal when the resolver applied them.
+
+use bstr::BStr;
+use bun_collections::ArrayHashMap;
+use bun_core::{Output, fmt as bun_fmt, strings};
+use bun_install::dependency::{self, DependencyExt as _, TagExt as _};
+use bun_install::{DependencyID, PackageID, PackageManager, invalid_package_id};
+use bun_semver::semver_string::Builder as StringBuilder;
+
+use crate::lockfile::package::PackageColumns as _;
+use crate::resolution::Tag as ResolutionTag;
+
+/// Walks the fully-resolved lockfile and emits an error for every transitive
+/// dependency that is specified with a non-registry source. Returns the
+/// number of violations reported (so the caller can decide whether to exit).
+pub fn enforce_block_exotic_subdeps(manager: &PackageManager) -> usize {
+    let pkgs = manager.lockfile.packages.slice();
+    if pkgs.len() == 0 {
+        return 0;
+    }
+
+    // Like `verify_resolutions`: stay quiet under `--silent`, still fail.
+    let silent = manager.options.log_level.is_silent();
+
+    let pkg_resolutions = pkgs.items_resolution();
+    let pkg_names = pkgs.items_name();
+    let pkg_dependencies = pkgs.items_dependencies();
+    let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+    let resolutions = manager.lockfile.buffers.resolutions.as_slice();
+    let dependencies = manager.lockfile.buffers.dependencies.as_slice();
+
+    // Dedupe by (parent_id, child_pkg_id) — the same resolved package can
+    // appear as a dep of more than one parent and we only want to report
+    // each distinct edge once.
+    let mut seen: ArrayHashMap<u64, ()> = ArrayHashMap::default();
+    let mut header_printed = false;
+    let mut count: usize = 0;
+
+    for _parent_id in 0..pkgs.len() {
+        let parent_id: PackageID = _parent_id as PackageID;
+        let parent_res = &pkg_resolutions[parent_id as usize];
+
+        // Only transitive edges — skip root and workspace parents.
+        if parent_res.tag == ResolutionTag::Root || parent_res.tag == ResolutionTag::Workspace {
+            continue;
+        }
+
+        let parent_deps = pkg_dependencies[parent_id as usize];
+        for _dep_id in parent_deps.begin()..parent_deps.end() {
+            let dep_id: DependencyID = _dep_id as DependencyID;
+            if (dep_id as usize) >= dependencies.len() {
+                continue;
+            }
+            if (dep_id as usize) >= resolutions.len() {
+                continue;
+            }
+
+            let dep_pkg_id = resolutions[dep_id as usize];
+            if dep_pkg_id == invalid_package_id {
+                continue;
+            }
+            if (dep_pkg_id as usize) >= pkgs.len() {
+                continue;
+            }
+
+            let dep = &dependencies[dep_id as usize];
+            let dep_res_tag = pkg_resolutions[dep_pkg_id as usize].tag;
+
+            // Consult the same override the resolver applied: gate and
+            // realname-keyed hash both mirror
+            // `enqueue_dependency_with_main_and_success_fn` (bun.lock.rs
+            // carries the same pair).
+            let name_hash = match dep.version.tag {
+                dependency::Tag::DistTag
+                | dependency::Tag::Git
+                | dependency::Tag::Github
+                | dependency::Tag::Npm
+                | dependency::Tag::Tarball
+                | dependency::Tag::Workspace => {
+                    StringBuilder::string_hash(dep.realname().slice(string_buf))
+                }
+                _ => dep.name_hash,
+            };
+            let overridable = !dep.behavior.is_workspace()
+                && (dep.version.tag != dependency::Tag::Npm || !dep.version.npm().is_alias);
+            let overridden = if overridable {
+                manager
+                    .lockfile
+                    .overrides
+                    .get(&manager.lockfile, dep_id, name_hash)
+            } else {
+                None
+            };
+            let literal_raw: &[u8] = match overridden.as_ref() {
+                Some(ovr) => ovr.literal.slice(string_buf),
+                None => dep.version.literal.slice(string_buf),
+            };
+
+            let Some(verdict) = classify(dep_res_tag, literal_raw) else {
+                continue;
+            };
+
+            let key = ((parent_id as u64) << 32) | (dep_pkg_id as u64);
+            let gop = bun_core::handle_oom(seen.get_or_put(key));
+            if gop.found_existing {
+                continue;
+            }
+
+            count += 1;
+            if silent {
+                continue;
+            }
+
+            if !header_printed {
+                header_printed = true;
+                Output::err_generic(
+                    "<b>install.blockExoticSubdeps<r> is enabled, but the following transitive dependencies use non-registry sources:",
+                    (),
+                );
+            }
+
+            let parent_name = pkg_names[parent_id as usize].slice(string_buf);
+            let dep_name = dep.name.slice(string_buf);
+            // Informational only; the verdict comes from `dep_res_tag`. The
+            // literal can print empty when the lockfile clone pass wiped it.
+            // Macro form so only the template is tag-rewritten and the
+            // untrusted interpolated bytes print verbatim.
+            bun_core::pretty_errorln!(
+                "  <b>{}<r><d>@{}<r> depends on <b>{}<r><d>@{}<r> via <yellow>{}<r> source",
+                BStr::new(parent_name),
+                parent_res.fmt(string_buf, bun_fmt::PathSep::Auto),
+                BStr::new(dep_name),
+                BStr::new(literal_raw),
+                verdict,
+            );
+        }
+    }
+
+    if count > 0 && !silent {
+        bun_core::pretty_errorln!(
+            "\n<d>To allow these, disable <b>install.blockExoticSubdeps<r><d> in bunfig.toml or set <b>block-exotic-subdeps=false<r><d> in .npmrc; to fix a single offender, add an <b>overrides<r><d> entry in package.json pointing it at a registry version (an override to a non-registry source is itself blocked).<r>",
+        );
+        Output::flush();
+    }
+    count
+}
+
+/// Returns the exotic-source label if the (resolution, literal) pair is
+/// exotic per this policy, or `None` if it's allowed.
+#[inline]
+fn classify(res_tag: ResolutionTag, literal_raw: &[u8]) -> Option<&'static str> {
+    // Trim like `Dependency::parse` does so re-inference matches the
+    // resolver's read of the same literal (untrimmed bytes skew `infer()`:
+    // `" workspace:*"` reads as a git SCP shorthand, for example).
+    let literal = strings::trim_left(literal_raw, b" \t\n\r");
+    let literal_tag = dependency::Tag::infer(literal);
+
+    // `catalog:` is root-authored. The resolver dereferences it inline, so
+    // the resolution carries the catalog target's tag; the stored literal
+    // is the only signal the parent wrote `catalog:`.
+    if literal_tag == dependency::Tag::Catalog {
+        return None;
+    }
+
+    match res_tag {
+        ResolutionTag::Uninitialized | ResolutionTag::Root | ResolutionTag::Npm => None,
+
+        // These tags are unreachable via `linkWorkspacePackages` or any
+        // other implicit rewrite; the resolution alone is authoritative.
+        ResolutionTag::Git => Some("git"),
+        ResolutionTag::Github => Some("github"),
+        ResolutionTag::LocalTarball => Some("local_tarball"),
+        ResolutionTag::RemoteTarball => Some("remote_tarball"),
+        ResolutionTag::Symlink => Some("symlink"),
+        ResolutionTag::SingleFileModule => Some("single_file_module"),
+        ResolutionTag::Folder => Some("folder"),
+
+        // `.workspace` can come from `linkWorkspacePackages` rewriting a
+        // plain transitive semver; the parent's literal disambiguates.
+        ResolutionTag::Workspace => match literal_tag {
+            dependency::Tag::Uninitialized | dependency::Tag::Npm | dependency::Tag::DistTag => {
+                None
+            }
+            dependency::Tag::Catalog => None,
+            dependency::Tag::Folder => Some("folder"),
+            dependency::Tag::Symlink => Some("symlink"),
+            dependency::Tag::Workspace => Some("workspace"),
+            dependency::Tag::Git => Some("git"),
+            dependency::Tag::Github => Some("github"),
+            dependency::Tag::Tarball => Some("tarball"),
+        },
+
+        // Unknown tag (open u8 newtype): fail closed.
+        _ => Some("unknown"),
+    }
+}

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -45,6 +45,7 @@ use crate::package_manager_real::{
     save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
 };
 
+use super::block_exotic_subdeps;
 use super::security_scanner;
 
 pub fn install_with_manager(
@@ -713,6 +714,13 @@ pub fn install_with_manager(
         manager.verify_resolutions(log_level);
 
         super::package_json_write_back::edit_after_resolve(manager)?;
+
+        if manager.options.enable.block_exotic_subdeps() {
+            let violations = block_exotic_subdeps::enforce_block_exotic_subdeps(manager);
+            if violations > 0 {
+                Global::exit(1);
+            }
+        }
 
         if manager.options.security_scanner.is_some() {
             run_security_scanner(

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -260,6 +260,7 @@ pub mod api {
         pub hoist: Option<bool>,
         /// `offline = true`: `bun install` never touches the network.
         pub offline: Option<bool>,
+        pub block_exotic_subdeps: Option<bool>,
     }
 
     #[repr(u8)]

--- a/test/cli/install/block-exotic-subdeps.test.ts
+++ b/test/cli/install/block-exotic-subdeps.test.ts
@@ -1,0 +1,545 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+/**
+ * Tests for `install.blockExoticSubdeps` — a supply-chain hardening flag
+ * modeled on pnpm's option of the same name. When enabled, bun install
+ * rejects any *transitive* dependency that is specified with a non-registry
+ * source (file, folder, git, github, tarball URL, workspace, symlink).
+ * The root package's own direct deps are NOT restricted.
+ *
+ * https://pnpm.io/11.x/supply-chain-security#prevent-exotic-transitive-dependencies
+ */
+
+// Each test spawns `bun install` in its own tempDir. Point the install cache
+// at a per-test subdir so concurrent tests don't race on the shared cache
+// and so leftover state from unrelated runs can't affect resolution.
+function envForDir(dir: string): NodeJS.Dict<string> {
+  return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") };
+}
+
+describe.concurrent("install.blockExoticSubdeps", () => {
+  test("rejects a transitive file-folder dependency", async () => {
+    using dir = tempDir("block-exotic-transitive-folder", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        // Root's own direct dep is folder — that's allowed.
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      // parent-pkg is itself a folder dep at the root level (allowed),
+      // but it has a *transitive* folder dep "inner" — that's the violation.
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({
+        name: "inner",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    // parent-pkg pulled in a non-registry transitive — should be flagged.
+    expect(stderr).toContain("inner");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("allows exotic ROOT dependencies when flag is on", async () => {
+    // Root package uses a file: dep (exotic) but no exotic *transitives*.
+    using dir = tempDir("block-exotic-root-ok", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { leaf: "file:./leaf" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "leaf/package.json": JSON.stringify({
+        name: "leaf",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Should NOT complain — only direct root deps are exotic.
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).toBe(0);
+  });
+
+  test("default (flag unset) allows exotic transitives", async () => {
+    // Same fixture as the rejection case but with no bunfig setting —
+    // confirms the flag is opt-in and defaults to allowing exotic subdeps.
+    using dir = tempDir("block-exotic-default-off", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+      }),
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({
+        name: "inner",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).toBe(0);
+  });
+
+  test("explicit false allows exotic transitives", async () => {
+    using dir = tempDir("block-exotic-explicit-false", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = false
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({
+        name: "inner",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reports the exotic source tag in the error", async () => {
+    // Sanity: the error should identify the *kind* of exotic source
+    // (folder, local_tarball, git, ...) so the user knows what to audit.
+    using dir = tempDir("block-exotic-source-tag", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({
+        name: "inner",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Mentions the parent that pulled in the exotic dep.
+    expect(stderr).toContain("parent-pkg");
+    // Mentions the bad dep's name.
+    expect(stderr).toContain("inner");
+    // Mentions *which* non-registry source was used — "folder" for file:./x.
+    expect(stderr).toContain("folder");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("reads block-exotic-subdeps from .npmrc", async () => {
+    // .npmrc parity with the bunfig.toml key.
+    using dir = tempDir("block-exotic-npmrc", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+      }),
+      ".npmrc": "block-exotic-subdeps=true\n",
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({
+        name: "inner",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    expect(stderr).toContain("inner");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("rejects a transitive workspace: reference pulled in by a folder dep", async () => {
+    // If a non-workspace parent smuggles in a workspace: ref, that's exactly
+    // the kind of exotic transitive the flag exists to block.
+    using dir = tempDir("block-exotic-workspace-leak", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["pkgs/*"],
+        dependencies: {
+          // Root pulls in the folder dep directly (allowed at root level),
+          // but the folder dep itself references a workspace:* member,
+          // which is then a transitive workspace edge.
+          "folder-parent": "file:./folder-parent",
+        },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "folder-parent/package.json": JSON.stringify({
+        name: "folder-parent",
+        version: "1.0.0",
+        dependencies: { "ws-member": "workspace:*" },
+      }),
+      "pkgs/ws-member/package.json": JSON.stringify({
+        name: "ws-member",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    expect(stderr).toContain("ws-member");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("does NOT block a folder dep that uses a plain semver for a workspace member", async () => {
+    // Regression: `linkWorkspacePackages` (default true) redirects a
+    // transitive plain-semver dep to a local workspace copy, giving it
+    // `Resolution.Tag.workspace`. The folder parent's *specifier* is still
+    // a plain npm semver — nobody wrote `workspace:` — so this must NOT
+    // trip blockExoticSubdeps.
+    using dir = tempDir("block-exotic-link-workspace-semver", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["pkgs/*"],
+        dependencies: {
+          "folder-parent": "file:./folder-parent",
+        },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "folder-parent/package.json": JSON.stringify({
+        name: "folder-parent",
+        version: "1.0.0",
+        // Plain npm semver, NOT workspace:*. Bun's linkWorkspacePackages
+        // will still resolve this to the local ws-member copy.
+        dependencies: { "ws-member": "^1.0.0" },
+      }),
+      "pkgs/ws-member/package.json": JSON.stringify({
+        name: "ws-member",
+        version: "1.0.0",
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).toBe(0);
+  });
+
+  test("still blocks when root override is also exotic, and reports the override literal", async () => {
+    // An exotic-to-exotic override still trips the flag — and crucially the
+    // error message names the OVERRIDE's literal (not the transitive
+    // parent's), proving `enforceBlockExoticSubdeps` consulted the
+    // override map rather than the stale transitive spec.
+    using dir = tempDir("block-exotic-override-still-exotic", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+        overrides: { inner: "file:./inner-override" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      "inner/package.json": JSON.stringify({ name: "inner", version: "1.0.0" }),
+      "inner-override/package.json": JSON.stringify({ name: "inner", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    // The override's literal — NOT the transitive parent's `file:../inner` —
+    // is what must appear, proving we routed through the override.
+    expect(stderr).toContain("inner-override");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("does NOT block when root override redirects an exotic transitive to a registry version", async () => {
+    // The canonical mitigation path: override `inner` from its exotic
+    // folder specifier to a plain semver. With `linkWorkspacePackages`
+    // (default true) and a matching workspace member, the semver resolves
+    // locally — no network, no registry required — and the block does not
+    // fire because the override's literal (`^1.0.0`) is non-exotic.
+    using dir = tempDir("block-exotic-override-registry", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["pkgs/*"],
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+        overrides: { inner: "^1.0.0" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "file:../inner" },
+      }),
+      // Workspace member that `^1.0.0` satisfies. linkWorkspacePackages
+      // redirects the semver here offline.
+      "pkgs/inner/package.json": JSON.stringify({ name: "inner", version: "1.0.0" }),
+      // Original exotic target — left in place to prove that even though
+      // parent-pkg's literal still points here, the override wins.
+      "inner/package.json": JSON.stringify({ name: "inner", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The override's literal `^1.0.0` is plain npm semver, not exotic, so
+    // the block must NOT fire regardless of what parent-pkg wrote.
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).toBe(0);
+  });
+
+  test("blocks exotic specifiers that have attacker-controlled leading whitespace", async () => {
+    // `Dependency::parse` trims leading whitespace before classifying a
+    // specifier but stores the *untrimmed* string as `.literal`. classify()
+    // re-infers from that literal for `.workspace` resolutions, so it must
+    // trim the same way: untrimmed `" workspace:*"` mis-infers as a git
+    // SCP shorthand. The block must fire AND carry the correct `workspace`
+    // source label (asserted below), which pins the trim.
+    using dir = tempDir("block-exotic-whitespace-bypass", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["pkgs/*"],
+        dependencies: { "folder-parent": "file:./folder-parent" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      // One leading space before `workspace:` — JSON.stringify preserves
+      // whitespace inside string values verbatim, which is exactly the
+      // attacker vector this test exercises.
+      "folder-parent/package.json": JSON.stringify({
+        name: "folder-parent",
+        version: "1.0.0",
+        dependencies: { "ws-member": " workspace:*" },
+      }),
+      "pkgs/ws-member/package.json": JSON.stringify({ name: "ws-member", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    expect(stderr).toContain("ws-member");
+    // The source label must be `workspace`, not the git SCP shorthand the
+    // untrimmed literal would infer as — this is what pins the trim.
+    expect(stderr).toContain("via workspace source");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("does not claim a transitive 'catalog:' reference that fails to resolve", async () => {
+    // `catalog:` is only usable by workspace packages (pnpm parity), so a
+    // non-workspace folder parent writing `catalog:` fails resolution
+    // upstream of this flag. The flag must not mislabel that resolve
+    // failure as an exotic-subdep violation. classify() also keeps a
+    // catalog short-circuit as defense in case a catalog-dereferenced
+    // resolution ever reaches a checked edge again.
+    using dir = tempDir("block-exotic-catalog-transitive", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+        workspaces: {
+          catalog: { shared: "file:./shared" },
+        },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { shared: "catalog:" },
+      }),
+      "shared/package.json": JSON.stringify({ name: "shared", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The failure is the resolver's, not this flag's.
+    expect(stderr).toContain("failed to resolve");
+    expect(stderr).not.toContain("blockExoticSubdeps");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("blocks when a root override redirects a registry transitive to an exotic source", async () => {
+    // The transitive wrote a plain registry semver; the root's override is
+    // what introduces the non-registry source. The override literal is the
+    // effective specifier (it replaces the nested one before the check), so
+    // the block fires and the error names the override's own literal.
+    using dir = tempDir("block-exotic-override-introduces-exotic", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        dependencies: { "parent-pkg": "file:./parent-pkg" },
+        overrides: { inner: "file:./my-fork" },
+      }),
+      "bunfig.toml": `[install]
+blockExoticSubdeps = true
+`,
+      "parent-pkg/package.json": JSON.stringify({
+        name: "parent-pkg",
+        version: "1.0.0",
+        dependencies: { inner: "^1.0.0" },
+      }),
+      "my-fork/package.json": JSON.stringify({ name: "inner", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: envForDir(String(dir)),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("blockExoticSubdeps");
+    // Names the override's literal, making clear the user's own override
+    // is the non-registry source.
+    expect(stderr).toContain("my-fork");
+    expect(exitCode).not.toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #30336.

Adds a bunfig.toml option modeled on [pnpm's `blockExoticSubdeps`](https://pnpm.io/11.x/supply-chain-security#prevent-exotic-transitive-dependencies) that hardens against supply-chain attacks by refusing installs where a *transitive* dependency resolves to a non-registry source.

## What it does

```toml
# bunfig.toml
[install]
blockExoticSubdeps = true
```

With the flag on, `bun install` fails if any nested dependency resolves to:
- a git URL (`git+https://...`, `github:owner/repo`)
- a remote tarball URL
- a local tarball (`file:./foo.tgz`)
- a local folder (`file:./foo`)
- a symlink (`link:./foo`)
- a `workspace:*` ref pulled in by a non-workspace parent

Direct dependencies of the root package (and any workspace package) are **unaffected** — only *nested* deps are restricted. Default is `false`.

Also accepts `block-exotic-subdeps` in `.npmrc` for parity with other install options.

## Output

```
error: install.blockExoticSubdeps is enabled, but the following transitive dependencies use non-registry sources:
  parent-pkg@parent-pkg depends on inner via folder source (inner)

To allow these, unset install.blockExoticSubdeps in bunfig.toml.
```

## Where the check runs

Post-resolution, right after `verifyResolutions` in `install_with_manager.zig` — the same phase where the security scanner runs. At that point the lockfile is fully populated, so the walk is a single O(packages × deps/pkg) pass over `lockfile.packages` → `buffers.resolutions`, skipping edges whose parent is `.root` or `.workspace`.

## Files

- `src/options_types/schema.zig` — `BunInstall.block_exotic_subdeps: ?bool`
- `src/cli/bunfig.zig` — parse `install.blockExoticSubdeps`
- `src/ini/ini.zig` — parse `.npmrc` `block-exotic-subdeps`
- `src/install/PackageManager/PackageManagerOptions.zig` — `Enable.block_exotic_subdeps` + wire from config
- `src/install/PackageManager/block_exotic_subdeps.zig` — lockfile walk + error reporting (new file)
- `src/install/PackageManager/install_with_manager.zig` — call the enforcer after `verifyResolutions`
- `docs/runtime/bunfig.mdx` — user-facing doc entry
- `test/cli/install/block-exotic-subdeps.test.ts` — 5 tests covering rejection, top-level exemption, default-off, explicit-false, and error-message shape

## Verification

```
$ bun bd test test/cli/install/block-exotic-subdeps.test.ts
 5 pass
 0 fail
 13 expect() calls
```

Gate-checked: the rejection test fails on main (baseline has no error; exit 0) and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 26 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/block-exotic-subdeps.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/block-exotic-subdeps.test.ts:
52 |       stderr: "pipe",
53 |     });
54 | 
55 |     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
56 | 
57 |     expect(stderr).toContain("blockExoticSubdeps");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "blockExoticSubdeps"
Received: "Saved lockfile\n"

      at <anonymous> (/workspace/bun/test/cli/install/block-exotic-subdeps.test.ts:57:20)
(fail) install.blockExoticSubdeps > rejects a transitive file-folder dependency [229.46ms]
(pass) install.blockExoticSubdeps > allows exotic ROOT dependencies when flag is on [179.28ms]
(pass) install.blockExoticSubdeps > default (flag unset) allows exotic transitives [183.80ms]
193 |     });
194 | 
195 |     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
196 | 
197 |     // Mentions the parent that pulled in the ex
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/block-exotic-subdeps.test.ts:
52 |       stderr: "pipe",
53 |     });
54 | 
55 |     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
56 | 
57 |     expect(stderr).toContain("blockExoticSubdeps");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "blockExoticSubdeps"
Received: "Saved lockfile\n"

      at <anonymous> (/workspace/bun/test/cli/install/block-exotic-subdeps.test.ts:57:20)
193 |     });
194 | 
195 |     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
196 | 
197 |     // Mentions the parent that pulled in the exotic dep.
198 |     expect(stderr).toContain("parent-pkg");
                         ^
error: expect(received).toContain(expected)

Expected to contain: "parent-pkg"
Received: "Saved lockfile\n"

      at <anonymous> (/workspace/bun/test/cli/install/block-exotic-subdeps.test.ts:198:20)
231 |       stderr: "pipe",
232 |     });
233 | 
234 |     const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/block-exotic-subdeps.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/block-exotic-subdeps.test.ts:
(pass) install.blockExoticSubdeps > rejects a transitive file-folder dependency [201.73ms]
(pass) install.blockExoticSubdeps > allows exotic ROOT dependencies when flag is on [156.31ms]
(pass) install.blockExoticSubdeps > default (flag unset) allows exotic transitives [161.74ms]
(pass) install.blockExoticSubdeps > explicit false allows exotic transitives [165.09ms]
(pass) install.blockExoticSubdeps > reports the exotic source tag in the error [170.85ms]
(pass) install.blockExoticSubdeps > reads block-exotic-subdeps from .npmrc [160.82ms]
(pass) install.blockExoticSubdeps > rejects a transitive workspace: reference pulled in by a folder dep [159.56ms]
(pass) install.blockExoticSubdeps > does NOT block a folder dep that uses a plain semver for a workspace member [158.45ms]
(pass) install.blockExoticSubdeps > still blocks when root override is also exotic, and reports the override literal [170.58ms]
(pass) install.bloc
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 635ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7403ms)
Bundle modules (33ms)
Postprocesss modules (51ms)
Bundle Functions (661ms)
Generate Code (28ms)

[8.20s] Bundled "src/js" for production
  2624 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/bor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/bunfig.mdx                            |  32 ++
 src/bunfig/bunfig.rs                               |   7 +
 src/ini/lib.rs                                     |   6 +
 src/install/PackageManager.rs                      |   4 +
 .../PackageManager/PackageManagerOptions.rs        |  16 +-
 src/install/PackageManager/block_exotic_subdeps.rs | 208 ++++++++
 src/install/PackageManager/install_with_manager.rs |   8 +
 src/options_types/schema.rs                        |   1 +
 test/cli/install/block-exotic-subdeps.test.ts      | 545 +++++++++++++++++++++
 9 files changed, 826 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 26

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
docs/runtime/bunfig.mdx                                  5      5    100
src/bunfig/bunfig.rs                                     2      2    100
src/ini/lib.rs                                           2      2    100
src/install/PackageManager.rs                            5      8    100
src/install/PackageManager/PackageManagerOptions.rs     10     10    100
src/install/PackageManager/block_exotic_subdeps.rs      19     38    100
src/install/PackageManager/install_with_manager.rs       6      8    100
src/options_types/schema.rs                              4      5    100
test/cli/install/block-exotic-subdeps.test.ts           22     25    100
```

</details>

<!-- robobun:evidence:end -->