### PR TITLE
Fix segfault in Bun.inspect for circular JSX elements

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -1136,7 +1136,7 @@ pub const Formatter = struct {
 
         pub fn canHaveCircularReferences(tag: Tag) bool {
             return switch (tag) {
-                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event => true,
+                .Function, .Array, .Object, .Map, .Set, .Error, .Class, .Event, .JSX => true,
                 else => false,
             };
         }

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -326,7 +326,7 @@ pub const JestPrettyFormat = struct {
             }
 
             pub inline fn canHaveCircularReferences(tag: Tag) bool {
-                return tag == .Array or tag == .Object or tag == .Map or tag == .Set;
+                return tag == .Array or tag == .Object or tag == .Map or tag == .Set or tag == .JSX;
             }
 
             const Result = struct {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -316,6 +316,38 @@ it("jsx with fragment", () => {
   expect(input).toBe(output);
 });
 
+it("jsx with circular reference", () => {
+  const el = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el.key = el;
+  expect(Bun.inspect(el)).toBe("<div key=[Circular] />");
+
+  const el2 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el2.props.foo = el2;
+  expect(Bun.inspect(el2)).toBe("<div foo=[Circular] />");
+
+  const el3 = {
+    $$typeof: Symbol.for("react.element"),
+    type: "div",
+    key: null,
+    ref: null,
+    props: {},
+  };
+  el3.props.children = el3;
+  expect(Bun.inspect(el3)).toBe("<div>\n  [Circular]\n</div>");
+});
+
 it("inspect", () => {
   expect(Bun.inspect(new TypeError("what")).includes("TypeError: what")).toBe(true);
   expect(Bun.inspect("hi")).toBe('"hi"');


### PR DESCRIPTION
## What does this PR do?

Fixes a segfault in `Bun.inspect()` / `console.log()` when formatting a React element that contains a circular reference to itself via `key`, `props.children`, or any other prop.

```js
const el = {
  $$typeof: Symbol.for("react.element"),
  type: "div",
  key: null,
  ref: null,
  props: {},
};
el.key = el;
Bun.inspect(el); // previously: SIGSEGV (stack overflow)
                 // now: '<div key=[Circular] />'
```

The `.JSX` formatter tag was missing from `canHaveCircularReferences()`, so the visited-map check and the `StackCheck` guard that protect `Object`, `Array`, `Map`, `Set`, etc. never ran for JSX, and formatting recursed until the native stack was exhausted.

## How did you verify your code works?

Added a regression test in `test/js/bun/util/inspect.test.js` covering circular `key`, circular arbitrary prop, and circular `children`. The new test crashes the process on current canary and passes with this change. Full `inspect.test.js` suite (73 tests) passes.

Fuzzer fingerprint: `471aa8ea6d631cd1`