### PR TITLE
Validate `app.bundlerOptions` is an object in `Bun.serve`

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "ssr", ssr_options);
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime property_name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ property_name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const enable = minify_options.asBoolean();
+                options.minify_syntax = enable;
+                options.minify_identifiers = enable;
+                options.minify_whitespace = enable;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ property_name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -670,3 +670,43 @@ describe("Bun.serve unix socket validation", () => {
     }
   });
 });
+
+describe("Bun.serve app.bundlerOptions validation", () => {
+  const primitives = [42, true, false, "hello", Symbol("x"), 1n];
+
+  test("non-object bundlerOptions throws", () => {
+    for (const value of primitives) {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        serve({ app: { bundlerOptions: value } });
+      }).toThrow("'app.bundlerOptions' must be an object");
+    }
+  });
+
+  test.each(["server", "client", "ssr"])("non-object bundlerOptions.%s throws", key => {
+    for (const value of primitives) {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        serve({ app: { bundlerOptions: { [key]: value } } });
+      }).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+    }
+  });
+
+  test("non-object/non-boolean bundlerOptions.server.minify throws", () => {
+    for (const value of [42, "hello", Symbol("x"), 1n]) {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        serve({ app: { bundlerOptions: { server: { minify: value } } } });
+      }).toThrow("'app.bundlerOptions.server.minify' must be a boolean or an object");
+    }
+  });
+
+  test("boolean bundlerOptions.server.minify does not crash", () => {
+    for (const value of [true, false]) {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        serve({ app: { bundlerOptions: { server: { minify: value } } } });
+      }).toThrow("'app' is missing 'framework'");
+    }
+  });
+});


### PR DESCRIPTION
Found by Fuzzilli (fingerprint `86855f8bedcf582b`).

Passing a primitive value for `app.bundlerOptions`, or for its `server` / `client` / `ssr` sub-options, hit a debug assertion in `JSValue.get()` because the code called property accessors on a non-object without validating first. The `minify` option had the same problem, and additionally `minify: false` fell through to the object path and asserted as well.

```js
Bun.serve({ app: { bundlerOptions: { server: 42 } } });
// panic(main thread): reached unreachable code
//   JSValue.get (target.isObject() assertion)
//   BuildConfigSubset.fromJS (bake.zig:208)
```

Now these cases throw a `TypeError` describing which property was invalid.