### PR TITLE
fix(inspect): handle circular refs and non-object props in JSX formatter

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }
@@ -3140,13 +3140,11 @@ pub const Formatter = struct {
                     }
                 }
 
-                if (try value.get(this.globalThis, "props")) |props| {
+                if (try value.get(this.globalThis, "props")) |props| if (props.getObject()) |props_obj| {
                     const prev_quote_strings = this.quote_strings;
                     defer this.quote_strings = prev_quote_strings;
                     this.quote_strings = true;
 
-                    // SAFETY: JSX props are always objects
-                    const props_obj = props.getObject().?;
                     var props_iter = try jsc.JSPropertyIterator(.{
                         .skip_empty_name = true,
                         .include_value = true,
@@ -3303,7 +3301,7 @@ pub const Formatter = struct {
                             }
                         }
                     }
-                }
+                };
 
                 writer.writeAll(" />");
             },

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,29 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular props", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null };
+  el.props = el;
+  expect(Bun.inspect(el)).toContain("[Circular]");
+});
+
+it("jsx with circular prop value", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props.foo = el;
+  expect(Bun.inspect(el)).toBe("<div foo=[Circular] />");
+});
+
+it("jsx with circular children", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: {} };
+  el.props.children = el;
+  expect(Bun.inspect(el)).toBe("<div>\n  [Circular]\n</div>");
+});
+
+it("jsx with non-object props", () => {
+  const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: 42 };
+  expect(Bun.inspect(el)).toBe("<div />");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

`Bun.inspect()` / `console.log()` crashed with a stack overflow when formatting a React element whose `props` (or a prop value, or `children`) referenced the element itself:

```js
const el = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null };
el.props = el;
Bun.inspect(el); // segfault (stack overflow)
```

The `.JSX` tag was missing from `canHaveCircularReferences()`, so the visited-map check and the `StackCheck` guard that protect other recursive formatters (`.Object`, `.Array`, `.Map`, …) never ran for JSX elements, allowing unbounded recursion into `props`/`children`.

Also removes the `props.getObject().?` force-unwrap — since `$$typeof` detection works on any object, `props` is user-controlled and can be a primitive, which previously panicked with "attempt to use null value".

Now prints `[Circular]` like other circular structures:

```
<div foo=[Circular] />
```

Found by Fuzzilli. Fingerprint: `ae1fb4ec8882b8cf`

## How did you verify your code works?

Added tests in `test/js/bun/util/inspect.test.js` covering circular `props`, circular prop values, circular `children`, and non-object `props`. All 76 inspect tests pass with `bun bd test`; the new tests crash the system bun.