### PR TITLE
Fix crash when formatting WeakMap/WeakSet with user-set size property

### DIFF
--- a/src/jsc/ConsoleObject.zig
+++ b/src/jsc/ConsoleObject.zig
@@ -2757,14 +2757,19 @@ pub const Formatter = struct {
                 writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
             },
             .Map => {
+                const is_weak = value.jsType() == .WeakMap;
+                const map_name = if (is_weak) "WeakMap" else "Map";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{map_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{map_name});
@@ -2864,14 +2869,19 @@ pub const Formatter = struct {
                 writer.writeAll("}");
             },
             .Set => {
+                const is_weak = value.jsType() == .WeakSet;
+                const set_name = if (is_weak) "WeakSet" else "Set";
+
+                if (is_weak) {
+                    return writer.print("{s} {{}}", .{set_name});
+                }
+
                 const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                 const length = try length_value.coerce(i32, this.globalThis);
 
                 const prev_quote_strings = this.quote_strings;
                 this.quote_strings = true;
                 defer this.quote_strings = prev_quote_strings;
-
-                const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                 if (length == 0) {
                     return writer.print("{s} {{}}", .{set_name});

--- a/src/test_runner/diff_format.zig
+++ b/src/test_runner/diff_format.zig
@@ -43,7 +43,9 @@ pub const DiffFormatter = struct {
                 1,
                 &received_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
 
             JestPrettyFormat.format(
                 .Debug,
@@ -52,7 +54,9 @@ pub const DiffFormatter = struct {
                 1,
                 &expected_buf.writer,
                 fmt_options,
-            ) catch {}; // TODO:
+            ) catch {
+                _ = this.globalThis.clearExceptionExceptTermination();
+            };
         }
 
         var received_slice = received_buf.written();

--- a/src/test_runner/pretty_format.zig
+++ b/src/test_runner/pretty_format.zig
@@ -1307,14 +1307,19 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll(comptime Output.prettyFmt("<cyan>" ++ fmt ++ "<r>", enable_ansi_colors));
                 },
                 .Map => {
+                    const is_weak = value.jsType() == .WeakMap;
+                    const map_name = if (is_weak) "WeakMap" else "Map";
+
+                    if (is_weak) {
+                        return writer.print("{s} {{}}", .{map_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
                     const prev_quote_strings = this.quote_strings;
                     this.quote_strings = true;
                     defer this.quote_strings = prev_quote_strings;
-
-                    const map_name = if (value.jsType() == .WeakMap) "WeakMap" else "Map";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{map_name});
@@ -1335,6 +1340,14 @@ pub const JestPrettyFormat = struct {
                     writer.writeAll("\n");
                 },
                 .Set => {
+                    const is_weak = value.jsType() == .WeakSet;
+                    const set_name = if (is_weak) "WeakSet" else "Set";
+
+                    if (is_weak) {
+                        this.writeIndent(Writer, writer_) catch {};
+                        return writer.print("{s} {{}}", .{set_name});
+                    }
+
                     const length_value = try value.get(this.globalThis, "size") orelse jsc.JSValue.jsNumberFromInt32(0);
                     const length = length_value.toInt32();
 
@@ -1343,8 +1356,6 @@ pub const JestPrettyFormat = struct {
                     defer this.quote_strings = prev_quote_strings;
 
                     this.writeIndent(Writer, writer_) catch {};
-
-                    const set_name = if (value.jsType() == .WeakSet) "WeakSet" else "Set";
 
                     if (length == 0) {
                         return writer.print("{s} {{}}", .{set_name});

--- a/test/js/bun/test/expect-weakmap-size.test.ts
+++ b/test/js/bun/test/expect-weakmap-size.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 
 test("expect().toEqual() diff with WeakMap that has a user-set size property does not crash", () => {
   const wm = new WeakMap();

--- a/test/js/bun/test/expect-weakmap-size.test.ts
+++ b/test/js/bun/test/expect-weakmap-size.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+
+test("expect().toEqual() diff with WeakMap that has a user-set size property does not crash", () => {
+  const wm = new WeakMap();
+  // @ts-expect-error
+  wm.size = 1000;
+  expect(() => expect(wm).toEqual({})).toThrow();
+  expect(() => expect(wm).toEqual(new Number())).toThrow();
+});
+
+test("expect().toEqual() diff with WeakSet that has a user-set size property does not crash", () => {
+  const ws = new WeakSet();
+  // @ts-expect-error
+  ws.size = 1000;
+  expect(() => expect(ws).toEqual({})).toThrow();
+  expect(() => expect(ws).toEqual(new Number())).toThrow();
+});
+
+test("expect().toEqual() diff with Map whose size getter throws does not crash", () => {
+  const m = new Map();
+  Object.defineProperty(m, "size", {
+    get() {
+      throw new TypeError("bad");
+    },
+  });
+  expect(() => expect(m).toEqual({})).toThrow();
+});
+
+test("Bun.inspect() of WeakMap/WeakSet with user-set size property does not throw", () => {
+  const wm = new WeakMap();
+  // @ts-expect-error
+  wm.size = 1000;
+  expect(Bun.inspect(wm)).toBe("WeakMap {}");
+
+  const ws = new WeakSet();
+  // @ts-expect-error
+  ws.size = 1000;
+  expect(Bun.inspect(ws)).toBe("WeakSet {}");
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a debug assertion crash (`!exception() || m_vm.hasPendingTerminationException()`) in `expect().toEqual()` when the received value is a `WeakMap` or `WeakSet` with a user-assigned `.size` own property and the expected value is an object.

```js
const wm = new WeakMap();
wm.size = 1000;
expect(wm).toEqual({}); // crashed
```

### Root cause

`WeakMap` and `WeakSet` are not iterable and have no intrinsic `.size`. The jest pretty formatter and `Bun.inspect`/`console.log` formatter both looked up the `"size"` property and, if non-zero, called `forEach()` to print entries. On weak collections that `forEach()` throws a `TypeError`.

In `DiffFormatter.format`, the error from formatting the received value was swallowed with `catch {}` while the JS exception stayed pending on the VM. The next `JestPrettyFormat.format` call for the expected value then tripped the exception-scope assertion.

### Fix

- Print `WeakMap {}` / `WeakSet {}` unconditionally for weak collections in both the jest pretty formatter and the console/inspect formatter, skipping `.size` lookup and iteration entirely. This also fixes `console.log` / `Bun.inspect` throwing `TypeError` on such values.
- In `DiffFormatter`, clear any pending JS exception when a format call fails so a throwing getter (e.g. a `Map` with an overridden `size` getter) can't leave the VM in a bad state for the second format call.

## How did you verify your code works?

Added `test/js/bun/test/expect-weakmap-size.test.ts` covering:
- `expect(WeakMap/WeakSet with .size).toEqual(obj)` no longer crashes and reports the diff.
- `expect(Map with throwing size getter).toEqual(obj)` no longer crashes.
- `Bun.inspect(WeakMap/WeakSet with .size)` returns `"WeakMap {}"` / `"WeakSet {}"` instead of throwing.

Found via Fuzzilli (fingerprint `cd91284c5d80ddae`).