### PR TITLE
css: extract type-independent prologue/epilogue from parser closure trampolines (−320 KB)

### DIFF
--- a/src/css/css_parser.zig
+++ b/src/css/css_parser.zig
@@ -1151,36 +1151,49 @@ fn parse_qualified_rule(
     return parse_nested_block(input, P.QualifiedRuleParser.QualifiedRule, &closure, Closure.parsefn);
 }
 
-fn parse_until_before(
+// The `parse_until_before`, `parse_until_after`, and `parse_nested_block` functions below
+// are generic over the closure type and get monomorphized once per call-site closure
+// (hundreds of instances each in release builds). Their bodies are >70% type-independent:
+// block-type lookup, Delimiters union setup, nested Parser struct init,
+// `consume_until_end_of_block` cleanup, the post-parse delimiter-scan while loop. Only the
+// inner `parseEntirely(closure, &nested)` call is closure-specific.
+//
+// To keep binary size down, the type-independent prologue/epilogue is extracted into
+// non-generic `noinline` helpers so each monomorphized generic body is just a few calls.
+//
+// The generic bodies themselves are also `noinline`: without it, LLVM inlines the now-tiny
+// bodies into recursive callers like `parse_at_rule`, hoisting the nested `Parser` stack
+// slot into a frame that persists through deep recursion (nested `@media` etc.) and
+// reducing the max nesting depth before stack overflow.
+
+noinline fn parse_until_before_begin(
     parser: *Parser,
     delimiters_: Delimiters,
-    error_behavior: ParseUntilErrorBehavior,
-    comptime T: type,
-    closure: anytype,
-    comptime parse_fn: *const fn (@TypeOf(closure), *Parser) Result(T),
-) Result(T) {
+    delimited_parser: *Parser,
+) Delimiters {
     const delimiters = bun.bits.@"or"(Delimiters, parser.stop_before, delimiters_);
-    const result = result: {
-        var delimited_parser = Parser{
-            .input = parser.input,
-            .at_start_of = if (parser.at_start_of) |block_type| brk: {
-                parser.at_start_of = null;
-                break :brk block_type;
-            } else null,
-            .stop_before = delimiters,
-            .import_records = parser.import_records,
-            .flags = parser.flags,
-            .extra = parser.extra,
-        };
-        const result = delimited_parser.parseEntirely(T, closure, parse_fn);
-        if (error_behavior == .stop and result.isErr()) {
-            return result;
-        }
-        if (delimited_parser.at_start_of) |block_type| {
-            consume_until_end_of_block(block_type, &delimited_parser.input.tokenizer);
-        }
-        break :result result;
+    delimited_parser.* = Parser{
+        .input = parser.input,
+        .at_start_of = if (parser.at_start_of) |block_type| brk: {
+            parser.at_start_of = null;
+            break :brk block_type;
+        } else null,
+        .stop_before = delimiters,
+        .import_records = parser.import_records,
+        .flags = parser.flags,
+        .extra = parser.extra,
     };
+    return delimiters;
+}
+
+noinline fn parse_until_before_end(
+    parser: *Parser,
+    delimited_parser: *Parser,
+    delimiters: Delimiters,
+) void {
+    if (delimited_parser.at_start_of) |block_type| {
+        consume_until_end_of_block(block_type, &delimited_parser.input.tokenizer);
+    }
 
     // FIXME: have a special-purpose tokenizer method for this that does less work.
     while (true) {
@@ -1195,25 +1208,27 @@ fn parse_until_before(
             else => break,
         }
     }
-
-    return result;
 }
 
-// fn parse_until_before_impl(parser: *Parser, delimiters: Delimiters, error_behavior: Parse
-
-pub fn parse_until_after(
+noinline fn parse_until_before(
     parser: *Parser,
-    delimiters: Delimiters,
+    delimiters_: Delimiters,
     error_behavior: ParseUntilErrorBehavior,
     comptime T: type,
     closure: anytype,
-    comptime parsefn: *const fn (@TypeOf(closure), *Parser) Result(T),
+    comptime parse_fn: *const fn (@TypeOf(closure), *Parser) Result(T),
 ) Result(T) {
-    const result = parse_until_before(parser, delimiters, error_behavior, T, closure, parsefn);
-    const is_err = result.isErr();
-    if (error_behavior == .stop and is_err) {
+    var delimited_parser: Parser = undefined;
+    const delimiters = parse_until_before_begin(parser, delimiters_, &delimited_parser);
+    const result = delimited_parser.parseEntirely(T, closure, parse_fn);
+    if (error_behavior == .stop and result.isErr()) {
         return result;
     }
+    parse_until_before_end(parser, &delimited_parser, delimiters);
+    return result;
+}
+
+noinline fn parse_until_after_end(parser: *Parser, delimiters: Delimiters) void {
     const next_byte = parser.input.tokenizer.nextByte();
     if (next_byte != null and !bun.bits.contains(Delimiters, parser.stop_before, .fromByte(next_byte))) {
         if (bun.Environment.isDebug) bun.debugAssert(bun.bits.contains(Delimiters, delimiters, Delimiters.fromByte(next_byte)));
@@ -1224,10 +1239,25 @@ pub fn parse_until_after(
             consume_until_end_of_block(BlockType.curly_bracket, &parser.input.tokenizer);
         }
     }
+}
+
+pub fn parse_until_after(
+    parser: *Parser,
+    delimiters: Delimiters,
+    error_behavior: ParseUntilErrorBehavior,
+    comptime T: type,
+    closure: anytype,
+    comptime parsefn: *const fn (@TypeOf(closure), *Parser) Result(T),
+) Result(T) {
+    const result = parse_until_before(parser, delimiters, error_behavior, T, closure, parsefn);
+    if (error_behavior == .stop and result.isErr()) {
+        return result;
+    }
+    parse_until_after_end(parser, delimiters);
     return result;
 }
 
-fn parse_nested_block(parser: *Parser, comptime T: type, closure: anytype, comptime parsefn: *const fn (@TypeOf(closure), *Parser) Result(T)) Result(T) {
+noinline fn parse_nested_block_begin(parser: *Parser, nested_parser: *Parser) BlockType {
     const block_type: BlockType = if (parser.at_start_of) |block_type| brk: {
         parser.at_start_of = null;
         break :brk block_type;
@@ -1238,23 +1268,33 @@ fn parse_nested_block(parser: *Parser, comptime T: type, closure: anytype, compt
         \\token was just consumed.
     );
 
-    const closing_delimiter = switch (block_type) {
-        .curly_bracket => Delimiters{ .close_curly_bracket = true },
-        .square_bracket => Delimiters{ .close_square_bracket = true },
-        .parenthesis => Delimiters{ .close_parenthesis = true },
+    const closing_delimiter: Delimiters = switch (block_type) {
+        .curly_bracket => .{ .close_curly_bracket = true },
+        .square_bracket => .{ .close_square_bracket = true },
+        .parenthesis => .{ .close_parenthesis = true },
     };
-    var nested_parser = Parser{
+    nested_parser.* = Parser{
         .input = parser.input,
         .stop_before = closing_delimiter,
         .import_records = parser.import_records,
         .flags = parser.flags,
         .extra = parser.extra,
     };
-    const result = nested_parser.parseEntirely(T, closure, parsefn);
+    return block_type;
+}
+
+noinline fn parse_nested_block_end(parser: *Parser, nested_parser: *Parser, block_type: BlockType) void {
     if (nested_parser.at_start_of) |block_type2| {
         consume_until_end_of_block(block_type2, &nested_parser.input.tokenizer);
     }
     consume_until_end_of_block(block_type, &parser.input.tokenizer);
+}
+
+noinline fn parse_nested_block(parser: *Parser, comptime T: type, closure: anytype, comptime parsefn: *const fn (@TypeOf(closure), *Parser) Result(T)) Result(T) {
+    var nested_parser: Parser = undefined;
+    const block_type = parse_nested_block_begin(parser, &nested_parser);
+    const result = nested_parser.parseEntirely(T, closure, parsefn);
+    parse_nested_block_end(parser, &nested_parser, block_type);
     return result;
 }
 

--- a/test/bundler/css/nested-parsing.test.ts
+++ b/test/bundler/css/nested-parsing.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+// Regression coverage for the CSS parser's generic closure trampolines
+// `parse_nested_block` / `parse_until_before` / `parse_until_after` in
+// src/css/css_parser.zig. These are monomorphized per call-site closure and
+// share non-generic prologue/epilogue helpers to keep binary size down; this
+// test exercises a representative spread of those call sites (nested at-rules,
+// functional pseudo-classes, supports(), var(), calc(), env(), gradients,
+// comma lists) so that a regression in the shared helpers surfaces as an
+// output diff.
+describe("css", () => {
+  itBundled("css/nested-block-trampolines", {
+    files: {
+      "index.css": /* css */ `
+        @layer base, components;
+
+        @layer base {
+          @supports (display: grid) and (not (display: inline-grid)) {
+            @media screen and (min-width: 300px), (orientation: landscape) {
+              @container sidebar (width > 200px) {
+                .grid:is(.a, .b):not(:nth-child(2n + 1 of .item)) {
+                  --x: var(--y, calc(1px + 2%));
+                  color: color-mix(in srgb, red 20%, blue);
+                  background: linear-gradient(to right, rgb(0 0 0 / 0.5), hsl(120 50% 50%));
+                  grid-template-columns: repeat(3, minmax(0, 1fr));
+                  transition: color 1s, opacity 2s !important;
+                }
+                .grid > [data-x="y"] { content: attr(data-x); }
+              }
+            }
+          }
+        }
+
+        @scope (.light) to (.dark) {
+          @media (prefers-color-scheme: dark) {
+            :scope { color: env(safe-area-inset-top, 0px); }
+          }
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        @layer base, components;
+
+        @layer base {
+          @supports (display: grid) and ( not (display: inline-grid)) {
+            @media screen and (min-width: 300px), (orientation: landscape) {
+              @container sidebar (width > 200px) {
+                .grid:is(.a, .b):not(:nth-child(odd of .item)) {
+                  --x: var(--y, calc(1px + 2%));
+                  color: #30c;
+                  background: linear-gradient(to right, #00000080, #40bf40);
+                  grid-template-columns: repeat(3, minmax(0, 1fr));
+                  transition: color 1s, opacity 2s !important;
+                }
+
+                .grid > [data-x="y"] {
+                  content: attr(data-x);
+                }
+              }
+            }
+          }
+        }
+
+        @scope (.light) to (.dark) {
+          @media (prefers-color-scheme: dark) {
+            :scope {
+              color: env(safe-area-inset-top, 0px);
+            }
+          }
+        }
+        "
+      `);
+    },
+  });
+
+  // Moderately deep at-rule nesting. The refactored closure trampolines keep
+  // each generic body `noinline` so the nested `Parser` stack slot stays in a
+  // leaf frame during recursion; without that, LLVM can inline the tiny
+  // generic body into `parse_at_rule` and push the per-level stack footprint
+  // high enough to overflow well before this depth. The only existing coverage
+  // for this in `css-fuzz.test.ts` is gated behind `!isCI`.
+  const depth = 40;
+  itBundled("css/nested-at-rule-recursion", {
+    files: {
+      "index.css": `${"@media screen{".repeat(depth)}.x{color:red}${"}".repeat(depth)}`,
+    },
+    outdir: "/out",
+    minifyWhitespace: true,
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      expect(api.readFile("/out/index.css")).toBe(
+        `${"@media screen{".repeat(depth)}.x{color:red}${"}".repeat(depth)}\n`,
+      );
+    },
+  });
+});


### PR DESCRIPTION
## What

`parse_nested_block`, `parse_until_before`, and `parse_until_after` in `src/css/css_parser.zig` are generic over the closure type and get monomorphized once per call-site closure. In the release build:

| | instances | bytes | avg |
|---|---|---|---|
| `parse_nested_block` (before) | 427 | 181,090 | 424 |
| `parse_until_before` (before) | 106 | 63,620 | 600 |

Their bodies are >70% type-independent: block-type lookup, `Delimiters` union setup, nested `Parser` struct init, `consume_until_end_of_block` cleanup, the post-parse delimiter-scan loop. Only the inner `parseEntirely(closure, &nested)` call is closure-specific.

## How

Extract the type-independent setup/cleanup into non-generic `noinline` helpers:
- `parse_nested_block_begin` / `parse_nested_block_end`
- `parse_until_before_begin` / `parse_until_before_end`
- `parse_until_after_end`

Each monomorphized generic body is now: begin → `parseEntirely` → end.

| | instances | bytes | avg |
|---|---|---|---|
| `parse_nested_block` (after) | 429 | 129,435 | 301 |
| `parse_until_before` (after) | 108 | 38,439 | 355 |
| 5 non-generic helpers | 5 | 508 | — |

The generic bodies themselves are also marked `noinline`. Without it, LLVM inlines the now-tiny bodies into recursive callers like `parse_at_rule`, hoisting the nested `Parser` stack slot into a frame that persists through deep recursion (nested `@media` etc.) and reducing the max nesting depth before stack overflow. With `noinline`, max nesting depth matches main (~306 levels of `@media screen { ... }`).

## Result

| | before | after | Δ |
|---|---|---|---|
| release `bun` (stripped) | 91,814,856 | 91,487,176 | **−327,680 B (−320 KB)** |
| `bun-profile` | 363,483,040 | 362,979,472 | −503,568 B (−492 KB) |

The direct trampoline savings are ~76 KB; the rest comes from `noinline` on the generic bodies preventing them from being inlined into (and bloating) their callers.

## Verified

- `bun bd test test/js/bun/css/css.test.ts test/bundler/css/ test/bundler/esbuild/css.test.ts` — 1251 pass, 0 fail
- `css-fuzz.test.ts` — 5/5 runs pass on the new release binary
- `bun build` and `bun build --minify` output is **byte-identical** to main on all 15 CSS fixtures in `test/js/bun/css/files/` (bootstrap, tailwind, bulma, foundation, uikit, materialize, pico, tachyons, animate, normalize, hint, bulma.min, foundation.min, random-gradients, trainer-gallery-holo)
- Max `@media` nesting depth before stack overflow matches main (both handle 306, crash at ~307)

CSS parsing only runs in `bun build` with CSS inputs — cold path, no perf risk.