### PR TITLE
Extract format-independent body from createErrorInstance (-444 KB)

### DIFF
--- a/src/jsc/JSGlobalObject.zig
+++ b/src/jsc/JSGlobalObject.zig
@@ -284,47 +284,113 @@ pub const JSGlobalObject = opaque {
         return result;
     }
 
-    pub fn createErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
-        if (comptime std.meta.fieldNames(@TypeOf(args)).len > 0) {
-            var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());
-            var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
-            defer buf.deinit();
-            var writer = &buf.writer;
-            writer.print(fmt, args) catch {
-                // if an exception occurs in the middle of formatting the error message, it's better to just return the formatting string than an error about an error.
-                // Clear any pending JS exception (e.g. from Symbol.toPrimitive) so that throwValue doesn't hit assertNoException.
-                _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toErrorInstance(this);
+    /// Error class selector for `createErrorInstanceWithFmtImpl`.
+    const ErrorKind = enum(u8) {
+        err,
+        type_error,
+        syntax_error,
+        range_error,
+
+        fn construct(kind: ErrorKind, str: *const ZigString, global: *JSGlobalObject) JSValue {
+            return switch (kind) {
+                .err => str.toErrorInstance(global),
+                .type_error => str.toTypeErrorInstance(global),
+                .syntax_error => str.toSyntaxErrorInstance(global),
+                .range_error => str.toRangeErrorInstance(global),
             };
-
-            // Ensure we clone it.
-            var str = ZigString.initUTF8(buf.written());
-
-            return str.toErrorInstance(this);
-        } else {
-            if (comptime strings.isAllASCII(fmt)) {
-                return String.static(fmt).toErrorInstance(this);
-            } else {
-                return ZigString.initUTF8(fmt).toErrorInstance(this);
-            }
         }
+    };
+
+    /// Type-erased printer invoked by `createErrorInstanceWithFmtImpl`. This is
+    /// the only bit that differs per comptime format string.
+    const PrintErrorFn = *const fn (*std.Io.Writer, *const anyopaque) std.Io.Writer.Error!void;
+
+    fn PrintThunk(comptime fmt: [:0]const u8, comptime Args: type) type {
+        return struct {
+            fn print(w: *std.Io.Writer, args: *const anyopaque) std.Io.Writer.Error!void {
+                const a: *const Args = @ptrCast(@alignCast(args));
+                return w.print(fmt, a.*);
+            }
+        };
+    }
+
+    /// Shared, format-independent body of `createErrorInstance` and siblings.
+    ///
+    /// The per-format wrappers are monomorphized hundreds of times across the
+    /// codebase; keeping the boilerplate (stack buffer setup, exception
+    /// handling, UTF-8 marking, cleanup) in a single `noinline` body keeps each
+    /// wrapper to a handful of instructions.
+    noinline fn createErrorInstanceWithFmtImpl(
+        this: *JSGlobalObject,
+        kind: ErrorKind,
+        print_fn: PrintErrorFn,
+        args_ptr: *const anyopaque,
+        fallback: [:0]const u8,
+        strip_ansi: bool,
+    ) JSValue {
+        var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());
+        var buf = std.Io.Writer.Allocating.initCapacity(stack_fallback.get(), 2048) catch unreachable;
+        defer buf.deinit();
+
+        print_fn(&buf.writer, args_ptr) catch {
+            // If an exception occurs while formatting the error message it's
+            // better to return the raw format string than an error about an
+            // error. Clear any pending JS exception (e.g. Symbol.toPrimitive)
+            // so that `throwValue` doesn't hit `assertNoException`.
+            _ = this.clearExceptionExceptTermination();
+            var fb = ZigString.initUTF8(fallback);
+            return kind.construct(&fb, this);
+        };
+
+        const msg = if (strip_ansi)
+            stripAnsiSgrInPlace(buf.written())
+        else
+            buf.written();
+
+        // Ensure we clone it.
+        var str = ZigString.initUTF8(msg);
+        return kind.construct(&str, this);
+    }
+
+    /// Strip ANSI SGR escape sequences (`ESC '[' … 'm'`) from `buf` in place.
+    /// These are the only sequences `Output.prettyFmt` emits. Bytes outside
+    /// such sequences (including other ESC uses) are preserved verbatim.
+    fn stripAnsiSgrInPlace(buf: []u8) []u8 {
+        var out: usize = 0;
+        var i: usize = 0;
+        while (i < buf.len) {
+            if (buf[i] == 0x1b and i + 1 < buf.len and buf[i + 1] == '[') {
+                var j = i + 2;
+                while (j < buf.len and (buf[j] == ';' or (buf[j] >= '0' and buf[j] <= '9'))) : (j += 1) {}
+                if (j < buf.len and buf[j] == 'm') {
+                    i = j + 1;
+                    continue;
+                }
+            }
+            buf[out] = buf[i];
+            out += 1;
+            i += 1;
+        }
+        return buf[0..out];
+    }
+
+    pub fn createErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
+        const Args = @TypeOf(args);
+        if (comptime std.meta.fieldNames(Args).len > 0) {
+            return createErrorInstanceWithFmtImpl(this, .err, &PrintThunk(fmt, Args).print, &args, fmt, false);
+        }
+        if (comptime strings.isAllASCII(fmt)) {
+            return String.static(fmt).toErrorInstance(this);
+        }
+        return ZigString.initUTF8(fmt).toErrorInstance(this);
     }
 
     pub fn createTypeErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
-        if (comptime std.meta.fieldNames(@TypeOf(args)).len > 0) {
-            var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());
-            var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
-            defer buf.deinit();
-            var writer = buf.writer();
-            writer.print(fmt, args) catch {
-                _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toTypeErrorInstance(this);
-            };
-            var str = ZigString.fromUTF8(buf.slice());
-            return str.toTypeErrorInstance(this);
-        } else {
-            return ZigString.static(fmt).toTypeErrorInstance(this);
+        const Args = @TypeOf(args);
+        if (comptime std.meta.fieldNames(Args).len > 0) {
+            return createErrorInstanceWithFmtImpl(this, .type_error, &PrintThunk(fmt, Args).print, &args, fmt, false);
         }
+        return ZigString.static(fmt).toTypeErrorInstance(this);
     }
 
     pub fn createDOMExceptionInstance(this: *JSGlobalObject, code: jsc.WebCore.DOMExceptionCode, comptime fmt: [:0]const u8, args: anytype) JSError!JSValue {
@@ -342,37 +408,19 @@ pub const JSGlobalObject = opaque {
     }
 
     pub fn createSyntaxErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
-        if (comptime std.meta.fieldNames(@TypeOf(args)).len > 0) {
-            var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());
-            var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
-            defer buf.deinit();
-            var writer = buf.writer();
-            writer.print(fmt, args) catch {
-                _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toSyntaxErrorInstance(this);
-            };
-            var str = ZigString.fromUTF8(buf.slice());
-            return str.toSyntaxErrorInstance(this);
-        } else {
-            return ZigString.static(fmt).toSyntaxErrorInstance(this);
+        const Args = @TypeOf(args);
+        if (comptime std.meta.fieldNames(Args).len > 0) {
+            return createErrorInstanceWithFmtImpl(this, .syntax_error, &PrintThunk(fmt, Args).print, &args, fmt, false);
         }
+        return ZigString.static(fmt).toSyntaxErrorInstance(this);
     }
 
     pub fn createRangeErrorInstance(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
-        if (comptime std.meta.fieldNames(@TypeOf(args)).len > 0) {
-            var stack_fallback = std.heap.stackFallback(1024 * 4, this.allocator());
-            var buf = bun.MutableString.init2048(stack_fallback.get()) catch unreachable;
-            defer buf.deinit();
-            var writer = buf.writer();
-            writer.print(fmt, args) catch {
-                _ = this.clearExceptionExceptTermination();
-                return ZigString.static(fmt).toRangeErrorInstance(this);
-            };
-            var str = ZigString.fromUTF8(buf.slice());
-            return str.toRangeErrorInstance(this);
-        } else {
-            return ZigString.static(fmt).toRangeErrorInstance(this);
+        const Args = @TypeOf(args);
+        if (comptime std.meta.fieldNames(Args).len > 0) {
+            return createErrorInstanceWithFmtImpl(this, .range_error, &PrintThunk(fmt, Args).print, &args, fmt, false);
         }
+        return ZigString.static(fmt).toRangeErrorInstance(this);
     }
 
     pub fn createRangeError(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) JSValue {
@@ -425,9 +473,32 @@ pub const JSGlobalObject = opaque {
     }
 
     pub fn throwPretty(this: *JSGlobalObject, comptime fmt: [:0]const u8, args: anytype) bun.JSError {
-        const instance = switch (Output.enable_ansi_colors_stderr) {
-            inline else => |enabled| this.createErrorInstance(Output.prettyFmt(fmt, enabled), args),
+        const Args = @TypeOf(args);
+        const colored = comptime Output.prettyFmt(fmt, true);
+        const plain = comptime Output.prettyFmt(fmt, false);
+        // Only strip when the format string actually introduces ANSI codes.
+        // This keeps behaviour identical for formats that contain no markup.
+        const has_markup = comptime std.mem.indexOfScalar(u8, colored, 0x1b) != null;
+
+        const instance = inst: {
+            if (comptime std.meta.fieldNames(Args).len > 0) {
+                // Format once with the colored template, then strip ANSI SGR
+                // sequences at runtime when colours are disabled. This halves
+                // the number of `Writer.print` monomorphizations versus the
+                // previous `inline else` over `enable_ansi_colors_stderr`.
+                break :inst createErrorInstanceWithFmtImpl(
+                    this,
+                    .err,
+                    &PrintThunk(colored, Args).print,
+                    &args,
+                    plain,
+                    has_markup and !Output.enable_ansi_colors_stderr,
+                );
+            }
+            const s: [:0]const u8 = if (!has_markup or Output.enable_ansi_colors_stderr) colored else plain;
+            break :inst ZigString.initUTF8(s).toErrorInstance(this);
         };
+
         if (instance == .zero) {
             bun.assert(this.hasException());
             return error.JSError;

--- a/test/js/bun/test/error-message-formatting.test.ts
+++ b/test/js/bun/test/error-message-formatting.test.ts
@@ -52,35 +52,38 @@ describe("throwPretty color handling", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
-    return stdout + stderr;
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out: stdout + stderr, exitCode };
   }
 
   test("NO_COLOR strips all ANSI SGR sequences from the error message", async () => {
-    const out = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
+    const { out, exitCode } = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
     // The error body must be present...
     expect(out).toContain("expect(received).toBe(expected)");
     expect(out).toContain("Expected: 2");
     expect(out).toContain("Received: 1");
     // ...and contain no escape bytes at all.
     expect(out.includes(ESC)).toBe(false);
+    expect(exitCode).toBe(1);
   });
 
   test("FORCE_COLOR keeps ANSI SGR sequences in the error message", async () => {
-    const out = await run({ FORCE_COLOR: "1", NO_COLOR: undefined });
+    const { out, exitCode } = await run({ FORCE_COLOR: "1", NO_COLOR: undefined });
     // `received` is wrapped in <red>...</r>; `expected` in <green>...</r>.
     expect(out).toContain(`${ESC}[31mreceived`);
     expect(out).toContain(`${ESC}[32mexpected`);
     expect(out).toContain(`${ESC}[32m2${ESC}[0m`);
     expect(out).toContain(`${ESC}[31m1${ESC}[0m`);
+    expect(exitCode).toBe(1);
   });
 
   test("NO_COLOR output matches prettyFmt(fmt, false) exactly for the error body", async () => {
-    const out = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
+    const { out, exitCode } = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
     // This is the exact text `Output.prettyFmt(fmt, false)` would have
     // produced for the toBe failure format string. It must survive the
     // strip-after-format path unchanged.
     const expectedBody = "expect(received).toBe(expected)\n\nExpected: 2\nReceived: 1\n";
     expect(out).toContain(expectedBody);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/error-message-formatting.test.ts
+++ b/test/js/bun/test/error-message-formatting.test.ts
@@ -8,7 +8,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 const ESC = "\x1b";
 
-describe("createErrorInstance message formatting", () => {
+describe.concurrent("createErrorInstance message formatting", () => {
   test("TypeError / RangeError / Error messages are formatted with args", async () => {
     const src = `
       const out = [];
@@ -35,7 +35,7 @@ describe("createErrorInstance message formatting", () => {
   });
 });
 
-describe("throwPretty color handling", () => {
+describe.concurrent("throwPretty color handling", () => {
   // `expect(1).toBe(2)` fails via `throwPretty` with a format string that
   // contains <d>/<r>/<green>/<red> markup.
   async function run(extraEnv: Record<string, string | undefined>) {

--- a/test/js/bun/test/error-message-formatting.test.ts
+++ b/test/js/bun/test/error-message-formatting.test.ts
@@ -3,7 +3,7 @@
 // with a type-erased per-format printer; this test pins the observable
 // output so that refactor stays honest.
 
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 const ESC = "\x1b";

--- a/test/js/bun/test/error-message-formatting.test.ts
+++ b/test/js/bun/test/error-message-formatting.test.ts
@@ -1,0 +1,86 @@
+// Behavior-preservation tests for `createErrorInstance` / `throwPretty` in
+// `src/jsc/JSGlobalObject.zig`. These paths share a single `noinline` body
+// with a type-erased per-format printer; this test pins the observable
+// output so that refactor stays honest.
+
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const ESC = "\x1b";
+
+describe("createErrorInstance message formatting", () => {
+  test("TypeError / RangeError / Error messages are formatted with args", async () => {
+    const src = `
+      const out = [];
+      try { require('util').getSystemErrorName('nope'); } catch (e) { out.push(e.constructor.name + ': ' + e.message); }
+      try { Buffer.alloc(-1); } catch (e) { out.push(e.constructor.name + ': ' + e.message); }
+      try { new TextDecoder('no-such-encoding-xyz'); } catch (e) { out.push(e.constructor.name + ': ' + e.message); }
+      process.stdout.write(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out).toEqual([
+      `TypeError: The "err" argument must be of type number. Received type string ('nope')`,
+      `RangeError: The value of "size" is out of range. It must be >= 0 and <= 4294967296. Received -1`,
+      `RangeError: Unsupported encoding label "no-such-encoding-xyz"`,
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("throwPretty color handling", () => {
+  // `expect(1).toBe(2)` fails via `throwPretty` with a format string that
+  // contains <d>/<r>/<green>/<red> markup.
+  async function run(extraEnv: Record<string, string | undefined>) {
+    using dir = tempDir("throw-pretty", {
+      "t.test.ts": `
+        import { test, expect } from "bun:test";
+        test("t", () => { expect(1).toBe(2); });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "t.test.ts"],
+      env: { ...bunEnv, ...extraEnv },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+    return stdout + stderr;
+  }
+
+  test("NO_COLOR strips all ANSI SGR sequences from the error message", async () => {
+    const out = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
+    // The error body must be present...
+    expect(out).toContain("expect(received).toBe(expected)");
+    expect(out).toContain("Expected: 2");
+    expect(out).toContain("Received: 1");
+    // ...and contain no escape bytes at all.
+    expect(out.includes(ESC)).toBe(false);
+  });
+
+  test("FORCE_COLOR keeps ANSI SGR sequences in the error message", async () => {
+    const out = await run({ FORCE_COLOR: "1", NO_COLOR: undefined });
+    // `received` is wrapped in <red>...</r>; `expected` in <green>...</r>.
+    expect(out).toContain(`${ESC}[31mreceived`);
+    expect(out).toContain(`${ESC}[32mexpected`);
+    expect(out).toContain(`${ESC}[32m2${ESC}[0m`);
+    expect(out).toContain(`${ESC}[31m1${ESC}[0m`);
+  });
+
+  test("NO_COLOR output matches prettyFmt(fmt, false) exactly for the error body", async () => {
+    const out = await run({ NO_COLOR: "1", FORCE_COLOR: undefined });
+    // This is the exact text `Output.prettyFmt(fmt, false)` would have
+    // produced for the toBe failure format string. It must survive the
+    // strip-after-format path unchanged.
+    const expectedBody = "expect(received).toBe(expected)\n\nExpected: 2\nReceived: 1\n";
+    expect(out).toContain(expectedBody);
+  });
+});

--- a/test/js/bun/test/error-message-formatting.test.ts
+++ b/test/js/bun/test/error-message-formatting.test.ts
@@ -86,4 +86,39 @@ describe.concurrent("throwPretty color handling", () => {
     expect(out).toContain(expectedBody);
     expect(exitCode).toBe(1);
   });
+
+  test("NO_COLOR strips ANSI SGR sequences that arrive via runtime args", async () => {
+    // A custom expect() label is interpolated into the throwPretty format
+    // string via `{f}`. When the user has NO_COLOR set they should not see
+    // colour escapes in the resulting error.message — including ones they
+    // put in the label themselves. The old two-template path spliced the
+    // label bytes through verbatim; the single-template + strip path removes
+    // them along with the template's own markup.
+    using dir = tempDir("throw-pretty-label", {
+      "t.test.ts": `
+        import { test, expect } from "bun:test";
+        test("t", () => {
+          try {
+            expect(1, "PRE_\\x1b[31mRED\\x1b[0m_POST").toBeNull();
+          } catch (e) {
+            process.stdout.write(JSON.stringify({ msg: e.message }));
+          }
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "t.test.ts"],
+      env: { ...bunEnv, NO_COLOR: "1", FORCE_COLOR: undefined },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const line = stdout.split("\n").find(l => l.startsWith(`{"msg"`));
+    expect(line).toBeDefined();
+    const { msg } = JSON.parse(line!) as { msg: string };
+    expect(msg).toStartWith("PRE_RED_POST\n\nReceived: ");
+    expect(msg.includes(ESC)).toBe(false);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## What

`createErrorInstance` (and `createTypeErrorInstance` / `createSyntaxErrorInstance` / `createRangeErrorInstance`) were monomorphized once per comptime format string — **778 specializations totaling ~200 KB** of `.text`, plus ~50 KB of FDE unwind info. Of each ~257 B body, only the `w.print(fmt, args)` call is actually format-specific; the rest (`stackFallback` setup, `Io.Writer.Allocating.initCapacity`, `clearExceptionExceptTermination`, `ZigString.initUTF8`, `toErrorInstance`, cleanup, prologue/epilogue) is byte-identical.

`throwPretty` compounded this with `switch (enable_ansi_colors_stderr) { inline else => |c| createErrorInstance(prettyFmt(fmt, c), args) }`, doubling the instantiation count.

## How

- Add `noinline fn createErrorInstanceWithFmtImpl(this, kind, printFn, args_ptr, fallback, strip_ansi)` containing the shared body. An `ErrorKind` enum dispatches to the right `to{,Type,Syntax,Range}ErrorInstance`.
- `PrintThunk(fmt, Args).print` is a 1-line type-erased wrapper calling `w.print(fmt, args.*)` — compiles to **10 bytes** each.
- The generic `create{,Type,Syntax,Range}ErrorInstance` wrappers become trivial forwarders.
- `throwPretty` formats once with `prettyFmt(fmt, true)` and passes `strip_ansi = !enable_ansi_colors_stderr` (only when the format actually contains markup). `stripAnsiSgrInPlace` removes `ESC '[' [0-9;]* 'm'` — exactly what `prettyFmt` emits. The args passed to `throwPretty` (`value.toFmt()`, `DiffFormatter`) already key their own color output off `enable_ansi_colors_stderr`, so when colors are off there is nothing extra to strip and the result is byte-identical.

## Numbers (linux-x64 release, stripped)

| | before | after | Δ |
|---|---:|---:|---:|
| **binary** | 91,876,296 | 91,421,640 | **−444 KB** |
| `.text` | 54,119,436 | 53,795,340 | −316 KB |
| `.eh_frame` | 2,792,184 | 2,737,184 | −54 KB |
| `.eh_frame_hdr` | 569,276 | 558,660 | −10 KB |
| `.rodata` | 32,959,160 | 32,904,248 | −54 KB |

Symbol counts (from `bun-profile`):

| | before | after |
|---|---:|---:|
| `createErrorInstance__anon_*` | 778 funcs / 199,930 B | 24 funcs / 1,575 B |
| `PrintThunk(...).print` | — | 470 funcs / 4,700 B |
| `createErrorInstanceWithFmtImpl` | — | 1 func / 610 B |

## Verification

- `bun bd test test/js/bun/test/error-message-formatting.test.ts` — new test pinning TypeError/RangeError messages and `throwPretty` output with `FORCE_COLOR` / `NO_COLOR` (passes on both main and this branch; the refactor is behavior-preserving).
- `bun bd test test/js/bun/test/expect.test.js` — 397 pass (1 unrelated stress-test timeout in debug container).
- `bun bd test test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts` — exercises the format-failure fallback path.
- `bun bd test test/js/node/util/util.test.js` — 192 pass.
- `bun run zig:check-all` — all targets compile.
- Manual: `expect(1).toBe(2)` error body byte-diffed against `main` for both `FORCE_COLOR=1` and `NO_COLOR=1`.

Error paths only; not perf-critical.