### PR TITLE
Add bun.sys.rusage with bionic-correct size for Android

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -276,6 +276,19 @@ export const sigactionLayout: () =>
       sizeof: number;
     } = $newZigFunction("sys.zig", "TestingAPIs.sigactionLayout", 0);
 
+export const rusageLayout: () =>
+  | undefined
+  | {
+      sizeof: number;
+      sizeofSpawnRusage: number;
+      sizeofStdPosixRusage: number;
+      hasReservedTail: boolean;
+      isAndroid: boolean;
+      maxrss: number;
+      utime_usec: number;
+      stime_usec: number;
+    } = $newZigFunction("sys.zig", "TestingAPIs.rusageLayout", 0);
+
 export const stringsInternals = {
   /**
    * Calls `bun.strings.toUTF16AllocForReal(allocator, bytes, false, true)` and

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -94,7 +94,10 @@ else if (Environment.isFreeBSD)
         nivcsw: isize,
     }
 else
-    std.posix.rusage;
+    // `std.posix.rusage` is oversized on Android (musl's `__reserved`
+    // tail, which bionic doesn't have). `bun.sys.rusage` is a transparent
+    // alias everywhere else.
+    bun.sys.rusage;
 
 // const ShellSubprocessMini = bun.shell.ShellSubprocessMini;
 pub const ProcessExitHandler = struct {

--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -71,32 +71,11 @@ pub fn uv_getrusage(process: *uv.uv_process_t) win_rusage {
 }
 pub const Rusage = if (Environment.isWindows)
     win_rusage
-    // std.posix.rusage has no .freebsd arm; field names also differ
-    // (ru_* instead of bare). Define a layout-compatible struct so
-    // ResourceUsage can use the same field names everywhere.
-else if (Environment.isFreeBSD)
-    extern struct {
-        utime: std.c.timeval,
-        stime: std.c.timeval,
-        maxrss: isize,
-        ixrss: isize,
-        idrss: isize,
-        isrss: isize,
-        minflt: isize,
-        majflt: isize,
-        nswap: isize,
-        inblock: isize,
-        oublock: isize,
-        msgsnd: isize,
-        msgrcv: isize,
-        nsignals: isize,
-        nvcsw: isize,
-        nivcsw: isize,
-    }
 else
-    // `std.posix.rusage` is oversized on Android (musl's `__reserved`
-    // tail, which bionic doesn't have). `bun.sys.rusage` is a transparent
-    // alias everywhere else.
+    // `std.posix.rusage` is oversized on Android (musl's `__reserved` tail,
+    // which bionic doesn't have) and missing entirely on FreeBSD.
+    // `bun.sys.rusage` carries per-platform overrides for both and is a
+    // transparent alias of `std.posix.rusage` everywhere else.
     bun.sys.rusage;
 
 // const ShellSubprocessMini = bun.shell.ShellSubprocessMini;

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -2292,6 +2292,49 @@ pub fn sigaction(sig: u8, noalias act: ?*const Sigaction, noalias oact: ?*Sigact
     _ = libc_sigaction(sig, act, oact);
 }
 
+/// bionic's `struct rusage` is the bare kernel struct (144B on LP64) — it
+/// does NOT carry the `__reserved: [16]long` tail that musl (and therefore
+/// `std.os.linux.rusage`, which `std.c.rusage` aliases on Linux) appends.
+/// `wait4()` / `getrusage()` are output-only and bionic writes only the
+/// first 144B, so the oversized Zig type doesn't corrupt anything today —
+/// but it leaves 128B of uninitialized stack in the tail, which breaks any
+/// future `@memcmp` / "is this still zero" / serialization of the struct
+/// and makes `@sizeOf` lie. Until the Zig stdlib grows an `abi.isAndroid()`
+/// case for `rusage`, use this instead of `std.posix.rusage`.
+pub const rusage = if (Environment.isAndroid) extern struct {
+    // bionic libc/include/sys/resource.h -> <linux/resource.h> (kernel
+    // layout, no reserved tail). Bun only targets LP64 Android.
+    comptime {
+        bun.assert(@sizeOf(usize) == 8);
+        // Trip when the Zig stdlib drops the musl `__reserved` tail on
+        // Android so this workaround can be removed.
+        if (!@hasField(std.posix.rusage, "__reserved") and
+            @sizeOf(std.posix.rusage) == @sizeOf(@This()))
+            @compileError("std.posix.rusage now matches bionic; remove the bun.sys.rusage workaround");
+    }
+
+    utime: std.c.timeval,
+    stime: std.c.timeval,
+    maxrss: c_long,
+    ixrss: c_long,
+    idrss: c_long,
+    isrss: c_long,
+    minflt: c_long,
+    majflt: c_long,
+    nswap: c_long,
+    inblock: c_long,
+    oublock: c_long,
+    msgsnd: c_long,
+    msgrcv: c_long,
+    nsignals: c_long,
+    nvcsw: c_long,
+    nivcsw: c_long,
+
+    pub const SELF = 0;
+    pub const CHILDREN = -1;
+    pub const THREAD = 1;
+} else std.posix.rusage;
+
 pub fn ppoll(fds: []std.posix.pollfd, timeout: ?*std.posix.timespec, sigmask: ?*const std.posix.sigset_t) Maybe(usize) {
     while (true) {
         const rc = switch (Environment.os) {

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -2292,15 +2292,22 @@ pub fn sigaction(sig: u8, noalias act: ?*const Sigaction, noalias oact: ?*Sigact
     _ = libc_sigaction(sig, act, oact);
 }
 
-/// bionic's `struct rusage` is the bare kernel struct (144B on LP64) — it
-/// does NOT carry the `__reserved: [16]long` tail that musl (and therefore
-/// `std.os.linux.rusage`, which `std.c.rusage` aliases on Linux) appends.
-/// `wait4()` / `getrusage()` are output-only and bionic writes only the
-/// first 144B, so the oversized Zig type doesn't corrupt anything today —
-/// but it leaves 128B of uninitialized stack in the tail, which breaks any
-/// future `@memcmp` / "is this still zero" / serialization of the struct
-/// and makes `@sizeOf` lie. Until the Zig stdlib grows an `abi.isAndroid()`
-/// case for `rusage`, use this instead of `std.posix.rusage`.
+/// `std.posix.rusage` is wrong for two of Bun's targets:
+///
+/// * **Android**: bionic's `struct rusage` is the bare kernel struct (144B
+///   on LP64) — it does NOT carry the `__reserved: [16]long` tail that musl
+///   (and therefore `std.os.linux.rusage`, which `std.c.rusage` aliases on
+///   Linux) appends. `wait4()` / `getrusage()` are output-only and bionic
+///   only writes the first 144B, so the oversized Zig type doesn't corrupt
+///   anything today — but it leaves 128B of uninitialized stack in the
+///   tail, which breaks any future `@memcmp` / "is this still zero" /
+///   serialization of the struct and makes `@sizeOf` lie.
+///
+/// * **FreeBSD**: `std.c.rusage` has no `.freebsd` arm at all (falls through
+///   to `void`).
+///
+/// Until the Zig stdlib gains those cases, use this instead of
+/// `std.posix.rusage`. On every other POSIX target it's a transparent alias.
 pub const rusage = if (Environment.isAndroid) extern struct {
     // bionic libc/include/sys/resource.h -> <linux/resource.h> (kernel
     // layout, no reserved tail). Bun only targets LP64 Android.
@@ -2329,6 +2336,36 @@ pub const rusage = if (Environment.isAndroid) extern struct {
     nsignals: c_long,
     nvcsw: c_long,
     nivcsw: c_long,
+
+    pub const SELF = 0;
+    pub const CHILDREN = -1;
+    pub const THREAD = 1;
+} else if (Environment.isFreeBSD) extern struct {
+    // FreeBSD sys/sys/resource.h. `std.c.rusage` has no `.freebsd` arm
+    // (falls through to `void`), so supply one. Previously this lived in
+    // `bun.spawn.Rusage` (process.zig); centralised here so `bun.sys.rusage`
+    // is usable on every POSIX target.
+    comptime {
+        if (std.posix.rusage != void)
+            @compileError("std.posix.rusage now has a FreeBSD arm; remove the bun.sys.rusage workaround");
+    }
+
+    utime: std.c.timeval,
+    stime: std.c.timeval,
+    maxrss: isize,
+    ixrss: isize,
+    idrss: isize,
+    isrss: isize,
+    minflt: isize,
+    majflt: isize,
+    nswap: isize,
+    inblock: isize,
+    oublock: isize,
+    msgsnd: isize,
+    msgrcv: isize,
+    nsignals: isize,
+    nvcsw: isize,
+    nivcsw: isize,
 
     pub const SELF = 0;
     pub const CHILDREN = -1;

--- a/src/sys_jsc/error_jsc.zig
+++ b/src/sys_jsc/error_jsc.zig
@@ -90,10 +90,10 @@ pub const TestingAPIs = struct {
     }
 
     /// Verifies `bun.sys.rusage`'s layout matches the host libc by filling
-    /// one via `getrusage(RUSAGE_SELF)`. On Android, `std.posix.rusage`
-    /// carries musl's 128B `__reserved` tail that bionic doesn't write,
-    /// leaving the struct partially uninitialized; `bun.sys.rusage` drops
-    /// that tail. On every other POSIX it's a transparent alias.
+    /// one via `getrusage(RUSAGE_SELF)`. `std.posix.rusage` is oversized on
+    /// Android (musl's 128B `__reserved` tail that bionic doesn't write)
+    /// and missing entirely on FreeBSD; `bun.sys.rusage` carries overrides
+    /// for both and aliases `std.posix.rusage` everywhere else.
     ///
     /// Returned fields let the test check that (a) libc populated the
     /// struct through our type (non-zero CPU time / sane maxrss) and
@@ -103,7 +103,7 @@ pub const TestingAPIs = struct {
         if (comptime !Environment.isPosix) return .js_undefined;
 
         // Go through libc with our type rather than `std.posix.getrusage`,
-        // whose return type is the possibly-oversized `std.posix.rusage`.
+        // whose return type is the possibly-wrong `std.posix.rusage`.
         const getrusage = @extern(
             *const fn (who: c_int, usage: *bun.sys.rusage) callconv(.c) c_int,
             .{ .name = "getrusage" },
@@ -114,6 +114,7 @@ pub const TestingAPIs = struct {
         return (try jsc.JSObject.create(.{
             .sizeof = @as(f64, @floatFromInt(@sizeOf(bun.sys.rusage))),
             .sizeofSpawnRusage = @as(f64, @floatFromInt(@sizeOf(bun.spawn.Rusage))),
+            // 0 on FreeBSD (`std.posix.rusage` is `void` there).
             .sizeofStdPosixRusage = @as(f64, @floatFromInt(@sizeOf(std.posix.rusage))),
             .hasReservedTail = @hasField(bun.sys.rusage, "__reserved"),
             .isAndroid = Environment.isAndroid,

--- a/src/sys_jsc/error_jsc.zig
+++ b/src/sys_jsc/error_jsc.zig
@@ -88,6 +88,42 @@ pub const TestingAPIs = struct {
             .sizeof = @as(f64, @floatFromInt(@sizeOf(bun.sys.Sigaction))),
         }, globalThis)).toJS();
     }
+
+    /// Verifies `bun.sys.rusage`'s layout matches the host libc by filling
+    /// one via `getrusage(RUSAGE_SELF)`. On Android, `std.posix.rusage`
+    /// carries musl's 128B `__reserved` tail that bionic doesn't write,
+    /// leaving the struct partially uninitialized; `bun.sys.rusage` drops
+    /// that tail. On every other POSIX it's a transparent alias.
+    ///
+    /// Returned fields let the test check that (a) libc populated the
+    /// struct through our type (non-zero CPU time / sane maxrss) and
+    /// (b) `@sizeOf` agrees with `bun.spawn.Rusage` — the thing actually
+    /// handed to `wait4()`. POSIX-only.
+    pub fn rusageLayout(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        if (comptime !Environment.isPosix) return .js_undefined;
+
+        // Go through libc with our type rather than `std.posix.getrusage`,
+        // whose return type is the possibly-oversized `std.posix.rusage`.
+        const getrusage = @extern(
+            *const fn (who: c_int, usage: *bun.sys.rusage) callconv(.c) c_int,
+            .{ .name = "getrusage" },
+        );
+        var r: bun.sys.rusage = std.mem.zeroes(bun.sys.rusage);
+        _ = getrusage(bun.sys.rusage.SELF, &r);
+
+        return (try jsc.JSObject.create(.{
+            .sizeof = @as(f64, @floatFromInt(@sizeOf(bun.sys.rusage))),
+            .sizeofSpawnRusage = @as(f64, @floatFromInt(@sizeOf(bun.spawn.Rusage))),
+            .sizeofStdPosixRusage = @as(f64, @floatFromInt(@sizeOf(std.posix.rusage))),
+            .hasReservedTail = @hasField(bun.sys.rusage, "__reserved"),
+            .isAndroid = Environment.isAndroid,
+            .maxrss = @as(f64, @floatFromInt(r.maxrss)),
+            .utime_usec = @as(f64, @floatFromInt(r.utime.sec)) * 1_000_000 +
+                @as(f64, @floatFromInt(r.utime.usec)),
+            .stime_usec = @as(f64, @floatFromInt(r.stime.sec)) * 1_000_000 +
+                @as(f64, @floatFromInt(r.stime.usec)),
+        }, globalThis)).toJS();
+    }
 };
 
 const std = @import("std");

--- a/test/internal/rusage-layout.test.ts
+++ b/test/internal/rusage-layout.test.ts
@@ -1,12 +1,18 @@
 // bun.sys.rusage must match the host libc's `struct rusage`. Zig's
-// std.posix.rusage on Linux is the musl struct, which carries a
-// `__reserved: [16]long` tail (272B total on LP64). bionic's `struct
-// rusage` is the bare kernel struct (144B on LP64) — no reserved tail.
-// `wait4()`/`getrusage()` are output-only so the oversized std type
-// doesn't corrupt anything today, but it leaves 128B of uninitialized
-// stack in the tail, which would break any future `@memcmp` / "still
-// zero?" / serialization of the struct. bun.sys.rusage drops the tail on
-// Android and is a transparent alias of std.posix.rusage elsewhere.
+// std.posix.rusage is wrong for two of Bun's targets:
+//
+//  * Android: it's the musl struct, which carries a `__reserved: [16]long`
+//    tail (272B total on LP64). bionic's `struct rusage` is the bare
+//    kernel struct (144B on LP64) — no reserved tail. `wait4()`/
+//    `getrusage()` are output-only so the oversized std type doesn't
+//    corrupt anything today, but it leaves 128B of uninitialized stack in
+//    the tail, which would break any future `@memcmp` / "still zero?" /
+//    serialization of the struct.
+//  * FreeBSD: std.c.rusage has no .freebsd arm at all (falls through to
+//    `void`).
+//
+// bun.sys.rusage carries overrides for both and is a transparent alias of
+// std.posix.rusage elsewhere.
 //
 // This test fills a bun.sys.rusage via libc getrusage(RUSAGE_SELF) and
 // checks the fields came back populated (proving the type is usable with
@@ -35,8 +41,11 @@ test.skipIf(!isPosix)("bun.sys.rusage matches the host libc's struct rusage", ()
     expect(r!.hasReservedTail).toBe(false);
     // The std type we're working around is 272B.
     expect(r!.sizeofStdPosixRusage).toBeGreaterThan(r!.sizeof);
-  } else {
-    // Transparent alias on glibc/musl/Darwin.
+  } else if (r!.sizeofStdPosixRusage > 0) {
+    // Transparent alias on glibc/musl/Darwin. On FreeBSD std.posix.rusage
+    // is `void` (size 0), so the override is expected and this check is
+    // skipped — the maxrss/cputime checks below still prove the override
+    // round-trips through libc.
     expect(r!.sizeof).toBe(r!.sizeofStdPosixRusage);
   }
 

--- a/test/internal/rusage-layout.test.ts
+++ b/test/internal/rusage-layout.test.ts
@@ -1,0 +1,47 @@
+// bun.sys.rusage must match the host libc's `struct rusage`. Zig's
+// std.posix.rusage on Linux is the musl struct, which carries a
+// `__reserved: [16]long` tail (272B total on LP64). bionic's `struct
+// rusage` is the bare kernel struct (144B on LP64) — no reserved tail.
+// `wait4()`/`getrusage()` are output-only so the oversized std type
+// doesn't corrupt anything today, but it leaves 128B of uninitialized
+// stack in the tail, which would break any future `@memcmp` / "still
+// zero?" / serialization of the struct. bun.sys.rusage drops the tail on
+// Android and is a transparent alias of std.posix.rusage elsewhere.
+//
+// This test fills a bun.sys.rusage via libc getrusage(RUSAGE_SELF) and
+// checks the fields came back populated (proving the type is usable with
+// the host libc) and that bun.spawn.Rusage — what actually gets handed to
+// wait4() — is the same size.
+import { expect, test } from "bun:test";
+import { isPosix } from "harness";
+
+test.skipIf(!isPosix)("bun.sys.rusage matches the host libc's struct rusage", () => {
+  // Resolve lazily so a build without the binding fails this test rather
+  // than erroring at module load (which the junit reporter counts as 0
+  // failures).
+  const { rusageLayout } = require("bun:internal-for-testing") as typeof import("bun:internal-for-testing");
+  expect(rusageLayout).toBeFunction();
+
+  const r = rusageLayout();
+  expect(r).toBeDefined();
+
+  // bun.spawn.Rusage (the type passed to wait4) must be bun.sys.rusage,
+  // not std.posix.rusage directly.
+  expect(r!.sizeofSpawnRusage).toBe(r!.sizeof);
+
+  if (r!.isAndroid) {
+    // bionic: kernel struct, 144B on LP64, no reserved tail.
+    expect(r!.sizeof).toBe(144);
+    expect(r!.hasReservedTail).toBe(false);
+    // The std type we're working around is 272B.
+    expect(r!.sizeofStdPosixRusage).toBeGreaterThan(r!.sizeof);
+  } else {
+    // Transparent alias on glibc/musl/Darwin.
+    expect(r!.sizeof).toBe(r!.sizeofStdPosixRusage);
+  }
+
+  // getrusage(RUSAGE_SELF) through our type produced sane values: we've
+  // consumed some CPU and have a non-zero resident set.
+  expect(r!.maxrss).toBeGreaterThan(0);
+  expect(r!.utime_usec + r!.stime_usec).toBeGreaterThan(0);
+});

--- a/test/internal/rusage-layout.test.ts
+++ b/test/internal/rusage-layout.test.ts
@@ -19,9 +19,14 @@
 // the host libc) and that bun.spawn.Rusage — what actually gets handed to
 // wait4() — is the same size.
 import { expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { isWindows } from "harness";
 
-test.skipIf(!isPosix)("bun.sys.rusage matches the host libc's struct rusage", () => {
+// Gate on !isWindows rather than harness's `isPosix`: the latter is
+// `darwin || linux || freebsd`, which excludes Android (where Bun reports
+// process.platform === "android"), so the `if (r!.isAndroid)` assertions
+// below would never run. The Zig binding already returns undefined on
+// Windows; this matches its `!Environment.isPosix` guard.
+test.skipIf(isWindows)("bun.sys.rusage matches the host libc's struct rusage", () => {
   // Resolve lazily so a build without the binding fails this test rather
   // than erroring at module load (which the junit reporter counts as 0
   // failures).

--- a/test/internal/sigaction-layout.test.ts
+++ b/test/internal/sigaction-layout.test.ts
@@ -11,9 +11,14 @@
 // handler pointer and flags round-trip. That property holds iff the Zig
 // struct agrees with libc's on this platform.
 import { expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { isWindows } from "harness";
 
-test.skipIf(!isPosix)("bun.sys.Sigaction matches the host libc's struct sigaction", () => {
+// Gate on !isWindows rather than harness's `isPosix`: the latter is
+// `darwin || linux || freebsd`, which excludes Android (where Bun reports
+// process.platform === "android"), so the bionic round-trip this test
+// exists for would never run. Matches the Zig binding's own
+// `!Environment.isPosix` guard.
+test.skipIf(isWindows)("bun.sys.Sigaction matches the host libc's struct sigaction", () => {
   // Resolve lazily so a build without the binding fails this test rather
   // than erroring at module load (which the junit reporter counts as 0
   // failures).


### PR DESCRIPTION
## Problem

`std.posix.rusage` is wrong for two of Bun's targets:

* **Android**: Zig's `std.os.linux.rusage` (which `std.c.rusage` / `std.posix.rusage` alias on Linux) is the musl struct — 272B on LP64, including a trailing `__reserved: [16]long`. bionic's `struct rusage` is the bare kernel struct, 144B on LP64, with no reserved tail. `wait4()` / `getrusage()` are output-only and bionic only writes the first 144B, so the oversized type doesn't corrupt anything today — but it leaves 128B of uninitialized stack in the tail, which breaks any future `@memcmp` / "is this still zero" / serialization and makes `@sizeOf` lie.
* **FreeBSD**: `std.c.rusage` has no `.freebsd` arm at all — it falls through to `void`. `bun.spawn.Rusage` already worked around this with a bespoke `extern struct` inline in `process.zig`.

## Fix

Add `bun.sys.rusage` in `src/sys/sys.zig`, alongside #30389's `bun.sys.Sigaction`:

* **Android**: an `extern struct` matching the kernel / bionic layout — `utime`, `stime`, 14 × `c_long`, no `__reserved`. 144B on LP64.
* **FreeBSD**: the `extern struct` previously inlined in `process.zig`, moved here so `bun.sys.rusage` is usable on every POSIX target.
* **Everywhere else**: transparent alias of `std.posix.rusage`, so nothing changes.

`bun.spawn.Rusage` collapses to `if (Windows) win_rusage else bun.sys.rusage`. `PosixSpawn.wait4` already `@ptrCast`s the usage pointer, so no extern signature change is needed.

Each override carries a comptime tripwire that fires when the Zig stdlib gains a correct definition, so the workaround can be removed.

## Verification

```
$ zig build check-android-debug -Dandroid_ndk_sysroot=…/sysroot --summary all
check-android-debug success
  compile obj bun-debug Debug x86_64-linux-android  success
  compile obj bun-debug Debug aarch64-linux-android success

$ zig build check-freebsd-debug -Dfreebsd_sysroot=…/sysroot --summary all
check-freebsd-debug success
  compile obj bun-debug Debug x86_64-freebsd.14.0  success
  compile obj bun-debug Debug aarch64-freebsd.14.0 success
```

`bun run zig:check-all` passes all 16 targets.

Confirmed against the NDK and FreeBSD sysroot headers: both define `struct rusage` as exactly the 16-field struct with `long`-typed members and no reserved tail.

`test/internal/rusage-layout.test.ts` fills a `bun.sys.rusage` via libc `getrusage(RUSAGE_SELF)` and checks (a) the fields come back populated — proving the type is usable with the host libc, (b) `bun.spawn.Rusage` is the same size, and (c) on Android specifically, the size is 144 and there's no `__reserved` field.

Existing `spawn` tests (exit-code, spawn-signal) and `test/internal/sigaction-layout.test.ts` still pass.
