### PR TITLE
Bun.mmap: ignore non-object options argument

### DIFF
--- a/src/runtime/api/BunObject.zig
+++ b/src/runtime/api/BunObject.zig
@@ -1215,7 +1215,7 @@ pub fn mmapFile(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.
     var offset: usize = 0;
     var map_size: ?usize = null;
 
-    if (args.nextEat()) |opts| {
+    if (args.nextEat()) |opts| if (opts.isObject()) {
         flags.TYPE = if ((try opts.getBooleanLoose(globalThis, "shared")) orelse true)
             .SHARED
         else
@@ -1244,7 +1244,7 @@ pub fn mmapFile(globalThis: *jsc.JSGlobalObject, callframe: *jsc.CallFrame) bun.
             offset = @intCast(offset_value);
             offset = std.mem.alignBackwardAnyAlign(usize, offset, std.heap.pageSize());
         }
-    }
+    };
 
     const map = switch (bun.sys.mmapFile(buf_z, flags, map_size, offset)) {
         .result => |map| map,

--- a/test/js/bun/util/mmap.test.js
+++ b/test/js/bun/util/mmap.test.js
@@ -77,6 +77,11 @@ describe.skipIf(isWindows)("Bun.mmap", async () => {
     expect(() => Bun.mmap(path, { size: -1 })).toThrow("size must be a non-negative integer");
   });
 
+  it.each([undefined, null, 123, "str", true])("mmap ignores non-object options (%p)", opts => {
+    const map = Bun.mmap(path, opts);
+    expect(new TextDecoder().decode(map)).toBe("olleh");
+  });
+
   it("mmap handles non-number offset/size without crashing", () => {
     // These should not crash - non-number values coerce to 0 per JavaScript semantics
     // Previously these caused assertion failures (issue ENG-22413)


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash in `Bun.mmap()` when the second (options) argument is not an object.

```js
Bun.mmap("/some/path", 123);       // crashed
Bun.mmap("/some/path", undefined); // crashed
Bun.mmap("/some/path", null);      // crashed
```

`JSValue.get()` asserts that the target is an object. `mmapFile` called `opts.getBooleanLoose()` directly on whatever was passed as the second argument without checking. Now non-object values are ignored and default options are used.

Found by Fuzzilli (fingerprint `de19086115240384`).

## How did you verify your code works?

Added a parametrized regression test to `test/js/bun/util/mmap.test.js` covering `undefined`, `null`, numbers, strings, and booleans. Verified the old debug build crashes on the new test and the fixed build passes all 12 tests in the file.