### PR TITLE
install: take subcommand as runtime param in CommandLineArguments.parse (−156 KB)

### DIFF
--- a/src/clap/clap.zig
+++ b/src/clap/clap.zig
@@ -353,6 +353,16 @@ pub const ParseOptions = struct {
     allocator: mem.Allocator = heap.page_allocator,
     diagnostic: ?*Diagnostic = null,
     stop_after_positional_at: usize = 0,
+
+    /// Optional override of the parameters the streaming parser will accept.
+    ///
+    /// When parsing many subcommands that share a result struct layout (see
+    /// `ComptimeClap.params_converted`), pass a per-subcommand subset here so that
+    /// only that subcommand's flags are recognized while results are still stored
+    /// into the shared superset struct. Each entry's `id` must index into the same
+    /// flags/options slots as the comptime `params` the `ComptimeClap` was built with.
+    /// When null, the comptime `params` are used.
+    stream_params: ?[]const Param(usize) = null,
 };
 
 /// Same as `parseEx` but uses the `args.OsIterator` by default.
@@ -374,6 +384,7 @@ pub fn parse(
         .allocator = res.arena.allocator(),
         .diagnostic = opt.diagnostic,
         .stop_after_positional_at = opt.stop_after_positional_at,
+        .stream_params = opt.stream_params,
     });
     return res;
 }

--- a/src/clap/comptime.zig
+++ b/src/clap/comptime.zig
@@ -39,6 +39,11 @@ pub fn ComptimeClap(
         passthrough_positionals: []const []const u8,
         allocator: mem.Allocator,
 
+        /// The comptime `params` with each id remapped to its storage slot in
+        /// this struct. Exposed so callers can build runtime subsets for
+        /// `ParseOptions.stream_params` that share the same storage layout.
+        pub const params_converted = converted_params;
+
         pub fn parse(iter: anytype, opt: clap.ParseOptions) !@This() {
             const allocator = opt.allocator;
             var multis = [_]std.array_list.Managed([]const u8){undefined} ** multi_options;
@@ -59,7 +64,7 @@ pub fn ComptimeClap(
             };
 
             var stream = clap.StreamingClap(usize, @typeInfo(@TypeOf(iter)).pointer.child){
-                .params = converted_params,
+                .params = opt.stream_params orelse converted_params,
                 .iter = iter,
                 .diagnostic = opt.diagnostic,
             };

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -170,6 +170,114 @@ const why_params: []const ParamType = &(shared_params ++ [_]ParamType{
     clap.parseParam("--depth <NUM>                          Maximum depth of the dependency tree to display") catch unreachable,
 });
 
+const audit_full_params: []const ParamType = &(shared_params ++ audit_params[0..audit_params.len].*);
+
+/// Returns the clap parameter table for `subcommand` (the same table used by
+/// `printHelp`). `parse` uses `streamParamsFor` for the actual parsing subset.
+fn paramsFor(comptime subcommand: Subcommand) []const ParamType {
+    return switch (subcommand) {
+        .install => install_params,
+        .update => update_params,
+        .pm => pm_params,
+        .add => add_params,
+        .remove => remove_params,
+        .link => link_params,
+        .unlink => unlink_params,
+        .patch => patch_params,
+        .@"patch-commit" => patch_commit_params,
+        .outdated => outdated_params,
+        .pack => pack_params,
+        .publish => publish_params,
+        .why => why_params,
+        .audit => audit_full_params,
+        .info => info_params,
+        .scan => pm_params, // scan uses the same params as pm command
+    };
+}
+
+/// Do `a` and `b` describe the same logical parameter? Matching by long name
+/// (or positional/short-only) — not by help text or short alias — so that
+/// subcommand tables that expose the same long name with different short
+/// aliases (e.g. `--filter` vs `-F, --filter`) share a storage slot.
+fn isSameParam(a: ParamType, b: ParamType) bool {
+    if (a.names.long == null and a.names.short == null) {
+        return b.names.long == null and b.names.short == null;
+    }
+    if (a.names.long) |a_long| {
+        const b_long = b.names.long orelse return false;
+        return std.mem.eql(u8, a_long, b_long);
+    }
+    if (a.names.short) |a_short| {
+        if (b.names.long != null) return false;
+        return b.names.short == a_short;
+    }
+    return false;
+}
+
+/// Deduplicated union of every subcommand's params. Used as the single
+/// comptime `params` argument to `clap.parse` so the body of `parse` is
+/// instantiated once instead of once per subcommand. The per-subcommand
+/// subset is selected at runtime via `ParseOptions.stream_params`.
+const all_params: []const ParamType = all: {
+    @setEvalBranchQuota(1_000_000);
+    var merged: []const ParamType = &.{};
+    for (std.enums.values(Subcommand)) |subcommand| {
+        for (paramsFor(subcommand)) |param| {
+            const exists = for (merged) |existing| {
+                if (isSameParam(param, existing)) break true;
+            } else false;
+            if (!exists) merged = merged ++ &[_]ParamType{param};
+        }
+    }
+    break :all merged;
+};
+
+const AllClap = clap.ComptimeClap(clap.Help, all_params);
+
+/// Build the streaming-parser subset for one subcommand. Each entry keeps
+/// that subcommand's exact `names` (so short-alias differences between
+/// subcommands are preserved) while its `id` points at the matching storage
+/// slot in the shared `all_params` result struct.
+fn buildStreamParams(comptime subcommand_params: []const ParamType) []const clap.Param(usize) {
+    @setEvalBranchQuota(1_000_000);
+    comptime {
+        var out: [subcommand_params.len]clap.Param(usize) = undefined;
+        for (subcommand_params, 0..) |param, i| {
+            const match = for (AllClap.params_converted) |converted| {
+                const original: ParamType = .{
+                    .names = converted.names,
+                    .takes_value = converted.takes_value,
+                };
+                if (isSameParam(param, original)) break converted;
+            } else @compileError("subcommand param missing from all_params");
+            if (match.takes_value != param.takes_value) {
+                @compileError("param '" ++ (param.names.long orelse "<positional>") ++
+                    "' has inconsistent takes_value across subcommands");
+            }
+            out[i] = .{
+                .id = match.id,
+                .names = param.names,
+                .takes_value = param.takes_value,
+            };
+        }
+        const final = out;
+        return &final;
+    }
+}
+
+const stream_params_by_subcommand = blk: {
+    @setEvalBranchQuota(1_000_000);
+    var table: std.EnumArray(Subcommand, []const clap.Param(usize)) = undefined;
+    for (std.enums.values(Subcommand)) |subcommand| {
+        table.set(subcommand, buildStreamParams(paramsFor(subcommand)));
+    }
+    break :blk table;
+};
+
+fn streamParamsFor(subcommand: Subcommand) []const clap.Param(usize) {
+    return stream_params_by_subcommand.get(subcommand);
+}
+
 cache_dir: ?string = null,
 lockfile: string = "",
 token: string = "",
@@ -749,36 +857,15 @@ pub fn printHelp(subcommand: Subcommand) void {
     }
 }
 
-pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !CommandLineArguments {
+pub fn parse(allocator: std.mem.Allocator, subcommand: Subcommand) !CommandLineArguments {
     Output.is_verbose = Output.isVerbose();
-
-    const params: []const ParamType = switch (subcommand) {
-        .install => install_params,
-        .update => update_params,
-        .pm => pm_params,
-        .add => add_params,
-        .remove => remove_params,
-        .link => link_params,
-        .unlink => unlink_params,
-        .patch => patch_params,
-        .@"patch-commit" => patch_commit_params,
-        .outdated => outdated_params,
-        .pack => pack_params,
-        .publish => publish_params,
-        .why => why_params,
-
-        // TODO: we will probably want to do this for other *_params. this way extra params
-        // are not included in the help text
-        .audit => shared_params ++ audit_params,
-        .info => info_params,
-        .scan => pm_params, // scan uses the same params as pm command
-    };
 
     var diag = clap.Diagnostic{};
 
-    var args = clap.parse(clap.Help, params, .{
+    var args = clap.parse(clap.Help, all_params, .{
         .diagnostic = &diag,
         .allocator = allocator,
+        .stream_params = streamParamsFor(subcommand),
     }) catch |err| {
         printHelp(subcommand);
         diag.report(Output.errorWriter(), err) catch {};
@@ -868,23 +955,23 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     }
 
     // commands that support --filter
-    if (comptime subcommand.supportsWorkspaceFiltering()) {
+    if (subcommand.supportsWorkspaceFiltering()) {
         cli.filters = args.options("--filter");
     }
 
-    if (comptime subcommand.supportsJsonOutput()) {
+    if (subcommand.supportsJsonOutput()) {
         cli.json_output = args.flag("--json");
     }
 
-    if (comptime subcommand == .outdated) {
+    if (subcommand == .outdated) {
         // fake --dry-run, we don't actually resolve+clean the lockfile
         cli.dry_run = true;
         cli.recursive = args.flag("--recursive");
         // cli.json_output = args.flag("--json");
     }
 
-    if (comptime subcommand == .pack or subcommand == .pm or subcommand == .publish) {
-        if (comptime subcommand != .publish) {
+    if (subcommand == .pack or subcommand == .pm or subcommand == .publish) {
+        if (subcommand != .publish) {
             if (args.option("--destination")) |dest| {
                 cli.pack_destination = dest;
             }
@@ -898,7 +985,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
         }
     }
 
-    if (comptime subcommand == .publish) {
+    if (subcommand == .publish) {
         if (args.option("--tag")) |tag| {
             cli.publish_config.tag = tag;
         }
@@ -926,7 +1013,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
 
     // link and unlink default to not saving, all others default to
     // saving.
-    if (comptime subcommand == .link or subcommand == .unlink) {
+    if (subcommand == .link or subcommand == .unlink) {
         cli.no_save = !args.flag("--save");
     } else {
         cli.no_save = args.flag("--no-save");
@@ -954,7 +1041,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
         };
     }
 
-    if (comptime subcommand == .audit) {
+    if (subcommand == .audit) {
         if (args.option("--audit-level")) |level| {
             cli.audit_level = AuditLevel.fromString(level) orelse {
                 Output.errGeneric("invalid `--audit-level` value: '{s}'. Valid values are: low, moderate, high, critical", .{level});
@@ -1017,7 +1104,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
         cli.os = os_negatable.combine();
     }
 
-    if (comptime subcommand == .add or subcommand == .install) {
+    if (subcommand == .add or subcommand == .install) {
         cli.development = args.flag("--development") or args.flag("--dev");
         cli.optional = args.flag("--optional");
         cli.peer = args.flag("--peer");
@@ -1051,7 +1138,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
         };
     }
 
-    if (comptime subcommand == .update) {
+    if (subcommand == .update) {
         cli.latest = args.flag("--latest");
         cli.interactive = args.flag("--interactive");
         cli.recursive = args.flag("--recursive");
@@ -1103,7 +1190,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
         Global.crash();
     }
 
-    if (comptime subcommand == .pm) {
+    if (subcommand == .pm) {
         // `bun pm version` command options
         if (args.option("--git-tag-version")) |git_tag_version| {
             if (strings.eqlComptime(git_tag_version, "true")) {
@@ -1126,7 +1213,7 @@ pub fn parse(allocator: std.mem.Allocator, comptime subcommand: Subcommand) !Com
     }
 
     // `bun pm why` and `bun why` options
-    if (comptime subcommand == .pm or subcommand == .why) {
+    if (subcommand == .pm or subcommand == .why) {
         cli.top_only = args.flag("--top");
         if (args.option("--depth")) |depth| {
             cli.depth = std.fmt.parseInt(usize, depth, 10) catch {

--- a/src/install/PackageManager/CommandLineArguments.zig
+++ b/src/install/PackageManager/CommandLineArguments.zig
@@ -172,8 +172,11 @@ const why_params: []const ParamType = &(shared_params ++ [_]ParamType{
 
 const audit_full_params: []const ParamType = &(shared_params ++ audit_params[0..audit_params.len].*);
 
-/// Returns the clap parameter table for `subcommand` (the same table used by
-/// `printHelp`). `parse` uses `streamParamsFor` for the actual parsing subset.
+/// Returns the clap parameter table that `parse` accepts for `subcommand`.
+/// Mirrors the per-subcommand switch that used to live inline in `parse`
+/// (including `.audit` accepting `shared_params ++ audit_params` even though
+/// `printHelp(.audit)` only renders `audit_params`). Used both to build
+/// `all_params` and the per-subcommand `streamParamsFor` subsets.
 fn paramsFor(comptime subcommand: Subcommand) []const ParamType {
     return switch (subcommand) {
         .install => install_params,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.zig
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.zig
@@ -681,9 +681,7 @@ pub fn updatePackageJSONAndInstall(
     ctx: Command.Context,
     subcommand: Subcommand,
 ) !void {
-    var cli = switch (subcommand) {
-        inline else => |cmd| try PackageManager.CommandLineArguments.parse(ctx.allocator, cmd),
-    };
+    var cli = try PackageManager.CommandLineArguments.parse(ctx.allocator, subcommand);
 
     // The way this works:
     // 1. Run the bundler on source files

--- a/test/cli/install/bun-install-cli-args.test.ts
+++ b/test/cli/install/bun-install-cli-args.test.ts
@@ -4,7 +4,38 @@
 // for the streaming parser, so these tests verify that short-flag
 // resolution stays subcommand-specific.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+
+// `CommandLineArguments.parse` used to be instantiated once per Subcommand
+// (16×) because `subcommand` was a comptime parameter and each variant fed a
+// different comptime params table into `clap.parse`. It now takes `subcommand`
+// at runtime and should compile to a single instance. This guards against it
+// silently fanning back out (e.g. someone reintroducing `inline else`).
+//
+// Debug-only: release binaries are stripped. Linux/macOS-only: uses `nm`.
+test.skipIf(isWindows || !isDebug)(
+  "CommandLineArguments.parse is instantiated once",
+  async () => {
+    // Zig mangles as `install.PackageManager.CommandLineArguments.parse__<hash>`
+    // (and `parse__anon_<n>__<hash>` for each comptime-specialized copy). The
+    // debug binary is large, so filter inside the pipeline rather than pulling
+    // the whole symbol table into JS.
+    const needle = "install.PackageManager.CommandLineArguments.parse__";
+    const { stdout, exitCode } = await Bun.$`nm --defined-only ${bunExe()} | grep -F ${needle}`
+      .nothrow()
+      .quiet();
+    const text = stdout.toString("utf8");
+    const matches = text.split("\n").filter(line => line.includes(needle));
+    // If the toolchain ever stops emitting this symbol name the test becomes a
+    // no-op, so require at least one match.
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    // Previously 16 copies (one per Subcommand). Keep it at one.
+    expect(matches.length).toBe(1);
+    // grep exits 0 when it finds matches.
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
 
 async function run(cwd: string, args: string[]) {
   await using proc = Bun.spawn({

--- a/test/cli/install/bun-install-cli-args.test.ts
+++ b/test/cli/install/bun-install-cli-args.test.ts
@@ -3,8 +3,12 @@
 // as a runtime parameter and dispatches to a per-subcommand param table
 // for the streaming parser, so these tests verify that short-flag
 // resolution stays subcommand-specific.
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+
+beforeAll(() => {
+  setDefaultTimeout(1000 * 60 * 5);
+});
 
 // `CommandLineArguments.parse` used to be instantiated once per Subcommand
 // (16×) because `subcommand` was a comptime parameter and each variant fed a
@@ -48,7 +52,7 @@ async function run(cwd: string, args: string[]) {
   return { stdout, stderr, exitCode };
 }
 
-describe("package manager CLI args", () => {
+describe.concurrent("package manager CLI args", () => {
   describe("--help shows only each subcommand's own flags", () => {
     test.each([
       // [subcommand, flag that SHOULD appear, flag that must NOT appear]
@@ -161,7 +165,7 @@ describe("package manager CLI args", () => {
     using dir = tempDir("pm-cli-pm-version", {
       "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
     });
-    const { stdout, stderr } = await run(String(dir), [
+    const { stdout, stderr, exitCode } = await run(String(dir), [
       "pm",
       "version",
       "--no-git-tag-version",
@@ -174,6 +178,7 @@ describe("package manager CLI args", () => {
     const combined = stdout + stderr;
     expect(combined).not.toContain("Invalid Argument");
     expect(combined).not.toContain("does not take a value");
+    expect(exitCode).toBe(0);
     const pkgJson = await Bun.file(`${dir}/package.json`).json();
     expect(pkgJson.version).toBe("1.0.1-beta.0");
   });

--- a/test/cli/install/bun-install-cli-args.test.ts
+++ b/test/cli/install/bun-install-cli-args.test.ts
@@ -21,9 +21,7 @@ test.skipIf(isWindows || !isDebug)(
     // debug binary is large, so filter inside the pipeline rather than pulling
     // the whole symbol table into JS.
     const needle = "install.PackageManager.CommandLineArguments.parse__";
-    const { stdout, exitCode } = await Bun.$`nm --defined-only ${bunExe()} | grep -F ${needle}`
-      .nothrow()
-      .quiet();
+    const { stdout, exitCode } = await Bun.$`nm --defined-only ${bunExe()} | grep -F ${needle}`.nothrow().quiet();
     const text = stdout.toString("utf8");
     const matches = text.split("\n").filter(line => line.includes(needle));
     // If the toolchain ever stops emitting this symbol name the test becomes a

--- a/test/cli/install/bun-install-cli-args.test.ts
+++ b/test/cli/install/bun-install-cli-args.test.ts
@@ -1,0 +1,165 @@
+// Locks in per-subcommand CLI argument parsing behavior for the package
+// manager commands. `CommandLineArguments.parse` now takes `subcommand`
+// as a runtime parameter and dispatches to a per-subcommand param table
+// for the streaming parser, so these tests verify that short-flag
+// resolution stays subcommand-specific.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(cwd: string, args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("package manager CLI args", () => {
+  describe("--help shows only each subcommand's own flags", () => {
+    test.each([
+      // [subcommand, flag that SHOULD appear, flag that must NOT appear]
+      ["add", "-d, --dev", "--latest"],
+      ["install", "--filter", "--tag"],
+      ["update", "--latest", "--dev"],
+      ["remove", "--global", "--dev"],
+      ["outdated", "-F, --filter", "--dev"],
+      ["publish", "--tag", "--dev"],
+      ["pm", "bun pm pack", "--latest"],
+      ["audit", "--audit-level", "--dev"],
+      ["why", "--top", "--dev"],
+      ["link", "--save", "--dev"],
+      ["patch", "--commit", "--dev"],
+    ] as const)("%s", async (subcommand, mustContain, mustNotContain) => {
+      using dir = tempDir("pm-cli-help", {
+        "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      });
+      const { stdout, exitCode } = await run(String(dir), [subcommand, "--help"]);
+      expect(stdout).toContain(mustContain);
+      expect(stdout).not.toContain(mustNotContain);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("unknown short flags are rejected per subcommand", () => {
+    // These short flags exist for OTHER subcommands but not the one under test.
+    // The streaming parser should reject them with InvalidArgument, not silently
+    // accept them via the shared superset result struct.
+    test.each([
+      ["remove", "-d"], // -d is add/install only
+      ["remove", "-E"], // -E is add/install only
+      ["install", "-F"], // -F is outdated only (install has --filter long-only)
+      ["install", "-i"], // -i is update only
+      ["add", "-r"], // -r is update/outdated only
+      ["link", "-d"], // -d is add/install only
+      ["why", "-a"], // -a is add/install/pm only
+    ] as const)("bun %s %s", async (subcommand, short) => {
+      using dir = tempDir("pm-cli-short-reject", {
+        "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      });
+      const { stdout, stderr, exitCode } = await run(String(dir), [subcommand, short, "pkg"]);
+      const combined = stdout + stderr;
+      expect(combined).toContain(`Invalid Argument '${short}'`);
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  test("bun add -d adds to devDependencies (short flag maps to --dev)", async () => {
+    using dir = tempDir("pm-cli-add-dev", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      "pkg/package.json": JSON.stringify({ name: "localpkg", version: "1.0.0" }),
+    });
+    const { stderr, exitCode } = await run(String(dir), ["add", "-d", "file:./pkg"]);
+    expect(stderr).not.toContain("Invalid Argument");
+    expect(exitCode).toBe(0);
+    const pkgJson = await Bun.file(`${dir}/package.json`).json();
+    expect(pkgJson.devDependencies).toEqual({ localpkg: "file:./pkg" });
+    expect(pkgJson.dependencies).toBeUndefined();
+  });
+
+  test("bun add -E adds exact version (short flag maps to --exact)", async () => {
+    using dir = tempDir("pm-cli-add-exact", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+      "pkg/package.json": JSON.stringify({ name: "localpkg", version: "2.3.4" }),
+    });
+    const { stderr, exitCode } = await run(String(dir), ["add", "-E", "file:./pkg"]);
+    expect(stderr).not.toContain("Invalid Argument");
+    expect(exitCode).toBe(0);
+    const pkgJson = await Bun.file(`${dir}/package.json`).json();
+    expect(pkgJson.dependencies).toEqual({ localpkg: "file:./pkg" });
+  });
+
+  test("bun update --latest is recognized", async () => {
+    using dir = tempDir("pm-cli-update-latest", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["update", "--latest"]);
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Invalid Argument");
+    // update on an empty project succeeds with nothing to do
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun remove --latest is silently ignored (unknown long flag)", async () => {
+    // StreamingClap skips unrecognized long flags; --latest is update-only so
+    // remove should proceed as if it weren't passed (and fail on the missing
+    // package rather than on the flag).
+    using dir = tempDir("pm-cli-remove-latest", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    });
+    const { stdout, stderr } = await run(String(dir), ["remove", "--latest", "nonexistent"]);
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Invalid Argument '--latest'");
+    expect(combined).not.toMatch(/--latest.*does not take a value|requires a value/);
+  });
+
+  test("bun publish --tag recognizes subcommand-specific option", async () => {
+    using dir = tempDir("pm-cli-publish-tag", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0", private: true }),
+    });
+    const { stdout, stderr } = await run(String(dir), ["publish", "--tag", "beta", "--dry-run"]);
+    const combined = stdout + stderr;
+    // --tag takes a value; if parsing were wrong we'd get "does not take a value" or "Invalid Argument"
+    expect(combined).not.toContain("Invalid Argument '--tag'");
+    expect(combined).not.toContain("does not take a value");
+  });
+
+  test("bun pm parses --message and --preid (pm-only options)", async () => {
+    using dir = tempDir("pm-cli-pm-version", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0" }),
+    });
+    const { stdout, stderr } = await run(String(dir), [
+      "pm",
+      "version",
+      "--no-git-tag-version",
+      "--preid",
+      "beta",
+      "--message",
+      "msg",
+      "prerelease",
+    ]);
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Invalid Argument");
+    expect(combined).not.toContain("does not take a value");
+    const pkgJson = await Bun.file(`${dir}/package.json`).json();
+    expect(pkgJson.version).toBe("1.0.1-beta.0");
+  });
+
+  test("bun pm ls --depth recognizes pm-only option with value", async () => {
+    using dir = tempDir("pm-cli-pm-depth", {
+      "package.json": JSON.stringify({ name: "test", version: "1.0.0", dependencies: { localpkg: "file:./pkg" } }),
+      "pkg/package.json": JSON.stringify({ name: "localpkg", version: "1.0.0" }),
+    });
+    await run(String(dir), ["install"]);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["pm", "ls", "--depth", "1"]);
+    const combined = stdout + stderr;
+    expect(combined).not.toContain("Invalid Argument '--depth'");
+    expect(combined).not.toContain("invalid depth value");
+    expect(combined).not.toContain("requires a value");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/install/bun-install-cli-args.test.ts
+++ b/test/cli/install/bun-install-cli-args.test.ts
@@ -17,27 +17,23 @@ beforeAll(() => {
 // silently fanning back out (e.g. someone reintroducing `inline else`).
 //
 // Debug-only: release binaries are stripped. Linux/macOS-only: uses `nm`.
-test.skipIf(isWindows || !isDebug)(
-  "CommandLineArguments.parse is instantiated once",
-  async () => {
-    // Zig mangles as `install.PackageManager.CommandLineArguments.parse__<hash>`
-    // (and `parse__anon_<n>__<hash>` for each comptime-specialized copy). The
-    // debug binary is large, so filter inside the pipeline rather than pulling
-    // the whole symbol table into JS.
-    const needle = "install.PackageManager.CommandLineArguments.parse__";
-    const { stdout, exitCode } = await Bun.$`nm --defined-only ${bunExe()} | grep -F ${needle}`.nothrow().quiet();
-    const text = stdout.toString("utf8");
-    const matches = text.split("\n").filter(line => line.includes(needle));
-    // If the toolchain ever stops emitting this symbol name the test becomes a
-    // no-op, so require at least one match.
-    expect(matches.length).toBeGreaterThanOrEqual(1);
-    // Previously 16 copies (one per Subcommand). Keep it at one.
-    expect(matches.length).toBe(1);
-    // grep exits 0 when it finds matches.
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+test.skipIf(isWindows || !isDebug)("CommandLineArguments.parse is instantiated once", async () => {
+  // Zig mangles as `install.PackageManager.CommandLineArguments.parse__<hash>`
+  // (and `parse__anon_<n>__<hash>` for each comptime-specialized copy). The
+  // debug binary is large, so filter inside the pipeline rather than pulling
+  // the whole symbol table into JS.
+  const needle = "install.PackageManager.CommandLineArguments.parse__";
+  const { stdout, exitCode } = await Bun.$`nm --defined-only ${bunExe()} | grep -F ${needle}`.nothrow().quiet();
+  const text = stdout.toString("utf8");
+  const matches = text.split("\n").filter(line => line.includes(needle));
+  // If the toolchain ever stops emitting this symbol name the test becomes a
+  // no-op, so require at least one match.
+  expect(matches.length).toBeGreaterThanOrEqual(1);
+  // Previously 16 copies (one per Subcommand). Keep it at one.
+  expect(matches.length).toBe(1);
+  // grep exits 0 when it finds matches.
+  expect(exitCode).toBe(0);
+});
 
 async function run(cwd: string, args: string[]) {
   await using proc = Bun.spawn({


### PR DESCRIPTION
## What

`PackageManager.CommandLineArguments.parse` took `comptime subcommand: Subcommand` and switched on it to pick one of 16 comptime param tables for `clap.parse`. Because `clap.parse`'s return type depends on the comptime `params` slice, this produced 16 distinct `ComptimeClap(Help, params)` types and 16 copies of the ~400-line `parse` body, plus a fan-out of `Args`/`parseEx`/`flag`/`option` wrappers per type.

## How

- Build one comptime **superset** `all_params` table — the deduplicated union of every subcommand's params (matched by long name / positional). `clap.parse` is called once against this superset, so there is exactly one `ComptimeClap` type and one result struct.
- Add `ParseOptions.stream_params: ?[]const Param(usize)` and expose `ComptimeClap.params_converted`. `ComptimeClap.parse` now iterates `opt.stream_params orelse converted_params` so a runtime-selected subset can drive the streaming parser while storing into the shared superset struct.
- For each subcommand, build a comptime subset of `Param(usize)` whose `id` points at the matching superset slot but whose `names` come from that subcommand's original table. This preserves per-subcommand short-alias behavior (`-a` = `--analyze` on install/add vs `-a` = `--all` on pm; `-F` on outdated only; etc.) and unknown-short-flag rejection.
- `subcommand` becomes a plain runtime parameter; every `comptime subcommand == .x` guard becomes a runtime branch. The `inline else` dispatch in `updatePackageJSONAndInstall` collapses to a direct call.

## Binary size

Release stripped `bun`, linux-x64:

|                 | before     | after      | Δ            |
| --------------- | ---------- | ---------- | ------------ |
| stripped binary | 91,892,680 | 91,732,936 | **−159,744** |

`bun-profile` symbol counts:

|                                       | before         | after         |
| ------------------------------------- | -------------- | ------------- |
| `CommandLineArguments.parse` copies   | 16 (66,448 B)  | 1 (7,157 B)   |
| `ComptimeClap`-related symbols        | 907            | 456           |

## Verification

- `--help` output for `install`, `add`, `update`, `remove`, `link`, `unlink`, `outdated`, `publish`, `audit`, `info`, `why`, `patch`, `pm` is **byte-identical** to `main`.
- `bun remove -d pkg`, `bun install -F '*'`, `bun add -r pkg`, `bun why -a pkg` → still `Invalid Argument '<short>'` (subset restriction works).
- `bun add -d file:./pkg` → devDependencies; `bun add -E file:./pkg` → exact; `bun pm version --preid beta prerelease` → `1.0.1-beta.0`.
- New `test/cli/install/bun-install-cli-args.test.ts` (25 cases) locks in per-subcommand arg-table scoping and short-flag rejection.
- `bun run zig:check-all` passes on all targets.
- `test/cli/install/bun-install.test.ts`, `bun-update`, `bun-patch`, `bun-install-cpu-os`, `bun-pm`, `bun-pack`, `bun-publish`, `bun-remove`, `bun-pm-why`, `bun-pm-version`, `minimum-release-age`: same pass/fail sets on release builds of `main` vs this branch.