### PR TITLE
codegen: outline ErrorCode.Error.fmt/throw shared bodies (−144 KiB)

### DIFF
--- a/src/codegen/generate-node-errors.ts
+++ b/src/codegen/generate-node-errors.ts
@@ -127,18 +127,44 @@ zig += `
     return Bun__createErrorWithCode(globalThis, this, message);
   }
 
-  pub fn fmt(this: Error, globalThis: *jsc.JSGlobalObject, comptime fmt_str: [:0]const u8, args: anytype) jsc.JSValue {
-    if (comptime std.meta.fieldNames(@TypeOf(args)).len == 0) {
-      var message = bun.String.static(fmt_str);
-      return toJS(this, globalThis, &message);
-    }
+  // -- Non-generic cold paths --------------------------------------------
+  // fmt()/throw() below take a comptime format string + anytype args, so
+  // they are monomorphized once per call site. The bodies are thin wrappers
+  // around Bun__createErrorWithCode; outlining the shared work into these
+  // noinline, non-generic helpers and marking fmt()/throw() inline collapses
+  // hundreds of per-site stubs into a single call to one of these.
 
+  /// Shared body for every zero-argument fmt() instantiation.
+  pub noinline fn fmtStatic(this: Error, globalThis: *jsc.JSGlobalObject, str: [:0]const u8) jsc.JSValue {
+    var message = bun.String.static(str);
+    return toJS(this, globalThis, &message);
+  }
+
+  /// Shared body for every zero-argument throw() instantiation.
+  pub noinline fn throwStatic(this: Error, globalThis: *jsc.JSGlobalObject, str: [:0]const u8) bun.JSError {
+    return globalThis.throwValue(fmtStatic(this, globalThis, str));
+  }
+
+  /// Shared toJS + throwValue tail for throw() when a formatted bun.String
+  /// has already been built.
+  pub noinline fn throwFromString(this: Error, globalThis: *jsc.JSGlobalObject, message: *bun.String) bun.JSError {
+    return globalThis.throwValue(toJS(this, globalThis, message));
+  }
+
+  pub inline fn fmt(this: Error, globalThis: *jsc.JSGlobalObject, comptime fmt_str: [:0]const u8, args: anytype) jsc.JSValue {
+    if (comptime std.meta.fieldNames(@TypeOf(args)).len == 0) {
+      return fmtStatic(this, globalThis, fmt_str);
+    }
     var message = bun.handleOom(bun.String.createFormat(fmt_str, args));
     return toJS(this, globalThis, &message);
   }
 
-  pub fn throw(this: Error, globalThis: *jsc.JSGlobalObject, comptime fmt_str: [:0]const u8, args: anytype) bun.JSError {
-    return globalThis.throwValue(fmt(this, globalThis, fmt_str, args));
+  pub inline fn throw(this: Error, globalThis: *jsc.JSGlobalObject, comptime fmt_str: [:0]const u8, args: anytype) bun.JSError {
+    if (comptime std.meta.fieldNames(@TypeOf(args)).len == 0) {
+      return throwStatic(this, globalThis, fmt_str);
+    }
+    var message = bun.handleOom(bun.String.createFormat(fmt_str, args));
+    return throwFromString(this, globalThis, &message);
   }
 
 };

--- a/test/js/node/error-code.test.ts
+++ b/test/js/node/error-code.test.ts
@@ -1,0 +1,124 @@
+// Exercises the generated `ErrorCode.Error.fmt` / `Error.throw` helpers from
+// `src/codegen/generate-node-errors.ts` → `build/<profile>/codegen/ErrorCode.zig`.
+//
+// Both code paths are covered:
+//   - zero-arg messages (outlined to `fmtStatic` / `throwStatic`)
+//   - formatted messages (outlined to `createFormat` + `toJS` / `throwFromString`)
+//
+// For each case we assert the full (code, name, constructor, message) tuple so
+// that any regression in how these errors are constructed — wrong prototype,
+// wrong .code, truncated/garbled message — fails loudly.
+
+import { expect, test } from "bun:test";
+import crypto from "node:crypto";
+import dns from "node:dns";
+import zlib from "node:zlib";
+
+function errorOf(fn: () => unknown) {
+  try {
+    fn();
+  } catch (e) {
+    const err = e as Error & { code?: string };
+    return {
+      code: err.code,
+      name: err.name,
+      ctor: err.constructor.name,
+      message: err.message,
+    };
+  }
+  expect.unreachable();
+}
+
+// --- zero-arg messages: Error.{fmt,throw}(code, global, "literal", .{}) ----
+
+test("ErrorCode zero-arg: crypto.timingSafeEqual length mismatch", () => {
+  expect(errorOf(() => crypto.timingSafeEqual(Buffer.alloc(1), Buffer.alloc(2)))).toEqual({
+    code: "ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH",
+    name: "RangeError",
+    ctor: "RangeError",
+    message: "Input buffers must have the same byte length",
+  });
+});
+
+test("ErrorCode zero-arg: crypto.timingSafeEqual wrong argument type", () => {
+  expect(errorOf(() => crypto.timingSafeEqual("x" as any, Buffer.alloc(1)))).toEqual({
+    code: "ERR_INVALID_ARG_TYPE",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: 'The "buf1" argument must be an instance of ArrayBuffer, Buffer, TypedArray, or DataView.',
+  });
+});
+
+test("ErrorCode zero-arg: crypto.setEngine is unsupported", () => {
+  expect(errorOf(() => crypto.setEngine("x"))).toEqual({
+    code: "ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED",
+    name: "Error",
+    ctor: "Error",
+    message: "Custom engines not supported by BoringSSL",
+  });
+});
+
+test("ErrorCode zero-arg: Bun.randomUUIDv5 missing name", () => {
+  expect(errorOf(() => (Bun as any).randomUUIDv5())).toEqual({
+    code: "ERR_INVALID_ARG_TYPE",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: 'The "name" argument must be specified',
+  });
+});
+
+test("ErrorCode zero-arg: Bun.randomUUIDv5 invalid namespace", () => {
+  expect(errorOf(() => (Bun as any).randomUUIDv5("a", "not-a-uuid"))).toEqual({
+    code: "ERR_INVALID_ARG_VALUE",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: "Invalid UUID format for namespace",
+  });
+});
+
+// --- formatted messages: Error.{fmt,throw}(code, global, "…{…}…", .{…}) ----
+
+test("ErrorCode formatted: crypto.pbkdf2Sync invalid digest", () => {
+  expect(errorOf(() => crypto.pbkdf2Sync("p", "s", 1, 16, "notadigest"))).toEqual({
+    code: "ERR_CRYPTO_INVALID_DIGEST",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: "Invalid digest: notadigest",
+  });
+});
+
+test("ErrorCode formatted: crypto.randomInt max <= min", () => {
+  expect(errorOf(() => crypto.randomInt(5, 2))).toEqual({
+    code: "ERR_OUT_OF_RANGE",
+    name: "RangeError",
+    ctor: "RangeError",
+    message: 'The value of "max" is out of range. It must be greater than the value of "min" (5). Received 2',
+  });
+});
+
+test("ErrorCode formatted: zlib.crc32 out-of-range seed", () => {
+  expect(errorOf(() => zlib.crc32("abc", -1))).toEqual({
+    code: "ERR_OUT_OF_RANGE",
+    name: "RangeError",
+    ctor: "RangeError",
+    message: 'The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received -1',
+  });
+});
+
+test("ErrorCode formatted: zlib.crc32 wrong data type", () => {
+  expect(errorOf(() => zlib.crc32(123 as any))).toEqual({
+    code: "ERR_INVALID_ARG_TYPE",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: 'The "data" property must be an instance of Buffer, TypedArray, DataView, or ArrayBuffer. Received number',
+  });
+});
+
+test("ErrorCode formatted: dns.Resolver#setLocalAddress invalid IP", () => {
+  expect(errorOf(() => new dns.Resolver().setLocalAddress("notanip"))).toEqual({
+    code: "ERR_INVALID_IP_ADDRESS",
+    name: "TypeError",
+    ctor: "TypeError",
+    message: 'Invalid IP address: "notanip"',
+  });
+});


### PR DESCRIPTION
## What

`Error.fmt()` and `Error.throw()` in the generated `ErrorCode.zig` (from `src/codegen/generate-node-errors.ts`) take a `comptime` format string and `anytype` args, so Zig emits a separate function for every distinct call site. In a release build that's ~1300 near-identical stubs whose bodies are just "build a `bun.String`, call `Bun__createErrorWithCode`, (throw)".

This change:
- adds three non-generic `noinline` helpers on the `Error` enum — `fmtStatic`, `throwStatic`, `throwFromString` — that hold the shared body once;
- marks `fmt()`/`throw()` as `inline` so each call site becomes a single call into one of those helpers (for zero-argument messages) or `bun.String.createFormat(...)` + one helper call (for formatted messages), instead of a call into its own monomorphized stub.

No behavioural change — error `.code`, `.name`, constructor and `.message` are unchanged.

## Release binary size (x86_64-linux)

| section | before | after | Δ |
| --- | ---: | ---: | ---: |
| `.text` | 54,126,604 | 54,012,428 | **−114,176** |
| `.eh_frame` | 2,792,524 | 2,751,524 | **−41,000** |
| stripped total | 91,876,296 | 91,728,840 | **−147,456** |

`nm` on the profile binary: **1024** `ErrorCode.Error.fmt__anon_*` + **278** `ErrorCode.Error.throw__anon_*` symbols → **0**. Replaced by exactly `fmtStatic`, `throwStatic`, `throwFromString` alongside the existing `toJS`.

## Verification

- Spot-check: `fs.readFileSync({})`, `Buffer.alloc("x")`, `Buffer.from(null)`, `new TextDecoder("nope")` — `.code` / `.name` / constructor / `.message` byte-identical to baseline.
- `bun bd test test/js/node/buffer.test.js` — 462 pass / 26,066 expect() (heavy `ERR_BUFFER_OUT_OF_BOUNDS` / `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` coverage).
- `bun bd test test/js/node/util/validators.test.ts test/js/node/crypto/{pbkdf2,crypto-random}.test.ts test/js/node/url/url.test.ts test/js/node/readline/readline.node.test.ts test/js/node/assert test/js/node/zlib/zlib.test.ts` — all pass.
- `bun bd test test/js/bun/test/expect.test.js` — 397 pass (exercises `throwInvalidArgumentType`).