### PR TITLE
http: arm idle timer on open so a stalled TLS handshake times out

### DIFF
--- a/src/bun_core/env_var.zig
+++ b/src/bun_core/env_var.zig
@@ -37,6 +37,11 @@ pub const BUN_CONFIG_DISABLE_ioctl_ficlonerange = New(kind.boolean, "BUN_CONFIG_
 ///
 /// It's unclear why this was done.
 pub const BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS = New(kind.unsigned, "BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS", .{ .default = 30 });
+/// Idle timeout for HTTP client sockets (fetch / `bun install`), in seconds.
+/// The timer is armed when the socket opens and re-armed on every read/write;
+/// if it fires the request fails with `error.Timeout`. Covers the TLS
+/// handshake through the response body. 0 disables. See `src/http/http.zig`.
+pub const BUN_CONFIG_HTTP_IDLE_TIMEOUT = New(kind.unsigned, "BUN_CONFIG_HTTP_IDLE_TIMEOUT", .{ .default = 300 });
 pub const BUN_CRASH_REPORT_URL = New(kind.string, "BUN_CRASH_REPORT_URL", .{});
 pub const BUN_DEBUG = New(kind.string, "BUN_DEBUG", .{});
 pub const BUN_DEBUG_ALL = New(kind.boolean, "BUN_DEBUG_ALL", .{});

--- a/src/http/HTTPContext.zig
+++ b/src/http/HTTPContext.zig
@@ -564,6 +564,15 @@ pub fn NewHTTPContext(comptime ssl: bool) type {
 
                 terminateSocket(socket);
             }
+            /// Short-tick (seconds-granularity) idle timer. Same handling as
+            /// `onLongTimeout`; `HTTPClient.setTimeout` routes to whichever
+            /// timer suits the configured duration, so both must dispatch.
+            pub fn onTimeout(
+                ptr: *anyopaque,
+                socket: HTTPSocket,
+            ) void {
+                onLongTimeout(ptr, socket);
+            }
             pub fn onConnectError(
                 ptr: *anyopaque,
                 socket: HTTPSocket,

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -225,11 +225,10 @@ pub fn onStart(opts: InitOpts) void {
     bun.http.default_arena = Arena.init();
     bun.http.default_allocator = bun.http.default_arena.allocator();
 
-    if (bun.getenvZ("BUN_CONFIG_HTTP_IDLE_TIMEOUT")) |raw| {
-        if (std.fmt.parseInt(c_uint, raw, 10)) |secs| {
-            bun.http.idle_timeout_seconds = secs;
-        } else |_| {}
-    }
+    bun.http.idle_timeout_seconds = @intCast(@min(
+        bun.env_var.BUN_CONFIG_HTTP_IDLE_TIMEOUT.get(),
+        std.math.maxInt(c_uint),
+    ));
 
     const loop = bun.jsc.MiniEventLoop.initGlobal(null, null);
 

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -225,6 +225,12 @@ pub fn onStart(opts: InitOpts) void {
     bun.http.default_arena = Arena.init();
     bun.http.default_allocator = bun.http.default_arena.allocator();
 
+    if (bun.getenvZ("BUN_CONFIG_HTTP_IDLE_TIMEOUT")) |raw| {
+        if (std.fmt.parseInt(c_uint, raw, 10)) |secs| {
+            bun.http.idle_timeout_seconds = secs;
+        } else |_| {}
+    }
+
     const loop = bun.jsc.MiniEventLoop.initGlobal(null, null);
 
     if (Environment.isWindows) {

--- a/src/http/HTTPThread.zig
+++ b/src/http/HTTPThread.zig
@@ -225,10 +225,17 @@ pub fn onStart(opts: InitOpts) void {
     bun.http.default_arena = Arena.init();
     bun.http.default_allocator = bun.http.default_arena.allocator();
 
-    bun.http.idle_timeout_seconds = @intCast(@min(
-        bun.env_var.BUN_CONFIG_HTTP_IDLE_TIMEOUT.get(),
-        std.math.maxInt(c_uint),
-    ));
+    // uSockets' long-timeout counter is `% 240` minutes (see
+    // `us_socket_long_timeout` in packages/bun-usockets/src/socket.c), so
+    // values above 239 min wrap around and fire early. Clamp here — it's the
+    // only assignment — so the underlying timer can't wrap, and round values
+    // above 240s up to a whole minute so `socket.setTimeout`'s floor-to-
+    // minute long-timer path never yields a timeout *shorter* than requested.
+    // Normalising once here keeps the h1 (`HTTPClient.setTimeout`) and h2
+    // (`ClientSession.rearmTimeout`) paths identical without duplicating the
+    // math at each call site.
+    const raw: u64 = @min(bun.env_var.BUN_CONFIG_HTTP_IDLE_TIMEOUT.get(), 239 * 60);
+    bun.http.idle_timeout_seconds = @intCast(if (raw > 240) ((raw + 59) / 60) * 60 else raw);
 
     const loop = bun.jsc.MiniEventLoop.initGlobal(null, null);
 

--- a/src/http/h2_client/ClientSession.zig
+++ b/src/http/h2_client/ClientSession.zig
@@ -330,8 +330,7 @@ fn rearmTimeout(this: *ClientSession) void {
         }
         break :blk false;
     };
-    this.socket.timeout(0);
-    this.socket.setTimeoutMinutes(if (want) 5 else 0);
+    this.socket.setTimeout(if (want) HTTPClient.idle_timeout_seconds else 0);
 }
 
 /// HTTP-thread wake-up from `scheduleResponseBodyDrain`: JS just enabled

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -2215,16 +2215,17 @@ pub fn cloneMetadata(this: *HTTPClient) void {
 
 pub fn setTimeout(this: *HTTPClient, socket: anytype) void {
     // Duration comes from `idle_timeout_seconds` (tunable via
-    // `BUN_CONFIG_HTTP_IDLE_TIMEOUT`, set low in tests). `socket.setTimeout`
-    // picks the short-tick timer for values ≤ 240s and the minute-granularity
-    // long timer above that (rounded up), so the default — 300s → 5-minute
-    // long timer — matches the previous hard-coded behaviour exactly.
+    // `BUN_CONFIG_HTTP_IDLE_TIMEOUT`, set low in tests) and is normalised once
+    // in `HTTPThread.onStart` — clamped to the uSockets long-timer bound and
+    // rounded up to a whole minute above 240s — so this is a plain
+    // pass-through. `socket.setTimeout` picks the short-tick timer for values
+    // ≤ 240s and the minute-granularity long timer above that, so the default
+    // 300s maps to the same 5-minute long timer as before.
     if (this.flags.disable_timeout or idle_timeout_seconds == 0) {
         socket.setTimeout(0);
         return;
     }
-    const secs = idle_timeout_seconds;
-    socket.setTimeout(if (secs > 240) ((secs + 59) / 60) * 60 else secs);
+    socket.setTimeout(idle_timeout_seconds);
 }
 
 pub fn drainResponseBody(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -29,7 +29,9 @@ comptime {
 /// `error.Timeout`. 0 disables the timer (matching `disable_timeout = true`).
 /// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes — the
 /// previous hard-coded value — so unchanged environments see identical
-/// behaviour except that the handshake phase is now also covered.
+/// behaviour except that the handshake phase is now also covered. Values
+/// above 240s are served by uSockets' minute-granularity long timer (see
+/// `socket.setTimeout`), so they round up to the next whole minute.
 pub var idle_timeout_seconds: c_uint = 300;
 
 pub var overridden_default_user_agent: []const u8 = "";
@@ -191,7 +193,7 @@ pub fn onOpen(
     // blocked in epoll_wait forever. Previously the first `setTimeout` call
     // was inside `onWritable`, which only runs *after* the handshake
     // completes. See https://github.com/oven-sh/bun/issues/30325.
-    client.setTimeout(socket, 5);
+    client.setTimeout(socket);
 
     if (client.signals.get(.aborted)) {
         client.closeAndAbort(comptime is_ssl, socket);
@@ -1622,7 +1624,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
     switch (this.state.request_stage) {
         .pending, .headers, .opened => {
             log("sendInitialRequestPayload", .{});
-            this.setTimeout(socket, 5);
+            this.setTimeout(socket);
             const result = sendInitialRequestPayload(this, is_first_call, is_ssl, socket) catch |err| {
                 this.closeAndFail(err, is_ssl, socket);
                 return;
@@ -1670,7 +1672,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
         },
         .body => {
             log("send body", .{});
-            this.setTimeout(socket, 5);
+            this.setTimeout(socket);
 
             switch (this.state.original_request_body) {
                 .bytes => {
@@ -1720,7 +1722,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
             if (this.proxy_tunnel) |proxy| {
                 switch (this.state.original_request_body) {
                     .bytes => {
-                        this.setTimeout(socket, 5);
+                        this.setTimeout(socket);
 
                         const to_send = this.state.request_body;
                         const sent = proxy.write(to_send) catch return; // just wait and retry when onWritable! if closed internally will call proxy.onClose
@@ -1745,7 +1747,7 @@ pub fn onWritable(this: *HTTPClient, comptime is_first_call: bool, comptime is_s
         .proxy_headers => {
             log("send proxy headers", .{});
             if (this.proxy_tunnel) |proxy| {
-                this.setTimeout(socket, 5);
+                this.setTimeout(socket);
                 var stack_buffer = std.heap.stackFallback(1024 * 16, bun.default_allocator);
                 const allocator = stack_buffer.get();
                 var temporary_send_buffer = std.array_list.Managed(u8).fromOwnedSlice(allocator, &stack_buffer.buffer);
@@ -1852,7 +1854,7 @@ inline fn handleShortRead(
         }
     }
 
-    this.setTimeout(socket, 5);
+    this.setTimeout(socket);
 }
 
 pub fn handleOnDataHeaders(
@@ -2002,7 +2004,7 @@ pub fn handleOnDataHeaders(
             }
         }
     } else if (this.state.response_stage == .body_chunk) {
-        this.setTimeout(socket, 5);
+        this.setTimeout(socket);
         {
             const report_progress = this.handleResponseBodyChunkedEncoding(to_read) catch |err| {
                 this.closeAndFail(err, is_ssl, socket);
@@ -2037,7 +2039,7 @@ pub fn onData(
 
     if (this.proxy_tunnel) |proxy| {
         // if we have a tunnel we dont care about the other stages, we will just tunnel the data
-        this.setTimeout(socket, 5);
+        this.setTimeout(socket);
         proxy.receive(incoming_data);
         return;
     }
@@ -2047,7 +2049,7 @@ pub fn onData(
             this.handleOnDataHeaders(is_ssl, incoming_data, ctx, socket);
         },
         .body => {
-            this.setTimeout(socket, 5);
+            this.setTimeout(socket);
 
             const report_progress = this.handleResponseBody(incoming_data, false) catch |err| {
                 this.closeAndFail(err, is_ssl, socket);
@@ -2061,7 +2063,7 @@ pub fn onData(
         },
 
         .body_chunk => {
-            this.setTimeout(socket, 5);
+            this.setTimeout(socket);
 
             const report_progress = this.handleResponseBodyChunkedEncoding(incoming_data) catch |err| {
                 this.closeAndFail(err, is_ssl, socket);
@@ -2211,19 +2213,18 @@ pub fn cloneMetadata(this: *HTTPClient) void {
     }
 }
 
-pub fn setTimeout(this: *HTTPClient, socket: anytype, _: c_uint) void {
-    // The `minutes` parameter is retained for call-site compatibility but is
-    // no longer used; every caller passed the same hard-coded `5`. The actual
-    // duration now comes from `idle_timeout_seconds` so it can be tuned via
-    // `BUN_CONFIG_HTTP_IDLE_TIMEOUT` (and set low in tests). `socket.setTimeout`
+pub fn setTimeout(this: *HTTPClient, socket: anytype) void {
+    // Duration comes from `idle_timeout_seconds` (tunable via
+    // `BUN_CONFIG_HTTP_IDLE_TIMEOUT`, set low in tests). `socket.setTimeout`
     // picks the short-tick timer for values ≤ 240s and the minute-granularity
-    // long timer above that, so the default (300s → 5 min long timer) is
-    // exactly the previous behaviour.
+    // long timer above that (rounded up), so the default — 300s → 5-minute
+    // long timer — matches the previous hard-coded behaviour exactly.
     if (this.flags.disable_timeout or idle_timeout_seconds == 0) {
         socket.setTimeout(0);
         return;
     }
-    socket.setTimeout(idle_timeout_seconds);
+    const secs = idle_timeout_seconds;
+    socket.setTimeout(if (secs > 240) ((secs + 59) / 60) * 60 else secs);
 }
 
 pub fn drainResponseBody(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {

--- a/src/http/http.zig
+++ b/src/http/http.zig
@@ -23,6 +23,15 @@ comptime {
     @export(&max_http_header_size, .{ .name = "BUN_DEFAULT_MAX_HTTP_HEADER_SIZE" });
 }
 
+/// Idle timeout for HTTP client sockets, in seconds. The timer is armed in
+/// `onOpen` (so it covers the TLS handshake) and re-armed on every read/write;
+/// if no bytes move in either direction for this long the request fails with
+/// `error.Timeout`. 0 disables the timer (matching `disable_timeout = true`).
+/// Overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`. Default is 5 minutes — the
+/// previous hard-coded value — so unchanged environments see identical
+/// behaviour except that the handshake phase is now also covered.
+pub var idle_timeout_seconds: c_uint = 300;
+
 pub var overridden_default_user_agent: []const u8 = "";
 
 const print_every = 0;
@@ -174,6 +183,15 @@ pub fn onOpen(
     }
     client.registerAbortTracker(is_ssl, socket);
     log("Connected {s} \n", .{client.url.href});
+
+    // Arm the idle timer immediately so a stalled TLS handshake (server
+    // accepts TCP but never answers ClientHello, or a NAT/middlebox silently
+    // drops the flow under load) eventually fails with error.Timeout instead
+    // of leaving the request — and for `bun install`, the whole process —
+    // blocked in epoll_wait forever. Previously the first `setTimeout` call
+    // was inside `onWritable`, which only runs *after* the handshake
+    // completes. See https://github.com/oven-sh/bun/issues/30325.
+    client.setTimeout(socket, 5);
 
     if (client.signals.get(.aborted)) {
         client.closeAndAbort(comptime is_ssl, socket);
@@ -2193,15 +2211,19 @@ pub fn cloneMetadata(this: *HTTPClient) void {
     }
 }
 
-pub fn setTimeout(this: *HTTPClient, socket: anytype, minutes: c_uint) void {
-    if (this.flags.disable_timeout) {
-        socket.timeout(0);
-        socket.setTimeoutMinutes(0);
+pub fn setTimeout(this: *HTTPClient, socket: anytype, _: c_uint) void {
+    // The `minutes` parameter is retained for call-site compatibility but is
+    // no longer used; every caller passed the same hard-coded `5`. The actual
+    // duration now comes from `idle_timeout_seconds` so it can be tuned via
+    // `BUN_CONFIG_HTTP_IDLE_TIMEOUT` (and set low in tests). `socket.setTimeout`
+    // picks the short-tick timer for values ≤ 240s and the minute-granularity
+    // long timer above that, so the default (300s → 5 min long timer) is
+    // exactly the previous behaviour.
+    if (this.flags.disable_timeout or idle_timeout_seconds == 0) {
+        socket.setTimeout(0);
         return;
     }
-
-    socket.timeout(0);
-    socket.setTimeoutMinutes(minutes);
+    socket.setTimeout(idle_timeout_seconds);
 }
 
 pub fn drainResponseBody(this: *HTTPClient, comptime is_ssl: bool, socket: NewHTTPContext(is_ssl).HTTPSocket) void {

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -10,7 +10,7 @@
 // configurable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT` so this test can run in a
 // few seconds rather than the 5-minute default.
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import * as net from "node:net";
 

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -1,0 +1,72 @@
+// https://github.com/oven-sh/bun/issues/30325
+//
+// `bun install` would hang indefinitely when an HTTPS registry connection
+// stalled during the TLS handshake: the HTTP client only armed its idle
+// timer once `onWritable` fired *after* the handshake completed, so a server
+// that accepted TCP (socket ESTABLISHED) but never answered ClientHello left
+// the request — and the whole install — blocked in epoll_wait with no timer.
+//
+// The fix arms the idle timer in `onOpen()` and makes the duration
+// configurable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT` so this test can run in a
+// few seconds rather than the 5-minute default.
+
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import * as net from "node:net";
+
+test("bun install times out when the registry accepts TCP but never completes the TLS handshake", async () => {
+  // Raw TCP listener: accepts the connection, reads (and discards) the
+  // ClientHello, and never writes a single byte back. From the client's
+  // point of view the socket is ESTABLISHED but the handshake stalls forever.
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer(socket => {
+    sockets.add(socket);
+    socket.on("data", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as net.AddressInfo).port;
+
+  try {
+    using dir = tempDir("install-handshake-stall", {
+      "package.json": JSON.stringify({
+        name: "stall-repro",
+        version: "1.0.0",
+        dependencies: { lodash: "4.17.21" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "https://127.0.0.1:${port}/"\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: {
+        ...bunEnv,
+        // Trip the idle timer after a few seconds instead of 5 minutes.
+        BUN_CONFIG_HTTP_IDLE_TIMEOUT: "3",
+        // Don't spin through 5 retries (each its own timeout) — one is enough
+        // to prove the request completed with an error rather than hanging.
+        BUN_CONFIG_HTTP_RETRY_COUNT: "0",
+        // Keep the self-signed / hostname-mismatch check from short-circuiting
+        // the handshake with a different error before the stall is observed.
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const combined = stdout + stderr;
+    // The manifest GET should have failed with the idle-timeout error. Exact
+    // wording differs between paths ("Timeout", "timed out"), so accept either.
+    expect(combined.toLowerCase()).toMatch(/time.?out|timed out/);
+    // Must have actually exited — a hang would never reach here, and a
+    // successful install (somehow) would be wrong.
+    expect(exitCode).not.toBe(0);
+  } finally {
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+}, 60_000);


### PR DESCRIPTION
Fixes the `bun install` hang reported in #30325 (latest comment — still reproducing on 1.3.13).

## Repro

Point `bun install` at an HTTPS registry that accepts TCP but never answers the TLS ClientHello:

```ts
// raw TCP server that swallows the ClientHello and never replies
net.createServer(s => s.on("data", () => {})).listen(0);
```

```toml
[install]
registry = "https://127.0.0.1:<port>/"
```

`bun install` connects, the socket goes ESTABLISHED, and the process blocks in `epoll_wait` forever with no timer armed. This is the state the reporter captured in their Gitea/Kubernetes CI: three ESTABLISHED sockets to the npm CDN, zero rx/tx, 14+ minutes and counting.

## Root cause

`HTTPClient.onOpen()` starts the TLS handshake but does not arm the socket's idle timer — the first `setTimeout(socket, 5)` call is in `onWritable()`, which only runs *after* the handshake completes. Freshly-connected sockets inherit `long_timeout = 255` (disabled) from the connecting socket, so a stall anywhere between TCP-connect and handshake-done has no timer at all. The `bun install` main loop then waits forever on `pendingTaskCount() == 0` because the `NetworkTask` callback never fires.

The earlier fixes in #29611 / #29649 covered a different hang (4xx/5xx tarball responses not releasing the task slot); they didn't touch this path.

## Fix

- Arm the idle timer in `onOpen()` so it covers the TLS handshake.
- Wire the short-tick `onTimeout` handler in `HTTPContext.Handler` alongside the existing `onLongTimeout` — `socket.setTimeout(seconds)` picks whichever timer fits the duration, so both must dispatch.
- Read the idle-timeout duration from a new `BUN_CONFIG_HTTP_IDLE_TIMEOUT` env var (seconds). Default is 300 — the previous hard-coded 5 minutes — so nothing changes for unconfigured environments except that the handshake phase is now covered. `0` disables the timer (same as `disable_timeout = true`).
- Route the experimental h2 client session's `rearmTimeout` through the same value for consistency.

## Verification

New test `test/cli/install/bun-install-stalled-tls.test.ts` starts a raw TCP server that accepts connections and never replies, points `bun install` at it over `https://`, sets `BUN_CONFIG_HTTP_IDLE_TIMEOUT=3` / `BUN_CONFIG_HTTP_RETRY_COUNT=0`, and asserts the install fails with a timeout error.

```
# without this change
(fail) bun install times out when the registry accepts TCP but never completes the TLS handshake [60004.48ms]
  ^ this test timed out after 60000ms.

# with this change
(pass) bun install times out when the registry accepts TCP but never completes the TLS handshake [4483.87ms]
```

`fetch-http2-client.test.ts` (58 tests) and `bun-install-retry.test.ts` still pass.

Fixes #30325