### PR TITLE
fix: accept legacy string argument in jest.useFakeTimers()

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -95,7 +95,7 @@ declare module "bun:test" {
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
     function setTimeout(milliseconds: number): void;
-    function useFakeTimers(options?: { now?: number | Date }): typeof vi;
+    function useFakeTimers(options?: { now?: number | Date } | "modern" | "legacy"): typeof vi;
     function useRealTimers(): typeof vi;
     function advanceTimersByTime(milliseconds: number): typeof vi;
     function advanceTimersToNextTimer(): typeof vi;

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -344,20 +344,26 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     let args = frame.arguments_as_array::<1>();
     if args.len() > 0 && !args[0].is_undefined() {
         let options_value = args[0];
-        if !options_value.is_object() {
+        // Jest legacy API: jest.useFakeTimers('modern') or jest.useFakeTimers('legacy')
+        // Both are no-ops in modern Jest (only 'modern' implementation exists).
+        // Accept and ignore string arguments for backwards compatibility.
+        if options_value.is_string() {
+            // no-op: fall through to activate with default time
+        } else if !options_value.is_object() {
             return Err(global.throw_invalid_arguments(format_args!(
                 "useFakeTimers() expects an options object"
             )));
-        }
-        if let Some(now) = options_value.get(global, "now")? {
-            if now.is_number() {
-                js_now = now.as_number();
-            } else if now.is_date() {
-                js_now = now.get_unix_timestamp();
-            } else {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "'now' must be a number or Date"
-                )));
+        } else {
+            if let Some(now) = options_value.get(global, "now")? {
+                if now.is_number() {
+                    js_now = now.as_number();
+                } else if now.is_date() {
+                    js_now = now.get_unix_timestamp();
+                } else {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "'now' must be a number or Date"
+                    )));
+                }
             }
         }
     }

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -446,4 +446,13 @@ describe("useFakeTimers with options", () => {
     expect(performance.now()).toBe(500);
     expect(Date.now()).toBe(targetTime + 500);
   });
+
+  test("useFakeTimers accepts legacy string argument for Jest compat", () => {
+    // Jest 26 API: jest.useFakeTimers('modern') or jest.useFakeTimers('legacy')
+    // Both should be accepted without throwing.
+    expect(() => vi.useFakeTimers("modern")).not.toThrow();
+    vi.useRealTimers();
+    expect(() => vi.useFakeTimers("legacy")).not.toThrow();
+    vi.useRealTimers();
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `jest.useFakeTimers('modern')` and `jest.useFakeTimers('legacy')` throwing `TypeError: useFakeTimers() expects an options object`.

Jest 26 accepted a string argument to select the timer implementation. Since Jest 27, only the 'modern' implementation exists and the string argument is a no-op. Many codebases migrating from Jest still have `jest.useFakeTimers('modern')` calls.

### How did you verify your code works?

- ✅ New test passes with `bun run build:release` + `./build/release/bun test`
- ✅ New test fails with system bun (30 pass, 1 fail → 31 pass, 0 fail)
- ✅ Full fake-timers test suite passes (31/31)

### Fix

Guard in `src/runtime/test_runner/timers/FakeTimers.rs`: skip options parsing when the argument is a string.

```rust
if options_value.is_string() {
    // no-op: fall through to activate with default time
} else if !options_value.is_object() {
    return Err(global.throw_invalid_arguments(format_args!(
        "useFakeTimers() expects an options object"
    )));
} else {
    // parse options...
}
```

No existing GitHub issue found for this — discovered during a Jest-to-bun migration.