### PR TITLE
fetch(proxy): clear response buffer after CONNECT envelope handoff

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3120,7 +3120,37 @@ impl<'a> HTTPClient<'a> {
         } else {
             crate::ssl_config::SSLConfig::ZERO
         };
+        // Take ownership of the CONNECT accumulation buffer BEFORE entering
+        // ProxyTunnel::start. The envelope has been fully consumed by the
+        // caller (handle_on_data_headers); we leave an empty buffer behind so
+        // that when the tunnel later re-enters handle_on_data_headers with
+        // decrypted upstream bytes, the stale CONNECT envelope isn't re-parsed
+        // as the user-facing response (see #30381). Without this, a split
+        // CONNECT 200 response (envelope arriving across two TCP reads) stays
+        // buffered; the tunnel's re-entry appends the decrypted upstream bytes
+        // onto it, re-parses the envelope as the response (leaking
+        // proxy-agent / connection: close into response.headers), and hands
+        // the upstream's raw HTTP/1.1 bytes to the body unparsed.
+        //
+        // `start_payload` may alias into this buffer's heap storage on the
+        // split-read path, but `std::mem::take` swaps only the `Vec` header —
+        // the heap allocation (and thus the bytes `start_payload` points at)
+        // stays put until `envelope_buf` is dropped at the end of this
+        // function. ProxyTunnel::start copies `start_payload` into the TLS BIO
+        // via start_with_payload -> BIO_write before it returns, so the bytes
+        // are captured before the drop.
+        //
+        // We hold the buffer in a local and drop it AFTER start() rather than
+        // clearing `self.state.response_message_buffer` afterwards:
+        // ProxyTunnel::start has synchronous failure paths (SSLWrapper init
+        // error, or a handshake-traffic error that synchronously fires
+        // on_close) that call close_and_fail -> fail -> the result callback,
+        // which can free the AsyncHTTP that embeds `*self`. Touching `self`
+        // after start() returns would be a use-after-free.
+        let envelope_buf = std::mem::take(&mut self.state.response_message_buffer);
         ProxyTunnel::start::<IS_SSL>(self, socket, &ssl_options, start_payload);
+        // Must not reference `self` past this point — see comment above.
+        drop(envelope_buf);
     }
 
     #[inline]

--- a/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
+++ b/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
@@ -1,0 +1,175 @@
+// Regression test for https://github.com/oven-sh/bun/issues/30381
+//
+// When fetch() goes through an HTTP CONNECT proxy to an `https://` target
+// and the proxy's `HTTP/1.1 200 Connection established` envelope is delivered
+// across multiple TCP reads, Bun's fetch client used to:
+//
+//   1. Leak the CONNECT envelope headers (`proxy-agent`, `connection: close`)
+//      into `response.headers` instead of the upstream's real headers.
+//   2. Dump the upstream's raw `HTTP/1.1 200 OK\r\n…` envelope, chunked size
+//      prefixes (`1b\r\n`), and the chunked terminator (`0\r\n\r\n`) into
+//      `response.body` as unparsed bytes.
+//   3. Hang forever (or until TCP FIN) because the chunked terminator was
+//      never recognized — a spec-compliant keep-alive upstream that doesn't
+//      promptly FIN would deadlock the stream.
+//
+// Root cause: `handleShortRead` stashed partial envelope bytes into
+// `state.response_message_buffer` and `handleOnDataHeaders` re-entered from
+// `ProxyTunnel.onData` with `response_stage == .proxy_headers`, appending
+// decrypted upstream bytes onto the stale envelope and re-parsing it as the
+// user-facing response. The fix deinits the buffer in `startProxyHandshake`
+// after the TLS BIO has copied any trailing payload.
+//
+// A CONNECT response that arrives in one TCP read does NOT trigger the bug —
+// the buffer stays empty on the first parse. This test forces two separate
+// reads by enabling TCP_NODELAY and pausing between the two writes with a
+// `Bun.sleep(5)` yield so the kernel flushes the first segment and the
+// fetch client's HTTP thread consumes it before the second segment lands.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
+
+// Give the subprocess headroom on slow ASAN CI machines — the combined
+// setup (Bun.serve TLS + net.createServer + fetch TLS handshake) runs
+// ~2.3s on a loaded ASAN debug build locally, which leaves very little
+// margin under bun:test's default 5s timeout on a contended CI runner.
+test("fetch through CONNECT proxy with split 200 envelope surfaces upstream response (#30381)", async () => {
+  // Subprocess so we can strip NO_PROXY/no_proxy from the environment.
+  // CI and dev environments commonly set NO_PROXY to cover loopback
+  // (localhost, 127.0.0.1), which would cause the explicit `proxy:`
+  // option to be silently bypassed and the test to exercise a direct
+  // fetch instead of the CONNECT tunnel.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import net from "node:net";
+        const tlsCert = ${JSON.stringify(tlsCert)};
+
+        using upstream = Bun.serve({
+          port: 0,
+          tls: tlsCert,
+          hostname: "127.0.0.1",
+          async fetch() {
+            return new Response(
+              new ReadableStream({
+                start(controller) {
+                  controller.enqueue(new TextEncoder().encode("hello "));
+                  controller.enqueue(new TextEncoder().encode("world"));
+                  controller.close();
+                },
+              }),
+              {
+                status: 200,
+                headers: {
+                  "content-type": "text/event-stream",
+                  "x-upstream-marker": "from-upstream",
+                },
+              },
+            );
+          },
+        });
+        const upstreamPort = upstream.port;
+
+        const proxy = net.createServer(client => {
+          let reqBuf = Buffer.alloc(0);
+          client.on("data", chunk => {
+            reqBuf = Buffer.concat([reqBuf, chunk]);
+            if (!reqBuf.includes("\\r\\n\\r\\n")) return;
+            const first = reqBuf.toString("latin1").split("\\r\\n", 1)[0];
+            if (!first.startsWith("CONNECT ")) {
+              client.end("HTTP/1.1 400 Bad Request\\r\\n\\r\\n");
+              return;
+            }
+            const upstreamSock = net.connect(upstreamPort, "127.0.0.1", async () => {
+              // Force handleShortRead on the client by making the CONNECT
+              // 200 envelope arrive across two separate onData() calls in
+              // the fetch client. Nagle + TCP coalescence would otherwise
+              // batch back-to-back writes into one segment. Disable Nagle
+              // and yield between writes — the yield gives the kernel time
+              // to flush the first segment and the fetch client's HTTP
+              // thread time to consume it before the second segment lands
+              // in the receive buffer.
+              client.setNoDelay(true);
+              const envelope = Buffer.from(
+                "HTTP/1.1 200 Connection established\\r\\nConnection: close\\r\\nProxy-Agent: splitproxy\\r\\n\\r\\n",
+              );
+              client.write(envelope.subarray(0, 20));
+              // Yield via the OS timer queue so the fetch client (running
+              // on the HTTP thread, not the JS event loop) observes the
+              // first packet as an independent read. Bun.sleep(5) bounces
+              // through the kernel scheduler — the only mechanism that
+              // lets a cross-thread consumer make progress under ASAN CI
+              // load. A microtask yield like Bun.sleep(0) or
+              // Promise.resolve() only drains THIS thread's queue and
+              // wouldn't help.
+              await Bun.sleep(5);
+              client.write(envelope.subarray(20));
+              client.pipe(upstreamSock);
+              upstreamSock.pipe(client);
+            });
+            upstreamSock.on("error", () => client.destroy());
+            client.on("error", () => upstreamSock.destroy());
+            client.removeAllListeners("data");
+          });
+        });
+        await new Promise(r => proxy.listen(0, "127.0.0.1", r));
+        const proxyUrl = "http://127.0.0.1:" + proxy.address().port;
+
+        const response = await fetch("https://127.0.0.1:" + upstreamPort + "/", {
+          proxy: proxyUrl,
+          tls: { rejectUnauthorized: false },
+          keepalive: false,
+        });
+
+        const body = await response.text();
+        proxy.close();
+
+        const result = {
+          status: response.status,
+          marker: response.headers.get("x-upstream-marker"),
+          contentType: response.headers.get("content-type"),
+          proxyAgent: response.headers.get("proxy-agent"),
+          body,
+        };
+        console.log(JSON.stringify(result));
+        process.exit(0);
+      `,
+    ],
+    env: (() => {
+      const e = { ...bunEnv };
+      delete e.NO_PROXY;
+      delete e.no_proxy;
+      delete e.HTTP_PROXY;
+      delete e.http_proxy;
+      delete e.HTTPS_PROXY;
+      delete e.https_proxy;
+      return e;
+    })(),
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 20_000,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("stderr:", stderr, "stdout:", stdout);
+
+  // Before the fix, this assertion failed in three ways:
+  //   - `marker` and `contentType` were null (CONNECT envelope leaked as
+  //     user-facing headers; upstream's real headers never surfaced).
+  //   - `proxyAgent` was "splitproxy" (leaked from CONNECT envelope).
+  //   - `body` either contained raw "HTTP/1.1 200 OK\r\n..." + "6\r\nhello
+  //     \r\n5\r\nworld\r\n0\r\n\r\n" (unparsed envelope + chunked framing),
+  //     or the subprocess hit the 20s timeout (chunked terminator never
+  //     recognized; keep-alive server held the socket open).
+  // Assert stdout before exit code so failures show the response payload.
+  expect(JSON.parse(stdout.trim())).toEqual({
+    status: 200,
+    marker: "from-upstream",
+    contentType: "text/event-stream",
+    proxyAgent: null,
+    body: "hello world",
+  });
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
+++ b/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
@@ -85,8 +85,8 @@ test("fetch through CONNECT proxy with split 200 envelope surfaces upstream resp
               return;
             }
             const upstreamSock = net.connect(upstreamPort, "127.0.0.1", async () => {
-              // Force handleShortRead on the client by making the CONNECT
-              // 200 envelope arrive across two separate onData() calls in
+              // Force handle_short_read on the client by making the CONNECT
+              // 200 envelope arrive across two separate on_data() calls in
               // the fetch client. Nagle + TCP coalescence would otherwise
               // batch back-to-back writes into one segment. Disable Nagle
               // and yield between writes — the yield gives the kernel time

--- a/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
+++ b/test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
@@ -13,12 +13,14 @@
 //      never recognized — a spec-compliant keep-alive upstream that doesn't
 //      promptly FIN would deadlock the stream.
 //
-// Root cause: `handleShortRead` stashed partial envelope bytes into
-// `state.response_message_buffer` and `handleOnDataHeaders` re-entered from
-// `ProxyTunnel.onData` with `response_stage == .proxy_headers`, appending
-// decrypted upstream bytes onto the stale envelope and re-parsing it as the
-// user-facing response. The fix deinits the buffer in `startProxyHandshake`
-// after the TLS BIO has copied any trailing payload.
+// Root cause: `handle_short_read` stashed partial envelope bytes into
+// `state.response_message_buffer` and `handle_on_data_headers` re-entered
+// from `ProxyTunnel`'s `on_data` with `response_stage == proxy_headers`,
+// appending decrypted upstream bytes onto the stale envelope and re-parsing
+// it as the user-facing response. The fix (`src/http/lib.rs`,
+// `start_proxy_handshake`) `std::mem::take`s the buffer into a local before
+// `ProxyTunnel::start` and drops it after the TLS BIO has copied any
+// trailing payload.
 //
 // A CONNECT response that arrives in one TCP read does NOT trigger the bug —
 // the buffer stays empty on the first parse. This test forces two separate


### PR DESCRIPTION
## Problem

When an HTTPS request goes through an HTTP CONNECT proxy and the proxy's `HTTP/1.1 200 Connection established` envelope is delivered across multiple TCP reads, Bun's fetch client leaks the CONNECT envelope into the user-facing response:

- `response.headers` contains the proxy's envelope headers (`proxy-agent`, `connection: close`) instead of the upstream's actual headers.
- `response.body` receives the upstream's raw `HTTP/1.1 200 OK\r\n…` envelope, chunk size prefixes (`1b\r\n`), and the chunked terminator (`0\r\n\r\n`) as unparsed bytes.
- Because the chunked terminator is never recognized as end-of-body, a spec-compliant keep-alive upstream that doesn't promptly FIN hangs the fetch indefinitely.

A CONNECT response that lands in one TCP read doesn't trigger this — the bug needs `handle_short_read` to have stashed partial bytes.

Fixes #30381.

## Root cause

`handle_short_read` appends partial envelope bytes into `self.state.response_message_buffer`. On the next `on_data`, `handle_on_data_headers` concatenates the remainder, parses the full envelope, and calls `start_proxy_handshake` — but nothing clears the buffer afterwards.

`start_proxy_handshake` hands the trailing payload to `ProxyTunnel::start`, which sets up TLS. Once the handshake completes and decrypted upstream bytes start arriving, `ProxyTunnel`'s `on_data` (with `response_stage == proxy_headers`) re-enters `handle_on_data_headers`. There the `!response_message_buffer.list.is_empty()` branch triggers — the buffer still holds the CONNECT envelope — so the decrypted upstream bytes get appended onto the envelope. Parsing re-parses the envelope as the user-facing response; `clone_metadata` commits it; the upstream's real `HTTP/1.1 200 OK` falls through as body data.

## Fix

This PR targets the Rust HTTP client (`src/http/lib.rs`), which is what the current build compiles and links (the Zig `src/http/http.zig` is dormant).

Take ownership of `response_message_buffer` into a stack local via `std::mem::take` **before** calling `ProxyTunnel::start`, leaving an empty buffer in `self.state`, and drop the local **after** `start()` returns:

- `std::mem::take` swaps only the `Vec` header, so `start_payload` (which may alias the buffer's heap storage on the split-read path) stays valid until `ProxyTunnel::start` copies it into the TLS BIO via `start_with_payload` → `BIO_write`.
- The buffer is dropped via the local rather than by clearing `self.state` afterwards because `ProxyTunnel::start` has synchronous failure paths (SSLWrapper init error, or a handshake-traffic error that synchronously fires `on_close`) that call `close_and_fail` → `fail` → the result callback, which can free the `AsyncHTTP` embedding `self`. Touching `self` after `start()` returns would be a use-after-free.

## Verification

`test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts` — spawns a subprocess (with `NO_PROXY` stripped so loopback actually goes through the proxy) that:
1. Starts a `Bun.serve` HTTPS upstream emitting a response with a marker header.
2. Starts a CONNECT proxy that writes the 200 Established envelope in two writes with `setNoDelay` + a yield between them so the envelope arrives across two reads and `handle_short_read` runs.
3. Fetches through the proxy and asserts the upstream's headers + body surface correctly.

```
bun bd test test/js/web/fetch/fetch-proxy-connect-tunnel-split-envelope.test.ts
  → PASS (with fix)

# without the fix (reverting the src/http/lib.rs change):
  → FAIL — response.headers is the CONNECT envelope (proxy-agent: splitproxy,
           content-type/marker null) and response.body contains the raw
           upstream HTTP/1.1 envelope instead of the parsed body
```
