### PR TITLE
install: make `features: Features` runtime in `Package.parseWithJSON`

### DIFF
--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -212,7 +212,7 @@ pub fn Package(comptime SemverIntType: type) type {
             lockfile: *Lockfile,
             pm: *PackageManager,
             package_json: *PackageJSON,
-            comptime features: Features,
+            features: Features,
         ) !@This() {
             var package = @This(){};
 
@@ -958,7 +958,7 @@ pub fn Package(comptime SemverIntType: type) type {
             source: *const logger.Source,
             comptime ResolverContext: type,
             resolver: *ResolverContext,
-            comptime features: Features,
+            features: Features,
         ) !void {
             initializeStore();
             const json = JSON.parsePackageJSONUTF8(source, log, allocator) catch |err| {
@@ -986,9 +986,9 @@ pub fn Package(comptime SemverIntType: type) type {
             allocator: Allocator,
             log: *logger.Log,
             source: *const logger.Source,
-            comptime group: DependencyGroup,
+            group: DependencyGroup,
             string_builder: *StringBuilder,
-            comptime features: Features,
+            features: Features,
             package_dependencies: []Dependency,
             dependencies_count: u32,
             comptime tag: ?Dependency.Version.Tag,
@@ -1230,11 +1230,11 @@ pub fn Package(comptime SemverIntType: type) type {
 
             // `peerDependencies` may be specified on existing dependencies. Packages in `workspaces` are deduplicated when
             // the array is processed
-            if (comptime features.check_for_duplicate_dependencies and !group.behavior.isPeer() and !group.behavior.isWorkspace()) {
+            if (features.check_for_duplicate_dependencies and !group.behavior.isPeer() and !group.behavior.isWorkspace()) {
                 const entry = lockfile.scratch.duplicate_checker_map.getOrPutAssumeCapacity(external_alias.hash);
                 if (entry.found_existing) {
                     // duplicate dependencies are allowed in optionalDependencies
-                    if (comptime group.behavior.isOptional()) {
+                    if (group.behavior.isOptional()) {
                         for (package_dependencies[0..dependencies_count]) |*package_dep| {
                             if (package_dep.name_hash == this_dep.name_hash) {
                                 package_dep.* = this_dep;
@@ -1277,7 +1277,7 @@ pub fn Package(comptime SemverIntType: type) type {
             json: Expr,
             comptime ResolverContext: type,
             resolver: *ResolverContext,
-            comptime features: Features,
+            features: Features,
         ) !void {
             var string_builder = lockfile.stringBuilder();
             var total_dependencies_count: u32 = 0;
@@ -1329,7 +1329,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (comptime !features.is_main) {
+            if (!features.is_main) {
                 if (json.asProperty("version")) |version_q| {
                     if (version_q.expr.asString(allocator)) |version_str| {
                         string_builder.count(version_str);
@@ -1372,41 +1372,35 @@ pub fn Package(comptime SemverIntType: type) type {
                 resolver.count(*Lockfile.StringBuilder, &string_builder, json);
             }
 
-            const dependency_groups = comptime brk: {
-                var out_groups: [
-                    @as(usize, @intFromBool(features.workspaces)) +
-                        @as(usize, @intFromBool(features.dependencies)) +
-                        @as(usize, @intFromBool(features.dev_dependencies)) +
-                        @as(usize, @intFromBool(features.optional_dependencies)) +
-                        @as(usize, @intFromBool(features.peer_dependencies))
-                ]DependencyGroup = undefined;
+            var dependency_groups_buf: [5]DependencyGroup = undefined;
+            const dependency_groups: []const DependencyGroup = brk: {
                 var out_group_i: usize = 0;
 
                 if (features.workspaces) {
-                    out_groups[out_group_i] = DependencyGroup.workspaces;
+                    dependency_groups_buf[out_group_i] = DependencyGroup.workspaces;
                     out_group_i += 1;
                 }
 
                 if (features.dependencies) {
-                    out_groups[out_group_i] = DependencyGroup.dependencies;
+                    dependency_groups_buf[out_group_i] = DependencyGroup.dependencies;
                     out_group_i += 1;
                 }
 
                 if (features.dev_dependencies) {
-                    out_groups[out_group_i] = DependencyGroup.dev;
+                    dependency_groups_buf[out_group_i] = DependencyGroup.dev;
                     out_group_i += 1;
                 }
                 if (features.optional_dependencies) {
-                    out_groups[out_group_i] = DependencyGroup.optional;
+                    dependency_groups_buf[out_group_i] = DependencyGroup.optional;
                     out_group_i += 1;
                 }
 
                 if (features.peer_dependencies) {
-                    out_groups[out_group_i] = DependencyGroup.peer;
+                    dependency_groups_buf[out_group_i] = DependencyGroup.peer;
                     out_group_i += 1;
                 }
 
-                break :brk out_groups;
+                break :brk dependency_groups_buf[0..out_group_i];
             };
 
             var workspace_names = WorkspaceMap.init(allocator);
@@ -1446,7 +1440,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             };
 
-            inline for (dependency_groups) |group| {
+            for (dependency_groups) |group| {
                 if (json.asProperty(group.prop)) |dependencies_q| brk: {
                     switch (dependencies_q.expr.data) {
                         .e_array => |arr| {
@@ -1553,7 +1547,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (comptime features.trusted_dependencies) {
+            if (features.trusted_dependencies) {
                 if (json.asProperty("trustedDependencies")) |q| {
                     switch (q.expr.data) {
                         .e_array => |arr| {
@@ -1585,7 +1579,7 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (comptime features.is_main) {
+            if (features.is_main) {
                 lockfile.overrides.parseCount(lockfile, json, &string_builder);
 
                 if (json.get("workspaces")) |workspaces_expr| {
@@ -1633,19 +1627,17 @@ pub fn Package(comptime SemverIntType: type) type {
                 }
             }
 
-            if (comptime !features.is_main) {
-                if (comptime ResolverContext != void) {
-                    package.resolution = try resolver.resolve(
-                        *Lockfile.StringBuilder,
-                        &string_builder,
-                        json,
-                    );
-                }
-            } else {
+            if (features.is_main) {
                 package.resolution = .{
                     .tag = .root,
                     .value = .{ .root = {} },
                 };
+            } else if (comptime ResolverContext != void) {
+                package.resolution = try resolver.resolve(
+                    *Lockfile.StringBuilder,
+                    &string_builder,
+                    json,
+                );
             }
 
             if (json.asProperty("patchedDependencies")) |patched_deps| {
@@ -1753,7 +1745,7 @@ pub fn Package(comptime SemverIntType: type) type {
             package.scripts.filled = true;
 
             // It is allowed for duplicate dependencies to exist in optionalDependencies and regular dependencies
-            if (comptime features.check_for_duplicate_dependencies) {
+            if (features.check_for_duplicate_dependencies) {
                 lockfile.scratch.duplicate_checker_map.clearRetainingCapacity();
                 try lockfile.scratch.duplicate_checker_map.ensureTotalCapacity(total_dependencies_count);
             }
@@ -1779,7 +1771,7 @@ pub fn Package(comptime SemverIntType: type) type {
 
             total_dependencies_count = 0;
 
-            inline for (dependency_groups) |group| {
+            for (dependency_groups) |group| {
                 if (group.behavior.isWorkspace()) {
                     var seen_workspace_names = TrustedDependenciesSet{};
                     defer seen_workspace_names.deinit(allocator);
@@ -1993,7 +1985,7 @@ pub fn Package(comptime SemverIntType: type) type {
             lockfile.buffers.resolutions.items = lockfile.buffers.resolutions.items.ptr[0..new_len];
 
             // This function depends on package.dependencies being set, so it is done at the very end.
-            if (comptime features.is_main) {
+            if (features.is_main) {
                 try lockfile.overrides.parseAppend(pm, lockfile, package, log, source, json, &string_builder);
 
                 var found_any_catalog_or_catalog_object = false;

--- a/src/install/resolvers/folder_resolver.zig
+++ b/src/install/resolvers/folder_resolver.zig
@@ -151,7 +151,7 @@ pub const FolderResolution = union(Tag) {
         manager: *PackageManager,
         abs: stringZ,
         version: Dependency.Version,
-        comptime features: Features,
+        features: Features,
         comptime ResolverType: type,
         resolver: *ResolverType,
     ) !Lockfile.Package {

--- a/test/cli/install/parse-features.test.ts
+++ b/test/cli/install/parse-features.test.ts
@@ -3,10 +3,50 @@
 // peerDependencies / trustedDependencies / peerDependenciesMeta, across the root
 // package and workspace packages. Guards the refactor that made `features: Features`
 // a runtime parameter.
-import { write } from "bun";
+import { which, write } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+// `Package.parseWithJSON` and `Package.parseDependency` used to take
+// `comptime features: Features` / `comptime group: DependencyGroup`, which
+// stamped out a separate copy of each function for every (ResolverContext,
+// Features, group) combination — 9 and 17 respectively in a debug build.
+// After making those parameters runtime, the instance counts collapse to the
+// number of distinct ResolverContext types (parseWithJSON) and distinct
+// comptime `tag` values (parseDependency).
+//
+// This test reads the symbol table of the binary under test and asserts the
+// instance counts stay at the collapsed level. It's skipped when the binary
+// is stripped (CI release builds) or `nm` is unavailable.
+test.skipIf(isWindows || !which("nm"))(
+  "Package.parseWithJSON/parseDependency are not over-monomorphised on Features",
+  async () => {
+    // `nm` on a debug+ASAN binary emits hundreds of MB; pipe through grep so
+    // only the handful of matching lines reach this process.
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `nm '${bunExe()}' 2>/dev/null | grep -E '\\.parseWithJSON|\\.parseDependency'`],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lines = stdout.split("\n").filter(Boolean);
+    const parseWithJSON = lines.filter(l => l.includes(".parseWithJSON"));
+    const parseDependency = lines.filter(l => l.includes(".parseDependency"));
+
+    // Binary is stripped (CI release) or nm failed — nothing to assert.
+    if (parseWithJSON.length === 0 && parseDependency.length === 0) return;
+
+    // Before: 9 parseWithJSON instances (one per (ResolverContext, Features) pair).
+    // After:  one per ResolverContext type (7 today).
+    expect(parseWithJSON.length).toBeLessThanOrEqual(7);
+
+    // Before: 17 parseDependency instances in debug (comptime group × features × tag).
+    // After:  one per comptime `tag` value (2: .workspace and null).
+    expect(parseDependency.length).toBeLessThanOrEqual(2);
+  },
+);
 
 test("parseWithJSON handles all dependency groups across root and workspace packages", async () => {
   using dir = tempDir("parse-features", {

--- a/test/cli/install/parse-features.test.ts
+++ b/test/cli/install/parse-features.test.ts
@@ -1,0 +1,204 @@
+// Covers Package.parseWithJSON handling every Features flag combination in
+// one install: workspaces / dependencies / devDependencies / optionalDependencies /
+// peerDependencies / trustedDependencies / peerDependenciesMeta, across the root
+// package and workspace packages. Guards the refactor that made `features: Features`
+// a runtime parameter.
+import { write } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+test("parseWithJSON handles all dependency groups across root and workspace packages", async () => {
+  using dir = tempDir("parse-features", {
+    "package.json": JSON.stringify({
+      name: "root",
+      version: "1.0.0",
+      workspaces: ["packages/*"],
+      dependencies: {
+        "pkg-a": "workspace:*",
+      },
+      devDependencies: {
+        "pkg-b": "workspace:*",
+      },
+      optionalDependencies: {
+        "pkg-c": "workspace:*",
+      },
+      peerDependencies: {
+        "pkg-a": "workspace:*",
+      },
+      trustedDependencies: ["pkg-a", "pkg-b"],
+    }),
+    "packages/pkg-a/package.json": JSON.stringify({
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: {
+        "pkg-b": "workspace:*",
+      },
+      peerDependencies: {
+        "pkg-c": "*",
+      },
+      peerDependenciesMeta: {
+        "pkg-c": { optional: true },
+        // meta-only entry (no matching peerDependencies key) → synthesised
+        // optional peer on "*"
+        "pkg-b": { optional: true },
+      },
+    }),
+    "packages/pkg-b/package.json": JSON.stringify({
+      name: "pkg-b",
+      version: "2.0.0",
+      devDependencies: {
+        "pkg-a": "workspace:^",
+      },
+      optionalDependencies: {
+        "pkg-c": "workspace:~",
+      },
+    }),
+    "packages/pkg-c/package.json": JSON.stringify({
+      name: "pkg-c",
+      version: "3.0.0",
+    }),
+  });
+
+  // folder dep below points at a relative dir with its own package.json
+  await write(
+    join(String(dir), "local-dep", "package.json"),
+    JSON.stringify({
+      name: "local-dep",
+      version: "0.0.1",
+      peerDependencies: { "pkg-a": "*" },
+    }),
+  );
+  await write(
+    join(String(dir), "packages", "pkg-c", "package.json"),
+    JSON.stringify({
+      name: "pkg-c",
+      version: "3.0.0",
+      dependencies: {
+        "local-dep": "file:../../local-dep",
+      },
+    }),
+  );
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--lockfile-only"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+
+  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+
+  // Root package: all five dependency groups present, in a stable order,
+  // plus trustedDependencies surviving the Features.is_main path.
+  expect(lockfile).toMatchInlineSnapshot(`
+    "{
+      "lockfileVersion": 1,
+      "configVersion": 1,
+      "workspaces": {
+        "": {
+          "name": "root",
+          "dependencies": {
+            "pkg-a": "workspace:*",
+          },
+          "devDependencies": {
+            "pkg-b": "workspace:*",
+          },
+          "optionalDependencies": {
+            "pkg-c": "workspace:*",
+          },
+          "peerDependencies": {
+            "pkg-a": "workspace:*",
+          },
+        },
+        "packages/pkg-a": {
+          "name": "pkg-a",
+          "version": "1.0.0",
+          "dependencies": {
+            "pkg-b": "workspace:*",
+          },
+          "peerDependencies": {
+            "pkg-b": "*",
+            "pkg-c": "*",
+          },
+          "optionalPeers": [
+            "pkg-b",
+            "pkg-c",
+          ],
+        },
+        "packages/pkg-b": {
+          "name": "pkg-b",
+          "version": "2.0.0",
+          "devDependencies": {
+            "pkg-a": "workspace:^",
+          },
+          "optionalDependencies": {
+            "pkg-c": "workspace:~",
+          },
+        },
+        "packages/pkg-c": {
+          "name": "pkg-c",
+          "version": "3.0.0",
+          "dependencies": {
+            "local-dep": "file:../../local-dep",
+          },
+        },
+      },
+      "trustedDependencies": [
+        "pkg-b",
+        "pkg-a",
+      ],
+      "packages": {
+        "pkg-a": ["pkg-a@workspace:packages/pkg-a"],
+
+        "pkg-b": ["pkg-b@workspace:packages/pkg-b"],
+
+        "pkg-c": ["pkg-c@workspace:packages/pkg-c"],
+
+        "pkg-c/local-dep": ["local-dep@file:local-dep", { "peerDependencies": { "pkg-a": "*" } }],
+      }
+    }
+    "
+  `);
+});
+
+test("parseWithJSON warns on duplicate dependencies in root package.json", async () => {
+  // Features.main sets check_for_duplicate_dependencies=true; a key listed in both
+  // dependencies and devDependencies should warn (not in optionalDependencies though,
+  // where duplication is allowed and the optional entry wins).
+  using dir = tempDir("parse-features-dup", {
+    "package.json": JSON.stringify({
+      name: "root",
+      version: "1.0.0",
+      workspaces: ["packages/*"],
+      dependencies: {
+        "pkg-a": "workspace:*",
+      },
+      devDependencies: {
+        "pkg-a": "workspace:*",
+      },
+    }),
+    "packages/pkg-a/package.json": JSON.stringify({
+      name: "pkg-a",
+      version: "1.0.0",
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--lockfile-only"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Duplicate dependency");
+  expect(stderr).toContain('"pkg-a"');
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/parse-features.test.ts
+++ b/test/cli/install/parse-features.test.ts
@@ -3,8 +3,8 @@
 // peerDependencies / trustedDependencies / peerDependenciesMeta, across the root
 // package and workspace packages. Guards the refactor that made `features: Features`
 // a runtime parameter.
-import { which, write } from "bun";
-import { expect, test } from "bun:test";
+import { which } from "bun";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -48,95 +48,85 @@ test.skipIf(isWindows || !which("nm"))(
   },
 );
 
-test("parseWithJSON handles all dependency groups across root and workspace packages", async () => {
-  using dir = tempDir("parse-features", {
-    "package.json": JSON.stringify({
-      name: "root",
-      version: "1.0.0",
-      workspaces: ["packages/*"],
-      dependencies: {
-        "pkg-a": "workspace:*",
-      },
-      devDependencies: {
-        "pkg-b": "workspace:*",
-      },
-      optionalDependencies: {
-        "pkg-c": "workspace:*",
-      },
-      peerDependencies: {
-        "pkg-a": "workspace:*",
-      },
-      trustedDependencies: ["pkg-a", "pkg-b"],
-    }),
-    "packages/pkg-a/package.json": JSON.stringify({
-      name: "pkg-a",
-      version: "1.0.0",
-      dependencies: {
-        "pkg-b": "workspace:*",
-      },
-      peerDependencies: {
-        "pkg-c": "*",
-      },
-      peerDependenciesMeta: {
-        "pkg-c": { optional: true },
-        // meta-only entry (no matching peerDependencies key) → synthesised
-        // optional peer on "*"
-        "pkg-b": { optional: true },
-      },
-    }),
-    "packages/pkg-b/package.json": JSON.stringify({
-      name: "pkg-b",
-      version: "2.0.0",
-      devDependencies: {
-        "pkg-a": "workspace:^",
-      },
-      optionalDependencies: {
-        "pkg-c": "workspace:~",
-      },
-    }),
-    "packages/pkg-c/package.json": JSON.stringify({
-      name: "pkg-c",
-      version: "3.0.0",
-    }),
-  });
+describe.concurrent("parseWithJSON", () => {
+  test("handles all dependency groups across root and workspace packages", async () => {
+    using dir = tempDir("parse-features", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "pkg-a": "workspace:*",
+        },
+        devDependencies: {
+          "pkg-b": "workspace:*",
+        },
+        optionalDependencies: {
+          "pkg-c": "workspace:*",
+        },
+        peerDependencies: {
+          "pkg-a": "workspace:*",
+        },
+        trustedDependencies: ["pkg-a", "pkg-b"],
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          "pkg-b": "workspace:*",
+        },
+        peerDependencies: {
+          "pkg-c": "*",
+        },
+        peerDependenciesMeta: {
+          "pkg-c": { optional: true },
+          // meta-only entry (no matching peerDependencies key) → synthesised
+          // optional peer on "*"
+          "pkg-b": { optional: true },
+        },
+      }),
+      "packages/pkg-b/package.json": JSON.stringify({
+        name: "pkg-b",
+        version: "2.0.0",
+        devDependencies: {
+          "pkg-a": "workspace:^",
+        },
+        optionalDependencies: {
+          "pkg-c": "workspace:~",
+        },
+      }),
+      "packages/pkg-c/package.json": JSON.stringify({
+        name: "pkg-c",
+        version: "3.0.0",
+        dependencies: {
+          // folder dep — exercises the Features.folder path
+          "local-dep": "file:../../local-dep",
+        },
+      }),
+      "local-dep/package.json": JSON.stringify({
+        name: "local-dep",
+        version: "0.0.1",
+        peerDependencies: { "pkg-a": "*" },
+      }),
+    });
 
-  // folder dep below points at a relative dir with its own package.json
-  await write(
-    join(String(dir), "local-dep", "package.json"),
-    JSON.stringify({
-      name: "local-dep",
-      version: "0.0.1",
-      peerDependencies: { "pkg-a": "*" },
-    }),
-  );
-  await write(
-    join(String(dir), "packages", "pkg-c", "package.json"),
-    JSON.stringify({
-      name: "pkg-c",
-      version: "3.0.0",
-      dependencies: {
-        "local-dep": "file:../../local-dep",
-      },
-    }),
-  );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--lockfile-only"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
 
-  expect(stderr).not.toContain("error:");
-  expect(exitCode).toBe(0);
+    const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
 
-  const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
-
-  // Root package: all five dependency groups present, in a stable order,
-  // plus trustedDependencies surviving the Features.is_main path.
-  expect(lockfile).toMatchInlineSnapshot(`
+    // Root package: all five dependency groups present, in a stable order,
+    // plus trustedDependencies surviving the Features.is_main path.
+    expect(lockfile).toMatchInlineSnapshot(`
     "{
       "lockfileVersion": 1,
       "configVersion": 1,
@@ -205,40 +195,41 @@ test("parseWithJSON handles all dependency groups across root and workspace pack
     }
     "
   `);
-});
-
-test("parseWithJSON warns on duplicate dependencies in root package.json", async () => {
-  // Features.main sets check_for_duplicate_dependencies=true; a key listed in both
-  // dependencies and devDependencies should warn (not in optionalDependencies though,
-  // where duplication is allowed and the optional entry wins).
-  using dir = tempDir("parse-features-dup", {
-    "package.json": JSON.stringify({
-      name: "root",
-      version: "1.0.0",
-      workspaces: ["packages/*"],
-      dependencies: {
-        "pkg-a": "workspace:*",
-      },
-      devDependencies: {
-        "pkg-a": "workspace:*",
-      },
-    }),
-    "packages/pkg-a/package.json": JSON.stringify({
-      name: "pkg-a",
-      version: "1.0.0",
-    }),
   });
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "install", "--lockfile-only"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  test("warns on duplicate dependencies in root package.json", async () => {
+    // Features.main sets check_for_duplicate_dependencies=true; a key listed in both
+    // dependencies and devDependencies should warn (not in optionalDependencies though,
+    // where duplication is allowed and the optional entry wins).
+    using dir = tempDir("parse-features-dup", {
+      "package.json": JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "pkg-a": "workspace:*",
+        },
+        devDependencies: {
+          "pkg-a": "workspace:*",
+        },
+      }),
+      "packages/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+      }),
+    });
 
-  expect(stderr).toContain("Duplicate dependency");
-  expect(stderr).toContain('"pkg-a"');
-  expect(exitCode).toBe(0);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", "--lockfile-only"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("Duplicate dependency");
+    expect(stderr).toContain('"pkg-a"');
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## What

`Package.parseWithJSON` / `parseDependency` / `parse` / `fromPackageJSON` previously took `comptime features: Features` (and `parseDependency` also took `comptime group: DependencyGroup`), producing a distinct monomorphic instantiation for each `(ResolverContext, Features)` combination. Combined with two `inline for (dependency_groups)` loops inside `parseWithJSON`, this stamped out **9 copies of `parseWithJSON`** (~100 KB) and **8 copies of `parseDependency`** (~37 KB) into the release binary.

`Features` is a 9-bool struct gating which dependency sections to read. These checks are trivial branches on a cold path — `parseWithJSON` runs once per `package.json` during `bun install`.

## Change

- `features: Features` → runtime parameter in `parseWithJSON` / `parseDependency` / `parse` / `fromPackageJSON` / `readPackageJSONFromDisk`
- `group: DependencyGroup` → runtime parameter in `parseDependency`
- Comptime-sized `dependency_groups` array → stack `[5]DependencyGroup` + runtime slice
- Two `inline for (dependency_groups)` → regular `for`
- `comptime features.X` guards → runtime `features.X`

Left alone:
- `comptime ResolverContext: type` — needed for generic dispatch on `.count()` / `.resolve()` / `.checkBundledDependencies()`
- `fromNPM` — uses `@field(package_version, group.field)`, which needs the field name at comptime
- `comptime tag: ?Dependency.Version.Tag` in `parseDependency` — only two values (`.workspace` / `null`), one per branch

## Size impact (release linux-x64-gnu)

|  | baseline | patched |
|---|---|---|
| `parseWithJSON` instances | 9 (100,351 B) | 7 (87,499 B) |
| `parseDependency` instances | 8 (37,530 B) | 2 (9,727 B) |
| `.text` | 90,527,091 B | 90,490,231 B |
| stripped `bun` | 91,876,296 B | 91,843,528 B |

**−36,860 bytes `.text` / −32 KB stripped binary.**

## Verification

- `bun run zig:check-all` passes
- `bun.lock` is **byte-identical** between baseline and patched release builds on a project exercising `workspaces` + `dependencies` + `devDependencies` + `optionalDependencies` + `peerDependencies` + `peerDependenciesMeta` + `trustedDependencies` + a `file:` folder dep
- `test/cli/install/` suite has no new failures vs `main` debug build (remaining failures are pre-existing network/verdaccio timeouts in the container)
- New `test/cli/install/parse-features.test.ts` snapshot-locks the lockfile output across all `Features` branches

This is a pure refactor — behaviour is unchanged, so the new test passes on both `main` and this branch (it's a regression guard for the code path, not a fail-before-fix gate).