### PR TITLE
test_command: make status a runtime parameter in reporter functions

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1766,7 +1766,12 @@ mod draft {
                     .store(handle as *mut core::ffi::c_void, Ordering::Relaxed);
             }
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             reset_on_posix();
         }
@@ -2907,7 +2912,12 @@ mod draft {
             let _ = spawn_result;
             let _ = url;
         }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "android",
+            target_os = "freebsd"
+        ))]
         {
             let mut buf = bun_core::PathBuffer::default();
             let mut buf2 = bun_core::PathBuffer::default();

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -409,7 +409,12 @@ mod errno_name_tests {
         assert_eq!(Error::from_errno(0), Error::UNEXPECTED);
         assert_eq!(Error::from_errno(9999), Error::UNEXPECTED);
         // errno 11 is platform-specific: EAGAIN on linux/windows, EDEADLK on darwin/bsd.
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         {
             assert_eq!(Error::from_errno(11), Error::intern("EAGAIN"));
             assert_eq!(Error::from_errno(104), Error::intern("ECONNRESET"));
@@ -464,7 +469,12 @@ mod errno_name_tests {
             coreutils_error_map::get(2),
             Some("No such file or directory")
         );
-        #[cfg(any(target_os = "linux", target_os = "android", windows, target_family = "wasm"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            windows,
+            target_family = "wasm"
+        ))]
         assert_eq!(
             coreutils_error_map::get(11),
             Some("Resource temporarily unavailable")

--- a/src/perf/tracy.rs
+++ b/src/perf/tracy.rs
@@ -756,7 +756,12 @@ fn dlsym<T: Copy>(symbol: &'static core::ffi::CStr) -> Option<T> {
                 ];
                 #[cfg(windows)]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[c"tracy.dll"];
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+                #[cfg(not(any(
+                    target_os = "macos",
+                    target_os = "linux",
+                    target_os = "android",
+                    windows
+                )))]
                 const PATHS_TO_TRY: &[&core::ffi::CStr] = &[];
 
                 // TODO(port): RTLD flags — Zig used `@bitCast(@as(i32, -2))` on

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -679,7 +679,10 @@ pub const BASE_RUNTIME_TRANSPILER_PARAMS: &[ParamType] =
 // built with `comptime_table!(.., cold)` and stay in plain `.rodata`, where
 // `src/startup.order` can still cluster the ones a sampled cold path actually
 // hits without weighing down the `.rodata.startup` fault-around window.
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".rodata.startup"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".rodata.startup")
+)]
 pub static AUTO_TABLE: &clap::ConvertedTable = clap::comptime_table!(AUTO_PARAMS);
 pub static RUN_TABLE: &clap::ConvertedTable = clap::comptime_table!(RUN_PARAMS, cold);
 pub static BUILD_TABLE: &clap::ConvertedTable = clap::comptime_table!(BUILD_PARAMS, cold);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -552,7 +552,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// not share `.text` pages with the hot `bun run <script>` dispatch path.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn configure_run_transpiler_linker(this_transpiler: &mut Transpiler<'static>) {
         this_transpiler.resolver.opts.load_tsconfig_json = true;
         this_transpiler.options.load_tsconfig_json = true;
@@ -870,7 +873,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// initializing JSC.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_bun_shell(
         ctx: &mut ContextData,
         entry_path: &[u8],
@@ -1669,7 +1675,10 @@ fn log_clear_msgs(vm: &mut VirtualMachine) {
 
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
     if let Some(log) = vm.log {
@@ -1689,7 +1698,10 @@ fn dump_build_error(vm: &mut VirtualMachine) {
 /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
@@ -1703,7 +1715,10 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! {
     if log_has_msgs(vm) {
         dump_build_error(vm);
@@ -1722,7 +1737,10 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &bun_core::Error) -> ! 
 /// exit: bump the exit code and print the sourcemap note + version string.
 #[cold]
 #[inline(never)]
-#[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
 fn print_unhandled_version_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
@@ -1762,7 +1780,10 @@ impl RunCommand {
     /// `.text.hot` fault-around window the `require('fs')` startup path pulls in.
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn boot_failed_exit(ctx: &mut ContextData, display_name: &[u8], err: &bun_core::Error) -> ! {
         // SAFETY: `ctx.log` was set in `create_context_data` (single-threaded
         // CLI startup) and is process-lifetime.
@@ -3022,7 +3043,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_missing_script() -> ! {
         Output::err_generic(
             "Missing script to execute. Bun's provided 'node' cli wrapper does not support a repl.",
@@ -3033,7 +3057,10 @@ impl RunCommand {
 
     #[cold]
     #[inline(never)]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"), unsafe(link_section = ".text.unlikely"))]
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "android"),
+        unsafe(link_section = ".text.unlikely")
+    )]
     fn exec_as_if_node_boot_failed(
         ctx: &mut ContextData,
         basename: &[u8],

--- a/src/runtime/cli/test_command.zig
+++ b/src/runtime/cli/test_command.zig
@@ -39,31 +39,22 @@ pub fn escapeXml(str: string, writer: anytype) !void {
         try writer.writeAll(str[last..]);
     }
 }
-fn fmtStatusTextLine(status: bun_test.Execution.Result, emoji_or_color: bool) []const u8 {
+fn fmtStatusTextLine(status: bun_test.Execution.Result, comptime emoji_or_color: bool) []const u8 {
     // emoji and color might be split into two different options in the future
     // some terminals support color, but not emoji.
     // For now, they are the same.
-    return switch (emoji_or_color) {
-        true => switch (status.basicResult()) {
-            .pending => Output.prettyFmt("<r><d>…<r>", emoji_or_color),
-            .pass => Output.prettyFmt("<r><green>✓<r>", emoji_or_color),
-            .fail => Output.prettyFmt("<r><red>✗<r>", emoji_or_color),
-            .skip => Output.prettyFmt("<r><yellow>»<d>", emoji_or_color),
-            .todo => Output.prettyFmt("<r><magenta>✎<r>", emoji_or_color),
-        },
-        else => switch (status.basicResult()) {
-            .pending => Output.prettyFmt("<r><d>(pending)<r>", emoji_or_color),
-            .pass => Output.prettyFmt("<r><green>(pass)<r>", emoji_or_color),
-            .fail => Output.prettyFmt("<r><red>(fail)<r>", emoji_or_color),
-            .skip => Output.prettyFmt("<r><yellow>(skip)<d>", emoji_or_color),
-            .todo => Output.prettyFmt("<r><magenta>(todo)<r>", emoji_or_color),
-        },
+    return switch (status.basicResult()) {
+        .pending => comptime Output.prettyFmt(if (emoji_or_color) "<r><d>…<r>" else "<r><d>(pending)<r>", emoji_or_color),
+        .pass => comptime Output.prettyFmt(if (emoji_or_color) "<r><green>✓<r>" else "<r><green>(pass)<r>", emoji_or_color),
+        .fail => comptime Output.prettyFmt(if (emoji_or_color) "<r><red>✗<r>" else "<r><red>(fail)<r>", emoji_or_color),
+        .skip => comptime Output.prettyFmt(if (emoji_or_color) "<r><yellow>»<d>" else "<r><yellow>(skip)<d>", emoji_or_color),
+        .todo => comptime Output.prettyFmt(if (emoji_or_color) "<r><magenta>✎<r>" else "<r><magenta>(todo)<r>", emoji_or_color),
     };
 }
 
-pub fn writeTestStatusLine(comptime status: bun_test.Execution.Result, writer: anytype) void {
+pub fn writeTestStatusLine(status: bun_test.Execution.Result, writer: anytype) void {
     switch (Output.enable_ansi_colors_stderr) {
-        inline else => |enable_ansi_colors_stderr| writer.print(comptime fmtStatusTextLine(status, enable_ansi_colors_stderr), .{}) catch unreachable,
+        inline else => |enable_ansi_colors_stderr| writer.writeAll(fmtStatusTextLine(status, enable_ansi_colors_stderr)) catch unreachable,
     }
 }
 
@@ -603,7 +594,7 @@ pub const CommandLineReporter = struct {
     pub fn handleTestStart(_: *TestRunner.Callback, _: Test.ID) void {}
 
     fn printTestLine(
-        comptime status: bun_test.Execution.Result,
+        status: bun_test.Execution.Result,
         sequence: *bun_test.Execution.ExecutionSequence,
         test_entry: *bun_test.ExecutionEntry,
         elapsed_ns: u64,
@@ -632,29 +623,27 @@ pub const CommandLineReporter = struct {
                 false => .{ "", "<r><b>" },
             };
 
-            switch (Output.enable_ansi_colors_stderr) {
-                inline else => |_| switch (status) {
-                    .fail_because_expected_assertion_count => {
-                        // not sent to writer so it doesn't get printed twice
-                        const expected_count = if (sequence.expect_assertions == .exact) sequence.expect_assertions.exact else 12345;
-                        Output.err(error.AssertionError, "expected <green>{d} assertion{s}<r>, but test ended with <red>{d} assertion{s}<r>\n", .{
-                            expected_count,
-                            if (expected_count == 1) "" else "s",
-                            sequence.expect_call_count,
-                            if (sequence.expect_call_count == 1) "" else "s",
-                        });
-                        Output.flush();
-                    },
-                    .fail_because_expected_has_assertions => {
-                        Output.err(error.AssertionError, "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n", .{});
-                        Output.flush();
-                    },
-                    .fail_because_timeout, .fail_because_hook_timeout, .fail_because_timeout_with_done_callback, .fail_because_hook_timeout_with_done_callback => if (Output.is_github_action) {
-                        Output.printError("::error title=error: Test \"{s}\" timed out after {d}ms::\n", .{ display_label, test_entry.timeout });
-                        Output.flush();
-                    },
-                    else => {},
+            switch (status) {
+                .fail_because_expected_assertion_count => {
+                    // not sent to writer so it doesn't get printed twice
+                    const expected_count = if (sequence.expect_assertions == .exact) sequence.expect_assertions.exact else 12345;
+                    Output.err(error.AssertionError, "expected <green>{d} assertion{s}<r>, but test ended with <red>{d} assertion{s}<r>\n", .{
+                        expected_count,
+                        if (expected_count == 1) "" else "s",
+                        sequence.expect_call_count,
+                        if (sequence.expect_call_count == 1) "" else "s",
+                    });
+                    Output.flush();
                 },
+                .fail_because_expected_has_assertions => {
+                    Output.err(error.AssertionError, "received <red>0 assertions<r>, but expected <green>at least one assertion<r> to be called\n", .{});
+                    Output.flush();
+                },
+                .fail_because_timeout, .fail_because_hook_timeout, .fail_because_timeout_with_done_callback, .fail_because_hook_timeout_with_done_callback => if (Output.is_github_action) {
+                    Output.printError("::error title=error: Test \"{s}\" timed out after {d}ms::\n", .{ display_label, test_entry.timeout });
+                    Output.flush();
+                },
+                else => {},
             }
 
             if (Output.enable_ansi_colors_stderr) {
@@ -725,7 +714,7 @@ pub const CommandLineReporter = struct {
     }
 
     fn maybePrintJunitLine(
-        comptime status: bun_test.Execution.Result,
+        status: bun_test.Execution.Result,
         buntest: *bun_test.BunTest,
         sequence: *bun_test.Execution.ExecutionSequence,
         test_entry: *bun_test.ExecutionEntry,
@@ -881,43 +870,40 @@ pub const CommandLineReporter = struct {
         const base_writer = output_buf.writer(buntest.gpa);
         var writer = base_writer;
 
-        switch (sequence.result) {
-            inline else => |result| {
-                if (result != .skipped_because_label) {
-                    if (buntest.reporter != null and buntest.reporter.?.reporters.dots and (comptime switch (result.basicResult()) {
-                        .pass, .skip, .todo, .pending => true,
-                        .fail => false,
-                    })) {
-                        switch (Output.enable_ansi_colors_stderr) {
-                            inline else => |enable_ansi_colors_stderr| switch (comptime result.basicResult()) {
-                                .pass => writer.print(comptime Output.prettyFmt("<r><green>.<r>", enable_ansi_colors_stderr), .{}) catch {},
-                                .skip => writer.print(comptime Output.prettyFmt("<r><yellow>.<d>", enable_ansi_colors_stderr), .{}) catch {},
-                                .todo => writer.print(comptime Output.prettyFmt("<r><magenta>.<r>", enable_ansi_colors_stderr), .{}) catch {},
-                                .pending => writer.print(comptime Output.prettyFmt("<r><d>.<r>", enable_ansi_colors_stderr), .{}) catch {},
-                                .fail => writer.print(comptime Output.prettyFmt("<r><red>.<r>", enable_ansi_colors_stderr), .{}) catch {},
-                            },
-                        }
-                        buntest.reporter.?.last_printed_dot = true;
-                    } else if (((comptime result.basicResult()) != .fail) and (buntest.reporter != null and buntest.reporter.?.reporters.only_failures)) {
-                        // when using --only-failures, only print failures
-                    } else {
-                        buntest.bun_test_root.onBeforePrint();
-
-                        writeTestStatusLine(result, &writer);
-                        const dim = switch (comptime result.basicResult()) {
-                            .todo => if (bun.jsc.Jest.Jest.runner) |runner| !runner.run_todo else true,
-                            .skip, .pending => true,
-                            .pass, .fail => false,
-                        };
-                        switch (dim) {
-                            inline else => |dim_comptime| printTestLine(result, sequence, test_entry, elapsed_ns, &writer, dim_comptime),
-                        }
-                    }
+        const result = sequence.result;
+        if (result != .skipped_because_label) {
+            if (buntest.reporter != null and buntest.reporter.?.reporters.dots and switch (result.basicResult()) {
+                .pass, .skip, .todo, .pending => true,
+                .fail => false,
+            }) {
+                switch (Output.enable_ansi_colors_stderr) {
+                    inline else => |enable_ansi_colors_stderr| switch (result.basicResult()) {
+                        .pass => writer.print(comptime Output.prettyFmt("<r><green>.<r>", enable_ansi_colors_stderr), .{}) catch {},
+                        .skip => writer.print(comptime Output.prettyFmt("<r><yellow>.<d>", enable_ansi_colors_stderr), .{}) catch {},
+                        .todo => writer.print(comptime Output.prettyFmt("<r><magenta>.<r>", enable_ansi_colors_stderr), .{}) catch {},
+                        .pending => writer.print(comptime Output.prettyFmt("<r><d>.<r>", enable_ansi_colors_stderr), .{}) catch {},
+                        .fail => writer.print(comptime Output.prettyFmt("<r><red>.<r>", enable_ansi_colors_stderr), .{}) catch {},
+                    },
                 }
-                // always print junit if needed
-                maybePrintJunitLine(result, buntest, sequence, test_entry, elapsed_ns);
-            },
+                buntest.reporter.?.last_printed_dot = true;
+            } else if (result.basicResult() != .fail and (buntest.reporter != null and buntest.reporter.?.reporters.only_failures)) {
+                // when using --only-failures, only print failures
+            } else {
+                buntest.bun_test_root.onBeforePrint();
+
+                writeTestStatusLine(result, &writer);
+                const dim = switch (result.basicResult()) {
+                    .todo => if (bun.jsc.Jest.Jest.runner) |runner| !runner.run_todo else true,
+                    .skip, .pending => true,
+                    .pass, .fail => false,
+                };
+                switch (dim) {
+                    inline else => |dim_comptime| printTestLine(result, sequence, test_entry, elapsed_ns, &writer, dim_comptime),
+                }
+            }
         }
+        // always print junit if needed
+        maybePrintJunitLine(result, buntest, sequence, test_entry, elapsed_ns);
 
         const formatted_line = output_buf.items[initial_length..];
         if (buntest.reporter != null and buntest.reporter.?.worker_ipc_file_idx != null) {

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -515,7 +515,12 @@ impl UpgradeCommand {
         {
             "powershell -c 'irm bun.sh/install.ps1|iex'"
         }
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "windows")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "macos",
+            target_os = "windows"
+        )))]
         {
             // TODO(port): Environment.os.displayString() at comptime
             "(TODO: Install script for this platform)"

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4499,13 +4499,14 @@ pub(crate) fn resolve_embedded_file_to_buf(
     // Spec ModuleLoader.zig:43-45 — `tmpname(extname, buf, bun.hash(file.name))`.
     let mut tmpname_buf = bun_paths::path_buffer_pool::get();
     let tmpfilename =
-        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name))
-            .ok()?;
+        Fs::FileSystem::tmpname(extname, &mut tmpname_buf[..], bun_wyhash::hash(file_name)).ok()?;
 
     // Spec ModuleLoader.zig:47 — `bun.fs.FileSystem.instance.tmpdir()`.
     // SAFETY: `FileSystem::instance()` returns the process-global singleton
     // pointer (initialized at startup).
-    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() }).tmpdir().ok()?;
+    let tmpdir = (unsafe { &mut *Fs::FileSystem::instance() })
+        .tmpdir()
+        .ok()?;
     let tmpdir_fd: bun_sys::Fd = tmpdir.fd;
 
     // Spec ModuleLoader.zig:50-51 — `bun.Tmpfile.create(tmpdir, tmpfilename)`.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -358,7 +358,10 @@ fn find_playwright_shell() -> Option<ZBox> {
     }
 
     // Fall back to the non-cft linux arm64 layout.
-    #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))]
+    #[cfg(all(
+        any(target_os = "linux", target_os = "android"),
+        target_arch = "aarch64"
+    ))]
     {
         let bin_parts2: [&[u8]; 3] = [
             cache_dir,
@@ -633,7 +636,12 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
         b"BraveSoftware\\Brave-Browser\\User Data\\DevToolsActivePort",
         b"Microsoft\\Edge\\User Data\\DevToolsActivePort",
     ];
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android", windows)))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        windows
+    )))]
     let candidates: &[&[u8]] = &[];
 
     let mut path_buf = path_buffer_pool::get();

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -3224,7 +3224,10 @@ mod spawn_process_body {
             // that are read *after* the wait, so falling through to the memfd block
             // below is required.
             let status: Status = 'blk: {
-                if no_orphans && (cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos")) {
+                if no_orphans
+                    && (cfg!(any(target_os = "linux", target_os = "android"))
+                        || cfg!(target_os = "macos"))
+                {
                     let ppid = ParentDeathWatchdog::ppid_to_watch().unwrap_or(0);
                     #[cfg(target_os = "macos")]
                     let r: Option<Maybe<Status>> = wait_mac_kqueue(
@@ -3245,7 +3248,11 @@ mod spawn_process_body {
                         &mut out_fds_to_wait_for,
                         &mut out_fds,
                     );
-                    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+                    #[cfg(not(any(
+                        target_os = "linux",
+                        target_os = "android",
+                        target_os = "macos"
+                    )))]
                     let r: Option<Maybe<Status>> = {
                         let _ = ppid;
                         None

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -775,7 +775,10 @@ pub fn spawn_process_posix(
     let mut dup_stdout_to_stderr: bool = false;
 
     // The label is only referenced from the Linux memfd fast-path below.
-    #[cfg_attr(not(any(target_os = "linux", target_os = "android")), allow(unused_labels))]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "android")),
+        allow(unused_labels)
+    )]
     'stdio: for i in 0..3usize {
         let fileno = Fd::from_native(FdT::try_from(i).unwrap());
         let flag: u32 = (if i == 0 {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1307,7 +1307,7 @@ describe("bun test", () => {
             test.todo("todo that passes", () => { expect(1).toBe(1); });
             test("has-assertions fail", () => { expect.hasAssertions(); });
             test("assertion-count fail", () => { expect.assertions(5); expect(1).toBe(1); });
-            test("timeout", async () => { await new Promise(r => setTimeout(r, 50)); }, 1);
+            test("timeout", async () => { await Bun.sleep(50); }, 1);
             test("timeout with done", (done) => { setTimeout(done, 50); }, 1);
           });
         });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1290,6 +1290,57 @@ describe("bun test", () => {
     `);
   });
 
+  test("reporter output for each test result status", () => {
+    // Exercises every Execution.Result variant so the per-status reporter
+    // formatting (status marker, scope chain, explanation lines) stays locked down.
+    const stderr = runTest({
+      args: ["--todo"],
+      input: `
+        import { test, expect, describe } from "bun:test";
+        describe("outer", () => {
+          describe("inner", () => {
+            test("pass", () => { expect(1).toBe(1); });
+            test("fail", () => { expect(1).toBe(2); });
+            test.skip("skip", () => {});
+            test.todo("todo");
+            test.failing("failing that passes", () => { expect(1).toBe(1); });
+            test.todo("todo that passes", () => { expect(1).toBe(1); });
+            test("has-assertions fail", () => { expect.hasAssertions(); });
+            test("assertion-count fail", () => { expect.assertions(5); expect(1).toBe(1); });
+            test("timeout", async () => { await new Promise(r => setTimeout(r, 50)); }, 1);
+            test("timeout with done", (done) => { setTimeout(done, 50); }, 1);
+          });
+        });
+      `,
+      env: { GITHUB_ACTIONS: undefined, CI: undefined },
+    });
+    // Keep only the reporter-generated lines: status markers, the "  ^ this test ..."
+    // explanations, and the AssertionError lines printed for expect.assertions/hasAssertions.
+    const lines = stderr
+      .replace(/ \[[\d.]+m?s\]/g, "")
+      .replace(/after \d+ms/g, "after Nms")
+      .split("\n")
+      .filter(line => /^\((pass|fail|skip|todo)\) |^  \^ |^AssertionError:/.test(line));
+    expect(lines.join("\n")).toMatchInlineSnapshot(`
+      "(pass) outer > inner > pass
+      (fail) outer > inner > fail
+      (skip) outer > inner > skip
+      (todo) outer > inner > todo
+      (fail) outer > inner > failing that passes
+        ^ this test is marked as failing but it passed. Remove \`.failing\` if tested behavior now works
+      (fail) outer > inner > todo that passes
+        ^ this test is marked as todo but passes. Remove \`.todo\` if tested behavior now works
+      AssertionError: received 0 assertions, but expected at least one assertion to be called
+      (fail) outer > inner > has-assertions fail
+      AssertionError: expected 5 assertions, but test ended with 1 assertion
+      (fail) outer > inner > assertion-count fail
+      (fail) outer > inner > timeout
+        ^ this test timed out after Nms.
+      (fail) outer > inner > timeout with done
+        ^ this test timed out after Nms, before its done callback was called. If a done callback was not intended, remove the last parameter from the test callback function"
+    `);
+  });
+
   test("--tsconfig-override works", () => {
     const dir = tempDirWithFiles("test-tsconfig-override", {
       "math.test.ts": `


### PR DESCRIPTION
## What

`handleTestCompleted` (`src/cli/test_command.zig`) used `switch (sequence.result) { inline else => |result| ... }` and forwarded `result` as a `comptime` parameter into `maybePrintJunitLine`, `printTestLine`, and `writeTestStatusLine`, stamping out 14 copies of each per `Execution.Result` variant.

None of them actually need `status` at comptime:

- **`maybePrintJunitLine`** — only passes `status` to `junit.writeTestCase(...)`, which already takes a runtime value. Just drop `comptime`.
- **`printTestLine`** — uses `status` in runtime switches and `status.isPass()`. Also removed a dead `switch (Output.enable_ansi_colors_stderr) { inline else => |_| ... }` wrapper that captured `_` and never used it.
- **`writeTestStatusLine` / `fmtStatusTextLine`** — restructured so `emoji_or_color` is the `comptime` parameter (needed for `Output.prettyFmt`) and `status` is runtime; result is written with `writeAll` instead of `print`.
- **`handleTestCompleted`** — dropped the outer `inline else`, stripped `comptime` from the `result.basicResult()` calls. The `enable_ansi_colors_stderr` and `dim` bools stay comptime where `Output.prettyFmt` requires it.

This is a cold path (`bun test` result reporting, once per test).

## Verification

Output is byte-identical (modulo timing values) for a fixture exercising all 14 `Execution.Result` variants (pass / fail / skip / todo / `test.failing` passing / `test.todo` passing / `expect.hasAssertions` fail / `expect.assertions` fail / timeout / timeout-with-done) across:
- default reporter, `FORCE_COLOR=1`
- default reporter, `NO_COLOR=1`
- `--reporter=junit` XML
- `--reporter=dot`

Existing tests pass:
- `test/js/junit-reporter/junit.test.js` (snapshot)
- `test/cli/test/bun-test.test.ts` (70 pass, 6 pre-existing todo)
- `test/cli/test/retry-flag.test.ts`
- `test/cli/test/claudecode-flag.test.ts` (snapshot — exercises `isPass` path)
- `test/cli/test/test-timeout-behavior.test.ts`
- `test/cli/test/parallel.test.ts -t junit`

`bun run zig:check-all` passes on all targets.