### PR TITLE
release: mirror Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,12 +206,13 @@ jobs:
           push-to-fork: oven-sh/DefinitelyTyped
           branch: ${{env.BUN_VERSION}}
   docker:
-    name: Release to Dockerhub
+    name: Release to Dockerhub and GHCR
     runs-on: ubuntu-latest
     needs: sign
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.use-docker == 'true' }}
     permissions:
       contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -241,7 +242,9 @@ jobs:
         name: Setup Docker metadata
         uses: docker/metadata-action@v5
         with:
-          images: oven/bun
+          images: |
+            oven/bun
+            ghcr.io/${{ github.repository_owner }}/bun
           flavor: |
             latest=false
           tags: |
@@ -255,7 +258,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push to Docker
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to Docker and GHCR
         uses: docker/build-push-action@v6
         with:
           context: ./dockerhub/${{ matrix.dir || matrix.variant }}


### PR DESCRIPTION
Closes #30365.
Closes #25654.

## What

The release workflow's `docker` job now publishes each image variant to **GitHub Container Registry** (`ghcr.io/oven-sh/bun`) in addition to Docker Hub (`oven/bun`).

## Why

Docker Hub's anonymous pull rate limits are aggressive enough that CI systems and shared environments hit them regularly. GHCR is free, built-in to GitHub, and has no equivalent pull limit for public images — a ready-made mirror that lets users swap `FROM oven/bun` for `FROM ghcr.io/oven-sh/bun` when they need one.

## How

`docker/metadata-action` accepts multiple images and expands every generated tag across all of them, and `docker/build-push-action` pushes the combined tag list in a single step. That means the same build and the same tag scheme (`latest`, `debian`, `alpine`, `1.x.y`, `1.x.y-slim`, etc.) land in both registries with one extra login step:

```yaml
images: |
  oven/bun
  ghcr.io/${{ github.repository_owner }}/bun
```

Plus `packages: write` on the job and a `ghcr.io` login using `GITHUB_TOKEN` — no new secrets required.

The `docker/metadata-action` auto-emits `org.opencontainers.image.source=https://github.com/oven-sh/bun`, which GHCR uses to link the package back to this repo.

## One-time maintainer step after first release

GHCR creates new packages as **private** by default, even when linked to a public repo. The auto-minted `GITHUB_TOKEN` doesn't have scope to flip that (`PATCH /orgs/{org}/packages/container/{name}` requires `admin:org`), so the package has to be made public once by a maintainer:

- **Easier**: at https://github.com/organizations/oven-sh/settings/packages, set the default visibility for new packages to Public before the first release run.
- **Or**: after the first release publishes `ghcr.io/oven-sh/bun`, open the package page → Package settings → Change visibility → Public.

Either way is a one-time click per package. After that, every subsequent release push from this workflow stays public automatically.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` passes.
- The `docker` job is gated behind release / cron / `workflow_dispatch` with `use-docker: true`, so it won't run on this PR. It exercises end-to-end on the next scheduled release.