### PR TITLE
escapeHTML: collapse comptime-unrolled scalar path into a runtime loop

### DIFF
--- a/src/string/immutable/escapeHTML.zig
+++ b/src/string/immutable/escapeHTML.zig
@@ -49,32 +49,25 @@ pub fn escapeHTMLForLatin1Input(allocator: std.mem.Allocator, latin1: []const u8
             };
         }
 
-        pub fn push(comptime len: anytype, chars_: *const [len]u8, allo: std.mem.Allocator) callconv(bun.callconv_inline) Escaped(u8) {
-            const chars = chars_.*;
+        pub fn push(chars: []const u8, allo: std.mem.Allocator) Escaped(u8) {
             var total: usize = 0;
-
-            comptime var remain_to_comp = len;
-            comptime var comp_i = 0;
-
-            inline while (remain_to_comp > 0) : (remain_to_comp -= 1) {
-                total += lengths[chars[comp_i]];
-                comp_i += 1;
+            for (chars) |c| {
+                total += lengths[c];
             }
 
-            if (total == len) {
+            if (total == chars.len) {
                 return .{ .original = {} };
             }
 
             const output = allo.alloc(u8, total) catch unreachable;
             var head = output.ptr;
-            inline for (comptime bun.range(0, len)) |i| {
-                head += @This().append(head, chars[i]);
+            for (chars) |c| {
+                head += @This().append(head, c);
             }
 
             return Escaped(u8){ .allocated = output };
         }
     };
-    @setEvalBranchQuota(5000);
     switch (latin1.len) {
         0 => return Escaped(u8){ .static = "" },
         1 => return switch (latin1[0]) {
@@ -110,36 +103,7 @@ pub fn escapeHTMLForLatin1Input(allocator: std.mem.Allocator, latin1: []const u8
         },
 
         // The simd implementation is slower for inputs less than 32 bytes.
-        3 => return Scalar.push(3, latin1[0..3], allocator),
-        4 => return Scalar.push(4, latin1[0..4], allocator),
-        5 => return Scalar.push(5, latin1[0..5], allocator),
-        6 => return Scalar.push(6, latin1[0..6], allocator),
-        7 => return Scalar.push(7, latin1[0..7], allocator),
-        8 => return Scalar.push(8, latin1[0..8], allocator),
-        9 => return Scalar.push(9, latin1[0..9], allocator),
-        10 => return Scalar.push(10, latin1[0..10], allocator),
-        11 => return Scalar.push(11, latin1[0..11], allocator),
-        12 => return Scalar.push(12, latin1[0..12], allocator),
-        13 => return Scalar.push(13, latin1[0..13], allocator),
-        14 => return Scalar.push(14, latin1[0..14], allocator),
-        15 => return Scalar.push(15, latin1[0..15], allocator),
-        16 => return Scalar.push(16, latin1[0..16], allocator),
-        17 => return Scalar.push(17, latin1[0..17], allocator),
-        18 => return Scalar.push(18, latin1[0..18], allocator),
-        19 => return Scalar.push(19, latin1[0..19], allocator),
-        20 => return Scalar.push(20, latin1[0..20], allocator),
-        21 => return Scalar.push(21, latin1[0..21], allocator),
-        22 => return Scalar.push(22, latin1[0..22], allocator),
-        23 => return Scalar.push(23, latin1[0..23], allocator),
-        24 => return Scalar.push(24, latin1[0..24], allocator),
-        25 => return Scalar.push(25, latin1[0..25], allocator),
-        26 => return Scalar.push(26, latin1[0..26], allocator),
-        27 => return Scalar.push(27, latin1[0..27], allocator),
-        28 => return Scalar.push(28, latin1[0..28], allocator),
-        29 => return Scalar.push(29, latin1[0..29], allocator),
-        30 => return Scalar.push(30, latin1[0..30], allocator),
-        31 => return Scalar.push(31, latin1[0..31], allocator),
-        32 => return Scalar.push(32, latin1[0..32], allocator),
+        3...32 => return Scalar.push(latin1, allocator),
 
         else => {
             var remaining = latin1;


### PR DESCRIPTION
## Summary

`escapeHTMLForLatin1Input` had 30 fully inline-unrolled specializations of
`Scalar.push` — one per input length 3..32 — producing a 113 KB function in
release builds. This PR replaces them with a single runtime loop, shrinking
the function to ~12 KB and the overall binary by ~99 KB.

| | before | after |
|---|---|---|
| `escapeHTMLForLatin1Input` (`__text`) | 113,004 B | 11,756 B |
| release binary (arm64-darwin) | 61,878,048 B | 61,778,976 B |

## Performance

Benchmarked `Bun.escapeHTML` on 3–32 byte inputs (the affected path) and
on >32 byte inputs (unchanged SIMD path), 3 alternating rounds of 5
runs each on Apple M4 Max, taking the median:

| input | before (ns) | after (ns) | Δ |
|---|---|---|---|
| len=3 clean | 18.0 / 18.3 | 17.5 / 17.5 | −3 % |
| len=3 dirty | 43.6 / 43.2 | 41.3 / 41.2 | −5 % |
| len=8 dirty | 53.5 / 52.1 | 51.8 / 51.2 | −2.5 % |
| len=16 clean | 21.6 / 21.2 | 19.0 / 18.1 | −13 % |
| len=24 clean | 26.0 / 25.6 | 24.1 / 22.7 | −10 % |
| len=32 clean | 28.4 / 28.0 | 25.4 / 24.6 | −11 % |
| len=64 SIMD clean (unchanged) | 20.1 / 19.8 | 19.9 / 18.7 | within noise |
| len=64 SIMD dirty (unchanged) | 217 / 212 | 216 / 215 | within noise |

No regression — slightly *faster*, since the function now fits comfortably
in L1 instruction cache (the per-length branches in the old switch each had
to load up to 4 KB of unique unrolled code).

## Test plan

- [x] `bun bd test test/js/bun/util/escapeHTML.test.js` — 4 pass / 0 fail
- [x] release build link verified (linker map shows `Scalar.push` is inlined,
      no extra symbol)
- [ ] CI