### PR TITLE
bake: validate bundlerOptions values are objects in Bun.serve app config

### DIFF
--- a/src/bake/bake.zig
+++ b/src/bake/bake.zig
@@ -68,14 +68,17 @@ pub const UserOptions = struct {
         }
 
         if (try config.getOptional(global, "bundlerOptions", JSValue)) |js_options| {
+            if (!js_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions' must be an object", .{});
+            }
             if (try js_options.getOptional(global, "server", JSValue)) |server_options| {
-                bundler_options.server = try BuildConfigSubset.fromJS(global, server_options);
+                bundler_options.server = try BuildConfigSubset.fromJS(global, "server", server_options);
             }
             if (try js_options.getOptional(global, "client", JSValue)) |client_options| {
-                bundler_options.client = try BuildConfigSubset.fromJS(global, client_options);
+                bundler_options.client = try BuildConfigSubset.fromJS(global, "client", client_options);
             }
             if (try js_options.getOptional(global, "ssr", JSValue)) |ssr_options| {
-                bundler_options.ssr = try BuildConfigSubset.fromJS(global, ssr_options);
+                bundler_options.ssr = try BuildConfigSubset.fromJS(global, "ssr", ssr_options);
             }
         }
 
@@ -202,8 +205,12 @@ const BuildConfigSubset = struct {
     minify_identifiers: ?bool = null,
     minify_whitespace: ?bool = null,
 
-    pub fn fromJS(global: *jsc.JSGlobalObject, js_options: JSValue) bun.JSError!BuildConfigSubset {
+    pub fn fromJS(global: *jsc.JSGlobalObject, comptime name: []const u8, js_options: JSValue) bun.JSError!BuildConfigSubset {
         var options = BuildConfigSubset{};
+
+        if (!js_options.isObject()) {
+            return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ "' must be an object", .{});
+        }
 
         if (try js_options.getOptional(global, "sourcemap", JSValue)) |val| brk: {
             if (try bun.schema.api.SourceMapMode.fromJS(global, val)) |sourcemap| {
@@ -215,11 +222,16 @@ const BuildConfigSubset = struct {
         }
 
         if (try js_options.getOptional(global, "minify", JSValue)) |minify_options| brk: {
-            if (minify_options.isBoolean() and minify_options.asBoolean()) {
-                options.minify_syntax = minify_options.asBoolean();
-                options.minify_identifiers = minify_options.asBoolean();
-                options.minify_whitespace = minify_options.asBoolean();
+            if (minify_options.isBoolean()) {
+                const value = minify_options.asBoolean();
+                options.minify_syntax = value;
+                options.minify_identifiers = value;
+                options.minify_whitespace = value;
                 break :brk;
+            }
+
+            if (!minify_options.isObject()) {
+                return global.throwInvalidArguments("'" ++ api_name ++ ".bundlerOptions." ++ name ++ ".minify' must be a boolean or an object", .{});
             }
 
             if (try minify_options.getBooleanLoose(global, "whitespace")) |value| {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -670,3 +670,26 @@ describe("Bun.serve unix socket validation", () => {
     }
   });
 });
+
+describe("app.bundlerOptions validation", () => {
+  test("non-object bundlerOptions should throw", () => {
+    expect(() => {
+      // @ts-expect-error - Testing invalid input
+      serve({ port: 0, app: { bundlerOptions: 10n } });
+    }).toThrow("'app.bundlerOptions' must be an object");
+  });
+
+  test.each(["server", "client", "ssr"])("non-object bundlerOptions.%s should throw", key => {
+    expect(() => {
+      // @ts-expect-error - Testing invalid input
+      serve({ port: 0, app: { bundlerOptions: { [key]: 10n } } });
+    }).toThrow(`'app.bundlerOptions.${key}' must be an object`);
+  });
+
+  test("non-object non-boolean bundlerOptions.client.minify should throw", () => {
+    expect(() => {
+      // @ts-expect-error - Testing invalid input
+      serve({ port: 0, app: { bundlerOptions: { client: { minify: 10n } } } });
+    }).toThrow("'app.bundlerOptions.client.minify' must be a boolean or an object");
+  });
+});


### PR DESCRIPTION
Fuzzilli found a debug assertion crash (`f58e213c79f019d0`) when passing non-object values into `app.bundlerOptions` in `Bun.serve`.

```js
Bun.serve({
  app: {
    bundlerOptions: {
      client: 10n
    }
  }
});
```

```
panic(main thread): reached unreachable code
bun.debugAssert
jsc.JSValue.JSValue.get (JSValue.zig:1534)
jsc.JSValue.JSValue.getOptional
bake.bake.BuildConfigSubset.fromJS (bake.zig:208)
bake.bake.UserOptions.fromJS (bake.zig:75)
runtime.server.ServerConfig.fromJS
runtime.api.BunObject.serve
```

`JSValue.get` asserts its target is an object, but `bundlerOptions`, its `server`/`client`/`ssr` sub-options, and the `minify` option were never validated before property access. This also fixes `minify: false` which would have fallen through the `isBoolean() and asBoolean()` check into property access on a boolean.

Now throws `TypeError: 'app.bundlerOptions.client' must be an object` etc.