### PR TITLE
test_runner/recover: use setjmp/longjmp on Android

### DIFF
--- a/src/runtime/test_runner/harness/recover.rs
+++ b/src/runtime/test_runner/harness/recover.rs
@@ -6,11 +6,17 @@
 
 use core::cell::Cell;
 
+// musl and bionic (Android) lack getcontext/setcontext (obsoleted in
+// POSIX.1-2008, never implemented in bionic); both provide setjmp/longjmp.
 #[cfg(windows)]
 type Context = bun_sys::windows::CONTEXT;
-#[cfg(all(target_os = "linux", target_env = "musl"))]
+#[cfg(any(all(target_os = "linux", target_env = "musl"), target_os = "android"))]
 type Context = musl::jmp_buf;
-#[cfg(not(any(windows, all(target_os = "linux", target_env = "musl"))))]
+#[cfg(not(any(
+    windows,
+    all(target_os = "linux", target_env = "musl"),
+    target_os = "android"
+)))]
 type Context = libc::ucontext_t;
 
 thread_local! {
@@ -96,13 +102,17 @@ unsafe extern "system" {
 }
 
 // darwin, bsd, gnu linux
-#[cfg(not(any(windows, all(target_os = "linux", target_env = "musl"))))]
+#[cfg(not(any(
+    windows,
+    all(target_os = "linux", target_env = "musl"),
+    target_os = "android"
+)))]
 unsafe extern "C" {
     pub fn setcontext(ucp: *const libc::ucontext_t) -> !;
 }
 
-// linux musl
-#[cfg(all(target_os = "linux", target_env = "musl"))]
+// linux musl / android bionic
+#[cfg(any(all(target_os = "linux", target_env = "musl"), target_os = "android"))]
 mod musl {
     use core::ffi::c_int;
     // This is a STACK VALUE (a zeroed `Context` lives on the caller's stack and
@@ -111,9 +121,10 @@ mod musl {
     // setjmp scribble past the allocation. musl's full `jmp_buf` is
     // `{ __jmp_buf __jb; unsigned long __fl; unsigned long __ss[16]; }`, where
     // `__jmp_buf` is 8 longs on x86_64 and 22 longs on aarch64 — i.e. 25 and 39
-    // longs total respectively. 64×u64 (512 bytes) over-reserves the full
-    // struct on every musl arch; alignment of `long` is at most 8, so
-    // align(16) over-aligns.
+    // longs total respectively. bionic's is `long[_JBLEN]` with _JBLEN = 11 on
+    // x86_64 and 32 on aarch64. 64×u64 (512 bytes) over-reserves the full
+    // struct on every musl and bionic arch; alignment of `long` is at most 8,
+    // so align(16) over-aligns.
     #[repr(C, align(16))]
     pub(super) struct jmp_buf {
         _buf: [u64; 64],
@@ -131,12 +142,16 @@ unsafe fn get_context(ctx: *mut Context) {
         // SAFETY: ctx is a valid, writable, properly-aligned CONTEXT (caller contract).
         unsafe { bun_sys::windows::ntdll_context::RtlCaptureContext(ctx) };
     }
-    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg(any(all(target_os = "linux", target_env = "musl"), target_os = "android"))]
     {
         // SAFETY: ctx is a valid, writable, properly-aligned jmp_buf (caller contract).
         let _ = unsafe { musl::setjmp(ctx) };
     }
-    #[cfg(not(any(windows, all(target_os = "linux", target_env = "musl"))))]
+    #[cfg(not(any(
+        windows,
+        all(target_os = "linux", target_env = "musl"),
+        target_os = "android"
+    )))]
     {
         // The `libc` crate omits the getcontext(3) binding on Darwin and the
         // BSDs; declare it locally (uniform across all unix targets).
@@ -154,13 +169,17 @@ unsafe fn set_context(ctx: *const Context) -> ! {
         // this thread; the captured frame is still live (caller contract).
         unsafe { RtlRestoreContext(ctx, core::ptr::null()) };
     }
-    #[cfg(all(target_os = "linux", target_env = "musl"))]
+    #[cfg(any(all(target_os = "linux", target_env = "musl"), target_os = "android"))]
     {
         // SAFETY: ctx points to a jmp_buf previously filled by setjmp on this
         // thread; the captured frame is still live (caller contract).
         unsafe { musl::longjmp(ctx, 1) };
     }
-    #[cfg(not(any(windows, all(target_os = "linux", target_env = "musl"))))]
+    #[cfg(not(any(
+        windows,
+        all(target_os = "linux", target_env = "musl"),
+        target_os = "android"
+    )))]
     {
         // SAFETY: ctx points to a ucontext_t previously filled by getcontext on
         // this thread; the captured frame is still live (caller contract).

--- a/test/internal/recover-android.test.ts
+++ b/test/internal/recover-android.test.ts
@@ -1,0 +1,124 @@
+// Verifies src/runtime/test_runner/harness/recover.rs does not reference
+// setcontext()/getcontext() when compiled for Android. bionic never
+// implemented the ucontext family (obsoleted in POSIX.1-2008), so linking
+// against it would fail. The fix routes Android through the setjmp/longjmp
+// path already used for musl.
+//
+// This test builds the `bun_runtime` crate as an rlib for
+// aarch64-linux-android and inspects the undefined symbols it emits.
+
+import { describe, expect, test } from "bun:test";
+import { isLinux } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+function hasAndroidTarget(rustup: string): boolean {
+  const r = Bun.spawnSync({
+    cmd: [rustup, "target", "list", "--installed"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return r.exitCode === 0 && r.stdout.toString().includes("aarch64-linux-android");
+}
+
+// CI test runners ship a stripped checkout without vendor/ path deps
+// (e.g. vendor/lolhtml/c-api). `cargo metadata` (without --no-deps) fails
+// fast when any workspace path dep is missing, so use it as the "is the
+// workspace buildable here" probe. A timeout bounds the module-scope
+// probe in case cargo blocks on the global package-cache lock or a slow
+// registry fetch — on timeout, exitCode is null and we skip. (--offline
+// would over-skip: it fails when any transitive registry crate isn't in
+// the local cache, even when `cargo build -p bun_runtime` has everything
+// it needs.)
+function workspaceResolvable(cargo: string): boolean {
+  const r = Bun.spawnSync({
+    cmd: [cargo, "metadata", "--format-version=1", "--locked"],
+    cwd: repoRoot,
+    stdout: "ignore",
+    stderr: "ignore",
+    timeout: 30_000,
+  });
+  return r.exitCode === 0;
+}
+
+const cargo = Bun.which("cargo");
+// rustup is checked separately — distro-packaged cargo (apt/dnf) ships
+// without it, and Bun.spawnSync throws ENOENT (it does not return a
+// non-zero exitCode) when the executable is missing.
+const rustup = Bun.which("rustup");
+const skip = !isLinux || cargo == null || rustup == null || !hasAndroidTarget(rustup) || !workspaceResolvable(cargo);
+
+describe.skipIf(skip)("recover.rs on Android", () => {
+  // Building bun_runtime for aarch64-linux-android can be slow on a cold
+  // cargo cache; warm incremental rebuilds are ~40s.
+  test(
+    "does not reference setcontext/getcontext (bionic lacks them)",
+    async () => {
+      // Build bun_runtime as an rlib for Android. Reuses the workspace
+      // target dir so cached dependency builds aren't thrown away — only
+      // bun_runtime itself is rebuilt if its sources changed. Pin
+      // --target-dir so an ambient CARGO_TARGET_DIR doesn't redirect
+      // output away from the rlib path checked below.
+      await using build = Bun.spawn({
+        cmd: [
+          cargo!,
+          "build",
+          "-p",
+          "bun_runtime",
+          "--target",
+          "aarch64-linux-android",
+          "--target-dir",
+          "target",
+          "--message-format=short",
+        ],
+        cwd: repoRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, CARGO_TERM_COLOR: "never" },
+      });
+      const [buildOut, buildErr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      if (buildExit !== 0) {
+        // Surface the cargo output so the failure is actionable.
+        expect(buildErr + buildOut).toBe("");
+      }
+      expect(buildExit).toBe(0);
+
+      const rlib = join(repoRoot, "target", "aarch64-linux-android", "debug", "libbun_runtime.rlib");
+      expect(existsSync(rlib)).toBe(true);
+
+      await using nm = Bun.spawn({
+        cmd: ["nm", "-u", rlib],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [nmOut, nmErr, nmExit] = await Promise.all([nm.stdout.text(), nm.stderr.text(), nm.exited]);
+      // nm on an .rlib prints "no symbols" for some archive members; that's
+      // expected noise on stderr.
+      void nmErr;
+
+      const undef = new Set(
+        nmOut
+          .split("\n")
+          .map(l => l.trim().replace(/^U\s+/, "").split(/\s+/).pop())
+          .filter(Boolean),
+      );
+
+      // bionic does not provide setcontext/getcontext; referencing them
+      // makes the crate unlinkable on Android.
+      expect(undef.has("setcontext")).toBe(false);
+      expect(undef.has("getcontext")).toBe(false);
+
+      // It should instead go through setjmp/longjmp, which bionic has.
+      expect(undef.has("setjmp")).toBe(true);
+      expect(undef.has("longjmp")).toBe(true);
+      expect(nmExit).toBe(0);
+    },
+    10 * 60 * 1000,
+  );
+});


### PR DESCRIPTION
## Problem

`src/runtime/test_runner/harness/recover.rs` selects its context type as:

```rust
#[cfg(all(target_os = "linux", target_env = "musl"))]
type Context = musl::jmp_buf;
#[cfg(not(any(windows, all(target_os = "linux", target_env = "musl"))))]
type Context = libc::ucontext_t;
```

On Android (`target_os = "android"`) this falls through to `libc::ucontext_t` and emits `extern "C" setcontext` / `getcontext`. bionic has **no** `getcontext`/`setcontext`/`makecontext`/`swapcontext` — they were obsoleted in POSIX.1-2008 and never implemented in bionic. Once anything calls into this module on an Android build, the link fails with unresolved `setcontext`/`getcontext`.

bionic *does* have `setjmp`/`longjmp`, so the existing musl path works for Android too.

## Fix

Add `target_os = "android"` to every setjmp-path cfg gate in `recover.rs` (4 positive, 4 negative). On non-Android targets this adds a never-true disjunct, so codegen is unchanged. The existing `[u64; 64]` `jmp_buf` over-reservation covers bionic as well (`long[_JBLEN]` with `_JBLEN` = 11 on x86_64, 32 on aarch64).

## Verification

- `cargo check -p bun_runtime` on host and `--target aarch64-linux-android` both pass.
- `nm -u target/aarch64-linux-android/debug/libbun_runtime.rlib`:
  - **before**: `U getcontext`, `U setcontext`
  - **after**: `U setjmp`, `U longjmp`
- Confirmed against the NDK's bionic `libc.so` (`nm -D`): exports `setjmp`/`longjmp`/`sigsetjmp`/`siglongjmp`, no `setcontext`/`getcontext`.
- New `test/internal/recover-android.test.ts` builds the `bun_runtime` rlib for `aarch64-linux-android` and asserts the above via `nm -u`. Fails against main, passes with the fix. Skips when `cargo`/`rustup`/the Android rustup target aren't available, or when the cargo workspace path deps aren't present (CI test runners ship a stripped checkout without `vendor/`).

## Conflict resolution

- Rebased onto main after #30412 (Rust rewrite): `recover.zig` moved under `src/runtime/` and the live implementation became `recover.rs`; the fix was retargeted accordingly and the original zig-compiler-based test was replaced with a cargo-based one.
- Rebased after #31116 (clippy) and #30877/#31746/#31783 (comment cleanup), which touched adjacent lines in `recover.rs`.
- Rebased after #32621 removed all `.zig` porting-reference sources: dropped this PR's matching `recover.zig` edit since the file no longer exists. The PR is now `recover.rs` + the test only.
