### PR TITLE
jsc-stress: add Yarr \B + surrogate match-length underflow regression test

### DIFF
--- a/test/js/bun/jsc-stress/fixtures/yarr-non-bmp-backtrack-trampoline-index-sync.js
+++ b/test/js/bun/jsc-stress/fixtures/yarr-non-bmp-backtrack-trampoline-index-sync.js
@@ -1,0 +1,65 @@
+// @bun
+// Regression test for the Yarr JIT non-BMP first-character optimization.
+//
+// `/\B|x{1,2}?/u.exec("a\u{10ffff}b")[0].length` returned 4294967295.
+//
+// The BodyAlternativeEnd backtrack trampoline, when looping from a last
+// alternative whose minimumSize is greater than the first's, advanced
+// matchStart by firstCharacterAdditionalReadSize but left m_regs.index
+// unchanged. A zero-width first alternative (e.g. \B) could then succeed
+// with output[0] > output[1], and the computed match length underflowed to
+// (unsigned)-1 = 4294967295.
+//
+// Fixed upstream in WebKit 116394de195b (webkit.org/b/312604), which landed
+// in Bun via the WEBKIT_VERSION bump to d81bcc3d833c.
+//
+// The optimization is enabled when ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP),
+// which today is ARM64-only; before the fix every aarch64 CI lane reproduced
+// the underflow. On other architectures this exercises the non-optimized path
+// and must also pass.
+
+function check(re, input, label) {
+  var m = re.exec(input);
+  if (m === null) return;
+  if (typeof m[0] !== "string")
+    throw new Error(label + ": match[0] is not a string");
+  // The whole-match slice must never have end < start. When it does,
+  // jsSubstringOfResolved wraps and .length becomes (unsigned)-1.
+  if (m[0].length > input.length)
+    throw new Error(label + ": match[0].length=" + m[0].length + " exceeds input.length=" + input.length);
+  if (m.index + m[0].length > input.length)
+    throw new Error(label + ": match extends past end (index=" + m.index + " len=" + m[0].length + ")");
+}
+
+var inputs = [
+  "a\u{10ffff}b",
+  "a\u{10ffff}",
+  "\u{10ffff}b",
+  "\u{10ffff}",
+  "a\u{10ffff}\u{10ffff}b",
+  "aa\u{10ffff}bb",
+];
+
+for (var i = 0; i < testLoopCount; ++i) {
+  for (var j = 0; j < inputs.length; ++j) {
+    var s = inputs[j];
+    // delta == 1 (last alt minSize 1, first alt minSize 0)
+    check(/\B|x{1,2}?/u, s, "\\B|x{1,2}? on " + JSON.stringify(s));
+    // delta == 2 (last alt minSize 2, first alt minSize 0)
+    check(/\B|xy{1,2}?/u, s, "\\B|xy{1,2}? on " + JSON.stringify(s));
+    // Second alternative that matches past the pair.
+    check(/\B|b{1,2}?/u, s, "\\B|b{1,2}? on " + JSON.stringify(s));
+    // /m disables the optimization; must behave identically to the interpreter.
+    check(/\B|x{1,2}?/mu, s, "\\B|x{1,2}?/mu on " + JSON.stringify(s));
+  }
+
+  // Direct assertion for the originally-reported case: any match must be empty.
+  var m = /\B|x{1,2}?/u.exec("a\u{10ffff}b");
+  if (m !== null && m[0].length !== 0)
+    throw new Error("expected empty match, got length " + m[0].length);
+
+  // Upstream's reduction (WebKit bug 312604): m[0] is "", so m[0][0] is undefined.
+  var u = /\B|c./u.exec("a\ud800\udc00");
+  if (u !== null && u[0][0] !== undefined)
+    throw new Error("expected undefined, got " + JSON.stringify(u[0][0]));
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -59,6 +59,8 @@ const jsFixtures = [
   // FTL - RegExp
   "ftl-regexp-exec.js",
   "ftl-regexp-test.js",
+  // Yarr JIT
+  "yarr-non-bmp-backtrack-trampoline-index-sync.js",
   // FTL - Arguments
   "ftl-getmyargumentslength.js",
   "ftl-getmyargumentslength-inline.js",


### PR DESCRIPTION
## What

```js
bun -e 'console.log(/\B|x{1,2}?/u.exec("a\u{10ffff}b")[0].length)'
```

On ARM64 with Bun <= 1.3.14 this prints `4294967295` (`(unsigned)-1`). On x86_64 it prints `0`.

## Why

The Yarr JIT's non-BMP first-character optimization (`ENABLE_YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP`, ARM64-only) records `firstCharacterAdditionalReadSize = 1` whenever `tryReadUnicodeChar` decodes a surrogate pair, so the body-alternative retry loop can step past the whole code point.

In the `BodyAlternativeEnd` backtrack trampoline, the branch taken when `lastAlternative.minimumSize > firstAlternative.minimumSize` set `matchStart = index + firstCharacterAdditionalReadSize` but jumped to `beginOp->m_reentry` without applying the same adjustment to `m_regs.index`. A zero-width first alternative such as `\B` could then succeed at the stale `index`, producing `output[0] > output[1]`; `createRegExpMatchesArray` built the whole-match substring with length `(unsigned)(end - start) = 4294967295`.

## Fix

Fixed upstream in WebKit while this PR was open: [WebKit/WebKit@116394de195b](https://github.com/WebKit/WebKit/commit/116394de195b) ("[JSC] Yarr JIT \B+unicode+surrogate produces corrupted JSString, crashes WebContent", [webkit.org/b/312604](https://bugs.webkit.org/show_bug.cgi?id=312604)) applies the same trampoline change plus a `SetForScope` guard on word-boundary assertion reads.

That commit reached this repo through the `WEBKIT_VERSION` bump to `d81bcc3d833c` in #33133, so `main` is already fixed. My equivalent source change, oven-sh/WebKit#221, was closed as superseded.

## This PR

Adds `test/js/bun/jsc-stress/fixtures/yarr-non-bmp-backtrack-trampoline-index-sync.js` so a future WebKit bump cannot silently regress this. The fixture asserts the whole-match substring is always well-formed (`length <= input.length`, `index + length <= input.length`) across the pattern shapes that reach this trampoline branch (`delta == 1`, `delta == 2`, a matching second alternative, `/mu` which disables the optimization), plus upstream's reduction from webkit.org/b/312604.

No `src/**` change; the source fix arrived via the WebKit dependency.

## Verification

**Fail before** (CI [build 52790](https://buildkite.com/bun/bun/builds/52790), this branch at `d4c75723` on the pre-#33133 WebKit): every aarch64 lane that ran `jsc-stress.test.ts` (darwin-26, darwin-14, debian-13, ubuntu-25.04, alpine-3.23, windows-11) failed with

```
error: \B|x{1,2}? on "a<U+10FFFF>b": match[0].length=4294967295 exceeds input.length=4
```

**Pass after** (rebased onto `main`, which carries the fixed WebKit `c9ad5813fd`):

```
$ bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts -t yarr
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > yarr-non-bmp-backtrack-trampoline-index-sync.js
```

x86_64 never enables the optimization, so the meaningful pass/fail signal is the aarch64 lanes.