### PR TITLE
Add bun.sys.ucontext_t with bionic-correct layout on x86_64 Android

### DIFF
--- a/src/crash_handler/crash_handler.zig
+++ b/src/crash_handler/crash_handler.zig
@@ -863,7 +863,7 @@ const metadata_version_line = std.fmt.comptimePrint(
     },
 );
 
-fn handleSegfaultPosix(sig: i32, info: *const std.posix.siginfo_t, _: ?*const anyopaque) callconv(.c) noreturn {
+fn handleSegfaultPosix(sig: i32, info: *const std.posix.siginfo_t, _: ?*const bun.sys.ucontext_t) callconv(.c) noreturn {
     const addr = switch (bun.Environment.os) {
         .linux => @intFromPtr(info.fields.sigfault.addr),
         .mac, .freebsd => @intFromPtr(info.addr),
@@ -915,7 +915,11 @@ var windows_segfault_handle: ?windows.HANDLE = null;
 pub fn resetOnPosix() void {
     if (bun.Environment.enable_asan) return;
     var act = bun.sys.Sigaction{
-        .handler = .{ .sigaction = handleSegfaultPosix },
+        // `sigaction_fn`'s third parameter is `?*anyopaque`; ours is typed as
+        // `?*const bun.sys.ucontext_t` so future readers get the bionic-correct
+        // layout on x86_64 Android. Same C ABI — the kernel always passes a
+        // `ucontext_t*` there for `SA_SIGINFO` handlers.
+        .handler = .{ .sigaction = @ptrCast(&handleSegfaultPosix) },
         .mask = bun.sys.sigemptyset(),
         .flags = (std.posix.SA.SIGINFO | std.posix.SA.RESTART | std.posix.SA.RESETHAND),
     };

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -276,6 +276,14 @@ export const sigactionLayout: () =>
       sizeof: number;
     } = $newZigFunction("sys.zig", "TestingAPIs.sigactionLayout", 0);
 
+export const ucontextLayout: () =>
+  | undefined
+  | { sizeof: number; mcontext: number; sigmask: number; fpregs_mem: number; android: boolean } = $newZigFunction(
+  "sys.zig",
+  "TestingAPIs.ucontextLayout",
+  0,
+);
+
 export const stringsInternals = {
   /**
    * Calls `bun.strings.toUTF16AllocForReal(allocator, bytes, false, true)` and

--- a/src/sys/sys.zig
+++ b/src/sys/sys.zig
@@ -2308,6 +2308,51 @@ pub fn ppoll(fds: []std.posix.pollfd, timeout: ?*std.posix.timespec, sigmask: ?*
     }
 }
 
+/// `std.c.ucontext_t` on `.linux` forwards to `std.os.linux.<arch>.ucontext_t`,
+/// which is the glibc/musl layout: a 1024-bit (128-byte) `sigmask` between
+/// `uc_mcontext` and `fpregs_mem`. bionic x86_64's `ucontext_t`
+/// (`<sys/ucontext.h>`) puts only a bare `union { sigset_t; sigset64_t; }` —
+/// one `c_ulong`, 8 bytes — in that slot, so `__fpregs_mem` starts 120 bytes
+/// earlier than the Zig stdlib expects. aarch64 bionic happens to match the
+/// glibc layout because it explicitly pads `uc_sigmask` back out to 128 bytes
+/// (`char __padding[128 - sizeof(sigset_t)]`).
+///
+/// Nothing dereferences the signal handler's `ucontext_t*` today, but this
+/// type exists so that if the crash handler ever starts reading register
+/// state (e.g. `uc_mcontext.gregs[REG_RIP]`) it does so from the correct
+/// offsets on x86_64 Android. Use this instead of `std.posix.ucontext_t`.
+pub const ucontext_t = if (Environment.isAndroid and Environment.isX64) extern struct {
+    flags: c_ulong,
+    link: ?*@This(),
+    stack: std.c.stack_t,
+    // bionic's x86_64 `mcontext_t` (`{gregset_t, fpregset_t, __reserved1[8]}`)
+    // is byte-identical to glibc's, so reuse the stdlib definition.
+    mcontext: std.os.linux.mcontext_t,
+    // bionic LP64: `sigset_t` and `sigset64_t` are both `unsigned long`
+    // (see `bun.sys.sigset_t` above); the anonymous union collapses to a
+    // single `c_ulong` with no padding.
+    sigmask: sigset_t,
+    // bionic `struct _libc_fpstate` — 512 bytes, same as the glibc
+    // `fpregs_mem` backing store. Accessed via `mcontext.fpregs`.
+    fpregs_mem: [64]usize,
+
+    comptime {
+        bun.assert(@sizeOf(usize) == 8);
+        // Offsets from bionic `<sys/ucontext.h>` for `__x86_64__`:
+        //   uc_flags @0, uc_link @8, uc_stack @16, uc_mcontext @40,
+        //   uc_sigmask @296, __fpregs_mem @304, sizeof == 816.
+        bun.assert(@offsetOf(@This(), "mcontext") == 40);
+        bun.assert(@offsetOf(@This(), "sigmask") == 296);
+        bun.assert(@offsetOf(@This(), "fpregs_mem") == 304);
+        bun.assert(@sizeOf(@This()) == 816);
+        // Trip when the Zig stdlib gains a bionic `ucontext_t` so this
+        // workaround can be dropped. The glibc-shaped struct std currently
+        // uses is 936 bytes (128-byte sigmask); bionic's is 816.
+        if (@sizeOf(std.c.ucontext_t) == @sizeOf(@This()))
+            @compileError("std.c.ucontext_t now matches bionic x86_64; remove the bun.sys.ucontext_t workaround");
+    }
+} else posix.ucontext_t;
+
 pub fn recv(fd: bun.FD, buf: []u8, flag: u32) Maybe(usize) {
     const adjusted_len = @min(buf.len, max_count);
     const debug_timer = bun.Output.DebugTimer.start();

--- a/src/sys_jsc/error_jsc.zig
+++ b/src/sys_jsc/error_jsc.zig
@@ -88,6 +88,26 @@ pub const TestingAPIs = struct {
             .sizeof = @as(f64, @floatFromInt(@sizeOf(bun.sys.Sigaction))),
         }, globalThis)).toJS();
     }
+
+    /// Exposes `bun.sys.ucontext_t`'s layout so tests can assert it matches
+    /// the host libc. `std.c.ucontext_t` on `.linux` assumes the glibc/musl
+    /// layout (128-byte sigmask); bionic x86_64 has an 8-byte sigmask, so
+    /// `fpregs_mem` sits 120 bytes earlier. `bun.sys.ucontext_t` carries the
+    /// bionic-correct struct on x86_64 Android and aliases `std.posix` on
+    /// every other target — this returns the offsets the crash handler would
+    /// see if it dereferenced its saved `ucontext_t*`. Linux x86_64 only
+    /// (aarch64 has no `fpregs_mem` field, other OSes have unrelated layouts).
+    pub fn ucontextLayout(globalThis: *jsc.JSGlobalObject, _: *jsc.CallFrame) bun.JSError!jsc.JSValue {
+        if (comptime !(Environment.isLinux and Environment.isX64)) return .js_undefined;
+        const T = bun.sys.ucontext_t;
+        return (try jsc.JSObject.create(.{
+            .sizeof = @as(f64, @sizeOf(T)),
+            .mcontext = @as(f64, @offsetOf(T, "mcontext")),
+            .sigmask = @as(f64, @offsetOf(T, "sigmask")),
+            .fpregs_mem = @as(f64, @offsetOf(T, "fpregs_mem")),
+            .android = Environment.isAndroid,
+        }, globalThis)).toJS();
+    }
 };
 
 const std = @import("std");

--- a/test/internal/ucontext-layout.test.ts
+++ b/test/internal/ucontext-layout.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "bun:test";
+import { ucontextLayout } from "bun:internal-for-testing";
+import { isLinux } from "harness";
+
+// `bun.sys.ucontext_t` is the type the crash handler's SA_SIGINFO third
+// parameter is declared as. On Linux x86_64 it must match the host libc's
+// `ucontext_t` so that reading `uc_mcontext.gregs[REG_RIP]` / `fpregs_mem`
+// from a saved signal context lands on the right bytes.
+//
+// Zig's `std.c.ucontext_t` hardcodes the glibc/musl layout (128-byte
+// sigmask). bionic x86_64 puts only a single `c_ulong` there, so
+// `__fpregs_mem` is 120 bytes earlier. `bun.sys.ucontext_t` overrides the
+// layout on x86_64 Android and aliases `std.posix.ucontext_t` everywhere
+// else — this test pins the alias to the glibc/musl offsets on CI and, when
+// run on an x86_64 Android device, to the bionic offsets.
+test.skipIf(!(isLinux && process.arch === "x64"))("bun.sys.ucontext_t matches host libc on Linux x86_64", () => {
+  const layout = ucontextLayout();
+  expect(layout).toBeDefined();
+
+  // `uc_mcontext` sits at the same offset on glibc, musl, and bionic: it is
+  // preceded only by `{uc_flags, uc_link, uc_stack}` whose sizes are fixed by
+  // the kernel ABI.
+  const expected = layout!.android
+    ? // bionic libc/include/sys/ucontext.h, __x86_64__: uc_sigmask is a bare
+      // `union { sigset_t; sigset64_t; }` == one `unsigned long`.
+      { sizeof: 816, mcontext: 40, sigmask: 296, fpregs_mem: 304, android: true }
+    : // glibc/musl: `sigmask` is `[1024 / @bitSizeOf(c_ulong)]c_ulong`
+      // (128 bytes), pushing `fpregs_mem` out to 424.
+      { sizeof: 936, mcontext: 40, sigmask: 296, fpregs_mem: 424, android: false };
+
+  expect(layout).toEqual(expected);
+});

--- a/test/internal/ucontext-layout.test.ts
+++ b/test/internal/ucontext-layout.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test";
 import { ucontextLayout } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
 import { isLinux } from "harness";
 
 // `bun.sys.ucontext_t` is the type the crash handler's SA_SIGINFO third

--- a/test/internal/ucontext-layout.test.ts
+++ b/test/internal/ucontext-layout.test.ts
@@ -24,9 +24,12 @@ test.skipIf(!((isLinux || isAndroid) && process.arch === "x64"))(
     expect(layout).toBeDefined();
 
     // `uc_mcontext` sits at the same offset on glibc, musl, and bionic: it is
-    // preceded only by `{uc_flags, uc_link, uc_stack}` whose sizes are fixed by
-    // the kernel ABI.
-    const expected = layout!.android
+    // preceded only by `{uc_flags, uc_link, uc_stack}` whose sizes are fixed
+    // by the kernel ABI. Branch on the JS-side `isAndroid` (process.platform),
+    // not `layout.android` (Zig-side Environment.isAndroid), so a regression
+    // where Zig misreports the target doesn't pick its own expected values —
+    // `expect(layout).toEqual(expected)` then also asserts the two agree.
+    const expected = isAndroid
       ? // bionic libc/include/sys/ucontext.h, __x86_64__: uc_sigmask is a bare
         // `union { sigset_t; sigset64_t; }` == one `unsigned long`.
         { sizeof: 816, mcontext: 40, sigmask: 296, fpregs_mem: 304, android: true }

--- a/test/internal/ucontext-layout.test.ts
+++ b/test/internal/ucontext-layout.test.ts
@@ -2,6 +2,10 @@ import { ucontextLayout } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { isLinux } from "harness";
 
+// Bun reports `process.platform === "android"` (not "linux") on bionic; the
+// Zig-side `Environment.isLinux` still sees it as `.linux` + `.android` ABI.
+const isAndroid = process.platform === "android";
+
 // `bun.sys.ucontext_t` is the type the crash handler's SA_SIGINFO third
 // parameter is declared as. On Linux x86_64 it must match the host libc's
 // `ucontext_t` so that reading `uc_mcontext.gregs[REG_RIP]` / `fpregs_mem`
@@ -13,20 +17,23 @@ import { isLinux } from "harness";
 // layout on x86_64 Android and aliases `std.posix.ucontext_t` everywhere
 // else — this test pins the alias to the glibc/musl offsets on CI and, when
 // run on an x86_64 Android device, to the bionic offsets.
-test.skipIf(!(isLinux && process.arch === "x64"))("bun.sys.ucontext_t matches host libc on Linux x86_64", () => {
-  const layout = ucontextLayout();
-  expect(layout).toBeDefined();
+test.skipIf(!((isLinux || isAndroid) && process.arch === "x64"))(
+  "bun.sys.ucontext_t matches host libc on Linux x86_64",
+  () => {
+    const layout = ucontextLayout();
+    expect(layout).toBeDefined();
 
-  // `uc_mcontext` sits at the same offset on glibc, musl, and bionic: it is
-  // preceded only by `{uc_flags, uc_link, uc_stack}` whose sizes are fixed by
-  // the kernel ABI.
-  const expected = layout!.android
-    ? // bionic libc/include/sys/ucontext.h, __x86_64__: uc_sigmask is a bare
-      // `union { sigset_t; sigset64_t; }` == one `unsigned long`.
-      { sizeof: 816, mcontext: 40, sigmask: 296, fpregs_mem: 304, android: true }
-    : // glibc/musl: `sigmask` is `[1024 / @bitSizeOf(c_ulong)]c_ulong`
-      // (128 bytes), pushing `fpregs_mem` out to 424.
-      { sizeof: 936, mcontext: 40, sigmask: 296, fpregs_mem: 424, android: false };
+    // `uc_mcontext` sits at the same offset on glibc, musl, and bionic: it is
+    // preceded only by `{uc_flags, uc_link, uc_stack}` whose sizes are fixed by
+    // the kernel ABI.
+    const expected = layout!.android
+      ? // bionic libc/include/sys/ucontext.h, __x86_64__: uc_sigmask is a bare
+        // `union { sigset_t; sigset64_t; }` == one `unsigned long`.
+        { sizeof: 816, mcontext: 40, sigmask: 296, fpregs_mem: 304, android: true }
+      : // glibc/musl: `sigmask` is `[1024 / @bitSizeOf(c_ulong)]c_ulong`
+        // (128 bytes), pushing `fpregs_mem` out to 424.
+        { sizeof: 936, mcontext: 40, sigmask: 296, fpregs_mem: 424, android: false };
 
-  expect(layout).toEqual(expected);
-});
+    expect(layout).toEqual(expected);
+  },
+);


### PR DESCRIPTION
## Problem

`std.c.ucontext_t` on `.linux` forwards to `std.os.linux.<arch>.ucontext_t`, which is the glibc/musl layout: `{flags, link, stack, mcontext, sigmask[128B], fpregs_mem[512B]}`. bionic x86_64's `ucontext_t` (`<sys/ucontext.h>`) puts only a bare `union { sigset_t; sigset64_t; }` — one `c_ulong`, 8 bytes — between `uc_mcontext` and `__fpregs_mem`, so `__fpregs_mem` starts **120 bytes earlier** than the Zig stdlib expects.

aarch64 is accidentally correct: bionic explicitly pads `uc_sigmask` back to 128 bytes there (`char __padding[128 - sizeof(sigset_t)]`).

**No current breakage** — `handleSegfaultPosix` takes the ucontext arg as `?*const anyopaque` and never dereferences it. This is proactive: if the crash handler ever starts reading register state from the saved context (e.g. `uc_mcontext.gregs[REG_RIP]` / `REG_RSP` instead of the live siginfo), x86_64 Android would read the wrong offsets.

## Fix

Same pattern as #30389 (on which this is now based):

- `src/sys/sys.zig`: add `pub const ucontext_t` — on x86_64 Android, an `extern struct` matching bionic `<sys/ucontext.h>` (`__x86_64__`), with comptime offset assertions (`uc_mcontext @40`, `uc_sigmask @296`, `__fpregs_mem @304`, `sizeof == 816`) and a tripwire that fires when `std.c.ucontext_t` shrinks to the bionic size so the workaround can be dropped. Everywhere else it's a transparent alias of `std.posix.ucontext_t`. The `sigmask` field reuses `bun.sys.sigset_t`.
- `src/crash_handler/crash_handler.zig`: `handleSegfaultPosix`'s third parameter is now `?*const bun.sys.ucontext_t` (still unused, but correctly typed for future use). `@ptrCast` at the one assignment site since `Sigaction.sigaction_fn` types the slot as `?*anyopaque` — same C ABI.
- `test/internal/ucontext-layout.test.ts`: pins `@sizeOf` / `@offsetOf(bun.sys.ucontext_t, …)` to the host-libc values on Linux x86_64 (glibc/musl on CI, bionic when run on device).

`src/test_runner/harness/recover.zig` also references `std.c.ucontext_t`, but that's a separate problem (bionic has no `setcontext`/`getcontext` at all — it would need the `setjmp`/`longjmp` path like musl) and that file is currently unreferenced.

## Verification

```
$ zig build check-android -Dandroid_ndk_sysroot=/opt/android-ndk/…/sysroot --summary all
check-android success
  compile obj bun-debug Debug x86_64-linux-android  success
  compile obj bun-debug Debug aarch64-linux-android success
  compile obj bun ReleaseFast x86_64-linux-android  success
  compile obj bun ReleaseFast aarch64-linux-android success

$ bun bd test test/internal/ucontext-layout.test.ts
(pass) bun.sys.ucontext_t matches host libc on Linux x86_64
  → {sizeof:936, mcontext:40, sigmask:296, fpregs_mem:424, android:false}
```

`bun run zig:check-all` passes all 16 targets. Intentionally breaking an offset assertion (`@sizeOf == 817`) correctly fails the x86_64-android compile.

No Android runtime test is included — the misbehaviour only surfaces when the kernel fills the structure on a real x86_64 Android device, which CI does not run, and nothing in Bun currently dereferences it.
