### PR TITLE
node:http: dispatch request on first write() and emit response in duplex mode

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -99,22 +99,24 @@ function ClientRequest(input, options, cb) {
   let writeCount = 0;
   let resolveNextChunk: ((end: boolean) => void) | undefined = _end => {};
 
+  // Node sends headers + first chunk immediately on the first write(). We
+  // defer by a tick so that `write(chunk); end();` in the same tick still
+  // takes the non-duplex fast path via send(). If end() hasn't been called by
+  // then, start the request in duplex mode so the server can respond while
+  // the body stream stays open (docker-modem relies on this for
+  // `container.exec` with stdin: true).
+  function startFetchAfterFirstWriteNT(self) {
+    if (!fetching && !self.destroyed && !self.finished) {
+      startFetch();
+    }
+  }
+
   const pushChunk = chunk => {
     this[kBodyChunks].push(chunk);
     if (writeCount > 1) {
       startFetch();
     } else if (writeCount === 1) {
-      // Node sends headers + first chunk immediately on the first write().
-      // We defer by a tick so that `write(chunk); end();` in the same tick
-      // still takes the non-duplex fast path via send(). If end() hasn't been
-      // called by then, start the request in duplex mode so the server can
-      // respond while the body stream stays open (docker-modem relies on this
-      // for `container.exec` with stdin: true).
-      process.nextTick(self => {
-        if (!fetching && !self.destroyed && !self.finished) {
-          startFetch();
-        }
-      }, this);
+      process.nextTick(startFetchAfterFirstWriteNT, this);
     }
     resolveNextChunk?.(false);
   };
@@ -588,6 +590,14 @@ function ClientRequest(input, options, cb) {
   // 'finish' once req.end() is eventually called.
   let deferredRequestClose = false;
 
+  function emitFinishAndDeferredCloseNT() {
+    maybeEmitFinish();
+    if (deferredRequestClose) {
+      deferredRequestClose = false;
+      maybeEmitClose();
+    }
+  }
+
   const send = () => {
     this.finished = true;
 
@@ -602,13 +612,7 @@ function ClientRequest(input, options, cb) {
       if (!!$debug) globalReportError(err);
       this.emit("error", err);
     } finally {
-      process.nextTick(() => {
-        maybeEmitFinish();
-        if (deferredRequestClose) {
-          deferredRequestClose = false;
-          maybeEmitClose();
-        }
-      });
+      process.nextTick(emitFinishAndDeferredCloseNT);
     }
   };
 

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -458,7 +458,9 @@ function ClientRequest(input, options, cb) {
                 }
                 if (res.statusCode === 304) {
                   res.complete = true;
-                  maybeEmitClose();
+                  // maybeEmitClose() already ran above (finished) or is
+                  // deferred via deferredRequestClose (duplex) — no need to
+                  // call it again and bypass the self.finished gate.
                   return;
                 }
               }

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -103,6 +103,18 @@ function ClientRequest(input, options, cb) {
     this[kBodyChunks].push(chunk);
     if (writeCount > 1) {
       startFetch();
+    } else if (writeCount === 1) {
+      // Node sends headers + first chunk immediately on the first write().
+      // We defer by a tick so that `write(chunk); end();` in the same tick
+      // still takes the non-duplex fast path via send(). If end() hasn't been
+      // called by then, start the request in duplex mode so the server can
+      // respond while the body stream stays open (docker-modem relies on this
+      // for `container.exec` with stdin: true).
+      process.nextTick(self => {
+        if (!fetching && !self.destroyed && !self.finished) {
+          startFetch();
+        }
+      }, this);
     }
     resolveNextChunk?.(false);
   };
@@ -442,9 +454,10 @@ function ClientRequest(input, options, cb) {
           );
         };
 
-        if (!keepOpen) {
-          handleResponse();
-        }
+        // Emit the response as soon as headers arrive, even when the request
+        // body is still being streamed (duplex mode). Node.js emits 'response'
+        // independently of whether req.end() has been called.
+        handleResponse();
 
         onEnd();
       });

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -204,10 +204,6 @@ function ClientRequest(input, options, cb) {
 
   this.flushHeaders = function () {
     if (!fetching) {
-      this[kAbortController] ??= new AbortController();
-      this[kAbortController].signal.addEventListener("abort", onAbort, {
-        once: true,
-      });
       startFetch();
     }
   };
@@ -284,6 +280,16 @@ function ClientRequest(input, options, cb) {
     }
 
     fetching = true;
+
+    // Every entry point that dispatches the request (send(), flushHeaders(),
+    // and the write() → pushChunk paths) must have an AbortController wired
+    // up before the fetch starts so that req.abort()/req.destroy()/timeouts
+    // and options.signal can cancel the in-flight request. Centralise that
+    // here so new callers cannot forget it.
+    if (!this[kAbortController]) {
+      this[kAbortController] = new AbortController();
+      this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
+    }
 
     const method = this[kMethod];
 
@@ -441,7 +447,15 @@ function ClientRequest(input, options, cb) {
                   res._dump();
                 }
               } finally {
-                maybeEmitClose();
+                if (self.finished) {
+                  maybeEmitClose();
+                } else {
+                  // Request body is still streaming (duplex); emitting
+                  // 'prefinish'/'close' now would fire before 'finish' (or
+                  // with no 'finish' at all). Defer until req.end() runs
+                  // and send() schedules maybeEmitFinish().
+                  deferredRequestClose = true;
+                }
                 if (res.statusCode === 304) {
                   res.complete = true;
                   maybeEmitClose();
@@ -567,11 +581,13 @@ function ClientRequest(input, options, cb) {
 
   let onEnd = () => {};
   let handleResponse: (() => void) | undefined = () => {};
+  // Set once handleResponse()'s nextTick has run and found the writable side
+  // still open; send() uses this to emit 'close' in the correct order after
+  // 'finish' once req.end() is eventually called.
+  let deferredRequestClose = false;
 
   const send = () => {
     this.finished = true;
-    this[kAbortController] ??= new AbortController();
-    this[kAbortController].signal.addEventListener("abort", onAbort, { once: true });
 
     var body = this[kBodyChunks] && this[kBodyChunks].length > 1 ? new Blob(this[kBodyChunks]) : this[kBodyChunks]?.[0];
 
@@ -584,7 +600,13 @@ function ClientRequest(input, options, cb) {
       if (!!$debug) globalReportError(err);
       this.emit("error", err);
     } finally {
-      process.nextTick(maybeEmitFinish.bind(this));
+      process.nextTick(() => {
+        maybeEmitFinish();
+        if (deferredRequestClose) {
+          deferredRequestClose = false;
+          maybeEmitClose();
+        }
+      });
     }
   };
 

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -1,21 +1,8 @@
 // https://github.com/oven-sh/bun/issues/13696
-//
-// testcontainers (via docker-modem) talks to the Docker daemon over a unix
-// socket using node:http. For `container.exec({ stdin: true })`, docker-modem
-// sends a POST with `Transfer-Encoding: chunked`, writes the JSON body with a
-// single `req.write(body)`, and intentionally does *not* call `req.end()` so
-// that stdin can be streamed to the container later. The Docker daemon replies
-// immediately with the exec output while the request body stream stays open.
-//
-// Bun's node:http client previously:
-//   1. Only dispatched the request after the *second* write() (or end()/
-//      flushHeaders()), so a single write() without end() never sent anything.
-//   2. In duplex mode, deferred emitting 'response' until the request body
-//      generator finished, i.e. until req.end() was called.
-//
-// Both behaviours together meant the request was never sent and the response
-// was never delivered, causing testcontainers' wait strategies that rely on
-// container.exec() (the default HostPortWaitStrategy) to hang until timeout.
+// node:http ClientRequest: a single req.write() without req.end() never sent
+// the request, and in duplex mode 'response' was held back until req.end().
+// docker-modem relies on write-once-keep-open for container.exec stdin, which
+// is why testcontainers' default HostPortWaitStrategy hung until timeout.
 
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
@@ -132,19 +119,21 @@ for (const socketMode of ["tcp", "unix"] as const) {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
     const lines = stdout.trim().split("\n");
     // The server must have received the request (a single write() dispatches
     // it), the response must be emitted with status 200, every body chunk must
     // be delivered, and the response must end cleanly.
-    expect(lines).toEqual([
-      "request-seen",
-      "response-status:200",
-      "recv:chunk-0",
-      "recv:chunk-1",
-      "recv:chunk-2",
-      "response-end",
-    ]);
+    expect({ lines, stderr }).toEqual({
+      lines: [
+        "request-seen",
+        "response-status:200",
+        "recv:chunk-0",
+        "recv:chunk-1",
+        "recv:chunk-2",
+        "response-end",
+      ],
+      stderr: expect.not.stringContaining("request-error"),
+    });
     expect(exitCode).toBe(0);
   });
 }
@@ -208,7 +197,9 @@ setTimeout(() => process.exit(0), 3000).unref();
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("body:hello");
+  expect({ stdout: stdout.trim(), stderr }).toEqual({
+    stdout: "body:hello",
+    stderr: expect.not.stringContaining("request-error"),
+  });
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -124,14 +124,7 @@ for (const socketMode of ["tcp", "unix"] as const) {
     // it), the response must be emitted with status 200, every body chunk must
     // be delivered, and the response must end cleanly.
     expect({ lines, stderr }).toEqual({
-      lines: [
-        "request-seen",
-        "response-status:200",
-        "recv:chunk-0",
-        "recv:chunk-1",
-        "recv:chunk-2",
-        "response-end",
-      ],
+      lines: ["request-seen", "response-status:200", "recv:chunk-0", "recv:chunk-1", "recv:chunk-2", "response-end"],
       stderr: expect.not.stringContaining("request-error"),
     });
     expect(exitCode).toBe(0);

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -5,20 +5,18 @@
 // is why testcontainers' default HostPortWaitStrategy hung until timeout.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // Runs a fixture that simulates docker-modem's chunked POST with an open
 // request body, against a raw TCP server that responds before the request is
 // finished. Prints "recv:<text>" for each response chunk as it arrives, and
 // "request-seen" once the server has received the headers.
-const fixture = (socketMode: "tcp" | "unix") => `
+const fixture = (socketPath: string | undefined) => `
 const net = require("net");
 const http = require("http");
-const os = require("os");
-const path = require("path");
-const fs = require("fs");
 
-const socketMode = ${JSON.stringify(socketMode)};
+const socketPath = ${JSON.stringify(socketPath)};
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -45,22 +43,12 @@ const server = net.createServer((sock) => {
   });
 });
 
-let listenArgs;
-let requestOpts;
-if (socketMode === "unix") {
-  const socketPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "bun-13696-")), "docker.sock");
-  listenArgs = [socketPath];
-  requestOpts = { socketPath, path: "/exec/abc/start" };
-} else {
-  listenArgs = [0, "127.0.0.1"];
-  requestOpts = undefined; // filled in after listen
-}
+const listenArgs = socketPath ? [socketPath] : [0, "127.0.0.1"];
 
 server.listen(...listenArgs, () => {
-  if (socketMode === "tcp") {
-    const { port } = server.address();
-    requestOpts = { host: "127.0.0.1", port, path: "/exec/abc/start" };
-  }
+  const requestOpts = socketPath
+    ? { socketPath, path: "/exec/abc/start" }
+    : { host: "127.0.0.1", port: server.address().port, path: "/exec/abc/start" };
 
   // docker-modem passes an empty callback here and attaches 'response'
   // separately via req.on('response', ...).
@@ -110,8 +98,11 @@ setTimeout(() => process.exit(0), 3000).unref();
 
 for (const socketMode of ["tcp", "unix"] as const) {
   test(`http.request delivers response while request body stream is still open (${socketMode})`, async () => {
+    using dir = tempDir("issue-13696", {});
+    const socketPath = socketMode === "unix" ? join(String(dir), "docker.sock") : undefined;
+
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture(socketMode)],
+      cmd: [bunExe(), "-e", fixture(socketPath)],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/regression/issue/13696.test.ts
+++ b/test/regression/issue/13696.test.ts
@@ -1,0 +1,214 @@
+// https://github.com/oven-sh/bun/issues/13696
+//
+// testcontainers (via docker-modem) talks to the Docker daemon over a unix
+// socket using node:http. For `container.exec({ stdin: true })`, docker-modem
+// sends a POST with `Transfer-Encoding: chunked`, writes the JSON body with a
+// single `req.write(body)`, and intentionally does *not* call `req.end()` so
+// that stdin can be streamed to the container later. The Docker daemon replies
+// immediately with the exec output while the request body stream stays open.
+//
+// Bun's node:http client previously:
+//   1. Only dispatched the request after the *second* write() (or end()/
+//      flushHeaders()), so a single write() without end() never sent anything.
+//   2. In duplex mode, deferred emitting 'response' until the request body
+//      generator finished, i.e. until req.end() was called.
+//
+// Both behaviours together meant the request was never sent and the response
+// was never delivered, causing testcontainers' wait strategies that rely on
+// container.exec() (the default HostPortWaitStrategy) to hang until timeout.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Runs a fixture that simulates docker-modem's chunked POST with an open
+// request body, against a raw TCP server that responds before the request is
+// finished. Prints "recv:<text>" for each response chunk as it arrives, and
+// "request-seen" once the server has received the headers.
+const fixture = (socketMode: "tcp" | "unix") => `
+const net = require("net");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+
+const socketMode = ${JSON.stringify(socketMode)};
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const server = net.createServer((sock) => {
+  let buf = "";
+  let responded = false;
+  sock.on("data", async (d) => {
+    buf += d.toString("latin1");
+    if (responded || !buf.includes("\\r\\n\\r\\n")) return;
+    responded = true;
+    console.log("request-seen");
+    // Docker's exec response has no Content-Length and no chunked encoding;
+    // it just writes raw frames until the connection closes.
+    sock.write(
+      "HTTP/1.1 200 OK\\r\\n" +
+      "Content-Type: application/vnd.docker.raw-stream\\r\\n" +
+      "\\r\\n",
+    );
+    for (let i = 0; i < 3; i++) {
+      sock.write("chunk-" + i + "\\n");
+      await wait(50);
+    }
+    sock.end();
+  });
+});
+
+let listenArgs;
+let requestOpts;
+if (socketMode === "unix") {
+  const socketPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "bun-13696-")), "docker.sock");
+  listenArgs = [socketPath];
+  requestOpts = { socketPath, path: "/exec/abc/start" };
+} else {
+  listenArgs = [0, "127.0.0.1"];
+  requestOpts = undefined; // filled in after listen
+}
+
+server.listen(...listenArgs, () => {
+  if (socketMode === "tcp") {
+    const { port } = server.address();
+    requestOpts = { host: "127.0.0.1", port, path: "/exec/abc/start" };
+  }
+
+  // docker-modem passes an empty callback here and attaches 'response'
+  // separately via req.on('response', ...).
+  const req = http.request(
+    {
+      ...requestOpts,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+      },
+    },
+    function () {},
+  );
+
+  req.on("response", (res) => {
+    console.log("response-status:" + res.statusCode);
+    res.setEncoding("utf8");
+    res.on("data", (chunk) => {
+      for (const line of chunk.split("\\n")) {
+        if (line) console.log("recv:" + line);
+      }
+    });
+    res.on("end", () => {
+      console.log("response-end");
+      server.close();
+      // The request body stream is still open; end it now so the process
+      // can exit cleanly.
+      req.end();
+    });
+  });
+
+  req.on("error", (err) => {
+    console.error("request-error:" + err.message);
+    process.exit(1);
+  });
+
+  // Single write, no req.end(). docker-modem does exactly this for
+  // openStdin: true.
+  req.write(JSON.stringify({ Detach: false, Tty: true }));
+});
+
+// Exit with whatever we've collected so far if the response never arrives,
+// so the parent test gets a clean assertion failure instead of a timeout.
+setTimeout(() => process.exit(0), 3000).unref();
+`;
+
+for (const socketMode of ["tcp", "unix"] as const) {
+  test(`http.request delivers response while request body stream is still open (${socketMode})`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(socketMode)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const lines = stdout.trim().split("\n");
+    // The server must have received the request (a single write() dispatches
+    // it), the response must be emitted with status 200, every body chunk must
+    // be delivered, and the response must end cleanly.
+    expect(lines).toEqual([
+      "request-seen",
+      "response-status:200",
+      "recv:chunk-0",
+      "recv:chunk-1",
+      "recv:chunk-2",
+      "response-end",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+}
+
+// Also cover the case where flushHeaders() is called explicitly (which already
+// started the fetch in duplex mode) but the response was still being held back
+// until req.end().
+test("http.request emits 'response' in duplex mode after flushHeaders() without end()", async () => {
+  const src = `
+const net = require("net");
+const http = require("http");
+
+const server = net.createServer((sock) => {
+  let buf = "";
+  let responded = false;
+  sock.on("data", (d) => {
+    buf += d.toString("latin1");
+    if (responded || !buf.includes("\\r\\n\\r\\n")) return;
+    responded = true;
+    sock.write("HTTP/1.1 200 OK\\r\\nContent-Type: text/plain\\r\\n\\r\\nhello");
+    sock.end();
+  });
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const { port } = server.address();
+  const req = http.request({
+    host: "127.0.0.1",
+    port,
+    path: "/",
+    method: "POST",
+    headers: { "Transfer-Encoding": "chunked" },
+  });
+  req.on("response", (res) => {
+    let body = "";
+    res.setEncoding("utf8");
+    res.on("data", (c) => (body += c));
+    res.on("end", () => {
+      console.log("body:" + body);
+      server.close();
+      req.end();
+    });
+  });
+  req.on("error", (err) => {
+    console.error("request-error:" + err.message);
+    process.exit(1);
+  });
+  req.flushHeaders();
+  req.write("payload");
+});
+
+setTimeout(() => process.exit(0), 3000).unref();
+`;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("body:hello");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #13696
Fixes #23970

Related: #21342, #29012, #18982.

## Reproduction

```js
const req = http.request({
  method: "POST",
  headers: { "Transfer-Encoding": "chunked" },
  ...
});
req.on("response", res => res.on("data", ...));
req.write(body);
// req.end() intentionally NOT called — request body stream kept open
```

In Node, the request goes out on the first `write()` and the `'response'` event fires as soon as headers arrive, while the request body stream stays open for further writes.

In Bun, the request was **never sent** and `'response'` was never emitted.

## Cause

In `_http_client.ts`:

1. `pushChunk` only called `startFetch()` when `writeCount > 1`, so a single `write()` without `end()`/`flushHeaders()` never dispatched the request.
2. When `startFetch()` ran with `isDuplex = true` (body still streaming), `handleResponse()` was gated on `!keepOpen` and otherwise deferred until the body generator finished — i.e. until `req.end()`.

docker-modem hits both for `container.exec({ stdin: true })`: it sends a chunked POST, writes the JSON options once, and keeps the request open so it can stream stdin to the container. This is what makes testcontainers' default `HostPortWaitStrategy` (which shells into the container via `exec` to check ports) hang until timeout.

## Fix

- First `write()` now schedules `startFetch()` for the next tick. If `end()` runs in the same tick, `send()` still takes the non-duplex fast path (`fetching` / `finished` guards prevent the deferred start from doing anything).
- `handleResponse()` is now called unconditionally when response headers arrive, matching Node's event ordering. The existing self-clear (`handleResponse = undefined`) keeps later call sites no-ops.

## Verification

`test/regression/issue/13696.test.ts` simulates docker-modem's exec pattern against a raw TCP server and a Unix-socket server (Docker daemon uses a Unix socket). Both, plus the `flushHeaders()` variant, hang/timeout on current `main` and pass with this change.

Existing `write()`/`end()` combinations (same-tick, next-tick, multi-chunk, empty) match Node output unchanged.

## Related issues checked

- **#23970** (single `req.write()` without `end()` never reaches server): same root cause, verified fixed.
- **#21620** (write, then `setTimeout`, then write+end): already passes on 1.3.13, not this bug.
- **#29012** / **#18982** (dockerode `exec.start`/`attach` with `hijack: true`): this PR gets the request out the door and delivers the 101 response, so they no longer *hang* — but Bun emits `'response'` instead of `'upgrade'` for the 101, which docker-modem treats as an unexpected status. Fully fixing those needs the separate `'upgrade'` event work (#25278).
