### PR TITLE
worker: unregister ScriptExecutionContext eagerly on teardown

### DIFF
--- a/src/jsc/bindings/ScriptExecutionContext.cpp
+++ b/src/jsc/bindings/ScriptExecutionContext.cpp
@@ -209,10 +209,21 @@ void ScriptExecutionContext::addToContextsMap()
     Locker locker { allScriptExecutionContextsMapLock };
     ASSERT(!allScriptExecutionContextsMap().contains(m_identifier));
     allScriptExecutionContextsMap().add(m_identifier, this);
+    m_isInContextsMap = true;
 }
 
 void ScriptExecutionContext::removeFromContextsMap()
 {
+    // Idempotent: worker teardown removes the entry eagerly (before the
+    // final GC) so nested workers' dispatchExit/dispatchError can't post to
+    // a VM that is about to set has_terminated. ~GlobalObject — which runs
+    // whenever GC eventually collects the global, possibly never before
+    // vm.deinit() — calls this again; the flag short-circuits that second
+    // call so the ASSERT-free remove() isn't needed and we still catch real
+    // mismatches via the destructor's !contains() ASSERT.
+    if (!m_isInContextsMap)
+        return;
+    m_isInContextsMap = false;
     Locker locker { allScriptExecutionContextsMapLock };
     ASSERT(allScriptExecutionContextsMap().contains(m_identifier));
     allScriptExecutionContextsMap().remove(m_identifier);

--- a/src/jsc/bindings/ScriptExecutionContext.h
+++ b/src/jsc/bindings/ScriptExecutionContext.h
@@ -138,6 +138,13 @@ private:
     JSC::JSGlobalObject* m_globalObject = nullptr;
     WTF::URL m_url = WTF::URL();
     ScriptExecutionContextIdentifier m_identifier;
+    // Tracks whether m_identifier is currently registered in the global
+    // contexts map. Worker teardown removes the entry explicitly (so child
+    // workers' dispatchExit sees the context as gone instead of posting to a
+    // terminated VM) and ~GlobalObject may try again once GC finally collects
+    // the global; the flag makes the second call a no-op. Only written on the
+    // context's own thread.
+    bool m_isInContextsMap { false };
 
     UncheckedKeyHashSet<ContextDestructionObserver*> m_destructionObservers;
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -551,6 +551,20 @@ extern "C" void WebWorker__teardownJSCVM(Zig::GlobalObject* globalObject)
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // TODO: handle or assert none?
         vm.deleteAllCode(JSC::DeleteAllCodeEffort::PreventCollectionAndDeleteAllCode);
+        // Take the context out of the global map now rather than relying on
+        // the collect below to finalize ~GlobalObject and do it. That collect
+        // is best-effort: any JSC::Strong, conservative stack root, or
+        // DOM object with hasPendingActivity (e.g. an entangled MessagePort
+        // with a listener) keeps the global marked, so ~GlobalObject may not
+        // run before shutdown() proceeds to vm.deinit() and sets
+        // has_terminated. A nested child worker's dispatchExit posting to
+        // this context between those two points would then trip the
+        // enqueueTaskConcurrent has_terminated assert. Removing the entry
+        // here makes postTaskTo() return false instead. ~GlobalObject's
+        // later removeFromContextsMap() is a no-op once m_isInContextsMap
+        // is cleared.
+        if (auto* ctx = globalObject->scriptExecutionContext())
+            ctx->removeFromContextsMap();
         gcUnprotect(globalObject);
         globalObject = nullptr;
     }


### PR DESCRIPTION
The GC collect inside teardownJSCVM is best-effort: any JSC::Strong, conservative stack root, or DOM object with hasPendingActivity (e.g. an entangled MessagePort with a listener) keeps the global marked. When ~GlobalObject doesn't run before shutdown() reaches vm.deinit() / arena_.deinit(), the context stays registered in allScriptExecutionContextsMap with a dangling pointer. Any concurrent postTaskTo — such as the main thread still sending postMessage to a worker that threw on its first message — would find the stale entry and write into freed memory, crashing in mi_malloc.

Fix: remove the context from the map explicitly in WebWorker__teardownJSCVM before gcUnprotect, while the globalObject is still alive. This makes postTaskTo() return false deterministically once teardown begins.

Make removeFromContextsMap() idempotent via an m_isInContextsMap flag so ~GlobalObject's later call (whenever GC eventually collects the global) is a no-op rather than an assertion failure.

Fixes: #30348
