### PR TITLE
docs: remove duplicate Runtime & Debugging sidebar group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -536,23 +536,6 @@
             ]
           },
           {
-            "group": "Utilities",
-            "icon": "wrench",
-            "pages": [
-              "/guides/util/hash-a-password",
-              "/guides/util/javascript-uuid",
-              "/guides/util/base64",
-              "/guides/util/gzip",
-              "/guides/util/deflate",
-              "/guides/util/escape-html",
-              "/guides/util/deep-equals",
-              "/guides/util/sleep",
-              "/guides/util/file-url-to-path",
-              "/guides/util/path-to-file-url",
-              "/guides/util/which-path-to-executable-bin"
-            ]
-          },
-          {
             "group": "HTML Processing",
             "icon": "file-code",
             "pages": ["/guides/html-rewriter/extract-links", "/guides/html-rewriter/extract-social-meta"]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -493,19 +493,6 @@
             ]
           },
           {
-            "group": "Runtime & Debugging",
-            "icon": "bug",
-            "pages": [
-              "/guides/runtime/vscode-debugger",
-              "/guides/runtime/web-debugger",
-              "/guides/runtime/heap-snapshot",
-              "/guides/runtime/build-time-constants",
-              "/guides/runtime/define-constant",
-              "/guides/runtime/cicd",
-              "/guides/runtime/codesign-macos-executable"
-            ]
-          },
-          {
             "group": "Module System",
             "icon": "box",
             "pages": [


### PR DESCRIPTION
Fixes #30374
Fixes #25369

## Repro
Open any Guides page, e.g. https://bun.com/docs/guides/runtime/codesign-macos-executable — the left sidebar shows **Runtime & Debugging** twice (once under *Deployment*, once under *Test Runner*) and **Utilities** twice (once under *Runtime & Debugging*, once under *File System*).

## Cause
`docs/docs.json` ("Guides" tab) defined two groups for each title:

- **Runtime & Debugging** — first occurrence at line 326 (9 pages), second at line 495 (7 pages, strict subset of the first).
- **Utilities** — first occurrence at line 341 (19 pages), second at line 552 (11 pages, strict subset of the first).

Both were introduced accidentally in #24201 (docs-repo migration). Mintlify renders both, so users see the same links twice in each case.

## Fix
Remove the second occurrence of each duplicated group. Every page they listed remains reachable via the first (superset) group, so no sidebar entries are lost — the Guides sidebar just stops listing them twice.

## Verification
- `python3 -c "import json; json.load(open('docs/docs.json'))"` → valid JSON
- `grep -c '"Runtime & Debugging"' docs/docs.json` → 1 (was 2)
- Guides-tab `"group": "Utilities"` count → 1 (was 2); the unrelated `Utilities` group in the Runtime tab (line 154) is untouched.
- `git diff` is 30 deleted lines across two adjacent blocks, no other changes.
