### PR TITLE
cli: take runtime `Command.Tag` in `Arguments.parse` / `Bunfig.Parser.parse`

### DIFF
--- a/src/clap/clap.zig
+++ b/src/clap/clap.zig
@@ -2,6 +2,9 @@ pub const args = @import("./args.zig");
 
 pub const ComptimeClap = @import("./comptime.zig").ComptimeClap;
 pub const StreamingClap = @import("./streaming.zig").StreamingClap;
+pub const runtime = @import("./runtime.zig");
+pub const ParamSet = runtime.ParamSet;
+pub const RuntimeArgs = runtime.RuntimeArgs;
 
 /// The names a ::Param can have.
 pub const Names = struct {

--- a/src/clap/runtime.zig
+++ b/src/clap/runtime.zig
@@ -1,0 +1,213 @@
+//! Runtime-params variant of `ComptimeClap`. The params slice and
+//! param→storage-index mapping are still computed at comptime (see `ParamSet`)
+//! so the binary carries one small table per distinct params list, but which
+//! table to use is selected at *runtime*. Accessors (`flag`/`option`/`options`)
+//! do a linear name scan at runtime instead of resolving to an array index at
+//! compile time.
+//!
+//! Used by `Arguments.parse` so it can take `cmd: Command.Tag` as a runtime
+//! value instead of `comptime cmd`, collapsing the per-command monomorphized
+//! copies into one function body.
+//!
+//! Unlike `ComptimeClap`, looking up a flag/option that is not present in the
+//! current params set is *not* an error — it returns `false` / `null` / `&.{}`.
+//! Call sites are expected to guard per-command flags with `if (cmd == .X)`
+//! anyway, so a missing flag is just one that never matched.
+
+/// Precomputed metadata for one distinct params list.
+///
+/// `converted` mirrors `ComptimeClap`'s `converted_params`: each param's `id`
+/// is its index into the matching storage slice (flags / single / multi).
+pub const ParamSet = struct {
+    converted: []const clap.Param(usize),
+    n_flags: usize,
+    n_single: usize,
+    n_multi: usize,
+
+    pub fn init(comptime params: []const clap.Param(clap.Help)) ParamSet {
+        @setEvalBranchQuota(1_000_000);
+        comptime var n_flags: usize = 0;
+        comptime var n_single: usize = 0;
+        comptime var n_multi: usize = 0;
+        comptime var converted: []const clap.Param(usize) = &.{};
+        inline for (params) |param| {
+            comptime var index: usize = 0;
+            if (param.names.long != null or param.names.short != null) {
+                switch (param.takes_value) {
+                    .none => {
+                        index = n_flags;
+                        n_flags += 1;
+                    },
+                    .one, .one_optional => {
+                        index = n_single;
+                        n_single += 1;
+                    },
+                    .many => {
+                        index = n_multi;
+                        n_multi += 1;
+                    },
+                }
+            }
+            converted = converted ++ [_]clap.Param(usize){.{
+                .id = index,
+                .names = param.names,
+                .takes_value = param.takes_value,
+            }};
+        }
+        return .{
+            .converted = converted,
+            .n_flags = n_flags,
+            .n_single = n_single,
+            .n_multi = n_multi,
+        };
+    }
+};
+
+/// Parsed arguments with runtime-sized storage. Interface matches
+/// `clap.Args(...)` so call sites can swap between the two.
+pub const RuntimeArgs = struct {
+    arena: bun.ArenaAllocator,
+    exe_arg: ?[:0]const u8,
+
+    params: []const clap.Param(usize),
+    flags_storage: []bool,
+    single_storage: []?[]const u8,
+    multi_storage: [][]const []const u8,
+    pos: []const []const u8,
+    passthrough_positionals: []const []const u8,
+
+    pub fn deinit(self: *RuntimeArgs) void {
+        self.arena.deinit();
+    }
+
+    pub fn flag(self: *const RuntimeArgs, name: []const u8) bool {
+        const param = self.findParam(name) orelse return false;
+        if (param.takes_value != .none) return false;
+        return self.flags_storage[param.id];
+    }
+
+    pub fn option(self: *const RuntimeArgs, name: []const u8) ?[]const u8 {
+        const param = self.findParam(name) orelse return null;
+        if (param.takes_value != .one and param.takes_value != .one_optional) return null;
+        return self.single_storage[param.id];
+    }
+
+    pub fn options(self: *const RuntimeArgs, name: []const u8) []const []const u8 {
+        const param = self.findParam(name) orelse return &.{};
+        if (param.takes_value != .many) return &.{};
+        return self.multi_storage[param.id];
+    }
+
+    pub fn positionals(self: *const RuntimeArgs) []const []const u8 {
+        return self.pos;
+    }
+
+    pub fn remaining(self: *const RuntimeArgs) []const []const u8 {
+        return self.passthrough_positionals;
+    }
+
+    fn findParam(self: *const RuntimeArgs, name: []const u8) ?*const clap.Param(usize) {
+        // Name is always a string literal with leading dashes ("-s" or "--long").
+        for (self.params) |*param| {
+            if (name.len == 2 and name[0] == '-') {
+                if (param.names.short) |s| {
+                    if (name[1] == s) return param;
+                }
+            }
+            if (name.len > 2 and name[0] == '-' and name[1] == '-') {
+                const bare = name[2..];
+                if (param.names.long) |l| {
+                    if (mem.eql(u8, bare, l)) return param;
+                }
+                for (param.names.long_aliases) |alias| {
+                    if (mem.eql(u8, bare, alias)) return param;
+                }
+            }
+        }
+        return null;
+    }
+};
+
+/// Same as `clap.parse` but with a runtime `ParamSet` and dynamically sized
+/// storage. Uses `args.OsIterator` (reads `bun.argv`).
+pub fn parse(set: *const ParamSet, opt: clap.ParseOptions) !RuntimeArgs {
+    var iter = clap.args.OsIterator.init(opt.allocator);
+    var res = RuntimeArgs{
+        .arena = iter.arena,
+        .exe_arg = iter.exe_arg,
+        .params = set.converted,
+        .flags_storage = &.{},
+        .single_storage = &.{},
+        .multi_storage = &.{},
+        .pos = &.{},
+        .passthrough_positionals = &.{},
+    };
+    const arena_alloc = res.arena.allocator();
+
+    res.flags_storage = try arena_alloc.alloc(bool, set.n_flags);
+    @memset(res.flags_storage, false);
+    res.single_storage = try arena_alloc.alloc(?[]const u8, set.n_single);
+    @memset(res.single_storage, null);
+    res.multi_storage = try arena_alloc.alloc([]const []const u8, set.n_multi);
+    @memset(res.multi_storage, &.{});
+
+    var multis = try arena_alloc.alloc(std.array_list.Managed([]const u8), set.n_multi);
+    for (multis) |*multi| {
+        multi.* = std.array_list.Managed([]const u8).init(arena_alloc);
+    }
+
+    var pos = std.array_list.Managed([]const u8).init(arena_alloc);
+    var passthrough_positionals = std.array_list.Managed([]const u8).init(arena_alloc);
+
+    var stream = clap.StreamingClap(usize, clap.args.OsIterator){
+        .params = set.converted,
+        .iter = &iter,
+        .diagnostic = opt.diagnostic,
+    };
+
+    while (try stream.next()) |arg| {
+        const param = arg.param;
+        if (param.names.long == null and param.names.short == null) {
+            try pos.append(arg.value.?);
+            if (opt.stop_after_positional_at > 0 and pos.items.len >= opt.stop_after_positional_at) {
+                var remaining_ = stream.iter.remain;
+                const first: []const u8 = if (remaining_.len > 0) bun.span(remaining_[0]) else "";
+                if (first.len > 0 and mem.eql(u8, first, "--")) {
+                    remaining_ = remaining_[1..];
+                }
+
+                try passthrough_positionals.ensureTotalCapacityPrecise(remaining_.len);
+                for (remaining_) |arg_| {
+                    // use bun.span due to the optimization for long strings
+                    passthrough_positionals.appendAssumeCapacity(bun.span(arg_));
+                }
+                break;
+            }
+        } else if (param.takes_value == .one or param.takes_value == .one_optional) {
+            debug.assert(res.single_storage.len != 0);
+            if (res.single_storage.len != 0)
+                res.single_storage[param.id] = arg.value orelse "";
+        } else if (param.takes_value == .many) {
+            debug.assert(multis.len != 0);
+            if (multis.len != 0)
+                try multis[param.id].append(arg.value.?);
+        } else {
+            debug.assert(res.flags_storage.len != 0);
+            if (res.flags_storage.len != 0)
+                res.flags_storage[param.id] = true;
+        }
+    }
+
+    for (multis, 0..) |*multi, i|
+        res.multi_storage[i] = try multi.toOwnedSlice();
+    res.pos = try pos.toOwnedSlice();
+    res.passthrough_positionals = try passthrough_positionals.toOwnedSlice();
+    return res;
+}
+
+const bun = @import("bun");
+const clap = @import("./clap.zig");
+
+const std = @import("std");
+const debug = std.debug;
+const mem = std.mem;

--- a/src/clap/runtime.zig
+++ b/src/clap/runtime.zig
@@ -142,6 +142,7 @@ pub fn parse(set: *const ParamSet, opt: clap.ParseOptions) !RuntimeArgs {
         .pos = &.{},
         .passthrough_positionals = &.{},
     };
+    errdefer res.arena.deinit();
     const arena_alloc = res.arena.allocator();
 
     res.flags_storage = try arena_alloc.alloc(bool, set.n_flags);

--- a/src/cli/Arguments.zig
+++ b/src/cli/Arguments.zig
@@ -255,19 +255,41 @@ pub const test_only_params = [_]ParamType{
 };
 pub const test_params = test_only_params ++ runtime_params_ ++ transpiler_params_ ++ base_params_;
 
-fn loadGlobalBunfig(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: Command.Tag) !void {
+/// Catch-all params for commands without their own flag set.
+/// Matches the `else` branch of `Command.tagParams`.
+pub const default_params = base_params_ ++ runtime_params_ ++ transpiler_params_;
+
+/// Precomputed `ParamSet` tables so `parse` can pick the right clap params
+/// at runtime instead of monomorphizing the whole function per `Command.Tag`.
+const auto_param_set = clap.ParamSet.init(&auto_params);
+const run_param_set = clap.ParamSet.init(&run_params);
+const build_param_set = clap.ParamSet.init(&build_params);
+const test_param_set = clap.ParamSet.init(&test_params);
+const default_param_set = clap.ParamSet.init(&default_params);
+
+fn paramSetFor(cmd: Command.Tag) *const clap.ParamSet {
+    return switch (cmd) {
+        .AutoCommand => &auto_param_set,
+        .RunCommand, .RunAsNodeCommand, .BunxCommand => &run_param_set,
+        .BuildCommand => &build_param_set,
+        .TestCommand => &test_param_set,
+        else => &default_param_set,
+    };
+}
+
+fn loadGlobalBunfig(allocator: std.mem.Allocator, ctx: Command.Context, cmd: Command.Tag) !void {
     if (ctx.has_loaded_global_config) return;
 
     ctx.has_loaded_global_config = true;
 
     var config_buf: bun.PathBuffer = undefined;
     if (getHomeConfigPath(&config_buf)) |path| {
-        try loadBunfig(allocator, true, path, ctx, comptime cmd);
+        try loadBunfig(allocator, true, path, ctx, cmd);
     }
 }
 
-pub fn loadConfigPath(allocator: std.mem.Allocator, auto_loaded: bool, config_path: [:0]const u8, ctx: Command.Context, comptime cmd: Command.Tag) !void {
-    if (comptime cmd.readGlobalConfig()) {
+pub fn loadConfigPath(allocator: std.mem.Allocator, auto_loaded: bool, config_path: [:0]const u8, ctx: Command.Context, cmd: Command.Tag) !void {
+    if (cmd.readGlobalConfig()) {
         loadGlobalBunfig(allocator, ctx, cmd) catch |err| {
             if (auto_loaded) return;
 
@@ -282,7 +304,7 @@ pub fn loadConfigPath(allocator: std.mem.Allocator, auto_loaded: bool, config_pa
     try loadBunfig(allocator, auto_loaded, config_path, ctx, cmd);
 }
 
-fn loadBunfig(allocator: std.mem.Allocator, auto_loaded: bool, config_path: [:0]const u8, ctx: Command.Context, comptime cmd: Command.Tag) !void {
+fn loadBunfig(allocator: std.mem.Allocator, auto_loaded: bool, config_path: [:0]const u8, ctx: Command.Context, cmd: Command.Tag) !void {
     const source = switch (bun.sys.File.toSource(config_path, allocator, .{ .convert_bom = true })) {
         .result => |s| s,
         .err => |err| {
@@ -322,7 +344,7 @@ fn getHomeConfigPath(buf: *bun.PathBuffer) ?[:0]const u8 {
 
     return null;
 }
-pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx: Command.Context, comptime cmd: Command.Tag) OOM!void {
+pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx: Command.Context, cmd: Command.Tag) OOM!void {
     // If running as a standalone executable with autoloadBunfig disabled, skip config loading
     // unless an explicit config path was provided via --config
     if (user_config_path_ == null) {
@@ -334,12 +356,12 @@ pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx:
     }
 
     var config_buf: bun.PathBuffer = undefined;
-    if (comptime cmd.readGlobalConfig()) {
+    if (cmd.readGlobalConfig()) {
         if (!ctx.has_loaded_global_config) {
             ctx.has_loaded_global_config = true;
 
             if (getHomeConfigPath(&config_buf)) |path| {
-                loadConfigPath(allocator, true, path, ctx, comptime cmd) catch |err| {
+                loadConfigPath(allocator, true, path, ctx, cmd) catch |err| {
                     if (ctx.log.hasAny()) {
                         ctx.log.print(Output.errorWriter()) catch {};
                     }
@@ -393,7 +415,7 @@ pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx:
         config_path = config_buf[0..config_path_.len :0];
     }
 
-    loadConfigPath(allocator, auto_loaded, config_path, ctx, comptime cmd) catch |err| {
+    loadConfigPath(allocator, auto_loaded, config_path, ctx, cmd) catch |err| {
         if (ctx.log.hasAny()) {
             ctx.log.print(Output.errorWriter()) catch {};
         }
@@ -404,19 +426,19 @@ pub fn loadConfig(allocator: std.mem.Allocator, user_config_path_: ?string, ctx:
 }
 
 pub fn loadConfigWithCmdArgs(
-    comptime cmd: Command.Tag,
+    cmd: Command.Tag,
     allocator: std.mem.Allocator,
-    args: clap.Args(clap.Help, cmd.params()),
+    args: *const clap.RuntimeArgs,
     ctx: Command.Context,
 ) OOM!void {
-    return try loadConfig(allocator, args.option("--config"), ctx, comptime cmd);
+    return try loadConfig(allocator, args.option("--config"), ctx, cmd);
 }
 
-pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: Command.Tag) !Api.TransformOptions {
+pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, cmd: Command.Tag) !Api.TransformOptions {
     var diag = clap.Diagnostic{};
-    const params_to_parse = comptime cmd.params();
+    const param_set = paramSetFor(cmd);
 
-    var args = clap.parse(clap.Help, params_to_parse, .{
+    var args = clap.runtime.parse(param_set, .{
         .diagnostic = &diag,
         .allocator = allocator,
         .stop_after_positional_at = switch (cmd) {
@@ -695,8 +717,8 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     ctx.args.absolute_working_dir = cwd;
     ctx.positionals = args.positionals();
 
-    if (comptime Command.Tag.loads_config.get(cmd)) {
-        try loadConfigWithCmdArgs(cmd, allocator, args, ctx);
+    if (Command.Tag.loads_config.get(cmd)) {
+        try loadConfigWithCmdArgs(cmd, allocator, &args, ctx);
     }
 
     var opts: Api.TransformOptions = ctx.args;
@@ -715,10 +737,10 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
     // Node added a `--loader` flag (that's kinda like `--register`). It's
     // completely different from ours.
-    const loader_tuple = if (cmd != .RunAsNodeCommand)
+    const loader_tuple: LoaderColonList = if (cmd != .RunAsNodeCommand)
         try LoaderColonList.resolve(allocator, args.options("--loader"))
     else
-        .{ .keys = &[_]u8{}, .values = &[_]Api.Loader{} };
+        .{ .keys = &.{}, .values = &.{} };
 
     if (loader_tuple.keys.len > 0) {
         opts.loaders = .{
@@ -821,7 +843,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
         }
 
         if (args.option("--port")) |port_str| {
-            if (comptime cmd == .RunAsNodeCommand) {
+            if (cmd == .RunAsNodeCommand) {
                 // TODO: prevent `node --port <script>` from working
                 ctx.runtime_options.eval.script = port_str;
                 ctx.runtime_options.eval.eval_and_print = true;
@@ -1170,7 +1192,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
 
         const TargetMatcher = strings.ExactSizeMatcher(8);
         if (args.option("--target")) |_target| brk: {
-            if (comptime cmd == .BuildCommand) {
+            if (cmd == .BuildCommand) {
                 if (args.flag("--compile")) {
                     if (_target.len > 4 and strings.hasPrefixComptime(_target, "bun-")) {
                         ctx.bundler_options.compile_target = CLI.Cli.CompileTarget.from(_target[3..]);
@@ -1544,7 +1566,7 @@ pub fn parse(allocator: std.mem.Allocator, ctx: Command.Context, comptime cmd: C
     if (opts.entry_points.len == 0) {
         var entry_points = ctx.positionals;
 
-        switch (comptime cmd) {
+        switch (cmd) {
             .BuildCommand => {
                 if (entry_points.len > 0 and (strings.eqlComptime(
                     entry_points[0],

--- a/src/cli/bunfig.zig
+++ b/src/cli/bunfig.zig
@@ -177,7 +177,7 @@ pub const Bunfig = struct {
             }
         }
 
-        pub fn parse(this: *Parser, comptime cmd: Command.Tag) !void {
+        pub fn parse(this: *Parser, cmd: Command.Tag) !void {
             bun.analytics.Features.bunfig += 1;
 
             const json = this.json;
@@ -224,7 +224,7 @@ pub const Bunfig = struct {
                 try this.loadEnvConfig(env_expr);
             }
 
-            if (comptime cmd == .RunCommand or cmd == .AutoCommand) {
+            if (cmd == .RunCommand or cmd == .AutoCommand) {
                 if (json.get("serve")) |expr| {
                     if (expr.get("port")) |port| {
                         try this.expect(port, .e_number);
@@ -245,14 +245,14 @@ pub const Bunfig = struct {
                 }
             }
 
-            if (comptime cmd == .RunCommand or cmd == .AutoCommand) {
+            if (cmd == .RunCommand or cmd == .AutoCommand) {
                 if (json.get("smol")) |expr| {
                     try this.expect(expr, .e_boolean);
                     this.ctx.runtime_options.smol = expr.data.e_boolean.value;
                 }
             }
 
-            if (comptime cmd == .TestCommand) {
+            if (cmd == .TestCommand) {
                 if (json.get("test")) |test_| {
                     if (test_.get("root")) |root| {
                         this.ctx.debug.test_directory = root.asString(this.allocator) orelse "";
@@ -509,7 +509,7 @@ pub const Bunfig = struct {
                 }
             }
 
-            if (comptime cmd.isNPMRelated() or cmd == .RunCommand or cmd == .AutoCommand or cmd == .TestCommand) {
+            if (cmd.isNPMRelated() or cmd == .RunCommand or cmd == .AutoCommand or cmd == .TestCommand) {
                 if (json.getObject("install")) |install_obj| {
                     var install: *api.BunInstall = this.ctx.install orelse brk: {
                         const install = try this.allocator.create(api.BunInstall);
@@ -1021,14 +1021,14 @@ pub const Bunfig = struct {
             }
 
             if (json.get("bundle")) |_bun| {
-                if (comptime cmd == .BuildCommand or cmd == .RunCommand or cmd == .AutoCommand or cmd == .BuildCommand) {
+                if (cmd == .BuildCommand or cmd == .RunCommand or cmd == .AutoCommand) {
                     if (_bun.get("outdir")) |dir| {
                         try this.expectString(dir);
                         this.bunfig.output_dir = try dir.data.e_string.string(allocator);
                     }
                 }
 
-                if (comptime cmd == .BuildCommand) {
+                if (cmd == .BuildCommand) {
                     if (_bun.get("logLevel")) |expr2| {
                         try this.loadLogLevel(expr2);
                     }
@@ -1251,7 +1251,7 @@ pub const Bunfig = struct {
         }
     };
 
-    pub fn parse(allocator: std.mem.Allocator, source: *const logger.Source, ctx: Command.Context, comptime cmd: Command.Tag) !void {
+    pub fn parse(allocator: std.mem.Allocator, source: *const logger.Source, ctx: Command.Context, cmd: Command.Tag) !void {
         const log_count = ctx.log.errors + ctx.log.warnings;
 
         const expr = if (strings.eqlComptime(source.path.name.ext[1..], "toml")) TOML.parse(source, ctx.log, allocator, true) catch |err| {

--- a/src/cli/cli.zig
+++ b/src/cli/cli.zig
@@ -326,7 +326,7 @@ pub const Command = struct {
     /// `ContextData.create` body — kept here because it calls `Arguments.parse`
     /// and reaches into Windows watcher hooks. Aliased onto `ContextData` in
     /// `options_types/Context.zig`.
-    pub fn createContextData(allocator: std.mem.Allocator, log: *logger.Log, comptime command: Command.Tag) anyerror!Context {
+    pub fn createContextData(allocator: std.mem.Allocator, log: *logger.Log, command: Command.Tag) anyerror!Context {
         Cli.cmd = command;
         context_data = .{
             .args = std.mem.zeroes(api.TransformOptions),
@@ -336,7 +336,7 @@ pub const Command = struct {
         };
         global_cli_ctx = &context_data;
 
-        if (comptime Command.Tag.uses_global_options.get(command)) {
+        if (Command.Tag.uses_global_options.get(command)) {
             global_cli_ctx.args = try Arguments.parse(allocator, global_cli_ctx, command);
         }
 
@@ -856,18 +856,18 @@ pub const Command = struct {
 
     pub const Tag = @import("../options_types/CommandTag.zig").Tag;
 
-    pub fn tagParams(comptime cmd: Tag) []const Arguments.ParamType {
-        return comptime &switch (cmd) {
-            .AutoCommand => Arguments.auto_params,
-            .RunCommand, .RunAsNodeCommand => Arguments.run_params,
-            .BuildCommand => Arguments.build_params,
-            .TestCommand => Arguments.test_params,
-            .BunxCommand => Arguments.run_params,
-            else => Arguments.base_params_ ++ Arguments.runtime_params_ ++ Arguments.transpiler_params_,
+    pub fn tagParams(cmd: Tag) []const Arguments.ParamType {
+        return switch (cmd) {
+            .AutoCommand => &Arguments.auto_params,
+            .RunCommand, .RunAsNodeCommand => &Arguments.run_params,
+            .BuildCommand => &Arguments.build_params,
+            .TestCommand => &Arguments.test_params,
+            .BunxCommand => &Arguments.run_params,
+            else => &Arguments.default_params,
         };
     }
 
-    pub fn tagPrintHelp(comptime cmd: Tag, show_all_flags: bool) void {
+    pub fn tagPrintHelp(cmd: Tag, show_all_flags: bool) void {
         switch (cmd) {
 
             // the output of --help uses the following syntax highlighting
@@ -1039,7 +1039,7 @@ pub const Command = struct {
                 Output.flush();
             },
             Command.Tag.HelpCommand => {
-                HelpCommand.printWithReason(.explicit);
+                HelpCommand.printWithReason(.explicit, show_all_flags);
             },
             Command.Tag.UpgradeCommand => {
                 const intro_text =
@@ -1115,6 +1115,7 @@ pub const Command = struct {
                     .UpdateInteractiveCommand => .update,
                     .PublishCommand => .publish,
                     .AuditCommand => .audit,
+                    else => unreachable,
                 });
             },
             .InfoCommand => {

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -3,7 +3,7 @@
 // instead of a per-command `ComptimeClap` instantiation. Each command's
 // distinctive flag must still be recognized and wired to the same option.
 
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
@@ -40,11 +40,7 @@ describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [quietOut, quietErr, quietCode] = await Promise.all([
-      quiet.stdout.text(),
-      quiet.stderr.text(),
-      quiet.exited,
-    ]);
+    const [quietOut, quietErr, quietCode] = await Promise.all([quiet.stdout.text(), quiet.stderr.text(), quiet.exited]);
     expect(quietErr).not.toContain("$ echo loud");
     expect(quietOut).toContain("loud");
     expect(quietCode).toBe(0);
@@ -107,20 +103,17 @@ describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
     expect(runCode).toBe(0);
   });
 
-  describe.each([[], ["run"], ["build"], ["test"], ["upgrade"], ["exec"]])(
-    "`bun %s --help`",
-    (...sub: string[]) => {
-      test("renders", async () => {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), ...sub, "--help"],
-          env: { ...bunEnv, NO_COLOR: "1" },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect((stdout + stderr).length).toBeGreaterThan(40);
-        expect(code).toBe(0);
+  describe.each([[], ["run"], ["build"], ["test"], ["upgrade"], ["exec"]])("`bun %s --help`", (...sub: string[]) => {
+    test("renders", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...sub, "--help"],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
       });
-    },
-  );
+      const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect((stdout + stderr).length).toBeGreaterThan(40);
+      expect(code).toBe(0);
+    });
+  });
 });

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -15,8 +15,7 @@ describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("123\n");
     expect(code).toBe(0);
   });
@@ -32,8 +31,9 @@ describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [, loudErr] = await Promise.all([loud.stdout.text(), loud.stderr.text(), loud.exited]);
+    const [, loudErr, loudCode] = await Promise.all([loud.stdout.text(), loud.stderr.text(), loud.exited]);
     expect(loudErr).toContain("$ echo loud");
+    expect(loudCode).toBe(0);
 
     await using quiet = Bun.spawn({
       cmd: [bunExe(), "run", "--silent", "hello"],
@@ -56,8 +56,7 @@ describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
       cwd: String(dir),
       stderr: "pipe",
     });
-    const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // minify folds 1+1 → 2 and drops whitespace
     expect(stdout).not.toContain("1 + 1");
     expect(stdout).toContain("=2");

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -1,0 +1,126 @@
+// Exercises `Arguments.parse` with per-command flags now that the function
+// takes a runtime `Command.Tag` and dispatches through `clap.RuntimeArgs`
+// instead of a per-command `ComptimeClap` instantiation. Each command's
+// distinctive flag must still be recognized and wired to the same option.
+
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
+  test("--define reaches the transpiler for AutoCommand", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--define", "FOO:123", "-e", "console.log(FOO)"],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("123\n");
+    expect(code).toBe(0);
+  });
+
+  test("--silent reaches RunCommand and suppresses the command echo", async () => {
+    using dir = tempDir("args-run", {
+      "package.json": JSON.stringify({ name: "t", scripts: { hello: "echo loud" } }),
+    });
+    await using loud = Bun.spawn({
+      cmd: [bunExe(), "run", "hello"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, loudErr] = await Promise.all([loud.stdout.text(), loud.stderr.text(), loud.exited]);
+    expect(loudErr).toContain("$ echo loud");
+
+    await using quiet = Bun.spawn({
+      cmd: [bunExe(), "run", "--silent", "hello"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [quietOut, quietErr, quietCode] = await Promise.all([
+      quiet.stdout.text(),
+      quiet.stderr.text(),
+      quiet.exited,
+    ]);
+    expect(quietErr).not.toContain("$ echo loud");
+    expect(quietOut).toContain("loud");
+    expect(quietCode).toBe(0);
+  });
+
+  test("--minify --target are BuildCommand-only and still parse", async () => {
+    using dir = tempDir("args-build", { "in.ts": `export const x = 1 + 1;\n` });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--minify", "--target=node", String(dir) + "/in.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // minify folds 1+1 → 2 and drops whitespace
+    expect(stdout).not.toContain("1 + 1");
+    expect(stdout).toContain("=2");
+    expect(code).toBe(0);
+  });
+
+  test("--bail is TestCommand-only and still parses", async () => {
+    using dir = tempDir("args-test", {
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        test("first", () => { expect(1).toBe(2); });
+        test("second", () => { expect(1).toBe(1); });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--bail=1", "a.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, code] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // bail=1 stops after first failure, so "second" never runs
+    expect(stderr).toContain("Bailed out after 1 failure");
+    expect(stderr).not.toContain("second");
+    expect(code).not.toBe(0);
+  });
+
+  test("bunfig [run] section loads for RunCommand", async () => {
+    using dir = tempDir("args-bunfig", {
+      "bunfig.toml": `[run]\nsilent = true\n`,
+      "package.json": JSON.stringify({ name: "t", scripts: { hello: "echo ran" } }),
+    });
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "run", "hello"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    // [run].silent suppresses the "$ echo ran" line
+    expect(runErr).not.toContain("$ echo ran");
+    expect(runOut).toContain("ran");
+    expect(runCode).toBe(0);
+  });
+
+  describe.each([[], ["run"], ["build"], ["test"], ["upgrade"], ["exec"]])(
+    "`bun %s --help`",
+    (...sub: string[]) => {
+      test("renders", async () => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), ...sub, "--help"],
+          env: { ...bunEnv, NO_COLOR: "1" },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect((stdout + stderr).length).toBeGreaterThan(40);
+        expect(code).toBe(0);
+      });
+    },
+  );
+});

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -8,9 +8,11 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
   test("--define reaches the transpiler for AutoCommand", async () => {
+    using dir = tempDir("args-auto", {});
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--define", "FOO:123", "-e", "console.log(FOO)"],
       env: bunEnv,
+      cwd: String(dir),
       stderr: "pipe",
     });
     const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -4,7 +4,34 @@
 // distinctive flag must still be recognized and wired to the same option.
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// The point of the refactor is that `Arguments.parse` / `Bunfig.Parser.parse`
+// are no longer monomorphized per `Command.Tag`. On a build with the old
+// `comptime cmd` parameter the symbol table carries one
+// `cli.Arguments.parse__anon_*` per reachable command (≈9); after the change
+// there is exactly one. This test reads `nm` output for the binary under
+// test and asserts that count. It necessarily skips on Windows (no `nm`) and
+// on stripped release binaries (no Zig symbols to read).
+describe("Arguments.parse is not monomorphized per Command.Tag", () => {
+  const nm = Bun.spawnSync({ cmd: ["nm", bunExe()], stdout: "pipe", stderr: "pipe" });
+  const symbols = nm.exitCode === 0 ? nm.stdout.toString() : "";
+  const argumentsParse = symbols.match(/ cli\.Arguments\.parse__/g) ?? [];
+  // Zero matches means either `nm` is unavailable or the binary is stripped
+  // (release). In that case there is nothing we can assert here.
+  const canInspect = !isWindows && argumentsParse.length > 0;
+
+  test.skipIf(!canInspect)("exactly one instantiation each", () => {
+    const counts = {
+      "cli.Arguments.parse": argumentsParse.length,
+      "cli.bunfig.Bunfig.Parser.parse": (symbols.match(/ cli\.bunfig\.Bunfig\.Parser\.parse__/g) ?? []).length,
+    };
+    expect(counts).toEqual({
+      "cli.Arguments.parse": 1,
+      "cli.bunfig.Bunfig.Parser.parse": 1,
+    });
+  });
+});
 
 describe.concurrent("Arguments.parse runtime cmd dispatch", () => {
   test("--define reaches the transpiler for AutoCommand", async () => {

--- a/test/cli/run/arguments-parse.test.ts
+++ b/test/cli/run/arguments-parse.test.ts
@@ -14,12 +14,20 @@ import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 // test and asserts that count. It necessarily skips on Windows (no `nm`) and
 // on stripped release binaries (no Zig symbols to read).
 describe("Arguments.parse is not monomorphized per Command.Tag", () => {
-  const nm = Bun.spawnSync({ cmd: ["nm", bunExe()], stdout: "pipe", stderr: "pipe" });
-  const symbols = nm.exitCode === 0 ? nm.stdout.toString() : "";
+  // Bun.spawnSync *throws* ENOENT when the executable isn't in $PATH (unlike
+  // Node's spawnSync which returns { error }), so gate and catch so a
+  // missing `nm` degrades to a skip instead of failing the describe body.
+  let symbols = "";
+  if (!isWindows) {
+    try {
+      const nm = Bun.spawnSync({ cmd: ["nm", bunExe()], stdout: "pipe", stderr: "pipe" });
+      if (nm.exitCode === 0) symbols = nm.stdout.toString();
+    } catch {}
+  }
   const argumentsParse = symbols.match(/ cli\.Arguments\.parse__/g) ?? [];
   // Zero matches means either `nm` is unavailable or the binary is stripped
   // (release). In that case there is nothing we can assert here.
-  const canInspect = !isWindows && argumentsParse.length > 0;
+  const canInspect = argumentsParse.length > 0;
 
   test.skipIf(!canInspect)("exactly one instantiation each", () => {
     const counts = {


### PR DESCRIPTION
### What

`Arguments.parse` (`src/cli/Arguments.zig`) and `Bunfig.Parser.parse` (`src/cli/bunfig.zig`) were both generic over `comptime cmd: Command.Tag`. The `cmd` value only gates a handful of `if (cmd == .X)` blocks; the rest of the body is identical. With the `loadConfig*` chain and `createContextData` also threading `comptime cmd` through, this monomorphized the whole CLI-startup parse path once per reachable command tag.

### How

- New `clap.RuntimeArgs` (`src/clap/runtime.zig`): same parse loop as `ComptimeClap`, but storage is runtime-sized and `flag()`/`option()`/`options()` do a linear name scan instead of a comptime index. Missing flags return `false` / `null` / `&.{}` since per-command flags are already guarded by `if (cmd == .X)`.
- `clap.ParamSet` precomputes the `converted_params` table for each distinct params list at comptime; `Arguments.parse` picks one at runtime via `paramSetFor(cmd)`.
- `Bunfig.Parser.parse`, `Bunfig.parse`, `loadConfig`, `loadConfigPath`, `loadBunfig`, `loadGlobalBunfig`, `loadConfigWithCmdArgs`, `createContextData`, `tagParams`, and `tagPrintHelp` now all take runtime `cmd`.
- Making `tagPrintHelp` a runtime switch surfaced a latent `HelpCommand.printWithReason(.explicit)` call that was missing its second argument (hidden by comptime lazy eval because no caller ever passed `.HelpCommand`).
- Fixed the `LoaderColonList` else-branch literal that had the wrong field types (also previously hidden by comptime branch elimination).

### Result

Stripped linux-x64 release binary:

```
baseline: 91,892,680 bytes
patched:  91,728,840 bytes
delta:    -163,840 bytes (-160.0 KB)
```

`--help` output for `bun`, `bun run`, `bun build`, `bun test`, `bun install` is byte-identical to baseline.

### Verification

- `bun bd test test/cli/run/arguments-parse.test.ts` — per-command flag parsing + bunfig dispatch + `--help` rendering across commands
- `bun bd test test/cli/bun.test.ts test/cli/bunfig-test-options.test.ts test/cli/console-depth.test.ts`
- `bun run zig:check-all`