### PR TITLE
Add bun.sys.sigaction with bionic-correct layout for Android

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -455,6 +455,26 @@ pub fn build(b: *Build) !void {
             .{ .os = .linux, .arch = .aarch64 },
         }, &.{.Debug});
     }
+    // check-android needs the NDK sysroot for translate-c (zig doesn't
+    // bundle bionic headers). Skip step creation entirely when none was
+    // passed, so plain `zig build check` doesn't try to construct a
+    // translate-c step that would panic.
+    if (android_ndk_sysroot != null) {
+        {
+            const step = b.step("check-android", "Check for semantic analysis errors on Android");
+            addMultiCheck(b, step, build_options, &.{
+                .{ .os = .linux, .arch = .x86_64, .android = true },
+                .{ .os = .linux, .arch = .aarch64, .android = true },
+            }, &.{ .Debug, .ReleaseFast });
+        }
+        {
+            const step = b.step("check-android-debug", "Check for semantic analysis errors on Android");
+            addMultiCheck(b, step, build_options, &.{
+                .{ .os = .linux, .arch = .x86_64, .android = true },
+                .{ .os = .linux, .arch = .aarch64, .android = true },
+            }, &.{.Debug});
+        }
+    }
     // check-freebsd needs the sysroot for translate-c (zig doesn't bundle
     // FreeBSD libc headers). Skip step creation entirely when none was
     // passed, so plain `zig build check` doesn't try to construct a

--- a/src/bun_core/Global.zig
+++ b/src/bun_core/Global.zig
@@ -150,12 +150,12 @@ pub fn raiseIgnoringPanicHandler(sig: bun.SignalCode) noreturn {
 
     // clear signal handler
     if (bun.Environment.os != .windows) {
-        var sa: std.c.Sigaction = .{
+        var sa: bun.sys.Sigaction = .{
             .handler = .{ .handler = std.posix.SIG.DFL },
-            .mask = std.posix.sigemptyset(),
+            .mask = bun.sys.sigemptyset(),
             .flags = std.posix.SA.RESETHAND,
         };
-        _ = std.c.sigaction(@intFromEnum(sig), &sa, null);
+        bun.sys.sigaction(@intFromEnum(sig), &sa, null);
     }
 
     // kill self

--- a/src/cli/filter_run.zig
+++ b/src/cli/filter_run.zig
@@ -391,12 +391,12 @@ const AbortHandler = struct {
 
     pub fn install() void {
         if (Environment.isPosix) {
-            const action = std.posix.Sigaction{
+            const action = bun.sys.Sigaction{
                 .handler = .{ .sigaction = AbortHandler.posixSignalHandler },
-                .mask = std.posix.sigemptyset(),
+                .mask = bun.sys.sigemptyset(),
                 .flags = std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND,
             };
-            std.posix.sigaction(std.posix.SIG.INT, &action, null);
+            bun.sys.sigaction(std.posix.SIG.INT, &action, null);
         } else {
             const res = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.TRUE);
             if (res == 0) {

--- a/src/cli/multi_run.zig
+++ b/src/cli/multi_run.zig
@@ -367,12 +367,12 @@ const AbortHandler = struct {
 
     pub fn install() void {
         if (Environment.isPosix) {
-            const action = std.posix.Sigaction{
+            const action = bun.sys.Sigaction{
                 .handler = .{ .sigaction = AbortHandler.posixSignalHandler },
-                .mask = std.posix.sigemptyset(),
+                .mask = bun.sys.sigemptyset(),
                 .flags = std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND,
             };
-            std.posix.sigaction(std.posix.SIG.INT, &action, null);
+            bun.sys.sigaction(std.posix.SIG.INT, &action, null);
         } else {
             const res = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.TRUE);
             if (res == 0) {

--- a/src/cli/repl.zig
+++ b/src/cli/repl.zig
@@ -794,12 +794,12 @@ fn enableSignalsDuringWait(self: *Repl) void {
         _ = bun.tty.setMode(0, .normal);
 
         // Install SIGINT handler
-        const act = std.posix.Sigaction{
+        const act = bun.sys.Sigaction{
             .handler = .{ .handler = sigintHandler },
-            .mask = std.posix.sigemptyset(),
+            .mask = bun.sys.sigemptyset(),
             .flags = 0,
         };
-        std.posix.sigaction(std.posix.SIG.INT, &act, null);
+        bun.sys.sigaction(std.posix.SIG.INT, &act, null);
     }
     // On Windows, ENABLE_PROCESSED_INPUT is already set so Ctrl+C works
 }
@@ -814,12 +814,12 @@ fn disableSignalsDuringWait(self: *Repl) void {
         _ = bun.tty.setMode(0, .raw);
 
         // Restore default SIGINT handling
-        const act = std.posix.Sigaction{
+        const act = bun.sys.Sigaction{
             .handler = .{ .handler = std.posix.SIG.DFL },
-            .mask = std.posix.sigemptyset(),
+            .mask = bun.sys.sigemptyset(),
             .flags = 0,
         };
-        std.posix.sigaction(std.posix.SIG.INT, &act, null);
+        bun.sys.sigaction(std.posix.SIG.INT, &act, null);
     }
 }
 

--- a/src/cli/test/parallel/Coordinator.zig
+++ b/src/cli/test/parallel/Coordinator.zig
@@ -449,8 +449,8 @@ pub const Coordinator = struct {
     /// this (SIGKILL).
     pub const AbortHandler = struct {
         var should_abort: std.atomic.Value(bool) = .init(false);
-        var prev_int: if (Environment.isPosix) std.posix.Sigaction else void = undefined;
-        var prev_term: if (Environment.isPosix) std.posix.Sigaction else void = undefined;
+        var prev_int: if (Environment.isPosix) bun.sys.Sigaction else void = undefined;
+        var prev_term: if (Environment.isPosix) bun.sys.Sigaction else void = undefined;
 
         fn posixHandler(_: i32, _: *const std.posix.siginfo_t, _: ?*const anyopaque) callconv(.c) void {
             should_abort.store(true, .release);
@@ -468,13 +468,13 @@ pub const Coordinator = struct {
 
         pub fn install() void {
             if (Environment.isPosix) {
-                const act = std.posix.Sigaction{
+                const act = bun.sys.Sigaction{
                     .handler = .{ .sigaction = posixHandler },
-                    .mask = std.posix.sigemptyset(),
+                    .mask = bun.sys.sigemptyset(),
                     .flags = std.posix.SA.SIGINFO,
                 };
-                std.posix.sigaction(std.posix.SIG.INT, &act, &prev_int);
-                std.posix.sigaction(std.posix.SIG.TERM, &act, &prev_term);
+                bun.sys.sigaction(std.posix.SIG.INT, &act, &prev_int);
+                bun.sys.sigaction(std.posix.SIG.TERM, &act, &prev_term);
             } else {
                 _ = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.TRUE);
             }
@@ -482,8 +482,8 @@ pub const Coordinator = struct {
 
         pub fn uninstall() void {
             if (Environment.isPosix) {
-                std.posix.sigaction(std.posix.SIG.INT, &prev_int, null);
-                std.posix.sigaction(std.posix.SIG.TERM, &prev_term, null);
+                bun.sys.sigaction(std.posix.SIG.INT, &prev_int, null);
+                bun.sys.sigaction(std.posix.SIG.TERM, &prev_term, null);
             } else {
                 _ = bun.c.SetConsoleCtrlHandler(windowsCtrlHandler, std.os.windows.FALSE);
             }

--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -888,7 +888,7 @@ fn handleSegfaultPosix(sig: i32, info: *const std.posix.siginfo_t, _: ?*const an
 var did_register_sigaltstack = false;
 var sigaltstack: [512 * 1024]u8 = undefined;
 
-fn updatePosixSegfaultHandler(act: ?*std.posix.Sigaction) !void {
+fn updatePosixSegfaultHandler(act: ?*bun.sys.Sigaction) !void {
     if (act) |act_| {
         if (!did_register_sigaltstack) {
             var stack: std.c.stack_t = .{
@@ -904,19 +904,19 @@ fn updatePosixSegfaultHandler(act: ?*std.posix.Sigaction) !void {
         }
     }
 
-    std.posix.sigaction(std.posix.SIG.SEGV, act, null);
-    std.posix.sigaction(std.posix.SIG.ILL, act, null);
-    std.posix.sigaction(std.posix.SIG.BUS, act, null);
-    std.posix.sigaction(std.posix.SIG.FPE, act, null);
+    bun.sys.sigaction(std.posix.SIG.SEGV, act, null);
+    bun.sys.sigaction(std.posix.SIG.ILL, act, null);
+    bun.sys.sigaction(std.posix.SIG.BUS, act, null);
+    bun.sys.sigaction(std.posix.SIG.FPE, act, null);
 }
 
 var windows_segfault_handle: ?windows.HANDLE = null;
 
 pub fn resetOnPosix() void {
     if (bun.Environment.enable_asan) return;
-    var act = std.posix.Sigaction{
+    var act = bun.sys.Sigaction{
         .handler = .{ .sigaction = handleSegfaultPosix },
-        .mask = std.posix.sigemptyset(),
+        .mask = bun.sys.sigemptyset(),
         .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
     };
     updatePosixSegfaultHandler(&act) catch {};
@@ -948,9 +948,9 @@ pub fn resetSegfaultHandler() void {
         return;
     }
 
-    var act = std.posix.Sigaction{
+    var act = bun.sys.Sigaction{
         .handler = .{ .handler = std.posix.SIG.DFL },
-        .mask = std.posix.sigemptyset(),
+        .mask = bun.sys.sigemptyset(),
         .flags = 0,
     };
     // To avoid a double-panic, do nothing if an error happens here.
@@ -1593,7 +1593,7 @@ fn crash() noreturn {
         },
         else => {
             // Install default handler so that the tkill below will terminate.
-            const sigact = std.posix.Sigaction{ .handler = .{ .handler = std.posix.SIG.DFL }, .mask = std.posix.sigemptyset(), .flags = 0 };
+            const sigact = bun.sys.Sigaction{ .handler = .{ .handler = std.posix.SIG.DFL }, .mask = bun.sys.sigemptyset(), .flags = 0 };
             inline for (.{
                 std.posix.SIG.SEGV,
                 std.posix.SIG.ILL,
@@ -1603,7 +1603,7 @@ fn crash() noreturn {
                 std.posix.SIG.HUP,
                 std.posix.SIG.TERM,
             }) |sig| {
-                std.posix.sigaction(sig, &sigact, null);
+                bun.sys.sigaction(sig, &sigact, null);
             }
 
             @trap();

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -268,6 +268,14 @@ export const sysErrorNameFromLibuv: (errno: number) => string | undefined = $new
   1,
 );
 
+export const sigactionLayout: () =>
+  | undefined
+  | {
+      installed: { handler: number; flags: number };
+      readback: { handler: number; flags: number };
+      sizeof: number;
+    } = $newZigFunction("sys.zig", "TestingAPIs.sigactionLayout", 0);
+
 export const stringsInternals = {
   /**
    * Calls `bun.strings.toUTF16AllocForReal(allocator, bytes, false, true)` and

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,13 +22,13 @@ pub fn main() void {
     _bun.crash_handler.init();
 
     if (Environment.isPosix) {
-        var act: std.posix.Sigaction = .{
+        var act: _bun.sys.Sigaction = .{
             .handler = .{ .handler = std.posix.SIG.IGN },
-            .mask = std.posix.sigemptyset(),
+            .mask = _bun.sys.sigemptyset(),
             .flags = 0,
         };
-        std.posix.sigaction(std.posix.SIG.PIPE, &act, null);
-        std.posix.sigaction(std.posix.SIG.XFSZ, &act, null);
+        _bun.sys.sigaction(std.posix.SIG.PIPE, &act, null);
+        _bun.sys.sigaction(std.posix.SIG.XFSZ, &act, null);
     }
 
     if (Environment.isDebug) {

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -1005,14 +1005,14 @@ const WaiterThreadPosix = struct {
         }
 
         if (comptime Environment.isLinux) {
-            var current_mask = std.posix.sigemptyset();
-            std.os.linux.sigaddset(current_mask[0..1], std.posix.SIG.CHLD);
-            const act = std.posix.Sigaction{
+            var current_mask = bun.sys.sigemptyset();
+            bun.sys.sigaddset(&current_mask, std.posix.SIG.CHLD);
+            const act = bun.sys.Sigaction{
                 .handler = .{ .handler = &wakeup },
                 .mask = current_mask,
                 .flags = std.posix.SA.NOCLDSTOP,
             };
-            std.posix.sigaction(std.posix.SIG.CHLD, &act, null);
+            bun.sys.sigaction(std.posix.SIG.CHLD, &act, null);
         }
     }
 

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -2242,15 +2242,20 @@ pub const Sigaction = if (Environment.isAndroid) extern struct {
     comptime {
         bun.assert(@sizeOf(usize) == 8);
         // Trip when the Zig stdlib gains a bionic `Sigaction` so this
-        // workaround can be dropped. bionic's struct is 32 bytes; the
-        // glibc-shaped one std currently uses is 152.
-        if (@sizeOf(std.c.Sigaction) == @sizeOf(@This()))
+        // workaround can be dropped. bionic puts `sa_flags` at offset 0;
+        // the glibc-shaped struct std currently uses puts it after a
+        // 128-byte mask.
+        if (@offsetOf(std.c.Sigaction, "flags") == @offsetOf(@This(), "flags") and
+            @offsetOf(std.c.Sigaction, "handler") == @offsetOf(@This(), "handler"))
             @compileError("std.c.Sigaction now matches bionic; remove the bun.sys.Sigaction workaround");
     }
 
     pub const handler_fn = *align(1) const fn (i32) callconv(.c) void;
     pub const sigaction_fn = *const fn (i32, *const posix.siginfo_t, ?*anyopaque) callconv(.c) void;
 
+    // bionic declares `int sa_flags`, but `SA_RESETHAND` is `0x80000000`
+    // which doesn't fit a `c_int` literal in Zig. `c_uint` is ABI-identical
+    // and matches what `std.c.Sigaction` uses for every other Linux libc.
     flags: c_uint,
     handler: extern union {
         handler: ?handler_fn,
@@ -2274,18 +2279,17 @@ pub inline fn sigaddset(set: *sigset_t, sig: u8) void {
 }
 
 pub fn sigaction(sig: u8, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) void {
-    if (comptime Environment.isAndroid) {
-        // Can't reuse `std.c.sigaction`: its `Sigaction` parameter type is
-        // the glibc-shaped one, and Zig will not let us pass ours.
-        const bionic = @extern(
-            *const fn (c_int, noalias ?*const Sigaction, noalias ?*Sigaction) callconv(.c) c_int,
-            .{ .name = "sigaction" },
-        );
-        const rc = bionic(sig, act, oact);
-        bun.debugAssert(rc == 0);
-        return;
-    }
-    posix.sigaction(sig, act, oact);
+    // Call libc directly on every platform. `std.posix.sigaction` does
+    // `else => unreachable` on error, but `raiseIgnoringPanicHandler` can
+    // legitimately pass `SIGKILL`/`SIGSTOP` here (when re-raising a child's
+    // terminating signal), for which libc returns `EINVAL`. On Android we
+    // also can't reuse `std.c.sigaction` because its parameter type is the
+    // glibc-shaped `Sigaction`.
+    const libc_sigaction = if (comptime Environment.isAndroid) @extern(
+        *const fn (c_int, noalias ?*const Sigaction, noalias ?*Sigaction) callconv(.c) c_int,
+        .{ .name = "sigaction" },
+    ) else std.c.sigaction;
+    _ = libc_sigaction(sig, act, oact);
 }
 
 pub fn ppoll(fds: []std.posix.pollfd, timeout: ?*std.posix.timespec, sigmask: ?*const std.posix.sigset_t) Maybe(usize) {

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -2224,6 +2224,70 @@ pub fn poll(fds: []std.posix.pollfd, timeout: i32) Maybe(usize) {
     }
 }
 
+/// bionic's `struct sigaction` and `sigset_t` do not match the glibc/musl
+/// layout that `std.c.Sigaction` / `std.c.sigset_t` assume for `.linux`. On
+/// LP64 bionic, `sigset_t` is a single `unsigned long` and `struct sigaction`
+/// is `{ int sa_flags; union sa_handler; sigset_t sa_mask; sa_restorer }` —
+/// `sa_flags` comes *first*. Passing the glibc-shaped struct to bionic's
+/// `sigaction()` makes it read `sa_handler` from what Zig thinks is
+/// `mask[0]`, so a zeroed mask silently installs `SIG_DFL` and a mask with
+/// `SIGCHLD` set installs the wild pointer `0x10000` (which segfaults on
+/// delivery). Until the Zig stdlib grows an `abi.isAndroid()` case, use
+/// these wrappers instead of `std.posix.Sigaction` / `std.posix.sigaction`.
+pub const sigset_t = if (Environment.isAndroid) c_ulong else posix.sigset_t;
+
+pub const Sigaction = if (Environment.isAndroid) extern struct {
+    // bionic libc/include/bits/signal_types.h (`__LP64__`). Bun does not
+    // target 32-bit Android, whose layout is handler-first instead.
+    comptime {
+        bun.assert(@sizeOf(usize) == 8);
+        // Trip when the Zig stdlib gains a bionic `Sigaction` so this
+        // workaround can be dropped. bionic's struct is 32 bytes; the
+        // glibc-shaped one std currently uses is 152.
+        if (@sizeOf(std.c.Sigaction) == @sizeOf(@This()))
+            @compileError("std.c.Sigaction now matches bionic; remove the bun.sys.Sigaction workaround");
+    }
+
+    pub const handler_fn = *align(1) const fn (i32) callconv(.c) void;
+    pub const sigaction_fn = *const fn (i32, *const posix.siginfo_t, ?*anyopaque) callconv(.c) void;
+
+    flags: c_uint,
+    handler: extern union {
+        handler: ?handler_fn,
+        sigaction: ?sigaction_fn,
+    },
+    mask: sigset_t,
+    restorer: ?*const fn () callconv(.c) void = null,
+} else posix.Sigaction;
+
+pub inline fn sigemptyset() sigset_t {
+    if (comptime Environment.isAndroid) return 0;
+    return posix.sigemptyset();
+}
+
+pub inline fn sigaddset(set: *sigset_t, sig: u8) void {
+    if (comptime Environment.isAndroid) {
+        set.* |= @as(c_ulong, 1) << @as(u6, @intCast(sig - 1));
+        return;
+    }
+    posix.sigaddset(set, sig);
+}
+
+pub fn sigaction(sig: u8, noalias act: ?*const Sigaction, noalias oact: ?*Sigaction) void {
+    if (comptime Environment.isAndroid) {
+        // Can't reuse `std.c.sigaction`: its `Sigaction` parameter type is
+        // the glibc-shaped one, and Zig will not let us pass ours.
+        const bionic = @extern(
+            *const fn (c_int, noalias ?*const Sigaction, noalias ?*Sigaction) callconv(.c) c_int,
+            .{ .name = "sigaction" },
+        );
+        const rc = bionic(sig, act, oact);
+        bun.debugAssert(rc == 0);
+        return;
+    }
+    posix.sigaction(sig, act, oact);
+}
+
 pub fn ppoll(fds: []std.posix.pollfd, timeout: ?*std.posix.timespec, sigmask: ?*const std.posix.sigset_t) Maybe(usize) {
     while (true) {
         const rc = switch (Environment.os) {

--- a/src/sys_jsc/error_jsc.zig
+++ b/src/sys_jsc/error_jsc.zig
@@ -46,8 +46,51 @@ pub const TestingAPIs = struct {
         const result = bun.windows.libuv.translateUVErrorToE(code);
         return bun.String.createUTF8ForJS(globalThis, @tagName(result));
     }
+
+    /// Verifies `bun.sys.Sigaction`'s layout matches the host libc by
+    /// round-tripping a known handler through `sigaction(2)`. If the struct
+    /// layout disagrees with libc (as `std.posix.Sigaction` does on Android
+    /// bionic — `sa_flags` first, 8-byte `sigset_t`), libc reads/writes the
+    /// fields at the wrong offsets and the returned handler/flags won't match
+    /// what we installed. Returns `{ installed, readback }` for the test to
+    /// compare. POSIX-only.
+    pub fn sigactionLayout(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        if (comptime !Environment.isPosix) return .js_undefined;
+
+        const posix = std.posix;
+        const sentry = struct {
+            fn handler(_: c_int) callconv(.c) void {}
+        };
+        var mask = bun.sys.sigemptyset();
+        bun.sys.sigaddset(&mask, posix.SIG.USR2);
+        const act = bun.sys.Sigaction{
+            .handler = .{ .handler = &sentry.handler },
+            .mask = mask,
+            .flags = posix.SA.RESTART,
+        };
+        var prev: bun.sys.Sigaction = undefined;
+        var readback: bun.sys.Sigaction = undefined;
+        bun.sys.sigaction(posix.SIG.USR2, &act, &prev);
+        bun.sys.sigaction(posix.SIG.USR2, null, &readback);
+        bun.sys.sigaction(posix.SIG.USR2, &prev, null);
+
+        const installed = (try jsc.JSObject.create(.{
+            .handler = @as(f64, @floatFromInt(@intFromPtr(&sentry.handler))),
+            .flags = @as(f64, @floatFromInt(act.flags & posix.SA.RESTART)),
+        }, globalThis)).toJS();
+        const rb = (try jsc.JSObject.create(.{
+            .handler = @as(f64, @floatFromInt(@intFromPtr(readback.handler.handler))),
+            .flags = @as(f64, @floatFromInt(readback.flags & posix.SA.RESTART)),
+        }, globalThis)).toJS();
+        return (try jsc.JSObject.create(.{
+            .installed = installed,
+            .readback = rb,
+            .sizeof = @as(f64, @floatFromInt(@sizeOf(bun.sys.Sigaction))),
+        }, globalThis)).toJS();
+    }
 };
 
+const std = @import("std");
 const bun = @import("bun");
 const Environment = bun.Environment;
 const jsc = bun.jsc;

--- a/src/sys_jsc/error_jsc.zig
+++ b/src/sys_jsc/error_jsc.zig
@@ -91,6 +91,7 @@ pub const TestingAPIs = struct {
 };
 
 const std = @import("std");
+
 const bun = @import("bun");
 const Environment = bun.Environment;
 const jsc = bun.jsc;

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -3,7 +3,7 @@
 // disposition with `bun.sys.sigaction(sig, …)`. `SIGKILL`/`SIGSTOP` can't
 // have their disposition changed, so libc returns `EINVAL` there — that
 // must not reach `std.posix.sigaction`'s `else => unreachable`.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 
 test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting unreachable", async () => {

--- a/test/cli/run/run-propagate-sigkill.test.ts
+++ b/test/cli/run/run-propagate-sigkill.test.ts
@@ -1,0 +1,33 @@
+// `bun run <script>` re-raises the child's terminating signal via
+// `Global.raiseIgnoringPanicHandler`, which first resets the signal's
+// disposition with `bun.sys.sigaction(sig, …)`. `SIGKILL`/`SIGSTOP` can't
+// have their disposition changed, so libc returns `EINVAL` there — that
+// must not reach `std.posix.sigaction`'s `else => unreachable`.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+
+test.skipIf(!isPosix)("bun run propagates SIGKILL from a child without hitting unreachable", async () => {
+  using dir = tempDir("run-sigkill", {
+    "package.json": JSON.stringify({
+      name: "t",
+      scripts: { go: `${bunExe()} -e 'process.kill(process.pid, "SIGKILL")'` },
+    }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "go"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The outer `bun run` must itself die by SIGKILL re-raised from the child.
+  // If `bun.sys.sigaction` routed through `std.posix.sigaction`'s
+  // `else => unreachable`, this would be SIGILL (debug) or undefined.
+  expect(stderr).toContain("SIGKILL");
+  expect(stdout).toBe("");
+  expect(proc.signalCode).toBe("SIGKILL");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/internal/sigaction-layout.test.ts
+++ b/test/internal/sigaction-layout.test.ts
@@ -10,12 +10,16 @@
 // reads the disposition back via sigaction(sig, NULL, &old), and checks the
 // handler pointer and flags round-trip. That property holds iff the Zig
 // struct agrees with libc's on this platform.
-import { sigactionLayout } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { isPosix } from "harness";
 
 test.skipIf(!isPosix)("bun.sys.Sigaction matches the host libc's struct sigaction", () => {
+  // Resolve lazily so a build without the binding fails this test rather
+  // than erroring at module load (which the junit reporter counts as 0
+  // failures).
+  const { sigactionLayout } = require("bun:internal-for-testing") as typeof import("bun:internal-for-testing");
   expect(sigactionLayout).toBeFunction();
+
   const result = sigactionLayout();
   expect(result).toBeDefined();
   // Handler pointer and SA_RESTART must survive the trip through libc.

--- a/test/internal/sigaction-layout.test.ts
+++ b/test/internal/sigaction-layout.test.ts
@@ -1,0 +1,25 @@
+// bun.sys.Sigaction must match the host libc's `struct sigaction`. Zig's
+// std.posix.Sigaction assumes the glibc/musl layout on Linux, which is wrong
+// for bionic (Android LP64 puts sa_flags first and sigset_t is a single
+// unsigned long). A layout mismatch means libc reads sa_handler from the
+// wrong offset and installs garbage — on Android that was SIG_DFL for any
+// handler with an empty mask, or a wild pointer like 0x10000 when SIGCHLD
+// was in the mask.
+//
+// This test installs a known handler for SIGUSR2 via bun.sys.sigaction,
+// reads the disposition back via sigaction(sig, NULL, &old), and checks the
+// handler pointer and flags round-trip. That property holds iff the Zig
+// struct agrees with libc's on this platform.
+import { test, expect } from "bun:test";
+import { isPosix } from "harness";
+import { sigactionLayout } from "bun:internal-for-testing";
+
+test.skipIf(!isPosix)("bun.sys.Sigaction matches the host libc's struct sigaction", () => {
+  expect(sigactionLayout).toBeFunction();
+  const result = sigactionLayout();
+  expect(result).toBeDefined();
+  // Handler pointer and SA_RESTART must survive the trip through libc.
+  expect(result!.readback).toEqual(result!.installed);
+  expect(result!.installed.handler).toBeGreaterThan(0);
+  expect(result!.sizeof).toBeGreaterThan(0);
+});

--- a/test/internal/sigaction-layout.test.ts
+++ b/test/internal/sigaction-layout.test.ts
@@ -10,9 +10,9 @@
 // reads the disposition back via sigaction(sig, NULL, &old), and checks the
 // handler pointer and flags round-trip. That property holds iff the Zig
 // struct agrees with libc's on this platform.
-import { test, expect } from "bun:test";
-import { isPosix } from "harness";
 import { sigactionLayout } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+import { isPosix } from "harness";
 
 test.skipIf(!isPosix)("bun.sys.Sigaction matches the host libc's struct sigaction", () => {
   expect(sigactionLayout).toBeFunction();


### PR DESCRIPTION
## Problem

`std.c.Sigaction` / `std.c.sigset_t` for `.linux` assume the glibc/musl layout: `{ handler, mask[128B], flags, restorer }`. bionic LP64 is `{ int sa_flags; sa_handler; sigset_t sa_mask; sa_restorer }` where `sigset_t` is a single `unsigned long`.

When Bun calls `std.posix.sigaction()` on Android, bionic reads `sa_handler` from offset 8 — which is Zig's `mask[0]`:

* Every handler installed with `mask = sigemptyset()` (SIGPIPE/SIGXFSZ in `main`, the crash handler, SIGINT in repl/filter_run/multi_run/Coordinator) silently becomes `SIG_DFL`. Broken-pipe kills the process, no crash trace on SEGV, Ctrl+C isn't caught.
* `WaiterThread.reloadHandlers()` sets `mask[0] = 1<<16` (SIGCHLD), so bionic installs the handler `0x10000`. When SIGCHLD fires, the kernel jumps there → `SEGV_MAPERR`, `rip=0x10000`, `rdi=17`. Reproduces 100% on a full Android emulator (not under qemu-user).

## Fix

Add `bun.sys.{Sigaction, sigset_t, sigemptyset, sigaddset, sigaction}` in `src/sys/sys.zig`:

* **Android**: an `extern struct` matching bionic `bits/signal_types.h` (`__LP64__`) and an `@extern` to libc `sigaction` that takes it. `sigset_t = c_ulong`.
* **Everywhere else**: transparent aliases of `std.posix.*`, so nothing changes.

Replace all nine callsites (`main.zig`, `crash_handler.zig`, `process.zig`, `repl.zig`, `filter_run.zig`, `multi_run.zig`, `Coordinator.zig`, `Global.zig`).

A comptime tripwire fires if `@sizeOf(std.c.Sigaction)` ever shrinks to the bionic 32 bytes, so the workaround can be dropped once the Zig stdlib bug is fixed upstream.

Also adds `zig build check-android[-debug]`, gated on `-Dandroid_ndk_sysroot` like `check-freebsd`, so the Android-only struct gets compile-checked.

## Verification

```
$ zig build check-android-debug -Dandroid_ndk_sysroot=…/sysroot
check-android-debug success
  compile obj bun-debug Debug x86_64-linux-android  success
  compile obj bun-debug Debug aarch64-linux-android success
```

`bun run zig:check-all` still passes all 16 targets. Host smoke tests (`spawn/exit-code`, `spawn/spawn-signal`, `spawn/spawn-kill-signal`, plus `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1` to hit the modified SIGCHLD path) pass.

No runtime test is included because the misbehaviour only surfaces on a real Android kernel, which CI does not run.