### PR TITLE
bake: validate fileSystemRouterTypes array elements are objects

### DIFF
--- a/src/codegen/bake-codegen.ts
+++ b/src/codegen/bake-codegen.ts
@@ -56,7 +56,7 @@ async function run() {
           side: JSON.stringify(side),
           IS_ERROR_RUNTIME: String(file === "error"),
           IS_BUN_DEVELOPMENT: String(!!debug),
-          OVERLAY_CSS: css("../runtime/bake/client/overlay.css", !!debug),
+          OVERLAY_CSS: JSON.stringify(css("../runtime/bake/client/overlay.css", !!debug)),
         },
         minify: {
           syntax: !debug,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -947,6 +947,12 @@ impl Framework {
             // releases the `Strong` held by its `JavascriptDefined` arm (the
             // only owning variant; the named styles are unit-like).
             while let Some(fsr_opts) = it.next()? {
+                if !fsr_opts.is_object() {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "'fileSystemRouterTypes[{}]' is not an object",
+                        i
+                    )));
+                }
                 let root = match get_optional_string(fsr_opts, global, b"root", refs)? {
                     Some(r) => r,
                     None => {

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,15 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+describe("framework config validation", () => {
+  test.each([1, "hello", null, true])("fileSystemRouterTypes with non-object element %p throws", item => {
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        // @ts-expect-error
+        app: { framework: { fileSystemRouterTypes: [item] } },
+      }),
+    ).toThrow("'fileSystemRouterTypes[0]' is not an object");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Validates that each element of `fileSystemRouterTypes` in `Bun.serve({ app: { framework: { ... } } })` is an object before reading properties from it, mirroring the existing `builtInModules` element check a few lines above in the same function.

The bug was found by Fuzzilli as a debug assertion panic in the Zig implementation: `JSValue.get()` asserted `isObject()` and a non-object array element (number, string, null, boolean) tripped it.

```
panic(main thread): reached unreachable code
jsc.JSValue.JSValue.get
src/jsc/JSValue.zig:1534
bake.bake.getOptionalString
bake.bake.Framework.fromJS
```

Main has since replaced bake with the Rust port and removed the `.zig` sources (#30412, #32621), and the Rust `JSValue::get` handles non-objects without asserting. So on current main the same input no longer panics, but it reports a misleading error: `'fileSystemRouterTypes[0]' is missing 'root'`. With the validation added here it reports what is actually wrong:

```
TypeError: 'fileSystemRouterTypes[0]' is not an object
 code: "ERR_INVALID_ARG_TYPE"
```

Also wraps the `OVERLAY_CSS` define in `bake-codegen.ts` with `JSON.stringify()` (like the `side` define next to it) so the codegen does not depend on `define` auto-quoting raw CSS text, which older bun versions reject.

## How did you verify your code works?

Added tests in `test/bake/framework-router.test.ts` covering number, string, null, and boolean array elements. They fail without the `bake_body.rs` change (wrong error message) and pass with it.

Found by Fuzzilli. Fingerprint: `780e04629922304e`
