### PR TITLE
Replace stable slice sorts with sort_unstable where stability is not observable

### DIFF
--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -1019,7 +1019,7 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
     md.extend_from_slice(b"Modules sorted by bytes contributed to the output bundle. Large modules may indicate bloat.\n\n");
 
     // Sort by bytes_in_output descending
-    input_files.sort_by_key(|b| std::cmp::Reverse(b.bytes_in_output));
+    input_files.sort_unstable_by_key(|b| std::cmp::Reverse(b.bytes_in_output));
 
     md.extend_from_slice(b"| Output Bytes | % of Total | Module | Format |\n");
     md.extend_from_slice(b"|--------------|------------|--------|--------|\n");
@@ -1206,7 +1206,7 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
                         }
                     }
 
-                    module_sizes.sort_by_key(|b| std::cmp::Reverse(b.bytes));
+                    module_sizes.sort_unstable_by_key(|b| std::cmp::Reverse(b.bytes));
 
                     let max_modules: usize = 15;
                     for (i, ms) in module_sizes.iter().enumerate() {
@@ -1243,7 +1243,7 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
         });
     }
 
-    highly_imported.sort_by_key(|b| std::cmp::Reverse(b.count));
+    highly_imported.sort_unstable_by_key(|b| std::cmp::Reverse(b.count));
 
     // Show most commonly imported modules
     if !highly_imported.is_empty() {
@@ -1294,7 +1294,7 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
         sorted_paths.push(PathOnly { path: key });
     }
 
-    sorted_paths.sort_by(|a, b| a.path.cmp(b.path));
+    sorted_paths.sort_unstable_by(|a, b| a.path.cmp(b.path));
 
     for sp in sorted_paths.iter() {
         let input_path = sp.path;

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2006,7 +2006,8 @@ fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JS
     }
 
     let array = JSValue::create_empty_array(global_this, sort_indices.len())?;
-    sort_indices.sort_by(|a, b| {
+    // Indices are keyed by unique file names, so stability is not required.
+    sort_indices.sort_unstable_by(|a, b| {
         if GraphFile::less_than_by_index(unsorted_files, *a, *b) {
             core::cmp::Ordering::Less
         } else if GraphFile::less_than_by_index(unsorted_files, *b, *a) {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2006,7 +2006,6 @@ fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JS
     }
 
     let array = JSValue::create_empty_array(global_this, sort_indices.len())?;
-    // Indices are keyed by unique file names, so stability is not required.
     sort_indices.sort_unstable_by(|a, b| {
         if GraphFile::less_than_by_index(unsorted_files, *a, *b) {
             core::cmp::Ordering::Less

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1025,8 +1025,9 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             });
         }
 
-        // Phase 2: Sort by package name, then by path as tiebreaker for deterministic ordering
-        matched_packages.sort_by(|a, b| {
+        // Phase 2: Sort by package name, then by path as tiebreaker for deterministic ordering.
+        // `dirpath` is unique per workspace, so the comparator is a total order and stability is moot.
+        matched_packages.sort_unstable_by(|a, b| {
             let name_order = a.name.cmp(&b.name);
             if name_order != core::cmp::Ordering::Equal {
                 return name_order;
@@ -1045,7 +1046,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                             matches.push(key);
                         }
                     }
-                    matches.as_mut_slice().sort();
+                    matches.as_mut_slice().sort_unstable();
                     for matched_name in &matches {
                         add_script_configs(
                             &mut configs,
@@ -1130,7 +1131,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
                     }
 
                     // Sort alphabetically
-                    matches.as_mut_slice().sort();
+                    matches.as_mut_slice().sort_unstable();
 
                     if matches.is_empty() {
                         bun_core::pretty_errorln!(

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1025,8 +1025,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             });
         }
 
-        // Phase 2: Sort by package name, then by path as tiebreaker for deterministic ordering.
-        // `dirpath` is unique per workspace, so the comparator is a total order and stability is moot.
+        // Phase 2: Sort by package name, then by path as tiebreaker for deterministic ordering
         matched_packages.sort_unstable_by(|a, b| {
             let name_order = a.name.cmp(&b.name);
             if name_order != core::cmp::Ordering::Equal {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -240,8 +240,12 @@ impl ServerConfig {
             }
         }
 
-        // sort the cloned static routes by name for determinism
-        // (descending by path: `order(b, a)`).
+        // Sort the cloned static routes by path for determinism (descending:
+        // `order(b, a)`). Must remain a stable sort: after dedup, distinct
+        // (method, path) entries can share a path, and their relative
+        // registration order into uWS decides which handler wins when e.g.
+        // `.any` and a specific method both register the same route.
+        // Preserving declaration order keeps user intent.
         list.sort_by(|a, b| strings::order(&b.path, &a.path));
 
         Ok(())

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -240,8 +240,8 @@ impl ServerConfig {
             }
         }
 
-        // Stable on purpose: same-path entries with different methods must keep
-        // declaration order, which decides uWS handler precedence.
+        // sort the cloned static routes by name for determinism
+        // (descending by path: `order(b, a)`).
         list.sort_by(|a, b| strings::order(&b.path, &a.path));
 
         Ok(())

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -240,12 +240,8 @@ impl ServerConfig {
             }
         }
 
-        // Sort the cloned static routes by path for determinism (descending:
-        // `order(b, a)`). Must remain a stable sort: after dedup, distinct
-        // (method, path) entries can share a path, and their relative
-        // registration order into uWS decides which handler wins when e.g.
-        // `.any` and a specific method both register the same route.
-        // Preserving declaration order keeps user intent.
+        // Stable on purpose: same-path entries with different methods must keep
+        // declaration order, which decides uWS handler precedence.
         list.sort_by(|a, b| strings::order(&b.path, &a.path));
 
         Ok(())

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -53,7 +53,8 @@ impl Export {
             .iter()
             .map(|(k, v)| (*k, *v))
             .collect();
-        entries.sort_by(|a, b| a.0.slice().cmp(b.0.slice()));
+        // Keys come from a hash map, so they are unique and stability is moot.
+        entries.sort_unstable_by(|a, b| a.0.slice().cmp(b.0.slice()));
 
         let mut buf = Vec::new();
         for (k, v) in &entries {

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -53,7 +53,6 @@ impl Export {
             .iter()
             .map(|(k, v)| (*k, *v))
             .collect();
-        // Keys come from a hash map, so they are unique and stability is moot.
         entries.sort_unstable_by(|a, b| a.0.slice().cmp(b.0.slice()));
 
         let mut buf = Vec::new();

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -403,8 +403,11 @@ impl Snapshots {
                 }
             });
 
-            // 1. sort ils_info by row, col
-            ils_info.sort_by(|a, b| {
+            // 1. sort ils_info by row, col. Stability is not observable:
+            // entries sharing a (line, col) are collapsed to a single write
+            // below, and divergent values error regardless of which one is
+            // encountered first.
+            ils_info.sort_unstable_by(|a, b| {
                 if InlineSnapshotToWrite::less_than_fn(a, b) {
                     core::cmp::Ordering::Less
                 } else if InlineSnapshotToWrite::less_than_fn(b, a) {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -403,10 +403,7 @@ impl Snapshots {
                 }
             });
 
-            // 1. sort ils_info by row, col. Stability is not observable:
-            // entries sharing a (line, col) are collapsed to a single write
-            // below, and divergent values error regardless of which one is
-            // encountered first.
+            // 1. sort ils_info by row, col
             ils_info.sort_unstable_by(|a, b| {
                 if InlineSnapshotToWrite::less_than_fn(a, b) {
                     core::cmp::Ordering::Less

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -600,8 +600,7 @@ impl MultiPartUpload {
                     b"<?xml version=\"1.0\" encoding=\"UTF-8\"?><CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
                 );
                 self.multipart_etags.with_mut(|etags| {
-                    // Sort by part number. Part numbers are unique (assigned from a
-                    // monotonically increasing counter), so stability is not required.
+                    // sort the etags
                     etags.sort_unstable_by_key(|a| a.number);
                     for tag in etags.drain(..) {
                         write!(

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -600,8 +600,9 @@ impl MultiPartUpload {
                     b"<?xml version=\"1.0\" encoding=\"UTF-8\"?><CompleteMultipartUpload xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">",
                 );
                 self.multipart_etags.with_mut(|etags| {
-                    // sort the etags
-                    etags.sort_by_key(|a| a.number);
+                    // Sort by part number. Part numbers are unique (assigned from a
+                    // monotonically increasing counter), so stability is not required.
+                    etags.sort_unstable_by_key(|a| a.number);
                     for tag in etags.drain(..) {
                         write!(
                             list,

--- a/test/js/bun/shell/commands/export.test.ts
+++ b/test/js/bun/shell/commands/export.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The `export` builtin sorts by key only (src/runtime/shell/builtin/export.rs
+// compares `a.0.slice()`), not by the full `KEY=VALUE` line. Sorting full
+// lines with JS `.sort()` diverges whenever one key is a strict prefix of
+// another whose next byte is < '=' (0x3D) — e.g. `ProgramFiles` vs
+// `ProgramFiles(x86)` on Windows. Use a key-only comparator to match what the
+// builtin actually guarantees.
+function sortedByKey(lines: readonly string[]): string[] {
+  const key = (l: string) => {
+    const i = l.indexOf("=");
+    return i === -1 ? l : l.slice(0, i);
+  };
+  return [...lines].sort((a, b) => (key(a) < key(b) ? -1 : key(a) > key(b) ? 1 : 0));
+}
+
+describe("export", () => {
+  // The `export` builtin with no arguments must list exported variables in
+  // lexicographic key order. The shell inherits the process environment, so we
+  // spawn a child with a small, deliberately unsorted environment to make the
+  // ordering observable. Guards the sort in src/runtime/shell/builtin/export.rs.
+  test("no arguments prints variables sorted lexicographically by key", async () => {
+    const script = `
+      import { $ } from "bun";
+      const { stdout } = await $\`export\`.quiet();
+      process.stdout.write(stdout);
+    `;
+
+    // Note: Windows treats environment variable names case-insensitively
+    // (src/runtime/shell/EnvMap.rs), so the lowercase probe must not case-fold
+    // onto any of the uppercase keys.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        ZEBRA: "1",
+        MANGO: "2",
+        APPLE: "3",
+        aardwolf: "4",
+        BANANA: "5",
+        AARDVARK: "6",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+
+    const lines = stdout.split("\n").filter(Boolean);
+    // Every variable we set must appear exactly once.
+    for (const key of ["ZEBRA", "MANGO", "APPLE", "aardwolf", "BANANA", "AARDVARK"]) {
+      expect(lines.filter(l => l.startsWith(`${key}=`))).toHaveLength(1);
+    }
+    // The full listing must be byte-wise sorted by key (uppercase letters sort
+    // before lowercase in ASCII, so "ZEBRA" < "aardwolf").
+    expect(lines).toEqual(sortedByKey(lines));
+    expect(lines.indexOf("AARDVARK=6")).toBeLessThan(lines.indexOf("ZEBRA=1"));
+    expect(lines.indexOf("ZEBRA=1")).toBeLessThan(lines.indexOf("aardwolf=4"));
+
+    expect(exitCode).toBe(0);
+  });
+
+  test("no arguments output is stable across runs", async () => {
+    const script = `
+      import { $ } from "bun";
+      const { stdout } = await $\`export\`.quiet();
+      process.stdout.write(stdout);
+    `;
+    const env = { ...bunEnv, ZZ: "1", AA: "2", MM: "3", BB: "4", YY: "5" };
+
+    const run = async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      return { stdout, exitCode };
+    };
+
+    const first = await run();
+    const second = await run();
+    expect(second.stdout).toBe(first.stdout);
+    const lines = first.stdout.split("\n").filter(Boolean);
+    expect(lines).toEqual(sortedByKey(lines));
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Rust's stable `slice::sort` (driftsort) is monomorphized once per element type and allocates a scratch buffer; `slice::sort_unstable` (ipnsort) is smaller and does not allocate. These call sites sort values that are already unique under the comparator, or feed into code that doesn't observe the relative order of equal elements, so the stable sort is dead weight.

> **History:** this PR was originally written against the Zig codebase (`std.mem.sort` → `std.sort.pdq`, -192 KB stripped release binary). Main has since been fully migrated to Rust, which deleted every file the original change touched. The Rust rewrite preserved the identical sort structure, so the per-call-site audit maps one-to-one and the change has been rewritten in Rust.

The source diff is the bare sort swaps; the audit below is the only place the per-site reasoning lives.

## Call-site audit

| File | Change | Safe because |
|---|---|---|
| `runtime/shell/builtin/export.rs` | `sort_by` → `sort_unstable_by` | env var keys from a hash map, unique |
| `runtime/test_runner/snapshot.rs` | `sort_by` → `sort_unstable_by` | entries sharing a `(line, col)` are collapsed to one write below the sort; divergent values error regardless of which one is seen first |
| `runtime/webcore/s3/multipart.rs` | `sort_by_key` → `sort_unstable_by_key` | part numbers come from a monotonic counter, unique |
| `bundler/linker_context/MetafileBuilder.rs` (x4) | `sort_by(_key)` → `sort_unstable_by(_key)` | markdown report tables; one sorts unique JSON object keys, the rest are display-only rankings |
| `runtime/api/BunObject.rs` `getEmbeddedFiles` | `sort_by` → `sort_unstable_by` | indices keyed by unique file names |
| `runtime/cli/multi_run.rs` `matched_packages` | `sort_by` → `sort_unstable_by` | comparator tiebreaks on `dirpath`, unique per workspace |
| `runtime/cli/multi_run.rs` script names (x2) | `sort()` → `sort_unstable()` | package.json script keys, unique |

**Deliberately left stable (unchanged in this PR):**

- `runtime/server/ServerConfig.rs` `normalize_static_routes_list`: after dedup by `(path, method)`, distinct entries can share a path, and their relative order decides which uWS handler wins when `.any` and a specific method both register the same route. Stability is load-bearing here.
- `install/isolated_install.rs` `dep_ids_sort_buf`: its `DepSorter` comparator carries a `TODO` about resolution ordering and was not part of the original audit. (The SCC hash sorts in that file already use `sort_unstable()` on main.)

## Verification

- `bun run rust:check` passes
- `test/js/bun/shell/commands/export.test.ts` (new): locks in the `export` builtin's lexicographic-by-key ordering contract; 2/2 pass
- `test/bundler/metafile.test.ts`: 44/44 pass
- `test/cli/run/filter-workspace.test.ts`: 58 pass, 2 skip
- `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts -t "inline snapshot"`: 34/34 pass
