### PR TITLE
fmt: route pure-{s} allocPrint through shared concat (-287 KB .text)

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -19,6 +19,7 @@ Conventions:
 | ------------------------------------------------------------ | ------------------------------------ |
 | `std.base64`                                                 | `bun.base64`                         |
 | `std.crypto.sha{...}`                                        | `bun.sha.Hashers.{...}`              |
+| `std.fmt.allocPrint` / `std.fmt.allocPrintSentinel`          | `bun.fmt.allocPrint` / `bun.fmt.allocPrintSentinel` |
 | `std.fs.cwd()`                                               | `bun.FD.cwd()`                       |
 | `std.fs.File`                                                | `bun.sys.File`                       |
 | `std.fs.path.join/dirname/basename`                          | `bun.path.join/dirname/basename`     |

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -15,18 +15,18 @@ Conventions:
 
 **Always use `bun.*` APIs instead of `std.*`.** The `bun` namespace (`@import("bun")`) provides cross-platform wrappers that preserve OS error info and never use `unreachable`. Using `std.fs`, `std.posix`, or `std.os` directly is wrong in this codebase.
 
-| Instead of                                                   | Use                                  |
-| ------------------------------------------------------------ | ------------------------------------ |
-| `std.base64`                                                 | `bun.base64`                         |
-| `std.crypto.sha{...}`                                        | `bun.sha.Hashers.{...}`              |
+| Instead of                                                   | Use                                                 |
+| ------------------------------------------------------------ | --------------------------------------------------- |
+| `std.base64`                                                 | `bun.base64`                                        |
+| `std.crypto.sha{...}`                                        | `bun.sha.Hashers.{...}`                             |
 | `std.fmt.allocPrint` / `std.fmt.allocPrintSentinel`          | `bun.fmt.allocPrint` / `bun.fmt.allocPrintSentinel` |
-| `std.fs.cwd()`                                               | `bun.FD.cwd()`                       |
-| `std.fs.File`                                                | `bun.sys.File`                       |
-| `std.fs.path.join/dirname/basename`                          | `bun.path.join/dirname/basename`     |
-| `std.mem.eql/indexOf/startsWith` (for strings)               | `bun.strings.eql/indexOf/startsWith` |
-| `std.posix.O` / `std.posix.mode_t` / `std.posix.fd_t`        | `bun.O` / `bun.Mode` / `bun.FD`      |
-| `std.posix.open/read/write/stat/mkdir/unlink/rename/symlink` | `bun.sys.*` equivalents              |
-| `std.process.Child`                                          | `bun.spawnSync`                      |
+| `std.fs.cwd()`                                               | `bun.FD.cwd()`                                      |
+| `std.fs.File`                                                | `bun.sys.File`                                      |
+| `std.fs.path.join/dirname/basename`                          | `bun.path.join/dirname/basename`                    |
+| `std.mem.eql/indexOf/startsWith` (for strings)               | `bun.strings.eql/indexOf/startsWith`                |
+| `std.posix.O` / `std.posix.mode_t` / `std.posix.fd_t`        | `bun.O` / `bun.Mode` / `bun.FD`                     |
+| `std.posix.open/read/write/stat/mkdir/unlink/rename/symlink` | `bun.sys.*` equivalents                             |
+| `std.process.Child`                                          | `bun.spawnSync`                                     |
 
 ## `bun.sys` — System Calls (`src/sys/sys.zig`)
 

--- a/src/bake/DevServer/DirectoryWatchStore.zig
+++ b/src/bake/DevServer/DirectoryWatchStore.zig
@@ -109,7 +109,7 @@ fn insert(
     const specifier_cloned = if (specifier[0] == '.' or std.fs.path.isAbsolute(specifier))
         try dev.allocator().dupe(u8, specifier)
     else
-        try std.fmt.allocPrint(dev.allocator(), "./{s}", .{specifier});
+        try bun.fmt.allocPrint(dev.allocator(), "./{s}", .{specifier});
     errdefer dev.allocator().free(specifier_cloned);
 
     if (gop.found_existing) {

--- a/src/bake/production.zig
+++ b/src/bake/production.zig
@@ -131,7 +131,7 @@ pub fn writeSourcemapToDisk(
 
     try source_maps.put(
         allocator,
-        try std.fmt.allocPrint(allocator, "bake:/{s}", .{without_prefix}),
+        try bun.fmt.allocPrint(allocator, "bake:/{s}", .{without_prefix}),
         OutputFile.Index.init(@intCast(source_map_index)),
     );
 }
@@ -146,7 +146,7 @@ pub fn buildWithVm(ctx: bun.cli.Command.Context, cwd: []const u8, vm: *VirtualMa
     Output.flush();
     var unresolved_config_entry_point = if (ctx.args.entry_points.len > 0) ctx.args.entry_points[0] else "./bun.app";
     if (bun.resolver.isPackagePath(unresolved_config_entry_point)) {
-        unresolved_config_entry_point = try std.fmt.allocPrint(ctx.allocator, "./{s}", .{unresolved_config_entry_point});
+        unresolved_config_entry_point = try bun.fmt.allocPrint(ctx.allocator, "./{s}", .{unresolved_config_entry_point});
     }
 
     const config_entry_point = b.resolver.resolve(cwd, unresolved_config_entry_point, .entry_point_build) catch |err| {
@@ -425,7 +425,7 @@ pub fn buildWithVm(ctx: bun.cli.Command.Context, cwd: []const u8, vm: *VirtualMa
 
                         try output_module_map.put(
                             allocator,
-                            try std.fmt.allocPrint(allocator, "bake:/{s}", .{without_prefix}),
+                            try bun.fmt.allocPrint(allocator, "bake:/{s}", .{without_prefix}),
                             OutputFile.Index.init(@intCast(i)),
                         );
                     },

--- a/src/bun.js.zig
+++ b/src/bun.js.zig
@@ -218,7 +218,7 @@ pub const Run = struct {
             defer bun.default_allocator.free(escaped_path);
             const escaped_period = try escapeForJSString(bun.default_allocator, ctx.runtime_options.cron_period);
             defer bun.default_allocator.free(escaped_period);
-            const cron_script = try std.fmt.allocPrint(bun.default_allocator,
+            const cron_script = try bun.fmt.allocPrint(bun.default_allocator,
                 \\const mod = await import("{s}");
                 \\const scheduled = (mod.default || mod).scheduled;
                 \\if (typeof scheduled !== "function") throw new Error("Module does not export default.scheduled()");

--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -1812,6 +1812,203 @@ pub fn outOfRange(value: anytype, options: OutOfRangeOptions) OutOfRangeFormatte
     return .{ .value = value, .min = options.min, .max = options.max, .field_name = options.field_name, .msg = options.msg };
 }
 
+/// Drop-in replacement for `std.fmt.allocPrint` that collapses the
+/// common "string concatenation" case into a single shared runtime
+/// function instead of a fresh `Writer.print` monomorphization per
+/// (fmt, args-tuple) pair.
+///
+/// When `fmt` consists solely of literal text and bare `{s}`
+/// placeholders (no width/precision/alignment, no `{{`/`}}` escapes),
+/// the call is lowered to `bun.strings.concat` over a flat array of
+/// slices. All such call sites — `"{s}@{s}"`, `"_{s}"`, `"{s}.exe"`,
+/// `"workspace:{s}"`, and so on — share one instantiation.
+///
+/// Any other format string forwards to `std.fmt.allocPrint` unchanged.
+pub fn allocPrint(
+    allocator: std.mem.Allocator,
+    comptime format: []const u8,
+    args: anytype,
+) std.mem.Allocator.Error![]u8 {
+    const plan = comptime parseConcatPlan(format, @TypeOf(args));
+    if (plan) |segments| {
+        if (comptime segments.len == 0) {
+            return allocator.alloc(u8, 0);
+        }
+        var parts: [segments.len][]const u8 = undefined;
+        fillConcatParts(segments, args, &parts);
+        return bun.strings.concat(allocator, &parts);
+    }
+    return std.fmt.allocPrint(allocator, format, args);
+}
+
+/// Sentinel-terminated counterpart to `allocPrint`. See `allocPrint`.
+pub fn allocPrintZ(
+    allocator: std.mem.Allocator,
+    comptime format: []const u8,
+    args: anytype,
+) std.mem.Allocator.Error![:0]u8 {
+    return allocPrintSentinel(allocator, format, args, 0);
+}
+
+/// Drop-in replacement for `std.fmt.allocPrintSentinel`. See `allocPrint`.
+pub fn allocPrintSentinel(
+    allocator: std.mem.Allocator,
+    comptime format: []const u8,
+    args: anytype,
+    comptime sentinel: u8,
+) std.mem.Allocator.Error![:sentinel]u8 {
+    const plan = comptime parseConcatPlan(format, @TypeOf(args));
+    if (plan) |segments| {
+        var parts: [segments.len][]const u8 = undefined;
+        fillConcatParts(segments, args, &parts);
+        return concatSentinel(allocator, &parts, sentinel);
+    }
+    return std.fmt.allocPrintSentinel(allocator, format, args, sentinel);
+}
+
+const ConcatSegment = union(enum) {
+    literal: []const u8,
+    arg: usize,
+};
+
+inline fn fillConcatParts(
+    comptime segments: []const ConcatSegment,
+    args: anytype,
+    parts: *[segments.len][]const u8,
+) void {
+    const fields = @typeInfo(@TypeOf(args)).@"struct".fields;
+    inline for (segments, 0..) |segment, i| {
+        parts[i] = switch (segment) {
+            .literal => |lit| lit,
+            .arg => |arg_idx| concatArgSlice(@field(args, fields[arg_idx].name)),
+        };
+    }
+}
+
+/// Coerce a `{s}`-compatible argument to `[]const u8`. Mirrors the set of
+/// types `std.fmt`'s `{s}` specifier accepts.
+inline fn concatArgSlice(value: anytype) []const u8 {
+    const T = @TypeOf(value);
+    return switch (@typeInfo(T)) {
+        .pointer => |info| switch (info.size) {
+            .many, .c => std.mem.span(value),
+            else => value,
+        },
+        else => value,
+    };
+}
+
+/// Concatenate string slices into a freshly-allocated, sentinel-terminated
+/// buffer. Shared by all `allocPrintSentinel` fast-path call sites.
+fn concatSentinel(
+    allocator: std.mem.Allocator,
+    parts: []const []const u8,
+    comptime sentinel: u8,
+) std.mem.Allocator.Error![:sentinel]u8 {
+    var len: usize = 0;
+    for (parts) |p| len += p.len;
+    const out = try allocator.allocSentinel(u8, len, sentinel);
+    var remain: []u8 = out;
+    for (parts) |p| {
+        @memcpy(remain[0..p.len], p);
+        remain = remain[p.len..];
+    }
+    bun.unsafeAssert(remain.len == 0);
+    return out;
+}
+
+/// Comptime-parse `format`. Returns a list of literal/arg segments when the
+/// format string is a pure `{s}`-concat pattern, or `null` to fall through
+/// to `std.fmt`.
+fn parseConcatPlan(comptime format: []const u8, comptime Args: type) ?[]const ConcatSegment {
+    const args_info = @typeInfo(Args);
+    if (args_info != .@"struct") return null;
+    const fields = args_info.@"struct".fields;
+
+    comptime var segments: []const ConcatSegment = &.{};
+    comptime var arg_idx: usize = 0;
+    comptime var i: usize = 0;
+
+    @setEvalBranchQuota(format.len * 100 + 1000);
+
+    inline while (i < format.len) {
+        const start = i;
+        inline while (i < format.len and format[i] != '{' and format[i] != '}') : (i += 1) {}
+        if (i > start) {
+            segments = segments ++ [_]ConcatSegment{.{ .literal = format[start..i] }};
+        }
+        if (i >= format.len) break;
+
+        // A brace. `std.fmt` unescapes `{{`/`}}`; rather than duplicate that
+        // logic we let `std.fmt` handle any format string containing escapes.
+        if (i + 1 < format.len and format[i + 1] == format[i]) return null;
+        if (format[i] == '}') return null; // stray close brace → defer to std.fmt error
+
+        // `{`: only the bare `{s}` placeholder is fast-pathed. Anything else
+        // (width, precision, positional, `{d}`, `{f}`, `{any}`, ...) falls
+        // through.
+        if (i + 2 < format.len and format[i + 1] == 's' and format[i + 2] == '}') {
+            if (arg_idx >= fields.len) return null;
+            // `{s}` on a by-value array would require taking the address of a
+            // temporary; defer to std.fmt for that uncommon case.
+            if (@typeInfo(fields[arg_idx].type) == .array) return null;
+            segments = segments ++ [_]ConcatSegment{.{ .arg = arg_idx }};
+            arg_idx += 1;
+            i += 3;
+            continue;
+        }
+        return null;
+    }
+
+    if (arg_idx != fields.len) return null;
+
+    const final = segments;
+    return final;
+}
+
+test "allocPrint concat fast path parity with std.fmt" {
+    const gpa = std.testing.allocator;
+    const name: []const u8 = "lodash";
+    const version: []const u8 = "4.17.21";
+
+    // Pure-{s} patterns should be fast-pathed and match std.fmt output.
+    inline for (.{
+        .{ "{s}@{s}", .{ name, version } },
+        .{ "_{s}", .{name} },
+        .{ "{s}", .{name} },
+        .{ "{s}/{s}", .{ name, version } },
+        .{ "workspace:{s}", .{name} },
+        .{ "{s}.exe", .{name} },
+        .{ "", .{} },
+        .{ "no placeholders", .{} },
+    }) |case| {
+        // Must be classified as fast-path.
+        try std.testing.expect(parseConcatPlan(case[0], @TypeOf(case[1])) != null);
+
+        const ours = try allocPrint(gpa, case[0], case[1]);
+        defer gpa.free(ours);
+        const theirs = try std.fmt.allocPrint(gpa, case[0], case[1]);
+        defer gpa.free(theirs);
+        try std.testing.expectEqualStrings(theirs, ours);
+
+        const ours_z = try allocPrintSentinel(gpa, case[0], case[1], 0);
+        defer gpa.free(ours_z);
+        try std.testing.expectEqualStrings(theirs, ours_z);
+        try std.testing.expectEqual(@as(u8, 0), ours_z.ptr[ours_z.len]);
+    }
+
+    // Non-{s} / escaped / optioned formats must fall through to std.fmt.
+    try std.testing.expect(parseConcatPlan("{d}", @TypeOf(.{@as(u32, 0)})) == null);
+    try std.testing.expect(parseConcatPlan("{{literal}}", @TypeOf(.{})) == null);
+    try std.testing.expect(parseConcatPlan("{s:5}", @TypeOf(.{name})) == null);
+    try std.testing.expect(parseConcatPlan("{f}", @TypeOf(.{name})) == null);
+
+    // And still produce correct output via the fall-through.
+    const braces = try allocPrint(gpa, "{{a}}", .{});
+    defer gpa.free(braces);
+    try std.testing.expectEqualStrings("{a}", braces);
+}
+
 /// esbuild has an 8 character truncation of a base32 encoded bytes. this
 /// is not exactly that, but it will appear as such. the character list
 /// chosen omits similar characters in the unlikely case someone is

--- a/src/bun_core/output.zig
+++ b/src/bun_core/output.zig
@@ -1297,7 +1297,7 @@ pub fn initScopedDebugWriterAtStartup() void {
             }
 
             // do not use libuv through this code path, since it might not be initialized yet.
-            const pid = std.fmt.allocPrint(bun.default_allocator, "{d}", .{getpid()}) catch @panic("failed to allocate path");
+            const pid = bun.fmt.allocPrint(bun.default_allocator, "{d}", .{getpid()}) catch @panic("failed to allocate path");
             defer bun.default_allocator.free(pid);
 
             const path_fmt = std.mem.replaceOwned(u8, bun.default_allocator, path, "{pid}", pid) catch @panic("failed to allocate path");

--- a/src/bundler/Chunk.zig
+++ b/src/bundler/Chunk.zig
@@ -555,7 +555,7 @@ pub const Chunk = struct {
                     const buffer = brk: {
                         if (enable_source_map_shifts and FeatureFlags.source_map_debug_id) {
                             // This comment must go before the //# sourceMappingURL comment
-                            const debug_id_fmt = std.fmt.allocPrint(
+                            const debug_id_fmt = bun.fmt.allocPrint(
                                 graph.heap.allocator(),
                                 "\n//# debugId={f}\n",
                                 .{bun.SourceMap.DebugIDFormatter{ .id = chunk.isolated_hash }},

--- a/src/bundler/LinkerContext.zig
+++ b/src/bundler/LinkerContext.zig
@@ -818,7 +818,7 @@ pub const LinkerContext = struct {
         if (comptime FeatureFlags.source_map_debug_id) {
             j.pushStatic("\",\n  \"debugId\": \"");
             j.push(
-                try std.fmt.allocPrint(worker.allocator, "{f}", .{bun.SourceMap.DebugIDFormatter{ .id = isolated_hash }}),
+                try bun.fmt.allocPrint(worker.allocator, "{f}", .{bun.SourceMap.DebugIDFormatter{ .id = isolated_hash }}),
                 worker.allocator,
             );
             j.pushStatic("\",\n  \"names\": []\n}");
@@ -1002,7 +1002,7 @@ pub const LinkerContext = struct {
                                 const source = &input_files[other_source_index];
                                 tla_pretty_path = source.path.pretty;
                                 notes.append(Logger.Data{
-                                    .text = bun.handleOom(std.fmt.allocPrint(c.allocator(), "The top-level await in {s} is here:", .{tla_pretty_path})),
+                                    .text = bun.handleOom(bun.fmt.allocPrint(c.allocator(), "The top-level await in {s} is here:", .{tla_pretty_path})),
                                     .location = .initOrNull(source, parent_result_tla_keyword),
                                 }) catch |err| bun.handleOom(err);
                                 break;
@@ -1018,7 +1018,7 @@ pub const LinkerContext = struct {
                             other_source_index = parent_tla_check.parent;
 
                             try notes.append(Logger.Data{
-                                .text = try std.fmt.allocPrint(c.allocator(), "The file {s} imports the file {s} here:", .{
+                                .text = try bun.fmt.allocPrint(c.allocator(), "The file {s} imports the file {s} here:", .{
                                     input_files[parent_source_index].path.pretty,
                                     input_files[other_source_index].path.pretty,
                                 }),
@@ -1029,9 +1029,9 @@ pub const LinkerContext = struct {
                         const source: *const Logger.Source = &input_files[source_index];
                         const imported_pretty_path = source.path.pretty;
                         const text: string = if (strings.eql(imported_pretty_path, tla_pretty_path))
-                            try std.fmt.allocPrint(c.allocator(), "This require call is not allowed because the imported file \"{s}\" contains a top-level await", .{imported_pretty_path})
+                            try bun.fmt.allocPrint(c.allocator(), "This require call is not allowed because the imported file \"{s}\" contains a top-level await", .{imported_pretty_path})
                         else
-                            try std.fmt.allocPrint(c.allocator(), "This require call is not allowed because the transitive dependency \"{s}\" contains a top-level await", .{tla_pretty_path});
+                            try bun.fmt.allocPrint(c.allocator(), "This require call is not allowed because the transitive dependency \"{s}\" contains a top-level await", .{tla_pretty_path});
 
                         try c.log.addRangeErrorWithNotes(source, record.range, text, notes.items);
                     }
@@ -1470,7 +1470,7 @@ pub const LinkerContext = struct {
                             false,
                         );
 
-                        const final_generated_name = bun.handleOom(std.fmt.allocPrint(c.allocator(), "{s}_{s}", .{ original_name, path_hash }));
+                        const final_generated_name = bun.handleOom(bun.fmt.allocPrint(c.allocator(), "{s}_{s}", .{ original_name, path_hash }));
                         bun.handleOom(c.mangled_props.put(c.allocator(), ref, final_generated_name));
                     }
                 }

--- a/src/bundler/ParseTask.zig
+++ b/src/bundler/ParseTask.zig
@@ -419,7 +419,7 @@ fn getAST(
             const path_to_use = brk: {
                 // Implements embedded sqlite
                 if (loader == .sqlite_embedded) {
-                    const embedded_path = std.fmt.allocPrint(allocator, "{f}A{d:0>8}", .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() }) catch unreachable;
+                    const embedded_path = bun.fmt.allocPrint(allocator, "{f}A{d:0>8}", .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() }) catch unreachable;
                     unique_key_for_additional_file.* = .{
                         .key = embedded_path,
                         .content_hash = ContentHasher.run(source.contents),
@@ -483,7 +483,7 @@ fn getAST(
                 return error.ParserError;
             }
 
-            const unique_key = std.fmt.allocPrint(allocator, "{f}A{d:0>8}", .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() }) catch unreachable;
+            const unique_key = bun.fmt.allocPrint(allocator, "{f}A{d:0>8}", .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() }) catch unreachable;
             // This injects the following code:
             //
             // require(unique_key)
@@ -633,7 +633,7 @@ fn getAST(
                 //
                 // To avoid a mutex, the actual insertion of the asset to DevServer
                 // is done on the bundler thread.
-                try std.fmt.allocPrint(
+                try bun.fmt.allocPrint(
                     allocator,
                     bun.bake.DevServer.asset_prefix ++ "/{s}{s}",
                     .{
@@ -642,7 +642,7 @@ fn getAST(
                     },
                 )
             else
-                try std.fmt.allocPrint(
+                try bun.fmt.allocPrint(
                     allocator,
                     "{f}A{d:0>8}",
                     .{ bun.fmt.hexIntLower(unique_key_prefix), source.index.get() },

--- a/src/bundler/ServerComponentParseTask.zig
+++ b/src/bundler/ServerComponentParseTask.zig
@@ -130,7 +130,7 @@ fn generateClientReferenceProxy(task: *ServerComponentParseTask, data: Data.Refe
         .data = if (task.ctx.transpiler.options.dev_server != null)
             data.other_source.path.pretty
         else
-            try std.fmt.allocPrint(b.allocator, "{f}S{d:0>8}", .{
+            try bun.fmt.allocPrint(b.allocator, "{f}S{d:0>8}", .{
                 bun.fmt.hexIntLower(task.ctx.unique_key),
                 data.other_source.index.get(),
             }),
@@ -142,7 +142,7 @@ fn generateClientReferenceProxy(task: *ServerComponentParseTask, data: Data.Refe
         // This error message is taken from
         // https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-server-dom-webpack/src/ReactFlightWebpackNodeLoader.js#L323-L354
         const err_msg_string = try if (is_default)
-            std.fmt.allocPrint(
+            bun.fmt.allocPrint(
                 b.allocator,
                 "Attempted to call the default export of {[module_path]s} from " ++
                     "the server, but it's on the client. It's not possible to invoke a " ++
@@ -151,7 +151,7 @@ fn generateClientReferenceProxy(task: *ServerComponentParseTask, data: Data.Refe
                 .{ .module_path = data.other_source.path.pretty },
             )
         else
-            std.fmt.allocPrint(
+            bun.fmt.allocPrint(
                 b.allocator,
                 "Attempted to call {[key]s}() from the server but {[key]s} " ++
                     "is on the client. It's not possible to invoke a client function from " ++

--- a/src/bundler/bundle_v2.zig
+++ b/src/bundler/bundle_v2.zig
@@ -1283,20 +1283,20 @@ pub const BundleV2 = struct {
                 if (!sc.separate_ssr_graph) bun.todoPanic(@src(), "separate_ssr_graph=false", .{});
 
                 const client_path = server.newExpr(E.String{
-                    .data = try std.fmt.allocPrint(alloc, "{f}S{d:0>8}", .{
+                    .data = try bun.fmt.allocPrint(alloc, "{f}S{d:0>8}", .{
                         bun.fmt.hexIntLower(this.unique_key),
                         source_id,
                     }),
                 });
                 const ssr_path = server.newExpr(E.String{
-                    .data = try std.fmt.allocPrint(alloc, "{f}S{d:0>8}", .{
+                    .data = try bun.fmt.allocPrint(alloc, "{f}S{d:0>8}", .{
                         bun.fmt.hexIntLower(this.unique_key),
                         ssr_index,
                     }),
                 });
 
                 for (keys, client_manifest_items) |export_name_string, *client_item| {
-                    const server_key_string = try std.fmt.allocPrint(alloc, "{f}S{d:0>8}#{s}", .{
+                    const server_key_string = try bun.fmt.allocPrint(alloc, "{f}S{d:0>8}#{s}", .{
                         bun.fmt.hexIntLower(this.unique_key),
                         source_id,
                         export_name_string,
@@ -1805,7 +1805,7 @@ pub const BundleV2 = struct {
                         if (template.needs(.target)) {
                             template.placeholder.target = @tagName(target);
                         }
-                        break :brk bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{f}", .{template}));
+                        break :brk bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{f}", .{template}));
                     };
 
                     const loader = loaders[index];
@@ -3285,7 +3285,7 @@ pub const BundleV2 = struct {
                         const hash = dev_server.assets.getHash(path.text) orelse @panic("cached asset not found");
                         import_record.path.text = path.text;
                         import_record.path.namespace = "file";
-                        import_record.path.pretty = std.fmt.allocPrint(this.allocator(), bun.bake.DevServer.asset_prefix ++ "/{s}{s}", .{
+                        import_record.path.pretty = bun.fmt.allocPrint(this.allocator(), bun.bake.DevServer.asset_prefix ++ "/{s}{s}", .{
                             &std.fmt.bytesToHex(std.mem.asBytes(&hash), .lower),
                             std.fs.path.extension(path.text),
                         }) catch |err| bun.handleOom(err);
@@ -3511,7 +3511,7 @@ pub const BundleV2 = struct {
         var js_parser_options = bun.js_parser.Parser.Options.init(this.transpilerForTarget(target).options.jsx, .html);
         js_parser_options.bundle = true;
 
-        const unique_key = try std.fmt.allocPrint(this.allocator(), "{f}H{d:0>8}", .{
+        const unique_key = try bun.fmt.allocPrint(this.allocator(), "{f}H{d:0>8}", .{
             bun.fmt.hexIntLower(this.unique_key),
             graph.html_imports.server_source_indices.len,
         });

--- a/src/bundler/entry_points.zig
+++ b/src/bundler/entry_points.zig
@@ -39,7 +39,7 @@ pub const FallbackEntryPoint = struct {
             if (count < entry.code_buffer.len) {
                 code = try std.fmt.bufPrint(&entry.code_buffer, fmt, args);
             } else {
-                code = try std.fmt.allocPrint(transpiler.allocator, fmt, args);
+                code = try bun.fmt.allocPrint(transpiler.allocator, fmt, args);
             }
         } else {
             const fmt =
@@ -55,7 +55,7 @@ pub const FallbackEntryPoint = struct {
             if (count < entry.code_buffer.len) {
                 code = try std.fmt.bufPrint(&entry.code_buffer, fmt, args);
             } else {
-                code = try std.fmt.allocPrint(transpiler.allocator, fmt, args);
+                code = try bun.fmt.allocPrint(transpiler.allocator, fmt, args);
             }
         }
 
@@ -175,7 +175,7 @@ pub const ServerEntryPoint = struct {
         const allocator = bun.default_allocator;
         const code = brk: {
             if (is_hot_reload_enabled) {
-                break :brk try std.fmt.allocPrint(
+                break :brk try bun.fmt.allocPrint(
                     allocator,
                     \\// @bun
                     \\import * as start from '{f}';
@@ -215,7 +215,7 @@ pub const ServerEntryPoint = struct {
                     },
                 );
             }
-            break :brk try std.fmt.allocPrint(
+            break :brk try bun.fmt.allocPrint(
                 allocator,
                 \\// @bun
                 \\import * as start from "{f}";

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -321,7 +321,7 @@ pub const Linker = struct {
                 if (strings.eqlComptime(namespace, "node")) {
                     if (comptime Environment.isDebug) bun.assert(strings.eqlComptime(source_path[0..5], "node:"));
 
-                    return Fs.Path.init(try std.fmt.allocPrint(
+                    return Fs.Path.init(try bun.fmt.allocPrint(
                         linker.allocator,
                         // assumption: already starts with "node:"
                         "{s}/{s}",

--- a/src/bundler/linker_context/MetafileBuilder.zig
+++ b/src/bundler/linker_context/MetafileBuilder.zig
@@ -215,8 +215,8 @@ pub fn generate(
         first_input = false;
 
         j.pushStatic("\n    ");
-        j.push(try std.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(path, .{})}), allocator);
-        j.push(try std.fmt.allocPrint(allocator, ": {{\n      \"bytes\": {d}", .{source.contents.len}), allocator);
+        j.push(try bun.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(path, .{})}), allocator);
+        j.push(try bun.fmt.allocPrint(allocator, ": {{\n      \"bytes\": {d}", .{source.contents.len}), allocator);
 
         // Write imports
         j.pushStatic(",\n      \"imports\": [");
@@ -234,7 +234,7 @@ pub fn generate(
                 j.pushStatic("\n        {\n          \"path\": ");
                 // Write path with JSON escaping - chunk references (unique_keys) will be resolved
                 // by breakOutputIntoPieces and code() below
-                j.push(try std.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(record.path.text, .{})}), allocator);
+                j.push(try bun.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(record.path.text, .{})}), allocator);
                 j.pushStatic(",\n          \"kind\": \"");
                 j.pushStatic(record.kind.label());
                 j.pushStatic("\"");
@@ -242,7 +242,7 @@ pub fn generate(
                 // Add "original" field if different from path
                 if (record.original_path.len > 0 and !std.mem.eql(u8, record.original_path, record.path.text)) {
                     j.pushStatic(",\n          \"original\": ");
-                    j.push(try std.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(record.original_path, .{})}), allocator);
+                    j.push(try bun.fmt.allocPrint(allocator, "{f}", .{bun.fmt.formatJSONStringUTF8(record.original_path, .{})}), allocator);
                 }
 
                 // Add "external": true for external imports

--- a/src/bundler/linker_context/computeChunks.zig
+++ b/src/bundler/linker_context/computeChunks.zig
@@ -57,7 +57,7 @@ pub noinline fn computeChunks(
                 break :brk try temp_allocator.dupe(u8, entry_point_chunk_bits.bytes(this.graph.entry_points.len));
             } else {
                 // Force HTML chunks to always be generated, even if there's an identical JS file.
-                break :brk try std.fmt.allocPrint(temp_allocator, "{f}", .{JSChunkKeyFormatter{
+                break :brk try bun.fmt.allocPrint(temp_allocator, "{f}", .{JSChunkKeyFormatter{
                     .has_html = has_html_chunk,
                     .entry_bits = entry_bits.bytes(this.graph.entry_points.len),
                 }});

--- a/src/bundler/linker_context/generateChunksInParallel.zig
+++ b/src/bundler/linker_context/generateChunksInParallel.zig
@@ -227,7 +227,7 @@ pub fn generateChunksInParallel(
             chunk_visit_map.setAll(false);
             chunk.template.placeholder.hash = hash.digest();
 
-            const rel_path = bun.handleOom(std.fmt.allocPrint(c.allocator(), "{f}", .{chunk.template}));
+            const rel_path = bun.handleOom(bun.fmt.allocPrint(c.allocator(), "{f}", .{chunk.template}));
             bun.path.platformToPosixInPlace(u8, rel_path);
 
             if ((try path_names_map.getOrPut(rel_path)).found_existing) {
@@ -295,7 +295,7 @@ pub fn generateChunksInParallel(
                 try c.log.addMsg(.{
                     .kind = .note,
                     .data = .{
-                        .text = try std.fmt.allocPrint(bun.default_allocator, name ++ " naming is '{s}', consider adding '[hash]' to make filenames unique", .{template}),
+                        .text = try bun.fmt.allocPrint(bun.default_allocator, name ++ " naming is '{s}', consider adding '[hash]' to make filenames unique", .{template}),
                     },
                 });
             }
@@ -323,7 +323,7 @@ pub fn generateChunksInParallel(
                 else
                     c.options.public_path;
                 const normalizer = bun.bundle_v2.cheapPrefixNormalizer(public_path, ch.final_rel_path);
-                const resolved = std.fmt.allocPrint(c.allocator(), "{s}{s}", .{ normalizer[0], normalizer[1] }) catch |err| bun.handleOom(err);
+                const resolved = bun.fmt.allocPrint(c.allocator(), "{s}{s}", .{ normalizer[0], normalizer[1] }) catch |err| bun.handleOom(err);
                 unique_key_to_path.put(ch.unique_key, resolved) catch |err| bun.handleOom(err);
             }
         }
@@ -624,7 +624,7 @@ pub fn generateChunksInParallel(
 
                             break :brk options.OutputFile.init(.{
                                 .output_path = bun.handleOom(bun.default_allocator.dupe(u8, source_provider_url_str.slice())),
-                                .input_path = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}" ++ bun.bytecode_extension, .{chunk.final_rel_path})),
+                                .input_path = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}" ++ bun.bytecode_extension, .{chunk.final_rel_path})),
                                 .input_loader = .js,
                                 .hash = if (chunk.template.placeholder.hash != null) bun.hash(bytecode) else null,
                                 .output_kind = .bytecode,
@@ -663,8 +663,8 @@ pub fn generateChunksInParallel(
                     if (chunk.content == .javascript and loader.isJavaScriptLike()) {
                         if (chunk.content.javascript.module_info_bytes) |module_info_bytes| {
                             break :brk options.OutputFile.init(.{
-                                .output_path = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.module-info", .{chunk.final_rel_path})),
-                                .input_path = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.module-info", .{chunk.final_rel_path})),
+                                .output_path = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}.module-info", .{chunk.final_rel_path})),
+                                .input_path = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}.module-info", .{chunk.final_rel_path})),
                                 .input_loader = .js,
                                 .hash = if (chunk.template.placeholder.hash != null) bun.hash(module_info_bytes) else null,
                                 .output_kind = .module_info,

--- a/src/bundler/linker_context/generateCodeForLazyExport.zig
+++ b/src/bundler/linker_context/generateCodeForLazyExport.zig
@@ -363,7 +363,7 @@ pub fn generateCodeForLazyExport(this: *LinkerContext, source_index: Index.Int) 
                 const generated = try this.generateNamedExportInFile(
                     source_index,
                     module_ref,
-                    try std.fmt.allocPrint(
+                    try bun.fmt.allocPrint(
                         this.allocator(),
                         "{f}_default",
                         .{this.parse_graph.input_files.items(.source)[source_index].fmtIdentifier()},

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.zig
@@ -164,7 +164,7 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
             var html_appender = std.heap.stackFallback(256, bun.default_allocator);
             const allocator = html_appender.get();
             if (this.chunk.getJSChunkForHTML(this.chunks)) |js_chunk| {
-                const script = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "<script type=\"module\">{s}</script>", .{js_chunk.unique_key}, 0));
+                const script = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "<script type=\"module\">{s}</script>", .{js_chunk.unique_key}, 0));
                 defer allocator.free(script);
                 try endTag.before(script, true);
             }
@@ -175,18 +175,18 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
             if (this.compile_to_standalone_html) {
                 // In standalone HTML mode, only put CSS in <head>; JS goes before </body>
                 if (this.chunk.getCSSChunkForHTML(this.chunks)) |css_chunk| {
-                    const style_tag = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "<style>{s}</style>", .{css_chunk.unique_key}, 0));
+                    const style_tag = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "<style>{s}</style>", .{css_chunk.unique_key}, 0));
                     array.appendAssumeCapacity(style_tag);
                 }
             } else {
                 // Put CSS before JS to reduce chances of flash of unstyled content
                 if (this.chunk.getCSSChunkForHTML(this.chunks)) |css_chunk| {
-                    const link_tag = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "<link rel=\"stylesheet\" crossorigin href=\"{s}\">", .{css_chunk.unique_key}, 0));
+                    const link_tag = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "<link rel=\"stylesheet\" crossorigin href=\"{s}\">", .{css_chunk.unique_key}, 0));
                     array.appendAssumeCapacity(link_tag);
                 }
                 if (this.chunk.getJSChunkForHTML(this.chunks)) |js_chunk| {
                     // type="module" scripts do not block rendering, so it is okay to put them in head
-                    const script = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "<script type=\"module\" crossorigin src=\"{s}\"></script>", .{js_chunk.unique_key}, 0));
+                    const script = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "<script type=\"module\" crossorigin src=\"{s}\"></script>", .{js_chunk.unique_key}, 0));
                     array.appendAssumeCapacity(script);
                 }
             }
@@ -297,7 +297,7 @@ fn generateCompileResultForHTMLChunkImpl(worker: *ThreadPool.Worker, c: *LinkerC
             if (!html_loader.added_body_script) {
                 if (html_loader.compile_to_standalone_html) {
                     if (html_loader.chunk.getJSChunkForHTML(html_loader.chunks)) |js_chunk| {
-                        const script = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "<script type=\"module\">{s}</script>", .{js_chunk.unique_key}, 0));
+                        const script = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "<script type=\"module\">{s}</script>", .{js_chunk.unique_key}, 0));
                         defer allocator.free(script);
                         bun.handleOom(html_loader.output.appendSlice(script));
                     }

--- a/src/bundler/linker_context/scanImportsAndExports.zig
+++ b/src/bundler/linker_context/scanImportsAndExports.zig
@@ -1142,7 +1142,7 @@ fn validateComposesFromProperties(
                             entry.value_ptr.range,
                             bun.handleOom(Logger.Log.allocPrint(v.allocator, "The first definition of {s} is in this style rule:", .{property_name})),
                         ),
-                        .{ .text = std.fmt.allocPrint(
+                        .{ .text = bun.fmt.allocPrint(
                             v.allocator,
                             "The specification of \"composes\" does not define an order when class declarations from separate files are composed together. " ++
                                 "The value of the {f} property for {f} may change unpredictably as the code is edited. " ++

--- a/src/bundler/linker_context/writeOutputFilesToDisk.zig
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.zig
@@ -276,7 +276,7 @@ pub fn writeOutputFilesToDisk(
 
                         break :brk options.OutputFile.init(.{
                             .output_path = bun.default_allocator.dupe(u8, source_provider_url_str.slice()) catch unreachable,
-                            .input_path = std.fmt.allocPrint(bun.default_allocator, "{s}" ++ bun.bytecode_extension, .{chunk.final_rel_path}) catch unreachable,
+                            .input_path = bun.fmt.allocPrint(bun.default_allocator, "{s}" ++ bun.bytecode_extension, .{chunk.final_rel_path}) catch unreachable,
                             .input_loader = .file,
                             .hash = if (chunk.template.placeholder.hash != null) bun.hash(bytecode) else null,
                             .output_kind = .bytecode,

--- a/src/bundler/options.zig
+++ b/src/bundler/options.zig
@@ -1440,7 +1440,7 @@ pub fn definesFromTransformOptions(
                     } else if (strings.eqlComptime(node_env, "test")) {
                         break :brk "\"test\"";
                     } else {
-                        break :brk try std.fmt.allocPrint(allocator, "\"{s}\"", .{node_env});
+                        break :brk try bun.fmt.allocPrint(allocator, "\"{s}\"", .{node_env});
                     }
                 }
             }

--- a/src/bundler_jsc/JSBundleCompletionTask.zig
+++ b/src/bundler_jsc/JSBundleCompletionTask.zig
@@ -140,11 +140,11 @@ pub const JSBundleCompletionTask = struct {
             .parse = true,
             .import_source = .{
                 .development = if (config.jsx.import_source.len > 0)
-                    try std.fmt.allocPrint(alloc, "{s}/jsx-dev-runtime", .{config.jsx.import_source})
+                    try bun.fmt.allocPrint(alloc, "{s}/jsx-dev-runtime", .{config.jsx.import_source})
                 else
                     "react/jsx-dev-runtime",
                 .production = if (config.jsx.import_source.len > 0)
-                    try std.fmt.allocPrint(alloc, "{s}/jsx-runtime", .{config.jsx.import_source})
+                    try bun.fmt.allocPrint(alloc, "{s}/jsx-runtime", .{config.jsx.import_source})
                 else
                     "react/jsx-runtime",
             },
@@ -269,7 +269,7 @@ pub const JSBundleCompletionTask = struct {
 
         // Add .exe extension for Windows targets if not already present
         if (compile_options.compile_target.os == .windows and !strings.hasSuffixComptime(full_outfile_path, ".exe")) {
-            full_outfile_path = std.fmt.allocPrint(bun.default_allocator, "{s}.exe", .{full_outfile_path}) catch |err| bun.handleOom(err);
+            full_outfile_path = bun.fmt.allocPrint(bun.default_allocator, "{s}.exe", .{full_outfile_path}) catch |err| bun.handleOom(err);
         } else {
             full_outfile_path = bun.handleOom(bun.default_allocator.dupe(u8, full_outfile_path));
         }
@@ -375,12 +375,12 @@ pub const JSBundleCompletionTask = struct {
                     const map_basename = if (current.dest_path.len > 0)
                         bun.path.basename(current.dest_path)
                     else
-                        bun.path.basename(bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path})));
+                        bun.path.basename(bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}.map", .{full_outfile_path})));
 
                     const sourcemap_full_path = if (dirname.len == 0 or strings.eqlComptime(dirname, "."))
                         bun.handleOom(bun.default_allocator.dupe(u8, map_basename))
                     else
-                        bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}{c}{s}", .{ dirname, std.fs.path.sep, map_basename }));
+                        bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}{c}{s}", .{ dirname, std.fs.path.sep, map_basename }));
 
                     // Write the sourcemap file to disk next to the executable
                     var pathbuf: bun.PathBuffer = undefined;

--- a/src/bundler_jsc/PluginRunner.zig
+++ b/src/bundler_jsc/PluginRunner.zig
@@ -122,13 +122,13 @@ pub const PluginRunner = struct {
 
         if (static_namespace) {
             return Fs.Path.initWithNamespace(
-                std.fmt.allocPrint(this.allocator, "{f}", .{file_path}) catch unreachable,
+                bun.fmt.allocPrint(this.allocator, "{f}", .{file_path}) catch unreachable,
                 user_namespace.byteSlice(),
             );
         } else {
             return Fs.Path.initWithNamespace(
-                std.fmt.allocPrint(this.allocator, "{f}", .{file_path}) catch unreachable,
-                std.fmt.allocPrint(this.allocator, "{f}", .{user_namespace}) catch unreachable,
+                bun.fmt.allocPrint(this.allocator, "{f}", .{file_path}) catch unreachable,
+                bun.fmt.allocPrint(this.allocator, "{f}", .{user_namespace}) catch unreachable,
             );
         }
     }
@@ -213,7 +213,7 @@ pub const PluginRunner = struct {
         defer user_namespace.deref();
 
         // Our super slow way of cloning the string into memory owned by jsc
-        const combined_string = std.fmt.allocPrint(this.allocator, "{f}:{f}", .{ user_namespace, file_path }) catch unreachable;
+        const combined_string = bun.fmt.allocPrint(this.allocator, "{f}:{f}", .{ user_namespace, file_path }) catch unreachable;
         var out_ = bun.String.init(combined_string);
         defer out_.deref();
         const jsval = out_.toJS(this.global_object) catch |err| {

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -1061,7 +1061,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     }
 
     if (opts.port != null and opts.origin == null) {
-        opts.origin = try std.fmt.allocPrint(allocator, "http://localhost:{d}/", .{opts.port.?});
+        opts.origin = try bun.fmt.allocPrint(allocator, "http://localhost:{d}/", .{opts.port.?});
     }
 
     const output_dir: ?string = null;

--- a/src/cli/audit_command.zig
+++ b/src/cli/audit_command.zig
@@ -282,7 +282,7 @@ fn collectPackagesForAudit(allocator: std.mem.Allocator, pm: *PackageManager, pr
             continue;
         }
 
-        const ver_str = try std.fmt.allocPrint(allocator, "{f}", .{res.value.npm.version.fmt(buf)});
+        const ver_str = try bun.fmt.allocPrint(allocator, "{f}", .{res.value.npm.version.fmt(buf)});
 
         var found_package: ?*@TypeOf(packages_list.items[0]) = null;
         for (packages_list.items) |*item| {
@@ -374,7 +374,7 @@ fn sendAuditRequest(allocator: std.mem.Allocator, pm: *PackageManager, body: []c
         headers.appendFmt("authorization", "Basic {s}", .{pm.options.scope.auth});
     }
 
-    const url_str = try std.fmt.allocPrint(allocator, "{s}/-/npm/v1/security/advisories/bulk", .{strings.withoutTrailingSlash(pm.options.scope.url.href)});
+    const url_str = try bun.fmt.allocPrint(allocator, "{s}/-/npm/v1/security/advisories/bulk", .{strings.withoutTrailingSlash(pm.options.scope.url.href)});
     defer allocator.free(url_str);
     const url = URL.parse(url_str);
 
@@ -438,7 +438,7 @@ fn parseVulnerability(allocator: std.mem.Allocator, package_name: []const u8, vu
                             }
                         } else if (value.data == .e_number) {
                             if (std.mem.eql(u8, field_name, "id")) {
-                                vulnerability.id = try std.fmt.allocPrint(allocator, "{d}", .{@as(u64, @intFromFloat(value.data.e_number.value))});
+                                vulnerability.id = try bun.fmt.allocPrint(allocator, "{d}", .{@as(u64, @intFromFloat(value.data.e_number.value))});
                             }
                         }
                     }
@@ -495,7 +495,7 @@ fn findDependencyPaths(
                     .is_direct = false,
                 };
 
-                const workspace_prefix = try std.fmt.allocPrint(allocator, "workspace:{s}", .{workspace_name});
+                const workspace_prefix = try bun.fmt.allocPrint(allocator, "workspace:{s}", .{workspace_name});
                 try workspace_path.path.append(workspace_prefix);
                 try workspace_path.path.append(try allocator.dupe(u8, target_package));
                 try paths.append(workspace_path);
@@ -576,7 +576,7 @@ fn findDependencyPaths(
             }
 
             if (workspace_name_for_dep) |workspace_name| {
-                const workspace_prefix = try std.fmt.allocPrint(allocator, "workspace:{s}", .{workspace_name});
+                const workspace_prefix = try bun.fmt.allocPrint(allocator, "workspace:{s}", .{workspace_name});
                 try path.path.insert(0, workspace_prefix);
             }
 

--- a/src/cli/build_command.zig
+++ b/src/cli/build_command.zig
@@ -334,7 +334,7 @@ pub const BuildCommand = struct {
             }
 
             if (ctx.bundler_options.outdir.len == 0 and outfile.len > 0 and !ctx.bundler_options.compile) {
-                this_transpiler.options.entry_naming = try std.fmt.allocPrint(allocator, "./{s}", .{
+                this_transpiler.options.entry_naming = try bun.fmt.allocPrint(allocator, "./{s}", .{
                     std.fs.path.basename(outfile),
                 });
                 if (std.fs.path.dirname(outfile)) |dir|
@@ -511,7 +511,7 @@ pub const BuildCommand = struct {
                 }
 
                 if (compile_target.os == .windows and !strings.hasSuffixComptime(outfile, ".exe")) {
-                    outfile = try std.fmt.allocPrint(allocator, "{s}.exe", .{outfile});
+                    outfile = try bun.fmt.allocPrint(allocator, "{s}.exe", .{outfile});
                 } else if (was_renamed_from_index and !bun.strings.eqlComptime(outfile, "index")) {
                     // If we're going to fail due to EISDIR, we should instead pick a different name.
                     if (bun.sys.directoryExistsAt(bun.FD.fromStdDir(root_dir), outfile).asValue() orelse false) {
@@ -562,9 +562,9 @@ pub const BuildCommand = struct {
                             else brk: {
                                 const exe_base = bun.path.basename(outfile);
                                 break :brk if (compile_target.os == .windows and !strings.hasSuffixComptime(exe_base, ".exe"))
-                                    try std.fmt.allocPrint(allocator, "{s}.exe.map", .{exe_base})
+                                    try bun.fmt.allocPrint(allocator, "{s}.exe.map", .{exe_base})
                                 else
-                                    try std.fmt.allocPrint(allocator, "{s}.map", .{exe_base});
+                                    try bun.fmt.allocPrint(allocator, "{s}.map", .{exe_base});
                             };
 
                             // root_dir already points to the outfile's parent directory,

--- a/src/cli/bunfig.zig
+++ b/src/cli/bunfig.zig
@@ -41,12 +41,12 @@ pub const Bunfig = struct {
             // Token
             if (url.username.len == 0 and url.password.len > 0) {
                 registry.token = url.password;
-                registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
+                registry.url = try bun.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
             } else if (url.username.len > 0 and url.password.len > 0) {
                 registry.username = url.username;
                 registry.password = url.password;
 
-                registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
+                registry.url = try bun.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
             } else {
                 // Do not include a trailing slash. There might be parameters at the end.
                 registry.url = url.href;

--- a/src/cli/bunx_command.zig
+++ b/src/cli/bunx_command.zig
@@ -467,13 +467,13 @@ pub const BunxCommand = struct {
                 //
                 // But the requested version will contain the url.
                 // The colon will break all platforms.
-                std.fmt.allocPrint(ctx.allocator, "{s}@{s}@{d}", .{
+                bun.fmt.allocPrint(ctx.allocator, "{s}@{s}@{d}", .{
                     initial_bin_name,
                     @tagName(update_request.version.tag),
                     bun.hash(update_request.name) +% bun.hash(display_version),
                 })
             else
-                try std.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
+                try bun.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
                     update_request.name,
                     display_version,
                 });
@@ -484,7 +484,7 @@ pub const BunxCommand = struct {
         // result_package_name -> used for path 'node_modules/{what}/package.json'
         const install_param, const result_package_name = if (update_request.name.len != 0)
             .{
-                try std.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
+                try bun.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
                     update_request.name,
                     display_version,
                 }),
@@ -495,7 +495,7 @@ pub const BunxCommand = struct {
             // to be the same as the calculated initial bin name. This allows us to have a predictable
             // node_modules folder structure.
             .{
-                try std.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
+                try bun.fmt.allocPrint(ctx.allocator, "{s}@{s}", .{
                     initial_bin_name,
                     display_version,
                 }),
@@ -547,7 +547,7 @@ pub const BunxCommand = struct {
         // If this format changes, please update cache clearing code in package_manager_command.zig
         const uid = if (bun.Environment.isPosix) bun.c.getuid() else bun.windows.userUniqueId();
         PATH = switch (PATH.len > 0) {
-            inline else => |path_is_nonzero| try std.fmt.allocPrint(
+            inline else => |path_is_nonzero| try bun.fmt.allocPrint(
                 ctx.allocator,
                 bun.pathLiteral("{s}/bunx-{d}-{s}/node_modules/.bin{s}{s}"),
                 .{

--- a/src/cli/create_command.zig
+++ b/src/cli/create_command.zig
@@ -1217,7 +1217,7 @@ pub const CreateCommand = struct {
 
                 //         _ = html_writer.writeAll(public_index_file_contents[0..body_closing_tag]) catch break :bail;
 
-                //         create_react_app_entry_point_path = std.fmt.allocPrint(
+                //         create_react_app_entry_point_path = bun.fmt.allocPrint(
                 //             ctx.allocator,
                 //             "./{s}",
 
@@ -1975,7 +1975,7 @@ pub const Example = struct {
 
         if (env_loader.map.get("GITHUB_TOKEN") orelse env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
-                headers_buf = try std.fmt.allocPrint(ctx.allocator, "AuthorizationBearer {s}", .{access_token});
+                headers_buf = try bun.fmt.allocPrint(ctx.allocator, "AuthorizationBearer {s}", .{access_token});
                 try header_entries.append(
                     ctx.allocator,
                     .{

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -434,7 +434,7 @@ fn addScriptConfigs(
     const group_start = configs.items.len;
 
     const label = if (label_prefix) |prefix|
-        try std.fmt.allocPrint(allocator, "{s}:{s}", .{ prefix, raw_name })
+        try bun.fmt.allocPrint(allocator, "{s}:{s}", .{ prefix, raw_name })
     else
         raw_name;
 
@@ -442,8 +442,8 @@ fn addScriptConfigs(
 
     if (script_content) |content| {
         // It's a package.json script - check for pre/post
-        const pre_name = try std.fmt.allocPrint(allocator, "pre{s}", .{raw_name});
-        const post_name = try std.fmt.allocPrint(allocator, "post{s}", .{raw_name});
+        const pre_name = try bun.fmt.allocPrint(allocator, "pre{s}", .{raw_name});
+        const post_name = try bun.fmt.allocPrint(allocator, "post{s}", .{raw_name});
 
         const pre_content = if (scripts_map) |sm| sm.get(pre_name) else null;
         const post_content = if (scripts_map) |sm| sm.get(post_name) else null;
@@ -493,7 +493,7 @@ fn addScriptConfigs(
             const bun_path = bun.selfExePath() catch "bun";
             // Quote the bun path so that backslashes on Windows are not
             // interpreted as escape characters by `bun exec` (Bun's shell).
-            const cmd_str = try std.fmt.allocPrint(allocator, "\"{s}\" {s}" ++ "\x00", .{ bun_path, raw_name });
+            const cmd_str = try bun.fmt.allocPrint(allocator, "\"{s}\" {s}" ++ "\x00", .{ bun_path, raw_name });
             break :brk cmd_str[0 .. cmd_str.len - 1 :0];
         } else try allocator.dupeZ(u8, raw_name);
         try configs.append(.{

--- a/src/cli/pack_command.zig
+++ b/src/cli/pack_command.zig
@@ -516,7 +516,7 @@ pub const PackCommand = struct {
         dir_subpath: string,
         entry_name: string,
     ) OOM!stringZ {
-        return std.fmt.allocPrintSentinel(allocator, "{s}{s}{s}", .{
+        return bun.fmt.allocPrintSentinel(allocator, "{s}{s}{s}", .{
             dir_subpath,
             if (dir_subpath.len == 0) "" else "/",
             entry_name,
@@ -721,7 +721,7 @@ pub const PackCommand = struct {
 
                                 const dep_name = dep.key.?.asString(ctx.allocator) orelse continue;
 
-                                const dep_subpath = try std.fmt.allocPrintSentinel(ctx.allocator, "{s}/node_modules/{s}", .{
+                                const dep_subpath = try bun.fmt.allocPrintSentinel(ctx.allocator, "{s}/node_modules/{s}", .{
                                     dir_subpath,
                                     dep_name,
                                 }, 0);
@@ -2187,7 +2187,7 @@ pub const PackCommand = struct {
                                                 allocator,
                                                 E.String,
                                                 .{
-                                                    .data = try std.fmt.allocPrint(allocator, "{s}{f}", .{
+                                                    .data = try bun.fmt.allocPrint(allocator, "{s}{f}", .{
                                                         switch (c) {
                                                             '^' => "^",
                                                             '~' => "~",

--- a/src/cli/package_manager_command.zig
+++ b/src/cli/package_manager_command.zig
@@ -277,7 +277,7 @@ pub const PackageManagerCommand = struct {
                     var iter = tmp_dir.iterate();
 
                     // This is to match 'bunx_command.BunxCommand.exec's logic
-                    const prefix = try std.fmt.allocPrint(ctx.allocator, "bunx-{d}-", .{
+                    const prefix = try bun.fmt.allocPrint(ctx.allocator, "bunx-{d}-", .{
                         if (bun.Environment.isPosix) bun.c.getuid() else bun.windows.userUniqueId(),
                     });
 
@@ -528,7 +528,7 @@ fn printNodeModulesFolderStructure(
     for (sorted_dependencies, 0..) |dependency_id, index| {
         const package_name = dependencies[dependency_id].name.slice(string_bytes);
         const fmt = "{s}" ++ std.fs.path.sep_str ++ "{s}" ++ std.fs.path.sep_str ++ "node_modules";
-        const possible_path = try std.fmt.allocPrint(allocator, fmt, .{ directory.relative_path, package_name });
+        const possible_path = try bun.fmt.allocPrint(allocator, fmt, .{ directory.relative_path, package_name });
         defer allocator.free(possible_path);
 
         if (index + 1 == sorted_dependencies.len) {

--- a/src/cli/pm_pkg_command.zig
+++ b/src/cli/pm_pkg_command.zig
@@ -149,7 +149,7 @@ pub const PmPkgCommand = struct {
             if (getJsonValue(ctx.allocator, pkg.root, key, if (args.len > 1) 4 else 2)) |value| {
                 if (args.len > 1) {
                     if (strings.lastIndexOfChar(value, '}')) |last_index| {
-                        const new_value = try std.fmt.allocPrint(ctx.allocator, "{s}  {s}", .{ value[0..last_index], value[last_index..] });
+                        const new_value = try bun.fmt.allocPrint(ctx.allocator, "{s}  {s}", .{ value[0..last_index], value[last_index..] });
                         try results.put(key, new_value);
                         continue;
                     }
@@ -331,9 +331,9 @@ pub const PmPkgCommand = struct {
             },
             .e_number => |n| {
                 if (@floor(n.value) == n.value) {
-                    return try std.fmt.allocPrint(allocator, "{d:.0}", .{n.value});
+                    return try bun.fmt.allocPrint(allocator, "{d:.0}", .{n.value});
                 } else {
-                    return try std.fmt.allocPrint(allocator, "{d}", .{n.value});
+                    return try bun.fmt.allocPrint(allocator, "{d}", .{n.value});
                 }
             },
             .e_null => {

--- a/src/cli/pm_version_command.zig
+++ b/src/cli/pm_version_command.zig
@@ -382,33 +382,33 @@ pub const PmVersionCommand = struct {
 
         switch (version_type) {
             .patch => {
-                return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}", .{ new_version.major, new_version.minor, new_version.patch + 1 });
+                return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}", .{ new_version.major, new_version.minor, new_version.patch + 1 });
             },
             .minor => {
-                return try std.fmt.allocPrint(allocator, "{d}.{d}.0", .{ new_version.major, new_version.minor + 1 });
+                return try bun.fmt.allocPrint(allocator, "{d}.{d}.0", .{ new_version.major, new_version.minor + 1 });
             },
             .major => {
-                return try std.fmt.allocPrint(allocator, "{d}.0.0", .{new_version.major + 1});
+                return try bun.fmt.allocPrint(allocator, "{d}.0.0", .{new_version.major + 1});
             },
             .prepatch => {
                 if (preid.len > 0) {
-                    return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.0", .{ new_version.major, new_version.minor, new_version.patch + 1, preid });
+                    return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.0", .{ new_version.major, new_version.minor, new_version.patch + 1, preid });
                 } else {
-                    return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-0", .{ new_version.major, new_version.minor, new_version.patch + 1 });
+                    return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-0", .{ new_version.major, new_version.minor, new_version.patch + 1 });
                 }
             },
             .preminor => {
                 if (preid.len > 0) {
-                    return try std.fmt.allocPrint(allocator, "{d}.{d}.0-{s}.0", .{ new_version.major, new_version.minor + 1, preid });
+                    return try bun.fmt.allocPrint(allocator, "{d}.{d}.0-{s}.0", .{ new_version.major, new_version.minor + 1, preid });
                 } else {
-                    return try std.fmt.allocPrint(allocator, "{d}.{d}.0-0", .{ new_version.major, new_version.minor + 1 });
+                    return try bun.fmt.allocPrint(allocator, "{d}.{d}.0-0", .{ new_version.major, new_version.minor + 1 });
                 }
             },
             .premajor => {
                 if (preid.len > 0) {
-                    return try std.fmt.allocPrint(allocator, "{d}.0.0-{s}.0", .{ new_version.major + 1, preid });
+                    return try bun.fmt.allocPrint(allocator, "{d}.0.0-{s}.0", .{ new_version.major + 1, preid });
                 } else {
-                    return try std.fmt.allocPrint(allocator, "{d}.0.0-0", .{new_version.major + 1});
+                    return try bun.fmt.allocPrint(allocator, "{d}.0.0-0", .{new_version.major + 1});
                 }
             },
             .prerelease => {
@@ -419,31 +419,31 @@ pub const PmVersionCommand = struct {
                     if (strings.lastIndexOfChar(current_prerelease, '.')) |dot_index| {
                         const number_str = current_prerelease[dot_index + 1 ..];
                         const next_num = std.fmt.parseInt(u32, number_str, 10) catch 0;
-                        return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.{d}", .{ new_version.major, new_version.minor, new_version.patch, identifier, next_num + 1 });
+                        return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.{d}", .{ new_version.major, new_version.minor, new_version.patch, identifier, next_num + 1 });
                     } else {
                         const num = std.fmt.parseInt(u32, current_prerelease, 10) catch null;
                         if (num) |n| {
                             if (preid.len > 0) {
-                                return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.{d}", .{ new_version.major, new_version.minor, new_version.patch, preid, n + 1 });
+                                return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.{d}", .{ new_version.major, new_version.minor, new_version.patch, preid, n + 1 });
                             } else {
-                                return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{d}", .{ new_version.major, new_version.minor, new_version.patch, n + 1 });
+                                return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{d}", .{ new_version.major, new_version.minor, new_version.patch, n + 1 });
                             }
                         } else {
-                            return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.1", .{ new_version.major, new_version.minor, new_version.patch, identifier });
+                            return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.1", .{ new_version.major, new_version.minor, new_version.patch, identifier });
                         }
                     }
                 } else {
                     new_version.patch += 1;
                     if (preid.len > 0) {
-                        return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.0", .{ new_version.major, new_version.minor, new_version.patch, preid });
+                        return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}.0", .{ new_version.major, new_version.minor, new_version.patch, preid });
                     } else {
-                        return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}-0", .{ new_version.major, new_version.minor, new_version.patch });
+                        return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}-0", .{ new_version.major, new_version.minor, new_version.patch });
                     }
                 }
             },
             else => {},
         }
-        return try std.fmt.allocPrint(allocator, "{d}.{d}.{d}", .{ new_version.major, new_version.minor, new_version.patch });
+        return try bun.fmt.allocPrint(allocator, "{d}.{d}.{d}", .{ new_version.major, new_version.minor, new_version.patch });
     }
 
     fn isGitClean(cwd: []const u8) bun.OOM!bool {
@@ -564,7 +564,7 @@ pub const PmVersionCommand = struct {
         const commit_message = if (custom_message) |msg|
             try std.mem.replaceOwned(u8, allocator, msg, "%s", version)
         else
-            try std.fmt.allocPrint(allocator, "v{s}", .{version});
+            try bun.fmt.allocPrint(allocator, "v{s}", .{version});
         defer allocator.free(commit_message);
 
         const commit_proc = bun.spawnSync(&.{
@@ -595,7 +595,7 @@ pub const PmVersionCommand = struct {
             },
         }
 
-        const tag_name = try std.fmt.allocPrint(allocator, "v{s}", .{version});
+        const tag_name = try bun.fmt.allocPrint(allocator, "v{s}", .{version});
         defer allocator.free(tag_name);
 
         const tag_proc = bun.spawnSync(&.{

--- a/src/cli/publish_command.zig
+++ b/src/cli/publish_command.zig
@@ -935,15 +935,15 @@ pub const PublishCommand = struct {
 
         const version_without_build_tag = Dependency.withoutBuildTag(package_version);
 
-        const integrity_fmt = try std.fmt.allocPrint(allocator, "{f}", .{bun.fmt.integrity(integrity, .full)});
+        const integrity_fmt = try bun.fmt.allocPrint(allocator, "{f}", .{bun.fmt.integrity(integrity, .full)});
 
-        try json.setString(allocator, "_id", try std.fmt.allocPrint(allocator, "{s}@{s}", .{ package_name, version_without_build_tag }));
+        try json.setString(allocator, "_id", try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ package_name, version_without_build_tag }));
         try json.setString(allocator, "_integrity", integrity_fmt);
         try json.setString(allocator, "_nodeVersion", Environment.reported_nodejs_version);
         // TODO: npm version
         try json.setString(allocator, "_npmVersion", "10.8.3");
         try json.setString(allocator, "integrity", integrity_fmt);
-        try json.setString(allocator, "shasum", try std.fmt.allocPrint(allocator, "{s}", .{std.fmt.bytesToHex(shasum, .lower)}));
+        try json.setString(allocator, "shasum", try bun.fmt.allocPrint(allocator, "{s}", .{std.fmt.bytesToHex(shasum, .lower)}));
 
         var dist_props = try allocator.alloc(G.Property, 3);
         dist_props[0] = .{
@@ -954,7 +954,7 @@ pub const PublishCommand = struct {
             ),
             .value = Expr.init(
                 E.String,
-                .{ .data = try std.fmt.allocPrint(allocator, "{f}", .{bun.fmt.integrity(integrity, .full)}) },
+                .{ .data = try bun.fmt.allocPrint(allocator, "{f}", .{bun.fmt.integrity(integrity, .full)}) },
                 logger.Loc.Empty,
             ),
         };
@@ -966,7 +966,7 @@ pub const PublishCommand = struct {
             ),
             .value = Expr.init(
                 E.String,
-                .{ .data = try std.fmt.allocPrint(allocator, "{s}", .{std.fmt.bytesToHex(shasum, .lower)}) },
+                .{ .data = try bun.fmt.allocPrint(allocator, "{s}", .{std.fmt.bytesToHex(shasum, .lower)}) },
                 logger.Loc.Empty,
             ),
         };
@@ -979,7 +979,7 @@ pub const PublishCommand = struct {
             .value = Expr.init(
                 E.String,
                 .{
-                    .data = try std.fmt.allocPrint(allocator, "http://{s}/{s}/-/{f}", .{
+                    .data = try bun.fmt.allocPrint(allocator, "http://{s}/{s}/-/{f}", .{
                         // always use replace https with http
                         // https://github.com/npm/cli/blob/9281ebf8e428d40450ad75ba61bc6f040b3bf896/workspaces/libnpmpublish/lib/publish.js#L120
                         strings.withoutTrailingSlash(strings.withoutPrefixComptime(registry.url.href, "https://")),
@@ -1210,7 +1210,7 @@ pub const PublishCommand = struct {
                     while (iter.next().unwrap() catch null) |entry| {
                         const name, const subpath = name_and_subpath: {
                             const name = entry.name.slice();
-                            const join = try std.fmt.allocPrintSentinel(allocator, "{s}{s}{s}", .{
+                            const join = try bun.fmt.allocPrintSentinel(allocator, "{s}{s}{s}", .{
                                 dir_subpath,
                                 // only using posix separators
                                 if (dir_subpath.len == 0) "" else std.fs.path.sep_str_posix,

--- a/src/cli/repl.zig
+++ b/src/cli/repl.zig
@@ -1495,7 +1495,7 @@ fn transformForRepl(self: *Repl, code: []const u8) ?[]const u8 {
     // If code starts with { (after whitespace) and doesn't end with ;
     const is_object_literal = isLikelyObjectLiteral(code);
     const processed_code = if (is_object_literal)
-        std.fmt.allocPrint(self.allocator, "({s})", .{code}) catch return null
+        bun.fmt.allocPrint(self.allocator, "({s})", .{code}) catch return null
     else
         code;
     defer if (is_object_literal) self.allocator.free(processed_code);

--- a/src/cli/run_command.zig
+++ b/src/cli/run_command.zig
@@ -1391,7 +1391,7 @@ pub const RunCommand = struct {
             const ext: []const u8 = if (bun.strings.endsWith(d.url, ".png")) ".png" else if (bun.strings.endsWith(d.url, ".jpg") or bun.strings.endsWith(d.url, ".jpeg")) ".jpg" else if (bun.strings.endsWith(d.url, ".gif")) ".gif" else if (bun.strings.endsWith(d.url, ".webp")) ".webp" else ".bin";
             var name_buf: [64]u8 = undefined;
             const name = std.fmt.bufPrint(&name_buf, "bun-md-{x}{s}", .{ bun.fastRandom(), ext }) catch continue;
-            const path = std.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch continue;
+            const path = bun.fmt.allocPrint(allocator, "{s}/{s}", .{ tmpdir, name }) catch continue;
 
             const fd = switch (bun.sys.openA(path, bun.O.WRONLY | bun.O.CREAT | bun.O.TRUNC, 0o600)) {
                 .result => |f| f,
@@ -1760,7 +1760,7 @@ pub const RunCommand = struct {
                     this_transpiler.env.map.put("npm_lifecycle_event", target_name) catch unreachable;
 
                     // allocate enough to hold "post${scriptname}"
-                    var temp_script_buffer = try std.fmt.allocPrint(ctx.allocator, "\x00pre{s}", .{target_name});
+                    var temp_script_buffer = try bun.fmt.allocPrint(ctx.allocator, "\x00pre{s}", .{target_name});
                     defer ctx.allocator.free(temp_script_buffer);
 
                     const package_json_path = root_dir_info.enclosing_package_json.?.source.path.text;

--- a/src/cli/test/ChangedFilesFilter.zig
+++ b/src/cli/test/ChangedFilesFilter.zig
@@ -270,7 +270,7 @@ pub fn initWatchTrigger(allocator: std.mem.Allocator) void {
         var rng = std.Random.DefaultPrng.init(@as(u64, @bitCast(std.time.milliTimestamp())) ^
             @as(u64, @intCast(std.c.getpid())));
         const tmpdir = bun.fs.FileSystem.RealFS.tmpdirPath();
-        const fresh = bun.handleOom(std.fmt.allocPrintSentinel(
+        const fresh = bun.handleOom(bun.fmt.allocPrintSentinel(
             allocator,
             "{s}{c}.bun-test-changed-{x}.trigger",
             .{ strings.withoutTrailingSlash(tmpdir), std.fs.path.sep, rng.random().int(u64) },

--- a/src/cli/test/parallel/runner.zig
+++ b/src/cli/test/parallel/runner.zig
@@ -41,7 +41,7 @@ pub fn runAsCoordinator(
     }
     defer if (worker_tmpdir) |d| bun.FD.cwd().deleteTree(d) catch {};
     if (ctx.test_options.reporters.junit or coverage_opts.enabled) {
-        const dir = try std.fmt.allocPrintSentinel(arena.allocator(), "{s}/bun-test-worker-{d}", .{
+        const dir = try bun.fmt.allocPrintSentinel(arena.allocator(), "{s}/bun-test-worker-{d}", .{
             bun.fs.FileSystem.RealFS.getDefaultTempDir(),
             if (bun.Environment.isWindows) std.os.windows.GetCurrentProcessId() else std.c.getpid(),
         }, 0);
@@ -66,7 +66,7 @@ pub fn runAsCoordinator(
     // and POSIX getenv() returns the first match.
     const envps = try arena.allocator().alloc([:null]?[*:0]const u8, K);
     for (envps, 0..) |*envp, i| {
-        const id = try std.fmt.allocPrint(arena.allocator(), "{d}", .{i + 1});
+        const id = try bun.fmt.allocPrint(arena.allocator(), "{d}", .{i + 1});
         bun.handleOom(vm.transpiler.env.map.put("JEST_WORKER_ID", id));
         bun.handleOom(vm.transpiler.env.map.put("BUN_TEST_WORKER_ID", id));
         envp.* = try vm.transpiler.env.map.createNullDelimitedEnvMap(arena.allocator());
@@ -152,7 +152,7 @@ fn buildWorkerArgv(arena: std.mem.Allocator, ctx: Command.Context) ![:null]?[*:0
 
     const printZ = struct {
         fn f(a: std.mem.Allocator, comptime fmt: []const u8, args: anytype) ![*:0]const u8 {
-            return (try std.fmt.allocPrintSentinel(a, fmt, args, 0)).ptr;
+            return (try bun.fmt.allocPrintSentinel(a, fmt, args, 0)).ptr;
         }
     }.f;
 
@@ -398,7 +398,7 @@ fn workerFlushAggregates(reporter: *CommandLineReporter, vm: *jsc.VirtualMachine
         else
             @intCast(std.c.getpid());
         if (reporter.reporters.junit) |junit| {
-            const path = bun.handleOom(std.fmt.allocPrintSentinel(bun.default_allocator, "{s}/w{d}.xml", .{ dir, id }, 0));
+            const path = bun.handleOom(bun.fmt.allocPrintSentinel(bun.default_allocator, "{s}/w{d}.xml", .{ dir, id }, 0));
             if (junit.current_file.len > 0) junit.endTestSuite() catch {};
             if (junit.writeToFile(path)) |_| {
                 worker_frame.begin(.junit_file);
@@ -409,7 +409,7 @@ fn workerFlushAggregates(reporter: *CommandLineReporter, vm: *jsc.VirtualMachine
             }
         }
         if (ctx.test_options.coverage.enabled) {
-            const path = bun.handleOom(std.fmt.allocPrintSentinel(bun.default_allocator, "{s}/cov{d}.lcov", .{ dir, id }, 0));
+            const path = bun.handleOom(bun.fmt.allocPrintSentinel(bun.default_allocator, "{s}/cov{d}.lcov", .{ dir, id }, 0));
             if (reporter.writeLcovOnly(vm, &ctx.test_options.coverage, path)) |_| {
                 worker_frame.begin(.coverage_file);
                 worker_frame.str(path);

--- a/src/cli/test_command.zig
+++ b/src/cli/test_command.zig
@@ -186,7 +186,7 @@ pub const JunitReporter = struct {
                     if (bun.env_var.GITHUB_SERVER_URL.get()) |github_server_url| {
                         if (bun.env_var.GITHUB_REPOSITORY.get()) |github_repository| {
                             if (github_run_id.len > 0 and github_server_url.len > 0 and github_repository.len > 0) {
-                                break :brk try std.fmt.allocPrint(allocator, "{s}/{s}/actions/runs/{s}", .{ github_server_url, github_repository, github_run_id });
+                                break :brk try bun.fmt.allocPrint(allocator, "{s}/{s}/actions/runs/{s}", .{ github_server_url, github_repository, github_run_id });
                             }
                         }
                     }
@@ -345,7 +345,7 @@ pub const JunitReporter = struct {
         const elapsed_time_seconds = elapsed_time_ms_f64 / std.time.ms_per_s;
 
         // Insert the summary attributes
-        const summary = try std.fmt.allocPrint(allocator,
+        const summary = try bun.fmt.allocPrint(allocator,
             \\tests="{d}" assertions="{d}" failures="{d}" skipped="{d}" time="{d}" hostname="{s}"
         , .{
             suite_info.metrics.test_cases,
@@ -531,7 +531,7 @@ pub const JunitReporter = struct {
             const allocator = stack_fallback_allocator.get();
             const metrics = this.total_metrics;
             const elapsed_time = @as(f64, @floatFromInt(std.time.nanoTimestamp() - bun.start_time)) / std.time.ns_per_s;
-            const summary = try std.fmt.allocPrint(allocator,
+            const summary = try bun.fmt.allocPrint(allocator,
                 \\tests="{d}" assertions="{d}" failures="{d}" skipped="{d}" time="{d}"
             , .{
                 metrics.test_cases,

--- a/src/cli/update_interactive_command.zig
+++ b/src/cli/update_interactive_command.zig
@@ -448,7 +448,7 @@ pub const UpdateInteractiveCommand = struct {
             if (pkg.is_catalog) {
                 // Store catalog updates for later processing
                 const catalog_key = if (pkg.catalog_name) |catalog_name|
-                    try std.fmt.allocPrint(bun.default_allocator, "{s}:{s}", .{ pkg.name, catalog_name })
+                    try bun.fmt.allocPrint(bun.default_allocator, "{s}:{s}", .{ pkg.name, catalog_name })
                 else
                     pkg.name;
 
@@ -1433,7 +1433,7 @@ pub const UpdateInteractiveCommand = struct {
                     const uses_default_registry = pkg.manager.options.scope.url_hash == Install.Npm.Registry.default_url_hash and
                         pkg.manager.scopeForPackageName(pkg.name).url_hash == Install.Npm.Registry.default_url_hash;
                     const package_url = if (Output.enable_ansi_colors_stdout and uses_default_registry)
-                        try std.fmt.allocPrint(bun.default_allocator, "https://npmjs.org/package/{s}/v/{s}", .{ pkg.name, brk: {
+                        try bun.fmt.allocPrint(bun.default_allocator, "https://npmjs.org/package/{s}/v/{s}", .{ pkg.name, brk: {
                             if (selected) {
                                 if (pkg.use_latest) {
                                     break :brk pkg.latest_version;
@@ -2011,17 +2011,17 @@ fn preserveVersionPrefix(original_version: string, new_version: string, allocato
             const second_char = orig_version[1];
             if ((first_char == '>' or first_char == '<') and second_char == '=') {
                 if (alias) |a| {
-                    return try std.fmt.allocPrint(allocator, "npm:{s}@{c}={s}", .{ a, first_char, new_version });
+                    return try bun.fmt.allocPrint(allocator, "npm:{s}@{c}={s}", .{ a, first_char, new_version });
                 }
-                return try std.fmt.allocPrint(allocator, "{c}={s}", .{ first_char, new_version });
+                return try bun.fmt.allocPrint(allocator, "{c}={s}", .{ first_char, new_version });
             }
             if (alias) |a| {
-                return try std.fmt.allocPrint(allocator, "npm:{s}@{c}{s}", .{ a, first_char, new_version });
+                return try bun.fmt.allocPrint(allocator, "npm:{s}@{c}{s}", .{ a, first_char, new_version });
             }
-            return try std.fmt.allocPrint(allocator, "{c}{s}", .{ first_char, new_version });
+            return try bun.fmt.allocPrint(allocator, "{c}{s}", .{ first_char, new_version });
         }
         if (alias) |a| {
-            return try std.fmt.allocPrint(allocator, "npm:{s}@{s}", .{ a, new_version });
+            return try bun.fmt.allocPrint(allocator, "npm:{s}@{s}", .{ a, new_version });
         }
     }
     return try allocator.dupe(u8, new_version);

--- a/src/cli/upgrade_command.zig
+++ b/src/cli/upgrade_command.zig
@@ -17,7 +17,7 @@ pub const Version = struct {
             if (strings.eqlComptime(this.tag, "canary")) {
                 const Cli = @import("./cli.zig");
 
-                return std.fmt.allocPrint(
+                return bun.fmt.allocPrint(
                     bun.default_allocator,
                     "bun-canary-timestamp-{f}",
                     .{
@@ -131,7 +131,7 @@ pub const UpgradeCommand = struct {
 
         if (env_loader.map.get("GITHUB_TOKEN") orelse env_loader.map.get("GITHUB_ACCESS_TOKEN")) |access_token| {
             if (access_token.len > 0) {
-                headers_buf = try std.fmt.allocPrint(allocator, default_github_headers ++ "AuthorizationBearer {s}", .{access_token});
+                headers_buf = try bun.fmt.allocPrint(allocator, default_github_headers ++ "AuthorizationBearer {s}", .{access_token});
                 try header_entries.append(
                     allocator,
                     .{
@@ -561,7 +561,7 @@ pub const UpgradeCommand = struct {
                     }
                 } else if (comptime Environment.isWindows) {
                     // Run a powershell script to unzip the file
-                    const unzip_script = try std.fmt.allocPrint(
+                    const unzip_script = try bun.fmt.allocPrint(
                         ctx.allocator,
                         "$global:ProgressPreference='SilentlyContinue';Expand-Archive -Path \"{f}\" \"{f}\" -Force",
                         .{
@@ -759,7 +759,7 @@ pub const UpgradeCommand = struct {
                     // we rename the old executable to a temporary name, and then move the new executable to the old name.
                     // This is because Windows locks the executable while it's running.
                     current_executable_buf[target_dir_.len] = '\\';
-                    outdated_filename = try std.fmt.allocPrintSentinel(ctx.allocator, "{s}\\{s}.outdated", .{
+                    outdated_filename = try bun.fmt.allocPrintSentinel(ctx.allocator, "{s}\\{s}.outdated", .{
                         target_dirname,
                         target_filename,
                     }, 0);

--- a/src/cli/why_command.zig
+++ b/src/cli/why_command.zig
@@ -461,10 +461,10 @@ pub const WhyCommand = struct {
                 const is_dep_last = dep_idx == sorted_dependents.len - 1;
                 const prefix_char = if (is_dep_last) "└─ " else "├─ ";
 
-                const full_prefix = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ prefix, prefix_char });
+                const full_prefix = try bun.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ prefix, prefix_char });
                 printPackageWithType(full_prefix, &dep);
 
-                const next_prefix = try std.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ prefix, if (is_dep_last) "   " else "│  " });
+                const next_prefix = try bun.fmt.allocPrint(ctx.allocator, "{s}{s}", .{ prefix, if (is_dep_last) "   " else "│  " });
 
                 const print_break_line = is_dep_last and sorted_dependents.len > 1 and !printed_break_line;
                 try printDependencyTree(ctx, dep.pkg_id, next_prefix, depth + 1, printed_break_line or print_break_line, dep.workspace);

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -1782,7 +1782,7 @@ fn spawnSymbolizer(program: [:0]const u8, alloc: std.mem.Allocator, trace: *cons
     for (trace.instruction_addresses[0..trace.index]) |addr| {
         const line = StackLine.fromAddress(addr, &name_bytes) orelse
             continue;
-        try argv.append(try std.fmt.allocPrint(alloc, "0x{X}", .{line.address}));
+        try argv.append(try bun.fmt.allocPrint(alloc, "0x{X}", .{line.address}));
     }
 
     var child = std.process.Child.init(argv.items, alloc);

--- a/src/css/css_modules.zig
+++ b/src/css/css_modules.zig
@@ -123,7 +123,7 @@ pub const CssModule = struct {
 
         this.references.put(
             allocator,
-            bun.handleOom(std.fmt.allocPrint(allocator, "--{s}", .{the_hash})),
+            bun.handleOom(bun.fmt.allocPrint(allocator, "--{s}", .{the_hash})),
             reference,
         ) catch |err| bun.handleOom(err);
 
@@ -396,7 +396,7 @@ pub fn hash(allocator: Allocator, comptime fmt: []const u8, args: anytype, at_st
     var stack_fallback = std.heap.stackFallback(128, allocator);
     const fmt_alloc = if (count <= 128) stack_fallback.get() else allocator;
     var hasher = bun.Wyhash11.init(0);
-    var fmt_str = bun.handleOom(std.fmt.allocPrint(fmt_alloc, fmt, args));
+    var fmt_str = bun.handleOom(bun.fmt.allocPrint(fmt_alloc, fmt, args));
     hasher.update(fmt_str);
 
     const h: u32 = @truncate(hasher.final());

--- a/src/css/error.zig
+++ b/src/css/error.zig
@@ -64,7 +64,7 @@ pub fn Err(comptime T: type) type {
                 .kind = .err,
                 .data = .{
                     .location = if (this.loc) |*loc| try loc.toLocation(source, allocator) else null,
-                    .text = try std.fmt.allocPrint(allocator, "{f}", .{this.kind}),
+                    .text = try bun.fmt.allocPrint(allocator, "{f}", .{this.kind}),
                 },
             });
 

--- a/src/css/media_query.zig
+++ b/src/css/media_query.zig
@@ -1485,7 +1485,7 @@ pub fn MediaFeatureName(comptime FeatureId: type) type {
             const final_name = if (is_webkit) name: {
                 // PERF: stack buffer here?
                 free_str = true;
-                break :name bun.handleOom(std.fmt.allocPrint(input.allocator(), "-webkit-{s}", .{name}));
+                break :name bun.handleOom(bun.fmt.allocPrint(input.allocator(), "-webkit-{s}", .{name}));
             } else name;
 
             defer if (is_webkit) {

--- a/src/dns/dns.zig
+++ b/src/dns/dns.zig
@@ -254,7 +254,7 @@ pub fn addressToString(address: *const std.net.Address) bun.OOM!bun.String {
         std.posix.AF.INET6 => {
             var stack = std.heap.stackFallback(512, default_allocator);
             const allocator = stack.get();
-            var out = try std.fmt.allocPrint(allocator, "{f}", .{address.*});
+            var out = try bun.fmt.allocPrint(allocator, "{f}", .{address.*});
             defer allocator.free(out);
             // TODO: this is a hack, fix it
             // This removes [.*]:port

--- a/src/http/AsyncHTTP.zig
+++ b/src/http/AsyncHTTP.zig
@@ -233,7 +233,7 @@ pub fn init(
                 defer password_alloc.free(password);
 
                 // concat user and password
-                const auth = std.fmt.allocPrint(allocator, "{s}:{s}", .{ username, password }) catch unreachable;
+                const auth = bun.fmt.allocPrint(allocator, "{s}:{s}", .{ username, password }) catch unreachable;
                 defer allocator.free(auth);
                 const size = std.base64.standard.Encoder.calcSize(auth.len);
                 var buf = this.allocator.alloc(u8, size + "Basic ".len) catch unreachable;
@@ -310,7 +310,7 @@ fn reset(this: *AsyncHTTP) !void {
                 defer password_alloc.free(password);
 
                 // concat user and password
-                const auth = std.fmt.allocPrint(this.allocator, "{s}:{s}", .{ username, password }) catch unreachable;
+                const auth = bun.fmt.allocPrint(this.allocator, "{s}:{s}", .{ username, password }) catch unreachable;
                 defer this.allocator.free(auth);
                 const size = std.base64.standard.Encoder.calcSize(auth.len);
                 var buf = this.allocator.alloc(u8, size + "Basic ".len) catch unreachable;

--- a/src/http_jsc/websocket_client.zig
+++ b/src/http_jsc/websocket_client.zig
@@ -1221,7 +1221,7 @@ pub fn NewWebSocketClient(comptime ssl: bool) type {
                 inner: {
                     var fixed_buffer = std.heap.FixedBufferAllocator.init(&close_reason_buf);
                     const allocator = fixed_buffer.allocator();
-                    const wrote = std.fmt.allocPrint(allocator, "{f}", .{str.*}) catch break :inner;
+                    const wrote = bun.fmt.allocPrint(allocator, "{f}", .{str.*}) catch break :inner;
                     this.sendCloseWithBody(tcp, code, wrote.ptr[0..125], wrote.len);
                     return;
                 }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.zig
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.zig
@@ -1444,7 +1444,7 @@ fn buildRequestBody(
     // Build request with user overrides
     if (user_host) |h| {
         return .{
-            .body = try std.fmt.allocPrint(
+            .body = try bun.fmt.allocPrint(
                 allocator,
                 "GET {s} HTTP/1.1\r\n" ++
                     "Host: {s}\r\n" ++
@@ -1462,7 +1462,7 @@ fn buildRequestBody(
     }
 
     return .{
-        .body = try std.fmt.allocPrint(
+        .body = try bun.fmt.allocPrint(
             allocator,
             "GET {s} HTTP/1.1\r\n" ++
                 "Host: {f}\r\n" ++

--- a/src/ini/ini.zig
+++ b/src/ini/ini.zig
@@ -260,7 +260,7 @@ pub const Parser = struct {
                     return "[Object object]";
                 },
                 else => {
-                    const str = try std.fmt.allocPrint(arena_allocator, "{f}", .{ToStringFormatter{ .d = json_val.data }});
+                    const str = try bun.fmt.allocPrint(arena_allocator, "{f}", .{ToStringFormatter{ .d = json_val.data }});
                     if (comptime usage == .section) return singleStrRope(ropealloc, str);
                     return str;
                 },

--- a/src/install/PackageInstaller.zig
+++ b/src/install/PackageInstaller.zig
@@ -809,7 +809,7 @@ pub const PackageInstaller = struct {
             if (this.manager.lockfile.patched_dependencies.entries.len == 0 and this.manager.patched_dependencies_to_remove.entries.len == 0) break :brk .{ null, null, null, false };
             var sfa = std.heap.stackFallback(1024, this.lockfile.allocator);
             const alloc = sfa.get();
-            const name_and_version = std.fmt.allocPrint(alloc, "{s}@{s}", .{
+            const name_and_version = bun.fmt.allocPrint(alloc, "{s}@{s}", .{
                 pkg_name.slice(this.lockfile.buffers.string_bytes.items),
                 package_version,
             }) catch unreachable;

--- a/src/install/PackageManager/PackageJSONEditor.zig
+++ b/src/install/PackageManager/PackageJSONEditor.zig
@@ -246,7 +246,7 @@ pub fn editUpdateNoArgs(
                         if (manager.options.do.update_to_latest) {
                             // is it an aliased package
                             const temp_version = if (alias_at_index) |at_index|
-                                bun.handleOom(std.fmt.allocPrint(allocator, "{s}@latest", .{version_literal[0..at_index]}))
+                                bun.handleOom(bun.fmt.allocPrint(allocator, "{s}@latest", .{version_literal[0..at_index]}))
                             else
                                 bun.handleOom(allocator.dupe(u8, "latest"));
 
@@ -299,7 +299,7 @@ pub fn editUpdateNoArgs(
                                     const new_version = new_version: {
                                         const version_fmt = resolution.value.npm.version.fmt(string_buf);
                                         if (options.exact_versions) {
-                                            break :new_version try std.fmt.allocPrint(allocator, "{f}", .{version_fmt});
+                                            break :new_version try bun.fmt.allocPrint(allocator, "{f}", .{version_fmt});
                                         }
 
                                         const version_literal = version_literal: {
@@ -312,9 +312,9 @@ pub fn editUpdateNoArgs(
 
                                         const pinned_version = Semver.Version.whichVersionIsPinned(version_literal);
                                         break :new_version try switch (pinned_version) {
-                                            .patch => std.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
-                                            .minor => std.fmt.allocPrint(allocator, "~{f}", .{version_fmt}),
-                                            .major => std.fmt.allocPrint(allocator, "^{f}", .{version_fmt}),
+                                            .patch => bun.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
+                                            .minor => bun.fmt.allocPrint(allocator, "~{f}", .{version_fmt}),
+                                            .major => bun.fmt.allocPrint(allocator, "^{f}", .{version_fmt}),
                                         };
                                     };
 
@@ -325,7 +325,7 @@ pub fn editUpdateNoArgs(
                                         // e.g. "dep": "npm:@foo/bar@1.2.3"
                                         if (strings.lastIndexOfChar(dep_literal, '@')) |at_index| {
                                             dep.value = Expr.allocate(allocator, E.String, .{
-                                                .data = try std.fmt.allocPrint(allocator, "{s}@{s}", .{
+                                                .data = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{
                                                     dep_literal[0..at_index],
                                                     new_version,
                                                 }),
@@ -704,7 +704,7 @@ pub fn edit(
                             const new_version = new_version: {
                                 const version_fmt = resolutions[request.package_id].value.npm.version.fmt(manager.lockfile.buffers.string_bytes.items);
                                 if (options.exact_versions) {
-                                    break :new_version try std.fmt.allocPrint(allocator, "{f}", .{version_fmt});
+                                    break :new_version try bun.fmt.allocPrint(allocator, "{f}", .{version_fmt});
                                 }
 
                                 const version_literal = version_literal: {
@@ -719,9 +719,9 @@ pub fn edit(
 
                                 const pinned_version = Semver.Version.whichVersionIsPinned(version_literal);
                                 break :new_version try switch (pinned_version) {
-                                    .patch => std.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
-                                    .minor => std.fmt.allocPrint(allocator, "~{f}", .{version_fmt}),
-                                    .major => std.fmt.allocPrint(allocator, "^{f}", .{version_fmt}),
+                                    .patch => bun.fmt.allocPrint(allocator, "{f}", .{version_fmt}),
+                                    .minor => bun.fmt.allocPrint(allocator, "~{f}", .{version_fmt}),
+                                    .major => bun.fmt.allocPrint(allocator, "^{f}", .{version_fmt}),
                                 };
                             };
 
@@ -729,7 +729,7 @@ pub fn edit(
                                 const dep_literal = entry.value.original_version_literal;
 
                                 if (strings.lastIndexOfChar(dep_literal, '@')) |at_index| {
-                                    break :npm try std.fmt.allocPrint(allocator, "{s}@{s}", .{
+                                    break :npm try bun.fmt.allocPrint(allocator, "{s}@{s}", .{
                                         dep_literal[0..at_index],
                                         new_version,
                                     });
@@ -743,7 +743,7 @@ pub fn edit(
                         (manager.subcommand == .update and request.version.tag == .npm and !request.version.value.npm.version.isExact()))
                     {
                         const new_version = try switch (options.exact_versions) {
-                            inline else => |exact_versions| std.fmt.allocPrint(
+                            inline else => |exact_versions| bun.fmt.allocPrint(
                                 allocator,
                                 if (comptime exact_versions) "{f}" else "^{f}",
                                 .{
@@ -755,7 +755,7 @@ pub fn edit(
                         if (request.version.tag == .npm and request.version.value.npm.is_alias) {
                             const dep_literal = request.version.literal.slice(request.version_buf);
                             if (strings.indexOfChar(dep_literal, '@')) |at_index| {
-                                break :npm try std.fmt.allocPrint(allocator, "{s}@{s}", .{
+                                break :npm try bun.fmt.allocPrint(allocator, "{s}@{s}", .{
                                     dep_literal[0..at_index],
                                     new_version,
                                 });

--- a/src/install/PackageManager/PackageManagerLifecycle.zig
+++ b/src/install/PackageManager/PackageManagerLifecycle.zig
@@ -91,7 +91,7 @@ pub fn determinePreinstallState(
             const patch_hash: ?u64 = brk: {
                 if (manager.lockfile.patched_dependencies.entries.len == 0) break :brk null;
                 var sfb = std.heap.stackFallback(1024, manager.lockfile.allocator);
-                const name_and_version = std.fmt.allocPrint(
+                const name_and_version = bun.fmt.allocPrint(
                     sfb.get(),
                     "{s}@{f}",
                     .{

--- a/src/install/PackageManager/UpdateRequest.zig
+++ b/src/install/PackageManager/UpdateRequest.zig
@@ -87,7 +87,7 @@ pub fn parseWithError(
         }
         switch (subcommand) {
             .link, .unlink => if (!strings.hasPrefixComptime(input, "link:")) {
-                input = std.fmt.allocPrint(allocator, "{0s}@link:{0s}", .{input}) catch unreachable;
+                input = bun.fmt.allocPrint(allocator, "{0s}@link:{0s}", .{input}) catch unreachable;
             },
             else => {},
         }

--- a/src/install/PackageManager/patchPackage.zig
+++ b/src/install/PackageManager/patchPackage.zig
@@ -452,7 +452,7 @@ pub fn doPatchCommit(
         Global.crash();
     }
 
-    const patch_key = bun.handleOom(std.fmt.allocPrint(manager.allocator, "{s}", .{resolution_label}));
+    const patch_key = bun.handleOom(bun.fmt.allocPrint(manager.allocator, "{s}", .{resolution_label}));
     const patchfile_path = bun.handleOom(manager.allocator.dupe(u8, path_in_patches_dir));
     _ = bun.sys.unlink(bun.path.joinZ(&[_][]const u8{ changes_dir, ".bun-patch-tag" }, .auto));
 
@@ -633,7 +633,7 @@ pub fn preparePatch(manager: *PackageManager) !void {
             const existing_patchfile_hash = existing_patchfile_hash: {
                 var __sfb = std.heap.stackFallback(1024, manager.allocator);
                 const allocator = __sfb.get();
-                const name_and_version = std.fmt.allocPrint(allocator, "{s}@{f}", .{ name, actual_package.resolution.fmt(strbuf, .posix) }) catch unreachable;
+                const name_and_version = bun.fmt.allocPrint(allocator, "{s}@{f}", .{ name, actual_package.resolution.fmt(strbuf, .posix) }) catch unreachable;
                 defer allocator.free(name_and_version);
                 const name_and_version_hash = String.Builder.stringHash(name_and_version);
                 if (lockfile.patched_dependencies.get(name_and_version_hash)) |patched_dep| {
@@ -671,7 +671,7 @@ pub fn preparePatch(manager: *PackageManager) !void {
             const existing_patchfile_hash = existing_patchfile_hash: {
                 var __sfb = std.heap.stackFallback(1024, manager.allocator);
                 const sfballoc = __sfb.get();
-                const name_and_version = std.fmt.allocPrint(sfballoc, "{s}@{f}", .{ name, pkg.resolution.fmt(strbuf, .posix) }) catch unreachable;
+                const name_and_version = bun.fmt.allocPrint(sfballoc, "{s}@{f}", .{ name, pkg.resolution.fmt(strbuf, .posix) }) catch unreachable;
                 defer sfballoc.free(name_and_version);
                 const name_and_version_hash = String.Builder.stringHash(name_and_version);
                 if (manager.lockfile.patched_dependencies.get(name_and_version_hash)) |patched_dep| {

--- a/src/install/PackageManager/runTasks.zig
+++ b/src/install/PackageManager/runTasks.zig
@@ -1168,7 +1168,7 @@ pub fn allocGitHubURL(this: *const PackageManager, repository: *const Repository
     const repo = this.lockfile.str(&repository.repo);
     const committish = this.lockfile.str(&repository.committish);
 
-    return std.fmt.allocPrint(
+    return bun.fmt.allocPrint(
         this.allocator,
         "{s}/repos/{s}/{s}{s}tarball/{s}",
         .{

--- a/src/install/hosted_git_info.zig
+++ b/src/install/hosted_git_info.zig
@@ -851,7 +851,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "git@{s}:{s}/{s}.git{s}{s}",
                         .{ self.domain(), user.?, project, cmsh_sep, cmsh },
@@ -869,7 +869,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         allocator,
                         "git@{s}:{s}.git{s}{s}",
                         .{ self.domain(), project, cmsh_sep, cmsh },
@@ -898,7 +898,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "git+ssh://git@{s}/{s}/{s}.git{s}{s}",
                         .{ self.domain(), user.?, project, cmsh_sep, cmsh },
@@ -916,7 +916,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         allocator,
                         "git+ssh://git@{s}/{s}.git{s}{s}",
                         .{ self.domain(), project, cmsh_sep, cmsh },
@@ -950,7 +950,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "git+https://{s}{s}{s}/{s}/{s}.git{s}{s}",
                         .{ auth_str, auth_sep, self.domain(), user.?, project, cmsh_sep, cmsh },
@@ -971,7 +971,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "git+https://{s}/{s}.git{s}{s}",
                         .{ self.domain(), project, cmsh_sep, cmsh },
@@ -992,7 +992,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "https://{s}/{s}/{s}.git{s}{s}",
                         .{ self.domain(), user.?, project, cmsh_sep, cmsh },
@@ -1022,7 +1022,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "{s}{s}/{s}{s}{s}",
                         .{ self.shortcut(), user.?, project, cmsh_sep, cmsh },
@@ -1041,7 +1041,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         alloc,
                         "{s}{s}{s}{s}",
                         .{ self.shortcut(), project, cmsh_sep, cmsh },
@@ -1449,7 +1449,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         allocator,
                         "git://{s}{s}{s}/{s}/{s}.git{s}{s}",
                         .{ auth_str, auth_sep, self.domain(), user.?, project, cmsh_sep, cmsh },
@@ -1470,7 +1470,7 @@ const HostProvider = enum {
                     const cmsh: []const u8 = if (committish) |c| c else "";
                     const cmsh_sep = if (cmsh.len > 0) "#" else "";
 
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         allocator,
                         "git://{s}/{s}.git{s}{s}",
                         .{ self.domain(), project, cmsh_sep, cmsh },

--- a/src/install/lockfile/Package.zig
+++ b/src/install/lockfile/Package.zig
@@ -1246,7 +1246,7 @@ pub fn Package(comptime SemverIntType: type) type {
                         var notes = try allocator.alloc(logger.Data, 1);
 
                         notes[0] = .{
-                            .text = try std.fmt.allocPrint(lockfile.allocator, "\"{s}\" originally specified here", .{external_alias.slice(buf)}),
+                            .text = try bun.fmt.allocPrint(lockfile.allocator, "\"{s}\" originally specified here", .{external_alias.slice(buf)}),
                             .location = logger.Location.initOrNull(source, source.rangeOfString(entry.value_ptr.*)),
                         };
 

--- a/src/install/lockfile/bun.lock.zig
+++ b/src/install/lockfile/bun.lock.zig
@@ -75,7 +75,7 @@ pub const Stringifier = struct {
                     const dep = deps_buf[dep_id];
 
                     // clobber, there isn't data
-                    try pkg_map.put(try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{
+                    try pkg_map.put(try bun.fmt.allocPrint(allocator, "{s}{s}{s}", .{
                         node.relative_path,
                         if (node.depth == 0) "" else "/",
                         dep.name.slice(buf),

--- a/src/install/npm.zig
+++ b/src/install/npm.zig
@@ -354,7 +354,7 @@ pub const Registry = struct {
 
             if (needs_normalize) {
                 url = URL.parse(
-                    try std.fmt.allocPrint(allocator, "{s}://{f}/{s}/", .{
+                    try bun.fmt.allocPrint(allocator, "{s}://{f}/{s}/", .{
                         url.displayProtocol(),
                         url.displayHost(),
                         strings.trim(url.pathname, "/"),

--- a/src/install/patch_install.zig
+++ b/src/install/patch_install.zig
@@ -289,7 +289,7 @@ pub const PatchTask = struct {
         const resolution_label, const resolution_tag = brk: {
             // TODO: fix this threadsafety issue.
             const resolution = &this.manager.lockfile.packages.items(.resolution)[patch.pkg_id];
-            break :brk .{ bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{f}", .{resolution.fmt(this.manager.lockfile.buffers.string_bytes.items, .posix)})), resolution.tag };
+            break :brk .{ bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{f}", .{resolution.fmt(this.manager.lockfile.buffers.string_bytes.items, .posix)})), resolution.tag };
         };
         defer this.manager.allocator.free(resolution_label);
 

--- a/src/install/yarn.zig
+++ b/src/install/yarn.zig
@@ -176,7 +176,7 @@ pub const YarnLock = struct {
                     owner = path_without_commit[0..slash_idx];
                     repo = path_without_commit[slash_idx + 1 ..];
                 }
-                url = try std.fmt.allocPrint(
+                url = try bun.fmt.allocPrint(
                     self.allocator,
                     "https://github.com/{s}",
                     .{path_without_commit},
@@ -494,7 +494,7 @@ fn processDeps(
     while (deps_it.next()) |dep| {
         const dep_name = dep.key_ptr.*;
         const dep_version = dep.value_ptr.*;
-        const dep_spec = try std.fmt.allocPrint(
+        const dep_spec = try bun.fmt.allocPrint(
             temp_allocator,
             "{s}@{s}",
             .{ dep_name, dep_version },
@@ -1014,7 +1014,7 @@ pub fn migrateYarnLockfile(
 
     if (root_dependencies.items.len > 0) {
         for (root_dependencies.items) |dep| {
-            const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep.name, dep.version });
+            const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep.name, dep.version });
             defer allocator.free(dep_spec);
 
             var found_idx: ?usize = null;
@@ -1156,7 +1156,7 @@ pub fn migrateYarnLockfile(
                 while (deps_it.next()) |dep| {
                     const dep_name = dep.key_ptr.*;
                     const dep_version = dep.value_ptr.*;
-                    const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version });
+                    const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version });
                     defer allocator.free(dep_spec);
 
                     if (yarn_lock.findEntryBySpec(dep_spec)) |dep_entry| {
@@ -1185,7 +1185,7 @@ pub fn migrateYarnLockfile(
     }
 
     for (root_dependencies.items) |dep| {
-        const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep.name, dep.version });
+        const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep.name, dep.version });
         defer allocator.free(dep_spec);
 
         for (yarn_lock.entries.items, 0..) |entry, idx| {
@@ -1257,7 +1257,7 @@ pub fn migrateYarnLockfile(
             }
 
             if (!found_in_index) {
-                const fallback_name = try std.fmt.allocPrint(allocator, "{s}#{}", .{ base_name, package_id });
+                const fallback_name = try bun.fmt.allocPrint(allocator, "{s}#{}", .{ base_name, package_id });
                 defer allocator.free(fallback_name);
 
                 const fallback_hash = stringHash(fallback_name);
@@ -1340,7 +1340,7 @@ pub fn migrateYarnLockfile(
                         if (dep_package_id != package_id) {
                             const parent_name = package_names[dep_package_id];
 
-                            const potential_name = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ parent_name, base_name });
+                            const potential_name = try bun.fmt.allocPrint(allocator, "{s}/{s}", .{ parent_name, base_name });
 
                             var name_already_used = false;
                             var value_iter = scoped_names.valueIterator();
@@ -1373,7 +1373,7 @@ pub fn migrateYarnLockfile(
                 },
                 else => "unknown",
             };
-            scoped_name = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ base_name, version_str });
+            scoped_name = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ base_name, version_str });
         }
 
         if (scoped_name) |final_scoped_name| {
@@ -1455,7 +1455,7 @@ pub fn migrateYarnLockfile(
 
             try this.buffers.dependencies.append(allocator, dep);
 
-            const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ root_dep.name, root_dep.version });
+            const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ root_dep.name, root_dep.version });
             defer allocator.free(dep_spec);
 
             if (spec_to_package_id.get(dep_spec)) |pkg_id| {
@@ -1513,7 +1513,7 @@ pub fn migrateYarnLockfile(
                     .behavior = .{ .prod = true },
                 });
 
-                const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
+                const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
                 defer allocator.free(dep_spec);
 
                 if (spec_to_package_id.get(dep_spec)) |res_pkg_id| {
@@ -1557,7 +1557,7 @@ pub fn migrateYarnLockfile(
                     .behavior = .{ .optional = true },
                 });
 
-                const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
+                const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
                 defer allocator.free(dep_spec);
 
                 if (spec_to_package_id.get(dep_spec)) |res_pkg_id| {
@@ -1601,7 +1601,7 @@ pub fn migrateYarnLockfile(
                     .behavior = .{ .peer = true },
                 });
 
-                const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
+                const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
                 defer allocator.free(dep_spec);
 
                 if (spec_to_package_id.get(dep_spec)) |res_pkg_id| {
@@ -1645,7 +1645,7 @@ pub fn migrateYarnLockfile(
                     .behavior = .{ .dev = true },
                 });
 
-                const dep_spec = try std.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
+                const dep_spec = try bun.fmt.allocPrint(allocator, "{s}@{s}", .{ dep_name, dep_version_literal });
                 defer allocator.free(dep_spec);
 
                 if (spec_to_package_id.get(dep_spec)) |res_pkg_id| {

--- a/src/install_jsc/install_binding.zig
+++ b/src/install_jsc/install_binding.zig
@@ -47,7 +47,7 @@ pub const bun_install_js_bindings = struct {
             .ok => {},
         }
 
-        const stringified = bun.handleOom(std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(lockfile, .{
+        const stringified = bun.handleOom(bun.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(lockfile, .{
             .whitespace = .indent_2,
             .emit_null_optional_fields = true,
             .emit_nonportable_numbers_as_strings = true,

--- a/src/interchange/toml/lexer.zig
+++ b/src/interchange/toml/lexer.zig
@@ -113,7 +113,7 @@ pub const Lexer = struct {
             return;
         }
 
-        const errorMessage = std.fmt.allocPrint(self.log.msgs.allocator, format, args) catch unreachable;
+        const errorMessage = bun.fmt.allocPrint(self.log.msgs.allocator, format, args) catch unreachable;
         try self.log.addErrorOpts(errorMessage, .{
             .source = &self.source,
             .loc = r.loc,

--- a/src/js_parser/ast/E.zig
+++ b/src/js_parser/ast/E.zig
@@ -444,7 +444,7 @@ pub const Number = struct {
                     double_digit[abs];
             }
 
-            return std.fmt.allocPrint(allocator, "{d}", .{@as(i32, @intCast(int_value))}) catch return null;
+            return bun.fmt.allocPrint(allocator, "{d}", .{@as(i32, @intCast(int_value))}) catch return null;
         }
 
         if (std.math.isNan(value)) {

--- a/src/js_parser/ast/P.zig
+++ b/src/js_parser/ast/P.zig
@@ -1121,7 +1121,7 @@ pub fn NewParser_(
                 // Duplicate exports are an error
                 var notes = try p.allocator.alloc(logger.Data, 1);
                 notes[0] = logger.Data{
-                    .text = try std.fmt.allocPrint(p.allocator, "\"{s}\" was originally exported here", .{alias}),
+                    .text = try bun.fmt.allocPrint(p.allocator, "\"{s}\" was originally exported here", .{alias}),
                     .location = logger.Location.initOrNull(p.source, js_lexer.rangeOfIdentifier(p.source, name.alias_loc)),
                 };
                 try p.log.addRangeErrorFmtWithNotes(
@@ -2377,7 +2377,7 @@ pub fn NewParser_(
                                                 logger.rangeData(
                                                     p.source,
                                                     r,
-                                                    std.fmt.allocPrint(
+                                                    bun.fmt.allocPrint(
                                                         allocator,
                                                         "{s} was originally declared here",
                                                         .{name},
@@ -2985,7 +2985,7 @@ pub fn NewParser_(
         }
 
         pub fn createDefaultName(p: *P, loc: logger.Loc) !js_ast.LocRef {
-            const identifier = try std.fmt.allocPrint(p.allocator, "{s}_default", .{try p.source.path.name.nonUniqueNameString(p.allocator)});
+            const identifier = try bun.fmt.allocPrint(p.allocator, "{s}_default", .{try p.source.path.name.nonUniqueNameString(p.allocator)});
 
             const name = js_ast.LocRef{ .loc = loc, .ref = try p.newSymbol(Symbol.Kind.other, identifier) };
 
@@ -3208,8 +3208,8 @@ pub fn NewParser_(
                 .with_statement => "With statements",
                 .delete_bare_name => "\"delete\" of a bare identifier",
                 .for_in_var_init => "Variable initializers within for-in loops",
-                .eval_or_arguments => try std.fmt.allocPrint(p.allocator, "Declarations with the name \"{s}\"", .{detail}),
-                .reserved_word => try std.fmt.allocPrint(p.allocator, "\"{s}\" is a reserved word and", .{detail}),
+                .eval_or_arguments => try bun.fmt.allocPrint(p.allocator, "Declarations with the name \"{s}\"", .{detail}),
+                .reserved_word => try bun.fmt.allocPrint(p.allocator, "\"{s}\" is a reserved word and", .{detail}),
                 .legacy_octal_literal => "Legacy octal literals",
                 .legacy_octal_escape => "Legacy octal escape sequences",
                 .if_else_function_stmt => "Function declarations inside if statements",
@@ -3239,13 +3239,13 @@ pub fn NewParser_(
                     else => {},
                 }
                 if (why.len == 0) {
-                    why = try std.fmt.allocPrint(p.allocator, "This file is implicitly in strict mode because of the \"{s}\" keyword here", .{p.source.textForRange(where)});
+                    why = try bun.fmt.allocPrint(p.allocator, "This file is implicitly in strict mode because of the \"{s}\" keyword here", .{p.source.textForRange(where)});
                 }
                 var notes = try p.allocator.alloc(logger.Data, 1);
                 notes[0] = logger.rangeData(p.source, where, why);
-                try p.log.addRangeErrorWithNotes(p.source, r, try std.fmt.allocPrint(p.allocator, "{s} cannot be used in strict mode", .{text}), notes);
+                try p.log.addRangeErrorWithNotes(p.source, r, try bun.fmt.allocPrint(p.allocator, "{s} cannot be used in strict mode", .{text}), notes);
             } else if (!can_be_transformed and p.isStrictModeOutputFormat()) {
-                try p.log.addRangeError(p.source, r, try std.fmt.allocPrint(p.allocator, "{s} cannot be used with the ESM output format due to strict mode", .{text}));
+                try p.log.addRangeError(p.source, r, try bun.fmt.allocPrint(p.allocator, "{s} cannot be used with the ESM output format due to strict mode", .{text}));
             }
         }
 
@@ -5753,7 +5753,7 @@ pub fn NewParser_(
         pub fn generateTempRefWithScope(p: *P, default_name: ?string, scope: *Scope) Ref {
             const name = (if (p.willUseRenamer()) default_name else null) orelse brk: {
                 p.temp_ref_count += 1;
-                break :brk bun.handleOom(std.fmt.allocPrint(p.allocator, "__bun_temp_ref_{x}$", .{p.temp_ref_count}));
+                break :brk bun.handleOom(bun.fmt.allocPrint(p.allocator, "__bun_temp_ref_{x}$", .{p.temp_ref_count}));
             };
             const ref = bun.handleOom(p.newSymbol(.other, name));
 
@@ -6630,7 +6630,7 @@ pub fn NewParser_(
                 if (p.options.bundle and (p.options.code_splitting or p.needsWrapperRef(parts.items))) {
                     break :brk p.newSymbol(
                         .other,
-                        std.fmt.allocPrint(
+                        bun.fmt.allocPrint(
                             p.allocator,
                             "require_{f}",
                             .{p.source.fmtIdentifier()},

--- a/src/js_parser/ast/Parser.zig
+++ b/src/js_parser/ast/Parser.zig
@@ -1077,7 +1077,7 @@ pub const Parser = struct {
                     var notes = ListManaged(logger.Data).init(p.allocator);
 
                     try notes.append(logger.Data{
-                        .text = try std.fmt.allocPrint(p.allocator, "Try require({f}) instead", .{bun.fmt.QuotedFormatter{ .text = record.path.text }}),
+                        .text = try bun.fmt.allocPrint(p.allocator, "Try require({f}) instead", .{bun.fmt.QuotedFormatter{ .text = record.path.text }}),
                     });
 
                     if (uses_module_ref) {

--- a/src/js_parser/ast/lowerDecorators.zig
+++ b/src/js_parser/ast/lowerDecorators.zig
@@ -579,7 +579,7 @@ pub fn LowerDecorators(
             var inner_class_ref: Ref = class_name_ref;
             if (!is_expr) {
                 const cns = p.symbols.items[class_name_ref.innerIndex()].original_name;
-                inner_class_ref = newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}", .{cns}) catch unreachable);
+                inner_class_ref = newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}", .{cns}) catch unreachable);
             }
 
             const class_decorators = class.ts_decorators;
@@ -627,7 +627,7 @@ pub fn LowerDecorators(
                     const dec_name = if (dec_counter == 1)
                         "_dec"
                     else
-                        std.fmt.allocPrint(p.allocator, "_dec{d}", .{dec_counter}) catch unreachable;
+                        bun.fmt.allocPrint(p.allocator, "_dec{d}", .{dec_counter}) catch unreachable;
                     const dec_ref = newSym(p, .other, dec_name);
                     prop_dec_refs.put(p.allocator, prop_idx, dec_ref) catch unreachable;
                     if (is_expr) {
@@ -640,7 +640,7 @@ pub fn LowerDecorators(
                     const key_name = if (computed_key_counter == 1)
                         "_computedKey"
                     else
-                        std.fmt.allocPrint(p.allocator, "_computedKey{d}", .{computed_key_counter}) catch unreachable;
+                        bun.fmt.allocPrint(p.allocator, "_computedKey{d}", .{computed_key_counter}) catch unreachable;
                     const key_ref = newSym(p, .other, key_name);
                     computed_key_refs.put(p.allocator, prop_idx, key_ref) catch unreachable;
                     if (is_expr) {
@@ -760,9 +760,9 @@ pub fn LowerDecorators(
                             const nk = methodKind(prop);
                             const existing = private_lowered_map.get(npriv_inner);
                             const ws_ref = if (existing) |ex| ex.storage_ref else brk: {
-                                break :brk newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}", .{npriv_orig[1..]}) catch unreachable);
+                                break :brk newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}", .{npriv_orig[1..]}) catch unreachable);
                             };
-                            const fn_nm = std.fmt.allocPrint(p.allocator, "_{s}{s}", .{ npriv_orig[1..], fnSuffix(nk) }) catch unreachable;
+                            const fn_nm = bun.fmt.allocPrint(p.allocator, "_{s}{s}", .{ npriv_orig[1..], fnSuffix(nk) }) catch unreachable;
                             const fn_ref = newSym(p, .other, fn_nm);
 
                             var new_info = if (existing) |ex| ex else PrivateLoweredInfo{ .storage_ref = ws_ref };
@@ -788,7 +788,7 @@ pub fn LowerDecorators(
                             continue;
                         } else {
                             // Non-decorated private field → WeakMap
-                            const wm_nm = std.fmt.allocPrint(p.allocator, "_{s}", .{npriv_orig[1..]}) catch unreachable;
+                            const wm_nm = bun.fmt.allocPrint(p.allocator, "_{s}", .{npriv_orig[1..]}) catch unreachable;
                             const wm_ref = newSym(p, .other, wm_nm);
                             private_lowered_map.put(p.allocator, npriv_inner, .{ .storage_ref = wm_ref }) catch unreachable;
                             prefix_stmts.append(varDecl(p, wm_ref, newWeakMapExpr(p, loc), loc)) catch unreachable;
@@ -820,8 +820,8 @@ pub fn LowerDecorators(
                     if (prop.kind == .auto_accessor) {
                         const accessor_name = brk: {
                             if (prop.key.?.data == .e_string)
-                                break :brk std.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable;
-                            const name = std.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
+                                break :brk bun.fmt.allocPrint(p.allocator, "_{s}", .{prop.key.?.data.e_string.data}) catch unreachable;
+                            const name = bun.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
                             accessor_storage_counter += 1;
                             break :brk name;
                         };
@@ -933,9 +933,9 @@ pub fn LowerDecorators(
                     if (k >= 1 and k <= 3) {
                         // Decorated private method/getter/setter → WeakSet
                         const existing = private_lowered_map.get(priv_inner);
-                        const ws_ref = if (existing) |ex| ex.storage_ref else newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
+                        const ws_ref = if (existing) |ex| ex.storage_ref else newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
                         private_storage_ref = ws_ref;
-                        const fn_ref = newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}{s}", .{ private_orig[1..], fnSuffix(k) }) catch unreachable);
+                        const fn_ref = newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}{s}", .{ private_orig[1..], fnSuffix(k) }) catch unreachable);
                         private_method_fn_ref = fn_ref;
 
                         var new_info = if (existing) |ex| ex else PrivateLoweredInfo{ .storage_ref = ws_ref };
@@ -950,16 +950,16 @@ pub fn LowerDecorators(
                         dec_arg_count = 6;
                     } else if (k == 5) {
                         // Decorated private field → WeakMap
-                        const wm_ref = newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
+                        const wm_ref = newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
                         private_storage_ref = wm_ref;
                         private_lowered_map.put(p.allocator, priv_inner, .{ .storage_ref = wm_ref }) catch unreachable;
                         prefix_stmts.append(varDecl(p, wm_ref, newWeakMapExpr(p, loc), loc)) catch unreachable;
                         dec_arg_count = 5;
                     } else if (k == 4) {
                         // Decorated private auto-accessor → WeakMap + descriptor
-                        const wm_ref = newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
+                        const wm_ref = newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}", .{private_orig[1..]}) catch unreachable);
                         private_storage_ref = wm_ref;
-                        const acc_ref = newSym(p, .other, std.fmt.allocPrint(p.allocator, "_{s}_acc", .{private_orig[1..]}) catch unreachable);
+                        const acc_ref = newSym(p, .other, bun.fmt.allocPrint(p.allocator, "_{s}_acc", .{private_orig[1..]}) catch unreachable);
                         private_method_fn_ref = acc_ref;
                         private_lowered_map.put(p.allocator, priv_inner, .{
                             .storage_ref = wm_ref,
@@ -972,8 +972,8 @@ pub fn LowerDecorators(
                     // Decorated public auto-accessor → WeakMap
                     const accessor_name = brk: {
                         if (key_expr.data == .e_string)
-                            break :brk std.fmt.allocPrint(p.allocator, "_{s}", .{key_expr.data.e_string.data}) catch unreachable;
-                        const name = std.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
+                            break :brk bun.fmt.allocPrint(p.allocator, "_{s}", .{key_expr.data.e_string.data}) catch unreachable;
+                        const name = bun.fmt.allocPrint(p.allocator, "_accessor_storage{d}", .{accessor_storage_counter}) catch unreachable;
                         accessor_storage_counter += 1;
                         break :brk name;
                     };

--- a/src/js_parser/ast/maybe.zig
+++ b/src/js_parser/ast/maybe.zig
@@ -212,7 +212,7 @@ pub fn AstMaybe(
                                     if (!named_export_entry.found_existing) {
                                         const new_ref = p.newSymbol(
                                             .other,
-                                            std.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(key)}) catch unreachable,
+                                            bun.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(key)}) catch unreachable,
                                         ) catch unreachable;
                                         bun.handleOom(p.module_scope.generated.append(p.allocator, new_ref));
                                         named_export_entry.value_ptr.* = .{
@@ -318,7 +318,7 @@ pub fn AstMaybe(
                                 if (!named_export_entry.found_existing) {
                                     const new_ref = p.newSymbol(
                                         .other,
-                                        std.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(name)}) catch unreachable,
+                                        bun.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(name)}) catch unreachable,
                                     ) catch unreachable;
                                     bun.handleOom(p.module_scope.generated.append(p.allocator, new_ref));
                                     named_export_entry.value_ptr.* = .{
@@ -425,7 +425,7 @@ pub fn AstMaybe(
                             // Inline import.meta.url as file:// URL
                             const bunstr = bun.String.fromBytes(p.source.path.text);
                             defer bunstr.deref();
-                            const url = std.fmt.allocPrint(p.allocator, "{f}", .{jsc.URL.fileURLFromString(bunstr)}) catch unreachable;
+                            const url = bun.fmt.allocPrint(p.allocator, "{f}", .{jsc.URL.fileURLFromString(bunstr)}) catch unreachable;
                             return p.newExpr(E.String.init(url), name_loc);
                         }
                     }
@@ -491,7 +491,7 @@ pub fn AstMaybe(
                                     if (!named_export_entry.found_existing) {
                                         const new_ref = p.newSymbol(
                                             .other,
-                                            std.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(name)}) catch unreachable,
+                                            bun.fmt.allocPrint(p.allocator, "${f}", .{bun.fmt.fmtIdentifier(name)}) catch unreachable,
                                         ) catch unreachable;
                                         bun.handleOom(p.module_scope.generated.append(p.allocator, new_ref));
                                         named_export_entry.value_ptr.* = .{
@@ -568,7 +568,7 @@ pub fn AstMaybe(
                             p.log.addError(
                                 p.source,
                                 loc,
-                                std.fmt.allocPrint(
+                                bun.fmt.allocPrint(
                                     p.allocator,
                                     "import.meta.hot.{s} does not exist",
                                     .{name},

--- a/src/js_parser/ast/parseStmt.zig
+++ b/src/js_parser/ast/parseStmt.zig
@@ -370,7 +370,7 @@ pub fn ParseStmt(
                         const import_record_index = p.addImportRecord(.stmt, parsedPath.loc, parsedPath.text);
                         const path_name = fs.PathName.init(parsedPath.text);
                         const namespace_ref = p.storeNameInRef(
-                            std.fmt.allocPrint(
+                            bun.fmt.allocPrint(
                                 p.allocator,
                                 "import_{f}",
                                 .{

--- a/src/js_parser/ast/visitExpr.zig
+++ b/src/js_parser/ast/visitExpr.zig
@@ -103,7 +103,7 @@ pub fn VisitExpr(
                         const r = js_lexer.rangeOfIdentifier(p.source, expr.loc);
                         var notes = p.allocator.alloc(logger.Data, 1) catch unreachable;
                         notes[0] = logger.Data{
-                            .text = std.fmt.allocPrint(p.allocator, "The symbol \"{s}\" was declared a constant here:", .{name}) catch unreachable,
+                            .text = bun.fmt.allocPrint(p.allocator, "The symbol \"{s}\" was declared a constant here:", .{name}) catch unreachable,
                             .location = logger.Location.initOrNull(p.source, js_lexer.rangeOfIdentifier(p.source, result.declare_loc.?)),
                         };
 
@@ -1512,7 +1512,7 @@ pub fn VisitExpr(
                             p.log.addError(
                                 p.source,
                                 expr.loc,
-                                std.fmt.allocPrint(
+                                bun.fmt.allocPrint(
                                     p.allocator,
                                     "\"useState\" is not available in a server component. If you need interactivity, consider converting part of this to a Client Component (by adding `\"use client\";` to the top of the file).",
                                     .{},

--- a/src/js_parser/lexer.zig
+++ b/src/js_parser/lexer.zig
@@ -209,7 +209,7 @@ fn NewLexer_(
                 return;
             }
 
-            const errorMessage = std.fmt.allocPrint(self.allocator, format, args) catch unreachable;
+            const errorMessage = bun.fmt.allocPrint(self.allocator, format, args) catch unreachable;
             try self.log.addRangeError(&self.source, r, errorMessage);
             self.prev_error_loc = r.loc;
 
@@ -226,7 +226,7 @@ fn NewLexer_(
                 return;
             }
 
-            const errorMessage = std.fmt.allocPrint(self.allocator, format, args) catch unreachable;
+            const errorMessage = bun.fmt.allocPrint(self.allocator, format, args) catch unreachable;
             try self.log.addRangeErrorWithNotes(
                 &self.source,
                 r,

--- a/src/jsc/AsyncModule.zig
+++ b/src/jsc/AsyncModule.zig
@@ -466,37 +466,37 @@ pub const AsyncModule = struct {
         const globalThis = this.globalThis;
 
         const msg: []u8 = try switch (result.err) {
-            error.PackageManifestHTTP400 => std.fmt.allocPrint(
+            error.PackageManifestHTTP400 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 400 while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
             ),
-            error.PackageManifestHTTP401 => std.fmt.allocPrint(
+            error.PackageManifestHTTP401 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 401 while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
             ),
-            error.PackageManifestHTTP402 => std.fmt.allocPrint(
+            error.PackageManifestHTTP402 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 402 while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
             ),
-            error.PackageManifestHTTP403 => std.fmt.allocPrint(
+            error.PackageManifestHTTP403 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 403 while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
             ),
-            error.PackageManifestHTTP404 => std.fmt.allocPrint(
+            error.PackageManifestHTTP404 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "Package '{s}' was not found",
                 .{result.name},
             ),
-            error.PackageManifestHTTP4xx => std.fmt.allocPrint(
+            error.PackageManifestHTTP4xx => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 4xx while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
             ),
-            error.PackageManifestHTTP5xx => std.fmt.allocPrint(
+            error.PackageManifestHTTP5xx => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 5xx while resolving package '{s}' at '{s}'",
                 .{ result.name, result.url },
@@ -509,13 +509,13 @@ pub const AsyncModule = struct {
                 else
                     "No match found";
 
-                break :brk std.fmt.allocPrint(
+                break :brk bun.fmt.allocPrint(
                     bun.default_allocator,
                     "{s} '{s}' for package '{s}' (but package exists)",
                     .{ prefix, vm.packageManager().lockfile.str(&result.version.literal), result.name },
                 );
             },
-            else => |err| std.fmt.allocPrint(
+            else => |err| bun.fmt.allocPrint(
                 bun.default_allocator,
                 "{s} resolving package '{s}' at '{s}'",
                 .{ bun.asByteSlice(@errorName(err)), result.name, result.url },
@@ -564,47 +564,47 @@ pub const AsyncModule = struct {
         };
 
         const msg: []u8 = try switch (result.err) {
-            error.TarballHTTP400 => std.fmt.allocPrint(
+            error.TarballHTTP400 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 400 downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP401 => std.fmt.allocPrint(
+            error.TarballHTTP401 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 401 downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP402 => std.fmt.allocPrint(
+            error.TarballHTTP402 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 402 downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP403 => std.fmt.allocPrint(
+            error.TarballHTTP403 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 403 downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP404 => std.fmt.allocPrint(
+            error.TarballHTTP404 => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 404 downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP4xx => std.fmt.allocPrint(
+            error.TarballHTTP4xx => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 4xx downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballHTTP5xx => std.fmt.allocPrint(
+            error.TarballHTTP5xx => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "HTTP 5xx downloading package '{s}@{f}'",
                 msg_args,
             ),
-            error.TarballFailedToExtract => std.fmt.allocPrint(
+            error.TarballFailedToExtract => bun.fmt.allocPrint(
                 bun.default_allocator,
                 "Failed to extract tarball for package '{s}@{f}'",
                 msg_args,
             ),
-            else => |err| std.fmt.allocPrint(
+            else => |err| bun.fmt.allocPrint(
                 bun.default_allocator,
                 "{s} downloading package '{s}@{f}'",
                 .{

--- a/src/jsc/BuildMessage.zig
+++ b/src/jsc/BuildMessage.zig
@@ -29,7 +29,7 @@ pub const BuildMessage = struct {
     }
 
     pub fn toStringFn(this: *BuildMessage, globalThis: *jsc.JSGlobalObject) jsc.JSValue {
-        const text = std.fmt.allocPrint(default_allocator, "BuildMessage: {s}", .{this.msg.data.text}) catch {
+        const text = bun.fmt.allocPrint(default_allocator, "BuildMessage: {s}", .{this.msg.data.text}) catch {
             return globalThis.throwOutOfMemoryValue();
         };
         var str = ZigString.init(text);

--- a/src/jsc/JSGlobalObject.zig
+++ b/src/jsc/JSGlobalObject.zig
@@ -502,7 +502,7 @@ pub const JSGlobalObject = opaque {
         // Avoid tiny extra allocation
         var stack = std.heap.stackFallback(128, bun.default_allocator);
         const allocator_ = stack.get();
-        const buffer = try std.fmt.allocPrint(allocator_, comptime "{s} " ++ fmt, .{@errorName(err)});
+        const buffer = try bun.fmt.allocPrint(allocator_, comptime "{s} " ++ fmt, .{@errorName(err)});
         defer allocator_.free(buffer);
         const str = ZigString.initUTF8(buffer);
         const err_value = str.toErrorInstance(this);
@@ -1008,7 +1008,7 @@ pub const JSGlobalObject = opaque {
             var fallback = std.heap.stackFallback(256, bun.default_allocator);
             var alloc = fallback.get();
 
-            const buf = std.fmt.allocPrint(alloc, fmt, args) catch unreachable;
+            const buf = bun.fmt.allocPrint(alloc, fmt, args) catch unreachable;
             var zig_str = jsc.ZigString.init(buf);
             zig_str.detectEncoding();
             // it alwayas clones

--- a/src/jsc/ResolveMessage.zig
+++ b/src/jsc/ResolveMessage.zig
@@ -73,37 +73,37 @@ pub const ResolveMessage = struct {
     pub fn fmt(allocator: std.mem.Allocator, specifier: string, referrer: string, err: anyerror, import_kind: bun.ImportKind) !string {
         if (import_kind != .require_resolve and bun.strings.hasPrefixComptime(specifier, "node:")) {
             // This matches Node.js exactly.
-            return try std.fmt.allocPrint(allocator, "No such built-in module: {s}", .{specifier});
+            return try bun.fmt.allocPrint(allocator, "No such built-in module: {s}", .{specifier});
         }
         switch (err) {
             error.ModuleNotFound => {
                 if (strings.eqlComptime(referrer, "bun:main")) {
-                    return try std.fmt.allocPrint(allocator, "Module not found '{s}'", .{specifier});
+                    return try bun.fmt.allocPrint(allocator, "Module not found '{s}'", .{specifier});
                 }
                 if (Resolver.isPackagePath(specifier) and !strings.containsChar(specifier, '/')) {
-                    return try std.fmt.allocPrint(allocator, "Cannot find package '{s}' from '{s}'", .{ specifier, referrer });
+                    return try bun.fmt.allocPrint(allocator, "Cannot find package '{s}' from '{s}'", .{ specifier, referrer });
                 } else {
-                    return try std.fmt.allocPrint(allocator, "Cannot find module '{s}' from '{s}'", .{ specifier, referrer });
+                    return try bun.fmt.allocPrint(allocator, "Cannot find module '{s}' from '{s}'", .{ specifier, referrer });
                 }
             },
             error.InvalidDataURL => {
-                return try std.fmt.allocPrint(allocator, "Cannot resolve invalid data URL '{s}' from '{s}'", .{ specifier, referrer });
+                return try bun.fmt.allocPrint(allocator, "Cannot resolve invalid data URL '{s}' from '{s}'", .{ specifier, referrer });
             },
             error.InvalidURL => {
-                return try std.fmt.allocPrint(allocator, "Cannot resolve invalid URL '{s}' from '{s}'", .{ specifier, referrer });
+                return try bun.fmt.allocPrint(allocator, "Cannot resolve invalid URL '{s}' from '{s}'", .{ specifier, referrer });
             },
             else => {
                 if (Resolver.isPackagePath(specifier)) {
-                    return try std.fmt.allocPrint(allocator, "{s} while resolving package '{s}' from '{s}'", .{ @errorName(err), specifier, referrer });
+                    return try bun.fmt.allocPrint(allocator, "{s} while resolving package '{s}' from '{s}'", .{ @errorName(err), specifier, referrer });
                 } else {
-                    return try std.fmt.allocPrint(allocator, "{s} while resolving '{s}' from '{s}'", .{ @errorName(err), specifier, referrer });
+                    return try bun.fmt.allocPrint(allocator, "{s} while resolving '{s}' from '{s}'", .{ @errorName(err), specifier, referrer });
                 }
             },
         }
     }
 
     pub fn toStringFn(this: *ResolveMessage, globalThis: *jsc.JSGlobalObject) jsc.JSValue {
-        const text = std.fmt.allocPrint(default_allocator, "ResolveMessage: {s}", .{this.msg.data.text}) catch {
+        const text = bun.fmt.allocPrint(default_allocator, "ResolveMessage: {s}", .{this.msg.data.text}) catch {
             return globalThis.throwOutOfMemoryValue();
         };
         var str = ZigString.init(text);

--- a/src/jsc/VirtualMachine.zig
+++ b/src/jsc/VirtualMachine.zig
@@ -2038,13 +2038,13 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
                         .data = logger.rangeData(
                             null,
                             logger.Range.None,
-                            std.fmt.allocPrint(globalThis.allocator(), "Unexpected pending import in \"{f}\". To automatically install npm packages with Bun, please use an import statement instead of require() or dynamic import().\nThis error can also happen if dependencies import packages which are not referenced anywhere. Worst case, run `bun install` and opt-out of the node_modules folder until we come up with a better way to handle this error.", .{specifier}) catch unreachable,
+                            bun.fmt.allocPrint(globalThis.allocator(), "Unexpected pending import in \"{f}\". To automatically install npm packages with Bun, please use an import statement instead of require() or dynamic import().\nThis error can also happen if dependencies import packages which are not referenced anywhere. Worst case, run `bun install` and opt-out of the node_modules folder until we come up with a better way to handle this error.", .{specifier}) catch unreachable,
                         ),
                     };
                 }
 
                 break :brk logger.Msg{
-                    .data = logger.rangeData(null, logger.Range.None, std.fmt.allocPrint(globalThis.allocator(), "{s} while building {f}", .{ @errorName(err), specifier }) catch unreachable),
+                    .data = logger.rangeData(null, logger.Range.None, bun.fmt.allocPrint(globalThis.allocator(), "{s} while building {f}", .{ @errorName(err), specifier }) catch unreachable),
                 };
             };
             {
@@ -2095,7 +2095,7 @@ pub fn processFetchLog(globalThis: *JSGlobalObject, specifier: bun.String, refer
                 globalThis.createAggregateError(
                     errors,
                     &ZigString.init(
-                        std.fmt.allocPrint(globalThis.allocator(), "{d} errors building \"{f}\"", .{
+                        bun.fmt.allocPrint(globalThis.allocator(), "{d} errors building \"{f}\"", .{
                             errors.len,
                             specifier,
                         }) catch unreachable,

--- a/src/jsc/ZigStackFrame.zig
+++ b/src/jsc/ZigStackFrame.zig
@@ -31,7 +31,7 @@ pub const ZigStackFrame = extern struct {
         }
 
         if (!this.source_url.isEmpty()) {
-            frame.file = try std.fmt.allocPrint(allocator, "{f}", .{this.sourceURLFormatter(root_path, origin, true, false)});
+            frame.file = try bun.fmt.allocPrint(allocator, "{f}", .{this.sourceURLFormatter(root_path, origin, true, false)});
         }
 
         frame.position = this.position;

--- a/src/jsc/web_worker.zig
+++ b/src/jsc/web_worker.zig
@@ -319,7 +319,7 @@ pub fn create(
         .store_fd = parent.transpiler.resolver.store_fd,
         .name = brk: {
             if (!name_str.isEmpty()) {
-                break :brk bun.handleOom(std.fmt.allocPrintSentinel(bun.default_allocator, "{f}", .{name_str}, 0));
+                break :brk bun.handleOom(bun.fmt.allocPrintSentinel(bun.default_allocator, "{f}", .{name_str}, 0));
             }
             break :brk "";
         },

--- a/src/logger/logger.zig
+++ b/src/logger/logger.zig
@@ -780,7 +780,7 @@ pub const Log = struct {
 
     pub inline fn allocPrint(allocator: std.mem.Allocator, comptime fmt: string, args: anytype) OOM!string {
         return switch (Output.enable_ansi_colors_stderr) {
-            inline else => |enable_ansi_colors| std.fmt.allocPrint(allocator, Output.prettyFmt(fmt, enable_ansi_colors), args),
+            inline else => |enable_ansi_colors| bun.fmt.allocPrint(allocator, Output.prettyFmt(fmt, enable_ansi_colors), args),
         };
     }
 
@@ -1188,7 +1188,7 @@ pub const Log = struct {
         notes[0] = rangeData(
             source,
             source.rangeOfIdentifier(old_loc),
-            try std.fmt.allocPrint(allocator, "\"{s}\" was originally declared here", .{name}),
+            try bun.fmt.allocPrint(allocator, "\"{s}\" was originally declared here", .{name}),
         );
 
         try self.addRangeErrorFmtWithNotes(

--- a/src/options_types/schema.zig
+++ b/src/options_types/schema.zig
@@ -2894,12 +2894,12 @@ pub const api = struct {
                 // Token
                 if (url.username.len == 0 and url.password.len > 0) {
                     registry.token = url.password;
-                    registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
+                    registry.url = try bun.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
                 } else if (url.username.len > 0 and url.password.len > 0) {
                     registry.username = url.username;
                     registry.password = url.password;
 
-                    registry.url = try std.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
+                    registry.url = try bun.fmt.allocPrint(this.allocator, "{s}://{f}/{s}/", .{ url.displayProtocol(), url.displayHost(), std.mem.trim(u8, url.pathname, "/") });
                 } else {
                     // Do not include a trailing slash. There might be parameters at the end.
                     registry.url = url.href;

--- a/src/patch_jsc/testing.zig
+++ b/src/patch_jsc/testing.zig
@@ -83,7 +83,7 @@ pub const TestingAPIs = struct {
         };
         defer patchfile.deinit(bun.default_allocator);
 
-        const str = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{f}", .{std.json.fmt(patchfile, .{})}));
+        const str = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{f}", .{std.json.fmt(patchfile, .{})}));
         const outstr = bun.String.borrowUTF8(str);
         return outstr.toJS(globalThis);
     }

--- a/src/resolver/fs.zig
+++ b/src/resolver/fs.zig
@@ -555,7 +555,7 @@ pub const FileSystem = struct {
                 // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw#remarks
                 .windows => {
                     if (bun.env_var.SYSTEMROOT.get() orelse bun.env_var.WINDIR.get()) |windir| {
-                        return std.fmt.allocPrint(
+                        return bun.fmt.allocPrint(
                             bun.default_allocator,
                             "{s}\\Temp",
                             .{strings.withoutTrailingSlash(windir)},
@@ -572,7 +572,7 @@ pub const FileSystem = struct {
                     var tmp_buf: bun.PathBuffer = undefined;
                     const cwd = std.posix.getcwd(&tmp_buf) catch @panic("Failed to get cwd for platformTempDir");
                     const root = bun.path.windowsFilesystemRoot(cwd);
-                    return std.fmt.allocPrint(
+                    return bun.fmt.allocPrint(
                         bun.default_allocator,
                         "{s}\\Windows\\Temp",
                         .{strings.withoutTrailingSlash(root)},
@@ -1949,7 +1949,7 @@ pub const Path = struct {
     }
 
     pub fn generateKey(p: *Path, allocator: std.mem.Allocator) !string {
-        return try std.fmt.allocPrint(allocator, "{s}://{s}", .{ p.namespace, p.text });
+        return try bun.fmt.allocPrint(allocator, "{s}://{s}", .{ p.namespace, p.text });
     }
 
     pub fn init(text: string) Path {

--- a/src/resolver/resolver.zig
+++ b/src/resolver/resolver.zig
@@ -263,7 +263,7 @@ pub const Result = struct {
 
             try log.addMsg(Msg{
                 .kind = .err,
-                .data = logger.rangeData(_source, r, std.fmt.allocPrint(m.notes.allocator, fmt, args)),
+                .data = logger.rangeData(_source, r, bun.fmt.allocPrint(m.notes.allocator, fmt, args)),
                 .notes = try m.toOwnedSlice(),
             });
         }
@@ -336,7 +336,7 @@ pub const DebugLogs = struct {
 
     pub fn addNoteFmt(d: *DebugLogs, comptime fmt: string, args: anytype) void {
         @branchHint(.cold);
-        return d.addNote(std.fmt.allocPrint(d.notes.allocator, fmt, args) catch unreachable);
+        return d.addNote(bun.fmt.allocPrint(d.notes.allocator, fmt, args) catch unreachable);
     }
 };
 
@@ -2525,7 +2525,7 @@ pub const Resolver = struct {
                                     const index_query = dir_entries.get(file_name);
                                     if (index_query != null and index_query.?.entry.kind(&r.fs.fs, r.store_fd) == .file) {
                                         if (r.debug_logs) |*debug| {
-                                            missing_suffix = std.fmt.allocPrint(r.allocator, "/{s}", .{file_name}) catch unreachable;
+                                            missing_suffix = bun.fmt.allocPrint(r.allocator, "/{s}", .{file_name}) catch unreachable;
                                             defer r.allocator.free(missing_suffix);
                                             const parts = [_]string{ package_json.name, package_subpath };
                                             debug.addNoteFmt("The import {s} is missing the suffix {s}", .{ ResolvePath.join(parts, .auto), missing_suffix });
@@ -4123,7 +4123,7 @@ pub const Resolver = struct {
                         var symlink = entry.symlink(rfs, r.store_fd);
                         if (symlink.len > 0) {
                             if (r.debug_logs) |*logs| {
-                                logs.addNote(std.fmt.allocPrint(r.allocator, "Resolved symlink \"{s}\" to \"{s}\"", .{ path, symlink }) catch unreachable);
+                                logs.addNote(bun.fmt.allocPrint(r.allocator, "Resolved symlink \"{s}\" to \"{s}\"", .{ path, symlink }) catch unreachable);
                             }
                             info.abs_real_path = symlink;
                         } else if (parent_.abs_real_path.len > 0) {
@@ -4132,7 +4132,7 @@ pub const Resolver = struct {
                             symlink = r.fs.dirname_store.append(string, r.fs.absBuf(&parts, bufs(.dir_info_uncached_filename))) catch unreachable;
 
                             if (r.debug_logs) |*logs| {
-                                logs.addNote(std.fmt.allocPrint(r.allocator, "Resolved symlink \"{s}\" to \"{s}\"", .{ path, symlink }) catch unreachable);
+                                logs.addNote(bun.fmt.allocPrint(r.allocator, "Resolved symlink \"{s}\" to \"{s}\"", .{ path, symlink }) catch unreachable);
                             }
                             lookup.entry.cache.symlink = PathString.init(symlink);
                             info.abs_real_path = symlink;

--- a/src/runtime/api/BunObject.zig
+++ b/src/runtime/api/BunObject.zig
@@ -261,7 +261,7 @@ pub fn braces(global: *jsc.JSGlobalObject, brace_str: bun.String, opts: gen.Brac
     const expansion_count = Braces.calculateExpandedAmount(lexer_output.tokens.items[0..]);
 
     if (opts.tokenize) {
-        const str = bun.handleOom(std.fmt.allocPrint(global.bunVM().allocator, "{f}", .{std.json.fmt(lexer_output.tokens.items[0..], .{})}));
+        const str = bun.handleOom(bun.fmt.allocPrint(global.bunVM().allocator, "{f}", .{std.json.fmt(lexer_output.tokens.items[0..], .{})}));
         defer global.bunVM().allocator.free(str);
         var bun_str = bun.String.fromBytes(str);
         return bun_str.toJS(global);
@@ -271,7 +271,7 @@ pub fn braces(global: *jsc.JSGlobalObject, brace_str: bun.String, opts: gen.Brac
         const ast_node = parser.parse() catch |err| {
             return global.throwError(err, "failed to parse braces");
         };
-        const str = bun.handleOom(std.fmt.allocPrint(global.bunVM().allocator, "{f}", .{std.json.fmt(ast_node, .{})}));
+        const str = bun.handleOom(bun.fmt.allocPrint(global.bunVM().allocator, "{f}", .{std.json.fmt(ast_node, .{})}));
         defer global.bunVM().allocator.free(str);
         var bun_str = bun.String.fromBytes(str);
         return bun_str.toJS(global);

--- a/src/runtime/api/JSTranspiler.zig
+++ b/src/runtime/api/JSTranspiler.zig
@@ -94,7 +94,7 @@ pub const Config = struct {
                     if (val.len == 0) {
                         val = jsc.ZigString.init("\"\"");
                     }
-                    values.appendAssumeCapacity(std.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable);
+                    values.appendAssumeCapacity(bun.fmt.allocPrint(allocator, "{f}", .{val}) catch unreachable);
                 }
 
                 this.transform.define = api.StringMap{
@@ -114,7 +114,7 @@ pub const Config = struct {
                     try external.toZigString(&zig_str, globalThis);
                     if (zig_str.len == 0) break :external;
                     var single_external = allocator.alloc(string, 1) catch unreachable;
-                    single_external[0] = std.fmt.allocPrint(allocator, "{f}", .{zig_str}) catch unreachable;
+                    single_external[0] = bun.fmt.allocPrint(allocator, "{f}", .{zig_str}) catch unreachable;
                     this.transform.external = single_external;
                 } else if (toplevel_type.isArray()) {
                     const count = try external.getLength(globalThis);
@@ -131,7 +131,7 @@ pub const Config = struct {
                         var zig_str = jsc.ZigString.init("");
                         try entry.toZigString(&zig_str, globalThis);
                         if (zig_str.len == 0) continue;
-                        externals[i] = std.fmt.allocPrint(allocator, "{f}", .{zig_str}) catch unreachable;
+                        externals[i] = bun.fmt.allocPrint(allocator, "{f}", .{zig_str}) catch unreachable;
                         i += 1;
                     }
 
@@ -638,7 +638,7 @@ fn exportReplacementValue(value: JSValue, globalThis: *JSGlobalObject, allocator
 
     if (value.isString()) {
         const str = JSAst.E.String{
-            .data = try std.fmt.allocPrint(allocator, "{f}", .{try value.getZigString(globalThis)}),
+            .data = try bun.fmt.allocPrint(allocator, "{f}", .{try value.getZigString(globalThis)}),
         };
         const out = try allocator.create(JSAst.E.String);
         out.* = str;
@@ -795,7 +795,7 @@ fn getParseResult(this: *JSTranspiler, allocator: std.mem.Allocator, code: []con
     // If code starts with { and doesn't end with ; it might be an object literal
     // that would otherwise be parsed as a block statement
     const processed_code: []const u8 = if (this.config.repl_mode and isLikelyObjectLiteral(code))
-        std.fmt.allocPrint(allocator, "({s})", .{code}) catch code
+        bun.fmt.allocPrint(allocator, "({s})", .{code}) catch code
     else
         code;
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.zig
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.zig
@@ -1162,7 +1162,7 @@ pub fn appendEnvpFromJS(globalThis: *jsc.JSGlobalObject, object: *jsc.JSObject, 
             return globalThis.ERR(.INVALID_ARG_VALUE, "The property 'options.env['{f}']' must be a string without null bytes. Received \"{f}\"", .{ key.toZigString(), value_bunstr.toZigString() }).throw();
         }
 
-        const line = try std.fmt.allocPrintSentinel(envp.allocator, "{f}={f}", .{ key, value_bunstr.toZigString() }, 0);
+        const line = try bun.fmt.allocPrintSentinel(envp.allocator, "{f}={f}", .{ key, value_bunstr.toZigString() }, 0);
 
         if (key.eqlComptime("PATH")) {
             PATH.* = bun.asByteSlice(line["PATH=".len..]);

--- a/src/runtime/api/cron.zig
+++ b/src/runtime/api/cron.zig
@@ -31,7 +31,7 @@ fn CronJobBase(comptime Self: type) type {
             bun.assert(this.remaining_fds > 0);
             this.remaining_fds -= 1;
             if (this.err_msg == null)
-                this.err_msg = std.fmt.allocPrint(bun.default_allocator, "Failed to read process output: {s}", .{@tagName(err.getErrno())}) catch null;
+                this.err_msg = bun.fmt.allocPrint(bun.default_allocator, "Failed to read process output: {s}", .{@tagName(err.getErrno())}) catch null;
             this.maybeFinished();
         }
 
@@ -78,7 +78,7 @@ pub const CronRegisterJob = struct {
 
     fn setErr(this: *CronRegisterJob, comptime fmt: []const u8, args: anytype) void {
         if (this.err_msg == null)
-            this.err_msg = std.fmt.allocPrint(bun.default_allocator, fmt, args) catch null;
+            this.err_msg = bun.fmt.allocPrint(bun.default_allocator, fmt, args) catch null;
     }
 
     fn maybeFinished(this: *CronRegisterJob) void {
@@ -225,7 +225,7 @@ pub const CronRegisterJob = struct {
         };
 
         // Build new entry with single-quoted paths to prevent shell injection
-        const new_entry = std.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}\n{s} '{s}' run --cron-title={s} --cron-period='{s}' '{s}'\n", .{
+        const new_entry = bun.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}\n{s} '{s}' run --cron-title={s} --cron-period='{s}' '{s}'\n", .{
             this.title, this.schedule, this.bun_exe, this.title, this.schedule, this.abs_path,
         }) catch {
             this.setErr("Out of memory", .{});
@@ -288,7 +288,7 @@ pub const CronRegisterJob = struct {
             return;
         };
 
-        const launch_agents_dir = std.fmt.allocPrint(bun.default_allocator, "{s}/Library/LaunchAgents", .{home}) catch {
+        const launch_agents_dir = bun.fmt.allocPrint(bun.default_allocator, "{s}/Library/LaunchAgents", .{home}) catch {
             this.setErr("Out of memory", .{});
             this.finish();
             return;
@@ -333,7 +333,7 @@ pub const CronRegisterJob = struct {
         };
         defer bun.default_allocator.free(xml_sched);
 
-        const plist = std.fmt.allocPrint(bun.default_allocator,
+        const plist = bun.fmt.allocPrint(bun.default_allocator,
             \\<?xml version="1.0" encoding="UTF-8"?>
             \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
             \\<plist version="1.0">
@@ -574,7 +574,7 @@ pub const CronRemoveJob = struct {
 
     fn setErr(this: *CronRemoveJob, comptime fmt: []const u8, args: anytype) void {
         if (this.err_msg == null)
-            this.err_msg = std.fmt.allocPrint(bun.default_allocator, fmt, args) catch null;
+            this.err_msg = bun.fmt.allocPrint(bun.default_allocator, fmt, args) catch null;
     }
 
     fn maybeFinished(this: *CronRemoveJob) void {
@@ -1285,7 +1285,7 @@ fn validateTitle(title: []const u8) bool {
 
 /// Filter crontab content, removing any entry with matching title marker.
 fn filterCrontab(content: []const u8, title: [:0]const u8, result: *std.array_list.Managed(u8)) !void {
-    const marker = try std.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}", .{title});
+    const marker = try bun.fmt.allocPrint(bun.default_allocator, "# bun-cron: {s}", .{title});
     defer bun.default_allocator.free(marker);
     var skip_next = false;
     var lines = std.mem.splitScalar(u8, content, '\n');
@@ -1424,7 +1424,7 @@ fn cronToCalendarInterval(schedule: []const u8) ![]const u8 {
 }
 
 fn appendCalendarKey(result: *std.array_list.Managed(u8), key: []const u8, val: i32) !void {
-    const line = try std.fmt.allocPrint(bun.default_allocator, "        <key>{s}</key>\n        <integer>{d}</integer>\n", .{ key, val });
+    const line = try bun.fmt.allocPrint(bun.default_allocator, "        <key>{s}</key>\n        <integer>{d}</integer>\n", .{ key, val });
     defer bun.default_allocator.free(line);
     try result.appendSlice(line);
 }
@@ -1610,7 +1610,7 @@ fn cronToTaskXml(
     const xml_path = try xmlEscape(abs_path);
     defer allocator.free(xml_path);
 
-    const action_xml = try std.fmt.allocPrint(allocator,
+    const action_xml = try bun.fmt.allocPrint(allocator,
         \\  </Triggers>
         \\  <Principals>
         \\    <Principal>
@@ -1750,7 +1750,7 @@ fn computeStepInterval(comptime T: type, bits: T, _: u7, max: u7) ?u32 {
 }
 
 fn allocPrintZ(allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) std.mem.Allocator.Error![:0]const u8 {
-    return std.fmt.allocPrintSentinel(allocator, fmt, args, 0);
+    return bun.fmt.allocPrintSentinel(allocator, fmt, args, 0);
 }
 
 /// Create a temp file path with a random suffix to avoid TOCTOU/symlink attacks.

--- a/src/runtime/api/html_rewriter.zig
+++ b/src/runtime/api/html_rewriter.zig
@@ -61,7 +61,7 @@ pub const HTMLRewriter = struct {
         callFrame: *jsc.CallFrame,
         listener: JSValue,
     ) bun.JSError!JSValue {
-        const selector_slice = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{f}", .{selector_name}));
+        const selector_slice = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{f}", .{selector_name}));
         defer bun.default_allocator.free(selector_slice);
 
         var selector = LOLHTML.HTMLSelector.parse(selector_slice) catch

--- a/src/runtime/crypto/PasswordObject.zig
+++ b/src/runtime/crypto/PasswordObject.zig
@@ -357,7 +357,7 @@ pub const JSPasswordObject = struct {
                 hash: []const u8,
 
                 pub fn toErrorInstance(this: Value, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
-                    const error_code = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "PASSWORD{f}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}));
+                    const error_code = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "PASSWORD{f}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}));
                     defer bun.default_allocator.free(error_code);
                     const instance = globalObject.createErrorInstance("Password hashing failed with error \"{s}\"", .{@errorName(this.err)});
                     instance.put(globalObject, ZigString.static("code"), jsc.ZigString.init(error_code).toJS(globalObject));
@@ -571,7 +571,7 @@ pub const JSPasswordObject = struct {
                 pass: bool,
 
                 pub fn toErrorInstance(this: Value, globalObject: *jsc.JSGlobalObject) jsc.JSValue {
-                    const error_code = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "PASSWORD{f}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}));
+                    const error_code = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "PASSWORD{f}", .{PascalToUpperUnderscoreCaseFormatter{ .input = @errorName(this.err) }}));
                     defer bun.default_allocator.free(error_code);
                     const instance = globalObject.createErrorInstance("Password verification failed with error \"{s}\"", .{@errorName(this.err)});
                     instance.put(globalObject, ZigString.static("code"), jsc.ZigString.init(error_code).toJS(globalObject));

--- a/src/runtime/dns_jsc/dns.zig
+++ b/src/runtime/dns_jsc/dns.zig
@@ -3547,7 +3547,7 @@ pub const Resolver = struct {
         var channel = try resolver.getChannelOrError(globalThis);
 
         // This string will be freed in `CAresNameInfo.deinit`
-        const cache_name = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s}|{d}", .{ addr_s, port }));
+        const cache_name = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s}|{d}", .{ addr_s, port }));
 
         const key = GetNameInfoRequest.PendingCacheKey.init(cache_name);
         var cache = resolver.getOrPutIntoResolvePendingCache(

--- a/src/runtime/ffi/ffi.zig
+++ b/src/runtime/ffi/ffi.zig
@@ -14,7 +14,7 @@ fn getDlError(allocator: std.mem.Allocator) ![]const u8 {
 
         // For now, just return the error code as we'd need to implement FormatMessageW in Zig
         // This is still better than a generic message
-        return try std.fmt.allocPrint(allocator, "error code {d}", .{err_int});
+        return try bun.fmt.allocPrint(allocator, "error code {d}", .{err_int});
     } else {
         // On POSIX systems, use dlerror() to get the actual system error
         const msg = if (std.c.dlerror()) |err_ptr|
@@ -1076,7 +1076,7 @@ pub const FFI = struct {
                     defer if (dlerror_buf) |buf| bun.default_allocator.free(buf);
                     const dlerror_msg = dlerror_buf orelse "unknown error";
 
-                    const msg = bun.handleOom(std.fmt.allocPrint(
+                    const msg = bun.handleOom(bun.fmt.allocPrint(
                         bun.default_allocator,
                         "Failed to open library \"{s}\": {s}",
                         .{ name, dlerror_msg },

--- a/src/runtime/node/node_fs.zig
+++ b/src/runtime/node/node_fs.zig
@@ -6075,7 +6075,7 @@ pub const NodeFS = struct {
         bun.assert(flavor == .sync);
 
         const watcher = args.createStatWatcher() catch |err| {
-            const buf = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "Failed to watch file {f}", .{bun.fmt.QuotedFormatter{ .text = args.path.slice() }}));
+            const buf = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "Failed to watch file {f}", .{bun.fmt.QuotedFormatter{ .text = args.path.slice() }}));
             defer bun.default_allocator.free(buf);
             args.global_this.throwValue((jsc.SystemError{
                 .message = bun.String.init(buf),

--- a/src/runtime/server/NodeHTTPResponse.zig
+++ b/src/runtime/server/NodeHTTPResponse.zig
@@ -488,7 +488,7 @@ pub fn writeHead(this: *NodeHTTPResponse, globalObject: *jsc.JSGlobalObject, cal
         }
 
         const message = if (status_message_slice.len > 0) status_message_slice.slice() else "HM";
-        const status_message = bun.handleOom(std.fmt.allocPrint(allocator, "{d} {s}", .{ status_code, message }));
+        const status_message = bun.handleOom(bun.fmt.allocPrint(allocator, "{d} {s}", .{ status_code, message }));
         defer allocator.free(status_message);
         writeHeadInternal(this.raw_response.?, globalObject, status_message, headers_object_value);
         break :do_it;

--- a/src/runtime/server/RequestContext.zig
+++ b/src/runtime/server/RequestContext.zig
@@ -437,7 +437,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             const fallback_container = arena_allocator.create(Api.FallbackMessageContainer) catch unreachable;
             defer arena_allocator.destroy(fallback_container);
             fallback_container.* = Api.FallbackMessageContainer{
-                .message = std.fmt.allocPrint(arena_allocator, comptime Output.prettyFmt(fmt, false), args) catch unreachable,
+                .message = bun.fmt.allocPrint(arena_allocator, comptime Output.prettyFmt(fmt, false), args) catch unreachable,
                 .router = null,
                 .reason = .fetch_event_handler,
                 .cwd = VirtualMachine.get().transpiler.fs.top_level_dir,

--- a/src/runtime/server/ServerConfig.zig
+++ b/src/runtime/server/ServerConfig.zig
@@ -1019,13 +1019,13 @@ pub fn fromJS(
             defer bun.default_allocator.free(@constCast(original_base_uri));
             if (needsBrackets) {
                 args.base_uri = (if ((port == 80 and args.ssl_config == null) or (port == 443 and args.ssl_config != null))
-                    std.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]/{s}", .{
+                    bun.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]/{s}", .{
                         protocol,
                         hostname,
                         strings.trimLeadingChar(args.base_url.pathname, '/'),
                     })
                 else
-                    std.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]:{d}/{s}", .{
+                    bun.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]:{d}/{s}", .{
                         protocol,
                         hostname,
                         port,
@@ -1033,13 +1033,13 @@ pub fn fromJS(
                     })) catch unreachable;
             } else {
                 args.base_uri = (if ((port == 80 and args.ssl_config == null) or (port == 443 and args.ssl_config != null))
-                    std.fmt.allocPrint(bun.default_allocator, "{s}://{s}/{s}", .{
+                    bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}/{s}", .{
                         protocol,
                         hostname,
                         strings.trimLeadingChar(args.base_url.pathname, '/'),
                     })
                 else
-                    std.fmt.allocPrint(bun.default_allocator, "{s}://{s}:{d}/{s}", .{
+                    bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}:{d}/{s}", .{
                         protocol,
                         hostname,
                         port,
@@ -1058,20 +1058,20 @@ pub fn fromJS(
         const protocol: string = if (args.ssl_config != null) "https" else "http";
         if (needsBrackets) {
             args.base_uri = (if ((port == 80 and args.ssl_config == null) or (port == 443 and args.ssl_config != null))
-                std.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]/", .{
+                bun.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]/", .{
                     protocol,
                     hostname,
                 })
             else
-                std.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]:{d}/", .{ protocol, hostname, port })) catch unreachable;
+                bun.fmt.allocPrint(bun.default_allocator, "{s}://[{s}]:{d}/", .{ protocol, hostname, port })) catch unreachable;
         } else {
             args.base_uri = (if ((port == 80 and args.ssl_config == null) or (port == 443 and args.ssl_config != null))
-                std.fmt.allocPrint(bun.default_allocator, "{s}://{s}/", .{
+                bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}/", .{
                     protocol,
                     hostname,
                 })
             else
-                std.fmt.allocPrint(bun.default_allocator, "{s}://{s}:{d}/", .{ protocol, hostname, port })) catch unreachable;
+                bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}:{d}/", .{ protocol, hostname, port })) catch unreachable;
         }
 
         if (!strings.isAllASCII(hostname)) {

--- a/src/runtime/server/server.zig
+++ b/src/runtime/server/server.zig
@@ -1483,7 +1483,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 },
             };
 
-            const buf = try std.fmt.allocPrint(default_allocator, "{f}", .{fmt});
+            const buf = try bun.fmt.allocPrint(default_allocator, "{f}", .{fmt});
             defer default_allocator.free(buf);
 
             return bun.String.cloneUTF8(buf);
@@ -1971,7 +1971,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (comptime !has_h3) unreachable;
             this.h3_listener = socket;
             if (socket) |s| {
-                this.h3_alt_svc = std.fmt.allocPrintSentinel(
+                this.h3_alt_svc = bun.fmt.allocPrintSentinel(
                     bun.default_allocator,
                     "h3=\":{d}\"; ma=86400",
                     .{s.getLocalPort()},
@@ -2726,7 +2726,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             //     uuid: string,
             //   }
             // }
-            const json_string = std.fmt.allocPrint(bun.default_allocator, "{{ \"workspace\": {{ \"root\": {f}, \"uuid\": \"{f}\" }} }}", .{
+            const json_string = bun.fmt.allocPrint(bun.default_allocator, "{{ \"workspace\": {{ \"root\": {f}, \"uuid\": \"{f}\" }} }}", .{
                 bun.fmt.formatJSONStringUTF8(this.dev_server.?.root, .{}),
                 uuid,
             }) catch |err| bun.handleOom(err);

--- a/src/runtime/socket/tls_socket_functions.zig
+++ b/src/runtime/socket/tls_socket_functions.zig
@@ -634,7 +634,7 @@ noinline fn getSSLException(globalThis: *jsc.JSGlobalObject, defaultMessage: []c
 
     if (written > 0) {
         const message = output_buf[0..written];
-        zig_str = ZigString.init(bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "OpenSSL {s}", .{message})));
+        zig_str = ZigString.init(bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "OpenSSL {s}", .{message})));
         var encoded_str = zig_str.withEncoding();
         encoded_str.markGlobal();
 

--- a/src/runtime/webcore/Blob.zig
+++ b/src/runtime/webcore/Blob.zig
@@ -760,7 +760,7 @@ pub fn fromDOMFormData(
     // Always allocate content_type with the default allocator so deinit() can
     // free it unconditionally; the only caller passes bun.default_allocator
     // anyway, but don't rely on that.
-    blob.content_type = std.fmt.allocPrint(bun.default_allocator, "multipart/form-data; boundary={s}", .{boundary}) catch |err| bun.handleOom(err);
+    blob.content_type = bun.fmt.allocPrint(bun.default_allocator, "multipart/form-data; boundary={s}", .{boundary}) catch |err| bun.handleOom(err);
     blob.content_type_allocated = true;
     blob.content_type_was_set = true;
 

--- a/src/runtime/webcore/Request.zig
+++ b/src/runtime/webcore/Request.zig
@@ -534,7 +534,7 @@ pub fn ensureURL(this: *Request) bun.OOM!void {
                     };
                 } else {
                     // slow path
-                    const temp_url = try std.fmt.allocPrint(bun.default_allocator, "{s}{f}{s}", .{
+                    const temp_url = try bun.fmt.allocPrint(bun.default_allocator, "{s}{f}{s}", .{
                         this.getProtocol(),
                         fmt,
                         req_url,

--- a/src/runtime/webcore/fetch.zig
+++ b/src/runtime/webcore/fetch.zig
@@ -694,7 +694,7 @@ fn fetchImpl(
                             return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
                         }
                         defer href.deref();
-                        const buffer = try std.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
+                        const buffer = try bun.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
                         url = ZigURL.parse(buffer[0..url.href.len]);
                         if (url.isFile()) {
                             url_type = URLType.file;
@@ -721,7 +721,7 @@ fn fetchImpl(
                                         return JSPromise.dangerouslyCreateRejectedPromiseValueWithoutNotifyingVM(globalThis, err);
                                     }
                                     defer href.deref();
-                                    const buffer = try std.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
+                                    const buffer = try bun.fmt.allocPrint(allocator, "{s}{f}", .{ url_proxy_buffer, href });
                                     url = ZigURL.parse(buffer[0..url.href.len]);
                                     if (url.isFile()) {
                                         url_type = URLType.file;

--- a/src/runtime/webcore/fetch/FetchTasklet.zig
+++ b/src/runtime/webcore/fetch/FetchTasklet.zig
@@ -1125,7 +1125,7 @@ pub const FetchTasklet = struct {
                 // `fetch(url, { proxy: "..." })` option.
                 if (env_proxy.href.len > 0) {
                     const old_url_len = url.href.len;
-                    const new_buffer = try std.fmt.allocPrint(bun.default_allocator, "{s}{s}", .{ fetch_tasklet.url_proxy_buffer, env_proxy.href });
+                    const new_buffer = try bun.fmt.allocPrint(bun.default_allocator, "{s}{s}", .{ fetch_tasklet.url_proxy_buffer, env_proxy.href });
                     if (fetch_tasklet.url_proxy_buffer.len > 0) {
                         bun.default_allocator.free(fetch_tasklet.url_proxy_buffer);
                     }

--- a/src/runtime/webcore/s3/client.zig
+++ b/src/runtime/webcore/s3/client.zig
@@ -737,7 +737,6 @@ pub fn readableStream(
 const Credentials = @import("../../../s3_signing/credentials.zig");
 const S3ListObjects = @import("./list_objects.zig");
 const S3SimpleRequest = @import("./simple_request.zig");
-const std = @import("std");
 
 const bun = @import("bun");
 const jsc = bun.jsc;

--- a/src/runtime/webcore/s3/client.zig
+++ b/src/runtime/webcore/s3/client.zig
@@ -70,10 +70,10 @@ pub fn downloadSlice(
             if (size_ > 0) {
                 end -= 1;
             }
-            break :brk bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "bytes={}-{}", .{ offset, end }));
+            break :brk bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "bytes={}-{}", .{ offset, end }));
         }
         if (offset == 0) break :brk null;
-        break :brk bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "bytes={}-", .{offset}));
+        break :brk bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "bytes={}-", .{offset}));
     };
 
     try S3SimpleRequest.executeSimpleS3Request(this, .{
@@ -544,10 +544,10 @@ pub fn downloadStream(
             if (size_ > 0) {
                 end -= 1;
             }
-            break :brk bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "bytes={}-{}", .{ offset, end }));
+            break :brk bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "bytes={}-{}", .{ offset, end }));
         }
         if (offset == 0) break :brk null;
-        break :brk bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "bytes={}-", .{offset}));
+        break :brk bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "bytes={}-", .{offset}));
     };
 
     var result = this.signRequest(.{

--- a/src/runtime/webview/ChromeProcess.zig
+++ b/src/runtime/webview/ChromeProcess.zig
@@ -216,7 +216,7 @@ fn findPlaywrightShell(alloc: std.mem.Allocator) ?[:0]const u8 {
     //   non-cft: chrome-linux/headless_shell   (linux arm64 only)
     const arch = if (comptime bun.Environment.isAarch64) "arm64" else "x64";
     const plat = if (comptime bun.Environment.isMac) "mac" else "linux";
-    const subdir_cft = std.fmt.allocPrint(alloc, "chrome-headless-shell-{s}-{s}/chrome-headless-shell", .{ plat, arch }) catch return null;
+    const subdir_cft = bun.fmt.allocPrint(alloc, "chrome-headless-shell-{s}-{s}/chrome-headless-shell", .{ plat, arch }) catch return null;
     defer alloc.free(subdir_cft);
 
     const bin_buf = bun.path_buffer_pool.get();
@@ -277,12 +277,12 @@ fn spawn(vm: *jsc.VirtualMachine, userDataDir: ?[*:0]const u8, explicitPath: ?[*
     // the default profile (~/Library/Application Support/Google/Chrome) and
     // aborts if a real Chrome is already running.
     const dataDir = if (userDataDir) |d|
-        try std.fmt.allocPrintSentinel(alloc, "--user-data-dir={s}", .{d}, 0)
+        try bun.fmt.allocPrintSentinel(alloc, "--user-data-dir={s}", .{d}, 0)
     else blk: {
         // pid_t → u32 cast so {d} formats. Fresh dir per parent process;
         // multiple Bun.WebView instances in one process share the Chrome.
         const pid: u32 = @intCast(std.c.getpid());
-        break :blk try std.fmt.allocPrintSentinel(alloc, "--user-data-dir=/tmp/bun-chrome-{d}", .{pid}, 0);
+        break :blk try bun.fmt.allocPrintSentinel(alloc, "--user-data-dir=/tmp/bun-chrome-{d}", .{pid}, 0);
     };
 
     var argv: std.ArrayListUnmanaged(?[*:0]const u8) = .{};

--- a/src/s3_signing/credentials.zig
+++ b/src/s3_signing/credentials.zig
@@ -131,7 +131,7 @@ pub const S3Credentials = struct {
         // Format the date
         return .{
             .numeric_day = secs - time.secs,
-            .date = std.fmt.allocPrint(allocator, "{d:0>4}{d:0>2}{d:0>2}T{d:0>2}{d:0>2}{d:0>2}Z", .{
+            .date = bun.fmt.allocPrint(allocator, "{d:0>4}{d:0>2}{d:0>2}T{d:0>2}{d:0>2}{d:0>2}Z", .{
                 year,
                 month,
                 day,
@@ -437,10 +437,10 @@ pub const S3Credentials = struct {
                         return error.InvalidEndpoint;
                     }
                     // default to https://<BUCKET_NAME>.s3.<REGION>.amazonaws.com/
-                    endpoint = try std.fmt.allocPrint(bun.default_allocator, "{s}.s3.{s}.amazonaws.com", .{ bucket, region });
+                    endpoint = try bun.fmt.allocPrint(bun.default_allocator, "{s}.s3.{s}.amazonaws.com", .{ bucket, region });
                     break :brk_host endpoint;
                 }
-                endpoint = try std.fmt.allocPrint(bun.default_allocator, "s3.{s}.amazonaws.com", .{region});
+                endpoint = try bun.fmt.allocPrint(bun.default_allocator, "s3.{s}.amazonaws.com", .{region});
                 break :brk_host endpoint;
             }
         };
@@ -531,41 +531,41 @@ pub const S3Credentials = struct {
                     // Add parameters in alphabetical order: Content-MD5, X-Amz-Acl, X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-Security-Token, X-Amz-SignedHeaders, response-content-disposition, response-content-type, x-amz-request-payer, x-amz-storage-class
 
                     if (encoded_content_md5) |encoded_content_md5_value| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "Content-MD5={s}", .{encoded_content_md5_value}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "Content-MD5={s}", .{encoded_content_md5_value}));
                     }
 
                     if (acl) |acl_value| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Acl={s}", .{acl_value}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Acl={s}", .{acl_value}));
                     }
 
-                    try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Algorithm=AWS4-HMAC-SHA256", .{}));
+                    try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Algorithm=AWS4-HMAC-SHA256", .{}));
 
-                    try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Credential={s}%2F{s}%2F{s}%2F{s}%2Faws4_request", .{ this.accessKeyId, amz_day, region, service_name }));
+                    try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Credential={s}%2F{s}%2F{s}%2F{s}%2Faws4_request", .{ this.accessKeyId, amz_day, region, service_name }));
 
-                    try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Date={s}", .{amz_date}));
+                    try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Date={s}", .{amz_date}));
 
-                    try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Expires={}", .{expires}));
+                    try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Expires={}", .{expires}));
 
                     if (encoded_session_token) |token| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-Security-Token={s}", .{token}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-Security-Token={s}", .{token}));
                     }
 
-                    try query_parts.append(try std.fmt.allocPrint(allocator, "X-Amz-SignedHeaders=host", .{}));
+                    try query_parts.append(try bun.fmt.allocPrint(allocator, "X-Amz-SignedHeaders=host", .{}));
 
                     if (encoded_content_disposition) |cd| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "response-content-disposition={s}", .{cd}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "response-content-disposition={s}", .{cd}));
                     }
 
                     if (encoded_content_type) |ct| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "response-content-type={s}", .{ct}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "response-content-type={s}", .{ct}));
                     }
 
                     if (request_payer) {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "x-amz-request-payer=requester", .{}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "x-amz-request-payer=requester", .{}));
                     }
 
                     if (storage_class) |storage_class_value| {
-                        try query_parts.append(try std.fmt.allocPrint(allocator, "x-amz-storage-class={s}", .{storage_class_value}));
+                        try query_parts.append(try bun.fmt.allocPrint(allocator, "x-amz-storage-class={s}", .{storage_class_value}));
                     }
 
                     // Join query parameters with &
@@ -594,43 +594,43 @@ pub const S3Credentials = struct {
                 // Add parameters in alphabetical order: Content-MD5, X-Amz-Acl, X-Amz-Algorithm, X-Amz-Credential, X-Amz-Date, X-Amz-Expires, X-Amz-Security-Token, X-Amz-Signature, X-Amz-SignedHeaders, response-content-disposition, response-content-type, x-amz-request-payer, x-amz-storage-class
 
                 if (encoded_content_md5) |encoded_content_md5_value| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "Content-MD5={s}", .{encoded_content_md5_value}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "Content-MD5={s}", .{encoded_content_md5_value}));
                 }
 
                 if (acl) |acl_value| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Acl={s}", .{acl_value}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Acl={s}", .{acl_value}));
                 }
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Algorithm=AWS4-HMAC-SHA256", .{}));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Algorithm=AWS4-HMAC-SHA256", .{}));
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Credential={s}%2F{s}%2F{s}%2F{s}%2Faws4_request", .{ this.accessKeyId, amz_day, region, service_name }));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Credential={s}%2F{s}%2F{s}%2F{s}%2Faws4_request", .{ this.accessKeyId, amz_day, region, service_name }));
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Date={s}", .{amz_date}));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Date={s}", .{amz_date}));
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Expires={}", .{expires}));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Expires={}", .{expires}));
 
                 if (encoded_session_token) |token| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Security-Token={s}", .{token}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Security-Token={s}", .{token}));
                 }
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-Signature={s}", .{std.fmt.bytesToHex(signature[0..DIGESTED_HMAC_256_LEN], .lower)}));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-Signature={s}", .{std.fmt.bytesToHex(signature[0..DIGESTED_HMAC_256_LEN], .lower)}));
 
-                try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "X-Amz-SignedHeaders=host", .{}));
+                try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "X-Amz-SignedHeaders=host", .{}));
 
                 if (encoded_content_disposition) |cd| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "response-content-disposition={s}", .{cd}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "response-content-disposition={s}", .{cd}));
                 }
 
                 if (encoded_content_type) |ct| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "response-content-type={s}", .{ct}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "response-content-type={s}", .{ct}));
                 }
 
                 if (request_payer) {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "x-amz-request-payer=requester", .{}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "x-amz-request-payer=requester", .{}));
                 }
 
                 if (storage_class) |storage_class_value| {
-                    try url_query_parts.append(try std.fmt.allocPrint(url_allocator, "x-amz-storage-class={s}", .{storage_class_value}));
+                    try url_query_parts.append(try bun.fmt.allocPrint(url_allocator, "x-amz-storage-class={s}", .{storage_class_value}));
                 }
 
                 // Join URL query parameters with &
@@ -642,7 +642,7 @@ pub const S3Credentials = struct {
                     url_allocator.free(part);
                 }
 
-                break :brk try std.fmt.allocPrint(bun.default_allocator, "{s}://{s}{s}?{s}", .{ protocol, host, normalizedPath, url_query_string.items });
+                break :brk try bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}{s}?{s}", .{ protocol, host, normalizedPath, url_query_string.items });
             } else {
                 const canonical = try CanonicalRequest.format(
                     &tmp_buffer,
@@ -668,7 +668,7 @@ pub const S3Credentials = struct {
 
                 const signature = bun.hmac.generate(sigDateRegionServiceReq, signValue, .sha256, &hmac_sig_service) orelse return error.FailedToGenerateSignature;
 
-                break :brk try std.fmt.allocPrint(
+                break :brk try bun.fmt.allocPrint(
                     bun.default_allocator,
                     "AWS4-HMAC-SHA256 Credential={s}/{s}/{s}/{s}/aws4_request, SignedHeaders={s}, Signature={s}",
                     .{ this.accessKeyId, amz_day, region, service_name, signed_headers, std.fmt.bytesToHex(signature[0..DIGESTED_HMAC_256_LEN], .lower) },
@@ -698,7 +698,7 @@ pub const S3Credentials = struct {
             .acl = signOptions.acl,
             .storage_class = signOptions.storage_class,
             .request_payer = request_payer,
-            .url = try std.fmt.allocPrint(bun.default_allocator, "{s}://{s}{s}{s}", .{ protocol, host, normalizedPath, if (search_params) |s| s else "" }),
+            .url = try bun.fmt.allocPrint(bun.default_allocator, "{s}://{s}{s}{s}", .{ protocol, host, normalizedPath, if (search_params) |s| s else "" }),
             ._headers = [_]picohttp.Header{
                 .{ .name = "x-amz-content-sha256", .value = aws_content_hash },
                 .{ .name = "x-amz-date", .value = amz_date },

--- a/src/semver/SemverQuery.zig
+++ b/src/semver/SemverQuery.zig
@@ -173,7 +173,7 @@ pub const Group = struct {
     }
 
     pub fn jsonStringify(this: *const Group, writer: anytype) !void {
-        const temp = try std.fmt.allocPrint(bun.default_allocator, "{f}", .{this.fmt()});
+        const temp = try bun.fmt.allocPrint(bun.default_allocator, "{f}", .{this.fmt()});
         defer bun.default_allocator.free(temp);
         try std.json.encodeJsonString(temp, .{}, writer);
     }

--- a/src/shell/Builtin.zig
+++ b/src/shell/Builtin.zig
@@ -789,7 +789,7 @@ pub fn taskErrorToString(this: *Builtin, comptime kind: Kind, err: anytype) []co
 pub fn fmtErrorArena(this: *Builtin, comptime kind: ?Kind, comptime fmt_: []const u8, args: anytype) []u8 {
     const cmd_str = comptime if (kind) |k| @tagName(k) ++ ": " else "";
     const fmt = cmd_str ++ fmt_;
-    return bun.handleOom(std.fmt.allocPrint(this.arena.allocator(), fmt, args));
+    return bun.handleOom(bun.fmt.allocPrint(this.arena.allocator(), fmt, args));
 }
 
 // --- Shell Builtin Commands ---

--- a/src/shell/builtin/cp.zig
+++ b/src/shell/builtin/cp.zig
@@ -475,12 +475,12 @@ pub const ShellCpTask = struct {
 
         // Any source directory without -R is an error
         if (src_is_dir and !this.opts.recursive) {
-            const errmsg = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s} is a directory (not copied)", .{this.src}));
+            const errmsg = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s} is a directory (not copied)", .{this.src}));
             return .{ .custom = errmsg };
         }
 
         if (!src_is_dir and bun.strings.eql(src, tgt)) {
-            const errmsg = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s} and {s} are identical (not copied)", .{ this.src, this.src }));
+            const errmsg = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s} and {s} are identical (not copied)", .{ this.src, this.src }));
             return .{ .custom = errmsg };
         }
 
@@ -518,15 +518,15 @@ pub const ShellCpTask = struct {
             } else if (this.operands == 2) {
                 // source_dir -> new_target_dir
             } else {
-                const errmsg = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "directory {s} does not exist", .{this.tgt}));
+                const errmsg = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "directory {s} does not exist", .{this.tgt}));
                 return .{ .custom = errmsg };
             }
             copying_many = true;
         }
         // Handle the "3rd synopsis": source_files... -> target
         else {
-            if (src_is_dir) return .{ .custom = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s} is a directory (not copied)", .{this.src})) };
-            if (!tgt_exists or !tgt_is_dir) return .{ .custom = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{s} is not a directory", .{this.tgt})) };
+            if (src_is_dir) return .{ .custom = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s} is a directory (not copied)", .{this.src})) };
+            if (!tgt_exists or !tgt_is_dir) return .{ .custom = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{s} is not a directory", .{this.tgt})) };
             const basename = ResolvePath.basename(src[0..src.len]);
             const parts: []const []const u8 = &.{
                 tgt[0..tgt.len],

--- a/src/shell/builtin/seq.zig
+++ b/src/shell/builtin/seq.zig
@@ -89,7 +89,7 @@ fn do(this: *@This()) Yield {
     defer arena.deinit();
 
     while (if (this.increment > 0) current <= this._end else current >= this._end) : (current += this.increment) {
-        const str = bun.handleOom(std.fmt.allocPrint(arena.allocator(), "{d}", .{current}));
+        const str = bun.handleOom(bun.fmt.allocPrint(arena.allocator(), "{d}", .{current}));
         defer _ = arena.reset(.retain_capacity);
         _ = this.print(str);
         _ = this.print(this.separator);

--- a/src/shell/interpreter.zig
+++ b/src/shell/interpreter.zig
@@ -886,7 +886,7 @@ pub const Interpreter = struct {
                 test_tokens.append(test_tok) catch @panic("OOPS");
             }
 
-            const str = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "{f}", .{std.json.fmt(test_tokens.items[0..], .{})}));
+            const str = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "{f}", .{std.json.fmt(test_tokens.items[0..], .{})}));
             defer bun.default_allocator.free(str);
             debug("Tokens: {s}", .{str});
         }

--- a/src/shell/shell.zig
+++ b/src/shell/shell.zig
@@ -175,13 +175,13 @@ pub const GlobalJS = struct {
 
     pub inline fn throwInvalidArguments(this: @This(), comptime fmt: []const u8, args: anytype) ShellErr {
         return .{
-            .invalid_arguments = .{ .val = bun.handleOom(std.fmt.allocPrint(this.globalThis.bunVM().allocator, fmt, args)) },
+            .invalid_arguments = .{ .val = bun.handleOom(bun.fmt.allocPrint(this.globalThis.bunVM().allocator, fmt, args)) },
         };
     }
 
     pub inline fn throwTODO(this: @This(), msg: []const u8) ShellErr {
         return .{
-            .todo = bun.handleOom(std.fmt.allocPrint(this.globalThis.bunVM().allocator, "{s}", .{msg})),
+            .todo = bun.handleOom(bun.fmt.allocPrint(this.globalThis.bunVM().allocator, "{s}", .{msg})),
         };
     }
 
@@ -190,14 +190,14 @@ pub const GlobalJS = struct {
     }
 
     pub inline fn handleError(this: @This(), err: anytype, comptime fmt: []const u8) ShellErr {
-        const str = bun.handleOom(std.fmt.allocPrint(this.globalThis.bunVM().allocator, "{s} " ++ fmt, .{@errorName(err)}));
+        const str = bun.handleOom(bun.fmt.allocPrint(this.globalThis.bunVM().allocator, "{s} " ++ fmt, .{@errorName(err)}));
         return .{
             .custom = str,
         };
     }
 
     pub inline fn throw(this: @This(), comptime fmt: []const u8, args: anytype) ShellErr {
-        const str = bun.handleOom(std.fmt.allocPrint(this.globalThis.bunVM().allocator, fmt, args));
+        const str = bun.handleOom(bun.fmt.allocPrint(this.globalThis.bunVM().allocator, fmt, args));
         return .{
             .custom = str,
         };
@@ -258,18 +258,18 @@ pub const GlobalMini = struct {
 
     pub inline fn throwTODO(this: @This(), msg: []const u8) ShellErr {
         return .{
-            .todo = bun.handleOom(std.fmt.allocPrint(this.mini.allocator, "{s}", .{msg})),
+            .todo = bun.handleOom(bun.fmt.allocPrint(this.mini.allocator, "{s}", .{msg})),
         };
     }
 
     pub inline fn throwInvalidArguments(this: @This(), comptime fmt: []const u8, args: anytype) ShellErr {
         return .{
-            .invalid_arguments = .{ .val = bun.handleOom(std.fmt.allocPrint(this.allocator(), fmt, args)) },
+            .invalid_arguments = .{ .val = bun.handleOom(bun.fmt.allocPrint(this.allocator(), fmt, args)) },
         };
     }
 
     pub inline fn handleError(this: @This(), err: anytype, comptime fmt: []const u8) ShellErr {
-        const str = bun.handleOom(std.fmt.allocPrint(this.mini.allocator, "{s} " ++ fmt, .{@errorName(err)}));
+        const str = bun.handleOom(bun.fmt.allocPrint(this.mini.allocator, "{s} " ++ fmt, .{@errorName(err)}));
         return .{
             .custom = str,
         };
@@ -294,7 +294,7 @@ pub const GlobalMini = struct {
     }
 
     pub inline fn throw(this: @This(), comptime fmt: []const u8, args: anytype) ShellErr {
-        const str = bun.handleOom(std.fmt.allocPrint(this.allocator(), fmt, args));
+        const str = bun.handleOom(bun.fmt.allocPrint(this.allocator(), fmt, args));
         return .{
             .custom = str,
         };
@@ -2118,12 +2118,12 @@ pub const Parser = struct {
     }
 
     fn add_error(self: *Parser, comptime fmt: []const u8, args: anytype) !void {
-        const error_msg = try std.fmt.allocPrint(self.alloc, fmt, args);
+        const error_msg = try bun.fmt.allocPrint(self.alloc, fmt, args);
         try self.errors.append(.{ .msg = error_msg });
     }
 
     fn add_error_expected_pipeline_item(self: *Parser, kind: AST.Expr.Tag) !void {
-        const error_msg = try std.fmt.allocPrint(self.alloc, "Expected a command, assignment, or subshell but got: {s}", .{@tagName(kind)});
+        const error_msg = try bun.fmt.allocPrint(self.alloc, "Expected a command, assignment, or subshell but got: {s}", .{@tagName(kind)});
         try self.errors.append(.{ .msg = error_msg });
     }
 };
@@ -4622,7 +4622,7 @@ pub const TestingAPIs = struct {
             try test_tokens.append(test_tok);
         }
 
-        const str = bun.handleOom(std.fmt.allocPrint(globalThis.bunVM().allocator, "{f}", .{std.json.fmt(test_tokens.items[0..], .{})}));
+        const str = bun.handleOom(bun.fmt.allocPrint(globalThis.bunVM().allocator, "{f}", .{std.json.fmt(test_tokens.items[0..], .{})}));
 
         defer globalThis.bunVM().allocator.free(str);
         var bun_str = bun.String.fromBytes(str);
@@ -4680,7 +4680,7 @@ pub const TestingAPIs = struct {
             return globalThis.throwError(err, "failed to lex/parse shell");
         };
 
-        const str = bun.handleOom(std.fmt.allocPrint(globalThis.bunVM().allocator, "{f}", .{std.json.fmt(script_ast, .{})}));
+        const str = bun.handleOom(bun.fmt.allocPrint(globalThis.bunVM().allocator, "{f}", .{std.json.fmt(script_ast, .{})}));
 
         defer globalThis.bunVM().allocator.free(str);
         return bun.String.createUTF8ForJS(globalThis, str);

--- a/src/shell/states/Expansion.zig
+++ b/src/shell/states/Expansion.zig
@@ -565,7 +565,7 @@ fn onGlobWalkDone(this: *Expansion, task: *ShellGlobTask) Yield {
             return .{ .expansion = this };
         }
 
-        const msg = bun.handleOom(std.fmt.allocPrint(this.base.allocator(), "no matches found: {s}", .{this.child_state.glob.walker.pattern}));
+        const msg = bun.handleOom(bun.fmt.allocPrint(this.base.allocator(), "no matches found: {s}", .{this.child_state.glob.walker.pattern}));
         this.state = .{
             .err = bun.shell.ShellErr{
                 .custom = msg,

--- a/src/shell/subproc.zig
+++ b/src/shell/subproc.zig
@@ -746,7 +746,7 @@ pub const ShellSubprocess = struct {
                 const key = entry.key_ptr.*.slice();
                 const value = entry.value_ptr.*.slice();
 
-                var line = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ key, value }, 0));
+                var line = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "{s}={s}", .{ key, value }, 0));
 
                 if (bun.strings.eqlComptime(key, "PATH")) {
                     this.PATH = bun.asByteSlice(line["PATH=".len..]);
@@ -870,7 +870,7 @@ pub const ShellSubprocess = struct {
             @ptrCast(spawn_args.env_array.items.ptr),
         ) catch |err| {
             spawn_options.deinit();
-            return .{ .err = .{ .custom = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, "Failed to spawn process: {s}", .{@errorName(err)})) } };
+            return .{ .err = .{ .custom = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, "Failed to spawn process: {s}", .{@errorName(err)})) } };
         }) {
             .err => |err| {
                 spawn_options.deinit();

--- a/src/shell_parser/braces.zig
+++ b/src/shell_parser/braces.zig
@@ -374,7 +374,7 @@ pub const Parser = struct {
     }
 
     fn add_error(self: *Parser, comptime fmt: []const u8, args: anytype) !void {
-        const error_msg = try std.fmt.allocPrint(self.alloc, fmt, args);
+        const error_msg = try bun.fmt.allocPrint(self.alloc, fmt, args);
         try self.errors.append(.{ .msg = error_msg });
     }
 };

--- a/src/sql_jsc/mysql/JSMySQLConnection.zig
+++ b/src/sql_jsc/mysql/JSMySQLConnection.zig
@@ -603,7 +603,7 @@ pub inline fn getWriter(this: *@This()) NewWriter(MySQLConnection.Writer) {
     return this.#connection.writer();
 }
 fn failFmt(this: *@This(), error_code: AnyMySQLError.Error, comptime fmt: [:0]const u8, args: anytype) void {
-    const message = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, fmt, args));
+    const message = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, fmt, args));
     defer bun.default_allocator.free(message);
 
     const err = AnyMySQLError.mysqlErrorToJS(this.#globalObject, message, error_code);

--- a/src/sql_jsc/postgres/PostgresSQLConnection.zig
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.zig
@@ -346,7 +346,7 @@ pub fn failWithJSValue(this: *PostgresSQLConnection, value: JSValue) void {
 }
 
 pub fn failFmt(this: *PostgresSQLConnection, code: []const u8, comptime fmt: [:0]const u8, args: anytype) void {
-    const message = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, fmt, args));
+    const message = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, fmt, args));
     defer bun.default_allocator.free(message);
 
     const err = createPostgresError(this.globalObject, message, .{ .code = code }) catch |e| this.globalObject.takeError(e);
@@ -1679,7 +1679,7 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
                     defer bun.z_allocator.free(server_salt_decoded_base64);
                     try sasl.computeSaltedPassword(server_salt_decoded_base64, iteration_count, this);
 
-                    const auth_string = try std.fmt.allocPrint(
+                    const auth_string = try bun.fmt.allocPrint(
                         bun.z_allocator,
                         "n=*,r={s},r={s},s={s},i={s},c=biws,r={s}",
                         .{
@@ -1703,7 +1703,7 @@ pub fn on(this: *PostgresSQLConnection, comptime MessageType: @Type(.enum_litera
                     var client_key_xor_base64_buf = std.mem.zeroes([bun.base64.encodeLenFromSize(32)]u8);
                     const xor_base64_len = bun.base64.encode(&client_key_xor_base64_buf, &client_key_xor_buffer);
 
-                    const payload = try std.fmt.allocPrint(
+                    const payload = try bun.fmt.allocPrint(
                         bun.z_allocator,
                         "c=biws,r={s},p={s}",
                         .{ cont.r, client_key_xor_base64_buf[0..xor_base64_len] },

--- a/src/sql_jsc/postgres/Signature.zig
+++ b/src/sql_jsc/postgres/Signature.zig
@@ -91,7 +91,7 @@ pub fn generate(globalObject: *jsc.JSGlobalObject, query: []const u8, array_valu
         return error.InvalidQueryBinding;
     }
     // max u64 length is 20, max prepared_statement_name length is 63
-    const prepared_statement_name = if (unnamed) "" else try std.fmt.allocPrint(bun.default_allocator, "P{s}${d}", .{ name.items[0..@min(40, name.items.len)], prepared_statement_id });
+    const prepared_statement_name = if (unnamed) "" else try bun.fmt.allocPrint(bun.default_allocator, "P{s}${d}", .{ name.items[0..@min(40, name.items.len)], prepared_statement_id });
 
     return Signature{
         .prepared_statement_name = prepared_statement_name,

--- a/src/standalone_graph/StandaloneModuleGraph.zig
+++ b/src/standalone_graph/StandaloneModuleGraph.zig
@@ -625,7 +625,7 @@ pub const StandaloneModuleGraph = struct {
         }
 
         pub fn failFmt(comptime fmt: []const u8, args: anytype) CompileResult {
-            return .{ .err = .{ .message = bun.handleOom(std.fmt.allocPrint(bun.default_allocator, fmt, args)) } };
+            return .{ .err = .{ .message = bun.handleOom(bun.fmt.allocPrint(bun.default_allocator, fmt, args)) } };
         }
 
         pub fn deinit(this: *const @This()) void {
@@ -1117,7 +1117,7 @@ pub const StandaloneModuleGraph = struct {
             }
         else blk: {
             var exe_path_buf: bun.PathBuffer = undefined;
-            const version_str = bun.handleOom(std.fmt.allocPrintSentinel(allocator, "{f}", .{target}, 0));
+            const version_str = bun.handleOom(bun.fmt.allocPrintSentinel(allocator, "{f}", .{target}, 0));
             defer allocator.free(version_str);
 
             var needs_download: bool = true;

--- a/src/string/string.zig
+++ b/src/string/string.zig
@@ -219,7 +219,7 @@ pub const String = extern struct {
 
         var sba = std.heap.stackFallback(512, bun.default_allocator);
         const alloc = sba.get();
-        const buf = try std.fmt.allocPrint(alloc, fmt, args);
+        const buf = try bun.fmt.allocPrint(alloc, fmt, args);
         defer alloc.free(buf);
         return cloneUTF8(buf);
     }

--- a/src/test_runner/jest.zig
+++ b/src/test_runner/jest.zig
@@ -457,7 +457,7 @@ pub fn formatLabel(globalThis: *JSGlobalObject, label: string, function_args: []
                     args_idx += 1;
                 },
                 '#' => {
-                    const test_index_str = bun.handleOom(std.fmt.allocPrint(allocator, "{d}", .{test_idx}));
+                    const test_index_str = bun.handleOom(bun.fmt.allocPrint(allocator, "{d}", .{test_idx}));
                     defer allocator.free(test_index_str);
                     bun.handleOom(list.appendSlice(test_index_str));
                     idx += 1;

--- a/src/url/url.zig
+++ b/src/url/url.zig
@@ -211,12 +211,12 @@ pub const URL = struct {
         const has_uplevels = std.mem.indexOf(u8, dirname, "../") != null;
 
         if (has_uplevels) {
-            return try std.fmt.allocPrint(allocator, "{s}/abs:{s}", .{ this.origin, absolute_path });
+            return try bun.fmt.allocPrint(allocator, "{s}/abs:{s}", .{ this.origin, absolute_path });
         } else {
             var out: [2048]u8 = undefined;
 
             const normalized_path = joinNormalize(&out, prefix, dirname, basename, extname);
-            return try std.fmt.allocPrint(allocator, "{s}/{s}", .{ this.origin, normalized_path });
+            return try bun.fmt.allocPrint(allocator, "{s}/{s}", .{ this.origin, normalized_path });
         }
     }
 

--- a/test/internal/ban-limits.json
+++ b/test/internal/ban-limits.json
@@ -34,6 +34,8 @@
   "std.debug.dumpStackTrace": 0,
   "std.debug.print": 0,
   "std.enums.tagName(": 2,
+  "std.fmt.allocPrint(": 2,
+  "std.fmt.allocPrintSentinel(": 1,
   "std.fs.Dir": 164,
   "std.fs.File": 90,
   "std.fs.cwd": 109,

--- a/test/internal/ban-words.test.ts
+++ b/test/internal/ban-words.test.ts
@@ -21,6 +21,8 @@ const words: Record<string, { reason: string; regex?: boolean }> = {
   "std.StringHashMapUnmanaged(": { reason: "bun.StringHashMapUnmanaged has a faster `eql`" },
   "std.StringHashMap(": { reason: "bun.StringHashMap has a faster `eql`" },
   "std.enums.tagName(": { reason: "Use bun.tagName instead" },
+  "std.fmt.allocPrint(": { reason: "Use bun.fmt.allocPrint: it routes pure-{s} format strings through a shared concat to cut per-call-site monomorphizations (binary size)" },
+  "std.fmt.allocPrintSentinel(": { reason: "Use bun.fmt.allocPrintSentinel: it routes pure-{s} format strings through a shared concat to cut per-call-site monomorphizations (binary size)" },
   "std.unicode": { reason: "Use bun.strings instead" },
   "std.Thread.Mutex": {reason: "Use bun.Mutex instead" },
   ".jsBoolean(true)": { reason: "Use .true instead" },


### PR DESCRIPTION
## What

`std.fmt.allocPrint` / `std.fmt.allocPrintSentinel` generate a fresh `Writer.print` monomorphization per `(fmt, args-tuple)` pair. Of the 406 + 22 call sites in `src/`, ~35% use format strings composed solely of bare `{s}` placeholders and literal text — `"{s}@{s}"`, `"_{s}"`, `"workspace:{s}"`, `"{s}.exe"`, `"X-Amz-Date={s}"`, `"./{s}"`, `"{s}/{s}"`, and so on — which are plain string concatenation in disguise.

## How

Adds `bun.fmt.allocPrint` / `bun.fmt.allocPrintSentinel` / `bun.fmt.allocPrintZ`. At comptime they parse the format string; when it's purely `{s}` + literals (no width/precision/positional/escapes) they lower the call to a flat `[N][]const u8` array fed to a single shared `bun.strings.concat` (or a sentinel-terminated equivalent). Any other format string forwards unchanged to `std.fmt.allocPrint*`.

All `src/` call sites are mechanically swapped to the `bun.fmt` entry points, and `test/internal/ban-words.test.ts` now bans direct `std.fmt.allocPrint(` / `std.fmt.allocPrintSentinel(` so the convention sticks.

## Binary size (linux-x64 release, stripped)

|                | before       | after        | Δ         |
| -------------- | ------------ | ------------ | --------- |
| `bun`          | 91,569,096 B | 91,257,800 B | **−304 KB** |
| `.text`        | 53,962,252 B | 53,675,020 B | −287 KB   |

| symbol group                        | before | after |
| ----------------------------------- | -----: | ----: |
| `Io.Writer.print__anon_*`           | 5031   | 4364  |
| `std.fmt.allocPrint__anon_*`        | 1111   | 494   |

## Verification

- `zig:check-all` passes (all targets, debug + release).
- No behavior change: `bun.fmt.allocPrint` output is byte-identical to `std.fmt.allocPrint` (Zig test block in `fmt.zig` asserts parity for the fast-path patterns and verifies non-`{s}` formats fall through).
- Integration tests for touched call sites pass with the release build: yarn-lock migration (16/16), `bun-add` (same pass/fail as main — only pre-existing git-network failures), `bun-pm` (12/12), `bun-audit` + `bun-pm-why` (44/44), `bun-pack` (70/70), es-decorators (147/147), bundler edgecase (103/103), s3-signature-order (1/1), bunshell (354/355 — same pre-existing EACCES-as-root failure as main).
- Spot-checked `bun install` / `bun outdated` / `bun build` error output manually.