### PR TITLE
Bun.serve: validate websocket.perMessageDeflate is a boolean or object

### DIFF
--- a/src/runtime/server/WebSocketServerContext.zig
+++ b/src/runtime/server/WebSocketServerContext.zig
@@ -172,6 +172,10 @@ pub fn onCreate(globalObject: *jsc.JSGlobalObject, object: JSValue) bun.JSError!
                 break :getter;
             }
 
+            if (!per_message_deflate.isObject()) {
+                return globalObject.throwInvalidArguments("websocket expects perMessageDeflate to be a boolean or an object", .{});
+            }
+
             if (try per_message_deflate.getTruthy(globalObject, "compress")) |compression| {
                 if (compression.isBoolean()) {
                     server.compression |= if (compression.toBoolean()) uws.SHARED_COMPRESSOR else 0;

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -521,6 +521,35 @@ describe("Server", () => {
       }));
       */
     it.todo("perMessageDeflate");
+    describe("perMessageDeflate (validation)", () => {
+      it.each([1073741824, "hello", 1n, Symbol()])("throws when not a boolean or object", value => {
+        expect(() => {
+          serve({
+            port: 0,
+            fetch: () => new Response(),
+            websocket: {
+              message() {},
+              // @ts-expect-error
+              perMessageDeflate: value,
+            },
+          });
+        }).toThrow("websocket expects perMessageDeflate to be a boolean or an object");
+      });
+      it.each([true, false, null, undefined, {}, { compress: true, decompress: "shared" }] as const)(
+        "accepts %p",
+        value => {
+          using server = serve({
+            port: 0,
+            fetch: () => new Response(),
+            websocket: {
+              message() {},
+              perMessageDeflate: value as any,
+            },
+          });
+          expect(server.port).toBeGreaterThan(0);
+        },
+      );
+    });
   });
 });
 describe("ServerWebSocket", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash when `websocket.perMessageDeflate` is set to a primitive value that isn't a boolean (e.g. a number, string, bigint, or symbol).

```js
Bun.serve({
  port: 0,
  fetch: () => new Response(),
  websocket: {
    message() {},
    perMessageDeflate: 1073741824,
  },
});
```

Previously this fell through the `undefined` / `boolean` / `null` checks in `WebSocketServerContext.onCreate` and called `JSValue.getTruthy("compress")` on the primitive, hitting `bun.debugAssert(target.isObject())` in `JSValue.get`.

Now it throws `TypeError: websocket expects perMessageDeflate to be a boolean or an object`.

## How did you verify your code works?

Added validation tests in `test/js/bun/websocket/websocket-server.test.ts` covering invalid primitives (number, string, bigint, symbol) and valid values (`true`, `false`, `null`, `undefined`, `{}`, `{ compress, decompress }`).

Found by Fuzzilli. Fingerprint: `3fbce3302b421eec`