### PR TITLE
Collapse subspaceForImpl<T> template instantiations (-80 KB release binary)

### DIFF
--- a/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
+++ b/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
@@ -29,10 +29,8 @@ static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm) {
         return nullptr;
     return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMyClassT = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMyClassT = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForMyClassT; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForMyClassT; });
 }
 ```
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -557,10 +557,8 @@ class ${name} final : public JSC::InternalFunction {
 
         return WebCore::subspaceForImpl<${name}, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.${clientSubspaceFor("BunClass")}Constructor.get(); },
-            [](auto& spaces, auto&& space) { spaces.${clientSubspaceFor("BunClass")}Constructor = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.${subspaceFor("BunClass")}Constructor.get(); },
-            [](auto& spaces, auto&& space) { spaces.${subspaceFor("BunClass")}Constructor = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.${clientSubspaceFor("BunClass")}Constructor; },
+            [](auto& spaces) -> auto& { return spaces.${subspaceFor("BunClass")}Constructor; });
       }
 
       // Must be defined for each specialization class.
@@ -1368,10 +1366,8 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
                 return nullptr;
             return WebCore::subspaceForImpl<${name}, WebCore::UseCustomHeapCellType::No>(
                 vm,
-                [](auto& spaces) { return spaces.${clientSubspaceFor(typeName)}.get(); },
-                [](auto& spaces, auto&& space) { spaces.${clientSubspaceFor(typeName)} = std::forward<decltype(space)>(space); },
-                [](auto& spaces) { return spaces.${subspaceFor(typeName)}.get(); },
-                [](auto& spaces, auto&& space) { spaces.${subspaceFor(typeName)} = std::forward<decltype(space)>(space); });
+                [](auto& spaces) -> auto& { return spaces.${clientSubspaceFor(typeName)}; },
+                [](auto& spaces) -> auto& { return spaces.${subspaceFor(typeName)}; });
         }
 
         static void destroy(JSC::JSCell*);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -44,10 +44,8 @@ function header() {
                     return nullptr;                                                                                                                                                 
                 return WebCore::subspaceForImpl<${constructor}, WebCore::UseCustomHeapCellType::No>(                                                                    
                     vm,                                                                                                                                                             
-                    [](auto& spaces) { return spaces.m_clientSubspaceForJSSinkConstructor.get(); },                                                                                 
-                    [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSinkConstructor = std::forward<decltype(space)>(space); },                                                               
-                    [](auto& spaces) { return spaces.m_subspaceForJSSinkConstructor.get(); },                                                                                       
-                    [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSinkConstructor = std::forward<decltype(space)>(space); });                                                                    
+                    [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSinkConstructor; },                                                               
+                    [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSinkConstructor; });                                                                    
             }                                                                                                                                                                       
                                                                                                                                                                                     
             static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)                                                          
@@ -83,10 +81,8 @@ function header() {
                     return nullptr;                                                                                                                                                 
                 return WebCore::subspaceForImpl<${className}, WebCore::UseCustomHeapCellType::No>(                                                                                 
                     vm,                                                                                                                                                             
-                    [](auto& spaces) { return spaces.m_clientSubspaceForJSSink.get(); },                                                                                            
-                    [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSink = std::forward<decltype(space)>(space); },                                                                          
-                    [](auto& spaces) { return spaces.m_subspaceForJSSink.get(); },                                                                                                  
-                    [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSink = std::forward<decltype(space)>(space); });                                                                               
+                    [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSink; },                                                                          
+                    [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSink; });                                                                               
             }                                                                                                                                                                       
                                                                                                                                                                                     
             static void destroy(JSC::JSCell*);                                                                                                                                      
@@ -144,10 +140,8 @@ function header() {
                         return nullptr;
                     return WebCore::subspaceForImpl<${controller}, WebCore::UseCustomHeapCellType::No>(
                         vm,
-                        [](auto& spaces) { return spaces.m_clientSubspaceForJSSinkController.get(); },
-                        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSinkController = std::forward<decltype(space)>(space); },
-                        [](auto& spaces) { return spaces.m_subspaceForJSSinkController.get(); },
-                        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSinkController = std::forward<decltype(space)>(space); });
+                        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSinkController; },
+                        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSinkController; });
                 }
 
                 static void destroy(JSC::JSCell*);

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -38,10 +38,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<AsyncContextFrame, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForAsyncContextFrame.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAsyncContextFrame = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForAsyncContextFrame.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForAsyncContextFrame = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForAsyncContextFrame; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForAsyncContextFrame; });
     }
 
     AsyncContextFrame(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue callback_, JSC::JSValue context_)

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -173,4 +173,33 @@ void JSVMClientData::create(VM* vm, void* bunVM, bool isWorkerVM)
     clientData->builtinFunctions().exportNames();
 }
 
+JSC::GCClient::IsoSubspace* subspaceForImplSlow(
+    JSC::VM& vm,
+    JSVMClientData& clientData,
+    std::unique_ptr<JSC::GCClient::IsoSubspace>& clientSlot,
+    std::unique_ptr<JSC::IsoSubspace>& serverSlot,
+    const JSC::HeapCellType& heapCellType,
+    size_t cellSize,
+    uint8_t numberOfLowerTierPreciseCells,
+    bool hasOutputConstraints)
+{
+    auto& heapData = clientData.heapData();
+    Locker locker { heapData.lock() };
+
+    JSC::IsoSubspace* space = serverSlot.get();
+    if (!space) {
+        // Matches ISO_SUBSPACE_INIT as used by the former inline body: every
+        // subspace created through subspaceForImpl<T> was already named "T"
+        // because the macro stringified the template parameter, not the type.
+        serverSlot = makeUnique<JSC::IsoSubspace>("T"_s, vm.heap, heapCellType, cellSize, numberOfLowerTierPreciseCells);
+        space = serverSlot.get();
+
+        if (hasOutputConstraints)
+            heapData.outputConstraintSpaces().append(space);
+    }
+
+    clientSlot = makeUnique<JSC::GCClient::IsoSubspace>(*space);
+    return clientSlot.get();
+}
+
 } // namespace WebCore

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -188,9 +188,7 @@ JSC::GCClient::IsoSubspace* subspaceForImplSlow(
 
     JSC::IsoSubspace* space = serverSlot.get();
     if (!space) {
-        // Matches ISO_SUBSPACE_INIT as used by the former inline body: every
-        // subspace created through subspaceForImpl<T> was already named "T"
-        // because the macro stringified the template parameter, not the type.
+        // "T" preserves the name ISO_SUBSPACE_INIT(…, T) produced for these subspaces before.
         serverSlot = makeUnique<JSC::IsoSubspace>("T"_s, vm.heap, heapCellType, cellSize, numberOfLowerTierPreciseCells);
         space = serverSlot.get();
 

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -237,10 +237,7 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {
 
-// Out-of-line slow path shared by every subspaceForImpl<T> instantiation.
-// The template wrapper keeps only the fast-path cache check inline and
-// forwards the T-dependent constants + slot addresses here on a miss, so
-// the lock + IsoSubspace construction is emitted once instead of per-class.
+// Shared slow path for subspaceForImpl<T>; kept out of line so it is emitted once, not per T.
 JSC::GCClient::IsoSubspace* subspaceForImplSlow(
     JSC::VM&,
     JSVMClientData&,

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -237,48 +237,48 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {
 
-template<typename T, UseCustomHeapCellType useCustomHeapCellType, typename GetClient, typename SetClient, typename GetServer, typename SetServer>
-ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, GetClient getClient, SetClient setClient, GetServer getServer, SetServer setServer, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
+// Out-of-line slow path shared by every subspaceForImpl<T> instantiation.
+// The template wrapper keeps only the fast-path cache check inline and
+// forwards the T-dependent constants + slot addresses here on a miss, so
+// the lock + IsoSubspace construction is emitted once instead of per-class.
+JSC::GCClient::IsoSubspace* subspaceForImplSlow(
+    JSC::VM&,
+    JSVMClientData&,
+    std::unique_ptr<JSC::GCClient::IsoSubspace>& clientSlot,
+    std::unique_ptr<JSC::IsoSubspace>& serverSlot,
+    const JSC::HeapCellType&,
+    size_t cellSize,
+    uint8_t numberOfLowerTierPreciseCells,
+    bool hasOutputConstraints);
+
+template<typename T, UseCustomHeapCellType useCustomHeapCellType, typename ClientSlot, typename ServerSlot>
+ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, ClientSlot clientSlot, ServerSlot serverSlot, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
 {
     auto& clientData = *downcast<JSVMClientData>(vm.clientData);
-    auto& clientSubspaces = clientData.clientSubspaces();
-    if (auto* clientSpace = getClient(clientSubspaces))
+    std::unique_ptr<JSC::GCClient::IsoSubspace>& clientSlotRef = clientSlot(clientData.clientSubspaces());
+    if (auto* clientSpace = clientSlotRef.get())
         return clientSpace;
 
+    static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
+
     auto& heapData = clientData.heapData();
-    Locker locker { heapData.lock() };
+    const JSC::HeapCellType* heapCellType;
+    if constexpr (useCustomHeapCellType == UseCustomHeapCellType::Yes)
+        heapCellType = &getCustomHeapCellType(heapData);
+    else if constexpr (std::is_base_of_v<JSC::JSDestructibleObject, T>)
+        heapCellType = &vm.heap.destructibleObjectHeapCellType;
+    else
+        heapCellType = &vm.heap.cellHeapCellType;
 
-    auto& subspaces = heapData.subspaces();
-    JSC::IsoSubspace* space = getServer(subspaces);
-    if (!space) {
-        JSC::Heap& heap = vm.heap;
-        std::unique_ptr<JSC::IsoSubspace> uniqueSubspace;
-        static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
-        if constexpr (useCustomHeapCellType == UseCustomHeapCellType::Yes)
-            uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, getCustomHeapCellType(heapData), T);
-        else {
-            if constexpr (std::is_base_of_v<JSC::JSDestructibleObject, T>)
-                uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, heap.destructibleObjectHeapCellType, T);
-            else
-                uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, T);
-        }
-        space = uniqueSubspace.get();
-        setServer(subspaces, WTF::move(uniqueSubspace));
+    IGNORE_WARNINGS_BEGIN("unreachable-code")
+    IGNORE_WARNINGS_BEGIN("tautological-compare")
+    void (*myVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = T::visitOutputConstraints;
+    void (*jsCellVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = JSC::JSCell::visitOutputConstraints;
+    bool hasOutputConstraints = myVisitOutputConstraint != jsCellVisitOutputConstraint;
+    IGNORE_WARNINGS_END
+    IGNORE_WARNINGS_END
 
-        IGNORE_WARNINGS_BEGIN("unreachable-code")
-        IGNORE_WARNINGS_BEGIN("tautological-compare")
-        void (*myVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = T::visitOutputConstraints;
-        void (*jsCellVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = JSC::JSCell::visitOutputConstraints;
-        if (myVisitOutputConstraint != jsCellVisitOutputConstraint)
-            heapData.outputConstraintSpaces().append(space);
-        IGNORE_WARNINGS_END
-        IGNORE_WARNINGS_END
-    }
-
-    auto uniqueClientSubspace = makeUnique<JSC::GCClient::IsoSubspace>(*space);
-    auto* clientSpace = uniqueClientSubspace.get();
-    setClient(clientSubspaces, WTF::move(uniqueClientSubspace));
-    return clientSpace;
+    return subspaceForImplSlow(vm, clientData, clientSlotRef, serverSlot(heapData.subspaces()), *heapCellType, sizeof(T), T::numberOfLowerTierPreciseCells, hasOutputConstraints);
 }
 
 static JSVMClientData* clientData(JSC::VM& vm)

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -545,10 +545,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSBunInspectorConnection, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBunInspectorConnection.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunInspectorConnection = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBunInspectorConnection.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBunInspectorConnection = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBunInspectorConnection; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForBunInspectorConnection; });
     }
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -429,10 +429,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSModuleMock, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSModuleMock.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSModuleMock = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSModuleMock.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSModuleMock = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSModuleMock; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSModuleMock; });
     }
 
     void finishCreation(JSC::VM&);

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -119,10 +119,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<Process, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForProcessObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForProcessObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForProcessObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForProcessObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForProcessObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForProcessObject; });
     }
 
     void finishCreation(JSC::VM& vm);

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -66,10 +66,8 @@ public:
 
         return WebCore::subspaceForImpl<CallSite, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForCallSite.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCallSite = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForCallSite.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForCallSite = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCallSite; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForCallSite; });
     }
 
     JSC::JSValue thisValue() const { return m_thisValue.get(); }

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -43,10 +43,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ErrorCodeCache, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForErrorCodeCache.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForErrorCodeCache = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForErrorCodeCache.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForErrorCodeCache = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForErrorCodeCache; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForErrorCodeCache; });
     }
 
     static ErrorCodeCache* create(VM& vm, Structure* structure);

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -61,10 +61,8 @@ public:
 
         return WebCore::subspaceForImpl<ImportMetaObject, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForImportMeta.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForImportMeta = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForImportMeta.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForImportMeta = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForImportMeta; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForImportMeta; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, bool isBake = false);

--- a/src/jsc/bindings/InternalModuleRegistry.h
+++ b/src/jsc/bindings/InternalModuleRegistry.h
@@ -43,10 +43,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<InternalModuleRegistry, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForInternalModuleRegistry.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForInternalModuleRegistry = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForInternalModuleRegistry.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForInternalModuleRegistry = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForInternalModuleRegistry; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForInternalModuleRegistry; });
     }
 
     static InternalModuleRegistry* create(VM& vm, Structure* structure);

--- a/src/jsc/bindings/JSBakeResponse.cpp
+++ b/src/jsc/bindings/JSBakeResponse.cpp
@@ -139,10 +139,8 @@ JSC::GCClient::IsoSubspace* JSBakeResponse::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBakeResponse, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBakeResponse.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBakeResponse = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBakeResponse.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBakeResponse = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBakeResponse; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForBakeResponse; });
 }
 
 JSBakeResponse::JSBakeResponse(JSC::VM& vm, JSC::Structure* structure, void* sinkPtr)

--- a/src/jsc/bindings/JSBufferList.cpp
+++ b/src/jsc/bindings/JSBufferList.cpp
@@ -250,10 +250,8 @@ JSC::GCClient::IsoSubspace* JSBufferList::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBufferList, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBufferList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBufferList = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBufferList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBufferList = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBufferList; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForBufferList; });
 }
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSBufferListPrototype, JSBufferListPrototype::Base);

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -72,10 +72,8 @@ JSC::GCClient::IsoSubspace* JSBunRequest::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBunRequest, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBunRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBunRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBunRequest = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBunRequest; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForBunRequest; });
 }
 
 JSObject* JSBunRequest::params() const

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -146,10 +146,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSBundlerPlugin, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBundlerPlugin.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBundlerPlugin = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBundlerPlugin.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBundlerPlugin = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBundlerPlugin; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForBundlerPlugin; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSCommonJSExtensions.h
+++ b/src/jsc/bindings/JSCommonJSExtensions.h
@@ -30,10 +30,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCommonJSExtensions, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCommonJSExtensions.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCommonJSExtensions = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCommonJSExtensions.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCommonJSExtensions = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSCommonJSExtensions; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSCommonJSExtensions; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -139,10 +139,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCommonJSModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCommonJSModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCommonJSModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCommonJSModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCommonJSModule = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSCommonJSModule; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSCommonJSModule; });
     }
 
     bool hasEvaluated = false;

--- a/src/jsc/bindings/JSFFIFunction.h
+++ b/src/jsc/bindings/JSFFIFunction.h
@@ -61,10 +61,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSFFIFunction, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFFIFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFFIFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFFIFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFFIFunction = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForFFIFunction; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForFFIFunction; });
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -170,10 +170,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSMockImplementation, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockImplementation.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockImplementation = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockImplementation.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockImplementation = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSMockImplementation; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSMockImplementation; });
     }
 
     // either a function or a return value, depends on kind
@@ -456,10 +454,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSMockFunction, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockFunction = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSMockFunction; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSMockFunction; });
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
@@ -1271,10 +1267,8 @@ JSC::GCClient::IsoSubspace* MockWithImplementationCleanupData::subspaceFor(JSC::
 {
     return WebCore::subspaceForImpl<MockWithImplementationCleanupData, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMockWithImplementationCleanupData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMockWithImplementationCleanupData = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMockWithImplementationCleanupData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMockWithImplementationCleanupData = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForMockWithImplementationCleanupData; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForMockWithImplementationCleanupData; });
 }
 
 MockWithImplementationCleanupData* MockWithImplementationCleanupData::create(VM& vm, Structure* structure)

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -25,10 +25,8 @@ JSC::GCClient::IsoSubspace* JSNextTickQueue::subspaceFor(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSNextTickQueue, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSNextTickQueue.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNextTickQueue = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSNextTickQueue.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNextTickQueue = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSNextTickQueue; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSNextTickQueue; });
 }
 
 JSNextTickQueue* JSNextTickQueue::create(VM& vm, Structure* structure)

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -135,10 +135,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSNodePerformanceHooksHistogram, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSNodePerformanceHooksHistogram.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSNodePerformanceHooksHistogram.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSNodePerformanceHooksHistogram; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSNodePerformanceHooksHistogram; });
     }
 
     JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, HistogramData&& histogramData)

--- a/src/jsc/bindings/JSSocketHandlers.cpp
+++ b/src/jsc/bindings/JSSocketHandlers.cpp
@@ -21,10 +21,8 @@ JSC::GCClient::IsoSubspace* JSSocketHandlers::subspaceFor(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSSocketHandlers, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSSocketHandlers.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSocketHandlers = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSSocketHandlers.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSocketHandlers = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSocketHandlers; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSocketHandlers; });
 }
 
 JSC::Structure* JSSocketHandlers::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -395,10 +395,8 @@ JSC::GCClient::IsoSubspace* JSStringDecoder::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSStringDecoder, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStringDecoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStringDecoder = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStringDecoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStringDecoder = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForStringDecoder; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForStringDecoder; });
 }
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSStringDecoderPrototype, JSStringDecoderPrototype::Base);

--- a/src/jsc/bindings/JSWrappingFunction.h
+++ b/src/jsc/bindings/JSWrappingFunction.h
@@ -43,10 +43,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSWrappingFunction, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForWrappingFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWrappingFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForWrappingFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForWrappingFunction = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWrappingFunction; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForWrappingFunction; });
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/JSX509Certificate.h
+++ b/src/jsc/bindings/JSX509Certificate.h
@@ -122,10 +122,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSX509Certificate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSX509Certificate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSX509Certificate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSX509Certificate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSX509Certificate = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSX509Certificate; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSX509Certificate; });
     }
 
     static JSValue computeSubject(ncrypto::X509View view, JSGlobalObject*, bool legacy);

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -60,10 +60,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<PendingVirtualModuleResult, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForPendingVirtualModuleResult.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPendingVirtualModuleResult = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForPendingVirtualModuleResult.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForPendingVirtualModuleResult = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPendingVirtualModuleResult; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForPendingVirtualModuleResult; });
     }
 
     JS_EXPORT_PRIVATE static PendingVirtualModuleResult* create(VM&, Structure*);

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -66,10 +66,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NativePromiseContext, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNativePromiseContext.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNativePromiseContext.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNativePromiseContext; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNativePromiseContext; },
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNativePromiseContext; });
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -864,10 +864,8 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMS
         return nullptr;
     return WebCore::subspaceForImpl<NodeVMSpecialSandbox, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSpecialSandbox.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSpecialSandbox = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeVMSpecialSandbox.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSpecialSandbox = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeVMSpecialSandbox; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeVMSpecialSandbox; });
 }
 
 NodeVMSpecialSandbox* NodeVMSpecialSandbox::create(VM& vm, NodeVMGlobalObject* globalObject)
@@ -924,10 +922,8 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMG
         return nullptr;
     return WebCore::subspaceForImpl<NodeVMGlobalObject, WebCore::UseCustomHeapCellType::Yes>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMGlobalObject.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMGlobalObject = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeVMGlobalObject.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMGlobalObject = std::forward<decltype(space)>(space); },
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeVMGlobalObject; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeVMGlobalObject; },
         [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNodeVMGlobalObject; });
 }
 

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -51,10 +51,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMScript, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMScript.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMScript = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMScript.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMScript = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeVMScript; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeVMScript; });
     }
 
     static void destroy(JSC::JSCell*);

--- a/src/jsc/bindings/NodeVMSourceTextModule.h
+++ b/src/jsc/bindings/NodeVMSourceTextModule.h
@@ -17,10 +17,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMSourceTextModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSourceTextModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSourceTextModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMSourceTextModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSourceTextModule = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeVMSourceTextModule; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeVMSourceTextModule; });
     }
 
     static JSObject* createPrototype(VM& vm, JSGlobalObject* globalObject);

--- a/src/jsc/bindings/NodeVMSyntheticModule.h
+++ b/src/jsc/bindings/NodeVMSyntheticModule.h
@@ -21,10 +21,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMSyntheticModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSyntheticModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSyntheticModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMSyntheticModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSyntheticModule = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeVMSyntheticModule; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeVMSyntheticModule; });
     }
 
     static JSObject* createPrototype(VM& vm, JSGlobalObject* globalObject);

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -128,10 +128,8 @@ public:
 
         return WebCore::subspaceForImpl<TTYWrapObject, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTTYWrapObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForTTYWrapObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTTYWrapObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForTTYWrapObject; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSObject* prototype)

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -79,10 +79,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ServerRouteList, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForServerRouteList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForServerRouteList = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForServerRouteList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForServerRouteList = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForServerRouteList; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForServerRouteList; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/StrongRootBlock.cpp
+++ b/src/jsc/bindings/StrongRootBlock.cpp
@@ -22,10 +22,8 @@ JSC::GCClient::IsoSubspace* StrongRootBlock::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<StrongRootBlock, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStrongRootBlock.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStrongRootBlock = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStrongRootBlock.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStrongRootBlock = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForStrongRootBlock; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForStrongRootBlock; });
 }
 
 StrongRootBlock* StrongRootBlock::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3090,10 +3090,8 @@ JSC::GCClient::IsoSubspace* GlobalObject::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<GlobalObject, WebCore::UseCustomHeapCellType::Yes>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWorkerGlobalScope.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWorkerGlobalScope = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWorkerGlobalScope.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWorkerGlobalScope = std::forward<decltype(space)>(space); },
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWorkerGlobalScope; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWorkerGlobalScope; },
         [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForJSWorkerGlobalScope; });
 }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -867,10 +867,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiClass, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiClass.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiClass = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiClass.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiClass = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNapiClass; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNapiClass; });
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/napi_external.h
+++ b/src/jsc/bindings/napi_external.h
@@ -39,10 +39,8 @@ public:
 
         return WebCore::subspaceForImpl<NapiExternal, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiExternal.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiExternal = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiExternal.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiExternal = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNapiExternal; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNapiExternal; });
     }
 
     ~NapiExternal();

--- a/src/jsc/bindings/napi_handle_scope.h
+++ b/src/jsc/bindings/napi_handle_scope.h
@@ -35,10 +35,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiHandleScopeImpl, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiHandleScopeImpl.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiHandleScopeImpl = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiHandleScopeImpl.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiHandleScopeImpl = std::forward<decltype(space)>(space); },
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNapiHandleScopeImpl; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNapiHandleScopeImpl; },
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNapiHandleScopeImpl; });
     }
 

--- a/src/jsc/bindings/napi_type_tag.h
+++ b/src/jsc/bindings/napi_type_tag.h
@@ -29,10 +29,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiTypeTag, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiTypeTag.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiTypeTag = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiTypeTag.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiTypeTag = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNapiTypeTag; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForNapiTypeTag; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -153,10 +153,8 @@ public:
 
         return WebCore::subspaceForImpl<JSNodeHTTPServerSocket, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSNodeHTTPServerSocket.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNodeHTTPServerSocket = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSNodeHTTPServerSocket.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodeHTTPServerSocket = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSNodeHTTPServerSocket; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSNodeHTTPServerSocket; });
     }
 
     void detach();

--- a/src/jsc/bindings/node/crypto/JSCipher.h
+++ b/src/jsc/bindings/node/crypto/JSCipher.h
@@ -55,10 +55,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCipher, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCipher.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCipher = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCipher.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCipher = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSCipher; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSCipher; });
     }
 
     bool checkCCMMessageLength(int32_t messageLen) const

--- a/src/jsc/bindings/node/crypto/JSDiffieHellman.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellman.h
@@ -40,10 +40,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSDiffieHellman, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSDiffieHellman.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSDiffieHellman = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSDiffieHellman.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSDiffieHellman = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSDiffieHellman; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSDiffieHellman; });
     }
 
 private:

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
@@ -41,10 +41,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSDiffieHellmanGroup, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSDiffieHellmanGroup.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSDiffieHellmanGroup = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSDiffieHellmanGroup.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSDiffieHellmanGroup = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSDiffieHellmanGroup; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSDiffieHellmanGroup; });
     }
 
 private:

--- a/src/jsc/bindings/node/crypto/JSECDH.h
+++ b/src/jsc/bindings/node/crypto/JSECDH.h
@@ -37,10 +37,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSECDH, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSECDH.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSECDH = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSECDH.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSECDH = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSECDH; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSECDH; });
     }
 
     ncrypto::ECKeyPointer m_key;

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -66,10 +66,8 @@ JSC::GCClient::IsoSubspace* JSHash::subspaceFor(JSC::VM& vm)
 
     return WebCore::subspaceForImpl<JSHash, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSHash.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHash = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSHash.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHash = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSHash; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSHash; });
 }
 
 JSHash* JSHash::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/node/crypto/JSHmac.cpp
+++ b/src/jsc/bindings/node/crypto/JSHmac.cpp
@@ -64,10 +64,8 @@ JSC::GCClient::IsoSubspace* JSHmac::subspaceFor(JSC::VM& vm)
 
     return WebCore::subspaceForImpl<JSHmac, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSHmac.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHmac = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSHmac.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHmac = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSHmac; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSHmac; });
 }
 
 JSHmac* JSHmac::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/node/crypto/JSPrivateKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSPrivateKeyObject.h
@@ -36,10 +36,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSPrivateKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSPrivateKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSPrivateKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSPrivateKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSPrivateKeyObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSPrivateKeyObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSPrivateKeyObject; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSPublicKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSPublicKeyObject.h
@@ -37,10 +37,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSPublicKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSPublicKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSPublicKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSPublicKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSPublicKeyObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSPublicKeyObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSPublicKeyObject; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSSecretKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSSecretKeyObject.h
@@ -36,10 +36,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSSecretKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSSecretKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSecretKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSSecretKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSecretKeyObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSecretKeyObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSecretKeyObject; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -97,10 +97,8 @@ JSC::GCClient::IsoSubspace* JSSign::subspaceFor(JSC::VM& vm)
         return nullptr;
     return WebCore::subspaceForImpl<JSSign, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSSign.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSign = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSSign.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSign = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSign; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSign; });
 }
 
 // JSSignPrototype implementation

--- a/src/jsc/bindings/node/crypto/JSVerify.cpp
+++ b/src/jsc/bindings/node/crypto/JSVerify.cpp
@@ -105,10 +105,8 @@ JSC::GCClient::IsoSubspace* JSVerify::subspaceFor(JSC::VM& vm)
         return nullptr;
     return WebCore::subspaceForImpl<JSVerify, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSVerify.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSVerify = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSVerify.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSVerify = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSVerify; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForJSVerify; });
 }
 
 // JSVerifyPrototype implementation

--- a/src/jsc/bindings/node/http/JSConnectionsList.h
+++ b/src/jsc/bindings/node/http/JSConnectionsList.h
@@ -32,10 +32,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSConnectionsList, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSConnectionsList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSConnectionsList = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSConnectionsList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSConnectionsList = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSConnectionsList; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSConnectionsList; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/http/JSHTTPParser.h
+++ b/src/jsc/bindings/node/http/JSHTTPParser.h
@@ -32,10 +32,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSHTTPParser, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSHTTPParser.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHTTPParser = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSHTTPParser.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHTTPParser = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSHTTPParser; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSHTTPParser; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -500,10 +500,8 @@ public:
     {
         return WebCore::subspaceForImpl<JSSQLStatement, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSSQLStatement.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSQLStatement = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSSQLStatement.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSQLStatement = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSSQLStatement; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSSQLStatement; });
     }
     DECLARE_VISIT_CHILDREN;
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -1199,10 +1199,8 @@ GCClient::IsoSubspace* JSDatabaseSync::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDatabaseSync, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteDatabaseSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteDatabaseSync = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteDatabaseSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteDatabaseSync = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteDatabaseSync; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteDatabaseSync; });
 }
 
 // ─── DatabaseSync prototype functions ───────────────────────────────────────
@@ -2586,10 +2584,8 @@ GCClient::IsoSubspace* JSStatementSync::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStatementSync, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteStatementSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteStatementSync = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteStatementSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteStatementSync = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteStatementSync; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteStatementSync; });
 }
 
 // ─── Parameter binding ──────────────────────────────────────────────────────
@@ -3071,10 +3067,8 @@ GCClient::IsoSubspace* JSStatementSyncIterator::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStatementSyncIterator, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteStatementSyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteStatementSyncIterator = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteStatementSyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteStatementSyncIterator = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteStatementSyncIterator; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteStatementSyncIterator; });
 }
 
 static inline JSObject* createIterResult(VM& vm, JSGlobalObject* globalObject, bool done, JSValue value)
@@ -3259,10 +3253,8 @@ GCClient::IsoSubspace* JSNodeSqliteSession::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteSession, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteSession.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteSession = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteSession.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteSession = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteSession; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteSession; });
 }
 
 #define THIS_SESSION()                                                                                                 \
@@ -3428,10 +3420,8 @@ GCClient::IsoSubspace* JSNodeSqliteLimits::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteLimits, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteLimits.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteLimits = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteLimits.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteLimits = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteLimits; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteLimits; });
 }
 
 bool JSNodeSqliteLimits::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
@@ -3580,10 +3570,8 @@ GCClient::IsoSubspace* JSNodeSqliteTagStore::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteTagStore, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteTagStore.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteTagStore = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteTagStore.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteTagStore = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNodeSqliteTagStore; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNodeSqliteTagStore; });
 }
 
 JSStatementSync* JSNodeSqliteTagStore::prepare(JSGlobalObject* globalObject, ThrowScope& scope, CallFrame* callFrame)

--- a/src/jsc/bindings/v8/shim/Function.h
+++ b/src/jsc/bindings/v8/shim/Function.h
@@ -24,10 +24,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<Function, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForV8Function.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForV8Function = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForV8Function.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForV8Function = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForV8Function; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForV8Function; });
     }
 
     FunctionTemplate* functionTemplate() const { return m_functionTemplate.get(); }

--- a/src/jsc/bindings/v8/shim/FunctionTemplate.h
+++ b/src/jsc/bindings/v8/shim/FunctionTemplate.h
@@ -41,10 +41,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<FunctionTemplate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFunctionTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFunctionTemplate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFunctionTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFunctionTemplate = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForFunctionTemplate; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForFunctionTemplate; });
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/v8/shim/GlobalInternals.h
+++ b/src/jsc/bindings/v8/shim/GlobalInternals.h
@@ -34,10 +34,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<GlobalInternals, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForV8GlobalInternals.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForV8GlobalInternals = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForV8GlobalInternals.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForV8GlobalInternals = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForV8GlobalInternals; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForV8GlobalInternals; });
     }
 
     JSC::Structure* objectTemplateStructure(JSC::JSGlobalObject* globalObject) const

--- a/src/jsc/bindings/v8/shim/HandleScopeBuffer.h
+++ b/src/jsc/bindings/v8/shim/HandleScopeBuffer.h
@@ -33,10 +33,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<HandleScopeBuffer, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForHandleScopeBuffer.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForHandleScopeBuffer.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForHandleScopeBuffer; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForHandleScopeBuffer; });
     }
 
     TaggedPointer* createHandle(JSC::JSCell* object, const Map* map, JSC::VM& vm);

--- a/src/jsc/bindings/v8/shim/InternalFieldObject.h
+++ b/src/jsc/bindings/v8/shim/InternalFieldObject.h
@@ -21,10 +21,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<InternalFieldObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForInternalFieldObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForInternalFieldObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForInternalFieldObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForInternalFieldObject = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForInternalFieldObject; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForInternalFieldObject; });
     }
 
     // never changes size

--- a/src/jsc/bindings/v8/shim/ObjectTemplate.h
+++ b/src/jsc/bindings/v8/shim/ObjectTemplate.h
@@ -28,10 +28,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ObjectTemplate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForObjectTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForObjectTemplate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForObjectTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForObjectTemplate = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForObjectTemplate; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForObjectTemplate; });
     }
 
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -228,10 +228,8 @@ JSC::GCClient::IsoSubspace* JSAbortController::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSAbortController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAbortController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAbortController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAbortController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAbortController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForAbortController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForAbortController; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -353,10 +353,8 @@ JSC::GCClient::IsoSubspace* JSAbortSignal::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSAbortSignal, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAbortSignal.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAbortSignal = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAbortSignal.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAbortSignal = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForAbortSignal; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForAbortSignal; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -416,10 +416,8 @@ JSC::GCClient::IsoSubspace* JSBroadcastChannel::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBroadcastChannel, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBroadcastChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBroadcastChannel = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBroadcastChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBroadcastChannel = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBroadcastChannel; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForBroadcastChannel; });
 }
 
 void JSBroadcastChannel::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCloseEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCloseEvent.cpp
@@ -318,10 +318,8 @@ JSC::GCClient::IsoSubspace* JSCloseEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCloseEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCloseEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCloseEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCloseEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCloseEvent = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCloseEvent; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCloseEvent; });
 }
 
 void JSCloseEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -889,10 +889,8 @@ GCClient::IsoSubspace* JSCookie::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCookie, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCookie.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookie = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCookie.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCookie = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCookie; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCookie; });
 }
 
 void JSCookie::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -553,10 +553,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<CookieMapIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForCookieMapIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookieMapIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForCookieMapIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForCookieMapIterator = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCookieMapIterator; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForCookieMapIterator; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -632,10 +630,8 @@ GCClient::IsoSubspace* JSCookieMap::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCookieMap, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCookieMap.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookieMap = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCookieMap.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCookieMap = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCookieMap; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCookieMap; });
 }
 
 void JSCookieMap::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCustomEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCustomEvent.cpp
@@ -301,10 +301,8 @@ JSC::GCClient::IsoSubspace* JSCustomEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCustomEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCustomEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCustomEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCustomEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCustomEvent = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCustomEvent; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCustomEvent; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -318,10 +318,8 @@ JSC::GCClient::IsoSubspace* JSDOMException::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMException, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMException.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMException = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMException.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMException = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDOMException; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDOMException; });
 }
 
 void JSDOMException::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -536,10 +536,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<DOMFormDataIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForDOMFormDataIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMFormDataIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForDOMFormDataIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMFormDataIterator = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDOMFormDataIterator; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForDOMFormDataIterator; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -698,10 +696,8 @@ JSC::GCClient::IsoSubspace* JSDOMFormData::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMFormData, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMFormData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMFormData = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMFormData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMFormData = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDOMFormData; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDOMFormData; });
 }
 
 void JSDOMFormData::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -867,10 +867,8 @@ JSC::GCClient::IsoSubspace* JSDOMURL::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMURL, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMURL.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMURL = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMURL.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMURL = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDOMURL; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDOMURL; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSErrorEvent.cpp
+++ b/src/jsc/bindings/webcore/JSErrorEvent.cpp
@@ -375,10 +375,8 @@ JSC::GCClient::IsoSubspace* JSErrorEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSErrorEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForErrorEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForErrorEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForErrorEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForErrorEvent = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForErrorEvent; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForErrorEvent; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSEvent.cpp
+++ b/src/jsc/bindings/webcore/JSEvent.cpp
@@ -583,10 +583,8 @@ JSC::GCClient::IsoSubspace* JSEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEvent = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForEvent; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForEvent; });
 }
 
 void JSEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -511,10 +511,8 @@ JSC::GCClient::IsoSubspace* JSEventEmitter::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEventEmitter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEventEmitter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEventEmitter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEventEmitter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEventEmitter = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForEventEmitter; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForEventEmitter; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSEventTarget.cpp
+++ b/src/jsc/bindings/webcore/JSEventTarget.cpp
@@ -306,10 +306,8 @@ JSC::GCClient::IsoSubspace* JSEventTarget::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEventTarget, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEventTarget.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEventTarget = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEventTarget.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEventTarget = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForEventTarget; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForEventTarget; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -528,10 +528,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<FetchHeadersIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFetchHeadersIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFetchHeadersIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFetchHeadersIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFetchHeadersIterator = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForFetchHeadersIterator; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForFetchHeadersIterator; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -637,10 +635,8 @@ JSC::GCClient::IsoSubspace* JSFetchHeaders::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSFetchHeaders, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForFetchHeaders.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFetchHeaders = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForFetchHeaders.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForFetchHeaders = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForFetchHeaders; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForFetchHeaders; });
 }
 
 void JSFetchHeaders::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSMIMEParams.h
+++ b/src/jsc/bindings/webcore/JSMIMEParams.h
@@ -22,10 +22,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMIMEParams.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMIMEParams = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMIMEParams.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMIMEParams = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSMIMEParams; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSMIMEParams; });
     }
 
     static JSMIMEParams* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSMap* map);

--- a/src/jsc/bindings/webcore/JSMIMEType.h
+++ b/src/jsc/bindings/webcore/JSMIMEType.h
@@ -23,10 +23,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMIMEType.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMIMEType = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMIMEType.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMIMEType = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSMIMEType; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSMIMEType; });
     }
 
     static JSMIMEType* create(JSC::VM& vm, JSC::Structure* structure, WTF::String type, WTF::String subtype, JSMIMEParams* params);

--- a/src/jsc/bindings/webcore/JSMessageChannel.cpp
+++ b/src/jsc/bindings/webcore/JSMessageChannel.cpp
@@ -216,10 +216,8 @@ JSC::GCClient::IsoSubspace* JSMessageChannel::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessageChannel, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessageChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessageChannel = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessageChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessageChannel = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForMessageChannel; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForMessageChannel; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSMessageEvent.cpp
+++ b/src/jsc/bindings/webcore/JSMessageEvent.cpp
@@ -464,10 +464,8 @@ JSC::GCClient::IsoSubspace* JSMessageEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessageEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessageEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessageEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessageEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessageEvent = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForMessageEvent; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForMessageEvent; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -412,10 +412,8 @@ JSC::GCClient::IsoSubspace* JSMessagePort::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessagePort, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessagePort.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessagePort = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessagePort.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessagePort = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForMessagePort; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForMessagePort; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -541,10 +541,8 @@ JSC::GCClient::IsoSubspace* JSPerformance::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformance, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformance.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformance = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformance.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformance = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformance; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformance; });
 }
 
 void JSPerformance::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
@@ -256,10 +256,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceEntry::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceEntry, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceEntry.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceEntry = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceEntry.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceEntry = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceEntry; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceEntry; });
 }
 
 void JSPerformanceEntry::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceMark.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceMark.cpp
@@ -207,10 +207,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceMark::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceMark, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceMark.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceMark = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceMark.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceMark = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceMark; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceMark; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceMeasure.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceMeasure.cpp
@@ -173,10 +173,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceMeasure::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceMeasure, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceMeasure.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceMeasure = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceMeasure.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceMeasure = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceMeasure; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceMeasure; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
@@ -331,10 +331,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceObserver::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceObserver, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceObserver.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceObserver = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceObserver.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceObserver = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceObserver; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceObserver; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
@@ -233,10 +233,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceObserverEntryList::subspaceForImpl(JSC:
 {
     return WebCore::subspaceForImpl<JSPerformanceObserverEntryList, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceObserverEntryList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceObserverEntryList = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceObserverEntryList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceObserverEntryList = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceObserverEntryList; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceObserverEntryList; });
 }
 
 void JSPerformanceObserverEntryList::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceResourceTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceResourceTiming.cpp
@@ -520,7 +520,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceResourceTimingPrototypeFunction_toJSON, (J
 
 JSC::GCClient::IsoSubspace* JSPerformanceResourceTiming::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSPerformanceResourceTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceResourceTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceResourceTiming = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForPerformanceResourceTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceResourceTiming = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSPerformanceResourceTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceResourceTiming; }, [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceResourceTiming; });
 }
 
 void JSPerformanceResourceTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
@@ -236,7 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceServerTimingPrototypeFunction_toJSON, (JSG
 
 JSC::GCClient::IsoSubspace* JSPerformanceServerTiming::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSPerformanceServerTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceServerTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceServerTiming = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForPerformanceServerTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceServerTiming = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSPerformanceServerTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceServerTiming; }, [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceServerTiming; });
 }
 
 void JSPerformanceServerTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
@@ -561,10 +561,8 @@ JSC::GCClient::IsoSubspace* JSPerformanceTiming::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceTiming, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceTiming.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceTiming = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceTiming.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceTiming = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPerformanceTiming; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPerformanceTiming; });
 }
 
 void JSPerformanceTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -315,10 +315,8 @@ JSC::GCClient::IsoSubspace* JSTextEncoder::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextEncoder, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoder = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoder = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTextEncoder; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTextEncoder; });
 }
 
 void JSTextEncoder::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSURLPattern.cpp
+++ b/src/jsc/bindings/webcore/JSURLPattern.cpp
@@ -461,7 +461,7 @@ JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_exec, (JSGlobalObject * l
 
 JSC::GCClient::IsoSubspace* JSURLPattern::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSURLPattern, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForURLPattern.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLPattern = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForURLPattern.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForURLPattern = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSURLPattern, UseCustomHeapCellType::No>(vm, [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForURLPattern; }, [](auto& spaces) -> auto& { return spaces.m_subspaceForURLPattern; });
 }
 
 void JSURLPattern::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -680,10 +680,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<URLSearchParamsIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForURLSearchParamsIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLSearchParamsIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForURLSearchParamsIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForURLSearchParamsIterator = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForURLSearchParamsIterator; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForURLSearchParamsIterator; });
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -759,10 +757,8 @@ JSC::GCClient::IsoSubspace* JSURLSearchParams::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSURLSearchParams, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForURLSearchParams.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLSearchParams = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForURLSearchParams.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForURLSearchParams = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForURLSearchParams; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForURLSearchParams; });
 }
 
 void JSURLSearchParams::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
@@ -193,10 +193,8 @@ GCClient::IsoSubspace* JSWasmStreamingCompiler::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWasmStreamingCompiler, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWasmStreamingCompiler.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWasmStreamingCompiler = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWasmStreamingCompiler.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWasmStreamingCompiler = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWasmStreamingCompiler; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWasmStreamingCompiler; });
 }
 
 void JSWasmStreamingCompiler::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -947,10 +947,8 @@ JSC::GCClient::IsoSubspace* JSWebSocket::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSWebSocket, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWebSocket.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWebSocket = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWebSocket.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWebSocket = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWebSocket; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWebSocket; });
 }
 
 size_t JSWebSocket::estimatedSize(JSCell* cell, JSC::VM& vm)

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -952,10 +952,8 @@ JSC::GCClient::IsoSubspace* JSWorker::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSWorker, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWorker.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWorker = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWorker.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWorker = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWorker; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWorker; });
 }
 
 void JSWorker::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -59,10 +59,8 @@ GCClient::IsoSubspace* JSAsyncIteratorSourceOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSAsyncIteratorSourceOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAsyncIteratorSourceOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAsyncIteratorSourceOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAsyncIteratorSourceOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAsyncIteratorSourceOperation = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForAsyncIteratorSourceOperation; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForAsyncIteratorSourceOperation; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -84,10 +84,8 @@ GCClient::IsoSubspace* JSBunStandaloneTextSink::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSBunStandaloneTextSink, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBunStandaloneTextSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunStandaloneTextSink = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBunStandaloneTextSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBunStandaloneTextSink = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBunStandaloneTextSink; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForBunStandaloneTextSink; });
 }
 
 DEFINE_VISIT_CHILDREN(JSBunStandaloneTextSink);
@@ -141,10 +139,8 @@ GCClient::IsoSubspace* JSOneShotDirectSink::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSOneShotDirectSink, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForOneShotDirectSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForOneShotDirectSink = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForOneShotDirectSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForOneShotDirectSink = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForOneShotDirectSink; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForOneShotDirectSink; });
 }
 
 DEFINE_VISIT_CHILDREN(JSOneShotDirectSink);
@@ -206,10 +202,8 @@ GCClient::IsoSubspace* JSReadableStreamIntoArrayOperation::subspaceForImpl(VM& v
 {
     return WebCore::subspaceForImpl<JSReadableStreamIntoArrayOperation, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamIntoArrayOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamIntoArrayOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamIntoArrayOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamIntoArrayOperation = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamIntoArrayOperation; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamIntoArrayOperation; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamIntoArrayOperation);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -79,10 +79,8 @@ GCClient::IsoSubspace* JSNativeStreamSourceAdapter::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNativeStreamSourceAdapter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNativeStreamSourceAdapter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNativeStreamSourceAdapter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNativeStreamSourceAdapter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNativeStreamSourceAdapter = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForNativeStreamSourceAdapter; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForNativeStreamSourceAdapter; });
 }
 
 template<typename Visitor>
@@ -124,10 +122,8 @@ GCClient::IsoSubspace* JSDirectSinkCloseState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDirectSinkCloseState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDirectSinkCloseState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDirectSinkCloseState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDirectSinkCloseState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDirectSinkCloseState = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDirectSinkCloseState; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDirectSinkCloseState; });
 }
 
 template<typename Visitor>
@@ -182,10 +178,8 @@ GCClient::IsoSubspace* JSReadStreamIntoSinkOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadStreamIntoSinkOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadStreamIntoSinkOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadStreamIntoSinkOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadStreamIntoSinkOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadStreamIntoSinkOperation = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadStreamIntoSinkOperation; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadStreamIntoSinkOperation; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -94,10 +94,8 @@ template<> GCClient::IsoSubspace* JSByteLengthQueuingStrategyConstructor::subspa
 {
     return WebCore::subspaceForImpl<JSByteLengthQueuingStrategyConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForByteLengthQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForByteLengthQueuingStrategyConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForByteLengthQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForByteLengthQueuingStrategyConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForByteLengthQueuingStrategyConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForByteLengthQueuingStrategyConstructor; });
 }
 
 template<> void JSByteLengthQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -231,10 +229,8 @@ GCClient::IsoSubspace* JSByteLengthQueuingStrategy::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSByteLengthQueuingStrategy, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForByteLengthQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForByteLengthQueuingStrategy = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForByteLengthQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForByteLengthQueuingStrategy = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForByteLengthQueuingStrategy; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForByteLengthQueuingStrategy; });
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -131,10 +131,8 @@ template<> GCClient::IsoSubspace* JSCompressionStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSCompressionStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCompressionStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCompressionStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCompressionStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCompressionStreamConstructor; });
 }
 
 template<> void JSCompressionStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -225,10 +223,8 @@ GCClient::IsoSubspace* JSCompressionStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCompressionStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCompressionStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCompressionStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCompressionStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCompressionStream; });
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsCompressionStreamPrototypeGetter_constructor, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -94,10 +94,8 @@ template<> GCClient::IsoSubspace* JSCountQueuingStrategyConstructor::subspaceFor
 {
     return WebCore::subspaceForImpl<JSCountQueuingStrategyConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCountQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCountQueuingStrategyConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCountQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCountQueuingStrategyConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCountQueuingStrategyConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCountQueuingStrategyConstructor; });
 }
 
 template<> void JSCountQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -231,10 +229,8 @@ GCClient::IsoSubspace* JSCountQueuingStrategy::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCountQueuingStrategy, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCountQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCountQueuingStrategy = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCountQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCountQueuingStrategy = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCountQueuingStrategy; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCountQueuingStrategy; });
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
@@ -47,10 +47,8 @@ GCClient::IsoSubspace* JSCrossRealmTransformState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCrossRealmTransformState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCrossRealmTransformState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCrossRealmTransformState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCrossRealmTransformState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCrossRealmTransformState = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCrossRealmTransformState; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCrossRealmTransformState; });
 }
 
 DEFINE_VISIT_CHILDREN(JSCrossRealmTransformState);

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -131,10 +131,8 @@ template<> GCClient::IsoSubspace* JSDecompressionStreamConstructor::subspaceForI
 {
     return WebCore::subspaceForImpl<JSDecompressionStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDecompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDecompressionStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDecompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDecompressionStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDecompressionStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDecompressionStreamConstructor; });
 }
 
 template<> void JSDecompressionStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -225,10 +223,8 @@ GCClient::IsoSubspace* JSDecompressionStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDecompressionStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDecompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDecompressionStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDecompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDecompressionStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDecompressionStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDecompressionStream; });
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsDecompressionStreamPrototypeGetter_constructor, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -92,10 +92,8 @@ GCClient::IsoSubspace* JSDirectStreamController::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDirectStreamController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDirectStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDirectStreamController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDirectStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDirectStreamController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForDirectStreamController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForDirectStreamController; });
 }
 
 DEFINE_VISIT_CHILDREN(JSDirectStreamController);

--- a/src/jsc/bindings/webcore/streams/JSPullIntoDescriptor.cpp
+++ b/src/jsc/bindings/webcore/streams/JSPullIntoDescriptor.cpp
@@ -51,10 +51,8 @@ GCClient::IsoSubspace* JSPullIntoDescriptor::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSPullIntoDescriptor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPullIntoDescriptor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPullIntoDescriptor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPullIntoDescriptor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPullIntoDescriptor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForPullIntoDescriptor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForPullIntoDescriptor; });
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -88,10 +88,8 @@ GCClient::IsoSubspace* JSReadRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadRequest = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadRequest; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadRequest; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadRequest);
@@ -293,10 +291,8 @@ GCClient::IsoSubspace* JSReadIntoRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadIntoRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadIntoRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadIntoRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadIntoRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadIntoRequest = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadIntoRequest; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadIntoRequest; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadIntoRequest);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -352,10 +352,8 @@ GCClient::IsoSubspace* JSReadableByteStreamController::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableByteStreamController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableByteStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableByteStreamController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableByteStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableByteStreamController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableByteStreamController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableByteStreamController; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -287,10 +287,8 @@ template<> GCClient::IsoSubspace* JSReadableStreamConstructor::subspaceForImpl(J
 {
     return WebCore::subspaceForImpl<JSReadableStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamConstructor; });
 }
 
 template<> void JSReadableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -481,10 +479,8 @@ GCClient::IsoSubspace* JSReadableStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStream; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStream);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
@@ -122,10 +122,8 @@ GCClient::IsoSubspace* JSReadableStreamAsyncIterator::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamAsyncIterator, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamAsyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamAsyncIterator = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamAsyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamAsyncIterator = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamAsyncIterator; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamAsyncIterator; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamAsyncIterator);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -214,10 +214,8 @@ template<> GCClient::IsoSubspace* JSReadableStreamBYOBReaderConstructor::subspac
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBReaderConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBReaderConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBReaderConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamBYOBReaderConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamBYOBReaderConstructor; });
 }
 
 template<> void JSReadableStreamBYOBReaderConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -348,10 +346,8 @@ GCClient::IsoSubspace* JSReadableStreamBYOBReader::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBReader, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBReader = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBReader = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamBYOBReader; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamBYOBReader; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamBYOBReader);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -173,10 +173,8 @@ GCClient::IsoSubspace* JSReadableStreamBYOBRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBRequest = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamBYOBRequest; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamBYOBRequest; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamBYOBRequest);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -301,10 +301,8 @@ GCClient::IsoSubspace* JSReadableStreamDefaultController::subspaceForImpl(VM& vm
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamDefaultController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamDefaultController; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -516,10 +516,8 @@ template<> GCClient::IsoSubspace* JSReadableStreamDefaultReaderConstructor::subs
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultReaderConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultReaderConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultReaderConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamDefaultReaderConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamDefaultReaderConstructor; });
 }
 
 template<> void JSReadableStreamDefaultReaderConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -653,10 +651,8 @@ GCClient::IsoSubspace* JSReadableStreamDefaultReader::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultReader, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultReader = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultReader = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForReadableStreamDefaultReader; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForReadableStreamDefaultReader; });
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamDefaultReader);

--- a/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
@@ -45,10 +45,8 @@ GCClient::IsoSubspace* JSStreamFromIterableContext::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamFromIterableContext, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamFromIterableContext.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamFromIterableContext = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamFromIterableContext.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamFromIterableContext = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForStreamFromIterableContext; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForStreamFromIterableContext; });
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamFromIterableContext);

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -65,10 +65,8 @@ GCClient::IsoSubspace* JSStreamPipeToOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamPipeToOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamPipeToOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamPipeToOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamPipeToOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamPipeToOperation = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForStreamPipeToOperation; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForStreamPipeToOperation; });
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamPipeToOperation);

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
@@ -46,10 +46,8 @@ GCClient::IsoSubspace* JSStreamTeeState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamTeeState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamTeeState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamTeeState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamTeeState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamTeeState = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForStreamTeeState; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForStreamTeeState; });
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamTeeState);

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -109,10 +109,8 @@ template<> GCClient::IsoSubspace* JSTextDecoderStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSTextDecoderStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextDecoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextDecoderStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextDecoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextDecoderStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTextDecoderStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTextDecoderStreamConstructor; });
 }
 
 template<> void JSTextDecoderStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -266,10 +264,8 @@ GCClient::IsoSubspace* JSTextDecoderStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextDecoderStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextDecoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextDecoderStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextDecoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextDecoderStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTextDecoderStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTextDecoderStream; });
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -109,10 +109,8 @@ template<> GCClient::IsoSubspace* JSTextEncoderStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSTextEncoderStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoderStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoderStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTextEncoderStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTextEncoderStreamConstructor; });
 }
 
 template<> void JSTextEncoderStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -226,10 +224,8 @@ GCClient::IsoSubspace* JSTextEncoderStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextEncoderStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoderStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoderStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTextEncoderStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTextEncoderStream; });
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -103,10 +103,8 @@ template<> GCClient::IsoSubspace* JSTransformStreamConstructor::subspaceForImpl(
 {
     return WebCore::subspaceForImpl<JSTransformStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTransformStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTransformStreamConstructor; });
 }
 
 template<> void JSTransformStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -263,10 +261,8 @@ GCClient::IsoSubspace* JSTransformStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTransformStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTransformStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTransformStream; });
 }
 
 DEFINE_VISIT_CHILDREN(JSTransformStream);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -256,10 +256,8 @@ GCClient::IsoSubspace* JSTransformStreamDefaultController::subspaceForImpl(VM& v
 {
     return WebCore::subspaceForImpl<JSTransformStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStreamDefaultController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForTransformStreamDefaultController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForTransformStreamDefaultController; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -105,10 +105,8 @@ template<> GCClient::IsoSubspace* JSWritableStreamConstructor::subspaceForImpl(J
 {
     return WebCore::subspaceForImpl<JSWritableStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWritableStreamConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWritableStreamConstructor; });
 }
 
 template<> void JSWritableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -263,10 +261,8 @@ GCClient::IsoSubspace* JSWritableStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWritableStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStream = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWritableStream; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWritableStream; });
 }
 
 DEFINE_VISIT_CHILDREN(JSWritableStream);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -309,10 +309,8 @@ GCClient::IsoSubspace* JSWritableStreamDefaultController::subspaceForImpl(VM& vm
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultController = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWritableStreamDefaultController; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWritableStreamDefaultController; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -239,10 +239,8 @@ template<> GCClient::IsoSubspace* JSWritableStreamDefaultWriterConstructor::subs
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultWriterConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultWriterConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultWriterConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultWriterConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultWriterConstructor = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWritableStreamDefaultWriterConstructor; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWritableStreamDefaultWriterConstructor; });
 }
 
 template<> void JSWritableStreamDefaultWriterConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -368,10 +366,8 @@ GCClient::IsoSubspace* JSWritableStreamDefaultWriter::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultWriter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultWriter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultWriter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultWriter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultWriter = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForWritableStreamDefaultWriter; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForWritableStreamDefaultWriter; });
 }
 
 DEFINE_VISIT_CHILDREN(JSWritableStreamDefaultWriter);

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -312,10 +312,8 @@ JSC::GCClient::IsoSubspace* JSCryptoKey::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCryptoKey, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCryptoKey.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCryptoKey = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCryptoKey.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCryptoKey = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForCryptoKey; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForCryptoKey; });
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -804,10 +804,8 @@ JSC::GCClient::IsoSubspace* JSSubtleCrypto::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSSubtleCrypto, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForSubtleCrypto.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForSubtleCrypto = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForSubtleCrypto.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForSubtleCrypto = std::forward<decltype(space)>(space); });
+        [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForSubtleCrypto; },
+        [](auto& spaces) -> auto& { return spaces.m_subspaceForSubtleCrypto; });
 }
 
 void JSSubtleCrypto::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/runtime/bake/BakeGlobalObject.h
+++ b/src/runtime/bake/BakeGlobalObject.h
@@ -17,10 +17,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<GlobalObject, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBakeGlobalScope.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBakeGlobalScope = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBakeGlobalScope.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBakeGlobalScope = std::forward<decltype(space)>(space); },
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForBakeGlobalScope; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForBakeGlobalScope; },
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForBakeGlobalObject; });
     }
 

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -211,10 +211,8 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSWebView, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSWebView.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSWebView = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSWebView.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSWebView = std::forward<decltype(space)>(space); });
+            [](auto& spaces) -> auto& { return spaces.m_clientSubspaceForJSWebView; },
+            [](auto& spaces) -> auto& { return spaces.m_subspaceForJSWebView; });
     }
 
 private:

--- a/test/js/bun/jsc/iso-subspace-allocation.test.ts
+++ b/test/js/bun/jsc/iso-subspace-allocation.test.ts
@@ -10,7 +10,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-test("IsoSubspace lazy init survives GC across all HeapCellType branches", async () => {
+test.concurrent("IsoSubspace lazy init survives GC across all HeapCellType branches", async () => {
   // Run in a subprocess so every class hits the cold subspaceForImpl path
   // (the test runner has already warmed most of them in this VM).
   await using proc = Bun.spawn({
@@ -95,10 +95,13 @@ test("IsoSubspace lazy init survives GC across all HeapCellType branches", async
   expect(exitCode).toBe(0);
 });
 
-test("IsoSubspace lazy init across Worker VMs (shared server slot, per-VM client slot)", async () => {
-  // Workers share the JSHeapData (server subspaces) under useGlobalGC but get
-  // their own clientSubspaces; the locked double-check in subspaceForImplSlow
-  // is what keeps that safe.
+test.concurrent("IsoSubspace lazy init across Worker VMs (per-VM cold init)", async () => {
+  // Each Worker gets its own VM and (without useGlobalGC) its own JSHeapData,
+  // so every Worker independently takes the cold path through
+  // subspaceForImplSlow for each class it allocates. This guards the slow
+  // path running on several heaps at once and the cleanup on Worker
+  // termination; the cross-VM shared-server-slot branch only applies when
+  // JSC::Options::useGlobalGC() is enabled, which Bun does not set.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/jsc/iso-subspace-allocation.test.ts
+++ b/test/js/bun/jsc/iso-subspace-allocation.test.ts
@@ -7,7 +7,7 @@
 // BunClientData.cpp); this test exercises each of its branches so a
 // regression in that function shows up as a crash or GC corruption rather
 // than silently wrong behavior in some rarely-allocated class.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("IsoSubspace lazy init survives GC across all HeapCellType branches", async () => {

--- a/test/js/bun/jsc/iso-subspace-allocation.test.ts
+++ b/test/js/bun/jsc/iso-subspace-allocation.test.ts
@@ -1,0 +1,147 @@
+// subspaceForImpl<T> is the lazy-init path that every JS class with its own
+// IsoSubspace goes through on first allocation. It picks a HeapCellType,
+// constructs the server IsoSubspace under a lock, optionally registers it as
+// an output-constraint space, then constructs the per-VM GCClient wrapper.
+//
+// The slow path is shared out-of-line (subspaceForImplSlow in
+// BunClientData.cpp); this test exercises each of its branches so a
+// regression in that function shows up as a crash or GC corruption rather
+// than silently wrong behavior in some rarely-allocated class.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("IsoSubspace lazy init survives GC across all HeapCellType branches", async () => {
+  // Run in a subprocess so every class hits the cold subspaceForImpl path
+  // (the test runner has already warmed most of them in this VM).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      /* js */ `
+        const vm = require("node:vm");
+        const { EventEmitter } = require("node:events");
+
+        // JSDestructibleObject branch (heap.destructibleObjectHeapCellType):
+        // generated classes are all JSDestructibleObject-derived.
+        let keep = [
+          new Blob(["x"]),
+          new Request("http://a/"),
+          new Response("b"),
+          new Headers({ a: "1" }),
+          new URLSearchParams("a=1"),
+          new TextEncoder(),
+          new TextDecoder(),
+          new FormData(),
+          Bun.CryptoHasher ? new Bun.CryptoHasher("sha1") : null,
+        ];
+
+        // Non-destructible branch (heap.cellHeapCellType): AsyncContextFrame,
+        // reached via AsyncLocalStorage.run.
+        const { AsyncLocalStorage } = require("node:async_hooks");
+        const als = new AsyncLocalStorage();
+        als.run({ v: 1 }, () => {
+          if (als.getStore().v !== 1) throw new Error("als");
+        });
+
+        // UseCustomHeapCellType::Yes branch: NodeVMGlobalObject + the global
+        // object itself. Also re-enters subspaceForImpl from a nested VM.
+        const ctx = vm.createContext({ out: null });
+        vm.runInContext("out = 1 + 1", ctx);
+        if (ctx.out !== 2) throw new Error("vm");
+
+        // visitOutputConstraints override -> outputConstraintSpaces().append:
+        // MessageChannel / MessagePort / EventEmitter all override it.
+        const mc = new MessageChannel();
+        const ee = new EventEmitter();
+        ee.on("x", () => {});
+        const po = new PerformanceObserver(() => {});
+        keep.push(mc, ee, po);
+
+        Bun.gc(true);
+
+        // Second allocation of each hits the fast path (client slot cached).
+        let keep2 = [
+          new Blob(["y"]),
+          new Request("http://b/"),
+          new Response("c"),
+          new MessageChannel(),
+          vm.createContext({}),
+        ];
+
+        Bun.gc(true);
+
+        // Drop everything and collect — destructors run through the
+        // HeapCellType picked by subspaceForImpl.
+        keep = null;
+        keep2 = null;
+        mc.port1.close();
+        mc.port2.close();
+        Bun.gc(true);
+        Bun.gc(true);
+
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});
+
+test("IsoSubspace lazy init across Worker VMs (shared server slot, per-VM client slot)", async () => {
+  // Workers share the JSHeapData (server subspaces) under useGlobalGC but get
+  // their own clientSubspaces; the locked double-check in subspaceForImplSlow
+  // is what keeps that safe.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "--smol",
+      "-e",
+      /* js */ `
+        const src = \`
+          const { parentPort } = require("node:worker_threads");
+          // Force a spread of subspace first-allocations in this VM.
+          const keep = [
+            new Blob(["w"]),
+            new Response("w"),
+            new URL("http://w/"),
+            new MessageChannel(),
+            new AbortController(),
+          ];
+          Bun.gc(true);
+          parentPort.postMessage("done");
+        \`;
+
+        const workers = [];
+        for (let i = 0; i < 4; i++) {
+          workers.push(
+            new Promise((resolve, reject) => {
+              const w = new Worker("data:text/javascript," + encodeURIComponent(src));
+              w.onmessage = () => { w.terminate(); resolve(); };
+              w.onerror = reject;
+            }),
+          );
+        }
+        await Promise.all(workers);
+        Bun.gc(true);
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`WebCore::subspaceForImpl<T>` in `src/jsc/bindings/BunClientData.h` was an `ALWAYS_INLINE` template instantiated ~270 times — once per JS class with its own `IsoSubspace` (generated classes via `generate-classes.ts` + `generate-jssink.ts` + ~115 hand-written call sites). Each instantiation inlined the entire slow path: take the heapData lock, construct a `JSC::IsoSubspace`, optionally register it as an output-constraint space, then construct the `GCClient::IsoSubspace` wrapper.

Only a handful of values actually vary with `T`:
- `sizeof(T)` and `T::numberOfLowerTierPreciseCells`
- which `HeapCellType` to use (destructible / cell / custom)
- whether `T::visitOutputConstraints` overrides `JSCell`'s
- the two `std::unique_ptr` storage slots in `DOMIsoSubspaces` / `DOMClientIsoSubspaces`

Everything else is byte-identical across instantiations.

## How

- Add a single out-of-line `subspaceForImplSlow(...)` in `BunClientData.cpp` that takes the T-dependent values above as plain parameters and does the locking + allocation + registration.
- Shrink the template wrapper to: fast-path cache check → compute the 5 constants/addresses → tail-call the shared function.
- Change the call-site lambda convention from **four** lambdas (`get`/`set` pairs returning/assigning `.get()`) to **two** that return the `std::unique_ptr` slot by reference. Updated both codegen scripts + all hand-written call sites mechanically.

The `ISO_SUBSPACE_INIT` macro previously stringified the template parameter name, so every subspace was already named `"T"` — preserved that behavior.

## Size

| | before | after | Δ |
|-|-|-|-|
| stripped release `bun` | 91,892,680 | 91,810,760 | **−80 KB** |
| `.text` section | 90,534,907 | 90,457,083 | −76 KB |
| `bun-profile` (unstripped) | 364,739,736 | 364,219,864 | −508 KB |
| `ZigGeneratedClasses.cpp.o` (release) | 26,052,144 | 25,057,880 | −971 KB |
| `ZigGeneratedClasses.cpp.o` (debug+ASAN) | 36,198,528 | 35,100,208 | −1.07 MB |

This path runs at most once per class per VM — not hot.

## Verification

- `bun bd -e "Bun.gc(true); ...; Bun.gc(true)"` across Blob/Request/Response/URL/vm.createContext/MessageChannel/AbortController
- `test/js/bun/jsc-stress/jsc-stress.test.ts` — 83/83 pass
- `test/js/node/events/event-emitter.test.ts` — 63/63 pass (exercises `visitOutputConstraints` registration)
- `test/js/web/workers/message-channel.test.ts` — 12/12 pass (output-constraint + GC)
- `test/js/node/vm/vm.test.ts` — 198 pass (exercises `UseCustomHeapCellType::Yes` path)
- `test/js/bun/sqlite/sqlite.test.js` — 70 pass